### PR TITLE
[Bugfix] Deleted Cinstance does not have the Proxy dependency for Zync anymore

### DIFF
--- a/app/events/zync_event.rb
+++ b/app/events/zync_event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ZyncEvent < RailsEventStore::Event
+class ZyncEvent < BaseEventStoreEvent
 
   # Create Zync Event
 
@@ -62,13 +62,9 @@ class ZyncEvent < RailsEventStore::Event
   private
 
   def non_persisted_dependencies
-    proxy_id = data[:proxy_id]
     case record
-    when Cinstance
-      [Service.new({id: data[:service_id]}, without_protection: true),
-       Proxy.new({id: proxy_id}, without_protection: true)]
-    when Proxy
-      [Proxy.new({id: proxy_id}, without_protection: true)]
+    when Proxy, Cinstance
+      [Service.new({id: data[:service_id]}, without_protection: true)]
     else
       NONE
     end

--- a/test/events/zync_event_test.rb
+++ b/test/events/zync_event_test.rb
@@ -18,6 +18,18 @@ class ZyncEventTest < ActiveSupport::TestCase
     assert_equal [ service = application.service, service.proxy ], event.dependencies
   end
 
+  def test_non_persisted_dependencies_for_application
+    application = FactoryBot.build(:simple_cinstance, service: FactoryBot.create(:simple_service))
+    assert event = ZyncEvent.create(Applications::ApplicationDeletedEvent.create(application), application)
+    assert_equal [application.service_id], event.dependencies.map(&:id)
+  end
+
+  def test_non_persisted_dependencies_for_proxy
+    proxy = FactoryBot.build(:proxy, service: FactoryBot.create(:simple_service))
+    assert event = ZyncEvent.create(OIDC::ProxyChangedEvent.create(proxy), proxy)
+    assert_equal [proxy.service_id], event.dependencies.map(&:id)
+  end
+
   def test_record
     application = FactoryBot.create(:simple_cinstance)
     parent_event = RailsEventStore::Event.new


### PR DESCRIPTION
Fixes https://github.com/3scale/porta/issues/538
The application does not need the proxy to delete in Zync, so when it is a deleted application, it's only dependency is the Service, which exists.