### PR TITLE
[THREESCALE-1947/THREESCALE-1949] adds checkboxes for oidc auth options

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -209,7 +209,8 @@ class Api::IntegrationsController < Api::BaseController
       :error_headers_auth_failed, :error_auth_failed, :error_status_auth_missing,
       :error_headers_auth_missing, :error_auth_missing, :error_status_no_match,
       :error_headers_no_match, :error_no_match, :api_test_path, :policies_config,
-      proxy_rules_attributes: [:_destroy, :id, :http_method, :pattern, :delta, :metric_id, :redirect_url]
+      proxy_rules_attributes: [:_destroy, :id, :http_method, :pattern, :delta, :metric_id, :redirect_url],
+      oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES
     ]
 
     if Rails.application.config.three_scale.apicast_custom_url || @proxy.saas_configuration_driven_apicast_self_managed?

--- a/app/models/cms/email_template.rb
+++ b/app/models/cms/email_template.rb
@@ -120,7 +120,6 @@ class CMS::EmailTemplate < CMS::Template
 
         unless email.join.split('@').last == domain
           errors.add(field, :wrong_domain)
-          #binding.pry
         end
       end
     end

--- a/app/models/oidc_configuration.rb
+++ b/app/models/oidc_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OIDCConfiguration < ApplicationRecord
   class Config < ActiveRecord::Coders::JSON
     include ActiveModel::Serialization
@@ -20,18 +22,18 @@ class OIDCConfiguration < ApplicationRecord
     BOOLEAN_ATTRIBUTES = FLOWS
 
     ATTRIBUTES = BOOLEAN_ATTRIBUTES
-    attr_accessor *ATTRIBUTES
+    attr_accessor(*ATTRIBUTES)
 
     # Defining accessor for boolean to always store `true` or `false`
     BOOLEAN_ATTRIBUTES.each do |attr|
       define_method "#{attr}=" do |value|
         # Always set to `true` or `false`
         # TODO: Rails 5.0 `#type_cast_from_database` will be replaced by `#cast`
-        instance_variable_set :"@#{attr}", !!ActiveRecord::Type::Boolean.new.type_cast_from_database(value)
+        instance_variable_set :"@#{attr}", !!ActiveRecord::Type::Boolean.new.type_cast_from_database(value) #rubocop:disable Style/DoubleNegation
       end
     end
 
-    def initialize(attributes={})
+    def initialize(attributes = {})
       assign_attributes(attributes)
     end
 
@@ -44,7 +46,7 @@ class OIDCConfiguration < ApplicationRecord
         public_send "#{attr}=", attributes[attr]
       end
     end
-    alias_method :attributes=, :assign_attributes
+    alias attributes= assign_attributes
 
     def attributes
       ATTRIBUTES.each_with_object(ActiveSupport::HashWithIndifferentAccess.new) do |attr, object|
@@ -56,8 +58,8 @@ class OIDCConfiguration < ApplicationRecord
   belongs_to :oidc_configurable, polymorphic: true
   serialize :config, OIDCConfiguration::Config
 
-  delegate *OIDCConfiguration::Config::ATTRIBUTES, to: :config
-  delegate *OIDCConfiguration::Config::ATTRIBUTES.map{|attr| "#{attr}=" }, to: :config
+  delegate(*OIDCConfiguration::Config::ATTRIBUTES, to: :config)
+  delegate(*OIDCConfiguration::Config::ATTRIBUTES.map {|attr| "#{attr}=" }, to: :config)
 
   # Always initialize a valid `config`
   after_initialize :config

--- a/app/models/oidc_configuration.rb
+++ b/app/models/oidc_configuration.rb
@@ -11,8 +11,10 @@ class OIDCConfiguration < ApplicationRecord
     end
 
     FLOWS = %i[
-      service_accounts_enabled standard_flow_enabled
-      implicit_flow_enabled direct_access_grants_enabled
+      standard_flow_enabled
+      implicit_flow_enabled
+      service_accounts_enabled
+      direct_access_grants_enabled
     ].freeze
 
     BOOLEAN_ATTRIBUTES = FLOWS

--- a/app/models/oidc_configuration.rb
+++ b/app/models/oidc_configuration.rb
@@ -1,0 +1,70 @@
+class OIDCConfiguration < ApplicationRecord
+  class Config < ActiveRecord::Coders::JSON
+    include ActiveModel::Serialization
+
+    def self.load(string)
+      new(super || {})
+    end
+
+    def self.dump(record)
+      super(record.attributes)
+    end
+
+    BOOLEAN_ATTRIBUTES = %i[
+      service_accounts_enabled standard_flow_enabled
+      implicit_flow_enabled direct_access_grants_enabled
+    ].freeze
+
+    ATTRIBUTES = BOOLEAN_ATTRIBUTES
+    attr_accessor *ATTRIBUTES
+
+    # Defining accessor for boolean to always store `true` or `false`
+    BOOLEAN_ATTRIBUTES.each do |attr|
+      define_method "#{attr}=" do |value|
+        # Always set to `true` or `false`
+        # TODO: Rails 5.0 `#type_cast_from_database` will be replaced by `#cast`
+        instance_variable_set :"@#{attr}", !!ActiveRecord::Type::Boolean.new.type_cast_from_database(value)
+      end
+    end
+
+    def initialize(attributes={})
+      assign_attributes(attributes)
+    end
+
+    # TODO: Rails 5. This would be much better with ActiveModel::AttributeAssignment
+    # Correctly assign attributes by removing those that are not valid.
+    # FIXME: Probably better to raise a NoMethodError?
+    def assign_attributes(attrs)
+      attributes = ActiveSupport::HashWithIndifferentAccess.new.merge attrs
+      ATTRIBUTES.each do |attr|
+        public_send "#{attr}=", attributes[attr]
+      end
+    end
+    alias_method :attributes=, :assign_attributes
+
+    def attributes
+      ATTRIBUTES.each_with_object(ActiveSupport::HashWithIndifferentAccess.new) do |attr, object|
+        object[attr] = public_send(attr)
+      end
+    end
+  end
+
+  belongs_to :oidc_configurable, polymorphic: true
+  serialize :config, OIDCConfiguration::Config
+
+  delegate *OIDCConfiguration::Config::ATTRIBUTES, to: :config
+  delegate *OIDCConfiguration::Config::ATTRIBUTES.map{|attr| "#{attr}=" }, to: :config
+
+  # Always initialize a valid `config`
+  after_initialize :config
+
+  private
+
+  def read_attribute_for_serialization(name)
+    if name.to_s == 'config'
+      config.attributes
+    else
+      super
+    end
+  end
+end

--- a/app/models/oidc_configuration.rb
+++ b/app/models/oidc_configuration.rb
@@ -10,10 +10,12 @@ class OIDCConfiguration < ApplicationRecord
       super(record.attributes)
     end
 
