### PR TITLE
Exceptions for automatic suspension and deletion of inactive providers

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -109,6 +109,13 @@ class Account < ApplicationRecord
 
   before_destroy :destroy_features
 
+  def self.free
+    where.has do
+      # TODO: I will refactor this :)
+      not_exists Contract.where.has { user_account_id == BabySqueel[:accounts].id }.where.has { (paid_until >= 6.months.ago) | (variable_cost_paid_until >= 6.months.ago) }
+    end
+  end
+
   def destroy_features
     features.destroy_all
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -116,6 +116,13 @@ class Account < ApplicationRecord
     end
   end
 
+  def self.not_enterprise
+    where.has do
+      # TODO: I will refactor this :)
+      not_exists ApplicationPlan.where('plans.system_name LIKE ?', '%enterprise%').where(issuer_id: Service.where.has { account_id == BabySqueel[:accounts].id } )
+    end
+  end
+
   def destroy_features
     features.destroy_all
   end

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -94,6 +94,7 @@ module Account::States
       end
     end
 
+    scope :without_suspended, -> { where.not(state: :suspended) }
     scope :without_deleted, ->(without = true) { where.has { state != :scheduled_for_deletion } if without }
 
     scope :by_state, ->(state) do

--- a/app/models/application_plan.rb
+++ b/app/models/application_plan.rb
@@ -22,8 +22,6 @@ class ApplicationPlan < Plan
 
   delegate :metrics, :to => :service
 
-  scope :enterprise, -> { where.has { (system_name =~ '%enterprise%') } }
-
   DEFAULT_CONTRACT_OPTIONS = { :name => '%s\'s App', :description => 'Default application created on signup.' }.freeze
 
   def provider_account

--- a/app/models/application_plan.rb
+++ b/app/models/application_plan.rb
@@ -16,11 +16,13 @@ class ApplicationPlan < Plan
     if provider == :all || provider.blank?
       {}
     else
-      where(services: { account_id: provider.id }).joins(:service).references(:service).readonly(false)
+      where(services: { account_id: provider }).joins(:service).references(:service).readonly(false)
     end
   }
 
   delegate :metrics, :to => :service
+
+  scope :enterprise, -> { where.has { (system_name =~ '%enterprise%') } }
 
   DEFAULT_CONTRACT_OPTIONS = { :name => '%s\'s App', :description => 'Default application created on signup.' }.freeze
 

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -1,5 +1,6 @@
 
 class Contract < ApplicationRecord
+  MAX_UNPAID_TIME = 6.months
   # Need to define table_name before audited because of
   # https://github.com/collectiveidea/audited/blob/f03c5b5d1717f2ebec64032d269316dc74476056/lib/audited/auditor.rb#L305-L311
   self.table_name = 'cinstances'
@@ -86,8 +87,10 @@ class Contract < ApplicationRecord
     where.has { name.op('COLLATE', sql(collate)).matches(pattern)}
   }
 
-  scope :by_account, lambda { |account| where({ :user_account_id => account.id } ) }
+  scope :by_account, ->(account) { where.has { user_account_id == account } }
   scope :by_account_query, lambda { |query| where( { :user_account_id => Account.buyers.search_ids(query) } ) }
+
+  scope :has_paid_on, ->(paid_time = MAX_UNPAID_TIME.ago) { where.has { (paid_until >= paid_time) | (variable_cost_paid_until >= paid_time) } }
 
   def self.by_plan_type(type)
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -44,9 +44,8 @@ class Service < ApplicationRecord
     super.reject { |column| column.name == 'buyer_can_see_log_requests'}
   end
 
-  def self.of_account(account)
-    where(account_id: account)
-  end
+  scope :of_account, ->(account) { where.has { account_id == account } }
+  scope :with_enterprise_application_plans, -> { joins(:application_plans).merge(ApplicationPlan.enterprise) }
 
   has_one :proxy, dependent: :destroy, inverse_of: :service, autosave: true
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -45,7 +45,7 @@ class Service < ApplicationRecord
   end
 
   scope :of_account, ->(account) { where.has { account_id == account } }
-  scope :with_enterprise_application_plans, -> { joins(:application_plans).merge(ApplicationPlan.enterprise) }
+  scope :with_enterprise_application_plans, -> { joins(:application_plans).where('plans.system_name LIKE ?', '%enterprise%') }
 
   has_one :proxy, dependent: :destroy, inverse_of: :service, autosave: true
 

