### PR TITLE
[gem] Expose sidekiq metrics to prometheus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ C:\\nppdf32Log\\debuglog.txt
 /config/smtp.yml
 /config/zync.yml
 /config/redhat_customer_portal.yml
+/config/prometheus.yml
 /db/*.sql
 /db/safe.json
 /db/*.sql*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,7 +115,7 @@ Layout/SpaceInsideHashLiteralBraces:
 
 # Offense count: 514
 # Cop supports --auto-correct.
-Style/SpaceInsideBrackets:
+Layout/SpaceInsideReferenceBrackets:
   Enabled: false
 
 # Offense count: 240
@@ -166,7 +166,7 @@ Layout/MultilineHashBraceLayout:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: symmetrical, new_line, same_line
-Style/MultilineMethodCallBraceLayout:
+Layout/MultilineMethodCallBraceLayout:
   Enabled: false
 
 # Offense count: 7988

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -50,6 +50,7 @@ gem 'sinatra', require: false # for sidekiq web
 gem 'sidekiq', '< 6', require: %w(sidekiq sidekiq/web)
 gem 'sidekiq-cron', require: %w(sidekiq/cron sidekiq/cron/web)
 gem 'sidekiq-lock'
+gem 'sidekiq-prometheus-exporter'
 
 gem 'activemerchant', '~> 1.77.0'
 gem 'active_merchant-adyen12', github: '3scale/active_merchant-adyen12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -698,6 +698,8 @@ GEM
     sidekiq-lock (0.3.1)
       redis (>= 3.0.5)
       sidekiq (>= 2.14.0)
+    sidekiq-prometheus-exporter (0.1.6)
+      sidekiq (>= 3.3.1)
     signet (0.5.1)
       addressable (>= 2.2.3)
       faraday (>= 0.9.0.rc5)
@@ -963,6 +965,7 @@ DEPENDENCIES
   sidekiq-batch (~> 0.1.1)
   sidekiq-cron
   sidekiq-lock
+  sidekiq-prometheus-exporter
   simplecov (~> 0.10.0)
   sinatra
   slim-rails (~> 3.0)

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -708,6 +708,8 @@ GEM
       sidekiq (>= 2.14.0)
     sidekiq-pro (3.7.1)
       sidekiq (>= 4.1.5)
+    sidekiq-prometheus-exporter (0.1.6)
+      sidekiq (>= 3.3.1)
     signet (0.5.1)
       addressable (>= 2.2.3)
       faraday (>= 0.9.0.rc5)
@@ -977,6 +979,7 @@ DEPENDENCIES
   sidekiq-cron
   sidekiq-lock
   sidekiq-pro (~> 3.4)!
+  sidekiq-prometheus-exporter
   simplecov (~> 0.10.0)
   sinatra
   slim-rails (~> 3.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -184,6 +184,9 @@ module System
     config.three_scale.plan_rules = ActiveSupport::OrderedOptions.new
     config.three_scale.plan_rules.merge!(try_config_for(:plan_rules) || {})
 
+    config.three_scale.prometheus = ActiveSupport::OrderedOptions.new
+    config.three_scale.prometheus.merge!(try_config_for(:prometheus) || {})
+
     three_scale = config_for(:settings).symbolize_keys
     three_scale[:error_reporting_stages] = three_scale[:error_reporting_stages].to_s.split(/\W+/)
 

--- a/config/docker/prometheus.yml
+++ b/config/docker/prometheus.yml
@@ -1,0 +1,15 @@
+base: &base
+  username:
+  password:
+
+development:
+  <<: *base
+
+production:
+  <<: *base
+
+preview:
+  <<: *base
+
+test:
+  <<: *base

--- a/config/examples/prometheus.yml
+++ b/config/examples/prometheus.yml
@@ -1,0 +1,15 @@
+base: &base
+  username:
+  password:
+
+development:
+  <<: *base
+
+production:
+  <<: *base
+
+preview:
+  <<: *base
+
+test:
+  <<: *base

--- a/config/initializers/bugfix-rails-18666.rb
+++ b/config/initializers/bugfix-rails-18666.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'action_controller/metal/http_authentication.rb'
+
+ActionController::HttpAuthentication::Basic.module_eval do
+  def auth_scheme(request)
+    request.authorization.to_s.split(' ', 2).first
+  end
+
+  def auth_param(request)
+    request.authorization.to_s.split(' ', 2).second
+  end
+end
+

--- a/config/initializers/bugfix_rails_18666.rb
+++ b/config/initializers/bugfix_rails_18666.rb
@@ -2,6 +2,7 @@
 
 require 'action_controller/metal/http_authentication.rb'
 
+# TODO: remove when migrated to rails 5.0
 ActionController::HttpAuthentication::Basic.module_eval do
   def auth_scheme(request)
     request.authorization.to_s.split(' ', 2).first
@@ -11,4 +12,3 @@ ActionController::HttpAuthentication::Basic.module_eval do
     request.authorization.to_s.split(' ', 2).second
   end
 end
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,12 @@ class CdnAssets
   end
 end
 
+
 System::Application.routes.draw do
+  constraints MasterDomainWithAuthBasicConstraint.new(ThreeScale.config.prometheus.username, ThreeScale.config.prometheus.password) do
+    mount Sidekiq::Prometheus::Exporter.to_app, at: '/system'
+  end
+
   mount CdnAssets.new => '/_cdn_assets_' unless Rails.configuration.three_scale.assets_cdn_host
 
   resource :openid

--- a/test/integration/prometheus_test.rb
+++ b/test/integration/prometheus_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PrometheusTest < ActionDispatch::IntegrationTest
+  def setup
+    config = ThreeScale.config.prometheus
+    config.stubs(username: 'user', password: 'secret')
+    @authorization = ActionController::HttpAuthentication::Basic.encode_credentials(config.username, config.password)
+    Rails.application.routes_reloader.reload!
+  end
+
+  def teardown
+    Rails.application.routes_reloader.reload!
+  end
+
+  test 'metrics on master domain' do
+    host! master_account.self_domain
+
+    get '/system/metrics', {}, authorization: @authorization
+    assert_response :success
+
+    assert_raises ActionController::RoutingError do
+      get '/system/metrics'
+    end
+  end
+
+  test 'metrics on provider admin domain' do
+    provider = FactoryGirl.create(:simple_provider)
+
+    host! provider.self_domain
+    assert_raises ActionController::RoutingError do
+      get '/system/metrics', {}, authorization: @authorization
+    end
+    assert_raises ActionController::RoutingError do
+      get '/system/metrics'
+    end
+  end
+
+  test 'metrics on provider domain' do
+    provider = FactoryGirl.create(:simple_provider)
+    host! provider.domain
+
+    # The assertion is a bit different from admin domain as CMS has a wildcard route
+    get '/system/metrics', {}, authorization: @authorization
+    assert_response :not_found
+
+    get '/system/metrics'
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
Closes https://github.com/3scale/infrastructure/issues/574

The metrics are exposed as:

http://${MASTER_DOMAIN}/system/metrics

Metrics are only available if authentication basic is configured by setting in the `config/prometheus.yml` file the `username` and `password`

