### PR TITLE
[policy] THREESCALE-1987 Merge builtin policies with custom ones

### DIFF
--- a/app/controllers/admin/api/policies_controller.rb
+++ b/app/controllers/admin/api/policies_controller.rb
@@ -18,7 +18,7 @@ class Admin::Api::PoliciesController < Admin::Api::BaseController
   ##~ op.parameters.add @parameter_access_token
   #
   def index
-    policies = Policies::PoliciesListService.call
+    policies = Policies::PoliciesListService.call(current_account)
 
     respond_to do |format|
       format.json { render json: policies }

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -23,7 +23,7 @@ module Account::ProviderMethods
     has_one  :web_hook, inverse_of: :account
     has_many :alerts
 
-    has_many :policies
+    has_many :policies, inverse_of: :account
 
     has_many :provider_audits, foreign_key: :provider_id, class_name: Audited.audit_class.name
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Policy < ApplicationRecord
-  belongs_to :account
+  belongs_to :account, inverse_of: :policies
 
   validates :version, uniqueness: { scope: %i[account_id name] }
   validates :name, :version, :account_id, :schema, presence: true

--- a/app/services/policies/policies_list_service.rb
+++ b/app/services/policies/policies_list_service.rb
@@ -1,11 +1,59 @@
 # frozen_string_literal: true
 
 require 'jsonclient'
+require 'set'
 
 class Policies::PoliciesListService
-
-  def self.call
+  def self.call(account)
     response = ::JSONClient.get(ThreeScale.config.sandbox_proxy.apicast_registry_url)
-    response.body.symbolize_keys[:policies] if response.ok?
+    list = response.ok? ? PolicyList.from_hash(response.body['policies']) : PolicyList.new
+    list.merge!(PolicyList.new(account.policies)) if account.provider_can_use?(:policy_registry)
+    list.to_h
+  end
+
+  class PolicyList
+    include Enumerable
+
+    attr_reader :sets
+    protected :sets
+    delegate :each, to: :sets
+
+    def initialize(policies = [])
+      @sets = Hash.new { |hash, key| hash[key] = Set.new }
+      policies.each(&method(:add))
+    end
+
+    # This smells :reek:FeatureEnvy
+    # but it is OK
+    def add(policy)
+      @sets[policy.name.to_s].add(policy.schema)
+    end
+
+    def merge(other)
+      object = dup
+      object.merge!(other)
+      object
+    end
+
+    def merge!(other)
+      @sets.deep_merge!(other.to_h) do |_key, values, other_values|
+        values + other_values
+      end
+    end
+
+    def initialize_copy(source)
+      super
+      @sets = source.sets.dup
+    end
+
+    def self.from_hash(hash)
+      object = new
+      object.merge!(hash.as_json)
+      object
+    end
+
+    def to_h
+      @sets.transform_values(&:to_a).as_json
+    end
   end
 end

--- a/app/services/policies/policies_list_service.rb
+++ b/app/services/policies/policies_list_service.rb
@@ -6,7 +6,8 @@ require 'set'
 class Policies::PoliciesListService
   def self.call(account)
     response = ::JSONClient.get(ThreeScale.config.sandbox_proxy.apicast_registry_url)
-    list = response.ok? ? PolicyList.from_hash(response.body['policies']) : PolicyList.new
+    return unless response.ok?
+    list = PolicyList.from_hash(response.body['policies'])
     list.merge!(PolicyList.new(account.policies)) if account.provider_can_use?(:policy_registry)
     list.to_h
   end

