### PR TITLE
Include Dashboard option in ContextSelector

### DIFF
--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -8,6 +8,7 @@ import { render } from 'react-dom'
 import { ApiSearch } from './ApiSearch'
 import getActiveMenuTitle from '../utils/getActiveMenuTitle'
 
+const DASHBOARD_PATH = '/p/admin/dashboard'
 const AUDIENCE_PATH = '/buyers/accounts'
 
 const ContextSelector = ({ apis, currentApi, activeMenu }) => (
@@ -16,6 +17,9 @@ const ContextSelector = ({ apis, currentApi, activeMenu }) => (
       <span> {getActiveMenuTitle(activeMenu, currentApi)} <i className='fa fa-chevron-down' /></span>
     </a>
     <ul id="context-menu" className="PopNavigation-list u-toggleable">
+      <li className="PopNavigation-listItem">
+        <a className="PopNavigation-link" href={DASHBOARD_PATH}>Dashboard</a>
+      </li>
       <li className="PopNavigation-listItem">
         <a className="PopNavigation-link" href={AUDIENCE_PATH}>Audience</a>
       </li>

--- a/app/javascript/src/Navigation/components/ContextSelector.spec.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.spec.jsx
@@ -29,8 +29,15 @@ it('should render itself', () => {
   expect(contextSelector.find(ContextSelector).exists()).toEqual(true)
 })
 
-it('should have a Audience option on top', () => {
-  const audience = contextSelector.find('#context-menu').childAt(0)
+it('should have a Dashboard option on top', () => {
+  const dashboard = contextSelector.find('#context-menu').childAt(0)
+  expect(dashboard.exists()).toEqual(true)
+  expect(dashboard.text()).toEqual('Dashboard')
+  expect(dashboard.find('a').props().href).not.toBeUndefined()
+})
+
+it('should have a Audience option after Dashboard', () => {
+  const audience = contextSelector.find('#context-menu').childAt(1)
   expect(audience.exists()).toEqual(true)
   expect(audience.text()).toEqual('Audience')
   expect(audience.find('a').props().href).not.toBeUndefined()


### PR DESCRIPTION
Adds a missing _Dashboard_ option in the context selector.

Follows up on: #137 

Fixes: https://issues.jboss.org/browse/THREESCALE-1395