### PR TITLE
Fix testing menus for Finance::Provider::InvoicesControllerTest

### DIFF
--- a/test/integration/provider/invoices_controller_test.rb
+++ b/test/integration/provider/invoices_controller_test.rb
@@ -22,7 +22,7 @@ class Finance::Provider::InvoicesControllerTest < ActionDispatch::IntegrationTes
       assert_response :success
       assert_template 'finance/provider/invoices/index'
       assert_not_nil assigns(:invoices)
-      assert_active_menu(:finance)
+      assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
     end
 
     should 'list invoices by month' do
@@ -43,7 +43,7 @@ class Finance::Provider::InvoicesControllerTest < ActionDispatch::IntegrationTes
         get admin_finance_invoice_path @invoice
         assert_response :success
         assert_equal @invoice, assigns(:invoice)
-        assert_active_menu(:finance)
+        assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
       end
 
       should 'show without buyer_account' do
@@ -52,14 +52,14 @@ class Finance::Provider::InvoicesControllerTest < ActionDispatch::IntegrationTes
         @invoice.buyer_account.destroy!
         get admin_finance_invoice_path @invoice
         assert_response :success
-        assert_active_menu(:finance)
+        assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
       end
 
       should 'edit' do
         get edit_admin_finance_invoice_path @invoice
         assert_response :success
         assert_equal @invoice, assigns(:invoice)
-        assert_active_menu(:finance)
+        assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
       end
 
       should 'update' do

--- a/test/test_helpers/menu.rb
+++ b/test/test_helpers/menu.rb
@@ -3,6 +3,10 @@ module TestHelpers
     def assert_active_menu(menu)
       assert_equal menu, assigns(:active_menus).try!(:[], :main_menu)
     end
+
+    def assert_active_menus(expected_menus)
+      assert_equal expected_menus, assigns(:active_menus)
+    end
   end
 end
 


### PR DESCRIPTION
Test it has the proper menus
![image](https://user-images.githubusercontent.com/11318903/47141453-00476480-d2c1-11e8-8aae-306ec695ceeb.png)
