### PR TITLE
[random-test-failure] Use verbose: true for diagnostic

### DIFF
--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -123,7 +123,7 @@ class Account::SearchTest < ActiveSupport::TestCase
 
     ThinkingSphinx::Test.run do
       ThinkingSphinx::Test.config
-      ThinkingSphinx::Test.index
+      ThinkingSphinx::Test.index verbose: true
 
       buyer.bought_cinstances.pluck(:user_key).each do |user_key|
         assert_equal [buyer.id], Account.scope_search(query: user_key).pluck(:id)


### PR DESCRIPTION
There is a random failure happening on CircleCi. Hard to reproduce locally.
Adding more verbosity so I can see what is happening next time it fails to fix it

```
Failure:
Minitest::Result#test_search_user_key_without_keyword_with_many_records_is_always_indexed_and_found [/opt/app-root/src/project/test/unit/account/search_test.rb:129]
Minitest::Assertion: Expected: [3]
  Actual: []
```

