### PR TITLE
[API] Endpoint to show custom policy

### DIFF
--- a/app/controllers/admin/api/registry/policies_controller.rb
+++ b/app/controllers/admin/api/registry/policies_controller.rb
@@ -9,7 +9,7 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   representer ::Policy
 
   before_action :authorize_policies
-  before_action :find_policy, only: %i[update]
+  before_action :find_policy, only: %i[update show]
 
   # swagger
   ##~ sapi = source2swagger.namespace("Policy Registry API")
@@ -52,6 +52,22 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   ##~ op.parameters.add :name => "schema", :description => "New JSON Schema of the policy", :required => false, :dataType => "string", :paramType => "query"
   def update
     policy.update_attributes(policy_params)
+    respond_with(policy)
+  end
+
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/registry/policies/{id}.json"
+  ##~ e.responseClass = "policy"
+  #
+  ##~ op             = e.operations.add
+  ##~ op.httpMethod  = "GET"
+  ##~ op.summary     = "APIcast Policy Registry Read"
+  ##~ op.description = "Returns the APIcast policy by ID"
+  ##~ op.group       = "apicast_policies"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  ##~ op.parameters.add @parameter_policy_id
+  def show
     respond_with(policy)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -691,7 +691,7 @@ without fake Core server your after commit callbacks will crash and you might ge
 
       namespace :registry, defaults: { format: :json } do
         constraints(id: /[\w.-]+/) do
-          resources :policies, only: [:create, :update]
+          resources :policies, only: [:create, :update, :show]
         end
       end
     end

--- a/doc/active_docs/Policy Registry API.json
+++ b/doc/active_docs/Policy Registry API.json
@@ -93,6 +93,35 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/admin/api/registry/policies/{id}.json",
+      "responseClass": "policy",
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "summary": "APIcast Policy Registry Read",
+          "description": "Returns the APIcast policy by ID",
+          "group": "apicast_policies",
+          "parameters": [
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            },
+            {
+              "name": "id",
+              "description": "ID of the policy. It can be an integer value or a combination 'name-version' of the policy (e.g. 'mypolicy-1.0')",
+              "dataType": "string",
+              "required": true,
+              "paramType": "path"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/test/integration/admin/api/api_docs_services_controller_test.rb
+++ b/test/integration/admin/api/api_docs_services_controller_test.rb
@@ -88,7 +88,7 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
     end
 
     def test_update_unexistent_service
-      put admin_api_active_doc_path(api_docs_service, format: :json), update_params(service_id: 200)
+      put admin_api_active_doc_path(api_docs_service, format: :json), update_params(service_id: Service.last.id + 1)
       assert_response :unprocessable_entity
       assert_contains JSON.parse(response.body).dig('errors', 'service'), 'not found'
     end

--- a/test/integration/admin/api/registry/policies_controller_test.rb
+++ b/test/integration/admin/api/registry/policies_controller_test.rb
@@ -117,6 +117,14 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     assert_response :not_found
   end
 
+  test 'GET show returns the policy' do
+    policy = FactoryBot.create(:policy, account: @provider)
+    get admin_api_registry_policy_path(policy, access_token: @access_token.value)
+    assert_response :success
+    json = JSON.parse(response.body)['policy']
+    assert_equal policy.id, json['id']
+  end
+
   def policy_params(token = @access_token.value)
     @policy_attributes ||= FactoryBot.build(:policy).attributes.symbolize_keys.slice(:name, :version, :schema)
     { policy: @policy_attributes, access_token: token }


### PR DESCRIPTION
**What this PR does / why we need it**
It defines an endpoint to show a provider's custom policy registry.

![screen shot 2019-02-28 at 8 39 24 pm](https://user-images.githubusercontent.com/1842261/53593640-7924ca00-3b99-11e9-9457-7fdc74f7cebf.png)


**Which issue(s) this PR fixes**
Closes [THREESCALE-1986](https://issues.jboss.org/browse/THREESCALE-1986)