### PR TITLE
Fix '/apiconfig/alerts' route

### DIFF
--- a/app/controllers/api/alerts_controller.rb
+++ b/app/controllers/api/alerts_controller.rb
@@ -7,6 +7,7 @@ class Api::AlertsController < FrontendController
   before_action :find_service
 
   def index
+    activate_menu :dashboard
     @search = ThreeScale::Search.new(search_params)
     @account_search = ThreeScale::Search.new(@search.account)
 


### PR DESCRIPTION
Fixes the alerts route for all services
![image](https://user-images.githubusercontent.com/11318903/47108502-1d8e1b80-d24c-11e8-88bf-5127b15be97c.png)
And now `test/integration/api/alerts_controller_test.rb` also passes.