### PR TITLE
List of plans in AccountDeletionConfig feature accept SQL Wildcard Characters

### DIFF
--- a/config/examples/features.yml
+++ b/config/examples/features.yml
@@ -5,7 +5,7 @@ features: &default
     account_suspension: 90
     contract_unpaid_time: 183
     disabled_for_app_plans:
-    - enterprise
+    - '%enterprise%'
 
 development:
   <<: *default

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -976,7 +976,13 @@ class CinstanceTest < ActiveSupport::TestCase
     id_cinstance_with_pro_plan               = FactoryBot.create(:application_contract, plan: FactoryBot.create(:application_plan, system_name: 'pro')).id
     id_cinstance_with_enterprise_plan        = FactoryBot.create(:application_contract, plan: FactoryBot.create(:application_plan, system_name: 'enterprise')).id
     id_cinstance_with_another_plan           = FactoryBot.create(:application_contract, plan: FactoryBot.create(:application_plan, system_name: 'system_name_1')).id
-    id_service_contract_with_enterprise_plan = FactoryBot.create(:service_contract,     plan: FactoryBot.create(:service_plan, system_name: 'system_name_2')).id
+    id_service_contract_with_enterprise_plan = FactoryBot.create(:service_contract,     plan: FactoryBot.create(:service_plan, system_name: 'enterprise')).id
+
+    ids_cinstances_enterprise = Cinstance.by_plan_system_name('enterprise').pluck(:id)
+    assert_includes     ids_cinstances_enterprise, id_cinstance_with_enterprise_plan
+    assert_not_includes ids_cinstances_enterprise, id_cinstance_with_pro_plan
+    assert_not_includes ids_cinstances_enterprise, id_cinstance_with_another_plan
+    assert_not_includes ids_cinstances_enterprise, id_service_contract_with_enterprise_plan
 
     ids_cinstances_by_plan_system_name = Cinstance.by_plan_system_name(%w[enterprise pro]).pluck(:id)
     assert_includes     ids_cinstances_by_plan_system_name, id_cinstance_with_enterprise_plan
@@ -984,10 +990,16 @@ class CinstanceTest < ActiveSupport::TestCase
     assert_not_includes ids_cinstances_by_plan_system_name, id_cinstance_with_another_plan
     assert_not_includes ids_cinstances_by_plan_system_name, id_service_contract_with_enterprise_plan
 
-    ids_cinstances_enterprise = Cinstance.by_plan_system_name('enterprise').pluck(:id)
-    assert_includes     ids_cinstances_enterprise, id_cinstance_with_enterprise_plan
-    assert_not_includes ids_cinstances_enterprise, id_cinstance_with_pro_plan
-    assert_not_includes ids_cinstances_enterprise, id_cinstance_with_another_plan
-    assert_not_includes ids_cinstances_enterprise, id_service_contract_with_enterprise_plan
+    ids_cinstances_enterprise_like = Cinstance.by_plan_system_name('%rpris%').pluck(:id)
+    assert_includes     ids_cinstances_enterprise_like, id_cinstance_with_enterprise_plan
+    assert_not_includes ids_cinstances_enterprise_like, id_cinstance_with_pro_plan
+    assert_not_includes ids_cinstances_enterprise_like, id_cinstance_with_another_plan
+    assert_not_includes ids_cinstances_enterprise_like, id_service_contract_with_enterprise_plan
+
+    ids_cinstances_like_list = Cinstance.by_plan_system_name(%w[%terpr% %pr%]).pluck(:id)
+    assert_includes     ids_cinstances_like_list, id_cinstance_with_enterprise_plan
+    assert_includes     ids_cinstances_like_list, id_cinstance_with_pro_plan
+    assert_not_includes ids_cinstances_like_list, id_cinstance_with_another_plan
+    assert_not_includes ids_cinstances_like_list, id_service_contract_with_enterprise_plan
   end
 end


### PR DESCRIPTION
Part of [THREESCALE-2132 - [Refactor & Bugfix] Improvements in automatic suspension and deletion of tenants](https://issues.jboss.org/browse/THREESCALE-2132)
It blocks https://github.com/3scale/porta/pull/745 because if we merge that one first, it means that we will destroy accounts that shouldn't be destroyed.
The config edited in the _deploy_ repo: https://github.com/3scale/deploy/pull/554 (tested in preview)