### PR TITLE
Adds a delay to showing/hiding submenus

### DIFF
--- a/app/views/shared/provider/navigation/_vertical_nav.html.slim
+++ b/app/views/shared/provider/navigation/_vertical_nav.html.slim
@@ -50,16 +50,38 @@ nav.vertical-nav#mainmenu
 
   javascript:
     var nav = document.querySelector('.vertical-nav'),
-    navItem = document.querySelectorAll('.secondary-nav-item-pf');
-    for (var i = 0; i < navItem.length; i++) {
-      navItem[i].addEventListener('mouseover', function() {
-        this.classList.add('is-hover');
-        nav.classList.add('hover-secondary-nav-pf');
-      });
-      navItem[i].addEventListener('mouseout', function() {
-        this.classList.remove('is-hover');
-        nav.classList.remove('hover-secondary-nav-pf');
-      });
+    navItems = document.querySelectorAll('.secondary-nav-item-pf');
+    var navItemHover = null
+
+    for (var i = 0; i < navItems.length; i++) {
+      var navItem = navItems[i]
+
+      var makeDelayedShowOnHover = function(item, index) {
+        return function() {
+          navItemHover = index
+          setTimeout(function() {
+            if (index === navItemHover) {
+              item.classList.add('is-hover');
+              nav.classList.add('hover-secondary-nav-pf');
+            }
+          }, 750)
+        }
+      }
+
+      var makeDelayedHideOnHover = function(item, index) {
+        return function() {
+          navItemHover = null
+          setTimeout(function() {
+            if (index !== navItemHover) {
+              item.classList.remove('is-hover');
+              nav.classList.remove('hover-secondary-nav-pf');
+            }
+          }, 750)
+        }
+      }
+
+      navItem.addEventListener('mouseenter', makeDelayedShowOnHover(navItem, i));
+      navItem.addEventListener('mouseleave', makeDelayedHideOnHover(navItem, i));
     }
 
     var store = window.localStorage

--- a/app/views/shared/provider/navigation/_vertical_nav.html.slim
+++ b/app/views/shared/provider/navigation/_vertical_nav.html.slim
@@ -64,7 +64,7 @@ nav.vertical-nav#mainmenu
               item.classList.add('is-hover');
               nav.classList.add('hover-secondary-nav-pf');
             }
-          }, 750)
+          }, 250)
         }
       }
 
@@ -76,7 +76,7 @@ nav.vertical-nav#mainmenu
               item.classList.remove('is-hover');
               nav.classList.remove('hover-secondary-nav-pf');
             }
-          }, 750)
+          }, 250)
         }
       }
 

--- a/app/views/shared/provider/navigation/_vertical_nav.html.slim
+++ b/app/views/shared/provider/navigation/_vertical_nav.html.slim
@@ -51,37 +51,45 @@ nav.vertical-nav#mainmenu
   javascript:
     var nav = document.querySelector('.vertical-nav'),
     navItems = document.querySelectorAll('.secondary-nav-item-pf');
-    var navItemHover = null
+    var itemFlaggedToShow = null
+    var itemFlaggedToHide = null
 
     for (var i = 0; i < navItems.length; i++) {
       var navItem = navItems[i]
 
-      var makeDelayedShowOnHover = function(item, index) {
+      var makeFlagItemToShow = function(me) {
         return function() {
-          navItemHover = index
+          itemFlaggedToShow = me
           setTimeout(function() {
-            if (index === navItemHover) {
-              item.classList.add('is-hover');
+            if (itemFlaggedToShow === me) {
+              navItems[me].classList.add('is-hover');
               nav.classList.add('hover-secondary-nav-pf');
+              itemFlaggedToShow = null
+
+              if (itemFlaggedToHide !== me && itemFlaggedToHide !== null) {
+                navItems[itemFlaggedToHide].classList.remove('is-hover');
+                itemFlaggedToHide = null
+              }
             }
           }, 250)
         }
       }
 
-      var makeDelayedHideOnHover = function(item, index) {
+      var makeFlagItemToHide = function(me) {
         return function() {
-          navItemHover = null
+          itemFlaggedToHide = me
           setTimeout(function() {
-            if (index !== navItemHover) {
-              item.classList.remove('is-hover');
+            if (itemFlaggedToShow === null) {
+              navItems[me].classList.remove('is-hover');
               nav.classList.remove('hover-secondary-nav-pf');
+              itemFlaggedToHide = null
             }
           }, 250)
         }
       }
 
-      navItem.addEventListener('mouseenter', makeDelayedShowOnHover(navItem, i));
-      navItem.addEventListener('mouseleave', makeDelayedHideOnHover(navItem, i));
+      navItem.addEventListener('mouseenter', makeFlagItemToShow(i));
+      navItem.addEventListener('mouseleave', makeFlagItemToHide(i));
     }
 
     var store = window.localStorage

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -4,10 +4,10 @@
   "assets/glyphicons-halflings-regular.ttf": "/packs/assets/glyphicons-halflings-regular.e18bbf611f2a2e43afc071aa2f4e1512.ttf",
   "assets/glyphicons-halflings-regular.woff": "/packs/assets/glyphicons-halflings-regular.fa2772327f55d8198301fdb8bcfc8158.woff",
   "assets/glyphicons-halflings-regular.woff2": "/packs/assets/glyphicons-halflings-regular.448c34a56d699c29117adc64c43affeb.woff2",
-  "dashboard.js": "/packs/dashboard-d82423d86708f4cd2909.js",
-  "dashboard.js.map": "/packs/dashboard-d82423d86708f4cd2909.js.map",
-  "navigation.js": "/packs/navigation-b6dcdffc52a8a45fd8e0.js",
-  "navigation.js.map": "/packs/navigation-b6dcdffc52a8a45fd8e0.js.map",
-  "policies.js": "/packs/policies-221156de03fef790b50b.js",
-  "policies.js.map": "/packs/policies-221156de03fef790b50b.js.map"
+  "dashboard.js": "/packs/dashboard-17a2fa73a0589bc10e33.js",
+  "dashboard.js.map": "/packs/dashboard-17a2fa73a0589bc10e33.js.map",
+  "navigation.js": "/packs/navigation-7fd12a328f9bc2a39fd6.js",
+  "navigation.js.map": "/packs/navigation-7fd12a328f9bc2a39fd6.js.map",
+  "policies.js": "/packs/policies-52c7097d040c42facb93.js",
+  "policies.js.map": "/packs/policies-52c7097d040c42facb93.js.map"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Imitates original Patternfly behavior of [vertical navigation](https://www.patternfly.org/pattern-library/navigation/vertical-navigation/vertical-navigation.html) by adding a delay to the submenus, when mouse hovers.

Also changed `mouseover -> mouseenter` and `mouseout -> mouseleave` for a better performance: events would be triggered when hovering the mouse over the same element.

**Verification steps** 

- Any submenu should be shown after a brief delay when overing.
- If moving the mouse away before submenu appears, it won't.
- If moving the mouse away after submenu appeared, it will hide after a brief delay.