--- a/app/views/api/integrations/apicast/shared/_policies.html.slim
+++ b/app/views/api/integrations/apicast/shared/_policies.html.slim
@@ -6,7 +6,7 @@
 
 javascript:
   document.addEventListener('DOMContentLoaded', function () {
-    var registry = #{json Policies::PoliciesListService.call}
+    var registry = #{json Policies::PoliciesListService.call(current_account)}
     var chain = #{json @proxy.policies_config}
     var serviceId = #{json @service.id}
     initPolicies({element: 'policies', registry: registry, chain: chain, serviceId: serviceId})

--- a/test/integration/user-management-api/policies_test.rb
+++ b/test/integration/user-management-api/policies_test.rb
@@ -16,11 +16,8 @@ class Admin::Api::PoliciesTest < ActionDispatch::IntegrationTest
 
   def test_index
     rolling_updates_on
-    ThreeScale.config.sandbox_proxy.stubs(apicast_registry_url: 'https://example.com/policies')
-    stub_request(:get, 'https://example.com/policies')
-      .to_return(status: 200, body: "{\"policies\":[{\"schema\":\"1\"}]}",
-                 headers: { 'Content-Type' => 'application/json' })
+    Policies::PoliciesListService.expects(:call).with(@provider).returns("{\"cors\":[{\"schema\":\"1\"}]}")
     get admin_api_policies_path(format: :json), provider_key: @provider.api_key
-    assert_match "[{\"schema\":\"1\"}]", response.body
+    assert_match "{\"cors\":[{\"schema\":\"1\"}]}", response.body
   end
 end

--- a/test/unit/services/policies/policies_list_service_test.rb
+++ b/test/unit/services/policies/policies_list_service_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Policies::PoliciesListServiceTest < ActiveSupport::TestCase
@@ -6,13 +8,111 @@ class Policies::PoliciesListServiceTest < ActiveSupport::TestCase
     @service = Policies::PoliciesListService
   end
 
-  def test_call
+  GATEWAY_API_MANAGEMENT_RESPONSE = {
+    policies: {
+      cors: [{
+        version: 'builtin',
+        description: 'CORS Policy'
+      }],
+      tls: [{
+        version: 'builtin',
+        description: 'TLS Policy'
+      }]
+    }
+  }.freeze
+
+  test 'call with no access to registry' do
     ThreeScale.config.sandbox_proxy.stubs(apicast_registry_url: 'https://apicast-staging.proda.example.com/policies')
     stub_request(:get, "https://apicast-staging.proda.example.com/policies")
-      .to_return(status: 200, body: "{\"policies\":[{\"schema\":\"1\"}]}",
-                  headers: { 'Content-Type' => 'application/json' })
+      .to_return(status: 200, body: GATEWAY_API_MANAGEMENT_RESPONSE.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
 
-    policies = @service.call
-    assert_equal [{"schema" => "1"}], policies
+    account = FactoryBot.build_stubbed(:simple_provider)
+    account.expects(:provider_can_use?).with(:policy_registry).returns(false)
+    account.expects(:policies).never
+
+    policies = @service.call(account)
+    assert_equal GATEWAY_API_MANAGEMENT_RESPONSE[:policies].as_json, policies
+  end
+
+  test 'call with custom policies' do
+    ThreeScale.config.sandbox_proxy.stubs(apicast_registry_url: 'https://apicast-staging.proda.example.com/policies')
+    stub_request(:get, "https://apicast-staging.proda.example.com/policies")
+      .to_return(status: 200, body: GATEWAY_API_MANAGEMENT_RESPONSE.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+
+    account = FactoryBot.build_stubbed(:simple_provider)
+
+    cors_v2 = {
+      version: '2.0.0',
+      description: 'CORS Policy V2'
+    }
+
+    header_v1 = {
+      version: '1.1.5',
+      description: 'Header Policy V1'
+    }
+
+    policies = [
+      Policy.new(name: 'cors', version: '2.0.0', schema: cors_v2),
+      Policy.new(name: 'header', version: '1.1.5', schema: header_v1),
+    ]
+
+    account.expects(:provider_can_use?).with(:policy_registry).returns(true)
+    account.expects(:policies).returns(policies)
+
+    custom_policies = GATEWAY_API_MANAGEMENT_RESPONSE.dup
+    custom_policies[:policies][:cors].push(cors_v2)
+    custom_policies[:policies][:header] = [header_v1]
+
+    assert_equal custom_policies[:policies].as_json, @service.call(account)
+  end
+
+  class PolicyListTest < ActiveSupport::TestCase
+
+    def test_add
+      policy1_schema_v1 =  {
+        version: '1.0.0',
+        description: 'Some description'
+      }.as_json
+
+      policy1_schema_v2 =  {
+        version: '2.0.0',
+        description: 'Some description'
+      }.as_json
+
+      hash = {
+        policy1: [
+          policy1_schema_v1
+        ]
+      }.as_json
+
+
+      list = Policies::PoliciesListService::PolicyList.from_hash(hash)
+      assert_equal hash, list.to_h
+
+      list.add(Policy.new(name: 'policy1', version: '1.0.0', schema: policy1_schema_v1))
+      list.add(Policy.new(name: 'policy1', version: '2.0.0', schema: policy1_schema_v2))
+
+      new_hash = hash.dup
+      new_hash['policy1'].push(policy1_schema_v2)
+      assert_equal new_hash, list.to_h
+    end
+
+    def test_merge
+      list1 = Policies::PoliciesListService::PolicyList.from_hash({pol: [{version: '1.0'}]})
+      list2 = Policies::PoliciesListService::PolicyList.from_hash({pol: [{version: '2.0'}], pol2: [{version: '3.0'}]})
+      list3 = list1.merge(list2)
+      expected_hash = {
+        pol: [
+          {version: '1.0'},
+          {version: '2.0'}
+        ],
+        pol2: [
+          {version: '3.0'}
+        ]
+      }.as_json
+      assert_equal(expected_hash, list3.to_h)
+    end
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-1987](https://issues.jboss.org/browse/THREESCALE-1987)

When provider can use custom policies, those policies are merged to the builtin ones