### PR TITLE
THREESCALE-940 Forbid bypassing SSL when host starts with system-

### DIFF
--- a/openshift/system/config/settings.yml
+++ b/openshift/system/config/settings.yml
@@ -1,6 +1,6 @@
 base: &default
   superdomain: <%= superdomain = ENV.fetch('THREESCALE_SUPERDOMAIN', 'example.com') %>
-  apicast_internal_host_regexp: '\Asystem-(.*)\Z'
+  apicast_internal_host_regexp: '\Asystem-(master|provider|developer)\Z'
   secure_cookie: true
   force_ssl: true
   apicast_oauth: true


### PR DESCRIPTION
**What this PR does / why we need it**:

When making a request from internal pods to system-app in OpenShift we use system-master, system-provider or system-developer services.
Those requests are using plain HTTP. Other requests should use HTTPS.

Any other requests coming from system-* host will be redirected to SSL


**Which issue(s) this PR fixes** 

Fixes https://issues.jboss.org/browse/THREESCALE-940