### PR TITLE
Fix Cucumber navigation to find Apps in old/applications/providers/search

### DIFF
--- a/features/old/applications/providers/search.feature
+++ b/features/old/applications/providers/search.feature
@@ -39,8 +39,7 @@ Feature: Providers's applications searching, sorting and filtering
       | BobApp  | bob     |
 
   Scenario: Search scoped by service
-    When I follow "API" within the main menu
-    And I follow "Latest Apps"
+    When I follow "Apps"
     Then I should see following table:
       | Name    | Account |
       | JaneApp | jane    |


### PR DESCRIPTION
Now finding Apps is much easier from the Dashboard 😄 So this feature goes through the new path