### PR TITLE
[hotfix] Service discovery should not be accessible if not enabled in the config

### DIFF
--- a/app/lib/service_discovery/oauth_configuration.rb
+++ b/app/lib/service_discovery/oauth_configuration.rb
@@ -22,7 +22,7 @@ module ServiceDiscovery
     # Consider that when it is done via service_account, we do not need the oauth configuration
     # We already have a bearer_token to authenticate
     def oauth_configuration_ready?
-      service_account? || oauth_configuration.present?
+      enabled && (service_account? || oauth_configuration.present?)
     end
     alias service_accessible? oauth_configuration_ready?
 

--- a/test/unit/service_discovery/oauth_configuration_test.rb
+++ b/test/unit/service_discovery/oauth_configuration_test.rb
@@ -57,7 +57,24 @@ class ServiceDiscovery::OAuthConfigurationTest < ActiveSupport::TestCase
     assert_equal 2, subject.retries
   end
 
-  test 'service_accessible??' do
+  test 'service_accessible? when not enabled' do
+    config.stubs(enabled: false)
+    subject.stubs(oauth_configuration: nil)
+    refute subject.service_accessible?
+
+    subject.stubs(oauth_configuration: well_known_response)
+    refute subject.service_accessible?
+
+    subject.stubs(authentication_method: ActiveSupport::StringInquirer.new('service_account'))
+    refute subject.service_accessible?
+
+    subject.stubs(oauth_configuration: nil)
+    refute subject.service_accessible?
+
+  end
+
+  test 'service_accessible? when enabled' do
+    config.stubs(enabled: true)
     subject.stubs(oauth_configuration: nil)
     refute subject.service_accessible?
 


### PR DESCRIPTION


![](https://files.slack.com/files-pri/T025GE0MG-FE2N5LA6L/screen_shot_2018-11-14_at_15.08.32.png)
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Forbid access to service discovery if it is not enabled in the configuration

This should not be there
![image](https://user-images.githubusercontent.com/64276/48504411-f6c00680-e844-11e8-96e1-5ff20e5ec923.png)
