### PR TITLE
Remove unused tech_support_email and admin_support_email

### DIFF
--- a/app/controllers/admin/api/services_controller.rb
+++ b/app/controllers/admin/api/services_controller.rb
@@ -78,8 +78,6 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add :name => "name", :description => "New name for the service.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
   ##~ op.parameters.add :name => "description", :description => "New description for the service.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
   ##~ op.parameters.add :name => "support_email", :description => "New support email.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
-  ##~ op.parameters.add :name => "tech_support_email", :description => "New technical support email.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
-  ##~ op.parameters.add :name => "admin_support_email", :description => "New admin support email.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
   ##~ op.parameters.add :name => "deployment_option", :description => "Deployment option for the gateway: 'hosted' for APIcast hosted, 'self-managed' for APIcast Self-managed option", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
   ##~ op.parameters.add :name => "backend_version", :description => "Authentication mode: '1' for API key, '2' for App Id / App Key, 'oidc' for OpenID Connect", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
   ##~ op.parameters.add @parameter_extra_short

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -108,13 +108,13 @@ class Service < ApplicationRecord
     end
   end)
 
-  validates :tech_support_email, :admin_support_email, :credit_card_support_email, format: { with: /.+@.+\..+/, allow_blank: true }
+  validates :credit_card_support_email, format: { with: /.+@.+\..+/, allow_blank: true }
 
   validates :name, presence: true
 
   validates :default_end_user_plan, presence: { unless: :end_user_registration_required? }
   validates :name, :logo_file_name, :logo_content_type, :state, :draft_name,
-            :tech_support_email, :admin_support_email, :credit_card_support_email,
+            :credit_card_support_email,
             :buyer_plan_change_permission, :system_name, :backend_version, :support_email, :deployment_option,
             length: { maximum: 255 }
   validates :infobar, :terms, :notification_settings, :oneline_description, :description,
@@ -368,8 +368,6 @@ class Service < ApplicationRecord
 
       xml.deployment_option deployment_option
       xml.support_email support_email
-      xml.tech_support_email tech_support_email
-      xml.admin_support_email admin_support_email
 
       xml.end_user_registration_required end_user_registration_required
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -43,7 +43,7 @@ class Service < ApplicationRecord
   end
 
   def self.columns
-    super.reject { |column| column.name == 'buyer_can_see_log_requests'}
+    super.reject { |column| %w[buyer_can_see_log_requests tech_support_email admin_support_email].include?(column.name) }
   end
 
   scope :of_account, ->(account) { where.has { account_id == account } }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -15,7 +15,7 @@ class Service < ApplicationRecord
 
   has_system_name uniqueness_scope: :account_id
 
-  attr_readonly :system_name
+  attr_readonly :system_name, :admin_support_email, :tech_support_email
 
   validates :backend_version, inclusion: { in: ->(service) { BackendVersion.usable_versions(service: service) }}
 

--- a/app/representers/service_representer.rb
+++ b/app/representers/service_representer.rb
@@ -12,8 +12,6 @@ module ServiceRepresenter
   property :backend_version
   property :deployment_option
   property :support_email
-  property :tech_support_email
-  property :admin_support_email
   property :description
 
   property :created_at

--- a/app/views/account_messenger/expired_credit_card_notification_for_buyer.text.liquid
+++ b/app/views/account_messenger/expired_credit_card_notification_for_buyer.text.liquid
@@ -4,8 +4,8 @@ Thank you for using our service.
 
 We are writing you because your Credit Card is about to expire. To continue using the service, please update the new payment details in the next 10 days. You can find them on the Account tab of your API Dashboard.
 
-{% if admin_support_email %}
-If you need any help, please don't hesitate to contact us on {{admin_support_email}}.
+{% if support_email %}
+If you need any help, please don't hesitate to contact us on {{support_email}}.
 {% endif %}
 
 Thank you very much.

