### PR TITLE
Removes batch wrapping from PurgeOldEventsWorker

### DIFF
--- a/app/workers/purge_old_events_worker.rb
+++ b/app/workers/purge_old_events_worker.rb
@@ -4,11 +4,6 @@ class PurgeOldEventsWorker
   include Sidekiq::Worker
 
   def perform
-    batch = Sidekiq::Batch.new
-    batch.description = 'Purge old events'
-
-    batch.jobs do
-      EventStore::Event.stale.find_each(&DeletePlainObjectWorker.method(:perform_later))
-    end
+    EventStore::Event.stale.find_each(&DeletePlainObjectWorker.method(:perform_later))
   end
 end


### PR DESCRIPTION
The batch control over a potentially very large unindexed table is causing the job to last a long time to finish and we don't really need a batch to control that job.