### PR TITLE
[WIP] Reset tenant_id as code

### DIFF
--- a/app/concerns/reset_tenant_id.rb
+++ b/app/concerns/reset_tenant_id.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+module ResetTenantId
+  extend ActiveSupport::Concern
+
+  class Configurator
+    include Singleton
+    attr_reader :definitions
+
+    def initialize
+      @definitions = {}
+    end
+
+    def define(klass,  &block)
+      definition = definitions[klass] ||= Definition.new(klass)
+      definition.instance_exec(&block)
+    end
+  end
+
+  class Definition
+    attr_reader :queries, :klass
+    delegate :each_value, to: :queries
+
+    def initialize(klass)
+      @klass = klass
+      @queries = {}
+    end
+
+    def updates(name, options = {}, &block)
+      @queries[name.to_sym] = Query.new(klass, name, options, &block)
+    end
+
+    def [](name)
+      @queries[name.to_sym]
+    end
+  end
+
+  class Query
+    module FindEach
+      def find_each(*options, &block)
+        defined?(super) ? super(*options, &block) : each(&block)
+      end
+    end
+
+    attr_reader :klass, :name, :update, :collection
+
+    def initialize(klass, name, options = {}, &block)
+      @klass = klass
+      @name = name.to_sym
+      @collection = wrap_collection(options[:collection] || @name)
+      @update = wrap_update(options[:with] || block)
+    end
+
+    private
+
+    # :nodoc:
+    # Returns an object responding to #call(record)
+    def wrap_update(with)
+      case with
+      when NilClass
+        raise ArgumentError, 'Pass in `:with` option or a block'
+      when Symbol
+        proc do |record|
+          record.update_column :tenant_id, record.public_send(with) # rubocop:disable Rails/SkipsModelValidations
+        end
+      else
+        with
+      end
+    end
+
+    # :nodoc:
+    # Wraps into a proc so it can be executed in the context of the klass
+    # and defer the evaluation when actually executing it
+    def wrap_collection(collection)
+      case collection
+      when Proc
+        proc { klass.instance_exec(&collection).extend(FindEach) }
+      when Symbol, String
+        proc { klass.public_send(collection).extend(FindEach) }
+      when Enumerable
+        proc { collection.tap{|object| object.extend(FindEach) } }
+      else
+        proc { collection.extend(FindEach) }
+      end
+    end
+  end
+
+  class Runner
+    attr_reader :definitions
+
+    def initialize(definitions)
+      @definitions = definitions
+    end
+
+    def execute(name)
+      query = find_query(name)
+      execute_query(query)
+    end
+
+    def execute_all
+      definitions.each_value do |query|
+        execute_query(query)
+      end
+    end
+
+    def find_query(name)
+      definitions[name.to_sym] or raise ArgumentError, "Cannot find a query with name `#{name}`"
+    end
+
+    private
+
+    def execute_query(query)
+      query.collection.call.find_each(&query.update)
+    end
+  end
+
+  def reset_tenant_id!(name)
+    runner = ResetTenantId::Runner.new(ResetTenantId::Configurator.instance.definitions[self.class])
+    query = runner.find_query(name)
+    query.update.call(self)
+  end
+
+  module ClassMethods
+
+    # define_reset_tenant_id do
+    #   updates(:buyers, with: :provider_account_id)
+    #
+    #   updates(:buyers) do |record|
+    #     record.provider_account_id
+    #   end
+    #
+    #   updates(first_3_accounts, collection: Account.find(1,2,3), with: :provider_account_id)
+    #
+    #   updates(:all_tags, collection: -> { ActiveRecord::Base.connection.execute("SELECT id, account_id FROM tags") }) do |record|
+    #     id, account_id = record
+    #     ActiveRecord::Base.connection.execute("UPDATE tags SET tenant_id = account_id WHERE id = #{id}")
+    #   end
+    # end
+    def define_reset_tenant_id(&block)
+      ResetTenantId::Configurator.instance.define(self, &block)
+    end
+
+    def reset_tenant_id!(name = nil)
+      runner = ResetTenantId::Runner.new(ResetTenantId::Configurator.instance.definitions[self])
+      if name
+        runner.execute(name)
+      else
+        runner.execute_all
+      end
+    end
+  end
+end

