### PR TITLE
[Service - ApiDocs relationship] Create relationship and adapt endpoints for Create and Update (UI & API)

### DIFF
--- a/app/controllers/admin/api/api_docs_services_controller.rb
+++ b/app/controllers/admin/api/api_docs_services_controller.rb
@@ -78,7 +78,7 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   ##~ op.parameters.add :name => "skip_swagger_validations", :description => "Set to 'true' to skip validation of the Swagger specification, or 'false' to validate the spec", :dataType => "boolean", :paramType => "query"
   #
   def update
-    @api_docs_service.update_attributes(api_docs_params)
+    @api_docs_service.update(api_docs_params, without_protection: true)
     respond_with(@api_docs_service)
   end
 
@@ -105,7 +105,7 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   protected
 
   def api_docs_params(*extra_params)
-    permit_params = %i(name body description published skip_swagger_validations) + extra_params
+    permit_params = %i[name body description published skip_swagger_validations service_id] + extra_params
     params.require(:api_docs_service).permit(*permit_params)
   end
 

--- a/app/controllers/admin/api/api_docs_services_controller.rb
+++ b/app/controllers/admin/api/api_docs_services_controller.rb
@@ -44,9 +44,12 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   ##~ op.description = "Creates a new ActiveDocs spec"
   ##~ op.group = "active_docs"
   #
+  ##~ @parameter_service_id = {:name => "service_id", :description => "Service ID of the ActiveDocs spec", :dataType => "int", :paramType => "query", :required => false}
+  #
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add :name => "name", :description => "Name of the ActiveDocs spec", :required => true, :dataType => "string", :paramType => "query"
   ##~ op.parameters.add :name => "system_name", :description => "System Name of the ActiveDocs spec. Only ASCII letters, numbers, dashes and underscores are allowed. If blank, 'system_name' will be generated from the 'name' parameter", :required => false, :dataType => "string", :paramType => "query"
+  ##~ op.parameters.add @parameter_service_id
   ##~ op.parameters.add :name => "body", :description => "ActiveDocs specification in JSON format (based on Swagger)", :dataType => "string", :required => true, :paramType => "query"
   ##~ op.parameters.add :name => "description", :description => "Description of the ActiveDocs spec", :dataType => "string", :paramType => "query"
   ##~ op.parameters.add :name => "published", :description => "Set to 'true' to publish the spec on the developer portal, or 'false' to hide it. The default value is 'false'", :dataType => "boolean", :paramType => "query"
@@ -72,6 +75,7 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_active_doc_id_by_id
   ##~ op.parameters.add :name => "name", :description => "Name of the ActiveDocs spec", :required => false, :dataType => "string", :paramType => "query"
+  ##~ op.parameters.add @parameter_service_id
   ##~ op.parameters.add :name => "body", :description => "ActiveDocs specification in JSON format (based on Swagger)", :dataType => "string", :paramType => "query"
   ##~ op.parameters.add :name => "description", :description => "Description of the ActiveDocs spec", :dataType => "string", :paramType => "query"
   ##~ op.parameters.add :name => "published", :description => "Set to 'true' to publish the spec on the developer portal, or 'false' to hide it", :dataType => "boolean", :paramType => "query"

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -99,7 +99,7 @@ class ApiDocs::Service < ApplicationRecord
 
   def service_belongs_to_account
     return true if account.services.accessible.where(id: service_id).exists?
-    errors.add(:base, :service_account_mismatch)
+    errors.add(:service, :not_found)
   end
 
   def should_notify?

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -18,6 +18,7 @@ class ApiDocs::Service < ApplicationRecord
   validates :name, :system_name, :base_path, :swagger_version, length: { maximum: 255 }
   validates :description, length: { maximum: 65535 }
   validates :body, length: { maximum: 4294967295, allow_blank: true }
+  validate :service_belongs_to_account, if: -> { service_id.present? && service_id_changed? }
 
   scope :published, -> { where(published: true) }
 
@@ -94,6 +95,12 @@ class ApiDocs::Service < ApplicationRecord
   end
 
   private
