### PR TITLE
[npm] No need of postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "lint": "flow && eslint .eslintrc app/javascript spec/javascripts",
     "test": "karma start --single-run",
     "jest": "jest",
-    "jest:watch": "npm run-script jest -- --watch",
-    "postinstall": "npm rebuild node-sass"
+    "jest:watch": "npm run-script jest -- --watch"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Current version of node-sass solves it doing it in build.js and install.js packages
called from package.json scripts

**What this PR does / why we need it**:

Cleaning our scripts.

**Which issue(s) this PR fixes** 

None. Maintenance task.
