### PR TITLE
NotificationDeliveryService nil value invalid event. Blank valid

### DIFF
--- a/app/services/notification_delivery_service.rb
+++ b/app/services/notification_delivery_service.rb
@@ -69,6 +69,6 @@ class NotificationDeliveryService
   private
 
   def invalid_event?
-    event_entity.data.any? { |_key, value| value.blank? }
+    event_entity.data.any? { |_key, value| value.nil? }
   end
 end

--- a/test/unit/services/notification_delivery_service_test.rb
+++ b/test/unit/services/notification_delivery_service_test.rb
@@ -27,13 +27,34 @@ class NotificationDeliveryServiceTest < ActiveSupport::TestCase
     end
   end
 
-  def test_invalid_event
-    event_data   = { provider: '', user: FactoryGirl.create(:simple_user) }
+  def test_nil_is_invalid_event
+    event_data   = { provider: nil, user: FactoryGirl.create(:simple_user) }
     event        = FactoryGirl.build_stubbed(:event, data: event_data)
     notification = FactoryGirl.build_stubbed(:notification)
     notification.expects(:parent_event).returns(event)
 
     assert_raise NotificationDeliveryService::InvalidEventError do
+      NotificationDeliveryService.new(notification).call
+    end
+  end
+
+  def test_false_boolean_attribute_is_valid_event
+    account = FactoryGirl.create(:simple_provider, buyer: false)
+    FactoryGirl.create(:active_admin, account: account)
+    event = Accounts::AccountDeletedEvent.create(account)
+    notification = FactoryGirl.build_stubbed(:notification, system_name: :account_deleted)
+    notification.expects(:parent_event).returns(event)
+
+    NotificationDeliveryService.new(notification).call
+  end
+
+  def test_empty_attribute_is_a_valid_event
+    ['', []].each do |empty_value|
+      service = FactoryGirl.build_stubbed(:simple_service, name: empty_value)
+      event = Services::ServiceDeletedEvent.create(service)
+      notification = FactoryGirl.build_stubbed(:notification, system_name: :service_deleted)
+      notification.expects(:parent_event).returns(event)
+
       NotificationDeliveryService.new(notification).call
     end
   end


### PR DESCRIPTION
Solution to the 1st problem of https://github.com/3scale/porta/issues/10
Allow event with `false` value in their attribute. They will not be considered invalid anymore.
This is done by changing the check from `blank?` to `nil?`, since that's the check we actually want.
Just for referencing, this started when we weren't open source yet, in https://github.com/3scale/system/pull/9439 😄 