### PR TITLE
:construction_worker: THREESCALE-1990 extracts js jobs reducing repet…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -720,15 +720,6 @@ workflows:
           requires:
             - dependencies_bundler
             - dependencies_npm
-      - lint:
-          requires:
-            - assets_precompile
-      - karma:
-          requires:
-            - assets_precompile
-      - jest:
-          requires:
-            - assets_precompile
       - unit:
           requires:
             - dependencies_bundler
@@ -751,9 +742,6 @@ workflows:
             - cucumber
             - integration
             - functional
-            - lint
-            - karma
-            - jest
           <<: *only-master-filter
       - notify_failure:
           requires:
@@ -762,9 +750,6 @@ workflows:
             - cucumber
             - integration
             - functional
-            - lint
-            - karma
-            - jest
           <<: *only-master-filter
 
   postgres_build:
@@ -790,15 +775,6 @@ workflows:
           requires:
             - deps_bundler_postgres
             - dependencies_npm
-      - lint:
-          requires:
-            - assets_precompile
-      - karma:
-          requires:
-            - assets_precompile
-      - jest:
-          requires:
-            - assets_precompile
       - unit-postgres:
           requires:
             - deps_bundler_postgres
@@ -821,9 +797,6 @@ workflows:
             - cucumber-postgres
             - integration-postgres
             - functional-postgres
-            - lint
-            - karma
-            - jest
           <<: *only-master-filter
       - notify_failure:
           requires:
@@ -832,9 +805,6 @@ workflows:
             - cucumber-postgres
             - integration-postgres
             - functional-postgres
-            - lint
-            - karma
-            - jest
           <<: *only-master-filter
 
   oracle_build:
@@ -861,15 +831,6 @@ workflows:
             - deps_bundler_oracle
             - dependencies_npm
 
-      - lint:
-          requires:
-            - assets_precompile
-      - karma:
-          requires:
-            - assets_precompile
-      - jest:
-          requires:
-            - assets_precompile
       - unit-oracle:
           requires:
             - deps_bundler_oracle
@@ -892,9 +853,6 @@ workflows:
             - cucumber-oracle
             - integration-oracle
             - functional-oracle
-            - lint
-            - karma
-            - jest
           <<: *only-master-filter
 
       - notify_failure:
@@ -904,9 +862,6 @@ workflows:
             - cucumber-oracle
             - integration-oracle
             - functional-oracle
-            - lint
-            - karma
-            - jest
           <<: *only-master-filter
 
   visual_tests:
@@ -929,6 +884,38 @@ workflows:
           context: percy
           requires:
             - assets_precompile
+
+  javascript_tests:
+    jobs:
+      - notify_start:
+          <<: *only-master-filter
+      - dependencies_bundler
+      - dependencies_npm
+      - assets_precompile:
+          requires:
+            - dependencies_bundler
+            - dependencies_npm
+      - lint:
+          requires:
+            - assets_precompile
+      - karma:
+          requires:
+            - assets_precompile
+      - jest:
+          requires:
+            - assets_precompile
+      - notify_success:
+          requires:
+            - lint
+            - karma
+            - jest
+          <<: *only-master-filter
+      - notify_failure:
+          requires:
+            - lint
+            - karma
+            - jest
+          <<: *only-master-filter
 
   visual_test-master:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -900,10 +900,10 @@ workflows:
             - assets_precompile
       - karma:
           requires:
-            - assets_precompile
+            - dependencies_npm
       - jest:
           requires:
-            - assets_precompile
+            - dependencies_npm
       - notify_success:
           requires:
             - lint


### PR DESCRIPTION
**What this PR does / why we need it**:

There are 3 JS related jobs in our CI: `karma`, `jest` and `lint` that do not depend on any DB. Right now they are being run in 3 different workflows therefore they should be extracted in their own dedicated workflow to be run only once.

**Which issue(s) this PR fixes** 

[THREESCALE-1990: JS tests in System are being executed 3 times more than needed](https://issues.jboss.org/browse/THREESCALE-1990)

**Verification steps** 

- All workflows finish successfully
- `karma`, `jest` and  `lint` are executed only in `javascript_tests` and one time
