### PR TITLE
THREESCALE-1382 Long metric names - Applications page

### DIFF
--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -261,3 +261,7 @@ td.thhead h3 {
 .u-tabular-number {
   font-family: $font-family-monospace;
 }
+
+table.list.list-checkmarks tr th {
+  word-break: break-word;
+}

--- a/app/helpers/usage_limits_helper.rb
+++ b/app/helpers/usage_limits_helper.rb
@@ -1,13 +1,11 @@
 module UsageLimitsHelper
 
-  TRUNCATE_CSS = 'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block'.freeze
-
   def display_usage_limit(usage_limit)
     h "#{usage_limit.value} #{usage_limit.metric.unit} / #{usage_limit.period}"
   end
 
   def display_metric_name(metric)
     name = metric.friendly_name
-    content_tag(:span, name, title: name, style: TRUNCATE_CSS)
+    content_tag(:span, name, title: name)
   end
 end


### PR DESCRIPTION
Long metric names break the layout on the Applications page

**What this PR does / why we need it**:

It adds word-break to long metrics and methods names

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1382

**Verification steps** 

APIs > Applications > YourApplicationName

**Before:**
![before](https://user-images.githubusercontent.com/13486237/46813479-11e7b400-cd77-11e8-9c8c-8a01a5364ecb.png)

**After:**
![after](https://user-images.githubusercontent.com/13486237/46813525-275cde00-cd77-11e8-9e0f-ee185d4b1bdc.png)
