### PR TITLE
[WIP] Circleci slack orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,15 @@ commands: # reusable commands with parameters
 
   notify_slack_if_failure:
     steps:
+      - run:
+          name: Check env
+          command: |
+            echo "env"
+            env
+            echo "export"
+            export
+            echo "$BASH_ENV"
+
       - slack/status:
           fail_only: 'true'
           webhook:  https://hooks.slack.com/services/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
@@ -506,7 +515,7 @@ jobs:
     - image: circleci/buildpack-deps
     steps:
       - slack/notify:
-          message: Build started on master, for $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.
+          message: Build started on $CIRCLE_BRANCH, for $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.
           color: "#D3D3D3"
           webhook: https://hooks.slack.com/services/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
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,12 +99,6 @@ dnsmasq-container: &dnsmasq-container
   - --no-poll
   - --address=/#/127.0.0.1
 
-notify_slack_if_failure: &notify_slack_if_failure
-  post-steps:
-    - slack/status:
-        fail_only: 'true'
-        webhook:  https://hooks.slack.com/services/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
-#        only_for_branch: "master"
 
 ##################################### CIRCLECI ORBS ############################################
 
@@ -147,6 +141,7 @@ commands: # reusable commands with parameters
             BUNDLE_JOBS: 3
       - save-gem-cache
       - *persist-vendored-dependencies-to-workspace
+      - notify_slack_if_failure
 
   clone-oracle-libraries:
     steps:
@@ -192,6 +187,7 @@ commands: # reusable commands with parameters
           command: |
             bundle exec rspec --format progress $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
       - upload-artifacts
+      - notify_slack_if_failure
 
   cucumber-tests:
     parameters:
@@ -215,6 +211,7 @@ commands: # reusable commands with parameters
       - store_artifacts:
           path: tmp/capybara
           destination: capybara
+      - notify_slack_if_failure
 
   rails-tests:
     parameters:
@@ -234,6 +231,7 @@ commands: # reusable commands with parameters
             TESTS=$(bundle exec rake "test:files:${CIRCLE_JOB%-oracle}" | circleci tests split --split-by=timings)
             bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace
       - upload-artifacts
+      - notify_slack_if_failure
 
   save-gem-cache:
     steps:
@@ -255,6 +253,13 @@ commands: # reusable commands with parameters
       - *store-test-artifacts
       - *store-log-artifacts
       - *upload-coverage
+
+  notify_slack_if_failure:
+    steps:
+      - slack/status:
+          fail_only: 'true'
+          webhook:  https://hooks.slack.com/services/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
+#        only_for_branch: "master"
 
 ##################################### CIRCLECI EXECUTORS ############################################
 
@@ -330,6 +335,7 @@ jobs:
           root: .
           paths:
             - ./node_modules
+      - notify_slack_if_failure
 
   assets_precompile:
     executor: builder
