### PR TITLE
[Service Discovery] Generic error on cluster resource fetch

### DIFF
--- a/test/unit/service_discovery/cluster_client_test.rb
+++ b/test/unit/service_discovery/cluster_client_test.rb
@@ -188,5 +188,14 @@ module ServiceDiscovery
         cluster.find_discoverable_service_by(namespace: 'my-namespace', name: 'my-api-staging').name
       end
     end
+
+    test 'raises generic client exception' do
+      exception = KubeException.new(123, 'generic error', mock)
+      cluster.expects(:get_project).with('my-namespace').raises(exception)
+
+      assert_raises(ServiceDiscovery::ClusterClient::ClusterClientError) do
+        cluster.find_project_by(name: 'my-namespace')
+      end
+    end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**

It makes the cluster client wrapper to raise generic error massages thrown by the actual clients while trying to fetch cluster resources. Now only 404's are raised.

**Which issue(s) this PR fixes** 

This will improve debuging of failures occurred while fetching cluster objects and prevent `ServiceDiscovery::ClusterResource#metadata delegated to resource.metadata, but resource is nil`.