### PR TITLE
Delete object worker optimization

### DIFF
--- a/app/workers/delete_object_hierarchy_worker.rb
+++ b/app/workers/delete_object_hierarchy_worker.rb
@@ -65,7 +65,7 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
     %i[success complete].each { |name| batch.on(name, self.class, callback_options) }
     yield
     bid = batch.bid
-    
+
     if Sidekiq::Batch::Status.new(bid).total.zero?
       on_complete(bid, callback_options)
     else
@@ -76,7 +76,7 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
 
   def delete_associations(object)
     object_associations = associations_to_destroy_for(object)
-    association_names = object_associations.map { |a| a.name }
+    association_names = object_associations.map(&:name)
     preloaded_object = association_names.any? ? object.class.eager_load(*association_names).find(object.id) : object
 
     object_associations.each do |reflection|

--- a/app/workers/delete_object_hierarchy_worker.rb
+++ b/app/workers/delete_object_hierarchy_worker.rb
@@ -9,7 +9,7 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
     Rails.logger.info "DeleteObjectHierarchyWorker#perform raised #{exception.class} with message #{exception.message}"
   end
 
-  queue_as :low
+  queue_as :deletion
 
   before_perform do |job|
     @object, workers_hierarchy = job.arguments

--- a/app/workers/find_and_delete_scheduled_accounts_worker.rb
+++ b/app/workers/find_and_delete_scheduled_accounts_worker.rb
@@ -4,7 +4,6 @@ class FindAndDeleteScheduledAccountsWorker
   include Sidekiq::Worker
 
   def perform
-    return unless ThreeScale.config.onpremises
     Account.deleted_since.find_each(&DeleteAccountHierarchyWorker.method(:perform_later))
   end
 end

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -18,7 +18,7 @@ namespace :sidekiq do
 
     args = []
     args.push(['--index', ENV.fetch('INDEX', '0')])
-    args.push(%w[backend_sync billing critical default events low priority web_hooks zync].flat_map { |queue| ['--queue', queue] })
+    args.push(%w[backend_sync billing critical default deletion events low priority web_hooks zync].flat_map { |queue| ['--queue', queue] })
 
     exec(envs, 'sidekiq', *args.flatten)
   end

--- a/test/performance/workers/delete_object_hierarchy_test.rb
+++ b/test/performance/workers/delete_object_hierarchy_test.rb
@@ -1,0 +1,18 @@
+require 'performance_helper'
+
+class Workers::DeleteObjectHierarchyTest < ActionDispatch::PerformanceTest
+  self.profile_options = { metrics: [:wall_time] }
+
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    @provider.schedule_for_deletion!
+
+    SystemOperation::DEFAULTS.keys.each do |name|
+      @provider.mail_dispatch_rules.create!(system_operation: SystemOperation.for(name))
+    end
+  end
+
+  def test_run
+    DeleteObjectHierarchyWorker.perform_now(@provider)
+  end
+end

--- a/test/workers/delete_object_hierarchy_worker_test.rb
+++ b/test/workers/delete_object_hierarchy_worker_test.rb
@@ -173,4 +173,39 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
       end
     end
   end
+
+  class DeleteProviderQueryCounterTest < ActiveSupport::TestCase
+
+    def save_queries(&block)
+      queries = []
+
+      counter_f = ->(name, started, finished, unique_id, payload) {
+        unless %w[ CACHE SCHEMA ].include?(payload[:name])
+          queries << payload
+        end
+      }
+
+      ActiveSupport::Notifications.subscribed(
+        counter_f,
+        "sql.active_record",
+        &block
+      )
+
+      queries
+    end
+
+    def setup
+      @provider = FactoryBot.create(:provider_account)
+      @provider.schedule_for_deletion!
+
+      SystemOperation::DEFAULTS.keys.each do |name|
+        @provider.mail_dispatch_rules.create!(system_operation: SystemOperation.for(name))
+      end
+    end
+
+    def test_queries
+      queries = save_queries{ DeleteObjectHierarchyWorker.perform_now(@provider) }
+      assert_equal 2, queries.count
+    end
+  end
 end

--- a/test/workers/find_and_delete_accounts_scheduled_worker_test.rb
+++ b/test/workers/find_and_delete_accounts_scheduled_worker_test.rb
@@ -9,10 +9,6 @@ class FindAndDeleteScheduledAccountsWorkerTest < ActiveSupport::TestCase
   end
 
   def test_perform
-    ThreeScale.config.stubs(onpremises: false)
-    DeleteAccountHierarchyWorker.expects(:perform_later).never
-    FindAndDeleteScheduledAccountsWorker.new.perform
-
     ThreeScale.config.stubs(onpremises: true)
     DeleteAccountHierarchyWorker.expects(:perform_later).times(7)
     FindAndDeleteScheduledAccountsWorker.new.perform


### PR DESCRIPTION
**What this PR does / why we need it**:

Delete object worker does many database queries. It loads all associations one by one. 

**Which issue(s) this PR fixes** 

All associations are being loaded in one eager loaded query.
Fixes [THREESCALE-2204 - Fix efficiency to destroy tenants/services and enable the worker again](https://issues.jboss.org/browse/THREESCALE-2204)