### PR TITLE
[WIP] FOSS CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,21 @@ store-test-artifacts: &store-test-artifacts
     path: tmp/junit
     destination: junit
 
-restore-caches: &restore-caches
+restore-bundler-cache: &restore-bundler-cache
   restore_cache:
     keys:
-      # when lock file changes, use increasingly general patterns to restore cache
       - 3scale-system-bundler-gems-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+restore-npm-cache: &restore-npm-cache
+  restore_cache:
+    keys:
       - 3scale-system-npm_jspm-{{ .Branch }}-{{ checksum "package.json" }}
+restore-gateway-cache: &restore-gateway-cache
+  restore_cache:
+    keys:
       - 3scale-system-gateway-{{ .Branch }}-{{ .Revision }}
+restore-assets-cache: &restore-assets-cache
+  restore_cache:
+    keys:
       - 3scale-system-assets-{{ .Branch }}-{{ .Revision }}
 
 
@@ -38,7 +46,7 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-bundler-cache
       - run:
           name: Install gems with bundler
           command: make bundle-in-container
@@ -53,7 +61,7 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-npm-cache
       - run:
           name: Install NPM dependencies
           command: make npm-install-in-container
@@ -69,7 +77,7 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-gateway-cache
       - run:
           name: Install Apicast dependencies
           command: make apicast-dependencies-in-container
@@ -83,7 +91,10 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-bundler-cache
+      - *restore-npm-cache
+      - *restore-gateway-cache
+      - *restore-assets-cache
       - run:
           name: Precompile assets
           command: make precompile-assets
@@ -99,7 +110,10 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-bundler-cache
+      - *restore-npm-cache
+      - *restore-gateway-cache
+      - *restore-assets-cache
       - run:
           name: Run tests 1
           command: MULTIJOB_KIND=1 make test
@@ -112,7 +126,10 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-bundler-cache
+      - *restore-npm-cache
+      - *restore-gateway-cache
+      - *restore-assets-cache
       - run:
           name: Run tests 2
           command: MULTIJOB_KIND=2 make test-no-deps
@@ -125,7 +142,10 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-bundler-cache
+      - *restore-npm-cache
+      - *restore-gateway-cache
+      - *restore-assets-cache
       - run:
           name: Run tests 3
           command: MULTIJOB_KIND=3 make test
@@ -138,7 +158,10 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-bundler-cache
+      - *restore-npm-cache
+      - *restore-gateway-cache
+      - *restore-assets-cache
       - run:
           name: Run tests 4
           command: MULTIJOB_KIND=4 make test
@@ -151,7 +174,10 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-bundler-cache
+      - *restore-npm-cache
+      - *restore-gateway-cache
+      - *restore-assets-cache
       - run:
           name: Run tests 5
           command: MULTIJOB_KIND=5 make test
@@ -164,7 +190,10 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-bundler-cache
+      - *restore-npm-cache
+      - *restore-gateway-cache
+      - *restore-assets-cache
       - run:
           name: Run tests 6
           command: MULTIJOB_KIND=6 make test
@@ -177,7 +206,10 @@ jobs:
     steps:
       - checkout
       - *git-submodules
-      - *restore-caches
+      - *restore-bundler-cache
+      - *restore-npm-cache
+      - *restore-gateway-cache
+      - *restore-assets-cache
       - run:
           name: Run tests 7
           command: PROXY_ENABLED=1 MULTIJOB_KIND=licenses make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ restore-caches: &restore-caches
 
 jobs:
   deps_bundler:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - *git-submodules
@@ -50,7 +51,8 @@ jobs:
             - ./vendor/bundle
             - ./.bundle/
   deps_npm:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - *git-submodules
@@ -64,7 +66,8 @@ jobs:
             - ./assets/jspm_packages
             - ./.jspm
   deps_apicast:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - *git-submodules
@@ -78,7 +81,8 @@ jobs:
 
 
   test1:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - *git-submodules
@@ -90,7 +94,8 @@ jobs:
       - *store-test-artifacts
 
   test2:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - *git-submodules
@@ -102,7 +107,8 @@ jobs:
       - *store-test-artifacts
 
   test3:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - *git-submodules
@@ -114,7 +120,8 @@ jobs:
       - *store-test-artifacts
 
   test4:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - *git-submodules
@@ -126,7 +133,8 @@ jobs:
       - *store-test-artifacts
 
   test5:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - *git-submodules
