### PR TITLE
Adds warning styling & info for catch-all mapping rules

### DIFF
--- a/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
@@ -10,9 +10,13 @@ $(document).on 'initialize', '#proxy', ->
 
   # Warning for "catch-all" rules
   setUpWarningForPattern = (pattern) ->
-    pattern.children('input').keyup (e) ->
-      warning = pattern.children('#catch-all-warning')
-      warning.css 'display', if e.currentTarget.value is '/' then 'block' else 'none'
+    input = pattern.children "input"
+    warning = pattern.children "#catch-all-warning"
+
+    warning.toggleClass "disabled", input.is(":disabled")
+    warning.toggleClass "hidden", input.attr("value") isnt "/"
+    input.keyup (e) ->
+      warning.toggleClass "hidden", e.currentTarget.value isnt "/"
 
   $('td.pattern').each -> setUpWarningForPattern $(this)
 
@@ -110,12 +114,15 @@ $(document).on 'initialize', '#proxy', ->
       tr.addClass "deleted"
       tr.find("input, select").attr "disabled", "disabled"
       tr.find("input.proxy_rule_id, .destroyer").removeAttr "disabled"
+    tr.find("span.fa-exclamation-triangle").addClass "disabled"
     tr.find("input").trigger "proxy.rule.change"
     false
 
   $("a[href=\"#edit-proxy-rule\"]").live "click", ->
     tr = $(this).closest("tr")
-    tr.find("select,input:not(.destroyer)").removeAttr "disabled"  unless tr.hasClass("deleted")
+    return if tr.hasClass "deleted"
+    tr.find("select,input:not(.destroyer)").removeAttr "disabled"
+    tr.find("span.fa-exclamation-triangle").removeClass "disabled"
     false
   #---------------------------------------------------------------------
 

--- a/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
@@ -8,6 +8,14 @@ $(document).on 'initialize', '#proxy', ->
   $("input.error").tipsy
     trigger: "focus"
 
+  # Warning for "catch-all" rules
+  setUpWarningForPattern = (pattern) ->
+    pattern.children('input').keyup (e) ->
+      warning = pattern.children('#catch-all-warning')
+      warning.css 'display', if e.currentTarget.value is '/' then 'block' else 'none'
+
+  $('td.pattern').each -> setUpWarningForPattern $(this)
+
   # API TEST REQUEST ------------------------------------------------
   $("form.proxy").on "change keyup", 'input, select', ->
     if $("#proxy_api_test_path").val()
@@ -90,6 +98,7 @@ $(document).on 'initialize', '#proxy', ->
     rule.find("input.position").val(newIndex)
     $mappingRuleList.append rule
     rule.find('.pattern input:first').focus()
+    setUpWarningForPattern rule.find('.pattern')
     false
 
   $("a[href=\"#delete-proxy-rule\"]").live "click", ->

--- a/app/assets/stylesheets/provider/admin/apiconfig/services/_proxies.scss
+++ b/app/assets/stylesheets/provider/admin/apiconfig/services/_proxies.scss
@@ -510,6 +510,16 @@ form.proxy {
 
     td {
       padding-right: 12px;
+
+      &.pattern {
+        position: relative;
+      }
+    }
+
+    span.fa-exclamation-triangle {
+      position: absolute;
+      right: line-height-times(1);
+      top: line-height-times(9 / 10);
     }
 
     .action.add {

--- a/app/assets/stylesheets/provider/admin/apiconfig/services/_proxies.scss
+++ b/app/assets/stylesheets/provider/admin/apiconfig/services/_proxies.scss
@@ -520,6 +520,15 @@ form.proxy {
       position: absolute;
       right: line-height-times(1);
       top: line-height-times(9 / 10);
+      color: $warning-color;
+
+      &.disabled {
+        color: unset;
+      }
+
+      &.hidden {
+        display: none;
+      }
     }
 
     .action.add {

--- a/app/views/api/integrations/apicast/shared/_mapping_rule.html.erb
+++ b/app/views/api/integrations/apicast/shared/_mapping_rule.html.erb
@@ -13,6 +13,11 @@
       <%= p.select 'http_method', ProxyRule::ALLOWED_HTTP_METHODS, {}, html_options %>
     </td>
     <td class="pattern">
+      <span
+        id="catch-all-warning"
+        class="fa fa-exclamation-triangle"
+        style="<%= 'display: none;' if rule.pattern != '/' %>"
+        title="<%= t('api.integrations.proxy.proxy_rule_catch_all_warning') %>"></span>
       <%= p.text_field_with_errors :pattern, html_options %>
     </td>
 

--- a/app/views/api/integrations/apicast/shared/_mapping_rule.html.erb
+++ b/app/views/api/integrations/apicast/shared/_mapping_rule.html.erb
@@ -15,8 +15,7 @@
     <td class="pattern">
       <span
         id="catch-all-warning"
-        class="fa fa-exclamation-triangle"
-        style="<%= 'display: none;' if rule.pattern != '/' %>"
+        class="fa fa-exclamation-triangle disabled <%= 'hidden' if rule.pattern != '/' %>"
         title="<%= t('api.integrations.proxy.proxy_rule_catch_all_warning') %>"></span>
       <%= p.text_field_with_errors :pattern, html_options %>
     </td>

--- a/app/views/api/integrations/apicast/shared/_mapping_rules.html.slim
+++ b/app/views/api/integrations/apicast/shared/_mapping_rules.html.slim
@@ -51,7 +51,10 @@ javascript:
         },
         stop: function () {
           $('tr:not(#new-proxy-rule-template)', this).each(function (index, mappingRule) {
-            if (!$(mappingRule).hasClass('deleted')) $(mappingRule).find('select,input:not(.destroyer)').removeAttr('disabled')
+            if (!$(mappingRule).hasClass('deleted')) {
+              $(mappingRule).find('select,input:not(.destroyer)').removeAttr('disabled')
+              $(mappingRule).find('span.fa-exclamation-triangle').removeClass('disabled')
+            }
             $(mappingRule).find('.position').val(index + 1)
           })
         }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -529,6 +529,8 @@ en:
         documentation_response_codes_tracking_url: '%{docs_base_url}/admin_portal_guide/response-codes-tracking'
         documentation_create_active_doc_spec: "%{docs_base_url}/using-developer-portal/create-activedocs-spec"
 
+        proxy_rule_catch_all_warning: |
+          "Catch all" Mapping Rules often lead to double counts when more specific rules are added.
         proxy_rule_help_html: |
           <h4>Mapping Rules Syntax</h4>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a ⚠️ icon inside Mapping Rules' _pattern_ input that shows up when its value equals `/`, meaning it is a "Catch All" Mapping Rule.
The warning won't show up when the input is empty since that's a wrong value and wouldn't be saved.
It is rendered first time by ruby then refreshed on `keyup` event by Javascript.

![rules](https://user-images.githubusercontent.com/11672286/55143377-ec8d0d80-513e-11e9-83df-fb9b2ed700b6.gif)

> NOTE: It's not clear in the gif but the icon is grayed only when the input is disabled.

**Which issue(s) this PR fixes** 
[THREESCALE-1861 Distinguished styling & info for catch-all mapping rules](https://issues.jboss.org/browse/THREESCALE-1861)

**Verification steps** 

1. Go to API > Integration > Configuration > Edit > Mapping Rules
1. All patterns matching `/` should have a warning icon with a tooltip
1. Edit and try different values to see such warning appear and disappear
1. With JS disabled, the warning will only appear at the start and it won't change
