### PR TITLE
Refactor dashboard_collection_link method

### DIFF
--- a/app/assets/stylesheets/provider/admin/_dashboard.scss
+++ b/app/assets/stylesheets/provider/admin/_dashboard.scss
@@ -13,12 +13,6 @@
     margin-top: line-height-times(1);
   }
 
-  &--audience {
-    .DashboardNavigation-link + .DashboardNavigation-link {
-      color: $warning-color;
-    }
-  }
-
   &--services {
     margin-top: line-height-times(1.4);
   }

--- a/app/helpers/provider/admin/dashboards_helper.rb
+++ b/app/helpers/provider/admin/dashboards_helper.rb
@@ -1,5 +1,7 @@
 module Provider::Admin::DashboardsHelper
 
+  # include ApplicationHelper
+
   # @param name [Symbol]
   # @param params [Hash]
   def dashboard_widget(name, params = {})
@@ -19,22 +21,32 @@ module Provider::Admin::DashboardsHelper
     widget.percentual_change > 0 ? 'u-plus' : 'u-minus'
   end
 
-  def dashboard_collection_link(singular_name, collection, path, plural = nil, icon_name = nil)
-    link_to path, class: 'DashboardNavigation-link' do
-      link_text = pluralize(number_to_human(collection.size), singular_name, plural)
-      link_text = link_text.prepend "#{icon(icon_name)} " if icon_name
-      link_text.html_safe
+  def dashboard_navigation_link(link_text, path, options = {})
+    link_to path, class: css_class({
+        'DashboardNavigation-link': true,
+        'u-notice': options.fetch(:notice, false)
+      }) do
+        icon_name = options.fetch(:icon_name, nil)
+        link_text = link_text.prepend "#{icon(icon_name)} " if icon_name
+        link_text.html_safe
     end
   end
 
-  def dashboard_secondary_collection_link(singular_name, collection, path, plural = nil)
-    link = ' ('
-    link << dashboard_collection_link(singular_name, collection, path, plural)
-    link << ')'
+  def dashboard_secondary_link(link_text, path, options = {})
+    safe_wrap_with_parenthesis(dashboard_navigation_link(link_text, path, options))
+  end
+  
+  def dashboard_collection_link(singular_name, collection, path, options = {})
+    link_text = pluralize(number_to_human(collection.size), singular_name, options.fetch(:plural, nil))
+    dashboard_navigation_link(link_text, path, options)
+  end
+  
+  def dashboard_secondary_collection_link(singular_name, collection, path, options = {})
+    safe_wrap_with_parenthesis(dashboard_collection_link(singular_name, collection, path, options))
   end
 
-  def dashboard_counter_link(collection, path)
-    link_to collection.size, path, class: "DashboardNavigation-link u-notice"
+  def safe_wrap_with_parenthesis(html)
+    " (#{h html})".html_safe
   end
 
   def show_pending_accounts_on_dashboard?

--- a/app/helpers/provider/admin/dashboards_helper.rb
+++ b/app/helpers/provider/admin/dashboards_helper.rb
@@ -1,6 +1,6 @@
 module Provider::Admin::DashboardsHelper
 
-  # include ApplicationHelper
+  include ApplicationHelper
 
   # @param name [Symbol]
   # @param params [Hash]

--- a/app/views/provider/admin/dashboards/_developers_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_developers_navigation.html.slim
@@ -5,52 +5,50 @@ nav.DashboardNavigation
       li.DashboardNavigation-list-item
         // Accounts
         => dashboard_collection_link 'Account',
-                                     buyers,
-                                     admin_buyers_accounts_path,
-                                     'Accounts',
-                                     'briefcase'
+                                      buyers,
+                                      admin_buyers_accounts_path,
+                                      icon_name: 'briefcase'
 
         // Pending Accounts
         - if show_pending_accounts_on_dashboard?
           == dashboard_secondary_collection_link 'Pending',
                                                   pending_buyers,
                                                   admin_buyers_accounts_path(search: {state: 'pending'}),
-                                                  'Pending'
+                                                  plural: 'Pending',
+                                                  notice: true
 
     - if can? :manage, :partners
       li.DashboardNavigation-list-item
         = dashboard_collection_link 'Application',
-                                applications,
-                                admin_buyers_applications_path,
-                                'Applications',
-                                'cubes'
+                                    applications,
+                                    admin_buyers_applications_path,
+                                    icon_name: 'cubes'
 
         - if can?(:manage, :monitoring) && alerts.any?
           == dashboard_secondary_collection_link 'Alert',
-                                      alerts,
-                                      admin_alerts_path,
-                                      'Alerts'
+                                                  alerts,
+                                                  admin_alerts_path,
+                                                  notice: true
 
     // Billing
     - if can?(:manage, :finance)
       li.DashboardNavigation-list-item
