### PR TITLE
More flexible tests execution

### DIFF
--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -138,35 +138,29 @@ namespace :integrate do
 
 
   desc 'Runs subset of full test suite, in parallel (1/8)'
-  task :parallel_1 => %i[cucumber_javascript rspec]
+  task :parallel_1 => %i[verify_empty_reports_folder prepare cucumber_javascript rspec]
 
   desc 'Runs subset of full test suite, in parallel (2/8)'
-  task :parallel_2 => [:integration]
+  task :parallel_2 => %i[verify_empty_reports_folder prepare integration]
 
   desc 'Runs subset of full test suite, in parallel (3/8)'
-  task :parallel_3 => [:integration]
+  task :parallel_3 => %i[verify_empty_reports_folder prepare integration]
 
   desc 'Runs subset of full test suite, in parallel (4/8)'
-  task :parallel_4 => %i[functional main_suite]
+  task :parallel_4 => %i[verify_empty_reports_folder prepare functional main_suite]
 
   desc 'Runs subset of full test suite, in parallel (5/8)'
-  task :parallel_5 => [:cucumber_non_tagged]
+  task :parallel_5 => %i[verify_empty_reports_folder prepare cucumber_non_tagged]
 
   desc 'Runs subset of full test suite, in parallel (6/8)'
-  task :parallel_6 => [:cucumber_for_categories]
+  task :parallel_6 => %i[verify_empty_reports_folder prepare cucumber_for_categories]
 
 
 
   desc 'Runs the whole continuous integration test suite'
-  task :parallel, [:log] => %i[verify_empty_reports_folder prepare] do |t, args|
-
-    if ENV['CI']
-      ENV['COVERAGE'] = '1'
-      ENV['PERCY_ENABLE'] = '0' # percy will be enabled just for one task
-    end
+  task :parallel, [:log] do |t, args|
 
     banner = print_banner_around
-
 
     time = Benchmark.measure do
 
@@ -183,7 +177,6 @@ namespace :integrate do
     banner.call("Finished in #{format('%.1fs', time.real)}\n\t")
 
     Rake::Task['integrate:report_coverage_to_codeclimate'].invoke(7)
-
 
   end
 
@@ -213,8 +206,13 @@ namespace :integrate do
 
   end
 
-
+  desc 'Set environment variables on test coverage and percy and prepare database'
   task :prepare do
+    if ENV['CI']
+      ENV['COVERAGE'] = '1'
+      ENV['PERCY_ENABLE'] = '0' # percy will be enabled just for one task
+    end
+
     silence_stream(STDOUT) do
       require 'system/database'
       ParallelTests::Tasks.run_in_parallel('RAILS_ENV=test rake db:drop db:create db:schema:load multitenant:triggers')

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -102,14 +102,7 @@ task :integrate, :log do |_, args|
     ],
     'licenses' => [
       test_commands[:license_checks],
-    ],
-    'commit_phase' =>
-      test_commands[:swagger] +
-      test_commands[:frontend] +
-      [
-        test_commands[:rspec],
-        test_commands[:license_checks],
-      ]
+    ]
   }
 
   jobs = ENV['MULTIJOB_KIND'].present? ? workload.fetch(ENV['MULTIJOB_KIND']) : workload.values.flatten

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -101,7 +101,6 @@ module TestOrchestrationHelpers
     end
   end
 
-
   def get_top_level_folder_path(path)
     path.descend.take(2).last
   end
@@ -119,14 +118,13 @@ module TestOrchestrationHelpers
   def verify_empty_reports_folder
     junit = Dir['tmp/junit/**']
 
-    return unless junit.present?
+    return if junit.blank?
 
     puts 'WARNING: tmp/junit is not empty'
     puts junit
     abort 'Will not continue, tmp/junit is not empty'
 
   end
-
 
   # rubocop:disable MethodLength
   def test_commands

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -92,50 +92,12 @@ namespace :integrate do
 
   end
 
-  task :cucumber_javascript => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:cucumber_javascript])
+  test_commands.keys.each do |command|
+    desc "Runs tests with #{command}"
+    task "#{command}" => :prepare do
+      Rake::Task['integrate:run_tests'].invoke(test_commands[command])
+    end
   end
-
-  task :rspec => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:rspec])
-  end
-
-  task :integration => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:integration])
-  end
-
-  task :swagger => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:swagger])
-  end
-
-  task :frontend => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:frontend])
-  end
-
-  task :functional => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:functional])
-  end
-
-  task :main_suite => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:main_suite])
-  end
-
-  task :cucumber_non_tagged => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:cucumber_non_tagged])
-  end
-
-  task :cucumber_for_categories => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:cucumber_for_categories])
-  end
-
-  task :license_checks => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:license_checks])
-  end
-
-  task :percy => :prepare do
-    Rake::Task['integrate:run_tests'].invoke(test_commands[:percy])
-  end
-
 
   desc 'Runs subset of full test suite, in parallel (1/8)'
   task :parallel_1 => %i[verify_empty_reports_folder prepare cucumber_javascript rspec]

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -77,7 +77,7 @@ task :integrate, :log do |_, args|
     :main_suite => "parallel_test --verbose #{test_dirs.join(' ')}",
   }
 
