### PR TITLE
[Refactor] ApplicationsHelper#relation_plans_service is more efficient and simpler

### DIFF
--- a/app/helpers/buyers/applications_helper.rb
+++ b/app/helpers/buyers/applications_helper.rb
@@ -36,9 +36,8 @@ module Buyers::ApplicationsHelper
   end
 
   def relation_plans_services(provider)
-    provider.application_plans.inject({}) do |hash, application_plan|
+    provider.application_plans.includes(:service).each_with_object({}) do |application_plan, hash|
       hash[application_plan.id] = application_plan.service.id
-      hash
     end.to_json
   end
 


### PR DESCRIPTION
I've tested the change and it works:
![image](https://user-images.githubusercontent.com/11318903/51490705-635b0280-1dac-11e9-93c6-0deeb494b0e1.png)

### Tasks

#### Fix N+1 Query for application_plan.service
![image](https://user-images.githubusercontent.com/11318903/51490621-22fb8480-1dac-11e9-960c-2dc63a149fb0.png)

#### Simplify the method
Refactor inject to each_with_object because it doesn't require returning the hash after each execution of the block.