### PR TITLE
[Service Discovery] Fix API endpoint without path

### DIFF
--- a/app/models/service_discovery/cluster_service.rb
+++ b/app/models/service_discovery/cluster_service.rb
@@ -37,7 +37,7 @@ module ServiceDiscovery
     end
 
     def specification_url
-      description_path.to_s.starts_with?('https') ? description_path : File.join(root, description_path.to_s.sub(/^\//, '').presence.to_s)
+      description_path.to_s.starts_with?('http') ? description_path : URI.join(root, description_path.to_s).to_s
     end
 
     def specification

--- a/app/models/service_discovery/cluster_service.rb
+++ b/app/models/service_discovery/cluster_service.rb
@@ -33,7 +33,7 @@ module ServiceDiscovery
     end
 
     def endpoint
-      File.join(root, path.to_s.sub(/^\//, '').presence)
+      URI.join(root, path.to_s).to_s
     end
 
     def specification_url

--- a/test/unit/service_discovery/cluster_service_test.rb
+++ b/test/unit/service_discovery/cluster_service_test.rb
@@ -104,11 +104,20 @@ module ServiceDiscovery
     end
 
     test 'specification url' do
-      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081/api/doc', @cluster_service.specification_url
-
       cluster_service_data = @cluster_service_data.deep_merge(metadata: { annotations: { :'discovery.3scale.net/description-path' => 'https://example.com/api-doc.json' } })
       cluster_service = ClusterService.new(cluster_service(cluster_service_data))
       assert_equal 'https://example.com/api-doc.json', cluster_service.specification_url
+
+      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081/api/doc', @cluster_service.specification_url
+
+      @cluster_service.stubs(description_path: '')
+      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081', @cluster_service.specification_url
+
+      @cluster_service.stubs(description_path: '/')
+      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081/', @cluster_service.specification_url
+
+      @cluster_service.stubs(description_path: nil)
+      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081', @cluster_service.specification_url
     end
 
     private

--- a/test/unit/service_discovery/cluster_service_test.rb
+++ b/test/unit/service_discovery/cluster_service_test.rb
@@ -88,6 +88,15 @@ module ServiceDiscovery
 
     test 'endpoint' do
       assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081/api', @cluster_service.endpoint
+
+      @cluster_service.stubs(path: '')
+      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081', @cluster_service.endpoint
+
+      @cluster_service.stubs(path: '/')
+      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081/', @cluster_service.endpoint
+
+      @cluster_service.stubs(path: nil)
+      assert_equal 'http://fake-api.fake-project.svc.cluster.local:8081', @cluster_service.endpoint
     end
 
     test 'description path' do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It's currently not possible to set the annotation `discovery.3scale.net/path` to empty string or "/".

**Which issue(s) this PR fixes** 

[THREESCALE-1587](https://issues.jboss.org/browse/THREESCALE-1587)

**Verification steps** 

- Set the `discovery.3scale.net/path` annotation of a service to "/" or empty string
- Import the service from OpenShift into 3scale
- system-sidekiq container should raise an error:
```
WARN: TypeError: no implicit conversion of nil into String
WARN: /opt/system/app/models/service_discovery/cluster_service.rb:36:in `join'
```

**Special notes for your reviewer**: