### PR TITLE
Remove duplication of npm install and npm dedupe in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,13 +34,15 @@ save-flow-typed-cache: &save-flow-typed-cache
     paths:
       - ./flow-typed
 
+npm-cache-key: &npm-cache-key node-v1-{{ checksum "package-lock.json" }}
+
 restore-npm-cache: &restore-npm-cache
   restore_cache:
-    key: node-v1-{{ checksum "package-lock.json" }}
+    key: *npm-cache-key
 
 save-npm-cache: &save-npm-cache
   save_cache:
-    key: node-v1-{{ checksum "package-lock.json" }}
+    key: *npm-cache-key
     paths:
       - ./node_modules
       - ./flow-typed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,14 @@ save-flow-typed-cache: &save-flow-typed-cache
 
 restore-npm-cache: &restore-npm-cache
   restore_cache:
-    keys:
-      - v1-npm-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+    key: node-v1-{{ checksum "package-lock.json" }}
+
+save-npm-cache: &save-npm-cache
+  save_cache:
+    key: node-v1-{{ checksum "package-lock.json" }}
+    paths:
+      - ./node_modules
+      - ./flow-typed
 
 restore-flow-typed-cache: &restore-flow-typed-cache
   restore_cache:
@@ -362,10 +368,7 @@ jobs:
             npm --version
             npm install
             npm dedupe
-      - save_cache:
-          key: v1-npm-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
-          paths:
-            - ./node_modules
+      - *save-npm-cache
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,6 @@ jobs:
           command: |
             npm --version
             npm install
-            npm dedupe
       - *save-npm-cache
       - persist_to_workspace:
           root: .

--- a/Rakefile
+++ b/Rakefile
@@ -67,9 +67,7 @@ Rake::Task['db:test:load'].enhance do
   Rake::Task['db:test:procedures'].invoke
 end
 
-# Replace yarn with npm
+# Remove yarn
 Rake::Task['yarn:install'].clear if Rake::Task.task_defined?('yarn:install')
 Rake::Task['webpacker:yarn_install'].clear
 Rake::Task['webpacker:check_yarn'].clear
-Rake::Task.define_task('webpacker:verify_install' => ['webpacker:check_npm'])
-Rake::Task.define_task('webpacker:compile' => ['webpacker:npm_install'])

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -49,6 +49,7 @@ RUN chgrp root /opt/system/
 
 ADD . ./
 ADD config/docker/* ./config/
+ADD package*.json ./
 
 RUN export ${BUNDLER_ENV} >/dev/null \
     && source /opt/system/etc/scl_enable \
@@ -57,6 +58,7 @@ RUN export ${BUNDLER_ENV} >/dev/null \
     && chmod g+w -vfR log tmp public/assets db/sphinx \
     && umask 0002 \ 
     && cd /opt/system \
+    && npm install --no-progress \
     && bundle exec rake assets:precompile tmp:clear \
     && rm log/*.log \
     && chmod g+w /opt/system/config

--- a/openshift/system/Dockerfile.on_prem
+++ b/openshift/system/Dockerfile.on_prem
@@ -49,6 +49,7 @@ RUN chgrp root /opt/system/
 
 ADD . ./
 ADD config/docker/* ./config/
+ADD package*.json ./
 ADD openshift/system/config/* ./config/
 
 RUN export ${BUNDLER_ENV} >/dev/null \
@@ -58,6 +59,7 @@ RUN export ${BUNDLER_ENV} >/dev/null \
     && chmod g+w -vfR log tmp public/assets db/sphinx \
     && umask 0002 \
     && cd /opt/system \
+    && npm install --no-progress \
     && bundle exec rake assets:precompile tmp:clear \
     && rm log/*.log \
     && chmod g+w /opt/system/config


### PR DESCRIPTION
`npm install` is run twice during each workflow, in `dependencies_npm` and `assets_precompile` jobs.

It takes a lot of time to complete even if modules are present. However, NPM modules can be safely shared between jobs and workflows until package-lock.json changes.

This way we can reduce the times it is run to the minimum, by using CircleCI cache properly.

Also `npm dedupe` is run twice, one during `dependencies_lint` and then again in `lint`. Simplified structure will be already stored in the cache therefore license_check should not complain about duplicated dependencies.