### PR TITLE
Fix bundler version for On-premises

### DIFF
--- a/openshift/system/Dockerfile.on_prem
+++ b/openshift/system/Dockerfile.on_prem
@@ -43,6 +43,7 @@ ENV BASH_ENV=/opt/system/etc/scl_enable \
 
 RUN export ${BUNDLER_ENV} \
     && source /opt/system/etc/scl_enable \
+    && gem install bundler --version 1.16.6 \
     && bundle install --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
 
 RUN chgrp root /opt/system/


### PR DESCRIPTION
**What this PR does / why we need it**:

It makes https://github.com/3scale/porta/blob/master/openshift/system/Dockerfile.on_prem to install a more recent version of bundler (1.16.6) than the one avaiable in the base image (1.10.6).

This started failing after https://github.com/3scale/porta/pull/44 as merged, particularly https://github.com/3scale/porta/commit/6bb972b031f95c63b90e0276262a83f56c121c6e#diff-33c867a743c81c1ce1e040ecbb221d39:
```
[!] There was an error parsing `Gemfile.base`: `mri_23` is not a valid platform. The available options are: [:ruby, :ruby_18, :ruby_19, :ruby_20, :ruby_21, :ruby_22, :mri, :mri_18, :mri_19, :mri_20, :mri_21, :mri_22, :rbx, :jruby, :jruby_18, :jruby_19, :mswin, :mswin_18, :mswin_19, :mswin_20, :mswin_21, :mswin64, :mswin64_19, :mswin64_20, :mswin64_21, :mingw, :mingw_18, :mingw_19, :mingw_20, :mingw_21, :mingw_22, :x64_mingw, :x64_mingw_20, :x64_mingw_21, :x64_mingw_22]. Bundler cannot continue.```