### PR TITLE
[Refactor] FrontendController#all_services for api_selector_services helper

### DIFF
--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -20,7 +20,6 @@ class FrontendController < ApplicationController
 
   before_action :login_required
   before_action :set_display_currency
-  before_action :all_services
 
   include RedhatCustomerPortalSupport::ControllerMethods::Banner
 
@@ -107,10 +106,6 @@ class FrontendController < ApplicationController
     else
       DEFAULT_LIQUID_LAYOUT
     end
-  end
-
-  def all_services
-    @api_selector_services = current_user.accessible_services.to_a if current_account.try!(:provider?)
   end
 
   def find_service(id = params[:service_id])

--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -83,4 +83,8 @@ module MenuHelper
     account = current_account.provider? ? current_account : current_account.provider_account
     account.settings.public_send(switch).is_a?(Settings::SwitchDenied)
   end
+
+  def api_selector_services
+    @api_selector_services ||= site_account.provider? && logged_in? ? current_user.accessible_services.includes(:account) : Service.none
+  end
 end

--- a/app/views/shared/_api_selector.html.slim
+++ b/app/views/shared/_api_selector.html.slim
@@ -4,7 +4,7 @@ javascript:
   document.addEventListener('DOMContentLoaded', function () {
     window.ApiSelector({
       currentApi: #{json @service},
-      apis: #{json @api_selector_services},
+      apis: #{json api_selector_services},
       controllerName: #{json controller_name}
     }, 'api_selector')
   })

--- a/app/views/shared/provider/_user_widget.html.slim
+++ b/app/views/shared/provider/_user_widget.html.slim
@@ -6,7 +6,7 @@ div id="user_widget"
       = link_to provider_admin_dashboard_path, class: 'header-link', title: 'Dashboard' do
         .header-logo
 
-  - if current_account.multiservice? && can?(:manage, :plans) && @api_selector_services.size > 1
+  - if current_account.multiservice? && can?(:manage, :plans) && api_selector_services.size > 1
     = render 'shared/api_selector'
 
   .PopNavigation.PopNavigation--docs


### PR DESCRIPTION
### Improvements
- [X] N+1 Query for account of services
I've found this `N+1 Query` when loading `/apiconfig/alerts`:

```
/apiconfig/alerts
N+1 Query detected
  Service => [:account]
  Add to your finder: :includes => [:account]
N+1 Query method call stack
  /Users/marta/Devel/porta/app/models/service.rb:397:in `support_email'
  /Users/marta/Devel/porta/app/helpers/json_helper.rb:5:in `json'
  /Users/marta/Devel/porta/app/views/shared/_api_selector.html.slim:7:in `_app_views_shared__api_selector_html_slim___3374156238745550695_70267119012920'
  /Users/marta/Devel/porta/app/views/shared/provider/_user_widget.html.slim:10:in `_app_views_shared_provider__user_widget_html_slim__4437274933794199262_70267111450280'
  /Users/marta/Devel/porta/app/views/layouts/provider.html.slim:20:in `_app_views_layouts_provider_html_slim__958426546298312323_70267087833860'
  /Users/marta/Devel/porta/lib/three_scale/middleware/dev_domain.rb:25:in `call'
  /Users/marta/Devel/porta/lib/three_scale/middleware/dev_domain.rb:25:in `call'
  /Users/marta/Devel/porta/lib/three_scale/middleware/multitenant.rb:116:in `_call'
  /Users/marta/Devel/porta/lib/three_scale/middleware/multitenant.rb:111:in `call'
  /Users/marta/Devel/porta/bin/rails:11:in `<top (required)>'
  /Users/marta/Devel/porta/bin/spring:13:in `require'
  /Users/marta/Devel/porta/bin/spring:13:in `<top (required)>'
```

- [X] without `to_a` before time
- [X] change `current_account.try(:provider?)` for `site_account.provider?`
- [X] helper memoized instead of `before_action`
