### PR TITLE
[Bugfix] Invitation does not require uniqueness emails including its buyers

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -44,9 +44,8 @@ class Invitation < ApplicationRecord
   private
 
   def email_is_not_taken
-    unless account.managed_users.by_email(email).empty?
-      errors.add(:email, 'has been taken by another user')
-    end
+    return if account.users.by_email(email).empty?
+    errors.add(:email, 'has been taken by another user')
   end
 
   def generate_token

--- a/test/unit/invitation_test.rb
+++ b/test/unit/invitation_test.rb
@@ -24,13 +24,12 @@ class InvitationTest < ActiveSupport::TestCase
     assert invitation.errors[:email].include? 'has been taken by another user'
   end
 
-  test 'requires the email to not belong to a buyer user' do
+  test 'does not require the email to not belong to a buyer user' do
     buyer = Factory :simple_buyer, :provider_account => @provider
     buyer_user = Factory(:simple_user, :account => buyer)
     invitation = Invitation.new(:account => @provider, :email => buyer_user.email)
 
-    refute invitation.valid?
-    assert invitation.errors[:email].include? 'has been taken by another user'
+    assert invitation.valid?
   end
 
   test 'does not require globally unique email' do


### PR DESCRIPTION
Fixes [THREESCALE-647](https://issues.jboss.org/browse/THREESCALE-647)
It allows inviting admin users with the same email of any of its buyers, but it keeps verifying it doesn't exist among the users of the same account.
