### PR TITLE
Application update events don't trigger zync when first*traffic_at fields are updated

### DIFF
--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -82,7 +82,7 @@ class Cinstance < Contract
   validates :description, presence: { :if => :description_required? }
 
   after_commit :push_webhook_key_updated, :on => :update, :if => :user_key_updated?
-  after_save :push_application_updated_event, on: :update
+  after_commit :push_application_updated_event, on: :update, unless: :only_traffic_updated?
 
   #this method marks that a human edition of the app is happening, thus description presence will be validated
   # this is done so e.g. to avoid change_plan to fail when the app misses description or name
@@ -403,6 +403,10 @@ class Cinstance < Contract
   end
 
   private
+
+  def only_traffic_updated?
+    (previous_changes.keys - %w[first_traffic_at first_daily_traffic_at updated_at]).empty?
+  end
 
   # It calls to `create_key_after_create` to check if it's possible to add
   # an application key.

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+require 'test_helper'
 
 class CinstanceTest < ActiveSupport::TestCase
 
@@ -879,6 +879,42 @@ class CinstanceTest < ActiveSupport::TestCase
 
       expect_backend_delete_key(app, app.application_keys.pluck_values.first)
       app.destroy
+    end
+  end
+
+  class ApplicationUpdatedSavedEventTest < ActiveSupport::TestCase
+    disable_transactional_fixtures!
+
+    def setup
+      @cinstance = FactoryBot.create(:cinstance)
+    end
+
+    attr_reader :cinstance
+
+    test 'ApplicationUpdatedEvent is created after an update' do
+      assert_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
+        cinstance.update!({description: 'example description to update cinstance'})
+      end
+    end
+
+    test 'ApplicationUpdatedEvent is not created after an update if the only changes are for first_traffic_at or first_daily_traffic_at' do
+      assert_no_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
+        cinstance.update_attribute(:first_traffic_at, 2.days.ago.round)
+      end
+
+      assert_no_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
+        cinstance.update_attribute(:first_daily_traffic_at, 2.days.ago.round)
+      end
+
+      assert_no_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
+        cinstance.update!({first_traffic_at: 1.day.ago.round, first_daily_traffic_at: 1.day.ago.round}, without_protection: true)
+      end
+    end
+
+    test 'ApplicationUpdatedEvent is created after an update when there are updated traffic and non-traffic attributes' do
+      assert_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
+        cinstance.update!({name: 'mycinstance', first_traffic_at: 1.day.ago.round, first_daily_traffic_at: 1.day.ago.round}, without_protection: true)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes [THREESCALE-2072 - Application update events trigger zync when first*traffic_at fields are updated](https://issues.jboss.org/browse/THREESCALE-2072)