### PR TITLE
[Docs] Specify that ServiceContracts belongs to Account Management API

### DIFF
--- a/app/controllers/admin/api/service_contracts_controller.rb
+++ b/app/controllers/admin/api/service_contracts_controller.rb
@@ -9,6 +9,7 @@ class Admin::Api::ServiceContractsController < Admin::Api::ServiceBaseController
 
 
   ##~ e = sapi.apis.add
+  ##~ sapi = source2swagger.namespace("Account Management API")
   ##~ e.path = "/admin/api/accounts/{account_id}/service_contracts.xml"
   ##~ e.responseClass = "service_contract"
   #


### PR DESCRIPTION
ServiceContracts belongs to `Account Management API`, but it is not specifically specified so right now it is correct but when I added a new API for https://github.com/3scale/porta/pull/593 and I generate the docs, this automatically goes there because it is not specifically defined, and that would be wrong.
I make a PR specifically for this because it is a bit unrelated to the other PR, just a side effect of it, and as it is already big and complicated enough, it is better to have this separately.