### PR TITLE
Enable for on-prem the deletion of accounts scheduled for deletion

### DIFF
--- a/app/workers/find_and_delete_scheduled_accounts_worker.rb
+++ b/app/workers/find_and_delete_scheduled_accounts_worker.rb
@@ -4,6 +4,7 @@ class FindAndDeleteScheduledAccountsWorker
   include Sidekiq::Worker
 
   def perform
+    return unless ThreeScale.config.onpremises
     Account.deleted_since.find_each(&DeleteAccountHierarchyWorker.method(:perform_later))
   end
 end

--- a/config/jobs.rb
+++ b/config/jobs.rb
@@ -27,6 +27,7 @@ module ThreeScale
     ].freeze
 
     DAILY = %w[
+      FindAndDeleteScheduledAccountsWorker.perform_async
       Audited.audit_class.delete_old
       LogEntry.delete_old
       Cinstance.notify_about_expired_trial_periods

--- a/test/workers/find_and_delete_accounts_scheduled_worker_test.rb
+++ b/test/workers/find_and_delete_accounts_scheduled_worker_test.rb
@@ -1,12 +1,19 @@
 require 'test_helper'
 class FindAndDeleteScheduledAccountsWorkerTest < ActiveSupport::TestCase
-  def test_perform
+  def setup
     quiet_period_time = Account::States::PERIOD_BEFORE_DELETION
     FactoryBot.create_list(:simple_buyer, 2)
     FactoryBot.create_list(:simple_buyer, 3, state: 'scheduled_for_deletion', state_changed_at: quiet_period_time.ago)
     FactoryBot.create_list(:simple_provider, 4, state: 'scheduled_for_deletion', state_changed_at: quiet_period_time.ago)
     FactoryBot.create_list(:simple_provider, 1, state: 'scheduled_for_deletion', state_changed_at: quiet_period_time.ago + 1.day)
-    assert_equal 7, Account.deleted_since.count
+  end
+
+  def test_perform
+    ThreeScale.config.stubs(onpremises: false)
+    DeleteAccountHierarchyWorker.expects(:perform_later).never
+    FindAndDeleteScheduledAccountsWorker.new.perform
+
+    ThreeScale.config.stubs(onpremises: true)
     DeleteAccountHierarchyWorker.expects(:perform_later).times(7)
     FindAndDeleteScheduledAccountsWorker.new.perform
   end


### PR DESCRIPTION
Otherwise tenants won't be destroyed at all for on-prem.
We need to fix the problem of destroying many at once for SaaS before enabling it for SaaS.