### PR TITLE
[API] Endpoint to update custom policy

### DIFF
--- a/app/controllers/admin/api/registry/policies_controller.rb
+++ b/app/controllers/admin/api/registry/policies_controller.rb
@@ -9,7 +9,7 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   representer ::Policy
 
   before_action :authorize_policies
-  before_action :find_policy, only: %i[show destroy]
+  before_action :find_policy, only: %i[show update destroy]
 
   # swagger
   ##~ sapi = source2swagger.namespace("Policy Registry API")
@@ -71,6 +71,25 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   ##~ e.responseClass = "policy"
   #
   ##~ op             = e.operations.add
+  ##~ op.httpMethod  = "PUT"
+  ##~ op.summary     = "APIcast Policy Registry Update"
+  ##~ op.description = "Updates an APIcast Policy"
+  ##~ op.group       = "apicast_policies"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  ##~ op.parameters.add @parameter_policy_id
+  ##~ op.parameters.add :name => "name", :description => "New name of the policy", :required => false, :dataType => "string", :paramType => "query"
+  ##~ op.parameters.add :name => "version", :description => "New version of the policy", :required => false, :dataType => "string", :paramType => "query"
+  ##~ op.parameters.add :name => "schema", :description => "New JSON Schema of the policy", :required => false, :dataType => "string", :paramType => "query"
+  def update
+    policy.update_attributes(policy_params)
+    respond_with(policy)
+  end
+
+  ##~ op             = e.operations.add
+  ##~ e.path = "/admin/api/registry/policies/{id}.json"
+  ##~ e.responseClass = "policy"
+  #
   ##~ op.httpMethod  = "DELETE"
   ##~ op.summary     = "APIcast Policy Registry Delete"
   ##~ op.description = "Deletes an APIcast policy by ID"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -693,7 +693,7 @@ without fake Core server your after commit callbacks will crash and you might ge
 
       namespace :registry, defaults: { format: :json } do
         constraints(id: /((?!\.json\Z|\.xml\Z)[^\/])+/) do
-          resources :policies, only: %i[create show index destroy]
+          resources :policies, only: %i[create show index update destroy]
         end
       end
     end

--- a/doc/active_docs/Policy Registry API.json
+++ b/doc/active_docs/Policy Registry API.json
@@ -100,6 +100,50 @@
       "responseClass": "policy",
       "operations": [
         {
+          "httpMethod": "PUT",
+          "summary": "APIcast Policy Registry Update",
+          "description": "Updates an APIcast Policy",
+          "group": "apicast_policies",
+          "parameters": [
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            },
+            {
+              "name": "id",
+              "description": "ID of the policy. It can be an integer value or a combination 'name-version' of the policy (e.g. 'mypolicy-1.0')",
+              "dataType": "string",
+              "required": true,
+              "paramType": "path"
+            },
+            {
+              "name": "name",
+              "description": "New name of the policy",
+              "required": false,
+              "dataType": "string",
+              "paramType": "query"
+            },
+            {
+              "name": "version",
+              "description": "New version of the policy",
+              "required": false,
+              "dataType": "string",
+              "paramType": "query"
+            },
+            {
+              "name": "schema",
+              "description": "New JSON Schema of the policy",
+              "required": false,
+              "dataType": "string",
+              "paramType": "query"
+            }
+          ]
+        },
+        {
           "httpMethod": "DELETE",
           "summary": "APIcast Policy Registry Delete",
           "description": "Deletes an APIcast policy by ID",

--- a/test/integration/admin/api/registry/policies_controller_test.rb
+++ b/test/integration/admin/api/registry/policies_controller_test.rb
@@ -125,6 +125,27 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     assert_same_elements expected_policy_ids, JSON.parse(response.body)['policies'].map { |policy| policy.dig('policy', 'id') }
   end
 
+  test 'PUT update updates the policy' do
+    policy = FactoryBot.create(:policy, account: @provider, version: '1.0')
+    new_schema = JSON.parse(file_fixture('policies/apicast-policy.json').read).merge('description': 'New description')
+    put admin_api_registry_policy_path(policy, policy: { schema: new_schema.to_json }, access_token: @access_token.value)
+    assert_response :success
+    assert_equal 'New description', policy.reload.schema['description']
+  end
+
+  test 'PUT update updates the policy when name-version is passed as id' do
+    policy = FactoryBot.create(:policy, account: @provider, name: 'my_policy', version: '1.0')
+    new_schema = JSON.parse(file_fixture('policies/apicast-policy.json').read).merge('description': 'New description')
+    put admin_api_registry_policy_path('my_policy-1.0', policy: { schema: new_schema.to_json }, access_token: @access_token.value)
+    assert_response :success
+    assert_equal 'New description', policy.reload.schema['description']
+  end
+
+  test 'PUT update returns not found when policy does not exist' do
+    put admin_api_registry_policy_path(id: 'inexistent-policy', policy: { version: '1.1' }, access_token: @access_token.value)
+    assert_response :not_found
+  end
+
   test 'DELETE destroy deletes the policy' do
     policy = FactoryBot.create(:policy, account: @provider)
     delete admin_api_registry_policy_path(policy, access_token: @access_token.value)


### PR DESCRIPTION
**What this PR does / why we need it**
It defines a new endpoint in the API to update a provider's custom policy registry.

![screen shot 2019-02-28 at 8 38 47 pm](https://user-images.githubusercontent.com/1842261/53593437-06b3ea00-3b99-11e9-8063-a7dda5ae443d.png)

**Which issue(s) this PR fixes**
Closes [THREESCALE-1986](https://issues.jboss.org/browse/THREESCALE-1986)

**Special notes for your reviewer**
Update and delete actions for policies can be considered unsafe because a policy may be in use. We should either freeze and forbid modification in policies currently in use and/or implement a `force` attribute to these state-modifier endpoints.