### PR TITLE
[2.4 Feature][Navigation] Move account plans to settings

### DIFF
--- a/app/controllers/buyers/account_plans_controller.rb
+++ b/app/controllers/buyers/account_plans_controller.rb
@@ -4,7 +4,7 @@ class Buyers::AccountPlansController < Api::PlansBaseController
   before_action :authorize_manage_account_plans!, :only => %i[new create]
   before_action :authorize_read_account_plans!
 
-  activate_menu :serviceadmin, :submenu =>  :account_plans
+  activate_menu! main_menu: :settings, submenu: :account_plans
 
   def index
     @new_plan = AccountPlan

--- a/app/views/shared/provider/_submenu.html.slim
+++ b/app/views/shared/provider/_submenu.html.slim
@@ -45,10 +45,6 @@ ul#second_nav.self_clear
       = provider_submenu_link 'Overview', admin_services_path
       = provider_submenu_link 'ActiveDocs', admin_api_docs_services_path, title: 'ActiveDocs'
 
-      - if current_account.settings.account_plans.allowed? && current_account.settings.account_plans_ui_visible?
-        = provider_submenu_link 'Account Plans', admin_buyers_account_plans_path,
-          title: 'Account Plans'
-
   - when :finance
     = provider_submenu_link 'Earnings by month', admin_finance_root_path, title: :overview
     = provider_submenu_link 'Invoices', admin_finance_invoices_path, title: :invoices
@@ -68,6 +64,9 @@ ul#second_nav.self_clear
     = provider_submenu_link 'Webhooks', edit_provider_admin_webhooks_path, title: :web_hooks, switch: :web_hooks, upgrade_notice: true
 
     = provider_submenu_link 'Emails', edit_admin_site_emails_path unless master_on_premises?
+
+    - if current_account.settings.account_plans.allowed? && current_account.settings.account_plans_ui_visible?
+      = provider_submenu_link 'Account Plans', admin_buyers_account_plans_path, title: :account_plans
 
   - when :buyers, :accounts
     - if can? :manage, :partners

--- a/features/old/api/plans/account_plans.feature
+++ b/features/old/api/plans/account_plans.feature
@@ -11,7 +11,7 @@ Feature: Different account plans
 
   Scenario: In allowed state, I should be able to do everything
     Given provider "foo.example.com" has "account_plans" switch allowed
-      And I am on the API dashboard page
+      And I am on the provider site page
     When I follow "Account Plans"
     Then I should see the copy button
 
@@ -23,5 +23,5 @@ Feature: Different account plans
   Scenario: In allowed state, but with Account Plans hidden I should not see Account Plans menu
     Given provider "foo.example.com" has "account_plans" switch allowed
       And provider has account plans hidden from the ui
-      And I am on the API dashboard page
+      And I am on the provider site page
       Then there should not be any mention of account plans

--- a/features/old/menu/provider.feature
+++ b/features/old/menu/provider.feature
@@ -49,7 +49,6 @@ Feature: Menu
       | Applications    |                      |                  |
       | API             |                      |                  |
       | -               | Overview             |                  |
-      | -               | Account Plans        |                  |
       | Developer Portal|                      |                  |
       | -               | Content              |                  |
       | -               | 0 Drafts             |                  |
@@ -67,6 +66,7 @@ Feature: Menu
       | -               | -                    | Signup           |
       | -               | -                    | Application      |
       | -               | Fields Definitions   |                  |
+      | -               | Account Plans        |                  |
 
 
     Scenario: With multiple applications enabled


### PR DESCRIPTION
Fixes [THREESCALE-1356](https://issues.jboss.org/browse/THREESCALE-1356)

Go to `provider-url/buyers/account_plans` and you will see the new navigation:
![image](https://user-images.githubusercontent.com/11318903/46428713-fd873400-c744-11e8-9b01-a34b57ed2d5b.png)

