### PR TITLE
Provider stats feature

### DIFF
--- a/app/views/provider/admin/dashboards/_service_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_service_navigation.html.slim
@@ -1,13 +1,13 @@
 nav.DashboardNavigation
   ul.DashboardNavigation-list
-    // Applications & Application Plans
 
-    li.DashboardNavigation-list-item
-      // Overview (not countable)
-      = link_to admin_service_path(service),
-                class: "DashboardNavigation-link" do
-        i.fa.fa-map>
-        | Overview
+    - if can?(:manage, :plans)
+      li.DashboardNavigation-list-item
+        // Overview (not countable)
+        = link_to admin_service_path(service),
+                  class: "DashboardNavigation-link" do
+          i.fa.fa-map>
+          | Overview
 
     - if can?(:manage, :monitoring)
       li.DashboardNavigation-list-item

--- a/features/old/authorization/provider_stats.feature
+++ b/features/old/authorization/provider_stats.feature
@@ -15,6 +15,8 @@ Feature: Provider stats section authorization
     Given current domain is the admin domain of provider "foo.example.com"
       And I am logged in as provider "foo.example.com"
     When I go to the provider dashboard
+    Then I should see the link "Analytics"
+    When I follow "Analytics"
     Then I should see the link "Analytics" in the main menu
 
     When I go to the <page> page
@@ -33,7 +35,7 @@ Feature: Provider stats section authorization
       And current domain is the admin domain of provider "foo.example.com"
      When I log in as provider "member"
       And I go to the provider dashboard
-    Then I should not see "Analytics" in the main menu
+    Then I should not see the link "Analytics"
 
     When I request the url of the '<page>' page then I should see an exception
   Examples:
@@ -50,7 +52,9 @@ Feature: Provider stats section authorization
      And current domain is the admin domain of provider "foo.example.com"
     When I log in as provider "member"
      And I go to the provider dashboard
-    Then I should see "Analytics" in the main menu
+    Then I should see "Analytics"
+    When I follow "Analytics"
+    Then I should see the link "Analytics" in the main menu
 
     When I go to the <page> page
     Then I should be on the <page> page


### PR DESCRIPTION
Fixes features/old/authorization/provider_stats.feature

**to do:**

- [ ] only show api's (and search) in context selector `if can?(:manage, :plans)` @josemigallas 