### PR TITLE
ActiveDocs' account is required now

### DIFF
--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -5,7 +5,7 @@ class ApiDocs::Service < ApplicationRecord
   include SystemName
   extend System::Database::Scopes::IdOrSystemName
 
-  belongs_to :account
+  belongs_to :account, required: true
 
   attr_accessible :account, :body, :name, :description, :published, :skip_swagger_validations
   attr_readonly :system_name

--- a/lib/tasks/swagger.rake
+++ b/lib/tasks/swagger.rake
@@ -8,9 +8,8 @@ namespace :swagger do
     validate!(scope)
   end
 
-  # TODO: this code is meant to be executed only 1 time :) later it can be removed
   task destroy_orphans: :environment do
-    ApiDocs::Service.joining { account.outer }.where.has { account.id == nil }.find_each(&DeletePlainObjectWorker.method(:perform_later))
+    ApiDocs::Service.joining { account.outer }.where.has { account.id == nil }.find_each(&DeleteObjectHierarchyWorker.method(:perform_later))
   end
 
   task stats_version: :environment do

--- a/test/unit/tasks/swagger_test.rb
+++ b/test/unit/tasks/swagger_test.rb
@@ -9,7 +9,7 @@ class Tasks::SwaggerTest < ActiveSupport::TestCase
   end
 
   test 'destroy_orphans' do
-    DeletePlainObjectWorker.expects(:perform_later).once.with { |swagger| swagger.account.blank? }
+    DeleteObjectHierarchyWorker.expects(:perform_later).once.with { |swagger| swagger.account.blank? }
     execute_rake_task 'swagger.rake', 'swagger:destroy_orphans'
   end
 end


### PR DESCRIPTION
This is beneficial for https://github.com/3scale/porta/pull/62
and specially discussed in https://github.com/3scale/porta/pull/62#discussion_r222043034

Account is mandatory for all ActiveDocs already, so enforcing this in the model as well makes checking other things easier 😄 

In another PR because it is a slightly risky change and I want to see if it breaks anything on its own first 😂 

