### PR TITLE
Destroy EndUsers of a Service when the Service is destroyed

### DIFF
--- a/app/events/notification_event.rb
+++ b/app/events/notification_event.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class NotificationEvent < BaseEventStoreEvent
 
   # Create Notification Event
 
   def self.create(system_name, event)
-    provider_id = event.provider.try!(:id)
+    provider_id = event.try(:provider)&.id || event.metadata[:provider_id]
 
     new(
       parent_event_id: event.event_id,

--- a/app/events/services/service_deleted_event.rb
+++ b/app/events/services/service_deleted_event.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class Services::ServiceDeletedEvent < ServiceRelatedEvent
   def self.create(service)
-    provider = service.provider
+    provider = service.account || Account.new({id: service.tenant_id}, without_protection: true)
 
     new(
       service_id:   service.id,

--- a/app/events/services/service_deleted_event.rb
+++ b/app/events/services/service_deleted_event.rb
@@ -4,13 +4,15 @@ class Services::ServiceDeletedEvent < ServiceRelatedEvent
   def self.create(service)
     provider = service.account || Account.new({id: service.tenant_id}, without_protection: true)
 
-    new(
+    data = {
       service_id:   service.id,
       service_name: service.name,
-      provider:     provider,
       metadata: {
         provider_id: provider.id
       }
-    )
+    }
+    data[:provider] = provider if provider.persisted?
+
+    new(data)
   end
 end

--- a/app/lib/event_store/repository.rb
+++ b/app/lib/event_store/repository.rb
@@ -153,6 +153,7 @@ module EventStore
                      )
       subscribe_event(ServiceTokenEventSubscriber.new, ServiceTokenDeletedEvent)
       subscribe_event(ServiceDeletionSubscriber.new, Services::ServiceScheduledForDeletionEvent)
+      subscribe_event(ServiceDeletedSubscriber.new, Services::ServiceDeletedEvent)
       subscribe_event(ZyncSubscriber.new, ZyncEvent)
     end
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -371,7 +371,7 @@ class NotificationMailer < ActionMailer::Base
   # @param [User] received
   delivers Services::ServiceDeletedEvent
   def service_deleted(event, receiver)
-    @provider_account = event.provider
+    @provider_account = Account.find(event.metadata[:provider_id])
     @receiver         = receiver
     @service_name     = event.service_name
     @event            = event

--- a/app/subscribers/service_deleted_subscriber.rb
+++ b/app/subscribers/service_deleted_subscriber.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ServiceDeletedSubscriber < AfterCommitSubscriber
+  def after_commit(event)
+    case event
+    when Services::ServiceDeletedEvent
+      BackendDeleteEndUsersWorker.perform_async(event.service_id)
+    else
+      raise "Unknown event type #{event.class}"
+    end
+  end
+end

--- a/app/subscribers/service_deleted_subscriber.rb
+++ b/app/subscribers/service_deleted_subscriber.rb
@@ -3,10 +3,8 @@
 class ServiceDeletedSubscriber < AfterCommitSubscriber
   def after_commit(event)
     case event
-    when Services::ServiceDeletedEvent
-      BackendDeleteEndUsersWorker.perform_async(event.service_id)
-    else
-      raise "Unknown event type #{event.class}"
+    when Services::ServiceDeletedEvent then BackendDeleteEndUsersWorker.enqueue(event)
+    else raise "Unknown event type #{event.class}"
     end
   end
 end

--- a/app/workers/backend_delete_end_users_worker.rb
+++ b/app/workers/backend_delete_end_users_worker.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BackendDeleteEndUsersWorker
+  include Sidekiq::Worker
+
+  def perform(service_id)
+    ThreeScale::Core::User.delete_all_for_service(service_id)
+  end
+end

--- a/app/workers/backend_delete_end_users_worker.rb
+++ b/app/workers/backend_delete_end_users_worker.rb
@@ -3,7 +3,12 @@
 class BackendDeleteEndUsersWorker
   include Sidekiq::Worker
 
-  def perform(service_id)
-    ThreeScale::Core::User.delete_all_for_service(service_id)
+  def self.enqueue(event)
+    perform_async(event.event_id)
+  end
+
+  def perform(event_id)
+    event = EventStore::Repository.find_event!(event_id)
+    ThreeScale::Core::User.delete_all_for_service(event.service_id)
   end
 end

--- a/test/events/services/service_deleted_event_test.rb
+++ b/test/events/services/service_deleted_event_test.rb
@@ -12,7 +12,6 @@ class Services::ServiceDeletedEventTest < ActiveSupport::TestCase
     assert event
     assert event.service_name, service.name
     assert event.service_id, service.id
-    assert event.provider, service.provider
   end
 
   def test_ability

--- a/test/events/services/service_deleted_event_test.rb
+++ b/test/events/services/service_deleted_event_test.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Services::ServiceDeletedEventTest < ActiveSupport::TestCase
+  disable_transactional_fixtures!
 
   def test_create
     service = FactoryBot.build_stubbed(:simple_service, id: 1, name: 'Alaska')
@@ -30,5 +33,19 @@ class Services::ServiceDeletedEventTest < ActiveSupport::TestCase
 
     assert_cannot Ability.new(member), :show, event
     assert_can Ability.new(admin), :show, event
+  end
+
+  def test_create_and_publish_when_provider_does_not_exists_anymore
+    provider = FactoryBot.create(:simple_provider)
+    service = FactoryBot.create(:simple_service, account: provider)
+
+    provider_id = provider.id
+    provider.delete
+
+    event = Services::ServiceDeletedEvent.create(service.reload)
+    Rails.application.config.event_store.publish_event(event)
+
+    event_stored = EventStore::Repository.find_event!(event.event_id)
+    assert_equal provider_id, event_stored.metadata.fetch(:provider_id)
   end
 end

--- a/test/functional/master/api/services_controller_test.rb
+++ b/test/functional/master/api/services_controller_test.rb
@@ -22,9 +22,12 @@ class Master::Api::ServicesControllerTest < ActionController::TestCase
     service   = FactoryBot.create(:simple_service, account: provider)
     app_plan  =  FactoryBot.create(:simple_application_plan, cinstances: [cinstance], issuer: service)
 
-    method_event_count = RailsEventStoreActiveRecord::Event.where(event_type: %w[Services::ServiceDeletedEvent NotificationEvent]).method(:count)
-    assert_difference(method_event_count, +2) do
-      delete :destroy, id: service.id, provider_id: provider.id, api_key: master_account.provider_key
+    method_service_deleted_event_count = RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceDeletedEvent).method(:count)
+    method_notification_event_count    = RailsEventStoreActiveRecord::Event.where(event_type: NotificationEvent).method(:count)
+    assert_difference(method_notification_event_count, +1) do
+      assert_difference(method_service_deleted_event_count, +1) do
+        delete :destroy, id: service.id, provider_id: provider.id, api_key: master_account.provider_key
+      end
     end
 
     assert_response 200

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -500,7 +500,8 @@ class NotificationMailerTest < ActionMailer::TestCase
   end
 
   def test_service_deleted
-    service = FactoryBot.build_stubbed(:simple_service, account: provider)
+    persisted_provider = FactoryBot.create(:simple_provider)
+    service = FactoryBot.build_stubbed(:simple_service, account: persisted_provider)
     event   = Services::ServiceDeletedEvent.create(service)
     mail    = NotificationMailer.service_deleted(event, receiver)
 
@@ -508,7 +509,7 @@ class NotificationMailerTest < ActionMailer::TestCase
 
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match "The service #{service.name} has been deleted.", body.encoded
-      assert_match url_helpers.provider_admin_dashboard_url(host: provider.admin_domain), body.encoded
+      assert_match url_helpers.provider_admin_dashboard_url(host: persisted_provider.admin_domain), body.encoded
     end
   end
 

--- a/test/subscribers/service_deleted_subscriber_test.rb
+++ b/test/subscribers/service_deleted_subscriber_test.rb
@@ -7,7 +7,7 @@ class ServiceDeletedSubscriberTest < ActiveSupport::TestCase
     service = FactoryBot.build_stubbed(:simple_service)
     event = Services::ServiceDeletedEvent.create(service)
 
-    BackendDeleteEndUsersWorker.expects(:perform_async).with(service.id)
+    BackendDeleteEndUsersWorker.expects(:enqueue).with(event)
 
     ServiceDeletedSubscriber.new.after_commit(event)
   end

