### PR TITLE
[API] Endpoint to create policies

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -108,7 +108,7 @@ gem 'prawn-format', '0.2.1'
 gem 'prawn-layout', '0.2.1'
 gem 'swagger-ui_rails2', git: 'https://github.com/3scale/swagger-ui_rails.git', branch: 'dev-2.1.3'
 gem 'swagger-ui_rails', git: 'https://github.com/3scale/swagger-ui_rails.git', branch: 'dev'
-gem 'json-schema'
+gem 'json-schema', git: 'https://github.com/3scale/json-schema.git'
 gem 'RedCloth', '~>4.3', require: false
 gem 'redcarpet', '~>3.4.0', require: false
 gem 'baby_squeel', '~> 1.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,13 @@ GIT
       rack
 
 GIT
+  remote: https://github.com/3scale/json-schema.git
+  revision: 26487618a68443e94d623bb585cb464b07d36702
+  specs:
+    json-schema (3.0.0)
+      addressable (>= 2.4)
+
+GIT
   remote: https://github.com/3scale/message_bus_client.git
   revision: d2e7f38c50fc8a0175ca4df4bbee5f2e090b2b77
   specs:
@@ -386,8 +393,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
-    json-schema (2.5.0)
-      addressable (~> 2.3)
     jwt (1.5.2)
     kgio (2.10.0)
     kubeclient (2.5.2)
@@ -872,7 +877,7 @@ DEPENDENCIES
   inherited_resources (~> 1.7.2)
   jquery-rails (~> 4.3)
   json (~> 1.8.1)
-  json-schema
+  json-schema!
   jwt (~> 1.5.2)
   kubeclient
   launchy

--- a/app/controllers/admin/api/member_permissions_controller.rb
+++ b/app/controllers/admin/api/member_permissions_controller.rb
@@ -41,7 +41,7 @@ class Admin::Api::MemberPermissionsController < Admin::Api::BaseController
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_admin_id_by_id
   ##~ op.parameters.add :name => "allowed_service_ids", :defaultName => "allowed_service_ids[]", :description => "IDs of the services that need to be enabled, URL-encoded array. To disable all services, set the value to '[]'. To enable all services, add parameter 'allowed_service_ids[]' with no value to the 'curl' command (can't be done in ActiveDocs)", :dataType => "custom", :allowMultiple => true, :required => false, :paramType => "query"
-  ##~ op.parameters.add :name => "allowed_sections", :defaultName => "allowed_sections[]", :description => "The list of sections in the admin portal that the user can access, URL-encoded array. Possible values: 'portal' (Developer Portal), 'finance' (Billing), 'settings', 'partners' (Developer Accounts -- Applications), 'monitoring' (Analytics), 'plans' (Integration & Application Plans). To disable all sections, set the value to '[]'.", :dataType => "custom", :allowMultiple => true, :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "allowed_sections", :defaultName => "allowed_sections[]", :description => "The list of sections in the admin portal that the user can access, URL-encoded array. Possible values: 'portal' (Developer Portal), 'finance' (Billing), 'settings', 'partners' (Developer Accounts -- Applications), 'monitoring' (Analytics), 'plans' (Integration & Application Plans), 'policy_registry'. To disable all sections, set the value to '[]'.", :dataType => "custom", :allowMultiple => true, :required => false, :paramType => "query"
   #
   def update
     authorize! :update_permissions, user

--- a/app/controllers/admin/api/personal/access_tokens_controller.rb
+++ b/app/controllers/admin/api/personal/access_tokens_controller.rb
@@ -19,7 +19,7 @@ class Admin::Api::Personal::AccessTokensController < Admin::Api::Personal::BaseC
   #
   ##~ op.parameters.add :name => "name", :description => "Name of the access token.", :dataType => "string", :required => true, :paramType => "query"
   ##~ op.parameters.add :name => "permission", :description => "Permission of the access token. It must be either 'ro' (read only) or 'rw' (read and write).", :dataType => "string", :required => true, :paramType => "query"
-  ##~ op.parameters.add :name => "scopes", :defaultName => "scopes[]", :description => "Scope of the access token. URL-encoded array containing one or more of the possible values. The possible values are, for a master user [\"account_management\", \"stats\"], and for a tenant user [\"finance\", \"account_management\", \"stats\"]", :dataType => "custom", :allowMultiple => true, :required => true, :paramType => "query"
+  ##~ op.parameters.add :name => "scopes", :defaultName => "scopes[]", :description => "Scope of the access token. URL-encoded array containing one or more of the possible values. The possible values are, for a master user [\"account_management\", \"stats\", \"policy_registry\"], and for a tenant user [\"finance\", \"account_management\", \"stats\", \"policy_registry\"]", :dataType => "custom", :allowMultiple => true, :required => true, :paramType => "query"
   #
   ##~ op.parameters.add @parameter_access_token
   #

--- a/app/controllers/admin/api/policies_controller.rb
+++ b/app/controllers/admin/api/policies_controller.rb
@@ -11,8 +11,8 @@ class Admin::Api::PoliciesController < Admin::Api::BaseController
   #
   ##~ op             = e.operations.add
   ##~ op.httpMethod  = "GET"
-  ##~ op.summary     = "APIcast Policies Registry"
-  ##~ op.description = "Returns APIcast Policies Registry"
+  ##~ op.summary     = "APIcast Policy Registry"
+  ##~ op.description = "Returns APIcast Policy Registry"
   ##~ op.group = "apicast_policies"
   #
   ##~ op.parameters.add @parameter_access_token

--- a/app/controllers/admin/api/registry/policies_controller.rb
+++ b/app/controllers/admin/api/registry/policies_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
+  self.access_token_scopes = :policy_registry
+
   clear_respond_to
   respond_to :json
 
@@ -8,7 +10,8 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
 
 
   # swagger
-  ##~ sapi = source2swagger.namespace("Account Management API")
+  ##~ sapi = source2swagger.namespace("Policy Registry API")
+  ##~ sapi.basePath = @base_path
   ##~ e = sapi.apis.add
   ##~ e.path = "/admin/api/registry/policies.json"
   ##~ e.responseClass = "policy"

--- a/app/controllers/admin/api/registry/policies_controller.rb
+++ b/app/controllers/admin/api/registry/policies_controller.rb
@@ -7,7 +7,23 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   representer ::Policy
 
 
-  # TODO: ApiDocs documentation :)
+  # swagger
+  ##~ sapi = source2swagger.namespace("Account Management API")
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/registry/policies.json"
+  ##~ e.responseClass = "policy"
+  #
+  ##~ op            = e.operations.add
+  ##~ op.httpMethod = "POST"
+  ##~ op.summary    = "APIcast Policy Registry Create"
+  ##~ op.description = "Creates an APIcast Policy"
+  ##~ op.group = "apicast_policies"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  ##~ op.parameters.add :name => "name", :description => "Name of the policy", :required => true, :dataType => "string", :paramType => "query"
+  ##~ op.parameters.add :name => "version", :description => "Version of the policy", :required => true, :dataType => "string", :paramType => "query"
+  ##~ op.parameters.add :name => "schema", :description => "JSON Schema of the policy", :required => true, :dataType => "string", :paramType => "query"
+  #
   def create
     respond_with current_account.policies.create(policy_params)
   end

--- a/app/controllers/admin/api/registry/policies_controller.rb
+++ b/app/controllers/admin/api/registry/policies_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
+  clear_respond_to
+  respond_to :json
+
+  representer ::Policy
+
+
+  # TODO: ApiDocs documentation :)
+  def create
+    respond_with current_account.policies.create(policy_params)
+  end
+
+  private
+
+  def policy_params
+    params.require(:policy).permit(:name, :version, :schema)
+  end
+end

--- a/app/controllers/admin/api/registry/policies_controller.rb
+++ b/app/controllers/admin/api/registry/policies_controller.rb
@@ -8,6 +8,7 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
 
   representer ::Policy
 
