### PR TITLE
[API] Access Token endpoints

### DIFF
--- a/app/controllers/admin/api/personal/access_tokens_controller.rb
+++ b/app/controllers/admin/api/personal/access_tokens_controller.rb
@@ -28,6 +28,24 @@ class Admin::Api::Personal::AccessTokensController < Admin::Api::Personal::BaseC
   end
 
   ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/personal/access_tokens.json"
+  ##~ e.responseClass = "List[access_token]"
+  #
+  ##~ op = e.operations.add
+  ##~ op.httpMethod = "GET"
+  ##~ op.summary   = "Personal Access Token List"
+  ##~ op.description = "Returns the list of access tokens of the user. If the parameter name is sent, it returns only those whose name contain the string of the param"
+  ##~ op.group = "access_token"
+  #
+  ##~ op.parameters.add :name => "name", :description => "Part of the name of the access token.", :dataType => "string", :required => false, :paramType => "query"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  #
+  def index
+    respond_with current_user.access_tokens.by_name(params[:name])
+  end
+
+  ##~ e = sapi.apis.add
   ##~ e.path = "/admin/api/personal/access_tokens/{id}.json"
   ##~ e.responseClass = "access_token"
   #
@@ -68,11 +86,7 @@ class Admin::Api::Personal::AccessTokensController < Admin::Api::Personal::BaseC
   private
 
   def token
-    @token ||= begin
-      id_or_value = params[:id]
-      scoped_access_tokens = current_user.access_tokens
-      scoped_access_tokens.by_value(id_or_value) || scoped_access_tokens.find(id_or_value)
-    end
+    @token ||= current_user.access_tokens.find_from_id_or_value!(params[:id])
   end
 
   def access_token_params

--- a/app/controllers/admin/api/personal/access_tokens_controller.rb
+++ b/app/controllers/admin/api/personal/access_tokens_controller.rb
@@ -1,30 +1,22 @@
 # frozen_string_literal: true
 
-class Admin::Api::AccessTokensController < Admin::Api::BaseController
-  clear_respond_to
-  respond_to :json
+class Admin::Api::Personal::AccessTokensController < Admin::Api::Personal::BaseController
+  # This needs to be done this way to don't conflict because we have 2 access_token params, the query param for authentication and the body param for create.
+  wrap_parameters AccessToken, name: :token
 
   representer AccessToken
 
-  # FIXME: make the name :access_token, but then it clashes with :access_token query param
-  # somehow we have to split query and body parameters
-  wrap_parameters AccessToken, name: :token
-
-  before_action :authorize_access_tokens
-
   ##~ sapi = source2swagger.namespace("Account Management API")
   ##~ e = sapi.apis.add
-  ##~ e.path = "/admin/api/users/{user_id}/access_tokens.json"
+  ##~ e.path = "/admin/api/personal/access_tokens.json"
   ##~ e.responseClass = "access_token"
   #
   ##~ op = e.operations.add
-  ##~ op.deprecated = true
   ##~ op.httpMethod = "POST"
-  ##~ op.summary   = "Access Token Create"
-  ##~ op.description = "[Deprecated API] Use \"Personal Access Tokens Create\". Creates an access token. Make sure to copy your new personal access token now. You will not be able to see it again as it is not stored for security reasons."
+  ##~ op.summary   = "Personal Access Token Create"
+  ##~ op.description = "Creates an access token. Make sure to copy your new personal access token now. You will not be able to see it again as it is not stored for security reasons."
   ##~ op.group = "access_token"
   #
-  ##~ op.parameters.add :name => "user_id", :description => "ID of the user.", :dataType => "integer", :paramType => "path", :required => true
   ##~ op.parameters.add :name => "name", :description => "Name of the access token.", :dataType => "string", :required => true, :paramType => "query"
   ##~ op.parameters.add :name => "permission", :description => "Permission of the access token. It must be either 'ro' (read only) or 'rw' (read and write).", :dataType => "string", :required => true, :paramType => "query"
   ##~ op.parameters.add :name => "scopes", :defaultName => "scopes[]", :description => "Scope of the access token. URL-encoded array containing one or more of the possible values values. The possible values are, for a master user [\"account_management\", \"stats\"], and for a tenant user [\"finance\", \"account_management\", \"stats\"]", :dataType => "custom", :allowMultiple => true, :required => true, :paramType => "query"
