### PR TITLE
Extends the documentation of the credentials_location option -- adds the Basic Auth option

### DIFF
--- a/app/controllers/admin/api/services/proxies_controller.rb
+++ b/app/controllers/admin/api/services/proxies_controller.rb
@@ -40,7 +40,7 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
   ##~ op.parameters.add @parameter_service_id_by_id_name
   ##~ op.parameters.add name: "endpoint", description: "Public Base URL for production environment.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "api_backend", description: "Private Base URL.", dataType: "string", paramType: "query", required: false
-  ##~ op.parameters.add name: "credentials_location", description: "Credentials Location. Either headers or query.", dataType: "string", paramType: "query", required: false
+  ##~ op.parameters.add name: "credentials_location", description: "Credentials Location. Either headers, query or authorization for the Basic Authorization.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "auth_app_key", description: "Parameter/Header where App Key is expected.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "auth_app_id", description: "Parameter/Header where App ID is expected.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "auth_user_key", description: "Parameter/Header where User Key is expected.", dataType: "string", paramType: "query", required: false

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -6173,7 +6173,7 @@
             },
             {
               "name": "credentials_location",
-              "description": "Credentials Location. Either headers or query.",
+              "description": "Credentials Location. Either headers, query or authorization for the Basic Authorization.",
               "dataType": "string",
               "paramType": "query",
               "required": false

--- a/doc/active_docs/preview/Account Management API.json
+++ b/doc/active_docs/preview/Account Management API.json
@@ -4951,7 +4951,7 @@
             },
             {
               "name": "credentials_location",
-              "description": "Credentials Location. Either headers or query.",
+              "description": "Credentials Location. Either headers, query or authorization for the Basic Authorization.",
               "dataType": "string",
               "paramType": "query",
               "required": false


### PR DESCRIPTION
This PR adds the `authorization` option to the API documentation for the proxy update where it is missing.

It is extending the #90 PR.

