### PR TITLE
UI enhancements for New API form

### DIFF
--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -364,6 +364,10 @@ form.formtastic fieldset > ol > li.text textarea {
   }
 }
 
+form.formtastic fieldset.inputs label.disabled {
+  color: $disabled-color;
+}
+
 select:disabled,
 form.formtastic fieldset.inputs input:disabled,
 form.formtastic fieldset.inputs input[readonly="readonly"] {

--- a/app/views/api/services/forms/_naming.html.slim
+++ b/app/views/api/services/forms/_naming.html.slim
@@ -1,4 +1,4 @@
 = form.inputs "Service" do
-  = form.input :name
+  = form.input :name, input_html: { autofocus: true }
   = form.system_name
   = form.input :description, input_html: { rows: 3 }

--- a/app/views/api/services/forms/_service_discovery.html.slim
+++ b/app/views/api/services/forms/_service_discovery.html.slim
@@ -1,22 +1,21 @@
 form class="formtastic" id="new_service_source"
   fieldset class="inputs"
-    legend Source
     ol
-      li class="radio"
+      li.radio
         fieldset
           ol
             li
               label for="source_manual"
                 = radio_button_tag :source, 'manual', checked: true
-                = "From Scratch"
+                = "Define manually"
             li
-              label for="source_discover"
-                - if service_discovery_usable?
-                   = radio_button_tag :source, 'discover'
-                   = "Discover"
-                - else
-                   = link_to "Login to get a token", service_discovery_presenter.authorize_url
-
+              label for="source_discover" class=('disabled' unless service_discovery_usable?)
+                = radio_button_tag :source, 'discover', false, disabled: !service_discovery_usable?
+                => "Import from OpenShift"
+                - unless service_discovery_usable?
+                  | (
+                  = link_to "Authenticate to enable this option", service_discovery_presenter.authorize_url
+                  | )
 
 = semantic_form_for service, url: provider_admin_service_discovery_services_path, html: { id: 'service_discovery', class: 'is-hidden' }  do |form|
   = form.hidden_field :source, value: 'discover'

--- a/app/views/api/services/new.html.slim
+++ b/app/views/api/services/new.html.slim
@@ -1,4 +1,4 @@
-h2 Create New Service
+h2 New API
 
 - if service_discovery_accessible?
   = render :partial => 'api/services/forms/service_discovery', :locals => { :service => @service }
@@ -6,4 +6,4 @@ h2 Create New Service
 = semantic_form_for @service, :url => admin_services_path do |form|
   = render :partial => 'api/services/forms/naming', :locals => { :form => form }
   = form.buttons do
-    = form.commit_button
+    = form.commit_button 'Add API'

--- a/features/old/services/multiservice.feature
+++ b/features/old/services/multiservice.feature
@@ -23,7 +23,7 @@ Feature: Multiservice feature
     When I am on the provider dashboard
      And I follow "New API"
      And I fill in "Name" with "Less fancy API"
-     And I press "Create"
+     And I press "Add API"
     Then I should see "Less fancy API"
 
   @javascript

--- a/features/old/services/switch.feature
+++ b/features/old/services/switch.feature
@@ -7,6 +7,7 @@ Feature: Services switch
     Given a provider "foo.example.com"
       And provider "foo.example.com" has multiple applications enabled
       And an application plan "pro3M" of provider "master"
+      And service discovery is not enabled
     Given current domain is the admin domain of provider "foo.example.com"
     When I log in as provider "foo.example.com"
 
@@ -24,4 +25,4 @@ Feature: Services switch
   Scenario: In allowed state (hidden and visible), I should be able to access the page by url
     Given provider "foo.example.com" has "multiple_services" switch allowed
       And I go to the new service page
-    Then I should see "New Service"
+    Then I should see "New API"


### PR DESCRIPTION
**What this PR does / why we need it**
Better naming for labels of the New API form, including the Service Discovery option, OAuth link, etc

![token-required](https://user-images.githubusercontent.com/1842261/47802401-74a5ed00-dd30-11e8-8147-5f17fa39b338.png)
![ready-to-discover](https://user-images.githubusercontent.com/1842261/47802415-7bccfb00-dd30-11e8-952e-9214393c3efd.png)
![discovering](https://user-images.githubusercontent.com/1842261/47802421-7e2f5500-dd30-11e8-9d12-203f6b2ca58f.png)

**Which issue(s) this PR fixes** 
https://docs.google.com/presentation/d/1ZEU5KmY5slLTteZm5r9o3a10nqVfQdozF8GfNL5oP5A/edit#slide=id.g40d2a2fcbf_2_40

**Verification steps**
Having Service Discovery feature enabled (better with SSO),
- Login to the Admin Portal
- From the Dashboard, click "New API"
- Switch between the two options "Define manually" and "Import from OpenShift"