### PR TITLE
[Service - ApiDocs relationship] Adapt Liquid Drops to it

### DIFF
--- a/app/controllers/admin/api/api_docs_services_controller.rb
+++ b/app/controllers/admin/api/api_docs_services_controller.rb
@@ -78,7 +78,7 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   ##~ op.parameters.add :name => "skip_swagger_validations", :description => "Set to 'true' to skip validation of the Swagger specification, or 'false' to validate the spec", :dataType => "boolean", :paramType => "query"
   #
   def update
-    @api_docs_service.update_attributes(api_docs_params)
+    @api_docs_service.update(api_docs_params, without_protection: true)
     respond_with(@api_docs_service)
   end
 
@@ -105,7 +105,7 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   protected
 
   def api_docs_params(*extra_params)
-    permit_params = %i(name body description published skip_swagger_validations) + extra_params
+    permit_params = %i[name body description published skip_swagger_validations service_id] + extra_params
     params.require(:api_docs_service).permit(*permit_params)
   end
 

--- a/app/controllers/admin/api/api_docs_services_controller.rb
+++ b/app/controllers/admin/api/api_docs_services_controller.rb
@@ -44,9 +44,12 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   ##~ op.description = "Creates a new ActiveDocs spec"
   ##~ op.group = "active_docs"
   #
+  ##~ @parameter_service_id = {:name => "service_id", :description => "Service ID of the ActiveDocs spec", :dataType => "int", :paramType => "query", :required => false}
+  #
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add :name => "name", :description => "Name of the ActiveDocs spec", :required => true, :dataType => "string", :paramType => "query"
   ##~ op.parameters.add :name => "system_name", :description => "System Name of the ActiveDocs spec. Only ASCII letters, numbers, dashes and underscores are allowed. If blank, 'system_name' will be generated from the 'name' parameter", :required => false, :dataType => "string", :paramType => "query"
+  ##~ op.parameters.add @parameter_service_id
   ##~ op.parameters.add :name => "body", :description => "ActiveDocs specification in JSON format (based on Swagger)", :dataType => "string", :required => true, :paramType => "query"
   ##~ op.parameters.add :name => "description", :description => "Description of the ActiveDocs spec", :dataType => "string", :paramType => "query"
   ##~ op.parameters.add :name => "published", :description => "Set to 'true' to publish the spec on the developer portal, or 'false' to hide it. The default value is 'false'", :dataType => "boolean", :paramType => "query"
@@ -72,6 +75,7 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_active_doc_id_by_id
   ##~ op.parameters.add :name => "name", :description => "Name of the ActiveDocs spec", :required => false, :dataType => "string", :paramType => "query"
+  ##~ op.parameters.add @parameter_service_id
   ##~ op.parameters.add :name => "body", :description => "ActiveDocs specification in JSON format (based on Swagger)", :dataType => "string", :paramType => "query"
   ##~ op.parameters.add :name => "description", :description => "Description of the ActiveDocs spec", :dataType => "string", :paramType => "query"
   ##~ op.parameters.add :name => "published", :description => "Set to 'true' to publish the spec on the developer portal, or 'false' to hide it", :dataType => "boolean", :paramType => "query"

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -99,7 +99,7 @@ class ApiDocs::Service < ApplicationRecord
 
   def service_belongs_to_account
     return true if account.services.accessible.where(id: service_id).exists?
-    errors.add(:base, :service_account_mismatch)
+    errors.add(:service, :not_found)
   end
 
   def should_notify?

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -18,6 +18,7 @@ class ApiDocs::Service < ApplicationRecord
   validates :name, :system_name, :base_path, :swagger_version, length: { maximum: 255 }
   validates :description, length: { maximum: 65535 }
   validates :body, length: { maximum: 4294967295, allow_blank: true }
+  validate :service_belongs_to_account, if: -> { service_id.present? && service_id_changed? }
 
   scope :published, -> { where(published: true) }
 
@@ -94,6 +95,12 @@ class ApiDocs::Service < ApplicationRecord
   end
 
   private
+
+  def service_belongs_to_account
+    return true if account.services.accessible.where(id: service_id).exists?
+    errors.add(:base, :service_account_mismatch)
+  end
+
   def should_notify?
     NotificationCenter.new(self).enabled?
   end

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -6,7 +6,7 @@ class ApiDocs::Service < ApplicationRecord
   extend System::Database::Scopes::IdOrSystemName
 
   belongs_to :account, required: true
-  belongs_to :service, class_name: '::Service'
+  belongs_to :service, class_name: '::Service', inverse_of: :api_docs_services
 
   attr_accessible :account, :body, :name, :description, :published, :skip_swagger_validations
   attr_readonly :system_name

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -6,7 +6,7 @@ class ApiDocs::Service < ApplicationRecord
   extend System::Database::Scopes::IdOrSystemName
 
   belongs_to :account, required: true
-  belongs_to :service
+  belongs_to :service, class_name: '::Service'
 
   attr_accessible :account, :body, :name, :description, :published, :skip_swagger_validations
   attr_readonly :system_name
@@ -21,6 +21,7 @@ class ApiDocs::Service < ApplicationRecord
   validate :service_belongs_to_account, if: -> { service_id.present? && service_id_changed? }
 
   scope :published, -> { where(published: true) }
+  scope :accessible, -> { joining { service.outer }.where.has { (service_id == nil) | (service.state != ::Service::DELETE_STATE) } }
 
   before_save :set_default_values
   before_save :prepare_base_path_notify

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -6,6 +6,7 @@ class ApiDocs::Service < ApplicationRecord
   extend System::Database::Scopes::IdOrSystemName
 
   belongs_to :account, required: true
+  belongs_to :service
 
   attr_accessible :account, :body, :name, :description, :published, :skip_swagger_validations
   attr_readonly :system_name

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -34,6 +34,7 @@ class Service < ApplicationRecord
     service.has_many :service_plans, as: :issuer, &DefaultPlanProxy
     service.has_many :application_plans, as: :issuer, &DefaultPlanProxy
     service.has_many :end_user_plans, &DefaultPlanProxy
+    service.has_many :api_docs_services, class_name: 'ApiDocs::Service'
   end
 
   def self.columns

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -90,7 +90,7 @@ class Service < ApplicationRecord
 
   has_many :service_tokens, inverse_of: :service, dependent: :destroy
 
-  scope :accessible, -> { where.not(state: DELETE_STATE.freeze) }
+  scope :accessible, -> { where.not(state: DELETE_STATE) }
   scope :of_approved_accounts, -> { joins(:account).merge(Account.approved) }
 
   validates :tech_support_email, :admin_support_email, :credit_card_support_email, format: { with: /.+@.+\..+/, allow_blank: true }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -10,6 +10,7 @@ class Service < ApplicationRecord
   include Logic::RollingUpdates::Service
   include SystemName
   extend System::Database::Scopes::IdOrSystemName
