### PR TITLE
bundler locked at 1.17.3

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -6,6 +6,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # on servers we don't have proper LANG
 Encoding.default_external = Encoding::UTF_8
 
+gem 'bundler', '1.17.3'
+
 gem 'aws-sdk', '~> 2'
 gem 'aws-sdk-rails', '~> 1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -832,6 +832,7 @@ DEPENDENCIES
   braintree (~> 2.89)
   bugsnag (~> 6.0)
   bullet (~> 4.2)
+  bundler (= 1.17.3)
   cancancan (~> 1.7.1)
   capybara (~> 2.18)!
   childprocess
@@ -978,4 +979,4 @@ RUBY VERSION
    ruby 2.3.6p384
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -838,6 +838,7 @@ DEPENDENCIES
   braintree (~> 2.89)
   bugsnag (~> 6.0)
   bullet (~> 4.2)
+  bundler (= 1.17.3)
   cancancan (~> 1.7.1)
   capybara (~> 2.18)!
   childprocess
@@ -985,4 +986,4 @@ RUBY VERSION
    ruby 2.3.6p384
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
will give error when executing `bundle` if the bundler version is not the one specified in the gemfile.