### PR TITLE
[opensource] Change component name in README: System -> Porta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 3scale "System" Component [![CircleCI](https://circleci.com/gh/3scale/porta.svg?style=svg)](https://circleci.com/gh/3scale/porta)[![Maintainability](https://api.codeclimate.com/v1/badges/1fe7e330e8507ea893be/maintainability)](https://codeclimate.com/github/3scale/porta/maintainability)[![codecov](https://codecov.io/gh/3scale/porta/branch/master/graph/badge.svg)](https://codecov.io/gh/3scale/porta)
+# 3scale "Porta" Component [![CircleCI](https://circleci.com/gh/3scale/porta.svg?style=svg)](https://circleci.com/gh/3scale/porta)[![Maintainability](https://api.codeclimate.com/v1/badges/1fe7e330e8507ea893be/maintainability)](https://codeclimate.com/github/3scale/porta/maintainability)[![codecov](https://codecov.io/gh/3scale/porta/branch/master/graph/badge.svg)](https://codecov.io/gh/3scale/porta)
 
-The 3scale `System` component is part of the 3Scale API Management solution and is responsible for serving the:
+The 3scale `Porta` component is part of the 3Scale API Management solution and is responsible for serving the:
 
 * Admin Portal for API Providers,
 * Account Management and Analytics APIs,


### PR DESCRIPTION
As the title says.
Since we call the component `Porta` everywhere now 😄 