### PR TITLE
Do not automatically destroy tenants that are scheduled for deletion

### DIFF
--- a/config/jobs.rb
+++ b/config/jobs.rb
@@ -31,7 +31,6 @@ module ThreeScale
       LogEntry.delete_old
       Cinstance.notify_about_expired_trial_periods
       Pdf::Dispatch.daily
-      FindAndDeleteScheduledAccountsWorker.perform_async
       DeleteProvidedAccessTokensWorker.perform_async
       DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
     ].freeze


### PR DESCRIPTION
After what happened today in SaaS, we need some days of margin to find a real solution to this problem.