### PR TITLE
Add CHF and SAR to the list of currencies

### DIFF
--- a/app/models/finance/billing_strategy.rb
+++ b/app/models/finance/billing_strategy.rb
@@ -23,8 +23,10 @@ class Finance::BillingStrategy < ApplicationRecord
     'CNY - Chinese Yuan Renminbi' => 'CNY',
     'CAD - Canadian Dollar' => 'CAD',
     'AUD - Australian Dollar' => 'AUD',
-    'JPY - Japanese Yen' => 'JPY'
-  }
+    'JPY - Japanese Yen' => 'JPY',
+    'CHF - Swiss Franc' => 'CHF',
+    'SAR - Saudi Riyal' => 'SAR'
+  }.freeze
 
   belongs_to :account
   alias_attribute :provider, :account

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -586,9 +586,6 @@ World(Module.new do
     when 'the finance page', 'the invoices by months page'
       admin_finance_root_path
 
-    when "finance settings"
-      admin_finance_settings_path
-
     when /(the )?finance settings( page)?/
       admin_finance_settings_path
 

--- a/test/unit/finance/billing_strategy_test.rb
+++ b/test/unit/finance/billing_strategy_test.rb
@@ -146,6 +146,14 @@ class Finance::BillingStrategyTest < ActiveSupport::TestCase
     assert @bs.errors.has_key?(:currency)
   end
 
+  test 'allow CHF and SAR' do
+    @bs.currency = 'CHF'
+    assert @bs.valid?
+
+    @bs.currency = 'SAR'
+    assert @bs.valid?
+  end
+
   test 'default to highest number in month + 1' do
     create_two_invoices
 


### PR DESCRIPTION
Fixes [THREESCALE-1594](https://issues.jboss.org/browse/THREESCALE-1594)
Support `CHF` and `SAR` currencies.

### Verification steps
It is following exactly the same of this code:
https://github.com/3scale/porta/blob/1689b23e5d239bb9435029eb75e1dd6afe89315d/features/old/finance/settings/provider.feature#L22-L32

But explained and with screenshots:
1. Go to `provider-url/finance/settings` (if you are in development and have the seeds in the DB, go to `http://provider-admin.example.com.lvh.me:3000/finance/settings`).
2. See the 2 new currencies in the list
![image](https://user-images.githubusercontent.com/11318903/49089430-d6884280-f25b-11e8-9b1e-a947088ac676.png)
3. Select one of them and save it. You should see this flash message:
![image](https://user-images.githubusercontent.com/11318903/49089497-f9b2f200-f25b-11e8-9e73-594e06c12b2f.png)
4. Create an invoice for this provider and one of its buyers. I did it by console with: `Account.find(2).billing_strategy.create_invoice!(:buyer_account => Account.find(3), :finalized_at => Date.new(2018,11,30))`
5. Go to `provider-url/finance` (in my case `http://provider-admin.example.com.lvh.me:3000/finance`) and you will see the invoice is in the selected currency:
![image](https://user-images.githubusercontent.com/11318903/49089942-f79d6300-f25c-11e8-8741-85689aab48ad.png)
![image](https://user-images.githubusercontent.com/11318903/49089961-02f08e80-f25d-11e8-9cd2-5bbcc7ad6275.png)