+  before_action :authorize_policies
 
   # swagger
   ##~ sapi = source2swagger.namespace("Policy Registry API")
@@ -32,6 +33,10 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   end
 
   private
+
+  def authorize_policies
+    authorize! :manage, :policy_registry
+  end
 
   def policy_params
     params.require(:policy).permit(:name, :version, :schema)

--- a/app/controllers/api_docs/services_controller.rb
+++ b/app/controllers/api_docs/services_controller.rb
@@ -113,8 +113,7 @@ class ApiDocs::ServicesController < FrontendController
   end.freeze
 
   def index
-    not_master_api_selector = proc { |api| api.fetch(:system_name) != :master_api }
-    render json: { host: '', apis: master? ? apis : apis(&not_master_api_selector) }
+    render json: { host: '', apis: apis(&method(:allowed_api?)) }
   end
 
   def show
@@ -123,5 +122,18 @@ class ApiDocs::ServicesController < FrontendController
     api_file['apis'] = exclude_plan_endpoints(api_file['apis']) if master_on_premises?
 
     render json: api_file
+  end
+
+  private
+
+  def allowed_api?(api)
+    case api[:system_name]
+    when :master_api
+      master?
+    when :policy_registry_api
+      current_account.tenant? && provider_can_use?(:policy_registry)
+    else
+      true
+    end
   end
 end

--- a/app/controllers/api_docs/services_controller.rb
+++ b/app/controllers/api_docs/services_controller.rb
@@ -94,7 +94,7 @@ class ApiDocs::ServicesController < FrontendController
     end
   end
 
