### PR TITLE
[utils] safeFromJson should warn and return undefined

### DIFF
--- a/app/javascript/src/utilities/json-utils.jsx
+++ b/app/javascript/src/utilities/json-utils.jsx
@@ -9,7 +9,8 @@ const safeFromJsonString = (json: string) => {
   try {
     return fromJsonString(json)
   } catch (err) {
-    throw new Error(`That doesn't look like a valid json: ${json}`)
+    console.warn('That doesn\'t look like a valid json!', err)
+    return undefined
   }
 }
 


### PR DESCRIPTION
* It's meant to use in a safe way
* If not you will be reinventing the wheel, what'd be the difference?!
Fixes https://github.com/3scale/porta/pull/746