### PR TITLE
move away from manually built builder image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ attach-to-workspace: &attach-to-workspace
     at: .
 
 system-builder: &system-builder
-  image: quay.io/3scale/system-builder:headless
+  image: quay.io/3scale/system-builder:latest
   environment:
     BUNDLE_FROZEN: true
     BUNDLE_PATH: 'vendor/bundle'


### PR DESCRIPTION
**What this PR does / why we need it**:

Since https://github.com/3scale/system-builder/pull/5 has been merged, we can move back to `latest` tag, which is automatically built by Quay.io trigger, from https://github.com/3scale/system-builder/ `master` branch.

**Which issue(s) this PR fixes** 

Fixes https://github.com/3scale/porta/issues/715

**Verification steps** 

If pipeline is green, we are good. 

**Special notes for your reviewer**:
