### PR TITLE
[Bugfix][Cuke] Check metric of sorted mapping rules by Name instead of ID

### DIFF
--- a/features/old/proxy.feature
+++ b/features/old/proxy.feature
@@ -86,7 +86,7 @@ Feature: Proxy integration
     And I drag the last mapping rule to the position 1
     And I save the proxy config
     Then the mapping rules should be in the following order:
-      | http_method | pattern | delta | metric_id |
-      | PUT         | /mixers | 1     | 2         |
-      | GET         | /       | 1     | 2         |
-      | POST        | /beers  | 2     | 2         |
+      | http_method | pattern | delta | metric |
+      | PUT         | /mixers | 1     | hits   |
+      | GET         | /       | 1     | hits   |
+      | POST        | /beers  | 2     | hits   |

--- a/features/step_definitions/proxy_steps.rb
+++ b/features/step_definitions/proxy_steps.rb
@@ -98,11 +98,13 @@ Given(/^I save the proxy config$/) do
 end
 
 Then(/^the mapping rules should be in the following order:$/) do |table|
-  data = @provider.default_service.proxy.proxy_rules.ordered
-  MAPPING_RULE_ATTR = %w[http_method pattern delta metric_id].freeze
+  data = @provider.default_service.proxy.proxy_rules.includes(:metric).ordered
+  MAPPING_RULE_ATTR = %w[http_method pattern delta metric].freeze
   data.each_with_index do |mapping_rule, index|
     MAPPING_RULE_ATTR.each do |attr|
-      assert_equal table.hashes[index][attr].to_s, mapping_rule[attr].to_s
+      actual_value = mapping_rule.public_send(attr)
+      actual_value = actual_value.name if attr == 'metric'
+      assert_equal table.hashes[index][attr].to_s, actual_value.to_s
     end
   end
 end


### PR DESCRIPTION
Fix bug for Oracle DB for the feature done in https://github.com/3scale/porta/pull/530.
An example of this bug is in https://circleci.com/gh/3scale/porta/35439#tests/containers/11
It makes sense because we can not promise the ID that the metric will have, and it does not give useful info to the user for being a cucumber feature anyway 😄 