### PR TITLE
Master bought cinstance should not appear as a provided cinstance

### DIFF
--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -37,7 +37,7 @@ class Api::ApplicationsController < Api::BaseController
       activate_menu :buyers, :accounts
     end
 
-    @cinstances = current_user.accessible_cinstances
+    @cinstances = accessible_not_bought_cinstances
                       .scope_search(@search).order_by(params[:sort], params[:direction])
                       .preload(:service, user_account: [:admin_user], plan: [:pricing_rules])
                       .paginate(pagination_params)
@@ -51,9 +51,12 @@ class Api::ApplicationsController < Api::BaseController
 
   private
 
+  def accessible_not_bought_cinstances
+    current_user.accessible_cinstances.not_bought_by(current_account)
+  end
+
   def find_cinstance
-    @cinstance = current_user.accessible_cinstances
-                   .provided_by(current_account)
+    @cinstance = accessible_not_bought_cinstances
                    .includes(plan: %i[service original plan_metrics pricing_rules])
                    .where(service: @service)
                    .find(params[:id])

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -143,6 +143,8 @@ class Cinstance < Contract
     joins(:service).references(:service).merge(Service.of_account(account)).readonly(false)
   end
 
+  scope :not_bought_by, ->(account) { where.has { user_account_id != account.id } }
+
   scope :can_be_managed, lambda {
                            includes(plan: :service)
                               .where(['services.buyers_manage_apps = ?', true])

--- a/test/integration/api/applications_controller_test.rb
+++ b/test/integration/api/applications_controller_test.rb
@@ -4,123 +4,155 @@ require 'test_helper'
 
 class Api::ApplicationsControllerTest < ActionDispatch::IntegrationTest
 
-  setup do
-    @provider = FactoryGirl.create(:provider_account)
-    login! @provider
-  end
-
-  attr_reader :provider
-
-  class Index < Api::ApplicationsControllerTest
+  class MasterLoggedInTest < Api::ApplicationsControllerTest
     setup do
-      @service = provider.services.first!
-      plans = FactoryGirl.create_list(:application_plan, 2, service: @service)
-      buyers = FactoryGirl.create_list(:buyer_account, 2, provider_account: provider)
-      plans.each_with_index { |plan, index| buyers[index].buy! plan }
+      login! master_account
+      @service = master_account.default_service
+      FactoryGirl.create(:cinstance, service: @service)
     end
 
     attr_reader :service
 
-    test 'index retrieves all cinstances of a service' do
+    test 'index retrieves all master\'s provided cinstances except those whose buyer is master' do
       get admin_service_applications_path(service)
 
       assert_response :ok
-      assert_same_elements service.cinstances.pluck(:id), assigns(:cinstances).map(&:id)
+      expected_cinstances_ids = service.cinstances.where.has { user_account_id != Account.master.id }.pluck(:id)
+      assert_same_elements expected_cinstances_ids, assigns(:cinstances).map(&:id)
     end
 
-    test 'index can retrieve the cinstances of an application plan belonging to a service' do
-      plan = service.application_plans.first!
-      get admin_service_applications_path(service, {application_plan_id: plan.id})
-
-      assert_response :ok
-      assert_same_elements plan.cinstances.pluck(:id), assigns(:cinstances).map(&:id)
-    end
-
-    test 'index can retrieve the cinstances of a buyer account' do
-      buyer = @provider.buyers.last!
-      get admin_service_applications_path(service, {account_id: buyer.id})
-
-      assert_response :ok
-      assert_same_elements buyer.bought_cinstances.pluck(:id), assigns(:cinstances).map(&:id)
-    end
-
-    test 'index does not show the services column even when the provider is multiservice' do
-      provider.services.create!(name: '2nd-service')
-      assert provider.reload.multiservice?
-      get admin_service_applications_path(service)
-      page = Nokogiri::HTML::Document.parse(response.body)
-      refute page.xpath("//tr").text.match /Service/
+    test 'show is visible for all master\'s provided cinstances except those whose buyer is master' do
+      buyer_master, provider_master = service.cinstances.partition { |cinstance| cinstance.user_account_id == Account.master.id }
+      buyer_master.each do |buyer_cinstance|
+        get admin_service_application_path(service, buyer_cinstance)
+        assert_response :not_found
+      end
+      provider_master.each do |provider_cinstance|
+        get admin_service_application_path(service, provider_cinstance)
+        assert_response :ok
+      end
     end
   end
 
-  class Show < Api::ApplicationsControllerTest
+  class TenantLoggedInTest < Api::ApplicationsControllerTest
     setup do
-      plan = FactoryGirl.create(:application_plan, issuer: provider.default_service)
-      @application = FactoryGirl.create(:cinstance, plan: plan)
+      @provider = FactoryGirl.create(:provider_account)
+      login! @provider
     end
 
-    attr_reader :application
+    attr_reader :provider
 
-    test 'show plan widget features are drawn correctly' do
-      service = provider.default_service
-      feature = FactoryGirl.create(:feature, featurable: service, name: 'ticked')
-      application.plan.features_plans.create!(feature: feature)
-      FactoryGirl.create(:feature, featurable: service, name: 'crossed')
+    class Index < TenantLoggedInTest
+      setup do
+        @service = provider.services.first!
+        plans = FactoryGirl.create_list(:application_plan, 2, service: @service)
+        buyers = FactoryGirl.create_list(:buyer_account, 2, provider_account: provider)
+        plans.each_with_index { |plan, index| buyers[index].buy! plan }
+      end
 
-      get admin_service_application_path(application.service, application)
+      attr_reader :service
 
-      assert_response :success
+      test 'index retrieves all cinstances of a service' do
+        get admin_service_applications_path(service)
 
-      page = Nokogiri::HTML::Document.parse(response.body)
-      assert page.xpath("//tr[@class='feature enabled']").text  =~ /ticked/
-      assert page.xpath("//tr[@class='feature disabled']").text =~ /crossed/
+        assert_response :ok
+        assert_same_elements service.cinstances.pluck(:id), assigns(:cinstances).map(&:id)
+      end
+
+      test 'index can retrieve the cinstances of an application plan belonging to a service' do
+        plan = service.application_plans.first!
+        get admin_service_applications_path(service, {application_plan_id: plan.id})
+
+        assert_response :ok
+        assert_same_elements plan.cinstances.pluck(:id), assigns(:cinstances).map(&:id)
+      end
+
+      test 'index can retrieve the cinstances of a buyer account' do
+        buyer = @provider.buyers.last!
+        get admin_service_applications_path(service, {account_id: buyer.id})
+
+        assert_response :ok
+        assert_same_elements buyer.bought_cinstances.pluck(:id), assigns(:cinstances).map(&:id)
+      end
+
+      test 'index does not show the services column even when the provider is multiservice' do
+        provider.services.create!(name: '2nd-service')
+        assert provider.reload.multiservice?
+        get admin_service_applications_path(service)
+        page = Nokogiri::HTML::Document.parse(response.body)
+        refute page.xpath("//tr").text.match /Service/
+      end
     end
 
-    test 'show plan of the app does not show in the plans select' do
-      application.customize_plan! # maybe not needed, but we are checking even that custom does not appear
+    class Show < TenantLoggedInTest
+      setup do
+        plan = FactoryGirl.create(:application_plan, issuer: provider.default_service)
+        @application = FactoryGirl.create(:cinstance, plan: plan)
+      end
 
-      get admin_service_application_path(application.service, application)
-      assert_response :success
+      attr_reader :application
 
-      page = Nokogiri::HTML::Document.parse(response.body)
-      assert page.xpath("//select[@id='cinstance_plan_id']/option").map(&:text).exclude?(application.plan.name)
+      test 'show plan widget features are drawn correctly' do
+        service = provider.default_service
+        feature = FactoryGirl.create(:feature, featurable: service, name: 'ticked')
+        application.plan.features_plans.create!(feature: feature)
+        FactoryGirl.create(:feature, featurable: service, name: 'crossed')
+
+        get admin_service_application_path(application.service, application)
+
+        assert_response :success
+
+        page = Nokogiri::HTML::Document.parse(response.body)
+        assert page.xpath("//tr[@class='feature enabled']").text  =~ /ticked/
+        assert page.xpath("//tr[@class='feature disabled']").text =~ /crossed/
+      end
+
+      test 'show plan of the app does not show in the plans select' do
+        application.customize_plan! # maybe not needed, but we are checking even that custom does not appear
+
+        get admin_service_application_path(application.service, application)
+        assert_response :success
+
+        page = Nokogiri::HTML::Document.parse(response.body)
+        assert page.xpath("//select[@id='cinstance_plan_id']/option").map(&:text).exclude?(application.plan.name)
+      end
+
+      test 'shows renders app and a message for utilization when backend is not available' do
+        get admin_service_application_path(application.service, application)
+        assert_response :success
+        assert_match 'was a problem getting utilization', response.body
+      end
+
+      test 'show renders application for the permitted services ids when there is no access to all services' do
+        second_service = FactoryGirl.create(:simple_service, account: provider)
+        second_plan = FactoryGirl.create(:application_plan, issuer: second_service)
+        second_app = FactoryGirl.create(:cinstance, plan: second_plan)
+
+        User.any_instance.expects(:has_access_to_all_services?).returns(false).at_least_once
+        User.any_instance.expects(:member_permission_service_ids).returns([application.issuer.id]).at_least_once
+        get admin_service_application_path(application.service, application)
+        assert_response :success
+        get admin_service_application_path(second_app.service, second_app)
+        assert_response :not_found
+      end
     end
 
-    test 'shows renders app and a message for utilization when backend is not available' do
-      get admin_service_application_path(application.service, application)
-      assert_response :success
-      assert_match 'was a problem getting utilization', response.body
-    end
+    class Edit < TenantLoggedInTest
+      setup do
+        plan = FactoryGirl.create(:application_plan, issuer: provider.default_service)
+        @application = FactoryGirl.create(:cinstance, plan: plan, name: 'example-name', description: 'example-description')
+      end
 
-    test 'show renders application for the permitted services ids when there is no access to all services' do
-      second_service = FactoryGirl.create(:simple_service, account: provider)
-      second_plan = FactoryGirl.create(:application_plan, issuer: second_service)
-      second_app = FactoryGirl.create(:cinstance, plan: second_plan)
+      attr_reader :application
 
-      User.any_instance.expects(:has_access_to_all_services?).returns(false).at_least_once
-      User.any_instance.expects(:member_permission_service_ids).returns([application.issuer.id]).at_least_once
-      get admin_service_application_path(application.service, application)
-      assert_response :success
-      get admin_service_application_path(second_app.service, second_app)
-      assert_response :not_found
-    end
-  end
-
-  class Edit < Api::ApplicationsControllerTest
-    setup do
-      plan = FactoryGirl.create(:application_plan, issuer: provider.default_service)
-      @application = FactoryGirl.create(:cinstance, plan: plan, name: 'example-name', description: 'example-description')
-    end
-
-    attr_reader :application
-
-    test 'edit renders correctly' do
-      get edit_admin_service_application_path(application.service, application)
-      assert_response :success
-      page = Nokogiri::HTML::Document.parse(response.body)
-      assert_equal 'example-name',  page.xpath("//input[@id='cinstance_name']").map { |node| node['value'] }.join
-      assert_equal "\nexample-description", page.xpath("//textarea[@id='cinstance_description']").text
-      assert_equal 1, page.xpath("//input[@type='submit']").length
+      test 'edit renders correctly' do
+        get edit_admin_service_application_path(application.service, application)
+        assert_response :success
+        page = Nokogiri::HTML::Document.parse(response.body)
+        assert_equal 'example-name',  page.xpath("//input[@id='cinstance_name']").map { |node| node['value'] }.join
+        assert_equal "\nexample-description", page.xpath("//textarea[@id='cinstance_description']").text
+        assert_equal 1, page.xpath("//input[@type='submit']").length
+      end
     end
   end
 

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -911,4 +911,11 @@ class CinstanceTest < ActiveSupport::TestCase
 
     assert_equal 1, app.keys_limit
   end
+
+  test '.not_bought_by' do
+    FactoryGirl.create(:cinstance, service: master_account.default_service)
+
+    expected_cinstance_ids = Cinstance.where.has { user_account_id != Account.master.id }.pluck(:id)
+    assert_same_elements expected_cinstance_ids, Cinstance.not_bought_by(master_account).pluck(:id)
+  end
 end


### PR DESCRIPTION
Fixes [THREESCALE-1474](https://issues.jboss.org/browse/THREESCALE-1474)

Master account has a cinstance for which he is both its provider and its buyer, and right now it is shown in the provided cinstances list, but when we click in its buyer (in this case itself), it says 404 because it tries to find it as a buyer and not itself.
In 2.2 we used to show both this cinstance in the provided cinstances list, and the master as its buyer when clicked on it.
I wonder: should we show both just like in 2.2 or should I hide both so the list of provided cinstances does not show this one?
[DECIDED] This PR it is doing the latter: Master bought_cinstance is not returned among its provided_cinstances.

![image](https://user-images.githubusercontent.com/11318903/48207980-1ac9a680-e372-11e8-9669-804e3eb78486.png)