@@ -349,6 +355,7 @@ jobs:
           paths:
             - ./public/assets
             - ./config/*.yml
+      - notify_slack_if_failure
 
   lint:
     executor: builder
@@ -386,6 +393,7 @@ jobs:
           path: doc/active_docs
           destination: active_docs
       - *upload-coverage
+      - notify_slack_if_failure
 
   unit:
     parallelism: 8
@@ -491,6 +499,7 @@ jobs:
             cd openshift/system
             docker build --build-arg=BUNDLER_ENV="$(env | grep -e ^BUNDLE_)" --file Dockerfile ../..
             docker build --file Dockerfile.on_prem --pull ../..
+      - notify_slack_if_failure
 
   notify_start:
     docker:
@@ -539,6 +548,7 @@ jobs:
       - store_artifacts:
           path: tmp/capybara
           destination: capybara
+      - notify_slack_if_failure
 
 ##################################### CIRCLECI WORKFLOWS ############################################
 
@@ -550,46 +560,41 @@ workflows:
 #          filters:
 #            branches:
 #              only: master
-      - dependencies_bundler:
-          *notify_slack_if_failure
-
-      - dependencies_npm:
-          *notify_slack_if_failure
+      - dependencies_bundler
+      - dependencies_npm
 
       - docker-build:
           context: org-global
-          <<: *notify_slack_if_failure
 
       - assets_precompile:
           requires:
             - dependencies_bundler
             - dependencies_npm
-          <<: *notify_slack_if_failure
 
       - lint:
           requires:
             - assets_precompile
-          <<: *notify_slack_if_failure
+          
       - unit:
           requires:
             - dependencies_bundler
-          <<: *notify_slack_if_failure
+          
       - functional:
           requires:
             - assets_precompile
-          <<: *notify_slack_if_failure
+          
       - integration:
           requires:
             - assets_precompile
-          <<: *notify_slack_if_failure
+          
       - rspec:
           requires:
             - dependencies_bundler
-          <<: *notify_slack_if_failure
+          
       - cucumber:
           requires:
             - assets_precompile
-          <<: *notify_slack_if_failure
+          
       - notify_success:
           requires:
             - rspec
@@ -615,47 +620,47 @@ workflows:
       - deps_bundler_oracle:
           requires:
             - manual_approval
-          <<: *notify_slack_if_failure
+          
       - dependencies_npm:
           requires:
             - manual_approval
-          <<: *notify_slack_if_failure
+          
       - docker-build:
           context: org-global
           requires:
             - manual_approval
-          <<: *notify_slack_if_failure
+          
       - assets_precompile:
           requires:
             - deps_bundler_oracle
             - dependencies_npm
-          <<: *notify_slack_if_failure
+          
 
       - lint:
           requires:
             - assets_precompile
-          <<: *notify_slack_if_failure
+          
       - unit-oracle:
           requires:
             - deps_bundler_oracle
-          <<: *notify_slack_if_failure
+          
 
       - functional-oracle:
           requires:
             - assets_precompile
-          <<: *notify_slack_if_failure
+          
       - integration-oracle:
           requires:
             - assets_precompile
-          <<: *notify_slack_if_failure
+          
       - rspec-oracle:
           requires:
             - deps_bundler_oracle
-          <<: *notify_slack_if_failure
+          
       - cucumber-oracle:
           requires:
             - assets_precompile
-          <<: *notify_slack_if_failure
+          
       - notify_success:
           requires:
             - rspec-oracle
@@ -677,19 +682,19 @@ workflows:
     - dependencies_bundler:
         requires:
         - manual_approval
-        <<: *notify_slack_if_failure
+        
     - dependencies_npm:
         requires:
         - manual_approval
-        <<: *notify_slack_if_failure
+
     - assets_precompile:
         requires:
         - dependencies_bundler
         - dependencies_npm
-        <<: *notify_slack_if_failure
+        
     - visual:
         context: percy
         requires:
         - assets_precompile
-        <<: *notify_slack_if_failure
+        
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,7 +506,7 @@ jobs:
     - image: circleci/buildpack-deps
     steps:
       - slack/notify:
-          message: All is well & green on $CIRCLE_BRANCH. Nothing to see here.
+          message: ":white_check_mark: All is well & green on $CIRCLE_BRANCH. Nothing to see here."
           color: "#00B700"
           webhook: https://hooks.slack.com/services/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
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,17 @@ dnsmasq-container: &dnsmasq-container
   - --no-poll
   - --address=/#/127.0.0.1
 
+notify_slack_if_failure: &notify_slack_if_failure
+  post-steps:
+    - slack/status:
+        fail_only: 'true'
+        only_for_branch: "master"
+
+##################################### CIRCLECI ORBS ############################################
+
+orbs:
+  slack: circleci/slack@volatile
+
 ##################################### CIRCLECI COMMANDS ############################################
 
 commands: # reusable commands with parameters
@@ -484,103 +495,17 @@ jobs:
     docker:
     - image: circleci/buildpack-deps
     steps:
-    - run:
-        name: Notify Slack about tests start
-        command: |
-          curl -X POST -H 'Content-type: application/json' \
-          --data \
-          "{ \
-            \"attachments\": [ \
-            { \
-              \"fallback\": \"Build started on master, for $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.\", \
-              \"color\": \"#D3D3D3\", \
-              \"pretext\": \"Build started on master: \", \
-              \"author_name\": \"$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME\", \
-              \"title\": \"Job: $CIRCLE_JOB  \", \
-              \"title_link\": \"$CIRCLE_BUILD_URL\", \
-              \"text\": \"Changes: $CIRCLE_COMPARE_URL\", \
-              \"fields\": [ \
-              { \
-                \"title\": \"Commit\", \
-                \"value\": \"$CIRCLE_SHA1\", \
-                \"short\": false \
-              }, \
-              { \
-                \"title\": \"GitHub Repo\", \
-                \"value\": \"$CIRCLE_REPOSITORY_URL\", \
-                \"short\": false \
-              }, \
-              { \
-                \"title\": \"Triggered by:\", \
-                \"value\": \"$CIRCLE_USERNAME\", \
-                \"short\": false \
-              } \
-              ] \
-            } \
-            ] \
-          }" $SLACK_WEBHOOK_URL
-
-  notify_failure:
-    docker:
-    - image: circleci/buildpack-deps
-    steps:
-    - run:
-        name: Notify Slack about tests failure
-        command: |
-          curl -X POST -H 'Content-type: application/json' \
-          --data \
-          "{ \
-            \"attachments\": [ \
-            { \
-              \"fallback\": \"Build failed on $CIRCLE_BRANCH, for $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.\", \
-              \"color\": \"#CD0000\", \
-              \"pretext\": \"Don't panic. Build failed on $CIRCLE_BRANCH !! \", \
-              \"author_name\": \"$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME\", \
-              \"title\": \"Job: $CIRCLE_JOB \", \
-              \"title_link\": \"$CIRCLE_BUILD_URL\", \
-              \"text\": \"$CIRCLE_BUILD_URL\", \
-              \"fields\": [ \
-              { \
-                \"title\": \"Commit\", \
-                \"value\": \"$CIRCLE_SHA1\", \
-                \"short\": false \
-              } \
-              ] \
-            } \
-            ] \
-          }" $SLACK_WEBHOOK_URL
-        when: on_fail
+      - slack/notify:
+          message: Build started on master, for $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.
+          color: "#D3D3D3"
 
   notify_success:
     docker:
     - image: circleci/buildpack-deps
     steps:
-    - run:
-        name: Notify Slack about tests passing
-        command: |
-          curl -X POST -H 'Content-type: application/json' \
-          --data \
-          "{ \
-            \"attachments\": [ \
-            { \
-              \"fallback\": \"All is well & green on $CIRCLE_BRANCH, for $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.\", \
-              \"color\": \"#00B700\", \
-              \"pretext\": \"All is well & green on $CIRCLE_BRANCH. Nothing to see here. \", \
-              \"author_name\": \"$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME\", \
-              \"title\": \"Job: $CIRCLE_JOB \", \
-              \"title_link\": \"$CIRCLE_BUILD_URL\", \
-              \"text\": \"$CIRCLE_BUILD_URL\", \
-              \"fields\": [ \
-              { \
-                \"title\": \"Commit\", \
-                \"value\": \"$CIRCLE_SHA1\", \
-                \"short\": false \
-              } \
-              ] \
-            } \
-            ] \
-          }" $SLACK_WEBHOOK_URL
-        when: on_success
+      - slack/notify:
+          message: All is well & green on $CIRCLE_BRANCH. Nothing to see here.
+          color: "#00B700"
 
 
 
@@ -622,45 +547,47 @@ workflows:
           filters:
             branches:
               only: master
-      - dependencies_bundler
-      - dependencies_npm
+      - dependencies_bundler:
+          *notify_slack_if_failure
+
+      - dependencies_npm:
+          *notify_slack_if_failure
+
       - docker-build:
           context: org-global
+          <<: *notify_slack_if_failure
+
       - assets_precompile:
           requires:
             - dependencies_bundler
             - dependencies_npm
+          <<: *notify_slack_if_failure
 
       - lint:
           requires:
             - assets_precompile
+          <<: *notify_slack_if_failure
       - unit:
           requires:
             - dependencies_bundler
+          <<: *notify_slack_if_failure
       - functional:
           requires:
             - assets_precompile
+          <<: *notify_slack_if_failure
       - integration:
           requires:
             - assets_precompile
+          <<: *notify_slack_if_failure
       - rspec:
           requires:
             - dependencies_bundler
+          <<: *notify_slack_if_failure
       - cucumber:
           requires:
             - assets_precompile
+          <<: *notify_slack_if_failure
       - notify_success:
-          requires:
-            - rspec
-            - unit
-            - cucumber
-            - integration
-            - functional
-            - lint
-          filters:
-            branches:
-              only: master
-      - notify_failure:
           requires:
             - rspec
             - unit
@@ -684,37 +611,48 @@ workflows:
               only: master
       - deps_bundler_oracle:
           requires:
-          - manual_approval
+            - manual_approval
+          <<: *notify_slack_if_failure
       - dependencies_npm:
           requires:
-          - manual_approval
+            - manual_approval
+          <<: *notify_slack_if_failure
       - docker-build:
           context: org-global
           requires:
-          - manual_approval
+            - manual_approval
+          <<: *notify_slack_if_failure
       - assets_precompile:
           requires:
             - deps_bundler_oracle
             - dependencies_npm
+          <<: *notify_slack_if_failure
 
       - lint:
           requires:
             - assets_precompile
+          <<: *notify_slack_if_failure
       - unit-oracle:
           requires:
             - deps_bundler_oracle
+          <<: *notify_slack_if_failure
+
       - functional-oracle:
           requires:
             - assets_precompile
+          <<: *notify_slack_if_failure
       - integration-oracle:
           requires:
             - assets_precompile
+          <<: *notify_slack_if_failure
       - rspec-oracle:
           requires:
             - deps_bundler_oracle
+          <<: *notify_slack_if_failure
       - cucumber-oracle:
           requires:
             - assets_precompile
+          <<: *notify_slack_if_failure
       - notify_success:
           requires:
             - rspec-oracle
@@ -727,17 +665,6 @@ workflows:
             branches:
               only: master
 
-      - notify_failure:
-          requires:
-            - rspec-oracle
-            - unit-oracle
-            - cucumber-oracle
-            - integration-oracle
-            - functional-oracle
-            - lint
-          filters:
-            branches:
-              only: master
 
   visual_tests:
     jobs:
@@ -747,15 +674,19 @@ workflows:
     - dependencies_bundler:
         requires:
         - manual_approval
+        <<: *notify_slack_if_failure
     - dependencies_npm:
         requires:
         - manual_approval
+        <<: *notify_slack_if_failure
     - assets_precompile:
         requires:
         - dependencies_bundler
         - dependencies_npm
+        <<: *notify_slack_if_failure
     - visual:
         context: percy
         requires:
         - assets_precompile
+        <<: *notify_slack_if_failure
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ notify_slack_if_failure: &notify_slack_if_failure
   post-steps:
     - slack/status:
         fail_only: 'true'
-        only_for_branch: "master"
+#        only_for_branch: "master"
 
 ##################################### CIRCLECI ORBS ############################################
 
@@ -543,10 +543,10 @@ workflows:
   version: 2
   mysql_build:
     jobs:
-      - notify_start:
-          filters:
-            branches:
-              only: master
+      - notify_start
+#          filters:
+#            branches:
+#              only: master
       - dependencies_bundler:
           *notify_slack_if_failure
 
@@ -595,9 +595,9 @@ workflows:
             - integration
             - functional
             - lint
-          filters:
-            branches:
-              only: master
+#          filters:
+#            branches:
+#              only: master
   oracle_build:
     jobs:
       - manual_approval: # <<< A job that will require manual approval in the CircleCI web application.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ notify_slack_if_failure: &notify_slack_if_failure
   post-steps:
     - slack/status:
         fail_only: 'true'
+        webhook:  https://hooks.slack.com/services/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
 #        only_for_branch: "master"
 
 ##################################### CIRCLECI ORBS ############################################
@@ -498,6 +499,7 @@ jobs:
       - slack/notify:
           message: Build started on master, for $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.
           color: "#D3D3D3"
+          webhook: https://hooks.slack.com/services/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
 
   notify_success:
     docker:
@@ -506,6 +508,7 @@ jobs:
       - slack/notify:
           message: All is well & green on $CIRCLE_BRANCH. Nothing to see here.
           color: "#00B700"
+          webhook: https://hooks.slack.com/services/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
 
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR helps simplifies our circleci config through use of Slack Orb, rather than implementing our own notification logic through the slack webhook API. 

In addition, our current implementation does not achieve our desired outcome (notify slack channel for builds on master branch only, whether all jobs succeed, or if any of them failed - including information about which one it was that failed). 

This PR should address that problem (raised in https://github.com/3scale/porta/issues/437) 

**Which issue(s) this PR fixes** 

Fixes  https://github.com/3scale/porta/issues/437

**Verification steps** 

N/A 

**Special notes for your reviewer**:

N/A