-  API_SYSTEM_NAMES = %i[service_management_api account_management_api analytics_api billing_api master_api].freeze
+  API_SYSTEM_NAMES = %i[service_management_api account_management_api analytics_api billing_api master_api policy_registry_api].freeze
 
   APIS = API_SYSTEM_NAMES.map do |system_name|
     {

--- a/app/javascript/src/Users/permissions.jsx
+++ b/app/javascript/src/Users/permissions.jsx
@@ -228,7 +228,8 @@ export const Form = { // eslint-disable-line no-unused-vars
       settings: 'Settings',
       partners: 'Developer Accounts -- Applications',
       monitoring: 'Analytics',
-      plans: 'Integration & Application Plans'
+      plans: 'Integration & Application Plans',
+      policy_registry: 'Policy Registry'
     }
     return (
       <Inputs name='Administrative'>

--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -58,7 +58,7 @@ module Logic
 
       class Base
         attr_reader :provider
-        delegate :master?, :provider?, :enterprise?, to: :provider
+        delegate :master?, :provider?, :enterprise?, :provider_can_use?, to: :provider
         delegate :id, to: :provider, prefix: true
 
         OPENSHIFT_PROVIDER_ID = 2
@@ -272,6 +272,16 @@ module Logic
       end
 
       class Policies < Base
+        def missing_config
+          false
+        end
+      end
+
+      class PolicyRegistry < Base
+        def enabled?
+          super && provider_can_use?(:policies)
+        end
+
         def missing_config
           false
         end

--- a/app/lib/three_scale/json_validator.rb
+++ b/app/lib/three_scale/json_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ThreeScale
+  class JSONValidator < ::JSON::Validator
+    def self.setup!
+      self.schema_reader = JSON::Schema::Reader.new(accept_uri: false, accept_file: false)
+    end
+
+    def self.setup
+      setup!
+    rescue StandardError => error
+      Rails.logger.info("Failed to setup JSON Validator: #{error}")
+      nil
+    end
+  end
+end

--- a/app/lib/three_scale/json_validator.rb
+++ b/app/lib/three_scale/json_validator.rb
@@ -2,15 +2,70 @@
 
 module ThreeScale
   class JSONValidator < ::JSON::Validator
-    def self.setup!
-      self.schema_reader = JSON::Schema::Reader.new(accept_uri: false, accept_file: false)
+    # Register new schema files/globs here to automatically load them on startup
+    # or add them manually later with ThreeScale::JSONValidator.add_schema(schema)
+    AUTOLOAD_SCHEMA_FILES  = [
+      'app/lib/three_scale/swagger/schemas/*.schema.json',
+      'app/lib/three_scale/swagger/schemas/1.2/*.json',
+      'app/lib/three_scale/policies/schemas/*.schema.json'
+    ].freeze
+    private_constant :AUTOLOAD_SCHEMA_FILES
+
+    def self.autoload_schemas
+      autoloaded_schema_files.each do |file|
+        begin
+          schema_json = JSON.parse(File.read(file))
+          add_schema(build_schema(schema_json))
+        rescue StandardError => error
+          Rails.logger.info("** Failed to register schema: #{file} -- #{error}")
+        end
+      end
     end
 
-    def self.setup
-      setup!
-    rescue StandardError => error
-      Rails.logger.info("Failed to setup JSON Validator: #{error}")
-      nil
+    def self.build_schema(schema_json)
+      JSON::Schema.new(schema_json, schema_id(schema_json))
+    end
+
+    def initialize(json, schema_reader_options = {})
+      @json = json
+      @schema_reader = build_schema_reader(schema_reader_options)
+    end
+
+    attr_reader :json, :schema_reader
+
+    def fully_validate(schema, opts = {})
+      options = opts.reverse_merge(schema_reader: schema_reader)
+      ::JSON::Validator.fully_validate(schema, json, options)
+    end
+
+    private
+
+    class << self
+      private
+
+      def autoloaded_schema_files
+        AUTOLOAD_SCHEMA_FILES.map { |glob| Dir.glob(glob) }.flatten
+      end
+
+      def schema_id(schema_json)
+        # https://json-schema.org/understanding-json-schema/basics.html#declaring-a-unique-identifier
+        attr = schema_draft(schema_json) <= 4 ? 'id' : '$id'
+        schema_json[attr]
+      end
+
+      def schema_draft(schema_json)
+        schema_json['$schema'].to_s.slice(%r{/draft-(\d{2})/}, 1).to_i
+      end
+    end
+
+    SCHEMA_READER_DEFAULT = { accept_uri: false, accept_file: false }.freeze
+    private_constant :SCHEMA_READER_DEFAULT
+
+    def build_schema_reader(opts = {})
+      options = opts.reverse_merge(SCHEMA_READER_DEFAULT)
+      JSON::Schema::Reader.new(options)
     end
   end
 end
+
+ThreeScale::JSONValidator.autoload_schemas

--- a/app/lib/three_scale/policies/schemas/json-draft-07.schema.json
+++ b/app/lib/three_scale/policies/schemas/json-draft-07.schema.json
@@ -1,0 +1,168 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-07/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": true
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true,
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentEncoding": { "type": "string" },
+        "if": { "$ref": "#" },
+        "then": { "$ref": "#" },
+        "else": { "$ref": "#" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": true
+}

--- a/app/lib/three_scale/policies/schemas/manifest.schema.json
+++ b/app/lib/three_scale/policies/schemas/manifest.schema.json
@@ -1,0 +1,68 @@
+{
+  "$id": "http://apicast.io/policy-v1/schema#manifest",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "schema": {
+      "$id": "#/definitions/schema",
+      "$ref": "http://json-schema.org/draft-07/schema#",
+      "default": {}
+    },
+    "version": {
+      "$id": "#/definitions/version",
+      "type": "string",
+      "title": "The Policy Version",
+      "description": "A semantic version of a policy.",
+      "examples": [
+        "1.3.4",
+        "0.1"
+      ],
+      "pattern": "^((\\d+\\.)?(\\d+\\.)?(\\*|\\d+))|builtin$"
+    }
+  },
+  "properties": {
+    "name": {
+      "$id": "/properties/name",
+      "type": "string",
+      "title": "The Policy Name",
+      "description": "Name of the policy.",
+      "examples": [
+        "Basic Authentication"
+      ],
+      "minLength": 1
+    },
+    "summary": {
+      "$id": "/properties/summary",
+      "type": "string",
+      "title": "The Policy Summary",
+      "description": "Short description of what the policy does",
+      "examples": [
+        "Enables CORS (Cross Origin Resource Sharing) request handling."
+      ],
+      "maxLength": 75
+    },
+    "description": {
+      "$id": "/properties/description",
+      "oneOf": [
+        { "type": "string",
+          "minLength": 1 },
+        { "type": "array", "items": { "type": "string" },
+          "minItems": 1
+        }
+      ],
+      "title": "The Policy Description",
+      "description": "Longer description of what the policy does.",
+      "examples": [
+        "Extract authentication credentials from the HTTP Authorization header and pass them to 3scale backend.",
+        [ "Redirect request to different upstream: ", " - based on path", "- set different Host header"]
+      ]
+    },
+    "version": {
+      "$ref": "#/definitions/version"
+    },
+    "configuration": {
+      "$ref": "#/definitions/schema"
+    }
+  },
+  "required": ["name", "version", "configuration", "summary"]
+}

--- a/app/lib/three_scale/policies/specification.rb
+++ b/app/lib/three_scale/policies/specification.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module ThreeScale
+  module Policies
+    class Specification
+      extend ActiveModel::Naming
+      extend ActiveModel::Translation
+
+      def initialize(body)
+        @errors = ActiveModel::Errors.new(self)
+
+        begin
+          @doc = JSON.parse(body.to_s)
+        rescue JSON::ParserError
+          @errors.add(:base, :invalid_json)
+        end
+
+        @doc ||= {}
+      end
+
+      attr_reader :errors, :doc
+
+      JSON_SCHEMA = {'$ref' => 'http://apicast.io/policy-v1/schema#'}.freeze
+
+      def valid?
+        return false if errors.any?
+        JSONValidator.fully_validate(JSON_SCHEMA, doc).each { |error| errors.add(:base, error) }
+        errors.empty?
+      end
+
+      def self.setup_json_validator!
+        JSONValidator.setup!
+
+        schemas = Rails.root.join('app', 'lib', 'three_scale', 'policies', 'schemas', '*.schema.json')
+        Dir.glob(schemas).each do |file|
+          schema = JSON.parse(File.read(file))
+          new_schema = JSON::Schema.new(schema, schema['$id'])
+          JSONValidator.add_schema(new_schema)
+        end
+      end
+
+      def self.setup_json_validator
+        setup_json_validator!
+      rescue StandardError => error
+        Rails.logger.info("Failed to register schema with error: #{error}")
+        nil
+
+      end
+    end
+  end
+end
+
+ThreeScale::Policies::Specification.setup_json_validator

--- a/app/lib/three_scale/swagger/specification.rb
+++ b/app/lib/three_scale/swagger/specification.rb
@@ -52,7 +52,7 @@ module ThreeScale
         JSON_SCHEMA = {'$ref' => 'http://swagger.io/v2/schema.json#'}.freeze
 
         def validate!
-          JSON::Validator.fully_validate(JSON_SCHEMA, @doc).each do |error|
+          JSONValidator.fully_validate(JSON_SCHEMA, @doc).each do |error|
             @errors.add(:base, error)
           end
         end
@@ -69,7 +69,7 @@ module ThreeScale
         JSON_SCHEMA = {'$ref' => 'http://swagger-api.github.io/schemas/v1.2/apiDeclaration.json#'}.freeze
 
         def validate!
-          JSON::Validator.fully_validate(JSON_SCHEMA, @doc).each do |error|
+          JSONValidator.fully_validate(JSON_SCHEMA, @doc).each do |error|
             @errors.add(:base, error)
           end
         end
@@ -168,8 +168,7 @@ module ThreeScale
       end
 
       def self.setup_json_validator
-        # Disable JSON::Validator access to internet and fs
-        JSON::Validator.schema_reader = JSON::Schema::Reader.new(accept_uri: false, accept_file: false)
+        JSONValidator.setup
 
         # Registers all the schemas in app/lib/three_scale/swagger/schemas
         general = Dir[Rails.root.join("app/lib/three_scale/swagger/schemas/*.schema.json")]
@@ -177,7 +176,7 @@ module ThreeScale
         (general + swagger12).each do | file |
           begin
             schema = JSON.parse(File.read(file))
-            JSON::Validator.add_schema(JSON::Schema.new(schema, schema["id"]))
+            JSONValidator.add_schema(JSON::Schema.new(schema, schema["id"]))
           rescue StandardError => error
             Rails.logger.info("** Failed to register schema: #{file} -- #{error}")
           end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -11,8 +11,8 @@ class AccessToken < ApplicationRecord
 
   scope :by_name, ->(name) { name.present? ? where("name LIKE ?", "%#{name}%") : all }
 
-  PERMISSIONS = options_to_hash(%w(ro rw)).freeze
-  SCOPES      = options_to_hash(%w(cms finance account_management stats)).freeze
+  PERMISSIONS = options_to_hash(%w[ro rw]).freeze
+  SCOPES      = options_to_hash(%w[cms finance account_management stats policy_registry]).freeze
 
   Scope = Struct.new(:key, :value) do
 

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -23,6 +23,8 @@ module Account::ProviderMethods
     has_one  :web_hook, inverse_of: :account
     has_many :alerts
 
+    has_many :policies
+
     has_many :provider_audits, foreign_key: :provider_id, class_name: Audited.audit_class.name
 
     has_many :usage_limits, through: :services

--- a/app/models/admin_section.rb
+++ b/app/models/admin_section.rb
@@ -1,6 +1,6 @@
 class AdminSection
 
-  PERMISSIONS = %I[ portal finance settings partners monitoring plans ].freeze
+  PERMISSIONS = %I[ portal finance settings partners monitoring plans policy_registry ].freeze
 
   def self.permissions
     if ThreeScale.master_on_premises?

--- a/app/models/admin_section.rb
+++ b/app/models/admin_section.rb
@@ -10,6 +10,10 @@ class AdminSection
     end
   end
 
+  def self.permissions_for_account(account)
+    account.provider_can_use?(:policy_registry) ? permissions : (permissions - %i[policy_registry])
+  end
+
   SECTIONS = PERMISSIONS + %I[ services ]
 
   def self.sections

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Policy < ApplicationRecord
+  belongs_to :account
+end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -2,4 +2,6 @@
 
 class Policy < ApplicationRecord
   belongs_to :account
+
+  validates :version, uniqueness: { scope: %i[account_id name] }
 end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -4,4 +4,5 @@ class Policy < ApplicationRecord
   belongs_to :account
 
   validates :version, uniqueness: { scope: %i[account_id name] }
+  validates :name, :version, :account_id, :schema, presence: true
 end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -5,4 +5,19 @@ class Policy < ApplicationRecord
 
   validates :version, uniqueness: { scope: %i[account_id name] }
   validates :name, :version, :account_id, :schema, presence: true
+  validate :belongs_to_a_tenant
+  validate :validate_schema_specification
+
+  private
+
+  def belongs_to_a_tenant
+    return if !account || account.tenant?
+    errors.add(:account, :not_tenant)
+  end
+
+  def validate_schema_specification
+    specification = ThreeScale::Policies::Specification.new(schema)
+    return if specification.valid?
+    specification.errors[:base].each { |error| errors.add(:schema, error) }
+  end
 end

--- a/app/representers/policy_representer.rb
+++ b/app/representers/policy_representer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PolicyRepresenter
+  include ThreeScale::JSONRepresenter
+
+  wraps_resource
+
+  property :id
+  property :name
+  property :version
+  property :schema
+  property :created_at
+  property :updated_at
+end

--- a/app/views/provider/admin/account/users/_form.html.erb
+++ b/app/views/provider/admin/account/users/_form.html.erb
@@ -60,7 +60,7 @@
               el: document.getElementById('user-permissions-widget'),
               state: <%= json @user.as_json(root: false, only: [:role], methods: [:admin_sections, :member_permission_service_ids]) %>,
               services: <%= json @services.as_json(root: false, only: [:id, :name, :description]) %>,
-              features: <%= json AdminSection.permissions %>
+              features: <%= json AdminSection.permissions_for_account(current_account) %>
             })
           })
         </script>

