### PR TITLE
Removes deprecation warnings for "equal_to nil"

### DIFF
--- a/test/functional/admin/api/services/mapping_rules_controller_test.rb
+++ b/test/functional/admin/api/services/mapping_rules_controller_test.rb
@@ -68,7 +68,7 @@ module Admin::Api::Services
         assert_response :success
       end
 
-      assert_equal nil, ProxyRule.last!.redirect_url
+      assert_nil, ProxyRule.last!.redirect_url
     end
 
 

--- a/test/functional/admin/api/services/mapping_rules_controller_test.rb
+++ b/test/functional/admin/api/services/mapping_rules_controller_test.rb
@@ -68,7 +68,7 @@ module Admin::Api::Services
         assert_response :success
       end
 
-      assert_nil, ProxyRule.last!.redirect_url
+      assert_nil ProxyRule.last!.redirect_url
     end
 
 

--- a/test/functional/provider/admin/messages/trash_controller_test.rb
+++ b/test/functional/provider/admin/messages/trash_controller_test.rb
@@ -50,7 +50,7 @@ class Provider::Admin::Messages::TrashControllerTest < ActionController::TestCas
     @message.reload
 
     assert_response :redirect
-    assert_nil, @message.hidden_at
+    assert_nil @message.hidden_at
   end
 
   def test_empty

--- a/test/functional/provider/admin/messages/trash_controller_test.rb
+++ b/test/functional/provider/admin/messages/trash_controller_test.rb
@@ -50,7 +50,7 @@ class Provider::Admin::Messages::TrashControllerTest < ActionController::TestCas
     @message.reload
 
     assert_response :redirect
-    assert_equal nil, @message.hidden_at
+    assert_nil, @message.hidden_at
   end
 
   def test_empty

--- a/test/integration/payment_gateways/braintree_blue_test.rb
+++ b/test/integration/payment_gateways/braintree_blue_test.rb
@@ -27,7 +27,7 @@ class BraintreeBlueTest < ActionDispatch::IntegrationTest
     @provider_account.payment_gateway_options[:public_key] = "AnY-pUbLiC-kEy"
     @provider_account.payment_gateway_options[:private_key] = "a1b2c3d4e5"
       login_with @buyer_account.admins.first.username, 'supersecret'
-      assert_equal nil, @buyer_account.credit_card_partial_number
+      assert_nil, @buyer_account.credit_card_partial_number
 
   end
 

--- a/test/integration/payment_gateways/braintree_blue_test.rb
+++ b/test/integration/payment_gateways/braintree_blue_test.rb
@@ -27,7 +27,7 @@ class BraintreeBlueTest < ActionDispatch::IntegrationTest
     @provider_account.payment_gateway_options[:public_key] = "AnY-pUbLiC-kEy"
     @provider_account.payment_gateway_options[:private_key] = "a1b2c3d4e5"
       login_with @buyer_account.admins.first.username, 'supersecret'
-      assert_nil, @buyer_account.credit_card_partial_number
+      assert_nil @buyer_account.credit_card_partial_number
 
   end
 

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -172,7 +172,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
       session.get '/login'
 
       session.assert_response :success
-      session.assert_equal nil, User.current
+      session.assert_nil, User.current
     end
   end
 

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -172,7 +172,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
       session.get '/login'
 
       session.assert_response :success
-      session.assert_nil, User.current
+      session.assert_nil User.current
     end
   end
 

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -70,7 +70,7 @@ class AccountTest < ActiveSupport::TestCase
     account.reload
 
     assert_raises(ActiveRecord::RecordNotFound) { service.reload }
-    assert_nil, account.default_service_id
+    assert_nil account.default_service_id
   end
 
   test '#trashed_messages' do
@@ -212,7 +212,7 @@ class AccountTest < ActiveSupport::TestCase
     end
 
     should 'have nil VAT rate' do
