### PR TITLE
Fixed hard-coded nodejs version

### DIFF
--- a/openshift/system/contrib/scl_enable
+++ b/openshift/system/contrib/scl_enable
@@ -1,4 +1,4 @@
 # This file contains automatic SCL enablement.
 unset BASH_ENV PROMPT_COMMAND ENV
 source scl_source enable rh-ruby23
-source scl_source enable rh-nodejs8
+source scl_source enable $NODEJS_SCL


### PR DESCRIPTION
**What this PR does / why we need it**:

the `NODEJS_SCL` environment variable is available on the software collections base image we are using and [was recently updated to nodejs 10](https://github.com/sclorg/s2i-base-container/blob/master/base/Dockerfile#L10) from [nodejs8 that it used to be](https://github.com/sclorg/s2i-base-container/blob/f517f392bdeb32903fb44dd9ccf3ce14a0ff4281/base/Dockerfile#L10). 

**Which issue(s) this PR fixes** 

Fixes https://github.com/3scale/porta/issues/563

**Verification steps** 

1. failing: run a docker build, using the brew pulp internal repository as the source of your `rhscl/ruby-23-rhel7:2.3` image. 
2. substitute hard-coded version with env var
3. passing: rerun docker build

**Special notes for your reviewer**:

the [base image we are using](https://github.com/3scale/porta/blob/master/openshift/system/Dockerfile#L1),  [uses the one linked to above as its own base image](https://github.com/sclorg/s2i-ruby-container/blob/master/2.3/Dockerfile#L1), where this env var is declared.
