### PR TITLE
Validate maximum length of strings in models (before reaching DB)

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,6 +1,8 @@
 class AccessToken < ApplicationRecord
   belongs_to :owner, class_name: 'User', inverse_of: :access_tokens
 
+  validates :name, length: { maximum: 255 }
+
   serialize :scopes, Array
 
   def self.options_to_hash(options)

--- a/app/models/cms/builtin.rb
+++ b/app/models/cms/builtin.rb
@@ -102,7 +102,7 @@ class CMS::Builtin < CMS::BasePage
   end
 
   def i18n_scope
-    self.class.to_s.underscore.split('/') + system_name.split('/')
+    self.class.to_s.underscore.split('/') + (system_name || '').split('/')
   end
 
   # CMS::Builtin::StaticPage
@@ -248,7 +248,7 @@ class CMS::Builtin < CMS::BasePage
     end
 
     def title
-      I18n.t("#{system_name}.title", scope: 'builtin_partials', default: system_name.humanize)
+      I18n.t("#{system_name}.title", scope: 'builtin_partials', default: (system_name || '').humanize)
     end
 
     def to_xml(options = {})

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,6 +1,7 @@
 class Country < ApplicationRecord
   validates :name, :code, presence: true
   validates :code, uniqueness: true
+  validates :name, :code, :currency, length: {maximum: 255}
 
   # Cuba, Iran, North Korea, Sudan, Syria
   T5_COUNTRIES_CODE = %w(CU IR KP SD SY).freeze

--- a/app/models/end_user_plan.rb
+++ b/app/models/end_user_plan.rb
@@ -17,6 +17,7 @@ class EndUserPlan < ApplicationRecord
   validates :service, :name, presence: true
   # TODO: this scope might be just :service_id, depends on how it is implemented in backend
   validates :name, uniqueness: { :scope => [:service_id] }
+  validates :name, length: { maximum: 255 }
 
   after_create :mark_as_default_if_needed
   after_update :update_service_if_needed

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -24,6 +24,7 @@ class Feature < ApplicationRecord
   attr_protected :featurable_id, :featurable_type, :tenant_id, :audit_ids
 
   validates :system_name, uniqueness: { :scope => [:featurable_id, :featurable_type] }
+  validates :system_name, :name, length: { maximum: 255 }
 
   def hide!
     update_attribute(:visible, false)

--- a/app/models/go_live_state.rb
+++ b/app/models/go_live_state.rb
@@ -4,6 +4,8 @@ class GoLiveState < ApplicationRecord
   serialize :steps, OpenStruct
   alias_attribute :closed, :finished
 
+  validates :recent, length: {maximum: 255}
+
   def advance(step, final_step=false)
     unless self.closed?
       step = step.to_s

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -44,6 +44,7 @@ class Invitation < ApplicationRecord
   private
 
   def email_is_not_taken
+    return unless account
     return if account.users.by_email(email).empty?
     errors.add(:email, 'has been taken by another user')
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -49,6 +49,11 @@ class Invoice < ApplicationRecord
                                     if: :friendly_id_changed?
                                   }
 
+  validates :from_address_name, :from_address_line1, :from_address_line2, :from_address_city, :from_address_region,
+            :from_address_state, :from_address_country, :from_address_zip, :from_address_phone, :to_address_name,
+            :to_address_line1, :to_address_line2, :to_address_city, :to_address_region, :to_address_state,
+            :to_address_country, :to_address_zip, :to_address_phone, length: {maximum: 255}
+
   default_scope -> { order('invoices.created_at DESC') }
 
   # 'conditions' is a simple convenience method defined here ... see below

--- a/app/models/invoice_counter.rb
+++ b/app/models/invoice_counter.rb
@@ -3,6 +3,8 @@
 class InvoiceCounter < ApplicationRecord
   belongs_to :provider_account, class_name: 'Account', inverse_of: :buyer_invoice_counters
 
