### PR TITLE
Remove reporting to Bugsnag for each perform of DeleteObjectHierarchyWorker with associations

### DIFF
--- a/app/workers/delete_object_hierarchy_worker.rb
+++ b/app/workers/delete_object_hierarchy_worker.rb
@@ -68,9 +68,7 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
     if Sidekiq::Batch::Status.new(bid).total.zero?
       on_complete(bid, callback_options)
     else
-      error_message = "DeleteObjectHierarchyWorker#batch_success_callback retry job with the hierarchy of workers: #{caller_worker_hierarchy}"
-      System::ErrorReporting.report_error(error_message)
-      info(error_message)
+      info("DeleteObjectHierarchyWorker#batch_success_callback retry job with the hierarchy of workers: #{caller_worker_hierarchy}")
       retry_job wait: 5.minutes
     end
   end


### PR DESCRIPTION
Remove this reporting to Bugsnag because it is done for every time we call to `DeleteObjectHierarchyWorker` and for each of its associations. It is too overwhelming.