### PR TITLE
[Refactor] Rename #provider_but_not_master? -> #tenant?

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -380,7 +380,7 @@ class Account < ApplicationRecord
     self[:provider] || master?
   end
 
-  def provider_but_not_master?
+  def tenant?
     provider && !master?
   end
 

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -77,7 +77,7 @@ module Account::States
       end
 
       event :suspend do
-        transition :approved => :suspended, if: :provider_but_not_master?
+        transition :approved => :suspended, if: :tenant?
       end
 
       event :resume do

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -34,13 +34,13 @@ class AccountTest < ActiveSupport::TestCase
 
   def test_provider_but_not_master
     account = FactoryGirl.build_stubbed(:simple_account, provider: false, master: false)
-    refute account.provider_but_not_master?
+    refute account.tenant?
     
     account.provider = true
-    assert account.provider_but_not_master?
+    assert account.tenant?
     
     account.master = true
-    refute account.provider_but_not_master?
+    refute account.tenant?
   end
 
   def test_destroy_association


### PR DESCRIPTION
It comes from the thread in https://github.com/3scale/porta/pull/17#discussion_r229269290
> Master is a "provider" by definition, but it won't ever be a "tenant".
