### PR TITLE
Master sudomains generated without '-admin'

### DIFF
--- a/app/lib/signup/master_domains_builder.rb
+++ b/app/lib/signup/master_domains_builder.rb
@@ -2,11 +2,7 @@
 
 class Signup::MasterDomainsBuilder < Signup::DomainsBuilder
   def generate
-    if current_subdomain.present?
-      Signup::Domains.new(subdomain: current_subdomain, self_subdomain: current_subdomain)
-    else
-      new_subdomain = generate_subdomain
-      Signup::Domains.new(subdomain: "#{new_subdomain}-admin", self_subdomain: "#{new_subdomain}-admin")
-    end
+    new_subdomain = current_subdomain.presence || generate_subdomain
+    Signup::Domains.new(subdomain: new_subdomain, self_subdomain: new_subdomain)
   end
 end

--- a/test/unit/account/domains_test.rb
+++ b/test/unit/account/domains_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
 
 class Account::DomainsTest < ActiveSupport::TestCase
-
   test '#domain must be downcase' do
     account_one = FactoryGirl.create(:simple_provider)
     account_one.subdomain = 'FOO'
@@ -11,6 +10,7 @@ class Account::DomainsTest < ActiveSupport::TestCase
   test '#domain must be unique' do
     account_one = FactoryGirl.create(:simple_provider)
 
+    ThreeScale.config.stubs(superdomain: 'example.com')
     account_two = Factory.build(:provider_account)
     account_two.domain = account_one.domain
 
@@ -21,6 +21,7 @@ class Account::DomainsTest < ActiveSupport::TestCase
   test '#domain uniqueness ignores deleted' do
     account_one = FactoryGirl.create(:simple_provider)
 
+    ThreeScale.config.stubs(superdomain: 'example.com')
     account_two = Factory.build(:provider_account)
     account_two.domain = account_one.domain
 
@@ -112,10 +113,10 @@ class Account::DomainsTest < ActiveSupport::TestCase
     end
     account.generate_domains
 
-    assert_equal 'new-master-account-admin',                                  account.subdomain
-    assert_equal 'new-master-account-admin',                                  account.self_subdomain
-    assert_equal "new-master-account-admin.#{ThreeScale.config.superdomain}", account.domain
-    assert_equal "new-master-account-admin.#{ThreeScale.config.superdomain}", account.self_domain
+    assert_equal 'new-master-account',                                  account.subdomain
+    assert_equal 'new-master-account',                                  account.self_subdomain
+    assert_equal "new-master-account.#{ThreeScale.config.superdomain}", account.domain
+    assert_equal "new-master-account.#{ThreeScale.config.superdomain}", account.self_domain
   end
 
   test '#generate_domains generates correctly custom for master' do

--- a/test/unit/signup/master_domains_builder_test.rb
+++ b/test/unit/signup/master_domains_builder_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Signup::MasterDomainsBuilderTest < ActiveSupport::TestCase
+  test 'org_name is base for the subdomain' do
+    new_domains = generate_domains(org_name: 'Master Account')
+    assert_equal 'master-account', new_domains.subdomain
+  end
+
+  test 'current_subdomain is kept if present' do
+    new_domains = generate_domains(org_name: 'Master Account', current_subdomain: 'master')
+    assert_equal 'master', new_domains.subdomain
+  end
+
+  test 'generates equal subdomain and self subdomain' do
+    new_domains = generate_domains(org_name: 'Master Account')
+    assert_equal new_domains.subdomain, new_domains.self_subdomain
+  end
+
+  private
+
+  def generate_domains(org_name:, current_subdomain: nil)
+    provider = FactoryGirl.build(:simple_provider)
+    domains_builder_params = { org_name: org_name, current_subdomain: current_subdomain, invalid_subdomain_condition: provider.method(:subdomain_exists?) }
+    Signup::MasterDomainsBuilder.new(**domains_builder_params).generate
+  end
+end


### PR DESCRIPTION
It ensures that master's subdomain and self_subdomain matches what the account holds in the database, no longer enforcing the hardcoded `-admin` suffix.

That comes together with https://github.com/3scale/openshift-templates/pull/387