@@ -138,7 +146,8 @@ jobs:
       - *store-test-artifacts
 
   test6:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - *git-submodules
@@ -150,7 +159,8 @@ jobs:
       - *store-test-artifacts
 
   licenses:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - *git-submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,109 @@
+version: 2.0
+
+#### YAML ANCHORS INSTEAD OF COMMANDS # while version 2.1 already supports commands, the local runner doesn't. When it does, we can upgrade.
+
+git-submodules: &git-submodules
+  run:
+    name: "Pull Submodules"
+    command: |
+      git submodule init
+      git submodule update
+
+store-junit-results: &store-junit-test-results
+  store_test_results:
+    path: tmp/junit
+
+store-test-artifacts: &store-test-artifacts
+  store_artifacts:
+    path: tmp/junit
+    destination: junit
+
+jobs:
+  test1:
+    machine: true
+    steps:
+      - checkout
+      - *git-submodules
+      - run:
+          name: Run tests 1
+          command: MULTIJOB_KIND=1 make test
+      - *store-junit-test-results
+      - *store-test-artifacts
+
+  test2:
+    machine: true
+    steps:
+      - checkout
+      - *git-submodules
+      - run:
+          name: Run tests 2
+          command: MULTIJOB_KIND=2 make test
+      - *store-junit-test-results
+      - *store-test-artifacts
+
+  test3:
+    machine: true
+    steps:
+      - checkout
+      - *git-submodules
+      - run:
+          name: Run tests 3
+          command: MULTIJOB_KIND=3 make test
+      - *store-junit-test-results
+      - *store-test-artifacts
+
+  test4:
+    machine: true
+    steps:
+      - checkout
+      - *git-submodules
+      - run:
+          name: Run tests 4
+          command: MULTIJOB_KIND=4 make test
+      - *store-junit-test-results
+      - *store-test-artifacts
+
+  test5:
+    machine: true
+    steps:
+      - checkout
+      - *git-submodules
+      - run:
+          name: Run tests 5
+          command: MULTIJOB_KIND=5 make test
+      - *store-junit-test-results
+      - *store-test-artifacts
+
+  test6:
+    machine: true
+    steps:
+      - checkout
+      - *git-submodules
+      - run:
+          name: Run tests 6
+          command: MULTIJOB_KIND=6 make test
+      - *store-junit-test-results
+      - *store-test-artifacts
+
+  licenses:
+    machine: true
+    steps:
+      - checkout
+      - *git-submodules
+      - run:
+          name: Run tests 7
+          command: PROXY_ENABLED=1 MULTIJOB_KIND=licenses make test
+      - *store-junit-test-results
+      - *store-test-artifacts
+
+workflows:
+  version: 2
+  parallel_build:
+    jobs:
+      - test1
+      - test2
+      - test3
+      - test4
+      - test5
+      - test6
+      - licenses

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ restore-assets-cache: &restore-assets-cache
 
 
 jobs:
-  deps_bundler:
+  dependencies_bundler:
     machine:
       docker_layer_caching: true
     steps:
@@ -55,7 +55,7 @@ jobs:
           paths:
             - ./vendor/bundle
             - ./.bundle/
-  deps_npm:
+  dependencies_npm:
     machine:
       docker_layer_caching: true
     steps:
@@ -71,7 +71,7 @@ jobs:
             - ./node_modules
             - ./assets/jspm_packages
             - ./.jspm
-  deps_apicast:
+  dependencies_apicast:
     machine:
       docker_layer_caching: true
     steps:
@@ -116,7 +116,7 @@ jobs:
       - *restore-assets-cache
       - run:
           name: Run tests 1
-          command: MULTIJOB_KIND=1 make test
+          command: MULTIJOB_KIND=1 make test-no-deps
       - *store-junit-test-results
       - *store-test-artifacts
 
@@ -148,7 +148,7 @@ jobs:
       - *restore-assets-cache
       - run:
           name: Run tests 3
-          command: MULTIJOB_KIND=3 make test
+          command: MULTIJOB_KIND=3 make test-no-deps
       - *store-junit-test-results
       - *store-test-artifacts
 
@@ -164,7 +164,7 @@ jobs:
       - *restore-assets-cache
       - run:
           name: Run tests 4
