### PR TITLE
[Bugfix] CreateServiceTokenWorker rescue ActiveRecord::RecordNotFound & ActiveJob::DeserializationError

### DIFF
--- a/test/workers/create_service_token_worker_test.rb
+++ b/test/workers/create_service_token_worker_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CreateServiceTokenWorkerTest < ActiveSupport::TestCase
@@ -27,6 +29,42 @@ class CreateServiceTokenWorkerTest < ActiveSupport::TestCase
         # for one event there should be only one service token
         CreateServiceTokenWorker.perform_async(event)
       end
+    end
+  end
+
+  def test_perform_reports_error_when_event_does_not_exist
+    System::ErrorReporting.expects(:report_error).once.with do |exception, options|
+      exception.is_a?(ActiveRecord::RecordNotFound) && (parameters = options[:parameters]) && parameters[:event_id] == 'fake-id'
+    end
+    Sidekiq::Testing.inline! { CreateServiceTokenWorker.perform_async('fake-id') }
+  end
+
+  class CreateServiceTokenWorkerDeserializationErrorTest < ActiveSupport::TestCase
+    def setup
+      @service = FactoryBot.create(:simple_service)
+      @user = FactoryBot.create(:simple_user)
+      @event = Services::ServiceCreatedEvent.create(service, user)
+      Rails.application.config.event_store.publish_event(event)
+    end
+
+    attr_reader :service, :user, :event
+
+    def test_perform_deserialization_error_no_service
+      expected_log_message = /CreateServiceTokenWorker#perform raised ActiveJob::DeserializationError with message: Error while trying to deserialize arguments: Couldn't find Service with 'id'=#{service.id}/
+      Rails.logger.stubs(:info) # There can be other logs as well :)
+      Rails.logger.expects(:info).with { |message| message.match(expected_log_message) }
+
+      service.delete
+      Sidekiq::Testing.inline! { CreateServiceTokenWorker.perform_async(event.event_id) }
+    end
+
+    def test_perform_deserialization_error_no_user
+      System::ErrorReporting.expects(:report_error).once.with do |exception, options|
+        exception.is_a?(ActiveJob::DeserializationError) && (parameters = options[:parameters]) && parameters[:event_id] == event.event_id
+      end
+
+      user.delete
+      Sidekiq::Testing.inline! { CreateServiceTokenWorker.perform_async(event.event_id) }
     end
   end
 end


### PR DESCRIPTION
Fixes [THREESCALE-2048](https://issues.jboss.org/browse/THREESCALE-2048)

What happened is a customer created and deleted a service very quickly (several times), and when a service is created, we also create an event with the service just created and with the user who did it:
https://github.com/3scale/porta/blob/245555bbef2f265cec806a8a6f40152a1ce57e66/app/events/services/service_created_event.rb#L7-L8
Later we asynchronously perform `CreateServiceTokenWorker`:
https://github.com/3scale/porta/blob/245555bbef2f265cec806a8a6f40152a1ce57e66/app/events/services/service_created_event.rb#L22-L24
So if by the time that `CreateServiceTokenWorker` is performed, the service does not exist anymore, it raises `ActiveJob::DeserializationError` with the proper error message, and it makes sense because what it does is creating a _service token_ for that service and notifying `backend` to create this _service token_ there too. But if the `Service` is already destroyed at this point, then no need to create anything, it is not a bug, it is the desired behaviour, so nothing to do...

However, If the exception is either that the event does not exist or that the user does not exist anymore, then it doesn't retry because it will fail anyway but it notifies bugsnag because it may be a bug in the code.