### PR TITLE
Master bought cinstance should not appear as a provided cinstance [Part 2]

### DIFF
--- a/app/controllers/buyers/applications_controller.rb
+++ b/app/controllers/buyers/applications_controller.rb
@@ -47,7 +47,7 @@ class Buyers::ApplicationsController < FrontendController
       activate_menu :buyers, :accounts, :listing
     end
 
-    @cinstances = current_user.accessible_cinstances
+    @cinstances = accessible_not_bought_cinstances
       .scope_search(@search).order_by(params[:sort], params[:direction])
       .preload(:service, user_account: [:admin_user], plan: [:pricing_rules])
       .paginate(pagination_params)
@@ -168,9 +168,12 @@ class Buyers::ApplicationsController < FrontendController
     end
   end
 
+  def accessible_not_bought_cinstances
+    current_user.accessible_cinstances.not_bought_by(current_account)
+  end
+
   def find_cinstance
-    @cinstance = current_user.accessible_cinstances
-                  .provided_by(current_account)
+    @cinstance = accessible_not_bought_cinstances
                   .includes(plan: [:service, :original, :plan_metrics, :pricing_rules])
                   .find(params[:id])
     @account = @cinstance.account
@@ -181,7 +184,7 @@ class Buyers::ApplicationsController < FrontendController
   end
 
   def find_service(id = params[:service_id])
-    @service = current_account.accessible_services.find(id) if id
+    @service = accessible_not_bought_cinstances.find(id) if id
   end
 
   def find_provider

--- a/test/integration/buyers/applications_controller_test.rb
+++ b/test/integration/buyers/applications_controller_test.rb
@@ -1,31 +1,49 @@
 require 'test_helper'
 
 class Buyers::ApplicationsTest < ActionDispatch::IntegrationTest
-  def setup
-    @provider = Factory(:provider_account)
+  class MasterLoggedInTest < Buyers::ApplicationsTest
+    setup do
+      login! master_account
+      FactoryGirl.create(:cinstance, service: master_account.default_service)
+    end
 
-    host! @provider.admin_domain
-    provider_login_with @provider.admins.first.username, "supersecret"
+    attr_reader :service
 
-    #TODO: dry with @ignore-backend tag on cucumber
-    stub_backend_get_keys
-    stub_backend_referrer_filters
-    stub_backend_utilization
+    test 'index retrieves all master\'s provided cinstances except those whose buyer is master' do
+      get admin_buyers_applications_path
+
+      assert_response :ok
+      expected_cinstances_ids = master_account.provided_cinstances.not_bought_by(master_account).pluck(:id)
+      assert_same_elements expected_cinstances_ids, assigns(:cinstances).map(&:id)
+    end
   end
 
-  test 'index shows the services column when the provider is multiservice' do
-    @provider.services.create!(name: '2nd-service')
-    assert @provider.reload.multiservice?
-    get admin_buyers_applications_path
-    page = Nokogiri::HTML::Document.parse(response.body)
-    assert page.xpath("//tr").text.match /Service/
-  end
+  class ProviderLoggedInTest < Buyers::ApplicationsTest
+    def setup
+      @provider = Factory(:provider_account)
 
-  test 'index does not show the services column when the provider is not multiservice' do
-    refute @provider.reload.multiservice?
-    get admin_buyers_applications_path
-    page = Nokogiri::HTML::Document.parse(response.body)
-    refute page.xpath("//tr").text.match /Service/
-  end
+      host! @provider.admin_domain
+      provider_login_with @provider.admins.first.username, "supersecret"
 
+      #TODO: dry with @ignore-backend tag on cucumber
+      stub_backend_get_keys
+      stub_backend_referrer_filters
+      stub_backend_utilization
+    end
+
+    test 'index shows the services column when the provider is multiservice' do
+      @provider.services.create!(name: '2nd-service')
+      assert @provider.reload.multiservice?
+      get admin_buyers_applications_path
+      page = Nokogiri::HTML::Document.parse(response.body)
+      assert page.xpath("//tr").text.match /Service/
+    end
+
+    test 'index does not show the services column when the provider is not multiservice' do
+      refute @provider.reload.multiservice?
+      get admin_buyers_applications_path
+      page = Nokogiri::HTML::Document.parse(response.body)
+      refute page.xpath("//tr").text.match /Service/
+    end
+  end
 end


### PR DESCRIPTION
Fixes [THREESCALE-1474](https://issues.jboss.org/browse/THREESCALE-1474)

Master account has a cinstance for which he is both its provider and its buyer, and right now it is shown in the provided cinstances list, but when we click in its buyer (in this case itself), it says 404 because it tries to find it as a buyer and not itself.

In the Dashboard, it also needs to show the number of applications properly, without the buyers, but @thomasmaas will do that in another PR.

### Tasks
- [X] This PR needs to do exactly the same as https://github.com/3scale/porta/pull/307 but for `Buyers::Applications#index`. The `show` is always from that other controller of the previous PR 😄 

![image](https://user-images.githubusercontent.com/11318903/48627239-5a1c7680-e9b4-11e8-9f11-d89eb3c07d3f.png)