### PR TITLE
[billing] Fix variable cost of new contracts on the last day of month

### DIFF
--- a/app/lib/finance/variable_cost.rb
+++ b/app/lib/finance/variable_cost.rb
@@ -17,7 +17,7 @@ module Finance
 
       transaction do
 
-        if variable_cost_paid_until.to_date < period.end
+        if should_bill_variable_cost?(period)
           intersection = intersect_with_unpaid_period(period, variable_cost_paid_until)
           # intersect_with_unpaid_period returns the intersection in
           # time, but it rounds from beginning of day of the first day
@@ -75,6 +75,15 @@ module Finance
       [ values, costs ]
     end
 
+    # Using `read_attribute` because the getter method is overloaded
+    def never_billed_variable_cost?
+      self[:variable_cost_paid_until].blank?
+    end
+
+    def should_bill_variable_cost?(period)
+      never_billed_variable_cost? || variable_cost_paid_until.to_date < period.end
+    end
+
     protected
 
     def bill_variable_fee_for(period, invoice, plan_to_bill)
@@ -96,6 +105,5 @@ module Finance
         )
       end
     end
-
   end
 end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -137,8 +137,8 @@ class Contract < ApplicationRecord
 
   # Using `read_attribute` because the getter method is overloaded
   # Meaning changing plan the same day of the creation of the contract
-  # Useful for prepaid billing see PrepaidBillingStrategy#bill_plan_change_safely
-  def not_billed_yet?
+  # Useful for prepaid billing. See PrepaidBillingStrategy#bill_plan_change_safely
+  def never_billed?
     self[:paid_until].blank?
   end
 

--- a/app/models/finance/prepaid_billing_strategy.rb
+++ b/app/models/finance/prepaid_billing_strategy.rb
@@ -119,7 +119,7 @@ class Finance::PrepaidBillingStrategy < Finance::BillingStrategy
   # Upgrade Plan A to Plan B|   100
   # Total                   |   100
   def bill_plan_change(contract, period)
-    if contract.not_billed_yet?
+    if contract.never_billed?
       bill_plan_change_for_unbilled_contract(contract, period)
     else
       bill_plan_change_for_billed_contract(contract, period)

--- a/app/observers/billing_observer.rb
+++ b/app/observers/billing_observer.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 class BillingObserver < ActiveRecord::Observer
 
-  class RangeForVariableCost < Range; end
+  class RangeForVariableCost < Range
+    def distance_in_seconds
+      (self.end.in_time_zone('UTC') - self.begin.in_time_zone('UTC')).to_i
+    end
+
+    def empty?
+      distance_in_seconds.zero?
+    end
+  end
+
   observe :contract
 
   # It is called 'manually' from Contract#notify_plan_changed
@@ -16,7 +25,7 @@ class BillingObserver < ActiveRecord::Observer
       last_midnight = Date.today.beginning_of_day
       period = RangeForVariableCost.new(period_from, last_midnight)
 
-      contract.bill_for_variable(period, current_invoice, plan)
+      contract.bill_for_variable(period, current_invoice, plan) unless period.try(:empty?)
     end
   end
 

--- a/features/finance/variable_cost.feature
+++ b/features/finance/variable_cost.feature
@@ -86,3 +86,19 @@ Feature: Variable cost on automatic billing
       | name                        | quantity |  cost     |
       | Hits                        |      500 |    50.00  |
       | Total cost                  |          |    50.00  |
+
+  Scenario: Variable cost in automated billing is always UTC
+    Given the provider time zone is "Pacific Time (US & Canada)"
+    And the buyer signed up for plan "VariableOnly" on 31st January 2019 22:00 PST
+    And the buyer makes a service transactions with:
+      | Metric   | Value  |
+      | hits     |    400 |
+    And time flies to 1st February 2019 12:00 PST
+    And the buyer makes a service transactions with:
+      | Metric   | Value  |
+      | hits     |    500 |
+    When time flies to 3rd March 2019
+    Then the buyer should have following line items for "February, 2019" invoice:
+      | name                        | quantity |  cost     |
+      | Hits                        |      900 |    90.00  |
+      | Total cost                  |          |    90.00  |

