### PR TITLE
[Service Discovery] refresh link on APIcast config page

### DIFF
--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -7,7 +7,10 @@ section.Configuration.Configuration--is-promoted class="Configuration--#{@show_p
 
     dl.u-dl
       dt.u-dl-term Private Base URL
-      dd.u-dl-definition = @proxy.api_backend
+      dd.u-dl-definition
+        = @proxy.api_backend
+        - if ThreeScale.config.service_discovery.enabled && @service.discovered?
+          = refresh_service_link(@service, label: 'refresh')
       dt.u-dl-term Mapping rules
       dd.u-dl-definition
         - if (last_rule = @proxy.proxy_rules.last)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Adds a second "refresh" link close to "Private Base URL" in the APIcast configuration page.

**Which issue(s) this PR fixes** 

Related to https://github.com/3scale/porta/issues/34 and https://github.com/3scale/porta/pull/129.

**Verification steps** 

1. Navigate to the "Integration & Configuration" page of an API discovered and imported from the cluster.
2. Spot the new "refresh" link on the right side of "Private Base URL"