### PR TITLE
[API] Create access token

### DIFF
--- a/app/controllers/admin/api/access_tokens_controller.rb
+++ b/app/controllers/admin/api/access_tokens_controller.rb
@@ -12,16 +12,33 @@ class Admin::Api::AccessTokensController < Admin::Api::BaseController
 
   before_action :authorize_access_tokens
 
+  ##~ sapi = source2swagger.namespace("Account Management API")
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/users/{user_id}/access_tokens.json"
+  ##~ e.responseClass = "access_token"
+  #
+  ##~ op = e.operations.add
+  ##~ op.httpMethod = "POST"
+  ##~ op.summary   = "Access Token Create"
+  ##~ op.description = "Creates an access token."
+  ##~ op.group = "access_token"
+  #
+  ##~ op.parameters.add :name => "user_id", :description => "ID of the user.", :dataType => "integer", :paramType => "path", :required => true
+  ##~ op.parameters.add :name => "name", :description => "Name of the access token.", :dataType => "string", :required => true, :paramType => "query"
+  ##~ op.parameters.add :name => "permission", :description => "Permission of the access token. It must be either 'ro' (read only) or 'rw' (read and write).", :dataType => "string", :required => true, :paramType => "query"
+  ##~ op.parameters.add :name => "scopes", :defaultName => "scopes[]", :description => "Scope of the access token. URL-encoded array containing one or more of the possible values values. The possible values are, for a master user [\"account_management\", \"stats\"], and for a tenant user [\"finance\", \"account_management\", \"stats\"]", :dataType => "custom", :allowMultiple => true, :required => true, :paramType => "query"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  #
   def create
     access_token = user.access_tokens.create(access_token_params)
-
     respond_with access_token
   end
 
   protected
 
   def access_token_params