--- a/config/abilities/provider_any.rb
+++ b/config/abilities/provider_any.rb
@@ -10,6 +10,8 @@ Ability.define do |user|
 
     can :manage, user
 
+    can(:manage, :policy_registry) if account.tenant? && account.provider_can_use?(:policy_registry)
+
     # Overriding `can :manage, user` and `can :manage, User, :id => user.id`
     cannot :update_permissions, User, &:admin?
 

--- a/config/docker/rolling_updates.yml
+++ b/config/docker/rolling_updates.yml
@@ -13,6 +13,7 @@ base: &default
   cms_api: false
   forum: true
   policies: false
+  policy_registry: false
   apicast_v2: true
   proxy_private_base_path: true
 

--- a/config/examples/rolling_updates.yml
+++ b/config/examples/rolling_updates.yml
@@ -13,6 +13,7 @@ base: &default
   cms_api: false
   forum: true
   policies: true
+  policy_registry: true
   proxy_private_base_path: true
   service_mesh_integration: false
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
     finance: 'Billing API'
     stats: 'Analytics API'
     account_management: 'Account Management API'
+    policy_registry: 'Policy Registry API'
     cms: 'Developer Portal API'
     ro: 'Read Only'
     rw: 'Read & Write'
@@ -111,6 +112,7 @@ en:
         names:
           service_management_api: 'Service Management API'
           account_management_api: 'Account Management API'
+          policy_registry_api: 'Policy Registry API'
           analytics_api: 'Analytics API'
           billing_api: 'Billing API'
           master_api: 'Master API'
@@ -127,6 +129,7 @@ en:
     settings: Settings
     services: Selected APIs
     plans: Integration & Application Plans
+    policy_registry: Policy Registry
 
   go_live_states:
     api_sandbox_traffic: "Done: Add your API endpoint and hit save & test"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -791,6 +791,8 @@ en:
           invalid_json_body_and_query_paramtypes: "JSON Spec can not have paramType='body' and paramType='query' on the same method."
           invalid_swagger: "JSON Spec is invalid"
           invalid_json: "Invalid JSON"
+        three_scale/policies/specification:
+          invalid_json: "Invalid JSON"
 
   activerecord:
     errors:
@@ -823,6 +825,10 @@ en:
           attributes:
             base:
               all_periods_used: "Metric cannot be disabled. Please contact support."
+        policy:
+          attributes:
+            account:
+              not_tenant: 'must be a tenant'
         proxy_rule:
           attributes:
             pattern:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -688,6 +688,10 @@ without fake Core server your after commit callbacks will crash and you might ge
         resource :failures, controller: 'web_hooks_failures', only: [:show, :destroy]
       end
       resource :settings, only: [:show, :update]
+
+      namespace :registry, defaults: { format: :json } do
+        resources :policies, only: :create
+      end
     end
   end
 

--- a/db/migrate/20190212111202_create_policies.rb
+++ b/db/migrate/20190212111202_create_policies.rb
@@ -1,0 +1,12 @@
+class CreatePolicies < ActiveRecord::Migration
+  def change
+    create_table :policies do |t|
+      t.string :name, null: false
+      t.string :version, null: false
+      t.binary :schema, null: false, limit: 16.megabytes
+      t.references :account, index: true, foreign_key: { on_delete: :cascade }, null: false, limit: 8
+      t.integer  :tenant_id, limit: 8
+      t.timestamps
+    end
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -824,7 +824,7 @@ ActiveRecord::Schema.define(version: 20190225170501) do
   add_index "notifications", ["user_id"], name: "index_notifications_on_user_id"
 
   create_table "oidc_configurations", force: :cascade do |t|
-    t.text   "config"
+    t.text     "config"
     t.string   "oidc_configurable_type",                null: false
     t.integer  "oidc_configurable_id",   precision: 38, null: false
     t.integer  "tenant_id",              precision: 38
@@ -944,6 +944,18 @@ ActiveRecord::Schema.define(version: 20190225170501) do
   add_index "plans", ["cost_per_month", "setup_fee"], name: "index_plans_on_cost_per_month_and_setup_fee"
   add_index "plans", ["issuer_id", "issuer_type", "type", "original_id"], name: "idx_plans_issuer_type_original"
   add_index "plans", ["issuer_id"], name: "fk_contracts_service_id"
+
+  create_table "policies", force: :cascade do |t|
+    t.string   "name",                      null: false
+    t.string   "version",                   null: false
+    t.binary   "schema",                    null: false
+    t.integer  "account_id", precision: 38, null: false
+    t.integer  "tenant_id",  precision: 38
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "policies", ["account_id"], name: "index_policies_on_account_id"
 
   create_table "posts", force: :cascade do |t|
     t.integer  "user_id",                    precision: 38
@@ -1450,6 +1462,7 @@ ActiveRecord::Schema.define(version: 20190225170501) do
 
   add_foreign_key "api_docs_services", "services"
   add_foreign_key "payment_details", "accounts", on_delete: :cascade
+  add_foreign_key "policies", "accounts", on_delete: :cascade
   add_foreign_key "provided_access_tokens", "users"
   add_foreign_key "proxy_configs", "proxies", on_delete: :cascade
   add_foreign_key "proxy_configs", "users", on_delete: :nullify

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -823,7 +823,7 @@ ActiveRecord::Schema.define(version: 20190225170501) do
   add_index "notifications", ["user_id"], name: "index_notifications_on_user_id", using: :btree
 
   create_table "oidc_configurations", force: :cascade do |t|
-    t.text   "config"
+    t.text     "config"
     t.string   "oidc_configurable_type",           null: false
     t.integer  "oidc_configurable_id",   limit: 8, null: false
     t.integer  "tenant_id",              limit: 8
@@ -943,6 +943,18 @@ ActiveRecord::Schema.define(version: 20190225170501) do
   add_index "plans", ["cost_per_month", "setup_fee"], name: "index_plans_on_cost_per_month_and_setup_fee", using: :btree
   add_index "plans", ["issuer_id", "issuer_type", "type", "original_id"], name: "idx_plans_issuer_type_original", using: :btree
   add_index "plans", ["issuer_id"], name: "fk_contracts_service_id", using: :btree
+
+  create_table "policies", force: :cascade do |t|
+    t.string   "name",                 null: false
+    t.string   "version",              null: false
+    t.binary   "schema",               null: false
+    t.integer  "account_id", limit: 8, null: false
+    t.integer  "tenant_id",  limit: 8
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "policies", ["account_id"], name: "index_policies_on_account_id", using: :btree
 
   create_table "posts", force: :cascade do |t|
     t.integer  "user_id",        limit: 8
@@ -1452,6 +1464,7 @@ ActiveRecord::Schema.define(version: 20190225170501) do
 
   add_foreign_key "api_docs_services", "services"
   add_foreign_key "payment_details", "accounts", on_delete: :cascade
+  add_foreign_key "policies", "accounts", on_delete: :cascade
   add_foreign_key "provided_access_tokens", "users"
   add_foreign_key "proxy_configs", "proxies", on_delete: :cascade
   add_foreign_key "proxy_configs", "users", on_delete: :nullify

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -824,7 +824,7 @@ ActiveRecord::Schema.define(version: 20190225170501) do
   add_index "notifications", ["user_id"], name: "index_notifications_on_user_id", using: :btree
 
   create_table "oidc_configurations", force: :cascade do |t|
