### PR TITLE
[cron] Commands are now properly generated

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -125,7 +125,7 @@ gem 'thinking-sphinx', '~> 3.2.0'
 gem 'ts-datetime-delta', require: 'thinking_sphinx/deltas/datetime_delta'
 gem 'diff-lcs', '~> 1.2'
 gem 'acts-as-taggable-on', '~> 4.0'
-gem 'whenever', '~> 0.9.4', require: false
+gem 'whenever', '~> 0.9.7', require: false
 gem 'will_paginate', '~> 3.1.0'
 
 gem 'rack-x_served_by', '~> 0.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -813,7 +813,7 @@ GEM
       railties (>= 4.2)
     webrobots (0.1.1)
     websocket (1.2.4)
-    whenever (0.9.4)
+    whenever (0.9.7)
       chronic (>= 0.6.3)
     will_paginate (3.1.0)
     xml-simple (1.1.5)
@@ -991,7 +991,7 @@ DEPENDENCIES
   unicorn-rails
   webmock (~> 1.21)
   webpacker (~> 3.3)
-  whenever (~> 0.9.4)
+  whenever (~> 0.9.7)
   will_paginate (~> 3.1.0)
   xpath (~> 2.1)
   yard

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -823,7 +823,7 @@ GEM
       railties (>= 4.2)
     webrobots (0.1.1)
     websocket (1.2.4)
-    whenever (0.9.4)
+    whenever (0.9.7)
       chronic (>= 0.6.3)
     will_paginate (3.1.0)
     xml-simple (1.1.5)
@@ -1005,14 +1005,14 @@ DEPENDENCIES
   unicorn-rails
   webmock (~> 1.21)
   webpacker (~> 3.3)
-  whenever (~> 0.9.4)
+  whenever (~> 0.9.7)
   will_paginate (~> 3.1.0)
   xpath (~> 2.1)
   yard
   zip-zip
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.7p456
 
 BUNDLED WITH
    1.16.6

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -13,9 +13,9 @@ env :MAILTO, ENV.fetch('SYSADMIN_EMAIL', '') # TODO: I'm not entirely convinced 
 bundle_path = ENV.fetch('BUNDLE_BIN_PATH') { `which bundle`.strip }
 
 set :bundle_command, "BUNDLE_GEMFILE=#{bundle_gemfile_env} #{Gem.ruby} #{bundle_path} exec"
-set :runner_command, "BUNDLE_GEMFILE=#{bundle_gemfile_env} #{Gem.ruby} script/rails runner"
-set :rake_command, "BUNDLE_GEMFILE=#{bundle_gemfile_env} #{Gem.ruby} #{`which rake`.strip}"
-set :ruby_command, "BUNDLE_GEMFILE=#{bundle_gemfile_env} #{Gem.ruby}"
+set :runner_command, "script/rails runner"
+set :rake_command, " #{`which rake`.strip}"
+set :ruby_command, Gem.ruby.to_s
 
 job_type :rake, "cd :path && :environment_variable=:environment :bundle_command :rake_command :task --silent :output"
 job_type :ruby, "cd :path && :bundle_command :ruby_command :task :output"


### PR DESCRIPTION
There were multiple environment declaration that are not needed


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It removes double declaration of environment variables


**Verification steps** 

* Run `whenever`
* verify that the environments are declared only once in the ouptut
* verify that all the commands are prepended with `bundle exec`


**Special notes for your reviewer**:

My local output

```
whenever                                                                                                                                
PATH=/home/bender/bin:/home/bender/.rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
MAILTO=""

0 0 * * 1 /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec script/rails runner -e production '\''ThreeScale::Jobs.run("Pdf::Dispatch.weekly") { Pdf::Dispatch.weekly }'\'' >> /var/log/cron.output'

0 0 * * 1 /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec script/rails runner -e production '\''ThreeScale::Jobs.run("JanitorWorker.perform_async") { JanitorWorker.perform_async }'\'' >> /var/log/cron.output'

0 * * * * /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec script/rails runner -e production '\''ThreeScale::Jobs.run("Rails.env") { Rails.env }'\'' >> /var/log/cron.output'

0 8 * * * /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec script/rails runner -e production '\''ThreeScale::Jobs.run("Audited::Adapters::ActiveRecord::Audit.delete_old") { Audited::Adapters::ActiveRecord::Audit.delete_old }'\'' >> /var/log/cron.output'

0 9 * * * /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec script/rails runner -e production '\''ThreeScale::Jobs.run("LogEntry.delete_old") { LogEntry.delete_old }'\'' >> /var/log/cron.output'

0 10 * * * /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec script/rails runner -e production '\''ThreeScale::Jobs.run("Cinstance.notify_about_expired_trial_periods") { Cinstance.notify_about_expired_trial_periods }'\'' >> /var/log/cron.output'

0 11 * * * /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec script/rails runner -e production '\''ThreeScale::Jobs.run("Pdf::Dispatch.daily") { Pdf::Dispatch.daily }'\'' >> /var/log/cron.output'

0 12 * * * /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec script/rails runner -e production '\''ThreeScale::Jobs.run("FindAndDeleteScheduledAccountsWorker.perform_async") { FindAndDeleteScheduledAccountsWorker.perform_async }'\'' >> /var/log/cron.output'

0 8 * * * /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec script/rails runner -e production '\''ThreeScale::Jobs.run("Finance::BillingStrategy.daily_canaries") { Finance::BillingStrategy.daily_canaries }'\'' >> /var/log/cron.output'

0 8 * * * /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec script/rails runner -e production '\''ThreeScale::Jobs.run("Finance::BillingStrategy.daily_rest") { Finance::BillingStrategy.daily_rest }'\'' >> /var/log/cron.output'

0 6 * * * /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && RAILS_ENV=production BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec /Users/hery/.rbenv/versions/2.3/bin/rake ts:index --silent >> /var/log/cron.output'

42 * * * * /bin/bash -l -c 'cd /Users/hery/Devel/3scale/porta && RAILS_ENV=production BUNDLE_GEMFILE=Gemfile /Users/hery/.rbenv/versions/2.3.7/bin/ruby /Users/hery/.rbenv/versions/2.3/bin/bundle exec /Users/hery/.rbenv/versions/2.3/bin/rake ts:in:delta --silent >> /var/log/cron.output'

## [message] Above is your schedule file converted to cron syntax; your crontab file was not updated.
## [message] Run `whenever --help' for more options.
```