### PR TITLE
[wip][rails-5.0] Remove symbolize gem

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -58,9 +58,6 @@ gem 'money', '6.7.1' # Lock to this version we use in production
 gem 'stripe' # we need the stripe gem because activemerchant can not generate Stripe's "customers"
 gem 'audited-activerecord'
 
-# Rails 4.1: this should not be needed, maybe replace it with enum -- http://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html
-# TODO: replace with enum because it is not compatible with rails 5.x and not maintained
-gem 'symbolize', '~> 4.5'
 gem 'acts_as_list', '~> 0.7.6'
 gem 'braintree', '~> 2.89'
 gem 'cancancan', '~> 1.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -750,10 +750,6 @@ GEM
       json (~> 1.8.1)
       mime-types (>= 1.25, < 3.0)
       rest-client (~> 1.4)
-    symbolize (4.5.2)
-      activemodel (>= 3.2, < 5)
-      activesupport (>= 3.2, < 5)
-      i18n
     temple (0.7.6)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
@@ -976,7 +972,6 @@ DEPENDENCIES
   stripe
   swagger-ui_rails!
   swagger-ui_rails2!
-  symbolize (~> 4.5)
   thin
   thinking-sphinx (~> 3.2.0)
   timecop (~> 0.8)

--- a/app/lib/backend/model_extensions/usage_limit.rb
+++ b/app/lib/backend/model_extensions/usage_limit.rb
@@ -27,7 +27,7 @@ module Backend
 
       def delete_backend_usage_limit
         if plan_and_service?
-          original_period = previously_changed?(:period) ? previous_changes[:period].compact.first : period
+          original_period = previously_changed?(:period) ? period_previous_change.compact.first : period
           ThreeScale::Core::UsageLimit.delete(service.backend_id, plan.backend_id, metric_id, original_period)
         end
 

--- a/app/models/cms/template.rb
+++ b/app/models/cms/template.rb
@@ -1,4 +1,5 @@
 class CMS::Template < ApplicationRecord
+  extend Symbolize
 
   include CMS::Filtering
 

--- a/app/models/cms/template.rb
+++ b/app/models/cms/template.rb
@@ -1,5 +1,5 @@
 class CMS::Template < ApplicationRecord
-  extend Symbolize
+  include Symbolize
 
   include CMS::Filtering
 

--- a/app/models/concerns/symbolize.rb
+++ b/app/models/concerns/symbolize.rb
@@ -1,14 +1,51 @@
 # frozen_string_literal: true
 module Symbolize
-  def symbolize(*attributes)
-    attributes.each do |attr|
-      class_eval <<-DEFINITION
-      def #{attr}
-        value = super
-        return if value.blank?
-        value.to_s.to_sym
+
+
+  extend ActiveSupport::Concern
+
+  included do
+    prepend AttributesAccessor
+    class_attribute :__symbolized_attributes, instance_writer: false
+  end
+
+  module AttributesAccessor
+    def attribute_previous_change(attr)
+      __symbolize_changes(attr, super)
+    end
+
+    def attribute_change(attr)
+      __symbolize_changes(attr, super)
+    end
+
+    private
+    def __symbolize_changes(attr, changed_values)
+      if changed_values.blank? || __symbolized_attributes.exclude?(attr.to_sym)
+        changed_values
+      else
+        changed_values.map{|value| value.blank? ? value : value.to_sym }
       end
-      DEFINITION
+    end
+  end
+
+  module ClassMethods
+    def symbolize(*attributes)
+      self.__symbolized_attributes ||= []
+      attributes.each do |attr|
+        unless self.__symbolized_attributes.include?(attr.to_sym)
+          define_symbolized_attribute_method(attr)
+          self.__symbolized_attributes += [attr.to_sym]
+        end
+      end
+    end
+
+    def define_symbolized_attribute_method(attr)
+      define_method(attr) do
+        value = super()
+        return if value.blank?
+        return value if __symbolized_attributes.exclude?(attr.to_sym)
+        value.to_sym
+      end
     end
   end
 end

--- a/app/models/concerns/symbolize.rb
+++ b/app/models/concerns/symbolize.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Symbolize
+  def symbolize(*attributes)
+    attributes.each do |attr|
+      class_eval <<-DEFINITION
+      def #{attr}
+        value = super
+        return if value.blank?
+        value.to_s.to_sym
+      end
+      DEFINITION
+    end
+  end
+end

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -180,7 +180,7 @@ class Configuration
   end
 
   class Value < ApplicationRecord
