### PR TITLE
Prevents Runtime error in integration/edit when APIcast not available

### DIFF
--- a/app/services/policies/policies_list_service.rb
+++ b/app/services/policies/policies_list_service.rb
@@ -15,7 +15,7 @@ class Policies::PoliciesListService
     list.merge! fetch_policies_from_apicast if builtin
     list.merge! policies_from_account(account)
     list.to_h
-  rescue *HTTP_ERROR, PoliciesListServiceError => error
+  rescue *HTTP_ERRORS, PoliciesListServiceError => error
     Rails.logger.error { error } and return
   end
 

--- a/app/services/policies/policies_list_service.rb
+++ b/app/services/policies/policies_list_service.rb
@@ -17,7 +17,7 @@ class Policies::PoliciesListService
   end
 
   def self.policies_from_account(account)
-    return account.policies if account.provider_can_use?(:policy_registry)
+    return PolicyList.new(account.policies) if account.provider_can_use?(:policy_registry)
   end
 
   class PolicyList

--- a/app/services/policies/policies_list_service.rb
+++ b/app/services/policies/policies_list_service.rb
@@ -10,14 +10,14 @@ class Policies::PoliciesListService
   def self.call(account, builtin: true)
     list = PolicyList.new
     list.merge! fetch_policies_from_apicast if builtin
-    list.merge! account.policies if provider_can_use_policies
+    list.merge! policies_from_account(account)
     list.to_h
   rescue PoliciesListServiceError => error
     Rails.logger.error { error } and return
   end
 
-  def self.provider_can_use_policies
-    account.provider_can_use?(:policy_registry)
+  def self.policies_from_account(account)
+    return account.policies if account.provider_can_use?(:policy_registry)
   end
 
   class PolicyList

--- a/app/services/policies/policies_list_service.rb
+++ b/app/services/policies/policies_list_service.rb
@@ -71,13 +71,11 @@ class Policies::PoliciesListService
 
   def self.fetch_policies_from_apicast
     apicast_registry_url = ThreeScale.config.sandbox_proxy.apicast_registry_url
-    begin
-      response = ::JSONClient.get(apicast_registry_url)
-      return response.body['policies'] if response.ok?
-      raise PoliciesListServiceError, "APIcast could not be found at url: '#{apicast_registry_url}'. Error: #{response.content}"
-    rescue *HTTP_ERRORS => error
-      raise PoliciesListServiceError, "APIcast could not be found at url: '#{apicast_registry_url}'. Error: #{error}"
-    end
+    response = ::JSONClient.get(apicast_registry_url)
+    return response.body['policies'] if response.ok?
+    raise PoliciesListServiceError, I18n.t('errors.messages.apicast_not_found', url: apicast_registry_url, error: response.content)
+  rescue *HTTP_ERRORS => error
+    raise PoliciesListServiceError, I18n.t('errors.messages.apicast_not_found', url: apicast_registry_url, error: error)
   end
 
   private_class_method :fetch_policies_from_apicast

--- a/config/examples/sandbox_proxy.yml
+++ b/config/examples/sandbox_proxy.yml
@@ -17,7 +17,7 @@ base: &default
   apicast_staging_endpoint: 'http://%{system_name}-%{account_id}.staging.%{env}apicast.dev:8080'
   apicast_production_endpoint: 'http://%{system_name}-%{account_id}.%{env}apicast.dev:8080'
   skip_deploy: false
-  apicast_registry_url: <%= ENV.fetch('APICAST_REGISTRY_URL', 'http://localhost:8090/policies') %>
+  apicast_registry_url: <%= ENV['APICAST_REGISTRY_URL'] %>
 
 development:
   <<: *default
@@ -42,7 +42,7 @@ test:
   apicast_staging_endpoint: 'http://%{system_name}-%{account_id}.staging.%{env}apicast.dev:8080'
   apicast_production_endpoint: 'http://%{system_name}-%{account_id}.%{env}apicast.dev:8080'
   skip_deploy: false
