### PR TITLE
Use a safer function explicitly sharing credentials with same origin.

### DIFF
--- a/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js
@@ -58,14 +58,9 @@ document.addEventListener("DOMContentLoaded", function(e) {
     return selectElem.appendChild(opt);
   };
   
-  function safe_fetch(url, init) {
-    const tempRequest = new Request(url, init);
-    return fetch(tempRequest, { credentials: "same-origin" });
-  }
-
   function fetchData(url, type) {
     if ('fetch' in window) {
-      safe_fetch(url)
+      fetch(url, { credentials: 'same-origin' })
       .then(function(response) {
           return response.json();
       })

--- a/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js
@@ -57,10 +57,15 @@ document.addEventListener("DOMContentLoaded", function(e) {
     opt.text = val;
     return selectElem.appendChild(opt);
   };
+  
+  function safe_fetch(url, init) {
+    const tempRequest = new Request(url, init);
+    return fetch(tempRequest, { credentials: "same-origin" });
+  }
 
   function fetchData(url, type) {
     if ('fetch' in window) {
-      fetch(url)
+      safe_fetch(url)
       .then(function(response) {
           return response.json();
       })

--- a/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/service_discovery.js
@@ -57,7 +57,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
     opt.text = val;
     return selectElem.appendChild(opt);
   };
-  
+
   function fetchData(url, type) {
     if ('fetch' in window) {
       fetch(url, { credentials: 'same-origin' })


### PR DESCRIPTION
**What this PR does / why we need it**:
Explicitly declare to share the credentials with the same-origin in the XHR request to the server.
The credentials is not shared by default in older browser versions, ...
check the compatibility list ...
https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials#Browser_compatibility

**Which issue(s) this PR fixes** 

fixes #594 

**Verification steps** 

0. Use a browser version previous from the offered list (i.e. Firefox 60.5.0 on RHEL 7.6)
1. Go to Admin Portal and try to define a new API service.
2. From the form select radio option : 'Import from Openshift'
3. Observe the XHR request retrieves the list of available projects from Openshift.

**Special notes for your reviewer**:
