### PR TITLE
style text beneath authorize link

### DIFF
--- a/app/assets/stylesheets/provider/layouts/_login.scss
+++ b/app/assets/stylesheets/provider/layouts/_login.scss
@@ -103,6 +103,11 @@ body.login-layout {
 
     &-alt {
       color: $light-color;
+      cursor: default;
+      
+      &:hover {
+        color: $light-color;
+      }
     }
   }
 

--- a/app/views/provider/sessions/new.html.slim
+++ b/app/views/provider/sessions/new.html.slim
@@ -14,7 +14,7 @@
         = auth.human_kind
     - if @presenter.show_username_password_related_content?
       div.authorizeLink.authorizeLink-alt
-        ' or sign in with your 3scale credentials
+        ' or sign in with your 3scale credentials:
   - if @presenter.show_username_password_related_content?
     div style=("display:#{params[:request_password_reset] ? 'none' : 'block'}")
       = semantic_form_for @session, html: { method: :post }, url:provider_sessions_path do |f|


### PR DESCRIPTION
text beneath authorize link should not highlight on hover or show pointer cursor.

<img width="332" alt="screenshot 2018-11-14 12 17 41" src="https://user-images.githubusercontent.com/54224/48479364-5e576100-e807-11e8-8e12-32b131ee618d.png">

