### PR TITLE
[billing] Fix negative invoices on plan downgrade on postpaid

### DIFF
--- a/features/finance/automatic_billing_postpaid.feature
+++ b/features/finance/automatic_billing_postpaid.feature
@@ -1,0 +1,121 @@
+@stats
+Feature: Automatic billing with plan changes on POSTPAID
+  As a provider I want to differentiate costs added by the automatic
+  billing job and my manually created invoices
+
+  Background:
+    Given a provider with billing and finance enabled
+    Given the provider service allows to change application plan directly
+    And the provider has one buyer
+    And the provider has a paid application plan "Paid" of 31 per month
+    And the provider has another paid application plan "Expensive" of 3100 per month
+
+  Scenario: Monthly fee on application plan upgrading the same day
+    Given all the rolling updates features are off
+    And the date is 1st January 2017
+    And the buyer signed up for plan "Paid"
+    Then the buyer changed to plan "Expensive"
+    When time flies to 3rd February 2017
+
+    Then the buyer should have following line items for "January, 2017" invoice:
+      | name                        | quantity |  cost     |
+      | Fixed fee ('Paid')          |          |    31.00  |
+      | Refund ('Paid')             |          |   -31.00  |
+      | Fixed fee ('Expensive')     |          | 3,100.00  |
+      | Total cost                  |          | 3,100.00  |
+
+  Scenario: Monthly fee on application plan downgrading the same day
+    Given all the rolling updates features are off
+    And the date is 1st January 2017
+    And the buyer signed up for plan "Expensive"
+    Then the buyer changed to plan "Paid"
+    When time flies to 3rd February 2017
+
+    Then the buyer should have following line items for "January, 2017" invoice:
+      | name                        | quantity |   cost    |
+      | Fixed fee ('Expensive')     |          |  3,100.00 |
+      | Refund ('Expensive')        |          | -3,100.00 |
+      | Fixed fee ('Paid')          |          |     31.00 |
+      | Total cost                  |          |     31.00 |
+
+  Scenario: Monthly fee on application plan downgrading on different day
+    Given all the rolling updates features are off
+    And the date is 1st January 2017 UTC
+    And the buyer signed up for plan "Expensive"
+    And time flies to 2nd January 2017
+    Then the buyer changed to plan "Paid"
+    When time flies to 3rd February 2017
+
+    Then the buyer should have following line items for "January, 2017" invoice:
+      | name                        | quantity |   cost    |
+      | Fixed fee ('Expensive')     |          |  3,100.00 |
+      | Refund ('Expensive')        |          | -3,000.00 |
+      | Fixed fee ('Paid')          |          |     30.00 |
+      | Total cost                  |          |    130.00 |
+    And there is only one invoice for "January, 2017"
+
+  Scenario: Monthly fee on several application plan upgrades in the middle of the month
+    Given all the rolling updates features are off
+    And the provider has a third paid application plan "ExpensiveAsHell" of 310000 per month
+    And the date is 1st January 2017 UTC
+    And the buyer signed up for plan "Paid"
+    And time flies to 2nd January 2017
+    Then the buyer changed to plan "Expensive"
+    And time flies to 3rd January 2017
+    Then the buyer changed to plan "ExpensiveAsHell"
+    When time flies to 3rd February 2017
+
+    Then the buyer should have following line items for "January, 2017" invoice:
+      | name                           | quantity |     cost    |
+      | Fixed fee ('Paid')             |          |      31.00  |
+      | Refund ('Paid')                |          |     -30.00  |
+      | Fixed fee ('Expensive')        |          |   3,000.00  |
+      | Refund ('Expensive')           |          |  -2,900.00  |
+      | Fixed fee ('ExpensiveAsHell')  |          | 290,000.00  |
+      | Total cost                     |          | 290,101.00  |
+    And there is only one invoice for "January, 2017"
+
+  Scenario: Monthly fee on application plan creating a new invoice manually, upgrading on different day
+    Given all the rolling updates features are off
+    And the date is 1st January 2017
+    And the buyer signed up for plan "Paid"
+    And time flies to 2nd January 2017
+    Then I create a new invoice from the API for this buyer for January, 2017 with:
+      | name                        |  cost      |
+      | Custom support              |    200.00  |
+
+    Then the buyer changed to plan "Expensive"
+    When time flies to 3rd February 2017
+
+    Then the buyer should have following line items for "January, 2017" in the 1st invoice:
+      | name                        | quantity |  cost     |
+      | Fixed fee ('Paid')          |          |    31.00  |
+      | Refund ('Paid')             |          |   -30.00  |
+      | Fixed fee ('Expensive')     |          | 3,000.00  |
+      | Total cost                  |          | 3,001.00  |
+    Then the buyer should have following line items for "January, 2017" in the 2nd invoice:
+      | name                        | quantity |  cost     |
+      | Custom support              |          |   200.00  |
+      | Total cost                  |          |   200.00  |
+
+  Scenario: Monthly fee on application plan upgrading the same day and a manual invoice was created
+    Given all the rolling updates features are off
+    And the date is 1st January 2017 UTC
+    And the buyer signed up for plan "Paid"
+    Then I create a new invoice from the API for this buyer for January, 2017 with:
+      | name                        |  cost      |
+      | Custom support              |    200.00  |
+
+    Then the buyer changed to plan "Expensive"
+    When time flies to 3rd February 2017
+
+    Then the buyer should have following line items for "January, 2017" in the 1st invoice:
+      | name                        | quantity |  cost     |
+      | Custom support              |          |   200.00  |
+      | Total cost                  |          |   200.00  |
+    Then the buyer should have following line items for "January, 2017" in the 2nd invoice:
+      | name                        | quantity |  cost     |
+      | Fixed fee ('Paid')          |          |    31.00  |
+      | Refund ('Paid')             |          |   -31.00  |
+      | Fixed fee ('Expensive')     |          | 3,100.00  |
+      | Total cost                  |          | 3,100.00  |

