### PR TITLE
[services#show] attributes should mirror post attributes

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -354,6 +354,12 @@ class Service < ApplicationRecord
       xml.state state
       xml.system_name system_name
       xml.backend_version proxy&.authentication_method
+      xml.description description
+
+      xml.deployment_option deployment_option
+      xml.support_email support_email
+      xml.tech_support_email tech_support_email
+      xml.admin_support_email admin_support_email
 
       xml.end_user_registration_required end_user_registration_required
 

--- a/app/representers/service_representer.rb
+++ b/app/representers/service_representer.rb
@@ -10,6 +10,11 @@ module ServiceRepresenter
   property :system_name
   property :end_user_registration_required
   property :backend_version
+  property :deployment_option
+  property :support_email
+  property :tech_support_email
+  property :admin_support_email
+  property :description
 
   property :created_at
   property :updated_at

--- a/test/integration/admin/api/services_controller_test.rb
+++ b/test/integration/admin/api/services_controller_test.rb
@@ -8,6 +8,18 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     login! master_account
   end
 
+  def test_show
+    get admin_api_service_path(master_account.default_service, format: :xml)
+    assert_response :ok
+    assert response.body.include?('deployment_option')
+    assert response.body.include?(master_account.default_service.deployment_option)
+
+    get admin_api_service_path(master_account.default_service, format: :json)
+    assert_response :ok
+    assert response.body.include?('deployment_option')
+    assert response.body.include?(master_account.default_service.deployment_option)
+  end
+
   test 'GET index works for Saas' do
     get admin_api_services_path
     assert_response :ok


### PR DESCRIPTION
**What this PR does / why we need it**:

Attributes provided in services#show endpoint should mirror attributes from services#post

**Which issue(s) this PR fixes** 

fixes https://github.com/3scale/porta/issues/133
fixes https://github.com/3scale/3scale-api-ruby/issues/38
