### PR TITLE
Fix ContextSelector scroll

### DIFF
--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -62,14 +62,20 @@ class ContextSelector extends React.Component {
   renderOptions () {
     const { apis } = this.props
     const { filterQuery } = this.state
-    const displayedApis = apis.filter(api => api.service.name.toLowerCase().indexOf(filterQuery) !== -1)
-
-    return displayedApis.map(({ service }) => (
+    const filteredApis = apis.filter(api => api.service.name.toLowerCase().indexOf(filterQuery) !== -1)
+    const displayedApis = filteredApis.map(({ service }) => (
       <li key={service.id} className="PopNavigation-listItem">
-        <a
-          className={this.getClassNamesFor({ api: service.id })} href={apiPathRoot(service.id)}>{service.name}</a>
+        <a className={this.getClassNamesFor({ api: service.id })} href={apiPathRoot(service.id)}>{service.name}</a>
       </li>
     ))
+
+    return (
+      <li className="PopNavigation-listItem">
+        <ul className="PopNavigation-results">
+          {displayedApis}
+        </ul>
+      </li>
+    )
   }
 
   render () {

--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -63,6 +63,11 @@ class ContextSelector extends React.Component {
     const { apis } = this.props
     const { filterQuery } = this.state
     const filteredApis = apis.filter(api => api.service.name.toLowerCase().indexOf(filterQuery) !== -1)
+
+    if (filteredApis.length === 0) {
+      return null
+    }
+
     const displayedApis = filteredApis.map(({ service }) => (
       <li key={service.id} className="PopNavigation-listItem">
         <a className={this.getClassNamesFor({ api: service.id })} href={apiPathRoot(service.id)}>{service.name}</a>

--- a/app/javascript/src/Navigation/components/ContextSelector.spec.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.spec.jsx
@@ -74,17 +74,17 @@ it('should highlight the selected context', () => {
 })
 
 describe('When there is only 1 service', () => {
-  it('should not have a search field', () => {
+  beforeEach(() => {
     contextSelector = getWrapper(apis.slice(0, 1))
-    expect(contextSelector.props().apis).toHaveLength(1)
+    expect(contextSelector.props().apis.length).toEqual(1)
+  })
 
+  it('should not have a search field', () => {
+    expect(contextSelector.props().apis).toHaveLength(1)
     expect(contextSelector.find('input').exists()).toEqual(false)
   })
 
   it('should have the only api after Audience', () => {
-    contextSelector = getWrapper(apis.slice(0, 1))
-    expect(contextSelector.props().apis).toHaveLength(1)
-
     const api = contextSelector.find('#context-menu').childAt(2)
     expect(api.exists()).toEqual(true)
     expect(api.text()).toEqual('api 0')
@@ -92,6 +92,10 @@ describe('When there is only 1 service', () => {
 })
 
 describe('When there are many services', () => {
+  beforeEach(() => {
+    expect(contextSelector.props().apis.length).toBeGreaterThan(0)
+  })
+
   it('should have a search field after audience', () => {
     const searchField = contextSelector.find('#context-menu').childAt(2)
 
@@ -101,33 +105,31 @@ describe('When there are many services', () => {
   })
 
   it('should have a list of apis after the search field', () => {
-    expect(contextSelector.props().apis).toHaveLength(apis.length)
+    expect(contextSelector.find('#context-menu').childAt(3).find('.PopNavigation-results').exists())
+      .toEqual(true)
+  })
 
-    const apiList = contextSelector.find('#context-menu').children().slice(3)
+  it('should render all APIs when input is empty', () => {
+    const input = contextSelector.find('input')
+    expect(input.props().value).toBeUndefined
+
+    const apiList = contextSelector.find('.PopNavigation-results').children()
     expect(apiList).toHaveLength(apis.length)
     expect(apiList.containsAllMatchingElements(
       apis.map(api => <li><a>{api.service.name}</a></li>)
     )).toEqual(true)
   })
 
-  it('should render all APIs when input is empty', () => {
-    const input = contextSelector.find('input')
-    const apiList = contextSelector.find('#context-menu').children().slice(3)
-
-    expect(input.props().value).toBeUndefined
-    expect(apiList).toHaveLength(apis.length)
-  })
-
   it('should filter APIs by name', () => {
     const input = contextSelector.find('input')
 
     input.simulate('change', { target: { value: 'api' } })
-    expect(contextSelector.find('#context-menu').children().slice(3)).toHaveLength(3)
+    expect(contextSelector.find('.PopNavigation-results').children()).toHaveLength(3)
 
     input.simulate('change', { target: { value: 'api 1' } })
-    expect(contextSelector.find('#context-menu').children().slice(3)).toHaveLength(1)
+    expect(contextSelector.find('.PopNavigation-results').children()).toHaveLength(1)
 
     input.simulate('change', { target: { value: 'wubba lubba dub dub' } })
-    expect(contextSelector.find('#context-menu').children().slice(3)).toHaveLength(0)
+    expect(contextSelector.find('.PopNavigation-results').children()).toHaveLength(0)
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds back the inner `ul` so thar services scroll instead of growing vertically.
<img width="160" alt="screen shot 2018-10-17 at 10 41 47" src="https://user-images.githubusercontent.com/11672286/47073898-91eb9f00-d1f9-11e8-81f9-632639a5d65e.png">

**Special notes for your reviewer**:

Also the list is hidden when `filteredApis` is empty to avoid ugly look.
<img width="160" alt="screen shot 2018-10-17 at 10 44 45" src="https://user-images.githubusercontent.com/11672286/47074022-ceb79600-d1f9-11e8-8d70-653089c2742b.png">              <img width="160" alt="screen shot 2018-10-17 at 10 45 28" src="https://user-images.githubusercontent.com/11672286/47074034-d414e080-d1f9-11e8-9f42-44c4fbcdfb8b.png">