@@ -32,24 +24,12 @@ class Admin::Api::AccessTokensController < Admin::Api::BaseController
   ##~ op.parameters.add @parameter_access_token
   #
   def create
-    access_token = user.access_tokens.create(access_token_params)
-    respond_with access_token
+    respond_with current_user.access_tokens.create(access_token_params)
   end
 
-  protected
+  private
 
   def access_token_params
     params.require(:token).permit(:name, :permission, scopes: [])
   end
-
-  def authorize_access_tokens
-    return unless current_user # # provider_key auth has no user
-
-    authorize! :manage, :access_tokens, user
-  end
-
-  def user
-    @_user = current_account.users.find(params.require(:user_id))
-  end
-
 end

--- a/app/controllers/admin/api/personal/access_tokens_controller.rb
+++ b/app/controllers/admin/api/personal/access_tokens_controller.rb
@@ -27,7 +27,53 @@ class Admin::Api::Personal::AccessTokensController < Admin::Api::Personal::BaseC
     respond_with current_user.access_tokens.create(access_token_params)
   end
 
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/personal/access_tokens/{id}.json"
+  ##~ e.responseClass = "access_token"
+  #
+  ##~ op            = e.operations.add
+  ##~ op.httpMethod = "DELETE"
+  ##~ op.summary    = "Personal Access Token Delete"
+  ##~ op.description = "Deletes an access token."
+  ##~ op.group = "access_token"
+  #
+  ##~ op.parameters.add :name => "id", :description => "ID or value of the access token.", :dataType => "integer", :paramType => "path", :required => true
+  #
+  ##~ op.parameters.add @parameter_access_token
+  #
+  def destroy
+    token.destroy
+    respond_with token
+  end
+
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/personal/access_tokens/{id}.json"
+  ##~ e.responseClass = "access_token"
+  #
+  ##~ op            = e.operations.add
+  ##~ op.httpMethod = "GET"
+  ##~ op.summary    = "Personal Access Token Read"
+  ##~ op.description = "Shows an access token."
+  ##~ op.group = "access_token"
+  #
+  ##~ op.parameters.add :name => "id", :description => "ID or value of the access token.", :dataType => "integer", :paramType => "path", :required => true
+  #
+  ##~ op.parameters.add @parameter_access_token
+  #
+  def show
+    respond_with token
+  end
+
+
   private
+
+  def token
+    @token ||= begin
+      id_or_value = params[:id]
+      scoped_access_tokens = current_user.access_tokens
+      scoped_access_tokens.by_value(id_or_value) || scoped_access_tokens.find(id_or_value)
+    end
+  end
 
   def access_token_params
     params.require(:token).permit(:name, :permission, scopes: [])

--- a/app/controllers/admin/api/personal/base_controller.rb
+++ b/app/controllers/admin/api/personal/base_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Admin::Api::Personal::BaseController < Admin::Api::BaseController
+  before_action :login_required
+  clear_respond_to
+  respond_to :json
+
+  def logged_in?
+    current_user.present?
+  end
+end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -9,6 +9,8 @@ class AccessToken < ApplicationRecord
     end.to_h
   end
 
+  scope :by_name, ->(name) { name.present? ? where("name LIKE ?", "%#{name}%") : all }
+
   PERMISSIONS = options_to_hash(%w(ro rw)).freeze
   SCOPES      = options_to_hash(%w(cms finance account_management stats)).freeze
 
@@ -120,6 +122,14 @@ class AccessToken < ApplicationRecord
     find_by(value: value.to_s.scrub)
   rescue ActiveRecord::StatementInvalid, ArgumentError # utf-8 issues
     nil
+  end
+
+  def self.find_from_id_or_value!(id_or_value)
+    find_from_id_or_value(id_or_value) or raise(ActiveRecord::RecordNotFound)
+  end
+
+  def self.find_from_id_or_value(id_or_value)
+    find_by(id: id_or_value) || find_from_value(id_or_value)
   end
 
   # This can't change or it will create new tokens for everyone

