### PR TITLE
Use absolute paths when importing in JSX files

### DIFF
--- a/app/javascript/packs/applications.js
+++ b/app/javascript/packs/applications.js
@@ -1,4 +1,4 @@
-import { initialize as planSelector } from '../src/Applications/plan_selector'
+import { initialize as planSelector } from 'Applications/plan_selector'
 
 document.addEventListener('DOMContentLoaded', () => {
   planSelector()

--- a/app/javascript/packs/bubbles.js
+++ b/app/javascript/packs/bubbles.js
@@ -1,5 +1,5 @@
-import { show as showBubble } from '../src/Onboarding/Bubble'
-import { Bubble } from '../src/Onboarding/Bubble'
+import { show as showBubble } from 'Onboarding/Bubble'
+import { Bubble } from 'Onboarding/Bubble'
 
 document.addEventListener('DOMContentLoaded', () => {
   window.Bubble = Bubble

--- a/app/javascript/packs/dashboard.js
+++ b/app/javascript/packs/dashboard.js
@@ -1,7 +1,7 @@
-import { widget as dashboardWidget } from '../src/Dashboard/index'
-import { initialize as toggleWidget } from '../src/Dashboard/toggle'
-import { render as renderChartWidget } from '../src/Dashboard/chart'
-import { ApiFilterWrapper } from '../src/Dashboard/components/ApiFilter'
+import { widget as dashboardWidget } from 'Dashboard/index'
+import { initialize as toggleWidget } from 'Dashboard/toggle'
+import { render as renderChartWidget } from 'Dashboard/chart'
+import { ApiFilterWrapper } from 'Dashboard/components/ApiFilter'
 
 document.addEventListener('DOMContentLoaded', () => {
   window.dashboardWidget = dashboardWidget

--- a/app/javascript/packs/navigation.js
+++ b/app/javascript/packs/navigation.js
@@ -1,5 +1,5 @@
-import { toggleNavigation, hideAllToggleable } from '../src/Navigation/utils/toggle_navigation'
-import { ContextSelectorWrapper } from '../src/Navigation/components/ContextSelector'
+import { toggleNavigation, hideAllToggleable } from 'Navigation/utils/toggle_navigation'
+import { ContextSelectorWrapper } from 'Navigation/components/ContextSelector'
 
 document.addEventListener('DOMContentLoaded', () => {
   window.toggleNavigation = toggleNavigation

--- a/app/javascript/packs/permissions.js
+++ b/app/javascript/packs/permissions.js
@@ -1,4 +1,4 @@
-import { render as renderPermissionsWidget } from '../src/Users/permissions'
+import { render as renderPermissionsWidget } from 'Users/permissions'
 
 document.addEventListener('DOMContentLoaded', () => {
   window.renderPermissionsWidget = renderPermissionsWidget

--- a/app/javascript/packs/policies.js
+++ b/app/javascript/packs/policies.js
@@ -1,4 +1,4 @@
-import initPolicies from '../src/Policies/index'
+import initPolicies from 'Policies/index'
 
 document.addEventListener('DOMContentLoaded', () => {
   window.initPolicies = initPolicies

--- a/app/javascript/packs/providerStats.js
+++ b/app/javascript/packs/providerStats.js
@@ -1,9 +1,9 @@
-import { statsUsage } from '../src/Stats/provider/stats_usage'
-import { statsDaysOfWeek } from '../src/Stats/provider/stats_days_of_week'
-import { statsHoursOfDay } from '../src/Stats/provider/stats_hours_of_day'
-import { statsTopApps } from '../src/Stats/provider/stats_top_apps'
-import { statsApplication } from '../src/Stats/provider/stats_application'
-import { statsResponseCodes } from '../src/Stats/provider/stats_response_codes'
+import { statsUsage } from 'Stats/provider/stats_usage'
+import { statsDaysOfWeek } from 'Stats/provider/stats_days_of_week'
+import { statsHoursOfDay } from 'Stats/provider/stats_hours_of_day'
+import { statsTopApps } from 'Stats/provider/stats_top_apps'
+import { statsApplication } from 'Stats/provider/stats_application'
+import { statsResponseCodes } from 'Stats/provider/stats_response_codes'
 import $ from 'jquery'
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/javascript/packs/services.js
+++ b/app/javascript/packs/services.js
@@ -1,4 +1,4 @@
-import { initialize as serviceInitialize } from '../src/services/index'
+import { initialize as serviceInitialize } from 'services/index'
 
 document.addEventListener('DOMContentLoaded', () => {
   window.serviceInitialize = serviceInitialize

--- a/app/javascript/packs/stats.js
+++ b/app/javascript/packs/stats.js
@@ -1,4 +1,4 @@
-import { statsApplication } from '../src/Stats/buyer'
+import { statsApplication } from 'Stats/buyer'
 import $ from 'jquery'
 
 window.$ = $

--- a/app/javascript/src/Dashboard/components/ApiFilter.jsx
+++ b/app/javascript/src/Dashboard/components/ApiFilter.jsx
@@ -8,7 +8,7 @@ import 'core-js/es6/array'
 import React from 'react'
 import { render } from 'react-dom'
 
-import '../styles/dashboard.scss'
+import 'Dashboard/styles/dashboard.scss'
 
 const ApiFilter = ({ apis, displayApis }) => {
   const onInputChange = event => {

--- a/app/javascript/src/Dashboard/index.jsx
+++ b/app/javascript/src/Dashboard/index.jsx
@@ -1,7 +1,7 @@
 import $ from 'jquery'
 
-import './chart'
-import toggle from './toggle'
+import 'Dashboard/chart'
+import toggle from 'Dashboard/toggle'
 
 export { toggle }
 

--- a/app/javascript/src/Dashboard/toggle.jsx
+++ b/app/javascript/src/Dashboard/toggle.jsx
@@ -1,5 +1,5 @@
-import toggle from '../utilities/toggle'
-import migrate from '../services/migrate'
+import toggle from 'utilities/toggle'
+import migrate from 'services/migrate'
 
 export function initialize () {
   migrate()

--- a/app/javascript/src/Navigation/components/ActiveMenuTitle.jsx
+++ b/app/javascript/src/Navigation/components/ActiveMenuTitle.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import 'core-js/es6/map'
 import 'core-js/es6/set'
 
-import '../styles/ActiveMenuTitle.scss'
+import 'Navigation/styles/ActiveMenuTitle.scss'
 
 const ActiveMenuTitle = ({ activeMenu, currentApi }) => {
   const getIconAndText = () => {

--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -6,9 +6,9 @@ import 'core-js/es6/set'
 import 'core-js/es6/array'
 import React from 'react'
 import { render } from 'react-dom'
-import { ActiveMenuTitle } from './ActiveMenuTitle'
+import { ActiveMenuTitle } from 'Navigation/components/ActiveMenuTitle'
 
-import '../styles/ContextSelector.scss'
+import 'Navigation/styles/ContextSelector.scss'
 
 const DASHBOARD_PATH = '/p/admin/dashboard'
 

--- a/app/javascript/src/Policies/actions/PolicyChain.jsx
+++ b/app/javascript/src/Policies/actions/PolicyChain.jsx
@@ -2,8 +2,8 @@
 
 import { RSAA } from 'redux-api-middleware'
 
-import type { RSSAAction } from '../types/index'
-import type { RegistryPolicy, ChainPolicy, StoredChainPolicy } from '../types/Policies'
+import type { RSSAAction } from 'Policies/types/index'
+import type { RegistryPolicy, ChainPolicy, StoredChainPolicy } from 'Policies/types/Policies'
 
 export type AddPolicyToChainAction = { type: 'ADD_POLICY_TO_CHAIN', policy: RegistryPolicy }
 export function addPolicyToChain (policy: RegistryPolicy): AddPolicyToChainAction {

--- a/app/javascript/src/Policies/actions/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/actions/PolicyConfig.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type { ChainPolicy } from '../types/Policies'
+import type { ChainPolicy } from 'types/Policies'
 
 export type UpdatePolicyConfigAction = { type: 'UPDATE_POLICY_CONFIG', policyConfig: ChainPolicy }
 export function updatePolicyConfig (policyConfig: ChainPolicy): UpdatePolicyConfigAction {

--- a/app/javascript/src/Policies/actions/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/actions/PolicyRegistry.jsx
@@ -1,8 +1,8 @@
 // @flow
 
 import { RSAA } from 'redux-api-middleware'
-import type { RSSAAction } from '../types/index'
-import type { RawRegistry } from '../types/Policies'
+import type { RSSAAction } from 'types/index'
+import type { RawRegistry } from 'types/Policies'
 
 export type FetchRegistrySuccessAction = { type: 'FETCH_REGISTRY_SUCCESS', payload: RawRegistry, meta: ?{} }
 export type FetchRegistryErrorAction = { type: 'FETCH_REGISTRY_ERROR', payload: Object, error: boolean, meta: ?{} }

--- a/app/javascript/src/Policies/actions/index.jsx
+++ b/app/javascript/src/Policies/actions/index.jsx
@@ -1,16 +1,16 @@
 // @flow
 
-import type { Dispatch, ThunkAction } from '../types/index'
+import type { Dispatch, ThunkAction } from 'types/index'
 import type {
   RawRegistry,
   RegistryPolicy,
   ChainPolicy,
   StoredChainPolicy
-} from '../types/Policies'
-import type { UIComponent } from '../actions/UISettings'
+} from 'types/Policies'
+import type { UIComponent } from 'Policies/actions/UISettings'
 
-import { uiComponentTransition } from '../actions/UISettings'
-import { fetchRegistry, loadRegistrySuccess } from '../actions/PolicyRegistry'
+import { uiComponentTransition } from 'Policies/actions/UISettings'
+import { fetchRegistry, loadRegistrySuccess } from 'Policies/actions/PolicyRegistry'
 
 import {
   addPolicyToChain,
@@ -19,9 +19,9 @@ import {
   updatePolicyInChain,
   fetchChain,
   loadChain
-} from '../actions/PolicyChain'
+} from 'Policies/actions/PolicyChain'
 
-import { updatePolicyConfig } from '../actions/PolicyConfig'
+import { updatePolicyConfig } from 'Policies/actions/PolicyConfig'
 
 const chainComponent: UIComponent = 'chain'
 const registryComponent: UIComponent = 'registry'

--- a/app/javascript/src/Policies/components/App.jsx
+++ b/app/javascript/src/Policies/components/App.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-named-as-default */
 import React from 'react'
-import PoliciesWidget from './PoliciesWidget'
+import PoliciesWidget from 'Policies/components/PoliciesWidget'
 
 // This is a class-based component because the current
 // version of hot reloading won't hot reload a stateless

--- a/app/javascript/src/Policies/components/PoliciesWidget.jsx
+++ b/app/javascript/src/Policies/components/PoliciesWidget.jsx
@@ -2,20 +2,20 @@
 
 import React from 'react'
 import { bindActionCreators } from 'redux'
-import * as actions from '../actions/index'
-import { PolicyConfig } from './PolicyConfig'
-import { PolicyChain } from './PolicyChain'
-import { PolicyRegistry } from './PolicyRegistry'
-import { PolicyChainHiddenInput } from './PolicyChainHiddenInput'
+import * as actions from 'Policies/actions/index'
+import { PolicyConfig } from 'Policies/components/PolicyConfig'
+import { PolicyChain } from 'Policies/components/PolicyChain'
+import { PolicyRegistry } from 'Policies/components/PolicyRegistry'
+import { PolicyChainHiddenInput } from 'Policies/components/PolicyChainHiddenInput'
 import { connect } from 'react-redux'
 
 import type {
   State
-} from '../types/State'
+} from 'Policies/types/State'
 
 import type {
   Dispatch
-} from '../types/index'
+} from 'Policies/types/index'
 
 const mapStateToProps = (state: State) => {
   return {

--- a/app/javascript/src/Policies/components/PolicyChain.jsx
+++ b/app/javascript/src/Policies/components/PolicyChain.jsx
@@ -8,9 +8,9 @@ import {
   arrayMove
 } from 'react-sortable-hoc'
 
-import type { ThunkAction } from '../types/index'
-import type { ChainPolicy } from '../types/Policies'
-import type { SortPolicyChainAction } from '../actions/PolicyChain'
+import type { ThunkAction } from 'Policies/types/index'
+import type { ChainPolicy } from 'Policies/types/Policies'
+import type { SortPolicyChainAction } from 'Policies/actions/PolicyChain'
 
 type Props = {
   visible: boolean,

--- a/app/javascript/src/Policies/components/PolicyChainHiddenInput.jsx
+++ b/app/javascript/src/Policies/components/PolicyChainHiddenInput.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import type { ChainPolicy } from '../types/Policies'
+import type { ChainPolicy } from 'Policies/types/Policies'
 
 const filteredPolicyKeys = ['configuration', 'name', 'version', 'enabled']
 

--- a/app/javascript/src/Policies/components/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/components/PolicyConfig.jsx
@@ -3,11 +3,11 @@
 import React from 'react'
 import Form from 'react-jsonschema-form'
 
-import type { ThunkAction } from '../types/index'
-import type { ChainPolicy } from '../types/Policies'
-import type { UpdatePolicyConfigAction } from '../actions/PolicyConfig'
+import type { ThunkAction } from 'Policies/types/index'
+import type { ChainPolicy } from 'Policies/types/Policies'
+import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
 
-import { isNotApicastPolicy } from './util'
+import { isNotApicastPolicy } from 'Policies/components/util'
 
 type Props = {
   visible: boolean,

--- a/app/javascript/src/Policies/components/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/components/PolicyRegistry.jsx
@@ -2,9 +2,9 @@
 
 import React from 'react'
 
-import type { RegistryPolicy } from '../types/Policies'
-import type { ThunkAction } from '../types/index'
-import { isNotApicastPolicy } from './util'
+import type { RegistryPolicy } from 'Policies/types/Policies'
+import type { ThunkAction } from 'Policies/types/index'
+import { isNotApicastPolicy } from 'Policies/components/util'
 
 type Props = {
   visible: boolean,

--- a/app/javascript/src/Policies/components/Root.jsx
+++ b/app/javascript/src/Policies/components/Root.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import { Provider } from 'react-redux'
 
-import App from './App'
+import App from 'Policies/components/App'
 
 export default function Root (props) {
   const { store } = props

--- a/app/javascript/src/Policies/components/util.jsx
+++ b/app/javascript/src/Policies/components/util.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type { RegistryPolicy, ChainPolicy } from '../types/Policies'
+import type { RegistryPolicy, ChainPolicy } from 'Policies/types/Policies'
 type Policy = RegistryPolicy | ChainPolicy
 
 function isNotApicastPolicy (policy: Policy): boolean {

--- a/app/javascript/src/Policies/index.jsx
+++ b/app/javascript/src/Policies/index.jsx
@@ -7,12 +7,12 @@ import 'core-js/es7/object'
 import React from 'react'
 import { render } from 'react-dom'
 import { AppContainer } from 'react-hot-loader'
-import Root from './components/Root'
-import configureStore from './store/configureStore'
-import { initialState } from './reducers/initialState'
-import * as actions from './actions/index'
+import Root from 'Policies/components/Root'
+import configureStore from 'Policies/store/configureStore'
+import { initialState } from 'Policies/reducers/initialState'
+import * as actions from 'Policies/actions/index'
 
-import './styles/policies.scss'
+import 'Policies/styles/policies.scss'
 
 const Policies = (store, element) => {
   render(

--- a/app/javascript/src/Policies/middleware/PolicyChain.jsx
+++ b/app/javascript/src/Policies/middleware/PolicyChain.jsx
@@ -1,10 +1,10 @@
 // @flow
 
-import type { RegistryPolicy, ChainPolicy, StoredChainPolicy } from '../types/Policies'
-import type { Dispatch, GetState, PolicyChainMiddlewareAction } from '../types/index'
+import type { RegistryPolicy, ChainPolicy, StoredChainPolicy } from 'Policies/types/Policies'
+import type { Dispatch, GetState, PolicyChainMiddlewareAction } from 'Policies/types/index'
 
-import { generateGuid } from '../reducers/util'
-import { loadChainSuccess, loadChainError, updatePolicyChain } from '../actions/PolicyChain'
+import { generateGuid } from 'Policies/reducers/util'
+import { loadChainSuccess, loadChainError, updatePolicyChain } from 'Policies/actions/PolicyChain'
 
 function findRegistryPolicy (registry: Array<RegistryPolicy>, storedPolicy: StoredChainPolicy): RegistryPolicy | typeof undefined {
   return registry.find(policy => (policy.name === storedPolicy.name && policy.version === storedPolicy.version))

--- a/app/javascript/src/Policies/reducers/PolicyChain.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyChain.jsx
@@ -1,15 +1,15 @@
 // @flow
 
-import { initialState } from './initialState'
-import { createReducer, generateGuid, updateArray } from './util'
-import type { ChainState } from '../types/State'
-import type { ChainPolicy, RegistryPolicy } from '../types/Policies'
+import { initialState } from 'Policies/reducers/initialState'
+import { createReducer, generateGuid, updateArray } from 'Policies/reducers/util'
+import type { ChainState } from 'Policies/types/State'
+import type { ChainPolicy, RegistryPolicy } from 'Policies/types/Policies'
 import type {
   AddPolicyToChainAction,
   FetchChainSuccessAction,
   SortPolicyChainAction,
   UpdatePolicyChainAction
-} from '../actions/PolicyChain'
+} from 'Policies/actions/PolicyChain'
 
 type UpdateChainPolicies = FetchChainSuccessAction | SortPolicyChainAction
 

--- a/app/javascript/src/Policies/reducers/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyConfig.jsx
@@ -1,10 +1,10 @@
 // @flow
 
-import type { ChainPolicy } from '../types/Policies'
-import type { UpdatePolicyConfigAction } from '../actions/PolicyConfig'
+import type { ChainPolicy } from 'Policies/types/Policies'
+import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
 
-import { initialState } from './initialState'
-import { updateObject, createReducer } from './util'
+import { initialState } from 'Policies/reducers/initialState'
+import { updateObject, createReducer } from 'Policies/reducers/util'
 
 function updatePolicyConfig (state: ChainPolicy, action: UpdatePolicyConfigAction): ChainPolicy {
   return updateObject(state, action.policyConfig)

--- a/app/javascript/src/Policies/reducers/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyRegistry.jsx
@@ -1,11 +1,11 @@
 // @flow
 
-import { initialState } from './initialState'
-import { createReducer, updateArray } from './util'
+import { initialState } from 'Policies/reducers/initialState'
+import { createReducer, updateArray } from 'Policies/reducers/util'
 
-import type { RegistryState } from '../types/State'
-import type { RawPolicy, RawRegistry, RegistryPolicy } from '../types/Policies'
-import type { FetchRegistrySuccessAction } from '../actions/PolicyRegistry'
+import type { RegistryState } from 'Policies/types/State'
+import type { RawPolicy, RawRegistry, RegistryPolicy } from 'Policies/types/Policies'
+import type { FetchRegistrySuccessAction } from 'Policies/actions/PolicyRegistry'
 
 function parsePolicies (registry: RawRegistry): Array<RegistryPolicy> {
   let policies: Array<RegistryPolicy> = []

--- a/app/javascript/src/Policies/reducers/UISettings.jsx
+++ b/app/javascript/src/Policies/reducers/UISettings.jsx
@@ -1,10 +1,10 @@
 // @flow
 
-import { initialState } from './initialState'
-import { createReducer, updateError, updateObject } from './util'
+import { initialState } from 'Policies/reducers/initialState'
+import { createReducer, updateError, updateObject } from 'Policies/reducers/util'
 
-import type { State } from '../types/State'
-import type { UIComponentTransitionAction } from '../actions/UISettings'
+import type { State } from 'Policies/types/State'
+import type { UIComponentTransitionAction } from 'Policies/actions/UISettings'
 
 function updateComponentTransition (state: State, action: UIComponentTransitionAction): State {
   return updateObject(state, {[action.hide]: false, [action.show]: true})

--- a/app/javascript/src/Policies/reducers/index.jsx
+++ b/app/javascript/src/Policies/reducers/index.jsx
@@ -2,10 +2,10 @@
 
 import { combineReducers } from 'redux'
 
-import UISettingsReducer from './UISettings'
-import RegistryReducer from './PolicyRegistry'
-import PolicyConfigReducer from './PolicyConfig'
-import ChainReducer from './PolicyChain'
+import UISettingsReducer from 'Policies/reducers/UISettings'
+import RegistryReducer from 'Policies/reducers/PolicyRegistry'
+import PolicyConfigReducer from 'Policies/reducers/PolicyConfig'
+import ChainReducer from 'Policies/reducers/PolicyChain'
 
 const rootReducer = combineReducers({
   chain: ChainReducer,

--- a/app/javascript/src/Policies/reducers/initialState.jsx
+++ b/app/javascript/src/Policies/reducers/initialState.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type {State} from '../types/State'
+import type {State} from 'Policies/types/State'
 
 export const initialState: State = {
   registry: [],

--- a/app/javascript/src/Policies/reducers/util.jsx
+++ b/app/javascript/src/Policies/reducers/util.jsx
@@ -1,7 +1,7 @@
 // @flow
 
-import type { State, StateSlice, UIState } from '../types/State'
-import type { Action, FetchErrorAction } from '../types/index'
+import type { State, StateSlice, UIState } from 'Policies/types/State'
+import type { Action, FetchErrorAction } from 'Policies/types/index'
 
 function updateObject (oldObject: Object, newValues: Object): Object {
   return {...oldObject, ...newValues}

--- a/app/javascript/src/Policies/store/configureStore.jsx
+++ b/app/javascript/src/Policies/store/configureStore.jsx
@@ -5,8 +5,8 @@ import { apiMiddleware } from 'redux-api-middleware'
 import createHistory from 'history/createBrowserHistory'
 // 'routerMiddleware': the new way of storing route changes with redux middleware since rrV4.
 import { routerMiddleware } from 'react-router-redux'
-import { policyChainMiddleware } from '../middleware/PolicyChain'
-import rootReducer from '../reducers'
+import { policyChainMiddleware } from 'Policies/middleware/PolicyChain'
+import rootReducer from 'Policies/reducers'
 export const history = createHistory()
 function configureStoreProd (initialState) {
   const reactRouterMiddleware = routerMiddleware(history)

--- a/app/javascript/src/Policies/types/State.jsx
+++ b/app/javascript/src/Policies/types/State.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type { RegistryPolicy, ChainPolicy } from './Policies'
+import type { RegistryPolicy, ChainPolicy } from 'Policies/types/Policies'
 
 export type UIState = {
   +registry: boolean,

--- a/app/javascript/src/Policies/types/index.jsx
+++ b/app/javascript/src/Policies/types/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type { State } from './State'
+import type { State } from 'Policies/types/State'
 import type {
   AddPolicyToChainAction,
   RemovePolicyFromChainAction,
@@ -11,14 +11,14 @@ import type {
   LoadChainSuccessAction,
   LoadChainErrorAction,
   UpdatePolicyChainAction
-} from '../actions/PolicyChain'
-import type { UIComponentTransitionAction } from '../actions/UISettings'
+} from 'Policies/actions/PolicyChain'
+import type { UIComponentTransitionAction } from 'Policies/actions/UISettings'
 import type {
   FetchRegistrySuccessAction,
   FetchRegistryErrorAction,
   LoadRegistrySuccessAction
-} from '../actions/PolicyRegistry'
-import type { UpdatePolicyConfigAction } from '../actions/PolicyConfig'
+} from 'Policies/actions/PolicyRegistry'
+import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
 
 type PolicyChainAction = AddPolicyToChainAction | SortPolicyChainAction
   | LoadChainSuccessAction | LoadChainErrorAction | UpdatePolicyChainAction

--- a/app/javascript/src/Stats/buyer/index.jsx
+++ b/app/javascript/src/Stats/buyer/index.jsx
@@ -1,3 +1,3 @@
-import { statsApplication } from './stats_application'
+import { statsApplication } from 'Stats/buyer/stats_application'
 
 export { statsApplication }

--- a/app/javascript/src/Stats/buyer/stats_application.jsx
+++ b/app/javascript/src/Stats/buyer/stats_application.jsx
@@ -1,12 +1,12 @@
 /** @jsx StatsUI.dom */
-import {StatsUsageChart} from '../lib/usage_chart'
-import {StatsUsageChartManager} from '../lib/usage_chart_manager'
-import {StatsMetrics} from '../lib/metrics_list'
-import {StatsSourceCollector} from '../lib/source_collector'
-import {StatsMethodsTable} from '../lib/methods_table'
-import {StatsApplicationMetricsSource} from '../lib/application_metrics_source'
-import {StatsCSVLink} from '../lib/csv_link'
-import {Stats} from '../lib/stats'
+import {StatsUsageChart} from 'Stats/lib/usage_chart'
+import {StatsUsageChartManager} from 'Stats/lib/usage_chart_manager'
+import {StatsMetrics} from 'Stats/lib/metrics_list'
+import {StatsSourceCollector} from 'Stats/lib/source_collector'
+import {StatsMethodsTable} from 'Stats/lib/methods_table'
+import {StatsApplicationMetricsSource} from 'Stats/lib/application_metrics_source'
+import {StatsCSVLink} from 'Stats/lib/csv_link'
+import {Stats} from 'Stats/lib/stats'
 
 export class StatsApplicationSourceCollector extends StatsSourceCollector {
   static get Source () {

--- a/app/javascript/src/Stats/index.jsx
+++ b/app/javascript/src/Stats/index.jsx
@@ -1,4 +1,4 @@
-import * as providerStats from './provider/index'
-import * as buyerStats from './buyer/index'
+import * as providerStats from 'Stats/provider/index'
+import * as buyerStats from 'Stats/buyer/index'
 
 export { providerStats, buyerStats }

--- a/app/javascript/src/Stats/lib/application_metrics_source.jsx
+++ b/app/javascript/src/Stats/lib/application_metrics_source.jsx
@@ -1,4 +1,4 @@
-import {StatsMetricsSource} from './metrics_source'
+import {StatsMetricsSource} from 'Stats/lib/metrics_source'
 
 export class StatsApplicationMetricsSource extends StatsMetricsSource {
   get url () {

--- a/app/javascript/src/Stats/lib/applications_selector.jsx
+++ b/app/javascript/src/Stats/lib/applications_selector.jsx
@@ -1,5 +1,5 @@
 /** @jsx StatsUI.dom */
-import {StatsUI} from './ui'
+import {StatsUI} from 'Stats/lib/ui'
 import $ from 'jquery'
 
 export class StatsApplicationsSelector extends StatsUI {

--- a/app/javascript/src/Stats/lib/applications_table.jsx
+++ b/app/javascript/src/Stats/lib/applications_table.jsx
@@ -1,7 +1,7 @@
 /** @jsx StatsUI.dom */
 import numeral from 'numeral'
 
-import {StatsUI} from './ui'
+import {StatsUI} from 'Stats/lib/ui'
 
 export class StatsApplicationsTable extends StatsUI {
   constructor ({container}) {

--- a/app/javascript/src/Stats/lib/applications_table.spec.js
+++ b/app/javascript/src/Stats/lib/applications_table.spec.js
@@ -1,4 +1,4 @@
-import { StatsApplicationsTable } from './applications_table'
+import { StatsApplicationsTable } from 'Stats/lib/applications_table'
 
 describe('StatsApplicationsTable', () => {
   let applicationsTable = new StatsApplicationsTable({container: '#applications_table'})

--- a/app/javascript/src/Stats/lib/average_chart_manager.jsx
+++ b/app/javascript/src/Stats/lib/average_chart_manager.jsx
@@ -1,5 +1,5 @@
-import {StatsChartManager} from './chart_manager'
-import {StatsAverageSeries} from './average_series'
+import {StatsChartManager} from 'Stats/lib/chart_manager'
+import {StatsAverageSeries} from 'Stats/lib/average_series'
 
 export class StatsAverageChartManager extends StatsChartManager {
   static get Series () {

--- a/app/javascript/src/Stats/lib/average_metrics_source.jsx
+++ b/app/javascript/src/Stats/lib/average_metrics_source.jsx
@@ -3,7 +3,7 @@ import 'core-js/modules/es6.map' // make Maps work on IE 11
 import moment from 'moment'
 import 'moment-range'
 
-import {StatsMetricsSource} from './metrics_source'
+import {StatsMetricsSource} from 'Stats/lib/metrics_source'
 
 export class StatsAverageMetricsSource extends StatsMetricsSource {
   get url () {

--- a/app/javascript/src/Stats/lib/average_series.jsx
+++ b/app/javascript/src/Stats/lib/average_series.jsx
@@ -1,4 +1,4 @@
-import {StatsSeries} from './series'
+import {StatsSeries} from 'Stats/lib/series'
 
 export class StatsAverageSeries extends StatsSeries {
   _seriesOptions (responses) {

--- a/app/javascript/src/Stats/lib/chart_manager.jsx
+++ b/app/javascript/src/Stats/lib/chart_manager.jsx
@@ -1,6 +1,6 @@
 import 'core-js/fn/symbol/index' // make Symbol work on IE 11
 import $ from 'jquery'
-import {StatsSeries} from './series'
+import {StatsSeries} from 'Stats/lib/series'
 
 export class StatsChartManager {
   constructor ({statsState, sources, chart, widgets = []}) {

--- a/app/javascript/src/Stats/lib/csv_link.jsx
+++ b/app/javascript/src/Stats/lib/csv_link.jsx
@@ -3,7 +3,7 @@ import 'core-js/fn/symbol/iterator' // make Symbol work on IE 11
 import moment from 'moment'
 import 'moment-timezone'
 
-import {StatsUI} from './ui'
+import {StatsUI} from 'Stats/lib/ui'
 
 const TIMESTAMP_FORMAT = 'DD MMM YYYY HH:mm:ss zz'
 

--- a/app/javascript/src/Stats/lib/menu.jsx
+++ b/app/javascript/src/Stats/lib/menu.jsx
@@ -5,9 +5,9 @@ import pluralize from 'pluralize'
 import $ from 'jquery'
 import 'jquery-ui/ui/widgets/datepicker'
 
-import * as helpers from './stats_helpers'
-import {StatsUI} from './ui'
-import {CustomRangeDate, PeriodRangeDate} from './state'
+import * as helpers from 'Stats/lib/stats_helpers'
+import {StatsUI} from 'Stats/lib/ui'
+import {CustomRangeDate, PeriodRangeDate} from 'Stats/lib/state'
 
 class Hook {
 

--- a/app/javascript/src/Stats/lib/methods_table.jsx
+++ b/app/javascript/src/Stats/lib/methods_table.jsx
@@ -3,7 +3,7 @@ import numeral from 'numeral'
 import moment from 'moment'
 import 'moment-timezone'
 
-import {StatsUI} from './ui'
+import {StatsUI} from 'Stats/lib/ui'
 
 const TIMESTAMP_FORMAT = 'DD MMM YYYY HH:mm:ss zz'
 

--- a/app/javascript/src/Stats/lib/metrics_list.jsx
+++ b/app/javascript/src/Stats/lib/metrics_list.jsx
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import {StatsMetric} from './metric'
+import {StatsMetric} from 'Stats/lib/metric'
 
 export class StatsMetrics {
   static getMetrics (url) {

--- a/app/javascript/src/Stats/lib/metrics_selector.jsx
+++ b/app/javascript/src/Stats/lib/metrics_selector.jsx
@@ -3,7 +3,7 @@ import $ from 'jquery'
 import numeral from 'numeral'
 import 'core-js/fn/array/find'
 
-import {StatsUI} from './ui'
+import {StatsUI} from 'Stats/lib/ui'
 
 export class StatsMetricsSelector extends StatsUI {
   constructor ({statsState, metrics, container}) {

--- a/app/javascript/src/Stats/lib/metrics_source.jsx
+++ b/app/javascript/src/Stats/lib/metrics_source.jsx
@@ -1,6 +1,6 @@
 import $ from 'jquery'
 
-import {StatsSource} from './source'
+import {StatsSource} from 'Stats/lib/source'
 
 export class StatsMetricsSource extends StatsSource {
   constructor ({id, details = {}}) {

--- a/app/javascript/src/Stats/lib/source_collector.jsx
+++ b/app/javascript/src/Stats/lib/source_collector.jsx
@@ -1,7 +1,7 @@
 import $ from 'jquery'
 import 'core-js/fn/array/find'
 
-import {StatsMetrics} from './metrics_list'
+import {StatsMetrics} from 'Stats/lib/metrics_list'
 
 export class StatsSourceCollector {
   constructor ({id, metrics}) {

--- a/app/javascript/src/Stats/lib/source_collector_chart_manager.jsx
+++ b/app/javascript/src/Stats/lib/source_collector_chart_manager.jsx
@@ -1,4 +1,4 @@
-import {StatsChartManager} from './chart_manager'
+import {StatsChartManager} from 'Stats/lib/chart_manager'
 
 export class StatsSourceCollectorChartManager extends StatsChartManager {
   constructor ({statsState, sources, chart, widgets = []}) {

--- a/app/javascript/src/Stats/lib/stats.jsx
+++ b/app/javascript/src/Stats/lib/stats.jsx
@@ -1,9 +1,9 @@
 import 'core-js/fn/object/assign' // make Object.assign on IE 11
-import {StatsStore} from './store'
-import {StatsState, PeriodRangeDate} from './state'
-import {StatsMenu} from './menu'
-import {StatsMetricsSelector} from './metrics_selector'
-import {StatsApplicationsSelector} from './applications_selector'
+import {StatsStore} from 'Stats/lib/store'
+import {StatsState, PeriodRangeDate} from 'Stats/lib/state'
+import {StatsMenu} from 'Stats/lib/menu'
+import {StatsMetricsSelector} from 'Stats/lib/metrics_selector'
+import {StatsApplicationsSelector} from 'Stats/lib/applications_selector'
 
 export const Stats = function ({ChartManager, Chart, Sources}) {
   const DEFAULT_PERIODS = [

--- a/app/javascript/src/Stats/lib/top_application_metrics_source.jsx
+++ b/app/javascript/src/Stats/lib/top_application_metrics_source.jsx
@@ -1,5 +1,5 @@
 import 'core-js/fn/object/assign' // make Object.assign on IE 11
-import {StatsApplicationMetricsSource} from './application_metrics_source'
+import {StatsApplicationMetricsSource} from 'Stats/lib/application_metrics_source'
 
 export class StatsTopApplicationMetricsSource extends StatsApplicationMetricsSource {
   params ({dateRange, selectedMetricName = 'hits'}) {

--- a/app/javascript/src/Stats/lib/top_apps_source_collector.jsx
+++ b/app/javascript/src/Stats/lib/top_apps_source_collector.jsx
@@ -1,7 +1,7 @@
 import 'core-js/fn/object/assign' // make Object.assign on IE 11
-import * as helpers from './stats_helpers'
-import {StatsSourceCollector} from './source_collector'
-import {StatsTopApplicationMetricsSource} from './top_application_metrics_source'
+import * as helpers from 'Stats/lib/stats_helpers'
+import {StatsSourceCollector} from 'Stats/lib/source_collector'
+import {StatsTopApplicationMetricsSource} from 'Stats/lib/top_application_metrics_source'
 
 export class StatsTopAppsSourceCollector extends StatsSourceCollector {
   static get Source () {

--- a/app/javascript/src/Stats/lib/usage_chart.jsx
+++ b/app/javascript/src/Stats/lib/usage_chart.jsx
@@ -1,5 +1,5 @@
 import 'core-js/fn/object/assign' // make Object.assign on IE 11
-import {StatsChart} from './chart'
+import {StatsChart} from 'Stats/lib/chart'
 
 export class StatsUsageChart extends StatsChart {
   constructor ({container, groupedSeries = []}) {

--- a/app/javascript/src/Stats/lib/usage_chart_manager.jsx
+++ b/app/javascript/src/Stats/lib/usage_chart_manager.jsx
@@ -1,5 +1,5 @@
-import {StatsUsageSeries} from './usage_series'
-import {StatsSourceCollectorChartManager} from './source_collector_chart_manager'
+import {StatsUsageSeries} from 'Stats/lib/usage_series'
+import {StatsSourceCollectorChartManager} from 'Stats/lib/source_collector_chart_manager'
 
 export class StatsUsageChartManager extends StatsSourceCollectorChartManager {
   static get Series () {

--- a/app/javascript/src/Stats/lib/usage_metrics_source.jsx
+++ b/app/javascript/src/Stats/lib/usage_metrics_source.jsx
@@ -1,4 +1,4 @@
-import {StatsMetricsSource} from './metrics_source'
+import {StatsMetricsSource} from 'Stats/lib/metrics_source'
 
 export class StatsUsageMetricsSource extends StatsMetricsSource {
   get url () {

--- a/app/javascript/src/Stats/lib/usage_series.jsx
+++ b/app/javascript/src/Stats/lib/usage_series.jsx
@@ -1,4 +1,4 @@
-import {StatsSeries} from './series'
+import {StatsSeries} from 'Stats/lib/series'
 
 export class StatsUsageSeries extends StatsSeries {
   _customOptions (responses) {

--- a/app/javascript/src/Stats/lib/usage_source_collector.jsx
+++ b/app/javascript/src/Stats/lib/usage_source_collector.jsx
@@ -1,5 +1,5 @@
-import {StatsSourceCollector} from './source_collector'
-import {StatsUsageMetricsSource} from './usage_metrics_source'
+import {StatsSourceCollector} from 'Stats/lib/source_collector'
+import {StatsUsageMetricsSource} from 'Stats/lib/usage_metrics_source'
 
 export class StatsUsageSourceCollector extends StatsSourceCollector {
   static get Source () {

--- a/app/javascript/src/Stats/provider/index.jsx
+++ b/app/javascript/src/Stats/provider/index.jsx
@@ -1,9 +1,9 @@
-import {statsResponseCodes} from './stats_response_codes'
-import {statsTopApps} from './stats_top_apps'
-import {statsUsage} from './stats_usage'
-import {statsHoursOfDay} from './stats_hours_of_day'
-import {statsDaysOfWeek} from './stats_days_of_week'
-import {statsApplication} from './stats_application'
+import {statsResponseCodes} from 'Stats/provider/stats_response_codes'
+import {statsTopApps} from 'Stats/provider/stats_top_apps'
+import {statsUsage} from 'Stats/provider/stats_usage'
+import {statsHoursOfDay} from 'Stats/provider/stats_hours_of_day'
+import {statsDaysOfWeek} from 'Stats/provider/stats_days_of_week'
+import {statsApplication} from 'Stats/provider/stats_application'
 
 export {
   statsResponseCodes,

--- a/app/javascript/src/Stats/provider/stats_application.jsx
+++ b/app/javascript/src/Stats/provider/stats_application.jsx
@@ -1,12 +1,12 @@
 /** @jsx StatsUI.dom */
-import {StatsUsageChart} from '../lib/usage_chart'
-import {StatsUsageChartManager} from '../lib/usage_chart_manager'
-import {StatsMetrics} from '../lib/metrics_list'
-import {StatsSourceCollector} from '../lib/source_collector'
-import {StatsMethodsTable} from '../lib/methods_table'
-import {StatsApplicationMetricsSource} from '../lib/application_metrics_source'
-import {StatsCSVLink} from '../lib/csv_link'
-import {Stats} from '../lib/stats'
+import {StatsUsageChart} from 'Stats/lib/usage_chart'
+import {StatsUsageChartManager} from 'Stats/lib/usage_chart_manager'
+import {StatsMetrics} from 'Stats/lib/metrics_list'
+import {StatsSourceCollector} from 'Stats/lib/source_collector'
+import {StatsMethodsTable} from 'Stats/lib/methods_table'
+import {StatsApplicationMetricsSource} from 'Stats/lib/application_metrics_source'
+import {StatsCSVLink} from 'Stats/lib/csv_link'
+import {Stats} from 'Stats/lib/stats'
 
 export class StatsApplicationSourceCollector extends StatsSourceCollector {
   static get Source () {

--- a/app/javascript/src/Stats/provider/stats_days_of_week.jsx
+++ b/app/javascript/src/Stats/provider/stats_days_of_week.jsx
@@ -1,12 +1,12 @@
 /** @jsx StatsUI.dom */
 
-import {PeriodRangeDate} from '../lib/state'
-import {StatsAverageMetricsSource} from '../lib/average_metrics_source'
-import {StatsChart} from '../lib/chart'
-import {StatsAverageChartManager} from '../lib/average_chart_manager'
-import {StatsMetrics} from '../lib/metrics_list'
-import {StatsCSVLink} from '../lib/csv_link'
-import {Stats} from '../lib/stats'
+import {PeriodRangeDate} from 'Stats/lib/state'
+import {StatsAverageMetricsSource} from 'Stats/lib/average_metrics_source'
+import {StatsChart} from 'Stats/lib/chart'
+import {StatsAverageChartManager} from 'Stats/lib/average_chart_manager'
+import {StatsMetrics} from 'Stats/lib/metrics_list'
+import {StatsCSVLink} from 'Stats/lib/csv_link'
+import {Stats} from 'Stats/lib/stats'
 
 import numeral from 'numeral'
 

--- a/app/javascript/src/Stats/provider/stats_hours_of_day.jsx
+++ b/app/javascript/src/Stats/provider/stats_hours_of_day.jsx
@@ -1,12 +1,12 @@
 /** @jsx StatsUI.dom */
 
-import {PeriodRangeDate} from '../lib/state'
-import {StatsAverageMetricsSource} from '../lib/average_metrics_source'
-import {StatsChart} from '../lib/chart'
-import {StatsAverageChartManager} from '../lib/average_chart_manager'
-import {StatsMetrics} from '../lib/metrics_list'
-import {StatsCSVLink} from '../lib/csv_link'
-import {Stats} from '../lib/stats'
+import {PeriodRangeDate} from 'Stats/lib/state'
+import {StatsAverageMetricsSource} from 'Stats/lib/average_metrics_source'
+import {StatsChart} from 'Stats/lib/chart'
+import {StatsAverageChartManager} from 'Stats/lib/average_chart_manager'
+import {StatsMetrics} from 'Stats/lib/metrics_list'
+import {StatsCSVLink} from 'Stats/lib/csv_link'
+import {Stats} from 'Stats/lib/stats'
 
 import numeral from 'numeral'
 

--- a/app/javascript/src/Stats/provider/stats_response_codes.jsx
+++ b/app/javascript/src/Stats/provider/stats_response_codes.jsx
@@ -1,13 +1,13 @@
 import 'core-js/fn/object/assign' // make Object.assign on IE 11
 import $ from 'jquery'
 
-import {StatsChart} from '../lib/chart'
-import {StatsChartManager} from '../lib/chart_manager'
-import {StatsState, PeriodRangeDate} from '../lib/state'
-import {StatsStore} from '../lib/store'
-import {StatsMetricsSource} from '../lib/metrics_source'
-import {StatsSeries} from '../lib/series'
-import {StatsMenu} from '../lib/menu'
+import {StatsChart} from 'Stats/lib/chart'
+import {StatsChartManager} from 'Stats/lib/chart_manager'
+import {StatsState, PeriodRangeDate} from 'Stats/lib/state'
+import {StatsStore} from 'Stats/lib/store'
+import {StatsMetricsSource} from 'Stats/lib/metrics_source'
+import {StatsSeries} from 'Stats/lib/series'
+import {StatsMenu} from 'Stats/lib/menu'
 
 const OPTIONS = {
   metrics: [

--- a/app/javascript/src/Stats/provider/stats_top_apps.jsx
+++ b/app/javascript/src/Stats/provider/stats_top_apps.jsx
@@ -2,16 +2,16 @@
 import 'core-js/fn/array/find'
 import moment from 'moment'
 
-import {StatsUI} from '../lib/ui'
-import {StatsChart} from '../lib/chart'
-import {StatsTopAppsSourceCollector} from '../lib/top_apps_source_collector'
-import {StatsSourceCollectorChartManager} from '../lib/source_collector_chart_manager'
-import {StatsSeries} from '../lib/series'
-import {StatsMetrics} from '../lib/metrics_list'
-import {StatsCSVLink} from '../lib/csv_link'
-import {StatsApplicationsTable} from '../lib/applications_table'
-import {applicationDetails} from '../lib/application_details'
-import {Stats} from '../lib/stats'
+import {StatsUI} from 'Stats/lib/ui'
+import {StatsChart} from 'Stats/lib/chart'
+import {StatsTopAppsSourceCollector} from 'Stats/lib/top_apps_source_collector'
+import {StatsSourceCollectorChartManager} from 'Stats/lib/source_collector_chart_manager'
+import {StatsSeries} from 'Stats/lib/series'
+import {StatsMetrics} from 'Stats/lib/metrics_list'
+import {StatsCSVLink} from 'Stats/lib/csv_link'
+import {StatsApplicationsTable} from 'Stats/lib/applications_table'
+import {applicationDetails} from 'Stats/lib/application_details'
+import {Stats} from 'Stats/lib/stats'
 
 export class StatsTopAppsMetrics extends StatsMetrics {
   getSelectedMetrics (selectedMetricName) {

--- a/app/javascript/src/Stats/provider/stats_usage.jsx
+++ b/app/javascript/src/Stats/provider/stats_usage.jsx
@@ -1,12 +1,12 @@
 /** @jsx StatsUI.dom */
-import {StatsUsageChart} from '../lib/usage_chart'
-import {PeriodRangeDate} from '../lib/state'
-import {StatsUsageSourceCollector} from '../lib/usage_source_collector'
-import {StatsMetrics} from '../lib/metrics_list'
-import {StatsMethodsTable} from '../lib/methods_table'
-import {StatsCSVLink} from '../lib/csv_link'
-import {StatsUsageChartManager} from '../lib/usage_chart_manager'
-import {Stats} from '../lib/stats'
+import {StatsUsageChart} from 'Stats/lib/usage_chart'
+import {PeriodRangeDate} from 'Stats/lib/state'
+import {StatsUsageSourceCollector} from 'Stats/lib/usage_source_collector'
+import {StatsMetrics} from 'Stats/lib/metrics_list'
+import {StatsMethodsTable} from 'Stats/lib/methods_table'
+import {StatsCSVLink} from 'Stats/lib/csv_link'
+import {StatsUsageChartManager} from 'Stats/lib/usage_chart_manager'
+import {Stats} from 'Stats/lib/stats'
 
 const DEFAULT_METRIC = 'hits'
 

--- a/app/javascript/src/services/index.jsx
+++ b/app/javascript/src/services/index.jsx
@@ -1,5 +1,5 @@
-import toggle, { moveState } from '../utilities/toggle'
-import migrate from './migrate'
+import toggle, { moveState } from 'utilities/toggle'
+import migrate from 'services/migrate'
 
 export function initialize () {
   migrate()

--- a/app/javascript/src/services/migrate.jsx
+++ b/app/javascript/src/services/migrate.jsx
@@ -1,7 +1,7 @@
 import 'core-js/fn/array/includes'
 import 'core-js/fn/array/find'
 
-import { setState } from '../utilities/toggle'
+import { setState } from 'utilities/toggle'
 
 const store = window.localStorage
 const key = 'cms-toggle-ids'

--- a/app/javascript/src/utilities/toggle.spec.js
+++ b/app/javascript/src/utilities/toggle.spec.js
@@ -1,4 +1,4 @@
-import { toggle, toggleState, recoverState, moveState } from './toggle'
+import { toggle, toggleState, recoverState, moveState } from 'utilities/toggle'
 
 describe('Toggle', () => {
   let icon, article


### PR DESCRIPTION
**What this PR does / why we need it**:

Absolute paths were enabled in #254 and it would be good to use them.

**Verification steps** 

`bundle exec rake webpack:compile` should fail if paths didn't work.
