### PR TITLE
Postgres timezone setting

### DIFF
--- a/config/docker/database.yml
+++ b/config/docker/database.yml
@@ -3,8 +3,11 @@ base: &default
 <% case ENV['DB']
    when 'oracle' %>
   adapter: oracle_enhanced
+  time_zone: 'UTC'
 <% when 'postgresql' %>
   adapter: postgresql
+  variables:
+    timezone: 'UTC'
 <% else %>
   adapter: mysql2
 <% end %>

--- a/config/examples/database.yml
+++ b/config/examples/database.yml
@@ -25,7 +25,8 @@ default: &DEFAULT
   password:
   database: systemdb
   host: <%= ENV.fetch('DB_PORT_3306_TCP_ADDR') { ENV['DB_PORT'] ? 'db' : ENV['DB_HOST'] } || '127.0.0.1' %>
-  time_zone: 'UTC'
+  variables:
+    timezone: 'UTC'
   pool: <%= ENV.fetch('RAILS_MAX_THREADS', 25) %>
 
 production:

--- a/openshift/system/config/database.yml
+++ b/openshift/system/config/database.yml
@@ -3,8 +3,11 @@ base: &default
 <% case ENV['DB']
    when 'oracle' %>
   adapter: oracle_enhanced
+  time_zone: 'UTC'
 <% when 'postgresql' %>
   adapter: postgresql
+  variables:
+    timezone: 'UTC'
 <% else %>
   adapter: mysql2
 <% end %>


### PR DESCRIPTION
**What this PR does / why we need it**
This PR fixes the setting of the postgres database timezone.

**Which issue(s) this PR fixes**
Some tests involving date comparison may pass on local (development) environment where TZ is other than UTC but still fail in CI. Example: https://github.com/3scale/porta/blob/2bb337a7a71bd1c116b0439dbcbe4eef2c5dde42/features/finance/automatic_billing_postpaid.feature#L78-L99

**Special notes for the reviewer**
This was originally considered as a fix for tests later known to be failing not because of timezone but rather due to Postgres timestamp/ordering issues. See https://github.com/3scale/porta/pull/617.