-    BOOLEAN_ATTRIBUTES = %i[
+    FLOWS = %i[
       service_accounts_enabled standard_flow_enabled
       implicit_flow_enabled direct_access_grants_enabled
     ].freeze
+
+    BOOLEAN_ATTRIBUTES = FLOWS
 
     ATTRIBUTES = BOOLEAN_ATTRIBUTES
     attr_accessor *ATTRIBUTES

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -13,6 +13,7 @@ class Proxy < ApplicationRecord
   has_many :proxy_rules, dependent: :destroy, inverse_of: :proxy
   has_many :proxy_configs, dependent: :delete_all, inverse_of: :proxy
   has_one :oidc_configuration, dependent: :delete, inverse_of: :oidc_configurable, as: :oidc_configurable
+  accepts_nested_attributes_for :oidc_configuration
 
   validates :api_backend, :error_status_no_match, :error_status_auth_missing, :error_status_auth_failed, presence: true
 
@@ -129,6 +130,11 @@ class Proxy < ApplicationRecord
 
   def plugin?
     !hosted? && !self_managed?
+  end
+
+
+  def oidc_configuration
+    super || (oidc? && build_oidc_configuration)
   end
 
   class DeploymentStrategy

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -12,6 +12,7 @@ class Proxy < ApplicationRecord
 
   has_many :proxy_rules, dependent: :destroy, inverse_of: :proxy
   has_many :proxy_configs, dependent: :delete_all, inverse_of: :proxy
+  has_one :oidc_configuration, dependent: :delete, inverse_of: :oidc_configurable, as: :oidc_configurable
 
   validates :api_backend, :error_status_no_match, :error_status_auth_missing, :error_status_auth_failed, presence: true
 

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -134,7 +134,7 @@ class Proxy < ApplicationRecord
 
 
   def oidc_configuration
-    super || (oidc? && build_oidc_configuration)
+    super || build_oidc_configuration(standard_flow_enabled: true)
   end
 
   class DeploymentStrategy

--- a/app/views/api/integrations/apicast/shared/_authentication_settings.html.slim
+++ b/app/views/api/integrations/apicast/shared/_authentication_settings.html.slim
@@ -1,6 +1,7 @@
 = f.toggled_inputs 'Authentication Settings' do
   - if @service.oidc?
     = f.input :oidc_issuer_endpoint, hint: true, input_html: { placeholder: "https://sso.example.com/auth/realms/gateway" }
+    = f.input :oidc_options, :as => :check_boxes, :collection => ["Standard Flow Enabled", "Implicit Flow Enabled", "Service Accounts Enabled", "Direct Access Grants Enabled"]
   - elsif @service.oauth?
     = f.input :oauth_login_url, label: "OAuth Authorization Endpoint", input_html: { placeholder: "https://#{parameterized_org_name_of_the_current_account}.com/authorize" },  hint: t("formtastic.hints.proxy.#{oauth_hint}")
 

--- a/app/views/api/integrations/apicast/shared/_authentication_settings.html.slim
+++ b/app/views/api/integrations/apicast/shared/_authentication_settings.html.slim
@@ -1,7 +1,11 @@
 = f.toggled_inputs 'Authentication Settings' do
   - if @service.oidc?
     = f.input :oidc_issuer_endpoint, hint: true, input_html: { placeholder: "https://sso.example.com/auth/realms/gateway" }
-    = f.input :oidc_options, :as => :check_boxes, :collection => ["Standard Flow Enabled", "Implicit Flow Enabled", "Service Accounts Enabled", "Direct Access Grants Enabled"]
+    = f.inputs "OIDC Authorization flow" do
+      = f.semantic_fields_for :oidc_configuration do |config|
+        - OIDCConfiguration::Config::FLOWS.each do |flow|
+          = config.input flow, :as => :boolean
+
   - elsif @service.oauth?
     = f.input :oauth_login_url, label: "OAuth Authorization Endpoint", input_html: { placeholder: "https://#{parameterized_org_name_of_the_current_account}.com/authorize" },  hint: t("formtastic.hints.proxy.#{oauth_hint}")
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1055,6 +1055,7 @@ en:
         hosted_proxy_endpoint: "Public Base URL"
         production_endpoint: "Public Base URL"
         oidc_issuer_endpoint: "OpenID Connect Issuer"
+
       profile:
         company_url: URL
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1080,6 +1080,12 @@ en:
         due_on: 'Due On'
         paid_on: 'Paid On'
 
+      oidc_configuration:
+        service_accounts_enabled: Service Accounts Flow
+        standard_flow_enabled: Authorization Code Flow
+        implicit_flow_enabled: Implicit Flow
+        direct_access_grants_enabled: Direct Access Grant Flow
+
   config:
     advanced_cms: Advanced CMS
 

--- a/db/migrate/20190225170501_create_oidc_configurations.rb
+++ b/db/migrate/20190225170501_create_oidc_configurations.rb
@@ -1,0 +1,13 @@
+class CreateOIDCConfigurations < ActiveRecord::Migration
+  def change
+    create_table :oidc_configurations do |t|
+      t.text :config
+      t.string :oidc_configurable_type, null: false
+      t.integer :oidc_configurable_id, limit: 8, null: false
+      t.integer :tenant_id, limit: 8
+
+      t.timestamps null: false
+    end
+    add_index :oidc_configurations, [:oidc_configurable_type, :oidc_configurable_id], unique: true, name: :oidc_configurable
+  end
+end

--- a/db/migrate/20190225170501_create_oidc_configurations.rb
+++ b/db/migrate/20190225170501_create_oidc_configurations.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# rubocop:disable
 class CreateOIDCConfigurations < ActiveRecord::Migration
   def change
     create_table :oidc_configurations do |t|
@@ -8,6 +11,6 @@ class CreateOIDCConfigurations < ActiveRecord::Migration
 
       t.timestamps null: false
     end
-    add_index :oidc_configurations, [:oidc_configurable_type, :oidc_configurable_id], unique: true, name: :oidc_configurable
+    add_index :oidc_configurations, %i[oidc_configurable_type oidc_configurable_id], unique: true, name: :oidc_configurable
   end
 end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190104134224) do