-    params.require(:token).permit(:name, :value, :permission, scopes: [])
+    params.require(:token).permit(:name, :permission, scopes: [])
   end
 
   def authorize_access_tokens

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -1,6 +1,58 @@
 {
   "apis": [
     {
+      "path": "/admin/api/users/{user_id}/access_tokens.json",
+      "responseClass": "access_token",
+      "operations": [
+        {
+          "httpMethod": "POST",
+          "summary": "Access Token Create",
+          "description": "Creates an access token.",
+          "group": "access_token",
+          "parameters": [
+            {
+              "name": "user_id",
+              "description": "ID of the user.",
+              "dataType": "integer",
+              "paramType": "path",
+              "required": true
+            },
+            {
+              "name": "name",
+              "description": "Name of the access token.",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query"
+            },
+            {
+              "name": "permission",
+              "description": "Permission of the access token. It must be either 'ro' (read only) or 'rw' (read and write).",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query"
+            },
+            {
+              "name": "scopes",
+              "defaultName": "scopes[]",
+              "description": "Scope of the access token. URL-encoded array containing one or more of the possible values values. The possible values are, for a master user [\"account_management\", \"stats\"], and for a tenant user [\"finance\", \"account_management\", \"stats\"]",
+              "dataType": "custom",
+              "allowMultiple": true,
+              "required": true,
+              "paramType": "query"
+            },
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": "/admin/api/account/authentication_providers.xml",
       "responseClass": "authentication_provider",
       "operations": [

--- a/spec/acceptance/api/access_token_spec.rb
+++ b/spec/acceptance/api/access_token_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+resource 'AccessToken' do
+  let(:resource) { FactoryBot.build(:access_token) }
+
+  json(:resource) do
+    let(:root) { 'access_token' }
+
+    it { subject.should have_properties(%w[id name scopes permission value]).from(resource) }
+  end
+end

--- a/test/factories/access_token.rb
+++ b/test/factories/access_token.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :access_token, class: ::AccessToken do
     association :owner, factory: :user
-    scopes { ['alaska'] }
+    scopes { ['stats'] }
     permission { 'rw' }
     sequence(:name)  { |n| "Alaska_#{n}" }
     sequence(:value) { |n| "wild_#{n}" }

--- a/test/integration/api/access_tokens_test.rb
+++ b/test/integration/api/access_tokens_test.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::AccessTokensTest < ActionDispatch::IntegrationTest
   def setup
-    @provider = FactoryBot.create(:provider_account)
+    @provider = FactoryBot.create(:simple_provider, provider_account: master_account)
     @admin = FactoryBot.create(:simple_admin, account: @provider)
     @admin.activate!
     @member = FactoryBot.create(:simple_user, account: @provider)
@@ -10,32 +12,78 @@ class Admin::Api::AccessTokensTest < ActionDispatch::IntegrationTest
     host! @provider.self_domain
   end
 
-  test 'create with access_token' do
-    access_token = FactoryBot.create(:access_token, owner: @admin, scopes: %w(account_management))
+  test 'create with access_token can not create for another user' do
+    access_token = FactoryBot.create(:access_token, owner: @admin, scopes: %w[account_management])
 
-    post admin_api_user_access_tokens_path(user_id: @admin.id, access_token: access_token.value, format: :json),
-         access_token_params
-    assert_response :created, response.body
+    user_id = @admin.id
+    assert_difference(AccessToken.method(:count), 1) do
+      post_request(user_id, {access_token: access_token.value})
+      assert_response :created, "Not created with response body #{response.body}"
+    end
+    assert_token_values(user_id)
 
-    post admin_api_user_access_tokens_path(user_id: @member.id, access_token: access_token.value, format: :json),
-         access_token_params
-    assert_response :forbidden, response.body
+
+    assert_no_difference(AccessToken.method(:count)) do
+      post_request(@member.id, {access_token: access_token.value})
+      assert_response :forbidden, "Not forbidden with response body #{response.body}"
+    end
   end
 
-  test 'create with provider_key' do
-    post admin_api_user_access_tokens_path(user_id: @admin.id, provider_key: @provider.provider_key, format: :json),
-         access_token_params
-    assert_response :created, response.body
+  test 'create does not accept a custom value' do
+    access_token = FactoryBot.create(:access_token, owner: @admin, scopes: %w[account_management])
 
-    post admin_api_user_access_tokens_path(user_id: @member.id, provider_key: @provider.provider_key, format: :json),
-         access_token_params
-    assert_response :created, response.body
+    user_id = @admin.id
+    assert_difference(AccessToken.method(:count), 1) do
+      post_request(user_id, {access_token: access_token.value}, {value: 'foobar'})
+      assert_response :created, "Not created with response body #{response.body}"
+    end
+    assert_not_equal 'foobar', AccessToken.last!.value
+  end
+
+  test 'create does not accept a wrong scope' do
+    access_token = FactoryBot.create(:access_token, owner: @admin, scopes: %w[account_management])
+
+    assert_no_difference(AccessToken.method(:count)) do
+      post_request(@admin.id, {access_token: access_token.value}, {scopes: ['wrong']})
+      assert_response :unprocessable_entity, "Not created with response body #{response.body}"
+      assert_equal ['invalid'], JSON.parse(response.body).dig('errors', 'scopes')
+    end
+  end
+
+  test 'create with provider_key can create for any user of that account' do
+    FactoryBot.create(:cinstance, service: master_account.default_service, user_account: @provider)
+
+    user_id = @admin.id
+    assert_difference(AccessToken.method(:count), 1) do
+      post_request(user_id, {provider_key: @provider.provider_key})
+      assert_response :created, "Not created with response body #{response.body}"
+    end
+    assert_token_values(user_id)
+
+
+    user_id = @member.id
+    assert_difference(AccessToken.method(:count), 1) do
+      post_request(user_id, {provider_key: @provider.provider_key})
+      assert_response :created, "Not created with response body #{response.body}"
+    end
+    assert_token_values(user_id)
   end
 
   protected
 
+  def assert_token_values(user_id)
+    token = AccessToken.last!
+    assert_equal user_id, token.owner_id
+    access_token_params.each do |attr_name, attr_value|
+      assert_equal token.public_send(attr_name), attr_value
+    end
+  end
+
+  def post_request(user_id, authentication = {}, different_params = {})
+    post admin_api_user_access_tokens_path(authentication.merge({user_id: user_id, format: :json})), access_token_params.merge(different_params)
+  end
+
   def access_token_params
-    { name: 'token name', permission: 'ro', value: 'foobar', scopes: %w(cms) }
+    { name: 'token name', permission: 'ro', scopes: %w[cms] }
   end
 end
-

--- a/test/integration/cms/base_controller_test.rb
+++ b/test/integration/cms/base_controller_test.rb
@@ -71,7 +71,8 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
         admin = master_account.admin_users.first
         member = FactoryBot.create(:member, account: master_account, admin_sections: ['portal'])
         [admin, member].each do |user|
-          token = FactoryBot.create(:access_token, owner: user, scopes: ['cms'], permission: 'rw')
+          token = FactoryBot.create(:access_token, owner: user, permission: 'rw')
+          token.update_column(:scopes, ['cms']) # It must be done this way because it is invalid now.
           with_api_routes do
             get '/cms_api', access_token: token.value
             assert_response :forbidden

--- a/test/integration/master/api/finance/accounts/billing_jobs_controller_test.rb
+++ b/test/integration/master/api/finance/accounts/billing_jobs_controller_test.rb
@@ -81,7 +81,7 @@ class Master::Api::Finance::Accounts::BillingJobsControllerTest < ActionDispatch
     end
 
     test 'scope account_management is required to create jobs' do
-      unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['other'])
+      unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['finance'])
       post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), access_token: unauthorized_token.value
       assert_response :forbidden
 

--- a/test/integration/master/api/finance/billing_jobs_controller_test.rb
+++ b/test/integration/master/api/finance/billing_jobs_controller_test.rb
@@ -95,7 +95,7 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
     end
 
     test 'scope account_management is required to create jobs' do
-      unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['other'])
+      unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['finance'])
       post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: unauthorized_token.value
       assert_response :forbidden
 

--- a/test/integration/stats/data/requests_to_api_test.rb
+++ b/test/integration/stats/data/requests_to_api_test.rb
@@ -25,7 +25,7 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
     get "/stats/applications/#{@application.id}/usage.json", params
     assert_response :success
 
-    token.scopes = ['alaska']
+    token.scopes = ['finance']
     token.save!
     # token does not include the right scope
     get "/stats/applications/#{@application.id}/usage.json", params

--- a/test/integration/user-management-api/credit_cards_test.rb
+++ b/test/integration/user-management-api/credit_cards_test.rb
@@ -41,7 +41,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
 
     user.admin_sections = ['finance']
     user.save!
-    token.scopes = ['alaska']
+    token.scopes = ['cms']
     token.save!
 
     put(admin_api_account_credit_card_path(@buyer, format: :xml), valid_params(token))

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -66,6 +66,27 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert_same_elements %w[account_management stats], member.allowed_access_token_scopes.values
   end
 
+  def test_validates_real_scopes
+    @token.owner = member
+    @token.scopes = %w[stats cms wrong]
+    refute @token.valid?
+    assert_equal ['invalid'], @token.errors[:scopes]
+
+    @token.owner = member
+    @token.scopes = %w[stats cms]
+    assert @token.valid?
+
+    ThreeScale.stubs(master_on_premises?: true)
+    @token.owner = member
+    @token.scopes = %w[stats cms]
+    refute @token.valid?
+    assert_equal ['invalid'], @token.errors[:scopes]
+
+    @token.owner = member
+    @token.scopes = %w[stats]
+    assert @token.valid?
+  end
+
   def test_human_scopes
     assert Array, @token.human_scopes
   end


### PR DESCRIPTION
Fixes [THREESCALE-1112](https://issues.jboss.org/browse/THREESCALE-1112)
Some of what is requested was already done before we became open source in https://github.com/3scale/system/pull/8441

### Tasks
- [X] Remove `value` from strong params
- [X] Add ApiDocs documentation
- [X] Improve tests and make sure that all works
- [X] AccessToken scopes validates valid scopes values
- [X] Spec AccessToken Representer

### Example of using the API endpoint
```bash
curl -v  POST "http://provider-admin.example.com.lvh.me:3000/admin/api/users/2/access_tokens.json" -d 'name=exampleee&permission=rw&scopes%5B%5D=cms&access_token=47f2128f72ad4b6e494b08f7cecc41a7e22c4a47f6215a7544f773392adf2af7'
```

```bash
curl -v  POST "http://provider-admin.example.com.lvh.me:3000/admin/api/users/2/access_tokens.json" -d 'name=example2&permission=ro&scopes%5B%5D=finance&scopes%5B%5D=stats&access_token=47f2128f72ad4b6e494b08f7cecc41a7e22c4a47f6215a7544f773392adf2af7'
```

![image](https://user-images.githubusercontent.com/11318903/50165902-323b6e00-02e6-11e9-8d97-64b9f47aedc7.png)


### ApiDocs Documentation
The documentation doesn't have `cms` because it is not public and officially unsupported.
![image](https://user-images.githubusercontent.com/11318903/50228548-87d84f00-03a8-11e9-9686-b260893fdcbc.png)
![image](https://user-images.githubusercontent.com/11318903/50228573-945ca780-03a8-11e9-888e-daaf33f5274e.png)