--- a/test/subscribers/service_deleted_subscriber_test.rb
+++ b/test/subscribers/service_deleted_subscriber_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ServiceDeletedSubscriberTest < ActiveSupport::TestCase
+  def test_create
+    service = FactoryBot.build_stubbed(:simple_service)
+    event = Services::ServiceDeletedEvent.create(service)
+
+    BackendDeleteEndUsersWorker.expects(:perform_async).with(service.id)
+
+    ServiceDeletedSubscriber.new.after_commit(event)
+  end
+end

--- a/test/test_helpers/backend.rb
+++ b/test/test_helpers/backend.rb
@@ -46,7 +46,7 @@ module TestHelpers
         clear_method ThreeScale::Core::UsageLimit.singleton_class,
           :save, :load_value, :delete
         clear_method ThreeScale::Core::User.singleton_class,
-          :load
+          :load, :delete_all_for_service
         clear_method ThreeScale::Core::ApplicationKey.singleton_class,
           :save, :delete
         clear_method ThreeScale::Core::ApplicationReferrerFilter.singleton_class,

--- a/test/unit/services/notification_delivery_service_test.rb
+++ b/test/unit/services/notification_delivery_service_test.rb
@@ -49,8 +49,9 @@ class NotificationDeliveryServiceTest < ActiveSupport::TestCase
   end
 
   def test_empty_attribute_is_a_valid_event
+    provider = FactoryBot.create(:simple_provider)
     ['', []].each do |empty_value|
-      service = FactoryBot.build_stubbed(:simple_service, name: empty_value)
+      service = FactoryBot.build_stubbed(:simple_service, name: empty_value, account: provider)
       event = Services::ServiceDeletedEvent.create(service)
       notification = FactoryBot.build_stubbed(:notification, system_name: :service_deleted)
       notification.expects(:parent_event).returns(event)

--- a/test/workers/backend_delete_end_users_worker_test.rb
+++ b/test/workers/backend_delete_end_users_worker_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class BackendDeleteEndUsersWorkerTest < ActiveSupport::TestCase
+  test 'perform' do
+    service_id = FactoryBot.create(:simple_service).id
+
+    ThreeScale::Core::User.expects(:delete_all_for_service).with(service_id)
+
+    Sidekiq::Testing.inline! { BackendDeleteEndUsersWorker.perform_async(service_id) }
+  end
+end

--- a/test/workers/backend_delete_end_users_worker_test.rb
+++ b/test/workers/backend_delete_end_users_worker_test.rb
@@ -4,10 +4,12 @@ require 'test_helper'
 
 class BackendDeleteEndUsersWorkerTest < ActiveSupport::TestCase
   test 'perform' do
-    service_id = FactoryBot.create(:simple_service).id
+    service = FactoryBot.create(:simple_service)
+    event = Services::ServiceDeletedEvent.create(service)
+    Rails.application.config.event_store.publish_event(event)
 
-    ThreeScale::Core::User.expects(:delete_all_for_service).with(service_id)
+    ThreeScale::Core::User.expects(:delete_all_for_service).with(service.id)
 
-    Sidekiq::Testing.inline! { BackendDeleteEndUsersWorker.perform_async(service_id) }
+    Sidekiq::Testing.inline! { BackendDeleteEndUsersWorker.enqueue(event) }
   end
 end

--- a/test/workers/process_notification_event_worker_test.rb
+++ b/test/workers/process_notification_event_worker_test.rb
@@ -37,11 +37,10 @@ class ProcessNotificationEventWorkerTest < ActiveSupport::TestCase
   end
 
   def test_create_notifications_with_master
-    master = Account.master rescue FactoryBot.create(:simple_master)
-    event  = CustomEvent.new(provider: master)
+    event  = CustomEvent.new(provider: master_account)
     notification = NotificationEvent.create(:application_created, event)
 
-    assert_equal master, @worker.create_notifications(notification)
+    assert_equal master_account, @worker.create_notifications(notification)
   end
 
   def test_skip_notifications_for_suspended_account


### PR DESCRIPTION
Part of [THREESCALE-1164 - Delete objects in Backend when the Provider is completely deleted for real](https://issues.jboss.org/browse/THREESCALE-1164)
Delete all end users of a Service when the Service is completely removed from System 😄 