### PR TITLE
Update state_changed_at from deleted_at with a SQL query because deleted_at is removed from Rails programatically

### DIFF
--- a/db/migrate/20181105212016_duplicate_deleted_at_state_changed_at.rb
+++ b/db/migrate/20181105212016_duplicate_deleted_at_state_changed_at.rb
@@ -2,11 +2,12 @@
 
 class DuplicateDeletedAtStateChangedAt < ActiveRecord::Migration
   def up
-    Account.transaction do
-      Account.scheduled_for_deletion.where.has{ deleted_at != nil }.find_each do |account|
-        account.update_column(:state_changed_at, account.deleted_at) or raise ActiveRecord::Error
-      end
-    end
+    # Done in a query instead of Ruby because later on deleted_at is removed programatically and otherwise it says it doesn't exist
+    query = <<~SQL
+      UPDATE accounts
+      SET state_changed_at = deleted_at
+      WHERE state = 'scheduled_for_deletion' AND (deleted_at IS NOT NULL);
+    SQL
   end
 
   def down

--- a/db/migrate/20181105212016_duplicate_deleted_at_state_changed_at.rb
+++ b/db/migrate/20181105212016_duplicate_deleted_at_state_changed_at.rb
@@ -2,12 +2,7 @@
 
 class DuplicateDeletedAtStateChangedAt < ActiveRecord::Migration
   def up
-    # Done in a query instead of Ruby because later on deleted_at is removed programatically and otherwise it says it doesn't exist
-    query = <<~SQL
-      UPDATE accounts
-      SET state_changed_at = deleted_at
-      WHERE state = 'scheduled_for_deletion' AND (deleted_at IS NOT NULL);
-    SQL
+    Account.scheduled_for_deletion.where.not(deleted_at: nil).update_all('state_changed_at = deleted_at')
   end
 
   def down

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -6,7 +6,8 @@ ARG BUNDLER_ENV
 ENV BUNDLER_ENV="${BUNDLER_ENV}" \
     TZ=:/etc/localtime \
     BUNDLE_GEMFILE=gemfiles/prod/Gemfile \
-    BUNDLE_WITHOUT=development:test
+    BUNDLE_WITHOUT=development:test \
+    NODEJS_SCL=rh-nodejs8
 
 WORKDIR /opt/system
 
@@ -15,11 +16,13 @@ ARG SPHINX_VERSION=2.2.11-1
 ADD openshift/system/sphinx-${SPHINX_VERSION}.rhel7.x86_64.rpm /tmp/sphinxsearch.rpm
 
 RUN yum -y update \
-    && yum -y install ImageMagick \
+    && yum -y install centos-release-scl-rh \
+                      ImageMagick \
                       ImageMagick-devel \
                       unixODBC-devel \
                       mysql \
                       file \
+                      rh-nodejs8 \
     && rpm -i /tmp/sphinxsearch.rpm \
     && rm /tmp/*.rpm \
     && yum install -y epel-release \

--- a/openshift/system/Dockerfile.on_prem
+++ b/openshift/system/Dockerfile.on_prem
@@ -6,7 +6,8 @@ ARG BUNDLER_ENV
 ENV BUNDLER_ENV="${BUNDLER_ENV}" \
     TZ=:/etc/localtime \
     BUNDLE_GEMFILE=Gemfile \
-    BUNDLE_WITHOUT=development:test
+    BUNDLE_WITHOUT=development:test \
+    NODEJS_SCL=rh-nodejs8
 
 WORKDIR /opt/system
 
@@ -15,11 +16,13 @@ ARG SPHINX_VERSION=2.2.11-1
 ADD openshift/system/sphinx-${SPHINX_VERSION}.rhel7.x86_64.rpm /tmp/sphinxsearch.rpm
 
 RUN yum -y update \
-    && yum -y install ImageMagick \
+    && yum -y install centos-release-scl-rh \
+              ImageMagick \
               ImageMagick-devel \
               unixODBC-devel \
               mysql \
               file \
+              rh-nodejs8 \
     && rpm -i /tmp/sphinxsearch.rpm \
     && rm /tmp/*.rpm \
     && yum install -y epel-release \


### PR DESCRIPTION
#### What this PR does / why we need it

We have a bug to migrate from 2.4 to 2.5 saying that `deleted_at` doesn't exist at the moment to run that migration.
To see the root cause of the problem, I followed the steps explained in _Verification Steps_ below. I replicated the error, I saw that `deleted_at` was in the schema, so I replicated all the steps again but running the migration without having `deleted_at` removed programatically in `Account.columns` this time, and it worked, so I knew it was that Ruby wasn't detecting but it was in the DB, so the solution is a query that runs in the DB and no Ruby side for that migration, because we need to keep the attribute removed programatically at this point (for SaaS).

By programatically deleted I mean this:
https://github.com/3scale/porta/blob/73fe1815a4419128e1708cbf5deca6c8776b90be/app/models/account.rb#L8-L10

#### Which issue(s) this PR fixes

Fixes [THREESCALE-2294 - Unable to upgrade from 2.4 to 2.5](https://issues.jboss.org/browse/THREESCALE-2294)

#### Verification steps 

1. Move to the code of the 2.4 release. `git checkout 7be3320b145d368f7d546e03264ac9618b2fddaa`
2. Stop spring if you have it running (`spring stop`) and reset the database to have the same that we had back then. `bundle exec rake db:drop db:create db:setup`
3. Move to the code of the 2.5 release with this commit as well 😄 . Either `git checkout 77db9ee8a36e782a6978ce0281af6797fdbcb7e0 && git cherry-pick 46ad4b4073248e06e2606ed40d329fa012cc5750` or `git fetch && git checkout fix/THREESCALE-2294-upgrade-migrations-2.4-to-2.5` to move to this branch directly.
4. Stop spring if you have it running (`spring stop`) and run the migrations. `bundle exec rake db:migrate` 

#### Notes for the reviewers
1. I tested locally with MySQL and Oracle. We didn't have PostgreSQL back then and [it was introduced for 2.5](https://github.com/3scale/porta/pull/376) so we don't have the migration problem for this DB.
2. There is a commit of the version of Node in docker because otherwise docker-build fails.