### PR TITLE
[WIP] Test for Hotfix UI API/Overview fetch stats usage

### DIFF
--- a/app/views/stats/_sparklines.html.erb
+++ b/app/views/stats/_sparklines.html.erb
@@ -1,6 +1,6 @@
 <div id="mini-charts">
   <% Array.wrap(metrics).each do |metric| %>
-    <div class="charts" id="chart-<%= metric.id %>" data-unit-pluralized="<%= metric.unit.pluralize %>" data-metric="<%= metric.name %>" data-source="<%= defined?(cinstance) ? usage_stats_data_applications_path(cinstance) : usage_stats_data_services_path(metric.service_id) %>">
+    <div class="charts" id="chart-<%= metric.id %>" data-unit-pluralized="<%= metric.unit.pluralize %>" data-metric="<%= metric.name %>" data-source="<%= defined?(cinstance) ? usage_stats_data_applications_path(cinstance) : admin_service_stats_usage_path(metric.service_id) %>">
       <% #TODO lenght 34 is the max that provider/dashboard and services/show charts allow w/o breaking %>
       <div title="<%= metric.friendly_name %>" class="metric-name"><%= metric.friendly_name %></div>
       <div class="spark"></div>

--- a/features/services/overview.feature
+++ b/features/services/overview.feature
@@ -1,0 +1,9 @@
+Feature: TODO
+
+  Background:
+    Given a provider is logged in
+
+  @selenium @javascript
+  Scenario: TODO
+    When I go to the API dashboard page
+    Then testing the analytics chart

--- a/features/step_definitions/stats/provider_charts.rb
+++ b/features/step_definitions/stats/provider_charts.rb
@@ -32,6 +32,26 @@ Then(/^there should be a c3 chart with the following data:$/) do |table|
   end
 end
 
+Then(/^testing the analytics chart$/) do
+  page.document.synchronize(Capybara.default_max_wait_time,
+                            errors: [Cucumber::Ast::Table::Different, Selenium::WebDriver::Error::JavascriptError]) do
+    values = page.evaluate_script <<-JS
+      (function(){
+        var $chart = $('#mini-charts > .charts')
+        var series = $chart.data().chart.data()
+        var values = series.map(function(s){
+          return {
+            name: s.id,
+            total: s.values.map(val => val.value).reduce((previous, current) => previous + current, 0)
+          }
+        })
+        return values
+      }());
+    JS
+    pp values
+  end
+end
+
 When(/^I select today from the stats menu$/) do
   page.should_not have_css('.StatsChart-container.is-loading')
   page.should have_css('.StatsMenu')


### PR DESCRIPTION
Add Cucumber feature for https://github.com/3scale/porta/pull/368

It is barely started now 😄 Michal gave me this to take as an example to be able to do it (or at least to get an idea of how to start):
https://github.com/3scale/porta/blob/27e408560463ebc4245538037ef08b5ed82f73c5/features/step_definitions/stats/provider_charts.rb#L1-L33

I am still figuring out how to do it 🤔 

This is the case that should fail:
![image](https://user-images.githubusercontent.com/11318903/49168944-f3467800-f338-11e8-82ba-1db20dc1db5a.png)

This is the case that should pass:
![image](https://user-images.githubusercontent.com/11318903/49168971-048f8480-f339-11e8-94be-ab44ab99cb64.png)
