### PR TITLE
[Bugfix] Delete Services through Sidekiq workers

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -188,7 +188,7 @@ class Service < ApplicationRecord
     end
 
     event :mark_as_deleted do
-      transition [:incomplete, :published, :offline, :hidden] => :deleted, unless: :last_accessible?
+      transition [:incomplete, :published, :offline, :hidden] => :deleted, unless: :default_or_last?
     end
 
     before_transition to: [:deleted], do: :deleted_by_state_machine

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -93,6 +93,7 @@ class Service < ApplicationRecord
   has_many :service_tokens, inverse_of: :service, dependent: :destroy
 
   scope :accessible, -> { where.not(state: DELETE_STATE) }
+  scope :deleted, -> { where(state: DELETE_STATE) }
   scope :of_approved_accounts, -> { joins(:account).merge(Account.approved) }
   scope(:permitted_for_user, lambda do |user|
     # TODO: this is probably wrong...

--- a/app/workers/delete_plain_object_worker.rb
+++ b/app/workers/delete_plain_object_worker.rb
@@ -16,7 +16,7 @@ class DeletePlainObjectWorker < ActiveJob::Base
     end
   end
 
-  rescue_from(ActiveRecord::StaleObjectError) do |_exception|
+  rescue_from(ActiveRecord::StaleObjectError) do |exception|
     Rails.logger.info "DeletePlainObjectWorker#perform raised #{exception.class} with message #{exception.message} for the hierarchy #{caller_worker_hierarchy}"
     retry_job if object.class.exists?(object.id)
   end

--- a/app/workers/delete_plain_object_worker.rb
+++ b/app/workers/delete_plain_object_worker.rb
@@ -8,12 +8,17 @@ class DeletePlainObjectWorker < ActiveJob::Base
     Rails.logger.info "DeletePlainObjectWorker#perform raised #{exception.class} with message #{exception.message}"
   end
 
-  rescue_from(ActiveRecord::RecordNotDestroyed, ActiveRecord::StaleObjectError) do |exception|
-    record = exception.record
-    if record.class.exists?(record.id)
+  rescue_from(ActiveRecord::RecordNotDestroyed) do |exception|
+    if object.class.exists?(object.id)
+      # We don't want to indefinitely try again to delete an object that for any reason can not be destroyed, so we just log it instead
       System::ErrorReporting.report_error(exception, parameters: { caller_worker_hierarchy: caller_worker_hierarchy,
-                                                                   error_messages: record.errors.full_messages })
+                                                                   error_messages: exception.record.errors.full_messages })
     end
+  end
+
+  rescue_from(ActiveRecord::StaleObjectError) do |_exception|
+    Rails.logger.info "DeletePlainObjectWorker#perform raised #{exception.class} with message #{exception.message} for the hierarchy #{caller_worker_hierarchy}"
+    retry_job if object.class.exists?(object.id)
   end
 
   queue_as :default

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -1,6 +1,12 @@
+# frozen_string_literal: true
+
 namespace :services do
   desc 'Create test contract for each existing service'
   task :create_test_contracts => :environment do
     Service.all.each(&:create_test_contract)
+  end
+
+  task :destroy_marked_as_deleted => :environment do
+    Service.deleted.find_each(&DeleteObjectHierarchyWorker.method(:perform_later))
   end
 end

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Tasks::ServicesTest < ActiveSupport::TestCase
+  test 'destroy_marked_as_deleted' do
+    provider = FactoryGirl.create(:simple_provider)
+    services = FactoryGirl.create_list(:simple_service, 2, account: provider)
+    services.first.mark_as_deleted!
+
+    DeleteObjectHierarchyWorker.expects(:perform_later).once.with do |object, _hierarchy|
+      object.id == services.first.id
+    end
+
+    execute_rake_task 'services.rake', 'services:destroy_marked_as_deleted'
+  end
+end

--- a/test/workers/delete_plain_object_worker_test.rb
+++ b/test/workers/delete_plain_object_worker_test.rb
@@ -56,23 +56,53 @@ class DeletePlainObjectWorkerTest < ActiveSupport::TestCase
   end
 
   class StaleObjectErrorTest < DeletePlainObjectWorkerTest
