### PR TITLE
Removes flow-typed install from standard install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,20 @@ store-log-artifacts: &store-log-artifacts
     path: log
     destination: log
 
+save-flow-typed-cache: &save-flow-typed-cache
+  save_cache:
+    key: flow-typed-{{ checksum "package-lock.json" }}
+    paths:
+      - ./flow-typed
+
 restore-npm-cache: &restore-npm-cache
   restore_cache:
     keys:
       - v1-npm-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+
+restore-flow-typed-cache: &restore-flow-typed-cache
+  restore_cache:
+    key: flow-typed-{{ checksum "package-lock.json" }}
 
 use-example-config-files: &use-example-config-files
   run:
@@ -356,12 +366,10 @@ jobs:
           key: v1-npm-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             - ./node_modules
-            - ./flow-typed
       - persist_to_workspace:
           root: .
           paths:
             - ./node_modules
-            - ./flow-typed
 
   assets_precompile:
     executor: builder
@@ -400,10 +408,13 @@ jobs:
           command: |
             bundle exec rake doc:swagger:validate:all
             bundle exec rake doc:swagger:generate:all
+      - *restore-flow-typed-cache
       - run:
           name: Eslint & Flow
           command: |
+            npm run flow:install
             npm run lint
+      - *save-flow-typed-cache
       - store_artifacts:
           path: doc/licenses
           destination: licenses

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
   "license": "Apache-2.0",
   "scripts": {
     "clear": "rm -rf node_modules/",
+    "flow:install": "flow-typed install",
     "lint": "flow && eslint .eslintrc app/javascript spec/javascripts",
     "test": "karma start --single-run",
     "jest": "jest",
     "jest:watch": "npm run-script jest -- --watch",
     "postshrinkwrap": "replace --silent 'http://' 'https://' ./package-lock.json",
-    "postinstall": "npm rebuild node-sass && flow-typed install"
+    "postinstall": "npm rebuild node-sass"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Flow typings are not required for porta to work, they only make sense for development and in order to `npm lint` to pass.

This PR is moving the `flow-typed install` step directly to `lint` job and using a cache.