### PR TITLE
Fixes SearchBoxTitle

### DIFF
--- a/app/javascript/src/Navigation/api_selector.jsx
+++ b/app/javascript/src/Navigation/api_selector.jsx
@@ -17,7 +17,7 @@ const Suggestions = (props) => {
 }
 
 const searchBoxTitle = (api, controllerName) => {
-  const title = (api && controllerName !== 'dashboards') ? `API: ${api.service.name.toUpperCase()}` : 'Jumpt to an API'
+  const title = (api && api.service.name && controllerName !== 'dashboards') ? `API: ${api.service.name.toUpperCase()} ` : 'Jump to an API '
   return (<span> {title} <i className='fa fa-chevron-down'></i></span>)
 }
 


### PR DESCRIPTION
I found what I believe is a bug. When creating a new service title is `API: `
![screen shot 2018-09-28 at 16 29 40](https://user-images.githubusercontent.com/11672286/46214804-2f129080-c33c-11e8-9094-53e4b04de608.png)



But I think it should be:
![screen shot 2018-09-28 at 16 29 13](https://user-images.githubusercontent.com/11672286/46214831-3c2f7f80-c33c-11e8-8898-dd689154b770.png)

Simplest solution is to check if `name` is empty but I think `api` should be `null` when in `apiconfig/services/new`.