-          command: MULTIJOB_KIND=4 make test
+          command: MULTIJOB_KIND=4 make test-no-deps
       - *store-junit-test-results
       - *store-test-artifacts
 
@@ -180,7 +180,7 @@ jobs:
       - *restore-assets-cache
       - run:
           name: Run tests 5
-          command: MULTIJOB_KIND=5 make test
+          command: MULTIJOB_KIND=5 make test-no-deps
       - *store-junit-test-results
       - *store-test-artifacts
 
@@ -196,7 +196,7 @@ jobs:
       - *restore-assets-cache
       - run:
           name: Run tests 6
-          command: MULTIJOB_KIND=6 make test
+          command: MULTIJOB_KIND=6 make test-no-deps
       - *store-junit-test-results
       - *store-test-artifacts
 
@@ -212,7 +212,7 @@ jobs:
       - *restore-assets-cache
       - run:
           name: Run tests 7
-          command: PROXY_ENABLED=1 MULTIJOB_KIND=licenses make test
+          command: PROXY_ENABLED=1 MULTIJOB_KIND=licenses make test-no-deps
       - *store-junit-test-results
       - *store-test-artifacts
 
@@ -220,45 +220,33 @@ workflows:
   version: 2
   parallel_build:
     jobs:
-      - deps_bundler
-      - deps_npm
-      - deps_apicast
+      - dependencies_bundler
+      - dependencies_npm
+      - dependencies_apicast
       - assets_precompile:
           requires:
-            - deps_bundler
-            - deps_npm
-            - deps_apicast
+            - dependencies_bundler
+            - dependencies_npm
+            - dependencies_apicast
 
-#      - test1:
-#          requires:
-#            - deps_bundler
-#            - deps_npm
-#            - deps_apicast
+      - test1:
+          requires:
+            - assets_precompile
       - test2:
           requires:
             - assets_precompile
-#      - test3:
-#          requires:
-#            - deps_bundler
-#            - deps_npm
-#            - deps_apicast
-#      - test4:
-#          requires:
-#            - deps_bundler
-#            - deps_npm
-#            - deps_apicast
-#      - test5:
-#          requires:
-#            - deps_bundler
-#            - deps_npm
-#            - deps_apicast
-#      - test6:
-#          requires:
-#            - deps_bundler
-#            - deps_npm
-#            - deps_apicast
-#      - licenses:
-#            requires:
-#              - deps_bundler
-#              - deps_npm
-#              - deps_apicast
+      - test3:
+          requires:
+            - assets_precompile
+      - test4:
+          requires:
+            - assets_precompile
+      - test5:
+          requires:
+            - assets_precompile
+      - test6:
+          requires:
+            - assets_precompile
+      - licenses:
+          requires:
+            - assets_precompile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,71 @@ store-test-artifacts: &store-test-artifacts
     path: tmp/junit
     destination: junit
 
+restore-caches: &restore-caches
+  restore_cache:
+    keys:
+      # when lock file changes, use increasingly general patterns to restore cache
+      - 3scale-system-gems-{{ .Branch }}-{{ checksum "Gemfile" }}
+      - 3scale-system-gems-{{ .Branch }}-
+      - 3scale-system-gems-
+      - 3scale-system-npm_jspm-{{ .Branch }}-{{ checksum "package.json" }}
+      - 3scale-system-npm_jspm-{{ .Branch }}-
+      - 3scale-system-npm_jspm-
+      - 3scale-system-gateway-{{ .Branch }}
+      - 3scale-system-gateway-
+
+
+
+
+
 jobs:
+  deps_bundler:
+    machine: true
+    steps:
+      - checkout
+      - *git-submodules
+      - run:
+          name: Install gems with bundler
+          command: make bundle-in-container
+      - save_cache:
+          key: 3scale-system-gems-{{ .Branch }}-{{ checksum "Gemfile" }}
+          paths:
+            - ./vendor/bundle
+            - ./.bundle/
+  deps_npm:
+    machine: true
+    steps:
+      - checkout
+      - *git-submodules
+      - run:
+          name: Install NPM dependencies
+          command: make npm-install-in-container
+      - save_cache:
+          key: 3scale-system-npm_jspm-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+            - ./assets/jspm_packages
+            - ./.jspm
+  deps_apicast:
+    machine: true
+    steps:
+      - checkout
+      - *git-submodules
+      - run:
+          name: Install Apicast dependencies
+          command: make apicast-dependencies-in-container
+      - save_cache:
+          key: 3scale-system-gateway-{{ .Branch }}
+          paths:
+            - ./vendor/docker-gateway/.luarocks
+
+
   test1:
     machine: true
     steps:
       - checkout
       - *git-submodules