--- a/app/representers/access_tokens_representer.rb
+++ b/app/representers/access_tokens_representer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module AccessTokensRepresenter
+  include ThreeScale::JSONRepresenter
+
+  wraps_collection :access_tokens
+
+  items extend: AccessTokenRepresenter
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -471,8 +471,8 @@ without fake Core server your after commit callbacks will crash and you might ge
       # called from heroku deploy hook after heroku proxy deploy script
       post 'heroku-proxy/deployed', to: 'heroku_proxy#deployed', as: :heroku_proxy_deployed
 
-      namespace :personal do
-        resources :access_tokens, only: %i[create]
+      namespace :personal, defaults: { format: :json } do
+        resources :access_tokens, only: %i[create destroy show]
       end
 
       # /admin/api/provider

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -471,6 +471,10 @@ without fake Core server your after commit callbacks will crash and you might ge
       # called from heroku deploy hook after heroku proxy deploy script
       post 'heroku-proxy/deployed', to: 'heroku_proxy#deployed', as: :heroku_proxy_deployed
 
+      namespace :personal do
+        resources :access_tokens, only: %i[create]
+      end
+
       # /admin/api/provider
       resource :provider, only: [:show, :update]
 
@@ -599,7 +603,7 @@ without fake Core server your after commit callbacks will crash and you might ge
           resource :permissions, controller: 'member_permissions', only: [:show, :update]
         end
 
-        resource :access_tokens, only: %i(create)
+        resources :access_tokens, only: %i[create]
       end
       resources :end_user_plans, :only => [:index] do
         scope module: :end_user_plans do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -472,7 +472,7 @@ without fake Core server your after commit callbacks will crash and you might ge
       post 'heroku-proxy/deployed', to: 'heroku_proxy#deployed', as: :heroku_proxy_deployed
 
       namespace :personal, defaults: { format: :json } do
