### PR TITLE
AuthorizationProvider bounce redirects to the authorize_url

### DIFF
--- a/app/controllers/provider/sessions_controller.rb
+++ b/app/controllers/provider/sessions_controller.rb
@@ -33,6 +33,11 @@ class Provider::SessionsController < FrontendController
     end
   end
 
+  def bounce
+    auth = domain_account.self_authentication_providers.find_by!(system_name: params.require(:system_name))
+    redirect_to ProviderOauthFlowPresenter.new(auth, request, request.host).authorize_url
+  end
+
   def destroy
     user = current_user
     logout_killing_session!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,7 @@ without fake Core server your after commit callbacks will crash and you might ge
   end
 
   get '/auth/:system_name/callback' => 'provider/sessions#create', constraints: MasterOrProviderDomainConstraint
+  get '/auth/:system_name/bounce' => 'provider/sessions#bounce', constraints: ProviderDomainConstraint, as: :authorization_provider_bounce
 
   namespace :provider, :path => 'p', constraints: MasterOrProviderDomainConstraint do
     get 'activate/:activation_code' => 'activations#create', :as => :activate

--- a/test/integration/provider/sessions_controller_test.rb
+++ b/test/integration/provider/sessions_controller_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Provider::SessionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @provider = FactoryGirl.create(:provider_account)
+    host! @provider.admin_domain
+    @authentication_provider = FactoryGirl.create(:self_authentication_provider, account: @provider)
+  end
+
+  attr_reader :authentication_provider
+
+  test 'bounce redirects to the authorize_url' do
+    get authorization_provider_bounce_path(authentication_provider.system_name)
+    request = mock('request', scheme: 'http', query_parameters: {})
+    assert_redirected_to ProviderOauthFlowPresenter.new(authentication_provider, request, @provider.admin_domain).authorize_url
+  end
+
+  test 'bounce returns not found if the authentication provider belongs to another provider' do
+    authentication_provider = FactoryGirl.create(:self_authentication_provider)
+    get authorization_provider_bounce_path(authentication_provider.system_name)
+    assert_response :not_found
+  end
+
+  test 'bounce to an non-existent system_name' do
+    get authorization_provider_bounce_path('fake-system-name')
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
There is a new route, `GET` on `/auth/:system_name/bounce` that redirects to the `authorize_url` of that `AuthenticationProvider`

Closes https://issues.jboss.org/browse/THREESCALE-1292