+      - *restore-caches
       - run:
           name: Run tests 1
           command: MULTIJOB_KIND=1 make test
@@ -35,9 +94,10 @@ jobs:
     steps:
       - checkout
       - *git-submodules
+      - *restore-caches
       - run:
           name: Run tests 2
-          command: MULTIJOB_KIND=2 make test
+          command: MULTIJOB_KIND=2 make test-no-deps
       - *store-junit-test-results
       - *store-test-artifacts
 
@@ -46,6 +106,7 @@ jobs:
     steps:
       - checkout
       - *git-submodules
+      - *restore-caches
       - run:
           name: Run tests 3
           command: MULTIJOB_KIND=3 make test
@@ -57,6 +118,7 @@ jobs:
     steps:
       - checkout
       - *git-submodules
+      - *restore-caches
       - run:
           name: Run tests 4
           command: MULTIJOB_KIND=4 make test
@@ -68,6 +130,7 @@ jobs:
     steps:
       - checkout
       - *git-submodules
+      - *restore-caches
       - run:
           name: Run tests 5
           command: MULTIJOB_KIND=5 make test
@@ -79,6 +142,7 @@ jobs:
     steps:
       - checkout
       - *git-submodules
+      - *restore-caches
       - run:
           name: Run tests 6
           command: MULTIJOB_KIND=6 make test
@@ -90,6 +154,7 @@ jobs:
     steps:
       - checkout
       - *git-submodules
+      - *restore-caches
       - run:
           name: Run tests 7
           command: PROXY_ENABLED=1 MULTIJOB_KIND=licenses make test
@@ -100,10 +165,42 @@ workflows:
   version: 2
   parallel_build:
     jobs:
-      - test1
-      - test2
-      - test3
-      - test4
-      - test5
-      - test6
-#      - licenses
+      - deps_bundler
+      - deps_npm
+      - deps_apicast
+
+#      - test1:
+#          requires:
+#            - deps_bundler
+#            - deps_npm
+#            - deps_apicast
+      - test2:
+          requires:
+            - deps_bundler
+            - deps_npm
+            - deps_apicast
+#      - test3:
+#          requires:
+#            - deps_bundler
+#            - deps_npm
+#            - deps_apicast
+#      - test4:
+#          requires:
+#            - deps_bundler
+#            - deps_npm
+#            - deps_apicast
+#      - test5:
+#          requires:
+#            - deps_bundler
+#            - deps_npm
+#            - deps_apicast
+#      - test6:
+#          requires:
+#            - deps_bundler
+#            - deps_npm
+#            - deps_apicast
+#      - licenses:
+#            requires:
+#              - deps_bundler
+#              - deps_npm
+#              - deps_apicast

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,4 +106,4 @@ workflows:
       - test4
       - test5
       - test6
-      - licenses
+#      - licenses

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,14 +22,10 @@ restore-caches: &restore-caches
   restore_cache:
     keys:
       # when lock file changes, use increasingly general patterns to restore cache
-      - 3scale-system-gems-{{ .Branch }}-{{ checksum "Gemfile" }}
-      - 3scale-system-gems-{{ .Branch }}-
-      - 3scale-system-gems-
+      - 3scale-system-bundler-gems-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       - 3scale-system-npm_jspm-{{ .Branch }}-{{ checksum "package.json" }}
-      - 3scale-system-npm_jspm-{{ .Branch }}-
-      - 3scale-system-npm_jspm-
-      - 3scale-system-gateway-{{ .Branch }}
-      - 3scale-system-gateway-
+      - 3scale-system-gateway-{{ .Branch }}-{{ .Revision }}
+      - 3scale-system-assets-{{ .Branch }}-{{ .Revision }}
 
 
 
@@ -42,11 +38,12 @@ jobs:
     steps:
       - checkout
       - *git-submodules
+      - *restore-caches
       - run:
           name: Install gems with bundler
           command: make bundle-in-container
       - save_cache:
-          key: 3scale-system-gems-{{ .Branch }}-{{ checksum "Gemfile" }}
+          key: 3scale-system-bundler-gems-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - ./vendor/bundle
             - ./.bundle/
