### PR TITLE
Fix CircleCI Tests: AccountDeletionConfig used to be tested leaving stubbed a wrong config

### DIFF
--- a/app/lib/account_deletion_config.rb
+++ b/app/lib/account_deletion_config.rb
@@ -1,27 +1,42 @@
 # frozen_string_literal: true
 
-module AccountDeletionConfig
-  module_function
-
-  def config
-    @config ||= load_config
+class AccountDeletionConfig
+  def self.configure(config = {})
+    @configuration = new(config)
   end
 
-  def valid?
-    instance_variable_defined?(:@valid) ? @valid : (@valid = check_validity)
+  def self.configuration
+    (@configuration || configure)
   end
 
-  def load_config
-    config = ThreeScale.config.features.account_deletion.each_with_object({}) do |(key, value), collection|
+  def self.config
+    configuration.config
+  end
+
+  def self.valid?
+    configuration.valid?
+  end
+
+  def initialize(config = {})
+    format_config(config)
+    check_validity(config)
+  end
+
+  attr_reader :config, :valid
+  alias valid? valid
+
+  private
+
+  def format_config(config)
+    config = (config || {}).each_with_object({}) do |(key, value), collection|
       collection[key.to_sym] = value if value.is_a?(Integer)
     end
-    ActiveSupport::OrderedOptions.new.merge(config)
+    @config = ActiveSupport::OrderedOptions.new.merge(config)
   end
 
-  def check_validity
-    valid = %i[account_suspension account_inactivity contract_unpaid_time].all? { |key| config.key?(key) }
-    return valid if valid || ThreeScale.config.features.account_deletion.blank?
+  def check_validity(initial_config)
+    @valid = %i[account_suspension account_inactivity contract_unpaid_time].all? { |key| config.key?(key) }
+    return if valid || initial_config.blank?
     Rails.logger.warn '[WARNING] Can\'t enable "automatic inactive tenant account deletion". Please revise your config"'
-    valid
   end
 end

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+AccountDeletionConfig.configure(Rails.configuration.three_scale.features.account_deletion)

--- a/test/unit/account_deletion_config_test.rb
+++ b/test/unit/account_deletion_config_test.rb
@@ -4,30 +4,29 @@ require 'test_helper'
 
 class AccountDeletionConfigTest < ActiveSupport::TestCase
   def setup
-    %i[@config @valid].each { |variable| AccountDeletionConfig.remove_instance_variable(variable) if AccountDeletionConfig.instance_variable_defined?(variable) }
     @valid_config = {'account_suspension' => 30, 'account_inactivity' => 50, 'contract_unpaid_time' => 70}
-  end
-
-  def teardown
-    %i[@config @valid].each { |variable| AccountDeletionConfig.remove_instance_variable(variable) if AccountDeletionConfig.instance_variable_defined?(variable) }
   end
 
   attr_reader :valid_config
 
   test 'loads and fetches all the values' do
-    ThreeScale.config.features.stubs(:account_deletion).returns(valid_config)
-    valid_config.each { |key, value| assert_equal value, AccountDeletionConfig.config.public_send(key) }
-    assert AccountDeletionConfig.valid?
+    valid_config.each { |key, value| assert_equal value, account_deletion_config.config.public_send(key) }
+    assert account_deletion_config.valid?
   end
 
   test 'marks as invalid if any value is not an integer' do
-    ThreeScale.config.features.stubs(:account_deletion).returns(valid_config.merge({'account_suspension' => 'foo'}))
-    refute AccountDeletionConfig.valid?
+    valid_config['account_suspension'] = 'foo'
+    refute account_deletion_config.valid?
   end
 
   test 'marks as invalid if any value is missing' do
     valid_config.delete('account_suspension')
-    ThreeScale.config.features.stubs(:account_deletion).returns(valid_config)
-    refute AccountDeletionConfig.valid?
+    refute account_deletion_config.valid?
+  end
+
+  private
+
+  def account_deletion_config
+    AccountDeletionConfig.new(valid_config)
   end
 end

--- a/test/unit/account_deletion_config_test.rb
+++ b/test/unit/account_deletion_config_test.rb
@@ -8,6 +8,10 @@ class AccountDeletionConfigTest < ActiveSupport::TestCase
     @valid_config = {'account_suspension' => 30, 'account_inactivity' => 50, 'contract_unpaid_time' => 70}
   end
 
+  def teardown
+    %i[@config @valid].each { |variable| AccountDeletionConfig.remove_instance_variable(variable) if AccountDeletionConfig.instance_variable_defined?(variable) }
+  end
+
   attr_reader :valid_config
 
   test 'loads and fetches all the values' do

--- a/test/workers/stale_account_worker_test.rb
+++ b/test/workers/stale_account_worker_test.rb
@@ -6,7 +6,7 @@ class StaleAccountWorkerTest < ActiveSupport::TestCase
   setup do
     account_suspension = 30
     config = {'account_suspension' => account_suspension, 'account_inactivity' => 50, 'contract_unpaid_time' => 70}
-    ThreeScale.config.features.stubs(:account_deletion).returns(config)
+    AccountDeletionConfig.configure(config)
 
     @accounts = {to_delete: [], not_to_delete: []}
 

--- a/test/workers/suspend_inactive_accounts_worker_test.rb
+++ b/test/workers/suspend_inactive_accounts_worker_test.rb
@@ -6,7 +6,7 @@ class SuspendInactiveAccountsWorkerTest < ActiveSupport::TestCase
   setup do
     account_inactivity = 50
     config = {'account_suspension' => 30, 'account_inactivity' => account_inactivity, 'contract_unpaid_time' => 70}
-    ThreeScale.config.features.stubs(:account_deletion).returns(config)
+    AccountDeletionConfig.configure(config)
 
     @accounts = {to_suspend: [], not_to_suspend: []}
 


### PR DESCRIPTION
This test fails sometimes in CircleCI:
https://github.com/3scale/porta/blob/bccc4581cc76b46c625c4db778e96c54cfd57e45/test/workers/suspend_inactive_accounts_worker_test.rb#L42
The reason is it happens when the tests of this class are executed first:
https://github.com/3scale/porta/blob/bccc4581cc76b46c625c4db778e96c54cfd57e45/test/unit/account_deletion_config_test.rb#L5

Now AccountDeletionConfig is a class configured by an initialiser 😄 