### PR TITLE
[npm] Remove postshrinkwrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "test": "karma start --single-run",
     "jest": "jest",
     "jest:watch": "npm run-script jest -- --watch",
-    "postshrinkwrap": "replace --silent 'http://' 'https://' ./package-lock.json",
     "postinstall": "npm rebuild node-sass"
   },
   "devDependencies": {


### PR DESCRIPTION
Relates to https://github.com/3scale/porta/pull/454
The issue is solved https://npm.community/t/some-packages-have-dist-tarball-as-http-and-not-https/285

Requirement is using npm 6+

Then

```
rm -rf ./node_modules
npm cache clean --force
npm install
```