-    t.text   "config",                 limit: 65535
+    t.text     "config",                 limit: 65535
     t.string   "oidc_configurable_type", limit: 255,   null: false
     t.integer  "oidc_configurable_id",   limit: 8,     null: false
     t.integer  "tenant_id",              limit: 8
@@ -944,6 +944,18 @@ ActiveRecord::Schema.define(version: 20190225170501) do
   add_index "plans", ["cost_per_month", "setup_fee"], name: "index_plans_on_cost_per_month_and_setup_fee", using: :btree
   add_index "plans", ["issuer_id", "issuer_type", "type", "original_id"], name: "idx_plans_issuer_type_original", using: :btree
   add_index "plans", ["issuer_id"], name: "fk_contracts_service_id", using: :btree
+
+  create_table "policies", force: :cascade do |t|
+    t.string   "name",       limit: 255,        null: false
+    t.string   "version",    limit: 255,        null: false
+    t.binary   "schema",     limit: 4294967295, null: false
+    t.integer  "account_id", limit: 8,          null: false
+    t.integer  "tenant_id",  limit: 8
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "policies", ["account_id"], name: "index_policies_on_account_id", using: :btree
 
   create_table "posts", force: :cascade do |t|
     t.integer  "user_id",        limit: 8
@@ -1453,6 +1465,7 @@ ActiveRecord::Schema.define(version: 20190225170501) do
 
   add_foreign_key "api_docs_services", "services"
   add_foreign_key "payment_details", "accounts", on_delete: :cascade
