### PR TITLE
[fix] Use only one place to reject columns

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -3,9 +3,14 @@
 require_dependency 'backend_client'
 
 class Account < ApplicationRecord
+  # Hack to remove payment_gateway_type, payment_gateway_options and deleted_at from @attributes
+  # It is enough for rails not persisting them in actual columns.
   def self.columns
-    super.reject { |c| c.name == "deleted_at" }
+    super.reject {|column| /\Apayment_gateway_(type|options)|deleted_at\Z/ =~ column.name }
   end
+
+  # need to reset column information to clear column_names and such
+  reset_column_information
 
   set_date_columns :credit_card_expires_on
 

--- a/app/models/account/gateway.rb
+++ b/app/models/account/gateway.rb
@@ -10,14 +10,7 @@ module Account::Gateway
 
     attr_accessor :payment_gateway_changed
 
-    # Hack to remove payment_gateway_type and payment_gateway_options from @attributes
-    # It is enough for rails not persisting them in actual columns.
-    def self.columns
-      super.reject{|column| /\Apayment_gateway_(type|options)\Z/ =~ column.name }
-    end
 
-    # need to reset column information to clear column_names and such
-    reset_column_information
   end
 
   # Payment gateway this account accepts payments through.

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -21,6 +21,12 @@ class AccountTest < ActiveSupport::TestCase
   should have_many :invoices
   should have_many :payment_transactions
 
+  def test_removed_columns
+    %W[payment_gateway_type payment_gateway_options deleted_at].each do |column|
+      refute_includes Account.column_names, column
+    end
+  end
+
   def test_not_master
     master = master_account
     buyer = FactoryBot.create(:simple_buyer, provider_account: master)


### PR DESCRIPTION
- Added a test
- Doing it in a single place so table columns are not retrieved again.
