### PR TITLE
[billing] Refactor postpaid plan change

### DIFF
--- a/app/lib/finance/fixed_fee.rb
+++ b/app/lib/finance/fixed_fee.rb
@@ -8,13 +8,13 @@ module Finance
 
     protected
 
-    def bill_fixed_fee_for(period, invoice)
+    def bill_fixed_fee_for(period, invoice, plan = self.plan)
       fixed_cost = plan.cost_for_period(period)
       if fixed_cost.nonzero?
         Finance::BackgroundBilling.new(invoice).create_line_item!(
           {
             contract: self,
-            plan_id: plan_id,
+            plan_id: plan.id,
             name: "Fixed fee ('#{plan.name}')",
             description: period.to_time_range.to_s,
             quantity: 1,

--- a/app/lib/finance/setup_fee.rb
+++ b/app/lib/finance/setup_fee.rb
@@ -3,12 +3,12 @@ module Finance
 
     protected
 
-    def bill_setup_fee_for(period, invoice)
+    def bill_setup_fee_for(period, invoice, plan = self.plan)
       if setup_fee && setup_fee.nonzero?
         Finance::BackgroundBilling.new(invoice).create_line_item!(
           {
             contract: self,
-            plan_id: plan_id,
+            plan_id: plan.id,
             name: "Setup fee ('#{plan.name}')",
             cost: setup_fee,
             type: LineItem::PlanCost

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -152,7 +152,7 @@ class Contract < ApplicationRecord
   #
   # @param [Month] period
   # @param [Invoice] invoice
-  def bill_for(period, invoice)
+  def bill_for(period, invoice, plan = self.plan)
     # TODO: this makes the bill_for method dependent on Time.zone.now
     # so it should be handled differently
     #
@@ -160,14 +160,15 @@ class Contract < ApplicationRecord
 
     transaction do
       if paid_until.to_date < period.end.to_date
+
         period = intersect_with_unpaid_period(period, paid_until)
 
-        bill_fixed_fee_for(period, invoice)
+        bill_fixed_fee_for(period, invoice, plan)
 
         self.paid_until = period.end
       end
 
-      bill_setup_fee_for(period, invoice)
+      bill_setup_fee_for(period, invoice, plan)
 
       # no validation because our DB has broken data
       # TODO: cleanup DB and add validations?

--- a/app/models/finance/billing_strategy.rb
+++ b/app/models/finance/billing_strategy.rb
@@ -391,16 +391,16 @@ class Finance::BillingStrategy < ApplicationRecord
     if cost.nonzero?
       sign = action == :refund ? -1 : 1
       reason = action == :refund ? 'Refund' : 'Fixed fee'
-      add_cost(contract, "#{reason} ('#{plan.name}')", period.to_s, cost * sign)
+      add_cost(contract, "#{reason} ('#{plan.name}')", period.to_s, cost * sign, plan)
     end
   end
 
-  def add_cost(contract, name, description, cost)
+  def add_cost(contract, name, description, cost, plan = contract.plan)
     invoice = invoice_for_cinstance(contract)
     Finance::BackgroundBilling.new(invoice).create_line_item!(
       {
         contract: contract,
-        plan_id: contract.plan_id,
+        plan_id: plan.id,
         name: name,
         description: description,
         quantity: 1,

--- a/app/models/finance/postpaid_billing_strategy.rb
+++ b/app/models/finance/postpaid_billing_strategy.rb
@@ -37,15 +37,10 @@ class Finance::PostpaidBillingStrategy < Finance::BillingStrategy
   def bill_plan_change(contract, period)
     plan = contract.plan
     old_plan = contract.old_plan
-    period_begin = period.begin.utc
-    period_end = period.end.utc
-    paid_until = contract.paid_until.utc
 
-    if paid_until < period_begin # This is only for fixed cost, so it means billing didn't run yet for the contract in the period
-      old_plan_period_begin = [paid_until, period_begin.beginning_of_month].max
-      old_plan_period = TimeRange.new(old_plan_period_begin, period_end)
-      add_plan_cost(:bill, contract, old_plan, old_plan_period)
-    end
+    period_begin = period.begin
+    invoice = invoice_for(contract.user_account, period_begin)
+    contract.bill_for(Month.new(period_begin), invoice, old_plan)
 
     add_plan_cost(:refund, contract, old_plan, period)
     add_plan_cost(:bill, contract, plan, period)

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -25,7 +25,7 @@ class LineItem < ApplicationRecord
       where(["#{table_name}.created_at <= ? AND #{table_name}.finished_at >= ?", time, time])
   }
 
-  scope :oldest_first, -> { order(:created_at) }
+  scope :oldest_first, -> { unscope(:order).order(:id) }
 
   delegate :currency, :buyer_account, :to => :invoice, :allow_nil => true
 

--- a/features/finance/automatic_billing_postpaid.feature
+++ b/features/finance/automatic_billing_postpaid.feature
@@ -38,6 +38,21 @@ Feature: Automatic billing with plan changes on POSTPAID
       | Fixed fee ('Paid')          |          |     31.00 |
       | Total cost                  |          |     31.00 |
 
+  Scenario: Monthly fee on application plan downgrading in the middle of the same day
+    Given all the rolling updates features are off
+    And the date is 1st January 2017
+    And the buyer signed up for plan "Expensive"
+    And the date is 1st January 2017 12:00
+    Then the buyer changed to plan "Paid"
+    When time flies to 3rd February 2017
+
+    Then the buyer should have following line items for "January, 2017" invoice:
+      | name                        | quantity |   cost    |
+      | Fixed fee ('Expensive')     |          |  3,100.00 |
+      | Refund ('Expensive')        |          | -3,050.00 |
+      | Fixed fee ('Paid')          |          |     30.50 |
+      | Total cost                  |          |     80.50 |
+
   Scenario: Monthly fee on application plan downgrading on different day
     Given all the rolling updates features are off
     And the date is 1st January 2017 UTC
@@ -57,7 +72,7 @@ Feature: Automatic billing with plan changes on POSTPAID
   Scenario: Monthly fee on several application plan upgrades in the middle of the month
     Given all the rolling updates features are off
     And the provider has a third paid application plan "ExpensiveAsHell" of 310000 per month
-    And the date is 1st January 2017 UTC
+    And the date is 1st January 2017
     And the buyer signed up for plan "Paid"
     And time flies to 2nd January 2017
     Then the buyer changed to plan "Expensive"


### PR DESCRIPTION
Refactors `Finance::PostpaidBillingStrategy#bill_plan_change` to use `Contract#bill_for` instead of duplicating logic.

It also introduces another test for plan changes in the middle of the day, specially targeting Postgres timestamp and ordering issues.

Related to https://github.com/3scale/porta/pull/588