-  kind = {
+  workload = {
     '1' => [
       test_commands[:cucumber_javascript],
       test_commands[:rspec],
@@ -112,7 +112,7 @@ task :integrate, :log do |_, args|
       ]
   }
 
-  tasks = ENV['MULTIJOB_KIND'].present? ? kind.fetch(ENV['MULTIJOB_KIND']) : kind.values.flatten
+  jobs = ENV['MULTIJOB_KIND'].present? ? workload.fetch(ENV['MULTIJOB_KIND']) : workload.values.flatten
 
   success, failure = "#{Color::GREEN}SUCCESS#{Color::CLEAR_COLOR}", "#{Color::RED}FAILURE#{Color::CLEAR_COLOR}"
 
@@ -126,7 +126,7 @@ task :integrate, :log do |_, args|
 
   total_time = 0
 
-  results = tasks.map do |task|
+  results = jobs.map do |task|
 
     command = nil
     result = report.execute(task, env: {RAILS_ENV: Rails.env}) do |cmd|
@@ -149,7 +149,7 @@ task :integrate, :log do |_, args|
                  Rails.root.join('tmp', 'codeclimate').tap(&:mkpath))
 
     system('codeclimate-batch',
-           '--groups', (kind.keys.size - 1).to_s,
+           '--groups', (workload.keys.size - 1).to_s,
            '--host', 'https://cc-3scale-amend.herokuapp.com',
            '--key', ENV.fetch('BUILD_TAG'))
   end

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -1,5 +1,20 @@
 require 'color'
 
+
+
+
+def print_banner_around
+  banner = ->(line) do
+    puts
+    puts "=" * 40
+    puts "== #{Color::BOLD}#{line}#{Color::CLEAR}"
+    puts "=" * 40
+    puts
+
+    line
+  end
+end
+
 desc 'Run continuous integration'
 task :integrate, :log do |_, args|
   if ENV['CI']
@@ -64,15 +79,7 @@ task :integrate, :log do |_, args|
 
   summary = []
 
-  banner = ->(line) do
-    puts
-    puts "=" * 40
-    puts "== #{Color::BOLD}#{line}#{Color::CLEAR}"
-    puts "=" * 40
-    puts
-
-    line
-  end
+  banner = print_banner_around
 
   require 'ci_reporter_shell'
 

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -16,15 +16,6 @@ def print_banner_around
 end
 
 
-def check_that_junit_reports_folder_is_empty
-  junit = Dir['tmp/junit/**']
-
-  if junit.present?
-    puts 'WARNING: tmp/junit is not empty'
-    puts junit
-    abort 'Will not continue, tmp/junit is not empty'
-  end
-end
 
 def resolve_test_directories
 
@@ -145,13 +136,11 @@ end
 
 
 desc 'Run continuous integration'
-task :integrate, :log do |_, args|
+task :integrate, :log => 'integrate:verify_empty_reports_folder' do |_, args|
   if ENV['CI']
     ENV['COVERAGE'] = '1'
     ENV['PERCY_ENABLE'] = '0' # percy will be enabled just for one task
   end
-
-  check_that_junit_reports_folder_is_empty
 
   abort 'failed to run integrate:prepare' unless system('rake integrate:prepare --trace')
 
@@ -161,6 +150,19 @@ task :integrate, :log do |_, args|
 end
 
 namespace :integrate do
+
+  desc 'Ensures that the test reports folder is empty'
+  task :verify_empty_reports_folder do
+    junit = Dir['tmp/junit/**']
+
+    if junit.present?
+      puts 'WARNING: tmp/junit is not empty'
+      puts junit
+      abort 'Will not continue, tmp/junit is not empty'
+    end
+
+  end
+
 
   task :prepare do
     silence_stream(STDOUT) do

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -15,12 +15,25 @@ def print_banner_around
   end
 end
 
+
+def check_that_junit_reports_folder_is_empty
+  junit = Dir['tmp/junit/**']
+
+  if junit.present?
+    puts 'WARNING: tmp/junit is not empty'
+    puts junit
+    abort 'Will not continue, tmp/junit is not empty'
+  end
+end
+
 desc 'Run continuous integration'
 task :integrate, :log do |_, args|
   if ENV['CI']
     ENV['COVERAGE'] = '1'
     ENV['PERCY_ENABLE'] = '0' # percy will be enabled just for one task
   end
+
+  check_that_junit_reports_folder_is_empty
 
   abort 'failed to run integrate:prepare' unless system('rake integrate:prepare --trace')
 
@@ -82,16 +95,8 @@ task :integrate, :log do |_, args|
   banner = print_banner_around
 
   require 'ci_reporter_shell'
-
   report = CiReporterShell.report('tmp/junit')
 
-  junit = Dir['tmp/junit/**']
-
-  if junit.present?
-    puts 'WARNING: tmp/junit is not empty'
-    puts junit
-    abort 'Will not continue, tmp/junit is not empty'
-  end
 
   total_time = 0
 

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -10,11 +10,108 @@ task :integrate => 'integrate:parallel'
 
 namespace :integrate do
 
