### PR TITLE
Stop updating deleted_at from Account

### DIFF
--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -59,8 +59,7 @@ module Account::States
       end
 
       after_transition any => any do |account|
-        time_state_changed_at = Time.zone.now
-        account.update_attributes(state_changed_at: time_state_changed_at, deleted_at: time_state_changed_at)
+        account.update_attributes(state_changed_at: Time.zone.now)
       end
 
       event :make_pending do

--- a/test/integration/master/api/providers_controller_test.rb
+++ b/test/integration/master/api/providers_controller_test.rb
@@ -209,7 +209,6 @@ class Master::Api::ProvidersControllerTest < ActionDispatch::IntegrationTest
       assert_response :ok
       assert_equal '', response.body
       assert provider.reload.scheduled_for_deletion?
-      assert_equal Time.zone.now.to_s, provider.deleted_at.to_s
       assert_equal Time.zone.now.to_s, provider.state_changed_at.to_s
     end
   end

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -279,7 +279,6 @@ class Account::StatesTest < ActiveSupport::TestCase
         Timecop.freeze do
           account.public_send(transition)
           assert_equal Time.zone.now.to_s, account.reload.state_changed_at.to_s
-          assert_equal Time.zone.now.to_s, account.reload.deleted_at.to_s
         end
       end
     end


### PR DESCRIPTION
Step 3 of https://github.com/3scale/porta/issues/290.
It removes the updates of `deleted_at` from the code. And https://github.com/3scale/porta/pull/295 actually removes the `deleted_at` attribute itself.

It is ok to have it done now because the previous step was a migration and not a task 😄 
https://github.com/3scale/porta/blob/e3b8d3a4f614d8923538c7649dd526087fa91b18/db/migrate/20181105212016_duplicate_deleted_at_state_changed_at.rb#L1-L15