### PR TITLE
Fix warning in eslint

### DIFF
--- a/app/javascript/src/Types/libs/libdefs.js
+++ b/app/javascript/src/Types/libs/libdefs.js
@@ -16,4 +16,5 @@ declare module 'core-js/fn/symbol' {
 
 }
 
+// eslint-disable-next-line flowtype/no-weak-types
 export type Window = any

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "update-dependencies": "npm run clean && npm i --no-progress",
     "check-dependencies": "npm ls --depth=0 || npm run update-dependencies",
     "flow:install": "flow-typed install",
-    "lint": "flow && eslint .eslintrc app/javascript spec/javascripts",
+    "lint": "flow && eslint app/javascript spec/javascripts",
     "test": "karma start --single-run",
     "jest": "jest",
     "jest:watch": "npm run-script jest -- --watch"


### PR DESCRIPTION
**What this PR does / why we need it**:

1. The eslint script is *wrong* at the moment: `eslintrc` is not supposed to be there. As a config file it is used by default and including it in the script means we want to _linter_ it.

2. Ignore usage of `any` in window, it's unavoidable so no reason to have this warning always showing up.

