### PR TITLE
[THREESCALE-1980] pagination for application plan limits

### DIFF
--- a/app/controllers/admin/api/application_plan_limits_controller.rb
+++ b/app/controllers/admin/api/application_plan_limits_controller.rb
@@ -14,20 +14,26 @@ class Admin::Api::ApplicationPlanLimitsController < Admin::Api::BaseController
   ##~ op.description = "Returns the list of all limits associated to an application plan."
   ##~ op.group = "application_plan_limits"
   #
+  ##~ @parameter_per_page_50 = {:name => "per_page", :description => "Number of results per page. Default and max is 50.", :dataType => "int", :paramType => "query", :defaultValue => "50"}
+  #
   ##~ op.parameters.add @parameter_access_token
+  ##~ op.parameters.add @parameter_page
+  ##~ op.parameters.add @parameter_per_page_50
   ##~ op.parameters.add @parameter_application_plan_id_by_id_name
   #
-
   def index
-    respond_with(usage_limits)
+    respond_with(usage_limits.paginate(page: current_page, per_page: per_page))
   end
 
   protected
+
   def application_plan
     @application_plan ||= accessible_application_plans.find(params[:application_plan_id])
   end
 
   def usage_limits
-    @usage_limits ||= application_plan.usage_limits
+    # [Rails bug, will be fixed in Rails 5] https://github.com/rails/rails/issues/8005
+    # includes(:plan, metric: [:service])
+    @usage_limits ||= application_plan.usage_limits.includes(metric: [:service])
   end
 end

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -1318,6 +1318,20 @@
               "threescale_name": "access_token"
             },
             {
+              "name": "page",
+              "description": "Page in the paginated list. Defaults to 1.",
+              "dataType": "int",
+              "paramType": "query",
+              "defaultValue": "1"
+            },
+            {
+              "name": "per_page",
+              "description": "Number of results per page. Default and max is 50.",
+              "dataType": "int",
+              "paramType": "query",
+              "defaultValue": "50"
+            },
+            {
               "name": "application_plan_id",
               "description": "ID of the application plan.",
               "dataType": "int",

--- a/test/integration/admin/api/application_plan_limits_controller_test.rb
+++ b/test/integration/admin/api/application_plan_limits_controller_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Admin::Api::ApplicationPlanLimitsControllerTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    login! @provider
+  end
+
+  def test_index
+    service = FactoryBot.create(:simple_service, account: @provider)
+    app_plan = FactoryBot.create(:simple_application_plan, issuer: service)
+    metric = FactoryBot.create(:metric, service: service)
+    metric.usage_limits.create(period: :week, value: 1, plan: app_plan)
+    metric.usage_limits.create(period: :month, value: 1, plan: app_plan)
+
+    get admin_api_application_plan_limits_path(app_plan, format: :json)
+    assert_equal 2, JSON.parse(response.body)['limits'].length
+
+    get admin_api_application_plan_limits_path(app_plan, per_page: 1, format: :json)
+    assert_equal 1, JSON.parse(response.body)['limits'].length
+
+    get admin_api_application_plan_limits_path(app_plan, per_page: 2, page: 2, format: :json)
+    assert_equal 0, JSON.parse(response.body)['limits'].length
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Page renders slow so a pagination has to be added.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1980


