### PR TITLE
Find inactive accounts and schedule them for deletion

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -55,6 +55,7 @@ class Account < ApplicationRecord
   scope :providers, -> { where(provider: true) }
 
   scope :providers_with_master, -> { where.has { (provider == true) | (master == true) } }
+  scope :tenants, -> { providers.not_master }
 
   #OPTIMIZE: adding master boolean a default to false, then this could be done
   # scope :buyers, :conditions => {:provider => false, :master => false}

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -1,5 +1,6 @@
 module Account::States
   PERIOD_BEFORE_DELETION = 15.days.freeze
+  MAX_PERIOD_OF_SUSPENSION = 90.days.freeze
   MAX_PERIOD_OF_INACTIVITY = 1.year.freeze
   STATES = %i[created pending approved rejected suspended scheduled_for_deletion].freeze
   extend ActiveSupport::Concern
@@ -102,6 +103,10 @@ module Account::States
 
     scope :deleted_since, ->(value = nil) do
       scheduled_for_deletion.where.has { state_changed_at <= (value || PERIOD_BEFORE_DELETION.ago) }
+    end
+
+    scope :suspended_since, ->(value = nil) do
+      suspended.where.has { state_changed_at <= (value || MAX_PERIOD_OF_SUSPENSION.ago) }
     end
 
     scope :inactive_since, ->(value = nil) do

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -122,7 +122,7 @@ module Account::States
     end
 
     def deletion_date
-      return nil if state_changed_at.blank? || !scheduled_for_deletion?
+      return if state_changed_at.blank? || !scheduled_for_deletion?
       (state_changed_at + PERIOD_BEFORE_DELETION)
     end
 

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -131,6 +131,10 @@ class Cinstance < Contract
   # "live", in a way).
   scope :live, -> { where(:state => ['live', 'deprecated'])}
 