@@ -56,6 +53,7 @@ jobs:
     steps:
       - checkout
       - *git-submodules
+      - *restore-caches
       - run:
           name: Install NPM dependencies
           command: make npm-install-in-container
@@ -71,13 +69,28 @@ jobs:
     steps:
       - checkout
       - *git-submodules
+      - *restore-caches
       - run:
           name: Install Apicast dependencies
           command: make apicast-dependencies-in-container
       - save_cache:
-          key: 3scale-system-gateway-{{ .Branch }}
+          key: 3scale-system-gateway-{{ .Branch }}-{{ .Revision }}
           paths:
             - ./vendor/docker-gateway/.luarocks
+  assets_precompile:
+    machine:
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - *git-submodules
+      - *restore-caches
+      - run:
+          name: Precompile assets
+          command: make precompile-assets
+      - save_cache:
+          key: 3scale-system-assets-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ./public/assets
 
 
   test1:
@@ -178,6 +191,11 @@ workflows:
       - deps_bundler
       - deps_npm
       - deps_apicast
+      - assets_precompile:
+          requires:
+            - deps_bundler
+            - deps_npm
+            - deps_apicast
 
 #      - test1:
 #          requires:
@@ -186,9 +204,7 @@ workflows:
 #            - deps_apicast
       - test2:
           requires:
-            - deps_bundler
-            - deps_npm
-            - deps_apicast
+            - assets_precompile
 #      - test3:
 #          requires:
 #            - deps_bundler

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,14 @@ docker: ## Prints docker version and info
 	@docker info
 	@echo
 
+precompile-assets-info:
+	@echo
+	@echo "======= Assets Precompile ======="
+	@echo
+precompile-assets: ## Precompiles static assets
+precompile-assets: CMD = bundle config && bundle exec rake assets:precompile RAILS_GROUPS=assets RAILS_ENV=production WEBPACKER_PRECOMPILE=false && bundle exec rake assets:precompile RAILS_GROUPS=assets RAILS_ENV=test WEBPACKER_PRECOMPILE=false
+precompile-assets: precompile-assets-info run
+
 test: ## Runs tests inside container build environment
 test: COMPOSE_FILE = $(COMPOSE_TEST_FILE)
 test: $(DOCKER_COMPOSE) info bundle-in-container npm-install-in-container jspm-install-in-container apicast-dependencies-in-container
@@ -120,7 +128,7 @@ run: $(DOCKER_COMPOSE)
 	@echo
 	@echo "======= Run ======="
 	@echo
-	$(DOCKER_COMPOSE) run --rm --name $(PROJECT)-build-run $(DOCKER_ENV) build bash -c "script/docker.sh && source script/proxy_env.sh && $(CMD)"
+	$(DOCKER_COMPOSE) run --rm --name $(PROJECT)-build-run $(DOCKER_ENV) build bash -c "script/docker.sh && source script/proxy_env.sh && echo \"$(CMD)\" && $(CMD)"
 
 bash: ## Opens up shell to environment where tests can be ran
 bash: CMD = script/docker.sh && bundle exec rake db:create db:test:load && bundle exec bash

--- a/dependencies.mk
+++ b/dependencies.mk
@@ -1,0 +1,45 @@
+bash-interactive: ## Opens up interactive shell in development environment inside container.
+bash-interactive: COMMAND = /bin/bash
+bash-interactive: bash-run
+
+bash-run: ## Runs arbitrary ${COMMAND} in development environment inside container.
+bash-run: COMPOSE_FILE = $(COMPOSE_TEST_FILE)
+bash-run: $(DOCKER_COMPOSE)
+	@echo
+	@echo "======= Run Command ======="
+	@echo
+	$(DOCKER_COMPOSE) run --rm --name $(PROJECT)-build-run $(DOCKER_ENV) build "$(COMMAND)"
+
+
+bundle-info:
+	@echo
+	@echo "======= Bundler ======="
+	@echo
+
+bundle-in-container: ## Installs dependencies using bundler, inside the build container. Run this after you make some changes to Gemfile.
+bundle-in-container: Gemfile
+bundle-in-container: CMD = bundle check --path=vendor/bundle --gemfile=Gemfile || ${PROXY_ENV} bundle install --deployment --retry=5 --gemfile=Gemfile && bundle config
+bundle-in-container: bundle-info run
+
+
+apicast-dependencies-info:
+	@echo
+	@echo "======= APIcast ======="
+	@echo
+
+apicast-dependencies-in-container: ## Fetches APICast dependencies by invoking `dependencies` target on apicast submodule.
+apicast-dependencies-in-container: CMD = cd vendor/docker-gateway && ls -al && ${PROXY_ENV} make dependencies && cd ../../
+apicast-dependencies-in-container: apicast-dependencies-info run
+
+npm-install-info:
+	@echo
+	@echo "======= NPM ======="
+	@echo
+
+npm-install-in-container: ## Installs NPM & JSPM dependencies in development environment inside container.
+npm-install-in-container: CMD = yarn --version && yarn global dir && ${PROXY_ENV} yarn install --frozen-lockfile --link-duplicates && jspm -v && ${PROXY_ENV} jspm dl-loader && ${PROXY_ENV} jspm install --lock || ${PROXY_ENV} jspm install --force
+npm-install-in-container: npm-install-info run
+
+
+
+