+  DELETE_STATE = 'deleted'.freeze
 
   has_system_name uniqueness_scope: :account_id
 
@@ -89,7 +90,7 @@ class Service < ApplicationRecord
 
   has_many :service_tokens, inverse_of: :service, dependent: :destroy
 
-  scope :accessible, -> { where.not(state: 'deleted'.freeze) }
+  scope :accessible, -> { where.not(state: DELETE_STATE.freeze) }
   scope :of_approved_accounts, -> { joins(:account).merge(Account.approved) }
 
   validates :tech_support_email, :admin_support_email, :credit_card_support_email, format: { with: /.+@.+\..+/, allow_blank: true }

--- a/app/representers/api_docs/service_representer.rb
+++ b/app/representers/api_docs/service_representer.rb
@@ -10,6 +10,7 @@ module ApiDocs::ServiceRepresenter
   property :published
   property :skip_swagger_validations
   property :body
+  property :service_id
 
   property :created_at
   property :updated_at

--- a/app/views/admin/api_docs/services/_form.html.slim
+++ b/app/views/admin/api_docs/services/_form.html.slim
@@ -9,6 +9,7 @@
     = form.input :system_name, input_html: { :disabled => true }
   = form.input :published, label: 'Publish?'
   = form.input :description, input_html: {rows: 3}
+  = form.input :service_id, as: :select, collection: @service_apis
   = form.input :body, label: 'API JSON Spec', inline_errors: :list
   = form.semantic_errors :base_path
   = form.input :skip_swagger_validations, as: :boolean

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -794,6 +794,11 @@ en:
             kind:
               not_found: "unavailable for this account type"
 
+        api_docs/service:
+          attributes:
+            base:
+              service_account_mismatch: 'The service must belong to the same account.'
+
         metric:
           attributes:
             base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -796,8 +796,8 @@ en:
 
         api_docs/service:
           attributes:
-            base:
-              service_account_mismatch: 'The service must belong to the same account.'
+            service:
+              not_found: 'not found'
 
         metric:
           attributes:

--- a/db/migrate/20180928114956_add_service_to_api_docs.rb
+++ b/db/migrate/20180928114956_add_service_to_api_docs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddServiceToApiDocs < ActiveRecord::Migration
+  def change
+    add_column :api_docs_services, :service_id, :integer, limit: 8, index: true
+    add_foreign_key :api_docs_services, :services
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180913135328) do
+ActiveRecord::Schema.define(version: 20180928114956) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -140,7 +140,10 @@ ActiveRecord::Schema.define(version: 20180913135328) do
     t.string   "base_path"
     t.string   "swagger_version"
     t.boolean  "skip_swagger_validations", limit: nil,                default: false
+    t.integer  "service_id",                           precision: 38
   end
+
+  add_index "api_docs_services", ["service_id"], name: "index_api_docs_services_on_service_id"
 
   create_table "application_keys", force: :cascade do |t|
     t.integer  "application_id", precision: 38, null: false
@@ -1418,6 +1421,7 @@ ActiveRecord::Schema.define(version: 20180913135328) do
     t.boolean  "application_key_updated_on",      limit: nil,                default: false
   end
 
+  add_foreign_key "api_docs_services", "services"
   add_foreign_key "event_store_events", "accounts", column: "provider_id", on_delete: :cascade
   add_foreign_key "payment_details", "accounts", on_delete: :cascade
   add_foreign_key "proxy_configs", "proxies", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180913135328) do
+ActiveRecord::Schema.define(version: 20180928114956) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -140,7 +140,10 @@ ActiveRecord::Schema.define(version: 20180913135328) do
     t.string   "base_path",                limit: 255
     t.string   "swagger_version",          limit: 255
     t.boolean  "skip_swagger_validations",                    default: false
+    t.integer  "service_id",               limit: 8
   end
+
+  add_index "api_docs_services", ["service_id"], name: "fk_rails_e4d18239f1", using: :btree
 
   create_table "application_keys", force: :cascade do |t|
     t.integer  "application_id", limit: 8,   null: false
@@ -1419,6 +1422,7 @@ ActiveRecord::Schema.define(version: 20180913135328) do
     t.boolean  "application_key_updated_on",                  default: false
   end
 