--- a/features/finance/automatic_billing_prepaid.feature
+++ b/features/finance/automatic_billing_prepaid.feature
@@ -1,5 +1,5 @@
 @stats
-Feature: Invoices creation by billing job or by API/UI
+Feature: Automatic billing with plan changes on PREPAID
   As a provider I want to differentiate costs added by the automatic
   billing job and my manually created invoices
 
@@ -104,4 +104,3 @@ Feature: Invoices creation by billing job or by API/UI
       | Total cost                                      |          | 3,100.00  |
     Then the buyer should have following line items for "February, 2017" in the 1st invoice:
       | Fixed fee ('Paid')                              |          | 3,100.00  |
-

--- a/features/step_definitions/plans/plans_steps.rb
+++ b/features/step_definitions/plans/plans_steps.rb
@@ -28,8 +28,8 @@ Given(/^the provider has a (default )?free application plan(?: "([^\"]*)")?$/) d
   @free_application_plan ||= create_plan :application, name: plan_name || 'Copper', issuer: @service, published: true, default: default.present?
 end
 
-Given(/^the provider has a(nother)? (default )?paid (application|service|account) plan(?: "([^\"]*)")?(?: of (\d+) per month)?$/) do |other, default, plan_type, plan_name, cost|
-  plan_type_name = (other ? 'other_' : '') + plan_type
+Given(/^the provider has a(nother|\ second|\ third)? (default )?paid (application|service|account) plan(?: "([^\"]*)")?(?: of (\d+) per month)?$/) do |other, default, plan_type, plan_name, cost|
+  plan_type_name = (other ? "#{other.strip}_" : '') + plan_type
   return instance_variable_get("@paid_#{plan_type_name}_plan") if instance_variable_defined?("@paid_#{plan_type_name}_plan")
   default_plan_names = {
     'application' => 'Gold',
@@ -45,7 +45,6 @@ Given(/^the provider has a(nother)? (default )?paid (application|service|account
   plan = create_plan plan_type.to_sym, name: plan_name, issuer: @service, cost: (cost || default_plan_costs[plan_type]), published: true, default: default.present?
   instance_variable_set("@paid_#{plan_type_name}_plan", plan)
 end
-
 
 Given /^(?:a|an)( default)?( published)? (#{PLANS}) plan "([^\"]*)" (?:of|for) ((?:provider|service) "[^\"]*")(?: for (\d+) monthly)?(?: exists)?$/ do |default, published, type, plan_name, issuer, cost|
   type ||= :application


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**

This PR prevents negative invoices from being generated on plan change on postpaid. This issue was fixed in the past for prepaid, but on postpaid billing mode, whenever a plan change happens from a more expensive plan to a less expensive one before billing runs for the contract for the first time, a negative amount invoice is generated. This is because the contract was never billed for the more expensive plan but a refund is issued anyway.

**Which issue(s) this PR fixes** 

[THREESCALE-995](https://issues.jboss.org/browse/THREESCALE-995)

**Verification steps** 

1. Define an application Plan A with monthly cost $200
2. Define a second application Plan B with monthly cost $50
3. Signup for Plan A
4. Change plan from A to B
5. If it's the first day of the month (otherwise prorated values will show instead), you should have an invoice generated with the following line items:

```
Fixed fee ('Plan A')     $200
Refund ('Plan A')       -$200
Fixed fee ('Plan B')      $50
Total cost                $50
```

instead of the old and incorrect:

```
Refund ('Plan A')       -$200
Fixed fee ('Plan B')      $50
Total cost              -$150
```