### PR TITLE
Email to developer on plan change performed via API

### DIFF
--- a/app/lib/logic/plan_changes.rb
+++ b/app/lib/logic/plan_changes.rb
@@ -68,8 +68,6 @@ module Logic
         permission = issuer.plan_change_permission(self.plan.class)
 
         self.change_plan!(new_plan)
-
-        CinstanceMessenger.plan_change_for_buyer(self).deliver if new_plan.is_a?(ApplicationPlan)
       end
 
       # Depending on the permissions of the plan issuer, this method

--- a/app/mailers/mail_preview.rb
+++ b/app/mailers/mail_preview.rb
@@ -1,5 +1,5 @@
 class MailPreview < MailView
-  FakeContract = Struct.new(:old_plan, :plan, :provider_account, :service, :account, :name)
+  FakeContract = Struct.new(:id, :old_plan, :plan, :provider_account, :service, :account, :name)
 
   def application_created
     event = Applications::ApplicationCreatedEvent.create(Cinstance.last, User.last)
@@ -21,7 +21,7 @@ class MailPreview < MailView
 
   def service_contract_plan_changed
     plans    = ServicePlan.last(2)
-    contract = FakeContract.new(plans.first, plans.second, Account.providers.last, Service.last, Account.last, '1')
+    contract = build_fake_contract(*plans)
     event    = ServiceContracts::ServiceContractPlanChangedEvent.create(
       contract, User.last
     )
@@ -110,11 +110,7 @@ class MailPreview < MailView
   end
 
   def cinstance_plan_changed
-    plans     = ServicePlan.last(2)
-    cinstance = FakeContract.new(plans.first, plans.second, Account.providers.last, Service.last, Account.last, '1')
-    event = Cinstances::CinstancePlanChangedEvent.create(cinstance, User.last)
-
-    NotificationMailer.cinstance_plan_changed(event, receiver)
+    NotificationMailer.cinstance_plan_changed(cinstance_plan_changed_event, receiver)
   end
 
   def message_received
@@ -157,5 +153,16 @@ class MailPreview < MailView
 
   def receiver
     @_receiver ||= User.last
+  end
+
+  def build_fake_contract(old_plan, new_plan)
+    FakeContract.new(1, old_plan, new_plan, Account.providers.last, Service.last, Account.last, '1')
+  end
+
+  def cinstance_plan_changed_event
+    plans = ApplicationPlan.last(2)
+    cinstance = build_fake_contract(*plans)
+
+    Cinstances::CinstancePlanChangedEvent.create(cinstance, User.last)
   end
 end

--- a/app/services/notifications/new_notification_system_migration.rb
+++ b/app/services/notifications/new_notification_system_migration.rb
@@ -1,12 +1,6 @@
 class Notifications::NewNotificationSystemMigration
   attr_reader :account
 
-  ENABLED_BY_DEFAULT = %i(cinstance_expired_trial invoices_to_review
-                          unsuccessfully_charged_invoice_provider
-                          unsuccessfully_charged_invoice_final_provider
-                          service_plan_change_requested
-                          application_plan_change_requested).freeze
-
   def self.run!(account)
     new(account).migrate!
   end
@@ -58,10 +52,10 @@ class Notifications::NewNotificationSystemMigration
                   when :new_contract
                     :service_contract_created
                   when :plan_change
-                    %i(service_contract_plan_changed cinstance_plan_changed
-                       cinstance_expired_trial).freeze
+                    %i[service_contract_plan_changed cinstance_plan_changed
+                       cinstance_expired_trial].freeze
                   when :limit_alerts
-                    %i(limit_alert_reached_provider limit_violation_reached_provider).freeze
+                    %i[limit_alert_reached_provider limit_violation_reached_provider].freeze
                   when :cinstance_cancellation
                     :cinstance_cancellation
                   when :contract_cancellation

--- a/test/integration/admin/api/buyers_applications_controller_test.rb
+++ b/test/integration/admin/api/buyers_applications_controller_test.rb
@@ -59,30 +59,61 @@ class Admin::Api::BuyersApplicationsControllerTest < ActionDispatch::Integration
 
       host! @provider.admin_domain
 
-      @account = FactoryBot.create(:buyer_account, provider_account: @provider)
+      @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
       @plan = FactoryBot.create(:application_plan, service: @provider.default_service)
-      @application = @account.buy! @plan
+      @application = @buyer.buy! @plan
     end
 
+    disable_transactional_fixtures!
+
     test 'change plan' do
-      new_plan = FactoryBot.create(:application_plan, service: @provider.default_service)
-
-      params = { access_token: @access_token.value, plan_id: new_plan.id }
-      put change_plan_admin_api_account_application_path(account_id: @account.id, id: @application.id, format: :xml), params
-
+      new_plan = create_new_plan_same_service
+      request_plan_change new_plan
       assert_response :success
       assert_equal new_plan, @application.reload.plan
     end
 
     test 'cannot change plan to a different service' do
       service  = FactoryBot.create(:service, account: @provider)