+ActiveRecord::Schema.define(version: 20190225170501) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -822,6 +822,17 @@ ActiveRecord::Schema.define(version: 20190104134224) do
 
   add_index "notifications", ["event_id"], name: "index_notifications_on_event_id"
   add_index "notifications", ["user_id"], name: "index_notifications_on_user_id"
+
+  create_table "oidc_configurations", force: :cascade do |t|
+    t.text   "config"
+    t.string   "oidc_configurable_type",                null: false
+    t.integer  "oidc_configurable_id",   precision: 38, null: false
+    t.integer  "tenant_id",              precision: 38
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+  end
+
+  add_index "oidc_configurations", ["oidc_configurable_type", "oidc_configurable_id"], name: "oidc_configurable", unique: true
 
   create_table "onboardings", force: :cascade do |t|
     t.integer  "account_id",              precision: 38

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190104134224) do
+ActiveRecord::Schema.define(version: 20190225170501) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -821,6 +821,17 @@ ActiveRecord::Schema.define(version: 20190104134224) do
 
   add_index "notifications", ["event_id"], name: "index_notifications_on_event_id", using: :btree
   add_index "notifications", ["user_id"], name: "index_notifications_on_user_id", using: :btree
+
+  create_table "oidc_configurations", force: :cascade do |t|
+    t.text   "config"
+    t.string   "oidc_configurable_type",           null: false
+    t.integer  "oidc_configurable_id",   limit: 8, null: false
+    t.integer  "tenant_id",              limit: 8
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+  end
+
+  add_index "oidc_configurations", ["oidc_configurable_type", "oidc_configurable_id"], name: "oidc_configurable", unique: true, using: :btree
 
   create_table "onboardings", force: :cascade do |t|
     t.integer  "account_id",              limit: 8

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190104134224) do
+ActiveRecord::Schema.define(version: 20190225170501) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -822,6 +822,17 @@ ActiveRecord::Schema.define(version: 20190104134224) do
 
   add_index "notifications", ["event_id"], name: "index_notifications_on_event_id", using: :btree
   add_index "notifications", ["user_id"], name: "index_notifications_on_user_id", using: :btree
