### PR TITLE
THREESCALE-2281 Do not read the database configuration every request

### DIFF
--- a/lib/system/database.rb
+++ b/lib/system/database.rb
@@ -8,6 +8,10 @@ module System
     module_function
 
     def configuration_specification
+      @configuration_specification ||= read_configuration_specification
+    end
+
+    def read_configuration_specification
       configurations = Rails.application.config.database_configuration
       resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(configurations)
       spec = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_sym

--- a/test/unit/system_database_test.rb
+++ b/test/unit/system_database_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class SystemDatabaseTest < ActiveSupport::TestCase
+
+  def test_configuration_specification_is_memoized
+    FakeFS do
+      expected_config = System::Database.configuration_specification
+      assert_instance_of ActiveRecord::ConnectionAdapters::ConnectionSpecification, expected_config
+      config_path = Rails.root.join('config', 'database.yml')
+
+      FakeFS::FileSystem.clone(config_path.dirname.to_s)
+      FakeFS::FileUtils.rm(config_path.to_s)
+      config = System::Database.configuration_specification
+
+      assert_same expected_config, config
+    end
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

This memoize the configuration specification. Thus preventing reading from file every request

**Which issue(s) this PR fixes** 

Fixes [THREESCALE-2281](https://issues.jboss.org/browse/THREESCALE-2281)

**Verification steps** 

1. boot the application with a valid database.yml
2. make a valid query to an API, for example  admin/api/service_features#index
3. verify the query is successful
4. Remove the config/database.yml file
5. make a valid query to an API, for example  admin/api/service_features#index
6. verify it fails with a 500 error:  "Could not load database configuration. No such file - [config/database.yml"]


Expected: step 6 should not fail with an error but succeed