### PR TITLE
Prevent Vertical Navigation items from scrolling up to the top when being clicked

### DIFF
--- a/app/views/shared/provider/navigation/_secondary_nav.html.slim
+++ b/app/views/shared/provider/navigation/_secondary_nav.html.slim
@@ -1,5 +1,5 @@
 li.list-group-item.secondary-nav-item-pf class=( active_submenu == submenu ? 'active' : '')
-  = link_to '#', class: "list-group-item-link-#{title.parameterize}" do
+  = link_to '#!', class: "list-group-item-link-#{title.parameterize}" do
     span.fa.fa-fw class="fa-#{icon}"
     span.list-group-item-value class="list-group-item-value-#{title.parameterize}"
       = title


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent section content from scrolling up when expanding/collapsing menus from the vertical navigation.

**Which issue(s) this PR fixes** 
https://issues.jboss.org/browse/THREESCALE-1477

**Verification steps** 
1. Navigate to a screen where there is enough content to scroll down a bit (e.g. Fields Definition)
2. Scroll down. Then collapse/expand any of the menus of vertical navigation (Accounts, Applications, Billing...)
3. Screen should not scroll up to the top when clicking those items

**Special notes for your reviewer**:
This is more a workaround than a fix, but a rather safe one. It would navigate to a `!` section but that's hardly ever going to be a title for anything.