### PR TITLE
Extract Karma and Jest tests from Lint job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
           command: |
             bundle exec rake doc:swagger:validate:all
             bundle exec rake doc:swagger:generate:all
-      - run:  
+      - run:
           name: Eslint & Flow
           command: |
             npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,19 +383,39 @@ jobs:
           command: |
             bundle exec rake doc:swagger:validate:all
             bundle exec rake doc:swagger:generate:all
-      - run:
-          name: NPM test
+      - run:  
+          name: Eslint & Flow
           command: |
-            npm test -- --reporters dots,junit --browsers ChromeHeadless
-            npm run-script jest
-      - *store-junit-test-results
-      - *store-test-artifacts
+            npm run lint
       - store_artifacts:
           path: doc/licenses
           destination: licenses
       - store_artifacts:
           path: doc/active_docs
           destination: active_docs
+
+  karma:
+    executor: builder
+    steps:
+      - checkout-with-submodules
+      - *attach-to-workspace
+      - run:
+          name: Karma tests
+          command: |
+            npm test -- --reporters dots,junit --browsers ChromeHeadless
+      - *store-junit-test-results
+      - *store-test-artifacts
+      - *upload-coverage
+
+  jest:
+    executor: builder
+    steps:
+      - checkout-with-submodules
+      - *attach-to-workspace
+      - run:
+          name: Jest specs
+          command: |
+            npm run-script jest
       - *upload-coverage
 
   unit:
@@ -691,6 +711,12 @@ workflows:
       - lint:
           requires:
             - assets_precompile
+      - karma:
+          requires:
+            - assets_precompile
+      - jest:
+          requires:
+            - assets_precompile
       - unit:
           requires:
             - dependencies_bundler
@@ -714,6 +740,8 @@ workflows:
             - integration
             - functional
             - lint
+            - karma
+            - jest
           filters:
             branches:
               only: master
@@ -725,6 +753,8 @@ workflows:
             - integration
             - functional
             - lint
+            - karma
+            - jest
           filters:
             branches:
               only: master
@@ -757,6 +787,12 @@ workflows:
       - lint:
           requires:
             - assets_precompile
+      - karma:
+          requires:
+            - assets_precompile
+      - jest:
+          requires:
+            - assets_precompile
       - unit-postgres:
           requires:
             - deps_bundler_postgres
@@ -780,6 +816,8 @@ workflows:
             - integration-postgres
             - functional-postgres
             - lint
+            - karma
+            - jest
           filters:
             branches:
               only: master
@@ -791,6 +829,8 @@ workflows:
             - integration-postgres
             - functional-postgres
             - lint
+            - karma
+            - jest
           filters:
             branches:
               only: master
@@ -824,6 +864,12 @@ workflows:
       - lint:
           requires:
             - assets_precompile
+      - karma:
+          requires:
+            - assets_precompile
+      - jest:
+          requires:
+            - assets_precompile
       - unit-oracle:
           requires:
             - deps_bundler_oracle
@@ -847,6 +893,8 @@ workflows:
             - integration-oracle
             - functional-oracle
             - lint
+            - karma
+            - jest
           filters:
             branches:
               only: master
@@ -859,6 +907,8 @@ workflows:
             - integration-oracle
             - functional-oracle
             - lint
+            - karma
+            - jest
           filters:
             branches:
               only: master

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "jasmine": true
   },
   "globals": {
+    "$": true,
     "fixture": true,
     "spyOnEvent": true
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "clear": "rm -rf node_modules/",
-    "pretest": "flow",
+    "lint": "flow && eslint .eslintrc app/javascript spec/javascripts",
     "test": "karma start --single-run",
     "jest": "jest",
     "jest:watch": "npm run-script jest -- --watch",

--- a/spec/javascripts/Stats/metrics_source.spec.js
+++ b/spec/javascripts/Stats/metrics_source.spec.js
@@ -30,7 +30,7 @@ describe('StatsMetricsSource', () => {
 
   it('should throw error when call url directly', () => {
     expect(() => {
-      source.url
+      source.url // eslint-disable-line no-unused-expressions
     }).toThrow(new Error('It should implement url getter in subclasses.'))
   })
 })

--- a/spec/javascripts/Stats/source.spec.js
+++ b/spec/javascripts/Stats/source.spec.js
@@ -17,7 +17,7 @@ describe('StatsSource', () => {
 
   it('should throw error when call url directly', () => {
     expect(() => {
-      source.url
+      source.url // eslint-disable-line no-unused-expressions
     }).toThrow(new Error('It should implement url getter in subclasses.'))
   })
 })

--- a/spec/javascripts/Stats/source_collector.spec.js
+++ b/spec/javascripts/Stats/source_collector.spec.js
@@ -24,7 +24,7 @@ describe('StatsSourceCollector', () => {
 
   it('should throw error on url getter', () => {
     expect(() => {
-      sourceCollector.url
+      sourceCollector.url // eslint-disable-line no-unused-expressions
     }).toThrow(new Error('It should implement url getter in subclasses.'))
   })
 

--- a/spec/javascripts/__mocks__/c3.js
+++ b/spec/javascripts/__mocks__/c3.js
@@ -1,1 +1,1 @@
-module.exports = () => 'c3';
+module.exports = () => 'c3'


### PR DESCRIPTION
**What this PR does / why we need it**:

It divides current `lint` job into 3: `lint`,  `karma` and `jest` to make it more clean and maintainable.

Also adds a new `lint` script to package.json so that *eslint* checks both source and specs.

**Verification steps** 

CircleCI should run these 3 jobs successfully.
