### PR TITLE
Master dashboard shows the right number of tenants

### DIFF
--- a/app/views/provider/admin/dashboards/show.html.slim
+++ b/app/views/provider/admin/dashboards/show.html.slim
@@ -14,7 +14,7 @@
           i.fa.fa-bullseye>
           | Audience
         - if can?(:manage, :partners) || can?(:manage, :finance) || can?(:manage, :portal) || can?(:manage, :settings)
-          = render 'developers_navigation', buyers: current_account.buyers,
+          = render 'developers_navigation', buyers: current_account.buyer_accounts.not_master,
                                           pending_buyers: current_account.buyers.pending,
                                           account_plans: current_account.account_plans.not_custom,
                                           forum_topics: current_account.forum.recent_topics,


### PR DESCRIPTION
Fixes [THREESCALE-1473](https://issues.jboss.org/browse/THREESCALE-1473)

Show the right number of tenants in the dashboard

### Verification steps
1. Go to the master admin portal
2. See the `1 account` in the first row for the audience
3. Click on the `1 account` and see just one