### PR TITLE
Fix Cucumber step: I navigate to the page of the partner name-of-partner

### DIFF
--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -5,7 +5,7 @@ When /^I navigate to the sent invitations page$/ do
 end
 
 When /^I navigate to the page of the partner "([^\"]*)"$/ do |partner|
-  click_link "Accounts"
+  click_link(text: /\A\d Accounts?\z/)
   click_link partner
 end
 


### PR DESCRIPTION
Fix all tests that use the step to navigate to partner. Now we click on a text that looks like "1 Account" or "20 Accounts".
Example of this in: `spring cucumber features/old/buyers/invitations/for_admins.feature:30`