### PR TITLE
[Service Discovery] Fill api_docs_services.service_id

### DIFF
--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -20,6 +20,8 @@ class ApiDocs::Service < ApplicationRecord
   validates :body, length: { maximum: 4294967295, allow_blank: true }
   validate :service_belongs_to_account, if: -> { service_id.present? && service_id_changed? }
 
+  before_validation(on: :create) { self.account ||= service&.account }
+
   scope :published, -> { where(published: true) }
   scope :accessible, -> { joining { service.outer }.where.has { (service_id == nil) | (service.state != ::Service::DELETE_STATE) } }
 

--- a/app/models/service_discovery/model_extensions.rb
+++ b/app/models/service_discovery/model_extensions.rb
@@ -33,10 +33,10 @@ module ServiceDiscovery
           return
         end
 
-        api_docs_service = provider.api_docs_services.build(name: cluster_service.name,
-                                                            body: spec_content,
-                                                            published: true,
-                                                            skip_swagger_validations: true)
+        api_docs_service = api_docs_services.build(name: cluster_service.name,
+                                                   body: spec_content,
+                                                   published: true,
+                                                   skip_swagger_validations: true)
 
         unless api_docs_service.save
           log_cluster_service_import_event(cluster_service, message: 'Could not create ActiveDocs',

--- a/test/unit/service_discovery/model_extensions_test.rb
+++ b/test/unit/service_discovery/model_extensions_test.rb
@@ -38,7 +38,7 @@ module ServiceDiscovery
                                specification: '{ "swagger" : "fake-swagger" }',
                                specification_type: 'application/swagger+json')
 
-        assert_difference @provider.api_docs_services do
+        assert_difference @service.api_docs_services.method(:count) do
           @service.import_cluster_active_docs(@cluster_service)
         end
       end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It makes the import of a swagger/OAS spec into an ActiveDoc on service discovery to also fill ApiDocs::Service.service_id, ensuring the relationship between the new API and the new API spec created.

**Which issue(s) this PR fixes** 

Related to https://github.com/3scale/porta/issues/34