### PR TITLE
Remove links to plans from dashboard

### DIFF
--- a/app/views/provider/admin/dashboards/_developers_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_developers_navigation.html.slim
@@ -16,11 +16,6 @@ nav.DashboardNavigation
                                                   pending_buyers,
                                                   admin_buyers_accounts_path(search: {state: 'pending'}),
                                                   'Pending'
-        // Account Plans
-        - elsif show_account_plans_on_dashboard?
-          == dashboard_secondary_collection_link 'Plan',
-                                                account_plans.not_custom,
-                                                admin_buyers_account_plans_path
 
     - if can? :manage, :partners
       li.DashboardNavigation-list-item
@@ -30,7 +25,7 @@ nav.DashboardNavigation
                                 'Applications',
                                 'cubes'
 
-        - if can?(:manage, :monitoring) && alerts.any? 
+        - if can?(:manage, :monitoring) && alerts.any?
           == dashboard_secondary_collection_link 'Alert',
                                       alerts,
                                       admin_alerts_path,

--- a/app/views/provider/admin/dashboards/_service_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_service_navigation.html.slim
@@ -25,12 +25,6 @@ nav.DashboardNavigation
                                        'Applications',
                                        'cubes'
 
-        // Application Plans
-        - if can?(:manage, :plans) && !master_on_premises?
-          == dashboard_secondary_collection_link 'Plan',
-                                                 service.application_plans.not_custom,
-                                                 admin_service_application_plans_path(service)
-
     - unread_alerts = current_account.buyer_alerts.by_service(service).unread
     - if can?(:manage, :monitoring) && unread_alerts.any?
       li.DashboardNavigation-list-item
@@ -47,12 +41,6 @@ nav.DashboardNavigation
         => dashboard_collection_link 'Subscription',
                                      service.service_contracts,
                                      admin_buyers_service_contracts_path(search: {service_id: service.id})
-
-        // Service Plans
-        - if show_service_plans_on_dashboard?(service)
-          == dashboard_secondary_collection_link 'Plan',
-                                                service.service_plans.not_custom,
-                                                admin_service_service_plans_path(service)
 
     // Active docs
     - if can?(:manage, :plans)

--- a/features/old/menu/dashboard.feature
+++ b/features/old/menu/dashboard.feature
@@ -29,12 +29,6 @@ Feature: Dashboard
     And I should see the link "Integrate this API" in the first api dashboard widget
     And I should see the link "0 ActiveDocs" in the first api dashboard widget
 
-  Scenario: Audience widget with "account_plans" switch allowed and more than 1 account plan
-    Given provider "foo.example.com" has "account_plans" switch allowed
-    And an account plan "second" of provider "foo.example.com"
-    When I go to the provider dashboard
-    Then I should see the link "2 Plans" in the audience dashboard widget
-
   Scenario: Audience widget with Finance enabled
     Given provider "foo.example.com" is charging
     And provider "foo.example.com" has "finance" switch allowed
@@ -47,4 +41,3 @@ Feature: Dashboard
     And a service plan "second" of provider "foo.example.com"
     When I go to the provider dashboard
     Then I should see the link "0 Subscriptions" in the first api dashboard widget
-    Then I should see the link "2 Plans" in the first api dashboard widget


### PR DESCRIPTION
…as they are secondary and space is limited. 

Docs are not affected by this change as we don't guide people through home page links.