### PR TITLE
[onprem] Synchronize templates and code rolling updates

### DIFF
--- a/openshift/system/config/rolling_updates.yml
+++ b/openshift/system/config/rolling_updates.yml
@@ -1,4 +1,5 @@
 base: &default
+  old_charts: false
   new_provider_documentation: false
   proxy_pro: false
   instant_bill_plan_change: false
@@ -14,6 +15,7 @@ base: &default
   apicast_v2: true
   forum: false
   published_service_plan_signup: true
+  apicast_oidc: true
   policies: true
   policy_registry: true
   proxy_private_base_path: true


### PR DESCRIPTION
So we can remove the rolling_updates.yml mount from the templates
And just document how to customize any rolling updates

Relates to https://github.com/3scale/3scale-operator/pull/117#issuecomment-478922952
Relates to https://issues.jboss.org/browse/THREESCALE-2604

Requires https://github.com/3scale/porta/pull/744


This is the same as https://github.com/3scale/3scale-amp-openshift-templates/blob/2.6.0.GA/amp/amp.yml#L1581-L1603 with `api_as_product: true`