+  orchestration_helpers = Module.new do
+    def self.print_banner_around
+      lambda do |line|
+        puts
+        puts "=" * 40
+        puts "== #{Color::BOLD}#{line}#{Color::CLEAR}"
+        puts "=" * 40
+        puts
+
+        line
+      end
+    end
+
+    def self.get_top_level_folder_path(path)
+      path.descend.take(2).last
+    end
+
+    def self.resolve_test_groups_by_path
+
+      obsolete_tests = %w[remote performance].map {|x| "test/#{x}"}
+
+      test_files = Pathname.glob('test/**/*_test.rb')
+      test_groups = test_files.group_by { |path| get_top_level_folder_path(path)}
+      test_groups.keys.map(&:to_s) - obsolete_tests
+
+    end
+
+    def self.verify_empty_reports_folder
+      junit = Dir['tmp/junit/**']
+
+      return if junit.blank?
+
+      puts 'WARNING: tmp/junit is not empty'
+      puts junit
+      abort 'Will not continue, tmp/junit is not empty'
+
+    end
+
+    # rubocop:disable MethodLength
+    def self.test_commands
+      tags_for_test_categories = %w[
+        @backend
+        @emails
+        @stats
+        @search
+        @no-txn
+      ]
+
+      test_dirs = resolve_test_groups_by_path
+
+      {
+        :cucumber_javascript => 'parallel_cucumber --verbose features -o "-b -p parallel --tags=@javascript --tags=~@fakeweb --tags=~@percy"',
+        :cucumber_non_tagged => %(parallel_cucumber --verbose features -o "-b -p parallel --tags=~@javascript #{tags_for_test_categories.map {|t| %(--tags=~#{t})}.join(' ')}"),
+        :cucumber_for_categories => %(parallel_cucumber --verbose features -o "-b -p parallel --tags=~@javascript --tags=#{tags_for_test_categories.join(',')}"),
+
+        :rspec => 'parallel_rspec --verbose spec',
+        :integration => "parallel_test --verbose #{test_dirs.delete('test/integration')}",
+        :swagger => [
+          'rake doc:swagger:validate:all',
+          'rake doc:swagger:generate:all',
+        ],
+        :frontend => [
+          'rake ci:jspm --trace',
+          'yarn test -- --reporters dots,junit --browsers Firefox',
+          'yarn jest',
+          'rake db:purge db:setup',
+        ],
+        :functional => "parallel_test --verbose #{test_dirs.delete('test/functional')}",
+        :license_checks => "export http_proxy=#{ENV['http_proxy']} https_proxy=#{ENV['https_proxy']}; rake ci:license_finder:run",
+        :main_suite => "parallel_test --verbose #{test_dirs.join(' ')}",
+        :percy => 'PERCY_ENABLE=1 cucumber -b -p parallel --tags=@percy features',
+      }
+
+    end
+    # rubocop:enable MethodLength
+
+    def self.run_tests(test_command)
+      success = "#{Color::GREEN}SUCCESS#{Color::CLEAR_COLOR}"
+      failure = "#{Color::RED}FAILURE#{Color::CLEAR_COLOR}"
+      banner = print_banner_around
+
+      require 'ci_reporter_shell'
+      report = CiReporterShell.report('tmp/junit')
+
+      command = nil
+      result = report.execute(test_command, env: {RAILS_ENV: Rails.env}) do |cmd|
+        banner.call("BEGIN: #{cmd}")
+        command = cmd
+      end
+
+      banner.call("FINISH (#{result.success? ? success : failure}): #{command} in #{format('%.1fs', result.time)}")
+
+      abort "#{test_command} FAILED" unless result.success?
+    end
+
+  end
+
   # Dynamically generate all tasks from test_commands
-  TestOrchestrationHelpers.test_commands.each_key do |command|
+  orchestration_helpers.test_commands.each_key do |command|
     desc "Runs tests with #{command}"
     task command.to_s => :prepare do
-      TestOrchestrationHelpers.run_tests(TestOrchestrationHelpers.test_commands[command])
+      orchestration_helpers.run_tests(orchestration_helpers.test_commands[command])
     end
   end
 
@@ -41,7 +138,7 @@ namespace :integrate do
   desc 'Runs the whole continuous integration test suite'
   task :parallel, [:log] do
 
-    banner = TestOrchestrationHelpers.print_banner_around
+    banner = orchestration_helpers.print_banner_around
 
     time = Benchmark.measure do
 
@@ -76,7 +173,7 @@ namespace :integrate do
       ENV['PERCY_ENABLE'] = '0' # percy will be enabled just for one task
     end
 
-    TestOrchestrationHelpers.verify_empty_reports_folder
+    orchestration_helpers.verify_empty_reports_folder
 
     silence_stream(STDOUT) do
       require 'system/database'
@@ -84,104 +181,5 @@ namespace :integrate do
       Rake::Task['ts:configure'].invoke
     end
   end
