### PR TITLE
Update first_admin_id of any type of accounts and do better

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,12 +1,21 @@
 # frozen_string_literal: true
 
 namespace :user do
-  desc 'Updates the first_admin_id attribute value for all providers.'
+  desc 'Updates the first_admin_id attribute value for all accounts.'
   task update_all_first_admin_id: :environment do
-    Account.transaction do
-      Account.providers.find_each do |account|
-        account.update!(first_admin_id: account.first_admin&.id)
-      end
-    end
+    impersonation_admin_username = ThreeScale.config.impersonation_admin['username']
+    complete_query = <<~SQL
+      UPDATE accounts
+      SET first_admin_id = ( SELECT id
+                             FROM users
+                             WHERE accounts.id = users.account_id
+                               AND users.role = 'admin'
+                               AND users.username <> '#{impersonation_admin_username}'
+                             #{System::Database.oracle? ? 'FETCH FIRST 1 ROWS ONLY' : 'LIMIT 1'}
+                            )
+      WHERE first_admin_id IS NULL
+    SQL
+    ActiveRecord::Base.connection.execute(complete_query)
+    puts 'The accounts\' first_admin_id have been updated.'
   end
 end

--- a/test/unit/tasks/user_test.rb
+++ b/test/unit/tasks/user_test.rb
@@ -10,10 +10,12 @@ class Tasks::UserTest < ActiveSupport::TestCase
       FactoryGirl.create(:admin, username: '3scaleadmin', account: provider)
       FactoryGirl.create_list(:admin, 2, account: provider)
     end
+
+    FactoryGirl.create(:admin, account: FactoryGirl.create(:simple_buyer, provider_account: providers.first))
   end
 
   test 'update_all_first_admin_id' do
     execute_rake_task 'user.rake', 'user:update_all_first_admin_id'
-    Account.providers.each { |account| assert_equal account.first_admin&.id, account.first_admin_id }
+    Account.find_each { |account| assert_equal account.first_admin&.id, account.first_admin_id }
   end
 end


### PR DESCRIPTION
This task was added in https://github.com/3scale/porta/pull/8
There were 2 problems with it:
1. We want it to be done for all type of accounts, which means developers too, not only providers.
2. It took too long and it ended up with the process being killed and nothing done 😞 

This PR fixes those problems.
Run it with `bundle exec rake user:update_all_first_admin_id`