### PR TITLE
Fix Tests for AccountApiDocsController: now with ActiveDocs title

### DIFF
--- a/test/integration/admin/api_docs/account_api_docs_controller_test.rb
+++ b/test/integration/admin/api_docs/account_api_docs_controller_test.rb
@@ -22,7 +22,7 @@ class Admin::ApiDocs::AccountApiDocsControllerTest < ActionDispatch::Integration
 
       get admin_api_docs_services_path
       refute_xpath "//nav[@class='vertical-nav']//li[contains(@class, 'active')]/a[contains(@href, '#{admin_service_api_docs_path(service)}')]/span", 'ActiveDocs' # The service menu
-      refute_xpath '//*[@id="content"]/h1', 'ActiveDocs' # The service title
+      assert_xpath '//*[@id="content"]/h1', 'ActiveDocs' # The service title
 
       page = Nokogiri::HTML::Document.parse(response.body)
       api_docs_name_list_nodes = page.xpath("//*[@id='content']/table/tbody/tr/td[1]/a") # From the resulting table, the first column of all api_docs
@@ -55,7 +55,7 @@ class Admin::ApiDocs::AccountApiDocsControllerTest < ActionDispatch::Integration
     test 'preview under the service scope when there is a service' do
       get preview_admin_api_docs_service_path(api_docs_service)
       refute_xpath "//nav[@class='vertical-nav']//li[contains(@class, 'active')]/a[contains(@href, '#{admin_service_api_docs_path(service)}')]/span", 'ActiveDocs' # The service menu
-      refute_xpath '//*[@id="content"]/h1', 'ActiveDocs' # The service title
+      assert_xpath '//*[@id="content"]/h1', 'ActiveDocs' # The service title
 
       api_docs_service.update({service_id: service.id}, without_protection: true)
       get preview_admin_api_docs_service_path(api_docs_service)
@@ -65,7 +65,7 @@ class Admin::ApiDocs::AccountApiDocsControllerTest < ActionDispatch::Integration
     test 'edit under the service scope when there is a service' do
       get edit_admin_api_docs_service_path(api_docs_service)
       refute_xpath "//nav[@class='vertical-nav']//li[contains(@class, 'active')]/a[contains(@href, '#{admin_service_api_docs_path(service)}')]/span", 'ActiveDocs' # The service menu
-      refute_xpath '//*[@id="content"]/h1', 'ActiveDocs' # The service title
+      assert_xpath '//*[@id="content"]/h1', 'ActiveDocs' # The service title
 
       api_docs_service.update({service_id: service.id}, without_protection: true)
       get edit_admin_api_docs_service_path(api_docs_service)


### PR DESCRIPTION
Fix the tests since the Account scope has the title as well now