### PR TITLE
[boot] Make redis check independent of environment

### DIFF
--- a/lib/tasks/boot.rake
+++ b/lib/tasks/boot.rake
@@ -16,8 +16,9 @@ namespace :boot do
   end
 
   desc 'Tries to connect to Redis'
-  task redis: :environment do
-    redis = System.redis
+  task :redis do
+    redis_config = Rails.application.config_for(:redis)
+    redis = Redis.new(redis_config)
     redis.ping
     puts "Connected to #{redis.id}"
   end


### PR DESCRIPTION
So we can properly check it without the need of the database to be up


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Checking Redis connectivity was depending on :environment
The :environment task needs MySQL to be up

We also need it for dependencies checking in https://github.com/3scale/openshift-templates/pull/360

**Which issue(s) this PR fixes** 

Relates to https://github.com/3scale/openshift-templates/pull/360

**Verification steps** 

- Shutdown MySQL
- Verify that `rake boot:redis` does not crash if Redis is up

**Special notes for your reviewer**: