### PR TITLE
[billing] Cancel non-positive invoices on charge

### DIFF
--- a/test/unit/invoice_test.rb
+++ b/test/unit/invoice_test.rb
@@ -314,6 +314,13 @@ class InvoiceTest < ActiveSupport::TestCase
     assert build_invoice.chargeable?
   end
 
+  test 'charge! should cancel the invoice if negative' do
+    @invoice.update_attribute(:state, 'pending')
+    @invoice.stubs(:cost).returns(-100.0.to_has_money('EUR'))
+    refute @invoice.charge!
+    assert_equal 'cancelled', @invoice.state
+  end
+
   test 'charge! should raise if cancelled or paid' do
     @invoice.cancel!
     assert_raises(Invoice::InvalidInvoiceStateException) { @invoice.charge! }


### PR DESCRIPTION
**What this PR does / why we need it**

What the title says, it ensures invoices with non-positive cost are cancelled when charged.

**Which issue(s) this PR fixes** 

Closes [THREESCALE-1420](https://issues.jboss.org/browse/THREESCALE-1420)

**Verification steps** 

- Subscribe to a paid plan (new application)
- Before billing is run, change to a free plan (this will generate a non-positive invoice)
- Charge the invoice
- The invoice should not be charged and its state should change to 'cancelled'