### PR TITLE
[Part 1] Change Accounts column name deleted_at -> state_changed_at

### DIFF
--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -75,7 +75,7 @@ module AccountHelper
     msg = t("buyers.accounts.edit.#{account.provider? ? 'schedule_for_deletion_confirmation' : 'delete_confirmation'}",
             deletion_time_left: distance_of_time_in_words(Account::States::PERIOD_BEFORE_DELETION),
             name: h(account.name),
-            deletion_date: (Time.zone.now.beginning_of_day + Account::States::PERIOD_BEFORE_DELETION).to_date.to_s(:long))
+            deletion_date: Account::States::PERIOD_BEFORE_DELETION.from_now.to_date.to_s(:long))
     alert = t('buyers.accounts.edit.delete.admin_restricted', admin: current_account.first_admin.try(:email))
 
     url = can?(:destroy, account) ? admin_buyers_account_path(account) : javascript_alert_url(alert)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -63,8 +63,6 @@ class Account < ApplicationRecord
   scope :without_deleted, ->(without = true) { where(deleted_at: nil) if without }
   scope :not_master, -> { where(master: [0, nil]) }
 
-  alias_attribute :state_changed_at, :deleted_at
-
   audited allow_mass_assignment: true
 
   # this is done in a callback because we want to do this AFTER the account is deleted

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -40,12 +40,13 @@ module Account::States
       end
 
       after_transition any - :scheduled_for_deletion => :scheduled_for_deletion do |account|
-        account.update_attributes(deleted_at: Time.zone.now.beginning_of_day)
+        time_deleted_at = Time.zone.now.beginning_of_day
+        account.update_attributes(deleted_at: time_deleted_at, state_changed_at: time_deleted_at)
         account.run_after_commit(:schedule_backend_sync_worker)
       end
 
       after_transition :scheduled_for_deletion => any - :scheduled_for_deletion do |account, _transition|
-        account.update_attributes(deleted_at: nil)
+        account.update_attributes(deleted_at: nil, state_changed_at: nil)
         account.run_after_commit(:schedule_backend_sync_worker)
       end
 

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -40,7 +40,7 @@ module Account::States
       end
 
       after_transition any - :scheduled_for_deletion => :scheduled_for_deletion do |account|
-        time_deleted_at = Time.zone.now.beginning_of_day
+        time_deleted_at = Time.zone.now
         account.update_attributes(deleted_at: time_deleted_at, state_changed_at: time_deleted_at)
         account.run_after_commit(:schedule_backend_sync_worker)
       end

--- a/db/migrate/20181105203727_add_accounts_state_changed_at.rb
+++ b/db/migrate/20181105203727_add_accounts_state_changed_at.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddAccountsStateChangedAt < ActiveRecord::Migration
+  def change
+    add_column :accounts, :state_changed_at, :datetime
+    add_index :accounts, %i[domain state_changed_at]
+    add_index :accounts, %i[self_domain state_changed_at]
+    add_index :accounts, %i[state state_changed_at]
+  end
+end

--- a/db/migrate/20181105212016_duplicate_deleted_at_state_changed_at.rb
+++ b/db/migrate/20181105212016_duplicate_deleted_at_state_changed_at.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class DuplicateDeletedAtStateChangedAt < ActiveRecord::Migration
+  def up
+    Account.transaction do
+      Account.scheduled_for_deletion.where.has{ deleted_at != nil }.find_each do |account|
+        account.update_column(:state_changed_at, account.deleted_at) or raise ActiveRecord::Error
+      end
+    end
+  end
+
+  def down
+    Account.update_all(state_changed_at: nil)
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181018082620) do
+ActiveRecord::Schema.define(version: 20181105203727) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -97,18 +97,22 @@ ActiveRecord::Schema.define(version: 20181018082620) do
     t.datetime "hosted_proxy_deployed_at"
     t.string   "po_number"
     t.datetime "deleted_at"
+    t.datetime "state_changed_at"
   end
 
   add_index "accounts", ["default_service_id"], name: "index_accounts_on_default_service_id"
   add_index "accounts", ["domain", "deleted_at"], name: "index_accounts_on_domain_and_deleted_at"
+  add_index "accounts", ["domain", "state_changed_at"], name: "index_accounts_on_domain_and_state_changed_at"
   add_index "accounts", ["domain"], name: "index_accounts_on_domain", unique: true
   add_index "accounts", ["master"], name: "index_accounts_on_master", unique: true
   add_index "accounts", ["provider_account_id", "created_at"], name: "index_accounts_on_provider_account_id_and_created_at"
   add_index "accounts", ["provider_account_id", "state"], name: "index_accounts_on_provider_account_id_and_state"
   add_index "accounts", ["provider_account_id"], name: "index_accounts_on_provider_account_id"
   add_index "accounts", ["self_domain", "deleted_at"], name: "index_accounts_on_self_domain_and_deleted_at"
+  add_index "accounts", ["self_domain", "state_changed_at"], name: "index_accounts_on_self_domain_and_state_changed_at"
   add_index "accounts", ["self_domain"], name: "index_accounts_on_self_domain", unique: true
   add_index "accounts", ["state", "deleted_at"], name: "index_accounts_on_state_and_deleted_at"
+  add_index "accounts", ["state", "state_changed_at"], name: "index_accounts_on_state_and_state_changed_at"
 
   create_table "alerts", force: :cascade do |t|
     t.integer  "account_id",   precision: 38,           null: false

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181105203727) do
+ActiveRecord::Schema.define(version: 20181105212016) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181105203727) do
+ActiveRecord::Schema.define(version: 20181105212016) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181018082620) do
+ActiveRecord::Schema.define(version: 20181105203727) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -97,18 +97,22 @@ ActiveRecord::Schema.define(version: 20181018082620) do
     t.datetime "hosted_proxy_deployed_at"
     t.string   "po_number",                                       limit: 255
     t.datetime "deleted_at"
