### PR TITLE
[wip] [billing] Fix create invoice deadlock

### DIFF
--- a/app/models/finance/billing_strategy.rb
+++ b/app/models/finance/billing_strategy.rb
@@ -166,7 +166,7 @@ class Finance::BillingStrategy < ApplicationRecord
   end
 
   def create_invoice_counter(period)
-    invoice_prefix = (billing_monthly? ? period : period.begin.year).to_param
+    invoice_prefix = period.to_param[0..(billing_monthly? ? 6 : 3)]
     InvoiceCounter.create(provider_account: account, invoice_prefix: invoice_prefix, invoice_count: 0)
   rescue ActiveRecord::RecordNotUnique
     InvoiceCounter.find_by(provider_account: account, invoice_prefix: invoice_prefix)

--- a/app/workers/create_invoice_worker.rb
+++ b/app/workers/create_invoice_worker.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Creates a zero-value invoice to a given buyer of a given provider
+# WARNING: Only for testing purposes -- NOT to be used in production
+class CreateInvoiceWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :billing, retry: 0
+
+  def self.enqueue(provider_account, buyer_account, period = Month.new(Time.now.utc))
+    perform_async(provider_account.id, buyer_account.id, period.to_param)
+  end
+
+  # [Integer] provider_account_id
+  # [Integer] buyer_account_id
+  # [String] period, YYYY-MM
+  def perform(provider_account_id, buyer_account_id, period)
+    return if Rails.env.production? # I said NOT TO BE USED IN PRODUCTION!!!
+
+    provider_account = Account.providers_with_master.find(provider_account_id)
+
+    provider_account.billing_strategy.create_invoice!(
+      buyer_account: provider_account.buyer_accounts.find(buyer_account_id),
+      period: Month.parse_month(period)
+    )
+  end
+end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It makes the triggers (Mysql and Oracle) on the `invoices` table to use the primary key of the table to perform the update of the friendly id, rather than the composite key (provider_account_id, invoice_prefix).

This prevents concurrent transactions to deadlock, specially in Mysql where a bugs seems to make granted shared locks to take precedence of crossed exclusive lock requests between transactions. T1 holds a shared lock, T2 requests exclusive lock on the same record and waits, but then T1 also requests exclusive lock despite of the shared lock granted.

**Which issue(s) this PR fixes** 

Closes https://github.com/3scale/porta/issues/28

**Special notes for your reviewer**: