### PR TITLE
[Bugfix] Service is not being deleted 

### DIFF
--- a/app/workers/delete_object_hierarchy_worker.rb
+++ b/app/workers/delete_object_hierarchy_worker.rb
@@ -4,6 +4,7 @@
 class DeleteObjectHierarchyWorker < ActiveJob::Base
 
   # TODO: Rails 5 --> discard_on ActiveJob::DeserializationError
+  # No need of ActiveRecord::RecordNotFound because that can only happen in the callbacks and those callbacks don't use this rescue_from but its own rescue
   rescue_from(ActiveJob::DeserializationError) do |exception|
     Rails.logger.info "DeleteObjectHierarchyWorker#perform raised #{exception.class} with message #{exception.message}"
   end
@@ -25,14 +26,22 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
     build_batch
   end
 
-  def on_success(_status, options)
+  def on_success(_, options)
+    on_finish('on_success', options)
+  end
+
+  def on_complete(_, options)
+    on_finish('on_complete', options)
+  end
+
+  def on_finish(method_name, options)
     workers_hierarchy = options['caller_worker_hierarchy']
-    info "Starting DeleteObjectHierarchyWorker#on_success with the hierarchy of workers: #{workers_hierarchy}"
-    object = GlobalID::Locator.locate options['object_global_id']
+    info "Starting DeleteObjectHierarchyWorker##{method_name} with the hierarchy of workers: #{workers_hierarchy}"
+    object = GlobalID::Locator.locate(options['object_global_id'])
     DeletePlainObjectWorker.perform_later(object, workers_hierarchy)
-    info "Finished DeleteObjectHierarchyWorker#on_success with the hierarchy of workers: #{workers_hierarchy}"
+    info "Finished DeleteObjectHierarchyWorker##{method_name} with the hierarchy of workers: #{workers_hierarchy}"
   rescue ActiveRecord::RecordNotFound => exception
-    Rails.logger.info "DeleteObjectHierarchyWorker#on_success raised #{exception.class} with message #{exception.message}"
+    info "DeleteObjectHierarchyWorker##{method_name} raised #{exception.class} with message #{exception.message}"
   end
 
   protected
@@ -44,7 +53,7 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
   def build_batch
     batch = Sidekiq::Batch.new
     batch.description = batch_description
-    batch_success_callback(batch) { batch.jobs { delete_associations(object) } }
+    batch_callbacks(batch) { batch.jobs { delete_associations(object) } }
     batch
   end
 
@@ -52,13 +61,18 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
     "Deleting #{object.class.name} [##{object.id}]"
   end
 
