### PR TITLE
Improve ApplicationsHelper#services_contracted

### DIFF
--- a/app/helpers/buyers/applications_helper.rb
+++ b/app/helpers/buyers/applications_helper.rb
@@ -11,7 +11,7 @@ module Buyers::ApplicationsHelper
   end
 
   def services_contracted(buyer)
-    buyer.bought_service_contracts.map(&:service).map(&:id).to_json
+    buyer.bought_service_contracts.services.pluck(:id).to_json
   end
 
   def service_plan_contracted_for_service(buyer)

--- a/test/unit/helpers/buyers/applications_helper_test.rb
+++ b/test/unit/helpers/buyers/applications_helper_test.rb
@@ -7,7 +7,7 @@ class Buyers::ApplicationsHelperTest < ActionView::TestCase
     service_ids = []
     service_ids << FactoryBot.create(:service_contract, user_account: buyer).service.id
     service_ids << FactoryBot.create(:service_contract, user_account: buyer).service.id
-    assert_equal services_contracted(buyer), service_ids.to_json
+    assert_same_elements service_ids, JSON.parse(services_contracted(buyer))
   end
 
   test "services_contracted should return a empty array" do


### PR DESCRIPTION
Fix order of test as explained in https://github.com/3scale/porta/pull/376/files#r248806142
Also the query is from the DB (more efficient) for this:
https://github.com/3scale/porta/blob/098c1fd6ab186c6876c323c56b349a2351f33e2f/app/models/account/buyer_methods.rb#L50-L62
