### PR TITLE
Add description for rake task impersonation_admin_user:update

### DIFF
--- a/lib/tasks/impersonation_admin_user.rake
+++ b/lib/tasks/impersonation_admin_user.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 namespace :impersonation_admin_user do
+  desc 'updates the username and the email of the impersonation admin user'
   task :update, %i[username domain] => :environment do |_task, args|
     username = ActiveRecord::Base.connection.quote(args[:username])
     domain = ActiveRecord::Base.connection.quote(args[:domain])


### PR DESCRIPTION
As requested by QE for [THREESCALE-1299 : [3scaleadmin user] Script to migrate current username and email according to the new values](https://issues.jboss.org/browse/THREESCALE-1299), it should be documented and appear in the list of rake tasks:
![image](https://user-images.githubusercontent.com/11318903/48486032-a59b1d00-e81a-11e8-97b9-0c8ef4ad24b9.png)
