### PR TITLE
Fix the ActiveDocs documentation for User Permissions Update endpoint

### DIFF
--- a/app/controllers/admin/api/member_permissions_controller.rb
+++ b/app/controllers/admin/api/member_permissions_controller.rb
@@ -40,8 +40,8 @@ class Admin::Api::MemberPermissionsController < Admin::Api::BaseController
   #
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_admin_id_by_id
-  ##~ op.parameters.add :name => "allowed_service_ids", :description => "IDs of the services that need to be enabled, comma-separated. To enable all services, no value should be provided. To disable all services, the value should be: '[]'.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
-  ##~ op.parameters.add :name => "allowed_sections", :description => "The list of sections in the admin portal that the user can access, comma-separated. Possible values: 'portal' (Developer Portal), 'finance' (Billing), 'settings', 'partners' (Developer Accounts -- Applications), 'monitoring' (Analytics), 'plans' (Integration & Application Plans)", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "allowed_service_ids", :defaultName => "allowed_service_ids[]", :description => "IDs of the services that need to be enabled, URL-encoded array. To disable all services, set the value to '[]'. To enable all services, add parameter 'allowed_service_ids[]' with no value to the 'curl' command (can't be done in ActiveDocs)", :dataType => "custom", :allowMultiple => true, :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "allowed_sections", :defaultName => "allowed_sections[]", :description => "The list of sections in the admin portal that the user can access, URL-encoded array. Possible values: 'portal' (Developer Portal), 'finance' (Billing), 'settings', 'partners' (Developer Accounts -- Applications), 'monitoring' (Analytics), 'plans' (Integration & Application Plans). To disable all sections, set the value to '[]'.", :dataType => "custom", :allowMultiple => true, :required => false, :paramType => "query"
   #
   def update
     authorize! :update_permissions, user

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -3979,17 +3979,19 @@
             },
             {
               "name": "allowed_service_ids",
-              "description": "IDs of the services that need to be enabled, comma-separated. To enable all services, no value should be provided. To disable all services, the value should be: '[]'.",
-              "dataType": "string",
-              "allowMultiple": false,
+              "defaultName": "allowed_service_ids[]",
+              "description": "IDs of the services that need to be enabled, URL-encoded array. To disable all services, set the value to '[]'. To enable all services, add parameter 'allowed_service_ids[]' with no value to the 'curl' command (can't be done in ActiveDocs)",
+              "dataType": "custom",
+              "allowMultiple": true,
               "required": false,
               "paramType": "query"
             },
             {
               "name": "allowed_sections",
-              "description": "The list of sections in the admin portal that the user can access, comma-separated. Possible values: 'portal' (Developer Portal), 'finance' (Billing), 'settings', 'partners' (Developer Accounts -- Applications), 'monitoring' (Analytics), 'plans' (Integration & Application Plans)",
-              "dataType": "string",
-              "allowMultiple": false,
+              "defaultName": "allowed_sections[]",
+              "description": "The list of sections in the admin portal that the user can access, URL-encoded array. Possible values: 'portal' (Developer Portal), 'finance' (Billing), 'settings', 'partners' (Developer Accounts -- Applications), 'monitoring' (Analytics), 'plans' (Integration & Application Plans). To disable all sections, set the value to '[]'.",
+              "dataType": "custom",
+              "allowMultiple": true,
               "required": false,
               "paramType": "query"
             }

--- a/vendor/active-docs/app/assets/javascripts/active-docs/templates.coffee
+++ b/vendor/active-docs/app/assets/javascripts/active-docs/templates.coffee
@@ -91,8 +91,8 @@ templates  =
   <tr class='zebra'>
     <td class='code'>${name} {{if allowMultiple }} <a class='add' href='#' data-guid='${guid}'>&nbsp;</a> {{/if}}</td>
     <td>
-      <input class='custom name' {{if threescale_name }}data-threescale-name='${threescale_name}'{{/if}} data-param-type='custom'  minlength='0' name='${name}' placeholder='name' type='text' value='' />
-      <input class='custom value' data-param-type='custom'  minlength='0' name='${name}' placeholder='value' type='text' value='' />
+      <input class='custom name' {{if threescale_name }}data-threescale-name='${threescale_name}'{{/if}} data-param-type='custom'  minlength='0' name='${name}' placeholder='name' type='text' value='${defaultName}' />
+      <input class='custom value' data-param-type='custom'  minlength='0' name='${name}' placeholder='value' type='text' value='${defaultValue}' />
       <input class='custom-hidden'  data-guid='${guid}' data-param-type='${paramType}' name='${name}' type='hidden' data-original-name='' value='' />
      <div class='apidocs-description'>
         ${description_inline}


### PR DESCRIPTION
**What this PR does / why we need it**:

The ActiveDocs documentation for the User Permission Update endpoint introduced in https://github.com/3scale/porta/pull/121 is wrong.

**Which issue(s) this PR fixes** 

Fixes https://issues.jboss.org/browse/THREESCALE-1703

**Verification steps** 

_Before:_
<img width="1032" alt="screen shot 2018-12-19 at 15 36 40" src="https://user-images.githubusercontent.com/1270328/50226591-ef3fd000-03a3-11e9-928f-4b30302d4b93.png">

_After:_

<img width="1035" alt="screenshot_for_member_solution_3125541" src="https://user-images.githubusercontent.com/1270328/50227559-48106800-03a6-11e9-8acb-574d31231c3a.png">

**Special notes for your reviewer**:

Adds additional parameters `defaultName` and `defaultValue` to ActiveDocs template for "custom" field type to help user understand how it works. Further description of how the API works can be found here: https://access.redhat.com/solutions/3125541

Also pasting it below.

## Full Documentation

The following endpoints are available for managing member user permissions (`{id}` is the member user ID):

- _User Permissions Read_ `GET /admin/api/users/{id}/permissions.xml`
- _User Permissions Update_ ` PUT /admin/api/users/{id}/permissions.xml`

#### Request
The **User Permissions Update** accepts the following parameters:

- `access_token` – should be a Read & Write Access Token with Account Management API scope. Only users with **full admin permissions** are allowed to update other users' permissions, so the access token should belong to an full admin.
- `allowed_sections`  – the list of the allowed admin sections. The possible values are:
  - `portal` – Developer Portal
  - `finance` – Billing
  - `settings` – Settings
  - `partners` – Developer Accounts -- Applications
  - `monitoring` – Analytics
  - `plans` – Integration & Application Plans
- `allowed_service_ids` – the list of the allowed service IDs.

The parameters `allowed_sections` and `allowed_service_ids` need to be passed in the body encoded as query string array. Multiple values can be passed in one request.

For example, to enable Billing and Analytics sections for services with IDs 123 and 567, for the admin member user with id 890 the corresponding `curl` command will be:

~~~
curl -v -X PUT "https://<ADMIN_PORTAL_URL>/admin/api/users/890/permissions.xml" -d 'access_token=<ACCESS_TOKEN>&allowed_sections%5B%5D=finance&allowed_sections%5B%5D=monitoring&allowed_service_ids%5B%5D=123&allowed_service_ids%5B%5D=567'
~~~

where `%5B%5D` is the URL-encoded `[]` representing the array.

All sections and service IDs that need to be enabled should be included in the request. The sections or services that are missing in the request will be disabled (in case they were enabled previously).

The invalid `allowed_sections` and the non-existing `allowed_service_ids` will be filtered out.

To disable all sections, set `allowed_sections` to an empty array: `allowed_sections%5B%5D=%5B%5D`.
To disable all services, set `allowed_service_ids` to an empty array: `allowed_service_ids%5B%5D=%5B%5D`.

To enable all services (_All current and future APIs_), do not provide any value for `allowed_service_ids`: `allowed_service_ids%5B%5D`.

If only `allowed_service_ids` is provided in the request, the allowed sections remain unchanged. Just as if only `allowed_sections` is provided in the request, the allowed service IDs remain unchanged.

#### Response

The response has the following format (corresponds to the example `curl` command provided in the Request description):
~~~
<permissions>
  <user_id>890</user_id>
  <role>member</role>
  <allowed_sections>
    <allowed_section>monitoring</allowed_section>
    <allowed_section>finance</allowed_section>
  </allowed_sections>
  <allowed_service_ids>
    <allowed_service_id>123</allowed_service_id>
    <allowed_service_id>567</allowed_service_id>
  </allowed_service_ids>
</permissions>
~~~

A user with no available sections and no available services would be shown as follows:
~~~
<permissions>
  <user_id>890</user_id>
  <role>member</role>
  <allowed_sections/>
  <allowed_service_ids/>
</permissions>
~~~

The admin users have unlimited access to all sections and all services (_All current and future APIs_), the admin user's permissions cannot be updated. The response to the _User Permissions Read_ endpoint for an admin user would be as follows:
~~~
<permissions>
  <user_id>70</user_id>
  <role>admin</role>
  <allowed_sections>
    <allowed_section>portal</allowed_section>
    <allowed_section>finance</allowed_section>
    <allowed_section>settings</allowed_section>
    <allowed_section>partners</allowed_section>
    <allowed_section>monitoring</allowed_section>
    <allowed_section>plans</allowed_section>
  </allowed_sections>
</permissions>
~~~
Note that if all services (_All current and future APIs_) are enabled, the field `allowed_service_ids` does not appear in the response.