### PR TITLE
Removes incorrect comment about calculation of variable cost

### DIFF
--- a/features/finance/instant_bill_plan_change.feature
+++ b/features/finance/instant_bill_plan_change.feature
@@ -57,9 +57,6 @@ Feature: Instant biling plan change feature
     # but actually the total (fixed + variable) > 0
     # This is a case we need to solve with negative invoices
 
-    # FIXME: the cost for hits is wrong
-    # 1000 - 100 = 900 and for each hits it costs 0.1 so it should be 90.00 and not 90.10
-    # it seems that it counts 901 hits instead
     And the buyer should have following line items for "January, 2017" in the 3rd invoice:
       | name                                                    | quantity |  cost     |
       | Hits                                                    |     1000 |     90.10 |


### PR DESCRIPTION
**What this PR does / why we need it**

The value of $90.10 asserted in the test to be the expected amount billed for variable cost is actually correct. The pricing rule says "from 100 to infinity" $0.1 should be applied per hit, meaning that up to the 99th hit, it should be free. Therefore, in the case of 1000 hits, it's actually 901 of them that should be charged $0.1 each, in a total of $90.10.

This PR removes a `FIXME` comment in the code that suggested the correct amount to bill should be $90.00 (1000 - 100 = 900 hits * $0.1).