--- a/docker-compose.test-mysql.yml
+++ b/docker-compose.test-mysql.yml
@@ -21,7 +21,15 @@ services:
       DB_HOST: ${PROJECT:-system}-database
       DISABLE_SPRING: "true"
     volumes:
-      - .:/opt/system/  
+      - .:/opt/system/
+      - ./tmp/cache:/opt/system/tmp/cache/
+      - ./node_modules:/opt/system/node_modules
+      - ./assets/jspm_packages:/opt/system/assets/jspm_packages
+      - ./public/assets:/opt/system/public/assets
+      - ./.jspm:/root/.jspm
+      - ./vendor/bundle:/opt/system/vendor/bundle
+      - ./.bundle:/opt/system/.bundle
+      - ./vendor/docker-gateway/.luarocks:/home/ruby/.luarocks
     volumes_from:
       - cache
     depends_on:

--- a/docker-compose.test-mysql.yml
+++ b/docker-compose.test-mysql.yml
@@ -6,12 +6,12 @@ services:
     container_name: ${PROJECT:-system}-database
     network_mode: bridge
   cache:
-    build: .
+    image: quay.io/gsaslis/3scale-system-builder
     network_mode: none
     container_name: ${PROJECT:-system}-cache
     command: sleep infinity 
   build:
-    build: .
+    image: quay.io/gsaslis/3scale-system-builder
     dns: 127.0.0.1
     container_name: ${PROJECT:-system}-build
     network_mode: bridge
@@ -20,6 +20,8 @@ services:
     environment:
       DB_HOST: ${PROJECT:-system}-database
       DISABLE_SPRING: "true"
+    volumes:
+      - .:/opt/system/  
     volumes_from:
       - cache
     depends_on:

--- a/script/docker.sh
+++ b/script/docker.sh
@@ -33,7 +33,7 @@ echo
 echo "======= NPM ======="
 echo
 yarn --version
-time bash -c "CXX=g++-4.8 ${PROXY_ENV} yarn install"
+time bash -c "CXX=g++ ${PROXY_ENV} yarn install"
 echo
 
 echo "======= JSPM ======="

--- a/script/docker.sh
+++ b/script/docker.sh
@@ -19,7 +19,10 @@ echo
 env
 echo
 
