### PR TITLE
[THREESCALE-1917] service should be deleted with api key

### DIFF
--- a/app/controllers/admin/api/services_controller.rb
+++ b/app/controllers/admin/api/services_controller.rb
@@ -100,7 +100,7 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add @parameter_service_id_by_id
   #
   def destroy
-    authorize! :destroy, service
+    authorize!(:destroy, service) if current_user
     service.mark_as_deleted!
 
     respond_with(service)

--- a/test/integration/admin/api/services_controller_test.rb
+++ b/test/integration/admin/api/services_controller_test.rb
@@ -55,4 +55,17 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     get admin_api_services_path
     assert_response :forbidden
   end
+
+  class WithProviderKey < ActionDispatch::IntegrationTest
+
+    def test_delete
+      provider = FactoryBot.create(:provider_account)
+      host! provider.admin_domain
+      service = FactoryBot.create(:service, account: provider)
+      refute service.deleted?
+      delete admin_api_service_path(service, provider_key: provider.api_key)
+      assert_response :ok
+      assert service.reload.deleted?
+    end
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Service cannot be deleted with provider key.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1917
