### PR TITLE
Kubernetes/Openshift Service Discovery feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ C:\\nppdf32Log\\debuglog.txt
 /config/rolling_updates.yml
 /config/paperclip.yml
 /config/plan_rules.yml
+/config/service_discovery.yml
 /config/smtp.yml
 /config/zync.yml
 /config/redhat_customer_portal.yml

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -262,3 +262,5 @@ oracle = lambda do
 end
 gem 'activerecord-oracle_enhanced-adapter', '~> 1.6.0', install_if: oracle
 gem 'ruby-oci8', require: false, install_if: oracle
+
+gem 'kubeclient'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,8 +392,15 @@ GEM
     hike (1.2.3)
     hiredis (0.6.0)
     htmlentities (4.3.4)
+    http (2.2.2)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
+    http-form_data (1.0.3)
+    http_parser.rb (0.6.0)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
@@ -415,6 +422,10 @@ GEM
       addressable (~> 2.3)
     jwt (1.5.2)
     kgio (2.10.0)
+    kubeclient (2.5.2)
+      http (>= 0.98, < 3)
+      recursive-open-struct (~> 1.0.0)
+      rest-client
     launchy (2.4.3)
       addressable (~> 2.3)
     license_finder (2.1.2)
@@ -596,6 +607,7 @@ GEM
       ffi (>= 0.5.0)
     recaptcha (4.1.0)
       json
+    recursive-open-struct (1.0.5)
     redcarpet (3.4.0)
     redis (3.3.5)
     redis-namespace (1.5.2)
@@ -904,6 +916,7 @@ DEPENDENCIES
   json (~> 1.8.1)
   json-schema
   jwt (~> 1.5.2)
+  kubeclient
   launchy
   license_finder (~> 2.1.2)
   license_finder_xml_reporter!

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -367,8 +367,15 @@ GEM
     hike (1.2.3)
     hiredis (0.6.0)
     htmlentities (4.3.4)
+    http (2.2.2)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
+    http-form_data (1.0.3)
+    http_parser.rb (0.6.0)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
@@ -390,6 +397,10 @@ GEM
       addressable (~> 2.3)
     jwt (1.5.2)
     kgio (2.10.0)
+    kubeclient (2.5.2)
+      http (>= 0.98, < 3)
+      recursive-open-struct (~> 1.0.0)
+      rest-client
     launchy (2.4.3)
       addressable (~> 2.3)
     license_finder (2.1.2)
@@ -563,6 +574,7 @@ GEM
       ffi (>= 0.5.0)
     recaptcha (4.1.0)
       json
+    recursive-open-struct (1.0.5)
     redcarpet (3.4.0)
     redis (3.3.5)
     redis-namespace (1.5.2)
@@ -865,6 +877,7 @@ DEPENDENCIES
   json (~> 1.8.1)
   json-schema
   jwt (~> 1.5.2)
+  kubeclient
   launchy
   license_finder (~> 2.1.2)
   license_finder_xml_reporter!
@@ -960,4 +973,4 @@ DEPENDENCIES
   zip-zip
 
 BUNDLED WITH
-   1.16.2
+   1.16.4

--- a/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
@@ -14,13 +14,13 @@ $ ->
 
   show_service_form = (source, discover_func, scratch_func)->
     if source == 'discover'
-      form_scratch.classList.add('is-hidden')
-      form_discover.classList.remove('is-hidden')
+      $(form_scratch).addClass 'is-hidden'
+      $(form_discover).removeClass 'is-hidden'
       discover_func() unless typeof discover_func == 'undefined'
     else
-      form_scratch.classList.remove('is-hidden')
-      form_discover.classList.add('is-hidden')
-      scratch_func() unless typeof scratch_func == 'undefined'
+      $(form_scratch).removeClass 'is-hidden'
+      $(form_discover).addClass 'is-hidden'
+      scratch_func?()
 
   change_service_source = (e)->
     clear_namespaces()

--- a/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
@@ -61,8 +61,12 @@ $ ->
       if services.length > 0
         form_discover.service_name.selectedIndex = 1
 
-  if form_source != null and typeof form_source != 'undefined'
-    $(form_source.source).click change_service_source
+  if form_source?
+    radioGroup = form_source.source
+    i = 0
+    while i < radioGroup.length
+      radioGroup[i].addEventListener 'click', change_service_source
+      i++
 
-  if form_discover != null and typeof form_discover != 'undefined'
+  if form_discover?
     form_discover.service_namespace.addEventListener 'change', change_cluster_namespace

--- a/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
@@ -1,10 +1,14 @@
 $ ->
-  form_source = $('form#new_service_source')[0]
-  form_scratch = $('form#new_service,form#create_service')[0]
-  form_discover = $('form#service_discovery')[0]
+  form_source = document.getElementById 'new_service_source'
+  form_scratch = document.querySelectorAll('form#new_service,form#create_service')[0]
+  form_discover = document.getElementById 'service_discovery'
 
   clear_select_options = (select)->
-    $(select).find('option').not(':first').remove()
+    options = select.getElementsByTagName('option')
+    i = options.length - 1
+    while i > 0
+      options[i].remove()
+      --i
 
   clear_namespaces = ()->
     clear_select_options form_discover.service_namespace
@@ -14,12 +18,12 @@ $ ->
 
   show_service_form = (source, discover_func, scratch_func)->
     if source == 'discover'
-      $(form_scratch).addClass 'is-hidden'
-      $(form_discover).removeClass 'is-hidden'
-      discover_func() unless typeof discover_func == 'undefined'
+      form_scratch.classList.add('is-hidden')
+      form_discover.classList.remove('is-hidden')
+      discover_func?()
     else
-      $(form_scratch).removeClass 'is-hidden'
-      $(form_discover).addClass 'is-hidden'
+      form_scratch.classList.remove('is-hidden')
+      form_discover.classList.add('is-hidden')
       scratch_func?()
 
   change_service_source = (e)->
@@ -52,8 +56,10 @@ $ ->
       if services.length > 0
         form_discover.service_name.selectedIndex = 1
 
-  unless typeof form_source == 'undefined'
-    $(form_source.source).click change_service_source
+  if form_source != null and typeof form_source != 'undefined'
+    form_source.source.forEach (item) ->
+      item.addEventListener 'click', change_service_source
+      return
 
-  unless typeof form_discover == 'undefined'
-    $(form_discover.service_namespace).live 'change', change_cluster_namespace
+  if form_discover != null and typeof form_discover != 'undefined'
+    form_discover.service_namespace.addEventListener 'change', change_cluster_namespace

--- a/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
@@ -37,12 +37,18 @@ $ ->
     if selected_namespace != ''
       fetch_services(selected_namespace)
 
+  addOptionToSelect = (selectElem, val)->
+    opt = document.createElement 'option'
+    opt.text = val
+    opt.value = val
+    selectElem.appendChild opt
+
   fetch_namespaces = ()->
     $.getJSON '/p/admin/service_discovery/projects.json', (data)->
       projects = data.projects
       projects.forEach (project, index, array) ->
-        namespace = project.metadata.name
-        $(form_discover.service_namespace).append("<option value=\"#{namespace}\">#{namespace}</option>")
+        addOptionToSelect(form_discover.service_namespace, project.metadata.name)
+
       if projects.length > 0
         form_discover.service_namespace.selectedIndex = 1
         change_cluster_namespace()
@@ -51,8 +57,7 @@ $ ->
     $.getJSON "/p/admin/service_discovery/namespaces/#{namespace}/services.json", (data)->
       services = data.services
       services.forEach (service, index, array) ->
-        service_name = service.metadata.name
-        $(form_discover.service_name).append("<option value=\"#{service_name}\">#{service_name}</option>")
+        addOptionToSelect(form_discover.service_name, service.metadata.name)
       if services.length > 0
         form_discover.service_name.selectedIndex = 1
 

--- a/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
@@ -1,47 +1,59 @@
 $ ->
