### PR TITLE
Fix typo in doc of provider.logo_url drop

### DIFF
--- a/doc/liquid/drops.md
+++ b/doc/liquid/drops.md
@@ -701,6 +701,19 @@ OAuth callback url.
 
 
 ## Methods
+### login_url
+
+### user_identified?
+
+-----------
+
+# Base drop
+
+
+
+
+
+## Methods
 ### errors
 
 If a form for this model is rendered after unsuccessful submission,
@@ -723,19 +736,6 @@ Returns the resource URL of the result.
 
 ### description
 Returns a descriptive string for the result.
-
------------
-
-# Base drop
-
-
-
-
-
-## Methods
-### login_url
-
-### user_identified?
 
 -----------
 
@@ -1612,6 +1612,27 @@ this returns the errors that occurred.
 
 
 ## Methods
+### type
+
+Possible types of the messages are:
+
+ - success (not used by now)
+ - info
+ - warning
+ - danger
+        
+
+### text
+
+-----------
+
+# Message drop
+
+
+
+
+
+## Methods
 ### errors
 
 If a form for this model is rendered after unsuccessful submission,
@@ -1651,27 +1672,6 @@ Returns the name of the sender.
 Returns the name of the receiver.
 
 ### recipients
-
------------
-
-# Message drop
-
-
-
-
-
-## Methods
-### type
-
-Possible types of the messages are:
-
- - success (not used by now)
- - info
- - warning
- - danger
-        
-
-### text
 
 -----------
 
@@ -2122,13 +2122,20 @@ this returns the errors that occurred.
 {{ post.errors.name | inline_errors }}
 ```
 
-### title
+### body
+Text of the post.
 
-### kind
+### topic
+Every post belongs to a [topic](#topic-drop).
+
+### created_at
+Date when this post created.
+```liquid
+{{ post.created_at | date: i18n.short_date }}
+```
 
 ### url
-
-### description
+The URL of this post within its topic.
 
 -----------
 
@@ -2150,20 +2157,13 @@ this returns the errors that occurred.
 {{ post.errors.name | inline_errors }}
 ```
 
-### body
-Text of the post.
+### title
 
-### topic
-Every post belongs to a [topic](#topic-drop).
-
-### created_at
-Date when this post created.
-```liquid
-{{ post.created_at | date: i18n.short_date }}
-```
+### kind
 
 ### url
-The URL of this post within its topic.
+
+### description
 
 -----------
 
@@ -2270,7 +2270,7 @@ Returns the telephone number of the account.
 ### logo_url
 Returns the logo URL.
 ```liquid
-<img src={{ provider.logo_url }}"/>
+<img src="{{ provider.logo_url }}"/>
 ```
 
 ### multiple_services_allowed?
@@ -2871,12 +2871,9 @@ this returns the errors that occurred.
 ```
 
 ### title
-
-### kind
+Name of the topic. Submitted when first post to the thread is posted.
 
 ### url
-
-### description
 
 -----------
 
@@ -2899,9 +2896,12 @@ this returns the errors that occurred.
 ```
 
 ### title
-Name of the topic. Submitted when first post to the thread is posted.
+
+### kind
 
 ### url
+
+### description
 
 -----------
 

--- a/lib/developer_portal/lib/liquid/drops/provider.rb
+++ b/lib/developer_portal/lib/liquid/drops/provider.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Liquid
   module Drops
     class Provider < Drops::Base
 
-      example %{
+      example %(
         <div>Domain {{ provider.domain }}</div>
 
         {% if provider.multiple_applications_allowed? %}
@@ -20,7 +22,7 @@ module Liquid
 
         For general questions contact us at {{ provider.support_email }}.
         For invoice or payment related questions contact us at {{ provider.finance_support_email }}.
-      }
+      )
 
       allowed_name :provider
       deprecated_name :user_account, :provider_account, :sender, :site_account, :account
@@ -91,7 +93,7 @@ module Liquid
       desc """*True* if developers can have more separate applications with
               their own keys, stats, etc. __Depends on your 3scale plan__.
            """
-      example %{
+      example %(
         {% if provider.multiple_applications_allowed? %}
            <div>
              <p>Applications</p>
@@ -104,11 +106,10 @@ module Liquid
         {% else %}
            <div>Application {{ account.applications.first.name }}</div>
         {% endif %}
-      }
+      )
       def multiple_applications_allowed?
         @model.settings.multiple_applications.visible?
       end
-
 
       def logo_url
         if logo = @model.profile.logo
@@ -119,13 +120,13 @@ module Liquid
       desc """*True* if your 3scale plan allows you to manage multiple APIs
                as separate [services][support-terminology-service].
            """
-      example %{
+      example %(
         {% if provider.multiple_services_allowed? %}
           {% for service in provider.services %}
              Service {{ service.name }} is available.
           {% endfor %}
         {% endif %}
-      }
+      )
       def multiple_services_allowed?
         @model.multiservice? && @model.has_visible_services_with_plans?
       end
@@ -138,7 +139,7 @@ module Liquid
               associated with them (__depends on your 3scale plan__)
               and its visibility has been turned on for your develoeper
               portal in the [settings][cms-feature-visibility]."""
-      example %{
+      example %(
         {% if provider.multiple_users_allowed? %}
           <ul id="subsubmenu">
             <li>
@@ -149,32 +150,32 @@ module Liquid
             </li>
           </ul>
         {% endif %}
-      }
+      )
       def multiple_users_allowed?
         @model.settings.multiple_users.visible?
       end
 
       desc "Returns all published account plans."
-      example %{
+      example %(
         <p>We offer following account plans:</p>
         <ul>
         {% for plan in model.account_plans %}
           <li>{{ plan.name }} <input type="radio" name="plans[id]" value="{{ plan.id }}"/></li>
         {% endfor %}
         </ul>
-      }
+      )
       def account_plans
         Drops::AccountPlan.wrap(@model.account_plans.published)
       end
 
       desc "Returns all defined services."
-      example %{
+      example %(
         <p>You can sign up to any of our services!</p>
         <ul>
         {% for service in provider.services %}
           <li>{{ service.name }} <a href="/signup/service/{{ service.system_name }}">Signup!</a></li>
         {% endfor %}
-      }
+      )
       def services
         Drops::Service.wrap(@model.services)
       end
@@ -190,9 +191,9 @@ module Liquid
       end
 
       desc "Returns the logo URL."
-      example %{
+      example %(
         <img src="{{ provider.logo_url }}"/>
-      }
+      )
       def logo_url
         if logo = @model.try(:profile).try(:logo)
           logo.url(:large)

--- a/lib/developer_portal/lib/liquid/drops/provider.rb
+++ b/lib/developer_portal/lib/liquid/drops/provider.rb
@@ -191,7 +191,7 @@ module Liquid
 
       desc "Returns the logo URL."
       example %{
-        <img src={{ provider.logo_url }}"/>
+        <img src="{{ provider.logo_url }}"/>
       }
       def logo_url
         if logo = @model.try(:profile).try(:logo)


### PR DESCRIPTION
For information, after modifying the file, we regenerate the documentation with `rake doc:liquid:generate`