### PR TITLE
Fix Functional Test for ServicesController

### DIFF
--- a/test/functional/api/services_controller_test.rb
+++ b/test/functional/api/services_controller_test.rb
@@ -97,9 +97,7 @@ class Api::ServicesControllerTest < ActionController::TestCase
     @controller.stubs(:authorize_plans)
     @controller.stubs(:can_create?).returns(true)
 
-    Service.any_instance.stubs(save: true, persisted?: true)
-
-    post :create, service: { system_name: 'Test bubbles' }
+    post :create, service: { name: 'Test bubbles' }
 
     assert_response 302
     assert_equal 'api_done', @provider.reload.onboarding.bubble_api_state

--- a/test/functional/api/services_controller_test.rb
+++ b/test/functional/api/services_controller_test.rb
@@ -21,13 +21,6 @@ class Api::ServicesControllerTest < ActionController::TestCase
     assert_response 404
   end
 
-  def test_index
-    get :index
-
-    assert_equal 2, assigns(:services).count
-    assert_response 200
-  end
-
   def test_show
     get :show, id: @service.id
 


### PR DESCRIPTION
Services index does not exist anymore so it is normal to fail the test.
The create does not stub save and persist but actually make it save for real so it can redirect to the show.