### PR TITLE
Fix navigation hint for dev portal access code

### DIFF
--- a/lib/developer_portal/app/views/developer_portal/access_codes/show.html.erb
+++ b/lib/developer_portal/app/views/developer_portal/access_codes/show.html.erb
@@ -23,8 +23,8 @@
         <%= submit_tag('Enter') %>
       <% end %>
       <p>
-        You can setup the site access code in your admin dashboard
-        under <em>'Settings &gt; Developer Portal'.</em>
+        You can configure the developer portal access code in your admin portal
+        under <em>'Audience &gt; Developer Portal &gt; Domains &amp; Access'.</em>
       </p>
       <p>Please make sure that you have cookies enabled!</p>
   </body>


### PR DESCRIPTION
The navigation in the UI has changed, but the hint on this page didn't reflect it.
This PR sets the correct location of the access token settings (and clarifies the terms).