+
+  create_table "oidc_configurations", force: :cascade do |t|
+    t.text   "config",                 limit: 65535
+    t.string   "oidc_configurable_type", limit: 255,   null: false
+    t.integer  "oidc_configurable_id",   limit: 8,     null: false
+    t.integer  "tenant_id",              limit: 8
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+  end
+
+  add_index "oidc_configurations", ["oidc_configurable_type", "oidc_configurable_id"], name: "oidc_configurable", unique: true, using: :btree
 
   create_table "onboardings", force: :cascade do |t|
     t.integer  "account_id",              limit: 8

--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -521,6 +521,13 @@ System::Database::MySQL.define do
     SQL
   end
 
+  # FIXME: This will not work when we have more than 1 oidc_configurable_type
+  trigger 'oidc_configurations' do
+    <<~SQL
+      SET NEW.tenant_id = (SELECT tenant_id FROM proxies WHERE id = NEW.oidc_configurable_id AND tenant_id <> master_id);
+    SQL
+  end
+
   procedure 'sp_invoices_friendly_id', invoice_id: 'bigint' do
     <<~SQL
       BEGIN

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -537,6 +537,13 @@ System::Database::Oracle.define do
     SQL
   end
 
+  # FIXME: This will not work when we have more than 1 oidc_configurable_type
+  trigger 'oidc_configurations' do
+    <<~SQL
+      SELECT tenant_id INTO :new.tenant_id FROM proxies WHERE id = :new.oidc_configurable_id AND tenant_id <> master_id;
+    SQL
+  end
+
   procedure 'sp_invoices_friendly_id', invoice_id: 'NUMBER' do
     <<~SQL
         v_provider_account_id NUMBER;

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -537,6 +537,12 @@ System::Database::Postgres.define do
     SQL
   end
 
+  trigger 'oidc_configurations' do
+    <<~SQL
+      SELECT tenant_id INTO NEW.tenant_id FROM proxies WHERE id = NEW.oidc_configurable_id AND tenant_id <> master_id;
+    SQL
+  end
+
   procedure 'sp_invoices_friendly_id', invoice_id: 'numeric' do
     <<~SQL
       DECLARE

--- a/lib/tasks/multitenant/triggers.rake
+++ b/lib/tasks/multitenant/triggers.rake
@@ -107,6 +107,8 @@ namespace :multitenant do
     ServiceToken.update_all "tenant_id = (SELECT tenant_id FROM services WHERE id = service_id AND tenant_id <> #{MASTER_ID})"
     SSOAuthorization.update_all "tenant_id = (SELECT tenant_id FROM users WHERE id = user_id AND tenant_id <> #{MASTER_ID})"
     ProvidedAccessToken.update_all "tenant_id = account_id WHERE account_id <> #{MASTER_ID}"
+    # FIXME: This will not work when we have more than 1 oidc_configurable_type
+    OIDConfiguration.update_all "tenant_id = (SELECT tenant_id FROM proxies WHERE id = oidc_configurable_id AND tenant_id <> #{MASTER_ID})"
   end
 end
 

--- a/test/integration/api/integration_test.rb
+++ b/test/integration/api/integration_test.rb
@@ -72,4 +72,17 @@ class IntegrationsTest < ActionDispatch::IntegrationTest
     get "/apiconfig/services/#{service.id}/integration/edit"
     assert_response :success
   end
+
+
+  test 'update OIDC Authorization flows' do
+    rolling_updates_off
+    service = FactoryBot.create(:simple_service, account: @provider)
+    ProxyTestService.any_instance.stubs(disabled?: true)
+    patch admin_service_integration_path(service_id: service, proxy: {oidc_configuration_attributes: {standard_flow_enabled: false, direct_access_grants_enabled: true}})
+    assert_response :redirect
+
+    service.reload
+    refute service.proxy.oidc_configuration.standard_flow_enabled
+    assert service.proxy.oidc_configuration.direct_access_grants_enabled
+  end
 end

