### PR TITLE
Empty seed USER_EMAIL param/env var

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -126,7 +126,7 @@ master.update_columns(provider: false)
 ###
 
 user_login = ENV.fetch('USER_LOGIN', 'admin')
-user_email = ENV.fetch('USER_EMAIL', "#{user_login}@#{provider.domain}")
+user_email = ENV['USER_EMAIL'].presence || "#{user_login}@#{provider.domain}"
 user_password = ENV.fetch('USER_PASSWORD') { SecureRandom.base64(32) }
 
 user = User.create!(username: user_login, password: user_password, password_confirmation: user_password) do |user|


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**

It ensures the `USER_EMAIL` env var is present (as opposed to provided as an empty string or not provided at all) before setting a default value based on `USER_LOGIN` and provider domain.

The fix follows Option 2 presented by @miguelsorianod at https://github.com/3scale/3scale-operator/pull/12#issuecomment-450836585.

**Which issue(s) this PR fixes** 

Part of [THREESCALE-1763](https://issues.jboss.org/browse/THREESCALE-1763)