### PR TITLE
Don't show finance in main menu if account has the finance switch denied

### DIFF
--- a/app/views/shared/provider/navigation/audience/_billing.html.slim
+++ b/app/views/shared/provider/navigation/audience/_billing.html.slim
@@ -16,9 +16,11 @@
   li.list-group-item
     span.list-group-item-value.label Settings
 
-  = render vertical_nav_item,
-          title: 'Charging & Gateway',
-          path:  admin_finance_settings_path
+  // this setting needs more than just editingng auth, as such it's not a setting
+  - if can?(:manage, :finance)
+    = render vertical_nav_item,
+            title: 'Charging & Gateway',
+            path:  admin_finance_settings_path
 
   = render vertical_nav_item,
           title: 'Credit Card Policies',

--- a/app/views/shared/provider/navigation/audience/_nav.html.slim
+++ b/app/views/shared/provider/navigation/audience/_nav.html.slim
@@ -8,14 +8,14 @@
                      vertical_nav_item: vertical_nav_item,
                      submenu: :accounts }
 
-- if can?(:manage, :finance) || can?(:manage, :settings)
-  = render partial: 'shared/provider/navigation/audience/billing',
-           layout: layout_secondary_nav,
-           locals: { title: 'Billing',
-                     icon: 'credit-card',
-                     vertical_nav_item: vertical_nav_item,
-                     submenu: :finance }
-  //main_menu_item :finance, 'Billing', admin_finance_root_path, :switch => :finance, :upgrade_notice => !master_on_premises?
+- if can?(:see, :finance)
+  - if can?(:manage, :finance) || can?(:manage, :settings)
+    = render partial: 'shared/provider/navigation/audience/billing',
+             layout: layout_secondary_nav,
+             locals: { title: 'Billing',
+                       icon: 'credit-card',
+                       vertical_nav_item: vertical_nav_item,
+                       submenu: :finance }
 
 - if can?(:manage, :portal) || can?(:manage, :settings)
   = render partial: 'shared/provider/navigation/audience/portal',

--- a/features/old/switches/finance.feature
+++ b/features/old/switches/finance.feature
@@ -18,8 +18,10 @@ Feature: Finance switch
     Given provider "foo.example.com" has "finance" switch denied
     When I log in as provider "foo.example.com"
     Then I should not see "Billing" in the audience dashboard widget
+    When I follow "Accounts"
+    Then I should not see "Billing" in the main menu
 
-  Scenario: Finance page invites to upgrade
+  Scenario: Finance page forbidden if finance not enabled
     Given provider "foo.example.com" has "finance" switch denied
     When I log in as provider "foo.example.com"
     And I want to go to the finance page


### PR DESCRIPTION
Finance was showing in the main menu (in audience section) even if account didn't have billing enabled. This takes care of that.

Also there is 1 item under billing settings that needs `manage: finance` authorization and thus shouldn't be shown to users with `manage: settings` only auth.