-      assert_nil, @account.vat_rate
+      assert_nil @account.vat_rate
 
       @account.update_attribute(:vat_rate, 0)
       assert_equal 0.0, @account.reload.vat_rate

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -70,7 +70,7 @@ class AccountTest < ActiveSupport::TestCase
     account.reload
 
     assert_raises(ActiveRecord::RecordNotFound) { service.reload }
-    assert_equal nil, account.default_service_id
+    assert_nil, account.default_service_id
   end
 
   test '#trashed_messages' do
@@ -212,7 +212,7 @@ class AccountTest < ActiveSupport::TestCase
     end
 
     should 'have nil VAT rate' do
-      assert_equal nil, @account.vat_rate
+      assert_nil, @account.vat_rate
 
       @account.update_attribute(:vat_rate, 0)
       assert_equal 0.0, @account.reload.vat_rate

--- a/test/unit/api_authentication/http_authentication_test.rb
+++ b/test/unit/api_authentication/http_authentication_test.rb
@@ -10,7 +10,7 @@ class ApiAuthentication::HttpAuthenticationTest < MiniTest::Unit::TestCase
   def test_invalid_encoding
     @request = stub('request', authorization: "\x255")
 
-    assert_nil, http_authentication
+    assert_nil http_authentication
   end
 
   def test_http_user_authentication

--- a/test/unit/api_authentication/http_authentication_test.rb
+++ b/test/unit/api_authentication/http_authentication_test.rb
@@ -10,7 +10,7 @@ class ApiAuthentication::HttpAuthenticationTest < MiniTest::Unit::TestCase
   def test_invalid_encoding
     @request = stub('request', authorization: "\x255")
 
-    assert_equal nil, http_authentication
+    assert_nil, http_authentication
   end
 
   def test_http_user_authentication

--- a/test/unit/cms/template_test.rb
+++ b/test/unit/cms/template_test.rb
@@ -38,7 +38,7 @@ class CMS::TemplateTest < ActiveSupport::TestCase
 
   test 'publish' do
     page = Factory(:cms_page, draft: 'something to publish')
-    assert_equal nil, page.content
+    assert_nil, page.content
     page.publish!
     assert_equal page.content, 'something to publish'
     assert_equal 2, page.versions.count

--- a/test/unit/cms/template_test.rb
+++ b/test/unit/cms/template_test.rb
@@ -38,7 +38,7 @@ class CMS::TemplateTest < ActiveSupport::TestCase
 
   test 'publish' do
     page = Factory(:cms_page, draft: 'something to publish')
-    assert_nil, page.content
+    assert_nil page.content
     page.publish!
     assert_equal page.content, 'something to publish'
     assert_equal 2, page.versions.count

--- a/test/unit/deploy/basic_info_test.rb
+++ b/test/unit/deploy/basic_info_test.rb
@@ -5,7 +5,7 @@ class BasicInfoTest < ActiveSupport::TestCase
   test 'env empty' do
     ENV['AMP_RELEASE'] = nil
     System::Deploy.load_info!
-    assert_equal nil, System::Deploy.info.release
+    assert_nil, System::Deploy.info.release
   end
 
   test 'env not empty' do

--- a/test/unit/deploy/basic_info_test.rb
+++ b/test/unit/deploy/basic_info_test.rb
@@ -5,7 +5,7 @@ class BasicInfoTest < ActiveSupport::TestCase
   test 'env empty' do
     ENV['AMP_RELEASE'] = nil
     System::Deploy.load_info!
-    assert_nil, System::Deploy.info.release
+    assert_nil System::Deploy.info.release
   end
 
   test 'env not empty' do

--- a/test/unit/developer_portal/controller_methods/plan_changes_methods_test.rb
+++ b/test/unit/developer_portal/controller_methods/plan_changes_methods_test.rb
@@ -27,11 +27,11 @@ module DeveloperPortal::ControllerMethods
     end
 
     def test_store_plan_change!
-      assert_equal nil, @store[1]
+      assert_nil, @store[1]
 
       @controller.send(:store_plan_change!, 1, '')
 
-      assert_equal nil, @store[1]
+      assert_nil, @store[1]
 
       @controller.send(:store_plan_change!, 1, 2)
 
@@ -39,7 +39,7 @@ module DeveloperPortal::ControllerMethods
     end
 
     def test_unstore_plan_change!
-      assert_equal nil, @store[1]
+      assert_nil, @store[1]
 
       @controller.send(:store_plan_change!, 1, 2)
 
@@ -47,7 +47,7 @@ module DeveloperPortal::ControllerMethods
 
       @controller.send(:unstore_plan_change!, 1)
 
-      assert_equal nil, @store[1]
+      assert_nil, @store[1]
     end
 
     def test_plan_ids
@@ -67,7 +67,7 @@ module DeveloperPortal::ControllerMethods
     end
 
     def test_fetch
-      assert_equal nil, @store[1]
+      assert_nil, @store[1]
 
       @store.save(1, 2)
 

--- a/test/unit/developer_portal/controller_methods/plan_changes_methods_test.rb
+++ b/test/unit/developer_portal/controller_methods/plan_changes_methods_test.rb
@@ -27,11 +27,11 @@ module DeveloperPortal::ControllerMethods
     end
 
     def test_store_plan_change!
-      assert_nil, @store[1]
+      assert_nil @store[1]
 
       @controller.send(:store_plan_change!, 1, '')
 
-      assert_nil, @store[1]
+      assert_nil @store[1]
 
       @controller.send(:store_plan_change!, 1, 2)
 
@@ -39,7 +39,7 @@ module DeveloperPortal::ControllerMethods
     end
 
     def test_unstore_plan_change!
-      assert_nil, @store[1]
+      assert_nil @store[1]
 
       @controller.send(:store_plan_change!, 1, 2)
 
@@ -47,7 +47,7 @@ module DeveloperPortal::ControllerMethods
 
       @controller.send(:unstore_plan_change!, 1)
 
-      assert_nil, @store[1]
+      assert_nil @store[1]
     end
 
     def test_plan_ids
@@ -67,7 +67,7 @@ module DeveloperPortal::ControllerMethods
     end
 
     def test_fetch
-      assert_nil, @store[1]
+      assert_nil @store[1]
 
       @store.save(1, 2)
 

--- a/test/unit/forms/onboarding/api_form_test.rb
+++ b/test/unit/forms/onboarding/api_form_test.rb
@@ -6,7 +6,7 @@ class Onboarding::ApiFormTest < ActiveSupport::TestCase
     api = Onboarding::ApiForm.new(service: FactoryGirl.build(:service),
                                   proxy:   FactoryGirl.build(:proxy))
 
