### PR TITLE
Update newrelic_rpm in Prod Gemfile

### DIFF
--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -458,7 +458,7 @@ GEM
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
     netrc (0.11.0)
-    newrelic_rpm (5.6.0.349)
+    newrelic_rpm (5.7.0.350)
     nokogiri (1.9.1)
       mini_portile2 (~> 2.4.0)
     non-stupid-digest-assets (1.0.9)


### PR DESCRIPTION
I did `make bundle` after adding a Gem in https://github.com/3scale/porta/pull/593 and it also updated Nokogiri for this Gemfile. But it does not belong to that PR as said in [here](https://github.com/3scale/porta/pull/593#discussion_r257736973).