### PR TITLE
THREESCALE-1470 Highlights more visible

### DIFF
--- a/app/assets/stylesheets/provider/_colors.scss
+++ b/app/assets/stylesheets/provider/_colors.scss
@@ -116,6 +116,9 @@ $secondary-button-border-color: $osloGray;
 $disabled-button-color: $white;
 $disabled-button-bg-color: $altoGray;
 $disabled-button-border-color: $altoGray;
+
+$glow-color: $highlight-color;
+$glow-background-color: $wildSandGray;
 /// --- login ---
 
 $login-content-color: $font-color;

--- a/app/assets/stylesheets/provider/admin/cms/_cms_intro.scss
+++ b/app/assets/stylesheets/provider/admin/cms/_cms_intro.scss
@@ -1,5 +1,3 @@
-$glow-color: $highlight-color;
-
 @mixin cms-intro-coloring($name, $color2) {
   $color: $color2;
 
@@ -80,22 +78,27 @@ $glow-color: $highlight-color;
 
 #cms-sidebar {
   li.glowing.active, li.glowing {
-    color: $glow-color !important;
+    background-color: $glow-background-color;
   }
 
   input.glowing {
+    background-color: $glow-background-color;
     color: $glow-color !important;
 
     &::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+      background-color: $glow-background-color;
       color: $glow-color !important;
     }
     &::-moz-placeholder { /* Firefox 19+ */
+      background-color: $glow-background-color;
       color: $glow-color !important;
     }
     &:-ms-input-placeholder { /* IE 10+ */
+      background-color: $glow-background-color;
       color: $glow-color !important;
     }
     &:-moz-placeholder { /* Firefox 18- */
+      background-color: $glow-background-color;
       color: $glow-color !important;
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

The highlights in the CMS tool for the designing the developer portal should be more visible. Right now it's changing text color to link color, maybe text color to alert color would be enough. The idea is that peripheral vision should be able to detect the change

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1470

