### PR TITLE
Activate sidebar 'Methods & Metrics'

### DIFF
--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -4,7 +4,7 @@ class Api::MetricsController < Api::BaseController
   before_action :find_metric, except: [:new, :create, :index]
   before_action :build_metric, only: [:new, :create]
 
-  activate_menu :serviceadmin, :integration, :methods_and_metrics
+  activate_menu :serviceadmin, :integration, :methods_metrics
   sublayout 'api/service'
 
   def index


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11318903/47361257-c5cf3480-d6d1-11e8-8589-a9269da35d5a.png)

The key was checking at `app/views/shared/provider/navigation/_vertical_nav_item.html.slim` for the values of `@active_menus[:sidebar]` and `title`, then look at `lib/menu_system.rb` in `active_menu?` and do the conversions in the same way. The error was it was comparing `'methods_and_metrics'` with just `methos_metrics` after the conversion of both.