### PR TITLE
Fixes Dev database name in database.yml

### DIFF
--- a/config/examples/database.yml
+++ b/config/examples/database.yml
@@ -31,7 +31,7 @@ production:
 
 development:
   <<: *DEFAULT
-  database: 3scale_system_production
+  database: 3scale_system_development
 
 test:
   <<: *DEFAULT


### PR DESCRIPTION
Database for dev environment should have its own name:
`3scale_system_production` -> `3scale_system_development`