### PR TITLE
Implements Persistent Vertical Navigation Toggle

### DIFF
--- a/app/assets/stylesheets/provider/_theme.scss
+++ b/app/assets/stylesheets/provider/_theme.scss
@@ -28,6 +28,7 @@
 @import 'provider/flash';
 @import 'provider/user_widget';
 @import 'provider/pop_navigation';
+@import 'provider/vert_nav_toggle';
 
 @import 'provider/cms';
 

--- a/app/assets/stylesheets/provider/_vert_nav_toggle.scss
+++ b/app/assets/stylesheets/provider/_vert_nav_toggle.scss
@@ -1,0 +1,3 @@
+.vert-nav-toggle {
+  float: left;
+}

--- a/app/views/shared/provider/_user_widget.html.slim
+++ b/app/views/shared/provider/_user_widget.html.slim
@@ -1,6 +1,9 @@
 = javascript_pack_tag 'navigation'
 
 div id="user_widget"
+  - unless active_menu?(:main_menu, :dashboard)
+    a.PopNavigation-trigger.u-toggler.vert-nav-toggle
+      => icon('bars')
   ul id="top-menu-nav"
     li class=('active' if active_menu?(:topmenu, :dashboard) )
       = link_to provider_admin_dashboard_path, class: 'header-link', title: 'Dashboard' do
@@ -72,4 +75,13 @@ javascript:
       if (e.target.type !== 'search') {
         window.hideAllToggleable()
       }
+    })
+    .on('click', '.vert-nav-toggle', function (e) {
+      var shouldVertNavCollapse = !JSON.parse(store.isVerticalNavCollapsed)
+
+      document.querySelector('.nav-pf-vertical')
+        .classList
+        .toggle('collapsed', shouldVertNavCollapse)
+
+      store.isVerticalNavCollapsed = shouldVertNavCollapse
     })

--- a/app/views/shared/provider/navigation/_vertical_nav.html.slim
+++ b/app/views/shared/provider/navigation/_vertical_nav.html.slim
@@ -214,3 +214,7 @@ nav.vertical-nav
         nav.classList.remove('hover-secondary-nav-pf');
       });
     }
+
+    var store = window.localStorage
+    nav.classList
+      .toggle('collapsed', JSON.parse(store.isVerticalNavCollapsed))


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a button in the MastHead for toggling the vertical navigation. Collapse state is stored in localStorage so that it persist after refreshing.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1390

**Verification steps** 

1. Button is rendered in MastHead only when vertical nav is available (e.g. not in Dashboard)
<img width="300" alt="screen shot 2018-10-10 at 11 16 11" src="https://user-images.githubusercontent.com/11672286/46726182-1bd9bc00-cc7e-11e8-8f08-3c58518cbae2.png">
<img width="300" alt="screen shot 2018-10-10 at 11 16 03" src="https://user-images.githubusercontent.com/11672286/46726191-2005d980-cc7e-11e8-9554-e240a124246a.png">

2. Clicking on the button alternatively collapses/expands the vertical navigation
<img width="300" alt="screen shot 2018-10-10 at 11 15 53" src="https://user-images.githubusercontent.com/11672286/46726210-28f6ab00-cc7e-11e8-9dc1-76d380344bbc.png">

3. Refreshing the browser does not change vert nav state: it keeps being collapsed/expanded

**Special notes for your reviewer**:
Please ignore the the _Master Account_ ribbon look.

TODOs:
- [x] Rebase
- [ ] Check styles 
- [ ] Add Test
