### PR TITLE
adds verification steps to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,5 +13,9 @@
 > Replace this comment with references to related issues. This will ensure the issue(s) are closed automatically when the PR gets merged.
 > e.g. `fixes #<issue number>(, fixes #<issue_number>, ...)`
 
+**Verification steps** 
+
+> Replace this with a list of necessary steps to verify the PR meets your expectations.
+> e.g. `1. Go to Admin Portal, make sure that ...`
 
 **Special notes for your reviewer**:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a suggestion for including the section **Verification Steps** in the PR template. It makes it easier and quicker for any reviewer to verify the issue has been addressed properly or that the changes work as expected.

