### PR TITLE
[fix] rake boot:database should only exit when db is not ready

### DIFF
--- a/lib/tasks/boot.rake
+++ b/lib/tasks/boot.rake
@@ -11,7 +11,7 @@ namespace :boot do
   task :database do
     begin
       require 'system/database'
-      exit System::Database.ready?
+      exit false unless System::Database.ready?
     end
   end
 


### PR DESCRIPTION
Otherwise it will not run other following tasks
Bug introduced in https://github.com/3scale/porta/pull/83/commits/884ed69c4f3dc24db4590a0beff06bb6f1fc6854