### PR TITLE
[THREESCALE-1868] more default parameters for api#applications_plan

### DIFF
--- a/app/controllers/admin/api/application_plans_controller.rb
+++ b/app/controllers/admin/api/application_plans_controller.rb
@@ -50,6 +50,10 @@ class Admin::Api::ApplicationPlansController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add @parameter_service_id_by_id_name
   ##~ op.parameters.add :name => "name", :description => "Name of the application plan.", :dataType => "string", :required => true, :paramType => "query"
   ##~ op.parameters.add :name => "approval_required", :description => "Set the 'Applications require approval?' to 'true' or 'false'", :dataType => "boolean", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "cost_per_month", :description => "Cost per month", :dataType => "decimal", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "setup_fee", :description => "Setup fee", :dataType => "decimal", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "trial_period_days", :description => "Trial period days", :dataType => "integer", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "end_user_required", :description => "End user required", :dataType => "boolean", :required => false, :paramType => "query"
   ##~ op.parameters.add @parameter_system_name_by_name
   ##~ op.parameters.add @parameter_application_plan_state_event
   #
@@ -87,6 +91,10 @@ class Admin::Api::ApplicationPlansController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add @parameter_application_plan_id_by_id
   ##~ op.parameters.add :name => "name", :description => "Name of the application plan.", :dataType => "string", :paramType => "query"
   ##~ op.parameters.add :name => "approval_required", :description => "Set the 'Applications require approval?' to 'true' or 'false'", :dataType => "boolean", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "cost_per_month", :description => "Cost per month", :dataType => "decimal", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "setup_fee", :description => "Setup fee", :dataType => "decimal", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "trial_period_days", :description => "Trial period days", :dataType => "integer", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "end_user_required", :description => "End user required", :dataType => "boolean", :required => false, :paramType => "query"
   ##~ op.parameters.add @parameter_application_plan_state_event
   #
   def update
@@ -132,7 +140,8 @@ class Admin::Api::ApplicationPlansController < Admin::Api::ServiceBaseController
 
   protected
 
-  DEFAULT_PARAMS = %i[name state_event description approval_required].freeze
+  DEFAULT_PARAMS = %i[name state_event description approval_required trial_period_days
+                      cost_per_month setup_fee end_user_required].freeze
 
   def application_plan_update_params
     params.require(:application_plan).permit(DEFAULT_PARAMS)

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -1786,6 +1786,34 @@
               "paramType": "query"
             },
             {
+              "name": "cost_per_month",
+              "description": "Cost per month",
+              "dataType": "decimal",
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "setup_fee",
+              "description": "Setup fee",
+              "dataType": "decimal",
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "trial_period_days",
+              "description": "Trial period days",
+              "dataType": "integer",
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "end_user_required",
+              "description": "End user required",
+              "dataType": "boolean",
+              "required": false,
+              "paramType": "query"
+            },
+            {
               "name": "system_name",
               "description": "System Name of the object to be created. System names cannot be modified after creation, they are used as the key to identify the objects.",
               "dataType": "string",
@@ -1877,6 +1905,34 @@
             {
               "name": "approval_required",
               "description": "Set the 'Applications require approval?' to 'true' or 'false'",
+              "dataType": "boolean",
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "cost_per_month",
+              "description": "Cost per month",
+              "dataType": "decimal",
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "setup_fee",
+              "description": "Setup fee",
+              "dataType": "decimal",
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "trial_period_days",
+              "description": "Trial period days",
+              "dataType": "integer",
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "end_user_required",
+              "description": "End user required",
               "dataType": "boolean",
               "required": false,
               "paramType": "query"


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow updating extra Application Plan values from system API.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1868
