### PR TITLE
Fix percy runs by scoping env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,6 +689,7 @@ workflows:
         - dependencies_bundler
         - dependencies_npm
     - visual:
+        context: percy
         requires:
         - assets_precompile
 


### PR DESCRIPTION
**What this PR does / why we need it**:

circleci contexts allow environment variables to only be used in jobs where they are needed.

**Which issue(s) this PR fixes** 

Adding the `PERCY_TOKEN` environment variable to the project settings in circleci causes some errors in other jobs (e.g. https://circleci.com/gh/3scale/porta/12361?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link ).

**Verification steps** 


**Special notes for your reviewer**:

More info on circleci contexts: https://circleci.com/docs/2.0/contexts/#section=projects