### PR TITLE
Threescale 1883

### DIFF
--- a/app/helpers/mailers_helper.rb
+++ b/app/helpers/mailers_helper.rb
@@ -2,7 +2,7 @@
 
 module MailersHelper
   def master_mailer_name
-    ThreeScale.config.onpremises ? Account.master.org_name : '3scale'
+    ThreeScale.config.onpremises ? Account.master.org_name : 'Red Hat 3scale'
   end
 
   def prepare_email(subject:, to:, **options)

--- a/app/views/provider_user_mailer/activation.text.erb
+++ b/app/views/provider_user_mailer/activation.text.erb
@@ -1,9 +1,9 @@
 Dear <%= @user.informal_name %>,
 
-Thank you for joining <%= master_mailer_name %>. Please, activate your account by visiting:
+Thank you for signing up to Red Hat 3scale! Your account has been created.
+
+To activate your account, please visit:
 
 <%= @activate_url %>
 
-Have a great day,
-
-The <%= master_mailer_name %> team.
+You will then be able to login with your email and password. If you have problems activating your account please contact customer service (https://access.redhat.com/customerservice).

--- a/app/views/provider_user_mailer/activation.text.erb
+++ b/app/views/provider_user_mailer/activation.text.erb
@@ -1,12 +1,12 @@
 Dear <%= @user.informal_name %>,
 
-Thank you for signing up to Red Hat 3scale! Your account has been created.
+Thank you for signing up to <%= master_mailer_name %>! Your account has been created.
 
 To activate your account, please visit:
 
 <%= @activate_url %>
 
-You will then be able to login with your email and password. If you have problems activating your account please contact customer service (https://access.redhat.com/customerservice).
+You will then be able to login with your email and password. 
 
 Cheers,
-The Red Hat 3scale Team
+The <%= master_mailer_name %> Team

--- a/app/views/provider_user_mailer/activation.text.erb
+++ b/app/views/provider_user_mailer/activation.text.erb
@@ -7,3 +7,6 @@ To activate your account, please visit:
 <%= @activate_url %>
 
 You will then be able to login with your email and password. If you have problems activating your account please contact customer service (https://access.redhat.com/customerservice).
+
+Cheers,
+The Red Hat 3scale Team

--- a/app/views/provider_user_mailer/activation_reminder.text.erb
+++ b/app/views/provider_user_mailer/activation_reminder.text.erb
@@ -1,10 +1,8 @@
 <%= @user.informal_name %>,
 
-A couple of days ago you signed up for <%= master_mailer_name %> to manage your API.
+A couple of days ago you signed up for Red Hat 3scale to manage your API.
 Now would be as good a time as any to activate your account:
 
 <%= @activate_url %>
 
-Thanks!
-
-The <%= master_mailer_name %> team.
+You will then be able to login with your email and password. If you have problems activating your account please contact customer service (https://access.redhat.com/customerservice).

--- a/app/views/provider_user_mailer/activation_reminder.text.erb
+++ b/app/views/provider_user_mailer/activation_reminder.text.erb
@@ -6,3 +6,6 @@ Now would be as good a time as any to activate your account:
 <%= @activate_url %>
 
 You will then be able to login with your email and password. If you have problems activating your account please contact customer service (https://access.redhat.com/customerservice).
+
+Cheers,
+The Red Hat 3scale Team

--- a/app/views/provider_user_mailer/activation_reminder.text.erb
+++ b/app/views/provider_user_mailer/activation_reminder.text.erb
@@ -1,11 +1,12 @@
 <%= @user.informal_name %>,
 
-A couple of days ago you signed up for Red Hat 3scale to manage your API.
+A couple of days ago you signed up for <%= master_mailer_name %> to manage your API.
+
 Now would be as good a time as any to activate your account:
 
 <%= @activate_url %>
 
-You will then be able to login with your email and password. If you have problems activating your account please contact customer service (https://access.redhat.com/customerservice).
+You will then be able to login with your email and password.
 
 Cheers,
-The Red Hat 3scale Team
+The <%= master_mailer_name %> Team

--- a/app/views/provider_user_mailer/lost_domain.text.erb
+++ b/app/views/provider_user_mailer/lost_domain.text.erb
@@ -11,3 +11,6 @@ If you continue having problems or if you have not requested this, please contac
 <% else %>
 If you continue having problems or if you have not requested this, please open a Support Case at https://access.redhat.com/support and we will get back to you as soon as possible.
 <% end %>
+
+Cheers,
+The Red Hat 3scale Team

--- a/app/views/provider_user_mailer/lost_domain.text.erb
+++ b/app/views/provider_user_mailer/lost_domain.text.erb
@@ -11,5 +11,3 @@ If you continue having problems or if you have not requested this, please contac
 <% else %>
 If you continue having problems or if you have not requested this, please open a Support Case at https://access.redhat.com/support and we will get back to you as soon as possible.
 <% end %>
-
-The <%= master_mailer_name %> team.

--- a/app/views/provider_user_mailer/lost_domain.text.erb
+++ b/app/views/provider_user_mailer/lost_domain.text.erb
@@ -13,4 +13,4 @@ If you continue having problems or if you have not requested this, please open a
 <% end %>
 
 Cheers,
-The Red Hat 3scale Team
+The <%= master_mailer_name %> Team

--- a/app/views/provider_user_mailer/provider_lost_password.text.erb
+++ b/app/views/provider_user_mailer/provider_lost_password.text.erb
@@ -9,5 +9,3 @@ If you continue having problems or if you have not requested this change, please
 <% else %>
 If you continue having problems or if you have not requested this change, please open a Support Case at https://access.redhat.com/support.
 <% end %>
-
-The <%= master_mailer_name %> team.

--- a/app/views/provider_user_mailer/provider_lost_password.text.erb
+++ b/app/views/provider_user_mailer/provider_lost_password.text.erb
@@ -9,3 +9,6 @@ If you continue having problems or if you have not requested this change, please
 <% else %>
 If you continue having problems or if you have not requested this change, please open a Support Case at https://access.redhat.com/support.
 <% end %>
+
+Cheers,
+The Red Hat 3scale Team

--- a/app/views/provider_user_mailer/provider_lost_password.text.erb
+++ b/app/views/provider_user_mailer/provider_lost_password.text.erb
@@ -11,4 +11,4 @@ If you continue having problems or if you have not requested this change, please
 <% end %>
 
 Cheers,
-The Red Hat 3scale Team
+The <%= master_mailer_name %> Team

--- a/test/unit/mailers/provider_user_mailer_test.rb
+++ b/test/unit/mailers/provider_user_mailer_test.rb
@@ -24,9 +24,9 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
         assert_match %r{Dear #{user.informal_name}}, email_body
-        assert_match %r{Thank you for joining 3scale}, email_body
+        assert_match %r{Thank you for signing up to Red Hat 3scale}, email_body
         assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
-        assert_match %r{The 3scale team}, email_body
+        assert_match %r{The Red Hat 3scale Team}, email_body
       end
 
       test 'activation reminder' do
@@ -39,9 +39,8 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
         assert_match %r{#{user.informal_name}}, email_body
-        assert_match %r{A couple of days ago you signed up for 3scale to manage your API}, email_body
         assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
-        assert_match %r{The 3scale team}, email_body
+        assert_match %r{The Red Hat 3scale Team}, email_body
       end
 
       test 'lost_domain' do
@@ -56,7 +55,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
 
         assert_match %r{Dear User}, email_body
         assert_match %r{https://#{account.domain}/p/login}, email_body
-        assert_match %r{The 3scale team}, email_body
+        assert_match %r{The Red Hat 3scale Team}, email_body
       end
 
       test 'lost_password' do
@@ -71,7 +70,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_match %r{Dear #{user.display_name}}, email_body
         assert_match %r{You can reset your password by visiting the following link}, email_body
         assert_match %r{#{account.admin_domain}/p/password}, email_body
-        assert_match %r{The 3scale team}, email_body
+        assert_match %r{The Red Hat 3scale Team}, email_body
       end
     end
 
@@ -91,9 +90,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
         assert_match %r{Dear #{user.informal_name}}, email_body
-        assert_match %r{Thank you for joining #{master_account.org_name}}, email_body
         assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
-        assert_match %r{The #{master_account.org_name} team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
 
@@ -107,9 +104,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
         assert_match %r{#{user.informal_name}}, email_body
-        assert_match %r{A couple of days ago you signed up for #{master_account.org_name} to manage your API}, email_body
         assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
-        assert_match %r{The #{master_account.org_name} team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
 
@@ -125,7 +120,6 @@ class ProviderUserMailerTest < ActionMailer::TestCase
 
         assert_match %r{Dear User}, email_body
         assert_match %r{https://#{account.domain}/p/login}, email_body
-        assert_match %r{The #{master_account.org_name} team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
 
@@ -141,7 +135,6 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_match %r{Dear #{user.display_name}}, email_body
         assert_match %r{You can reset your password by visiting the following link}, email_body
         assert_match %r{#{account.admin_domain}/p/password}, email_body
-        assert_match %r{The #{master_account.org_name} team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
 

--- a/test/unit/mailers/provider_user_mailer_test.rb
+++ b/test/unit/mailers/provider_user_mailer_test.rb
@@ -39,6 +39,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
         assert_match %r{#{user.informal_name}}, email_body
+        assert_match %r{A couple of days ago you signed up for Red Hat 3scale to manage your API}, email_body
         assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
         assert_match %r{The Red Hat 3scale Team}, email_body
       end

--- a/test/unit/mailers/provider_user_mailer_test.rb
+++ b/test/unit/mailers/provider_user_mailer_test.rb
@@ -90,7 +90,9 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
         assert_match %r{Dear #{user.informal_name}}, email_body
+        assert_match %r{Thank you for signing up to #{master_account.org_name}}, email_body
         assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
+        assert_match %r{The #{master_account.org_name} Team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
 
@@ -104,7 +106,9 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
         assert_match %r{#{user.informal_name}}, email_body
+        assert_match %r{A couple of days ago you signed up for #{master_account.org_name} to manage your API}, email_body
         assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
+        assert_match %r{The #{master_account.org_name} Team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
 
@@ -120,6 +124,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
 
         assert_match %r{Dear User}, email_body
         assert_match %r{https://#{account.domain}/p/login}, email_body
+        assert_match %r{The #{master_account.org_name} Team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
 
@@ -135,6 +140,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_match %r{Dear #{user.display_name}}, email_body
         assert_match %r{You can reset your password by visiting the following link}, email_body
         assert_match %r{#{account.admin_domain}/p/password}, email_body
+        assert_match %r{The #{master_account.org_name} Team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
 


### PR DESCRIPTION
Improving perception of customer so they know emails come from Red Hat 3scale.

Takes care of https://issues.jboss.org/browse/THREESCALE-1883

Emails can be triggered from the product, only SaaS is affected:
- activation: create a new account
- activation reminder: 3 days without activating the account
- password reminder: click on forgot password
- domain reminder: click on forgot domain (not sure if this exists anymore?)

Emails should say 'Red Hat 3scale' instead of only '3scale' and all references to '3scale' by itself should have been removed.