+  validates :invoice_prefix, length: {maximum: 255}
+
   # FIXME: This is subject to race condition
   def update_count(new_count)
     return if self.invoice_count >= new_count

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -31,6 +31,7 @@ class Message < ApplicationRecord
   has_many   :recipients, -> { kind_first }, class_name: 'MessageRecipient', dependent: :destroy
 
   validates :sender_id, presence: true
+  validates :type, :origin, length: { maximum: 255 }
 
   after_save :update_recipients
   after_initialize :default_values

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -25,6 +25,7 @@ class Metric < ApplicationRecord
   attr_protected :service_id, :parent_id, :tenant_id, :audit_ids
   validates :unit, presence: true, unless: :child?
   validates :friendly_name, uniqueness: {scope: :service_id}, presence: true
+  validates :system_name, :unit, :friendly_name, length: { maximum: 255 }
 
   validate :only_hits_has_children
 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -7,8 +7,8 @@ class Partner < ApplicationRecord
   has_many :providers, class_name: "Account"
   has_many :application_plans
 
-  validates :name, presence: true
-  validates :api_key, presence: true
+  validates :name, :api_key, presence: true
+  validates :name, :api_key, :system_name, :logout_url, length: { maximum: 255 }
 
   def signup_type
     "partner:#{system_name}"

--- a/app/models/payment_detail.rb
+++ b/app/models/payment_detail.rb
@@ -17,7 +17,8 @@ class PaymentDetail < ApplicationRecord
   validates :credit_card_partial_number, length: { :maximum => 4,
                                                    :allow_blank => true,
                                                    :message => "must be the final 4 digits only" }
-  validates :credit_card_auth_code, :credit_card_authorize_net_payment_profile_token, length: {maximum: 255}
+  validates :buyer_reference, :payment_service_reference, :credit_card_partial_number, :credit_card_auth_code,
+            :credit_card_authorize_net_payment_profile_token, length: {maximum: 255}
 
   alias_attribute :credit_card_auth_code, :buyer_reference
   alias_attribute :credit_card_authorize_net_payment_profile_token, :payment_service_reference

--- a/app/models/payment_transaction.rb
+++ b/app/models/payment_transaction.rb
@@ -13,6 +13,8 @@ class PaymentTransaction < ApplicationRecord
   has_money :amount
 
   validates :amount, presence: true
+  validates :currency, length: {maximum: 4}
+  validates :message, :reference, :action, length: {maximum: 255}
 
   attr_protected :account_id, :invoice_id, :success, :test, :tenant_id
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -27,6 +27,7 @@ class Policy < ApplicationRecord
 
   before_validation :set_identifier
   validates :identifier, uniqueness: { scope: :account_id }
+  validates :name, :version, length: { maximum: 255 }
 
   def self.find_by_id_or_name_version(id_or_name_version)
     where.has { (id == id_or_name_version) | (identifier == id_or_name_version) }.first

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,6 +4,8 @@ class Profile < ApplicationRecord
   serialize :customers_type
   validates :company_size, presence: true
   validates :company_type, presence: { :if => :company_profile? }
+  validates :oneline_description, :company_url, :company_type, :customers_type, :company_size, :blog_url, :rssfeed_url,
+  :email_sales, :email_techsupport, :email_press, :products_delivered, length: {maximum: 255}
 
   # this validation should be out of the 'validates_presence_of' because
   # signup_without_plan_with_account_profile makes use of the

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -59,8 +59,8 @@ class Proxy < ApplicationRecord
                       format: { with: HTTP_HEADER }
 
   validates :api_test_path, length: { maximum: 8192 }
-  validates :endpoint, :api_backend, :auth_app_key, :auth_app_id, :auth_user_key,
-            :credentials_location, :error_auth_failed, :error_auth_missing,
+  validates :endpoint, :api_backend, :auth_app_key, :auth_app_id, :auth_user_key, :oidc_issuer_endpoint,
+            :credentials_location, :error_auth_failed, :error_auth_missing, :authentication_method,
             :error_headers_auth_failed, :error_headers_auth_missing, :error_no_match,
             :error_headers_no_match, :secret_token, :hostname_rewrite, :sandbox_endpoint,
             length: { maximum: 255 }