-  form = $('form#new_service,form#create_service')[0]
+  form_source = $('form#new_service_source')[0]
+  form_scratch = $('form#new_service,form#create_service')[0]
+  form_discover = $('form#service_discovery')[0]
+
+  clear_select_options = (select)->
+    $(select).find('option').not(':first').remove()
+
+  clear_namespaces = ()->
+    clear_select_options form_discover.service_namespace
+
+  clear_service_names = ()->
+    clear_select_options form_discover.service_name
+
+  show_service_form = (source, discover_func, scratch_func)->
+    if source == 'discover'
+      form_scratch.classList.add('is-hidden')
+      form_discover.classList.remove('is-hidden')
+      discover_func() unless typeof discover_func == 'undefined'
+    else
+      form_scratch.classList.remove('is-hidden')
+      form_discover.classList.add('is-hidden')
+      scratch_func() unless typeof scratch_func == 'undefined'
 
   change_service_source = (e)->
-    $(form.namespace).find('option').not(':first').remove()
-    if form.source.value == 'discover'
-      form.namespace.removeAttribute('disabled')
-      $(form.service_name).replaceWith('<select name="service[name]" id="service_name"><option/></select>')
-      form.service_system_name.setAttribute('readonly', true)
-      $.getJSON '/p/admin/service_discovery/projects.json', (data)->
-        data.projects.forEach (project, index, array) ->
-          namespace = project.metadata.name
-          $(form.namespace).append("<option value=\"#{namespace}\">#{namespace}</option>")
-        if data.projects.length > 0
-          form.namespace.selectedIndex = 1
-          change_cluster_namespace()
-    else
-      form.namespace.setAttribute('disabled', 'disabled')
-      $(form.service_name).replaceWith('<input type="text" name="service[name]" id="service_name" maxlength="255"/>')
-      form.service_system_name.removeAttribute('readonly')
-      form.service_system_name.value = ''
+    clear_namespaces()
+    clear_service_names()
+    show_service_form(form_source.source.value, fetch_namespaces)
 
   change_cluster_namespace = (e)->
-    $(form.service_name).find('option').not(':first').remove()
-    form.service_system_name.value = ''
-    selected_namespace = $(form.namespace).find('option:checked').val()
+    clear_service_names()
+    selected_namespace = form_discover.service_namespace.value
     if selected_namespace != ''
-      $.getJSON "/p/admin/service_discovery/namespaces/#{selected_namespace}/services.json", (data)->
-        data.services.forEach (service, index, array) ->
-          metadata = service.metadata
-          $(form.service_name).append("<option value=\"#{metadata.name}\">#{metadata.name}</option>")
-        if data.services.length > 0
-          form.service_name.selectedIndex = 1
-          change_cluster_service()
-    else
-      form.service_system_name.value = ''
+      fetch_services(selected_namespace)
 
-  change_cluster_service = (e)->
-    if form.service_name.value != ''
-      form.service_system_name.value = "#{form.namespace.value}-#{form.service_name.value}"
-    else
-      form.service_system_name.value = ''
+  fetch_namespaces = ()->
+    $.getJSON '/p/admin/service_discovery/projects.json', (data)->
+      projects = data.projects
+      projects.forEach (project, index, array) ->
+        namespace = project.metadata.name
+        $(form_discover.service_namespace).append("<option value=\"#{namespace}\">#{namespace}</option>")
+      if projects.length > 0
+        form_discover.service_namespace.selectedIndex = 1
+        change_cluster_namespace()
 
-  unless typeof form == 'undefined'
-    $(form.source).click change_service_source
-    $(form.namespace).live 'change', change_cluster_namespace
-    $(form).on 'change', "select[name='service[name]']", change_cluster_service
+  fetch_services = (namespace)->
+    $.getJSON "/p/admin/service_discovery/namespaces/#{namespace}/services.json", (data)->
+      services = data.services
+      services.forEach (service, index, array) ->
+        service_name = service.metadata.name
+        $(form_discover.service_name).append("<option value=\"#{service_name}\">#{service_name}</option>")
+      if services.length > 0
+        form_discover.service_name.selectedIndex = 1
+
+  unless typeof form_source == 'undefined'
+    $(form_source.source).click change_service_source
+
+  unless typeof form_discover == 'undefined'
+    $(form_discover.service_namespace).live 'change', change_cluster_namespace

--- a/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
@@ -62,9 +62,7 @@ $ ->
         form_discover.service_name.selectedIndex = 1
 
   if form_source != null and typeof form_source != 'undefined'
-    form_source.source.forEach (item) ->
-      item.addEventListener 'click', change_service_source
-      return
+    $(form_source.source).click change_service_source
 
   if form_discover != null and typeof form_discover != 'undefined'
     form_discover.service_namespace.addEventListener 'change', change_cluster_namespace

--- a/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js.coffee
@@ -1,0 +1,47 @@
+$ ->
+  form = $('form#new_service,form#create_service')[0]
+
+  change_service_source = (e)->
+    $(form.namespace).find('option').not(':first').remove()
+    if form.source.value == 'discover'
+      form.namespace.removeAttribute('disabled')
+      $(form.service_name).replaceWith('<select name="service[name]" id="service_name"><option/></select>')
+      form.service_system_name.setAttribute('readonly', true)
+      $.getJSON '/p/admin/service_discovery/projects.json', (data)->
+        data.projects.forEach (project, index, array) ->
+          namespace = project.metadata.name
+          $(form.namespace).append("<option value=\"#{namespace}\">#{namespace}</option>")
+        if data.projects.length > 0
+          form.namespace.selectedIndex = 1
+          change_cluster_namespace()
+    else
+      form.namespace.setAttribute('disabled', 'disabled')
+      $(form.service_name).replaceWith('<input type="text" name="service[name]" id="service_name" maxlength="255"/>')
+      form.service_system_name.removeAttribute('readonly')
+      form.service_system_name.value = ''
+
+  change_cluster_namespace = (e)->
+    $(form.service_name).find('option').not(':first').remove()
+    form.service_system_name.value = ''
+    selected_namespace = $(form.namespace).find('option:checked').val()
+    if selected_namespace != ''
+      $.getJSON "/p/admin/service_discovery/namespaces/#{selected_namespace}/services.json", (data)->
+        data.services.forEach (service, index, array) ->
+          metadata = service.metadata
+          $(form.service_name).append("<option value=\"#{metadata.name}\">#{metadata.name}</option>")
+        if data.services.length > 0
+          form.service_name.selectedIndex = 1
+          change_cluster_service()
+    else
+      form.service_system_name.value = ''
+
+  change_cluster_service = (e)->
+    if form.service_name.value != ''
+      form.service_system_name.value = "#{form.namespace.value}-#{form.service_name.value}"
+    else
+      form.service_system_name.value = ''
+
+  unless typeof form == 'undefined'
+    $(form.source).click change_service_source
+    $(form.namespace).live 'change', change_cluster_namespace
+    $(form).on 'change', "select[name='service[name]']", change_cluster_service

--- a/app/assets/javascripts/provider/layout/provider.js
+++ b/app/assets/javascripts/provider/layout/provider.js
@@ -10,6 +10,7 @@
 //= require extra_fields
 //= require vendor/underscore.min.js
 //= require provider
+//= require provider/admin/apiconfig/services/service_discovery
 //= require application
 //= require vendor/jquery.iframe-post-form.js
 //= require vendor/jquery.sparkline.min.js

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -38,9 +38,12 @@ class Api::ServicesController < Api::BaseController
     @service.attributes = params[:service]
     @service.system_name = params[:service][:system_name]
 
-    if can_create? && @service.save
-      @service.import_cluster_definitions(params[:namespace]) if ThreeScale.config.service_discovery.enabled && params[:source] == 'discover'
+    if params[:source] == 'discover'
+      @service.discovered = true
+      @service.cluster_namespace = params[:namespace].presence
+    end
 
+    if can_create? && @service.save
       flash[:notice] =  'Service created.'
       onboarding.bubble_update('api')
       redirect_to admin_services_path(anchor: "service_#{@service.id}")

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -34,22 +34,20 @@ class Api::ServicesController < Api::BaseController
   end
 
   def create
-    @service = collection.new # this is done in 2 steps so that the account_id is in place as preffix_key relies on it
-    @service.attributes = params[:service]
-    @service.system_name = params[:service][:system_name]
+    @service, success = create_or_build_service
 
-    if params[:source] == 'discover'
-      @service.discovered = true
-      @service.cluster_namespace = params[:namespace].presence
+    unless success
+      flash.now[:error] = "Couldn't create service. Check your Plan limits"
+      return render :new
     end
 
-    if can_create? && @service.save
+    if @service.persisted?
       flash[:notice] =  'Service created.'
       onboarding.bubble_update('api')
       redirect_to admin_services_path(anchor: "service_#{@service.id}")
     else
-      flash.now[:error] = "Couldn't create service. Check your Plan limits"
-      render :new
+      flash[:notice] =  "The service will be imported shortly. You will receive a notification when it is done."
+      redirect_to admin_services_path
     end
   end
 
@@ -98,5 +96,19 @@ class Api::ServicesController < Api::BaseController
 
   def authorize_admin_plans
     authorize! :admin, :plans
+  end
+
+  def create_service_params
+    params.require(:service).permit(:source, :name, :system_name, :description, :namespace)
+  end
+
+  def create_or_build_service
+    creation_service = ServiceCreationService.new(current_account, create_service_params)
+
+    if can_create?
+      [creation_service.call, creation_service.success?]
+    else
+      [creation_service.build_service, false]
+    end
   end
 end

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -39,6 +39,8 @@ class Api::ServicesController < Api::BaseController
     @service.system_name = params[:service][:system_name]
 
     if can_create? && @service.save
+      @service.import_cluster_definitions(params[:namespace]) if ThreeScale.config.service_discovery.enabled && params[:source] == 'discover'
+
       flash[:notice] =  'Service created.'
       onboarding.bubble_update('api')
       redirect_to admin_services_path(anchor: "service_#{@service.id}")

--- a/app/controllers/provider/admin/service_discovery/cluster_base_controller.rb
+++ b/app/controllers/provider/admin/service_discovery/cluster_base_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Provider::Admin::ServiceDiscovery::ClusterBaseController < Provider::Admin::BaseController
+  respond_to :json
+  before_action :find_cluster
+
+  attr_reader :cluster
+
+  protected
+
+  def find_cluster
+    @cluster ||= ::ServiceDiscovery::ClusterClient.new
+  end
+end

--- a/app/controllers/provider/admin/service_discovery/cluster_namespaces_controller.rb
+++ b/app/controllers/provider/admin/service_discovery/cluster_namespaces_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Provider::Admin::ServiceDiscovery::ClusterNamespacesController < Provider::Admin::ServiceDiscovery::ClusterBaseController
+end

--- a/app/controllers/provider/admin/service_discovery/cluster_projects_controller.rb
+++ b/app/controllers/provider/admin/service_discovery/cluster_projects_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Provider::Admin::ServiceDiscovery::ClusterProjectsController < Provider::Admin::ServiceDiscovery::ClusterBaseController
+  def index
+    render json: { projects: cluster.projects_with_discoverables.map(&:to_json) }
+  end
+end

--- a/app/controllers/provider/admin/service_discovery/cluster_services_controller.rb
+++ b/app/controllers/provider/admin/service_discovery/cluster_services_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Provider::Admin::ServiceDiscovery::ClusterServicesController < Provider::Admin::ServiceDiscovery::ClusterBaseController
+  def index
+    render json: { services: cluster.discoverable_services(namespace: params.require(:namespace_id)).map(&:to_json) }
+  end
+
+  def show
+    cluster_service = cluster.find_discoverable_service_by(namespace: params.require(:namespace_id), name: params[:id])
+    render json: cluster_service.to_json
+  rescue ::ServiceDiscovery::ClusterClient::ResourceNotFound => exception
+    render_error exception.message, status: :not_found
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -10,6 +10,8 @@ class Service < ApplicationRecord
   include Logic::RollingUpdates::Service
   include SystemName
   extend System::Database::Scopes::IdOrSystemName
+  include ServiceDiscovery::ModelExtensions::Service
+
   DELETE_STATE = 'deleted'.freeze
 
   has_system_name uniqueness_scope: :account_id

--- a/app/models/service_discovery/cluster_client.rb
+++ b/app/models/service_discovery/cluster_client.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'kubeclient'
+
+module ServiceDiscovery
+  class ClusterClient
+    class ResourceNotFound < StandardError
+      def initialize(resource_type, name, namespace, labels = {})
+        resource_name = namespace.present? ? "#{namespace}/#{name}" : name
+        error_message = "Resource #{resource_name} of kind #{resource_type.to_s.camelize} not found"
+        error_message += " with labels #{labels}" if labels.present?
+        super(error_message)
+      end
+    end
+
+    def initialize(opts = {})
+      service_discovery_configs = ThreeScale.config.service_discovery.to_h
+      options = opts.reverse_merge(service_discovery_configs.slice(:server_scheme, :server_host, :server_port, :bearer_token))
+
+      @k8s = self.class.build_k8s_client(options)
+      @ocp = self.class.build_ocp_client(options)
+    end
+
+    attr_reader :k8s, :ocp
+
+    def method_missing(method_sym, *args, &block)
+      client = client_that_responds_to(method_sym)
+      return client.public_send(method_sym, *args, &block) if client
+      super
+    end
+
+    def respond_to_missing?(method_sym, include_private = false)
+      clients_respond_to?(method_sym) || super
+    end
+
+    def namespaces
+      # 'view' cluster-role permission is required
+      get_namespaces.map { |resource| ClusterNamespace.new(resource, self) }
+    end
+
+    def projects
+      get_projects.map { |resource| ClusterProject.new(resource, self) }
+    end
+
+    def services(namespace: nil, labels: {})
+      within_namespace(namespace, with_labels: labels) do |search_criteria|
+        get_services(search_criteria).map { |resource| ClusterService.new(resource, self) }
+      end
+    end
+
+    def routes(namespace: nil, labels: {})
+      within_namespace(namespace, with_labels: labels) do |search_criteria|
+        get_routes(search_criteria).map { |resource| ClusterRoute.new(resource, self) }
+      end
+    end
+
+    def find_namespace_by(name:)
+      find_resource(:namespace, name)
+    end
+
+    def find_project_by(name:)
+      find_resource(:project, name)
+    end
+
+    def find_service_by(name:, namespace:)
+      find_resource(:service, name, namespace)
+    end
+
+    def find_route_by(name:, namespace:)
+      find_resource(:route, name, namespace)
+    end
+
+    def discoverable_services(namespace: nil, labels: {})
+      services(namespace: namespace, labels: labels.merge(ClusterService.discovery_label_selector)).select(&:discoverable?)
+    end
+
+    def find_discoverable_service_by(name:, namespace:)
+      cluster_service = find_service_by(namespace: namespace, name: name)
+      raise ResourceNotFound.new('Service', namespace, name) unless cluster_service.discoverable?
+      cluster_service
+    end
+
+    def projects_with_discoverables
+      # Less efficient than fetching all discoverable services (unscoped) and then selecting the unique namespaces,
+      # but it allows using an user's (or user-level service account's) token to fetch the list of projects
+      projects.select { |project| discoverable_services(namespace: project.namespace).any? }
+    end
+
+    DEFAULT_CLUSTER_SCHEME = 'https'
+    DEFAULT_CLUSTER_HOST = 'kubernetes.default.svc.cluster.local'
+    DEFAULT_CLUSTER_PORT = 443
+
+    def self.build_api_endpoint(options = {})
+      server_scheme = options[:server_scheme] || DEFAULT_CLUSTER_SCHEME
+      server_host = options[:server_host] || DEFAULT_CLUSTER_HOST
+      server_port = options[:server_port] || DEFAULT_CLUSTER_PORT
+
+      api_path = options[:api_path].presence
+
+      "#{server_scheme}://#{server_host}:#{server_port}/#{api_path}"
+    end
+
+    def self.build_client_options(options = {})
+      [
+        build_api_endpoint(options),
+        'v1',
+        ssl_options: { verify_ssl: OpenSSL::SSL::VERIFY_NONE },
+        auth_options: { bearer_token: options[:bearer_token] }
+      ]
+    end
+
+    def self.build_ocp_client(options = {})
+      Kubeclient::Client.new(*build_client_options(options.merge(api_path: 'oapi')))
+    end
+
+    def self.build_k8s_client(options = {})
+      Kubeclient::Client.new(*build_client_options(options.merge(api_path: 'api')))
+    end
+
+    protected
+
+    def within_namespace(namespace, with_labels: {})
+      search_criteria = {}
+      search_criteria[:namespace] = namespace.presence
+
+      if with_labels.present?
+        label_selector = with_labels.map { |label, value| "#{label}=#{value}" }.join(',')
+        search_criteria[:label_selector] = label_selector
+      end
+
+      yield search_criteria
+    end
+
+    def find_resource(type, name, namespace = nil)
+      begin
+        args = [name, namespace.presence].compact
+        resource_data = public_send("get_#{type.to_s.downcase}", *args)
+        raise_not_found(type, name, namespace) unless resource_data
+      rescue KubeException => exception
+        raise_not_found(type, name, namespace) if exception.error_code == 404
+      end
+
+      klass = "ServiceDiscovery::Cluster#{type.to_s.camelize}".constantize
+      klass.new(resource_data, self)
+    end
+
+    def raise_not_found(resource_type, resource_name, namespace = nil, fields = {})
+      raise ResourceNotFound.new(resource_type, resource_name, namespace, fields)
+    end
+
+    def client_that_responds_to(method_sym)
+      [ocp, k8s].each do |client|
+        client_responds_to_method = client.respond_to?(method_sym)
+        return client if client_responds_to_method
+      end
+
+      nil
+    end
+
+    def clients_respond_to?(method_sym)
+      client_that_responds_to(method_sym).present?
+    end
+  end
+end