-  apicast_registry_url: <%= ENV.fetch('APICAST_REGISTRY_URL', 'http://localhost:8090/policies') %>
+  apicast_registry_url: <%= ENV['APICAST_REGISTRY_URL'] %>
 
 preview:
   <<: *default

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -768,7 +768,7 @@ en:
       invitation_not_found: "Invitation token did not exist."
       invitation_already_accepted: "Invitation token has already been accepted."
       protected_domain: "Sorry, this domain is protected"
-      apicast_not_found: "APIcast could not be found at url: '%{url}'. Error: %{error}"
+      apicast_not_found: "Failed to fetch APIcast policies from '%{url}'. Error: %{error}"
       oauth:
         code_incorrect_or_expired: "The code is incorrect or expired."
         token_incorrect_or_expired: "The token is incorrect or expired."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -768,6 +768,7 @@ en:
       invitation_not_found: "Invitation token did not exist."
       invitation_already_accepted: "Invitation token has already been accepted."
       protected_domain: "Sorry, this domain is protected"
+      apicast_not_found: "APIcast could not be found at url: '%{url}'. Error: %{error}"
       oauth:
         code_incorrect_or_expired: "The code is incorrect or expired."
         token_incorrect_or_expired: "The token is incorrect or expired."

--- a/features/old/api/settings.feature
+++ b/features/old/api/settings.feature
@@ -42,3 +42,10 @@ Feature: API Settings
     Then I should see "Service information updated"
     And I go to the provider side "MegaWidget" application page
     Then I should see "User Key"
+
+  Scenario: API settings don't crash when APICAST_REGISTRY_URL is undefined
+    Given apicast registry is undefined
+    When I log in as provider "foo.example.com"
+    And I go to the integration show page for service "API" of provider "foo.example.com"
+    And I follow "add the base URL of your API and save the configuration."
+    Then I should see "Integration"

--- a/features/step_definitions/apicast_steps.rb
+++ b/features/step_definitions/apicast_steps.rb
@@ -6,3 +6,8 @@ Given(/^apicast registry is stubbed$/) do
     .to_return(status: 200, body: "{\"policies\":{\"apicast\":[{\"description\":\"Main functionality of APIcast.\",\"$schema\":\"http:\\/\\/apicast.io\\/policy-v1\\/schema#manifest#\",\"name\":\"APIcast policy\",\"configuration\":{\"properties\":{},\"type\":\"object\"},\"version\":\"builtin\"}]}}",
                headers: { 'Content-Type' => 'application/json' })
 end
+
+Given(/^apicast registry is undefined$/) do
+  ThreeScale.config.sandbox_proxy.expects(:apicast_registry_url).returns(nil)
+  JSONClient.expects(:get).with(nil).raises(SocketError)
+end

--- a/test/unit/services/policies/policies_list_service_test.rb
+++ b/test/unit/services/policies/policies_list_service_test.rb
@@ -11,8 +11,8 @@ class Policies::PoliciesListServiceTest < ActiveSupport::TestCase
     ThreeScale.config.sandbox_proxy.stubs(apicast_registry_url: APICAST_REGISTRY_URL)
   end
 
-  def stub_apicast_request(status: 200, response_body: GATEWAY_API_MANAGEMENT_RESPONSE.to_json, headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, APICAST_REGISTRY_URL).to_return(status: status, response_body: response_body, headers: headers)
+  def stub_apicast_request(status: 200, body: GATEWAY_API_MANAGEMENT_RESPONSE.to_json)
+    stub_request(:get, APICAST_REGISTRY_URL).to_return(status: status, body: body, headers: { 'Content-Type' => 'application/json' })
   end
 
   GATEWAY_API_MANAGEMENT_RESPONSE = {


### PR DESCRIPTION
**What this PR does / why we need it**:

When APICAST_REGISTRY_URL is not provided, custom policies won't show up instead of crashing porta.

**Which issue(s) this PR fixes** 

[THREESCALE-2327: Prevent Integration Settings from crashing when APIcast not available](https://issues.jboss.org/browse/THREESCALE-2327)

**Verification steps** 

1. Navigate to any `tenantURL/apiconfig/services/:service_id/integration/edit`
2. There should be no 500 error but custom policies are empty
