### PR TITLE
Prevents policies in use from being modified

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -116,6 +116,10 @@ class Proxy < ApplicationRecord
     super(attr_policies_config.is_a?(String) ? attr_policies_config : attr_policies_config.to_json)
   end
 
+  def find_policy_config_by(name:, version:)
+    policies_config.find { |config| config['name'] == name && config['version'] == version }
+  end
+
   def policy_chain
     return unless provider_can_use?(:policies)
     raw_config = policies_config

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -826,6 +826,8 @@ en:
               all_periods_used: "Metric cannot be disabled. Please contact support."
         policy:
           attributes:
+            base:
+              currently_in_use: 'This policy is currently being used in one of your APIs and cannot be modified.'
             account:
               not_tenant: 'must be a tenant'
             schema:

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -519,6 +519,21 @@ class ProxyTest < ActiveSupport::TestCase
     assert Proxy.find(@proxy.id).oidc_configuration.direct_access_grants_enabled
   end
 
+  test 'find policy config' do
+    refute @proxy.find_policy_config_by(name: 'my-policy', version: '1.0.0')
+    refute @proxy.find_policy_config_by(name: 'my-other-policy', version: '0.5.0')
+
+    policy_config1 = { name: 'my-policy', version: '1.0.0', configuration: {}, enabled: true }.stringify_keys
+    policy_config2 = { name: 'my-other-policy', version: '0.5.0', configuration: {}, enabled: false }.stringify_keys
+
+    @proxy.policies_config = [policy_config1, policy_config2].map { |attr| Proxy::PolicyConfig.new(attr) }
+    @proxy.save!
+    @proxy.reload
+
+    assert_equal policy_config1, @proxy.find_policy_config_by(name: 'my-policy', version: '1.0.0')
+    assert_equal policy_config2, @proxy.find_policy_config_by(name: 'my-other-policy', version: '0.5.0')
+  end
+
   def analytics
     ThreeScale::Analytics::UserTracking.any_instance
   end


### PR DESCRIPTION
**What this PR does / why we need it**
It freezes a policy in use by any proxy of the provider so the policy cannot have its attributes name, version or schema modified, neither deleted.

<img width="1680" alt="Screen Shot 2019-03-21 at 9 17 31 AM" src="https://user-images.githubusercontent.com/1842261/54740193-f0f37c80-4bba-11e9-9b6d-6ed54a56dc83.png">

<img width="1680" alt="Screen Shot 2019-03-21 at 9 17 57 AM" src="https://user-images.githubusercontent.com/1842261/54740209-f94bb780-4bba-11e9-806b-c77fecf06c95.png">

<img width="1680" alt="Screen Shot 2019-03-21 at 9 22 19 AM" src="https://user-images.githubusercontent.com/1842261/54740266-1da79400-4bbb-11e9-9195-690d305f1834.png">

<img width="1680" alt="Screen Shot 2019-03-21 at 9 19 10 AM" src="https://user-images.githubusercontent.com/1842261/54740244-0e284b00-4bbb-11e9-887a-8bfff84a296b.png">


**Which issue(s) this PR fixes**
Closes [THREESCALE-2097](https://issues.jboss.org/browse/THREESCALE-2097)

**Special notes for the reviewer**
Why not to use `attr_readonly :name, :version, :schema` on `Policy`?
    1. It is not conditional
    2. It does not raise errors – just prevents modifications silently