### PR TITLE
Configurable deployment option labels for APIcast and Service Mesh

### DIFF
--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -83,4 +83,9 @@ module Api::IntegrationsHelper
   def deployment_option_is_service_mesh?(service)
     service.deployment_option =~ /^service_mesh/
   end
+
+  def edit_deployment_option_title(service)
+    title = deployment_option_is_service_mesh?(service) ? 'Service Mesh' : 'APIcast'
+    t(:edit_deployment_configuration, scope: :api_integrations_controller, deployment: title )
+  end
 end

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -1,9 +1,9 @@
 section.Configuration class=('Configuration--is-promoted' unless deployment_option_is_service_mesh?(@service)) class="Configuration--#{@show_presenter.test_state_modifier}"
 
-  = link_to 'edit APIcast configuration', edit_admin_service_integration_path(@service), class: 'SettingsBox-toggle'
+  = link_to edit_deployment_option_title(@service), edit_admin_service_integration_path(@service), class: 'SettingsBox-toggle'
 
   article.Configuration-summary data-state="open" class=("Environment--#{@show_presenter.test_state_modifier}" unless deployment_option_is_service_mesh?(@service))
-    h3.Configuration-title APIcast Configuration
+    h3.Configuration-title = deployment_option_is_service_mesh?(@service) ? 'Service mesh Configuration' : 'APIcast Configuration'
 
     dl.u-dl
       - unless deployment_option_is_service_mesh?(@service)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
     apicast_version_not_reverted: 'The APIcast version for this service could not be reverted'
     apicast_version_not_upgraded: 'The APIcast version for this service could not be upgraded'
     oidc_not_available_on_old_apicast: 'OpenID Connect is not supported for the old APIcast. Pick a different authentication option before reverting back.'
+    edit_deployment_configuration: 'edit %{deployment} configuration'
 
   access_token_options:
     finance: 'Billing API'


### PR DESCRIPTION
When choosing service mesh deployment option, the labels should use "Istio" and not "APIcast"
This is a small quick fix.

Before:

<img width="1662" alt="integrations_-_show___red_hat_3scale_api_management 1" src="https://user-images.githubusercontent.com/64276/53179713-8e778280-35f4-11e9-8cef-63d86dcbaff1.png">

After:

![screen shot 2019-02-21 at 16 24 48](https://user-images.githubusercontent.com/64276/53180152-5755a100-35f5-11e9-95ff-b27251a3c409.png)
