### PR TITLE
Move to CircleCI 2.1 config 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 
 #### YAML ANCHORS INSTEAD OF COMMANDS # while version 2.1 already supports commands, the local runner doesn't. When it does, we can upgrade.
 
@@ -91,6 +91,12 @@ oracle-db-container: &oracle-db-container
   command: |
     bash -c "sed -i.bak 's|2048|6144|g' /opt/oracle/dbca.rsp.tmpl && exec /opt/oracle/runOracle.sh"
 
+memcached-container: &memcached-container
+  image: memcached:1.5-alpine
+
+redis-container: &redis-container
+  image: redis:4.0-alpine
+
 clone-oracle-libs: &clone-oracle-libs
   run:
     name: "Fetch oracle libraries"
@@ -105,10 +111,31 @@ clone-oracle-libs: &clone-oracle-libs
       rm -rf vendor/oracle/*.zip
       sudo cp config/oracle/*.ini /etc/
 
-jobs:
-  dependencies_bundler:
+executors:
+  builder:
     docker:
       - *system-builder
+    working_directory: /opt/app-root/src/project
+
+  builder-with-mysql:
+    docker:
+      - *system-builder
+      - *mysql-container
+      - *memcached-container
+      - *redis-container
+    working_directory: /opt/app-root/src/project
+
+  builder-with-oracle:
+    docker:
+      - *system-builder
+      - *oracle-db-container
+      - *memcached-container
+      - *redis-container
+    working_directory: /opt/app-root/src/project
+
+jobs:
+  dependencies_bundler:
+    executor: builder
     steps:
       - checkout
       - *git-submodules
@@ -134,8 +161,7 @@ jobs:
           - ./vendor/bundle
           - ./.bundle/
   deps_bundler_oracle:
-    docker:
-      - *system-builder
+    executor: builder
     steps:
       - checkout
       - *git-submodules
@@ -165,8 +191,7 @@ jobs:
           - ./vendor/bundle
           - ./.bundle/
   dependencies_npm:
-    docker:
-      - *system-builder
+    executor: builder
     steps:
       - checkout
       - *git-submodules
@@ -187,8 +212,7 @@ jobs:
             - ./node_modules
 
   assets_precompile:
-    docker:
-      - *system-builder
+    executor: builder
     steps:
       - checkout
       - *git-submodules
@@ -208,11 +232,7 @@ jobs:
             - ./config/*.yml
 
   lint:
-    docker:
-      - *system-builder
-#      - *mysql-container
-#      - image: memcached:1.5-alpine
-#      - image: redis:4.0-alpine
+    executor: builder
     steps:
       - run:
           name: Start Xvfb
@@ -252,11 +272,7 @@ jobs:
   unit:
     parallelism: 8
     resource_class: small
-    docker:
-      - *system-builder
-      - *mysql-container
-      - image: memcached:1.5-alpine
-      - image: redis:4.0-alpine
+    executor: builder-with-mysql
     steps:
       - checkout
       - *git-submodules
@@ -274,11 +290,7 @@ jobs:
   unit-oracle:
     parallelism: 6
     resource_class: large
-    docker:
-    - *system-builder
-    - *oracle-db-container
-    - image: memcached:1.5-alpine
-    - image: redis:4.0-alpine
+    executor: builder-with-oracle
     steps:
     - checkout
     - *git-submodules
@@ -301,11 +313,7 @@ jobs:
   functional:
     parallelism: 2
     resource_class: small
-    docker:
-      - *system-builder
-      - *mysql-container
-      - image: memcached:1.5-alpine
-      - image: redis:4.0-alpine
+    executor: builder-with-mysql
     steps:
       - checkout
       - *git-submodules
@@ -323,11 +331,7 @@ jobs:
   functional-oracle:
     parallelism: 2
     resource_class: large
-    docker:
-    - *system-builder
-    - *oracle-db-container
-    - image: memcached:1.5-alpine
-    - image: redis:4.0-alpine
+    executor: builder-with-oracle
     steps:
     - checkout
     - *git-submodules
@@ -350,11 +354,7 @@ jobs:
   integration:
     parallelism: 8
     resource_class: small
-    docker:
-      - *system-builder
-      - *mysql-container
-      - image: memcached:1.5-alpine
-      - image: redis:4.0-alpine
+    executor: builder-with-mysql
     steps:
       - checkout
       - *git-submodules
@@ -372,11 +372,7 @@ jobs:
   integration-oracle:
     parallelism: 6
     resource_class: large
-    docker:
-    - *system-builder
-    - *oracle-db-container
-    - image: memcached:1.5-alpine
-    - image: redis:4.0-alpine
+    executor: builder-with-oracle
     steps:
     - checkout
     - *git-submodules
@@ -400,11 +396,7 @@ jobs:
   rspec:
     parallelism: 3
     resource_class: small
-    docker:
-      - *system-builder
-      - *mysql-container
-      - image: memcached:1.5-alpine
-      - image: redis:4.0-alpine
+    executor: builder-with-mysql
     steps:
       - checkout
       - *git-submodules
@@ -425,11 +417,7 @@ jobs:
   rspec-oracle:
     parallelism: 4
     resource_class: large
-    docker:
-      - *system-builder
-      - *oracle-db-container
-      - image: memcached:1.5-alpine
-      - image: redis:4.0-alpine
+    executor: builder-with-oracle
     steps:
       - checkout
       - *git-submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,9 +116,9 @@ redis-container: &redis-container
 
 dnsmasq-container: &dnsmasq-container
   image: quay.io/mikz/dnsmasq
-    command:
-    - --no-poll
-    - --address=/#/127.0.0.1
+  command:
+  - --no-poll
+  - --address=/#/127.0.0.1
 
 
 commands: # reusable commands with parameters
@@ -172,9 +172,9 @@ commands: # reusable commands with parameters
         type: string
     steps:
       - run:
-        name: Prepare database for tests
-        command: |
-          DB=<< parameters.database >> bundle exec rake ci:db:ready db:create db:test:prepare
+          name: Prepare database for tests
+          command: |
+            DB=<< parameters.database >> bundle exec rake ci:db:ready db:create db:test:prepare
 
   rspec-tests:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-#### YAML ANCHORS INSTEAD OF COMMANDS # while version 2.1 already supports commands, the local runner doesn't. When it does, we can upgrade.
+##################################### YAML ANCHORS  ############################################
 
 upload-coverage: &upload-coverage
   run:
@@ -102,6 +102,7 @@ dnsmasq-container: &dnsmasq-container
   - --no-poll
   - --address=/#/127.0.0.1
 
+##################################### CIRCLECI COMMANDS ############################################
 
 commands: # reusable commands with parameters
 
@@ -197,6 +198,7 @@ commands: # reusable commands with parameters
       - *store-log-artifacts
       - *upload-coverage
 
+##################################### CIRCLECI EXECUTORS ############################################
 
 executors:
   builder:
@@ -223,6 +225,8 @@ executors:
     working_directory: /opt/app-root/src/project
     environment:
       DB: oracle
+
+##################################### CIRCLECI JOBS ############################################
 
 jobs:
   dependencies_bundler:
@@ -609,6 +613,8 @@ jobs:
       - store_artifacts:
           path: tmp/capybara
           destination: capybara
+
+##################################### CIRCLECI WORKFLOWS ############################################
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ commands: # reusable commands with parameters
       - run:
           name: Install gems with bundler
           command: |
+            echo "Running gems install for database: $DB"
             bundle check || bundle install --deployment
             bundle clean
             # remove capybara-webkit source, save more than 400 MB
@@ -186,10 +187,19 @@ commands: # reusable commands with parameters
         type: string
     steps:
       - save_cache:
-          key: v1-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "gemfiles/prod/Gemfile.lock" }}
+          key: v1-bundler-gems-<< parameters.database >>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "gemfiles/prod/Gemfile.lock" }}
           paths:
           - ./vendor/bundle
           - ./.bundle/
+
+  restore-gem-cache:
+    parameters:
+      database:
+        type: string
+    steps:
+      - restore_cache:
+          keys:
+            - v1-bundler-gems-<< parameters.database >>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
 
   upload-artifacts:
     steps:
@@ -202,8 +212,14 @@ commands: # reusable commands with parameters
 
 executors:
   builder:
+    parameters:
+      database:
+        type: string
+        default: mysql
     docker:
       - *system-builder
+    environment:
+      DB: << parameters.database >>
     working_directory: /opt/app-root/src/project
 
   builder-with-mysql:
@@ -230,20 +246,26 @@ executors:
 
 jobs:
   dependencies_bundler:
-    executor: builder
+    executor:
+      name: builder
+      database: mysql
     steps:
       - checkout-with-submodules
-      - *restore-bundler-cache
+      - restore-gem-cache:
+          database: mysql
       - install-gem-dependencies
       - save-gem-cache:
           database: mysql
       - *persist-vendored-dependencies-to-workspace
 
   deps_bundler_oracle:
-    executor: builder
+    executor:
+      name: builder
+      database: oracle
     steps:
       - checkout-with-submodules
-      - *restore-bundler-cache
+      - restore-gem-cache:
+          database: oracle
       - clone-oracle-libraries
       - install-gem-dependencies
       - save-gem-cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,17 +152,38 @@ commands: # reusable commands with parameters
       - run:
           name: Prepare database for tests
           command: |
+            echo "Running for database: $DB"
             bundle exec rake ci:db:ready db:create db:test:prepare
 
   rspec-tests:
+    parameters:
+      extra-deps:
+        description: "Steps that will be executed in case extra dependencies are required, e.g. to connect to db."
+        type: steps
+        default: []
     steps:
+      - checkout-with-submodules
+      - *attach-to-workspace
+      - *use-example-config-files
+      - steps: << parameters.extra-deps >>
+      - prepare-db-for-tests
       - run:
           name: Rspec tests
           command: |
             bundle exec rspec --format progress $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+      - upload-artifacts
 
   cucumber-tests:
+    parameters:
+      extra-deps:
+        description: "Steps that will be executed in case extra dependencies are required, e.g. to connect to db."
+        type: steps
+        default: []
     steps:
+      - checkout-with-submodules
+      - *attach-to-workspace
+      - steps: << parameters.extra-deps >>
+      - prepare-db-for-tests
       - *disable-internet-access
       - run:
           name: Run cucumber tests
@@ -170,9 +191,23 @@ commands: # reusable commands with parameters
             TESTS=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
             bundle exec cucumber --profile ci ${TESTS}
       - *enable-internet-access
+      - upload-artifacts
+      - store_artifacts:
+          path: tmp/capybara
+          destination: capybara
 
   rails-tests:
+    parameters:
+      extra-deps:
+        description: "Steps that will be executed in case extra dependencies are required, e.g. to connect to db."
+        type: steps
+        default: []
     steps:
+      - checkout-with-submodules
+      - *attach-to-workspace
+      - *use-example-config-files
+      - steps: << parameters.extra-deps >>
+      - prepare-db-for-tests
       - run:
           name: Run Rails tests
           command: |
@@ -180,6 +215,7 @@ commands: # reusable commands with parameters
             bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace
           environment:
             LC_ALL: en_US.UTF-8
+      - upload-artifacts
 
   save-gem-cache:
     parameters:
@@ -354,95 +390,62 @@ jobs:
     parallelism: 8
     executor: builder-with-mysql
     steps:
-      - checkout-with-submodules
-      - *attach-to-workspace
-      - *use-example-config-files
-      - prepare-db-for-tests
       - rails-tests
-      - upload-artifacts
+
   unit-oracle:
     parallelism: 6
     executor: builder-with-oracle
     steps:
-      - checkout-with-submodules
-      - *attach-to-workspace
-      - clone-oracle-libraries
-      - *use-example-config-files
-      - prepare-db-for-tests
-      - rails-tests
-      - upload-artifacts
+      - rails-tests:
+          extra-deps:
+            - clone-oracle-libraries
 
   functional:
     parallelism: 2
     executor: builder-with-mysql
     steps:
-      - checkout-with-submodules
-      - *attach-to-workspace
-      - *use-example-config-files
-      - prepare-db-for-tests
       - rails-tests
-      - upload-artifacts
 
   functional-oracle:
     parallelism: 2
     executor: builder-with-oracle
     steps:
-      - checkout-with-submodules
-      - *attach-to-workspace
-      - clone-oracle-libraries
-      - *use-example-config-files
-      - prepare-db-for-tests
-      - rails-tests
-      - upload-artifacts
+      - rails-tests:
+          extra-deps:
+            - clone-oracle-libraries
+
 
   integration:
     parallelism: 8
     executor: builder-with-mysql
     steps:
-      - checkout-with-submodules
-      - *attach-to-workspace
-      - *use-example-config-files
-      - prepare-db-for-tests
       - rails-tests
-      - upload-artifacts
+
   integration-oracle:
     parallelism: 6
     executor: builder-with-oracle
     steps:
-      - checkout-with-submodules
-      - *attach-to-workspace
-      - clone-oracle-libraries
-      - *use-example-config-files
-      - prepare-db-for-tests
-      - rails-tests
-      - upload-artifacts
+      - rails-tests:
+          extra-deps:
+            - clone-oracle-libraries
 
   rspec:
     parallelism: 3
     executor: builder-with-mysql
     steps:
-      - checkout-with-submodules
-      - *attach-to-workspace
-      - *use-example-config-files
-      - prepare-db-for-tests
       - rspec-tests
-      - upload-artifacts
   rspec-oracle:
     parallelism: 4
     executor: builder-with-oracle
     steps:
-      - checkout-with-submodules
-      - *attach-to-workspace
-      - clone-oracle-libraries
-      - *use-example-config-files
-      - prepare-db-for-tests
-      - rspec-tests
-      - upload-artifacts
-
+      - rspec-tests:
+          extra-deps:
+            - clone-oracle-libraries
 
 
   cucumber:
     parallelism: 40
+    resource_class: small
     docker:
       - *system-builder
       - *dnsmasq-container
@@ -450,34 +453,23 @@ jobs:
       - *memcached-container
       - *redis-container
     steps:
-      - checkout-with-submodules
-      - *attach-to-workspace
-      - prepare-db-for-tests
       - cucumber-tests
-      - upload-artifacts
-      - store_artifacts:
-          path: tmp/capybara
-          destination: capybara
 
   cucumber-oracle:
     parallelism: 30
+    resource_class: large
     docker:
       - *system-builder
       - *dnsmasq-container
       - *oracle-db-container
       - *memcached-container
       - *redis-container
+    environment:
+      DB: oracle
     steps:
-      - checkout-with-submodules
-      - *attach-to-workspace
-      - clone-oracle-libraries
-      - prepare-db-for-tests
-      - cucumber-tests
-      - upload-artifacts
-      - store_artifacts:
-          path: tmp/capybara
-          destination: capybara
-
+      - cucumber-tests:
+          extra-deps:
+            - clone-oracle-libraries
 
   docker-build:
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,24 +37,6 @@ restore-npm-cache: &restore-npm-cache
     keys:
       - v1-npm-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
-rails-tests: &rails-tests
-  run:
-    name: Rails tests
-    command: |
-      TESTS=$(bundle exec rake "test:files:$CIRCLE_JOB" | circleci tests split --split-by=timings)
-      bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace
-    environment:
-      LC_ALL: en_US.UTF-8
-
-rails-tests-oracle: &rails-tests-oracle
-  run:
-    name: Rails tests
-    command: |
-      TESTS=$(bundle exec rake "test:files:${CIRCLE_JOB%-oracle}" | circleci tests split --split-by=timings)
-      DB=oracle bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace
-    environment:
-      LC_ALL: en_US.UTF-8
-
 use-example-config-files: &use-example-config-files
   run:
     name: Copy example config files into place to be used by tests
@@ -196,6 +178,19 @@ commands: # reusable commands with parameters
           command: |
             TESTS=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
             DB=<< parameters.database >> bundle exec cucumber --profile ci ${TESTS}
+
+  rails-tests:
+    parameters:
+      database:
+        type: string
+    steps:
+      - run:
+          name: Run Rails tests
+          command: |
+            TESTS=$(bundle exec rake "test:files:${CIRCLE_JOB%-oracle}" | circleci tests split --split-by=timings)
+            DB=<< parameters.database >> bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace
+          environment:
+            LC_ALL: en_US.UTF-8
 
   save-gem-cache:
     parameters:
@@ -348,7 +343,8 @@ jobs:
       - *use-example-config-files
       - prepare-db-for-tests:
           database: mysql
-      - *rails-tests
+      - rails-tests:
+          database: mysql
       - upload-artifacts
   unit-oracle:
     parallelism: 6
@@ -361,7 +357,8 @@ jobs:
     - *use-example-config-files
     - prepare-db-for-tests:
         database: oracle
-    - *rails-tests-oracle
+    - rails-tests:
+        database: oracle
     - upload-artifacts
 
   functional:
@@ -374,7 +371,8 @@ jobs:
       - *use-example-config-files
       - prepare-db-for-tests:
           database: mysql
-      - *rails-tests
+      - rails-tests:
+          database: oracle
       - upload-artifacts
 
   functional-oracle:
@@ -388,7 +386,8 @@ jobs:
     - *use-example-config-files
     - prepare-db-for-tests:
         database: oracle
-    - *rails-tests-oracle
+    - rails-tests:
+        database: oracle
     - upload-artifacts
 
   integration:
@@ -401,7 +400,8 @@ jobs:
       - *use-example-config-files
       - prepare-db-for-tests:
           database: mysql
-      - *rails-tests
+      - rails-tests:
+          database: mysql
       - upload-artifacts
   integration-oracle:
     parallelism: 6
@@ -414,7 +414,8 @@ jobs:
     - *use-example-config-files
     - prepare-db-for-tests:
         database: oracle
-    - *rails-tests-oracle
+    - rails-tests:
+        database: oracle
     - upload-artifacts
 
   rspec:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,7 @@ commands: # reusable commands with parameters
           command: |
             git clone git@github.com:3scale/system-libraries.git
             cp -R system-libraries/vendor/oracle/*.zip vendor/oracle
+            # using sudo due to `/opt/oracle/` set in: https://github.com/3scale/system-builder/blob/1bc3cec26bff04e0603e1a4908594b70a114dfe8/Dockerfile#L16-L17
             sudo unzip vendor/oracle/instantclient-basiclite-linux.x64-12.2.0.1.0.zip -d /opt/oracle
             sudo unzip vendor/oracle/instantclient-sdk-linux.x64-12.2.0.1.0.zip -d /opt/oracle
             sudo unzip vendor/oracle/instantclient-odbc-linux.x64-12.2.0.1.0-2.zip -d /opt/oracle
@@ -441,6 +442,8 @@ jobs:
       - *mysql-container
       - *memcached-container
       - *redis-container
+    environment:
+      DB: mysql
     steps:
       - cucumber-tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,6 @@ store-log-artifacts: &store-log-artifacts
     path: log
     destination: log
 
-restore-bundler-cache: &restore-bundler-cache
-  restore_cache:
-    keys:
-      - v1-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "gemfiles/prod/Gemfile.lock" }}
 restore-npm-cache: &restore-npm-cache
   restore_cache:
     keys:
@@ -117,7 +113,15 @@ commands: # reusable commands with parameters
             git submodule update
 
   install-gem-dependencies:
+    parameters:
+      extra-deps:
+        description: "Steps that will be executed in case extra dependencies."
+        type: steps
+        default: []
     steps:
+      - checkout-with-submodules
+      - restore-gem-cache
+      - steps: << parameters.extra-deps >>
       - run:
           name: Install gems with bundler
           command: |
@@ -129,6 +133,8 @@ commands: # reusable commands with parameters
           environment:
             BUNDLE_RETRY: 3
             BUNDLE_JOBS: 3
+      - save-gem-cache
+      - *persist-vendored-dependencies-to-workspace
 
   clone-oracle-libraries:
     steps:
@@ -217,24 +223,18 @@ commands: # reusable commands with parameters
       - upload-artifacts
 
   save-gem-cache:
-    parameters:
-      database:
-        type: string
     steps:
       - save_cache:
-          key: v1-bundler-gems-<< parameters.database >>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "gemfiles/prod/Gemfile.lock" }}
+          key: v1-bundler-gems-{{ .Environment.DB }}-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "gemfiles/prod/Gemfile.lock" }}
           paths:
           - ./vendor/bundle
           - ./.bundle/
 
   restore-gem-cache:
-    parameters:
-      database:
-        type: string
     steps:
       - restore_cache:
           keys:
-            - v1-bundler-gems-<< parameters.database >>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - v1-bundler-gems-{{ .Environment.DB }}-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "gemfiles/prod/Gemfile.lock" }}
 
   upload-artifacts:
     steps:
@@ -287,27 +287,16 @@ jobs:
       name: builder
       database: mysql
     steps:
-      - checkout-with-submodules
-      - restore-gem-cache:
-          database: mysql
       - install-gem-dependencies
-      - save-gem-cache:
-          database: mysql
-      - *persist-vendored-dependencies-to-workspace
 
   deps_bundler_oracle:
     executor:
       name: builder
       database: oracle
     steps:
-      - checkout-with-submodules
-      - restore-gem-cache:
-          database: oracle
-      - clone-oracle-libraries
-      - install-gem-dependencies
-      - save-gem-cache:
-          database: oracle
-      - *persist-vendored-dependencies-to-workspace
+      - install-gem-dependencies:
+          extra-deps:
+            - clone-oracle-libraries
 
   dependencies_npm:
     executor: builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,13 @@ github-access-through-ssh: &github-access-through-ssh
     fingerprints:
       - "36:6a:7a:93:88:52:12:dd:4c:84:3a:42:bf:8c:c3:58"
 
+persist-vendored-dependencies-to-workspace: &persist-vendored-dependencies-to-workspace
+  persist_to_workspace:
+    root: .
+    paths:
+    - ./vendor/bundle
+    - ./.bundle/
+
 upload-coverage: &upload-coverage
   run:
     name: Upload test coverage to Codecov
@@ -59,6 +66,23 @@ rails-tests-oracle: &rails-tests-oracle
       DB=oracle bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace
     environment:
       LC_ALL: en_US.UTF-8
+
+use-example-config-files: &use-example-config-files
+  run:
+    name: Copy example config files into place to be used by tests
+    command: |
+      cp config/examples/*.yml config/
+
+disable-internet-access: &disable-internet-access
+  run:
+    name: Disable internet access
+    command: sudo sed -c -i".bak" 's/127\.0\.0\.11$/127.0.0.1/' /etc/resolv.conf
+
+enable-internet-access: &enable-internet-access
+  run:
+    name: Enabled internet access
+    command: sudo sed -c -i".bak" 's/127\.0\.0\.1$/127.0.0.11/' /etc/resolv.conf
+    when: always
 
 attach-to-workspace: &attach-to-workspace
   attach_workspace:
@@ -122,6 +146,67 @@ clone-oracle-libs: &clone-oracle-libs
       rm -rf vendor/oracle/*.zip
       sudo cp config/oracle/*.ini /etc/
 
+commands: # reusable commands with parameters
+
+  install-gem-dependencies:
+    parameters:
+      database:
+        type: string
+    steps:
+      - run:
+          name: Install gems with bundler
+          command: |
+            DB=<< parameters.database >> bundle check || DB=<< parameters.database >> bundle install --deployment
+            DB=<< parameters.database >> bundle clean
+            # remove capybara-webkit source, save more than 400 MB
+            rm -rf "$BUNDLE_PATH/$(ruby -e 'puts Gem.ruby_engine')/$(ruby -e 'puts Gem.ruby_api_version')"/gems/capybara-webkit-*/src
+          environment:
+            BUNDLE_RETRY: 3
+            BUNDLE_JOBS: 3
+
+  prepare-db-for-tests:
+    parameters:
+      database:
+        type: string
+    steps:
+      - run:
+        name: Prepare database for tests
+        command: |
+          DB=<< parameters.database >> bundle exec rake ci:db:ready db:create db:test:prepare
+
+  rspec-tests:
+    parameters:
+      database:
+        type: string
+    steps:
+      - run:
+          name: Rspec tests
+          command: |
+            DB=<< parameters.database >> bundle exec rspec --format progress $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+
+  cucumber-tests:
+    parameters:
+      database:
+        type: string
+    steps:
+      - run:
+          name: Run cucumber tests
+          command: |
+            TESTS=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
+            DB=<< parameters.database >> bundle exec cucumber --profile ci ${TESTS}
+
+  save-gem-cache:
+    parameters:
+      database:
+        type: string
+    steps:
+      - save_cache:
+          key: v1-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "gemfiles/prod/Gemfile.lock" }}
+          paths:
+          - ./vendor/bundle
+          - ./.bundle/
+
+
 executors:
   builder:
     docker:
@@ -151,26 +236,12 @@ jobs:
       - checkout
       - *git-submodules
       - *restore-bundler-cache
-      - run:
-          name: Install gems with bundler
-          command: |
-            bundle check || bundle install --deployment
-            bundle clean
-            # remove capybara-webkit source, save more than 400 MB
-            rm -rf "$BUNDLE_PATH/$(ruby -e 'puts Gem.ruby_engine')/$(ruby -e 'puts Gem.ruby_api_version')"/gems/capybara-webkit-*/src
-          environment:
-            BUNDLE_RETRY: 3
-            BUNDLE_JOBS: 3
-      - save_cache:
-          key: v1-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "gemfiles/prod/Gemfile.lock" }}
-          paths:
-            - ./vendor/bundle
-            - ./.bundle/
-      - persist_to_workspace:
-          root: .
-          paths:
-          - ./vendor/bundle
-          - ./.bundle/
+      - install-gem-dependencies:
+          database: mysql
+      - save-gem-cache:
+          database: mysql
+      - *persist-vendored-dependencies-to-workspace
+
   deps_bundler_oracle:
     executor: builder
     steps:
@@ -179,26 +250,12 @@ jobs:
       - *restore-bundler-cache
       - *github-access-through-ssh
       - *clone-oracle-libs
