### PR TITLE
[Bugfix] Search engine doesn't always show a result when searching by user key

### DIFF
--- a/app/indices/account_index.rb
+++ b/app/indices/account_index.rb
@@ -17,7 +17,7 @@ ThinkingSphinx::Index.define(:account,
   set_property field_weights: { name: 2 }
 
   if System::Database.mysql? # rubocop:disable Style/IfUnlessModifier
-    set_property group_concat_max_len: 32_000
+    set_property group_concat_max_len: (32_000 - 1)
   end
 
   has :provider_account_id

--- a/app/indices/account_index.rb
+++ b/app/indices/account_index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ThinkingSphinx::Index.define(:account,
                              with: :active_record,
                              delta: ThinkingSphinx::Deltas::DatetimeDelta,
@@ -13,6 +15,10 @@ ThinkingSphinx::Index.define(:account,
   indexes users.id,                            as: :user_id
 
   set_property field_weights: { name: 2 }
+
+  if System::Database.mysql? # rubocop:disable Style/IfUnlessModifier
+    set_property group_concat_max_len: 32_000
+  end
 
   has :provider_account_id
   has :tenant_id

--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -1,6 +1,8 @@
-require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
+require 'test_helper'
 
 class Account::SearchTest < ActiveSupport::TestCase
+  disable_transactional_fixtures!
+
   test 'search without query returns all accounts by default, not using sphinx' do
     pending  = FactoryBot.create(:pending_account)
     approved = FactoryBot.create(:pending_account).tap(&:approve!)
@@ -109,6 +111,22 @@ class Account::SearchTest < ActiveSupport::TestCase
 
     result = provider.buyer_accounts.scope_search(:query => 'user_key: wrongkey')
     assert_equal 0, result.size
+  end
+
+  test 'search user_key without keyword with many records is always indexes and found' do
+    service = FactoryBot.create(:simple_service)
+    buyer = FactoryBot.create(:simple_buyer)
+    FactoryBot.create_list(:application_plan, 70, issuer: service).each do |plan|
+      plan.create_contract_with!(buyer)
+    end
+
+    ThinkingSphinx::Test.run do
+      ThinkingSphinx::Test.index
+
+      buyer.bought_cinstances.pluck(:user_key).each do |user_key|
+        assert_equal [buyer.id], Account.scope_search(query: user_key).pluck(:id)
+      end
+    end
   end
 
   # For mysterious reason, the thing didn't use to work when indifferent hash was passed in.

--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -113,10 +113,10 @@ class Account::SearchTest < ActiveSupport::TestCase
     assert_equal 0, result.size
   end
 
-  test 'search user_key without keyword with many records is always indexes and found' do
+  test 'search user_key without keyword with many records is always indexed and found' do
     service = FactoryBot.create(:simple_service)
     buyer = FactoryBot.create(:simple_buyer)
-    FactoryBot.create_list(:application_plan, 70, issuer: service).each do |plan|
+    FactoryBot.create_list(:application_plan, 5, issuer: service).each do |plan|
       plan.create_contract_with!(buyer)
     end
 


### PR DESCRIPTION
Fixes [THREESCALE-996 - Search engine doesn't show a result when searching by user key](https://issues.jboss.org/browse/THREESCALE-996)

### Problem
Sphinx is not indexing the `user_key` properly. We are using a `GROUP_CONCAT` with a limit of 1024 characters for all the user keys of the account, which is not enough, so that's why some of them can be found and some can not. This is not the first time it happens, so the solution in the code is this one:
https://github.com/3scale/porta/blob/bccc4581cc76b46c625c4db778e96c54cfd57e45/app/models/account/search.rb#L19-L27
https://github.com/3scale/porta/blob/bccc4581cc76b46c625c4db778e96c54cfd57e45/app/models/account/search.rb#L37-L41
https://github.com/3scale/porta/blob/bccc4581cc76b46c625c4db778e96c54cfd57e45/test/unit/account/search_test.rb#L100-L112
That means that if the search is done with `user_key: 1234` (imagining the `user_key` is `1234` for this example), it will do a regular SQL request, not using Sphinx, so it will work. But if it is done sending just `1234`, that will work only if this key is one of those inside those 1024 characters that have been indexed, otherwise it will not work.
This is not obvious for the people who do the search, more considering that the other attributes for search are sent without any prefix and only the value itself.


### What this PR does
Increases the amount of characters for that index 😄 