### PR TITLE
Fixes Codeclimate by encapsulating ReactWrapper

### DIFF
--- a/app/javascript/src/Dashboard/components/ApiFilter.jsx
+++ b/app/javascript/src/Dashboard/components/ApiFilter.jsx
@@ -6,7 +6,8 @@ import 'core-js/es6/set'
 import 'core-js/es6/array'
 
 import React from 'react'
-import { render } from 'react-dom'
+
+import { createReactWrapper } from 'utilities/createReactWrapper'
 
 import 'Dashboard/styles/dashboard.scss'
 
@@ -37,12 +38,6 @@ const ApiFilter = ({ apis, displayApis }: Props) => {
   )
 }
 
-const ApiFilterWrapper = (props: Props, element: string) => {
-  const container = document.getElementById(element)
-  if (container == null) {
-    throw new Error(`${element} is not part of the DOM`)
-  }
-  render(<ApiFilter {...props} />, container)
-}
+const ApiFilterWrapper = (props: Props, containerId: string) => createReactWrapper(<ApiFilter {...props} />, containerId)
 
 export { ApiFilter, ApiFilterWrapper }

--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -6,12 +6,12 @@ import 'core-js/es6/set'
 import 'core-js/es6/array'
 
 import React from 'react'
-import { render } from 'react-dom'
 import { ActiveMenuTitle } from 'Navigation/components/ActiveMenuTitle'
+import { createReactWrapper } from 'utilities/createReactWrapper'
 
 import 'Navigation/styles/ContextSelector.scss'
 
-import type { Api, Service, Menu, ReactWrapper } from 'Types'
+import type { Api, Service, Menu } from 'Types'
 
 type Props = {
   apis: Api[],
@@ -139,12 +139,6 @@ class ContextSelector extends React.Component<Props, State> {
   }
 }
 
-const ContextSelectorWrapper: ReactWrapper<Props> = (props, elementId) => {
-  const element = document.getElementById(elementId)
-  if (element == null) {
-    throw new Error(`${elementId} is not part of the DOM`)
-  }
-  render(<ContextSelector {...props} />, element)
-}
+const ContextSelectorWrapper = (props: Props, containerId: string) => createReactWrapper(<ContextSelector {...props} />, containerId)
 
 export { ContextSelector, ContextSelectorWrapper }

--- a/app/javascript/src/Types/ReactWrapper.jsx
+++ b/app/javascript/src/Types/ReactWrapper.jsx
@@ -1,3 +1,0 @@
-// @flow
-
-export type ReactWrapper<Props> = (Props, string) => void

--- a/app/javascript/src/Types/index.js
+++ b/app/javascript/src/Types/index.js
@@ -3,4 +3,3 @@
 export * from 'Types/Api'
 export * from 'Types/Service'
 export * from 'Types/NavigationTypes'
-export * from 'Types/ReactWrapper'

--- a/app/javascript/src/utilities/createReactWrapper.jsx
+++ b/app/javascript/src/utilities/createReactWrapper.jsx
@@ -1,0 +1,13 @@
+// @flow
+
+import { render } from 'react-dom'
+
+export function createReactWrapper <ElementType: React$ElementType> (element: React$Element<ElementType>, containerId: string) {
+  const container = document.getElementById(containerId)
+
+  if (container == null) {
+    throw new Error(`${containerId} is not part of the DOM`)
+  }
+
+  render(element, container)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

We render React components in rails by using a `ReactWrapper` function. It simply is a function that gets the props and a element id and calls `React#render`.

However Codeclimate has been complaining since the wrapper has grown in complexity (undefined-check for `document#getElementById`).

By encapsulating this logic, Codeclimate won't complain again.

**Verification steps** 

1. Codeclimate does not complain when adding new Components in rails.
2. Components render as expected (like ContextSelector and ApiSearch)

**Special notes for your reviewer**:
