### PR TITLE
Do not index master account + master account cannot be suspended

### DIFF
--- a/app/controllers/buyers/accounts_controller.rb
+++ b/app/controllers/buyers/accounts_controller.rb
@@ -16,7 +16,7 @@ class Buyers::AccountsController < Buyers::BaseController
     @countries = Country.all
     @account_plans = current_account.account_plans.stock
     @search = ThreeScale::Search.new(params[:search] || params)
-    @accounts = current_account.buyer_accounts.scope_search(@search).
+    @accounts = current_account.buyer_accounts.not_master.scope_search(@search).
         # this preloading collides with joins for sorting by country and plan
         includes(:bought_account_plan, :country)
                     .order_by(params[:sort], params[:direction])
@@ -86,7 +86,7 @@ class Buyers::AccountsController < Buyers::BaseController
 
   def find_account
     with_deleted = %w[show resume].include?(action_name)
-    @account = current_account.buyer_accounts.without_deleted(!with_deleted).find(params[:id])
+    @account = current_account.buyer_accounts.not_master.without_deleted(!with_deleted).find(params[:id])
   end
 
   def redirection_path

--- a/app/indices/account_index.rb
+++ b/app/indices/account_index.rb
@@ -27,4 +27,5 @@ ThinkingSphinx::Index.define(:account,
     has 'CRC32(accounts.state)', as: :state, type: :integer
   end
 
+  where 'COALESCE(accounts.master, 0) = 0'
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -60,6 +60,7 @@ class Account < ApplicationRecord
   scope :buyers, -> { where(provider: false, buyer: true) }
 
   scope :without_deleted, ->(without = true) { where(deleted_at: nil) if without }
+  scope :not_master, -> { where(master: [0, nil]) }
 
   audited allow_mass_assignment: true
 
@@ -376,6 +377,10 @@ class Account < ApplicationRecord
 
   def provider?
     self[:provider] || master?
+  end
+
+  def provider_but_not_master?
+    provider && !master?
   end
 
   # @param [SystemOperation] operation

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -77,7 +77,7 @@ module Account::States
       end
 
       event :suspend do
-        transition :approved => :suspended, if: :provider?
+        transition :approved => :suspended, if: :provider_but_not_master?
       end
 
       event :resume do

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -124,6 +124,13 @@ class Account::StatesTest < ActiveSupport::TestCase
     assert account.suspended?
   end
 
+  def test_suspend_master
+    account = FactoryGirl.build_stubbed(:simple_provider, master: true)
+    assert_raise StateMachines::InvalidTransition do
+      account.suspend!
+    end
+  end
+
   test 'resume account' do
     account = Account.new(state: 'suspended', domain: 'foo', self_domain: 'foobar', org_name: 'foo')
     account.provider_account = master_account

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -21,6 +21,28 @@ class AccountTest < ActiveSupport::TestCase
   should have_many :invoices
   should have_many :payment_transactions
 
+  def test_not_master
+    master = master_account
+    buyer = FactoryGirl.create(:simple_buyer, provider_account: master)
+
+    assert master.buyer_account_ids.include?(buyer.id)
+    assert master.buyer_account_ids.include?(master.id)
+
+    assert master.buyer_accounts.not_master.ids.include?(buyer.id)
+    refute master.buyer_accounts.not_master.ids.include?(master.id)
+  end
+
+  def test_provider_but_not_master
+    account = FactoryGirl.build_stubbed(:simple_account, provider: false, master: false)
+    refute account.provider_but_not_master?
+    
+    account.provider = true
+    assert account.provider_but_not_master?
+    
+    account.master = true
+    refute account.provider_but_not_master?
+  end
+
   def test_destroy_association
     account = FactoryGirl.create(:simple_account)
     service = FactoryGirl.create(:simple_service, account: account)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Master account appears in the buyer accounts search. Master account should not be searchable in the first place. Let's not create an account index in sphinx for master account and do not show `master: true` account on buyers/tenants page. 

Master account should not be suspendable. 
