### PR TITLE
Namespaces for sidekiq and messsage_bus redis keys

### DIFF
--- a/config/docker/message_bus.yml
+++ b/config/docker/message_bus.yml
@@ -4,6 +4,7 @@ base: &default
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://system-redis:6379/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
+    namespace: system-mbus
 
 production:
   <<: *default

--- a/config/docker/message_bus.yml
+++ b/config/docker/message_bus.yml
@@ -4,7 +4,7 @@ base: &default
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://system-redis:6379/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
-    namespace: system-mbus
+    namespace:
 
 production:
   <<: *default

--- a/config/docker/message_bus.yml
+++ b/config/docker/message_bus.yml
@@ -4,7 +4,7 @@ base: &default
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://system-redis:6379/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
-    namespace:
+    namespace: <%= ENV['MESSAGE_BUS_REDIS_NAMESPACE'] %>
 
 production:
   <<: *default

--- a/config/docker/redis.yml
+++ b/config/docker/redis.yml
@@ -2,7 +2,7 @@ default: &DEFAULT
   url: <%= ENV.fetch('REDIS_URL', 'redis://system-redis:6379/1') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
-  namespace:
+  namespace: <%= ENV['REDIS_NAMESPACE'] %>
 
 production:
   <<: *DEFAULT

--- a/config/docker/redis.yml
+++ b/config/docker/redis.yml
@@ -2,7 +2,7 @@ default: &DEFAULT
   url: <%= ENV.fetch('REDIS_URL', 'redis://system-redis:6379/1') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
-  namespace: system-sidekiq
+  namespace:
 
 production:
   <<: *DEFAULT

--- a/config/docker/redis.yml
+++ b/config/docker/redis.yml
@@ -2,6 +2,7 @@ default: &DEFAULT
   url: <%= ENV.fetch('REDIS_URL', 'redis://system-redis:6379/1') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
+  namespace: system-sidekiq
 
 production:
   <<: *DEFAULT

--- a/config/examples/message_bus.yml
+++ b/config/examples/message_bus.yml
@@ -1,29 +1,19 @@
 base: &default
   enabled: true
+  redis:
+    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
+    pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+    pool_timeout: 5
+    namespace: <%= ENV['MESSAGE_BUS_REDIS_NAMESPACE'] %>
 
 production:
   <<: *default
-  redis:
-    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
-    pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
-    pool_timeout: 5
-    namespace:
 
 preview:
   <<: *default
-  redis:
-    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
-    pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
-    pool_timeout: 5
-    namespace:
 
 development:
   <<: *default
-  redis:
-    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
-    pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
-    pool_timeout: 5
-    namespace:
 
 test:
   enabled: false

--- a/config/examples/message_bus.yml
+++ b/config/examples/message_bus.yml
@@ -7,6 +7,7 @@ production:
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
+    namespace: system-mbus
 
 preview:
   <<: *default
@@ -14,6 +15,7 @@ preview:
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
+    namespace: system-mbus
 
 development:
   <<: *default
@@ -21,6 +23,7 @@ development:
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
+    namespace: system-mbus
 
 test:
   enabled: false

--- a/config/examples/message_bus.yml
+++ b/config/examples/message_bus.yml
@@ -7,7 +7,7 @@ production:
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
-    namespace: system-mbus
+    namespace:
 
 preview:
   <<: *default
@@ -15,7 +15,7 @@ preview:
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
-    namespace: system-mbus
+    namespace:
 
 development:
   <<: *default
@@ -23,7 +23,7 @@ development:
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
-    namespace: system-mbus
+    namespace:
 
 test:
   enabled: false

--- a/config/examples/redis.yml
+++ b/config/examples/redis.yml
@@ -3,15 +3,15 @@ production:
   url: <%= ENV.fetch('REDIS_URL', 'redis://localhost/3') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
-  namespace: system-sidekiq
+  namespace:
 development:
   url: <%= ENV.fetch('REDIS_URL', 'redis://localhost/1') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