-      new_plan = FactoryBot.create(:application_plan, service: service)
-
-      params = { access_token: @access_token.value, plan_id: new_plan.id }
-      put change_plan_admin_api_account_application_path(account_id: @account.id, id: @application.id, format: :xml), params
-
+      new_plan_other_service = FactoryBot.create(:application_plan, service: service)
+      request_plan_change new_plan_other_service
       assert_response :unprocessable_entity
       assert_equal @plan, @application.reload.plan
+    end
+
+    test 'sends email to provider and buyer with new notification system' do
+      Account.any_instance.stubs(provider_can_use?: true)
+
+      Cinstances::CinstancePlanChangedEvent.expects(:create).with(@application, any_parameters).once
+      ContractMessenger.expects(:plan_change).never
+
+      ContractMessenger.expects(:plan_change_for_buyer).with(@application, any_parameters).once.returns(mock(deliver: true))
+
+      request_plan_change
+      assert_response :success
+    end
+
+    test 'sends email to provider and buyer with old notification system' do
+      Account.any_instance.stubs(provider_can_use?: false)
+
+      Cinstances::CinstancePlanChangedEvent.expects(:create).never
+      ContractMessenger.expects(:plan_change).with(@application, any_parameters).once.returns(mock(deliver: true))
+
+      ContractMessenger.expects(:plan_change_for_buyer).with(@application, any_parameters).once.returns(mock(deliver: true))
+
+      request_plan_change
+      assert_response :success
+    end
+
+    private
+
+    def request_plan_change(new_plan = create_new_plan_same_service)
+      params = { access_token: @access_token.value, plan_id: new_plan.id }
+      put change_plan_admin_api_account_application_path(account_id: @buyer.id, id: @application.id, format: :xml), params
+    end
+
+    def create_new_plan_same_service
+      FactoryBot.create(:application_plan, service: @provider.default_service)
     end
   end
 end

--- a/test/unit/observers/cinstance_observer_test.rb
+++ b/test/unit/observers/cinstance_observer_test.rb
@@ -154,8 +154,8 @@ class CinstanceObserverTest < ActiveSupport::TestCase
       @cinstance.save!
     end
 
-    context 'a message' do
-      setup { @message = Message.last }
+    context 'a message to provider' do
+      setup { @message = @buyer.messages.last }
 
       should 'be sent' do
         assert_not_nil @message
@@ -175,6 +175,23 @@ class CinstanceObserverTest < ActiveSupport::TestCase
       end
 
       should 'contain old plan name'
+
+      should 'contain new plan name' do
+        assert_match(@new_plan.name, @message.body)
+      end
+    end
+
+    context 'a message to buyer' do
+      setup { @message = @provider.messages.last }
+
+      should 'be sent' do
+        assert_not_nil @message
+        assert @message.sent?
+      end
+
+      should 'have the buyer as a recipient' do
+        assert_equal [@buyer], @message.to
+      end
 
       should 'contain new plan name' do
         assert_match(@new_plan.name, @message.body)

--- a/test/unit/observers/message_observer_test.rb
+++ b/test/unit/observers/message_observer_test.rb
@@ -45,12 +45,16 @@ class MessageObserverTest < ActiveSupport::TestCase
     Cinstances::CinstancePlanChangedEvent.expects(:create).once
     ContractMessenger.expects(:plan_change).never
 
+    ContractMessenger.expects(:plan_change_for_buyer).once.returns(mock(deliver: true))
+
     cinstance.change_plan! FactoryBot.create(:simple_application_plan, service: @service)
 
     Logic::RollingUpdates.stubs(skipped?: true)
 
     Cinstances::CinstancePlanChangedEvent.expects(:create).never
     ContractMessenger.expects(:plan_change).once.returns(mock(deliver: true))
+
+    ContractMessenger.expects(:plan_change_for_buyer).once.returns(mock(deliver: true))
 
     cinstance.change_plan! FactoryBot.create(:simple_application_plan, service: @service)
   end


### PR DESCRIPTION
**What this PR does / why we need it**
This PR makes application plan changes performed by the provider through the API to send a notification message to the buyer as well, as it does when performed in the Admin Portal.

![54424581-7f778200-4713-11e9-8832-960af2f96ea8](https://user-images.githubusercontent.com/1842261/54602688-9fc07d00-4a42-11e9-921b-cb65f6dd000c.png)

**Which issue(s) this PR fixes**
Closes [THREESCALE-923](https://issues.jboss.org/browse/THREESCALE-923).