### PR TITLE
[API] Service create/update with documentation and test for the 'description' param

### DIFF
--- a/app/controllers/admin/api/services_controller.rb
+++ b/app/controllers/admin/api/services_controller.rb
@@ -37,6 +37,7 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   #
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add :name => "name", :description => "Name of the service to be created.", :dataType => "string", :required => true, :paramType => "query"
+  ##~ op.parameters.add :name => "description", :description => "Description of the service to be created.", :dataType => "string", :required => false, :paramType => "query"
   ##~ op.parameters.add :name => "deployment_option", :description => "Deployment option for the gateway: 'hosted' for APIcast hosted, 'self_managed' for APIcast Self-managed option", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
   ##~ op.parameters.add :name => "backend_version", :description => "Authentication mode: '1' for API key, '2' for App Id / App Key, 'oidc' for OpenID Connect", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
   ##~ op.parameters.add @parameter_system_name_by_name
@@ -75,6 +76,7 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_service_id_by_id
   ##~ op.parameters.add :name => "name", :description => "New name for the service.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "description", :description => "New description for the service.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
   ##~ op.parameters.add :name => "support_email", :description => "New support email.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
   ##~ op.parameters.add :name => "tech_support_email", :description => "New technical support email.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"
   ##~ op.parameters.add :name => "admin_support_email", :description => "New admin support email.", :dataType => "string", :allowMultiple => false, :required => false, :paramType => "query"

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -6422,6 +6422,13 @@
               "paramType": "query"
             },
             {
+              "name": "description",
+              "description": "Description of the service to be created.",
+              "dataType": "string",
+              "required": false,
+              "paramType": "query"
+            },
+            {
               "name": "deployment_option",
               "description": "Deployment option for the gateway: 'hosted' for APIcast hosted, 'self_managed' for APIcast Self-managed option",
               "dataType": "string",
@@ -6507,6 +6514,14 @@
             {
               "name": "name",
               "description": "New name for the service.",
+              "dataType": "string",
+              "allowMultiple": false,
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "description",
+              "description": "New description for the service.",
               "dataType": "string",
               "allowMultiple": false,
               "required": false,

--- a/test/integration/admin/api/services_controller_test.rb
+++ b/test/integration/admin/api/services_controller_test.rb
@@ -8,16 +8,41 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     login! master_account
   end
 
-  def test_show
-    get admin_api_service_path(master_account.default_service, format: :xml)
-    assert_response :ok
-    assert response.body.include?('deployment_option')
-    assert response.body.include?(master_account.default_service.deployment_option)
+  def test_create
+    Account.any_instance.stubs(can_create_service?: true)
+    %i[xml json].each do |format|
+      requested_name = "example name #{format.to_s}"
+      requested_description = "example description #{format.to_s}"
+      assert_difference(master_account.services.method(:count)) do
+        post admin_api_services_path(format: format), {name: requested_name, description: requested_description}
+        assert_response :created
+      end
+      service = master_account.services.last
+      assert_equal requested_name, service.name
+      assert_equal requested_description, service.description
+    end
+  end
 
-    get admin_api_service_path(master_account.default_service, format: :json)
-    assert_response :ok
-    assert response.body.include?('deployment_option')
-    assert response.body.include?(master_account.default_service.deployment_option)
+  def test_update
+    service = master_account.default_service
+    %i[xml json].each do |format|
+      requested_name = "example name #{format.to_s}"
+      requested_description = "example description #{format.to_s}"
+      put admin_api_service_path(service, format: format), {name: requested_name, description: requested_description}
+      assert_response :ok
+      assert_equal requested_name, service.reload.name
+      assert_equal requested_description, service.description
+    end
+  end
+
+  def test_show
+    service = master_account.default_service
+    %i[xml json].each do |format|
+      get admin_api_service_path(service, format: format)
+      assert_response :ok
+      assert response.body.include?('deployment_option')
+      assert response.body.include?(service.deployment_option)
+    end
   end
 
   test 'GET index works for Saas' do


### PR DESCRIPTION
We were asked if it is possible to set the description of a service through the API, which it is, so this PR just adds the param in the ActiveDocs and adds some tests for that param 😄 

#### Create
![image](https://user-images.githubusercontent.com/11318903/51621633-4140bc00-1f35-11e9-8cd1-b7e513e25116.png)

![image](https://user-images.githubusercontent.com/11318903/51621704-5f0e2100-1f35-11e9-8df5-3dba810e4d00.png)


#### Update
![image](https://user-images.githubusercontent.com/11318903/51621772-82d16700-1f35-11e9-924c-9f82f5f9833a.png)

![image](https://user-images.githubusercontent.com/11318903/51621827-a5638000-1f35-11e9-8a03-98e15755eca0.png)

