### PR TITLE
[developer-portal] Swagger spec should return a 404 if not found

### DIFF
--- a/lib/developer_portal/app/controllers/developer_portal/swagger/spec_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/swagger/spec_controller.rb
@@ -24,7 +24,7 @@ class DeveloperPortal::Swagger::SpecController < DeveloperPortal::BaseController
   #   and somehow the call fails somewhere in the chain (api-docs-proxy/apache/nginx)
   def show
 
-    active_doc = site_account.api_docs_services.published.find_by_id_or_system_name params[:id]
+    active_doc = site_account.api_docs_services.published.find_by_id_or_system_name! params[:id]
 
     json = if active_doc.specification.swagger_2_0?
       active_doc.specification.as_json

--- a/test/integration/developer_portal/swagger/spec_controller_test.rb
+++ b/test/integration/developer_portal/swagger/spec_controller_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class DeveloperPortal::Swagger::SpecControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @active_doc = FactoryBot.create(:api_docs_service, published: true)
+    @provider = @active_doc.account
+    host! @provider.domain
+  end
+
+  def test_show
+    get developer_portal.swagger_spec_path(@active_doc), format: :json
+    assert_response :success
+    assert_equal(@active_doc.body, response.body)
+  end
+
+  def test_show_404
+    get developer_portal.swagger_spec_path('undefined'), format: :json
+    assert_response :not_found
+    assert_equal({status: 'Not found'}.to_json, response.body)
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

If passing a non-existent swagger spec identifier it raises a 503 for the spec.json in developer portal
