### PR TITLE
Fix UI API/Overview fetch stats usage

### DIFF
--- a/app/views/stats/_sparklines.html.erb
+++ b/app/views/stats/_sparklines.html.erb
@@ -1,6 +1,6 @@
 <div id="mini-charts">
   <% Array.wrap(metrics).each do |metric| %>
-    <div class="charts" id="chart-<%= metric.id %>" data-unit-pluralized="<%= metric.unit.pluralize %>" data-metric="<%= metric.name %>" data-source="<%= defined?(cinstance) ? usage_stats_data_applications_path(cinstance) : admin_service_stats_usage_path(metric.service_id) %>">
+    <div class="charts" id="chart-<%= metric.id %>" data-unit-pluralized="<%= metric.unit.pluralize %>" data-metric="<%= metric.name %>" data-source="<%= defined?(cinstance) ? usage_stats_data_applications_path(cinstance) : usage_stats_data_services_path(metric.service_id) %>">
       <% #TODO lenght 34 is the max that provider/dashboard and services/show charts allow w/o breaking %>
       <div title="<%= metric.friendly_name %>" class="metric-name"><%= metric.friendly_name %></div>
       <div class="spark"></div>


### PR DESCRIPTION
We aim to fix this:
![image](https://user-images.githubusercontent.com/11318903/49158567-cd15dd80-f322-11e8-804d-1672d0737504.png)

Bug introduced in https://github.com/3scale/porta/commit/b2db347c6f968442019cd91ceae0a879c0e74998#diff-4ceb896c14cace67f20a237b1e57be01L3