### PR TITLE
[db] Allow up to 2MB for proxy_configs content

### DIFF
--- a/app/models/proxy_config.rb
+++ b/app/models/proxy_config.rb
@@ -9,6 +9,9 @@ class ProxyConfig < ApplicationRecord
   VALID_ENVIRONMENTS = Hash.new { |_,env| ENVIRONMENT_CHECK.call(env) }
                            .merge('staging' => 'sandbox').freeze
 
+  # Do not set it too high though the column accept until 16.megabytes
+  MAX_CONTENT_LENGTH = 2.megabytes
+
   belongs_to :proxy, required: true
   belongs_to :user, required: false
 
@@ -21,6 +24,7 @@ class ProxyConfig < ApplicationRecord
   validates :content, :version, :environment, presence: true
   validates :environment, inclusion: { in: ENVIRONMENTS }
   validate :service_token_exists
+  validates :content, length: { maximum: MAX_CONTENT_LENGTH }
 
   after_create :update_version
   before_create :denormalize_hosts

--- a/db/migrate/20181205131457_extend_proxy_content_size.rb
+++ b/db/migrate/20181205131457_extend_proxy_content_size.rb
@@ -1,0 +1,6 @@
+class ExtendProxyContentSize < ActiveRecord::Migration
+  def change
+    # Oracle does not need this as it is already a CLOB
+    change_column :proxy_configs, :content, :mediumtext unless System::Database.oracle?
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1051,14 +1051,14 @@ ActiveRecord::Schema.define(version: 20181210222627) do
   add_index "proxies", ["service_id"], name: "index_proxies_on_service_id", using: :btree
 
   create_table "proxy_configs", force: :cascade do |t|
-    t.integer  "proxy_id",    limit: 8,                 null: false
+    t.integer  "proxy_id",    limit: 8,                    null: false
     t.integer  "user_id",     limit: 8
-    t.integer  "version",     limit: 4,     default: 0, null: false
+    t.integer  "version",     limit: 4,        default: 0, null: false
     t.integer  "tenant_id",   limit: 8
-    t.string   "environment", limit: 255,               null: false
-    t.text     "content",     limit: 65535,             null: false
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
+    t.string   "environment", limit: 255,                  null: false
+    t.text     "content",     limit: 16777215,             null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
     t.string   "hosts",       limit: 8192
   end
 

--- a/test/unit/proxy_config_test.rb
+++ b/test/unit/proxy_config_test.rb
@@ -98,6 +98,18 @@ class ProxyConfigTest < ActiveSupport::TestCase
     assert_contains proxy_config.errors[:service_token], proxy_config.errors.generate_message(:service_token, :missing)
   end
 
+  def test_maximum_length
+    proxy_config = FactoryGirl.build(:proxy_config)
+    content = proxy_config.content
+    json = JSON.parse(content).deep_symbolize_keys
+    json.merge!(foo: 'a' * 2.megabytes)
+    content = json.to_json
+    proxy_config.content = content
+
+    refute proxy_config.valid?
+    assert_contains proxy_config.errors[:content], proxy_config.errors.generate_message(:content, :too_long, count: ProxyConfig::MAX_CONTENT_LENGTH)
+  end
+
   private
 
   def json_content(hosts: [])


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/THREESCALE-1549

When there are too many objects in the proxy, the configuration cannot be saved

TODO in another PR

- [ ] ~Integration test to show an actual error~
- [ ] ~API Spec test to show an actual error~

Databases constraints:

- MySQL database has `MEDIUMTEXT` type (16M chars)
- Oracle database, we set all text as CLOB so virtually no limit
- PostgreSQL database, only has TEXT (virtually unlimited)

Application constraints:

The JSON that the application builds cannot superior than 2 megabytes. If there are too many objects and the generated content is superior than 2 megabytes then the `ProxyConfig` will not be saved.


