### PR TITLE
Fix migration for event_store_events when foreign key on provider_id does not exist

### DIFF
--- a/db/migrate/20181130072917_remove_foreign_key_events_accounts.rb
+++ b/db/migrate/20181130072917_remove_foreign_key_events_accounts.rb
@@ -1,5 +1,15 @@
+# frozen_string_literal: true
+
 class RemoveForeignKeyEventsAccounts < ActiveRecord::Migration
-  def change
+  def up
+    return unless foreign_keys(:event_store_events).detect {|fk| fk.column == 'provider_id' }
+
     remove_foreign_key :event_store_events, column: :provider_id
+  end
+
+  def down
+    return if foreign_keys(:event_store_events).detect {|fk| fk.column == 'provider_id' }
+
+    add_foreign_key :event_store_events, :accounts, column: :provider_id, on_delete: :cascade
   end
 end


### PR DESCRIPTION
We added this migration in https://github.com/3scale/porta/pull/38
But as explained in https://github.com/3scale/infrastructure/issues/597#issuecomment-445821750, in production this didn't exist so for those who have the database from preview, running this migration would make them have trouble. This fixes it.

I tested it by adding this code inside a new migration `rails generate migration` and then `rake db:migrate` and `rake db:rollback` in their possible situations.
![image](https://user-images.githubusercontent.com/11318903/50773695-c10e2b80-1291-11e9-8c83-ec069e214e0c.png)
