### PR TITLE
[drops] Liquid::Drops::Application#alerts is a Drops::Alert collection

### DIFF
--- a/doc/liquid/drops.md
+++ b/doc/liquid/drops.md
@@ -443,6 +443,7 @@ Returns 'true' if application state is pending.
 ### buyer_alerts_enabled?
 
 ### alerts
+Returns a list of not-deleted alerts for this application
 
 ### description
 Returns the description of the application.
@@ -700,19 +701,6 @@ OAuth callback url.
 
 
 ## Methods
-### login_url
-
-### user_identified?
-
------------
-
-# Base drop
-
-
-
-
-
-## Methods
 ### errors
 
 If a form for this model is rendered after unsuccessful submission,
@@ -735,6 +723,19 @@ Returns the resource URL of the result.
 
 ### description
 Returns a descriptive string for the result.
+
+-----------
+
+# Base drop
+
+
+
+
+
+## Methods
+### login_url
+
+### user_identified?
 
 -----------
 
@@ -1611,27 +1612,6 @@ this returns the errors that occurred.
 
 
 ## Methods
-### type
-
-Possible types of the messages are:
-
- - success (not used by now)
- - info
- - warning
- - danger
-        
-
-### text
-
------------
-
-# Message drop
-
-
-
-
-
-## Methods
 ### errors
 
 If a form for this model is rendered after unsuccessful submission,
@@ -1671,6 +1651,27 @@ Returns the name of the sender.
 Returns the name of the receiver.
 
 ### recipients
+
+-----------
+
+# Message drop
+
+
+
+
+
+## Methods
+### type
+
+Possible types of the messages are:
+
+ - success (not used by now)
+ - info
+ - warning
+ - danger
+        
+
+### text
 
 -----------
 
@@ -2870,9 +2871,12 @@ this returns the errors that occurred.
 ```
 
 ### title
-Name of the topic. Submitted when first post to the thread is posted.
+
+### kind
 
 ### url
+
+### description
 
 -----------
 
@@ -2895,12 +2899,9 @@ this returns the errors that occurred.
 ```
 
 ### title
-
-### kind
+Name of the topic. Submitted when first post to the thread is posted.
 
 ### url
-
-### description
 
 -----------
 

--- a/lib/developer_portal/lib/liquid/drops/application.rb
+++ b/lib/developer_portal/lib/liquid/drops/application.rb
@@ -57,8 +57,12 @@ module Liquid
         @contract.buyer_alerts_enabled?
       end
 
+      desc 'Returns a list of not-deleted alerts for this application'
       def alerts
-        @contract.alerts
+        @alerts ||= begin
+          collection = @contract.buyer_account.alerts.not_deleted.by_application(@contract).sorted
+          Liquid::Drops::Collection.for_drop(Liquid::Drops::Alert).new(collection)
+        end
       end
 
       desc "Returns the description of the application."

--- a/test/unit/liquid/drops/application_drop_test.rb
+++ b/test/unit/liquid/drops/application_drop_test.rb
@@ -21,6 +21,13 @@ class Liquid::Drops::ApplicationDropTest < ActiveSupport::TestCase
     assert_match Rails.application.routes.url_helpers.admin_service_application_path(@app.service, @app), @drop.admin_url
   end
 
+  test 'alerts' do
+    _provider_alerts = FactoryGirl.create_list(:limit_alert, 3, cinstance: @app, account: @app.provider_account)
+    expected_alerts = FactoryGirl.create_list(:limit_alert, 2, cinstance: @app, account: @app.buyer_account)
+    _deleted_alert = FactoryGirl.create(:limit_alert, cinstance: @app, account: @app.buyer_account, state: 'deleted')
+    assert_equal Drops::Collection.for_drop(Drops::Alert).new(expected_alerts), @drop.alerts
+  end
+
   context "field definitions" do
     setup do
       [{ :target => "Cinstance", :name => "visible_extra", :label => "visible_extra" },


### PR DESCRIPTION
We expect the same objects as the variable `alerts` in /admin/applications/:application_id/alerts

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Drops are a way to protect database objects. The current implementation is returning an ActiveRecord::Relation which should not be exposed in the view

