### PR TITLE
[Bugfix] Service default when multiservice and no param[:service_id]

### DIFF
--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -113,10 +113,10 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
   end
 
   def service
-    @service ||= if not site_account.multiservice?
-                   site_account.services.default
-                 elsif service_id = params[:service_id]
+    @service ||= if site_account.multiservice? && (service_id = params[:service_id])
                    site_account.services.find_by_id_or_system_name(service_id)
+                 else
+                   site_account.services.default
                  end
   end
 

--- a/test/integration/developer_portal/admin/applications_controller_test.rb
+++ b/test/integration/developer_portal/admin/applications_controller_test.rb
@@ -156,6 +156,16 @@ class DeveloperPortal::Admin::ApplicationsControllerTest < ActionDispatch::Integ
           assert @buyer_auth.bought_cinstance
         end
 
+        should 'creates with default service when it is multiservice but the service_id param is not sent' do
+          @provider.services.create!(name: 'second-service')
+
+          post admin_applications_path(cinstance: { plan_id: @plan.id, name: 'my app' })
+
+          assert_response :redirect
+          assert @buyer_auth.bought_cinstance
+          assert_equal @provider.services.default, @buyer_auth.bought_cinstance.service
+        end
+
         should 'enforce strong parameters on create' do
           assert_nothing_raised do
             post admin_applications_path(cinstance: { plan_id: @plan.id, name: 'my app', description: 'this is my new app', org_name: 'not allowed' })


### PR DESCRIPTION
fixes https://github.com/3scale/porta/issues/11
When there is no valid service_id param, it should probably pick the default. I am not sure about this yet though 🤔
And I am not sure that no `service_id` param was sent for this (from the params of this request):
```
{
  "service_id": "<NOT FOUND>"
}
```