### PR TITLE
Remove empty helpers' classes/modules and tests

### DIFF
--- a/app/helpers/admin/cinstances/invoices_helper.rb
+++ b/app/helpers/admin/cinstances/invoices_helper.rb
@@ -1,2 +1,0 @@
-module Admin::Cinstances::InvoicesHelper
-end

--- a/app/helpers/admin/cinstances/messages_helper.rb
+++ b/app/helpers/admin/cinstances/messages_helper.rb
@@ -1,2 +1,0 @@
-module Admin::Cinstances::MessagesHelper
-end

--- a/app/helpers/admin/contracts_helper.rb
+++ b/app/helpers/admin/contracts_helper.rb
@@ -1,2 +1,0 @@
-module Admin::ContractsHelper
-end

--- a/app/helpers/admin/finance/dashboards_helper.rb
+++ b/app/helpers/admin/finance/dashboards_helper.rb
@@ -1,2 +1,0 @@
-module Admin::Finance::DashboardsHelper
-end

--- a/app/helpers/admin/finance/line_items_helper.rb
+++ b/app/helpers/admin/finance/line_items_helper.rb
@@ -1,2 +1,0 @@
-module Admin::Finance::LineItemsHelper
-end

--- a/app/helpers/admin/sessions_helper.rb
+++ b/app/helpers/admin/sessions_helper.rb
@@ -1,2 +1,0 @@
-module Admin::SessionsHelper
-end

--- a/app/helpers/analytics/dashboards_helper.rb
+++ b/app/helpers/analytics/dashboards_helper.rb
@@ -1,2 +1,0 @@
-module Analytics::DashboardsHelper
-end

--- a/app/helpers/analytics/traffic_helper.rb
+++ b/app/helpers/analytics/traffic_helper.rb
@@ -1,2 +1,0 @@
-module Analytics::TrafficHelper
-end

--- a/app/helpers/analytics/users_helper.rb
+++ b/app/helpers/analytics/users_helper.rb
@@ -1,2 +1,0 @@
-module Analytics::UsersHelper
-end

--- a/app/helpers/api/account_plans_helper.rb
+++ b/app/helpers/api/account_plans_helper.rb
@@ -1,2 +1,0 @@
-module Api::AccountPlansHelper
-end

--- a/app/helpers/api/application_plans_helper.rb
+++ b/app/helpers/api/application_plans_helper.rb
@@ -1,2 +1,0 @@
-module Api::ApplicationPlansHelper
-end

--- a/app/helpers/api/service_plans_helper.rb
+++ b/app/helpers/api/service_plans_helper.rb
@@ -1,2 +1,0 @@
-module Api::ServicePlansHelper
-end

--- a/app/helpers/api/supports_helper.rb
+++ b/app/helpers/api/supports_helper.rb
@@ -1,2 +1,0 @@
-module Api::SupportsHelper
-end

--- a/app/helpers/cross_domain_sessions_helper.rb
+++ b/app/helpers/cross_domain_sessions_helper.rb
@@ -1,2 +1,0 @@
-module CrossDomainSessionsHelper
-end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,2 +1,0 @@
-module DashboardsHelper
-end

--- a/app/helpers/fields_definitions_helper.rb
+++ b/app/helpers/fields_definitions_helper.rb
@@ -1,2 +1,0 @@
-module FieldsDefinitionsHelper
-end

--- a/app/helpers/finance/provider/settings_helper.rb
+++ b/app/helpers/finance/provider/settings_helper.rb
@@ -1,3 +1,0 @@
-module Finance::Provider::SettingsHelper
-
-end

--- a/app/helpers/provider_sessions_helper.rb
+++ b/app/helpers/provider_sessions_helper.rb
@@ -1,2 +1,0 @@
-module ProviderSessionsHelper
-end

--- a/test/unit/helpers/api/application_plans_helper_test.rb
+++ b/test/unit/helpers/api/application_plans_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Api::ApplicationPlansHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/api/service_plans_helper_test.rb
+++ b/test/unit/helpers/api/service_plans_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Api::ServicePlansHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/api/supports_helper_test.rb
+++ b/test/unit/helpers/api/supports_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Api::SupportsHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/buyers/service_contracts_helper_test.rb
+++ b/test/unit/helpers/buyers/service_contracts_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Buyers::ServiceContractsHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/finance/provider/settings_helper_test.rb
+++ b/test/unit/helpers/finance/provider/settings_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class Finance::Provider::SettingsHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/reports_helper_test.rb
+++ b/test/unit/helpers/reports_helper_test.rb
@@ -1,5 +1,0 @@
-require 'test_helper'
-
-class ReportsHelperTest < ActionView::TestCase
-
-end


### PR DESCRIPTION
Removes empty `helpers` and empty tests of helpers.
It can get a bit confusing otherwise 😄 