### PR TITLE
[API] Endpoint to list custom policies

### DIFF
--- a/app/controllers/admin/api/registry/policies_controller.rb
+++ b/app/controllers/admin/api/registry/policies_controller.rb
@@ -21,6 +21,21 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   ##~ e.responseClass = "policy"
   #
   ##~ op            = e.operations.add
+  ##~ op.httpMethod = "GET"
+  ##~ op.summary    = "APIcast Policy Registry List"
+  ##~ op.description = "List the APIcast Policies"
+  ##~ op.group = "apicast_policies"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  def index
+    respond_with current_account.policies
+  end
+
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/registry/policies.json"
+  ##~ e.responseClass = "policy"
+  #
+  ##~ op            = e.operations.add
   ##~ op.httpMethod = "POST"
   ##~ op.summary    = "APIcast Policy Registry Create"
   ##~ op.description = "Creates an APIcast Policy"

--- a/app/representers/policies_representer.rb
+++ b/app/representers/policies_representer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'roar/json/collection'
+
+module PoliciesRepresenter
+  include ThreeScale::JSONRepresenter
+  include Roar::JSON::Collection
+
+  wraps_resource :policies
+  items extend: ::PolicyRepresenter
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -693,7 +693,7 @@ without fake Core server your after commit callbacks will crash and you might ge
 
       namespace :registry, defaults: { format: :json } do
         constraints(id: /((?!\.json\Z|\.xml\Z)[^\/])+/) do
-          resources :policies, only: [:create, :show]
+          resources :policies, only: [:create, :show, :index]
         end
       end
     end

--- a/doc/active_docs/Policy Registry API.json
+++ b/doc/active_docs/Policy Registry API.json
@@ -6,6 +6,28 @@
       "responseClass": "policy",
       "operations": [
         {
+          "httpMethod": "GET",
+          "summary": "APIcast Policy Registry List",
+          "description": "List the APIcast Policies",
+          "group": "apicast_policies",
+          "parameters": [
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/admin/api/registry/policies.json",
+      "responseClass": "policy",
+      "operations": [
+        {
           "httpMethod": "POST",
           "summary": "APIcast Policy Registry Create",
           "description": "Creates an APIcast Policy",

--- a/test/integration/admin/api/registry/policies_controller_test.rb
+++ b/test/integration/admin/api/registry/policies_controller_test.rb
@@ -117,6 +117,14 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     end
   end
 
+  test 'GET index returns the policies' do
+    FactoryBot.create_list(:policy, 3, account: @provider)
+    get admin_api_registry_policies_path(access_token: @access_token.value)
+    assert_response :success
+    expected_policy_ids = @provider.policies.pluck(:id)
+    assert_same_elements expected_policy_ids, JSON.parse(response.body)['policies'].map { |policy| policy.dig('policy', 'id') }
+  end
+
   def policy_params(token = @access_token.value)
     @policy_attributes ||= FactoryBot.build(:policy).attributes.symbolize_keys.slice(:name, :version, :schema)
     { policy: @policy_attributes, access_token: token }


### PR DESCRIPTION
**What this PR does / why we need it**
It defines a new endpoint in the API to list the provider's custom policies.

![screen shot 2019-03-05 at 7 24 09 pm](https://user-images.githubusercontent.com/1842261/53827818-4b19fe00-3f7c-11e9-942d-68b57197868e.png)

**Which issue(s) this PR fixes**
Closes [THREESCALE-2007](https://issues.jboss.org/browse/THREESCALE-2007)