### PR TITLE
[safe-migration] Programmatically reject the columns we are going to delete

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -3,6 +3,10 @@
 require_dependency 'backend_client'
 
 class Account < ApplicationRecord
+  def self.columns
+    super.reject { |c| c.name == "deleted_at" }
+  end
+
   set_date_columns :credit_card_expires_on
 
   # it has to be THE FIRST callback after create, so associations get the tenant id


### PR DESCRIPTION
Tell ActiveRecord to remove a column from the cache first
Deploy the code
Then actually remove it from the Database

https://blog.codeship.com/rails-migrations-zeo-downtime/

Need by #546