### PR TITLE
Fix Navigation Sidebar Forums->Threads active and not 'My Threads' and vice versa

### DIFF
--- a/app/controllers/forums/admin/forums_controller.rb
+++ b/app/controllers/forums/admin/forums_controller.rb
@@ -2,5 +2,5 @@ class Forums::Admin::ForumsController < FrontendController
   include ForumSupport::Admin
   include ForumSupport::Forums
 
-  activate_menu :buyers, :forum
+  activate_menu :buyers, :forum, :threads
 end

--- a/app/controllers/forums/admin/topics_controller.rb
+++ b/app/controllers/forums/admin/topics_controller.rb
@@ -2,5 +2,5 @@ class Forums::Admin::TopicsController < FrontendController
   include ForumSupport::Admin
   include ForumSupport::Topics
 
-  activate_menu :buyers, :forum, :threads
+  activate_menu :buyers, :forum, :my_threads
 end


### PR DESCRIPTION
### Problem (there were 2 active sidebars):
![image](https://user-images.githubusercontent.com/11318903/47363023-19dc1800-d6d6-11e8-8dec-0b64f119ce4c.png)

### Solution:
![image](https://user-images.githubusercontent.com/11318903/47363508-447aa080-d6d7-11e8-928a-e3d7f72714e0.png)

![image](https://user-images.githubusercontent.com/11318903/47363521-4a708180-d6d7-11e8-95d1-403e5f53d576.png)