-    extend Symbolize
+    include Symbolize
     self.table_name = 'configuration_values'
 
     # TODO: test!

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -180,6 +180,7 @@ class Configuration
   end
 
   class Value < ApplicationRecord
+    extend Symbolize
     self.table_name = 'configuration_values'
 
     # TODO: test!

--- a/app/models/member_permission.rb
+++ b/app/models/member_permission.rb
@@ -1,4 +1,5 @@
 class MemberPermission < ApplicationRecord
+  extend Symbolize
   belongs_to :user, touch: true
   validates :admin_section, inclusion: { :in => ->(_record) { AdminSection.sections } }
   validates :admin_section , uniqueness: { :scope => :user_id, if: Proc.new { |mp| mp.user_id } }

--- a/app/models/member_permission.rb
+++ b/app/models/member_permission.rb
@@ -1,5 +1,5 @@
 class MemberPermission < ApplicationRecord
-  extend Symbolize
+  include Symbolize
   belongs_to :user, touch: true
   validates :admin_section, inclusion: { :in => ->(_record) { AdminSection.sections } }
   validates :admin_section , uniqueness: { :scope => :user_id, if: Proc.new { |mp| mp.user_id } }

--- a/app/models/payment_gateway_setting.rb
+++ b/app/models/payment_gateway_setting.rb
@@ -2,6 +2,7 @@
 # Option is meant for optional things
 # Setting is for setting things up. In our case it is setting up the payment gateway
 class PaymentGatewaySetting < ApplicationRecord
+  extend Symbolize
   belongs_to :account, inverse_of: :payment_gateway_setting
   serialize :gateway_settings
   symbolize :gateway_type

--- a/app/models/payment_gateway_setting.rb
+++ b/app/models/payment_gateway_setting.rb
@@ -2,7 +2,7 @@
 # Option is meant for optional things
 # Setting is for setting things up. In our case it is setting up the payment gateway
 class PaymentGatewaySetting < ApplicationRecord
-  extend Symbolize
+  include Symbolize
   belongs_to :account, inverse_of: :payment_gateway_setting
   serialize :gateway_settings
   symbolize :gateway_type

--- a/app/models/payment_transaction.rb
+++ b/app/models/payment_transaction.rb
@@ -5,7 +5,7 @@ class ::ActiveMerchant::Billing::AuthorizeNetGateway
 end
 
 class PaymentTransaction < ApplicationRecord
-  extend Symbolize
+  include Symbolize
   belongs_to :account
   belongs_to :invoice, inverse_of: :payment_transactions
 

--- a/app/models/payment_transaction.rb
+++ b/app/models/payment_transaction.rb
@@ -5,6 +5,7 @@ class ::ActiveMerchant::Billing::AuthorizeNetGateway
 end
 
 class PaymentTransaction < ApplicationRecord
+  extend Symbolize
   belongs_to :account
   belongs_to :invoice, inverse_of: :payment_transactions
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -2,6 +2,7 @@
 class Plan < ApplicationRecord
   include ThreeScale::Search::Scopes
   class PeriodRangeCalculationError < StandardError; end
+  extend Symbolize
 
   self.allowed_sort_columns = %w[position name state contracts_count]
   self.default_sort_column = :position

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -2,7 +2,7 @@
 class Plan < ApplicationRecord
   include ThreeScale::Search::Scopes
   class PeriodRangeCalculationError < StandardError; end
-  extend Symbolize
+  include Symbolize
 
   self.allowed_sort_columns = %w[position name state contracts_count]
   self.default_sort_column = :position

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -1,6 +1,7 @@
 require 'simple_layout'
 
 class Settings < ApplicationRecord
+  extend Symbolize
   belongs_to :account, inverse_of: :settings
 
   audited allow_mass_assignment: true

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -1,7 +1,7 @@
 require 'simple_layout'
 
 class Settings < ApplicationRecord
-  extend Symbolize
+  include Symbolize
   belongs_to :account, inverse_of: :settings
 
   audited allow_mass_assignment: true

--- a/app/models/usage_limit.rb
+++ b/app/models/usage_limit.rb
@@ -1,5 +1,5 @@
 class UsageLimit < ApplicationRecord
-  extend Symbolize
+  include Symbolize
   attr_accessible :period, :value, :metric, :plan
 
   include Backend::ModelExtensions::UsageLimit

--- a/app/models/usage_limit.rb
+++ b/app/models/usage_limit.rb
@@ -1,4 +1,5 @@
 class UsageLimit < ApplicationRecord
+  extend Symbolize
   attr_accessible :period, :value, :metric, :plan
 
   include Backend::ModelExtensions::UsageLimit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 require 'digest/sha1'
 
 class User < ApplicationRecord
