### PR TITLE
Configure the Github app to prevent us for merging PRs to check for certain words in the title

### DIFF
--- a/.github/wip.yml
+++ b/.github/wip.yml
@@ -1,0 +1,6 @@
+locations:
+- title
+terms:
+- wip
+- do not merge
+- ⛔️


### PR DESCRIPTION
Before this used to be the default behaviour, but now by default it only checks for `WIP` in the title, so in order to check for `Do not merge` as well, which is not the same concept, we need this config file as  you can find at the moment in https://github.com/wip/app#configuration