### PR TITLE
Fixes THREESCALE-1922: Typo for HTTP Basic Authentication

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1100,7 +1100,7 @@ en:
     credentials_location:
       headers: "As HTTP Headers"
       query: "As query parameters (GET) or body parameters (POST/PUT/DELETE)"
-      authorization: "As HTTP Basic Authorization"
+      authorization: "As HTTP Basic Authentication"
 
   formtastic:
     hints:

--- a/features/provider/integration/edit.feature
+++ b/features/provider/integration/edit.feature
@@ -19,7 +19,7 @@ Feature: Edit Integration
     Given the service uses app_id/app_key as authentication method
     And I go to the service integration page
     And I toggle "Authentication Settings"
-    When I choose "As HTTP Basic Authorization"
+    When I choose "As HTTP Basic Authentication"
     Then The curl command uses Basic Authentication with app_id/app_key credentials
     When I choose "As query parameters (GET) or body parameters (POST/PUT/DELETE)"
     Then The curl command uses Query with app_id/app_key credentials


### PR DESCRIPTION
Changing "As HTTP Basic Authorization" to "As HTTP Basic Authorization"

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1922

**Verification steps** 

Go to Service integration > Edit APIcast configuration > Authentication settings > Credential locations

One label  should be set to  "As HTTP Basic Authentication"
