### PR TITLE
reCAPTCHA doesn't work in on-premises

### DIFF
--- a/app/lib/three_scale/spam_protection/protector.rb
+++ b/app/lib/three_scale/spam_protection/protector.rb
@@ -34,9 +34,10 @@ module ThreeScale::SpamProtection
 
       attr_reader :form, :protector
 
-      delegate :template, :to => :form
-      delegate :logged_in?, :to => :template, allow_nil: true
-      delegate :is_spam?, :checks, :to => :protector
+      delegate :template, to: :form
+      delegate :logged_in?, to: :template, allow_nil: true
+      delegate :is_spam?, :checks, to: :protector
+      delegate :captcha_configured?, to: Recaptcha
 
       def initialize(form, protector)
         @form = form
@@ -56,11 +57,11 @@ module ThreeScale::SpamProtection
       end
 
       def captcha_required?
-        not logged_in? and level == :captcha
+        (captcha_configured? && level == :captcha) && !logged_in?
       end
 
       def captcha_needed?
-        captcha_required? or not http_method.get? && is_spam?
+        captcha_required? || (!http_method.get? && is_spam?)
       end
 
       def enabled?

--- a/app/views/sites/spam_protections/edit.html.erb
+++ b/app/views/sites/spam_protections/edit.html.erb
@@ -6,9 +6,10 @@
   <%= form.inputs 'Spam protection against users that are not signed in' do %>
     <%= form.input  :spam_protection_level,
                 :label => false,
-                :hint => "When 'Suspicious only' is selected then CAPTCHA is shown only if the automated checks detect a possible spammer. For 'Always', CAPTCHA will always appear when a form is presented to a user who is not logged in.",
+                hint: t(".captcha_hint_#{Recaptcha.captcha_configured?.to_s}"),
                 :as => :radio,
-                :collection => ThreeScale::SpamProtection::Configuration::LEVELS  %>
+                :collection => ThreeScale::SpamProtection::Configuration::LEVELS,
+                disabled: !Recaptcha.captcha_configured?  %>
     <% end %>
 
   <%= form.buttons do %>

--- a/config/initializers/captchas.rb
+++ b/config/initializers/captchas.rb
@@ -1,30 +1,14 @@
-
-CAPTCHA_QUESTIONS = [ {:question => "What letter comes next: A B C...?", :answer => "D"},
-                      {:question => "What letter is missing A B ? D?", :answer => "C"},
-                      {:question => "What is the number before 12 and after 10? (number)", :answer => "11"},
-                      {:question => "Five times 2 is what? (number)", :answer => "10"},
-                      {:question => "Insert the next number in this sequence: 14, 16, ??, 20", :answer => "18"},
-                      {:question => "What is the number in our company's name (number)?", :answer => "3"},
-                      {:question => "Ten divided by two is what? (number)", :answer => "5"},
-                      {:question => "What day comes after Monday?", :answer => "tuesday"},
-                      {:question => "What is the last month of the year?", :answer => "december"},
-                      {:question => "How many minutes are there in two hours? (number)", :answer => "120"},
-                      {:question => "What is the opposite of down?", :answer => "up"},
-                      {:question => "What is the opposite of north?", :answer => "south"},
-                      {:question => "What is the opposite of bad?", :answer => "good"},
-                      {:question => "What is one times four? (number)", :answer => "4"},
-                      {:question => "What number comes after 20? (number)", :answer => "21"},
-                      {:question => "What month comes before July?", :answer => "june"},
-                      {:question => "What is fifteen divided by three? (number)", :answer => "5"},
-                      {:question => "What is equal to zero? (number)", :answer => "0"},
-                      {:question => "What comes next? 'Monday Tuesday Wednesday ?????'", :answer => "thursday"},
-                      {:question => "The grass is...?", :answer => "green"},
-                      {:question => "The grass is green, violets are...?", :answer => "blue"},
-                      {:question => "Write this text: '3scale'", :answer => "3scale"}]
+# frozen_string_literal: true
 
 Recaptcha.configure do |config|
   # Do not verify recaptcha keys if it is not correctly configured
   (config.skip_verify_env ||= []) << Rails.env if Rails.configuration.three_scale.recaptcha_private_key.blank?
   config.site_key = Rails.configuration.three_scale.recaptcha_public_key
   config.secret_key = Rails.configuration.three_scale.recaptcha_private_key
+end
+
+module Recaptcha
+  def self.captcha_configured?
+    Recaptcha.configuration.skip_verify_env.exclude?(Rails.env)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -407,6 +407,10 @@ en:
         resume: 'resumed'
 
   sites:
+    spam_protections: 
+      edit:
+        captcha_hint_false: 'reCAPTCHA has not been configured correctly, Spam Protection cannot be enabled.'
+        captcha_hint_true: "When 'Suspicious only' is selected then reCAPTCHA is shown only if the automated checks detect a possible spammer. For 'Always', reCAPTCHA will always appear when a form is presented to a user who is not logged in."
     usage_rules:
       edit:
         sso_integrations_info_html: |

--- a/lib/forum_support/posts.rb
+++ b/lib/forum_support/posts.rb
@@ -73,35 +73,5 @@ module ForumSupport
         @forum
       end
     end
-
-
-    # def show
-    #   respond_to do |format|
-    #     #FIXME this redirection fails when used on admin, the route is built wrong
-    #     format.html { redirect_to forum_topic(@forum, @topic) }
-    #     format.xml  do
-    #       find_post
-    #       render :xml  => @post
-    #     end
-    #   end
-    # end
-
-    # def new
-    #   @post = Post.new
-    #   @quiz_id = rand(CAPTCHA_QUESTIONS.length) # create the captcha question
-    #   respond_to do |format|
-    #     format.html
-    #     format.xml { render :xml => @post }
-    #   end
-    # end
-
-
-    # def human_tested
-    #   if @user.anonymous?
-    #     verify_recaptcha(:model => @post, :message => "Oh! It's error with reCAPTCHA!")
-    #   else
-    #     true
-    #   end
-    # end
   end
 end

--- a/test/integration/sites/spam_protection_test.rb
+++ b/test/integration/sites/spam_protection_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class Sites::SpamProtectionTest < ActionDispatch::IntegrationTest
+
+  def setup
+    provider = FactoryGirl.create(:provider_account)
+
+    login_provider provider
+
+    host! provider.admin_domain
+  end
+
+  def test_edit
+    get edit_admin_site_spam_protection_path
+    assert_response :success
+    assert_match 'reCAPTCHA has not been configured correctly', response.body
+
+    Recaptcha.expects(:captcha_configured?).returns(true).at_least_once
+    get edit_admin_site_spam_protection_path
+    assert_response :success
+    assert_not_match 'reCAPTCHA has not been configured correctly', response.body
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Not configured, but enabled reCaptcha breaks Developer portal login page.

Fixes https://issues.jboss.org/browse/THREESCALE-1108

