### PR TITLE
THREESCALE-1472-Api-Selector-Overlapped

### DIFF
--- a/app/assets/stylesheets/provider/_header.scss
+++ b/app/assets/stylesheets/provider/_header.scss
@@ -5,7 +5,7 @@
   padding: 0 0 0 0;
   position: fixed;
   width: 100%;
-  z-index: 10;
+  z-index: 1052; // select2 dropdown has z-index of 1051
   top: 0;
 
   &--master {


### PR DESCRIPTION
**What this PR does / why we need it**:

When creating new Application '/buyers/accounts/3/applications/new'. If Application plan field (#cinstance_plan_id) is expanded and at the same time user expand #api_selector this two elements overlap in unexpected way.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1472

**Special notes for your reviewer**:
![api-selector](https://user-images.githubusercontent.com/13486237/48258416-579aa980-e415-11e8-958f-376280906d6c.png)

**Note that I added extra whitespace below "API" just to have more height and be able to see the overlapping**