### PR TITLE
Cucumber feature for link from integration/edit to analytics usage

### DIFF
--- a/features/provider/integration/edit.feature
+++ b/features/provider/integration/edit.feature
@@ -1,0 +1,14 @@
+Feature: Edit Integration
+  In order to integrate with 3scale
+  As a provider
+  I want to be able to edit the integration
+
+  Background:
+    Given a provider is logged in
+     And all the rolling updates features are off
+
+  Scenario: Edit a tested integration has a link to the analytics usage
+    Given the service has been successfully tested
+    When I go to the service integration page
+     And I follow "the analytics section"
+    Then I should be on the provider stats usage page

--- a/features/step_definitions/plans/application_plans_steps.rb
+++ b/features/step_definitions/plans/application_plans_steps.rb
@@ -113,10 +113,6 @@ Then /^I should see the details of plan "([^"]*)"$/ do |plan_name|
   assert has_css? 'h3', :text => plan_name
 end
 
-Then /^I should be in the plans page$/ do
-  assert has_xpath?("//table[@id='contracts_table']")
-end
-
 Then /^I should see I have signed up (plan "[^"]*")$/ do |plan|
   assert has_xpath?("//td[@id='plan_#{plan.id}']", :text => 'Your Plan')
 end

--- a/features/step_definitions/service_steps.rb
+++ b/features/step_definitions/service_steps.rb
@@ -56,3 +56,7 @@ end
 Given /^the service of (provider "[^\"]*") has traffic$/ do |account|
   Service.any_instance.stubs(:has_traffic?).returns(true)
 end
+
+Given /^the service has been successfully tested$/ do
+  @provider.default_service.proxy.update_column(:api_test_success, true)
+end


### PR DESCRIPTION
Add a cucumber test for [THREESCALE-1496](https://issues.jboss.org/browse/THREESCALE-1496)
Fixed in https://github.com/3scale/porta/pull/316