### PR TITLE
[ci] Using docker:ci-2.3.4-1 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/3scale/docker:ci-2.3.1-3
+FROM quay.io/3scale/docker:ci-2.3.4-1
 
 ARG SPHINX_VERSION=2.2.11
 ARG BUNDLER_VERSION=1.12.5


### PR DESCRIPTION
(cherry picked from commit 511d1ea8170315811f2bd803e4086ab3cab1d158)

**What this PR does / why we need it**:
This is required in order to license_finder v5.5.2 work.
The update of license_finder is included in https://github.com/3scale/porta/pull/57/

Note: This probably won't be needed since we are going to upgrade to system_builder: 
https://github.com/3scale/porta/pull/341#issuecomment-440655543