### PR TITLE
Fix test random failure when master org_name exists

### DIFF
--- a/test/unit/signup/master_domains_builder_test.rb
+++ b/test/unit/signup/master_domains_builder_test.rb
@@ -4,23 +4,23 @@ require 'test_helper'
 
 class Signup::MasterDomainsBuilderTest < ActiveSupport::TestCase
   test 'org_name is base for the subdomain' do
-    new_domains = generate_domains(org_name: master_account.org_name)
-    assert_equal 'master-account', new_domains.subdomain
+    new_domains = generate_domains
+    assert_equal 'master-account-new', new_domains.subdomain
   end
 
   test 'current_subdomain is kept if present' do
-    new_domains = generate_domains(org_name: master_account.org_name, current_subdomain: 'master')
+    new_domains = generate_domains(current_subdomain: 'master')
     assert_equal 'master', new_domains.subdomain
   end
 
   test 'generates equal subdomain and self subdomain' do
-    new_domains = generate_domains(org_name: master_account.org_name)
+    new_domains = generate_domains
     assert_equal new_domains.subdomain, new_domains.self_subdomain
   end
 
   private
 
-  def generate_domains(org_name:, current_subdomain: nil)
+  def generate_domains(org_name: 'Master Account New', current_subdomain: nil)
     domains_builder_params = { org_name: org_name, current_subdomain: current_subdomain, invalid_subdomain_condition: master_account.method(:subdomain_exists?) }
     Signup::MasterDomainsBuilder.new(**domains_builder_params).generate
   end


### PR DESCRIPTION
Fixes the tests of https://circleci.com/gh/3scale/porta/6628#tests/containers/7
The problem is depending on the order of the execution of all our test suit, a master_account may already exist at this point and it would have the same org_name, so it generates the domain with the sufix `-2`, so I changed the tests to not use the same org_name