### PR TITLE
[bugfix] Provider password reset follows ActionMailer::Base.default_url_options

### DIFF
--- a/app/mailers/provider_user_mailer.rb
+++ b/app/mailers/provider_user_mailer.rb
@@ -17,7 +17,7 @@ class ProviderUserMailer < ActionMailer::Base
 
   def lost_password(user)
     @user = user
-    @url = Rails.application.routes.url_helpers.provider_password_url(password_reset_token: user.lost_password_token, host: domain(user.account))
+    @url = provider_password_url(password_reset_token: user.lost_password_token, host: domain(user.account))
 
     prepare_email(subject: 'Password Recovery', headers: {'X-SMTPAPI' => '{"category": "Lost password"}'}, to: user.email, template: 'provider_lost_password')
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not use Rails.application.routes.url_helpers in ProviderUserMailer

Otherwise the default_url_options will not be applied


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->


**Which issue(s) this PR fixes** 

Closes https://issues.jboss.org/browse/THREESCALE-1546