### PR TITLE
[WIP] Remove Account service_prefix

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -33,8 +33,7 @@ class Api::ServicesController < Api::BaseController
   end
 
   def create
-    @service = collection.new # this is done in 2 steps so that the account_id is in place as preffix_key relies on it
-    @service.attributes = params[:service]
+    @service = collection.new(params[:service])
     @service.system_name = params[:service][:system_name]
 
     if can_create? && @service.save

--- a/app/lib/backend/model_extensions/service.rb
+++ b/app/lib/backend/model_extensions/service.rb
@@ -8,7 +8,7 @@ module Backend
       end
 
       def backend_id
-        preffix_key
+        id
       end
 
       def update_backend_service

--- a/app/models/backend/transaction.rb
+++ b/app/models/backend/transaction.rb
@@ -134,7 +134,7 @@ module Backend
     end
 
     def self.storage_key(service_id, id)
-      ::Service.find(service_id).preffix_key "transactions/#{id}"
+      "transactions/#{id}"
     end
 
     def to_param

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -505,8 +505,7 @@ class Cinstance < Contract
   end
 
   def generate_key
-    #FIXME: service is not accessible here yet
-    plan.issuer.preffix_key(SecureRandom.hex(16))
+    SecureRandom.hex(16)
   end
 
   def end_users_switch

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -198,13 +198,6 @@ class Service < ApplicationRecord
     provider_can_use?(:proxy_pro) && proxy.self_managed?
   end
 
-  def preffix
-    @service_preffix ||= (provider&.service_preffix || '')
-  end
-
-  # by GrammarNazi
-  alias prefix preffix
-
   def publish_events
     OIDC::ServiceChangedEvent.create_and_publish!(self)
     OIDC::ProxyChangedEvent.create_and_publish!(proxy) if backend_version_change&.include?('oauth')
@@ -253,10 +246,6 @@ class Service < ApplicationRecord
 
   def backend_version
     BackendVersion.new(super)
-  end
-
-  def preffix_key(key = id)
-    [preffix.presence, key].compact.join
   end
 
   def published_plans


### PR DESCRIPTION
This preffix is not used anymore in SaaS and there is a problem for https://github.com/3scale/porta/pull/19

```ruby
Account.where.has { service_preffix != nil }.count
=> 0
```

Related to [THREESCALE-2025](https://issues.jboss.org/browse/THREESCALE-2025)