### PR TITLE
Bumps yard version in prod

### DIFF
--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -810,7 +810,7 @@ GEM
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    yard (0.9.5)
+    yard (0.9.18)
     zip-zip (0.3)
       rubyzip (>= 1.0.0)
 


### PR DESCRIPTION
It bumps yard version to 0.9.18 in production. Deploys using `gemfiles/prod/Gemfile` will fail until this gets merged.

Missing in https://github.com/3scale/porta/pull/641