### PR TITLE
[billing] Prevent non-positive invoices from being charged

### DIFF
--- a/app/models/account/billing.rb
+++ b/app/models/account/billing.rb
@@ -72,16 +72,6 @@ module Account::Billing
   #
   # options has :invoice
   def charge!(amount, options = {})
-    # should not be even called for zeros...
-    if amount.zero?
-      logger.info("Buyer #{self.id} was not charged (amount == 0)")
-      return nil
-    end
-    unless paying_monthly?
-      logger.info("Buyer #{self.id} was not charged (not paying monthly)")
-      return nil
-    end
-
     unless credit_card_stored?
       logger.info("Buyer #{self.id} was not charged: credit card missing")
       raise Finance::Payment::CreditCardMissing

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,6 +437,12 @@ en:
     creation_type:
       manual: 'manually created'
       background: 'automatically created'
+    reasons_cannot_charge:
+      not_paid: 'already paid'
+      provider_present: 'missing provider'
+      provider_payment_gateway_configured: 'missing payment gateway setting'
+      positive: 'non-chargeable amount'
+      buyer_account_paying_monthly: 'buyer not paying monthly'
 
   api:
     applications:

--- a/test/integration/finance/api/invoices_controller_test.rb
+++ b/test/integration/finance/api/invoices_controller_test.rb
@@ -136,6 +136,8 @@ class Finance::Api::InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_response 422
     assert_contains JSON.parse(response.body)['errors']['state'], invoice.errors.generate_message(:state, :not_in_chargeable_state, id: invoice.id)
 
+    invoice.line_items << LineItem.new(:cost => 100)
+
     invoice.fire_events! :issue
 
     # Heavy/ugly mocking on buyer charge!

--- a/test/unit/finance/charging_test.rb
+++ b/test/unit/finance/charging_test.rb
@@ -30,7 +30,7 @@ class Finance::ChargingTest < ActiveSupport::TestCase
       end
 
       should 'return false' do
-        assert_equal false, @invoice.charge!
+        refute @invoice.charge!
       end
 
       should 'not send charge notification email' do


### PR DESCRIPTION
**What this PR does / why we need it**

This makes not only zero-valued invoices to be prevented from being charged, but also the negative ones.

Instead of applying the condition at `Account#charge!`, the validation was moved to `Invoice#charge!`. This is possible because an account is always charged through an invoice.

**Which issue(s) this PR fixes** 

[THREESCALE-1378](https://issues.jboss.org/browse/THREESCALE-1378)

**Special notes for your reviewer**
1. I understand that not changing the status of the invoice will make it to be continuously attempted to charge. We should also fix that. Nevertheless, that behavior is not introduced by this PR itself, but rather present already since the bare possibility of non-positive invoices.

2. Another step to take is preventing negative line items from being added to the invoices in the first place.

I would say (1) and (2) above have their own contexts and can be either enhancements or bug fixes, while this PR is an immediate bug fix focused on preventing customers' credit cards from being charged with negative values.