### PR TITLE
Rewords metrics description

### DIFF
--- a/app/views/api/metrics/index.html.slim
+++ b/app/views/api/metrics/index.html.slim
@@ -82,7 +82,7 @@ section.Section.u-toggleableBySettingsBox data-state="open"
 section.Section.u-toggleableBySettingsBox data-state="open"
   h2 Metrics
   p
-    ' Hits are the built-in top-level metric and the parent metric of the methods. Other top level metrics can be added here if needed.
+    ' <em>Hits</em> is the built-in metric to which all methods report. Additional top-level metrics can be added here in order to track other usage that shouldn't increase the hit count.
     - if show_mappings?
       ' A metric needs to be mapped to one or more URL patterns in the
       => link_to 'Mapping Rules', edit_admin_service_integration_path(@service, anchor: 'mapping-rules'), data: { behavior: 'open-mapping-rules' }


### PR DESCRIPTION
**What this PR does / why we need it**:

Rewords the description of Metrics to make it more explicit that custom metrics are not included in _Hits_.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1206