-        = link_to admin_finance_root_path, class: "DashboardNavigation-link" do
-          i.fa.fa-credit-card>
-          | Billing
-
-
+        = dashboard_navigation_link 'Billing',
+                                    admin_finance_root_path,
+                                    icon_name: 'credit-card'
 
     // Dev Portal
     - if can?(:manage, :portal)
       li.DashboardNavigation-list-item
-        = link_to provider_admin_cms_root_path, class: "DashboardNavigation-link"
-          i.fa.fa-sitemap>
-          | Developer Portal
+        = dashboard_navigation_link 'Developer Portal',
+                                    provider_admin_cms_root_path,
+                                    icon_name: 'sitemap'
 
         - if current_account.templates.with_draft
           == dashboard_secondary_collection_link 'Draft',
-                                                 current_account.templates.with_draft,
-                                                 provider_admin_cms_changes_path
+                                                  current_account.templates.with_draft,
+                                                  provider_admin_cms_changes_path,
+                                                  notice: true
 
     // Forum
     - if show_forum_on_dashboard? && forum_topics.any?
@@ -58,16 +56,14 @@ nav.DashboardNavigation
         = dashboard_collection_link 'Forum Topic',
                                     forum_topics,
                                     admin_forum_path,
-                                    'Forum Topics',
-                                    'comments'
+                                    icon_name: 'comments'
 
     // Messages
     li.DashboardNavigation-list-item
       = dashboard_collection_link 'Message',
                                   current_account.messages.where(sender: !current_account),
                                   provider_admin_messages_root_path,
-                                  'Messages',
-                                  'envelope'
+                                  icon_name: 'envelope'
 
         - if unread_messages_presenter.show_counter?
           '

--- a/app/views/provider/admin/dashboards/_service_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_service_navigation.html.slim
@@ -3,17 +3,16 @@ nav.DashboardNavigation
 
     - if can?(:manage, :plans)
       li.DashboardNavigation-list-item
-        // Overview (not countable)
-        = link_to admin_service_path(service),
-                  class: "DashboardNavigation-link" do
-          i.fa.fa-map>
-          | Overview
+        // Overview
+        => dashboard_navigation_link 'Overview',
+                                     admin_service_path(service),
+                                     icon_name: 'map'
 
     - if can?(:manage, :monitoring)
       li.DashboardNavigation-list-item
-        = link_to admin_service_stats_usage_path(service), title: 'Analytics', class: "DashboardNavigation-link" do
-          i.fa.fa-bar-chart>
-          | Analytics
+        => dashboard_navigation_link 'Analytics',
+                                     admin_service_stats_usage_path(service),
+                                     icon_name: 'bar-chart'
 
     - if service.cinstances.any?
       li.DashboardNavigation-list-item
@@ -22,8 +21,7 @@ nav.DashboardNavigation
           => dashboard_collection_link 'Application',
                                        service.cinstances.not_bought_by(current_account),
                                        admin_service_applications_path(service),
-                                       'Applications',
-                                       'cubes'
+                                       icon_name: 'cubes'
 
     - unread_alerts = current_account.buyer_alerts.by_service(service).unread
     - if can?(:manage, :monitoring) && unread_alerts.any?
@@ -31,8 +29,8 @@ nav.DashboardNavigation
         = dashboard_collection_link 'Alert',
                                     unread_alerts,
                                     admin_service_alerts_path(service),
-                                    'Alerts',
-                                    'exclamation-triangle'
+                                    icon_name: 'exclamation-triangle',
+                                    notice: true
 
     // Subscriptions & Service Plans
     - if show_subscriptions_on_dashboard?(service)
@@ -41,32 +39,27 @@ nav.DashboardNavigation
         => dashboard_collection_link 'Subscription',
                                      service.service_contracts,
                                      admin_buyers_service_contracts_path(search: {service_id: service.id}),
-                                     'Subscriptions',
-                                     'paperclip'
+                                     icon_name: 'paperclip'
 
     // Active docs
     - if can?(:manage, :plans)
       li.DashboardNavigation-list-item
        = dashboard_collection_link 'ActiveDoc',
-                                 service.api_docs_services,
-                                 admin_service_api_docs_path(service),
-                                 'ActiveDocs',
-                                 'file-text'
+                                    service.api_docs_services,
+                                    admin_service_api_docs_path(service),
+                                    icon_name: 'file-text'
     // Integration
     - if can?(:manage, :plans)
