### PR TITLE
[Policies] Fix policiy chain in IE11

### DIFF
--- a/app/javascript/src/Policies/index.jsx
+++ b/app/javascript/src/Policies/index.jsx
@@ -4,6 +4,7 @@ import 'core-js/modules/es6.set'
 import 'core-js/modules/es6.map'
 import 'core-js/es7/array'
 import 'core-js/es7/object'
+import 'whatwg-fetch'
 
 import React from 'react'
 import { render } from 'react-dom'


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug presented in the proxy integration page when using IE11


* Using whatwg-fetch polifyll with our redux RSSA calls
* Since
https://github.com/agraboso/redux-api-middleware/releases/tag/v2.0.0 it
stop using isomorphic-fetch
* Breaks otherwise with browsers nos supporting or having an old
implementation of fetch standard


fixes https://issues.jboss.org/browse/THREESCALE-1711

**Verification steps** 
1. Set up 3scale 2.4
2. Integrate an API in a tenant account
3. Go to API > Configuration > POLICIES
