### PR TITLE
Fix random failure due to fixed id in the test

### DIFF
--- a/test/integration/admin/api/api_docs_services_controller_test.rb
+++ b/test/integration/admin/api/api_docs_services_controller_test.rb
@@ -88,7 +88,7 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
     end
 
     def test_update_unexistent_service
-      put admin_api_active_doc_path(api_docs_service, format: :json), update_params(service_id: 200)
+      put admin_api_active_doc_path(api_docs_service, format: :json), update_params(service_id: Service.last.id + 1)
       assert_response :unprocessable_entity
       assert_contains JSON.parse(response.body).dig('errors', 'service'), 'not found'
     end


### PR DESCRIPTION
Sometimes, depending on the tests run before Service.find(200) exists ...
So the test will not fail