--- a/app/workers/stale_account_worker.rb
+++ b/app/workers/stale_account_worker.rb
@@ -4,6 +4,7 @@ class StaleAccountWorker
   include Sidekiq::Worker
 
   def perform
+    return if ThreeScale.config.onpremises
     Account.tenants.suspended_since.find_each(&:schedule_for_deletion!)
   end
 end

--- a/app/workers/stale_account_worker.rb
+++ b/app/workers/stale_account_worker.rb
@@ -5,6 +5,6 @@ class StaleAccountWorker
 
   def perform
     return if ThreeScale.config.onpremises
-    Account.tenants.free.suspended_since.find_each(&:schedule_for_deletion!)
+    Account.tenants.free.not_enterprise.suspended_since.find_each(&:schedule_for_deletion!)
   end
 end

--- a/app/workers/stale_account_worker.rb
+++ b/app/workers/stale_account_worker.rb
@@ -5,6 +5,6 @@ class StaleAccountWorker
 
   def perform
     return if ThreeScale.config.onpremises
-    Account.tenants.suspended_since.find_each(&:schedule_for_deletion!)
+    Account.tenants.free.suspended_since.find_each(&:schedule_for_deletion!)
   end
 end

--- a/app/workers/suspend_inactive_accounts_worker.rb
+++ b/app/workers/suspend_inactive_accounts_worker.rb
@@ -5,6 +5,6 @@ class SuspendInactiveAccountsWorker
 
   def perform
     return if ThreeScale.config.onpremises
-    Account.tenants.free.not_enterprise.inactive_since.find_each(&:suspend!)
+    Account.tenants.free.not_enterprise.without_suspended.without_deleted.inactive_since.find_each(&:suspend!)
   end
 end

--- a/app/workers/suspend_inactive_accounts_worker.rb
+++ b/app/workers/suspend_inactive_accounts_worker.rb
@@ -5,6 +5,6 @@ class SuspendInactiveAccountsWorker
 
   def perform
     return if ThreeScale.config.onpremises
-    Account.tenants.inactive_since.find_each(&:suspend!)
+    Account.tenants.free.inactive_since.find_each(&:suspend!)
   end
 end

--- a/app/workers/suspend_inactive_accounts_worker.rb
+++ b/app/workers/suspend_inactive_accounts_worker.rb
@@ -5,6 +5,6 @@ class SuspendInactiveAccountsWorker
 
   def perform
     return if ThreeScale.config.onpremises
-    Account.tenants.free.inactive_since.find_each(&:suspend!)
+    Account.tenants.free.not_enterprise.inactive_since.find_each(&:suspend!)
   end
 end

--- a/app/workers/suspend_inactive_accounts_worker.rb
+++ b/app/workers/suspend_inactive_accounts_worker.rb
@@ -4,6 +4,7 @@ class SuspendInactiveAccountsWorker
   include Sidekiq::Worker
 
   def perform
+    return if ThreeScale.config.onpremises
     Account.tenants.inactive_since.find_each(&:suspend!)
   end
 end

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -1,6 +1,15 @@
 require 'test_helper'
 
 class Account::StatesTest < ActiveSupport::TestCase
+  test '.without_suspended' do
+    accounts = FactoryBot.create_list(:simple_provider, 2)
+    accounts.first.suspend!
+
+    ids_without_suspended = Account.without_suspended.pluck(:id)
+    assert_not_includes ids_without_suspended, accounts.first.id
+    assert_includes     ids_without_suspended, accounts.last.id
+  end
+
   test '.without_deleted' do
     accounts = FactoryBot.create_list(:simple_account, 2)
     accounts.first.schedule_for_deletion!

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -27,6 +27,20 @@ class AccountTest < ActiveSupport::TestCase
     end
   end
 
+  def test_class_method_free
+    paid_tenant = FactoryBot.create(:simple_provider)
+    FactoryBot.create(:application, user_account: paid_tenant, paid_until: 5.months.ago)
+
+    free_tenant = FactoryBot.create(:simple_provider)
+    FactoryBot.create(:application, user_account: free_tenant)
+
+    another_free_tenant = FactoryBot.create(:simple_provider)
+
+    assert_includes Account.free.pluck(:id), free_tenant.id
+    assert_includes Account.free.pluck(:id), another_free_tenant.id
+    assert_not_includes Account.free.pluck(:id), paid_tenant.id
+  end
+
   def test_not_master
     master = master_account
     buyer = FactoryBot.create(:simple_buyer, provider_account: master)

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -28,11 +28,17 @@ class AccountTest < ActiveSupport::TestCase
   end
 
   def test_class_method_free