--- a/app/models/service_discovery/cluster_namespace.rb
+++ b/app/models/service_discovery/cluster_namespace.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ServiceDiscovery
+  class ClusterNamespace < ClusterResource; end
+end

--- a/app/models/service_discovery/cluster_project.rb
+++ b/app/models/service_discovery/cluster_project.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ServiceDiscovery
+  class ClusterProject < NamespacedClusterResource
+    alias namespace name
+  end
+end

--- a/app/models/service_discovery/cluster_resource.rb
+++ b/app/models/service_discovery/cluster_resource.rb
@@ -48,6 +48,10 @@ module ServiceDiscovery
       @annotations ||= metadata[:annotations].to_h
     end
 
+    def to_json
+      resource.to_h.except(:kind, :apiVersion)
+    end
+
     def to_xml(options = {})
       properties = resource.to_h.except(:kind, :apiVersion)
       root = self.class.name.gsub(/ServiceDiscovery::Cluster/, '').downcase

--- a/app/models/service_discovery/cluster_resource.rb
+++ b/app/models/service_discovery/cluster_resource.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module ServiceDiscovery
+  class ClusterResource
+    class InvalidResourceDefinitionError < StandardError; end
+
+    def initialize(resource, cluster = nil)
+      @resource = resource
+      @cluster = cluster
+    end
+
+    attr_reader :resource, :cluster
+    protected :resource, :cluster
+
+    delegate :kind, :metadata, :spec, :status, to: :resource
+
+    def api_version
+      resource.apiVersion
+    end
+
+    def uid
+      metadata[:uid]
+    end
+
+    alias id uid
+
+    def name
+      metadata[:name]
+    end
+
+    def version
+      metadata[:resourceVersion]
+    end
+
+    def self_link
+      metadata[:selfLink]
+    end
+
+    def created_at
+      Time.zone.parse metadata[:creationTimestamp]
+    end
+
+    def labels
+      @labels ||= metadata[:labels].to_h
+    end
+
+    def annotations
+      @annotations ||= metadata[:annotations].to_h
+    end
+
+    def to_xml(options = {})
+      properties = resource.to_h.except(:kind, :apiVersion)
+      root = self.class.name.gsub(/ServiceDiscovery::Cluster/, '').downcase
+      properties.to_xml(options.merge(root: root))
+    end
+  end
+end

--- a/app/models/service_discovery/cluster_route.rb
+++ b/app/models/service_discovery/cluster_route.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ServiceDiscovery
+  class ClusterRoute < NamespacedClusterResource; end
+end

--- a/app/models/service_discovery/cluster_service.rb
+++ b/app/models/service_discovery/cluster_service.rb
@@ -5,6 +5,7 @@ module ServiceDiscovery
     # See https://github.com/kubernetes/kubernetes/blob/release-1.4/docs/proposals/service-discovery.md
 
     DISCOVERY_NAMESPACE = 'discovery.3scale.net'
+    OAS_CONTENT_TYPES = %w[application/swagger+json application/vnd.oai.openapi+json].freeze
 
     %w[scheme port path description-path].each do |field_name|
       define_method(field_name.tr('-', '_').to_sym) do
@@ -36,6 +37,26 @@ module ServiceDiscovery
       [root, path.presence].compact.join('/')
     end
 
+    def specification
+      fetch_specification unless specification_fetched?
+      @specification
+    end
+
+    def specification_url
+      url = [description_path]
+      url.unshift(root) unless description_path.starts_with?('http')
+      url.join('/')
+    end
+
+    def specification_type
+      fetch_specification unless specification_fetched?
+      @specification_type
+    end
+
+    def oas?
+      OAS_CONTENT_TYPES.any?(&specification_type.to_s.method(:starts_with?))
+    end
+
     def valid?
       # TODO: replace that with a JSON schema
       scheme.present? && port.presence.to_s =~ /\A(\d)+\Z/
@@ -53,6 +74,21 @@ module ServiceDiscovery
 
     def discovery_annotation(field_name = nil)
       annotations[self.class.discovery_key(field_name)]
+    end
+
+    def specification_fetched?
+      !!@specification_fetched
+    end
+
+    def fetch_specification
+      response = RestClient.get(specification_url)
+      @specification_fetched = true
+      @specification_type = response.headers[:content_type]
+      @specification = response.body
+    rescue SocketError, RestClient::Exception, Errno::ECONNREFUSED, Errno::ECONNRESET => exception
+      Rails.logger.error "Could not fetch specification of #{self_link}: #{exception.message}"
+      @specification_fetched = false
+      nil
     end
   end
 end

--- a/app/models/service_discovery/cluster_service.rb
+++ b/app/models/service_discovery/cluster_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ServiceDiscovery
+  class ClusterService < NamespacedClusterResource
+    # See https://github.com/kubernetes/kubernetes/blob/release-1.4/docs/proposals/service-discovery.md
+
+    DISCOVERY_NAMESPACE = 'discovery.3scale.net'
+
+    %w[scheme port path description-path].each do |field_name|
+      define_method(field_name.tr('-', '_').to_sym) do
+        discovery_annotation(field_name)
+      end
+    end
+
+    def self.discovery_key(field_name = nil)
+      [DISCOVERY_NAMESPACE, field_name].compact.join('/').to_sym
+    end
+
+    def self.discovery_label_selector
+      { discovery_key => 'true' }
+    end
+
+    def host
+      "#{name}.#{namespace}.svc.cluster.local"
+    end
+
+    def host_and_port
+      [host, port.presence].compact.join(':')
+    end
+
+    def root
+      "#{scheme}://#{host_and_port}"
+    end
+
+    def endpoint
+      [root, path.presence].compact.join('/')
+    end
+
+    def valid?
+      # TODO: replace that with a JSON schema
+      scheme.present? && port.presence.to_s =~ /\A(\d)+\Z/
+    end
+
+    def discoverable?
+      discovery_label.to_s == 'true' && valid?
+    end
+
+    protected
+
+    def discovery_label(field_name = nil)
+      labels[self.class.discovery_key(field_name)]
+    end
+
+    def discovery_annotation(field_name = nil)
+      annotations[self.class.discovery_key(field_name)]
+    end
+  end
+end

--- a/app/models/service_discovery/cluster_service.rb
+++ b/app/models/service_discovery/cluster_service.rb
@@ -34,7 +34,7 @@ module ServiceDiscovery
     end
 
     def endpoint
