### PR TITLE
DeletePlainObjectWorker ignores errors when the object has been destroyed

### DIFF
--- a/app/workers/delete_plain_object_worker.rb
+++ b/app/workers/delete_plain_object_worker.rb
@@ -9,8 +9,11 @@ class DeletePlainObjectWorker < ActiveJob::Base
   end
 
   rescue_from(ActiveRecord::RecordNotDestroyed, ActiveRecord::StaleObjectError) do |exception|
-    System::ErrorReporting.report_error(exception, parameters: { caller_worker_hierarchy: caller_worker_hierarchy,
-                                                                 error_messages: exception.record.errors.full_messages })
+    record = exception.record
+    if record.class.exists?(record.id)
+      System::ErrorReporting.report_error(exception, parameters: { caller_worker_hierarchy: caller_worker_hierarchy,
+                                                                   error_messages: record.errors.full_messages })
+    end
   end
 
   queue_as :default


### PR DESCRIPTION
By the beginning of September we had a `StaleObjectError` in `DeletePlainObjectWorker`. Back then I did https://github.com/3scale/system/pull/9431, and we weren't Open Source back then but all it contains inside is this:
https://github.com/3scale/porta/blob/164eba4828debfa97bbd13a0031486d941db223e/app/workers/delete_plain_object_worker.rb#L11-L14
And I explained there that I suspect that at this point the object has already been deleted and then we don't need to do anything else about it, but I added that to have more information if it happens again.
Now it happened again, and the log of it is:
```json
{
  "parameters": {
    "caller_worker_hierarchy": [
      "Hierarchy-Service-2555417761880",
      "Hierarchy-Proxy-108121",
      "Plain-Proxy-108121"
    ],
    "error_messages": []
  }
}
```
I checked in production if the object still exists and it doesn't:
![image](https://user-images.githubusercontent.com/11318903/48717545-ee3b4780-ec19-11e8-8b67-6f84c4681e5e.png)

So this PR aims to just ignore errors while deleting if the object has already being deleted somehow 😄
I didn't add any test because I have no idea how to reproduce this in a test 😕  