### PR TITLE
Daily deletion of long expired provided access tokens

### DIFF
--- a/app/models/provided_access_token.rb
+++ b/app/models/provided_access_token.rb
@@ -6,5 +6,6 @@ class ProvidedAccessToken < ApplicationRecord
 
   default_scope -> { order(expires_at: :desc)}
   scope :valid, -> { where.has { expires_at > Time.now.utc } }
-
+  scope :expired, ->(time = Time.now.utc) { where.has { expires_at <= time } }
+  scope :long_expired, -> { expired(1.day.ago.end_of_day) }
 end

--- a/config/jobs.rb
+++ b/config/jobs.rb
@@ -30,6 +30,7 @@ module ThreeScale
       Cinstance.notify_about_expired_trial_periods
       Pdf::Dispatch.daily
       FindAndDeleteScheduledAccountsWorker.perform_async
+      ProvidedAccessToken.long_expired.delete_all
     ].freeze
 
     BILLING = %w[


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It adds to the daily cron jobs a task to delete provided access tokens expired long ago (anything up to the previous day).

**Which issue(s) this PR fixes** 

[THREESCALE-1541](https://issues.jboss.org/browse/THREESCALE-1541)

**Special notes for your reviewer**:

The provided access tokens were originally added to be used in the context of the service discovery feature.