### PR TITLE
Fix cucumber feature old/api/alerts

### DIFF
--- a/features/old/api/alerts.feature
+++ b/features/old/api/alerts.feature
@@ -26,7 +26,7 @@ Feature: API Usage alerts
 
   Scenario: Navigation
     When I go to the provider dashboard
-     And I follow "API" within the main menu
+     And I follow "Overview"
      And I follow "Show all limit alerts for this service"
     Then I should be on the API alerts page of service "API" of provider "foo.example.com"
 


### PR DESCRIPTION
Fix cucumber feature in `features/old/api/alerts.feature`.
It just goes to the API by the new way 😄 