### PR TITLE
Remove repeated @cinstance variable

### DIFF
--- a/lib/developer_portal/app/controllers/developer_portal/buyer/stats_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/buyer/stats_controller.rb
@@ -4,8 +4,6 @@ class DeveloperPortal::Buyer::StatsController < DeveloperPortal::BaseController
   liquify prefix: 'stats'
 
   def index
-    @cinstances = applications
-
     if applications.present?
       assign_drops metrics: Liquid::Drops::Metric.wrap(metrics),
       methods: Liquid::Drops::Metric.wrap(methods),

--- a/test/functional/developer_portal/buyer/stats_controller_test.rb
+++ b/test/functional/developer_portal/buyer/stats_controller_test.rb
@@ -53,7 +53,7 @@ class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionContr
         get :index
 
         doc = Nokogiri::HTML.parse(response.body)
-        assert_equal [@live_app1, @live_app2], @controller.instance_variable_get('@cinstances')
+        assert_equal [@live_app1, @live_app2], assigns(:applications)
         assert_equal @live_app1.id.to_s,  doc.css('#client-name[data-client]').attr('data-client').value
       end
 


### PR DESCRIPTION
It uses the `@applications` instead 😄 
The only places in views where this is used is:
![image](https://user-images.githubusercontent.com/11318903/50145667-65640a00-02b2-11e9-866f-cc9b520143aa.png)

