### PR TITLE
[Hotfix] Fix redirect_url update link

### DIFF
--- a/app/views/buyers/applications/edit_redirect_url.html.erb
+++ b/app/views/buyers/applications/edit_redirect_url.html.erb
@@ -1,6 +1,6 @@
 <h2>Update the Redirect URL</h2>
 
-<%= semantic_form_for @cinstance, :url => admin_service_application_path(@cinstance.service, @cinstance) do |form| %>
+<%= semantic_form_for @cinstance, :url => admin_buyers_application_path(@cinstance) do |form| %>
   <%= form.inputs do %>
     <%= form.input :redirect_url, :label => 'Redirect URL', :as => :string,
                    :input_html => {:size => 100} %>


### PR DESCRIPTION
@mayorova  discovered this bug.
1. Go to the `show` page of an `application`
2. Click `Edit`, enter the url in a popup and click `Save`
3. It showed `404 Not Found page` because it tried to make a `POST` request to `provider-url/apiconfig/services/:service_id/applications/:application_id`

I broke this in https://github.com/3scale/porta/commit/29f64d5c2888005ecb0285ea1eedb4d529e6dec4#diff-51ecc5cd2637a2e14f8651147ed56f9bR3 😊 sorry 😞 