### PR TITLE
[API] Endpoint to show custom policy

### DIFF
--- a/app/controllers/admin/api/registry/policies_controller.rb
+++ b/app/controllers/admin/api/registry/policies_controller.rb
@@ -9,10 +9,13 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   representer ::Policy
 
   before_action :authorize_policies
+  before_action :find_policy, only: %i[show]
 
   # swagger
   ##~ sapi = source2swagger.namespace("Policy Registry API")
   ##~ sapi.basePath = @base_path
+  ##~ @parameter_policy_id = { :name => "id", :description => "ID of the policy. It can be an integer value or a combination 'name-version' of the policy (e.g. 'mypolicy-1.0')", :dataType => "string", :required => true, :paramType => "path" }
+
   ##~ e = sapi.apis.add
   ##~ e.path = "/admin/api/registry/policies.json"
   ##~ e.responseClass = "policy"
@@ -32,7 +35,25 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
     respond_with current_account.policies.create(policy_params)
   end
 
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/registry/policies/{id}.json"
+  ##~ e.responseClass = "policy"
+  #
+  ##~ op             = e.operations.add
+  ##~ op.httpMethod  = "GET"
+  ##~ op.summary     = "APIcast Policy Registry Read"
+  ##~ op.description = "Returns the APIcast policy by ID"
+  ##~ op.group       = "apicast_policies"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  ##~ op.parameters.add @parameter_policy_id
+  def show
+    respond_with(policy)
+  end
+
   private
+
+  attr_reader :policy
 
   def authorize_policies
     authorize! :manage, :policy_registry
@@ -40,5 +61,9 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
 
   def policy_params
     params.require(:policy).permit(:name, :version, :schema)
+  end
+
+  def find_policy
+    @policy ||= current_account.policies.find_by_id_or_name_version!(params[:id])
   end
 end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -8,6 +8,17 @@ class Policy < ApplicationRecord
   validate :belongs_to_a_tenant
   validate :validate_schema_specification
 
+  before_validation :set_identifier
+  validates :identifier, uniqueness: { scope: :account_id }
+
+  def self.find_by_id_or_name_version(id_or_name_version)
+    where.has { (id == id_or_name_version) | (identifier == id_or_name_version) }.first
+  end
+
+  def self.find_by_id_or_name_version!(id_or_name_version)
+    find_by_id_or_name_version(id_or_name_version) || raise(ActiveRecord::RecordNotFound)
+  end
+
   private
 
   def belongs_to_a_tenant
@@ -19,5 +30,9 @@ class Policy < ApplicationRecord
     specification = ThreeScale::Policies::Specification.new(schema)
     return if specification.valid?
     specification.errors[:base].each { |error| errors.add(:schema, error) }
+  end
+
+  def set_identifier
+    self.identifier = "#{name}-#{version}"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -692,7 +692,9 @@ without fake Core server your after commit callbacks will crash and you might ge
       resource :settings, only: [:show, :update]
 
       namespace :registry, defaults: { format: :json } do
-        resources :policies, only: :create
+        constraints(id: /((?!\.json\Z|\.xml\Z)[^\/])+/) do
+          resources :policies, only: [:create, :show]
+        end
       end
     end
   end

--- a/db/migrate/20190304094026_add_identifier_to_policies.rb
+++ b/db/migrate/20190304094026_add_identifier_to_policies.rb
@@ -1,0 +1,6 @@
+class AddIdentifierToPolicies < ActiveRecord::Migration
+  def change
+    add_column :policies, :identifier, :string # not adding null: false here so we can migrate in two steps
+    add_index :policies, [:account_id, :identifier], unique: true
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190225170501) do
+ActiveRecord::Schema.define(version: 20190304094026) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -953,8 +953,10 @@ ActiveRecord::Schema.define(version: 20190225170501) do
     t.integer  "tenant_id",  precision: 38
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "identifier"
   end
 
+  add_index "policies", ["account_id", "identifier"], name: "index_policies_on_account_id_and_identifier", unique: true
   add_index "policies", ["account_id"], name: "index_policies_on_account_id"
 
   create_table "posts", force: :cascade do |t|

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190225170501) do
+ActiveRecord::Schema.define(version: 20190304094026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -952,8 +952,10 @@ ActiveRecord::Schema.define(version: 20190225170501) do
     t.integer  "tenant_id",  limit: 8
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "identifier"
   end
 
+  add_index "policies", ["account_id", "identifier"], name: "index_policies_on_account_id_and_identifier", unique: true, using: :btree
   add_index "policies", ["account_id"], name: "index_policies_on_account_id", using: :btree
 
   create_table "posts", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190225170501) do
+ActiveRecord::Schema.define(version: 20190304094026) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -953,8 +953,10 @@ ActiveRecord::Schema.define(version: 20190225170501) do
     t.integer  "tenant_id",  limit: 8
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "identifier", limit: 255
   end
 
+  add_index "policies", ["account_id", "identifier"], name: "index_policies_on_account_id_and_identifier", unique: true, using: :btree
   add_index "policies", ["account_id"], name: "index_policies_on_account_id", using: :btree
 
   create_table "posts", force: :cascade do |t|

--- a/doc/active_docs/Policy Registry API.json
+++ b/doc/active_docs/Policy Registry API.json
@@ -43,6 +43,35 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/admin/api/registry/policies/{id}.json",
+      "responseClass": "policy",
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "summary": "APIcast Policy Registry Read",
+          "description": "Returns the APIcast policy by ID",
+          "group": "apicast_policies",
+          "parameters": [
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            },
+            {
+              "name": "id",
+              "description": "ID of the policy. It can be an integer value or a combination 'name-version' of the policy (e.g. 'mypolicy-1.0')",
+              "dataType": "string",
+              "required": true,
+              "paramType": "path"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -54,4 +54,29 @@ class PolicyTest < ActiveSupport::TestCase
     assert policy.valid?
     assert_empty policy.errors[:schema]
   end
+
+  test 'find policy by id or name and version' do
+    policy = FactoryBot.create(:policy, name: 'my-policy', version: '1.0')
+
+    assert_equal policy, Policy.find_by_id_or_name_version(policy.id)
+    assert_equal policy, Policy.find_by_id_or_name_version('my-policy-1.0')
+  end
+
+  test 'find policy by id or name and version when name contains spaces' do
+    policy = FactoryBot.create(:policy, name: 'this is my policy', version: '1.0')
+
+    assert_equal policy, Policy.find_by_id_or_name_version('this is my policy-1.0')
+  end
+
+  test 'update name or version also updates identifier' do
+    policy = FactoryBot.create(:policy, name: 'my-policy', version: '1.0')
+
+    policy.name = 'new-name'
+    policy.save
+    assert_equal 'new-name-1.0', policy.reload.identifier
+
+    policy.version = '1.1'
+    policy.save
+    assert_equal 'new-name-1.1', policy.reload.identifier
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**
It defines a new endpoint in the API to show a provider's custom policy registry.

![screen shot 2019-02-28 at 8 39 24 pm](https://user-images.githubusercontent.com/1842261/53593640-7924ca00-3b99-11e9-9457-7fdc74f7cebf.png)

**Which issue(s) this PR fixes**
Closes [THREESCALE-1984](https://issues.jboss.org/browse/THREESCALE-1984)