### PR TITLE
Fix Cucumbers: old/services/switch and old/authentication/skype

### DIFF
--- a/features/old/authentication/skypeid.feature
+++ b/features/old/authentication/skypeid.feature
@@ -34,7 +34,7 @@ Feature: SkypeID
     When I successfully sign in as "foo.example.com" on the master domain using SkypeID
     Then I should be logged in as user "foo.example.com"
     And the current domain should be the master domain
-    And I should be on the provider dashboard page
+    And I should be on the provider dashboard
 
   @security
   Scenario: Sign in attempt with skype name not registered in the system on buyer domain

--- a/features/old/services/switch.feature
+++ b/features/old/services/switch.feature
@@ -11,14 +11,14 @@ Feature: Services switch
     When I log in as provider "foo.example.com"
 
   Scenario: In denied state, I should see link to upgrade warning
-    Given I am on the provider dashboard page
-      And I follow "Create Service"
+    Given I am on the provider dashboard
+      And I follow "New API"
     Then I should be on the upgrade notice page for "multiple_services"
 
   Scenario: In allowed state (hidden and visible), I should have the functionality enabled
     Given provider "foo.example.com" has "multiple_services" switch allowed
-      And I am on the provider dashboard page
-      And I follow "Create Service"
+      And I am on the provider dashboard
+      And I follow "New API"
     Then I should be on the new service page
 
   Scenario: In allowed state (hidden and visible), I should be able to access the page by url


### PR DESCRIPTION
Fix `old/services/switch`, which is passing.
And a wrong link in `old/authentication/skype` although that feature is a `wip` since who knows when... 😂 