### PR TITLE
[db] Migration to prepare service resync for Kubernetes service discovery

### DIFF
--- a/db/migrate/20181008065816_add_kubernetes_service_link_to_service.rb
+++ b/db/migrate/20181008065816_add_kubernetes_service_link_to_service.rb
@@ -1,0 +1,5 @@
+class AddKubernetesServiceLinkToService < ActiveRecord::Migration
+  def change
+    add_column :services, :kubernetes_service_link, :string, null: true
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180928114956) do
+ActiveRecord::Schema.define(version: 20181008065816) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -1140,6 +1140,7 @@ ActiveRecord::Schema.define(version: 20180928114956) do
     t.string   "support_email"
     t.boolean  "referrer_filters_required",      limit: nil,                default: false
     t.string   "deployment_option",                                         default: "hosted"
+    t.string   "kubernetes_service_link"
   end
 
   add_index "services", ["account_id"], name: "idx_account_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180928114956) do
+ActiveRecord::Schema.define(version: 20181008065816) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -1140,6 +1140,7 @@ ActiveRecord::Schema.define(version: 20180928114956) do
     t.string   "support_email",                  limit: 255
     t.boolean  "referrer_filters_required",                    default: false
     t.string   "deployment_option",              limit: 255,   default: "hosted"
+    t.string   "kubernetes_service_link",        limit: 255
   end
 
   add_index "services", ["account_id"], name: "idx_account_id", using: :btree


### PR DESCRIPTION
So we can differenciate which are the services that are fetched from K8s and the others.
Store in this column the self_link so we can identify the service easily.