+  add_foreign_key "policies", "accounts", on_delete: :cascade
   add_foreign_key "provided_access_tokens", "users"
   add_foreign_key "proxy_configs", "proxies", on_delete: :cascade
   add_foreign_key "proxy_configs", "users", on_delete: :nullify

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -4082,7 +4082,7 @@
             {
               "name": "allowed_sections",
               "defaultName": "allowed_sections[]",
-              "description": "The list of sections in the admin portal that the user can access, URL-encoded array. Possible values: 'portal' (Developer Portal), 'finance' (Billing), 'settings', 'partners' (Developer Accounts -- Applications), 'monitoring' (Analytics), 'plans' (Integration & Application Plans). To disable all sections, set the value to '[]'.",
+              "description": "The list of sections in the admin portal that the user can access, URL-encoded array. Possible values: 'portal' (Developer Portal), 'finance' (Billing), 'settings', 'partners' (Developer Accounts -- Applications), 'monitoring' (Analytics), 'plans' (Integration & Application Plans), 'policy_registry'. To disable all sections, set the value to '[]'.",
               "dataType": "custom",
               "allowMultiple": true,
               "required": false,
@@ -4643,7 +4643,7 @@
             {
               "name": "scopes",
               "defaultName": "scopes[]",
-              "description": "Scope of the access token. URL-encoded array containing one or more of the possible values. The possible values are, for a master user [\"account_management\", \"stats\"], and for a tenant user [\"finance\", \"account_management\", \"stats\"]",
+              "description": "Scope of the access token. URL-encoded array containing one or more of the possible values. The possible values are, for a master user [\"account_management\", \"stats\", \"policy_registry\"], and for a tenant user [\"finance\", \"account_management\", \"stats\", \"policy_registry\"]",
               "dataType": "custom",
               "allowMultiple": true,
               "required": true,
@@ -4831,49 +4831,6 @@
             {
               "name": "site_access_code",
               "description": "Developer Portal Access Code.",
-              "dataType": "string",
-              "paramType": "query"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "path": "/admin/api/registry/policies.json",
-      "responseClass": "policy",
-      "operations": [
-        {
-          "httpMethod": "POST",
-          "summary": "APIcast Policy Registry Create",
-          "description": "Creates an APIcast Policy",
-          "group": "apicast_policies",
-          "parameters": [
-            {
-              "name": "access_token",
-              "description": "A personal Access Token",
-              "dataType": "string",
-              "required": true,
-              "paramType": "query",
-              "threescale_name": "access_token"
-            },
-            {
-              "name": "name",
-              "description": "Name of the policy",
-              "required": true,
-              "dataType": "string",
-              "paramType": "query"
-            },
-            {
-              "name": "version",
-              "description": "Version of the policy",
-              "required": true,
-              "dataType": "string",
-              "paramType": "query"
-            },
-            {
-              "name": "schema",
-              "description": "JSON Schema of the policy",
-              "required": true,
               "dataType": "string",
               "paramType": "query"
             }

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -4754,8 +4754,8 @@
       "operations": [
         {
           "httpMethod": "GET",
-          "summary": "APIcast Policies Registry",
-          "description": "Returns APIcast Policies Registry",
+          "summary": "APIcast Policy Registry",
+          "description": "Returns APIcast Policy Registry",
           "group": "apicast_policies",
           "parameters": [
             {
@@ -4831,6 +4831,49 @@
             {
               "name": "site_access_code",
               "description": "Developer Portal Access Code.",
+              "dataType": "string",
+              "paramType": "query"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/admin/api/registry/policies.json",
+      "responseClass": "policy",
+      "operations": [
+        {
+          "httpMethod": "POST",
+          "summary": "APIcast Policy Registry Create",
+          "description": "Creates an APIcast Policy",
+          "group": "apicast_policies",
+          "parameters": [
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            },
+            {
+              "name": "name",
+              "description": "Name of the policy",
+              "required": true,
+              "dataType": "string",
+              "paramType": "query"
+            },
+            {
+              "name": "version",
+              "description": "Version of the policy",
+              "required": true,
+              "dataType": "string",
+              "paramType": "query"
+            },
+            {
+              "name": "schema",
+              "description": "JSON Schema of the policy",
+              "required": true,
               "dataType": "string",
               "paramType": "query"
             }

--- a/doc/active_docs/Policy Registry API.json
+++ b/doc/active_docs/Policy Registry API.json
@@ -1,0 +1,48 @@
+{
+  "basePath": "",
+  "apis": [
+    {
+      "path": "/admin/api/registry/policies.json",
+      "responseClass": "policy",
+      "operations": [
+        {
+          "httpMethod": "POST",
+          "summary": "APIcast Policy Registry Create",
+          "description": "Creates an APIcast Policy",
+          "group": "apicast_policies",
+          "parameters": [
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            },
+            {
+              "name": "name",
+              "description": "Name of the policy",
+              "required": true,
+              "dataType": "string",
+              "paramType": "query"
+            },
+            {
+              "name": "version",
+              "description": "Version of the policy",
+              "required": true,
+              "dataType": "string",
+              "paramType": "query"
+            },
+            {
+              "name": "schema",
+              "description": "JSON Schema of the policy",
+              "required": true,
+              "dataType": "string",
+              "paramType": "query"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -28,6 +28,13 @@ GIT
       rack
 
 GIT
+  remote: https://github.com/3scale/json-schema.git
+  revision: 26487618a68443e94d623bb585cb464b07d36702
+  specs:
+    json-schema (3.0.0)
+      addressable (>= 2.4)
+
+GIT
   remote: https://github.com/3scale/message_bus_client.git
   revision: d2e7f38c50fc8a0175ca4df4bbee5f2e090b2b77
   specs:
@@ -390,8 +397,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
-    json-schema (2.5.0)
-      addressable (~> 2.3)
     jwt (1.5.2)
     kgio (2.10.0)
     kubeclient (2.5.2)
@@ -877,7 +882,7 @@ DEPENDENCIES
   inherited_resources (~> 1.7.2)
   jquery-rails (~> 4.3)
   json (~> 1.8.1)
-  json-schema
+  json-schema!
   jwt (~> 1.5.2)
   kubeclient
   launchy

--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -204,6 +204,12 @@ System::Database::MySQL.define do
     SQL
   end
 
+  trigger 'policies' do
+    <<~SQL
+      SET NEW.tenant_id = (SELECT tenant_id FROM accounts WHERE id = NEW.account_id AND tenant_id <> master_id);
+    SQL
+  end
+
   trigger 'posts' do
     <<~SQL
       SET NEW.tenant_id = (SELECT tenant_id FROM forums WHERE id = NEW.forum_id AND tenant_id <> master_id);

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -214,6 +214,12 @@ System::Database::Oracle.define do
     SQL
   end
 
+  trigger 'policies' do
+    <<~SQL
+      SELECT tenant_id INTO :new.tenant_id FROM accounts WHERE id = :new.account_id AND tenant_id <> master_id;
+    SQL
+  end
+
   trigger 'posts' do
     <<~SQL
       SELECT tenant_id INTO :new.tenant_id FROM forums WHERE id = :new.forum_id AND tenant_id <> master_id;

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -214,6 +214,12 @@ System::Database::Postgres.define do
     SQL
   end
 
+  trigger 'policies' do
+    <<~SQL
+      SELECT tenant_id INTO NEW.tenant_id FROM accounts WHERE id = NEW.account_id AND tenant_id <> master_id;
+    SQL
+  end
+
   trigger 'posts' do
     <<~SQL
       SELECT tenant_id INTO NEW.tenant_id FROM forums WHERE id = NEW.forum_id AND tenant_id <> master_id;

--- a/lib/tasks/multitenant/triggers.rake
+++ b/lib/tasks/multitenant/triggers.rake
@@ -107,6 +107,8 @@ namespace :multitenant do
     ServiceToken.update_all "tenant_id = (SELECT tenant_id FROM services WHERE id = service_id AND tenant_id <> #{MASTER_ID})"
     SSOAuthorization.update_all "tenant_id = (SELECT tenant_id FROM users WHERE id = user_id AND tenant_id <> #{MASTER_ID})"
     ProvidedAccessToken.update_all "tenant_id = account_id WHERE account_id <> #{MASTER_ID}"
+    Policy.update_all "tenant_id = (SELECT tenant_id FROM accounts WHERE id = policies.account_id AND tenant_id <> #{MASTER_ID})"
+
     # FIXME: This will not work when we have more than 1 oidc_configurable_type
     OIDConfiguration.update_all "tenant_id = (SELECT tenant_id FROM proxies WHERE id = oidc_configurable_id AND tenant_id <> #{MASTER_ID})"
   end

--- a/openshift/system/config/rolling_updates.yml
+++ b/openshift/system/config/rolling_updates.yml
@@ -15,6 +15,7 @@ base: &default
   forum: false
   published_service_plan_signup: true
   policies: true
+  policy_registry: true
   proxy_private_base_path: true
   service_mesh_integration: true
 

--- a/spec/acceptance/api/policy_spec.rb
+++ b/spec/acceptance/api/policy_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+resource 'Policy' do
+  let(:resource) { FactoryBot.create(:policy) }
+
+  json(:resource) do
+    let(:root) { 'policy' }
+
+    it { subject.should have_properties(%w[id name version schema created_at updated_at]).from(resource) }
+  end
+end

--- a/spec/javascripts/Users/permissions.spec.js
+++ b/spec/javascripts/Users/permissions.spec.js
@@ -83,6 +83,7 @@ describe('FeatureAccessInput', function () {
     expect(list(['services'])).toHaveClass(noServicePermissionsGranted)
     expect(list(['finance'])).toHaveClass(noServicePermissionsGranted)
     expect(list(['partners'])).not.toHaveClass(noServicePermissionsGranted)
+    expect(list(['policy_registry'])).toHaveClass(noServicePermissionsGranted)
   })
 
   it('renders children', function () {
@@ -116,12 +117,15 @@ describe('FeatureAccess', function () {
 
   it('has correct class name', function () {
     let node = render(<FeatureAccess value='partners'/>)
-
     expect(node).toHaveClass('FeatureAccessList-item--partners')
     expect(node).toContainElement('input.user_member_permission_ids--service')
 
     node = render(<FeatureAccess value='portal'/>)
     expect(node).toHaveClass('FeatureAccessList-item--portal')
+    expect(node).not.toContainElement('input.user_member_permission_ids--service')
+
+    node = render(<FeatureAccess value='policy_registry'/>)
+    expect(node).toHaveClass('FeatureAccessList-item--policy_registry')
     expect(node).not.toContainElement('input.user_member_permission_ids--service')
   })
 
@@ -223,6 +227,7 @@ describe('ServiceAccessList', function () {
     expect(list(['services'])).toHaveClass(noServicePermissionsGranted)
     expect(list(['finance'])).toHaveClass(noServicePermissionsGranted)
     expect(list(['partners'])).not.toHaveClass(noServicePermissionsGranted)
+    expect(list(['policy_registry'])).toHaveClass(noServicePermissionsGranted)
   })
 
   it('renders children', function () {

--- a/test/factories/other.rb
+++ b/test/factories/other.rb
@@ -108,7 +108,7 @@ FactoryBot.define do
   factory(:policy) do
     sequence(:name) { |n| "name #{n}" }
     sequence(:version) { |n| "version #{n}" }
-    schema { {foo: 'bar'}.to_json }
+    schema { {name: 'name example', version: '1', configuration: false, summary: 'example summary'}.to_json }
     association(:account, factory: :simple_provider)
   end
 end

--- a/test/factories/other.rb
+++ b/test/factories/other.rb
@@ -104,4 +104,11 @@ FactoryBot.define do
     association(:authentication_provider, factory: :authentication_provider)
     association(:user, factory: :user_with_account)
   end
+
+  factory(:policy) do
+    sequence(:name) { |n| "name #{n}" }
+    sequence(:version) { |n| "version #{n}" }
+    schema { {foo: 'bar'}.to_json }
+    association(:account, factory: :simple_provider)
+  end
 end

--- a/test/fixtures/policies/apicast-policy.json
+++ b/test/fixtures/policies/apicast-policy.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Upstream",
+  "summary": "Allows to modify the upstream URL of the request based on its path.",
+  "description":
+    ["This policy allows to modify the upstream URL (scheme, host and port) of the request based on its path. ",
+     "It accepts regular expressions and, when matched against the request path, ",
+     "replaces the upstream URL with a given string. \n",
+     "When combined with the APIcast policy, the upstream policy should be ",
+     "placed before it in the policy chain."],
+  "version": "builtin",
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "rules": {
+        "description": "list of rules to be applied",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "regex": {
+              "description": "regular expression to be matched",
+              "type": "string"
+            },
+            "url": {
+              "description": "new URL in case of match",
+              "type": "string"
+            }
+          },
+          "required": ["regex", "url"]
+        }
+      }
+    }
+  }
+}

--- a/test/integration/admin/api/registry/policies_controller_test.rb
+++ b/test/integration/admin/api/registry/policies_controller_test.rb
@@ -19,6 +19,15 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     policy_params[:policy].each { |key, value| assert_equal(value, policy.public_send(key)) }
   end
 
+  test 'POST create responds with an error message when it is incorrect' do
+    FactoryBot.create(:policy, policy_params[:policy].merge(account: @provider))
+    assert_no_difference(@provider.policies.method(:count)) do
+      post admin_api_registry_policies_path(policy_params)
+    end
+    assert_response :unprocessable_entity
+    assert_equal ['has already been taken'], JSON.parse(response.body).dig('errors', 'version')
+  end
+
   def policy_params
     { policy: {name: 'my-name', version: 'my-version', schema: '{"foo": "bar"}'}, access_token: @access_token.value }
   end

--- a/test/integration/admin/api/registry/policies_controller_test.rb
+++ b/test/integration/admin/api/registry/policies_controller_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    host! @provider.admin_domain
+    @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management], permission: 'rw')
+  end
+
+  test 'POST create with valid params persists with those values' do
+    assert_difference(@provider.policies.method(:count), 1) do
+      post admin_api_registry_policies_path(policy_params)
+    end
+    assert_response :created
+    assert JSON.parse(response.body).dig('policy', 'id')
+    policy = @provider.policies.last!
+    policy_params[:policy].each { |key, value| assert_equal(value, policy.public_send(key)) }
+  end
+
+  def policy_params
+    { policy: {name: 'my-name', version: 'my-version', schema: '{"foo": "bar"}'}, access_token: @access_token.value }
+  end
+end

--- a/test/integration/admin/api/registry/policies_controller_test.rb
+++ b/test/integration/admin/api/registry/policies_controller_test.rb
@@ -69,6 +69,7 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
   end
 
   def policy_params(token = @access_token.value)
-    { policy: {name: 'my-name', version: 'my-version', schema: '{"foo": "bar"}'}, access_token: token }
+    @policy_attributes ||= FactoryBot.build(:policy).attributes.symbolize_keys.slice(:name, :version, :schema)
+    { policy: @policy_attributes, access_token: token }
   end
 end

--- a/test/integration/api_docs/services_controller_test.rb
+++ b/test/integration/api_docs/services_controller_test.rb
@@ -43,7 +43,7 @@ class ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_equal ['host', 'apis'], index_result.keys
 
-      api_expected_names = ['Service Management API', 'Account Management API', 'Analytics API', 'Billing API']
+      api_expected_names = ['Service Management API', 'Account Management API', 'Analytics API', 'Billing API', 'Policy Registry API']
       assert_same_elements api_expected_names, index_result['apis'].map { |api| api['name'] }
 
       index_result['apis'].each_with_index do |api, index|
@@ -87,8 +87,8 @@ class ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
 
     def test_index_and_show
       expected_names = {
-          saas: ['Service Management API', 'Account Management API', 'Analytics API', 'Billing API', 'Master API'],
-          onpremises: ['Service Management API', 'Account Management API', 'Analytics API', 'Master API']
+          saas: ['Service Management API', 'Account Management API', 'Analytics API', 'Billing API', 'Master API', 'Policy Registry API'],
+          onpremises: ['Service Management API', 'Account Management API', 'Analytics API', 'Master API', 'Policy Registry API']
       }
 
       [true, false].each do |onpremises|

--- a/test/integration/api_docs/services_controller_test.rb
+++ b/test/integration/api_docs/services_controller_test.rb
@@ -19,6 +19,16 @@ class ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  def test_policies_not_shown_with_its_rolling_update_forbidden
+    ::Logic::RollingUpdates.stubs(enabled?: true)
+    ::Account.any_instance.stubs(provider_can_use?: false)
+
+    get api_docs_services_path(format: :json)
+    assert_response :success
+
+    assert_not_includes JSON.parse(response.body)['apis'].map { |api| api['name'] }, 'Policy Registry API'
+  end
+
   class ProviderAccountServicesControllerTest < ApiDocs::ServicesControllerTest
     def test_index_and_show_with_finance
       get '/api_docs/services.json'
@@ -87,8 +97,8 @@ class ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
 
     def test_index_and_show
       expected_names = {
-          saas: ['Service Management API', 'Account Management API', 'Analytics API', 'Billing API', 'Master API', 'Policy Registry API'],
-          onpremises: ['Service Management API', 'Account Management API', 'Analytics API', 'Master API', 'Policy Registry API']
+        saas: ['Service Management API', 'Account Management API', 'Analytics API', 'Billing API', 'Master API'],
+        onpremises: ['Service Management API', 'Account Management API', 'Analytics API', 'Master API']
       }
 
       [true, false].each do |onpremises|

--- a/test/test_helpers/file_fixtures.rb
+++ b/test/test_helpers/file_fixtures.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+# TODO: This can be removed after we migrate to Rails 5
+module ActiveSupport
+  module Testing
+    # Adds simple access to sample files called file fixtures.
+    # File fixtures are normal files stored in
+    # <tt>ActiveSupport::TestCase.file_fixture_path</tt>.
+    #
+    # File fixtures are represented as +Pathname+ objects.
+    # This makes it easy to extract specific information:
+    #
+    #   file_fixture("example.txt").read # get the file's content
+    #   file_fixture("example.mp3").size # get the file size
+    module FileFixtures
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :file_fixture_path, instance_writer: false
+      end
+
+      # Returns a +Pathname+ to the fixture file named +fixture_name+.
+      #
+      # Raises +ArgumentError+ if +fixture_name+ can't be found.
+      def file_fixture(fixture_name)
+        path = Pathname.new(File.join(file_fixture_path, fixture_name))
+
+        if path.exist?
+          path
+        else
+          msg = "the directory '%s' does not contain a file named '%s'"
+          raise ArgumentError, msg % [file_fixture_path, fixture_name]
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport::TestCase.class_eval do
+  include ActiveSupport::Testing::FileFixtures
+
+  self.fixture_path = Rails.root.join('test', 'fixtures')
+  self.file_fixture_path = self.fixture_path
+end

--- a/test/unit/abilities/provider_any_test.rb
+++ b/test/unit/abilities/provider_any_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Abilities::ProviderAdminTest < ActiveSupport::TestCase
+  setup do
+    @account = Account.new
+    @account.stubs(provider?: true)
+    @account.stubs(:provider_can_use?).with(any_parameters).returns(false)
+    @user = User.new({account: @account}, without_protection: true)
+  end
+
+  def test_policies_allowed
+    @account.expects(:provider_can_use?).with(:policy_registry).returns(true)
+    @account.stubs(tenant?: true)
+
+    assert_can Ability.new(@user), :manage, :policy_registry
+  end
+
+  def test_policies_no_rolling_update
+    @account.expects(:provider_can_use?).with(:policy_registry).returns(false)
+    @account.stubs(tenant?: true)
+
+    assert_cannot Ability.new(@user), :manage, :policy_registry
+  end
+
+  def test_policies_not_tenant
+    @account.stubs(tenant?: false)
+
+    assert_cannot Ability.new(@user), :manage, :policy_registry
+  end
+end

--- a/test/unit/admin_section_test.rb
+++ b/test/unit/admin_section_test.rb
@@ -22,4 +22,14 @@ class AdminSectionTest < ActiveSupport::TestCase
     ThreeScale.stubs(master_on_premises?: false)
     assert AdminSection.permissions.include?(:finance)
   end
+
+  def test_permissions_for_account
+    account = FactoryBot.create(:simple_provider)
+
+    account.stubs(provider_can_use?: true)
+    assert_same_elements AdminSection.permissions, AdminSection.permissions_for_account(account)
+
+    account.stubs(provider_can_use?: false)
+    assert_same_elements (AdminSection.permissions.reject { |permission| permission == :policy_registry }), AdminSection.permissions_for_account(account)
+  end
 end

--- a/test/unit/logic/rolling_updates_test.rb
+++ b/test/unit/logic/rolling_updates_test.rb
@@ -17,6 +17,22 @@ class Logic::RollingUpdatesTest < ActiveSupport::TestCase
     refute account.provider_can_use?(:policies)
   end
 
+  def test_policy_registry
+    account = FactoryBot.build_stubbed(:simple_account)
+
+    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policies: true, policy_registry: true })
+    assert account.provider_can_use?(:policy_registry)
+
+    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policies: true, policy_registry: false })
+    refute account.provider_can_use?(:policy_registry)
+
+    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policies: false, policy_registry: false })
+    refute account.provider_can_use?(:policy_registry)
+
+    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policies: false, policy_registry: true })
+    refute account.provider_can_use?(:policy_registry)
+  end
+
   def test_forum
     account = FactoryBot.build_stubbed(:simple_account)
 
@@ -97,7 +113,7 @@ class Logic::RollingUpdatesTest < ActiveSupport::TestCase
     user = User.new(username: ThreeScale.config.impersonation_admin['username'])
     controller_instance.expects(:current_user).returns(user).once
 
-    assert controller_instance.send(:provider_can_use?, :whathever)
+    assert controller_instance.send(:provider_can_use?, :whatever)
   end
 
   test "Controller: provider_can_use? delegate to current_account" do
@@ -107,10 +123,10 @@ class Logic::RollingUpdatesTest < ActiveSupport::TestCase
     controller_instance.expects(:current_user).returns(user).once
 
     provider = Account.new
-    provider.expects(:provider_can_use?).with(:whathever)
+    provider.expects(:provider_can_use?).with(:whatever)
     controller_instance.expects(:current_account).returns(provider).once
 
-    controller_instance.send(:provider_can_use?, :whathever)
+    controller_instance.send(:provider_can_use?, :whatever)
   end
 
   test 'provider can use duplicate_user_key feature' do
@@ -121,7 +137,7 @@ class Logic::RollingUpdatesTest < ActiveSupport::TestCase
     provider_2.stubs(:id).returns(2)
 
     assert provider_1.provider_can_use?(:duplicate_user_key)
-      refute provider_2.provider_can_use?(:duplicate_user_key)
+    refute provider_2.provider_can_use?(:duplicate_user_key)
   end
 
   class NewFeature < Logic::RollingUpdates::Features::Base

--- a/test/unit/member_permission_test.rb
+++ b/test/unit/member_permission_test.rb
@@ -50,5 +50,8 @@ class MemberPermissionTest < ActiveSupport::TestCase
 
     permission.admin_section = :services
     assert permission.valid?
+
+    permission.admin_section = :policy_registry
+    assert permission.valid?
   end
 end

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -3,6 +3,11 @@
 require 'test_helper'
 
 class PolicyTest < ActiveSupport::TestCase
+  should validate_presence_of :name
+  should validate_presence_of :version
+  should validate_presence_of :account_id
+  should validate_presence_of :schema
+
   test 'validates uniqueness of [account_id, name, version]' do
     persisted_policy = FactoryBot.create(:policy)
 

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PolicyTest < ActiveSupport::TestCase
+  test 'validates uniqueness of [account_id, name, version]' do
+    persisted_policy = FactoryBot.create(:policy)
+
+    invalid_policy = FactoryBot.build(:policy, name: persisted_policy.name, version: persisted_policy.version, account: persisted_policy.account)
+    refute invalid_policy.save
+    assert_equal ['has already been taken'], invalid_policy.errors[:version]
+
+    different_version_policy = FactoryBot.build(:policy, name: persisted_policy.name, account: persisted_policy.account)
+    assert different_version_policy.save
+
+    different_name_policy = FactoryBot.build(:policy, version: persisted_policy.version, account: persisted_policy.account)
+    assert different_name_policy.save
+
+    different_provider_policy = FactoryBot.build(:policy, name: persisted_policy.name, version: persisted_policy.version)
+    assert different_provider_policy.save
+  end
+end

--- a/test/unit/three_scale/json_validator_test.rb
+++ b/test/unit/three_scale/json_validator_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ThreeScale::JSONValidatorTest < ActiveSupport::TestCase
+  setup do
+    @klass = ThreeScale::JSONValidator
+  end
+
+  test 'autoload schema files' do
+    schema_files = @klass.send(:autoloaded_schema_files)
+    schema_files_count = schema_files.count
+    ::JSON::Validator.expects(:add_schema).times(schema_files_count)
+    @klass.autoload_schemas
+  end
+
+  test 'extract the schema draft' do
+    assert_equal 4, @klass.send(:schema_draft, { '$schema' => 'http://json-schema.org/draft-04/schema#' })
+    assert_equal 7, @klass.send(:schema_draft, { '$schema' => 'http://json-schema.org/draft-07/schema#' })
+    assert_equal 0, @klass.send(:schema_draft, {})
+  end
+
+  test 'extract the schema id' do
+    assert_equal 'my-id', @klass.send(:schema_id, { 'id' => 'my-id', '$schema' => 'http://json-schema.org/draft-04/schema#' })
+    assert_equal 'my-id', @klass.send(:schema_id, { '$id' => 'my-id', '$schema' => 'http://json-schema.org/draft-07/schema#' })
+  end
+
+  test 'schema build' do
+    schema_json = { '$id' => 'http://example.com/schema-v1/my-schema#frag', '$schema' => 'http://json-schema.org/draft-07/schema#' }
+    schema = @klass.build_schema schema_json
+    assert_kind_of JSON::Schema, schema
+  end
+
+  test 'fully validate' do
+    json = { json_key: 'json_value' }
+    schema = {}
+    validator = @klass.new(json)
+    @klass.expects(:fully_validate).with(schema, json, any_parameters)
+    validator.fully_validate(schema)
+  end
+end

--- a/test/unit/three_scale/policies/specification_test.rb
+++ b/test/unit/three_scale/policies/specification_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ThreeScale::Policies::SpecificationTest < ActiveSupport::TestCase
+
+  test '#valid? returns true when the schema is valid' do
+    doc = file_fixture('policies/apicast-policy.json').read
+    specification = ThreeScale::Policies::Specification.new(doc)
+
+    assert specification.valid?, 'specification should be valid'
+  end
+
+  test 'valid? returns false for an invalid specification and errors returns why' do
+    specification = ThreeScale::Policies::Specification.new('invalid json')
+    refute specification.valid?, 'specification should not be valid'
+    assert_equal ['Invalid JSON'], specification.errors[:base]
+
+    specification = ThreeScale::Policies::Specification.new('{"foo": "bar"}')
+    refute specification.valid?, 'specification should not be valid'
+    assert_includes specification.errors[:base], 'The property \'#/\' did not contain a required property of \'name\' in schema http://apicast.io/policy-v1/schema#'
+  end
+end


### PR DESCRIPTION
Fixes [THREESCALE-1910 - API Endpoint to create policies](https://issues.jboss.org/browse/THREESCALE-1910)

### Specific tasks
I recommend looking at it commit by commit.
- [X] Create policies table in the database containing the attributes as we agreed and belonging to an account:
![image](https://user-images.githubusercontent.com/11318903/52723110-3534a100-2fad-11e9-83c5-03904e0e8a68.png)
- [X] Create the first Policy representer to respond with this data created above (not the final response data of the request, but step by step 😄 ). This also implies creating the model and making the association between `Account` and `Policy`.
- [X] API endpoint to create policies. Happy path working and tested. Errors not done or tested yet.
- [X] Validate uniqueness of provider+name+version and test that the API request responds with the proper error.
- [X] Update Policy `tenant_id` with triggers and update the rake for "update all the current DB data for `tenant_id`".
- [X] ApiDocs documentation. First version, corresponding to https://github.com/3scale/porta/pull/593#issuecomment-463248681 .
- [X] Validate presence of name, version, account_id, and schema.
- [X] Create a new scope for `policy_registry` and authenticate with this scope.
- [X] Validate that the account is a tenant + Validate the json of `schema` using this manifest: https://github.com/3scale/apicast/blob/c3e431df20f65686798d1e67d8c4e9f568ef9c08/gateway/src/apicast/policy/manifest-schema.json
An example of this json would be: https://github.com/3scale/apicast/blob/master/gateway/src/apicast/policy/upstream/apicast-policy.json
- [X] Rolling update to enable this because this will be deployed in SaaS 1st. Disabled for master.
- [ ] Respond the data with the same format of what is being returned in:
https://github.com/3scale/porta/blob/587505f9971dbbf829e7671c9a488243c1be2b83/app/controllers/admin/api/policies_controller.rb#L20-L26