### PR TITLE
[wip] End-to-end test for service discovery

### DIFF
--- a/features/provider/service_discovery.feature
+++ b/features/provider/service_discovery.feature
@@ -1,0 +1,20 @@
+Feature: Service Discovery
+  In order to integrate with 3scale
+  Using a Kubernetes/Openshift cluster to deploy both 3scale onpremises and my APIs
+  As I provider
+  I want to be able to discover my services deployed to the cluster
+
+  Background:
+    Given a provider is logged in
+    And service discovery is enabled
+    And a discoverable API "fake-api" is deployed to the cluster
+    And all the rolling updates features are off
+    And I have proxy_private_base_path feature enabled
+
+  @javascript
+  Scenario: Create service
+    When I go to the new service page
+    And I create a service via Kubernetes discovery
+    And all background jobs related to service discovery are finished
+    And I go to the integration page for service "fake-api"
+    Then I should see a service with private URL to the local cluster

--- a/features/step_definitions/service_discovery_steps.rb
+++ b/features/step_definitions/service_discovery_steps.rb
@@ -1,3 +1,37 @@
 Given(/^service discovery is (not )?enabled$/) do |disabled|
-  ThreeScale.config.service_discovery.stubs(enabled: disabled.present?)
+  ThreeScale.config.service_discovery.stubs(enabled: disabled.blank?)
+end
+
+include TestHelpers::ServiceDiscovery
+
+Given(/^a discoverable API "([^\"]*)" is deployed to the cluster$/) do |api_name|
+  cluster_service_metadata = {
+    name: api_name || 'fake-api',
+    namespace: 'fake-project',
+    labels: { :'discovery.3scale.net' => 'true' },
+    annotations: {
+      :'discovery.3scale.net/scheme' => 'http',
+      :'discovery.3scale.net/port' => '8081',
+      :'discovery.3scale.net/path' => 'api',
+      :'discovery.3scale.net/description-path' => 'api/doc'
+    }
+  }
+  @cluster_service = ServiceDiscovery::ClusterService.new(cluster_service(metadata: cluster_service_metadata))
+end
+
+Given(/^I create a service via Kubernetes discovery$/) do
+  Sidekiq::Testing.fake!
+  ServiceCreationService.call(@provider, name: @cluster_service.name,
+                                         namespace: @cluster_service.namespace,
+                                         source: 'discover')
+end
+
+Given(/^all background jobs related to service discovery are finished$/) do
+  ServiceDiscovery::ClusterClient.any_instance.stubs(:find_discoverable_service_by).with(name: @cluster_service.name, namespace: @cluster_service.namespace).returns(@cluster_service)
+  @cluster_service.stubs(fetch_specification: false)
+  ServiceDiscovery::ImportClusterServiceDefinitionsWorker.drain
+end
+
+Then(/^I should see a service with private URL to the local cluster$/) do
+  assert_match @cluster_service.endpoint, page.body
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It adds an end-to-end cucumber test to the K8S/OCP Service Discovery. It also fixes a step definition related to the feature.

**Which issue(s) this PR fixes** 

Related to https://github.com/3scale/porta/pull/35

**Verification steps** 

N/A

**Special notes for your reviewer**:

The test does not actually use the API for the creation of services via system UI. Instead, it bypasses the controller layer going directly to the actual creation of the service, although basically doing the same thing which is delegating it to `ServiceCreationService`.