### PR TITLE
[Bugfix] Applications::ApplicationDeletedEvent is invalid because its provider is already deleted

### DIFF
--- a/app/events/applications/application_deleted_event.rb
+++ b/app/events/applications/application_deleted_event.rb
@@ -4,12 +4,10 @@ class Applications::ApplicationDeletedEvent < ApplicationRelatedEvent
 
   # @param [Cinstance] application
   def self.create(application)
-    provider = application.provider_account || Account.new
-
     new(
       application: MissingModel::MissingApplication.new(id: application.id),
       metadata: {
-        provider_id: provider.id,
+        provider_id: application.provider_account_id || application.tenant_id,
         zync: {
           service_id: application.service_id
         }

--- a/app/lib/event_store/event.rb
+++ b/app/lib/event_store/event.rb
@@ -49,7 +49,7 @@ module EventStore
 
     before_validation :provider_id_from_metadata
 
-    belongs_to :account, foreign_key: :provider_id, inverse_of: :events
+    belongs_to :account, foreign_key: :provider_id, inverse_of: :events, required: false
 
     alias provider account
 

--- a/app/lib/event_store/event.rb
+++ b/app/lib/event_store/event.rb
@@ -50,6 +50,9 @@ module EventStore
     before_validation :provider_id_from_metadata
 
     belongs_to :account, foreign_key: :provider_id, inverse_of: :events, required: false
+    # It is not required because when we delete a provider and all its relationships,
+    # we still want the events of the relationships to be saved in order to do the correspondent actions
+    # once the provider is deleted (whatever the subscribers tells them to do).
 
     alias provider account
 

--- a/db/migrate/20181130072917_remove_foreign_key_events_accounts.rb
+++ b/db/migrate/20181130072917_remove_foreign_key_events_accounts.rb
@@ -1,0 +1,5 @@
+class RemoveForeignKeyEventsAccounts < ActiveRecord::Migration
+  def change
+    remove_foreign_key :event_store_events, column: :provider_id
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181105212016) do
+ActiveRecord::Schema.define(version: 20181130072917) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -1435,7 +1435,6 @@ ActiveRecord::Schema.define(version: 20181105212016) do
   end
 
   add_foreign_key "api_docs_services", "services"
-  add_foreign_key "event_store_events", "accounts", column: "provider_id", on_delete: :cascade
   add_foreign_key "payment_details", "accounts", on_delete: :cascade
   add_foreign_key "provided_access_tokens", "users"
   add_foreign_key "proxy_configs", "proxies", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181105212016) do
+ActiveRecord::Schema.define(version: 20181130072917) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -1440,7 +1440,6 @@ ActiveRecord::Schema.define(version: 20181105212016) do
   end
 
   add_foreign_key "api_docs_services", "services"
-  add_foreign_key "event_store_events", "accounts", column: "provider_id", on_delete: :cascade
   add_foreign_key "payment_details", "accounts", on_delete: :cascade
   add_foreign_key "provided_access_tokens", "users"
   add_foreign_key "proxy_configs", "proxies", on_delete: :cascade

--- a/test/events/applications/application_deleted_event_test.rb
+++ b/test/events/applications/application_deleted_event_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationDeletedEventTest < ActiveSupport::TestCase
+  disable_transactional_fixtures!
+  def setup
+    @application = FactoryGirl.create(:cinstance)
+  end
+
+  attr_reader :application
+
+  def test_create_and_publish_when_application_does_not_exists_anymore
+    assert provider_id = application.provider_account.id
+    application.provider_account.delete
+
+    event = Applications::ApplicationDeletedEvent.create(application.reload)
+
+    Rails.application.config.event_store.publish_event(event)
+
+    event_stored = EventStore::Repository.find_event!(event.event_id)
+    assert_equal provider_id, event_stored.metadata.fetch(:provider_id)
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/3scale/porta/issues/37

Pick the `provider_account_id`, but if it doesn't exist anymore, pick the `tenant_id` 😄 

Fixes https://github.com/3scale/porta/issues/42

When the provider doesn't exist in DB anymore (has been deleted), the event should be saved anyway.

### Why we are removing the foreign key
We deleted a provider and all its relationships, but we still want the events of the relationships to be saved (in this case application) to do the correspondent actions once it is deleted (whatever the subscriber tells it to do).