### PR TITLE
Remove DB env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,19 @@ only-master-filter: &only-master-filter
     branches:
       only: master
 
+build-envs:
+  mysql: &build-envs-mysql
+    environment:
+      DATABASE_URL: mysql2://root:@127.0.0.1:3306/3scale_system_test
+
+  postgresql: &build-envs-postgresql
+    environment:
+      DATABASE_URL: postgresql://postgres:@127.0.0.1:5432/systemdb
+
+  oracle: &build-envs-oracle
+    environment:
+      DATABASE_URL: oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb
+
 ##################################### CIRCLECI COMMANDS ############################################
 
 commands: # reusable commands with parameters
@@ -171,7 +184,9 @@ commands: # reusable commands with parameters
       - run:
           name: Prepare database for tests
           command: |
-            echo "Running for database: $DB"
+            set +o pipefail
+            echo "Running for database: $(echo $DATABASE_URL | sed -e 's/\(oracle\|mysql\|postgresql\).*/\1/g')"
+            set -o pipefail
             bundle exec rake ci:db:ready db:create db:test:prepare
 
   rspec-tests:
@@ -278,8 +293,7 @@ executors:
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
-    environment:
-      DB: mysql
+    <<: *build-envs-mysql
 
   builder-with-postgres:
     resource_class: small
@@ -289,8 +303,7 @@ executors:
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
-    environment:
-      DB: postgresql
+    <<: *build-envs-postgresql
 
   builder-with-oracle:
     resource_class: large
@@ -300,8 +313,7 @@ executors:
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
-    environment:
-      DB: oracle
+    <<: *build-envs-oracle
 
 ##################################### CIRCLECI JOBS ############################################
 
@@ -504,6 +516,7 @@ jobs:
             - clone-oracle-libraries
 
   cucumber:
+    <<: *build-envs-mysql
     parallelism: 40
     resource_class: small
     docker:
@@ -512,12 +525,11 @@ jobs:
       - *mysql-container
       - *memcached-container
       - *redis-container
-    environment:
-      DB: mysql
     steps:
       - cucumber-tests
 
   cucumber-postgres:
+    <<: *build-envs-postgresql
     parallelism: 40
     resource_class: small
     docker:
@@ -526,12 +538,11 @@ jobs:
       - *postgres-container
       - *memcached-container
       - *redis-container
-    environment:
-      DB: postgresql
     steps:
       - cucumber-tests
 
   cucumber-oracle:
+    <<: *build-envs-oracle
     parallelism: 30
     resource_class: large
     docker:
@@ -540,8 +551,6 @@ jobs:
       - *oracle-db-container
       - *memcached-container
       - *redis-container
-    environment:
-      DB: oracle
     steps:
       - cucumber-tests:
           extra-deps:

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -269,9 +269,8 @@ gem 'webpacker', '~> 3.3'
 gem 'unicorn', require: false, group: [:production, :preview]
 gem 'developer_portal', path: 'lib/developer_portal'
 
-oracle = lambda do
-  (ENV['DB'] == 'oracle') || (ENV['ORACLE'] == '1') || ENV['DATABASE_URL']&.start_with?('oracle-enhanced://')
-end
+# NOTE: Use ENV['DB'] only to install oracle dependencies
+oracle = lambda { (ENV['ORACLE'] == '1') || ENV.fetch('DATABASE_URL', ENV['DB'])&.start_with?('oracle') }
 gem 'activerecord-oracle_enhanced-adapter', '~> 1.6.0', install_if: oracle
 gem 'ruby-oci8', require: false, install_if: oracle
 

--- a/config/docker/database.yml
+++ b/config/docker/database.yml
@@ -1,10 +1,10 @@
 base: &default
 
-<% case ENV['DB']
-   when 'oracle' %>
+<% case ENV['DATABASE_URL'].to_s
+   when /^oracle/ %>
   adapter: oracle_enhanced
   time_zone: 'UTC'
-<% when 'postgresql' %>
+<% when /^postgresql/ %>
   adapter: postgresql
   variables:
     timezone: 'UTC'

--- a/config/docker/thinking_sphinx.yml
+++ b/config/docker/thinking_sphinx.yml
@@ -27,10 +27,10 @@ development:
 
 test: &test
   <<: *sphinx
-  <% case ENV['DB']
-  when 'oracle' %>
+<% case ENV['DATABASE_URL'].to_s
+   when /^oracle/ %>
 sql_port: 1521
-  <% when 'postgresql' %>
+  <% when /^postgresql/ %>
 sql_port: 5432
   <% else %>
 mysql41:            <%= 9313 + ENV['TEST_ENV_NUMBER'].to_i %>

--- a/config/examples/database.yml
+++ b/config/examples/database.yml
@@ -1,11 +1,8 @@
-<% case ENV['DB']
-   when 'oracle' %>
+<% case ENV['DATABASE_URL'].to_s
+   when /^oracle/ %>
 default: &DEFAULT
   adapter: oracle_enhanced
-  username: rails
-  password: railspass
-  database: systempdb<%= ENV['TEST_ENV_NUMBER'] %>
-  host: <%= ENV.fetch('DB_PORT_3306_TCP_ADDR') { ENV['DB_PORT'] ? 'db' : ENV['DB_HOST'] } || '127.0.0.1' %>
+  url: <%= ENV['DATABASE_URL'] %>
   time_zone: 'UTC'
   pool: <%= ENV.fetch('RAILS_MAX_THREADS', 25) %>
 