+    recent_date = (Contract::MAX_UNPAID_TIME - 1.day).ago
+    old_date    = (Contract::MAX_UNPAID_TIME + 1.day).ago
+
     paid_tenant = FactoryBot.create(:simple_provider)
-    FactoryBot.create(:application, user_account: paid_tenant, paid_until: 5.months.ago)
+    FactoryBot.create(:application, user_account: paid_tenant, paid_until: recent_date)
+
+    paid_tenant = FactoryBot.create(:simple_provider)
+    FactoryBot.create(:application, user_account: paid_tenant, variable_cost_paid_until: recent_date)
 
     free_tenant = FactoryBot.create(:simple_provider)
-    FactoryBot.create(:application, user_account: free_tenant)
+    FactoryBot.create(:application, user_account: free_tenant, paid_until: old_date, variable_cost_paid_until: old_date)
 
     another_free_tenant = FactoryBot.create(:simple_provider)
 

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -41,6 +41,22 @@ class AccountTest < ActiveSupport::TestCase
     assert_not_includes Account.free.pluck(:id), paid_tenant.id
   end
 
+  def test_class_method_non_enterprise
+    enterprise_tenant = FactoryBot.create(:simple_provider)
+    FactoryBot.create(:simple_service, account: enterprise_tenant)
+    FactoryBot.create(:application_plan, system_name: '2014_enterprise_3M', issuer: enterprise_tenant.default_service)
+
+    non_enterprise_tenant = FactoryBot.create(:simple_provider)
+    FactoryBot.create(:simple_service, account: non_enterprise_tenant)
+    FactoryBot.create(:application_plan, system_name: '2017-pro-500k', issuer: non_enterprise_tenant.default_service)
+
+    another_non_enterprise_tenant = FactoryBot.create(:simple_provider)
+
+    assert_includes Account.not_enterprise.pluck(:id), non_enterprise_tenant.id
+    assert_includes Account.not_enterprise.pluck(:id), another_non_enterprise_tenant.id
+    assert_not_includes Account.not_enterprise.pluck(:id), enterprise_tenant.id
+  end
+
   def test_not_master
     master = master_account
     buyer = FactoryBot.create(:simple_buyer, provider_account: master)

--- a/test/unit/application_plan_test.rb
+++ b/test/unit/application_plan_test.rb
@@ -4,6 +4,20 @@ class ApplicationPlanTest < ActiveSupport::TestCase
 
   should belong_to :partner
 
+  test '.provided_by' do
+    tenants = FactoryBot.create_list(:simple_provider, 2)
+    tenants.each do |tenant|
+      service = FactoryBot.create(:simple_service, account: tenant)
+      FactoryBot.create_list(:application_plan, 2, issuer: service)
+    end
+
+    assert_equal({}, ApplicationPlan.provided_by(''))
+    assert_equal({}, ApplicationPlan.provided_by(:all))
+    tenants.each do |tenant|
+      assert_same_elements ApplicationPlan.where(issuer_id: tenant.services.first).pluck(:id), ApplicationPlan.provided_by(tenant.id).pluck(:id)
+    end
+  end
+
   should 'not allow setting of end_user_required' do
     plan = FactoryBot.create(:application_plan)
     plan.end_user_required = true
@@ -17,6 +31,16 @@ class ApplicationPlanTest < ActiveSupport::TestCase
     assert plan.valid?
   end
 
+  test '.enterprise' do
+    enterprise_plans = []
+    enterprise_plans << FactoryBot.create(:application_plan, system_name: 'enterprise')
+    enterprise_plans << FactoryBot.create(:application_plan, system_name: 'enterprise_1')
+    enterprise_plans << FactoryBot.create(:application_plan, system_name: '1_enterprise')
+    enterprise_plans << FactoryBot.create(:application_plan, system_name: '1_enterprise_1')
+    FactoryBot.create(:application_plan, system_name: 'another')
+
+    assert_same_elements enterprise_plans.map(&:id), ApplicationPlan.enterprise.pluck(:id)
+  end
 
 
   context '#customize' do

--- a/test/unit/application_plan_test.rb
+++ b/test/unit/application_plan_test.rb
@@ -31,17 +31,6 @@ class ApplicationPlanTest < ActiveSupport::TestCase
     assert plan.valid?
   end
 
-  test '.enterprise' do
-    enterprise_plans = []
-    enterprise_plans << FactoryBot.create(:application_plan, system_name: 'enterprise')
-    enterprise_plans << FactoryBot.create(:application_plan, system_name: 'enterprise_1')
-    enterprise_plans << FactoryBot.create(:application_plan, system_name: '1_enterprise')
-    enterprise_plans << FactoryBot.create(:application_plan, system_name: '1_enterprise_1')
-    FactoryBot.create(:application_plan, system_name: 'another')
-
-    assert_same_elements enterprise_plans.map(&:id), ApplicationPlan.enterprise.pluck(:id)
-  end
-
 
   context '#customize' do
     setup do

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -2,6 +2,18 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 class ServiceTest < ActiveSupport::TestCase
 
+  def test_with_enterprise_application_plans
+    FactoryBot.create(:simple_service)
+
+    FactoryBot.create(:application_plan, service: FactoryBot.create(:simple_service), system_name: 'example1')
+
+    service_with_enterprise_plan = FactoryBot.create(:simple_service)
+    FactoryBot.create(:application_plan, service: service_with_enterprise_plan, system_name: 'example2')
+    FactoryBot.create(:application_plan, service: service_with_enterprise_plan, system_name: 'enterprise')
+
+    assert_equal [service_with_enterprise_plan.id], Service.with_enterprise_application_plans.pluck(:id)
+  end
+
   def test_create_default_proxy
     Service.any_instance.expects(:create_proxy!).at_least_once
     FactoryBot.create(:simple_service, proxy: nil)

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -9,7 +9,7 @@ class ServiceTest < ActiveSupport::TestCase
 
     service_with_enterprise_plan = FactoryBot.create(:simple_service)
     FactoryBot.create(:application_plan, service: service_with_enterprise_plan, system_name: 'example2')
-    FactoryBot.create(:application_plan, service: service_with_enterprise_plan, system_name: 'enterprise')
+    FactoryBot.create(:application_plan, service: service_with_enterprise_plan, system_name: '1_enterprise_2')
 
     assert_equal [service_with_enterprise_plan.id], Service.with_enterprise_application_plans.pluck(:id)
   end

--- a/test/workers/stale_account_worker_test.rb
+++ b/test/workers/stale_account_worker_test.rb
@@ -34,4 +34,10 @@ class StaleAccountWorkerTest < ActiveSupport::TestCase
     StaleAccountWorker.new.perform
     (@accounts[:to_delete] + @accounts[:not_to_delete]).each { |account| refute account.reload.scheduled_for_deletion? }
   end
+
+  test 'it does not perform for paid accounts' do
+    Account.stubs(free: Account.none)
+    StaleAccountWorker.new.perform
+    (@accounts[:to_delete] + @accounts[:not_to_delete]).each { |account| refute account.reload.scheduled_for_deletion? }
+  end
 end

--- a/test/workers/stale_account_worker_test.rb
+++ b/test/workers/stale_account_worker_test.rb
@@ -40,4 +40,10 @@ class StaleAccountWorkerTest < ActiveSupport::TestCase
     StaleAccountWorker.new.perform
     (@accounts[:to_delete] + @accounts[:not_to_delete]).each { |account| refute account.reload.scheduled_for_deletion? }
   end
+
+  test 'it does not perform for enterprise accounts' do
+    Account.stubs(not_enterprise: Account.none)
+    StaleAccountWorker.new.perform
+    (@accounts[:to_delete] + @accounts[:not_to_delete]).each { |account| refute account.reload.scheduled_for_deletion? }
+  end
 end

--- a/test/workers/stale_account_worker_test.rb
+++ b/test/workers/stale_account_worker_test.rb
@@ -28,4 +28,10 @@ class StaleAccountWorkerTest < ActiveSupport::TestCase
     @accounts[:to_delete].each     { |account| assert account.reload.scheduled_for_deletion? }
     @accounts[:not_to_delete].each { |account| refute account.reload.scheduled_for_deletion? }
   end
+
+  test 'it does not perform for on-prem' do
+    ThreeScale.config.stubs(onpremises: true)
+    StaleAccountWorker.new.perform
+    (@accounts[:to_delete] + @accounts[:not_to_delete]).each { |account| refute account.reload.scheduled_for_deletion? }
+  end
 end

