### PR TITLE
Fix Eslint errors

### DIFF
--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -47,8 +47,10 @@ class ContextSelector extends React.Component {
   getClassNamesForMenu (menu) {
     const { activeMenu } = this.props
 
-    if (menu === 'dashboard' && activeMenu === 'dashboard' ||
-      menu === 'audience' && (['buyers', 'finance', 'cms', 'site'].indexOf(activeMenu) !== -1)) {
+    const isDashboardSelected = menu === 'dashboard' && activeMenu === 'dashboard'
+    const isAudienceSelected = menu === 'audience' && (['buyers', 'finance', 'cms', 'site'].indexOf(activeMenu) !== -1)
+
+    if (isDashboardSelected || isAudienceSelected) {
       return 'PopNavigation-link current-context'
     }
 

--- a/app/javascript/src/Policies/actions/UISettings.jsx
+++ b/app/javascript/src/Policies/actions/UISettings.jsx
@@ -26,4 +26,3 @@ export type APIRequestStopAction = { type: string }
 export function apiRequestStop (): APIRequestStopAction {
   return { type: 'API_REQUEST_STOP' }
 }
-

--- a/app/javascript/src/Stats/lib/metrics_list.jsx
+++ b/app/javascript/src/Stats/lib/metrics_list.jsx
@@ -17,7 +17,7 @@ export class StatsMetrics {
     return new Promise((resolve, reject) => {
       $.getJSON(url)
         .done(response => resolve(response))
-        .fail((xhr, status, error) => reject(`Request failed: ${status}, ${error}`))
+        .fail((xhr, status, error) => reject(new Error(`Request failed: ${status}, ${error}`)))
     })
   }
 

--- a/app/javascript/src/Stats/lib/metrics_source.jsx
+++ b/app/javascript/src/Stats/lib/metrics_source.jsx
@@ -27,7 +27,7 @@ export class StatsMetricsSource extends StatsSource {
     return new Promise((resolve, reject) => {
       this.request = $.getJSON(this.url, this.params(options))
         .done(response => resolve(this._processResponse(response, options)))
-        .fail((xhr, status, error) => reject(`Request failed: ${status}, ${error}`))
+        .fail((xhr, status, error) => reject(new Error(`Request failed: ${status}, ${error}`)))
     })
   }
 

--- a/app/javascript/src/Stats/lib/source_collector.jsx
+++ b/app/javascript/src/Stats/lib/source_collector.jsx
@@ -53,7 +53,7 @@ export class StatsSourceCollector {
     return new Promise((resolve, reject) => {
       $.getJSON(this.url, this.params(options))
         .then(response => resolve(response))
-        .fail((xhr, status, error) => reject(`Request failed: ${status}, ${error}`))
+        .fail((xhr, status, error) => reject(new Error(`Request failed: ${status}, ${error}`)))
     })
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes Eslint errors that breaks webpack compilation.

**Verification steps** 

Succesfully run `bundle exec webpack:dev`.
