### PR TITLE
[api] Applications should return oidc_configuration if service is using OIDC

### DIFF
--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -333,6 +333,8 @@ class Cinstance < Contract
 
       plan.to_xml(:builder => xml)
 
+      service.oidc_configuration.to_xml(builder: xml) if service.oidc?
+
       unless destroyed?
         fields_to_xml(xml)
         extra_fields_to_xml(xml)

--- a/app/models/oidc_configuration.rb
+++ b/app/models/oidc_configuration.rb
@@ -64,6 +64,18 @@ class OIDCConfiguration < ApplicationRecord
   # Always initialize a valid `config`
   after_initialize :config
 
+  # This would really be better with a XML representer
+  def to_xml(options={})
+    result = options[:builder] || ThreeScale::XML::Builder.new
+    result.oidc_configuration do |xml|
+      xml.id id
+      Config::ATTRIBUTES.each do |attr|
+        xml.tag!(attr, public_send(attr))
+      end
+    end
+  end
+
+
   private
 
   def read_attribute_for_serialization(name)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -492,6 +492,12 @@ class Service < ApplicationRecord
     end
   end
 
+  # This smells of :reek:NilCheck
+  # But that's OK :)
+  def oidc_configuration
+    proxy&.oidc_configuration || OIDCConfiguration.new
+  end
+
   private
 
   def deleted_by_state_machine

--- a/app/representers/cinstance_representer.rb
+++ b/app/representers/cinstance_representer.rb
@@ -36,6 +36,10 @@ module CinstanceRepresenter
     oauth.property :client_secret
   end
 
+  with_options(if: ->(*) { service.oidc? }, render_nil: true) do |oidc|
+    oidc.property :oidc_configuration, decorator: OIDCConfigurationRepresenter
+  end
+
   def provider_verification_key
     provider_public_key
   end
@@ -74,4 +78,5 @@ module CinstanceRepresenter
   end
 
   delegate :id, to: :service, prefix: true
+  delegate :oidc_configuration, to: :service
 end

--- a/app/representers/oidc_configuration_representer.rb
+++ b/app/representers/oidc_configuration_representer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module OIDCConfigurationRepresenter
+  include ThreeScale::JSONRepresenter
+
+  property :id
+  OIDCConfiguration::Config::ATTRIBUTES.each do |attr|
+    property attr
+  end
+end

--- a/test/test_helpers/xml_assertions.rb
+++ b/test/test_helpers/xml_assertions.rb
@@ -460,6 +460,15 @@ module TestHelpers
         assert xml.xpath('.//application/provider_verification_key').presence
       end
 
+      if attrs.delete(:oidc)
+        assert xml.xpath('.//application/oidc_configuration').presence
+
+        assert xml.xpath('.//application/oidc_configuration/standard_flow_enabled').presence
+        assert xml.xpath('.//application/oidc_configuration/implicit_flow_enabled').presence
+        assert xml.xpath('.//application/oidc_configuration/service_accounts_enabled').presence
+        assert xml.xpath('.//application/oidc_configuration/direct_access_grants_enabled').presence
+      end
+
       backend_v2    = attrs.delete(:v2)
       backend_oauth = attrs.delete(:oauth)
       if backend_v2 || backend_oauth

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -618,6 +618,21 @@ class ServiceTest < ActiveSupport::TestCase
     assert_same_elements member_permission_service_ids, Service.permitted_for_user(user).pluck(:id)
   end
 
+
+  test 'oidc_configuration' do
+    service = Service.new
+
+    proxy = Proxy.new
+    config = OIDCConfiguration.new
+    service.stubs(proxy: proxy)
+    proxy.expects(oidc_configuration: config)
+
+    assert_equal config, service.oidc_configuration
+
+    service.stubs(proxy: nil)
+    assert_instance_of(OIDCConfiguration, service.oidc_configuration)
+  end
+
   class DeploymentOptionTest < ActiveSupport::TestCase
     def test_all
       all = Service::DeploymentOption.all


### PR DESCRIPTION
Closes [THREESCALE-1948](https://issues.jboss.org/browse/THREESCALE-1948)

### Endpoint used by Zync

Zync needs to know which flows are enabled. Zync queries the  "/admin/api/applications/find.json" endpoint to configure the RH SSO correctly by application.

Implementation would be to send another field in the response (JSON/XML) corresponding to `oidc_configuration` as described in https://www.keycloak.org/docs-api/4.8/rest-api/index.html

Example:

```
		"oidc_configuration": {
			"service_accounts_enabled": true,
			"standard_flow_enabled": false,
			"implicit_flow_enabled": true,
			"direct_access_grants_enabled": true				
		}

```

