### PR TITLE
[Rename] AccessToken#by_value -> AccessToken#find_from_value

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -116,7 +116,7 @@ class AccessToken < ApplicationRecord
     super.reject { |column| column.name == 'owner_type' }
   end
 
-  def self.by_value(value)
+  def self.find_from_value(value)
     find_by(value: value.to_s.scrub)
   rescue ActiveRecord::StatementInvalid, ArgumentError # utf-8 issues
     nil

--- a/lib/api_authentication/by_access_token.rb
+++ b/lib/api_authentication/by_access_token.rb
@@ -102,7 +102,7 @@ module ApiAuthentication
 
     def authenticated_token
       return @authenticated_token if instance_variable_defined?(:@authenticated_token)
-      @authenticated_token = domain_account.access_tokens.by_value(access_token) if access_token
+      @authenticated_token = domain_account.access_tokens.find_from_value(access_token) if access_token
     end
 
     def enforce_access_token_permission

--- a/test/unit/api_authentication/by_authentication_token_test.rb
+++ b/test/unit/api_authentication/by_authentication_token_test.rb
@@ -20,7 +20,7 @@ class ApiAuthentication::ByAuthenticationTokenTest < MiniTest::Unit::TestCase
   def mock_token(attributes = {})
     @params = { access_token: 'some-token' }
     token = mock('access-token', attributes)
-    @access_tokens.expects(:by_value).with('some-token').returns(token)
+    @access_tokens.expects(:find_from_value).with('some-token').returns(token)
     token
   end
 


### PR DESCRIPTION
https://github.com/3scale/porta/pull/492#discussion_r249470181
It just changes the name of the method to a more accurate one since it returns an instance of `AccessToken` or `nil`