--- a/app/lib/thinking_sphinx/active_record/database_adapters/oracle_adapter.rb
+++ b/app/lib/thinking_sphinx/active_record/database_adapters/oracle_adapter.rb
@@ -45,4 +45,5 @@ class ThinkingSphinx::ActiveRecord::DatabaseAdapters::OracleAdapter <
   def utf8_query_pre
     []
   end
+
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -594,5 +594,8 @@ class Account < ApplicationRecord
     errors.add :master, 'can be only one' if scope.exists?(master: true)
   end
 
-  protected
+  define_reset_tenant_id do
+    updates(:buyers_not_master, collection: -> { buyers.not_master } , with: :provider_account_id)
+    updates(:providers, with: :id)
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,6 +2,7 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  include ResetTenantId
 
 
   sifter(:month_number) do |column|

--- a/test/unit/reset_tenant_id_test.rb
+++ b/test/unit/reset_tenant_id_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class ResetTenantIdTest < ActiveSupport::TestCase
+  class QueryTest < ActiveSupport::TestCase
+
+    attr_reader :klass, :record
+    def setup
+      @klass = mock('Klass')
+      @record = mock('instance')
+    end
+
+    test 'initialize without updater' do
+      assert_raises(ArgumentError) do
+        ResetTenantId::Query.new(mock, 'buyers')
+      end
+    end
+
+    test 'updates `:with` option as Symbol' do
+      record.expects(:id).returns('my-id')
+      record.expects(:update_column).with(:tenant_id, 'my-id')
+      query = ResetTenantId::Query.new(klass,  'buyers', with: :id)
+      query.update.call(record)
+    end
+
+    test 'updates `:with` option responding to `call`' do
+      record.expects(:id).returns('my-id')
+      record.expects(:update_database).with(:column, 'my-id')
+      query = ResetTenantId::Query.new(klass, 'buyers', with: ->(r){ r.update_database :column, r.id})
+      query.update.call(record)
+    end
+
+    test 'updates with block' do
+      record.expects(:id).returns('my-id')
+      record.expects(:update_database).with(:column, 'my-id')
+      query = ResetTenantId::Query.new(klass, 'buyers') do |record|
+        record.update_database :column, record.id
+      end
+      query.update.call(record)
+    end
+
+    test 'uses the `name` as collection' do
+      klass.expects(:buyers)
+      query = ResetTenantId::Query.new(klass, 'buyers', with: :id)
+      query.collection.call
+    end
+
+    test 'uses the `:collection` option as Enumerable' do
+      array = [1, 5, 9]
+      query = ResetTenantId::Query.new(klass, 'buyers', with: :id, collection: array)
+      assert_equal array, query.collection.call
+    end
+
+    test 'uses the `:collection` as Proc' do
+      klass.expects(:my_collection).returns(%w(a d g))
+      query = ResetTenantId::Query.new(klass, 'buyers', with: :id, collection: proc { my_collection })
+      assert_equal %w{a d g}, query.collection.call
+    end
+  end
+
+  class RunnerTest < ActiveSupport::TestCase
+    test 'execute' do
+      klass = mock('Klass')
+      record = OpenStruct.new id: 1
+      record.expects(:update_column).with(:tenant_id, 1)
+      klass.expects(:buyers).returns([record])
+      query = ResetTenantId::Query.new(klass,  'buyers', with: :id)
+      definitions = {
+        buyers: query
+      }
+
+      runner = ResetTenantId::Runner.new(definitions)
+      runner.execute(:buyers)
+    end
+  end
+end


### PR DESCRIPTION
## Issue description

When doing migration with pt-osc triggers are removed, thus new record in tables do not have the `tenant_id`, which can be problematic (data leak)

* The https://github.com/3scale/porta/blob/587505f9971dbbf829e7671c9a488243c1be2b83/lib/tasks/multitenant/triggers.rake cannot really be run on production environments.
Those requests are going to block the tables.
* Some are not compatible with all supported databases (MySQL, Postgres, Oracle 12c)
* Not really testable
* Cannot launch a reset per table/model

## Goals

* Make it database agnostic
* Add testing because it can be scary to have tenant_id set the wrong way. Possible data leak ...
* Definition in each model:
  * Why? that way it is handy to do `Account.reset_tenant_id!(:buyers)` Rather than ResetTenantId.call(Account, :buyers)
  *  if there is no model, use Arel to create the query (database agnostic)
