### PR TITLE
Reduce loops in Api Filter

### DIFF
--- a/app/views/provider/admin/dashboards/_services_filter.html.slim
+++ b/app/views/provider/admin/dashboards/_services_filter.html.slim
@@ -6,15 +6,13 @@
         var allApis = #{json @services}
 
         var displayApis = function(filteredApis) {
-          for (let i = 0; i < allApis.length; i++) {
-            var api = allApis[i];
-
+          allApis.forEach(function(api) {
             var isFilteredApi = filteredApis.some(function(filteredApi) {
               return filteredApi.service.id === api.service.id
             });
 
             document.getElementById("service_" + api.service.id).style.display = isFilteredApi ? "inline": "none";
-          }
+          })
         }
 
         window.ApiFilter({

--- a/app/views/provider/admin/dashboards/_services_filter.html.slim
+++ b/app/views/provider/admin/dashboards/_services_filter.html.slim
@@ -6,11 +6,14 @@
         var allApis = #{json @services}
 
         var displayApis = function(filteredApis) {
-          for (api = 0; api < allApis.length; api++) {
-            document.getElementById("service_" + allApis[api].service.id).style.display = "none"
-          }
-          for (api = 0; api < filteredApis.length; api++) {
-            document.getElementById("service_" + filteredApis[api].service.id).style.display = "inline"
+          for (let i = 0; i < allApis.length; i++) {
+            var api = allApis[i];
+
+            var isFilteredApi = filteredApis.some(function(filteredApi) {
+              return filteredApi.service.id === api.service.id
+            });
+
+            document.getElementById("service_" + api.service.id).style.display = isFilteredApi ? "inline": "none";
           }
         }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

By request of @hallelujah in [this coment](https://github.com/3scale/porta/pull/78#pullrequestreview-162126816), here it is a proposal to make api filter logic more readable (both solutions are identical logic-wise).

I've tried them both with 500 services and performance-wise the _double for_ is quicker. However the times are small enough to be negligible.

I personally think the _double for_ is more readable but I'd like to know your opinions.