+  scope :active_since, ->(activity_time) {
+    where.has { first_daily_traffic_at >= activity_time }
+  }
+
   # Return only cinstances live at given time. The time can be single time or
   # period (Range object) (from..to).
   scope :live_at, lambda { |period|

--- a/app/workers/stale_account_worker.rb
+++ b/app/workers/stale_account_worker.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class StaleAccountWorker
+  include Sidekiq::Worker
+
+  def perform
+    Account.tenants.suspended_since.find_each(&:schedule_for_deletion!)
+  end
+end

--- a/app/workers/suspend_inactive_accounts_worker.rb
+++ b/app/workers/suspend_inactive_accounts_worker.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SuspendInactiveAccountsWorker
+  include Sidekiq::Worker
+
+  def perform
+    Account.tenants.inactive_since.find_each(&:suspend!)
+  end
+end

--- a/config/jobs.rb
+++ b/config/jobs.rb
@@ -23,6 +23,7 @@ module ThreeScale
       Pdf::Dispatch.weekly
       JanitorWorker.perform_async
       SuspendInactiveAccountsWorker.perform_async
+      StaleAccountWorker.perform_async
     ].freeze
 
     DAILY = %w[

--- a/config/jobs.rb
+++ b/config/jobs.rb
@@ -22,6 +22,7 @@ module ThreeScale
     WEEK = %w[
       Pdf::Dispatch.weekly
       JanitorWorker.perform_async
+      SuspendInactiveAccountsWorker.perform_async
     ].freeze
 
     DAILY = %w[

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -185,6 +185,50 @@ class Account::StatesTest < ActiveSupport::TestCase
     assert_equal Account::States::PERIOD_BEFORE_DELETION.from_now.to_date, account.deletion_date.to_date
   end
 
+  test '.inactive_since' do
+    old_account_without_traffic = FactoryGirl.create(:simple_account)
+    old_account_without_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+
+    old_account_with_old_traffic = FactoryGirl.create(:simple_account)
+    old_account_with_old_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    cinstance = FactoryGirl.create(:cinstance, user_account: old_account_with_old_traffic)
+    cinstance.update_attribute(:first_daily_traffic_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+
+    recent_account_without_traffic = FactoryGirl.create(:simple_account)
+    recent_account_without_traffic.update_attribute(:created_at, (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
+    cinstance = FactoryGirl.create(:cinstance, user_account: recent_account_without_traffic)
+    cinstance.update_attribute(:first_daily_traffic_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+
+    recent_account_with_recent_traffic = FactoryGirl.create(:simple_account)
+    recent_account_with_recent_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    cinstance = FactoryGirl.create(:cinstance, user_account: recent_account_with_recent_traffic)
+    cinstance.update_attribute(:first_daily_traffic_at, (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
+
+    results = Account.inactive_since.pluck(:id)
+    assert_includes     results, old_account_without_traffic.id
+    assert_includes     results, old_account_with_old_traffic.id
+    assert_not_includes results, recent_account_without_traffic.id
+    assert_not_includes results, recent_account_with_recent_traffic.id
+  end
+
+  test '.without_traffic_since' do
+    account_without_traffic = FactoryGirl.create(:simple_account)
+
+    account_with_old_traffic = FactoryGirl.create(:simple_account)
+    cinstance = FactoryGirl.create(:cinstance, user_account: account_with_old_traffic)
+    cinstance.update_attribute(:first_daily_traffic_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+
+    account_with_recent_traffic = FactoryGirl.create(:simple_account)
+    cinstance = FactoryGirl.create(:cinstance, user_account: account_with_recent_traffic)
+    cinstance.update_attribute(:first_daily_traffic_at, (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
+
+    results = Account.without_traffic_since.pluck(:id)
+    assert_includes     results, account_without_traffic.id
+    assert_includes     results, account_with_old_traffic.id
+    assert_not_includes results, account_with_recent_traffic.id
+  end
+
+
   class CallbacksTest < ActiveSupport::TestCase
     disable_transactional_fixtures!
 

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -185,6 +185,14 @@ class Account::StatesTest < ActiveSupport::TestCase
     assert_equal Account::States::PERIOD_BEFORE_DELETION.from_now.to_date, account.deletion_date.to_date
   end
 
+  test '.suspended_since' do
+    accounts = FactoryGirl.create_list(:simple_account, 2, state: 'suspended')
+    approved_account = FactoryGirl.create(:simple_account, state: 'approved')
+    account_suspended_recently = FactoryGirl.create(:simple_account, state: 'suspended', state_changed_at: (Account::States::MAX_PERIOD_OF_SUSPENSION - 1.day).ago)
+    account_suspended_antiquely = FactoryGirl.create(:simple_account, state: 'suspended', state_changed_at: Account::States::MAX_PERIOD_OF_SUSPENSION.ago)
+    assert_equal [account_suspended_antiquely.id], Account.suspended_since.pluck(:id)
+  end
+
   test '.inactive_since' do
     old_account_without_traffic = FactoryGirl.create(:simple_account)
     old_account_without_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -186,9 +186,9 @@ class Account::StatesTest < ActiveSupport::TestCase
   end
 
   test '.suspended_since' do
-    accounts = FactoryGirl.create_list(:simple_account, 2, state: 'suspended')
-    approved_account = FactoryGirl.create(:simple_account, state: 'approved')
-    account_suspended_recently = FactoryGirl.create(:simple_account, state: 'suspended', state_changed_at: (Account::States::MAX_PERIOD_OF_SUSPENSION - 1.day).ago)
+    FactoryGirl.create(:simple_account, state: 'suspended')
+    FactoryGirl.create(:simple_account, state: 'approved')
+    FactoryGirl.create(:simple_account, state: 'suspended', state_changed_at: (Account::States::MAX_PERIOD_OF_SUSPENSION - 1.day).ago)
     account_suspended_antiquely = FactoryGirl.create(:simple_account, state: 'suspended', state_changed_at: Account::States::MAX_PERIOD_OF_SUSPENSION.ago)
     assert_equal [account_suspended_antiquely.id], Account.suspended_since.pluck(:id)
   end
@@ -199,18 +199,15 @@ class Account::StatesTest < ActiveSupport::TestCase
 
     old_account_with_old_traffic = FactoryGirl.create(:simple_account)
     old_account_with_old_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
-    cinstance = FactoryGirl.create(:cinstance, user_account: old_account_with_old_traffic)
-    cinstance.update_attribute(:first_daily_traffic_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    FactoryGirl.create(:cinstance, user_account: old_account_with_old_traffic, first_daily_traffic_at: Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
 
     recent_account_without_traffic = FactoryGirl.create(:simple_account)
     recent_account_without_traffic.update_attribute(:created_at, (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
-    cinstance = FactoryGirl.create(:cinstance, user_account: recent_account_without_traffic)
-    cinstance.update_attribute(:first_daily_traffic_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    FactoryGirl.create(:cinstance, user_account: recent_account_without_traffic, first_daily_traffic_at: (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
 
     recent_account_with_recent_traffic = FactoryGirl.create(:simple_account)
     recent_account_with_recent_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
-    cinstance = FactoryGirl.create(:cinstance, user_account: recent_account_with_recent_traffic)
-    cinstance.update_attribute(:first_daily_traffic_at, (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
+    FactoryGirl.create(:cinstance, user_account: recent_account_with_recent_traffic, first_daily_traffic_at: (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
 
     results = Account.inactive_since.pluck(:id)
     assert_includes     results, old_account_without_traffic.id
@@ -223,12 +220,10 @@ class Account::StatesTest < ActiveSupport::TestCase
     account_without_traffic = FactoryGirl.create(:simple_account)
 
     account_with_old_traffic = FactoryGirl.create(:simple_account)
-    cinstance = FactoryGirl.create(:cinstance, user_account: account_with_old_traffic)
-    cinstance.update_attribute(:first_daily_traffic_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    FactoryGirl.create(:cinstance, user_account: account_with_old_traffic, first_daily_traffic_at: Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
 
     account_with_recent_traffic = FactoryGirl.create(:simple_account)
-    cinstance = FactoryGirl.create(:cinstance, user_account: account_with_recent_traffic)
-    cinstance.update_attribute(:first_daily_traffic_at, (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
+    FactoryGirl.create(:cinstance, user_account: account_with_recent_traffic, first_daily_traffic_at: (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
 
     results = Account.without_traffic_since.pluck(:id)
     assert_includes     results, account_without_traffic.id

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -246,6 +246,13 @@ class CinstanceTest < ActiveSupport::TestCase
     assert_does_not_contain Cinstance.live, cinstance
   end
 
+  test '.active_since' do
+    cinstances = FactoryGirl.create_list(:cinstance, 2)
+    cinstances.first.update_attribute(:first_daily_traffic_at, 1.year.ago)
+    cinstances.last.update_attribute(:first_daily_traffic_at, 1.day.ago)
+    assert_equal [cinstances.last.id], Cinstance.active_since(1.month.ago).pluck(:id)
+  end
+
   test 'Cinstance.all returns non destroyed cinstanced' do
     cinstance = Factory(:cinstance)
     assert_contains Cinstance.all, cinstance

--- a/test/workers/stale_account_worker_test.rb
+++ b/test/workers/stale_account_worker_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class StaleAccountWorkerTest < ActiveSupport::TestCase
+  setup do
+    @accounts = {to_delete: [], not_to_delete: []}
+
+    tenant_suspended_long_ago = FactoryGirl.create(:simple_provider, state: 'suspended')
+    tenant_suspended_long_ago.update_attribute(:state_changed_at, Account::States::MAX_PERIOD_OF_SUSPENSION.ago)
+    @accounts[:to_delete] << tenant_suspended_long_ago
+
+    tenant_suspended_recently = FactoryGirl.create(:simple_provider, state: 'suspended')
+    tenant_suspended_recently.update_attribute(:state_changed_at, (Account::States::MAX_PERIOD_OF_SUSPENSION - 1.day).ago)
+    @accounts[:not_to_delete] << tenant_suspended_recently
+
+    buyer_suspended_long_ago = FactoryGirl.create(:simple_buyer, state: 'suspended')
+    buyer_suspended_long_ago.update_attribute(:state_changed_at, Account::States::MAX_PERIOD_OF_SUSPENSION.ago)
+    @accounts[:not_to_delete] << buyer_suspended_long_ago
+
+    tenant_approved_long_ago = FactoryGirl.create(:simple_provider, state: 'approved')
+    tenant_approved_long_ago.update_attribute(:state_changed_at, Account::States::MAX_PERIOD_OF_SUSPENSION.ago)
+    @accounts[:not_to_delete] << tenant_approved_long_ago
+  end
+
+  test 'perform schedules for deletion suspended accounts' do
+    StaleAccountWorker.new.perform
+    @accounts[:to_delete].each     { |account| assert account.reload.scheduled_for_deletion? }
+    @accounts[:not_to_delete].each { |account| refute account.reload.scheduled_for_deletion? }
+  end
+end

--- a/test/workers/suspend_inactive_accounts_worker_test.rb
+++ b/test/workers/suspend_inactive_accounts_worker_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SuspendInactiveAccountsWorkerTest < ActiveSupport::TestCase
+  setup do
+    @accounts = {to_suspend: [], not_to_suspend: []}
+
+    old_tenant_with_old_traffic = FactoryGirl.create(:simple_provider)
+    old_tenant_with_old_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    cinstance = FactoryGirl.create(:cinstance, user_account: old_tenant_with_old_traffic)
+    cinstance.update_attribute(:first_daily_traffic_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    @accounts[:to_suspend] << old_tenant_with_old_traffic
+
+    old_buyer_with_old_traffic = FactoryGirl.create(:simple_buyer)
+    old_buyer_with_old_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    cinstance = FactoryGirl.create(:cinstance, user_account: old_buyer_with_old_traffic)
+    cinstance.update_attribute(:first_daily_traffic_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    @accounts[:not_to_suspend] << old_buyer_with_old_traffic
+
+    recent_tenant_without_traffic = FactoryGirl.create(:simple_provider)
+    recent_tenant_without_traffic.update_attribute(:created_at, (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
+    @accounts[:not_to_suspend] << recent_tenant_without_traffic
+
+    recent_tenant_with_recent_traffic = FactoryGirl.create(:simple_provider)
+    recent_tenant_with_recent_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    cinstance = FactoryGirl.create(:cinstance, user_account: recent_tenant_with_recent_traffic)
+    cinstance.update_attribute(:first_daily_traffic_at, (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
+    @accounts[:not_to_suspend] << recent_tenant_with_recent_traffic
+
+    old_tenant_without_traffic = FactoryGirl.create(:simple_provider)
+    old_tenant_without_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    @accounts[:to_suspend] << old_tenant_without_traffic
+
+    master_account.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    @accounts[:not_to_suspend] << master_account
+  end
+
+  test 'perform suspends inactive accounts' do
+    SuspendInactiveAccountsWorker.new.perform
+    @accounts[:to_suspend].each     { |account| assert account.reload.suspended? }
+    @accounts[:not_to_suspend].each { |account| refute account.reload.suspended? }
+  end
+end

--- a/test/workers/suspend_inactive_accounts_worker_test.rb
+++ b/test/workers/suspend_inactive_accounts_worker_test.rb
@@ -8,14 +8,12 @@ class SuspendInactiveAccountsWorkerTest < ActiveSupport::TestCase
 
     old_tenant_with_old_traffic = FactoryGirl.create(:simple_provider)
     old_tenant_with_old_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
-    cinstance = FactoryGirl.create(:cinstance, user_account: old_tenant_with_old_traffic)
-    cinstance.update_attribute(:first_daily_traffic_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    FactoryGirl.create(:cinstance, user_account: old_tenant_with_old_traffic, first_daily_traffic_at: Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
     @accounts[:to_suspend] << old_tenant_with_old_traffic
 
     old_buyer_with_old_traffic = FactoryGirl.create(:simple_buyer)
     old_buyer_with_old_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
-    cinstance = FactoryGirl.create(:cinstance, user_account: old_buyer_with_old_traffic)
-    cinstance.update_attribute(:first_daily_traffic_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    FactoryGirl.create(:cinstance, user_account: old_buyer_with_old_traffic, first_daily_traffic_at: Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
     @accounts[:not_to_suspend] << old_buyer_with_old_traffic
 
     recent_tenant_without_traffic = FactoryGirl.create(:simple_provider)
@@ -24,8 +22,7 @@ class SuspendInactiveAccountsWorkerTest < ActiveSupport::TestCase
 
     recent_tenant_with_recent_traffic = FactoryGirl.create(:simple_provider)
     recent_tenant_with_recent_traffic.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
-    cinstance = FactoryGirl.create(:cinstance, user_account: recent_tenant_with_recent_traffic)
-    cinstance.update_attribute(:first_daily_traffic_at, (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
+    FactoryGirl.create(:cinstance, user_account: recent_tenant_with_recent_traffic, first_daily_traffic_at: (Account::States::MAX_PERIOD_OF_INACTIVITY - 1.day).ago)
     @accounts[:not_to_suspend] << recent_tenant_with_recent_traffic
 
     old_tenant_without_traffic = FactoryGirl.create(:simple_provider)


### PR DESCRIPTION
fixes https://github.com/3scale/porta/issues/13

Under this criteria (established by product):

- No traffic in the last year -> Suspend
- Suspended form more than 90 days -> Schedule for deletion