### PR TITLE
Test for Account submenu Billing options

### DIFF
--- a/app/lib/three_scale.rb
+++ b/app/lib/three_scale.rb
@@ -27,5 +27,9 @@ module ThreeScale
     ThreeScale.config.onpremises && ThreeScale.tenant_mode.master?
   end
 
+  def master_billing_enabled?
+    !ThreeScale.config.onpremises
+  end
+
   extend PrivateModule
 end

--- a/app/views/shared/provider/navigation/account/_nav.html.slim
+++ b/app/views/shared/provider/navigation/account/_nav.html.slim
@@ -26,7 +26,7 @@
                      vertical_nav_item: vertical_nav_item,
                      submenu: :users }
 
-  - if !ThreeScale.config.onpremises && !current_account.master?
+  - if ThreeScale.master_billing_enabled? && !current_account.master?
     = render partial: 'shared/provider/navigation/account/billing',
            layout: layout_secondary_nav,
            locals: { title: 'Billing',

--- a/features/old/menu/account_menu.feature
+++ b/features/old/menu/account_menu.feature
@@ -30,13 +30,25 @@ Feature: Menu of the Account screen
     | Users                     |
     | SSO Integrations          |
 
-    Scenario: finance disabled should not disable 3scale invoices
-      Given provider "foo.example.com" has "finance" switch denied
-      When I go to the provider dashboard
-       And I follow "Account"
-      Then I should see "3scale Invoices"
-       And I follow "3scale Invoices"
-      Then I should be on my invoices from 3scale page
+  Scenario: finance disabled should not disable 3scale invoices
+    Given provider "foo.example.com" has "finance" switch denied
+    When I go to the provider dashboard
+     And I follow "Account"
+    Then I should see "3scale Invoices"
+     And I follow "3scale Invoices"
+    Then I should be on my invoices from 3scale page
+
+  Scenario: Account menu when master is billing
+    Given master is billing tenants
+    When I go to the provider dashboard
+     And I follow "Account"
+    Then I should see "3scale Invoices"
+
+  Scenario: Account menu when master is not billing
+    Given master is not billing tenants
+    When I go to the provider dashboard
+     And I follow "Account"
+    Then I should not see "3scale Invoices"
 
   Scenario: Account menu structure with sso enforced
     Given the provider has "multiple_users" switch allowed

--- a/features/step_definitions/finance/providers/billing_settings_step.rb
+++ b/features/step_definitions/finance/providers/billing_settings_step.rb
@@ -74,3 +74,7 @@ Given /^(provider ".+?") doesn't have billing address$/ do |provider| #'
   end
   provider.save!
 end
+
+Given /^master is( not)? billing tenants$/ do |master_billing_disabled|
+  ThreeScale.stubs(master_billing_enabled?: !master_billing_disabled)
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

It tests whether Account submenu Billing options ('3scale Invoices' and such) appear according to the deployment – on-premises or not on-premises.