-  namespace: system-sidekiq
+  namespace:
 test:
   url: <%= ENV.fetch('REDIS_URL', 'redis://localhost/1') %>
   db: <%= 2 + ENV['TEST_ENV_NUMBER'].to_i %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
-  namespace: system-sidekiq
+  namespace:

--- a/config/examples/redis.yml
+++ b/config/examples/redis.yml
@@ -3,15 +3,15 @@ production:
   url: <%= ENV.fetch('REDIS_URL', 'redis://localhost/3') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
-  namespace:
+  namespace: <%= ENV['REDIS_NAMESPACE'] %>
 development:
   url: <%= ENV.fetch('REDIS_URL', 'redis://localhost/1') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
-  namespace:
+  namespace: <%= ENV['REDIS_NAMESPACE'] %>
 test:
   url: <%= ENV.fetch('REDIS_URL', 'redis://localhost/1') %>
   db: <%= 2 + ENV['TEST_ENV_NUMBER'].to_i %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
-  namespace:
+  namespace: <%= ENV['REDIS_NAMESPACE'] %>

--- a/config/examples/redis.yml
+++ b/config/examples/redis.yml
@@ -3,12 +3,15 @@ production:
   url: <%= ENV.fetch('REDIS_URL', 'redis://localhost/3') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
+  namespace: system-sidekiq
 development:
   url: <%= ENV.fetch('REDIS_URL', 'redis://localhost/1') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
+  namespace: system-sidekiq
 test:
   url: <%= ENV.fetch('REDIS_URL', 'redis://localhost/1') %>
   db: <%= 2 + ENV['TEST_ENV_NUMBER'].to_i %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
+  namespace: system-sidekiq

--- a/config/initializers/message_bus.rb
+++ b/config/initializers/message_bus.rb
@@ -5,9 +5,7 @@ require 'message_bus/backends/redis'
 
 class MessageBus::Redis::ReliablePubSub
   def new_redis_connection
-    namespace = Rails.configuration.three_scale.message_bus.deep_symbolize_keys.dig(:redis, :namespace)
-    redis = ::Redis.new(@redis_config)
-    namespace ? Redis::Namespace.new(namespace, redis: redis) : redis
+    ::Redis.new_with_namespace(@redis_config.merge(namespace: namespace))
   end
 end
 

--- a/config/initializers/message_bus.rb
+++ b/config/initializers/message_bus.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# Monkey patching message_bus to enforce redis namespace
+require 'message_bus/backends/redis'
+
+class MessageBus::Redis::ReliablePubSub
+  def new_redis_connection
+    namespace = Rails.configuration.three_scale.message_bus.deep_symbolize_keys.dig(:redis, :namespace)
+    redis = ::Redis.new(@redis_config)
+    namespace ? Redis::Namespace.new(namespace, redis: redis) : redis
+  end
+end
+
 Class.new do
   def initialize(message_bus_config = {})
     @config = message_bus_config.dup

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Redis
+  def self.new_with_namespace(options = {})
+    namespace = options[:namespace].presence
+    redis = new(options)
+    namespace ? Redis::Namespace.new(namespace, redis: redis) : redis
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Sidekiq::Client.try(:reliable_push!) unless Rails.env.test?
 
 Sidekiq.configure_server do |config|

--- a/lib/system/redis_pool.rb
+++ b/lib/system/redis_pool.rb
@@ -9,7 +9,11 @@ module System
     def initialize(config={})
       config = config.dup
       pool_config = config.extract!(:pool_size, :pool_timeout)
-      @pool = ConnectionPool.new(size: pool_config[:pool_size] || 5, timeout: pool_config[:pool_timeout] || 5 ) { Redis.new(config) }
+      @pool = ConnectionPool.new(size: pool_config[:pool_size] || 5, timeout: pool_config[:pool_timeout] || 5 ) do
+        namespace = config[:namespace]
+        redis = Redis.new(config)
+        namespace ? Redis::Namespace.new(namespace, redis: redis) : redis
+      end
     end
 
     # This class only respond to public methods of Redis

