### PR TITLE
[Bugfix] admin_buyers_application_url with an @application as param

### DIFF
--- a/app/views/notification_mailer/cinstance_expired_trial.html.slim
+++ b/app/views/notification_mailer/cinstance_expired_trial.html.slim
@@ -7,4 +7,4 @@ p
 p
   | #{@account.name} admin users have been notified and will receive an appropriately adjusted invoice for the next billing cycle.
 
-p= link_to 'View application', admin_buyers_application_url(@account)
+p= link_to 'View application', admin_buyers_application_url(@application)

--- a/app/views/notification_mailer/cinstance_expired_trial.text.erb
+++ b/app/views/notification_mailer/cinstance_expired_trial.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @receiver.informal_name %>
 <%= @account.name %>'s trial of the <%= application_friendly_name(@application) %> on the <%= @plan.name %> has expired.
 <%= @account.name %> admin users have been notified and will receive an appropriately adjusted invoice for the next billing cycle.
-To view application, follow this link: <%= admin_buyers_application_url(@account) %>
+To view application, follow this link: <%= admin_buyers_application_url(@application) %>
 
 

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -289,6 +289,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match 'Dear Foobar Admin', body.encoded
       assert_match "Alex's trial of the LALA application on the planLALA has expired.", body.encoded
+      assert_match url_helpers.admin_buyers_application_url(cinstance, host: cinstance.service.provider.admin_domain), body.encoded
     end
   end
 


### PR DESCRIPTION
`admin_buyers_application_url` should be from an `application` and not from an `account`.