### PR TITLE
Improve Rails log error message adding more info

### DIFF
--- a/lib/system/error_reporting.rb
+++ b/lib/system/error_reporting.rb
@@ -14,7 +14,7 @@ module System
     def report_error(exception, rack_env: nil, logger: Rails.logger, **parameters)
       options = OPTIONS.call(parameters, rack_env)
 
-      logger.error('Exception') { exception }
+      logger.error('Exception') { {exception: {class: exception.class, message: exception.message, backtrace: (exception.backtrace || [])[0..3]}, parameters: parameters} }
 
       ::Airbrake.notify_or_ignore(exception, options) if defined?(Airbrake)
       ::Bugsnag.notify(exception) do |report|


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds more info to the log of an error through Rails logger. Few days ago I received this logs from an error: https://gist.github.com/guicassolato/5e8a4c39b95909ca4b91775ea2b19136
It was not in production so I didn't have the information that we have in bugsnag and I really missed it. So this PR makes some useful information to be shown here as well.

**Verification steps** 

There are many ways, but for example:
1. Open Rails Console in test environment to have FactoryGirl available. With `RAILS_ENV=test bundle exec rails console`.
2. Create a service with only basic stuff through `service = FactoryGirl.create(:simple_service)`. It also creates a new provider with very simple data and this is its only service.
3. Do this: `DeletePlainObjectWorker.perform_now(service, ["JustATest-Service-#{service.id}"])`. It will try to remove the service but it won't be possible because it is the last one and will raise and catch an error of type `ActiveRecord::RecordNotDestroyed`, which will be logged.
With this PR, it will show something like this:
![image](https://user-images.githubusercontent.com/11318903/49637428-9ff1bb00-fa05-11e8-894b-0244a0b05692.png)
However, before this PR, the message that shows looks like this:
![image](https://user-images.githubusercontent.com/11318903/49637469-c31c6a80-fa05-11e8-9cd7-6bfe02d8bd4d.png)

