### PR TITLE
Do not send to error logger when API is accessed with RO token

### DIFF
--- a/lib/api_authentication/by_access_token.rb
+++ b/lib/api_authentication/by_access_token.rb
@@ -167,7 +167,6 @@ module ApiAuthentication
 
         connection.transaction(requires_new: true, &Proc.new)
       rescue ActiveRecord::StatementInvalid => error
-        System::ErrorReporting.report_error(error)
         case error.message
         when /Cannot execute statement in a READ ONLY transaction/,
              %r{may not perform insert/delete/update operation inside a READ ONLY transaction},


### PR DESCRIPTION
**What this PR does / why we need it**:

Using an read-only access token to update resources is forbidden.
To solve https://issues.jboss.org/browse/THREESCALE-1041, we implemented more logging to understand the cause.
Now it is solved we do not need the logging anymore