### PR TITLE
Ignore DeserializationError in PublishEnabledChangedEventForProviderApplicationsWorke when account is already deleted

### DIFF
--- a/app/workers/publish_enabled_changed_event_for_provider_applications_worker.rb
+++ b/app/workers/publish_enabled_changed_event_for_provider_applications_worker.rb
@@ -2,6 +2,10 @@
 
 # TODO: Rails 5 --> class PublishEnabledChangedEventForProviderApplicationsWorker < ApplicationJob
 class PublishEnabledChangedEventForProviderApplicationsWorker < ActiveJob::Base
+  rescue_from(ActiveJob::DeserializationError) do |exception|
+    Rails.logger.info "PublishEnabledChangedEventForProviderApplicationsWorker#perform raised #{exception.class} with message #{exception.message}"
+  end
+
   def perform(provider, previous_state)
     return unless [provider.state, previous_state].include?('scheduled_for_deletion')
     provider.buyer_applications.find_each(&:publish_enabled_changed_event)


### PR DESCRIPTION
So if someone creates, approves and destroys very quickly, there is nothing we can do 😄 
Fixes [THREESCALE-2034](https://issues.jboss.org/browse/THREESCALE-2034)