### PR TITLE
Quieting natively in 4.2

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -185,9 +185,6 @@ group :development do
 
   gem 'letter_opener', require: false if ENV.fetch('LETTER_OPENER', '1') == '0'
 
-  # Rails 4.2 have it built in
-  gem 'quiet_assets'
-
   gem 'yard', require: false
 
   # Install rubocop only when using RubyMine (for the rubocop plugin)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,8 +518,6 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (3.0.3)
-    quiet_assets (1.1.0)
-      railties (>= 3.1, < 5.0)
     rack (1.6.11)
     rack-no_animations (1.0.3)
     rack-openid (1.4.2)
@@ -915,7 +913,6 @@ DEPENDENCIES
   pry-doc (>= 0.8)
   pry-rails
   pry-stack_explorer
-  quiet_assets
   rack-no_animations (~> 1.0.3)
   rack-utf8_sanitizer
   rack-x_served_by (~> 0.1.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -253,6 +253,8 @@ module System
       System.redis = System::RedisPool.new(config.redis)
     end
 
+    config.assets.quiet = true
+
     initializer :jobs do
       # Loading jobs used by Whenever
       require_relative 'jobs'

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -523,8 +523,6 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (3.0.3)
-    quiet_assets (1.1.0)
-      railties (>= 3.1, < 5.0)
     rack (1.6.11)
     rack-no_animations (1.0.3)
     rack-openid (1.4.2)
@@ -922,7 +920,6 @@ DEPENDENCIES
   pry-doc (>= 0.8)
   pry-rails
   pry-stack_explorer
-  quiet_assets
   rack-no_animations (~> 1.0.3)
   rack-utf8_sanitizer
   rack-x_served_by (~> 0.1.1)


### PR DESCRIPTION
Removing quiet_assets gem as it is already native in Rails 4.2