### PR TITLE
Refactor dashboard collection link on saas

### DIFF
--- a/app/helpers/provider/admin/dashboards_helper.rb
+++ b/app/helpers/provider/admin/dashboards_helper.rb
@@ -20,10 +20,10 @@ module Provider::Admin::DashboardsHelper
   end
 
   def dashboard_collection_link(singular_name, collection, path, icon_name: nil, plural: nil, notice: false)
-    link_to path, class: 'DashboardNavigation-link' do
+    className = 'DashboardNavigation-link' + " u-notice" if notice
+    link_to path, class: className do
       link_text = pluralize(number_to_human(collection.size), singular_name, plural)
       link_text = link_text.prepend "#{icon(icon_name)} " if icon_name
-      link_text = link_text.prepend ".u-notice" if notice
       link_text.html_safe
     end
   end

--- a/app/helpers/provider/admin/dashboards_helper.rb
+++ b/app/helpers/provider/admin/dashboards_helper.rb
@@ -19,17 +19,18 @@ module Provider::Admin::DashboardsHelper
     widget.percentual_change > 0 ? 'u-plus' : 'u-minus'
   end
 
-  def dashboard_collection_link(singular_name, collection, path, plural = nil, icon_name = nil)
+  def dashboard_collection_link(singular_name, collection, path, icon_name: nil, plural: nil, notice: false)
     link_to path, class: 'DashboardNavigation-link' do
       link_text = pluralize(number_to_human(collection.size), singular_name, plural)
       link_text = link_text.prepend "#{icon(icon_name)} " if icon_name
+      link_text = link_text.prepend ".u-notice" if notice
       link_text.html_safe
     end
   end
 
-  def dashboard_secondary_collection_link(singular_name, collection, path, plural = nil)
+  def dashboard_secondary_collection_link(singular_name, collection, path, icon_name: nil, plural: nil, notice: false)
     link = ' ('
-    link << dashboard_collection_link(singular_name, collection, path, plural)
+    link << dashboard_collection_link(singular_name, collection, path, icon_name: icon_name, plural: plural, notice: notice)
     link << ')'
   end
 

--- a/app/views/provider/admin/dashboards/_developers_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_developers_navigation.html.slim
@@ -5,31 +5,28 @@ nav.DashboardNavigation
       li.DashboardNavigation-list-item
         // Accounts
         => dashboard_collection_link 'Account',
-                                     buyers,
-                                     admin_buyers_accounts_path,
-                                     'Accounts',
-                                     'briefcase'
+                                      buyers,
+                                      admin_buyers_accounts_path,
+                                      icon_name: 'briefcase'
 
         // Pending Accounts
         - if show_pending_accounts_on_dashboard?
           == dashboard_secondary_collection_link 'Pending',
                                                   pending_buyers,
                                                   admin_buyers_accounts_path(search: {state: 'pending'}),
-                                                  'Pending'
+                                                  plural: 'Pending'
 
     - if can? :manage, :partners
       li.DashboardNavigation-list-item
         = dashboard_collection_link 'Application',
-                                applications,
-                                admin_buyers_applications_path,
-                                'Applications',
-                                'cubes'
+                                    applications,
+                                    admin_buyers_applications_path,
+                                    icon_name: 'cubes'
 
         - if can?(:manage, :monitoring) && alerts.any?
           == dashboard_secondary_collection_link 'Alert',
-                                      alerts,
-                                      admin_alerts_path,
-                                      'Alerts'
+                                                  alerts,
+                                                  admin_alerts_path
 
     // Billing
     - if can?(:manage, :finance)
@@ -49,8 +46,8 @@ nav.DashboardNavigation
 
         - if current_account.templates.with_draft
           == dashboard_secondary_collection_link 'Draft',
-                                                 current_account.templates.with_draft,
-                                                 provider_admin_cms_changes_path
+                                                  current_account.templates.with_draft,
+                                                  provider_admin_cms_changes_path
 
     // Forum
     - if show_forum_on_dashboard? && forum_topics.any?
@@ -58,16 +55,14 @@ nav.DashboardNavigation
         = dashboard_collection_link 'Forum Topic',
                                     forum_topics,
                                     admin_forum_path,
-                                    'Forum Topics',
-                                    'comments'
+                                    icon_name: 'comments'
 
     // Messages
     li.DashboardNavigation-list-item
       = dashboard_collection_link 'Message',
                                   current_account.messages.where(sender: !current_account),
                                   provider_admin_messages_root_path,
-                                  'Messages',
-                                  'envelope'
+                                  icon_name: 'envelope'
 
         - if unread_messages_presenter.show_counter?
           '

--- a/app/views/provider/admin/dashboards/_service_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_service_navigation.html.slim
@@ -22,8 +22,7 @@ nav.DashboardNavigation
           => dashboard_collection_link 'Application',
                                        service.cinstances,
                                        admin_service_applications_path(service),
-                                       'Applications',
-                                       'cubes'
+                                       icon_name: 'cubes'
 
     - unread_alerts = current_account.buyer_alerts.by_service(service).unread
     - if can?(:manage, :monitoring) && unread_alerts.any?
@@ -31,8 +30,7 @@ nav.DashboardNavigation
         = dashboard_collection_link 'Alert',
                                     unread_alerts,
                                     admin_service_alerts_path(service),
-                                    'Alerts',
-                                    'exclamation-triangle'
+                                    icon_name: 'exclamation-triangle'
 
     // Subscriptions & Service Plans
     - if show_subscriptions_on_dashboard?(service)
@@ -48,10 +46,9 @@ nav.DashboardNavigation
     - if can?(:manage, :plans)
       li.DashboardNavigation-list-item
        = dashboard_collection_link 'ActiveDoc',
-                                 service.api_docs_services,
-                                 admin_service_api_docs_path(service),
-                                 'ActiveDocs',
-                                 'file-text'
+                                    service.api_docs_services,
+                                    admin_service_api_docs_path(service),
+                                    icon_name: 'file-text'
     // Integration
     - if can?(:manage, :plans)
       - if !service.has_traffic?


### PR DESCRIPTION
**What this PR does / why we need it**:

Proposal for refactoring `dashboard_collection_link` method.

BONUS

Adding a new argument `notice` to add `u-notice` class to the link easily. An example of how it would look (Applications):
<img width="500" alt="screen shot 2018-11-02 at 12 17 07" src="https://user-images.githubusercontent.com/11672286/47912554-5a3b5300-de99-11e8-9b46-03f331c96013.png">


**Which issue(s) this PR fixes** 

Comment from @hallelujah -> https://github.com/3scale/porta/pull/78#pullrequestreview-16212538
