### PR TITLE
Service Mesh on the Integraton page [THREESCALE-1426]

### DIFF
--- a/app/assets/stylesheets/provider/admin/apiconfig/services/_proxies.scss
+++ b/app/assets/stylesheets/provider/admin/apiconfig/services/_proxies.scss
@@ -71,9 +71,9 @@ form.formtastic fieldset > ol > li.radio--iconic fieldset ol {
         &:before {
           display: block;
           width: 30%;
-          height: 100px;
+          height: line-height-times(6);
           position: absolute;
-          top: 24px;
+          top: line-height-times(1);
           left: 0;
           content: "";
           background-repeat: no-repeat;
@@ -231,6 +231,10 @@ form.formtastic fieldset > ol > li.radio--iconic {
 
 .deployment_option_self_managed span:before {
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMTE1LjEyIDI0LjE5Ij48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTEuNTYyLTExLjEyNCkiPjxwYXRoIGQ9Im0xNC4wNSAzMi43Mjh2LTE5LjA2bDE5LjA2IDE5LjA2di0xOS4wNiIgaWQ9IjAiIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzA5MCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2Utd2lkdGg9IjUiLz48ZyBmaWxsPSIjMDkwIiBjb2xvcj0iIzAwMCI+PHBhdGggZD0ibTQ0LjY4OCAxMS4xODhsLS42ODggMS4yODEtNS4zMTMgOS42NTYtLjY4OCAxLjIxOS42ODggMS4yMTkgNS4zMTMgOS4zNDQuNzE5IDEuMjgxaDEuNDY5IDEwLjg3NSAxLjU2M2wuNjg4LTEuNDA2IDMuOTY5LTggMS43ODEtMy42MjVoLTQuMDNsLTEwLjE1Ni4wMzFjLTEuMzIxLS4wMTktMi41MzYgMS4xNzktMi41MzYgMi41IDAgMS4zMjEgMS4yMTUgMi41MTkgMi41MzYgMi41bDYuMTI1LS4wMzEtMS41IDMuMDNoLTcuODc1bC0zLjkwNi02Ljg3NSAzLjkzOC03LjEyNWg4LjM3N2wxLjk1MyA0LjAxaDUuMDNsLTMuMTcyLTcuNjAyLS42ODgtMS40MDZoLTEuNTYzLTExLjQwOHoiLz48cGF0aCBkPSJtNzAuMDEgMTEuMTU2Yy0xLjMwOS4wMTYtMi40ODUgMS4yMjItMi40NjkgMi41MzF2Ni41MTVoNXYtNi41MTVjLjAxNy0xLjMzLTEuMjAxLTIuNTQ4LTIuNTMxLTIuNTMxIi8+PC9nPjx1c2UgeGxpbms6aHJlZj0iIzAiIHRyYW5zZm9ybT0ibWF0cml4KC0xIDAgMCAxIDExMS4xNC4wNDgpIiB3aWR0aD0iNzQ0LjA5IiBoZWlnaHQ9IjEwNTIuMzYiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSguMTA2LjMzKSI+PHBhdGggaWQ9IjEiIGQ9Im0xMDQuOTEgMTMuMzc0bDE5LjA4IDE5LjAyIiBmaWxsPSJub25lIiBzdHJva2U9IiMwOTAiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1Ii8+PHVzZSBoZWlnaHQ9IjEwNTIuMzYiIHdpZHRoPSI3NDQuMDkiIHRyYW5zZm9ybT0ibWF0cml4KC0xIDAgMCAxIDIyOC45MyAwKSIgeGxpbms6aHJlZj0iIzEiLz48L2c+PHBhdGggZD0ibTcwLjAxIDM1LjJjLTEuMzA5LS4wMTYtMi40ODUtMS4yMjItMi40NjktMi41MzF2LTEwLjQ2NGg1djEwLjQ2NGMuMDE3IDEuMzMtMS4yMDEgMi41NDgtMi41MzEgMi41MzEiIGNvbG9yPSIjMDAwIiBmaWxsPSIjMDkwIi8+PC9nPjwvc3ZnPg==);
+}
+
+.deployment_option_service_mesh_istio span:before {
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48c3ZnIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMTYwIDI0MCI+ICA8ZyBpZD0ibG9nbyIgZmlsbD0iIzQ2NkJCMCI+ICAgIDxyZWN0IGlkPSJiYWNrZ3JvdW5kIiBmaWxsPSIjZmZmIiB3aWR0aD0iMTYwIiBoZWlnaHQ9IjI0MCIgLz4gICAgPHBvbHlnb24gaWQ9Imh1bGwiIHBvaW50cz0iMCwyMTAgMTYwLDIxMCA2MCwyNDAiLz4gICAgPHBvbHlnb24gaWQ9Im1haW5zYWlsIiBwb2ludHM9IjAsMjAwIDYwLDE5MCA2MCw4MCIvPiAgICA8cG9seWdvbiBpZD0iaGVhZHNhaWwiIHBvaW50cz0iNzAsMTkwIDE2MCwyMDAgNzAsMCIvPiAgPC9nPjwvc3ZnPg==);
 }
 
 .deployment_option_plugin_ruby span:before {

--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -93,6 +93,12 @@ module Logic
         end
       end
 
+      class ServiceMeshIntegration < Base
+        def missing_config
+          false
+        end
+      end
+
       class OldCharts < Base
         def missing_config
           false

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -457,6 +457,10 @@ class Proxy < ApplicationRecord
     self.class.config.fetch(:port) { Rails.env.test? ? '44432' : '443' }
   end
 
+  def deployable?
+    Service::DeploymentOption.gateways.include?(deployment_option)
+  end
+
   protected
 
   class PolicyConfig
@@ -540,6 +544,7 @@ class Proxy < ApplicationRecord
   end
 
   def deploy
+    return true unless deployable?
     apicast_configuration_driven ? deploy_v2 : deploy_v1
   end
 

--- a/app/services/proxy_test_service.rb
+++ b/app/services/proxy_test_service.rb
@@ -68,7 +68,7 @@ class ProxyTestService
   end
 
   def disabled?
-    !proxy
+    !proxy&.deployable?
   end
 
   def credentials

--- a/app/views/api/integrations/edit.html.slim
+++ b/app/views/api/integrations/edit.html.slim
@@ -14,8 +14,12 @@ javascript:
   = render 'api/integrations/apicast/shared/deployment_options' unless apicast_configuration_driven?
 
   .integration data-state="open"
-    - if @service.deployment_option.include?('plugin_')
+    - case @service.deployment_option
+    - when /^plugin_/
       = render 'api/integrations/plugin/plugin'
+    - when /^service_mesh_/
+      #proxy
+        = render 'api/integrations/service_mesh/form'
     - else
       #proxy
         - if apicast_configuration_driven?

--- a/app/views/api/integrations/service_mesh/_form.html.slim
+++ b/app/views/api/integrations/service_mesh/_form.html.slim
@@ -1,0 +1,16 @@
+= semantic_form_for @proxy,
+        url: admin_service_integration_path(@service, anchor: 'proxy'),
+        html: { \
+          data: { gid: @proxy.to_gid_param, version: @proxy.lock_version },
+                class: css_class('proxy-settings',
+                        oauth: @service.backend_version.oauth?,
+                        oidc: current_account.provider_can_use?(:apicast_oidc)) \
+        } do |f|
+
+  = f.hidden_field :lock_version
+
+  = render 'api/integrations/apicast/shared/mapping_rules', f: f
+
+  = f.buttons do
+    = f.button 'Update', button_html: { class: 'important-button update' }
+    = fixed_width_icon_link_to("Back to Integration & Configuration", "arrow-left", admin_service_integration_path(@service), class: 'next')

--- a/app/views/api/integrations/show.html.slim
+++ b/app/views/api/integrations/show.html.slim
@@ -6,10 +6,13 @@
   = render 'api/integrations/apicast/shared/deployment_options'
 
   .integration data-state="open"
-    - if @service.deployment_option.include?('plugin_')
+    - case @service.deployment_option
+    - when /^plugin_/
       = render 'api/integrations/plugin/plugin'
-    - elsif @show_presenter.any_sandbox_configs?
-      = render 'api/integrations/apicast/configuration_driven/apicast'
+    - when /^service_mesh/
     - else
-      ' To get started with this service on APIcast,
-      = link_to "add the base URL of your API and save the configuration.", edit_admin_service_integration_path(@service), class: "important-button"
+      - if @show_presenter.any_sandbox_configs?
+        = render 'api/integrations/apicast/configuration_driven/apicast'
+      - else
+        ' To get started with this service on APIcast,
+        = link_to "add the base URL of your API and save the configuration.", edit_admin_service_integration_path(@service), class: "important-button"

--- a/app/views/api/services/forms/_integration_settings.html.slim
+++ b/app/views/api/services/forms/_integration_settings.html.slim
@@ -115,15 +115,24 @@ javascript:
     = form.input :deployment_option,
       as: :radio,
       collection: Service.deployment_options(current_account)['Gateway'],
-      label: Service.deployment_options(current_account).keys[0],
+      label: 'Gateway',
       wrapper_html: { class: "radio--iconic gateway" },
       value_as_class: true,
       hint: t("formtastic.hints.deployment_option_gateway")
 
+    - if current_account.provider_can_use?(:service_mesh_integration)
+      = form.input :deployment_option,
+              as: :radio,
+              collection: Service.deployment_options(current_account)['Service Mesh'],
+              label: 'Service Mesh',
+              wrapper_html: {class: 'radio--iconic service_mesh'},
+              value_as_class: true,
+              hint: t('formtastic.hints.deployment_option_service_mesh')
+
     = form.input :deployment_option,
       as: :radio,
       collection: Service.deployment_options(current_account)['Plugin'],
-      label: 'Or ' + Service.deployment_options(current_account).keys[1],
+      label: 'Or Plugin',
       wrapper_html: { class: "radio--iconic plugin" },
       value_as_class: true,
       hint: t("formtastic.hints.deployment_option_plugin")

--- a/config/examples/rolling_updates.yml
+++ b/config/examples/rolling_updates.yml
@@ -14,6 +14,7 @@ base: &default
   forum: true
   policies: true
   proxy_private_base_path: true
+  service_mesh_integration: false
 
 development:
   <<: *default

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -577,8 +577,8 @@ en:
     apicast: APIcast<span>Nginx reverse proxy server.</span>
 
     service_mesh_istio: |
-      Istio
-      <span>Use Service Mesh.</span>
+      Istio (tech preview)
+      <span>A uniform way to secure, connect, and monitor microservices.</span>
 
     on_heroku: Heroku
     on_amazon: Amazon
@@ -1104,7 +1104,9 @@ en:
         Plugins provide a wrapper for the 3scale API that enables API Access Control and API Traffic Reporting without having to run another server.
         A plugin lives inside the code that powers your API. The plugin calls the 3scale API for Access Control & Traffic Reporting.
       deployment_option_service_mesh: |
-        Service Mesh ...
+        The term service mesh is used to describe the network of microservices that make up the applications and the interactions between them.
+        As a service mesh grows in size and complexity, it can become harder to understand and manage. Its requirements can include discovery, load balancing, failure recovery, metrics, and monitoring.
+        A service mesh also often has more complex operational requirements, like A/B testing, canary releases, rate limiting, access control, and end-to-end authentication.
       subdomain: "The domain name is the initial temporary domain name for your developer portal - you can change this to your own domain name later."
       handler: "Do you use any markup language?"
       liquid_enabled: "Process Liquid tags and drops?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,10 +570,15 @@ en:
       plugin_php: PHP Plugin
       plugin_rest: REST requests
       plugin_csharp: .NET Plugin
+      service_mesh_istio: Istio Service Mesh
 
     self_managed: APIcast self-managed<span>Manage your own NGINX based API gateway for ultimate flexibility and customization.</span>
     hosted: APIcast<span>a 3scale managed NGINX based API gateway for quick and reliable integrations</span>
     apicast: APIcast<span>Nginx reverse proxy server.</span>
+
+    service_mesh_istio: |
+      Istio
+      <span>Use Service Mesh.</span>
 
     on_heroku: Heroku
     on_amazon: Amazon
@@ -1098,6 +1103,8 @@ en:
       deployment_option_plugin: |
         Plugins provide a wrapper for the 3scale API that enables API Access Control and API Traffic Reporting without having to run another server.
         A plugin lives inside the code that powers your API. The plugin calls the 3scale API for Access Control & Traffic Reporting.
+      deployment_option_service_mesh: |
+        Service Mesh ...
       subdomain: "The domain name is the initial temporary domain name for your developer portal - you can change this to your own domain name later."
       handler: "Do you use any markup language?"
       liquid_enabled: "Process Liquid tags and drops?"

--- a/openshift/system/config/rolling_updates.yml
+++ b/openshift/system/config/rolling_updates.yml
@@ -16,6 +16,7 @@ base: &default
   published_service_plan_signup: true
   policies: true
   proxy_private_base_path: true
+  service_mesh_integration: false
 
 production:
   <<: *default

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -124,6 +124,14 @@ class ProxyTest < ActiveSupport::TestCase
       assert proxy.staging_endpoint
       assert proxy.production_endpoint
     end
+
+    def test_deployable
+      assert_predicate Service.new(deployment_option: 'hosted').build_proxy, :deployable?
+      assert_predicate Service.new(deployment_option: 'self_managed').build_proxy, :deployable?
+
+      refute_predicate Service.new(deployment_option: 'plugin_ruby').build_proxy, :deployable?
+      refute_predicate Service.new(deployment_option: 'plugin_perl').build_proxy, :deployable?
+    end
   end
 
   def test_apicast_configuration_driven

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -67,6 +67,14 @@ class ServiceTest < ActiveSupport::TestCase
     assert proxy.staging_endpoint
   end
 
+  def test_deployment_options
+    deployment_options = Service.deployment_options
+
+    assert_includes deployment_options, 'Gateway'
+    assert_includes deployment_options, 'Plugin'
+    assert_includes deployment_options, 'Service Mesh'
+  end
+
   # Now the last remaining service cannot be destroyed
   def test_stop_destroy_if_last
     service = FactoryGirl.create(:simple_service)
@@ -596,5 +604,40 @@ class ServiceTest < ActiveSupport::TestCase
 
     user.stubs(forbidden_some_services?: true)
     assert_same_elements member_permission_service_ids, Service.permitted_for_user(user).pluck(:id)
+  end
+
+  class DeploymentOptionTest < ActiveSupport::TestCase
+    def test_all
+      all = Service::DeploymentOption.all
+
+      assert_includes all, 'plugin_ruby'
+      assert_includes all, 'self_managed'
+      assert_includes all, 'service_mesh_istio'
+    end
+
+    def test_service_mesh
+      service_mesh = Service::DeploymentOption.service_mesh
+
+      assert_includes service_mesh, 'service_mesh_istio'
+      refute_includes service_mesh, 'plugin_ruby'
+      refute_includes service_mesh, 'hosted'
+    end
+
+    def test_gateways
+      gateways = Service::DeploymentOption.gateways
+
+      assert_includes gateways, 'self_managed'
+      assert_includes gateways, 'hosted'
+      refute_includes gateways, 'plugin_ruby'
+      refute_includes gateways, 'service_mesh_istio'
+    end
+
+    def test_plugins
+      plugins = Service::DeploymentOption.plugins
+
+      refute_includes plugins, 'self_managed'
+      refute_includes plugins, 'hosted'
+      assert_includes plugins, 'plugin_ruby'
+    end
   end
 end


### PR DESCRIPTION
* Introduce new rolling update.
* Implement `Proxy#deployable?` to skip deployments and testing.
* Add Service Mesh integration option only when the rolling update is
enabled.

Fixes [THREESCALE-1426](https://issues.jboss.org/browse/THREESCALE-1426)

Closes https://github.com/3scale/porta/issues/302

### Screenshots
<img width="1127" alt="screenshot 2018-10-30 at 15 49 46" src="https://user-images.githubusercontent.com/154571/47726789-7c479200-dc5b-11e8-8ca8-84c40270060e.png">
<img width="1459" alt="screenshot 2018-10-30 at 15 48 31" src="https://user-images.githubusercontent.com/154571/47726790-7ce02880-dc5b-11e8-9868-1d9f3d8e3927.png">