### PR TITLE
Removes Babel duplication in Webpack configs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,11 @@
 {
-  "plugins": ["syntax-dynamic-import", "transform-runtime"],
+  "plugins": [
+    "syntax-dynamic-import",
+    "transform-runtime",
+    "transform-object-rest-spread",
+    "transform-class-properties",
+    "transform-es2015-destructuring"
+  ],
   "presets": [
     "es2015",
     "react",
@@ -12,7 +18,11 @@
       ]
     },
     "test": {
-      "presets": ["es2015", "react", "stage-0"]
+      "presets": [
+        "es2015",
+        "react",
+        "stage-0"
+      ]
     }
   }
 }

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,40 +1,14 @@
 const environment = require('./environment')
 
-const customRules = {
-  module: {
-    rules: [
-      {
-        test: /\.jsx?$/,
-        exclude: /(node_modules)/,
-        enforce: 'pre',
-        loader: 'eslint-loader',
-        options: {
-          configFile: '.eslintrc'
-        }
-      },
-      {
-        test: /\.jsx?|.es6?|.spec.js?$/,
-        exclude: /(node_modules)/,
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              presets: ['es2015', 'react'],
-              plugins: ['transform-object-rest-spread', 'transform-class-properties', 'transform-es2015-destructuring']
-            }
-          }
-        ]
-      },
-      {
-        test: /(\.css|\.scss|\.sass)$/,
-        loader: 'style-loader!css-loader!sass-loader?modules&localIdentName=[name]---[local]---[hash:base64:5]'
-      },
-      {
-        test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/,
-        loader: 'file-loader?name=assets/[name].[hash].[ext]'
-      }
-    ]
+// Add Webpack custom configs here
+environment.loaders.append('eslint', {
+  test: /\.jsx?$/,
+  exclude: /(node_modules)/,
+  enforce: 'pre',
+  loader: 'eslint-loader',
+  options: {
+    configFile: '.eslintrc'
   }
-}
+})
 
-module.exports = Object.assign({}, environment, customRules)
+module.exports = environment.toWebpackConfig()

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,28 @@
 const { environment } = require('@rails/webpacker')
 
-module.exports = environment.toWebpackConfig()
+// Add global webpack configs here
+
+const babelLoader = environment.loaders.get('babel')
+babelLoader.test = /\.jsx?|.es6?|.spec.js?$/
+
+environment.loaders.delete('css')
+environment.loaders.delete('moduleCss')
+environment.loaders.delete('sass')
+environment.loaders.delete('moduleSass')
+
+environment.loaders.append('style', {
+  test: /(\.css|\.scss|\.sass)$/,
+  use: [
+    { loader: 'style-loader' },
+    { loader: 'css-loader' },
+    {
+      loader: 'sass-loader',
+      options: {
+        modules: true,
+        localIdentName: '[name]---[local]---[hash:base64:5]'
+      }
+    }
+  ]
+})
+
+module.exports = environment

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -3,7 +3,7 @@ const { environment } = require('@rails/webpacker')
 // Add global webpack configs here
 
 const babelLoader = environment.loaders.get('babel')
-babelLoader.test = /\.jsx?|.es6?|.spec.js?$/
+babelLoader.test = /\.jsx?|.spec.js?$/
 
 environment.loaders.delete('css')
 environment.loaders.delete('moduleCss')

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,31 +1,5 @@
 const environment = require('./environment')
 
-const customRules = {
-  module: {
-    rules: [
-      {
-        test: /\.jsx?|.es6?|.spec.js?$/,
-        exclude: /(node_modules)/,
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              presets: ['es2015', 'react'],
-              plugins: ['transform-object-rest-spread', 'transform-class-properties', 'transform-es2015-destructuring']
-            }
-          }
-        ]
-      },
-      {
-        test: /(\.css|\.scss|\.sass)$/,
-        loader: 'style-loader!css-loader!sass-loader?modules&localIdentName=[name]---[local]---[hash:base64:5]'
-      },
-      {
-        test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/,
-        loader: 'file-loader?name=assets/[name].[hash].[ext]'
-      }
-    ]
-  }
-}
+// Add Webpack custom configs here
 
-module.exports = Object.assign({}, environment, customRules)
+module.exports = environment.toWebpackConfig()

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -1,31 +1,5 @@
 const environment = require('./environment')
 
-const customRules = {
-  module: {
-    rules: [
-      {
-        test: /\.jsx?|.es6?|.spec.js?$/,
-        exclude: /(node_modules)/,
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              presets: ['es2015', 'react'],
-              plugins: ['transform-object-rest-spread', 'transform-class-properties', 'transform-es2015-destructuring']
-            }
-          }
-        ]
-      },
-      {
-        test: /(\.css|\.scss|\.sass)$/,
-        loader: 'style-loader!css-loader!sass-loader?modules&localIdentName=[name]---[local]---[hash:base64:5]'
-      },
-      {
-        test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/,
-        loader: 'file-loader?name=assets/[name].[hash].[ext]'
-      }
-    ]
-  }
-}
+// Add Webpack custom configs here
 
-module.exports = Object.assign({}, environment, customRules)
+module.exports = environment.toWebpackConfig()


### PR DESCRIPTION
**What this PR does / why we need it**:

Webpacker manages webpack itself, creating config files at compilation time. However this generated configs are being overridden in porta in a hardcoded way that leads to errors and uncontrolled results.

This PR gives this control back to Webpacker and Rails and apply all custom configs appropriately. This way config files look a bit more convoluted but also free us from managing webpack.js files.

Read more about how to manage webpack config with webpacker [here](https://github.com/rails/webpacker/blob/master/docs/webpack.md#webpack).

Thanks to this change we are able to better handle specific setups (dev, test, prod..) as well as reduce duplicated code in a safer and more maintainable way by means of JS.

