### PR TITLE
[THREESCALE-1840] Hide credentials forms when HTTP Basic Authentication es selected

### DIFF
--- a/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
@@ -214,6 +214,7 @@ $(document).on 'initialize', '#proxy', ->
     elt.value = switch proxy_credentials_location_value
       when 'headers' then elt.value.replace(/_/g,'-')
       when 'query' then elt.value.replace(/-/g,'_')
+      else elt.value
 
   $(document).on 'change', 'input[name="proxy[credentials_location]"]', (event) ->
     proxy_credentials_location_value = this.value

--- a/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
@@ -209,7 +209,9 @@ $(document).on 'initialize', '#proxy', ->
 
   proxy_credentials_location_value = $('input[name="proxy[credentials_location]"]:checked').val()
   credentials_forms = document.querySelectorAll('li[id^="proxy_auth_"]')
-  credentials_forms.forEach((el) -> el.classList.toggle('hidden', proxy_credentials_location_value is 'authorization'))
+
+  toggle_hidden_credentials_forms = () ->
+    credentials_forms.forEach((el) -> el.classList.toggle('hidden', proxy_credentials_location_value is 'authorization'))
 
   replace_hyphens_or_underscores = (elt) ->
     return unless elt
@@ -222,7 +224,7 @@ $(document).on 'initialize', '#proxy', ->
     proxy_credentials_location_value = this.value
     replace_hyphens_or_underscores(document.getElementById('proxy_auth_user_key'))
     toggle_form_changed_ui()
-    credentials_forms.forEach((el) -> el.classList.toggle('hidden', proxy_credentials_location_value is 'authorization'))
+    toggle_hidden_credentials_forms()
 
   $(document).on 'input', 'input#proxy_auth_user_key', (event) ->
     replace_hyphens_or_underscores(this)

--- a/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
@@ -208,10 +208,10 @@ $(document).on 'initialize', '#proxy', ->
     false
 
   proxy_credentials_location_value = $('input[name="proxy[credentials_location]"]:checked').val()
-  credentials_forms = document.querySelectorAll('li[id^="proxy_auth_"]')
+  credentials_forms = $('li[id^="proxy_auth_"]')
 
-  toggle_hidden_credentials_forms = () ->
-    credentials_forms.forEach((el) -> el.classList.toggle('hidden', proxy_credentials_location_value is 'authorization'))
+  toggle_hidden_credentials_forms = () -> credentials_forms.toggleClass('hidden', proxy_credentials_location_value is 'authorization')
+  toggle_hidden_credentials_forms()
 
   replace_hyphens_or_underscores = (elt) ->
     return unless elt

--- a/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
@@ -208,6 +208,8 @@ $(document).on 'initialize', '#proxy', ->
     false
 
   proxy_credentials_location_value = $('input[name="proxy[credentials_location]"]:checked').val()
+  credentials_forms = document.querySelectorAll('li[id^="proxy_auth_"]')
+  credentials_forms.forEach((el) -> el.classList.toggle('hidden', proxy_credentials_location_value is 'authorization'))
 
   replace_hyphens_or_underscores = (elt) ->
     return unless elt
@@ -220,6 +222,7 @@ $(document).on 'initialize', '#proxy', ->
     proxy_credentials_location_value = this.value
     replace_hyphens_or_underscores(document.getElementById('proxy_auth_user_key'))
     toggle_form_changed_ui()
+    credentials_forms.forEach((el) -> el.classList.toggle('hidden', proxy_credentials_location_value is 'authorization'))
 
   $(document).on 'input', 'input#proxy_auth_user_key', (event) ->
     replace_hyphens_or_underscores(this)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds class `hidden` to cred forms whenever _HTTP Basic Authentication_ option is selected.

**Which issue(s) this PR fixes** 

[THREESCALE-1840: Header undefined when choosing HTTP Authentication in service integration](https://issues.jboss.org/browse/THREESCALE-1840)

**Verification steps** 

1. Integration -> Configuration -> Edit APIcast settings
2. (With User Key auth mode) Change _Credentials location_, verify user-key hides when _HTTP Basic Auth_ is selected
3. (With App ID and App Key pair) Change _Credentials location_, verify app-id, app-key hides when _HTTP Basic Auth_ is selected

![auth-pull](https://user-images.githubusercontent.com/11672286/52944055-d38a8300-336e-11e9-85f9-6d139faf22fd.gif)