-      [root, path.presence].compact.join('/')
+      [root, path.to_s.sub(/^\//, '').presence].compact.join('/')
     end
 
     def specification
@@ -43,9 +43,7 @@ module ServiceDiscovery
     end
 
     def specification_url
-      url = [description_path]
-      url.unshift(root) unless description_path.starts_with?('http')
-      url.join('/')
+      description_path.starts_with?('http') ? description_path : [root, description_path.to_s.sub(/^\//, '').presence].compact.join('/')
     end
 
     def specification_type

--- a/app/models/service_discovery/model_extensions.rb
+++ b/app/models/service_discovery/model_extensions.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module ServiceDiscovery
+  module ModelExtensions
+    module Service
+      def self.included(base)
+        base.class_eval do
+          attr_accessor :namespace
+        end
+      end
+
+      def import_cluster_definitions(namespace)
+        return unless ThreeScale.config.service_discovery.enabled
+
+        # TODO: Perform async
+
+        self.namespace = namespace
+
+        import_cluster_service_endpoint
+        import_cluster_active_docs
+      rescue ServiceDiscovery::ClusterClient::ResourceNotFound
+      end
+
+      protected
+
+      def cluster
+        @cluster ||= ServiceDiscovery::ClusterClient.new
+      end
+
+      def cluster_service
+        @cluster_service ||= cluster.find_discoverable_service_by(namespace: namespace, name: name)
+      end
+
+      private
+
+      def import_cluster_service_endpoint
+        proxy.save_and_deploy(api_backend: cluster_service.endpoint)
+      end
+
+      def import_cluster_active_docs
+        return unless cluster_service.oas?
+
+        spec_content = cluster_service.specification
+        return if spec_content.blank?
+
+        provider.api_docs_services.create({ name: cluster_service.name,
+                                            body: spec_content,
+                                            published: true,
+                                            skip_swagger_validations: true })
+      end
+    end
+  end
+end

--- a/app/models/service_discovery/namespaced_cluster_resource.rb
+++ b/app/models/service_discovery/namespaced_cluster_resource.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ServiceDiscovery
+  class NamespacedClusterResource < ClusterResource
+    def namespace
+      metadata[:namespace]
+    end
+  end
+end

--- a/app/services/service_creation_service.rb
+++ b/app/services/service_creation_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class ServiceCreationService
+  def initialize(provider_account, service_attributes = {})
+    @provider_account = provider_account
+    @service_attributes = service_attributes
+  end
+
+  attr_reader :provider_account, :service_attributes, :success, :service
+
+  def self.call(*args)
+    object = new(*args)
+    object.call
+    object
+  end
+
+  def call
+    @service = discover? ? create_service_async : create_service
+  end
+
+  def create_service
+    service = build_service service_attributes.slice(:name, :system_name, :description)
+    @success = service.save
+    service
+  end
+
+  def create_service_async
+    ServiceDiscovery::ImportClusterServiceDefinitionsWorker.perform_async(provider_account.id, *service_attributes.values_at(:namespace, :name))
+    @success = true
+    build_service service_attributes.slice(:name)
+  end
+
+  def build_service(attributes = {})
+    provider_account.accessible_services.build(attributes.presence || service_attributes)
+  end
+
+  def discover?
+    service_attributes[:source] == 'discover'
+  end
+
+  def success?
+    !!success
+  end
+end

--- a/app/views/api/services/forms/_naming.html.slim
+++ b/app/views/api/services/forms/_naming.html.slim
@@ -1,4 +1,4 @@
-= form.inputs do
+= form.inputs "Service" do
   = form.input :name
   = form.system_name
   = form.input :description, input_html: { rows: 3 }

--- a/app/views/api/services/forms/_service_discovery.html.slim
+++ b/app/views/api/services/forms/_service_discovery.html.slim
@@ -1,0 +1,18 @@
+- if ThreeScale.config.service_discovery.enabled
+  fieldset class="inputs"
+    legend Source
+    ol
+      li class="radio"
+        fieldset
+          ol
+            li
+              label for="source_manual"
+                = radio_button_tag :source, 'manual', checked: true
+                = "From Scratch"
+            li
+              label for="source_discover"
+                = radio_button_tag :source, 'discover'
+                = "Discover"
+      li
+        label for="namespace" Namespace
+        = select_tag :namespace, nil, include_blank: true, disabled: true

--- a/app/views/api/services/forms/_service_discovery.html.slim
+++ b/app/views/api/services/forms/_service_discovery.html.slim
@@ -1,4 +1,4 @@
-- if ThreeScale.config.service_discovery.enabled
+form class="formtastic" id="new_service_source"
   fieldset class="inputs"
     legend Source
     ol
@@ -13,6 +13,16 @@
               label for="source_discover"
                 = radio_button_tag :source, 'discover'
                 = "Discover"
-      li
-        label for="namespace" Namespace
-        = select_tag :namespace, nil, include_blank: true, disabled: true
+
+= semantic_form_for service, url: admin_services_path, html: { id: 'service_discovery', class: 'is-hidden' }  do |form|
+  = form.hidden_field :source, value: 'discover'
+  = form.inputs "Service" do
+    li
+      label for="namespace" Namespace
+      = form.select :namespace, [], include_blank: true
+    li
+      label for="service_name" Name
+      = form.select :name, [], include_blank: true
+
+  = form.buttons do
+    = form.commit_button

--- a/app/views/api/services/new.html.slim
+++ b/app/views/api/services/new.html.slim
@@ -2,6 +2,7 @@ h2 Create New Service
 
 
 = semantic_form_for @service, :url => admin_services_path do |form|
+  = render :partial => 'api/services/forms/service_discovery', :locals => { :form => form }
   = render :partial => 'api/services/forms/naming', :locals => { :form => form }
   = form.buttons do
     = form.commit_button

--- a/app/views/api/services/new.html.slim
+++ b/app/views/api/services/new.html.slim
@@ -1,8 +1,9 @@
 h2 Create New Service
 
+- if ThreeScale.config.service_discovery.enabled
+  = render :partial => 'api/services/forms/service_discovery', :locals => { :service => @service }
 
 = semantic_form_for @service, :url => admin_services_path do |form|
-  = render :partial => 'api/services/forms/service_discovery', :locals => { :form => form }
   = render :partial => 'api/services/forms/naming', :locals => { :form => form }
   = form.buttons do
     = form.commit_button

--- a/app/workers/service_discovery/import_cluster_service_definitions_worker.rb
+++ b/app/workers/service_discovery/import_cluster_service_definitions_worker.rb
@@ -4,15 +4,22 @@ module ServiceDiscovery
   class ImportClusterServiceDefinitionsWorker
     include Sidekiq::Worker
 
-    def perform(service_id, cluster_namespace)
+    def perform(account_id, cluster_namespace, service_name)
       return unless ThreeScale.config.service_discovery.enabled
 
-      api = Service.find service_id
-      cluster = ServiceDiscovery::ClusterClient.new
-      cluster_service = cluster.find_discoverable_service_by(name: api.name, namespace: cluster_namespace)
+      account = Account.providers.find account_id
+      service_system_name = [cluster_namespace, service_name].join('-')
 
-      api.import_cluster_service_endpoint(cluster_service)
-      api.import_cluster_active_docs(cluster_service)
+      cluster = ServiceDiscovery::ClusterClient.new
+      cluster_service = cluster.find_discoverable_service_by(name: service_name, namespace: cluster_namespace)
+
+      service_creation = ServiceCreationService.call(account, name: service_name, system_name: service_system_name)
+      new_api = service_creation.service
+
+      return unless service_creation.success? && new_api.persisted?
+
+      new_api.import_cluster_service_endpoint(cluster_service)
+      new_api.import_cluster_active_docs(cluster_service)
     end
   end
 end

--- a/app/workers/service_discovery/import_cluster_service_definitions_worker.rb
+++ b/app/workers/service_discovery/import_cluster_service_definitions_worker.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ServiceDiscovery
+  class ImportClusterServiceDefinitionsWorker
+    include Sidekiq::Worker
+
+    def perform(service_id, cluster_namespace)
+      return unless ThreeScale.config.service_discovery.enabled
+
+      api = Service.find service_id
+      cluster = ServiceDiscovery::ClusterClient.new
+      cluster_service = cluster.find_discoverable_service_by(name: api.name, namespace: cluster_namespace)
+
+      api.import_cluster_service_endpoint(cluster_service)
+      api.import_cluster_active_docs(cluster_service)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -177,6 +177,10 @@ module System
 
     config.three_scale.rolling_updates.features = try_config_for(:rolling_updates)
 
+    config.three_scale.service_discovery = ActiveSupport::OrderedOptions.new
+    config.three_scale.service_discovery.enabled = false
+    config.three_scale.service_discovery.merge!(try_config_for(:service_discovery))
+
     config.three_scale.plan_rules = ActiveSupport::OrderedOptions.new
     config.three_scale.plan_rules.merge!(try_config_for(:plan_rules) || {})
 

--- a/config/docker/service_discovery.yml
+++ b/config/docker/service_discovery.yml
@@ -1,0 +1,24 @@
+default: &base
+  enabled: true
+  server_scheme: 'https'
+  server_port: 8443
+
+development:
+  <<: *base
+  server_host:
+  bearer_token:
+
+test:
+  <<: *base
+  server_host:
+  bearer_token:
+
+production:
+  <<: *base
+  server_host:
+  bearer_token:
+
+preview:
+  <<: *base
+  server_host:
+  bearer_token:

--- a/config/examples/service_discovery.yml
+++ b/config/examples/service_discovery.yml
@@ -1,0 +1,24 @@
+default: &base
+  enabled: true
+  server_scheme: 'https'
+  server_port: 8443
+
+development:
+  <<: *base
+  server_host:
+  bearer_token:
+
+test:
+  <<: *base
+  server_host:
+  bearer_token:
+
+production:
+  <<: *base
+  server_host:
+  bearer_token:
+
+preview:
+  <<: *base
+  server_host:
+  bearer_token:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -358,6 +358,13 @@ without fake Core server your after commit callbacks will crash and you might ge
 
         resources :invoices, :only => [:show, :index]
       end
+
+      namespace :service_discovery do
+        resources :namespaces, only: [], controller: 'cluster_namespaces' do
+          resources :services, only: [:index, :show], controller: 'cluster_services'
+        end
+        resources :projects, only: [:index], controller: 'cluster_projects'
+      end
     end
   end
 

--- a/features/old/services/multiservice.feature
+++ b/features/old/services/multiservice.feature
@@ -17,9 +17,11 @@ Feature: Multiservice feature
      And I should see "ID for API calls is"
      And I should see "system name is"
 
+  @javascript
   Scenario: Create new service
     Given I am logged in as provider "foo.example.com"
       And provider "foo.example.com" has "multiple_services" switch allowed
+      And service discovery is not enabled
     When I am on the services dashboard page
      And I follow "Create Service"
      And I fill in "Name" with "Less fancy API"

--- a/features/step_definitions/service_discovery_steps.rb
+++ b/features/step_definitions/service_discovery_steps.rb
@@ -1,0 +1,3 @@
+Given(/^service discovery is (not )?enabled$/) do |disabled|
+  ThreeScale.config.service_discovery.stubs(enabled: disabled.present?)
+end

--- a/openshift/system/config/service_discovery.yml
+++ b/openshift/system/config/service_discovery.yml
@@ -1,0 +1,21 @@
+default: &base
+  enabled: true
+  server_scheme: 'https'
+  server_host: 'kubernetes.default.svc.cluster.local'
+  server_port: 443
+
+development:
+  <<: *base
+  bearer_token:
+
+test:
+  <<: *base
+  bearer_token:
+
+production:
+  <<: *base
+  bearer_token:
+
+preview:
+  <<: *base
+  bearer_token:

--- a/test/functional/api/services_controller_test.rb
+++ b/test/functional/api/services_controller_test.rb
@@ -97,7 +97,7 @@ class Api::ServicesControllerTest < ActionController::TestCase
     @controller.stubs(:authorize_plans)
     @controller.stubs(:can_create?).returns(true)
 
-    Service.any_instance.stubs(save: true)
+    Service.any_instance.stubs(save: true, persisted?: true)
 
     post :create, service: { system_name: 'Test bubbles' }
 

--- a/test/test_helpers/service_discovery.rb
+++ b/test/test_helpers/service_discovery.rb
@@ -1,0 +1,112 @@
+module TestHelpers
+  module ServiceDiscovery
+
+    protected
+
+    def stub_external_cluster_initialization!
+      Kubeclient::Client.stubs(initialize_client: true)
+      Kubeclient::Client.any_instance.stubs(discover: true)
+    end
+
+    def cluster
+      @cluster ||= begin
+        stub_external_cluster_initialization!
+        ::ServiceDiscovery::ClusterClient.new
+      end
+    end
+
+    def cluster_resource(entity_type, data)
+      klass = Kubeclient::ClientMixin.resource_class(Kubeclient, entity_type)
+      cluster.new_entity(data, klass)
+    end
+
+    def cluster_namespace(data = {})
+      cluster_resource('Namespace', cluster_namespace_data(data))
+    end
+
+    def cluster_namespace_data(data = {})
+      {
+        metadata: {
+          name: 'fake-project',
+          selfLink: '/api/v1/namespaces/fake-project',
+          uid: '818ea53a-14f6-4f80-91f7-6a4b3d4bcd64',
+          resourceVersion: '40582061',
+          creationTimestamp: '2018-07-17T14:17:31Z',
+          annotations: {
+            :"openshift.io/description" => 'My Fake Project',
+            :"openshift.io/display-name" => 'Fake Project',
+            :"openshift.io/requester" => 'John Doe',
+          }
+        },
+        spec: { finalizers: ['openshift.io/origin', 'kubernetes'] },
+        status: { phase: 'Active' }
+      }.deep_merge(data)
+    end
+
+    def cluster_project(data = {})
+      cluster_resource('Project', cluster_project_data(data))
+    end
+
+    alias cluster_project_data cluster_namespace_data
+
+    def cluster_service(data = {})
+      cluster_resource('Service', cluster_service_data(data))
+    end
+
+    def cluster_service_data(data = {})
+      {
+        metadata: {
+          name: 'fake-api',
+          namespace: 'fake-project',
+          selfLink: '/api/v1/namespaces/fake-project/services/fake-api',
+          uid: 'bc6ad9cd-99f2-43a3-91b2-93b7038b0454',
+          resourceVersion: '40582387',
+          creationTimestamp: '2018-07-17T14:18:55Z',
+          labels: { app: 'fake-api', template: 'fake-template' },
+          annotations: { :"prometheus.io/path" => '/system/metrics', :"prometheus.io/scrape" => 'true'}
+        },
+        spec: {
+          ports: [{ name: 'http', protocol: 'TCP', port: 8080, targetPort: 8080 }],
+          selector: { app: 'fake-api' },
+          clusterIP: '122.50.171.300',
+          type: 'ClusterIP',
+          sessionAffinity: 'None'
+        },
+        status: { loadBalancer: {} }
+      }.deep_merge(data)
+    end
+
+    def cluster_route(data = {})
+      cluster_resource('Route', cluster_route_data(data))
+    end
+
+    def cluster_route_data(data = {})
+      {
+        metadata: {
+          name: 'fake-api-route',
+          namespace: 'fake-project',
+          selfLink: '/api/v1/namespaces/fake-project/services/fake-api',
+          uid: 'bc6ad9cd-99f2-43a3-91b2-93b7038b0454',
+          resourceVersion: '40582387',
+          creationTimestamp: '2018-07-17T14:18:55Z',
+          labels: { app: 'fake-api', template: 'fake-template' },
+          ownerReferences: [
+            {
+              apiVersion: 'template.openshift.io/v1',
+              blockOwnerDeletion: true,
+              kind: 'TemplateInstance',
+              name: '9eb4fa70-da5b-4dc4-971a-d0f1d2ca4836',
+              uid: '2592fdef-b5e2-11e8-bb60-06694f191946'
+            }
+          ],
+          annotations: { :"openshift.io/host.generated" => 'true'}
+        },
+        spec: {
+          host: 'fake-api-route.my-domain.test',
+          to: { kind: 'Service', name: 'fake-api', weight: 100 },
+        },
+        status: { routerName: 'router' }
+      }.deep_merge(data)
+    end
+  end
+end

--- a/test/unit/service_discovery/cluster_client_test.rb
+++ b/test/unit/service_discovery/cluster_client_test.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ServiceDiscovery
+  class ClusterClientTest < ActiveSupport::TestCase
+    include TestHelpers::ServiceDiscovery
+
+    test 'fetches default cluster connection data from settings' do
+      ThreeScale.config.expects(:service_discovery).returns({
+        server_scheme: 'https',
+        server_host: 'my-cluster.com',
+        server_port: 8443,
+        bearer_token: 'secret-token'
+      })
+
+      stub_external_cluster_initialization!
+
+      ClusterClient.new
+    end
+
+    test 'namespaces' do
+      cluster.stubs(get_namespaces: [
+        cluster_namespace(metadata: { name: 'namespace-1', uid: '246f96b6-89cc-11e8-b1c9-06694f191946' }),
+        cluster_namespace(metadata: { name: 'namespace-2', uid: 'b8ceb6b6-dfaf-48a5-ba55-cc7bd898cc26' }),
+        cluster_namespace(metadata: { name: 'namespace-3', uid: 'b60a2fea-4e23-4df4-b04d-c663ecb9c473' })
+      ])
+
+      assert_equal %w[namespace-1 namespace-2 namespace-3], cluster.namespaces.map(&:name)
+    end
+
+    test 'find namespace by name' do
+      cluster.expects(:get_namespace).with('my-namespace').returns(
+        cluster_namespace(metadata: { name: 'my-namespace', uid: '246f96b6-89cc-11e8-b1c9-06694f191946' }),
+      )
+
+      assert_equal '246f96b6-89cc-11e8-b1c9-06694f191946', cluster.find_namespace_by(name: 'my-namespace').uid
+    end
+
+    test 'projects' do
+      cluster.stubs(get_projects: [
+        cluster_project(metadata: { name: 'project-1', uid: '65b984b8-57cc-4fb3-9ecc-e7c1f51e8355' }),
+        cluster_project(metadata: { name: 'project-2', uid: '9649ec16-5500-4531-9f77-1bb2246cc672' }),
+        cluster_project(metadata: { name: 'project-3', uid: '7032a178-9ecc-460e-986d-50a9969ce547' })
+      ])
+
+      assert_equal %w[project-1 project-2 project-3], cluster.projects.map(&:name)
+    end
+
+    test 'find project by name' do
+      cluster.expects(:get_project).with('my-project').returns(
+        cluster_namespace(metadata: { name: 'my-project', uid: '65b984b8-57cc-4fb3-9ecc-e7c1f51e8355' }),
+      )
+
+      assert_equal '65b984b8-57cc-4fb3-9ecc-e7c1f51e8355', cluster.find_project_by(name: 'my-project').uid
+    end
+
+    test 'services' do
+      cluster.stubs(get_services: [
+        cluster_service(metadata: { name: 'my-api-staging',    uid: '220151f0-1918-4eca-808a-d4d07cea4b16', namespace: 'my-namespace' }, spec: { ports: [{ protocol: 'TCP', port: 3000, targetPort: 8080 }] }),
+        cluster_service(metadata: { name: 'my-api-production', uid: '97a926db-e104-44ac-a5dd-43a0cf5ec686', namespace: 'my-namespace' }, spec: { ports: [{ protocol: 'TCP', port: 3001, targetPort: 8080 }] })
+      ])
+
+      assert_equal %w[my-api-staging my-api-production], cluster.services(namespace: 'my-namespace').map(&:name)
+    end
+
+    test 'services in a given namespace' do
+      cluster.expects(:get_services).with(namespace: 'my-namespace').returns([
+        cluster_service(metadata: { name: 'my-api-staging',    uid: '220151f0-1918-4eca-808a-d4d07cea4b16', namespace: 'my-namespace' }, spec: { ports: [{ protocol: 'TCP', port: 3000, targetPort: 8080 }] }),
+        cluster_service(metadata: { name: 'my-api-production', uid: '97a926db-e104-44ac-a5dd-43a0cf5ec686', namespace: 'my-namespace' }, spec: { ports: [{ protocol: 'TCP', port: 3001, targetPort: 8080 }] })
+      ])
+      cluster.expects(:get_services).with(namespace: 'other-namespace').returns([
+        cluster_service(metadata: { name: 'my-other-api',      uid: 'b3ae7f5b-6188-4cc9-8fff-5fd4eff79056', namespace: 'other-namespace' }, spec: { ports: [{ protocol: 'TCP', port: 3000, targetPort: 8080 }] })
+      ])
+
+      assert_equal %w[my-api-staging my-api-production], cluster.services(namespace: 'my-namespace').map(&:name)
+      assert_equal %w[my-other-api], cluster.services(namespace: 'other-namespace').map(&:name)
+    end
+
+    test 'discoverable services' do
+      cluster.stubs(get_services: [
+        cluster_service(metadata: { name: 'non-discoverable-api', uid: '220151f0-1918-4eca-808a-d4d07cea4b16', namespace: 'my-namespace' }),
+        cluster_service(
+          metadata: {
+            name: 'discoverable-api',
+            uid: '97a926db-e104-44ac-a5dd-43a0cf5ec686',
+            namespace: 'my-namespace',
+            labels: {
+              :'discovery.3scale.net' => 'true',
+            },
+            annotations: {
+              :'discovery.3scale.net/scheme' => 'http',
+              :'discovery.3scale.net/port' => '8080',
+              :'discovery.3scale.net/path' => 'camel-rest-sql',
+              :'discovery.3scale.net/description-path' => 'camel-rest-sql/api-doc'
+            }
+          }
+        )
+      ])
+
+      assert_equal %w[discoverable-api], cluster.discoverable_services(namespace: 'my-namespace').map(&:name)
+    end
+
+    test 'find service by name' do
+      cluster.expects(:get_service).with('my-api-staging', 'my-namespace').returns(
+        cluster_service(metadata: { name: 'my-api-staging', uid: 'b3ae7f5b-6188-4cc9-8fff-5fd4eff79056', namespace: 'my-namespace' })
+      )
+
+      assert_equal 'my-api-staging', cluster.find_service_by(name: 'my-api-staging', namespace: 'my-namespace').name
+    end
+
+    test 'find discoverable service by name' do
+      discoverable_service = cluster_service(
+        metadata: {
+          name: 'my-api-staging',
+          uid: 'b3ae7f5b-6188-4cc9-8fff-5fd4eff79056',
+          namespace: 'my-namespace',
+          labels: {
+            :'discovery.3scale.net' => 'true',
+          },
+          annotations: {
+            :'discovery.3scale.net/scheme' => 'http',
+            :'discovery.3scale.net/port' => '8080',
+            :'discovery.3scale.net/path' => 'camel-rest-sql',
+            :'discovery.3scale.net/description-path' => 'camel-rest-sql/api-doc'
+          }
+        }
+      )
+      cluster.expects(:get_service).with('my-api-staging', 'my-namespace').returns(discoverable_service)
+
+      assert_equal 'my-api-staging', cluster.find_discoverable_service_by(name: 'my-api-staging', namespace: 'my-namespace').name
+    end
+
+    test 'project with discoverables' do
+      cluster.stubs(get_projects: [
+        cluster_project(metadata: { name: 'project-1', uid: '65b984b8-57cc-4fb3-9ecc-e7c1f51e8355' }),
+        cluster_project(metadata: { name: 'project-2', uid: '9649ec16-5500-4531-9f77-1bb2246cc672' })
+      ])
+
+      cluster.expects(:get_services).with(namespace: 'project-1', label_selector: 'discovery.3scale.net=true').returns([
+        cluster_service(metadata: { name: 'non-discoverable-api-1', uid: '220151f0-1918-4eca-808a-d4d07cea4b16', namespace: 'project-1' } )
+      ])
+
+      cluster.expects(:get_services).with(namespace: 'project-2', label_selector: 'discovery.3scale.net=true').returns([
+        cluster_service(metadata: { name: 'non-discoverable-api-2', uid: 'a608a921-d715-4192-9171-5306c476260a', namespace: 'project-2' } ),
+        cluster_service(
+          metadata: {
+            name: 'discoverable-api',
+            uid: '97a926db-e104-44ac-a5dd-43a0cf5ec686',
+            namespace: 'project-2',
+            labels: {
+              :'discovery.3scale.net' => 'true',
+            },
+            annotations: {
+              :'discovery.3scale.net/scheme' => 'http',
+              :'discovery.3scale.net/port' => '8080',
+              :'discovery.3scale.net/path' => 'camel-rest-sql',
+              :'discovery.3scale.net/description-path' => 'camel-rest-sql/api-doc'
+            }
+          }
+        )
+      ])
+
+      assert_equal %w[project-2], cluster.projects_with_discoverables.map(&:name)
+    end
+
+    test 'routes' do
+      cluster.stubs(get_routes: [
+        cluster_route(metadata: { name: 'my-api-staging-route',    uid: '220151f0-1918-4eca-808a-d4d07cea4b16', namespace: 'my-namespace' }, spec: { to: { kind: 'Service', name: 'my-api-staging' } }),
+        cluster_route(metadata: { name: 'my-api-production-route', uid: '97a926db-e104-44ac-a5dd-43a0cf5ec686', namespace: 'my-namespace' }, spec: { to: { kind: 'Service', name: 'my-api-production' } })
+      ])
+
+      assert_equal %w[my-api-staging-route my-api-production-route], cluster.routes(namespace: 'my-namespace').map(&:name)
+    end
+
+    test 'find route by name' do
+      cluster.expects(:get_route).with('my-api-staging-route', 'my-namespace').returns(
+        cluster_route(metadata: { name: 'my-api-staging-route', uid: '220151f0-1918-4eca-808a-d4d07cea4b16', namespace: 'my-namespace' }, spec: { to: { kind: 'Service', name: 'my-api-staging' } }),
+      )
+
+      assert_equal '220151f0-1918-4eca-808a-d4d07cea4b16', cluster.find_route_by(name: 'my-api-staging-route', namespace: 'my-namespace').uid
+    end
+
+    test 'raises resource not found' do
+      cluster.expects(:get_service).with('my-api-staging', 'my-namespace').returns(nil)
+
+      assert_raises(ServiceDiscovery::ClusterClient::ResourceNotFound) do
+        cluster.find_discoverable_service_by(namespace: 'my-namespace', name: 'my-api-staging').name
+      end
+    end
+  end
+end

--- a/test/unit/service_discovery/cluster_service_test.rb
+++ b/test/unit/service_discovery/cluster_service_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ServiceDiscovery
+  class ClusterServiceTest < ActiveSupport::TestCase
+    include TestHelpers::ServiceDiscovery
+
+    setup do
+      @cluster_service_data = {
+        metadata: {
+          name: 'fake-api',
+          namespace: 'fake-project',
+          selfLink: '/api/v1/namespaces/fake-project/services/fake-api',
+          uid: 'bc6ad9cd-99f2-43a3-91b2-93b7038b0454',
+          resourceVersion: '40582387',
+          creationTimestamp: '2018-07-17T14:18:55Z',
+          labels: {
+            :'discovery.3scale.net' => 'true',
+            app: 'fake-api',
+            template: 'fake-template'
+          },
+          annotations: {
+            :'discovery.3scale.net/scheme' => 'http',
+            :'discovery.3scale.net/port' => '8081',
+            :'discovery.3scale.net/path' => 'api',
+            :'discovery.3scale.net/description-path' => 'api/doc'
+          }
+        },
+        spec: {
+          ports: [{ name: 'http', protocol: 'TCP', port: 8080, targetPort: 8081 }],
+          selector: { app: 'fake-api' },
+          clusterIP: '122.50.171.300',
+          type: 'ClusterIP',
+          sessionAffinity: 'None'
+        },
+        status: { loadBalancer: {} }
+      }
+      @cluster_service = ClusterService.new(cluster_service(@cluster_service_data))
+    end
+
+    test 'valid' do
+      assert @cluster_service.valid?
+
+      invalid_cluster_service_data = @cluster_service_data.dup
+      invalid_cluster_service_data[:metadata][:annotations].delete(:'discovery.3scale.net/scheme')
+      invalid_cluster_service = ClusterService.new(cluster_service(invalid_cluster_service_data))
+      refute invalid_cluster_service.valid?
+
+      invalid_cluster_service_data = @cluster_service_data.dup
+      invalid_cluster_service_data[:metadata][:annotations].delete(:'discovery.3scale.net/port')
+      invalid_cluster_service = ClusterService.new(cluster_service(invalid_cluster_service_data))
+      refute invalid_cluster_service.valid?
+    end
+
+    test 'discoverable?' do
+      assert @cluster_service.discoverable?
+
+      undiscoverable_cluster_service_data = @cluster_service_data.dup
+      undiscoverable_cluster_service_data[:metadata][:labels].delete(:'discovery.3scale.net')
+      undiscoverable_cluster_service = ClusterService.new(cluster_service(undiscoverable_cluster_service_data))
+      refute undiscoverable_cluster_service.discoverable?
+    end
+
+    test 'scheme' do
+      assert_equal 'http', @cluster_service.scheme
+    end
+
+    test 'description path' do
+      assert_equal 'api/doc', @cluster_service.description_path
+    end
+
+    test 'host' do
+      assert_equal 'fake-api.fake-project.svc.cluster.local', @cluster_service.host
+    end
+
+    test 'port' do
+      assert_equal 8081, @cluster_service.port.to_i
+    end
+
+    test 'host and port' do
+      assert_equal 'fake-api.fake-project.svc.cluster.local:8081', @cluster_service.host_and_port
+    end
+
+    test 'root' do
+      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081', @cluster_service.root
+    end
+
+    test 'path' do
+      assert_equal 'api', @cluster_service.path
+    end
+
+    test 'endpoint' do
+      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081/api', @cluster_service.endpoint
+    end
+
+    private
+
+    def multiple_ports
+      { ports: [
+        { name: 'https', protocol: 'TCP', port: 443, targetPort: 8443 },
+        { name: 'http', protocol: 'TCP', port: 80, targetPort: 8080 }
+      ]}
+    end
+  end
+end

--- a/test/unit/service_discovery/cluster_service_test.rb
+++ b/test/unit/service_discovery/cluster_service_test.rb
@@ -66,10 +66,6 @@ module ServiceDiscovery
       assert_equal 'http', @cluster_service.scheme
     end
 
-    test 'description path' do
-      assert_equal 'api/doc', @cluster_service.description_path
-    end
-
     test 'host' do
       assert_equal 'fake-api.fake-project.svc.cluster.local', @cluster_service.host
     end
@@ -92,6 +88,26 @@ module ServiceDiscovery
 
     test 'endpoint' do
       assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081/api', @cluster_service.endpoint
+    end
+
+    test 'description path' do
+      assert_equal 'api/doc', @cluster_service.description_path
+    end
+
+    test 'specification url' do
+      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081/api/doc', @cluster_service.specification_url
+
+      cluster_service_data = @cluster_service_data.deep_merge(metadata: { annotations: { :'discovery.3scale.net/description-path' => 'https://example.com/api-doc.json' } })
+      cluster_service = ClusterService.new(cluster_service(cluster_service_data))
+      assert_equal 'https://example.com/api-doc.json', cluster_service.specification_url
+    end
+
+    test 'oas?' do
+      @cluster_service.expects(:specification_type).returns('application/vnd.oai.openapi+json')
+      assert @cluster_service.oas?
+
+      @cluster_service.expects(:specification_type).returns('application/xml')
+      refute @cluster_service.oas?
     end
 
     private


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It implements a Service Discovery feature inspired by https://github.com/kubernetes/kubernetes/blob/release-1.4/docs/proposals/service-discovery.md using the cluster API.

**Which issue(s) this PR fixes** 

Related to https://github.com/3scale/porta/issues/34 ([THREESCALE-1363](https://issues.jboss.org/browse/THREESCALE-1363))

**Special notes for your reviewer**:
A few TODOs:
- [x] Simplify the UI so it contains only 2 select boxes: namespace/project and service name
- [x] Postpone the creation of the bare service, delegating it to the background job, rather than creating first and importing cluster data later
- [x] Fix retrieval of port info – use a specific annotation instead of choosing from spec/ports
- [x] Resolve spec type from the Content-Type instead of using "api.service.kubernetes.io/description-language"
- [ ] Add more tests 😜

Left for a future PR
- Send a 3scale notification by the end of the asynchronous process
- Make Service Discovery namespace (and other stuff) configurable
- Add lookup attribute to table `services` (based on k8s object’s selfLink?)
- Update/resync button
- Replace configurable access tokens with RHSSO (OAuth)

Depends on https://github.com/3scale/porta/pull/3

Specially in order to support updates to the ActiveDocs too, it would be nice to have an association between `Service` (API) and `ApiDoc::Service` in 3scale. I suggest doing it in a separate PR. _Update:_ https://github.com/3scale/porta/pull/62