### PR TITLE
[opensource] Apply Apache 2.0 with LICENSE and NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Red Hat, Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,15 @@
+   Red Hat 3scale API Management, Porta
+   Copyright (c) 2010-2016 3scale, Inc
+   Copyright (c) 2016-2018 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
As @unleashed said in https://github.com/3scale/porta/pull/372#issuecomment-443411060

> APPLYING THE LICENSE TO NEW SOFTWARE
> To apply the ALv2 to a new software distribution, include one copy of the license text by copying the file:
> 
> http://www.apache.org/licenses/LICENSE-2.0.txt
> 
> into a file called LICENSE in the top directory of your distribution. If the distribution is a jar or tar file, try to add the LICENSE file first in order to place it at the top of the archive. This covers the collective licensing for the distribution.
> 
> In addition, a correct NOTICE file MUST be included in the same directory as the LICENSE file.
> 
> Each original source document (code and documentation, but excluding the LICENSE and NOTICE files) SHOULD include a short license header at the top. If the distribution contains documents not covered by CLA, CCLA or Software Grant (such as third-party libraries) then see the policy guide.
> 
> UPDATING EXISTING SOFTWARE
> In brief, the aim is to achieve a final distribution as described above in applying the license to new software. Some conversion tools are listed here.