--- a/features/finance/variable_cost.feature
+++ b/features/finance/variable_cost.feature
@@ -1,0 +1,88 @@
+@stats
+Feature: Variable cost on automatic billing
+  As a provider I want to bill for variable cost
+
+  Background:
+    Given a provider with billing and finance enabled
+    Given all the rolling updates features are off
+    And the provider has one buyer
+    And the provider has a paid application plan "VariableOnly" of 0 per month
+    And pricing rules on plan "VariableOnly":
+      | Metric   | Cost per unit | Min   | Max      |
+      | hits     |           0.1 |     1 | infinity |
+
+  Scenario: Variable cost in the middle of the first month of a contract subscribed days before
+    Given the buyer signed up for plan "VariableOnly" on 10th January 2019
+    And time flies to 15th January 2019
+    And the buyer makes a service transactions with:
+      | Metric   | Value  |
+      | hits     |    400 |
+    When time flies to 3rd February 2019
+    Then the buyer should have following line items for "January, 2019" invoice:
+      | name                        | quantity |  cost     |
+      | Hits                        |      400 |    40.00  |
+      | Total cost                  |          |    40.00  |
+
+  Scenario: Variable cost in the middle of the first month of a contract subscribed on the same day
+    Given the buyer signed up for plan "VariableOnly" on 10th January 2019
+    And the buyer makes a service transactions with:
+      | Metric   | Value  |
+      | hits     |    400 |
+    When time flies to 3rd February 2019
+    Then the buyer should have following line items for "January, 2019" invoice:
+      | name                        | quantity |  cost     |
+      | Hits                        |      400 |    40.00  |
+      | Total cost                  |          |    40.00  |
+
+  Scenario: Variable cost on the first day of the month of a new contract
+    Given the buyer signed up for plan "VariableOnly" on 1st January 2019
+    And the buyer makes a service transactions with:
+      | Metric   | Value  |
+      | hits     |    400 |
+    When time flies to 3rd February 2019
+    Then the buyer should have following line items for "January, 2019" invoice:
+      | name                        | quantity |  cost     |
+      | Hits                        |      400 |    40.00  |
+      | Total cost                  |          |    40.00  |
+
+  Scenario: Variable cost on the last day of the first month of a contract subscribed days before that
+    Given the buyer signed up for plan "VariableOnly" on 10th January 2019
+    And time flies to 31st January 2019
+    And the buyer makes a service transactions with:
+      | Metric   | Value  |
+      | hits     |    400 |
+    When time flies to 3rd February 2019
+    Then the buyer should have following line items for "January, 2019" invoice:
+      | name                        | quantity |  cost     |
+      | Hits                        |      400 |    40.00  |
+      | Total cost                  |          |    40.00  |
+
+  Scenario: Variable cost on the last day of the first month of a contract subscribed on the same day
+    Given the buyer signed up for plan "VariableOnly" on 31st January 2019
+    And the buyer makes a service transactions with:
+      | Metric   | Value  |
+      | hits     |    400 |
+    When time flies to 3rd February 2019
+    Then the buyer should have following line items for "January, 2019" invoice:
+      | name                        | quantity |  cost     |
+      | Hits                        |      400 |    40.00  |
+      | Total cost                  |          |    40.00  |
+
+  Scenario: Variable cost on the last day of the first month of a contract subscribed on the same day and other months
+    Given the buyer signed up for plan "VariableOnly" on 31st January 2019
+    And the buyer makes a service transactions with:
+      | Metric   | Value  |
+      | hits     |    400 |
+    And time flies to 1st February 2019
+    And the buyer makes a service transactions with:
+      | Metric   | Value  |
+      | hits     |    500 |
+    When time flies to 3rd March 2019
+    Then the buyer should have following line items for "January, 2019" invoice:
+      | name                        | quantity |  cost     |
+      | Hits                        |      400 |    40.00  |
+      | Total cost                  |          |    40.00  |
+    Then the buyer should have following line items for "February, 2019" invoice:
+      | name                        | quantity |  cost     |
+      | Hits                        |      500 |    50.00  |
+      | Total cost                  |          |    50.00  |