-
-end
-
-module TestOrchestrationHelpers
-
-  def print_banner_around
-    lambda do |line|
-      puts
-      puts "=" * 40
-      puts "== #{Color::BOLD}#{line}#{Color::CLEAR}"
-      puts "=" * 40
-      puts
-
-      line
-    end
-  end
-
-  def get_top_level_folder_path(path)
-    path.descend.take(2).last
-  end
-
-  def resolve_test_groups_by_path
-
-    obsolete_tests = %w[remote performance].map {|x| "test/#{x}"}
-
-    test_files = Pathname.glob('test/**/*_test.rb')
-    test_groups = test_files.group_by { |path| get_top_level_folder_path(path)}
-    test_groups.keys.map(&:to_s) - obsolete_tests
-
-  end
-
-  def verify_empty_reports_folder
-    junit = Dir['tmp/junit/**']
-
-    return if junit.blank?
-
-    puts 'WARNING: tmp/junit is not empty'
-    puts junit
-    abort 'Will not continue, tmp/junit is not empty'
-
-  end
-
-  # rubocop:disable MethodLength
-  def test_commands
-    tags_for_test_categories = %w[
-      @backend
-      @emails
-      @stats
-      @search
-      @no-txn
-    ]
-
-    test_dirs = resolve_test_groups_by_path
-
-    {
-      :cucumber_javascript => 'parallel_cucumber --verbose features -o "-b -p parallel --tags=@javascript --tags=~@fakeweb --tags=~@percy"',
-      :cucumber_non_tagged => %(parallel_cucumber --verbose features -o "-b -p parallel --tags=~@javascript #{tags_for_test_categories.map {|t| %(--tags=~#{t})}.join(' ')}"),
-      :cucumber_for_categories => %(parallel_cucumber --verbose features -o "-b -p parallel --tags=~@javascript --tags=#{tags_for_test_categories.join(',')}"),
-
-      :rspec => 'parallel_rspec --verbose spec',
-      :integration => "parallel_test --verbose #{test_dirs.delete('test/integration')}",
-      :swagger => [
-        'rake doc:swagger:validate:all',
-        'rake doc:swagger:generate:all',
-      ],
-      :frontend => [
-        'rake ci:jspm --trace',
-        'yarn test -- --reporters dots,junit --browsers Firefox',
-        'yarn jest',
-        'rake db:purge db:setup',
-      ],
-      :functional => "parallel_test --verbose #{test_dirs.delete('test/functional')}",
-      :license_checks => "export http_proxy=#{ENV['http_proxy']} https_proxy=#{ENV['https_proxy']}; rake ci:license_finder:run",
-      :main_suite => "parallel_test --verbose #{test_dirs.join(' ')}",
-      :percy => 'PERCY_ENABLE=1 cucumber -b -p parallel --tags=@percy features',
-    }
-
-  end
-  # rubocop:enable MethodLength
-
-  def run_tests(test_command)
-    success = "#{Color::GREEN}SUCCESS#{Color::CLEAR_COLOR}"
-    failure = "#{Color::RED}FAILURE#{Color::CLEAR_COLOR}"
-    banner = print_banner_around
-
-    require 'ci_reporter_shell'
-    report = CiReporterShell.report('tmp/junit')
-
-    command = nil
-    result = report.execute(test_command, env: {RAILS_ENV: Rails.env}) do |cmd|
-      banner.call("BEGIN: #{cmd}")
-      command = cmd
-    end
-
-    banner.call("FINISH (#{result.success? ? success : failure}): #{command} in #{format('%.1fs', result.time)}")
-
-    abort "#{test_command} FAILED" unless result.success?
-  end
-
 
 end

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -136,13 +136,11 @@ end
 
 
 desc 'Run continuous integration'
-task :integrate, :log => 'integrate:verify_empty_reports_folder' do |_, args|
+task :integrate, :log => ['integrate:verify_empty_reports_folder', 'integrate:prepare'] do |_, args|
   if ENV['CI']
     ENV['COVERAGE'] = '1'
     ENV['PERCY_ENABLE'] = '0' # percy will be enabled just for one task
   end
-
-  abort 'failed to run integrate:prepare' unless system('rake integrate:prepare --trace')
 
   jobs, workload = calculate_tests_to_run
 

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -64,6 +64,8 @@ end
 
 
 
+desc 'The default execution: the whole CI suite'
+task :integrate => 'integrate:parallel'
 
 
 namespace :integrate do

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -62,9 +62,11 @@ task :integrate, :log do |_, args|
 
     :rspec => 'parallel_rspec --verbose spec',
     :integration => "parallel_test --verbose #{test_dirs.delete('test/integration')}",