@@ -17,17 +14,15 @@ development:
 
 test:
   <<: *DEFAULT
-<% when 'postgresql' %>
+  url: <%= "#{ENV['DATABASE_URL']}#{ENV['TEST_ENV_NUMBER']}" %>
+<% when /^postgresql/ %>
 default: &DEFAULT
   adapter: postgresql
+  url: <%= ENV['DATABASE_URL'] %>
+  pool: <%= ENV.fetch('RAILS_MAX_THREADS', 25) %>
   encoding: unicode
-  username: postgres
-  password:
-  database: systemdb
-  host: <%= ENV.fetch('DB_PORT_3306_TCP_ADDR') { ENV['DB_PORT'] ? 'db' : ENV['DB_HOST'] } || '127.0.0.1' %>
   variables:
     timezone: 'UTC'
-  pool: <%= ENV.fetch('RAILS_MAX_THREADS', 25) %>
 
 production:
   <<: *DEFAULT
@@ -37,24 +32,22 @@ development:
 
 test:
   <<: *DEFAULT
-<% else %>
+  url: <%= "#{ENV['DATABASE_URL']}#{ENV['TEST_ENV_NUMBER']}" %>
+<% else; db_host = ENV.fetch('DB_PORT_3306_TCP_ADDR') { ENV['DB_PORT'] ? 'db' : ENV['DB_HOST'] } || '127.0.0.1' %>
 default: &DEFAULT
   adapter: mysql2
-  username: root
-  password:
   encoding: utf8
   collation: utf8_bin
-  host: <%= ENV.fetch('DB_PORT_3306_TCP_ADDR') { ENV['DB_PORT'] ? 'db' : ENV['DB_HOST'] } || '127.0.0.1' %>
 
 production:
   <<: *DEFAULT
-  database: 3scale_system_production
+  url: <%= ENV.fetch('DATABASE_URL', "mysql2://root:@#{db_host}:3306/3scale_system_production") %>
 
 development:
   <<: *DEFAULT
-  database: 3scale_system_development
+  url: <%= ENV.fetch('DATABASE_URL', "mysql2://root:@#{db_host}:3306/3scale_system_development") %>
 
 test:
   <<: *DEFAULT
-  database: 3scale_system_test<%= ENV['TEST_ENV_NUMBER'] %>
+  url: <%= ENV.fetch('DATABASE_URL', "mysql2://root:@#{db_host}:3306/3scale_system_test") %><%=ENV['TEST_ENV_NUMBER']%>
 <% end %>

--- a/config/thinking_sphinx.yml
+++ b/config/thinking_sphinx.yml
@@ -25,10 +25,10 @@ development:
 
 test: &test
   <<: *sphinx
-<% case ENV['DB']
-   when 'oracle' %>
+<% case ENV['DATABASE_URL'].to_s
+   when /^oracle/ %>
   sql_port: 1521
-<% when 'postgresql' %>
+<% when /^postgresql/ %>
   sql_port: 5432
 <% else %>
   mysql41:            <%= 9313 + ENV['TEST_ENV_NUMBER'].to_i %>

--- a/lib/tasks/ci/db.rake
+++ b/lib/tasks/ci/db.rake
@@ -9,7 +9,7 @@ namespace :ci do
       timeout = ENV.fetch('DB_BOOT_TIMEOUT', 300).to_i
       interval = ENV.fetch('DB_BOOT_SLEEP_SECONDS', 1).to_i
 
-      if ENV['DB'] == 'oracle'
+      if ENV['DATABASE_URL']&.start_with?('oracle')
         # allow some startup time for oracle to boot...  ¯\_(ツ)_/¯
         sleep 300
       end
@@ -21,7 +21,7 @@ namespace :ci do
         timeout -= interval
       end
 
-      if ENV['DB'] == 'oracle'
+      if ENV['DATABASE_URL']&.start_with?('oracle')
         # allow some MORE time for setup to complete in oracle...  ¯\_(ツ)_/¯
         sleep 300
       end

--- a/openshift/system/config/database.yml
+++ b/openshift/system/config/database.yml
@@ -1,10 +1,10 @@
 base: &default
 
-<% case ENV['DB']
-   when 'oracle' %>
+<% case ENV['DATABASE_URL'].to_s
+   when /^oracle/ %>
   adapter: oracle_enhanced
   time_zone: 'UTC'
-<% when 'postgresql' %>
+<% when /^postgresql/ %>
   adapter: postgresql
   variables:
     timezone: 'UTC'


### PR DESCRIPTION
**What this PR does / why we need it**

This PR removes any reference to the environment variable `DB` in porta, making it depend always and only on `DATABASE_URL` instead.

Safe defaults remain in place for mysql database (all environments).

Deployments that depend on `config/examples/database.yml`, in test environment, will automatically have the value of the `TEST_ENV_NUMBER` env var appended to the value of `DATABASE_URL` (thus modifying the  name of the database)


**Which issue(s) this PR fixes**

Without this, while using openshift templates, either
1) `DB` (environment variable) needs to come from a deployment parameter just like, independently, other database connection details (username, password); _OR_
2) multiple versions of the templates would have to be maintained (one per database option for porta), even for the 'ha' version (external database)