--- a/features/step_definitions/account_steps.rb
+++ b/features/step_definitions/account_steps.rb
@@ -100,6 +100,10 @@ Then /^(provider "[^"]*") time zone should be "([^"]*)"$/ do |provider, time_zon
   provider.timezone.should == time_zone
 end
 
+Then /^the provider time zone is "([^"]*)"$/ do |time_zone|
+  @provider.update_column(:timezone, time_zone)
+end
+
 Then /^(account "[^"]*") should be (provider|buyer|master)$/ do |account,type|
   assert account.send("#{type}?"), "Account '#{account.org_name}' is not a #{type}"
 end

--- a/features/step_definitions/plans/application_plans_steps.rb
+++ b/features/step_definitions/plans/application_plans_steps.rb
@@ -66,17 +66,6 @@ When /^I change application plan to "([^"]*)"$/ do |name|
   current_account.bought_cinstance.change_plan!(plan)
 end
 
-When /^I change application plan to "([^"]*)" on (.*)$/ do |name,date|
-  # this ensures billing actions are run
-  step %(time flies to #{date})
-
-  # and then we freeze the time
-  Timecop.freeze(Time.zone.parse(date)) do
-    step %(I change application plan to "#{name}")
-  end
-end
-
-
 Then /^(plan "[^\"]*") should be published$/ do |plan|
   assert plan.published?
 end

--- a/features/step_definitions/timecop_steps.rb
+++ b/features/step_definitions/timecop_steps.rb
@@ -37,7 +37,7 @@ end
 
 # Sufix 'on 5th July 2009'
 #
-Then /^(.+) on (\d+(?:th|st|nd|rd) \S* \d{4})$/ do |original, date|
+Then /^(.+) on (\d+(?:th|st|nd|rd) \S* \d{4}(?: .*)?)$/ do |original, date|
   # this ensures billing actions are run
   step %(time flies to #{date})
   # and then we freeze the time
@@ -59,4 +59,3 @@ Then /^the (?:date|time) should be (.*)$/ do |time|
   # if you really need full precision you should write another step
   assert_equal Time.zone.parse(time).beginning_of_hour, Time.zone.now.beginning_of_hour
 end
-


### PR DESCRIPTION
**What this PR does / why we need it**
This PR fixes an edge case of applications that signup on the last day of the month and generate variable cost on the first day of contract. Automated billing process fail to account the hits of this last day of the month.

This is initially because `variable_cost_paid_until` is `nil` when billing runs for the first time and gets replaced by `trial_period_expires_at || created_at` (the signup timestamp). A safe guard conditional of `Finance::VariableCost::bill_for_variable` that prevents paid contracts from being billed in duplicity performs a date comparison between `variable_cost_paid_until` and the end of billing period. Since the signup day in this case coincides with the end of the period, the variable cost is not accounted. In the month after that when billing runs again on the first day of the month, another safe guard ensures only variable cost generated within the period is accounted, again leaving that first day of traffic out of math.

**Which issue(s) this PR fixes** 
Closes [THREESCALE-534](https://issues.jboss.org/browse/THREESCALE-534)

**Verification steps** 
1. On the last day of the month, signup to an application plan with variable cost
2. Generate traffic enough to expect an invoice including variable cost
3. Wait until billing finishes on day 1 of the next month (the day after signing up)
4. You should now see an invoice that includes the variable cost corresponding to the traffic generated at step 2

**Special notes for your reviewer**
The PR adds tests for the following scenarios all without plan changes, simulating automated billing on postpaid:

1. Variable cost in the middle of the first month of a contract subscribed days before
2. Variable cost in the middle of the first month of a contract subscribed on the same day
3. Variable cost on the first day of the month of a new contract
4. Variable cost on the last day of the first month of a contract subscribed days before that
5. Variable cost on the last day of the first month of a contract subscribed on the same day
6. Variable cost on the last day of the first month of a contract subscribed on the same day and other months

Without the fix, scenarios 5 and 6 fail.