### PR TITLE
Configurable message bus settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ C:\\nppdf32Log\\debuglog.txt
 /config/cubert.yml
 /config/segment.yml
 /config/core.yml
+/config/message_bus.yml
 /config/mixpanel.yml
 /config/settings.yml
 /config/sandbox_proxy.yml

--- a/config/application.rb
+++ b/config/application.rb
@@ -199,6 +199,9 @@ module System
     config.three_scale.prometheus = ActiveSupport::OrderedOptions.new
     config.three_scale.prometheus.merge!(try_config_for(:prometheus) || {})
 
+    config.three_scale.message_bus = ActiveSupport::OrderedOptions.new
+    config.three_scale.message_bus.merge!(try_config_for(:message_bus) || {})
+
     three_scale = config_for(:settings).symbolize_keys
     three_scale[:error_reporting_stages] = three_scale[:error_reporting_stages].to_s.split(/\W+/)
 
@@ -228,7 +231,6 @@ module System
     config.middleware.insert_before Rack::Runtime, Rack::XServedBy # we can pass hashed hostname as parameter
 
     config.unicorn  = ActiveSupport::OrderedOptions[after_fork: []]
-
     config.unicorn.after_fork << MessageBus.method(:after_fork)
 
     config.action_dispatch.cookies_serializer = :hybrid

--- a/config/docker/message_bus.yml
+++ b/config/docker/message_bus.yml
@@ -1,0 +1,15 @@
+base: &default
+  enabled: true
+  redis:
+    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://system-redis:6379/8') %>
+    pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+    pool_timeout: 5
+
+production:
+  <<: *default
+
+preview:
+  <<: *default
+
+development:
+  <<: *default

--- a/config/examples/message_bus.yml
+++ b/config/examples/message_bus.yml
@@ -1,0 +1,28 @@
+base: &default
+  enabled: true
+
+production:
+  <<: *default
+  redis:
+    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
+    pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+    pool_timeout: 5
+
+preview:
+  <<: *default
+  redis:
+    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
+    pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+    pool_timeout: 5
+
+development:
+  <<: *default
+  redis:
+    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
+    pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+    pool_timeout: 5
+
+test:
+  enabled: false
+  keepalive_interval: 0
+  backend: :memory

--- a/openshift/system/config/message_bus.yml
+++ b/openshift/system/config/message_bus.yml
@@ -1,0 +1,15 @@
+base: &default
+  enabled: true
+  redis:
+    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://system-redis/8') %>
+    pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+    pool_timeout: 5
+
+production:
+  <<: *default
+
+preview:
+  <<: *default
+
+development:
+  <<: *default


### PR DESCRIPTION
**What this PR does / why we need it**
It makes message bus settings configurable. This is specially important for redis configuration not to enforce logical db '8', which is causing problems to setup 3scale with Redis Cluster/Enterprise.

**What issue(s) this PR fixes**
Closes [THREESCALE-2161](https://issues.jboss.org/browse/THREESCALE-2161)

**Special notes for your reviewer**
1. ~We're still using `REDIS_URL` env var here. Perhaps define a separate one?~

2. We could maybe fallback to System's default redis config in case Message Bus is enabled and missing some specific redis config for it (?).

----
_Important!_ We need to ensure the proper configurations are in place before deploying this.