### PR TITLE
[Service Discovery] Fill lookup column services.kubernetes_service_link

### DIFF
--- a/app/services/service_creation_service.rb
+++ b/app/services/service_creation_service.rb
@@ -19,7 +19,7 @@ class ServiceCreationService
   end
 
   def create_service
-    service = build_service service_attributes.slice(:name, :system_name, :description)
+    service = build_service service_attributes.slice(:name, :system_name, :description, :kubernetes_service_link)
     @success = service.save
     service
   end

--- a/app/workers/service_discovery/import_cluster_service_definitions_worker.rb
+++ b/app/workers/service_discovery/import_cluster_service_definitions_worker.rb
@@ -11,9 +11,12 @@ module ServiceDiscovery
       service_system_name = [cluster_namespace, service_name].join('-')
 
       cluster = ServiceDiscovery::ClusterClient.new
-      cluster_service = cluster.find_discoverable_service_by(name: service_name, namespace: cluster_namespace)
+      cluster_service = cluster.find_discoverable_service_by(name: service_name,
+                                                             namespace: cluster_namespace)
 
-      service_creation = ServiceCreationService.call(account, name: service_name, system_name: service_system_name)
+      service_creation = ServiceCreationService.call(account, name: service_name,
+                                                              system_name: service_system_name,
+                                                              kubernetes_service_link: cluster_service.self_link)
       new_api = service_creation.service
 
       return unless service_creation.success? && new_api.persisted?

--- a/test/unit/services/service_creation_service_test.rb
+++ b/test/unit/services/service_creation_service_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ServiceCreationServiceTest < ActiveSupport::TestCase
+  setup do
+    @provider = FactoryGirl.create(:simple_provider)
+  end
+
+  test 'call' do
+    assert_difference '@provider.services.count' do
+      ServiceCreationService.call(@provider, name: 'my-api', system_name: 'my-api')
+    end
+  end
+
+  test 'kubernetes_service_link' do
+    service_creation = ServiceCreationService.call(@provider, name: 'my-api', system_name: 'my-api', kubernetes_service_link: '/api/v1/namespaces/fake-project/services/fake-api')
+    assert_equal '/api/v1/namespaces/fake-project/services/fake-api', service_creation.service.kubernetes_service_link
+  end
+
+  test 'async' do
+    service_attributes = { name: 'my-api', namespace: 'my-project' }
+    assert_no_difference '@provider.services.count' do
+      ServiceDiscovery::ImportClusterServiceDefinitionsWorker.expects(:perform_async).with(@provider.id, *service_attributes.values_at(:namespace, :name))
+      ServiceCreationService.call(@provider, service_attributes.merge(source: 'discover'))
+    end
+  end
+
+  test 'source' do
+    service_creation = ServiceCreationService.new(@provider, name: 'my-api', source: 'discover')
+    service_creation.expects(:create_service).never
+    service_creation.expects(:create_service_async).returns(true)
+    service_creation.call
+
+    service_creation = ServiceCreationService.new(@provider, name: 'my-api', source: 'manual')
+    service_creation.expects(:create_service).returns(true)
+    service_creation.expects(:create_service_async).never
+    service_creation.call
+
+    service_creation = ServiceCreationService.new(@provider, name: 'my-api')
+    service_creation.expects(:create_service).returns(true)
+    service_creation.expects(:create_service_async).never
+    service_creation.call
+
+    service_creation = ServiceCreationService.new(@provider, name: 'my-api', source: 'unsupported-value')
+    service_creation.expects(:create_service).returns(true)
+    service_creation.expects(:create_service_async).never
+    service_creation.call
+  end
+
+  test 'discover?' do
+    refute ServiceCreationService.new(@provider).discover?
+    assert ServiceCreationService.new(@provider, source: 'discover').discover?
+  end
+
+  test 'success?' do
+    service_creation = ServiceCreationService.new(@provider, name: 'my-api', system_name: 'my-api')
+    Service.any_instance.stubs(save: true)
+    service_creation.create_service
+    assert service_creation.success?
+
+    Service.any_instance.stubs(save: false)
+    service_creation.create_service
+    refute service_creation.success?
+
+    service_creation_async = ServiceCreationService.new(@provider, name: 'my-api', namespace: 'my-project', source: 'discover')
+    ServiceDiscovery::ImportClusterServiceDefinitionsWorker.expects(:perform_async).returns(true)
+    service_creation_async.create_service_async
+    assert service_creation_async.success?
+
+    ServiceDiscovery::ImportClusterServiceDefinitionsWorker.expects(:perform_async).returns(false)
+    service_creation_async.create_service_async
+    assert service_creation_async.success?
+  end
+end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It makes the creation of APIs by service discovery to fill the lookup column `services.kubernetes_service_link` with the cluster service `selfLink` attribute.

The PR also introduces better tests for `ServiceCreationService`.

**Which issue(s) this PR fixes** 

Related to https://github.com/3scale/porta/issues/34