### PR TITLE
THREESCALE-1382: Adjusting word break in very large words

### DIFF
--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -134,9 +134,13 @@ table.data,
 table.list {
   td,
   th {
-    word-wrap: break-word;
     border-bottom: $border-width solid $border-color;
     font-weight: $font-weight-normal;
+    word-break: break-all;
+
+    &:nth-child(3) {
+      word-break: normal;
+    }
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Metrics with very long names break the design of tables

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-1382

**Verification steps** 

1) Define metric(s) with very long `name`, `system name` and `units` name 
2) Define `pricing rules` and `limits`for the metric(s)
3) Go to API > Applications > Listing > Your App name

**Before:**

![before](https://user-images.githubusercontent.com/13486237/54380368-8bb7fc80-468b-11e9-9f7b-bc684a94d44a.png)
---
**After:**

![after](https://user-images.githubusercontent.com/13486237/54380381-96729180-468b-11e9-915d-ca944ed15b01.png)