--- a/lib/system/redis_pool.rb
+++ b/lib/system/redis_pool.rb
@@ -10,9 +10,7 @@ module System
       config = config.dup
       pool_config = config.extract!(:pool_size, :pool_timeout)
       @pool = ConnectionPool.new(size: pool_config[:pool_size] || 5, timeout: pool_config[:pool_timeout] || 5 ) do
-        namespace = config[:namespace]
-        redis = Redis.new(config)
-        namespace ? Redis::Namespace.new(namespace, redis: redis) : redis
+        Redis.new_with_namespace(config)
       end
     end
 

--- a/openshift/system/config/message_bus.yml
+++ b/openshift/system/config/message_bus.yml
@@ -4,6 +4,7 @@ base: &default
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://system-redis/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
+    namespace: system-mbus
 
 production:
   <<: *default

--- a/openshift/system/config/message_bus.yml
+++ b/openshift/system/config/message_bus.yml
@@ -4,7 +4,7 @@ base: &default
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://system-redis/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
-    namespace:
+    namespace: <%= ENV['MESSAGE_BUS_REDIS_NAMESPACE'] %>
 
 production:
   <<: *default

--- a/openshift/system/config/message_bus.yml
+++ b/openshift/system/config/message_bus.yml
@@ -4,7 +4,7 @@ base: &default
     url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://system-redis/8') %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
-    namespace: system-mbus
+    namespace:
 
 production:
   <<: *default

--- a/openshift/system/config/redis.yml
+++ b/openshift/system/config/redis.yml
@@ -2,7 +2,7 @@ base: &default
   url: <%= ENV.fetch('REDIS_URL', 'redis://system-redis/1') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5
-  namespace: system-sidekiq
+  namespace:
 
 production:
   <<: *default

--- a/openshift/system/config/redis.yml
+++ b/openshift/system/config/redis.yml
@@ -2,7 +2,7 @@ base: &default
   url: <%= ENV.fetch('REDIS_URL', 'redis://system-redis/1') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5
-  namespace:
+  namespace: <%= ENV['REDIS_NAMESPACE'] %>
 
 production:
   <<: *default

--- a/openshift/system/config/redis.yml
+++ b/openshift/system/config/redis.yml
@@ -2,6 +2,7 @@ base: &default
   url: <%= ENV.fetch('REDIS_URL', 'redis://system-redis/1') %>
   pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5
+  namespace: system-sidekiq
 
 production:
   <<: *default

--- a/test/unit/redis_with_namespace_test.rb
+++ b/test/unit/redis_with_namespace_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class RedisWithNamespaceTest < ActiveSupport::TestCase
+  def test_new_with_namespace
+    config = {namespace: 'custom-namespace'}
+    redis = Redis.new_with_namespace(config)
+    assert_instance_of Redis::Namespace, redis
+    assert_equal 'custom-namespace', redis.namespace
+
+    config = {namespace: ''}
+    redis = Redis.new_with_namespace(config)
+    assert_instance_of Redis, redis
+
+    config = {namespace: nil}
+    redis = Redis.new_with_namespace(config)
+    assert_instance_of Redis, redis
+
+    redis = Redis.new_with_namespace
+    assert_instance_of Redis, redis
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**
It makes possible to enforce namespaces for all sidekiq and message_bus redis keys, so system can work with a single redis db without risk of key collision. This is not particularly relevant for the scenario where sidekiq and message_bus red/write to different redis instances/dbs, however it is a safe measure for the scenario where those components work on the same redis instance and same redis db, such when using Redis Entrerprise/Cluster.

<img width="412" alt="Screen Shot 2019-03-27 at 6 10 55 PM" src="https://user-images.githubusercontent.com/1842261/55097793-de96a880-50bc-11e9-93df-0dc6484b6e94.png">

**Which issue(s) this PR fixes**
Closes [THREESCALE-2173](https://issues.jboss.org/browse/THREESCALE-2173)

**Special notes for your reviewer**
message_bus is not compatible with redis-namespace OOTB, so we either monkey patch it or create our own fork of the gem.