-    def setup
-      @service = FactoryGirl.create(:simple_service)
-      FactoryGirl.create(:simple_service, account: @service.account) # This way the previous service can be destroyed
-      @proxy = FactoryGirl.create(:proxy, service: @service)
+    module LoadTargetWithFiber
+      # Overriding the `delete` method of HasOneAssociation https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/associations/has_one_association.rb#L53-L64
+      # When entering this method, override the `load_target` method so we can hand over the execution to the main thread
+      def delete
+        def load_target
+          super.tap { Fiber.yield }
+        end
+
+        super
+      end
     end
 
-    def test_perform_on_father_after_child_destroyed
-      service1 = @service
-      @service.proxy
+    def test_race_condition
+      service = FactoryGirl.create(:simple_service)
+      # There is a restriction on deleting service, at least one should remain
+      FactoryGirl.create(:simple_service, account: service.account)
 
-      proxy2 = Proxy.find(@proxy.id)
+      proxy = Proxy.find service.proxy.id
+      service = Service.find service.id
 
-      DeletePlainObjectWorker.perform_now(proxy2, %w[Hierarchy-Service-ID Hierarchy-Proxy-ID])
-      DeletePlainObjectWorker.perform_now(service1, ['Hierarchy-Service-ID'])
+      # Make sure that there is no more than one because it is a `has_one` association
+      assert_equal 1, Proxy.where(service_id: service.id).count
 
-      assert_raise(ActiveRecord::RecordNotFound) { @proxy.reload }
-      assert_raise(ActiveRecord::RecordNotFound) { @service.reload }
+      proxy_association = service.association :proxy
+
+      # Hook into the Eigenclass
+      class << proxy_association
+        prepend LoadTargetWithFiber
+      end
+
+      # Execute deletion of service but suspend the execution of deleting the proxy by `:dependent => :destroy`
+      f1 = Fiber.new do
+        DeletePlainObjectWorker.perform_now(service, ['Hierarchy-Service-ID'])
+      end
+
+      # Destroy the proxy in another thread
+      f2 = Fiber.new do
+        DeletePlainObjectWorker.perform_now(proxy, ['Hierarchy-Service-ID', 'Hierarchy-Proxy-ID'])
+      end
+
+      f1.resume
+      f2.resume
+      f1.resume
+
+      assert_raise(ActiveRecord::RecordNotFound) { proxy.reload }
+      assert_raise(ActiveRecord::RecordNotFound) { service.reload }
     end
+
   end
 end


### PR DESCRIPTION
Fixes [THREESCALE-1194 - Services marked as "deleted", but not actually getting deleted](https://issues.jboss.org/browse/THREESCALE-1194)

This is the log of one of times that happened: https://gist.github.com/guicassolato/5e8a4c39b95909ca4b91775ea2b19136
We also have this issue in bugsnag from production (SaaS), one example would be:
![image](https://user-images.githubusercontent.com/11318903/49519857-458c1980-f8a2-11e8-8dcb-7bc98d251c4d.png)
![image](https://user-images.githubusercontent.com/11318903/49519874-50df4500-f8a2-11e8-8f73-db8e3a5a693c.png)


The simplest way to reproduce it, without involving Sidekiq workers, is, as Hery discovered:
```
# console 1
service = Service.find id
service.proxy
------
# console 2
proxy = Proxy.find id
proxy.destroy
-----
# console 1
service.destroy!
```

The test of this PR reproduces it with the workers.

### Specific tasks
- [X] The first commit reproduces the error in a test a fixes it. Since the issue is the service tries to destroy its proxy, which is already destroyed, what it does is reload the service and retry, which works this time. It is also good to bear in mind that the object that the worker tries to destroy (in this case the service) is not the same as the object of exception.record (in this case the proxy).
- [X] The second commit makes the condition to mark a service as deleted to be the same as the condition to actually destroy it.
- [X] The third commit adds a rake task to remove all the current services that are marked as deleted, as explained in https://issues.jboss.org/browse/THREESCALE-1194?focusedCommentId=13664313&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13664313