+  add_foreign_key "api_docs_services", "services"
   add_foreign_key "event_store_events", "accounts", column: "provider_id", on_delete: :cascade
   add_foreign_key "payment_details", "accounts", on_delete: :cascade
   add_foreign_key "proxy_configs", "proxies", on_delete: :cascade

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -991,6 +991,13 @@
               "paramType": "query"
             },
             {
+              "name": "service_id",
+              "description": "Service ID of the ActiveDocs spec",
+              "dataType": "int",
+              "paramType": "query",
+              "required": false
+            },
+            {
               "name": "body",
               "description": "ActiveDocs specification in JSON format (based on Swagger)",
               "dataType": "string",
@@ -1050,6 +1057,13 @@
               "required": false,
               "dataType": "string",
               "paramType": "query"
+            },
+            {
+              "name": "service_id",
+              "description": "Service ID of the ActiveDocs spec",
+              "dataType": "int",
+              "paramType": "query",
+              "required": false
             },
             {
               "name": "body",

--- a/doc/liquid/drops.html
+++ b/doc/liquid/drops.html
@@ -843,6 +843,11 @@ this returns the errors that occurred.</p>
 
 <p>Returns the name of the spec.</p>
 
+<h3>
+<a name="service" class="anchor" href="#service"><span class="mini-icon mini-icon-link"></span></a>service</h3>
+
+<p>Returns the service of the spec if it has any or nil otherwise.</p>
+
 <hr>
 
 <h1>
@@ -1021,7 +1026,7 @@ it does not affect existing contracts.</p>
 <a name="application_keys_url" class="anchor" href="#application_keys_url"><span class="mini-icon mini-icon-link"></span></a>application_keys_url</h3>
 
 <h3>
-<a name="service" class="anchor" href="#service"><span class="mini-icon mini-icon-link"></span></a>service</h3>
+<a name="service-1" class="anchor" href="#service-1"><span class="mini-icon mini-icon-link"></span></a>service</h3>
 
 <p>Service to which the application belongs to.</p>
 
@@ -1249,7 +1254,7 @@ it does not affect existing contracts.</p>
 <p>Returns the usage limits of the plan.</p>
 
 <h3>
-<a name="service-1" class="anchor" href="#service-1"><span class="mini-icon mini-icon-link"></span></a>service</h3>
+<a name="service-2" class="anchor" href="#service-2"><span class="mini-icon mini-icon-link"></span></a>service</h3>
 
 <p>Returns the service of the plan.</p>
 
@@ -1290,6 +1295,20 @@ it does not affect existing contracts.</p>
 <a name="methods-8" class="anchor" href="#methods-8"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
 
 <h3>
+<a name="login_url" class="anchor" href="#login_url"><span class="mini-icon mini-icon-link"></span></a>login_url</h3>
+
+<h3>
+<a name="user_identified" class="anchor" href="#user_identified"><span class="mini-icon mini-icon-link"></span></a>user_identified?</h3>
+
+<hr>
+
+<h1>
+<a name="base-drop-1" class="anchor" href="#base-drop-1"><span class="mini-icon mini-icon-link"></span></a>Base drop</h1>
+
+<h2>
+<a name="methods-9" class="anchor" href="#methods-9"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
+
+<h3>
 <a name="errors-4" class="anchor" href="#errors-4"><span class="mini-icon mini-icon-link"></span></a>errors</h3>
 
 <p>If a form for this model is rendered after unsuccessful submission,
@@ -1320,20 +1339,6 @@ this returns the errors that occurred.</p>
 <a name="description-1" class="anchor" href="#description-1"><span class="mini-icon mini-icon-link"></span></a>description</h3>
 
 <p>Returns a descriptive string for the result.</p>
-
-<hr>
-
-<h1>
-<a name="base-drop-1" class="anchor" href="#base-drop-1"><span class="mini-icon mini-icon-link"></span></a>Base drop</h1>
-
-<h2>
-<a name="methods-9" class="anchor" href="#methods-9"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
-
-<h3>
-<a name="login_url" class="anchor" href="#login_url"><span class="mini-icon mini-icon-link"></span></a>login_url</h3>
-
-<h3>
-<a name="user_identified" class="anchor" href="#user_identified"><span class="mini-icon mini-icon-link"></span></a>user_identified?</h3>
 
 <hr>
 
@@ -2593,14 +2598,20 @@ this returns the errors that occurred.</p>
 <h3>
 <a name="title-1" class="anchor" href="#title-1"><span class="mini-icon mini-icon-link"></span></a>title</h3>
 
-<h3>
-<a name="kind-2" class="anchor" href="#kind-2"><span class="mini-icon mini-icon-link"></span></a>kind</h3>
+<p>Returns the title of the page.</p>
+
+<pre lang="liquid"><code>&lt;title&gt;{{ page.title }}&lt;/title&gt;
+</code></pre>
 
 <h3>
-<a name="url-8" class="anchor" href="#url-8"><span class="mini-icon mini-icon-link"></span></a>url</h3>
+<a name="system_name-5" class="anchor" href="#system_name-5"><span class="mini-icon mini-icon-link"></span></a>system_name</h3>
 
-<h3>
-<a name="description-5" class="anchor" href="#description-5"><span class="mini-icon mini-icon-link"></span></a>description</h3>
+<p>Returns system name of the page.</p>
+
+<pre lang="liquid"><code>{% if page.system_name == 'my_page' %}
+  {% include 'custom_header' %}
+{% endif %}
+</code></pre>
 
 <hr>
 
@@ -2625,20 +2636,14 @@ this returns the errors that occurred.</p>
 <h3>
 <a name="title-2" class="anchor" href="#title-2"><span class="mini-icon mini-icon-link"></span></a>title</h3>
 
-<p>Returns the title of the page.</p>
-
-<pre lang="liquid"><code>&lt;title&gt;{{ page.title }}&lt;/title&gt;
-</code></pre>
+<h3>
+<a name="kind-2" class="anchor" href="#kind-2"><span class="mini-icon mini-icon-link"></span></a>kind</h3>
 
 <h3>
-<a name="system_name-5" class="anchor" href="#system_name-5"><span class="mini-icon mini-icon-link"></span></a>system_name</h3>
+<a name="url-8" class="anchor" href="#url-8"><span class="mini-icon mini-icon-link"></span></a>url</h3>
 
-<p>Returns system name of the page.</p>
-
-<pre lang="liquid"><code>{% if page.system_name == 'my_page' %}
-  {% include 'custom_header' %}
-{% endif %}
-</code></pre>
+<h3>
+<a name="description-5" class="anchor" href="#description-5"><span class="mini-icon mini-icon-link"></span></a>description</h3>
 
 <hr>
 
@@ -3010,16 +3015,27 @@ this returns the errors that occurred.</p>
 </code></pre>
 
 <h3>
-<a name="title-4" class="anchor" href="#title-4"><span class="mini-icon mini-icon-link"></span></a>title</h3>
+<a name="body-1" class="anchor" href="#body-1"><span class="mini-icon mini-icon-link"></span></a>body</h3>
+
+<p>Text of the post.</p>
 
 <h3>
-<a name="kind-3" class="anchor" href="#kind-3"><span class="mini-icon mini-icon-link"></span></a>kind</h3>
+<a name="topic" class="anchor" href="#topic"><span class="mini-icon mini-icon-link"></span></a>topic</h3>
+
+<p>Every post belongs to a <a href="#topic-drop">topic</a>.</p>
+
+<h3>
+<a name="created_at-3" class="anchor" href="#created_at-3"><span class="mini-icon mini-icon-link"></span></a>created_at</h3>
+
+<p>Date when this post created.</p>
+
+<pre lang="liquid"><code>{{ post.created_at | date: i18n.short_date }}
+</code></pre>
 
 <h3>
 <a name="url-10" class="anchor" href="#url-10"><span class="mini-icon mini-icon-link"></span></a>url</h3>
 
-<h3>
-<a name="description-7" class="anchor" href="#description-7"><span class="mini-icon mini-icon-link"></span></a>description</h3>
+<p>The URL of this post within its topic.</p>
 
 <hr>
 
@@ -3042,27 +3058,16 @@ this returns the errors that occurred.</p>
 </code></pre>
 
 <h3>
-<a name="body-1" class="anchor" href="#body-1"><span class="mini-icon mini-icon-link"></span></a>body</h3>
-
-<p>Text of the post.</p>
+<a name="title-4" class="anchor" href="#title-4"><span class="mini-icon mini-icon-link"></span></a>title</h3>
 
 <h3>
-<a name="topic" class="anchor" href="#topic"><span class="mini-icon mini-icon-link"></span></a>topic</h3>
-
-<p>Every post belongs to a <a href="#topic-drop">topic</a>.</p>
-
-<h3>
-<a name="created_at-3" class="anchor" href="#created_at-3"><span class="mini-icon mini-icon-link"></span></a>created_at</h3>
-
-<p>Date when this post created.</p>
-
-<pre lang="liquid"><code>{{ post.created_at | date: i18n.short_date }}
-</code></pre>
+<a name="kind-3" class="anchor" href="#kind-3"><span class="mini-icon mini-icon-link"></span></a>kind</h3>
 
 <h3>
 <a name="url-11" class="anchor" href="#url-11"><span class="mini-icon mini-icon-link"></span></a>url</h3>
 
-<p>The URL of this post within its topic.</p>
+<h3>
+<a name="description-7" class="anchor" href="#description-7"><span class="mini-icon mini-icon-link"></span></a>description</h3>
 
 <hr>
 
@@ -3274,6 +3279,13 @@ For invoice or payment related questions contact us at {{ provider.finance_suppo
 <a name="api_specs" class="anchor" href="#api_specs"><span class="mini-icon mini-icon-link"></span></a>api_specs</h3>
 
 <p>Returns API spec collection.</p>
+
+<pre lang="liquid"><code>&lt;ul&gt;
+{% for api_spec in provider.api_specs %}
+  &lt;li&gt;{{ api_spec.system_name }}&lt;/li&gt;
+{% endfor %}
+&lt;/ul&gt;
+</code></pre>
 
 <hr>
 
@@ -3596,6 +3608,18 @@ logged in user if they are subscribed to this service, Nil otherwise.</p>
 
 <p>Support email of the service.</p>
 
+<h3>
+<a name="api_specs-1" class="anchor" href="#api_specs-1"><span class="mini-icon mini-icon-link"></span></a>api_specs</h3>
+
+<p>Returns API spec collection.</p>
+
+<pre lang="liquid"><code>&lt;ul&gt;
+{% for api_spec in service.api_specs %}
+  &lt;li&gt;{{ api_spec.system_name }}&lt;/li&gt;
+{% endfor %}
+&lt;/ul&gt;
+</code></pre>
+
 <hr>
 
 <h1>
@@ -3675,7 +3699,7 @@ it does not affect existing contracts.</p>
 <a name="change_plan_url-1" class="anchor" href="#change_plan_url-1"><span class="mini-icon mini-icon-link"></span></a>change_plan_url</h3>
 
 <h3>
-<a name="service-2" class="anchor" href="#service-2"><span class="mini-icon mini-icon-link"></span></a>service</h3>
+<a name="service-3" class="anchor" href="#service-3"><span class="mini-icon mini-icon-link"></span></a>service</h3>
 
 <h3>
 <a name="applications-1" class="anchor" href="#applications-1"><span class="mini-icon mini-icon-link"></span></a>applications</h3>
@@ -3818,7 +3842,7 @@ it does not affect existing contracts.</p>
 <p>Returns the monthly fixed fee of the plan.</p>
 
 <h3>
-<a name="service-3" class="anchor" href="#service-3"><span class="mini-icon mini-icon-link"></span></a>service</h3>
+<a name="service-4" class="anchor" href="#service-4"><span class="mini-icon mini-icon-link"></span></a>service</h3>
 
 <p><strong>Example:</strong> Using service plan drop in liquid.</p>
 
@@ -3901,10 +3925,14 @@ this returns the errors that occurred.</p>
 <h3>
 <a name="title-5" class="anchor" href="#title-5"><span class="mini-icon mini-icon-link"></span></a>title</h3>
 
-<p>Name of the topic. Submitted when first post to the thread is posted.</p>
+<h3>
+<a name="kind-4" class="anchor" href="#kind-4"><span class="mini-icon mini-icon-link"></span></a>kind</h3>
 
 <h3>
 <a name="url-12" class="anchor" href="#url-12"><span class="mini-icon mini-icon-link"></span></a>url</h3>
+
+<h3>
+<a name="description-10" class="anchor" href="#description-10"><span class="mini-icon mini-icon-link"></span></a>description</h3>
 
 <hr>
 
@@ -3929,14 +3957,10 @@ this returns the errors that occurred.</p>
 <h3>
 <a name="title-6" class="anchor" href="#title-6"><span class="mini-icon mini-icon-link"></span></a>title</h3>
 
-<h3>
-<a name="kind-4" class="anchor" href="#kind-4"><span class="mini-icon mini-icon-link"></span></a>kind</h3>
+<p>Name of the topic. Submitted when first post to the thread is posted.</p>
 
 <h3>
 <a name="url-13" class="anchor" href="#url-13"><span class="mini-icon mini-icon-link"></span></a>url</h3>
-
-<h3>
-<a name="description-10" class="anchor" href="#description-10"><span class="mini-icon mini-icon-link"></span></a>description</h3>
 
 <hr>
 

--- a/doc/liquid/drops.html
+++ b/doc/liquid/drops.html
@@ -846,7 +846,7 @@ this returns the errors that occurred.</p>
 <h3>
 <a name="service" class="anchor" href="#service"><span class="mini-icon mini-icon-link"></span></a>service</h3>
 
-<p>Returns the service of the spec if it has any or nil otherwise.</p>
+<p>Returns the service of the spec if it has any or <code>nil</code> otherwise.</p>
 
 <hr>
 
@@ -1295,20 +1295,6 @@ it does not affect existing contracts.</p>
 <a name="methods-8" class="anchor" href="#methods-8"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
 
 <h3>
-<a name="login_url" class="anchor" href="#login_url"><span class="mini-icon mini-icon-link"></span></a>login_url</h3>
-
-<h3>
-<a name="user_identified" class="anchor" href="#user_identified"><span class="mini-icon mini-icon-link"></span></a>user_identified?</h3>
-
-<hr>
-
-<h1>
-<a name="base-drop-1" class="anchor" href="#base-drop-1"><span class="mini-icon mini-icon-link"></span></a>Base drop</h1>
-
-<h2>
-<a name="methods-9" class="anchor" href="#methods-9"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
-
-<h3>
 <a name="errors-4" class="anchor" href="#errors-4"><span class="mini-icon mini-icon-link"></span></a>errors</h3>
 
 <p>If a form for this model is rendered after unsuccessful submission,
@@ -1339,6 +1325,20 @@ this returns the errors that occurred.</p>
 <a name="description-1" class="anchor" href="#description-1"><span class="mini-icon mini-icon-link"></span></a>description</h3>
 
 <p>Returns a descriptive string for the result.</p>
+
+<hr>
+
+<h1>
+<a name="base-drop-1" class="anchor" href="#base-drop-1"><span class="mini-icon mini-icon-link"></span></a>Base drop</h1>
+
+<h2>
+<a name="methods-9" class="anchor" href="#methods-9"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
+
+<h3>
+<a name="login_url" class="anchor" href="#login_url"><span class="mini-icon mini-icon-link"></span></a>login_url</h3>
+
+<h3>
+<a name="user_identified" class="anchor" href="#user_identified"><span class="mini-icon mini-icon-link"></span></a>user_identified?</h3>
 
 <hr>
 
@@ -1390,6 +1390,17 @@ this returns the errors that occurred.</p>
 <a name="methods-11" class="anchor" href="#methods-11"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
 
 <h3>
+<a name="change_plan" class="anchor" href="#change_plan"><span class="mini-icon mini-icon-link"></span></a>change_plan?</h3>
+
+<hr>
+
+<h1>
+<a name="can-drop-1" class="anchor" href="#can-drop-1"><span class="mini-icon mini-icon-link"></span></a>Can drop</h1>
+
+<h2>
+<a name="methods-12" class="anchor" href="#methods-12"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
+
+<h3>
 <a name="be_updated" class="anchor" href="#be_updated"><span class="mini-icon mini-icon-link"></span></a>be_updated?</h3>
 
 <h3>
@@ -1412,17 +1423,6 @@ this returns the errors that occurred.</p>
 
 <h3>
 <a name="delete_key" class="anchor" href="#delete_key"><span class="mini-icon mini-icon-link"></span></a>delete_key?</h3>
-
-<hr>
-
-<h1>
-<a name="can-drop-1" class="anchor" href="#can-drop-1"><span class="mini-icon mini-icon-link"></span></a>Can drop</h1>
-
-<h2>
-<a name="methods-12" class="anchor" href="#methods-12"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
-
-<h3>
-<a name="change_plan" class="anchor" href="#change_plan"><span class="mini-icon mini-icon-link"></span></a>change_plan?</h3>
 
 <hr>
 
@@ -2406,6 +2406,29 @@ this returns the errors that occurred.</p>
 <a name="methods-28" class="anchor" href="#methods-28"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
 
 <h3>
+<a name="type" class="anchor" href="#type"><span class="mini-icon mini-icon-link"></span></a>type</h3>
+
+<p>Possible types of the messages are:</p>
+
+<ul>
+<li>success (not used by now)</li>
+<li>info</li>
+<li>warning</li>
+<li>danger</li>
+</ul>
+
+<h3>
+<a name="text" class="anchor" href="#text"><span class="mini-icon mini-icon-link"></span></a>text</h3>
+
+<hr>
+
+<h1>
+<a name="message-drop-1" class="anchor" href="#message-drop-1"><span class="mini-icon mini-icon-link"></span></a>Message drop</h1>
+
+<h2>
+<a name="methods-29" class="anchor" href="#methods-29"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
+
+<h3>
 <a name="errors-15" class="anchor" href="#errors-15"><span class="mini-icon mini-icon-link"></span></a>errors</h3>
 
 <p>If a form for this model is rendered after unsuccessful submission,
@@ -2462,29 +2485,6 @@ this returns the errors that occurred.</p>
 
 <h3>
 <a name="recipients" class="anchor" href="#recipients"><span class="mini-icon mini-icon-link"></span></a>recipients</h3>
-
-<hr>
-
-<h1>
-<a name="message-drop-1" class="anchor" href="#message-drop-1"><span class="mini-icon mini-icon-link"></span></a>Message drop</h1>
-
-<h2>
-<a name="methods-29" class="anchor" href="#methods-29"><span class="mini-icon mini-icon-link"></span></a>Methods</h2><span class="up"> <a href="#table-of-contents">(up)</a></span>
-
-<h3>
-<a name="type" class="anchor" href="#type"><span class="mini-icon mini-icon-link"></span></a>type</h3>
-
-<p>Possible types of the messages are:</p>
-
-<ul>
-<li>success (not used by now)</li>
-<li>info</li>
-<li>warning</li>
-<li>danger</li>
-</ul>
-
-<h3>
-<a name="text" class="anchor" href="#text"><span class="mini-icon mini-icon-link"></span></a>text</h3>
 
 <hr>
 
@@ -3925,14 +3925,10 @@ this returns the errors that occurred.</p>
 <h3>
 <a name="title-5" class="anchor" href="#title-5"><span class="mini-icon mini-icon-link"></span></a>title</h3>
 
-<h3>
-<a name="kind-4" class="anchor" href="#kind-4"><span class="mini-icon mini-icon-link"></span></a>kind</h3>
+<p>Name of the topic. Submitted when first post to the thread is posted.</p>
 
 <h3>
 <a name="url-12" class="anchor" href="#url-12"><span class="mini-icon mini-icon-link"></span></a>url</h3>
-
-<h3>
-<a name="description-10" class="anchor" href="#description-10"><span class="mini-icon mini-icon-link"></span></a>description</h3>
 
 <hr>
 
@@ -3957,10 +3953,14 @@ this returns the errors that occurred.</p>
 <h3>
 <a name="title-6" class="anchor" href="#title-6"><span class="mini-icon mini-icon-link"></span></a>title</h3>
 
-<p>Name of the topic. Submitted when first post to the thread is posted.</p>
+<h3>
+<a name="kind-4" class="anchor" href="#kind-4"><span class="mini-icon mini-icon-link"></span></a>kind</h3>
 
 <h3>
 <a name="url-13" class="anchor" href="#url-13"><span class="mini-icon mini-icon-link"></span></a>url</h3>
+
+<h3>
+<a name="description-10" class="anchor" href="#description-10"><span class="mini-icon mini-icon-link"></span></a>description</h3>
 
 <hr>
 

--- a/doc/liquid/drops.md
+++ b/doc/liquid/drops.md
@@ -363,7 +363,7 @@ Returns the url of the API spec.
 Returns the name of the spec.
 
 ### service
-Returns the service of the spec if it has any or nil otherwise.
+Returns the service of the spec if it has any or `nil` otherwise.
 
 -----------
 
@@ -700,6 +700,19 @@ OAuth callback url.
 
 
 ## Methods
+### login_url
+
+### user_identified?
+
+-----------
+
+# Base drop
+
+
+
+
+
+## Methods
 ### errors
 
 If a form for this model is rendered after unsuccessful submission,
@@ -722,19 +735,6 @@ Returns the resource URL of the result.
 
 ### description
 Returns a descriptive string for the result.
-
------------
-
-# Base drop
-
-
-
-
-
-## Methods
-### login_url
-
-### user_identified?
 
 -----------
 
@@ -2121,20 +2121,13 @@ this returns the errors that occurred.
 {{ post.errors.name | inline_errors }}
 ```
 
-### body
-Text of the post.
+### title
 
-### topic
-Every post belongs to a [topic](#topic-drop).
-
-### created_at
-Date when this post created.
-```liquid
-{{ post.created_at | date: i18n.short_date }}
-```
+### kind
 
 ### url
-The URL of this post within its topic.
+
+### description
 
 -----------
 
@@ -2156,13 +2149,20 @@ this returns the errors that occurred.
 {{ post.errors.name | inline_errors }}
 ```
 
-### title
+### body
+Text of the post.
 
-### kind
+### topic
+Every post belongs to a [topic](#topic-drop).
+
+### created_at
+Date when this post created.
+```liquid
+{{ post.created_at | date: i18n.short_date }}
+```
 
 ### url
-
-### description
+The URL of this post within its topic.
 
 -----------
 
@@ -2870,12 +2870,9 @@ this returns the errors that occurred.
 ```
 
 ### title
-
-### kind
+Name of the topic. Submitted when first post to the thread is posted.
 
 ### url
-
-### description
 
 -----------
 
@@ -2898,9 +2895,12 @@ this returns the errors that occurred.
 ```
 
 ### title
-Name of the topic. Submitted when first post to the thread is posted.
+
+### kind
 
 ### url
+
+### description
 
 -----------
 

--- a/doc/liquid/drops.md
+++ b/doc/liquid/drops.md
@@ -362,6 +362,9 @@ Returns the url of the API spec.
 ### system_name
 Returns the name of the spec.
 
+### service
+Returns the service of the spec if it has any or nil otherwise.
+
 -----------
 
 # Application drop
@@ -2330,6 +2333,13 @@ You can enable or disable account management in the [usage rules section][usage-
 
 ### api_specs
 Returns API spec collection.
+```liquid
+<ul>
+{% for api_spec in provider.api_specs %}
+  <li>{{ api_spec.system_name }}</li>
+{% endfor %}
+</ul>
+```
 
 -----------
 
@@ -2603,6 +2613,16 @@ Returns the metrics of the service.
 
 ### support_email
 Support email of the service.
+
+### api_specs
+Returns API spec collection.
+```liquid
+<ul>
+{% for api_spec in service.api_specs %}
+  <li>{{ api_spec.system_name }}</li>
+{% endfor %}
+</ul>
+```
 
 -----------
 

--- a/lib/developer_portal/lib/liquid/drops/api_spec.rb
+++ b/lib/developer_portal/lib/liquid/drops/api_spec.rb
@@ -16,9 +16,9 @@ module Liquid
         @spec.system_name
       end
 
-      desc 'Returns the service of the spec if it has any or nil otherwise.'
+      desc 'Returns the service of the spec if it has any or `nil` otherwise.'
       def service
-        return nil unless (service = @spec.service)
+        return unless (service = @spec.service)
         Drops::Service.new(service)
       end
     end

--- a/lib/developer_portal/lib/liquid/drops/api_spec.rb
+++ b/lib/developer_portal/lib/liquid/drops/api_spec.rb
@@ -15,6 +15,12 @@ module Liquid
       def system_name
         @spec.system_name
       end
+
+      desc 'Returns the service of the spec if it has any or nil otherwise.'
+      def service
+        return nil unless (service = @spec.service)
+        Drops::Service.new(service)
+      end
     end
   end
 end

--- a/lib/developer_portal/lib/liquid/drops/provider.rb
+++ b/lib/developer_portal/lib/liquid/drops/provider.rb
@@ -201,7 +201,7 @@ module Liquid
 
       desc 'Returns API spec collection.'
       def api_specs
-        Drops::Collection.for_drop(Drops::ApiSpec).new(@model.api_docs_services)
+        Drops::Collection.for_drop(Drops::ApiSpec).new(@model.api_docs_services.accessible)
       end
 
       private

--- a/lib/developer_portal/lib/liquid/drops/provider.rb
+++ b/lib/developer_portal/lib/liquid/drops/provider.rb
@@ -200,6 +200,13 @@ module Liquid
       end
 
       desc 'Returns API spec collection.'
+      example %(
+        <ul>
+        {% for api_spec in provider.api_specs %}
+          <li>{{ api_spec.system_name }}</li>
+        {% endfor %}
+        </ul>
+      )
       def api_specs
         Drops::Collection.for_drop(Drops::ApiSpec).new(@model.api_docs_services.accessible)
       end

--- a/lib/developer_portal/lib/liquid/drops/service.rb
+++ b/lib/developer_portal/lib/liquid/drops/service.rb
@@ -199,6 +199,18 @@ module Liquid
         @service.infobar
       end
 
+      desc 'Returns API spec collection.'
+      example %(
+        <ul>
+        {% for api_spec in service.api_specs %}
+          <li>{{ api_spec.system_name }}</li>
+        {% endfor %}
+        </ul>
+      )
+      def api_specs
+        Drops::Collection.for_drop(Drops::ApiSpec).new(@service.api_docs_services)
+      end
+
       private
 
       def current_account

--- a/test/integration/admin/api/api_docs_services_controller_test.rb
+++ b/test/integration/admin/api/api_docs_services_controller_test.rb
@@ -10,13 +10,13 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
 
   class MasterAccountTest < Admin::Api::ApiDocsServicesControllerTest
     def test_index_json_saas
-      get admin_api_docs_services_path
+      get admin_api_active_docs_path
       assert_response :success
     end
 
     def test_index_json_on_premises
       ThreeScale.stubs(master_on_premises?: true)
-      get admin_api_docs_services_path
+      get admin_api_active_docs_path
       assert_response :forbidden
     end
 
@@ -24,6 +24,84 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
 
     def current_account
       master_account
+    end
+  end
+
+  class ProviderAccountTest < Admin::Api::ApiDocsServicesControllerTest
+    setup do
+      @provider = FactoryGirl.create(:provider_account)
+      @service = @provider.default_service
+      @api_docs_service = @provider.api_docs_services.create!({name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'})
+    end
+
+    attr_reader :provider, :service, :api_docs_service
+    alias current_account provider
+
+    def test_create_sets_all_attributes
+      assert_difference ::ApiDocs::Service.method(:count) do
+        post admin_api_active_docs_path(create_params(service_id: service.id, system_name: 'smart_service'))
+        assert_response :created
+      end
+
+      api_docs_service = provider.api_docs_services.last!
+      assert_equal 'smart_service', api_docs_service.system_name
+      assert_equal service.id, api_docs_service.service_id
+      create_params[:api_docs_service].each do |name, value|
+        expected_value = %i[published skip_swagger_validations].include?(name) ? (value == '1') : value
+        assert_equal expected_value, api_docs_service.public_send(name)
+      end
+      assert_equal provider.id, api_docs_service.account_id
+    end
+
+    def test_update_with_right_params
+      put admin_api_active_doc_path(api_docs_service), update_params(service_id: service.id)
+      assert_response :success
+
+      api_docs_service.reload
+      update_params[:api_docs_service].each do |name, value|
+        expected_value = %i[published skip_swagger_validations].include?(name) ? (value == '1') : value
+        assert_equal expected_value, api_docs_service.public_send(name)
+      end
+      assert_equal provider.id, api_docs_service.account_id
+    end
+
+    def test_update_can_remove_service
+      api_docs_service.update_attribute(:service_id, provider.default_service_id)
+      put admin_api_active_doc_path(api_docs_service), update_params(service_id: '')
+      assert_response :success
+      assert_nil api_docs_service.reload.service_id
+    end
+
+    def test_system_name_is_not_updated
+      old_system_name = api_docs_service.system_name
+      put admin_api_active_doc_path(api_docs_service), update_params(system_name: "#{old_system_name}-2")
+      assert_response :success
+      assert_equal old_system_name, api_docs_service.reload.system_name
+    end
+
+    def test_update_invalid_params
+      old_body = api_docs_service.body
+      put admin_api_active_doc_path(api_docs_service, format: :json), update_params(body: '{apis: []}')
+      assert_response :unprocessable_entity
+      assert_contains JSON.parse(response.body).dig('errors', 'body'), 'JSON Spec is invalid'
+      assert_equal old_body, api_docs_service.reload.body
+    end
+
+    private
+
+    def create_params(different_params = {})
+      @create_params ||= api_docs_params(different_params)
+    end
+
+    def update_params(different_params = {})
+      @update_params ||= api_docs_params(different_params).merge({id: api_docs_service.id})
+    end
+
+    def api_docs_params(different_params = {})
+      { api_docs_service: {
+        name: 'update_servone', body: '{"apis": [{"foo": "bar"}], "basePath": "http://example.net"}',
+        description: 'updated description', published: '1', skip_swagger_validations: '0'
+      }.merge(different_params) }
     end
   end
 end

--- a/test/integration/admin/api/api_docs_services_controller_test.rb
+++ b/test/integration/admin/api/api_docs_services_controller_test.rb
@@ -90,7 +90,7 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
     def test_update_unexistent_service
       put admin_api_active_doc_path(api_docs_service, format: :json), update_params(service_id: 200)
       assert_response :unprocessable_entity
-      assert_contains JSON.parse(response.body).dig('errors', 'base'), 'The service must belong to the same account.'
+      assert_contains JSON.parse(response.body).dig('errors', 'service'), 'not found'
     end
 
     private

--- a/test/integration/admin/api/api_docs_services_controller_test.rb
+++ b/test/integration/admin/api/api_docs_services_controller_test.rb
@@ -87,6 +87,12 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
       assert_equal old_body, api_docs_service.reload.body
     end
 
+    def test_update_unexistent_service
+      put admin_api_active_doc_path(api_docs_service, format: :json), update_params(service_id: 200)
+      assert_response :unprocessable_entity
+      assert_contains JSON.parse(response.body).dig('errors', 'base'), 'The service must belong to the same account.'
+    end
+
     private
 
     def create_params(different_params = {})

--- a/test/integration/admin/api_docs/services_controller_test.rb
+++ b/test/integration/admin/api_docs/services_controller_test.rb
@@ -72,7 +72,7 @@ class Admin::ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
 
     def test_update_unexistent_service
       put admin_api_docs_service_path(api_docs_service), update_params(service_id: 200)
-      assert_includes flash[:error], 'The service must belong to the same account.'
+      assert_includes flash[:error], 'Service not found'
     end
 
     private

--- a/test/integration/admin/api_docs/services_controller_test.rb
+++ b/test/integration/admin/api_docs/services_controller_test.rb
@@ -9,20 +9,71 @@ class Admin::ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
   end
 
   class ProviderLoggedInTest < Admin::ApiDocs::ServicesControllerTest
+    setup do
+      @provider = FactoryGirl.create(:provider_account)
+      @service = @provider.default_service
+      @api_docs_service = @provider.api_docs_services.create!({name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'})
+    end
 
-    test '#create sets the system_name' do
+    test '#create sets all the attributes, including the system_name and the service_id' do
       assert_difference ::ApiDocs::Service.method(:count) do
-        post admin_api_docs_services_path(create_params)
+        post admin_api_docs_services_path(create_params(service_id: service.id, system_name: 'smart_service'))
         assert_response :redirect
       end
-      assert_equal create_params[:api_docs_service][:system_name], api_docs_service.system_name
+
+      api_docs_service = provider.api_docs_services.last!
+      assert_equal 'smart_service', api_docs_service.system_name
+      assert_equal service.id, api_docs_service.service_id
+      create_params[:api_docs_service].each do |name, value|
+        expected_value = %i[published skip_swagger_validations].include?(name) ? (value == '1') : value
+        assert_equal expected_value, api_docs_service.public_send(name)
+      end
+      assert_equal provider.id, api_docs_service.account_id
+    end
+
+    test '#update with the right params' do
+      put admin_api_docs_service_path(api_docs_service), update_params(service_id: service.id)
+      assert_response :redirect
+      assert_equal 'ActiveDocs Spec was successfully updated.', flash[:notice]
+
+      api_docs_service.reload
+      update_params[:api_docs_service].each do |name, value|
+        expected_value = %i[published skip_swagger_validations].include?(name) ? (value == '1') : value
+        assert_equal expected_value, api_docs_service.public_send(name)
+      end
+      assert_equal provider.id, api_docs_service.account_id
+    end
+
+    def test_update_can_remove_service
+      api_docs_service.update_attribute(:service_id, provider.default_service_id)
+
+      put admin_api_docs_service_path(api_docs_service), update_params(service_id: '')
+      assert_response :redirect
+      assert_equal 'ActiveDocs Spec was successfully updated.', flash[:notice]
+
+      assert_nil api_docs_service.reload.service_id
+    end
+
+    def test_system_name_is_not_updated
+      old_system_name = api_docs_service.system_name
+
+      put admin_api_docs_service_path(api_docs_service), update_params(system_name: "#{old_system_name}-2")
+
+      assert_response :redirect
+      assert_equal old_system_name, api_docs_service.reload.system_name
+    end
+
+    def test_update_invalid_params
+      old_body = api_docs_service.body
+      put admin_api_docs_service_path(api_docs_service), update_params(body: '{apis: []}')
+      assert_includes flash[:error], 'JSON Spec is invalid'
+      assert_equal old_body, api_docs_service.reload.body
     end
 
     private
 
-    def current_account
-      @provider ||= FactoryGirl.create(:provider_account)
-    end
+    attr_reader :provider, :service, :api_docs_service
+    alias current_account provider
 
   end
 
@@ -99,12 +150,19 @@ class Admin::ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
 
   private
 
-  def create_params
-    { api_docs_service: { system_name: 'smart_service', name: 'servone', body: '{"basePath":"http://github.com", "apis":[]}'} }
+  def create_params(different_params = {})
+    @create_params ||= api_docs_params(different_params)
   end
 
-  def update_params
-    { id: api_docs_service.id, api_docs_service: { name: 'update_servone'} }
+  def update_params(different_params = {})
+    @update_params ||= api_docs_params(different_params).merge({id: api_docs_service.id})
+  end
+
+  def api_docs_params(different_params = {})
+    { api_docs_service: {
+      name: 'update_servone', body: '{"apis": [{"foo": "bar"}], "basePath": "http://example.net"}',
+      description: 'updated description', published: '0', skip_swagger_validations: '0'
+    }.merge(different_params) }
   end
 
   def api_docs_service

--- a/test/integration/admin/api_docs/services_controller_test.rb
+++ b/test/integration/admin/api_docs/services_controller_test.rb
@@ -70,6 +70,11 @@ class Admin::ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_equal old_body, api_docs_service.reload.body
     end
 
+    def test_update_unexistent_service
+      put admin_api_docs_service_path(api_docs_service), update_params(service_id: 200)
+      assert_includes flash[:error], 'The service must belong to the same account.'
+    end
+
     private
 
     attr_reader :provider, :service, :api_docs_service

--- a/test/unit/api_docs/service_test.rb
+++ b/test/unit/api_docs/service_test.rb
@@ -538,6 +538,15 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
   end
 
+  test 'scope accessible' do
+    services = FactoryGirl.create_list(:service, 2, account: account)
+    account.api_docs_services.create!(valid_attributes.merge({name: 'accessible'})) # accessible without service
+    account.api_docs_services.create!(valid_attributes.merge({service: services.first, name: 'service-accessible'}), without_protection: true) # accessible with service
+    account.api_docs_services.create!(valid_attributes.merge({service: services.last, name: 'service'}), without_protection: true) # non-accessible with service
+    services.last.mark_as_deleted!
+    assert_same_elements %w[accessible service-accessible], ApiDocs::Service.accessible.pluck(:name)
+  end
+
   private
 
   def valid_attributes

--- a/test/unit/api_docs/service_test.rb
+++ b/test/unit/api_docs/service_test.rb
@@ -515,7 +515,6 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     service          = FactoryGirl.build(:service)
     account          = service.account
     another_account  = FactoryGirl.build(:simple_provider)
-    valid_attributes = {name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'}
 
     api_doc = service.api_docs_services.new(valid_attributes)
     api_doc.account = account
@@ -534,4 +533,11 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     refute api_doc.valid?
     assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
   end
+
+  private
+
+  def valid_attributes
+    @valid_attribures ||= {name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'}
+  end
+
 end

--- a/test/unit/api_docs/service_test.rb
+++ b/test/unit/api_docs/service_test.rb
@@ -512,9 +512,9 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
   end
 
   test 'It validates the Service belongs to the Account if both are set' do
-    service          = FactoryGirl.build(:service)
+    service          = FactoryGirl.create(:service)
     account          = service.account
-    another_account  = FactoryGirl.build(:simple_provider)
+    another_account  = FactoryGirl.create(:simple_provider)
 
     api_doc = service.api_docs_services.new(valid_attributes)
     api_doc.account = account
@@ -532,12 +532,16 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     api_doc.service = service
     refute api_doc.valid?
     assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
+
+    api_doc = account.api_docs_services.new(valid_attributes.merge({service_id: service.id + 1000}), without_protection: true)
+    refute api_doc.valid?
+    assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
   end
 
   private
 
   def valid_attributes
-    @valid_attribures ||= {name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'}
+    @valid_attributes ||= {name: 'name', body: '{"apis": [], "basePath": "http://example.com"}'}
   end
 
 end

--- a/test/unit/api_docs/service_test.rb
+++ b/test/unit/api_docs/service_test.rb
@@ -526,16 +526,16 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     api_doc = service.api_docs_services.new(valid_attributes)
     api_doc.account = another_account
     refute api_doc.valid?
-    assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
+    assert_includes api_doc.errors[:service], 'not found'
 
     api_doc = another_account.api_docs_services.new(valid_attributes)
     api_doc.service = service
     refute api_doc.valid?
-    assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
+    assert_includes api_doc.errors[:service], 'not found'
 
     api_doc = account.api_docs_services.new(valid_attributes.merge({service_id: service.id + 1000}), without_protection: true)
     refute api_doc.valid?
-    assert_includes api_doc.errors[:base], 'The service must belong to the same account.'
+    assert_includes api_doc.errors[:service], 'not found'
   end
 
   test 'scope accessible' do

--- a/test/unit/liquid/drops/api_spec_drop_test.rb
+++ b/test/unit/liquid/drops/api_spec_drop_test.rb
@@ -6,11 +6,27 @@ class Liquid::Drops::ApiSpecDropTest < ActiveSupport::TestCase
 
   def setup
     provider = FactoryGirl.create(:provider_account)
-    spec = provider.api_docs_services.create!(:name => 'Das Paella', :body => '{"basePath":"http://paella4guiris", "apis":[]}', :published => true)
-    @api_spec = Drops::ApiSpec.new(spec)
+    @service = provider.default_service
+    @spec = provider.api_docs_services.create!(:name => 'Das Paella', :body => '{"basePath":"http://paella4guiris", "apis":[]}', :published => true)
   end
 
   test 'Returns the correct url of the API spec' do
-    assert_equal'/swagger/spec/das_paella.json', @api_spec.url
+    assert_equal'/swagger/spec/das_paella.json', api_spec.url
+  end
+
+  test 'Returns the right service drop' do
+    @spec.service = @service
+    @spec.save!
+    service_drop = api_spec.service
+    assert_instance_of Liquid::Drops::Service, service_drop
+    assert_equal @service.name, service_drop.name
+
+    @spec.service = nil
+    @spec.save!
+    assert_nil api_spec.service
+  end
+
+  def api_spec
+    Drops::ApiSpec.new(@spec)
   end
 end

--- a/test/unit/liquid/drops/service_drop_test.rb
+++ b/test/unit/liquid/drops/service_drop_test.rb
@@ -24,4 +24,13 @@ class Liquid::Drops::ServiceDropTest < ActiveSupport::TestCase
     ServiceContract.create! plan: plan, user_account: buyer
     assert_not_nil @drop.subscription
   end
+
+  test 'api_specs' do
+    @service.account.api_docs_services.create!({name: 'name-api-doc', system_name: 'api_doc', body: '{"apis": [{"foo": "bar"}], "basePath": "http://example.com"}', service_id: @service.id}, without_protection: true)
+    api_specs_collection_drop = @drop.api_specs
+    assert_equal 1, api_specs_collection_drop.length
+    api_spec_drop = api_specs_collection_drop.first
+    assert_instance_of Liquid::Drops::ApiSpec, api_spec_drop
+    assert_equal 'api_doc', api_spec_drop.system_name
+  end
 end


### PR DESCRIPTION
Depends on https://github.com/3scale/porta/pull/62 in which ActiveDocs and Service have a relationship.

fixes https://github.com/3scale/porta/issues/61 and belongs to [THREESCALE-1340](https://issues.jboss.org/browse/THREESCALE-1340)

1. Service drop -> api_specs
`http://provider-admin.example.com.lvh.me:3000/p/admin/liquid_docs#service-drop`
![image](https://user-images.githubusercontent.com/11318903/46407049-d8c39a00-c70d-11e8-8546-f6f48dd17a65.png)
2. ApiSpecs drop -> service
`http://provider-admin.example.com.lvh.me:3000/p/admin/liquid_docs#apispec-drop`
![image](https://user-images.githubusercontent.com/11318903/46422444-b09b6180-c734-11e8-9234-98b54dc4bb1e.png)
3. Improve the already existing ProviderDrop#api_specs documentation
`http://provider-admin.example.com.lvh.me:3000/p/admin/liquid_docs#provider-drop`
![image](https://user-images.githubusercontent.com/11318903/46407241-846cea00-c70e-11e8-9966-85f009f4f2b5.png)
Removing the access to deleted api_specs from provider for the service is already done in https://github.com/3scale/porta/pull/62