### PR TITLE
[cron] Sidekiq Cron weekly should equal to whenever weekly

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -25,7 +25,8 @@ every :month, roles: [:cron] do
   ThreeScale::Jobs::MONTH.each { |task| instance_exec(task, &job_proc) }
 end
 
-every :week, roles: [:cron] do
+# every week on Monday
+every '0 0 * * 1', roles: [:cron] do
   ThreeScale::Jobs::WEEK.each { |task| instance_exec(task, &job_proc) }
 end
 

--- a/openshift/system/config/sidekiq_schedule.yml
+++ b/openshift/system/config/sidekiq_schedule.yml
@@ -6,7 +6,7 @@ monthly_jobs:
   status: disabled
 
 weekly_jobs:
-  cron: '0 0 * * 0'
+  cron: '0 0 1,8,15,22 * *'
   class: CronJob::Enqueuer
   args: ['WEEK']
   description: "Pdf::Dispatch, JanitorWorker"

--- a/openshift/system/config/sidekiq_schedule.yml
+++ b/openshift/system/config/sidekiq_schedule.yml
@@ -6,7 +6,7 @@ monthly_jobs:
   status: disabled
 
 weekly_jobs:
-  cron: '0 0 1,8,15,22 * *'
+  cron: '0 0 * * 1'
   class: CronJob::Enqueuer
   args: ['WEEK']
   description: "Pdf::Dispatch, JanitorWorker"


### PR DESCRIPTION
So weekly means every 1,8,15,22 of the month for whenever
Though every Sunday or Monday, Xday of the week is more correct
This is to harmonize the different behaviour using either the OS cron or using sidekiq

Fixes: https://issues.jboss.org/browse/THREESCALE-1307