### PR TITLE
[Bugfix] ServicesContracts navigation under Accounts/Services for index

### DIFF
--- a/app/controllers/buyers/service_contracts_controller.rb
+++ b/app/controllers/buyers/service_contracts_controller.rb
@@ -8,7 +8,7 @@ class Buyers::ServiceContractsController < Buyers::BaseController
 
   include ThreeScale::Search::Helpers
 
-  activate_menu :buyers, :subscriptions
+  activate_menu :buyers, :accounts, :subscriptions
 
   def index
     @states = ServiceContract.allowed_states.collect(&:to_s).sort
@@ -21,8 +21,8 @@ class Buyers::ServiceContractsController < Buyers::BaseController
       @search.service_id = @service.id
     end
 
-    if params[:service_plan_id]
-      @plan = current_account.service_plans.find(params[:service_plan_id])
+    if (service_plan_id = params[:service_plan_id] || @search.service_plan_id)
+      @plan = current_account.service_plans.find(service_plan_id)
       @search.plan_id = @plan.id
       @service ||= @plan.service
     end
@@ -30,7 +30,6 @@ class Buyers::ServiceContractsController < Buyers::BaseController
     if params[:account_id]
       @account = current_account.buyers.find params[:account_id]
       @search.account = @account
-      activate_menu :buyers, :accounts
     end
 
     scope = current_account.provided_service_contracts


### PR DESCRIPTION
- ServiceContract#index under Accounts scope
![image](https://user-images.githubusercontent.com/11318903/47296612-1e8bc800-d613-11e8-8fe7-c68f820bc2a2.png)
- ServiceContract#index under Services scope
![image](https://user-images.githubusercontent.com/11318903/47296637-2d727a80-d613-11e8-99da-6eb767863ce6.png)
- ServiceContract#index under ServicePlans scope
![image](https://user-images.githubusercontent.com/11318903/47296651-3c592d00-d613-11e8-9a3e-b5b987087eda.png)

About the other actions of the controller being affected by this code, `edit` and `new` are under Account so it is correct:
![image](https://user-images.githubusercontent.com/11318903/47298154-51d05600-d617-11e8-9024-ada5b14a4eda.png)
