### PR TITLE
Clean Dashboard link to have service_id only once

### DIFF
--- a/app/views/provider/admin/dashboards/widgets/_service_integration_errors.html.slim
+++ b/app/views/provider/admin/dashboards/widgets/_service_integration_errors.html.slim
@@ -1,6 +1,6 @@
 - loaded = widget.loaded? && widget.value
 li id=(widget.id) class=("DashboardNavigation-list-item u-notice" if loaded)
   - if loaded
-    = link_to admin_service_errors_path(widget.params), title: 'Integration Errors', class: 'DashboardNavigation-link DashboardNavigation-link--alert' do
+    = link_to admin_service_errors_path(widget.params[:service_id]), title: 'Integration Errors', class: 'DashboardNavigation-link DashboardNavigation-link--alert' do
       ' Integration Errors
       i.fa.fa-exclamation-circle


### PR DESCRIPTION
Related to [THREESCALE-1331](https://issues.jboss.org/browse/THREESCALE-1331) and https://github.com/3scale/porta/pull/49
Now it points to a clean URL:
![image](https://user-images.githubusercontent.com/11318903/46158851-109a8f80-c27f-11e8-99a5-593949e23a22.png)
So `services/2/errors` instead of `/services/2/errors?service_id=2`