--- a/test/workers/suspend_inactive_accounts_worker_test.rb
+++ b/test/workers/suspend_inactive_accounts_worker_test.rb
@@ -50,4 +50,10 @@ class SuspendInactiveAccountsWorkerTest < ActiveSupport::TestCase
     SuspendInactiveAccountsWorker.new.perform
     (@accounts[:to_suspend] + @accounts[:not_to_suspend]).each { |account| refute account.reload.suspended? }
   end
+
+  test 'it does not perform for enterprise accounts' do
+    Account.stubs(not_enterprise: Account.none)
+    SuspendInactiveAccountsWorker.new.perform
+    (@accounts[:to_suspend] + @accounts[:not_to_suspend]).each { |account| refute account.reload.suspended? }
+  end
 end

--- a/test/workers/suspend_inactive_accounts_worker_test.rb
+++ b/test/workers/suspend_inactive_accounts_worker_test.rb
@@ -38,4 +38,10 @@ class SuspendInactiveAccountsWorkerTest < ActiveSupport::TestCase
     @accounts[:to_suspend].each     { |account| assert account.reload.suspended? }
     @accounts[:not_to_suspend].each { |account| refute account.reload.suspended? }
   end
+
+  test 'it does not perform for on-prem' do
+    ThreeScale.config.stubs(onpremises: true)
+    SuspendInactiveAccountsWorker.new.perform
+    (@accounts[:to_suspend] + @accounts[:not_to_suspend]).each { |account| refute account.reload.suspended? }
+  end
 end

--- a/test/workers/suspend_inactive_accounts_worker_test.rb
+++ b/test/workers/suspend_inactive_accounts_worker_test.rb
@@ -39,6 +39,20 @@ class SuspendInactiveAccountsWorkerTest < ActiveSupport::TestCase
     @accounts[:not_to_suspend].each { |account| refute account.reload.suspended? }
   end
 
+  test 'it does not perform for already suspended or deleted accounts' do
+    old_time = 5.years.ago
+    already_suspended = FactoryBot.create(:simple_provider, state: 'suspended', state_changed_at: old_time)
+    already_suspended.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+    already_deleted = FactoryBot.create(:simple_provider, state: 'scheduled_for_deletion', state_changed_at: old_time)
+    already_deleted.update_attribute(:created_at, Account::States::MAX_PERIOD_OF_INACTIVITY.ago)
+
+    SuspendInactiveAccountsWorker.new.perform
+
+    assert_equal old_time.to_date, already_suspended.reload.state_changed_at.to_date
+    assert_equal old_time.to_date, already_deleted.reload.state_changed_at.to_date
+    assert already_deleted.scheduled_for_deletion?
+  end
+
   test 'it does not perform for on-prem' do
     ThreeScale.config.stubs(onpremises: true)
     SuspendInactiveAccountsWorker.new.perform

--- a/test/workers/suspend_inactive_accounts_worker_test.rb
+++ b/test/workers/suspend_inactive_accounts_worker_test.rb
@@ -44,4 +44,10 @@ class SuspendInactiveAccountsWorkerTest < ActiveSupport::TestCase
     SuspendInactiveAccountsWorker.new.perform
     (@accounts[:to_suspend] + @accounts[:not_to_suspend]).each { |account| refute account.reload.suspended? }
   end
+
+  test 'it does not perform for paid accounts' do
+    Account.stubs(free: Account.none)
+    SuspendInactiveAccountsWorker.new.perform
+    (@accounts[:to_suspend] + @accounts[:not_to_suspend]).each { |account| refute account.reload.suspended? }
+  end
 end


### PR DESCRIPTION
Fixes [THREESCALE-1836 - Exceptions for automatic suspension and deletion of inactive providers](https://issues.jboss.org/browse/THREESCALE-1836)
Since https://github.com/3scale/porta/pull/17 we automatically suspend and destroy inactive tenants.

Now there are some situations where we do not want to automatically suspend (neither delete) inactive accounts.

- [X] Do not automatically suspend or delete inactive accounts in on-prem.
- [X] Do not automatically suspend or delete inactive paid accounts or that has paid for the last 6 months.
- [X] Do not automatically suspend or delete accounts with anything with "Enterprise" in the plan name.
- [X] Do not automatically suspend accounts that are already suspended or scheduled for deletion.