### PR TITLE
Cron automatically executed daily that destroys all services marked as 'deleted'

### DIFF
--- a/app/workers/destroy_all_deleted_objects_worker.rb
+++ b/app/workers/destroy_all_deleted_objects_worker.rb
@@ -2,6 +2,6 @@ class DestroyAllDeletedObjectsWorker
   include Sidekiq::Worker
 
   def perform(class_name)
-    class_name.constantize.deleted.destroy_all
+    class_name.constantize.deleted.find_each(&DeleteObjectHierarchyWorker.method(:perform_later))
   end
 end

--- a/config/jobs.rb
+++ b/config/jobs.rb
@@ -33,6 +33,7 @@ module ThreeScale
       Pdf::Dispatch.daily
       FindAndDeleteScheduledAccountsWorker.perform_async
       DeleteProvidedAccessTokensWorker.perform_async
+      DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
     ].freeze
 
     BILLING = %w[

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -7,6 +7,6 @@ namespace :services do
   end
 
   task :destroy_marked_as_deleted => :environment do
-    Service.deleted.find_each(&DeleteObjectHierarchyWorker.method(:perform_later))
+    DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
   end
 end

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -4,13 +4,7 @@ require 'test_helper'
 
 class Tasks::ServicesTest < ActiveSupport::TestCase
   test 'destroy_marked_as_deleted' do
-    provider = FactoryBot.create(:simple_provider)
-    services = FactoryBot.create_list(:simple_service, 2, account: provider)
-    services.first.mark_as_deleted!
-
-    DeleteObjectHierarchyWorker.expects(:perform_later).once.with do |object, _hierarchy|
-      object.id == services.first.id
-    end
+    DestroyAllDeletedObjectsWorker.expects(:perform_async).once.with('Service')
 
     execute_rake_task 'services.rake', 'services:destroy_marked_as_deleted'
   end

--- a/test/unit/three_scale/jobs_test.rb
+++ b/test/unit/three_scale/jobs_test.rb
@@ -7,7 +7,7 @@ class ThreeScale::JobsTest < ActiveSupport::TestCase
   ALL = MONTH + DAILY + BILLING + HOUR
 
   ALL.each do |job|
-    name = job.tr(':.', '_')
+    name = job.tr('():.', '_')
     module_eval <<-RUBY, __FILE__, __LINE__ + 1
       def test_#{name}
         FactoryBot.create(:provider_account)

--- a/test/workers/destroy_all_deleted_objects_worker_test.rb
+++ b/test/workers/destroy_all_deleted_objects_worker_test.rb
@@ -1,20 +1,30 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DestroyAllDeletedObjectsWorkerTest < ActiveSupport::TestCase
 
-  def setup
-    @message = FactoryBot.create(:received_message, deleted_at: DateTime.yesterday)
+  def test_perform_destroys_message_recipient
+    message = FactoryBot.create(:received_message, deleted_at: DateTime.yesterday)
+    Sidekiq::Testing.inline! do
+      assert_difference(MessageRecipient.method(:count), -1) do
+        DestroyAllDeletedObjectsWorker.perform_async('MessageRecipient')
+      end
+      assert_raise(ActiveRecord::RecordNotFound) { message.reload }
+    end
   end
 
-  def test_perform
+  def test_perform_enqueues_delete_object_hierarchy_worker_jobs
+    provider = FactoryBot.create(:simple_provider)
+    services = FactoryBot.create_list(:simple_service, 2, account: provider)
+    services.first.mark_as_deleted!
+
+    DeleteObjectHierarchyWorker.expects(:perform_later).once.with do |object, _hierarchy|
+      object.id == services.first.id
+    end
+
     Sidekiq::Testing.inline! do
-      assert @message.present?
-
-      DestroyAllDeletedObjectsWorker.perform_async('MessageRecipient')
-
-      assert_raise(ActiveRecord::RecordNotFound) do
-        @message.reload
-      end
+      DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
     end
   end
 end


### PR DESCRIPTION
Fixes [THREESCALE-1194](https://issues.jboss.org/browse/THREESCALE-1194)
A cron automatically executed daily that destroys all services marked as 'deleted'.