### PR TITLE
Improvements in TIME_TO_DELETE_ACCOUNT

### DIFF
--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -73,9 +73,9 @@ module AccountHelper
   def delete_buyer_link(account)
     return if account.scheduled_for_deletion?
     msg = t("buyers.accounts.edit.#{account.provider? ? 'schedule_for_deletion_confirmation' : 'delete_confirmation'}",
-            deletion_time_left: Account::States::TIME_TO_DELETE_ACCOUNT.inspect,
+            deletion_time_left: distance_of_time_in_words(Account::States::PERIOD_BEFORE_DELETION),
             name: h(account.name),
-            deletion_date: (Time.zone.now.beginning_of_day + Account::States::TIME_TO_DELETE_ACCOUNT).to_date.to_s(:long))
+            deletion_date: (Time.zone.now.beginning_of_day + Account::States::PERIOD_BEFORE_DELETION).to_date.to_s(:long))
     alert = t('buyers.accounts.edit.delete.admin_restricted', admin: current_account.first_admin.try(:email))
 
     url = can?(:destroy, account) ? admin_buyers_account_path(account) : javascript_alert_url(alert)

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -1,5 +1,5 @@
 module Account::States
-  TIME_TO_DELETE_ACCOUNT = 15.days.freeze
+  PERIOD_BEFORE_DELETION = 15.days.freeze
   STATES = %i[created pending approved rejected suspended scheduled_for_deletion].freeze
   extend ActiveSupport::Concern
 
@@ -94,13 +94,13 @@ module Account::States
       where(:state => state.to_s) if state.to_s != "all"
     end
 
-    scope :deleted_time_ago, ->(value = TIME_TO_DELETE_ACCOUNT) do
-      scheduled_for_deletion.where.has { deleted_at <= value.ago }
+    scope :deleted_since, ->(value = nil) do
+      scheduled_for_deletion.where.has { deleted_at <= (value || PERIOD_BEFORE_DELETION.ago) }
     end
 
     def deletion_date
       return nil unless deleted_at
-      (deleted_at + TIME_TO_DELETE_ACCOUNT)
+      (deleted_at + PERIOD_BEFORE_DELETION)
     end
 
     def enabled?

--- a/app/workers/find_and_delete_scheduled_accounts_worker.rb
+++ b/app/workers/find_and_delete_scheduled_accounts_worker.rb
@@ -4,6 +4,6 @@ class FindAndDeleteScheduledAccountsWorker
   include Sidekiq::Worker
 
   def perform
-    Account.deleted_time_ago.find_each(&DeleteAccountHierarchyWorker.method(:perform_later))
+    Account.deleted_since.find_each(&DeleteAccountHierarchyWorker.method(:perform_later))
   end
 end

--- a/test/unit/helpers/account_helper_test.rb
+++ b/test/unit/helpers/account_helper_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Api::AccountHelperTest < ActionView::TestCase
+  # TODO: this is not an independent test. There are too many dependencies among the helpers and this should be refactored
+  include MenuHelper
+  include ApplicationHelper
+  include ButtonsHelper
+  include AccountHelper
+
+  setup do
+    @provider = FactoryGirl.create(:simple_provider, provider_account: master_account)
+  end
+
+  attr_reader :provider
+  delegate :can?, to: :ability
+
+  class ProviderLoggedIn < Api::AccountHelperTest
+    def current_user
+      @current_user ||= FactoryGirl.create(:active_admin, account: provider)
+    end
+
+    test 'delete_buyer_link for a developer account' do
+      developer = FactoryGirl.create(:simple_buyer, provider_account: provider)
+
+      link = delete_buyer_link(developer)
+
+      assert_includes link, "href=\"#{admin_buyers_account_path(developer)}\""
+
+      assert_does_not_contain link, /data-confirm=\"[^=]*in 15 days/
+      assert_does_not_contain link, /data-confirm=\"[^=]*#{15.days.from_now.to_date.to_s(:long)}/
+      assert_contains link, /data-confirm=\"[^=]*Are you sure you want to delete/
+    end
+  end
+
+  class MasterLoggedIn < Api::AccountHelperTest
+    def current_user
+      @current_user ||= master_account.admin_users.first!
+    end
+
+    test 'delete_buyer_link for a tenant account' do
+      link = delete_buyer_link(provider)
+
+      assert_includes link, "href=\"#{admin_buyers_account_path(provider)}\""
+
+      assert_contains link, /data-confirm=\"[^=]*in 15 days/
+      assert_contains link, /data-confirm=\"[^=]*#{15.days.from_now.to_date.to_s(:long)}/
+      assert_does_not_contain link, /data-confirm=\"[^=]*Are you sure you want to delete/
+    end
+  end
+
+  private
+
+  def current_account
+    current_user.account
+  end
+
+  def ability
+    Ability.new(current_user)
+  end
+end

--- a/test/unit/helpers/api/account_plans_helper_test.rb
+++ b/test/unit/helpers/api/account_plans_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Api::AccountPlansHelperTest < ActionView::TestCase
-end


### PR DESCRIPTION
### Tasks
- [X] Change the name `TIME_TO_DELETE_ACCOUNT`. Requested in https://github.com/3scale/porta/pull/17#discussion_r229406719
- [X] Passing a Time argument rename the method. Just like for the request in https://github.com/3scale/porta/pull/17#discussion_r229412297
- [X] Add missing unit tests
- [X] Remove empty and misleading test file