-        resources :access_tokens, only: %i[create destroy show]
+        resources :access_tokens, except: %i[new edit]
       end
 
       # /admin/api/provider

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -4622,6 +4622,35 @@
       ]
     },
     {
+      "path": "/admin/api/personal/access_tokens.json",
+      "responseClass": "List[access_token]",
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "summary": "Personal Access Token List",
+          "description": "Returns the list of access tokens of the user. If the parameter name is sent, it returns only those whose name contain the string of the param",
+          "group": "access_token",
+          "parameters": [
+            {
+              "name": "name",
+              "description": "Part of the name of the access token.",
+              "dataType": "string",
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": "/admin/api/personal/access_tokens/{id}.json",
       "responseClass": "access_token",
       "operations": [

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -4622,6 +4622,64 @@
       ]
     },
     {
+      "path": "/admin/api/personal/access_tokens/{id}.json",
+      "responseClass": "access_token",
+      "operations": [
+        {
+          "httpMethod": "DELETE",
+          "summary": "Personal Access Token Delete",
+          "description": "Deletes an access token.",
+          "group": "access_token",
+          "parameters": [
+            {
+              "name": "id",
+              "description": "ID or value of the access token.",
+              "dataType": "integer",
+              "paramType": "path",
+              "required": true
+            },
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/admin/api/personal/access_tokens/{id}.json",
+      "responseClass": "access_token",
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "summary": "Personal Access Token Read",
+          "description": "Shows an access token.",
+          "group": "access_token",
+          "parameters": [
+            {
+              "name": "id",
+              "description": "ID or value of the access token.",
+              "dataType": "integer",
+              "paramType": "path",
+              "required": true
+            },
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": "/admin/api/policies.json",
       "responseClass": "json",
       "operations": [

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -5,9 +5,10 @@
       "responseClass": "access_token",
       "operations": [
         {
+          "deprecated": true,
           "httpMethod": "POST",
           "summary": "Access Token Create",
-          "description": "Creates an access token.",
+          "description": "[Deprecated API] Use \"Personal Access Tokens Create\". Creates an access token. Make sure to copy your new personal access token now. You will not be able to see it again as it is not stored for security reasons.",
           "group": "access_token",
           "parameters": [
             {
@@ -4570,6 +4571,51 @@
               "required": true,
               "paramType": "path",
               "threescale_name": "metric_ids"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/admin/api/personal/access_tokens.json",
+      "responseClass": "access_token",
+      "operations": [
+        {
+          "httpMethod": "POST",
+          "summary": "Personal Access Token Create",
+          "description": "Creates an access token. Make sure to copy your new personal access token now. You will not be able to see it again as it is not stored for security reasons.",
+          "group": "access_token",
+          "parameters": [
+            {
+              "name": "name",
+              "description": "Name of the access token.",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query"
+            },
+            {
+              "name": "permission",
+              "description": "Permission of the access token. It must be either 'ro' (read only) or 'rw' (read and write).",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query"
+            },
+            {
+              "name": "scopes",
+              "defaultName": "scopes[]",
+              "description": "Scope of the access token. URL-encoded array containing one or more of the possible values values. The possible values are, for a master user [\"account_management\", \"stats\"], and for a tenant user [\"finance\", \"account_management\", \"stats\"]",
+              "dataType": "custom",
+              "allowMultiple": true,
+              "required": true,
+              "paramType": "query"
+            },
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
             }
           ]
         }

--- a/spec/acceptance/api/access_token_spec.rb
+++ b/spec/acceptance/api/access_token_spec.rb
@@ -4,10 +4,24 @@ require 'rails_helper'
 
 resource 'AccessToken' do
   let(:resource) { FactoryBot.build(:access_token) }
+  let(:expected_properties) { %w[id name scopes permission value] }
 
   json(:resource) do
     let(:root) { 'access_token' }
 
-    it { subject.should have_properties(%w[id name scopes permission value]).from(resource) }
+    it { subject.should have_properties(expected_properties).from(resource) }
+  end
+
+  json(:collection) do
+    let(:root) { 'access_tokens' }
+    context do
+      let(:collection) { [resource, resource] }
+      it 'contains the access token data by its representer' do
+        subject.each do |subject_access_token|
+          subject_access_token.should include('access_token')
+          subject_access_token.fetch('access_token').should have_properties(expected_properties).from(resource)
+        end
+      end
+    end
   end
 end

--- a/test/integration/api/personal/access_tokens_test.rb
+++ b/test/integration/api/personal/access_tokens_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
+  def setup
+    @provider = FactoryBot.create(:simple_provider)
+    host! @provider.self_domain
+    @admin = FactoryBot.create(:simple_admin, account: @provider)
+    @admin_access_token = FactoryBot.create(:access_token, owner: @admin, scopes: %w[account_management])
+  end
+
+  test 'POST creates an access token for the admin user of the access token' do
+    assert_difference @admin.access_tokens.method(:count) do
+      post admin_api_personal_access_tokens_path({access_token: @admin_access_token.value, format: :json}), access_token_params
+      assert_response :created
+      assert JSON.parse(response.body).dig('access_token', 'value')
+    end
+  end
+
+  test 'POST creates an access token for member user with the right permissions and access token' do
+    authorized_member = FactoryBot.create(:member, account: @provider, admin_sections: [:partners])
+    access_token = FactoryBot.create(:access_token, owner: authorized_member, scopes: %w[account_management])
+
+    assert_difference authorized_member.access_tokens.method(:count) do
+      post admin_api_personal_access_tokens_path({access_token: access_token.value, format: :json}), access_token_params
+      assert_response :created
+    end
+  end
+
+  test 'POST does not create an access token for member user with the wrong permissions' do
+    unauthorized_member = FactoryBot.create(:member, account: @provider, admin_sections: [])
+    access_token = FactoryBot.create(:access_token, owner: unauthorized_member, scopes: %w[account_management])
+
+    assert_no_difference(AccessToken.method(:count)) do
+      post admin_api_personal_access_tokens_path({access_token: access_token.value, format: :json}), access_token_params
+      assert_response :forbidden
+    end
+  end
+
+  test 'POST does not create an access token for member user with the right permissions but wrong access token' do
+    authorized_member = FactoryBot.create(:member, account: @provider, admin_sections: [:partners])
+    wrong_token_scope = FactoryBot.create(:access_token, owner: authorized_member, scopes: %w[finance])
+
+    assert_no_difference(AccessToken.method(:count)) do
+      post admin_api_personal_access_tokens_path({access_token: wrong_token_scope.value, format: :json}), access_token_params
+      assert_response :forbidden
+    end
+  end
+
+  test 'POST does not accept a custom value' do
+    assert_difference @admin.access_tokens.method(:count) do
+      post admin_api_personal_access_tokens_path({access_token: @admin_access_token.value, format: :json}), access_token_params({value: 'foobar'})
+      assert_response :created
+      assert_not_equal 'foobar', JSON.parse(response.body).dig('access_token', 'value')
+    end
+  end
+
+  test 'POST does not accept a wrong scope' do
+    assert_no_difference(AccessToken.method(:count)) do
+      post admin_api_personal_access_tokens_path({access_token: @admin_access_token.value, format: :json}), access_token_params({scopes: %w[wrong]})
+      assert_response :unprocessable_entity
+      assert_equal ['invalid'], JSON.parse(response.body).dig('errors', 'scopes')
+    end
+  end
+
+  test 'POST create with provider_key is forbidden' do
+    FactoryBot.create(:cinstance, service: master_account.default_service, user_account: @provider)
+
+    assert_no_difference(AccessToken.method(:count)) do
+      post admin_api_personal_access_tokens_path({provider_key: @provider.provider_key, format: :json}), access_token_params
+      assert_response :forbidden
+    end
+  end
+
+  private
+
+  def access_token_params(different_params = {})
+    { name: 'token name', permission: 'ro', scopes: %w[finance] }.merge(different_params)
+  end
+
+  # TODO:
+  # documentation... api docs
+  # mark the previous api as deprecated
+end

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -91,6 +91,23 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert Array, @token.human_scopes
   end
 
+  def test_scope_by_name
+    %w[searchable another_name].each { |name| FactoryBot.create_list(:access_token, 2, name: name) }
+    assert_same_elements AccessToken.where('name LIKE \'%arch%\'').pluck(:id), AccessToken.by_name('arch').pluck(:id)
+    assert_same_elements AccessToken.all.pluck(:id), AccessToken.by_name('').pluck(:id)
+  end
+
+  def test_find_from_id_or_value_and_bang
+    FactoryBot.create_list(:access_token, 2).each do |token|
+      assert_equal token.id, AccessToken.find_from_id_or_value(token.id).id
+      assert_equal token.id, AccessToken.find_from_id_or_value(token.value).id
+      assert_equal token.id, AccessToken.find_from_id_or_value!(token.id).id
+      assert_equal token.id, AccessToken.find_from_id_or_value!(token.value).id
+    end
+    assert_nil AccessToken.find_from_id_or_value('fake')
+    assert_raise(ActiveRecord::RecordNotFound) { AccessToken.find_from_id_or_value!('fake') }
+  end
+
   private
 
   def member


### PR DESCRIPTION
Fixes [THREESCALE-1766 - Improve the API endpoints of access token](https://issues.jboss.org/browse/THREESCALE-1766)

The system/ruby team had a meeting about this and I will explain here what we decided. We also informed product about this.

### What we have right now (before this PR)
We have only 1 API endpoint for access tokens but we have much more in the UI. The API endpoint that we have right now was created years ago before we were open source in https://github.com/3scale/system/pull/8441 but it was not documented and officially not supported and we documented it and made it public recently in https://github.com/3scale/porta/pull/430

This endpoint right now is under the URL `provider-url/admin/api/users/:user_id/access_tokens`. An officially documented that customers can authenticate through access token and we will allow to create only if the user_id belongs to the same user. Which is true but we also have (not documented and officially unsupported) the possibility to authenticate through provider_key and then we will allow to create for any user of that same account.

This endpoint returns the value that it just created, and the creation is the only moment when we return the value.

We also need to keep in mind that apicast may need to authenticate through provider_key 😄 

### What we we aim to have (with this PR)
We want it to be similar to what we have in the UI. So what we will do the next endpoints.

#### Index/Search Access Token API endpoint
Under the URL `provider-url/admin/api/personal/access_tokens`. It will authenticate through the access_token and will return all the access tokens of the same user of the access_token if no extra parameter is sent. We will also allow the user to send a `name` string query param (like `provider-url/admin/api/access_tokens?name=example`) and we will return all the access tokens of that current user which name contains that string of the param.

For each access token we will return the following attributes.
  - scopes
  - permission
  - name

We will **not** return their values for security reasons 😄 

##### New endpoint
![image](https://user-images.githubusercontent.com/11318903/51483859-5c2af900-1d9a-11e9-8a8e-c39a48b34440.png)
Example of request without search: `curl -v  -X GET "http://provider-admin.example.com.lvh.me:3000/admin/api/personal/access_tokens.json?access_token=13d435a15183e848161ec41a3f5a41b3fee6f2f5bc41ddd0308884a7c42a98cd"`
Example of response:
```json
{
 "access_tokens": [
  {
   "access_token": {
    "id": 3,
    "name": "account",
    "scopes": [
     "account_management"
    ],
    "permission": "rw"
   }
  },
  {
   "access_token": {
    "id": 4,
    "name": "example",
    "scopes": [
     "finance",
     "stats"
    ],
    "permission": "ro"
   }
  },
  {
   "access_token": {
    "id": 5,
    "name": "new example and different",
    "scopes": [
     "account_management",
     "stats"
    ],
    "permission": "rw"
   }
  }
 ]
}
```
Example of request with search: `curl -v  -X GET "http://provider-admin.example.com.lvh.me:3000/admin/api/personal/access_tokens.json?name=xamp&access_token=13d435a15183e848161ec41a3f5a41b3fee6f2f5bc41ddd0308884a7c42a98cd"`

#### Show Access Token API endpoint
Under the URL `provider-url/admin/api/personal/access_tokens/ID` or `provider-url/admin/api/personal/access_tokens/VALUE`
It will authenticate through the access_token and only that same user can fetch an access token of its own. It can be fetched by `ID` or by its `value`.
We will return for the access token the same parameters as for the index (the previous endpoint).

##### New endpoint
![image](https://user-images.githubusercontent.com/11318903/51483833-4584a200-1d9a-11e9-90bb-a762b8b9c1d2.png)
Example of request: `curl -v  -X GET "http://provider-admin.example.com.lvh.me:3000/admin/api/personal/access_tokens/4.json?access_token=13d435a15183e848161ec41a3f5a41b3fee6f2f5bc41ddd0308884a7c42a98cd"`
Example of response:
```json
{
 "access_token": {
  "id": 4,
  "name": "example",
  "scopes": [
   "finance",
   "stats"
  ],
  "permission": "ro"
 }
}
```

#### Delete Access Token API endpoint
Under the URL `provider-url/admin/api/personal/access_tokens/ID` or `provider-url/admin/api/personal/access_tokens/VALUE`
It will authenticate through the access_token and only that same user can delete an access token of its own. It can be fetched by `ID` or by its `value`.

##### New endpoint
![image](https://user-images.githubusercontent.com/11318903/51483798-3271d200-1d9a-11e9-9582-3d50d7bd3797.png)
Example of request: `curl -v  -X DELETE "http://provider-admin.example.com.lvh.me:3000/admin/api/personal/access_tokens/5.json" -d 'access_token=13d435a15183e848161ec41a3f5a41b3fee6f2f5bc41ddd0308884a7c42a98cd'`

#### Create Access Token API endpoint
We will have a new endpoint that does exactly the same as we have, but with a different URL, under `provider-url/admin/api/personal/access_tokens`, and this new endpoint will allow to authenticate only through access_token and not through provider_key.
The endpoint that we had until now will keep working but will be deprecated.

We will also improve the documentation for both endpoints to have the following description:
> Creates an access token. Make sure to copy your new personal access token now. You will not be able to see it again as it is not stored for security reasons.

##### New endpoint
![image](https://user-images.githubusercontent.com/11318903/51483767-2259f280-1d9a-11e9-9826-895c15b3da7b.png)
Example of request: `curl -v  -X POST "http://provider-admin.example.com.lvh.me:3000/admin/api/personal/access_tokens.json" -d 'name=example&permission=ro&scopes%5B%5D=finance&scopes%5B%5D=stats&access_token=13d435a15183e848161ec41a3f5a41b3fee6f2f5bc41ddd0308884a7c42a98cd'`
Example of response:
```json
{
 "access_token": {
  "id": 4,
  "name": "example",
  "scopes": [
   "finance",
   "stats"
  ],
  "permission": "ro",
  "value": "90127a2b42c7b59151e026e170c36abf911df05f0592bf329e63a73461d545c4"
 }
}
```
![image](https://user-images.githubusercontent.com/11318903/51377384-0f7dbe80-1b0b-11e9-8a7c-34a687ced4d0.png)

##### Old endpoint (deprecated)
![image](https://user-images.githubusercontent.com/11318903/51483714-06eee780-1d9a-11e9-8612-86bda001f56e.png)