--- a/app/views/cinstance_messenger/expired_trial_period_notification.text.liquid
+++ b/app/views/cinstance_messenger/expired_trial_period_notification.text.liquid
@@ -4,8 +4,8 @@ This is a reminder that your trial account with us is due for renewal in 10 days
 
 In order to keep on benefiting from the API, please fill in the payment details on your Account tab.
 
-{% if admin_support_email %}
-If you have any questions, feel free to contact our support team {{admin_support_email}}.
+{% if support_email %}
+If you have any questions, feel free to contact our support team {{support_email}}.
 {% endif %}
 
 Best regards,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1054,10 +1054,8 @@ en:
 
       # Service attributes
       service:
-        admin_support_email: Administrative support email address
         credit_card_support_email: "Who should be emailed, to change credit card details?"
         friendly_id: URL
-        tech_support_email: Technical support email address
         txt_support: Contact and Support Information
 
       proxy:

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -6772,22 +6772,6 @@
               "paramType": "query"
             },
             {
-              "name": "tech_support_email",
-              "description": "New technical support email.",
-              "dataType": "string",
-              "allowMultiple": false,
-              "required": false,
-              "paramType": "query"
-            },
-            {
-              "name": "admin_support_email",
-              "description": "New admin support email.",
-              "dataType": "string",
-              "allowMultiple": false,
-              "required": false,
-              "paramType": "query"
-            },
-            {
               "name": "deployment_option",
               "description": "Deployment option for the gateway: 'hosted' for APIcast hosted, 'self-managed' for APIcast Self-managed option",
               "dataType": "string",

--- a/lib/developer_portal/lib/liquid/drops/service.rb
+++ b/lib/developer_portal/lib/liquid/drops/service.rb
@@ -181,7 +181,7 @@ module Liquid
         Drops::Metric.wrap(@service.metrics.top_level)
       end
 
-      # TODO: remove this and remove all references, views, controllers
+      # NOTE: keeping in case somebody already using 'admin_support_email' liquid
       hidden
       deprecated "Use **support_email** instead."
       def admin_support_email

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -42,6 +42,24 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     expected_signup_and_use.each { |attr_name, attr_value| assert_equal attr_value, service.public_send(attr_name) }
   end
 
+  # This test can be removed once used deprecated attributes have been removed from the schema
+  test 'deprecated attributes should not be updated' do
+    new_tech_support_email = 'foo.tech.support@example.com'
+    new_admin_support_email = 'foo.admin.support@example.com'
+
+    deprecated_update_params = { service:
+                                 { tech_support_email: new_tech_support_email,
+                                   admin_support_email: new_admin_support_email }
+                               }
+
+    put admin_service_path(service), deprecated_update_params
+
+    service.reload
+
+    assert_not_equal service.tech_support_email, new_tech_support_email
+    assert_not_equal service.admin_support_email, new_admin_support_email
+  end
+
   private
 
   def update_params

--- a/test/integration/user-management-api/services_test.rb
+++ b/test/integration/user-management-api/services_test.rb
@@ -99,16 +99,13 @@ class Admin::Api::ServicesTest < ActionDispatch::IntegrationTest
 
   test 'update the support email' do
     put(admin_api_service_path(@service), provider_key: @provider.api_key, :format => :xml,
-                                          support_email: 'supp@topo.com', tech_support_email: 'techtopo@topo.com',
-                                          admin_support_email: 'admintopo@topo.com')
+                                          support_email: 'supp@topo.com')
 
     assert_response :success
 
     @service.reload
 
     assert_equal 'supp@topo.com', @service.support_email
-    assert_equal 'techtopo@topo.com', @service.tech_support_email
-    assert_equal 'admintopo@topo.com',  @service.admin_support_email
   end
 
   pending_test 'update with wrong id' do


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes unused fields from the API request and response (they are not visible in the UI and not used anywhere).

**Which issue(s) this PR fixes** 

Closes https://issues.jboss.org/browse/THREESCALE-1615

**Verification steps** 

TBD

**Special notes for your reviewer**:
