### PR TITLE
[API] Endpoint to delete custom policies

### DIFF
--- a/app/controllers/admin/api/registry/policies_controller.rb
+++ b/app/controllers/admin/api/registry/policies_controller.rb
@@ -9,7 +9,7 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   representer ::Policy
 
   before_action :authorize_policies
-  before_action :find_policy, only: %i[show]
+  before_action :find_policy, only: %i[show destroy]
 
   # swagger
   ##~ sapi = source2swagger.namespace("Policy Registry API")
@@ -63,6 +63,23 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_policy_id
   def show
+    respond_with(policy)
+  end
+
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/registry/policies/{id}.json"
+  ##~ e.responseClass = "policy"
+  #
+  ##~ op             = e.operations.add
+  ##~ op.httpMethod  = "DELETE"
+  ##~ op.summary     = "APIcast Policy Registry Delete"
+  ##~ op.description = "Deletes an APIcast policy by ID"
+  ##~ op.group       = "apicast_policies"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  ##~ op.parameters.add @parameter_policy_id
+  def destroy
+    policy.destroy
     respond_with(policy)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -693,7 +693,7 @@ without fake Core server your after commit callbacks will crash and you might ge
 
       namespace :registry, defaults: { format: :json } do
         constraints(id: /((?!\.json\Z|\.xml\Z)[^\/])+/) do
-          resources :policies, only: [:create, :show, :index]
+          resources :policies, only: %i[create show index destroy]
         end
       end
     end

--- a/doc/active_docs/Policy Registry API.json
+++ b/doc/active_docs/Policy Registry API.json
@@ -94,6 +94,35 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/admin/api/registry/policies/{id}.json",
+      "responseClass": "policy",
+      "operations": [
+        {
+          "httpMethod": "DELETE",
+          "summary": "APIcast Policy Registry Delete",
+          "description": "Deletes an APIcast policy by ID",
+          "group": "apicast_policies",
+          "parameters": [
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            },
+            {
+              "name": "id",
+              "description": "ID of the policy. It can be an integer value or a combination 'name-version' of the policy (e.g. 'mypolicy-1.0')",
+              "dataType": "string",
+              "required": true,
+              "paramType": "path"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/test/integration/admin/api/registry/policies_controller_test.rb
+++ b/test/integration/admin/api/registry/policies_controller_test.rb
@@ -125,6 +125,13 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     assert_same_elements expected_policy_ids, JSON.parse(response.body)['policies'].map { |policy| policy.dig('policy', 'id') }
   end
 
+  test 'DELETE destroy deletes the policy' do
+    policy = FactoryBot.create(:policy, account: @provider)
+    delete admin_api_registry_policy_path(policy, access_token: @access_token.value)
+    assert_response :success
+    assert_empty response.body
+  end
+
   def policy_params(token = @access_token.value)
     @policy_attributes ||= FactoryBot.build(:policy).attributes.symbolize_keys.slice(:name, :version, :schema)
     { policy: @policy_attributes, access_token: token }


### PR DESCRIPTION
**What this PR does / why we need it**
It defines a new endpoint in the API to delete a provider's custom policy.

![screen shot 2019-03-05 at 7 43 09 pm](https://user-images.githubusercontent.com/1842261/53828891-2a06dc80-3f7f-11e9-879b-89f116e688d6.png)

**Which issue(s) this PR fixes**
Closes [THREESCALE-2008](https://issues.jboss.org/browse/THREESCALE-2008)

**Special notes for your reviewer**
Update and delete actions for policies can be considered unsafe because a policy may be in use. We should either freeze and forbid modification in policies currently in use and/or implement a `force` attribute to these state-modifier endpoints.