+
+  def service_belongs_to_account
+    return true if account.services.accessible.where(id: service_id).exists?
+    errors.add(:base, :service_account_mismatch)
+  end
+
   def should_notify?
     NotificationCenter.new(self).enabled?
   end

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -6,7 +6,7 @@ class ApiDocs::Service < ApplicationRecord
   extend System::Database::Scopes::IdOrSystemName
 
   belongs_to :account, required: true
-  belongs_to :service, class_name: '::Service'
+  belongs_to :service, class_name: '::Service', inverse_of: :api_docs_services
 
   attr_accessible :account, :body, :name, :description, :published, :skip_swagger_validations
   attr_readonly :system_name

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -6,7 +6,7 @@ class ApiDocs::Service < ApplicationRecord
   extend System::Database::Scopes::IdOrSystemName
 
   belongs_to :account, required: true
-  belongs_to :service
+  belongs_to :service, class_name: '::Service'
 
   attr_accessible :account, :body, :name, :description, :published, :skip_swagger_validations
   attr_readonly :system_name
@@ -21,6 +21,7 @@ class ApiDocs::Service < ApplicationRecord
   validate :service_belongs_to_account, if: -> { service_id.present? && service_id_changed? }
 
   scope :published, -> { where(published: true) }
+  scope :accessible, -> { joining { service.outer }.where.has { (service_id == nil) | (service.state != ::Service::DELETE_STATE) } }
 
   before_save :set_default_values
   before_save :prepare_base_path_notify

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -6,6 +6,7 @@ class ApiDocs::Service < ApplicationRecord
   extend System::Database::Scopes::IdOrSystemName
 
   belongs_to :account, required: true
+  belongs_to :service
 
   attr_accessible :account, :body, :name, :description, :published, :skip_swagger_validations
   attr_readonly :system_name

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -34,6 +34,7 @@ class Service < ApplicationRecord
     service.has_many :service_plans, as: :issuer, &DefaultPlanProxy
     service.has_many :application_plans, as: :issuer, &DefaultPlanProxy
     service.has_many :end_user_plans, &DefaultPlanProxy
+    service.has_many :api_docs_services, class_name: 'ApiDocs::Service'
   end
 
   def self.columns

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -90,7 +90,7 @@ class Service < ApplicationRecord
 
   has_many :service_tokens, inverse_of: :service, dependent: :destroy
 
-  scope :accessible, -> { where.not(state: DELETE_STATE.freeze) }
+  scope :accessible, -> { where.not(state: DELETE_STATE) }
   scope :of_approved_accounts, -> { joins(:account).merge(Account.approved) }
 
   validates :tech_support_email, :admin_support_email, :credit_card_support_email, format: { with: /.+@.+\..+/, allow_blank: true }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -10,6 +10,7 @@ class Service < ApplicationRecord
   include Logic::RollingUpdates::Service
   include SystemName
   extend System::Database::Scopes::IdOrSystemName
+  DELETE_STATE = 'deleted'.freeze
 
   has_system_name uniqueness_scope: :account_id
 
@@ -89,7 +90,7 @@ class Service < ApplicationRecord
 
   has_many :service_tokens, inverse_of: :service, dependent: :destroy
 
-  scope :accessible, -> { where.not(state: 'deleted'.freeze) }
+  scope :accessible, -> { where.not(state: DELETE_STATE.freeze) }
   scope :of_approved_accounts, -> { joins(:account).merge(Account.approved) }
 
   validates :tech_support_email, :admin_support_email, :credit_card_support_email, format: { with: /.+@.+\..+/, allow_blank: true }

--- a/app/representers/api_docs/service_representer.rb
+++ b/app/representers/api_docs/service_representer.rb
@@ -10,6 +10,7 @@ module ApiDocs::ServiceRepresenter
   property :published
   property :skip_swagger_validations
   property :body
+  property :service_id
 
   property :created_at
   property :updated_at

--- a/app/views/admin/api_docs/services/_form.html.slim
+++ b/app/views/admin/api_docs/services/_form.html.slim
@@ -9,6 +9,7 @@
     = form.input :system_name, input_html: { :disabled => true }
   = form.input :published, label: 'Publish?'
   = form.input :description, input_html: {rows: 3}
+  = form.input :service_id, as: :select, collection: @service_apis
   = form.input :body, label: 'API JSON Spec', inline_errors: :list
   = form.semantic_errors :base_path
   = form.input :skip_swagger_validations, as: :boolean

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -794,6 +794,11 @@ en:
             kind:
               not_found: "unavailable for this account type"
 
+        api_docs/service:
+          attributes:
+            base:
+              service_account_mismatch: 'The service must belong to the same account.'
+
         metric:
           attributes:
             base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -796,8 +796,8 @@ en:
 
         api_docs/service:
           attributes:
-            base:
-              service_account_mismatch: 'The service must belong to the same account.'
+            service:
+              not_found: 'not found'
 
         metric:
           attributes:

--- a/db/migrate/20180928114956_add_service_to_api_docs.rb
+++ b/db/migrate/20180928114956_add_service_to_api_docs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddServiceToApiDocs < ActiveRecord::Migration
+  def change
+    add_column :api_docs_services, :service_id, :integer, limit: 8, index: true
+    add_foreign_key :api_docs_services, :services
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180913135328) do
+ActiveRecord::Schema.define(version: 20180928114956) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -140,7 +140,10 @@ ActiveRecord::Schema.define(version: 20180913135328) do
     t.string   "base_path"
     t.string   "swagger_version"
     t.boolean  "skip_swagger_validations", limit: nil,                default: false
+    t.integer  "service_id",                           precision: 38
   end
+
+  add_index "api_docs_services", ["service_id"], name: "index_api_docs_services_on_service_id"
 
   create_table "application_keys", force: :cascade do |t|
     t.integer  "application_id", precision: 38, null: false
@@ -1418,6 +1421,7 @@ ActiveRecord::Schema.define(version: 20180913135328) do
     t.boolean  "application_key_updated_on",      limit: nil,                default: false
   end
 
+  add_foreign_key "api_docs_services", "services"
   add_foreign_key "event_store_events", "accounts", column: "provider_id", on_delete: :cascade
   add_foreign_key "payment_details", "accounts", on_delete: :cascade
   add_foreign_key "proxy_configs", "proxies", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180913135328) do
+ActiveRecord::Schema.define(version: 20180928114956) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -140,7 +140,10 @@ ActiveRecord::Schema.define(version: 20180913135328) do
     t.string   "base_path",                limit: 255
     t.string   "swagger_version",          limit: 255
     t.boolean  "skip_swagger_validations",                    default: false
+    t.integer  "service_id",               limit: 8
   end
+
+  add_index "api_docs_services", ["service_id"], name: "fk_rails_e4d18239f1", using: :btree
 
   create_table "application_keys", force: :cascade do |t|
     t.integer  "application_id", limit: 8,   null: false
@@ -1419,6 +1422,7 @@ ActiveRecord::Schema.define(version: 20180913135328) do
     t.boolean  "application_key_updated_on",                  default: false
   end
 
