### PR TITLE
[fix] Random test failures on comparing dates without microseconds

### DIFF
--- a/app/models/web_hook/event.rb
+++ b/app/models/web_hook/event.rb
@@ -137,11 +137,14 @@ class WebHook
 
     delegate :connection, to: 'ActiveRecord::Base'
 
+    # :reek:NilCheck
+    # That is fine as we want really to check for nil value in the changes
     def guess_event
+      resource_changes = @resource.previous_changes
       case
       when @resource.destroyed?
         'deleted'
-      when @resource.created_at.present? && @resource.created_at == @resource.updated_at
+      when resource_changes.key?('created_at') && resource_changes['created_at'].first.nil?
         'created'
       when @resource.updated_at.present?
         'updated'

--- a/test/unit/web_hook/event_test.rb
+++ b/test/unit/web_hook/event_test.rb
@@ -70,6 +70,19 @@ class WebHook::EventTest < ActiveSupport::TestCase
 
   end
 
+
+  test 'guess_event' do
+    provider = build_provider(:application_created_on => true)
+    provider.save!
+    assert_equal 'created', WebHook::Event.new(provider, provider).event
+
+    provider.update_column(:updated_at, provider.created_at + 0.0001.second)
+    provider.reload
+    event = WebHook::Event.new(provider, provider)
+
+    assert_equal 'updated', event.event
+  end
+
   # TODO: check xml of webhook event and compare it to model
 
   class EnqueueTest < ActiveSupport::TestCase

--- a/test/workers/web_hook_worker_test.rb
+++ b/test/workers/web_hook_worker_test.rb
@@ -3,30 +3,29 @@
 require 'test_helper'
 
 class WebHookWorkerTest < ActiveSupport::TestCase
-  disable_transactional_fixtures!
-
   setup do
-    User.current = nil
     @worker = WebHookWorker.new
   end
 
-  teardown do
-    User.current = nil
+  class TransactionalTest < ActiveSupport::TestCase
+    disable_transactional_fixtures!
+
+    test 'webhook job performs work' do
+      WebHook.delete_all
+      webhook = FactoryBot.create(:webhook, :account_created_on => true, :user_created_on => true)
+      Account.any_instance.stubs(:web_hooks_allowed?).returns(true)
+
+      User.current = webhook.account.users.first
+
+      jobs = WebHookWorker.jobs
+      assert jobs.empty?
+      FactoryBot.create(:buyer_account, :provider_account => webhook.account)
+      assert_equal 2, jobs.size
+    end
   end
 
-  test 'heandled errors' do
+  test 'handled errors' do
     assert_same_elements [SocketError, RestClient::Exception, Errno::ECONNREFUSED, Errno::ECONNRESET],  WebHookWorker::HANDLED_ERRORS
-  end
-
-  test 'webhook job performs work' do
-    webhook = FactoryBot.create(:webhook, :account_created_on => true, :user_created_on => true)
-    Account.any_instance.stubs(:web_hooks_allowed?).returns(true)
-    User.current = webhook.account.users.first
-
-    jobs = WebHookWorker.jobs
-    assert jobs.empty?
-    FactoryBot.create(:buyer_account, :provider_account => webhook.account)
-    assert_equal 2, jobs.size
   end
 
   test 'be retried' do


### PR DESCRIPTION
**What this PR does / why we need it**:

This is random test failure, if created_at and updated_at are in the same millisecond then the guess_event won't work.
When saved in database, Rails does not keep the micro seconds.