### PR TITLE
[Bugfix][Test] search user_key without keyword with many records is always indexed and found

### DIFF
--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -116,11 +116,13 @@ class Account::SearchTest < ActiveSupport::TestCase
   test 'search user_key without keyword with many records is always indexed and found' do
     service = FactoryBot.create(:simple_service)
     buyer = FactoryBot.create(:simple_buyer)
-    FactoryBot.create_list(:application_plan, 5, issuer: service).each do |plan|
-      plan.create_contract_with!(buyer)
+    FactoryBot.create_list(:application_plan, 5, issuer: service).each_with_index do |plan, index|
+      contract = plan.create_contract_with!(buyer)
+      contract.update_column(:user_key, (index.to_s * 256))
     end
 
     ThinkingSphinx::Test.run do
+      ThinkingSphinx::Test.config
       ThinkingSphinx::Test.index
 
       buyer.bought_cinstances.pluck(:user_key).each do |user_key|


### PR DESCRIPTION
This PR fixes 2 issues of the same test:
1. It makes the user_key to have 256 characters (the default one has 32 characters), which is the maximum allowed for that attribute. This way we ensure we are indexing `256 * 5 = 1280`, which is more than the default `1024`.
2. The test is sometimes failing in CircleCI, as it if it wasn't indexed. The problem is not the execution code itself but an issue in the test that this PR fixes (the `ThinkingSphinx::Test.config`)