@@ -90,8 +90,9 @@ class Proxy < ApplicationRecord
   delegate :account, to: :service, allow_nil: true
   delegate :provider_can_use?, to: :account, allow_nil: true
 
+  # This smells of :reek:NilCheck
   def authentication_method
-    super.presence || service.read_attribute(:backend_version)
+    super.presence || service&.read_attribute(:backend_version)
   end
 
   def deployment_option

--- a/app/models/proxy_log.rb
+++ b/app/models/proxy_log.rb
@@ -2,6 +2,7 @@ class ProxyLog < ApplicationRecord
   belongs_to :provider, :class_name => 'Account'
   scope :latest_first, -> { order(created_at: :desc) }
   validates :status, :lua_file, presence: true
+  validates :status, length: { maximum: 255 }
 
   def file_name
     "sandbox_proxy_#{provider.id}.lua"

--- a/app/models/proxy_rule.rb
+++ b/app/models/proxy_rule.rb
@@ -74,7 +74,7 @@ class ProxyRule < ApplicationRecord
   validates :pattern, format: { with: PatternParser.new, allow_blank: true }
   # a valid pattern is: slash alone or a path => maybe a dollar sign => maybe a query string
 
-  validates :pattern, length: { maximum: 256 }
+  validates :pattern, length: { maximum: 255 }
   validates :http_method, inclusion: { in: ALLOWED_HTTP_METHODS }
   validate :non_repeated_parameters
   validate :no_vars_in_keys
@@ -102,7 +102,7 @@ class ProxyRule < ApplicationRecord
   end
 
   def pattern_uri
-    Addressable::URI.parse(pattern)
+    Addressable::URI.parse(pattern || '')
   rescue Addressable::URI::InvalidURIError
     Addressable::URI.new
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -23,6 +23,8 @@ class Service < ApplicationRecord
   validates :support_email, format: { with: RE_EMAIL_OK, message: MSG_EMAIL_BAD,
                                       allow_blank: true }
 
+  validates :kubernetes_service_link, length: {maximum: 255}
+
   after_create :create_default_metrics, :create_default_service_plan, :create_default_proxy
   after_commit :update_notification_settings
 

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -9,6 +9,11 @@ class Settings < ApplicationRecord
 
   validates :product, inclusion: { in: %w(connect enterprise).freeze }
   validates :change_account_plan_permission, inclusion: { in: %w(request none credit_card request_credit_card direct).freeze }
+  validates :bg_colour, :link_colour, :text_colour, :menu_bg_colour, :link_label, :link_url, :menu_link_colour, :token_api,
+            :content_bg_colour, :tracker_code, :favicon, :plans_tab_bg_colour, :plans_bg_colour, :content_border_colour,
+            :cc_privacy_path, :cc_terms_path, :cc_refunds_path, :change_service_plan_permission, :spam_protection_level,
+            :authentication_strategy, :janrain_api_key, :janrain_relying_party, :cms_token, :cas_server_url, :sso_key,
+            :sso_login_url, :heroku_id, :heroku_name, length: { maximum: 255 }
 
   symbolize :spam_protection_level
 

--- a/app/models/sso_authorization.rb
+++ b/app/models/sso_authorization.rb
@@ -7,6 +7,7 @@ class SSOAuthorization < ApplicationRecord
 
   validates :uid, :authentication_provider, :user, presence: true
   validates :uid, uniqueness: { scope: :authentication_provider_id }
+  validates :uid, length: { maximum: 255 }
 
   scope :newest, -> { order(updated_at: :desc).first }
 

--- a/app/models/system_operation.rb
+++ b/app/models/system_operation.rb
@@ -3,6 +3,7 @@ class SystemOperation < ApplicationRecord
   has_many :mail_dispatch_rules, :dependent => :destroy
 
   validates :ref, uniqueness: true
