### PR TITLE
Permissions in a service-driven navigation context

### DIFF
--- a/app/assets/stylesheets/provider/admin/_dashboard.scss
+++ b/app/assets/stylesheets/provider/admin/_dashboard.scss
@@ -34,6 +34,9 @@
   &.is-closed {
     border-bottom: $border-width solid $border-color;
     height: auto;
+  }
+
+  &--toggleable.is-closed {
 
     .DashboardWidget,
     .DashboardNavigation-list-item {

--- a/app/views/layouts/api/_service.html.slim
+++ b/app/views/layouts/api/_service.html.slim
@@ -1,20 +1,21 @@
 ul#side-tabs
-  - if can?(:edit, @service)
+  - if can? :manage, :partners
     = sidebar_link :applications, admin_service_applications_path(@service)
+
+  - if can?(:manage, :plans)
     = sidebar_link 'Definition', admin_service_metrics_path(@service)
     = sidebar_link :integration, path_to_service(@service) if can?(:manage, :plans)
     = sidebar_link 'Application Plans', admin_service_application_plans_path(@service)
-
     = sidebar_link :settings, settings_admin_service_path(@service)
 
-  - if can?(:manage, :service_plans) && current_account.settings.service_plans_ui_visible?
-    = sidebar_link 'Service Plans', admin_service_service_plans_path(@service)
+    - if can?(:manage, :service_plans) && current_account.settings.service_plans_ui_visible?
+      = sidebar_link 'Service Plans', admin_service_service_plans_path(@service)
 
-  - if current_account.settings.end_user_plans_ui_visible?
-    = sidebar_link :end_user_plans, admin_service_end_user_plans_path(@service), switch: :end_users, upgrade_notice: true
+    - if current_account.settings.end_user_plans_ui_visible?
+      = sidebar_link :end_user_plans, admin_service_end_user_plans_path(@service), switch: :end_users, upgrade_notice: true
 
-  - if @service.end_users_allowed? && current_account.settings.end_user_plans_ui_visible?
-    = sidebar_link 'End-users', admin_service_end_users_path(@service), switch: :end_users, upgrade_notice: true
+    - if @service.end_users_allowed? && current_account.settings.end_user_plans_ui_visible?
+      = sidebar_link 'End-users', admin_service_end_users_path(@service), switch: :end_users, upgrade_notice: true
 
 #tab-content
   h2

--- a/app/views/provider/admin/dashboards/_service.html.slim
+++ b/app/views/provider/admin/dashboards/_service.html.slim
@@ -1,9 +1,10 @@
-section.DashboardSection.DashboardSection--service class=('DashboardSection--wide' unless can?(:manage, :partners)) class=('DashboardSection--toggleable is-closed u-legacy-cookie' if current_account.multiservice?) id=(dom_id service)
+section.DashboardSection.DashboardSection--service.is-closed class=('DashboardSection--toggleable is-closed u-legacy-cookie' if current_account.multiservice? && can?(:manage, :analytics)) id=(dom_id service)
   header.DashboardSection-header
-    h1.DashboardSection-title class=('DashboardSection-toggle' if current_account.multiservice?)
+    h1.DashboardSection-title class=('DashboardSection-toggle' if current_account.multiservice? && can?(:manage, :analytics))
       = friendly_service_name(service)
     = render 'service_navigation', service: service
 
   // service level widgets
-  = dashboard_widget :service_hits, service_id: service.to_param
-  = dashboard_widget :service_top_traffic, service_id: service.to_param if can?(:manage, :partners)
+  - if can?(:manage, :analytics)
+    = dashboard_widget :service_hits, service_id: service.to_param
+    = dashboard_widget :service_top_traffic, service_id: service.to_param

--- a/app/views/provider/admin/dashboards/_service_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_service_navigation.html.slim
@@ -1,18 +1,19 @@
 nav.DashboardNavigation
   ul.DashboardNavigation-list
     // Applications & Application Plans
-    - if can? :manage, :partners
-      li.DashboardNavigation-list-item
-        // Applications
+
+    li.DashboardNavigation-list-item
+      // Applications
+      - if can? :manage, :partners
         => dashboard_collection_link 'Application',
                                      service.cinstances,
                                      admin_service_applications_path(service)
 
-        // Application Plans
-        - if can?(:edit, service) && !master_on_premises?
-          == dashboard_secondary_collection_link 'Plan',
-                                                 service.application_plans.not_custom,
-                                                 admin_service_application_plans_path(service)
+      // Application Plans
+      - if can?(:manage, :plans) && !master_on_premises?
+        == dashboard_secondary_collection_link 'Plan',
+                                               service.application_plans.not_custom,
+                                               admin_service_application_plans_path(service)
 
     // Subscriptions & Service Plans
     - if show_subscriptions_on_dashboard?(service)
@@ -43,7 +44,7 @@ nav.DashboardNavigation
                                                  admin_service_end_user_plans_path(service)
 
     // Integration
-    - if can?(:edit, service) && !service.has_traffic?
+    - if can?(:manage, :plans) && !service.has_traffic?
       li.DashboardNavigation-list-item.u-notice
         = link_to "Integrate this API",
                   path_to_service(service),

--- a/app/views/provider/admin/dashboards/show.html.slim
+++ b/app/views/provider/admin/dashboards/show.html.slim
@@ -22,11 +22,10 @@
         = dashboard_widget :potential_upgrades if can?(:manage, :plans)
 
     // API Service Level
-    - if can?(:manage, :analytics)
-      = render collection: @services,
-               partial: 'provider/admin/dashboards/service',
-               cache: ->(service) { [ 'v1', 'dashboard', current_user, current_account, service, 'service' ] },
-               cache_options: { expires_in: 1.hour }
+    = render collection: @services,
+             partial: 'provider/admin/dashboards/service',
+             cache: ->(service) { [ 'v1', 'dashboard', current_user, current_account, service, 'service' ] },
+             cache_options: { expires_in: 1.hour }
 
     = render 'shared/service_access'
 
@@ -38,7 +37,3 @@ javascript:
   System.import('dashboard/toggle').then(function (m) {
     m.default()
   });
-
-
-
-

--- a/app/views/shared/provider/_submenu.html.slim
+++ b/app/views/shared/provider/_submenu.html.slim
@@ -42,6 +42,7 @@ ul#second_nav.self_clear
     = provider_submenu_link 'Traffic', admin_transactions_path
 
   - when :serviceadmin
+    - if can?(:manage, :plans)
       = provider_submenu_link 'Overview', admin_services_path
       = provider_submenu_link 'ActiveDocs', admin_api_docs_services_path, title: 'ActiveDocs'
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In a service driven navigation context "applications" and "active docs" sit inside the "API" menu. Also, the dashboard is the new API's page. We need more granular checks for showing/hiding service related content on the dashboard. (at this moment we only show service on dashboard if user can manage analytics.) We also need to make decisons which permission unlocks active docs and definition (metrics) as they are not locked at all at this moment.

things we won't do:
- fix api's top navigation level for members with app only access. This section will be gone in 2 weeks.

to do:
- [x] show minimal info on dashboard when user has access to applications
- [x] hide service menu items for which no access has been given
- [ ] lock down active docs & metrics controller [ future pr]

Member with applications access for some services will see those services and links to applications of those services on the dashboard.

<img width="1303" alt="screenshot 2018-10-03 20 21 27" src="https://user-images.githubusercontent.com/54224/46430748-3ece1280-c74a-11e8-92eb-3dbb334a481f.png">

that person will have a bit of a broken applications view (no top nav is active) but this will be fixed when we switch to PF vertical navigation.

<img width="1661" alt="screenshot 2018-10-03 18 28 04" src="https://user-images.githubusercontent.com/54224/46424741-3968cc00-c73a-11e8-9802-e8bc08ba0ec3.png">
