### PR TITLE
Fixing overlapping of metric names

### DIFF
--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -242,9 +242,9 @@ table#contracts_table tr td.thhead {
 
 table#metrics {
   tr td.title {
-    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 

--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -100,6 +100,11 @@ table.data {
       text-align: right;
     }
   }
+
+  &.u-sixEqualColumns tr td {
+    word-break: break-word;
+  }
+
 }
 
 .u-fiveEqualColumns {
@@ -233,6 +238,14 @@ table#contracts_table tr td.thhead {
   margin: line-height-times(1/4);
   padding-right: 0;
   padding-top: 0;
+}
+
+table#metrics {
+  tr td.title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 td.thhead h3 {

--- a/app/views/api/metrics/_metric.html.erb
+++ b/app/views/api/metrics/_metric.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag('tr', :id => dom_id(metric), :class => metric.child? ? 'child' : 'root') do %>
-  <td class="title"><%= h metric.friendly_name %></td>
+  <td class="title" title=<%= h metric.friendly_name %>><%= h metric.friendly_name %></td>
     <% if @plan.pricing_enabled? %>
     <td class="metrics-subtable-toggle pricing">
       <%= link_to polymorphic_path([:admin, @plan, metric, :pricing_rules]), :class => 'remote' do %>

--- a/app/views/api/metrics/_metric.html.erb
+++ b/app/views/api/metrics/_metric.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag('tr', :id => dom_id(metric), :class => metric.child? ? 'child' : 'root') do %>
-  <td class="title" title=<%= h metric.friendly_name %>><%= h metric.friendly_name %></td>
+  <td class="title" title="<%= h metric.friendly_name %>"><%= h metric.friendly_name %></td>
     <% if @plan.pricing_enabled? %>
     <td class="metrics-subtable-toggle pricing">
       <%= link_to polymorphic_path([:admin, @plan, metric, :pricing_rules]), :class => 'remote' do %>


### PR DESCRIPTION
Fixing overlapping of metric and methods names in tables

**Which issue(s) this PR fixes** 
[https://issues.jboss.org/browse/THREESCALE-1389](https://issues.jboss.org/browse/THREESCALE-1389)

**Verification steps** 
You need to create an Application Plan previously, with some long metrics and methods names.
Then, go to APIS > Application Plans, then select an Application Plan

**Before:**
![before-1](https://user-images.githubusercontent.com/13486237/46738122-ab429780-cc9d-11e8-97b6-1f876366bd94.png)

**After**
![after-1](https://user-images.githubusercontent.com/13486237/46738149-bb5a7700-cc9d-11e8-8c7b-a9f1db42ab2a.png)

**BEFORE:**
![before-2](https://user-images.githubusercontent.com/13486237/46738286-18eec380-cc9e-11e8-8030-1261cb9514e2.png)

**After**
![after-2](https://user-images.githubusercontent.com/13486237/46738304-22782b80-cc9e-11e8-8d82-418e87b0219d.png)


