### PR TITLE
Set contract plan to nil behaves like the rest of invalid plans

### DIFF
--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -412,7 +412,8 @@ class Cinstance < Contract
   end
 
   def same_service
-    errors.add(:plan_id, :not_allowed) if plan&.service != service
+    return if plan.blank? || plan.service == service
+    errors.add(:plan_id, :not_allowed)
   end
 
   def reject_if_pending

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -261,7 +261,7 @@ class Contract < ApplicationRecord
   # to run something after successful trnsaction
   #
   def change_plan_internal(new_plan, &block)
-    return if self.plan == new_plan || new_plan.nil?
+    return if self.plan == new_plan
     raise 'change_plan_internal must be called with a block' unless block_given?
 
     transaction do

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -684,10 +684,14 @@ class CinstanceTest < ActiveSupport::TestCase
       assert_includes @cinstance.errors['plan_id'], 'not allowed in this context'
     end
 
-    test 'cannot change plan to not plan at all' do
+    test 'cannot change plan to nil and adds the right error' do
       previous_plan = @cinstance.plan_id
-      assert_nothing_raised { @cinstance.change_plan! nil }
+      assert_raise ActiveRecord::RecordInvalid do
+        @cinstance.change_plan! nil
+      end
       assert_equal previous_plan, @cinstance.reload.plan_id
+      assert_includes @cinstance.errors[:plan], 'can\'t be blank'
+      assert_empty @cinstance.errors['plan_id']
     end
   end
 


### PR DESCRIPTION
What I meant after https://github.com/3scale/porta/pull/568#discussion_r252609016 and in  https://github.com/3scale/porta/pull/568#discussion_r253439950
Setting `nil` to a plan is invalid and should behave like such... if we make it have an error for all invalid plans and we have a validation for each, then this case should behave the same way.
Besides, setting it to `nil` should not have the error `'not allowed in this context'` in `plan_id` which is for when it is changed for another plan of another service, and in this case it would be confusing.