### PR TITLE
[api] Add 'approval_required' to plans endpoints

### DIFF
--- a/app/controllers/admin/api/application_plans_controller.rb
+++ b/app/controllers/admin/api/application_plans_controller.rb
@@ -49,6 +49,7 @@ class Admin::Api::ApplicationPlansController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_service_id_by_id_name
   ##~ op.parameters.add :name => "name", :description => "Name of the application plan.", :dataType => "string", :required => true, :paramType => "query"
+  ##~ op.parameters.add :name => "approval_required", :description => "Set the 'Applications require approval?' to 'true' or 'false'", :dataType => "boolean", :required => false, :paramType => "query"
   ##~ op.parameters.add @parameter_system_name_by_name
   ##~ op.parameters.add @parameter_application_plan_state_event
   #
@@ -85,6 +86,7 @@ class Admin::Api::ApplicationPlansController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add @parameter_service_id_by_id_name
   ##~ op.parameters.add @parameter_application_plan_id_by_id
   ##~ op.parameters.add :name => "name", :description => "Name of the application plan.", :dataType => "string", :paramType => "query"
+  ##~ op.parameters.add :name => "approval_required", :description => "Set the 'Applications require approval?' to 'true' or 'false'", :dataType => "boolean", :required => false, :paramType => "query"
   ##~ op.parameters.add @parameter_application_plan_state_event
   #
   def update
@@ -130,7 +132,7 @@ class Admin::Api::ApplicationPlansController < Admin::Api::ServiceBaseController
 
   protected
 
-  DEFAULT_PARAMS = %i[name state_event description].freeze
+  DEFAULT_PARAMS = %i[name state_event description approval_required].freeze
 
   def application_plan_update_params
     params.require(:application_plan).permit(DEFAULT_PARAMS)

--- a/app/controllers/admin/api/service_plans_controller.rb
+++ b/app/controllers/admin/api/service_plans_controller.rb
@@ -51,6 +51,7 @@ class Admin::Api::ServicePlansController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_service_id_by_id
   ##~ op.parameters.add :name => "name", :description => "Name of the service plan.", :dataType => "string", :required => true, :paramType => "query"
+  ##~ op.parameters.add :name => "approval_required", :description => "Set the 'Service subscriptions require approval?' to 'true' or 'false'", :dataType => "boolean", :required => false, :paramType => "query"
   ##~ op.parameters.add @parameter_system_name_by_name
   ##~ op.parameters.add @parameter_service_plan_state_event
   #
@@ -89,6 +90,7 @@ class Admin::Api::ServicePlansController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add @parameter_service_id_by_id_name
   ##~ op.parameters.add @parameter_service_plan_id_by_id
   ##~ op.parameters.add :name => "name", :description => "Name of the service plan.", :dataType => "string", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "approval_required", :description => "Set the 'Service subscriptions require approval?' to 'true' or 'false'", :dataType => "boolean", :required => false, :paramType => "query"
   ##~ op.parameters.add @parameter_service_plan_state_event
   #
   def update
@@ -135,7 +137,7 @@ class Admin::Api::ServicePlansController < Admin::Api::ServiceBaseController
 
   protected
 
-  DEFAULT_PARAMS = %i[name state_event].freeze
+  DEFAULT_PARAMS = %i[name state_event approval_required].freeze
 
   def service_plan_update_params
     params.require(:service_plan).permit(DEFAULT_PARAMS)

--- a/app/models/application_plan.rb
+++ b/app/models/application_plan.rb
@@ -58,6 +58,7 @@ class ApplicationPlan < Plan
       xml.service_id issuer_id
 
       xml.end_user_required end_user_required
+      xml.approval_required approval_required
 
       xml.setup_fee setup_fee
       xml.cost_per_month cost_per_month

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -379,6 +379,7 @@ class Plan < ApplicationRecord
       xml.type_  self.class.to_s.underscore
       xml.state state
 
+      xml.approval_required approval_required
       xml.setup_fee setup_fee
       xml.cost_per_month cost_per_month
       xml.trial_period_days trial_period_days

--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -37,7 +37,6 @@ class ServicePlan < Plan
       xml.type_ self.class.to_s.underscore
       xml.state state
       xml.service_id issuer_id
-      xml.approval_required approval_required
 
       xml.setup_fee setup_fee
       xml.cost_per_month cost_per_month

--- a/app/representers/plan_representer.rb
+++ b/app/representers/plan_representer.rb
@@ -10,6 +10,7 @@ module PlanRepresenter
     property :cost_per_month
     property :trial_period_days
     property :cancellation_period
+    property :approval_required
 
     property :default
 