-      - run:
-          name: Install gems with bundler
-          command: |
-            DB=oracle bundle check || DB=oracle bundle install --deployment
-            DB=oracle bundle clean
-            # remove capybara-webkit source, save more than 400 MB
-            rm -rf "$BUNDLE_PATH/$(ruby -e 'puts Gem.ruby_engine')/$(ruby -e 'puts Gem.ruby_api_version')"/gems/capybara-webkit-*/src
-          environment:
-            BUNDLE_RETRY: 3
-            BUNDLE_JOBS: 3
-      - save_cache:
-          key: v1-bundler-gems-oracle-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "gemfiles/prod/Gemfile.lock" }}
-          paths:
-            - ./vendor/bundle
-            - ./.bundle/
-      - persist_to_workspace:
-          root: .
-          paths:
-          - ./vendor/bundle
-          - ./.bundle/
+      - install-gem-dependencies:
+          database: oracle
+      - save-gem-cache:
+          database: oracle
+      - *persist-vendored-dependencies-to-workspace
+
   dependencies_npm:
     executor: builder
     steps:
@@ -286,11 +343,9 @@ jobs:
       - checkout
       - *git-submodules
       - *attach-to-workspace
-      - run:
-          name: Prepare database & config files
-          command: |
-            cp config/examples/*.yml config/
-            bundle exec rake db:create db:test:prepare
+      - *use-example-config-files
+      - prepare-db-for-tests:
+          database: mysql
       - *rails-tests
       - *store-junit-test-results
       - *store-test-artifacts
@@ -304,15 +359,11 @@ jobs:
     - checkout
     - *git-submodules
     - *attach-to-workspace
-    - add_ssh_keys:
-        fingerprints:
-        - "36:6a:7a:93:88:52:12:dd:4c:84:3a:42:bf:8c:c3:58"
+    - *github-access-through-ssh
     - *clone-oracle-libs
-    - run:
-        name: Prepare database & config files
-        command: |
-          cp config/examples/*.yml config/
-          DB=oracle bundle exec rake ci:db:ready db:create db:test:prepare
+    - *use-example-config-files
+    - prepare-db-for-tests:
+        database: oracle
     - *rails-tests-oracle
     - *store-junit-test-results
     - *store-test-artifacts
@@ -327,16 +378,15 @@ jobs:
       - checkout
       - *git-submodules
       - *attach-to-workspace
-      - run:
-          name: Prepare database & config files
-          command: |
-            cp config/examples/*.yml config/
-            bundle exec rake db:create db:test:prepare
+      - *use-example-config-files
+      - prepare-db-for-tests:
+          database: mysql
       - *rails-tests
       - *store-junit-test-results
       - *store-test-artifacts
       - *store-log-artifacts
       - *upload-coverage
+
   functional-oracle:
     parallelism: 2
     resource_class: large
@@ -345,15 +395,11 @@ jobs:
     - checkout
     - *git-submodules
     - *attach-to-workspace
-    - add_ssh_keys:
-        fingerprints:
-        - "36:6a:7a:93:88:52:12:dd:4c:84:3a:42:bf:8c:c3:58"
+    - *github-access-through-ssh
     - *clone-oracle-libs
-    - run:
-        name: Prepare database & config files
-        command: |
-          cp config/examples/*.yml config/
-          DB=oracle bundle exec rake ci:db:ready db:create db:test:prepare
+    - *use-example-config-files
+    - prepare-db-for-tests:
+        database: oracle
     - *rails-tests-oracle
     - *store-junit-test-results
     - *store-test-artifacts
@@ -368,11 +414,9 @@ jobs:
       - checkout
       - *git-submodules
       - *attach-to-workspace
-      - run:
-          name: Prepare database & config files
-          command: |
-            cp config/examples/*.yml config/
-            bundle exec rake db:create db:test:prepare
+      - *use-example-config-files
+      - prepare-db-for-tests:
+          database: mysql
       - *rails-tests
       - *store-junit-test-results
       - *store-test-artifacts
@@ -386,15 +430,11 @@ jobs:
     - checkout
     - *git-submodules
     - *attach-to-workspace
-    - add_ssh_keys:
-        fingerprints:
-        - "36:6a:7a:93:88:52:12:dd:4c:84:3a:42:bf:8c:c3:58"
+    - *github-access-through-ssh
     - *clone-oracle-libs
-    - run:
-        name: Prepare database & config files
-        command: |
-          cp config/examples/*.yml config/
-          DB=oracle bundle exec rake ci:db:ready db:create db:test:prepare
+    - *use-example-config-files
+    - prepare-db-for-tests:
+        database: oracle
     - *rails-tests-oracle
     - *store-junit-test-results
     - *store-test-artifacts
@@ -410,15 +450,11 @@ jobs:
       - checkout
       - *git-submodules
       - *attach-to-workspace
-      - run:
-          name: Prepare database & config files
-          command: |
-            cp config/examples/*.yml config/
-            bundle exec rake db:create db:test:prepare
-      - run:
-          name: Rspec tests
-          command: |
-            bundle exec rspec --format progress $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+      - *use-example-config-files
+      - prepare-db-for-tests:
+          database: mysql
+      - rspec-tests:
+          database: mysql
       - *store-junit-test-results
       - *store-test-artifacts
       - *store-log-artifacts
@@ -433,15 +469,11 @@ jobs:
       - *attach-to-workspace
       - *github-access-through-ssh
       - *clone-oracle-libs
-      - run:
-          name: Prepare database & config files
-          command: |
-            cp config/examples/*.yml config/
-            DB=oracle bundle exec rake ci:db:ready db:create db:test:prepare
-      - run:
-          name: Rspec tests
-          command: |
-            DB=oracle bundle exec rspec --format progress $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+      - *use-example-config-files
+      - prepare-db-for-tests:
+          database: oracle
+      - rspec-tests:
+          database: oracle
       - *store-junit-test-results
       - *store-test-artifacts
       - *store-log-artifacts
@@ -462,22 +494,12 @@ jobs:
       - checkout
       - *git-submodules
       - *attach-to-workspace
-      - run:
-          name: Prepare database
-          command: |
-            bundle exec rake db:create db:test:prepare
-      - run:
-          name: Disable internet access
-          command: sudo sed -c -i".bak" 's/127\.0\.0\.11$/127.0.0.1/' /etc/resolv.conf
-      - run:
-          name: Run cucumber tests
-          command: |
-            TESTS=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
-            bundle exec cucumber --profile ci ${TESTS}
-      - run:
-          name: Enabled internet access
-          command: sudo sed -c -i".bak" 's/127\.0\.0\.1$/127.0.0.11/' /etc/resolv.conf
-          when: always
+      - prepare-db-for-tests:
+          database: mysql
+      - *disable-internet-access
+      - cucumber-tests:
+          database: mysql
+      - *enable-internet-access
       - *store-junit-test-results
       - *store-test-artifacts
       - *store-log-artifacts
@@ -485,6 +507,7 @@ jobs:
           path: tmp/capybara
           destination: capybara
       - *upload-coverage
+
   cucumber-oracle:
     parallelism: 30
     resource_class: large
@@ -500,22 +523,12 @@ jobs:
       - *attach-to-workspace
       - *github-access-through-ssh
       - *clone-oracle-libs
-      - run:
-          name: Prepare database
-          command: |
-            DB=oracle bundle exec rake ci:db:ready db:create db:test:prepare
-      - run:
-          name: Disable internet access
-          command: sudo sed -c -i".bak" 's/127\.0\.0\.11$/127.0.0.1/' /etc/resolv.conf
-      - run:
-          name: Run cucumber tests
-          command: |
-            TESTS=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
-            DB=oracle bundle exec cucumber --profile ci ${TESTS}
-      - run:
-          name: Enabled internet access
-          command: sudo sed -c -i".bak" 's/127\.0\.0\.1$/127.0.0.11/' /etc/resolv.conf
-          when: always
+      - prepare-db-for-tests:
+          database: oracle
+      - *disable-internet-access
+      - cucumber-tests:
+          database: oracle
+      - *enable-internet-access
       - *store-junit-test-results
       - *store-test-artifacts
       - *store-log-artifacts
@@ -663,21 +676,14 @@ jobs:
       - checkout
       - *git-submodules
       - *attach-to-workspace
-      - run:
-          name: Prepare database
-          command: |
-            bundle exec rake db:create db:test:prepare
-      - run:
-          name: Disable internet access
-          command: sudo sed -c -i".bak" 's/127\.0\.0\.11$/127.0.0.1/' /etc/resolv.conf
+      - prepare-db-for-tests:
+          database: mysql
+      - *disable-internet-access
       - run:
           name: Run percy.io visual tests
           command: |
             PERCY_PROJECT=3scale/porta PERCY_BRANCH=$CIRCLE_BRANCH PERCY_COMMIT=$CIRCLE_SHA1 PERCY_ENABLE=1 bundle exec cucumber --profile ci --profile visual features
-      - run:
-          name: Enabled internet access
-          command: sudo sed -c -i".bak" 's/127\.0\.0\.1$/127.0.0.11/' /etc/resolv.conf
-          when: always
+      - *enable-internet-access
       - *store-junit-test-results
       - *store-test-artifacts
       - *store-log-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,17 +2,10 @@ version: 2.1
 
 #### YAML ANCHORS INSTEAD OF COMMANDS # while version 2.1 already supports commands, the local runner doesn't. When it does, we can upgrade.
 
-git-submodules: &git-submodules
+upload-coverage: &upload-coverage
   run:
-    name: "Pull Submodules"
-    command: |
-      git submodule init
-      git submodule update
-
-github-access-through-ssh: &github-access-through-ssh
-  add_ssh_keys:
-    fingerprints:
-      - "36:6a:7a:93:88:52:12:dd:4c:84:3a:42:bf:8c:c3:58"
+    name: Upload test coverage to Codecov
+    command: bash <(curl -s https://codecov.io/bash)
 
 persist-vendored-dependencies-to-workspace: &persist-vendored-dependencies-to-workspace
   persist_to_workspace:
@@ -20,11 +13,6 @@ persist-vendored-dependencies-to-workspace: &persist-vendored-dependencies-to-wo
     paths:
     - ./vendor/bundle
     - ./.bundle/
-
-upload-coverage: &upload-coverage
-  run:
-    name: Upload test coverage to Codecov
-    command: bash <(curl -s https://codecov.io/bash)
 
 store-junit-results: &store-junit-test-results
   store_test_results:
@@ -132,21 +120,17 @@ dnsmasq-container: &dnsmasq-container
     - --no-poll
     - --address=/#/127.0.0.1
 
-clone-oracle-libs: &clone-oracle-libs
-  run:
-    name: "Fetch oracle libraries"
-    command: |
-      git clone git@github.com:3scale/system-libraries.git
-      cp -R system-libraries/vendor/oracle/*.zip vendor/oracle
-      sudo unzip vendor/oracle/instantclient-basiclite-linux.x64-12.2.0.1.0.zip -d /opt/oracle
-      sudo unzip vendor/oracle/instantclient-sdk-linux.x64-12.2.0.1.0.zip -d /opt/oracle
-      sudo unzip vendor/oracle/instantclient-odbc-linux.x64-12.2.0.1.0-2.zip -d /opt/oracle
-      sudo ln -s /opt/oracle/instantclient_12_2/libclntsh.so.12.1 /opt/oracle/instantclient_12_2/libclntsh.so
-      sudo rm -rf /opt/system/vendor/oracle
-      rm -rf vendor/oracle/*.zip
-      sudo cp config/oracle/*.ini /etc/
 
 commands: # reusable commands with parameters
+
+  checkout-with-submodules:
+    steps:
+      - checkout
+      - run:
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update
 
   install-gem-dependencies:
     parameters:
@@ -163,6 +147,24 @@ commands: # reusable commands with parameters
           environment:
             BUNDLE_RETRY: 3
             BUNDLE_JOBS: 3
+
+  clone-oracle-libraries:
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+          - "36:6a:7a:93:88:52:12:dd:4c:84:3a:42:bf:8c:c3:58"
+      - run:
+          name: "Fetch oracle libraries"
+          command: |
+            git clone git@github.com:3scale/system-libraries.git
+            cp -R system-libraries/vendor/oracle/*.zip vendor/oracle
+            sudo unzip vendor/oracle/instantclient-basiclite-linux.x64-12.2.0.1.0.zip -d /opt/oracle
+            sudo unzip vendor/oracle/instantclient-sdk-linux.x64-12.2.0.1.0.zip -d /opt/oracle
+            sudo unzip vendor/oracle/instantclient-odbc-linux.x64-12.2.0.1.0-2.zip -d /opt/oracle
+            sudo ln -s /opt/oracle/instantclient_12_2/libclntsh.so.12.1 /opt/oracle/instantclient_12_2/libclntsh.so
+            sudo rm -rf /opt/system/vendor/oracle
+            rm -rf vendor/oracle/*.zip
+            sudo cp config/oracle/*.ini /etc/
 
   prepare-db-for-tests:
     parameters:
@@ -206,6 +208,13 @@ commands: # reusable commands with parameters
           - ./vendor/bundle
           - ./.bundle/
 
+  upload-artifacts:
+    steps:
+      - *store-junit-test-results
+      - *store-test-artifacts
+      - *store-log-artifacts
+      - *upload-coverage
+
 
 executors:
   builder:
@@ -233,8 +242,7 @@ jobs:
   dependencies_bundler:
     executor: builder
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *restore-bundler-cache
       - install-gem-dependencies:
           database: mysql
@@ -245,11 +253,9 @@ jobs:
   deps_bundler_oracle:
     executor: builder
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *restore-bundler-cache
-      - *github-access-through-ssh
-      - *clone-oracle-libs
+      - clone-oracle-libraries
       - install-gem-dependencies:
           database: oracle
       - save-gem-cache:
@@ -259,8 +265,7 @@ jobs:
   dependencies_npm:
     executor: builder
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *restore-npm-cache
       - run:
           name: Install NPM dependencies
@@ -280,8 +285,7 @@ jobs:
   assets_precompile:
     executor: builder
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *attach-to-workspace
       - run:
           name: Precompile assets
@@ -304,8 +308,7 @@ jobs:
           name: Start Xvfb
           command: Xvfb :99 -screen 0 1280x1024x24
           background: true
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *attach-to-workspace
       - run:
           name: Licences check
@@ -340,144 +343,107 @@ jobs:
     resource_class: small
     executor: builder-with-mysql
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *attach-to-workspace
       - *use-example-config-files
       - prepare-db-for-tests:
           database: mysql
       - *rails-tests
-      - *store-junit-test-results
-      - *store-test-artifacts
-      - *store-log-artifacts
-      - *upload-coverage
+      - upload-artifacts
   unit-oracle:
     parallelism: 6
     resource_class: large
     executor: builder-with-oracle
     steps:
-    - checkout
-    - *git-submodules
+    - checkout-with-submodules
     - *attach-to-workspace
-    - *github-access-through-ssh
-    - *clone-oracle-libs
+    - clone-oracle-libraries
     - *use-example-config-files
     - prepare-db-for-tests:
         database: oracle
     - *rails-tests-oracle
-    - *store-junit-test-results
-    - *store-test-artifacts
-    - *store-log-artifacts
-    - *upload-coverage
+    - upload-artifacts
 
   functional:
     parallelism: 2
     resource_class: small
     executor: builder-with-mysql
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *attach-to-workspace
       - *use-example-config-files
       - prepare-db-for-tests:
           database: mysql
       - *rails-tests
-      - *store-junit-test-results
-      - *store-test-artifacts
-      - *store-log-artifacts
-      - *upload-coverage
+      - upload-artifacts
 
   functional-oracle:
     parallelism: 2
     resource_class: large
     executor: builder-with-oracle
     steps:
-    - checkout
-    - *git-submodules
+    - checkout-with-submodules
     - *attach-to-workspace
-    - *github-access-through-ssh
-    - *clone-oracle-libs
+    - clone-oracle-libraries
     - *use-example-config-files
     - prepare-db-for-tests:
         database: oracle
     - *rails-tests-oracle
-    - *store-junit-test-results
-    - *store-test-artifacts
-    - *store-log-artifacts
-    - *upload-coverage
+    - upload-artifacts
 
   integration:
     parallelism: 8
     resource_class: small
     executor: builder-with-mysql
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *attach-to-workspace
       - *use-example-config-files
       - prepare-db-for-tests:
           database: mysql
       - *rails-tests
-      - *store-junit-test-results
-      - *store-test-artifacts
-      - *store-log-artifacts
-      - *upload-coverage
+      - upload-artifacts
   integration-oracle:
     parallelism: 6
     resource_class: large
     executor: builder-with-oracle
     steps:
-    - checkout
-    - *git-submodules
+    - checkout-with-submodules
     - *attach-to-workspace
-    - *github-access-through-ssh
-    - *clone-oracle-libs
+    - clone-oracle-libraries
     - *use-example-config-files
     - prepare-db-for-tests:
         database: oracle
     - *rails-tests-oracle
-    - *store-junit-test-results
-    - *store-test-artifacts
-    - *store-log-artifacts
-    - *upload-coverage
-
+    - upload-artifacts
 
   rspec:
     parallelism: 3
     resource_class: small
     executor: builder-with-mysql
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *attach-to-workspace
       - *use-example-config-files
       - prepare-db-for-tests:
           database: mysql
       - rspec-tests:
           database: mysql
-      - *store-junit-test-results
-      - *store-test-artifacts
-      - *store-log-artifacts
-      - *upload-coverage
+      - upload-artifacts
   rspec-oracle:
     parallelism: 4
     resource_class: large
     executor: builder-with-oracle
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *attach-to-workspace
-      - *github-access-through-ssh
-      - *clone-oracle-libs
+      - clone-oracle-libraries
       - *use-example-config-files
       - prepare-db-for-tests:
           database: oracle
       - rspec-tests:
           database: oracle
-      - *store-junit-test-results
-      - *store-test-artifacts
-      - *store-log-artifacts
-      - *upload-coverage
+      - upload-artifacts
 
 
 
@@ -491,8 +457,7 @@ jobs:
       - *memcached-container
       - *redis-container
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *attach-to-workspace
       - prepare-db-for-tests:
           database: mysql
@@ -500,13 +465,10 @@ jobs:
       - cucumber-tests:
           database: mysql
       - *enable-internet-access
-      - *store-junit-test-results
-      - *store-test-artifacts
-      - *store-log-artifacts
+      - upload-artifacts
       - store_artifacts:
           path: tmp/capybara
           destination: capybara
-      - *upload-coverage
 
   cucumber-oracle:
     parallelism: 30
@@ -518,24 +480,19 @@ jobs:
       - *memcached-container
       - *redis-container
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *attach-to-workspace
-      - *github-access-through-ssh
-      - *clone-oracle-libs
+      - clone-oracle-libraries
       - prepare-db-for-tests:
           database: oracle
       - *disable-internet-access
       - cucumber-tests:
           database: oracle
       - *enable-internet-access
-      - *store-junit-test-results
-      - *store-test-artifacts
-      - *store-log-artifacts
+      - upload-artifacts
       - store_artifacts:
           path: tmp/capybara
           destination: capybara
-      - *upload-coverage
 
 
   docker-build:
@@ -673,8 +630,7 @@ jobs:
       - *memcached-container
       - *redis-container
     steps:
-      - checkout
-      - *git-submodules
+      - checkout-with-submodules
       - *attach-to-workspace
       - prepare-db-for-tests:
           database: mysql
@@ -684,13 +640,10 @@ jobs:
           command: |
             PERCY_PROJECT=3scale/porta PERCY_BRANCH=$CIRCLE_BRANCH PERCY_COMMIT=$CIRCLE_SHA1 PERCY_ENABLE=1 bundle exec cucumber --profile ci --profile visual features
       - *enable-internet-access
-      - *store-junit-test-results
-      - *store-test-artifacts
-      - *store-log-artifacts
+      - upload-artifacts
       - store_artifacts:
           path: tmp/capybara
           destination: capybara
-      - *upload-coverage
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,15 +115,12 @@ commands: # reusable commands with parameters
             git submodule update
 
   install-gem-dependencies:
-    parameters:
-      database:
-        type: string
     steps:
       - run:
           name: Install gems with bundler
           command: |
-            DB=<< parameters.database >> bundle check || DB=<< parameters.database >> bundle install --deployment
-            DB=<< parameters.database >> bundle clean
+            bundle check || bundle install --deployment
+            bundle clean
             # remove capybara-webkit source, save more than 400 MB
             rm -rf "$BUNDLE_PATH/$(ruby -e 'puts Gem.ruby_engine')/$(ruby -e 'puts Gem.ruby_api_version')"/gems/capybara-webkit-*/src
           environment:
@@ -149,46 +146,34 @@ commands: # reusable commands with parameters
             sudo cp config/oracle/*.ini /etc/
 
   prepare-db-for-tests:
-    parameters:
-      database:
-        type: string
     steps:
       - run:
           name: Prepare database for tests
           command: |
-            DB=<< parameters.database >> bundle exec rake ci:db:ready db:create db:test:prepare
+            bundle exec rake ci:db:ready db:create db:test:prepare
 
   rspec-tests:
-    parameters:
-      database:
-        type: string
     steps:
       - run:
           name: Rspec tests
           command: |
-            DB=<< parameters.database >> bundle exec rspec --format progress $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            bundle exec rspec --format progress $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
 
   cucumber-tests:
-    parameters:
-      database:
-        type: string
     steps:
       - run:
           name: Run cucumber tests
           command: |
             TESTS=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
-            DB=<< parameters.database >> bundle exec cucumber --profile ci ${TESTS}
+            bundle exec cucumber --profile ci ${TESTS}
 
   rails-tests:
-    parameters:
-      database:
-        type: string
     steps:
       - run:
           name: Run Rails tests
           command: |
             TESTS=$(bundle exec rake "test:files:${CIRCLE_JOB%-oracle}" | circleci tests split --split-by=timings)
-            DB=<< parameters.database >> bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace
+            bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace
           environment:
             LC_ALL: en_US.UTF-8
 
@@ -224,6 +209,8 @@ executors:
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
+    environment:
+      DB: mysql
 
   builder-with-oracle:
     docker:
@@ -232,6 +219,8 @@ executors:
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
+    environment:
+      DB: oracle
 
 jobs:
   dependencies_bundler:
@@ -239,8 +228,7 @@ jobs:
     steps:
       - checkout-with-submodules
       - *restore-bundler-cache
-      - install-gem-dependencies:
-          database: mysql
+      - install-gem-dependencies
       - save-gem-cache:
           database: mysql
       - *persist-vendored-dependencies-to-workspace
@@ -251,8 +239,7 @@ jobs:
       - checkout-with-submodules
       - *restore-bundler-cache
       - clone-oracle-libraries
-      - install-gem-dependencies:
-          database: oracle
+      - install-gem-dependencies
       - save-gem-cache:
           database: oracle
       - *persist-vendored-dependencies-to-workspace
@@ -341,10 +328,8 @@ jobs:
       - checkout-with-submodules
       - *attach-to-workspace
       - *use-example-config-files
-      - prepare-db-for-tests:
-          database: mysql
-      - rails-tests:
-          database: mysql
+      - prepare-db-for-tests
+      - rails-tests
       - upload-artifacts
   unit-oracle:
     parallelism: 6
@@ -355,10 +340,8 @@ jobs:
     - *attach-to-workspace
     - clone-oracle-libraries
     - *use-example-config-files
-    - prepare-db-for-tests:
-        database: oracle
-    - rails-tests:
-        database: oracle
+    - prepare-db-for-tests
+    - rails-tests
     - upload-artifacts
 
   functional:
@@ -369,10 +352,8 @@ jobs:
       - checkout-with-submodules
       - *attach-to-workspace
       - *use-example-config-files
-      - prepare-db-for-tests:
-          database: mysql
-      - rails-tests:
-          database: oracle
+      - prepare-db-for-tests
+      - rails-tests
       - upload-artifacts
 
   functional-oracle:
@@ -384,10 +365,8 @@ jobs:
     - *attach-to-workspace
     - clone-oracle-libraries
     - *use-example-config-files
-    - prepare-db-for-tests:
-        database: oracle
-    - rails-tests:
-        database: oracle
+    - prepare-db-for-tests
+    - rails-tests
     - upload-artifacts
 
   integration:
@@ -398,10 +377,8 @@ jobs:
       - checkout-with-submodules
       - *attach-to-workspace
       - *use-example-config-files
-      - prepare-db-for-tests:
-          database: mysql
-      - rails-tests:
-          database: mysql
+      - prepare-db-for-tests
+      - rails-tests
       - upload-artifacts
   integration-oracle:
     parallelism: 6
@@ -412,10 +389,8 @@ jobs:
     - *attach-to-workspace
     - clone-oracle-libraries
     - *use-example-config-files
-    - prepare-db-for-tests:
-        database: oracle
-    - rails-tests:
-        database: oracle
+    - prepare-db-for-tests
+    - rails-tests
     - upload-artifacts
 
   rspec:
@@ -426,10 +401,8 @@ jobs:
       - checkout-with-submodules
       - *attach-to-workspace
       - *use-example-config-files
-      - prepare-db-for-tests:
-          database: mysql
-      - rspec-tests:
-          database: mysql
+      - prepare-db-for-tests
+      - rspec-tests
       - upload-artifacts
   rspec-oracle:
     parallelism: 4
@@ -440,10 +413,8 @@ jobs:
       - *attach-to-workspace
       - clone-oracle-libraries
       - *use-example-config-files
-      - prepare-db-for-tests:
-          database: oracle
-      - rspec-tests:
-          database: oracle
+      - prepare-db-for-tests
+      - rspec-tests
       - upload-artifacts
 
 
@@ -460,11 +431,9 @@ jobs:
     steps:
       - checkout-with-submodules
       - *attach-to-workspace
-      - prepare-db-for-tests:
-          database: mysql
+      - prepare-db-for-tests
       - *disable-internet-access
-      - cucumber-tests:
-          database: mysql
+      - cucumber-tests
       - *enable-internet-access
       - upload-artifacts
       - store_artifacts:
@@ -484,11 +453,9 @@ jobs:
       - checkout-with-submodules
       - *attach-to-workspace
       - clone-oracle-libraries
-      - prepare-db-for-tests:
-          database: oracle
+      - prepare-db-for-tests
       - *disable-internet-access
-      - cucumber-tests:
-          database: oracle
+      - cucumber-tests
       - *enable-internet-access
       - upload-artifacts
       - store_artifacts:
@@ -633,8 +600,7 @@ jobs:
     steps:
       - checkout-with-submodules
       - *attach-to-workspace
-      - prepare-db-for-tests:
-          database: mysql
+      - prepare-db-for-tests
       - *disable-internet-access
       - run:
           name: Run percy.io visual tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,13 +338,13 @@ jobs:
     resource_class: large
     executor: builder-with-oracle
     steps:
-    - checkout-with-submodules
-    - *attach-to-workspace
-    - clone-oracle-libraries
-    - *use-example-config-files
-    - prepare-db-for-tests
-    - rails-tests
-    - upload-artifacts
+      - checkout-with-submodules
+      - *attach-to-workspace
+      - clone-oracle-libraries
+      - *use-example-config-files
+      - prepare-db-for-tests
+      - rails-tests
+      - upload-artifacts
 
   functional:
     parallelism: 2
@@ -363,13 +363,13 @@ jobs:
     resource_class: large
     executor: builder-with-oracle
     steps:
-    - checkout-with-submodules
-    - *attach-to-workspace
-    - clone-oracle-libraries
-    - *use-example-config-files
-    - prepare-db-for-tests
-    - rails-tests
-    - upload-artifacts
+      - checkout-with-submodules
+      - *attach-to-workspace
+      - clone-oracle-libraries
+      - *use-example-config-files
+      - prepare-db-for-tests
+      - rails-tests
+      - upload-artifacts
 
   integration:
     parallelism: 8
@@ -387,13 +387,13 @@ jobs:
     resource_class: large
     executor: builder-with-oracle
     steps:
-    - checkout-with-submodules
-    - *attach-to-workspace
-    - clone-oracle-libraries
-    - *use-example-config-files
-    - prepare-db-for-tests
-    - rails-tests
-    - upload-artifacts
+      - checkout-with-submodules
+      - *attach-to-workspace
+      - clone-oracle-libraries
+      - *use-example-config-files
+      - prepare-db-for-tests
+      - rails-tests
+      - upload-artifacts
 
   rspec:
     parallelism: 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ system-builder: &system-builder
     TZ: UTC
     MASTER_PASSWORD: p
     USER_PASSWORD: p
+    LC_ALL: en_US.UTF-8
 
 mysql-container: &mysql-container
   image: circleci/mysql:5.7-ram
@@ -213,8 +214,6 @@ commands: # reusable commands with parameters
           command: |
             TESTS=$(bundle exec rake "test:files:${CIRCLE_JOB%-oracle}" | circleci tests split --split-by=timings)
             bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace
-          environment:
-            LC_ALL: en_US.UTF-8
       - upload-artifacts
 
   save-gem-cache:
@@ -434,6 +433,7 @@ jobs:
     executor: builder-with-mysql
     steps:
       - rspec-tests
+
   rspec-oracle:
     parallelism: 4
     executor: builder-with-oracle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,11 +161,13 @@ commands: # reusable commands with parameters
 
   cucumber-tests:
     steps:
+      - *disable-internet-access
       - run:
           name: Run cucumber tests
           command: |
             TESTS=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
             bundle exec cucumber --profile ci ${TESTS}
+      - *enable-internet-access
 
   rails-tests:
     steps:
@@ -432,9 +434,7 @@ jobs:
       - checkout-with-submodules
       - *attach-to-workspace
       - prepare-db-for-tests
-      - *disable-internet-access
       - cucumber-tests
-      - *enable-internet-access
       - upload-artifacts
       - store_artifacts:
           path: tmp/capybara
@@ -454,9 +454,7 @@ jobs:
       - *attach-to-workspace
       - clone-oracle-libraries
       - prepare-db-for-tests
-      - *disable-internet-access
       - cucumber-tests
-      - *enable-internet-access
       - upload-artifacts
       - store_artifacts:
           path: tmp/capybara

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,11 @@ git-submodules: &git-submodules
       git submodule init
       git submodule update
 
+github-access-through-ssh: &github-access-through-ssh
+  add_ssh_keys:
+    fingerprints:
+      - "36:6a:7a:93:88:52:12:dd:4c:84:3a:42:bf:8c:c3:58"
+
 upload-coverage: &upload-coverage
   run:
     name: Upload test coverage to Codecov
@@ -97,6 +102,12 @@ memcached-container: &memcached-container
 redis-container: &redis-container
   image: redis:4.0-alpine
 
+dnsmasq-container: &dnsmasq-container
+  image: quay.io/mikz/dnsmasq
+    command:
+    - --no-poll
+    - --address=/#/127.0.0.1
+
 clone-oracle-libs: &clone-oracle-libs
   run:
     name: "Fetch oracle libraries"
@@ -166,9 +177,7 @@ jobs:
       - checkout
       - *git-submodules
       - *restore-bundler-cache
-      - add_ssh_keys:
-          fingerprints:
-          - "36:6a:7a:93:88:52:12:dd:4c:84:3a:42:bf:8c:c3:58"
+      - *github-access-through-ssh
       - *clone-oracle-libs
       - run:
           name: Install gems with bundler
@@ -422,9 +431,7 @@ jobs:
       - checkout
       - *git-submodules
       - *attach-to-workspace
-      - add_ssh_keys:
-          fingerprints:
-          - "36:6a:7a:93:88:52:12:dd:4c:84:3a:42:bf:8c:c3:58"
+      - *github-access-through-ssh
       - *clone-oracle-libs
       - run:
           name: Prepare database & config files
@@ -447,13 +454,10 @@ jobs:
     resource_class: small
     docker:
       - *system-builder
-      - image: quay.io/mikz/dnsmasq
-        command:
-        - --no-poll
-        - --address=/#/127.0.0.1
+      - *dnsmasq-container
       - *mysql-container
-      - image: memcached:1.5-alpine
-      - image: redis:4.0-alpine
+      - *memcached-container
+      - *redis-container
     steps:
       - checkout
       - *git-submodules
@@ -486,20 +490,15 @@ jobs:
     resource_class: large
     docker:
       - *system-builder
-      - image: quay.io/mikz/dnsmasq
-        command:
-        - --no-poll
-        - --address=/#/127.0.0.1
+      - *dnsmasq-container
       - *oracle-db-container
-      - image: memcached:1.5-alpine
-      - image: redis:4.0-alpine
+      - *memcached-container
+      - *redis-container
     steps:
       - checkout
       - *git-submodules
       - *attach-to-workspace
-      - add_ssh_keys:
-          fingerprints:
-          - "36:6a:7a:93:88:52:12:dd:4c:84:3a:42:bf:8c:c3:58"
+      - *github-access-through-ssh
       - *clone-oracle-libs
       - run:
           name: Prepare database
@@ -657,13 +656,9 @@ jobs:
         - --no-poll
         - --address=/#/127.0.0.1
         - --server=/percy.io/8.8.8.8
-      - image: circleci/mysql:5.7-ram
-        environment:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_ROOT_PASSWORD: ''
-          MYSQL_DATABASE: circleci
-      - image: memcached:1.5-alpine
-      - image: redis:4.0-alpine
+      - *mysql-container
+      - *memcached-container
+      - *redis-container
     steps:
       - checkout
       - *git-submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,7 @@ executors:
     working_directory: /opt/app-root/src/project
 
   builder-with-mysql:
+    resource_class: small
     docker:
       - *system-builder
       - *mysql-container
@@ -233,6 +234,7 @@ executors:
       DB: mysql
 
   builder-with-oracle:
+    resource_class: large
     docker:
       - *system-builder
       - *oracle-db-container
@@ -350,7 +352,6 @@ jobs:
 
   unit:
     parallelism: 8
-    resource_class: small
     executor: builder-with-mysql
     steps:
       - checkout-with-submodules
@@ -361,7 +362,6 @@ jobs:
       - upload-artifacts
   unit-oracle:
     parallelism: 6
-    resource_class: large
     executor: builder-with-oracle
     steps:
       - checkout-with-submodules
@@ -374,7 +374,6 @@ jobs:
 
   functional:
     parallelism: 2
-    resource_class: small
     executor: builder-with-mysql
     steps:
       - checkout-with-submodules
@@ -386,7 +385,6 @@ jobs:
 
   functional-oracle:
     parallelism: 2
-    resource_class: large
     executor: builder-with-oracle
     steps:
       - checkout-with-submodules
@@ -399,7 +397,6 @@ jobs:
 
   integration:
     parallelism: 8
-    resource_class: small
     executor: builder-with-mysql
     steps:
       - checkout-with-submodules
@@ -410,7 +407,6 @@ jobs:
       - upload-artifacts
   integration-oracle:
     parallelism: 6
-    resource_class: large
     executor: builder-with-oracle
     steps:
       - checkout-with-submodules
@@ -423,7 +419,6 @@ jobs:
 
   rspec:
     parallelism: 3
-    resource_class: small
     executor: builder-with-mysql
     steps:
       - checkout-with-submodules
@@ -434,7 +429,6 @@ jobs:
       - upload-artifacts
   rspec-oracle:
     parallelism: 4
-    resource_class: large
     executor: builder-with-oracle
     steps:
       - checkout-with-submodules
@@ -449,7 +443,6 @@ jobs:
 
   cucumber:
     parallelism: 40
-    resource_class: small
     docker:
       - *system-builder
       - *dnsmasq-container
@@ -468,7 +461,6 @@ jobs:
 
   cucumber-oracle:
     parallelism: 30
-    resource_class: large
     docker:
       - *system-builder
       - *dnsmasq-container


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR migrates the circleci config from v2.0 to [version 2.1](https://circleci.com/docs/2.0/reusing-config/) 

**Which issue(s) this PR fixes** 

this is useful so we can start using the latest circleci features, like orbs. 
it will also keep the circleci config a little more DRY.

**Verification steps** 

tests should remain green. not changing anything in the app here. aiming this to be a simple refactoring

**Special notes for your reviewer**:

