### PR TITLE
[Bugfix] Fix ActiveDocs active menu for edit/preview under account scope

### DIFF
--- a/app/controllers/admin/api_docs/account_api_docs_controller.rb
+++ b/app/controllers/admin/api_docs/account_api_docs_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::ApiDocs::AccountApiDocsController < Admin::ApiDocs::BaseController
-  activate_menu! :active_docs
+  activate_menu :active_docs
 
   class NotImplementedServiceScopeError < RuntimeError; end
   rescue_from(NotImplementedServiceScopeError) do |exception|

--- a/app/views/shared/provider/navigation/_vertical_nav_item.html.slim
+++ b/app/views/shared/provider/navigation/_vertical_nav_item.html.slim
@@ -2,7 +2,7 @@
 - path ||= '#'
 - icon ||= nil
 
-li.list-group-item class=( active_menu?(:submenu, title) || current_page?(path) ? 'active' : '')
+li.list-group-item class=( active_menu?(:submenu, title) || active_menu?(:main_menu, title) || current_page?(path) ? 'active' : '')
   = link_to path do
     - if icon
       span.fa.fa-fw class="fa-#{icon}"


### PR DESCRIPTION
The problem was the Controller activates `main_menu` and the `active` class only activates if the `submenu` (not main menu) is that one, or if the url is the one it has (which is the case for the `index` 😉 ).