-    :frontend => [
+    :swagger => [
       'rake doc:swagger:validate:all',
       'rake doc:swagger:generate:all',
+    ],
+    :frontend => [
       'rake ci:jspm --trace',
       'yarn test -- --reporters dots,junit --browsers Firefox',
       'yarn jest',
@@ -83,7 +85,7 @@ task :integrate, :log do |_, args|
     '2' => [
       test_commands[:integration],
     ],
-    '3' => test_commands[:frontend],
+    '3' => test_commands[:swagger] + test_commands[:frontend],
     '4' => [
       test_commands[:functional],
       test_commands[:main_suite],
@@ -102,6 +104,7 @@ task :integrate, :log do |_, args|
       test_commands[:license_checks],
     ],
     'commit_phase' =>
+      test_commands[:swagger] +
       test_commands[:frontend] +
       [
         test_commands[:rspec],

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -17,13 +17,9 @@ task :integrate, :log do |_, args|
     @no-txn
   }
 
-  skip_directories = %w{test_helpers fixtures shoulda_macros factories}.map{|x| "test/#{x}"}
+  skip_directories_requiring_to_run_in_different_job_or_without_tests = %w{test_helpers fixtures shoulda_macros factories remote performance}.map{|x| "test/#{x}"}
 
-  test_dirs = Pathname.new("test").children.select(&:directory?).map(&:to_s) - skip_directories
-
-  # Must be run in different job
-  test_dirs.delete('test/remote')
-  test_dirs.delete('test/performance')
+  test_dirs = Pathname.new("test").children.select(&:directory?).map(&:to_s) - skip_directories_requiring_to_run_in_different_job_or_without_tests
 
   # parallel_cucumber --verbose features -o "-b -p parallel --tags=@javascript --tags=~@fakeweb --tags=~@percy" in 307.7s
   # parallel_rspec --verbose spec in 97.0s

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -60,7 +60,7 @@ def test_commands
   }
 
 end
-
+# rubocop:enable MethodLength
 
 
 

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -26,6 +26,14 @@ def check_that_junit_reports_folder_is_empty
   end
 end
 
+def resolve_test_directories
+
+  skip_directories_requiring_to_run_in_different_job_or_without_tests = %w{test_helpers fixtures shoulda_macros factories remote performance}.map {|x| "test/#{x}"}
+
+  test_dirs = Pathname.new("test").children.select(&:directory?).map(&:to_s) - skip_directories_requiring_to_run_in_different_job_or_without_tests
+
+end
+
 desc 'Run continuous integration'
 task :integrate, :log do |_, args|
   if ENV['CI']
@@ -45,10 +53,7 @@ task :integrate, :log do |_, args|
     @no-txn
   }
 