--- a/app/representers/service_plan_representer.rb
+++ b/app/representers/service_plan_representer.rb
@@ -4,8 +4,6 @@ module ServicePlanRepresenter
 
   wraps_resource
 
-  property :approval_required
-
   link :service do
     admin_api_service_url(issuer_id) if issuer_id
   end

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -1753,6 +1753,13 @@
               "paramType": "query"
             },
             {
+              "name": "approval_required",
+              "description": "Set the 'Applications require approval?' to 'true' or 'false'",
+              "dataType": "boolean",
+              "required": false,
+              "paramType": "query"
+            },
+            {
               "name": "system_name",
               "description": "System Name of the object to be created. System names cannot be modified after creation, they are used as the key to identify the objects.",
               "dataType": "string",
@@ -1839,6 +1846,13 @@
               "name": "name",
               "description": "Name of the application plan.",
               "dataType": "string",
+              "paramType": "query"
+            },
+            {
+              "name": "approval_required",
+              "description": "Set the 'Applications require approval?' to 'true' or 'false'",
+              "dataType": "boolean",
+              "required": false,
               "paramType": "query"
             },
             {
@@ -5221,6 +5235,13 @@
               "paramType": "query"
             },
             {
+              "name": "approval_required",
+              "description": "Set the 'Service subscriptions require approval?' to 'true' or 'false'",
+              "dataType": "boolean",
+              "required": false,
+              "paramType": "query"
+            },
+            {
               "name": "system_name",
               "description": "System Name of the object to be created. System names cannot be modified after creation, they are used as the key to identify the objects.",
               "dataType": "string",
@@ -5307,6 +5328,13 @@
               "name": "name",
               "description": "Name of the service plan.",
               "dataType": "string",
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "approval_required",
+              "description": "Set the 'Service subscriptions require approval?' to 'true' or 'false'",
+              "dataType": "boolean",
               "required": false,
               "paramType": "query"
             },

--- a/test/integration/admin/api/application_plans_controller_test.rb
+++ b/test/integration/admin/api/application_plans_controller_test.rb
@@ -25,7 +25,7 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
 
     def test_create_invalid_params_json
       assert_no_difference service.application_plans.method(:count) do
-        post admin_api_service_application_plans_path(application_plan_params('fakestate'))
+        post admin_api_service_application_plans_path(application_plan_params(state_event: 'fakestate'))
         assert_response :unprocessable_entity
         assert_equal ['invalid'], JSON.parse(response.body).dig('errors', 'state_event')
       end
@@ -42,7 +42,7 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
     def test_update_invalid_params_json
       original_values = {name: 'firstname', state: 'hidden', service: service}
       application_plan = FactoryBot.create(:application_plan, original_values)
-      put admin_api_service_application_plan_path(application_plan, application_plan_params('fakestate'))
+      put admin_api_service_application_plan_path(application_plan, application_plan_params(state_event: 'fakestate'))
       assert_response :unprocessable_entity
       assert_equal ['invalid'], JSON.parse(response.body).dig('errors', 'state_event')
       assert_equal original_values[:name], application_plan.reload.name
@@ -130,18 +130,28 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
       assert_equal 'Forbidden', JSON.parse(response.body)['status']
     end
 
+    def test_approval_required
+      assert_difference service.application_plans.method(:count) do
+        post admin_api_service_application_plans_path(application_plan_params(approval_required: true))
+        assert_response :success
+        assert JSON.parse(response.body).dig('application_plan', 'id').present?
+      end
+      application_plan = service.application_plans.last
+      assert application_plan.approval_required
+    end
+
     private
 
     def current_account
       master_account
     end
   end
-  
+
   private
-  
+
   attr_reader :service
 
-  def application_plan_params(state_event = 'publish')
-    @application_plan_params ||= { service_id: service.id, application_plan: { name: 'testing', system_name: 'testing', approval_required: 0, state_event: state_event }, format: :json }
+  def application_plan_params(state_event: 'publish', approval_required: 0)
+    @application_plan_params ||= { service_id: service.id, application_plan: { name: 'testing', system_name: 'testing', approval_required: approval_required, state_event: state_event }, format: :json }
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `approval_required` to the Account Management API endpoints (read and write).

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1075

**Verification steps** 

1. Create an application plan with API:
```
curl -v  -X POST "https://{ADMIN_PORTAL}/admin/api/services/{SERVICE_ID}/application_plans.xml" -d 'access_token={ACCESS_TOKEN}&name=test&approval_required=true'
```
2. Verify that the plan is created and the response has `<approval_required>true</approval_required>`

**Special notes for your reviewer**:
