### PR TITLE
[Part 2] Change Accounts column name deleted_at -> state_changed_at

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -60,7 +60,6 @@ class Account < ApplicationRecord
   # scope :buyers, :conditions => {:provider => false, :master => false}
   scope :buyers, -> { where(provider: false, buyer: true) }
 
-  scope :without_deleted, ->(without = true) { where(deleted_at: nil) if without }
   scope :not_master, -> { where(master: [0, nil]) }
 
   audited allow_mass_assignment: true

--- a/lib/migration/finance.rb
+++ b/lib/migration/finance.rb
@@ -110,7 +110,7 @@ module Migration
       end
 
       def self.find_invoice_zombies
-        ids = Invoice.connection.execute("select invoices.id from invoices join accounts on invoices.buyer_account_id = accounts.id where invoices.state in ('finalized', 'pending', 'open', 'unpaid') and accounts.deleted_at IS NOT NULL").map(&:first)
+        ids = Invoice.connection.execute("select invoices.id from invoices join accounts on invoices.buyer_account_id = accounts.id where invoices.state in ('finalized', 'pending', 'open', 'unpaid') and accounts.state = 'scheduled_for_deletion'").map(&:first)
 
         puts "There are #{ids.count} zombies."
       end

--- a/spec/acceptance/api/account_spec.rb
+++ b/spec/acceptance/api/account_spec.rb
@@ -145,7 +145,7 @@ resource "Account" do
       end
 
       context 'if scheduled_for_deletion' do
-        let(:resource) { FactoryGirl.build(:provider_account, state: 'scheduled_for_deletion', deleted_at: Time.zone.now.beginning_of_day) }
+        let(:resource) { FactoryGirl.build(:provider_account, state: 'scheduled_for_deletion', state_changed_at: Time.zone.now.beginning_of_day) }
         it { should have_properties(%w[state deletion_date]) }
       end
 
@@ -194,7 +194,7 @@ resource "Account" do
       end
 
       context 'if scheduled_for_deletion' do
-        let(:resource) { FactoryGirl.build(:provider_account, state: 'scheduled_for_deletion', deleted_at: Time.zone.now) }
+        let(:resource) { FactoryGirl.build(:provider_account, state: 'scheduled_for_deletion', state_changed_at: Time.zone.now) }
         it { should have_tags(%w[state deletion_date]).from(resource) }
       end
 

--- a/test/integration/master/api/providers_controller_test.rb
+++ b/test/integration/master/api/providers_controller_test.rb
@@ -210,6 +210,7 @@ class Master::Api::ProvidersControllerTest < ActionDispatch::IntegrationTest
       assert_equal '', response.body
       assert provider.reload.scheduled_for_deletion?
       assert_equal Time.zone.now.to_s, provider.deleted_at.to_s
+      assert_equal Time.zone.now.to_s, provider.state_changed_at.to_s
     end
   end
 

--- a/test/workers/find_and_delete_accounts_scheduled_worker_test.rb
+++ b/test/workers/find_and_delete_accounts_scheduled_worker_test.rb
@@ -3,9 +3,9 @@ class FindAndDeleteScheduledAccountsWorkerTest < ActiveSupport::TestCase
   def test_perform
     quiet_period_time = Account::States::PERIOD_BEFORE_DELETION
     FactoryGirl.create_list(:simple_buyer, 2)
-    FactoryGirl.create_list(:simple_buyer, 3, state: 'scheduled_for_deletion', deleted_at: quiet_period_time.ago)
-    FactoryGirl.create_list(:simple_provider, 4, state: 'scheduled_for_deletion', deleted_at: quiet_period_time.ago)
-    FactoryGirl.create_list(:simple_provider, 1, state: 'scheduled_for_deletion', deleted_at: quiet_period_time.ago + 1.day)
+    FactoryGirl.create_list(:simple_buyer, 3, state: 'scheduled_for_deletion', state_changed_at: quiet_period_time.ago)
+    FactoryGirl.create_list(:simple_provider, 4, state: 'scheduled_for_deletion', state_changed_at: quiet_period_time.ago)
+    FactoryGirl.create_list(:simple_provider, 1, state: 'scheduled_for_deletion', state_changed_at: quiet_period_time.ago + 1.day)
     assert_equal 7, Account.deleted_since.count
     DeleteAccountHierarchyWorker.expects(:perform_later).times(7)
     FindAndDeleteScheduledAccountsWorker.new.perform


### PR DESCRIPTION
Step 2 of https://github.com/3scale/porta/issues/290
Depends on https://github.com/3scale/porta/pull/294
Change the code to make it work using `state_changed_at` instead of `deleted_at`, although we keep duplicating all the data.