-  def batch_success_callback(batch)
-    options = { 'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => caller_worker_hierarchy }
-
-    batch.on(:success, self.class, options)
+  def batch_callbacks(batch)
+    %i[success complete].each { |name| batch.on(name, self.class, callback_options) }
     yield
     bid = batch.bid
-    on_success(bid, options) if Sidekiq::Batch::Status.new(bid).total.zero?
+    if Sidekiq::Batch::Status.new(bid).total.zero?
+      on_complete(bid, callback_options)
+    else
+      error_message = "DeleteObjectHierarchyWorker#batch_success_callback retry job with the hierarchy of workers: #{caller_worker_hierarchy}"
+      System::ErrorReporting.report_error(error_message)
+      info(error_message)
+      retry_job wait: 5.minutes
+    end
   end
 
   def delete_associations(object)
@@ -69,6 +83,10 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
   end
 
   private
+
+  def callback_options
+    { 'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => caller_worker_hierarchy }
+  end
 
   def delete_objects_of_association(main_object, association_name, worker)
     return unless (associated_objects = main_object.public_send(association_name))
@@ -91,5 +109,4 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
     delete_hierarchy_workers = Hash.new(DeleteObjectHierarchyWorker).merge('Account' => DeleteAccountHierarchyWorker)
     delete_hierarchy_workers[reflection.options[:class_name]]
   end
-
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,8 @@ module System
       config.is_a?(Hash) ? config.with_indifferent_access : config
     end
 
+    config.active_job.queue_adapter = :sidekiq
+
     def simple_try_config_for(*args)
       config_for(*args)
     rescue => error # rubocop:disable Style/RescueStandardError

--- a/test/integration/service_not_deleted_test.rb
+++ b/test/integration/service_not_deleted_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'sidekiq/testing'
+
+class ServiceNotDeletedTest < ActionDispatch::IntegrationTest
+  disable_transactional_fixtures!
+
+  def setup
+    @provider = FactoryBot.create(:provider_account, domain: 'provider.example.net', from_email: 'support@example.net')
+    login! @provider
+  end
+
+  def test_not_deleted
+    @provider.settings.allow_multiple_services!
+
+    Sidekiq::Testing.inline! do
+      (ENV['BRUTOFORCE'].present? ? 2000 : 1).times do |i|
+        service_name = "service foo #{i}"
+        post(admin_api_services_path, provider_key: @provider.api_key, format: :json, name: service_name)
+        assert_response :success
+        assert_service(@response.body, { account_id: @provider.id, name: service_name })
+        new_service = @provider.services.find_by_name(service_name)
+        assert new_service
+
+        delete admin_api_service_path(new_service.id, provider_key: @provider.api_key, format: :json)
+        assert_response 200
+        assert_raise(ActiveRecord::RecordNotFound) { Service.find(new_service.id) }
+      end
+    end
+  end
+end

--- a/test/workers/delete_object_hierarchy_worker_test.rb
+++ b/test/workers/delete_object_hierarchy_worker_test.rb
@@ -15,19 +15,16 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_callback
+  def test_success_callback_method
     caller_worker_hierarchy = %w[HTestClass123 HTestClass1123]
     DeletePlainObjectWorker.expects(:perform_later).with(object, caller_worker_hierarchy)
     hierarchy_worker.new.on_success(1, {'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => caller_worker_hierarchy})
   end
 
-  def test_success_when_empty_batch
-    worker = hierarchy_worker.new
-    worker.instance_variable_set(:@object, object)
+  def test_complete_callback_method
     caller_worker_hierarchy = %w[HTestClass123 HTestClass1123]
-    worker.instance_variable_set(:@caller_worker_hierarchy, caller_worker_hierarchy)
-    worker.expects(:on_success).with(anything, {'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => caller_worker_hierarchy})
-    worker.perform(object: object)
+    DeletePlainObjectWorker.expects(:perform_later).with(object, caller_worker_hierarchy)
+    hierarchy_worker.new.on_complete(1, {'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => caller_worker_hierarchy})
   end
 
   private
@@ -40,24 +37,36 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
     DeleteObjectHierarchyWorker
   end
 
-  class ObjectDoesNotExistAnymoreTest < DeleteObjectHierarchyWorkerTest
+  class DeleteObjectHierarchyWorkerWhenDoesNotHaveAssociationsTest < ActiveSupport::TestCase
+    def test_execute_success_when_empty_batch
+      object = FactoryBot.create(:metric)
+      worker = DeleteObjectHierarchyWorker.new
+      worker.instance_variable_set(:@object, object)
+      caller_worker_hierarchy = %w[HTestClass123 HTestClass1123]
+      worker.instance_variable_set(:@caller_worker_hierarchy, caller_worker_hierarchy)
+      worker.expects(:on_complete).with(anything, {'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => caller_worker_hierarchy})
+      worker.perform(object: object)
+    end
+  end
+
+  class DeleteObjectHierarchyWorkerWhenObjectDoesNotExistAnymoreTest < ActiveSupport::TestCase
     setup do
-      @object = FactoryBot.create(:provider_account)
+      @object = FactoryBot.create(:simple_account)
       Rails.logger.stubs(:info)
     end
+
+    attr_reader :object
 
     def test_perform_deserialization_error
       object.destroy!
       Rails.logger.expects(:info).with { |message| message.match(/DeleteObjectHierarchyWorker#perform raised ActiveJob::DeserializationError/) }
-      assert_nothing_raised(ActiveJob::DeserializationError) { hierarchy_worker.perform_now(object) }
+      Sidekiq::Testing.inline! { DeleteObjectHierarchyWorker.perform_later(object) }
     end
 
     def test_success_record_not_found
       object.destroy!
       Rails.logger.expects(:info).with("DeleteObjectHierarchyWorker#on_success raised ActiveRecord::RecordNotFound with message Couldn't find #{object.class} with 'id'=#{object.id}")
-      assert_nothing_raised(ActiveRecord::RecordNotFound) do
-        hierarchy_worker.new.on_success(1, {'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => %w[Hierarchy-TestClass-123]})
-      end
+      DeleteObjectHierarchyWorker.new.on_success(1, {'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => %w[Hierarchy-TestClass-123]})
     end
   end
 

--- a/test/workers/delete_plain_object_worker_test.rb
+++ b/test/workers/delete_plain_object_worker_test.rb
@@ -88,12 +88,12 @@ class DeletePlainObjectWorkerTest < ActiveSupport::TestCase
 
       # Execute deletion of service but suspend the execution of deleting the proxy by `:dependent => :destroy`
       f1 = Fiber.new do
-        DeletePlainObjectWorker.perform_now(service, ['Hierarchy-Service-ID'])
+        Sidekiq::Testing.inline! { DeletePlainObjectWorker.perform_now(service, ['Hierarchy-Service-ID']) }
       end
 
       # Destroy the proxy in another thread
       f2 = Fiber.new do
-        DeletePlainObjectWorker.perform_now(proxy, ['Hierarchy-Service-ID', 'Hierarchy-Proxy-ID'])
+        Sidekiq::Testing.inline! { DeletePlainObjectWorker.perform_now(proxy, ['Hierarchy-Service-ID', 'Hierarchy-Proxy-ID']) }
       end
 
       f1.resume


### PR DESCRIPTION
**What this PR does / why we need it**:

Some services are not being deleted because of "ghost" workers. Besides `..delete_object..` workers there are others, backend related. Those workers could be still in the queue when `batch_success_callback` is being called. Therefore, `service` (main object) wouldn't get destroyed at all. To fix that we implement `on_complete` batch callback that destroy the main object + we manually call `on_success` once batch is blank, if batch still contain some jobs, we'll retry the job after 5 minutes. 
