### PR TITLE
[wip][gem] Adding strong_migrations to protect against dangerous DB migrations

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -11,6 +11,7 @@ gem 'aws-sdk-rails', '~> 1.0'
 
 gem 'dotenv-rails', '~> 2.0'
 gem 'rails', '4.2.9'
+gem 'strong_migrations'
 #gem 'rails', '5.0.6'
 #gem 'activesupport', '4.2.9' # somehow paperclip needs to explicitly lock the version to not use 5.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -735,6 +735,8 @@ GEM
       json (~> 1.8.1)
       mime-types (>= 1.25, < 3.0)
       rest-client (~> 1.4)
+    strong_migrations (0.3.1)
+      activerecord (>= 3.2.0)
     symbolize (4.5.2)
       activemodel (>= 3.2, < 5)
       activesupport (>= 3.2, < 5)
@@ -953,6 +955,7 @@ DEPENDENCIES
   state_machines-activerecord (~> 0.5.0)
   statsd-ruby
   stripe
+  strong_migrations
   swagger-ui_rails!
   swagger-ui_rails2!
   symbolize (~> 4.5)
@@ -975,4 +978,4 @@ RUBY VERSION
    ruby 2.3.6p384
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+StrongMigrations.start_after = 20190104134224

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -458,7 +458,7 @@ GEM
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
     netrc (0.11.0)
-    newrelic_rpm (5.6.0.349)
+    newrelic_rpm (5.7.0.350)
     nokogiri (1.9.1)
       mini_portile2 (~> 2.4.0)
     non-stupid-digest-assets (1.0.9)
@@ -740,6 +740,8 @@ GEM
       json (~> 1.8.1)
       mime-types (>= 1.25, < 3.0)
       rest-client (~> 1.4)
+    strong_migrations (0.3.1)
+      activerecord (>= 3.2.0)
     symbolize (4.5.2)
       activemodel (>= 3.2, < 5)
       activesupport (>= 3.2, < 5)
@@ -960,6 +962,7 @@ DEPENDENCIES
   state_machines-activerecord (~> 0.5.0)
   statsd-ruby
   stripe
+  strong_migrations
   swagger-ui_rails!
   swagger-ui_rails2!
   symbolize (~> 4.5)
@@ -982,4 +985,4 @@ RUBY VERSION
    ruby 2.3.6p384
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
The goal is to be able to detect those migrations on development and prepare a safe way.

TODO:

- [ ] Verify that it is working for Oracle. If it is not easy to make it work with Oracle then at least it is a step for MySQL and Postgres

Fixes: https://issues.jboss.org/browse/THREESCALE-1859 (Red Hat internal only)