### PR TITLE
THREESCALE-1615 Removes support emails from API response

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -365,8 +365,6 @@ class Service < ApplicationRecord
 
       xml.deployment_option deployment_option
       xml.support_email support_email
-      xml.tech_support_email tech_support_email
-      xml.admin_support_email admin_support_email
 
       xml.end_user_registration_required end_user_registration_required
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It removes fields `tech_support_email` and `admin_support_email` from the Account Management API Service List's response.

**Which issue(s) this PR fixes** 

[THREESCALE-1615: Remove <tech_support_email/> and <admin_support_email/> fields from the 3scale Account Management API Service List](https://issues.jboss.org/browse/THREESCALE-1615)

**Verification steps** 

1. Copy your access token or create one if none exists at user/access_tokens.
1. Call the Service List API endpoint `$ curl ".../admin/api/services.xml?access_token=<token>"`
1. Verify there is no `tech_support_email` or `admin_support_email` values.

**Special notes for your reviewer**:
This is related to https://github.com/3scale/porta/pull/443