### PR TITLE
Basic authentication support for the proxy [THREESCALE-430]

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -42,7 +42,7 @@ class Proxy < ApplicationRecord
 
   validates :oauth_login_url, format: { without: OAUTH_PARAMS }, length: { maximum: 255 }
 
-  validates :credentials_location, inclusion: { in: %w(headers query), allow_nil: false }
+  validates :credentials_location, inclusion: { in: %w[headers query authorization], allow_nil: false }
 
   validates :error_status_no_match, :error_status_auth_missing, :error_status_auth_failed,
                             numericality: { greater_than_or_equal_to: 200, less_than: 600 }
@@ -319,6 +319,11 @@ class Proxy < ApplicationRecord
        param_name = opts[:original_names] ? x.to_s : send(keys_to_proxy_args[x])
        [ param_name, params[x]  ]
     end.to_h
+  end
+
+  def authorization_credentials
+    params = authentication_params_for_proxy.symbolize_keys
+    params.values_at(:user_key).compact.presence || params.values_at(:app_id, :app_key)
   end
 
   def skip_test_request?

--- a/app/services/proxy_test_service.rb
+++ b/app/services/proxy_test_service.rb
@@ -82,7 +82,10 @@ class ProxyTestService
       { query: credentials }
     when 'authorization'
       user, password = proxy.authorization_credentials
-      { header: { 'Authorization' => ["#{user}:#{password}"].pack('m').tr("\n", '') }}
+
+      # See: https://github.com/3scale/apicast/blob/e3130292b1b543c19a2de3c4f006da16d501964d/gateway/src/resty/http_authorization.lua#L13
+      encoded = Base64.encode64([user,password].join(':')).strip
+      { header: { 'Authorization' => "Basic #{encoded}"}}
     end
   end
 

--- a/app/services/proxy_test_service.rb
+++ b/app/services/proxy_test_service.rb
@@ -56,6 +56,7 @@ class ProxyTestService
     client.receive_timeout = 10
 
     client.transparent_gzip_decompression = true
+    client.force_basic_auth = true
 
     if (verify_mode = config.verify_mode)
       client.ssl_config.verify_mode = verify_mode
@@ -74,10 +75,14 @@ class ProxyTestService
   def credentials
     credentials = proxy.authentication_params_for_proxy
 
-    if proxy.credentials_location == 'headers'
+    case proxy.credentials_location
+    when 'headers'
       { header: credentials }
-    else
+    when 'query'
       { query: credentials }
+    when 'authorization'
+      user, password = proxy.authorization_credentials
+      { header: { 'Authorization' => ["#{user}:#{password}"].pack('m').tr("\n", '') }}
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1095,6 +1095,7 @@ en:
     credentials_location:
       headers: "As HTTP Headers"
       query: "As query parameters (GET) or body parameters (POST/PUT/DELETE)"
+      authorization: "As HTTP Basic Authorization"
 
   formtastic:
     hints:

--- a/features/provider/integration/edit.feature
+++ b/features/provider/integration/edit.feature
@@ -12,3 +12,16 @@ Feature: Edit Integration
     When I go to the service integration page
      And I follow "the analytics section"
     Then I should be on the provider stats usage page
+
+  # TODO: remove it when the Coffeescript is migrated to React
+  @javascript
+  Scenario: Changing the Authentication method should display the right curl command
+    Given the service uses app_id/app_key as authentication method
+    And I go to the service integration page
+    And I toggle "Authentication Settings"
+    When I choose "As HTTP Basic Authorization"
+    Then The curl command uses Basic Authentication with app_id/app_key credentials
+    When I choose "As query parameters (GET) or body parameters (POST/PUT/DELETE)"
+    Then The curl command uses Query with app_id/app_key credentials
+    When I choose "As HTTP Headers"
+    Then The curl command uses Headers with app_id/app_key credentials

--- a/features/step_definitions/proxy_steps.rb
+++ b/features/step_definitions/proxy_steps.rb
@@ -56,3 +56,20 @@ Then(/^I should see the Policy Chain$/) do
   page.should have_css(".PolicyRegistryList.is-hidden")
 
 end
+
+
+Then(%r{^The curl command uses (Basic Authentication|Query|Headers) with app_id/app_key credentials$}) do |authentication|
+  matches = {
+    'Basic Authentication' => %r{^curl "https?://APP_ID:APP_KEY@},
+    'Query' => %r{^curl "https?://.*\?app_id=APP_ID&app_key=APP_KEY"},
+    'Headers' => %r{^curl "https?://.*" -H 'app_id: APP_ID' -H 'app_key: APP_KEY'}
+  }
+  within '#api-test-curl' do
+    page.should have_content(matches[authentication])
+  end
+end
+
+Given(%r{^the service uses app_id/app_key as authentication method$}) do
+  @service ||= @provider.default_service
+  @service.update_attributes!(backend_version: '2')
+end

--- a/test/unit/helpers/api/integrations_helper_test.rb
+++ b/test/unit/helpers/api/integrations_helper_test.rb
@@ -25,6 +25,18 @@ class Api::IntegrationsHelperTest < ActionView::TestCase
     assert_match(/-H&#39;user_key: USER_KEY/, res) # 39 is ', 27 is escape
   end
 
+  test 'auth basic' do
+    @proxy.update_attributes(credentials_location: 'authorization')
+
+    res = api_test_curl(@proxy)
+    assert_match %r(http://USER_KEY@), res
+
+    @proxy.service.update_attributes(backend_version: '2')
+    @proxy.reload
+    res = api_test_curl(@proxy)
+    assert_match %r(http://APP_ID:APP_KEY@), res
+  end
+
   test 'no double ?' do
     @proxy.update_attributes(api_test_path:  '/a?b=c')
     res = api_test_curl(@proxy)
@@ -59,4 +71,5 @@ class Api::IntegrationsHelperTest < ActionView::TestCase
     refute(is_https?(1))
     refute(is_https?(nil))
   end
+
 end

--- a/test/unit/services/proxy_test_service_test.rb
+++ b/test/unit/services/proxy_test_service_test.rb
@@ -30,6 +30,15 @@ class ProxyTestServiceTest < ActiveSupport::TestCase
 
     @proxy.credentials_location = 'headers'
     assert_equal({header: {user_key: 'abcd'}}, @service.credentials)
+
+    @proxy.credentials_location = 'authorization'
+
+    encoded_string = Base64.encode64("abcd:").strip
+    assert_equal({header: {'Authorization' => "Basic #{encoded_string}"}}, @service.credentials)
+
+    @proxy.stubs(:authentication_params_for_proxy).returns({app_id: 'abcd', app_key: 'efgh'})
+    encoded_string = Base64.encode64("abcd:efgh").strip
+    assert_equal({header: {'Authorization' => "Basic #{encoded_string}"}}, @service.credentials)
   end
 
   def test_client


### PR DESCRIPTION
Support Basic (and possibly other) Authorization on APIcast.


I do not intend to finish this PR, but wanted to open it to show it is quite easy to do.

Closes [THREESCALE-430](https://issues.jboss.org/browse/THREESCALE-430)

# TODO

- [x] test the generated curl command
- [x] test the proxy test service
- [x] test the UI