-    assert_equal nil, api.backend
+    assert_nil, api.backend
 
 
     api = Onboarding::ApiForm.new(service: FactoryGirl.build(:service),
@@ -21,7 +21,7 @@ class Onboarding::ApiFormTest < ActiveSupport::TestCase
     api = Onboarding::ApiForm.new(service: FactoryGirl.build(:service),
                                   proxy:   FactoryGirl.build(:proxy))
 
-    assert_equal nil, api.name
+    assert_nil, api.name
 
 
     api = Onboarding::ApiForm.new(service: FactoryGirl.build(:service,

--- a/test/unit/forms/onboarding/api_form_test.rb
+++ b/test/unit/forms/onboarding/api_form_test.rb
@@ -6,7 +6,7 @@ class Onboarding::ApiFormTest < ActiveSupport::TestCase
     api = Onboarding::ApiForm.new(service: FactoryGirl.build(:service),
                                   proxy:   FactoryGirl.build(:proxy))
 
-    assert_nil, api.backend
+    assert_nil api.backend
 
 
     api = Onboarding::ApiForm.new(service: FactoryGirl.build(:service),
@@ -21,7 +21,7 @@ class Onboarding::ApiFormTest < ActiveSupport::TestCase
     api = Onboarding::ApiForm.new(service: FactoryGirl.build(:service),
                                   proxy:   FactoryGirl.build(:proxy))
 
-    assert_nil, api.name
+    assert_nil api.name
 
 
     api = Onboarding::ApiForm.new(service: FactoryGirl.build(:service,

--- a/test/unit/forms/onboarding/request_form_test.rb
+++ b/test/unit/forms/onboarding/request_form_test.rb
@@ -6,7 +6,7 @@ class Onboarding::RequestFormTest < ActiveSupport::TestCase
     proxy = FactoryGirl.build(:proxy)
     form = Onboarding::RequestForm.new(proxy)
 
-    assert_nil, form.path
+    assert_nil form.path
 
     assert form.validate(path: nil)
     assert form.save

--- a/test/unit/forms/onboarding/request_form_test.rb
+++ b/test/unit/forms/onboarding/request_form_test.rb
@@ -6,7 +6,7 @@ class Onboarding::RequestFormTest < ActiveSupport::TestCase
     proxy = FactoryGirl.build(:proxy)
     form = Onboarding::RequestForm.new(proxy)
 
-    assert_equal nil, form.path
+    assert_nil, form.path
 
     assert form.validate(path: nil)
     assert form.save

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -7,7 +7,7 @@ class ApplicationHelperTest < ActionView::TestCase
   def test_link_to_export_widget_for
     self.current_user = FactoryGirl.build_stubbed(:member, account: account)
     link = link_to_export_widget_for('Accounts')
-    assert_nil, link
+    assert_nil link
 
     self.current_user = FactoryGirl.build_stubbed(:admin, account: account)
     link = link_to_export_widget_for('Accounts')

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -7,7 +7,7 @@ class ApplicationHelperTest < ActionView::TestCase
   def test_link_to_export_widget_for
     self.current_user = FactoryGirl.build_stubbed(:member, account: account)
     link = link_to_export_widget_for('Accounts')
-    assert_equal nil, link
+    assert_nil, link
 
     self.current_user = FactoryGirl.build_stubbed(:admin, account: account)
     link = link_to_export_widget_for('Accounts')

--- a/test/unit/liquid/drops/invoice_drop_test.rb
+++ b/test/unit/liquid/drops/invoice_drop_test.rb
@@ -96,7 +96,7 @@ class Liquid::Drops::InvoiceDropTest < ActiveSupport::TestCase
   end
 
   should 'returns vat_rate' do
-    assert_equal nil, @drop.vat_rate
+    assert_nil, @drop.vat_rate
   end
 
   should 'returns payment_transactions' do

--- a/test/unit/liquid/drops/invoice_drop_test.rb
+++ b/test/unit/liquid/drops/invoice_drop_test.rb
@@ -96,7 +96,7 @@ class Liquid::Drops::InvoiceDropTest < ActiveSupport::TestCase
   end
 
   should 'returns vat_rate' do
-    assert_nil, @drop.vat_rate
+    assert_nil @drop.vat_rate
   end
 
   should 'returns payment_transactions' do

--- a/test/unit/liquid/drops/pagination_test.rb
+++ b/test/unit/liquid/drops/pagination_test.rb
@@ -27,7 +27,7 @@ class Liquid::Drops::PaginationDropTest < ActiveSupport::TestCase
 
   test 'head' do
     drop = Drops::Pagination.new(Invoice.paginate(page: 1, per_page: 3), @url_builder)
-    assert_nil, drop.previous
+    assert_nil drop.previous
     assert_equal 1, drop.current_page
     assert_equal 2, drop.next
   end
@@ -36,7 +36,7 @@ class Liquid::Drops::PaginationDropTest < ActiveSupport::TestCase
     drop = Drops::Pagination.new(Invoice.paginate(page: 4, per_page: 3), @url_builder)
     assert_equal 3, drop.previous
     assert_equal 4, drop.current_page
-    assert_nil, drop.next
+    assert_nil drop.next
   end
 
 

--- a/test/unit/liquid/drops/pagination_test.rb
+++ b/test/unit/liquid/drops/pagination_test.rb
@@ -27,7 +27,7 @@ class Liquid::Drops::PaginationDropTest < ActiveSupport::TestCase
 
   test 'head' do
     drop = Drops::Pagination.new(Invoice.paginate(page: 1, per_page: 3), @url_builder)
-    assert_equal nil, drop.previous
+    assert_nil, drop.previous
     assert_equal 1, drop.current_page
     assert_equal 2, drop.next
   end
@@ -36,7 +36,7 @@ class Liquid::Drops::PaginationDropTest < ActiveSupport::TestCase
     drop = Drops::Pagination.new(Invoice.paginate(page: 4, per_page: 3), @url_builder)
     assert_equal 3, drop.previous
     assert_equal 4, drop.current_page
-    assert_equal nil, drop.next
+    assert_nil, drop.next
   end
 
 

--- a/test/unit/liquid/filters/form_helpers_test.rb
+++ b/test/unit/liquid/filters/form_helpers_test.rb
@@ -14,7 +14,7 @@ class Liquid::Filters::FormHelpersTest < ActiveSupport::TestCase
   test 'inline_errors' do
     model = Liquid::Drops::Model.new(self)
 
-    assert_nil, inline_errors(model.errors)
+    assert_nil inline_errors(model.errors)
     errors.add(:setup, 'set up')
     errors.add(:teardown, 'tore down')
 

--- a/test/unit/liquid/filters/form_helpers_test.rb
+++ b/test/unit/liquid/filters/form_helpers_test.rb
@@ -14,7 +14,7 @@ class Liquid::Filters::FormHelpersTest < ActiveSupport::TestCase
   test 'inline_errors' do
     model = Liquid::Drops::Model.new(self)
 
-    assert_equal nil, inline_errors(model.errors)
+    assert_nil, inline_errors(model.errors)
     errors.add(:setup, 'set up')
     errors.add(:teardown, 'tore down')
 

--- a/test/unit/presenters/dashboard/top_traffic_presenter_test.rb
+++ b/test/unit/presenters/dashboard/top_traffic_presenter_test.rb
@@ -43,7 +43,7 @@ class TopTrafficPresenterTest < ActiveSupport::TestCase
     assert_equal 'app 2', second.name
 
     assert_kind_of Dashboard::TopTraffic::LeftAppPresenter, third
-    assert_equal nil, third.position
+    assert_nil, third.position
     assert_equal 'app 3', third.name
   end
 

--- a/test/unit/presenters/dashboard/top_traffic_presenter_test.rb
+++ b/test/unit/presenters/dashboard/top_traffic_presenter_test.rb
@@ -43,7 +43,7 @@ class TopTrafficPresenterTest < ActiveSupport::TestCase
     assert_equal 'app 2', second.name
 
     assert_kind_of Dashboard::TopTraffic::LeftAppPresenter, third
-    assert_nil, third.position
+    assert_nil third.position
     assert_equal 'app 3', third.name
   end
 

--- a/test/unit/service_discovery/well_known_fetcher_test.rb
+++ b/test/unit/service_discovery/well_known_fetcher_test.rb
@@ -47,10 +47,10 @@ class ServiceDiscovery::WellKnownFetcherTest < ActiveSupport::TestCase
 
   test 'call failed' do
     stub_request(:get, well_known_url).to_return(status: 500, body: '')
-    assert_nil, subject.call
+    assert_nil subject.call
 
     stub_request(:get, well_known_url).to_return(status: 200, body: '<xml></xml>')
-    assert_nil, subject.call
+    assert_nil subject.call
   end
 
   private

--- a/test/unit/service_discovery/well_known_fetcher_test.rb
+++ b/test/unit/service_discovery/well_known_fetcher_test.rb
@@ -47,10 +47,10 @@ class ServiceDiscovery::WellKnownFetcherTest < ActiveSupport::TestCase
 
   test 'call failed' do
     stub_request(:get, well_known_url).to_return(status: 500, body: '')
-    assert_equal nil, subject.call
+    assert_nil, subject.call
 
     stub_request(:get, well_known_url).to_return(status: 200, body: '<xml></xml>')
-    assert_equal nil, subject.call
+    assert_nil, subject.call
   end
 
   private

--- a/test/unit/services/messages/destroy_all_service_test.rb
+++ b/test/unit/services/messages/destroy_all_service_test.rb
@@ -10,7 +10,7 @@ class Messages::DestroyAllServiceTest < ActiveSupport::TestCase
 
   def test_run!
     Sidekiq::Testing.fake! do
-      assert_nil, @message.deleted_at
+      assert_nil @message.deleted_at
 
       ::Messages::DestroyAllService.run!({
         account:           @account,

--- a/test/unit/services/messages/destroy_all_service_test.rb
+++ b/test/unit/services/messages/destroy_all_service_test.rb
@@ -10,7 +10,7 @@ class Messages::DestroyAllServiceTest < ActiveSupport::TestCase
 
   def test_run!
     Sidekiq::Testing.fake! do
-      assert_equal nil, @message.deleted_at
+      assert_nil, @message.deleted_at
 
       ::Messages::DestroyAllService.run!({
         account:           @account,

--- a/test/unit/three_scale/oauth2/keycloak_client_test.rb
+++ b/test/unit/three_scale/oauth2/keycloak_client_test.rb
@@ -20,7 +20,7 @@ class ThreeScale::OAuth2::KeycloakClientTest < ActiveSupport::TestCase
     @authentication.options.expects(site: nil)
 
     assert_raises ThreeScale::OAuth2::KeycloakClient::MissingRealmError do
-      assert_equal nil, @oauth2.realm
+      assert_nil, @oauth2.realm
     end
   end
 

--- a/test/unit/three_scale/oauth2/keycloak_client_test.rb
+++ b/test/unit/three_scale/oauth2/keycloak_client_test.rb
@@ -20,7 +20,7 @@ class ThreeScale::OAuth2::KeycloakClientTest < ActiveSupport::TestCase
     @authentication.options.expects(site: nil)
 
     assert_raises ThreeScale::OAuth2::KeycloakClient::MissingRealmError do
-      assert_nil, @oauth2.realm
+      assert_nil @oauth2.realm
     end
   end
 

--- a/test/unit/three_scale/oauth2/redhat_customer_portal_client_test.rb
+++ b/test/unit/three_scale/oauth2/redhat_customer_portal_client_test.rb
@@ -20,7 +20,7 @@ class ThreeScale::OAuth2::RedhatCustomerPortalClientTest < ActiveSupport::TestCa
     @authentication.options.expects(site: nil)
 
     assert_raises ThreeScale::OAuth2::KeycloakClient::MissingRealmError do
-      assert_equal nil, @oauth2.realm
+      assert_nil, @oauth2.realm
     end
   end
 

--- a/test/unit/three_scale/oauth2/redhat_customer_portal_client_test.rb
+++ b/test/unit/three_scale/oauth2/redhat_customer_portal_client_test.rb
@@ -20,7 +20,7 @@ class ThreeScale::OAuth2::RedhatCustomerPortalClientTest < ActiveSupport::TestCa
     @authentication.options.expects(site: nil)
 
     assert_raises ThreeScale::OAuth2::KeycloakClient::MissingRealmError do
-      assert_nil, @oauth2.realm
+      assert_nil @oauth2.realm
     end
   end
 

--- a/test/unit/user_session_test.rb
+++ b/test/unit/user_session_test.rb
@@ -51,7 +51,7 @@ class UserSessionTest < ActiveSupport::TestCase
     refute session.valid?
 
     session.user_agent = nil
-    assert_nil, session.user_agent
+    assert_nil session.user_agent
     refute session.valid?
 
     session.user_agent = 'a' * 253

--- a/test/unit/user_session_test.rb
+++ b/test/unit/user_session_test.rb
@@ -51,7 +51,7 @@ class UserSessionTest < ActiveSupport::TestCase
     refute session.valid?
 
     session.user_agent = nil
-    assert_equal nil, session.user_agent
+    assert_nil, session.user_agent
     refute session.valid?
 
     session.user_agent = 'a' * 253


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes deprecation warning:
> DEPRECATED: Use assert_nil if expecting nil from .... This will fail in Minitest 6.