### PR TITLE
Bumps react-jsonschema-form version to 1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6353,7 +6353,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6371,11 +6372,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6388,15 +6391,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6499,7 +6505,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6509,6 +6516,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6521,17 +6529,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6548,6 +6559,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6620,7 +6632,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6630,6 +6643,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6705,7 +6719,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6735,6 +6750,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6752,6 +6768,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6790,11 +6807,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -16731,28 +16750,15 @@
       "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g=="
     },
     "react-jsonschema-form": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-jsonschema-form/-/react-jsonschema-form-1.2.0.tgz",
-      "integrity": "sha512-rR77qoFiQ5TxDYwsJz8UWmDner4jQ4xMnDqeV6Nvg7GtoEyOUoTVkI/SBMEzfXuF/piWZXYjquP96Hy/2L7C+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-jsonschema-form/-/react-jsonschema-form-1.3.0.tgz",
+      "integrity": "sha512-WrlQh0urJGkR4Sb9hMJLwsTkVYVYbpgtofZ+JxiI9FSFXAIfCiCwhZ7R0zEKFADlah3KrN3qC6VFE6HtFk6aZg==",
       "requires": {
-        "ajv": "^5.2.3",
+        "ajv": "^6.7.0",
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.7",
         "lodash.topath": "^4.5.2",
         "prop-types": "^15.5.8"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        }
       }
     },
     "react-lifecycles-compat": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
     "react-codemirror2": "^5.1.0",
-    "react-jsonschema-form": "^1.2.0",
+    "react-jsonschema-form": "^1.3.0",
     "react-redux": "^5.0.6",
     "react-sortable-hoc": "^1.6.1",
     "redux": "^4.0.1",

--- a/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
@@ -203,7 +203,7 @@ describe('PolicyForm', () => {
     const statusInput = policyFormWrapper.find('input')
     statusInput.simulate('change', { target: { value: 'NaN' } })
     const instance = policyFormWrapper.instance()
-    const event = {preventDefault: jest.fn()}
+    const event = {preventDefault: jest.fn(), persist: jest.fn()}
 
     instance.onSubmit(event)
     expect(policyFormWrapper.state().errors.length).toBe(1)


### PR DESCRIPTION
After upgrading to `1.3` our specs are failing due to this change: https://github.com/mozilla-services/react-jsonschema-form/commit/59038c0ce0f9f215e78e0f730d9e6138b5dcbf20#diff-07a63ede6fe55fca89398d42da737369R154

The problem is solved by simply updating our mock.