-  extend Symbolize
+  include Symbolize
 
   def self.columns
     super.reject { |c| c.name == "janrain_identifier" }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 require 'digest/sha1'
 
 class User < ApplicationRecord
+  extend Symbolize
 
   def self.columns
     super.reject { |c| c.name == "janrain_identifier" }
@@ -64,7 +65,6 @@ class User < ApplicationRecord
 
   has_many :access_tokens, foreign_key: :owner_id, dependent: :destroy, inverse_of: :owner
 
-  symbolize :role
   symbolize :signup_type
 
   validates :username, length: { :within => 3..40, :allow_blank => false }

--- a/app/models/user/roles.rb
+++ b/app/models/user/roles.rb
@@ -2,6 +2,7 @@ module User::Roles
   extend ActiveSupport::Concern
 
   included do
+    extend Symbolize
     DEFAULT_ROLES = [:admin, :member]
     MORE_ROLES = [:contributor]
     ROLES = DEFAULT_ROLES + MORE_ROLES

--- a/app/models/user/roles.rb
+++ b/app/models/user/roles.rb
@@ -2,7 +2,6 @@ module User::Roles
   extend ActiveSupport::Concern
 
   included do
-    extend Symbolize
     DEFAULT_ROLES = [:admin, :member]
     MORE_ROLES = [:contributor]
     ROLES = DEFAULT_ROLES + MORE_ROLES

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -760,10 +760,6 @@ GEM
       json (~> 1.8.1)
       mime-types (>= 1.25, < 3.0)
       rest-client (~> 1.4)
-    symbolize (4.5.2)
-      activemodel (>= 3.2, < 5)
-      activesupport (>= 3.2, < 5)
-      i18n
     temple (0.7.6)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
@@ -990,7 +986,6 @@ DEPENDENCIES
   stripe
   swagger-ui_rails!
   swagger-ui_rails2!
-  symbolize (~> 4.5)
   thin
   thinking-sphinx (~> 3.2.0)
   timecop (~> 0.8)

--- a/test/unit/concerns/symbolize_test.rb
+++ b/test/unit/concerns/symbolize_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class SymbolizeTest < ActiveSupport::TestCase
+  class UsageLimit < ApplicationRecord
+    self.table_name = 'usage_limits'
+    include Symbolize
+    symbolize :period
+
+    # Because it is null: false in DB
+    before_save :set_plan_type
+
+    private
+    def set_plan_type
+      self.plan_type ||= 'Plan'
+    end
+  end
+
+  def test_symbolization
+    usage = UsageLimit.new(period: 'year')
+    assert_equal :year, usage.period
+    usage.save!
+
+    usage.reload
+    assert_equal :year, usage.period
+  end
+
+  def test_period_change
+    usage = UsageLimit.create!(period: 'year')
+
+    usage.period = 'hour'
+    assert_equal :hour, usage.period
+    assert_equal [:year, :hour], usage.period_change
+  end
+
+  def test_period_previous_change
+    usage = UsageLimit.create!(period: 'year')
+    usage.period = 'hour'
+    usage.save!
+    assert_nil usage.period_change
+    assert_equal [:year, :hour], usage.period_previous_change
+  end
+
+  test '#changes is symbolized but not #previous_changes' do
+    usage = UsageLimit.new
+    usage.period = 'hour'
+    assert_equal({'period' => [nil, :hour]}, usage.changes)
+    usage.save!
+
+    usage.reload
+    assert_equal({}, usage.changes)
+    usage.period = 'day'
+    assert_equal({'period' => [:hour, :day]}, usage.changes)
+
+    usage.save!
+    # FIXME: sadly previous_changes are not symbolized (yet)
+    assert_equal({'period' => ['hour', 'day']}, usage.previous_changes)
+  end
+
+  test 'does not symbolizes other attribute' do
+    usage = UsageLimit.new period: :hour
+    usage.plan_type = 'ApplicationPlan'
+    assert_equal [nil, 'ApplicationPlan'], usage.plan_type_change
+    assert_equal 'ApplicationPlan', usage.plan_type
+
+    usage.save!
+    assert_equal [nil, 'ApplicationPlan'], usage.plan_type_previous_change
+    usage.reload
+    assert_equal 'ApplicationPlan', usage.plan_type
+  end
+
+end


### PR DESCRIPTION
It has no support in Rails 5.0 and was intended to be removed anyway in favor of `enum`

I cannot make it work with enum yet so I kinda backport it as internal library

TODO:

- [ ] Fix method only available in Rails 5.0