### PR TITLE
[accounts#find] find account by provider key or service token

### DIFF
--- a/app/models/account/master_methods.rb
+++ b/app/models/account/master_methods.rb
@@ -11,6 +11,10 @@ module Account::MasterMethods
       includes(:bought_cinstances).references(:bought_cinstances).merge(Cinstance.by_user_key(provider_key))
     }
 
+    scope :by_service_token, lambda { |service_token|
+      includes(:service_tokens).where(service_tokens: { value: service_token })
+    }
+
     before_destroy :avoid_destroy_of_master_account
 
     def avoid_destroy_of_master_account
@@ -24,12 +28,16 @@ module Account::MasterMethods
   end
 
   module ClassMethods
+    def find_by_service_token!(service_token, error: ActiveRecord::RecordNotFound)
+      by_service_token(service_token).first || raise(error)
+    end
+
     def find_by_provider_key(provider_key)
       by_provider_key(provider_key).first
     end
 
-    def find_by_provider_key!(provider_key)
-      find_by_provider_key(provider_key) || raise(Backend::ProviderKeyInvalid)
+    def find_by_provider_key!(provider_key, error: Backend::ProviderKeyInvalid)
+      find_by_provider_key(provider_key) || raise(error)
     end
   end
 end

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -108,6 +108,7 @@ module Account::ProviderMethods
     end
 
     has_many :services, dependent: :destroy, extend: FindOrDefault
+    has_many :service_tokens, through: :services
     has_many :accessible_services, -> { accessible }, class_name: 'Service', extend: FindOrDefault
     has_many :accessible_proxies, through: :accessible_services, source: :proxy
     has_many :accessible_proxy_configs, through: :accessible_proxies, source: :proxy_configs


### PR DESCRIPTION
**What this PR does / why we need it**:

To be able to find an account by provider key or service token.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1562