--- a/test/models/oidc_configuration_test.rb
+++ b/test/models/oidc_configuration_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class OIDCConfigurationTest < ActiveSupport::TestCase
+
+  def test_always_save_configuration_in_database
+    OIDCConfiguration.create(oidc_configurable_type: 'Contract', oidc_configurable_id: 1)
+    config = OIDCConfiguration.first
+    json = {
+      "service_accounts_enabled" => false,
+      "standard_flow_enabled" => false,
+      "implicit_flow_enabled" => false,
+      "direct_access_grants_enabled" => false
+    }
+    assert_equal json, JSON.parse(config.config_before_type_cast)
+  end
+
+  def test_assign_attributes
+    config = OIDCConfiguration::Config.new
+    config.assign_attributes(unexisting_attribute: 'value', service_accounts_enabled: true)
+    json = {
+      "service_accounts_enabled" => true,
+      "standard_flow_enabled" => false,
+      "implicit_flow_enabled" => false,
+      "direct_access_grants_enabled" => false
+    }
+    assert_equal json, config.attributes
+  end
+
+  def test_saving_config
+    record = OIDCConfiguration.create(oidc_configurable_type: 'Contract', oidc_configurable_id: 1)
+    record.implicit_flow_enabled = true
+    record.standard_flow_enabled = true
+    record.save!
+    record.reload
+    json = {
+      "service_accounts_enabled" => false,
+      "standard_flow_enabled" => true,
+      "implicit_flow_enabled" => true,
+      "direct_access_grants_enabled" => false
+    }
+
+    assert_equal json.to_json, record.config_before_type_cast
+  end
+end

--- a/test/models/oidc_configuration_test.rb
+++ b/test/models/oidc_configuration_test.rb
@@ -39,6 +39,6 @@ class OIDCConfigurationTest < ActiveSupport::TestCase
       "direct_access_grants_enabled" => false
     }
 
-    assert_equal json.to_json, record.config_before_type_cast
+    assert_equal json, JSON.parse(record.config_before_type_cast)
   end
 end

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -507,6 +507,18 @@ class ProxyTest < ActiveSupport::TestCase
     end
   end
 
+  test 'oidc_configuration standard flow enabled by default' do
+    assert_instance_of OIDCConfiguration, @proxy.oidc_configuration
+    assert @proxy.oidc_configuration.standard_flow_enabled
+    refute @proxy.oidc_configuration.implicit_flow_enabled
+    refute @proxy.oidc_configuration.service_accounts_enabled
+    refute @proxy.oidc_configuration.direct_access_grants_enabled
+
+    @proxy.oidc_configuration.direct_access_grants_enabled = true
+    @proxy.save!
+    assert Proxy.find(@proxy.id).oidc_configuration.direct_access_grants_enabled
+  end
+
   def analytics
     ThreeScale::Analytics::UserTracking.any_instance
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

When OIDC is selected as authentication method, 4 checkboxes appear at APicast's Authentication Settings with the following options:

* Authorization Code flow [selected by default]
* Implicit Flow Enabled
* Service Accounts Enabled (Client Credentials flow)
* Direct Access Grants Enabled (Resource Owner Password Credentials flow)

**Which issue(s) this PR fixes** 

[THREESCALE-1947: Configure OAuth flows in the UI](https://issues.jboss.org/browse/THREESCALE-1947)

[THREESCALE-1949](https://issues.jboss.org/browse/THREESCALE-1949)


**Verification steps** 

1. Make sure OpenID Connect is enabled in **rolling_updates.yml** (`apicast_oidc: true`)
2. Go to Integration > APIcast configuration > Select _OpenID Connect_
3. Go to Integration > Integration Settings > 4 above options should be right after _OpenID Connect Issuer_ form.
4. Check/Uncheck some options and click _Update_. Selected options should persist.


![image](https://user-images.githubusercontent.com/64276/53434513-198eb900-39f7-11e9-815d-22f70b24a26c.png)

TODO:

- [x] Integration tests
- [x] Unit tests