### PR TITLE
Update where(first_admin_id: nil) and skip validations and callbacks

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -3,10 +3,10 @@
 namespace :user do
   desc 'Updates the first_admin_id attribute value for all accounts.'
   task update_all_first_admin_id: :environment do
-    Account.find_each do |account|
-      next if account.first_admin_id.present? || !(user = account.first_admin)
+    Account.where(first_admin_id: nil).find_each do |account|
+      next unless (user = account.first_admin)
 
-      puts "Failed update of first_admin_id for Account ##{account.id}" unless account.update(first_admin_id: user.id)
+      puts "Failed update of first_admin_id for Account ##{account.id}" unless account.update_column(:first_admin_id, user.id) # rubocop:disable Rails/SkipsModelValidations
     end
     puts 'The accounts\' first_admin_id have been updated.'
   end


### PR DESCRIPTION
It failed and we don't know why.
![image](https://user-images.githubusercontent.com/11318903/49999149-5d485980-ff96-11e8-9f3d-6b5e0f1e3446.png)

We suspect that we should do `update_column` to skip validations and callbacks.
It also takes very long, which is acceptable but not ideal, but we don't want to complicate the code so I just added a `where(first_admin_id: nil)`.