+  validates :ref, :name, length: {maximum: 255}
 
   DEFAULTS = {'user_signup'            => 'New user signup',
               "new_app"                => "New application created",

--- a/app/models/topic_category.rb
+++ b/app/models/topic_category.rb
@@ -5,7 +5,7 @@ class TopicCategory < ApplicationRecord
 
   attr_protected :forum_id, :tenant_id
 
-  validates :name, presence: true
+  validates :name, presence: true, length: {maximum: 255}
   validates :name, uniqueness: { :scope => :forum_id }
 
   default_scope -> { order('name ASC') }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ApplicationRecord
             length: { maximum: 40 }
   validates :state, :role, :lost_password_token, :first_name, :last_name, :signup_type,
             :job_role, :last_login_ip, :email_verification_code, :title, :cas_identifier,
-            :authentication_id, :open_id,
+            :authentication_id, :open_id, :password_digest,
             length: { maximum: 255 }
 
   # strong passwords

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -7,6 +7,7 @@ class UserSession < ApplicationRecord
   has_one :account, through: :user
 
   validates :user_id, :key, presence: true
+  validates :ip, length: {maximum: 255}
 
   before_validation :set_unique_key, :on => :create
 

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+require 'test_helper'
 
 class MetricTest < ActiveSupport::TestCase
   should belong_to :service
@@ -12,6 +12,15 @@ class MetricTest < ActiveSupport::TestCase
 
   should_not allow_value('hellow world').for(:system_name)
   should_not allow_value('hello!').for(:system_name)
+
+  test 'validate length of strings' do
+    metric = FactoryBot.create(:metric)
+    Metric.columns.each do |column|
+      next unless column.type == :string
+      refute metric.update({column.name => ('a' * 256)})
+      assert_match /too long/, metric.errors[column.name].to_sentence
+    end
+  end
 
   def test_destroyable?
     service = FactoryBot.create(:simple_service)

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -13,15 +13,6 @@ class MetricTest < ActiveSupport::TestCase
   should_not allow_value('hellow world').for(:system_name)
   should_not allow_value('hello!').for(:system_name)
 
-  test 'validate length of strings' do
-    metric = FactoryBot.create(:metric)
-    Metric.columns.each do |column|
-      next unless column.type == :string
-      refute metric.update({column.name => ('a' * 256)})
-      assert_match /too long/, metric.errors[column.name].to_sentence
-    end
-  end
-
   def test_destroyable?
     service = FactoryBot.create(:simple_service)
     metric  = service.metrics.hits

--- a/test/unit/models_test.rb
+++ b/test/unit/models_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ModelsTest < ActiveSupport::TestCase
+
+  test 'validate length of strings for all models to do not raise an error reaching DB' do
+    exceptions = {
+      'ActiveRecord::SchemaMigration' => :all, 'Audited::Audit' => :all, 'RailsEventStoreActiveRecord::Event' => :all, 'EventStore::Event' => :all,
+      'System::Database::ConnectionProbe' => :all, 'ActsAsTaggableOn::Tag' => :all, 'ActsAsTaggableOn::Tagging' => :all, 'ApplicationRecord' => :all,
+      'FieldsDefinition' => %w[target], 'AuthenticationProvider' => %w[account_type], 'Feature' => %w[featurable_type scope], 'Message' => %w[state],
+      'UsageLimit' => %w[period plan_type], 'Policy' => %w[identifier], 'ProxyRule' => %w[metric_system_name], 'ProxyConfig' => %w[hosts],
+      'OIDCConfiguration' => %w[oidc_configurable_type], 'Invitation' => %w[token],
+      'Settings' => Switches::SWITCHES.map { |switch| "#{switch}_switch" },
+      'Invoice' => %w[pdf_file_name pdf_content_type state friendly_id fiscal_code vat_code currency creation_type], 'DeletedObject' => %w[owner_type object_type],
+      'Onboarding' => %w[wizard_state bubble_api_state bubble_metric_state bubble_deployment_state bubble_mapping_state bubble_limit_state],
+      'FeaturesPlan' => %w[plan_type], 'LogEntry' => %w[description], 'Notification' => %w[event_id], 'PlanMetric' => %w[plan_type],
+      'Profile' => %w[logo_file_name logo_content_type state], 'UserSession' => %w[key user_agent], 'CMS::Partial' => %w[content_type],
+      'CMS::EmailTemplate' => %w[content_type], 'CMS::Builtin' => %w[title], 'CMS::Builtin::StaticPage' => %w[title], 'CMS::Builtin::Page' => %w[title content_type],
+      'CMS::Builtin::Partial' => %w[title content_type], 'CMS::Portlet' => %w[content_type], 'CMS::Builtin::LegalTerm' => %w[title content_type],
+      'CMS::Portlet::Base' => %w[content_type], 'ExternalRssFeedPortlet' => %w[content_type], 'LatestForumPostsPortlet' => %w[content_type],
+      'TableOfContentsPortlet' => %w[content_type], 'AuthenticationProvider::GitHub' => %w[branding_state account_type],
+      'AuthenticationProvider::Keycloak' => %w[account_type], 'AuthenticationProvider::Auth0' => %w[account_type], 'AuthenticationProvider::Custom' => %w[account_type],
+      'AuthenticationProvider::ServiceDiscoveryProvider' => %w[account_type], 'AuthenticationProvider::RedhatCustomerPortal' => %w[account_type],
+      'Account' => %w[credit_card_auth_code credit_card_authorize_net_payment_profile_token credit_card_partial_number],
+      'DeadlockTest::Model' => :all, 'ThreeScale::SearchTest::Model' => :all
+    }
+
+    Rails.application.eager_load!
+    ActiveRecord::Base.descendants.each do |model|
+
+      exception_attributes = exceptions.fetch(model.name, [])
+      next if exception_attributes == :all
+
+      model.columns.each do |column|
+        column_name = column.name
+        next if column.type != :string || exception_attributes.include?(column_name)
+
+        column_sql_type = column.sql_type
+        next if column_sql_type.match(/\Acharacter varying\Z/)
+        length = column_sql_type.match(/\(([\d]+)\)/)[1].to_i
+
+        object = model.new({column_name => ('a' * (length + 1))}, without_protection: true)
+        object.valid?
+
+        column_errors = object.errors[column_name].to_sentence
+        next if column_errors.match(/is not included in the list/)
+        assert_match /too long/, column_errors, "#{model} is not validating the max length of #{length} for string '#{column_name}'"
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/proxy_rule_test.rb
+++ b/test/unit/proxy_rule_test.rb
@@ -97,13 +97,10 @@ class ProxyRuleTest < ActiveSupport::TestCase
     assert_equal({"foo" => "bar=lol"}, proxy_rule.querystring_parameters)
   end
 
-  test '256 is the max length' do
-    proxy_rule = FactoryBot.build_stubbed(:proxy_rule)
-    proxy_rule.pattern = '/'+ ("a" * 255)
-    assert_valid proxy_rule
-
-    proxy_rule.pattern = '/'+ ("a" * 256)
-    refute_valid proxy_rule
+  test 'when pattern is nil, path_pattern and query_pattern return empty values instead of raising errors' do
+    proxy_rule = ProxyRule.new
+    assert_equal '', proxy_rule.path_pattern
+    assert_nil proxy_rule.query_pattern
   end
 
   test 'redirect_url' do

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -79,6 +79,8 @@ class ProxyTest < ActiveSupport::TestCase
 
       proxy_2 = Proxy.new(service: Service.new(backend_version: 'ouath'))
       assert_equal 'ouath', proxy_2.authentication_method
+
+      assert_nil Proxy.new.authentication_method
     end
 
     def test_set_sandbox_endpoint_callback


### PR DESCRIPTION
Fixes [THREESCALE-2367](https://issues.jboss.org/browse/THREESCALE-2367)
It validates for all models that the length of the strings is not higher than what the field can take, so it doesn't reach the DB and it doesn't raise an error for requests through the API but responds with a nice error message instead.