+  add_foreign_key "api_docs_services", "services"
   add_foreign_key "event_store_events", "accounts", column: "provider_id", on_delete: :cascade
   add_foreign_key "payment_details", "accounts", on_delete: :cascade
   add_foreign_key "proxy_configs", "proxies", on_delete: :cascade

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -991,6 +991,13 @@
               "paramType": "query"
             },
             {
+              "name": "service_id",
+              "description": "Service ID of the ActiveDocs spec",
+              "dataType": "int",
+              "paramType": "query",
+              "required": false
+            },
+            {
               "name": "body",
               "description": "ActiveDocs specification in JSON format (based on Swagger)",
               "dataType": "string",
@@ -1050,6 +1057,13 @@
               "required": false,
               "dataType": "string",
               "paramType": "query"
+            },
+            {
+              "name": "service_id",
+              "description": "Service ID of the ActiveDocs spec",
+              "dataType": "int",
+              "paramType": "query",
+              "required": false
             },
             {
               "name": "body",

--- a/lib/developer_portal/lib/liquid/drops/provider.rb
+++ b/lib/developer_portal/lib/liquid/drops/provider.rb
@@ -201,7 +201,7 @@ module Liquid
 
       desc 'Returns API spec collection.'
       def api_specs
-        Drops::Collection.for_drop(Drops::ApiSpec).new(@model.api_docs_services)
+        Drops::Collection.for_drop(Drops::ApiSpec).new(@model.api_docs_services.accessible)
       end
 
       private

--- a/test/integration/admin/api/api_docs_services_controller_test.rb
+++ b/test/integration/admin/api/api_docs_services_controller_test.rb
@@ -10,13 +10,13 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
 
   class MasterAccountTest < Admin::Api::ApiDocsServicesControllerTest
     def test_index_json_saas
-      get admin_api_docs_services_path
+      get admin_api_active_docs_path
       assert_response :success
     end
 
     def test_index_json_on_premises
       ThreeScale.stubs(master_on_premises?: true)
-      get admin_api_docs_services_path
+      get admin_api_active_docs_path
       assert_response :forbidden
     end
 
@@ -24,6 +24,84 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
 
     def current_account
       master_account
+    end
+  end
+
+  class ProviderAccountTest < Admin::Api::ApiDocsServicesControllerTest
+    setup do
+      @provider = FactoryGirl.create(:provider_account)
+      @service = @provider.default_service
+      @api_docs_service = @provider.api_docs_services.create!({name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'})
+    end
+
+    attr_reader :provider, :service, :api_docs_service
+    alias current_account provider
+
+    def test_create_sets_all_attributes
+      assert_difference ::ApiDocs::Service.method(:count) do
+        post admin_api_active_docs_path(create_params(service_id: service.id, system_name: 'smart_service'))
+        assert_response :created
+      end
+
+      api_docs_service = provider.api_docs_services.last!
+      assert_equal 'smart_service', api_docs_service.system_name
+      assert_equal service.id, api_docs_service.service_id
+      create_params[:api_docs_service].each do |name, value|
+        expected_value = %i[published skip_swagger_validations].include?(name) ? (value == '1') : value
+        assert_equal expected_value, api_docs_service.public_send(name)
+      end
+      assert_equal provider.id, api_docs_service.account_id
+    end
+
+    def test_update_with_right_params
+      put admin_api_active_doc_path(api_docs_service), update_params(service_id: service.id)
+      assert_response :success
+
+      api_docs_service.reload
+      update_params[:api_docs_service].each do |name, value|
+        expected_value = %i[published skip_swagger_validations].include?(name) ? (value == '1') : value
+        assert_equal expected_value, api_docs_service.public_send(name)
+      end
+      assert_equal provider.id, api_docs_service.account_id
+    end
+
+    def test_update_can_remove_service
+      api_docs_service.update_attribute(:service_id, provider.default_service_id)
+      put admin_api_active_doc_path(api_docs_service), update_params(service_id: '')
+      assert_response :success
+      assert_nil api_docs_service.reload.service_id
+    end
+
+    def test_system_name_is_not_updated
+      old_system_name = api_docs_service.system_name
+      put admin_api_active_doc_path(api_docs_service), update_params(system_name: "#{old_system_name}-2")
+      assert_response :success
+      assert_equal old_system_name, api_docs_service.reload.system_name
+    end
+
+    def test_update_invalid_params
+      old_body = api_docs_service.body
+      put admin_api_active_doc_path(api_docs_service, format: :json), update_params(body: '{apis: []}')
+      assert_response :unprocessable_entity
+      assert_contains JSON.parse(response.body).dig('errors', 'body'), 'JSON Spec is invalid'
+      assert_equal old_body, api_docs_service.reload.body
+    end
+
+    private
+
+    def create_params(different_params = {})
+      @create_params ||= api_docs_params(different_params)
+    end
+
+    def update_params(different_params = {})
+      @update_params ||= api_docs_params(different_params).merge({id: api_docs_service.id})
+    end
+
+    def api_docs_params(different_params = {})
+      { api_docs_service: {
+        name: 'update_servone', body: '{"apis": [{"foo": "bar"}], "basePath": "http://example.net"}',
+        description: 'updated description', published: '1', skip_swagger_validations: '0'
+      }.merge(different_params) }
     end
   end
 end

--- a/test/integration/admin/api/api_docs_services_controller_test.rb
+++ b/test/integration/admin/api/api_docs_services_controller_test.rb
@@ -90,7 +90,7 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
     def test_update_unexistent_service
       put admin_api_active_doc_path(api_docs_service, format: :json), update_params(service_id: 200)
       assert_response :unprocessable_entity
-      assert_contains JSON.parse(response.body).dig('errors', 'base'), 'The service must belong to the same account.'
+      assert_contains JSON.parse(response.body).dig('errors', 'service'), 'not found'
     end
 
     private

--- a/test/integration/admin/api/api_docs_services_controller_test.rb
+++ b/test/integration/admin/api/api_docs_services_controller_test.rb
@@ -87,6 +87,12 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
       assert_equal old_body, api_docs_service.reload.body
     end
 
+    def test_update_unexistent_service
+      put admin_api_active_doc_path(api_docs_service, format: :json), update_params(service_id: 200)
+      assert_response :unprocessable_entity
+      assert_contains JSON.parse(response.body).dig('errors', 'base'), 'The service must belong to the same account.'
+    end
+
     private
 
     def create_params(different_params = {})

--- a/test/integration/admin/api_docs/services_controller_test.rb
+++ b/test/integration/admin/api_docs/services_controller_test.rb
@@ -72,7 +72,7 @@ class Admin::ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
 
     def test_update_unexistent_service
       put admin_api_docs_service_path(api_docs_service), update_params(service_id: 200)
-      assert_includes flash[:error], 'The service must belong to the same account.'
+      assert_includes flash[:error], 'Service not found'
     end
 
     private

--- a/test/integration/admin/api_docs/services_controller_test.rb
+++ b/test/integration/admin/api_docs/services_controller_test.rb
@@ -9,20 +9,71 @@ class Admin::ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
   end
 
   class ProviderLoggedInTest < Admin::ApiDocs::ServicesControllerTest
+    setup do
+      @provider = FactoryGirl.create(:provider_account)
+      @service = @provider.default_service
+      @api_docs_service = @provider.api_docs_services.create!({name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'})
+    end
 
-    test '#create sets the system_name' do
+    test '#create sets all the attributes, including the system_name and the service_id' do
       assert_difference ::ApiDocs::Service.method(:count) do
-        post admin_api_docs_services_path(create_params)
+        post admin_api_docs_services_path(create_params(service_id: service.id, system_name: 'smart_service'))
         assert_response :redirect
       end
-      assert_equal create_params[:api_docs_service][:system_name], api_docs_service.system_name
+
+      api_docs_service = provider.api_docs_services.last!
+      assert_equal 'smart_service', api_docs_service.system_name
+      assert_equal service.id, api_docs_service.service_id
+      create_params[:api_docs_service].each do |name, value|
+        expected_value = %i[published skip_swagger_validations].include?(name) ? (value == '1') : value
+        assert_equal expected_value, api_docs_service.public_send(name)
+      end
+      assert_equal provider.id, api_docs_service.account_id
+    end
+
+    test '#update with the right params' do
+      put admin_api_docs_service_path(api_docs_service), update_params(service_id: service.id)
+      assert_response :redirect
+      assert_equal 'ActiveDocs Spec was successfully updated.', flash[:notice]
+
+      api_docs_service.reload
+      update_params[:api_docs_service].each do |name, value|
+        expected_value = %i[published skip_swagger_validations].include?(name) ? (value == '1') : value
+        assert_equal expected_value, api_docs_service.public_send(name)
+      end
+      assert_equal provider.id, api_docs_service.account_id
+    end
+
+    def test_update_can_remove_service
+      api_docs_service.update_attribute(:service_id, provider.default_service_id)
+
+      put admin_api_docs_service_path(api_docs_service), update_params(service_id: '')
+      assert_response :redirect
+      assert_equal 'ActiveDocs Spec was successfully updated.', flash[:notice]
+
+      assert_nil api_docs_service.reload.service_id
+    end
+
+    def test_system_name_is_not_updated
+      old_system_name = api_docs_service.system_name
+
+      put admin_api_docs_service_path(api_docs_service), update_params(system_name: "#{old_system_name}-2")
+
+      assert_response :redirect
+      assert_equal old_system_name, api_docs_service.reload.system_name
+    end
+
+    def test_update_invalid_params
+      old_body = api_docs_service.body
+      put admin_api_docs_service_path(api_docs_service), update_params(body: '{apis: []}')
+      assert_includes flash[:error], 'JSON Spec is invalid'
+      assert_equal old_body, api_docs_service.reload.body
     end
 
     private
 
-    def current_account
-      @provider ||= FactoryGirl.create(:provider_account)
-    end
+    attr_reader :provider, :service, :api_docs_service
+    alias current_account provider
 
   end
 
@@ -99,12 +150,19 @@ class Admin::ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
 
   private
 
-  def create_params
-    { api_docs_service: { system_name: 'smart_service', name: 'servone', body: '{"basePath":"http://github.com", "apis":[]}'} }
+  def create_params(different_params = {})
+    @create_params ||= api_docs_params(different_params)
   end
 
-  def update_params
-    { id: api_docs_service.id, api_docs_service: { name: 'update_servone'} }
+  def update_params(different_params = {})
+    @update_params ||= api_docs_params(different_params).merge({id: api_docs_service.id})
+  end
+
+  def api_docs_params(different_params = {})
+    { api_docs_service: {
+      name: 'update_servone', body: '{"apis": [{"foo": "bar"}], "basePath": "http://example.net"}',
+      description: 'updated description', published: '0', skip_swagger_validations: '0'
+    }.merge(different_params) }
   end
 
   def api_docs_service

--- a/test/integration/admin/api_docs/services_controller_test.rb
+++ b/test/integration/admin/api_docs/services_controller_test.rb
@@ -70,6 +70,11 @@ class Admin::ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_equal old_body, api_docs_service.reload.body
     end
 
+    def test_update_unexistent_service
+      put admin_api_docs_service_path(api_docs_service), update_params(service_id: 200)
+      assert_includes flash[:error], 'The service must belong to the same account.'
+    end
+
     private
 
     attr_reader :provider, :service, :api_docs_service

--- a/test/unit/api_docs/service_test.rb
+++ b/test/unit/api_docs/service_test.rb
@@ -538,6 +538,15 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
   end
 
+  test 'scope accessible' do
+    services = FactoryGirl.create_list(:service, 2, account: account)
+    account.api_docs_services.create!(valid_attributes.merge({name: 'accessible'})) # accessible without service
+    account.api_docs_services.create!(valid_attributes.merge({service: services.first, name: 'service-accessible'}), without_protection: true) # accessible with service
+    account.api_docs_services.create!(valid_attributes.merge({service: services.last, name: 'service'}), without_protection: true) # non-accessible with service
+    services.last.mark_as_deleted!
+    assert_same_elements %w[accessible service-accessible], ApiDocs::Service.accessible.pluck(:name)
+  end
+
   private
 
   def valid_attributes

--- a/test/unit/api_docs/service_test.rb
+++ b/test/unit/api_docs/service_test.rb
@@ -515,7 +515,6 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     service          = FactoryGirl.build(:service)
     account          = service.account
     another_account  = FactoryGirl.build(:simple_provider)
-    valid_attributes = {name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'}
 
     api_doc = service.api_docs_services.new(valid_attributes)
     api_doc.account = account
@@ -534,4 +533,11 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     refute api_doc.valid?
     assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
   end
+
+  private
+
+  def valid_attributes
+    @valid_attribures ||= {name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'}
+  end
+
 end

--- a/test/unit/api_docs/service_test.rb
+++ b/test/unit/api_docs/service_test.rb
@@ -512,9 +512,9 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
   end
 
   test 'It validates the Service belongs to the Account if both are set' do
-    service          = FactoryGirl.build(:service)
+    service          = FactoryGirl.create(:service)
     account          = service.account
-    another_account  = FactoryGirl.build(:simple_provider)
+    another_account  = FactoryGirl.create(:simple_provider)
 
     api_doc = service.api_docs_services.new(valid_attributes)
     api_doc.account = account
@@ -532,12 +532,16 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     api_doc.service = service
     refute api_doc.valid?
     assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
+
+    api_doc = account.api_docs_services.new(valid_attributes.merge({service_id: service.id + 1000}), without_protection: true)
+    refute api_doc.valid?
+    assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
   end
 
   private
 
   def valid_attributes
-    @valid_attribures ||= {name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'}
+    @valid_attributes ||= {name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'}
   end
 
 end

--- a/test/unit/api_docs/service_test.rb
+++ b/test/unit/api_docs/service_test.rb
@@ -526,16 +526,16 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     api_doc = service.api_docs_services.new(valid_attributes)
     api_doc.account = another_account
     refute api_doc.valid?
-    assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
+    assert_includes api_doc.errors[:service], 'not found'
 
     api_doc = another_account.api_docs_services.new(valid_attributes)
     api_doc.service = service
     refute api_doc.valid?
-    assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
+    assert_includes api_doc.errors[:service], 'not found'
 
     api_doc = account.api_docs_services.new(valid_attributes.merge({service_id: service.id + 1000}), without_protection: true)
     refute api_doc.valid?
-    assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
+    assert_includes api_doc.errors[:service], 'not found'
   end
 
   test 'scope accessible' do


### PR DESCRIPTION
Part of [THREESCALE-1340](https://issues.jboss.org/browse/THREESCALE-1340)
Depends on https://github.com/3scale/infrastructure/issues/546

### Goals
- ApiDocs allows for service selection in edit so customers with free floating api docs can attach them to a service.
- If imported as part of "discovering a service" from the cluster, we should be able to also update that api doc when the service is updated ("rediscovered").

### New Endpoints

#### UI
##### Create
- Create/New form filled:
![image](https://user-images.githubusercontent.com/11318903/46342871-3be4fc00-c63c-11e8-95be-4c5acdb632e6.png)
- Once created (it is another ActiveDocs creation 😄 but I post this one for the flash message):
![image](https://user-images.githubusercontent.com/11318903/46343215-579cd200-c63d-11e8-8043-7485d3304411.png)
##### Update
- Update/Edit form filled:
![image](https://user-images.githubusercontent.com/11318903/46343066-e52bf200-c63c-11e8-9dc3-af3ed82a85e1.png)
- Once edited:
![image](https://user-images.githubusercontent.com/11318903/46343093-f2e17780-c63c-11e8-8d47-501390d16b79.png)

#### API
##### Create
- Swagger:
![image](https://user-images.githubusercontent.com/11318903/46343943-bfecb300-c63f-11e8-85c0-35a43ebeaafe.png)
![image](https://user-images.githubusercontent.com/11318903/46343953-cbd87500-c63f-11e8-8bd1-481f21045ec9.png)
- Curl request: `curl -v  -X POST "http://provider-admin.example.com.lvh.me:3000/admin/api/active_docs.json" -d 'access_token=your-access-token&name=created+through+api&system_name=api-system-name&service_id=2&body=%7B%22apis%22%3A+%5B%7B%22foo%22%3A+%22bar%22%7D%5D%2C+%22basePath%22%3A+%22http%3A%2F%2Fexample.com%22%7D&description=Description+ActiveDocs+created+through+API&published=1'`
- Response:
```json
{
 "api_doc": {
  "id": 4,
  "system_name": "api-system-name",
  "name": "created through api",
  "description": "Description ActiveDocs created through API",
  "published": true,
  "skip_swagger_validations": false,
  "body": "{\"apis\": [{\"foo\": \"bar\"}], \"basePath\": \"http://example.com\"}",
  "service_id": 2,
  "created_at": "2018-10-02T10:36:19Z",
  "updated_at": "2018-10-02T10:36:19Z"
 }
}
```
##### Update
- Swagger:
![image](https://user-images.githubusercontent.com/11318903/46344051-2b368500-c640-11e8-9843-22c874e34861.png)
![image](https://user-images.githubusercontent.com/11318903/46344059-34275680-c640-11e8-8877-eb9ef7245998.png)
- Curl request: `curl -v  -X PUT "http://provider-admin.example.com.lvh.me:3000/admin/api/active_docs/4.json" -d 'access_token=your-access-token&name=Edited+through+API&service_id=3&body=%7B%22apis%22%3A+%5B%7B%22zoo%22%3A+%22panda%22%7D%5D%2C+%22basePath%22%3A+%22http%3A%2F%2Fexample.net%22%7D&description=New+description&published=0&skip_swagger_validations=1'`
- Response:
```json

{
 "api_doc": {
  "id": 4,
  "system_name": "api-system-name",
  "name": "Edited through API",
  "description": "New description",
  "published": false,
  "skip_swagger_validations": true,
  "body": "{\"apis\": [{\"zoo\": \"panda\"}], \"basePath\": \"http://example.net\"}",
  "service_id": 2,
  "created_at": "2018-10-02T10:36:19Z",
  "updated_at": "2018-10-02T10:39:17Z"
 }
}
```