-  skip_directories_requiring_to_run_in_different_job_or_without_tests = %w{test_helpers fixtures shoulda_macros factories remote performance}.map{|x| "test/#{x}"}
-
-  test_dirs = Pathname.new("test").children.select(&:directory?).map(&:to_s) - skip_directories_requiring_to_run_in_different_job_or_without_tests
-
+  test_dirs = resolve_test_directories
 
 
   kind = {

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -121,7 +121,7 @@ namespace :integrate do
 
 
   desc 'Runs the whole continuous integration test suite'
-  task :parallel, [:log] do |t, args|
+  task :parallel, [:log] do
 
     banner = print_banner_around
 
@@ -144,7 +144,7 @@ namespace :integrate do
   end
 
   desc 'Report code coverage to CodeClimate'
-  task :report_coverage_to_codeclimate, :number_of_groups  do |t, args|
+  task :report_coverage_to_codeclimate, :number_of_groups  do
     if ENV['COVERAGE']
       puts 'Sending test coverage to CodeClimate'
       FileUtils.cp(Dir["#{Dir.tmpdir}/codeclimate-test-coverage-*"],

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -16,11 +16,17 @@ def print_banner_around
   end
 end
 
-def resolve_test_directories
+def get_top_level_folder_path(path)
+  path.descend.take(2).last
+end
 
-  directories_requiring_to_run_in_different_job_or_without_tests = %w[test_helpers fixtures shoulda_macros factories remote performance].map {|x| "test/#{x}"}
+def resolve_test_groups_by_path
 
-  Pathname.new("test").children.select(&:directory?).map(&:to_s) - directories_requiring_to_run_in_different_job_or_without_tests
+  obsolete_tests = %w[remote performance].map {|x| "test/#{x}"}
+
+  test_files = Pathname.glob('test/**/*_test.rb')
+  test_groups = test_files.group_by { |path| get_top_level_folder_path(path)}
+  test_groups.keys.map(&:to_s) - obsolete_tests
 
 end
 
@@ -34,7 +40,7 @@ def test_commands
     @no-txn
   ]
 
-  test_dirs = resolve_test_directories
+  test_dirs = resolve_test_groups_by_path
 
   {
     :cucumber_javascript => 'parallel_cucumber --verbose features -o "-b -p parallel --tags=@javascript --tags=~@fakeweb --tags=~@percy"',

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -93,9 +93,9 @@ task :integrate => 'integrate:parallel'
 
 namespace :integrate do
 
-  test_commands.keys.each do |command|
+  test_commands.each_key do |command|
     desc "Runs tests with #{command}"
-    task "#{command}" => :prepare do
+    task command.to_s => :prepare do
       run_tests(test_commands[command])
     end
   end
@@ -127,7 +127,7 @@ namespace :integrate do
 
     time = Benchmark.measure do
 
-      Rake::Task.tasks.select { |task| task.name =~ /^integrate:parallel_/ }.map { |task| task.invoke }
+      Rake::Task.tasks.select { |task| task.name =~ /^integrate:parallel_/ }.map(&:invoke)
       Rake::Task['integrate:license_checks'].invoke
     end
 

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -4,126 +4,44 @@ require 'color'
 require 'benchmark'
 
 
-def print_banner_around
-  lambda do |line|
-    puts
-    puts "=" * 40
-    puts "== #{Color::BOLD}#{line}#{Color::CLEAR}"
-    puts "=" * 40
-    puts
-
-    line
-  end
-end
-
-def get_top_level_folder_path(path)
-  path.descend.take(2).last
-end
-
-def resolve_test_groups_by_path
-
-  obsolete_tests = %w[remote performance].map {|x| "test/#{x}"}
-
-  test_files = Pathname.glob('test/**/*_test.rb')
-  test_groups = test_files.group_by { |path| get_top_level_folder_path(path)}
-  test_groups.keys.map(&:to_s) - obsolete_tests
-
-end
-
-# rubocop:disable MethodLength
-def test_commands
-  tags_for_test_categories = %w[
-    @backend
-    @emails
-    @stats
-    @search
-    @no-txn
-  ]
-
-  test_dirs = resolve_test_groups_by_path
-
-  {
-    :cucumber_javascript => 'parallel_cucumber --verbose features -o "-b -p parallel --tags=@javascript --tags=~@fakeweb --tags=~@percy"',
-    :cucumber_non_tagged => %(parallel_cucumber --verbose features -o "-b -p parallel --tags=~@javascript #{tags_for_test_categories.map {|t| %(--tags=~#{t})}.join(' ')}"),
-    :cucumber_for_categories => %(parallel_cucumber --verbose features -o "-b -p parallel --tags=~@javascript --tags=#{tags_for_test_categories.join(',')}"),
-
-    :rspec => 'parallel_rspec --verbose spec',
-    :integration => "parallel_test --verbose #{test_dirs.delete('test/integration')}",
-    :swagger => [
-      'rake doc:swagger:validate:all',
-      'rake doc:swagger:generate:all',
-    ],
-    :frontend => [
-      'rake ci:jspm --trace',
-      'yarn test -- --reporters dots,junit --browsers Firefox',
-      'yarn jest',
-      'rake db:purge db:setup',
-    ],
-    :functional => "parallel_test --verbose #{test_dirs.delete('test/functional')}",
-    :license_checks => "export http_proxy=#{ENV['http_proxy']} https_proxy=#{ENV['https_proxy']}; rake ci:license_finder:run",
-    :main_suite => "parallel_test --verbose #{test_dirs.join(' ')}",
-    :percy => 'PERCY_ENABLE=1 cucumber -b -p parallel --tags=@percy features',
-  }
-
-end
-# rubocop:enable MethodLength
-
-def run_tests(test_command)
-  success = "#{Color::GREEN}SUCCESS#{Color::CLEAR_COLOR}"
-  failure = "#{Color::RED}FAILURE#{Color::CLEAR_COLOR}"
-  banner = print_banner_around
-
-  require 'ci_reporter_shell'
-  report = CiReporterShell.report('tmp/junit')
-
-  command = nil
-  result = report.execute(test_command, env: {RAILS_ENV: Rails.env}) do |cmd|
-    banner.call("BEGIN: #{cmd}")
-    command = cmd
-  end
-
-  banner.call("FINISH (#{result.success? ? success : failure}): #{command} in #{format('%.1fs', result.time)}")
-
-  abort "#{test_command} FAILED" unless result.success?
-end
-
 desc 'The default execution: the whole CI suite'
 task :integrate => 'integrate:parallel'
 
 
 namespace :integrate do
 
-  test_commands.each_key do |command|
+  # Dynamically generate all tasks from test_commands
+  TestOrchestrationHelpers.test_commands.each_key do |command|
     desc "Runs tests with #{command}"
     task command.to_s => :prepare do
-      run_tests(test_commands[command])
+      TestOrchestrationHelpers.run_tests(TestOrchestrationHelpers.test_commands[command])
     end
   end
 
   desc 'Runs subset of full test suite, in parallel (1/8)'
-  task :parallel_1 => %i[verify_empty_reports_folder prepare cucumber_javascript rspec]
+  task :parallel_1 => %i[prepare cucumber_javascript rspec]
 
   desc 'Runs subset of full test suite, in parallel (2/8)'
-  task :parallel_2 => %i[verify_empty_reports_folder prepare integration]
+  task :parallel_2 => %i[prepare integration]
 
   desc 'Runs subset of full test suite, in parallel (3/8)'
-  task :parallel_3 => %i[verify_empty_reports_folder prepare integration]
+  task :parallel_3 => %i[prepare integration]
 
   desc 'Runs subset of full test suite, in parallel (4/8)'
-  task :parallel_4 => %i[verify_empty_reports_folder prepare functional main_suite]
+  task :parallel_4 => %i[prepare functional main_suite]
 
   desc 'Runs subset of full test suite, in parallel (5/8)'
-  task :parallel_5 => %i[verify_empty_reports_folder prepare cucumber_non_tagged]
+  task :parallel_5 => %i[prepare cucumber_non_tagged]
 
   desc 'Runs subset of full test suite, in parallel (6/8)'
-  task :parallel_6 => %i[verify_empty_reports_folder prepare cucumber_for_categories]
+  task :parallel_6 => %i[prepare cucumber_for_categories]
 
 
 
   desc 'Runs the whole continuous integration test suite'
   task :parallel, [:log] do
 
-    banner = print_banner_around
+    banner = TestOrchestrationHelpers.print_banner_around
 
     time = Benchmark.measure do
 
@@ -138,7 +56,6 @@ namespace :integrate do
 
   end
 
-  desc 'Report code coverage to CodeClimate'
   task :report_coverage_to_codeclimate, :number_of_groups  do
     if ENV['COVERAGE']
       puts 'Sending test coverage to CodeClimate'
@@ -152,18 +69,6 @@ namespace :integrate do
     end
   end
 
-  desc 'Ensures that the test reports folder is empty'
-  task :verify_empty_reports_folder do
-    junit = Dir['tmp/junit/**']
-
-    if junit.present?
-      puts 'WARNING: tmp/junit is not empty'
-      puts junit
-      abort 'Will not continue, tmp/junit is not empty'
-    end
-
-  end
-
   desc 'Set environment variables on test coverage and percy and prepare database'
   task :prepare do
     if ENV['CI']
@@ -171,11 +76,114 @@ namespace :integrate do
       ENV['PERCY_ENABLE'] = '0' # percy will be enabled just for one task
     end
 
+    TestOrchestrationHelpers.verify_empty_reports_folder
+
     silence_stream(STDOUT) do
       require 'system/database'
       ParallelTests::Tasks.run_in_parallel('RAILS_ENV=test rake db:drop db:create db:schema:load multitenant:triggers')
       Rake::Task['ts:configure'].invoke
     end
   end
+
+end
+
+module TestOrchestrationHelpers
+
+  def print_banner_around
+    lambda do |line|
+      puts
+      puts "=" * 40
+      puts "== #{Color::BOLD}#{line}#{Color::CLEAR}"
+      puts "=" * 40
+      puts
+
+      line
+    end
+  end
+
+
+  def get_top_level_folder_path(path)
+    path.descend.take(2).last
+  end
+
+  def resolve_test_groups_by_path
+
+    obsolete_tests = %w[remote performance].map {|x| "test/#{x}"}
+
+    test_files = Pathname.glob('test/**/*_test.rb')
+    test_groups = test_files.group_by { |path| get_top_level_folder_path(path)}
+    test_groups.keys.map(&:to_s) - obsolete_tests
+
+  end
+
+  def verify_empty_reports_folder
+    junit = Dir['tmp/junit/**']
+
+    return unless junit.present?
+
+    puts 'WARNING: tmp/junit is not empty'
+    puts junit
+    abort 'Will not continue, tmp/junit is not empty'
+
+  end
+
+
+  # rubocop:disable MethodLength
+  def test_commands
+    tags_for_test_categories = %w[
+      @backend
+      @emails
+      @stats
+      @search
+      @no-txn
+    ]
+
+    test_dirs = resolve_test_groups_by_path
+
+    {
+      :cucumber_javascript => 'parallel_cucumber --verbose features -o "-b -p parallel --tags=@javascript --tags=~@fakeweb --tags=~@percy"',
+      :cucumber_non_tagged => %(parallel_cucumber --verbose features -o "-b -p parallel --tags=~@javascript #{tags_for_test_categories.map {|t| %(--tags=~#{t})}.join(' ')}"),
+      :cucumber_for_categories => %(parallel_cucumber --verbose features -o "-b -p parallel --tags=~@javascript --tags=#{tags_for_test_categories.join(',')}"),
+
+      :rspec => 'parallel_rspec --verbose spec',
+      :integration => "parallel_test --verbose #{test_dirs.delete('test/integration')}",
+      :swagger => [
+        'rake doc:swagger:validate:all',
+        'rake doc:swagger:generate:all',
+      ],
+      :frontend => [
+        'rake ci:jspm --trace',
+        'yarn test -- --reporters dots,junit --browsers Firefox',
+        'yarn jest',
+        'rake db:purge db:setup',
+      ],
+      :functional => "parallel_test --verbose #{test_dirs.delete('test/functional')}",
+      :license_checks => "export http_proxy=#{ENV['http_proxy']} https_proxy=#{ENV['https_proxy']}; rake ci:license_finder:run",
+      :main_suite => "parallel_test --verbose #{test_dirs.join(' ')}",
+      :percy => 'PERCY_ENABLE=1 cucumber -b -p parallel --tags=@percy features',
+    }
+
+  end
+  # rubocop:enable MethodLength
+
+  def run_tests(test_command)
+    success = "#{Color::GREEN}SUCCESS#{Color::CLEAR_COLOR}"
+    failure = "#{Color::RED}FAILURE#{Color::CLEAR_COLOR}"
+    banner = print_banner_around
+
+    require 'ci_reporter_shell'
+    report = CiReporterShell.report('tmp/junit')
+
+    command = nil
+    result = report.execute(test_command, env: {RAILS_ENV: Rails.env}) do |cmd|
+      banner.call("BEGIN: #{cmd}")
+      command = cmd
+    end
+
+    banner.call("FINISH (#{result.success? ? success : failure}): #{command} in #{format('%.1fs', result.time)}")
+
+    abort "#{test_command} FAILED" unless result.success?
+  end
+
 
 end

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -21,22 +21,7 @@ task :integrate, :log do |_, args|
 
   test_dirs = Pathname.new("test").children.select(&:directory?).map(&:to_s) - skip_directories_requiring_to_run_in_different_job_or_without_tests
 
-  # parallel_cucumber --verbose features -o "-b -p parallel --tags=@javascript --tags=~@fakeweb --tags=~@percy" in 307.7s
-  # parallel_rspec --verbose spec in 97.0s
 
-  # parallel_test --verbose test/functional in 98.6s
-  # parallel_test --verbose test/mailers test/models test/unit test/controllers test/workers test/cve test/decorators test/helpers test/proxy_helpers test/subscribers test/support test/events in 311.7s
-
-  # parallel_test --verbose test/integration in 158.8s
-  # rake doc:swagger:validate:all in 6.3s
-  # rake ci:lint --trace in 7.4s
-  # rake ci:jspm --trace in 15.2s
-  # yarn test -- --reporters dots,junit --browsers Firefox in 10.7s
-  # rake db:setup in 10.3s
-
-  # parallel_cucumber --verbose features -o "-b -p parallel --tags=~@javascript --tags=~@backend --tags=~@emails --tags=~@stats --tags=~@search --tags=~@no-txn" in 428.6s
-
-  # parallel_cucumber --verbose features -o "-b -p parallel --tags=~@javascript --tags=@backend,@emails,@stats,@search,@no-txn" in 410.2s
 
   kind = {
     '1' => [

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -166,15 +166,13 @@ namespace :integrate do
 
     time = Benchmark.measure {
 
-
-    # Rake::Task[integrate:suite_parallel].invoke
-    Rake::Task['integrate:parallel_1'].invoke
-    Rake::Task['integrate:parallel_2'].invoke
-    Rake::Task['integrate:parallel_3'].invoke
-    Rake::Task['integrate:parallel_4'].invoke
-    Rake::Task['integrate:parallel_5'].invoke
-    Rake::Task['integrate:parallel_6'].invoke
-    Rake::Task['integrate:license_checks'].invoke
+      Rake::Task['integrate:parallel_1'].invoke
+      Rake::Task['integrate:parallel_2'].invoke
+      Rake::Task['integrate:parallel_3'].invoke
+      Rake::Task['integrate:parallel_4'].invoke
+      Rake::Task['integrate:parallel_5'].invoke
+      Rake::Task['integrate:parallel_6'].invoke
+      Rake::Task['integrate:license_checks'].invoke
     }
 
     # TODO: print summary

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -127,12 +127,7 @@ namespace :integrate do
 
     time = Benchmark.measure do
 
-      Rake::Task['integrate:parallel_1'].invoke
-      Rake::Task['integrate:parallel_2'].invoke
-      Rake::Task['integrate:parallel_3'].invoke
-      Rake::Task['integrate:parallel_4'].invoke
-      Rake::Task['integrate:parallel_5'].invoke
-      Rake::Task['integrate:parallel_6'].invoke
+      Rake::Task.tasks.select { |task| task.name =~ /^integrate:parallel_/ }.map { |task| task.invoke }
       Rake::Task['integrate:license_checks'].invoke
     end
 

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -72,7 +72,7 @@ task :integrate => 'integrate:parallel'
 namespace :integrate do
 
   desc 'Runs the set of tests passed as an argument, pretty formatting results, creating reports, etc.'
-  task :run_tests, [:some_tests] do |t, args|
+  task :run_tests, [:test_command] do |t, args|
     success = "#{Color::GREEN}SUCCESS#{Color::CLEAR_COLOR}"
     failure = "#{Color::RED}FAILURE#{Color::CLEAR_COLOR}"
     banner = print_banner_around
@@ -81,14 +81,14 @@ namespace :integrate do
     report = CiReporterShell.report('tmp/junit')
 
     command = nil
-    result = report.execute(args.some_tests, env: {RAILS_ENV: Rails.env}) do |cmd|
+    result = report.execute(args.test_command, env: {RAILS_ENV: Rails.env}) do |cmd|
       banner.call("BEGIN: #{cmd}")
       command = cmd
     end
 
     banner.call("FINISH (#{result.success? ? success : failure}): #{command} in #{format('%.1fs', result.time)}")
 
-    abort "#{args.some_tests} FAILED" unless result.success?
+    abort "#{args.test_command} FAILED" unless result.success?
 
   end
 

--- a/script/jenkins.sh
+++ b/script/jenkins.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_DIR=$(dirname "$(readlink -f $0)")
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 
-${SCRIPT_DIR}/docker.sh
+"${SCRIPT_DIR}/docker.sh"
 
 # lets make everything readable by everyone
 umask 0000
@@ -26,4 +26,11 @@ done
 if [ "x$PROXY_ENABLED" == "x1" ]; then
   source "${SCRIPT_DIR}/proxy_env.sh"
 fi
-exec env $PROXY_ENV bundle exec rake integrate --trace
+
+if [ "x$MULTIJOB_KIND" == "x" ]; then
+    MULTIJOB_KIND="integrate"
+fi
+
+# We do want it possible for multiple rake tasks to be passed as argument here.
+# shellcheck disable=SC2086
+exec env ${PROXY_ENV} bundle exec rake ${MULTIJOB_KIND} --trace


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR offers a reworking (not just refactoring, as some behaviour _has_ changed) of `integration.rake` into rake tasks. 

The behaviour change is intentional: 

Instead of relying on a single environment variable (MULTIJOB_KIND) that allows us to select just one kind of test suite to run, we can define the actual test suites in here as independent rake tasks.

This way, they can be orchestrated together in the same way as before (i.e. into a "MULTIJOB_KIND" type of run, with same behaviour), BUT, in doing so, we increase the flexibility to invoke independently each of the different rake tasks on the command line, getting rid of some of the complexity in the process.

**Which issue(s) this PR fixes**

Related to #22 

**Special notes for your reviewer:**

* I took this on partly because I also needed to get more acquainted with `rake`. If something looks like it's not right, please feel free to say so. 
* in reworking, I had to look a few things up WRT ruby itself. there's a chance i may have got sth wrong there or - much more likely - that there are better ways to write some things. 
I'd appreciate your hints ;) 