### PR TITLE
[end_users] Removal of End-users feature in on-prem

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -56,7 +56,8 @@ class Settings < ApplicationRecord
   # Using a constant here seems weird as it depends on some parameters
   def globally_denied_switches
     [
-      account.master_on_premises? ? :finance : nil
+      account.master_on_premises? ? :finance : nil,
+      ThreeScale.config.onpremises ? :end_users : nil
     ].compact
   end
 

--- a/test/integration/provider/admin/accounts_controller_test.rb
+++ b/test/integration/provider/admin/accounts_controller_test.rb
@@ -64,7 +64,7 @@ class Provider::Admin::AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [service_plan], account.bought_service_plans
     assert_equal [application_plan], account.bought_application_plans
     # should set the switches to everything is allowed (because it is enterprise and for on-prem it is validated)
-    switches = account.settings.switches
+    switches = account.settings.switches.except(:end_users)
     switches.each { |_name, switch| assert switch.allowed? }
   end
 

--- a/test/unit/abilities/end_users_test.rb
+++ b/test/unit/abilities/end_users_test.rb
@@ -7,6 +7,7 @@ class Abilities::EndUsersTest < ActiveSupport::TestCase
   def setup
     @provider = FactoryBot.create(:provider_account)
     assert @provider.settings.end_users.denied?
+    ThreeScale.config.stubs(onpremises: false)
   end
 
   test 'provider can manage end users' do
@@ -44,5 +45,49 @@ class Abilities::EndUsersTest < ActiveSupport::TestCase
 
     assert_can ability, :see, :end_users
     assert_cannot ability, :manage, :end_users
+  end
+
+  class Onpremises < ActiveSupport::TestCase
+    def setup
+      @provider = FactoryBot.create(:provider_account)
+      ThreeScale.config.stubs(onpremises: true)
+    end
+
+    test 'provider cannot manage end users' do
+      user = FactoryBot.create(:user, :account => @provider, :role => :member)
+      ability = Ability.new(user)
+
+      assert_cannot ability, :see, :end_users
+      assert_cannot ability, :admin, :end_users
+
+      @provider.settings.allow_end_users!
+      ability.reload!
+
+      assert_cannot ability, :see, :end_users
+      assert_cannot ability, :admin, :end_users
+
+      user.update_attribute :role, :admin
+      ability.reload!
+
+      assert_cannot ability, :manage, :end_users
+    end
+
+    test 'buyer cannot manage end users' do
+      buyer   = FactoryBot.create(:buyer_account, :provider_account => @provider)
+      user    = FactoryBot.create(:user, :account => buyer, :role => :member)
+      ability = Ability.new(user)
+
+      assert_cannot ability, :see, :end_users
+      assert_cannot ability, :admin, :end_users
+
+      @provider.settings.allow_end_users!
+      assert_cannot ability.reload!, :see, :end_users
+
+      @provider.settings.show_end_users!
+      ability.reload!
+
+      assert_cannot ability, :see, :end_users
+      assert_cannot ability, :manage, :end_users
+    end
   end
 end

--- a/test/unit/logic/provider_signup_test.rb
+++ b/test/unit/logic/provider_signup_test.rb
@@ -20,7 +20,7 @@ class Logic::ProviderSignupTest < ActiveSupport::TestCase
     ThreeScale.config.stubs(onpremises: true)
     enterprise_plan = FactoryBot.create(:application_plan, system_name: 'enterprise', name: 'enterprise', issuer: @service)
     @service.update_attribute(:default_application_plan, enterprise_plan)
-    default_signup_provider.settings.switches.each do |_name, switch|
+    default_signup_provider.settings.switches.except(:end_users).each do |_name, switch|
       assert switch.allowed?
     end
   end

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -205,14 +205,14 @@ class SettingsTest < ActiveSupport::TestCase
       assert_equal [], @provider.settings.globally_denied_switches
 
       ThreeScale.config.stubs(onpremises: true)
-      assert_equal [:finance], @provider.settings.globally_denied_switches
+      assert_equal [:finance, :end_users], @provider.settings.globally_denied_switches
 
       @provider.unstub(:master?)
       ThreeScale.config.stubs(onpremises: false)
       assert_equal [], @provider.settings.globally_denied_switches
 
       ThreeScale.config.stubs(onpremises: true)
-      assert_equal [], @provider.settings.globally_denied_switches
+      assert_equal [:end_users], @provider.settings.globally_denied_switches
     end
   end
 end

--- a/test/unit/signup/account_manager_test.rb
+++ b/test/unit/signup/account_manager_test.rb
@@ -90,7 +90,7 @@ class Signup::AccountManagerTest < ActiveSupport::TestCase
       assert_equal [service_plan], account.bought_service_plans
       assert_equal [application_plan], account.bought_application_plans
       # should set the switches to everything is allowed (because it is enterprise and for on-prem it is validated)
-      switches = account.settings.switches
+      switches = account.settings.switches.except(:end_users)
       switches.each { |_name, switch| assert switch.allowed? }
 
       # Saas
@@ -102,7 +102,7 @@ class Signup::AccountManagerTest < ActiveSupport::TestCase
       assert_equal [service_plan], account.bought_service_plans
       assert_equal [application_plan], account.bought_application_plans
       # should set the switches to nothing is allowed (because the enterprise plan for saas is not automatically validated)
-      switches = account.settings.switches
+      switches = account.settings.switches.except(:end_users)
       switches.each { |_name, switch| refute switch.allowed? }
     end
 


### PR DESCRIPTION
**What this PR does / why we need it**
It globally  denies end_users feature for on-premises


**Which issue(s) this PR fixes**
Closes [THREESCALE-1927](https://issues.jboss.org/browse/THREESCALE-1927)