-
-
-
+echo
+echo "======= Seeding Config files ======="
+echo
+cp config/examples/*.yml config/
+# Needed for Sphinx ODBC
+cp config/oracle/odbc*.ini /etc/
 

--- a/script/docker.sh
+++ b/script/docker.sh
@@ -19,33 +19,7 @@ echo
 env
 echo
 
-echo
-echo "======= Bundler ======="
-echo
-for gemfile in Gemfile Gemfile.on_prem
-do
-  bundle check --path=vendor/bundle --gemfile="${gemfile}" || time bash -c "${PROXY_ENV} bundle install --deployment --retry=5 --gemfile=${gemfile}"
-done
-bundle config
-echo
 
-echo
-echo "======= NPM ======="
-echo
-yarn --version
-time bash -c "CXX=g++ ${PROXY_ENV} yarn install"
-echo
 
-echo "======= JSPM ======="
-echo
-jspm -v
-jspm config registries.github.auth ${GITHUB_REPOSITORY_TOKEN}
-time bash -c "${PROXY_ENV} jspm dl-loader"
-time bash -x -c "export ${PROXY_ENV}; jspm install --lock|| jspm install --force"
-echo
 
-echo "======= APIcast ======="
 
-pushd vendor/docker-gateway
-time bash -c "${PROXY_ENV} make dependencies"
-popd

--- a/script/jenkins.sh
+++ b/script/jenkins.sh
@@ -8,10 +8,6 @@ SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 # lets make everything readable by everyone
 umask 0000
 
-cp config/examples/*.yml config/
-# Needed for Sphinx ODBC
-cp config/oracle/odbc*.ini /etc/
-
 boot_database()
 {
     bin/rake boot:database TEST_ENV_NUMBER=8

--- a/script/jenkins.sh
+++ b/script/jenkins.sh
@@ -8,6 +8,10 @@ SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 # lets make everything readable by everyone
 umask 0000
 
+cp config/examples/*.yml config/
+# Needed for Sphinx ODBC
+cp config/oracle/odbc*.ini /etc/
+
 echo "======= Assets Precompile ======="
 set -x
 

--- a/script/jenkins.sh
+++ b/script/jenkins.sh
@@ -12,12 +12,6 @@ cp config/examples/*.yml config/
 # Needed for Sphinx ODBC
 cp config/oracle/odbc*.ini /etc/
 
-echo "======= Assets Precompile ======="
-set -x
-
-time bundle exec rake assets:precompile RAILS_GROUPS=assets RAILS_ENV=production WEBPACKER_PRECOMPILE=false
-time bundle exec rake assets:precompile RAILS_GROUPS=assets RAILS_ENV=test WEBPACKER_PRECOMPILE=false
-
 boot_database()
 {
     bin/rake boot:database TEST_ENV_NUMBER=8

--- a/script/lib/docker
+++ b/script/lib/docker
@@ -22,6 +22,13 @@ launch_dnsmasq()
     ${SUDO} dnsmasq --no-resolv --listen-address=127.0.0.1 \
                     --address=/${DNSMASQ="#"}/127.0.0.1 \
                     --server=/raw.githubusercontent.com/8.8.8.8 \
+                    --server=/rubygems.org/8.8.8.8 \
+                    --server=/github.com/8.8.8.8 \
+                    --server=/registry.yarnpkg.com/8.8.8.8 \
+                    --server=/registry.npmjs.org/8.8.8.8 \
+                    --server=/nodejs.org/8.8.8.8 \
+                    --server=/luarocks.org/8.8.8.8 \
+                    --server=/stevedonovan.github.io/8.8.8.8 \
                     --server=/cc-3scale-amend.herokuapp.com/8.8.8.8 \
                     --server=/percy.io/8.8.8.8 \
                     --user=$(whoami)

--- a/script/lib/docker
+++ b/script/lib/docker
@@ -3,7 +3,7 @@
 # lower lever functions
 launch_redis()
 {
-    redis-server /etc/redis/redis.conf
+    redis-server /etc/redis.conf &
 }
 
 launch_memcached()
@@ -13,7 +13,7 @@ launch_memcached()
 
 launch_squid()
 {
-  squid3
+  squid
 }
 
 launch_dnsmasq()


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Move from private container image used for CI builds to public one
2. Proof-of-concept of using the public image in CircleCI
3. Reworked the flow of builds themselves, especially in particular to how dependencies are installed (now parallelised, i.e. faster AND only runs when changes are actually made to the files, making use of circleci caching, so we are saving considerable resources ) 

**Which issue(s) this PR fixes** 

The container image that is used to spin up containers, in which to run the tests, is currently private. This means contributors can't run builds locally. 

**Verification steps** 

N/A 

**Special notes for your reviewer**:

This is still WIP and is also blocked on #44. ( On my fork I have applied changes from #44, because an important step in the reworked pipeline is the dependencies installation and having the correct `Gemfile` is important. ) 

Additional work remaining here (in order): 

- [ ] get #44 merged
- [ ] switch from codeclimate to codecov for test coverage reports (PoC ready on my fork, but blocked on #44)
- [ ] Switch from `machine` executor in CircleCI to `docker` executor: meaning we'll be running our builds natively in containers ( fixes #93 )
- [ ] Use [CircleCI feature for splitting tests based on past timings](https://circleci.com/docs/2.0/parallelism-faster-jobs/#splitting-by-timings-data) to improve build times. 