### PR TITLE
Fix N+1 Query on ProviderData#application_plan_ids for service of application_plans

### DIFF
--- a/lib/api_docs/provider_data.rb
+++ b/lib/api_docs/provider_data.rb
@@ -32,7 +32,7 @@ module ApiDocs
 
     PLAN_NAME = ->(plan) { "#{plan.name} | #{plan.service.name}" }
     def application_plan_ids
-      @account.application_plans.latest.map do |plan|
+      @account.application_plans.includes(:service).latest.map do |plan|
         { :name => PLAN_NAME.call(plan),
           :value => plan.id }
       end


### PR DESCRIPTION
As I am working on https://github.com/3scale/porta/pull/62, I've found this `N+1 Query`:
```
/p/admin/api_docs/account_data.json
N+1 Query detected
  ApplicationPlan => [:service]
  Add to your finder: :includes => [:service]
N+1 Query method call stack
  /Users/marta/Devel/porta/lib/api_docs/provider_data.rb:33:in `block in <class:ProviderData>'
  /Users/marta/Devel/porta/lib/api_docs/provider_data.rb:36:in `block in application_plan_ids'
  /Users/marta/Devel/porta/lib/api_docs/provider_data.rb:35:in `application_plan_ids'
  /Users/marta/Devel/porta/lib/api_docs/account_data.rb:13:in `block in account_data'
  /Users/marta/Devel/porta/lib/api_docs/account_data.rb:13:in `map'
  /Users/marta/Devel/porta/lib/api_docs/account_data.rb:13:in `account_data'
  /Users/marta/Devel/porta/lib/api_docs/account_data.rb:20:in `return_account_data'
  /Users/marta/Devel/porta/lib/api_docs/account_data.rb:9:in `as_json'
  /Users/marta/Devel/porta/app/controllers/provider/admin/api_docs/account_data_controller.rb:6:in `block (2 levels) in show'
  /Users/marta/Devel/porta/app/controllers/provider/admin/api_docs/account_data_controller.rb:5:in `show'
  /Users/marta/Devel/porta/lib/three_scale/middleware/dev_domain.rb:25:in `call'
  /Users/marta/Devel/porta/lib/three_scale/middleware/dev_domain.rb:25:in `call'
  /Users/marta/Devel/porta/lib/three_scale/middleware/multitenant.rb:116:in `_call'
  /Users/marta/Devel/porta/lib/three_scale/middleware/multitenant.rb:111:in `call'
  /Users/marta/Devel/porta/bin/rails:11:in `<top (required)>'
  /Users/marta/Devel/porta/bin/spring:13:in `require'
  /Users/marta/Devel/porta/bin/spring:13:in `<top (required)>'
```
And the same log already says how to fix it easily 😄 

