### PR TITLE
Adding break lines to policies

### DIFF
--- a/app/javascript/src/Policies/styles/policies.scss
+++ b/app/javascript/src/Policies/styles/policies.scss
@@ -106,6 +106,7 @@ $subtleColor: #ddd;
 
     &-description {
       margin: 1rem 0 2rem;
+      white-space: pre-line;
     }
 
     .btn-info {


### PR DESCRIPTION
**What this PR does / why we need it**

It adds line breaks to the "description" fields in API > Integration > Edit > Policies

**JIRA**: [THREESCALE-1057](https://issues.jboss.org/browse/THREESCALE-1057)



**Before:**
![before](https://user-images.githubusercontent.com/13486237/46346629-ef53ed80-c648-11e8-8a07-555ebde99d54.jpg)

**After**
![after](https://user-images.githubusercontent.com/13486237/46346653-ff6bcd00-c648-11e8-8b8f-c56b2cc60221.jpg)

