### PR TITLE
THREESCALE-1382 Adding word-break to metric names in Current Utilization

### DIFF
--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -99,6 +99,9 @@ table.data {
     td.actions {
       text-align: right;
     }
+    td b.metric-name {
+      word-break: break-word;
+    }
   }
 
   &.u-sixEqualColumns tr td {
@@ -208,10 +211,6 @@ table .select {
 
 table.data td, table.horizontal th {
   border-bottom: $border-width solid $border-color;
-}
-
-table.data tr td b.metric-name {
-  word-break: break-word;
 }
 
 table.list th {

--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -2,6 +2,12 @@
 $table-columns-width: line-height-times(11);
 $search-header-width: line-height-times(4);
 
+// Utility styles
+// TODO: Move to a separate file
+.u-break-word {
+  word-break: break-word;
+}
+
 table {
   width: 100%;
 
@@ -98,9 +104,6 @@ table.data {
   tbody {
     td.actions {
       text-align: right;
-    }
-    td b.metric-name {
-      word-break: break-word;
     }
   }
 

--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -210,6 +210,10 @@ table.data td, table.horizontal th {
   border-bottom: $border-width solid $border-color;
 }
 
+table.data tr td b.metric-name {
+  word-break: break-word;
+}
+
 table.list th {
   text-align: left;
   padding-right: line-height-times(1/2);

--- a/app/views/buyers/applications/_utilization.html.erb
+++ b/app/views/buyers/applications/_utilization.html.erb
@@ -20,7 +20,7 @@
         <tr/>
       <% utilization.each do |item| %>
         <tr>
-          <td><b class="metric-name"><%=item.friendly_name %></b>&nbsp;(<%=item.system_name%>)</td>
+          <td><b class="u-break-word"><%=item.friendly_name %></b>&nbsp;(<%=item.system_name%>)</td>
           <td>per <b><%=item.period%></b></td>
           <%
 

--- a/app/views/buyers/applications/_utilization.html.erb
+++ b/app/views/buyers/applications/_utilization.html.erb
@@ -20,9 +20,9 @@
         <tr/>
       <% utilization.each do |item| %>
         <tr>
-          <td><b><%=item.friendly_name %></b>&nbsp;(<%=item.system_name%>)</td>
+          <td><b class="metric-name"><%=item.friendly_name %></b>&nbsp;(<%=item.system_name%>)</td>
           <td>per <b><%=item.period%></b></td>
-          <% 
+          <%
 
               utilization = "#{item.current_value}/#{item.max_value}"
 
@@ -47,4 +47,3 @@
 <%end%>
 
 </div>
-


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding word-break to metric names in Current Utilization

**Which issue(s) this PR fixes** 
https://issues.jboss.org/browse/THREESCALE-1382

**Special notes for your reviewer**:

**Before:**
-----
![before](https://user-images.githubusercontent.com/13486237/48272220-65b0f000-e43e-11e8-975a-4381e3724aae.png)
-----
**After:**
-----
![after](https://user-images.githubusercontent.com/13486237/48272244-706b8500-e43e-11e8-8a17-1cc54a09dc7b.png)
-----