### PR TITLE
[Oracle] Fix unique constraints to reference to the right index

### DIFF
--- a/db/migrate/20190104134224_fix_oracle_constraints_references_to_index_names.rb
+++ b/db/migrate/20190104134224_fix_oracle_constraints_references_to_index_names.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FixOracleConstraintsReferencesToIndexNames < ActiveRecord::Migration
+  def up
+    return unless System::Database.oracle?
+
+    db_connection = ActiveRecord::Base.connection
+    constraints_to_be_changed = [
+      {constraint_name: 'INDEX_ACCOUNTS_ON_DOMAIN',      column_name: 'DOMAIN',      table_name: 'ACCOUNTS', index_name: 'INDEX_ACCOUNTS_ON_DOMAIN_AND_DELETED_AT'},
+      {constraint_name: 'INDEX_ACCOUNTS_ON_SELF_DOMAIN', column_name: 'SELF_DOMAIN', table_name: 'ACCOUNTS', index_name: 'INDEX_ACCOUNTS_ON_SELF_DOMAIN_AND_DELETED_AT'}
+    ]
+    constraints_to_be_changed.each do |constraint_data|
+      constraint_name, table_name = constraint_data.values_at(:constraint_name, :table_name)
+      db_connection.execute("ALTER TABLE #{table_name} DROP CONSTRAINT #{constraint_name}")
+      db_connection.execute("ALTER TABLE #{table_name} ADD  CONSTRAINT #{constraint_name} UNIQUE (#{constraint_data[:column_name]}) USING INDEX #{constraint_name}")
+    end
+  end
+
+  def down; end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181210222627) do
+ActiveRecord::Schema.define(version: 20190104134224) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181210222627) do
+ActiveRecord::Schema.define(version: 20190104134224) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false


### PR DESCRIPTION
There is a bug in:
https://github.com/rsim/oracle-enhanced/blob/cd14e88a9f1101af7a4087c538249026e2595a7c/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb#L288-L296

Oracle references to the first index it finds, which is not necessarily the right one.
We noticed about this issue in https://github.com/3scale/porta/pull/295/ , when removing indexes was not allowed because we had for example the uniqueness constraint of Account `self_domain` being associated to the index of self_domain with deleted_at, which had no uniqueness.

### What this PR does
1. Update current unique constraints
2. Patch `add_index` to use the proper index

### Examples of the malformed versions
These are the malformed versions discovered in the other PR.
#### Hash format
```ruby
[
  { constraint_name: 'INDEX_ACCOUNTS_ON_DOMAIN',      column_name: 'DOMAIN',      table_name: 'ACCOUNTS', index_name: 'INDEX_ACCOUNTS_ON_DOMAIN_AND_DELETED_AT' },
  { constraint_name: 'INDEX_ACCOUNTS_ON_SELF_DOMAIN', column_name: 'SELF_DOMAIN', table_name: 'ACCOUNTS', index_name: 'INDEX_ACCOUNTS_ON_SELF_DOMAIN_AND_DELETED_AT' }
]
```
#### Table format
```
TABLE_NAME  | CONSTRAINT_NAME               | INDEX_NAME                                   | COLUMN_NAMES
----------- | ----------------------------- | -------------------------------------------- | ------------
ACCOUNTS    | INDEX_ACCOUNTS_ON_DOMAIN      | INDEX_ACCOUNTS_ON_DOMAIN_AND_DELETED_AT      | DOMAIN
ACCOUNTS    | INDEX_ACCOUNTS_ON_SELF_DOMAIN | INDEX_ACCOUNTS_ON_SELF_DOMAIN_AND_DELETED_AT | SELF_DOMAIN
```