### PR TITLE
[Bugfix] Report error tries "message" and "backtrace"

### DIFF
--- a/lib/system/error_reporting.rb
+++ b/lib/system/error_reporting.rb
@@ -14,7 +14,7 @@ module System
     def report_error(exception, rack_env: nil, logger: Rails.logger, **parameters)
       options = OPTIONS.call(parameters, rack_env)
 
-      logger.error('Exception') { {exception: {class: exception.class, message: exception.message, backtrace: (exception.backtrace || [])[0..3]}, parameters: parameters} }
+      logger.error('Exception') { {exception: {class: exception.class, message: (exception.try(:message) || exception.to_s), backtrace: (exception.try(:backtrace) || [])[0..3]}, parameters: parameters} }
 
       ::Airbrake.notify_or_ignore(exception, options) if defined?(Airbrake)
       ::Bugsnag.notify(exception) do |report|


### PR DESCRIPTION
Reporting error when the `Exception` it receives does not respond to `message` or `backtrace`.
It fixes these bugs: https://circleci.com/gh/3scale/porta/14609 and https://circleci.com/gh/3scale/porta/14612#tests/containers/2