### PR TITLE
[WIP] Run porta from Docker Container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ run: $(DOCKER_COMPOSE)
 	@echo
 	@echo "======= Run ======="
 	@echo
-	$(DOCKER_COMPOSE) run --rm --name $(PROJECT)-build-run $(DOCKER_ENV) build bash -c "$(CMD)"
+	$(DOCKER_COMPOSE) run --rm --service-ports --name $(PROJECT)-build-run $(DOCKER_ENV) build bash -c "$(CMD)"
 
 bash: ## Opens up shell to environment where tests can be ran
 bash: CMD = script/docker.sh && bundle exec rake db:create db:test:load && bundle exec bash

--- a/docker-compose.test-mysql.yml
+++ b/docker-compose.test-mysql.yml
@@ -16,7 +16,7 @@ services:
     container_name: ${PROJECT:-system}-build
     network_mode: bridge
     ports:
-      - "3000:3000"
+      - "3000"
     cap_add:
       - SYS_PTRACE
     environment:

--- a/docker-compose.test-mysql.yml
+++ b/docker-compose.test-mysql.yml
@@ -15,6 +15,8 @@ services:
     dns: 127.0.0.1
     container_name: ${PROJECT:-system}-build
     network_mode: bridge
+    ports:
+      - "3000:3000"
     cap_add:
       - SYS_PTRACE
     environment:


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes port 3000 from docker.
The idea behind this PR is to make porta work from the docker container out of the box, as it is described in [Entering a Running Container](https://github.com/3scale/porta/blob/master/INSTALL.md#entering-a-running-container).

**Which issue(s) this PR fixes** 

This one addresses issue #52. 

**Verification steps**
1. Follow [INSTALL.md](https://github.com/3scale/porta/blob/master/INSTALL.md) instrucctions until [Entering a running container](https://github.com/3scale/porta/blob/master/INSTALL.md#entering-a-running-container)
2. Open [localhost:3000](http://localhost:3000) and verify porta is running and accessible