+    t.datetime "state_changed_at"
   end
 
   add_index "accounts", ["default_service_id"], name: "index_accounts_on_default_service_id", using: :btree
   add_index "accounts", ["domain", "deleted_at"], name: "index_accounts_on_domain_and_deleted_at", using: :btree
+  add_index "accounts", ["domain", "state_changed_at"], name: "index_accounts_on_domain_and_state_changed_at", using: :btree
   add_index "accounts", ["domain"], name: "index_accounts_on_domain", unique: true, using: :btree
   add_index "accounts", ["master"], name: "index_accounts_on_master", unique: true, using: :btree
   add_index "accounts", ["provider_account_id", "created_at"], name: "index_accounts_on_provider_account_id_and_created_at", using: :btree
   add_index "accounts", ["provider_account_id", "state"], name: "index_accounts_on_provider_account_id_and_state", using: :btree
   add_index "accounts", ["provider_account_id"], name: "index_accounts_on_provider_account_id", using: :btree
   add_index "accounts", ["self_domain", "deleted_at"], name: "index_accounts_on_self_domain_and_deleted_at", using: :btree
+  add_index "accounts", ["self_domain", "state_changed_at"], name: "index_accounts_on_self_domain_and_state_changed_at", using: :btree
   add_index "accounts", ["self_domain"], name: "index_accounts_on_self_domain", unique: true, using: :btree
   add_index "accounts", ["state", "deleted_at"], name: "index_accounts_on_state_and_deleted_at", using: :btree
+  add_index "accounts", ["state", "state_changed_at"], name: "index_accounts_on_state_and_state_changed_at", using: :btree
 
   create_table "alerts", force: :cascade do |t|
     t.integer  "account_id",   limit: 8,                             null: false

--- a/spec/acceptance/api/account_spec.rb
+++ b/spec/acceptance/api/account_spec.rb
@@ -194,7 +194,7 @@ resource "Account" do
       end
 
       context 'if scheduled_for_deletion' do
-        let(:resource) { FactoryGirl.build(:provider_account, state: 'scheduled_for_deletion', deleted_at: Time.zone.now.beginning_of_day) }
+        let(:resource) { FactoryGirl.build(:provider_account, state: 'scheduled_for_deletion', deleted_at: Time.zone.now) }
         it { should have_tags(%w[state deletion_date]).from(resource) }
       end
 

--- a/test/integration/master/api/providers_controller_test.rb
+++ b/test/integration/master/api/providers_controller_test.rb
@@ -209,7 +209,7 @@ class Master::Api::ProvidersControllerTest < ActionDispatch::IntegrationTest
       assert_response :ok
       assert_equal '', response.body
       assert provider.reload.scheduled_for_deletion?
-      assert_equal Time.zone.now.beginning_of_day.to_s, provider.deleted_at.to_s
+      assert_equal Time.zone.now.to_s, provider.deleted_at.to_s
     end
   end
 

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -213,12 +213,12 @@ class Account::StatesTest < ActiveSupport::TestCase
 
       BackendProviderSyncWorker.expects(:enqueue).with(account.id)
 
-      Timecop.freeze do
-        account.schedule_for_deletion!
-        account.reload
-        assert_equal Time.zone.now.to_s, account.deleted_at.to_s
-        assert_equal Time.zone.now.to_s, account.state_changed_at.to_s
-      end
+      time = Time.zone.now
+      Time.zone.stubs(now: time)
+      account.schedule_for_deletion!
+      account.reload
+      assert_equal time.to_s, account.deleted_at.to_s
+      assert_equal time.to_s, account.state_changed_at.to_s
     end
   end
 end

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -216,8 +216,8 @@ class Account::StatesTest < ActiveSupport::TestCase
       Timecop.freeze do
         account.schedule_for_deletion!
         account.reload
-        assert_equal Time.zone.now.beginning_of_day, account.deleted_at
-        assert_equal Time.zone.now.beginning_of_day, account.state_changed_at
+        assert_equal Time.zone.now.to_s, account.deleted_at.to_s
+        assert_equal Time.zone.now.to_s, account.state_changed_at.to_s
       end
     end
   end

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -202,7 +202,9 @@ class Account::StatesTest < ActiveSupport::TestCase
       BackendProviderSyncWorker.expects(:enqueue).with(account.id)
 
       account.resume!
-      assert account.reload.deleted_at.nil?
+      account.reload
+      assert_nil account.deleted_at
+      assert_nil account.state_changed_at
     end
 
     def test_schedule_for_deletion
@@ -213,7 +215,9 @@ class Account::StatesTest < ActiveSupport::TestCase
 
       Timecop.freeze do
         account.schedule_for_deletion!
-        assert_equal Time.zone.now.beginning_of_day, account.reload.deleted_at
+        account.reload
+        assert_equal Time.zone.now.beginning_of_day, account.deleted_at
+        assert_equal Time.zone.now.beginning_of_day, account.state_changed_at
       end
     end
   end


### PR DESCRIPTION
Part 1 of https://github.com/3scale/porta/issues/290
In SaaS the migrations of the indexes in https://github.com/3scale/infrastructure/issues/576#issuecomment-436035644
- [X] Remove the alias I've made in https://github.com/3scale/porta/pull/292.
- [X] Create the new column called state_changed_at, with the same indexes as deleted_at.
- [x] Copy everything from deleted_at to state_changed_at with a script. Nothing to be removed though. 
- [x] Make sure that every time that deleted_at changes, it will make the change duplicated it state_changed_at.