-      - if !service.has_traffic?
-        li.DashboardNavigation-list-item.u-notice
-          = link_to path_to_service(service),
-                    class: "DashboardNavigation-link u-notice" do
-            i.fa.fa-gears>
-            | Integrate this API
-      - else
-        li.DashboardNavigation-list-item
-          = link_to path_to_service(service),
-                    class: "DashboardNavigation-link" do
-            i.fa.fa-wrench>
-            | Integration
+      li.DashboardNavigation-list-item
+        - if service.has_traffic?
+          = dashboard_navigation_link 'Integration',
+                                      path_to_service(service),
+                                      icon_name: 'wrench'
+        - else
+          = dashboard_navigation_link 'Integrate this API',
+                                      path_to_service(service),
+                                      icon_name: 'wrench',
+                                      notice: true
 
-
-    // Integration Errors
-    = dashboard_widget :service_integration_errors, service_id: service.to_param
+        // Integration Errors secondary link
+        = dashboard_widget :service_integration_errors, service_id: service.to_param

--- a/app/views/provider/admin/dashboards/widgets/_service_integration_errors.html.slim
+++ b/app/views/provider/admin/dashboards/widgets/_service_integration_errors.html.slim
@@ -1,6 +1,6 @@
 - loaded = widget.loaded? && widget.value
-li id=(widget.id) class=("DashboardNavigation-list-item u-notice" if loaded)
-  - if loaded
-    = link_to admin_service_errors_path(widget.params[:service_id]), title: 'Integration Errors', class: 'DashboardNavigation-link DashboardNavigation-link--alert' do
-      ' Integration Errors
-      i.fa.fa-exclamation-circle
+- if loaded
+  == dashboard_secondary_link 'Integration Errors',
+                              admin_service_errors_path(widget.params[:service_id]),
+                              icon_name: 'exclamation-circle',
+                              notice: true

--- a/test/unit/helpers/provider/admin/dashboards_helper_test.rb
+++ b/test/unit/helpers/provider/admin/dashboards_helper_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class Provider::Admin::DashboardsHelperTest < ActionView::TestCase
+  include Provider::Admin::DashboardsHelper
+
+  def setup
+    stubs(icon: '<i></i>')
+  end
+  
+  test 'dashboard_navigation_link creates basic link' do
+    assert_equal '<a class="DashboardNavigation-link" href="/path">Link</a>',
+      dashboard_navigation_link('Link', '/path')
+  end
+  
+  test 'dashboard_navigation_link can add an icon using options' do
+    assert_equal '<a class="DashboardNavigation-link" href="/path"><i></i> Link</a>',
+      dashboard_navigation_link('Link', '/path', { icon_name: 'foo' })
+  end
+
+  test 'dashboard_navigation_link can highlight link using options' do
+    assert_equal '<a class="DashboardNavigation-link u-notice" href="/path">Link</a>',
+      dashboard_navigation_link('Link', '/path', { notice: 'true' })
+  end
+
+  test 'dashboard_collection_link creates pluralized link' do
+    assert_equal '<a class="DashboardNavigation-link" href="/path">1 Number</a>',
+      dashboard_collection_link('Number', [1], '/path')
+
+    assert_equal '<a class="DashboardNavigation-link" href="/path">2 Numbers</a>',
+      dashboard_collection_link('Number', [1,2], '/path')
+  end
+
+  test 'dashboard_collection_link can use custom plural' do
+    assert_equal '<a class="DashboardNavigation-link" href="/path">2 Plural</a>',
+      dashboard_collection_link('Singular', [1,2], '/path', { plural: 'Plural' })
+  end
+
+  test 'dashboard_network_link and dashboard_navigation_link are equivalent' do
+    navigation_link = dashboard_navigation_link('1 Number', '/path')
+    collection_link = dashboard_collection_link('Number', [1], '/path')
+
+    assert_equal navigation_link, collection_link
+
+    navigation_link = dashboard_navigation_link('2 Numbers', '/path')
+    collection_link = dashboard_collection_link('Number', [1,2], '/path')
+
+    assert_equal navigation_link, collection_link
+  end
+
+  test 'safe_wrap_with_parenthesis should wrap link in parenthesis and return a safe html' do
+    link = '<a href="/foo">I am safe!</a>'
+    safe_link = safe_wrap_with_parenthesis(link)
+    assert " (#{link.html_safe})", safe_link
+    assert safe_link.html_safe?
+  end
+
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors `dashboard_collection_link` into 2 methods:
- `dashboard_navigation_link (text, path, options?)`
- `dashboard_collection_link (text, collection, path, options?)`

Options being `{ icon_name, notice }` and `{ icon_name, notice, plural }` respectively.

Adds possibility of including `u-notice` class in the link by means of `notice: boolean`.
Adds _secondary_ versions of each method above.

**Which issue(s) this PR fixes** 

Comment from @hallelujah -> https://github.com/3scale/porta/pull/78#pullrequestreview-16212538
