### PR TITLE
Dashboard improvements for 1 service accounts

### DIFF
--- a/app/assets/stylesheets/provider/admin/_dashboard.scss
+++ b/app/assets/stylesheets/provider/admin/_dashboard.scss
@@ -340,7 +340,7 @@
 .DashboardNavigation {
   float: right;
 
-  &--services {
+  #api_filter + &--services {
     margin-top: line-height-times(1/2);
   }
 

--- a/app/views/provider/admin/dashboards/_service.html.slim
+++ b/app/views/provider/admin/dashboards/_service.html.slim
@@ -1,4 +1,4 @@
-section.DashboardSection.DashboardSection--service.is-closed class=('DashboardSection--toggleable is-closed u-legacy-cookie' if current_account.multiservice? && can?(:manage, :analytics)) id=(dom_id service)
+section.DashboardSection.DashboardSection--service class=('DashboardSection--toggleable is-closed u-legacy-cookie' if current_account.multiservice? && can?(:manage, :analytics)) id=(dom_id service)
   header.DashboardSection-header
     h1.DashboardSection-title class=('DashboardSection-toggle' if current_account.multiservice? && can?(:manage, :analytics))
       = friendly_service_name(service)

--- a/app/views/provider/admin/dashboards/_services_filter.html.slim
+++ b/app/views/provider/admin/dashboards/_services_filter.html.slim
@@ -1,20 +1,23 @@
-#api_filter
+- if current_user.accessible_services.size > 1
+  #api_filter
 
-javascript:
-  document.addEventListener('DOMContentLoaded', function () {
-    var allApis = #{json @services}
+    javascript:
+      document.addEventListener('DOMContentLoaded', function () {
+        var allApis = #{json @services}
 
-    var displayApis = function(filteredApis) {
-      for (api = 0; api < allApis.length; api++) {
-        document.getElementById("service_" + allApis[api].service.id).style.display = "none"
-      }
-      for (api = 0; api < filteredApis.length; api++) {
-        document.getElementById("service_" + filteredApis[api].service.id).style.display = "inline"
-      }
-    }
+        var displayApis = function(filteredApis) {
+          for (api = 0; api < allApis.length; api++) {
+            document.getElementById("service_" + allApis[api].service.id).style.display = "none"
+          }
+          for (api = 0; api < filteredApis.length; api++) {
+            document.getElementById("service_" + filteredApis[api].service.id).style.display = "inline"
+          }
+        }
 
-    window.ApiFilter({
-      apis: allApis,
-      displayApis: displayApis
-    }, 'api_filter')
-  })
+        window.ApiFilter({
+          apis: allApis,
+          displayApis: displayApis
+        }, 'api_filter')
+      })
+- else
+  h1.DashboardSection-title APIs

--- a/app/views/provider/admin/dashboards/_services_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_services_navigation.html.slim
@@ -2,12 +2,13 @@ nav.DashboardNavigation.DashboardNavigation--services
   ul.DashboardNavigation-list
     - if can? :manage, :partners
 
-      li.DashboardNavigation-list-item
-        = dashboard_collection_link 'Application',
-                                applications,
-                                admin_buyers_applications_path,
-                                'Applications',
-                                'cubes'
+      - if current_user.accessible_services.size > 1
+        li.DashboardNavigation-list-item
+          = dashboard_collection_link 'Application',
+                                  applications,
+                                  admin_buyers_applications_path,
+                                  'Applications',
+                                  'cubes'
 
       li.DashboardNavigation-list-item
         = dashboard_collection_link 'ActiveDoc',

--- a/app/views/provider/admin/dashboards/_services_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_services_navigation.html.slim
@@ -31,10 +31,10 @@ nav.DashboardNavigation.DashboardNavigation--services
           i.fa.fa-play-circle>
           | Traffic
 
-    - if can? :manage, :multiple_services
-      li.DashboardNavigation-list-item
-        = fancy_link_to 'New API',
-          new_admin_service_path,
-          :class => 'new DashboardNavigation-link',
-          :switch => :multiple_services,
-          :upgrade_notice => true
+
+    li.DashboardNavigation-list-item
+      = fancy_link_to 'New API',
+        new_admin_service_path,
+        :class => 'new DashboardNavigation-link',
+        :switch => :multiple_services,
+        :upgrade_notice => true

--- a/app/views/provider/admin/dashboards/show.html.slim
+++ b/app/views/provider/admin/dashboards/show.html.slim
@@ -21,7 +21,7 @@
         // Account Level Widgets
         = dashboard_widget :new_accounts
         = dashboard_widget :potential_upgrades if can?(:manage, :plans)
-    section.DashboardSection.DashboardSection--audience class=('DashboardSection--wide' unless can?(:manage, :plans))
+    section.DashboardSection.DashboardSection--services class=('DashboardSection--wide' unless can?(:manage, :plans))
       - if current_user.accessible_services?
         header.DashboardSection-header.DashboardSection-header--extended
           = render 'services_filter'


### PR DESCRIPTION
**What this PR does / why we need it**:

Some improvements for users that only manage 1 api.

-  don't show API's filter box
-  don't show applications at all api's level
- always show new api link as it re-enforces the idea of API's section. (points to upgrade if not allowed)


current:
<img width="1290" alt="screen shot 2018-10-10 at 13 01 10" src="https://user-images.githubusercontent.com/54224/46733886-e5a63780-cc91-11e8-974b-7341b1082f57.png">

improved:
<img width="1284" alt="screen shot 2018-10-10 at 13 25 30" src="https://user-images.githubusercontent.com/54224/46733875-dc1ccf80-cc91-11e8-9790-f11cf5eb933e.png">