### PR TITLE
Use REDIS_URL for message bus when MESSAGE_BUS_REDIS_URL is missing

### DIFF
--- a/app/lib/three_scale/message_bus_config.rb
+++ b/app/lib/three_scale/message_bus_config.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module ThreeScale
+  class MessageBusConfig
+    def initialize(message_bus_config = {})
+      @config = message_bus_config.dup
+
+      @enabled = config.delete(:enabled)
+      @redis_config = build_redis_config(config.delete(:redis)) unless %i[memory postgres].include?(config[:backend]) # https://github.com/SamSaffron/message_bus/tree/v2.0.2/lib/message_bus/backends
+    end
+
+    attr_reader :config, :enabled, :redis_config
+
+    def configure_message_bus!
+      MessageBus.configure(config)
+      MessageBus.redis_config = redis_config if redis_config.present?
+
+      return MessageBus.off unless enabled
+
+      MessageBus.timer.on_error do |error|
+        System::ErrorReporting.report_error(error)
+      end
+      MessageBus.on_middleware_error do |env, error|
+        System::ErrorReporting.report_error(error, rack_env: env)
+      end
+    end
+
+    def self.build_redis_config(config)
+      redis_config = (config || {}).symbolize_keys
+      return redis_config if redis_config[:url].present?
+      redis_config.delete(:url)
+
+      # Uses default redis config in case message bus specific config has not 'url' or 'host' specified
+      default_redis_config = System::Application.config.redis.symbolize_keys
+
+      redis_config.reverse_merge!(default_redis_config)
+      redis_config[:db] = next_db(redis_db_in(default_redis_config)) if key_collision_prone?(redis_config, default_redis_config) # Prevents key collision with different dbs is necessary
+      redis_config
+    end
+
+    def self.key_collision_prone?(redis_config, default_redis_config)
+      return false if redis_config[:namespace].presence != default_redis_config[:namespace].presence
+      redis_db_in(redis_config) == redis_db_in(default_redis_config)
+    end
+
+    def self.redis_db_in(redis_config)
+      db = redis_config[:db].presence
+      return db.to_i if db
+      url = redis_config[:url].presence
+      return unless url
+      URI.parse(url).path[1..-1].to_s.to_i
+    end
+
+    def self.next_db(redis_db)
+      (redis_db+1)%16
+    end
+
+    delegate :build_redis_config, to: 'self.class'
+  end
+end

--- a/config/docker/message_bus.yml
+++ b/config/docker/message_bus.yml
@@ -1,7 +1,7 @@
 base: &default
   enabled: true
   redis:
-    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://system-redis:6379/8') %>
+    url: <%= ENV['MESSAGE_BUS_REDIS_URL'] %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
     namespace: <%= ENV['MESSAGE_BUS_REDIS_NAMESPACE'] %>

--- a/config/examples/message_bus.yml
+++ b/config/examples/message_bus.yml
@@ -1,7 +1,7 @@
 base: &default
   enabled: true
   redis:
-    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://localhost/8') %>
+    url: <%= ENV['MESSAGE_BUS_REDIS_URL'] %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
     namespace: <%= ENV['MESSAGE_BUS_REDIS_NAMESPACE'] %>

--- a/config/initializers/message_bus.rb
+++ b/config/initializers/message_bus.rb
@@ -9,30 +9,7 @@ class MessageBus::Redis::ReliablePubSub
   end
 end
 
-Class.new do
-  def initialize(message_bus_config = {})
-    @config = message_bus_config.dup
-
-    @enabled = config.delete(:enabled)
-    @redis_config = config.delete(:redis)
-  end
-
-  attr_reader :config, :enabled, :redis_config
-
-  def configure_message_bus!
-    MessageBus.configure(config)
-    MessageBus.redis_config = redis_config if redis_config.present?
-
-    return MessageBus.off unless enabled
-
-    MessageBus.timer.on_error do |error|
-      System::ErrorReporting.report_error(error)
-    end
-    MessageBus.on_middleware_error do |env, error|
-      System::ErrorReporting.report_error(error, rack_env: env)
-    end
-  end
-end.new(Rails.configuration.three_scale.message_bus).configure_message_bus!
+ThreeScale::MessageBusConfig.new(Rails.configuration.three_scale.message_bus).configure_message_bus!
 
 authenticated_request = lambda do |env|
   ActiveRecord::Base.connection_pool.with_connection do

--- a/openshift/system/config/message_bus.yml
+++ b/openshift/system/config/message_bus.yml
@@ -1,7 +1,7 @@
 base: &default
   enabled: true
   redis:
-    url: <%= ENV.fetch('MESSAGE_BUS_REDIS_URL', 'redis://system-redis/8') %>
+    url: <%= ENV['MESSAGE_BUS_REDIS_URL'] %>
     pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
     pool_timeout: 5
     namespace: <%= ENV['MESSAGE_BUS_REDIS_NAMESPACE'] %>

--- a/test/unit/three_scale/message_bus_config_test.rb
+++ b/test/unit/three_scale/message_bus_config_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ThreeScale
+  class MessageBusConfigTest < ActiveSupport::TestCase
+    setup do
+      System::Application.config.stubs(redis: { url: 'redis://my-redis/1' })
+    end
+
+    test '#redis_db_in' do
+      assert_equal 4, MessageBusConfig.redis_db_in(db: 4)
+      assert_equal 3, MessageBusConfig.redis_db_in(url: 'redis://my-redis/3')
+      assert_equal 0, MessageBusConfig.redis_db_in(url: 'redis://my-redis')
+    end
+
+    test '#next_db' do
+      assert_equal 1, MessageBusConfig.next_db(0)
+      assert_equal 0, MessageBusConfig.next_db(15)
+    end
+
+    test '#key_collision_prone?' do
+      different_db_configs = [
+        [{ url: 'redis://my-redis/0' }, { url: 'redis://my-redis/1' }],
+        [{ url: 'redis://my-redis/0' }, { host: 'my-redis', db: '1' }],
+        [{ host: 'my-redis', db: '0' }, { url: 'redis://my-redis/1' }],
+        [{ host: 'my-redis', db: '0' }, { host: 'my-redis', db: '1' }]
+      ]
+      different_db_configs.each { |(config1, config2)| refute MessageBusConfig.key_collision_prone?(config1, config2) }
+
+      same_db_configs = [
+        [{ url: 'redis://my-redis/0' }, { url: 'redis://my-redis/0' }],
+        [{ url: 'redis://my-redis/0' }, { host: 'my-redis', db: '0' }],
+        [{ host: 'my-redis', db: '0' }, { url: 'redis://my-redis/0' }],
+        [{ host: 'my-redis', db: '0' }, { host: 'my-redis', db: '0' }]
+      ]
+      same_db_configs.each do |(config1, config2)|
+        assert MessageBusConfig.key_collision_prone?(config1, config2)
+        refute MessageBusConfig.key_collision_prone?(config1.merge(namespace: 'ns'), config2)
+        refute MessageBusConfig.key_collision_prone?(config1, config2.merge(namespace: 'ns'))
+        refute MessageBusConfig.key_collision_prone?(config1.merge(namespace: 'ns'), config2.merge(namespace: 'other-ns'))
+        assert MessageBusConfig.key_collision_prone?(config1.merge(namespace: 'ns'), config2.merge(namespace: 'ns'))
+      end
+    end
+
+    test 'uses own config if url is present' do
+      config = MessageBusConfig.new(redis: { 'url' => 'redis://my-redis/5' })
+      assert_equal 'redis://my-redis/5', config.redis_config[:url]
+    end
+
+    test 'inherits default redis config' do
+      config = MessageBusConfig.new
+      assert_equal 'redis://my-redis/1', config.redis_config[:url]
+    end
+
+    test 'prevents key collision when inheriting default redis config' do
+      config = MessageBusConfig.new
+      assert_equal 'redis://my-redis/1', config.redis_config[:url]
+      assert_equal 2, config.redis_config[:db]
+
+      config = MessageBusConfig.new(redis: { url: nil })
+      assert_equal 'redis://my-redis/1', config.redis_config[:url]
+      assert_equal 2, config.redis_config[:db]
+
+      config = MessageBusConfig.new(redis: { db: 1 })
+      assert_equal 'redis://my-redis/1', config.redis_config[:url]
+      assert_equal 2, config.redis_config[:db]
+
+      config = MessageBusConfig.new(redis: { db: 8 })
+      assert_equal 'redis://my-redis/1', config.redis_config[:url]
+      assert_equal 8, config.redis_config[:db]
+
+      config = MessageBusConfig.new(redis: { namespace: 'ns' })
+      assert_equal 'redis://my-redis/1', config.redis_config[:url]
+      assert_equal 'ns', config.redis_config[:namespace]
+    end
+
+    test '#configure_message_bus!' do
+      config = { keepalive_interval: 0, backend: :memory }
+      MessageBus.expects(:configure).with(config)
+      MessageBusConfig.new(config).configure_message_bus!
+    end
+
+    test 'configures redis' do
+      redis_config = { 'url' => 'redis://my-redis' }
+      config = { enabled: true, backend: :redis, redis: redis_config }
+      MessageBus.expects(:redis_config=).with(redis_config.symbolize_keys)
+      MessageBusConfig.new(config).configure_message_bus!
+    end
+
+    test 'enabled/disabled' do
+      MessageBus.expects(:off)
+      MessageBusConfig.new(enabled: false).configure_message_bus!
+
+      MessageBus.expects(:off).never
+      MessageBusConfig.new(enabled: true).configure_message_bus!
+    end
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes message bus configuration to use `REDIS_URL` env var in case `MESSAGE_BUS_REDIS_URL` is not present. Nothing changes if `MESSAGE_BUS_REDIS_URL` is defined.

It keeps the behavior of using different redis dbs for `MessageBus` and `System.redis` in case namespaces are not configured for either of those redis connections.

**Which issue(s) this PR fixes** 

Closes [THREESCALE-2382](https://issues.jboss.org/browse/THREESCALE-2382) as an alternative to a templates solution approach.

**Verification steps**
Normal behavior setting `MESSAGE_BUS_REDIS_URL`
1. Boot porta setting `MESSAGE_BUS_REDIS_URL=redis://localhost/8`
2. Confirm that message bus redis entries are being sent to redis db 8
3. Confirm that Sidekiq redis entries are being sent to redis db 1

Without Redis namespaces
1. Boot porta without setting `MESSAGE_BUS_REDIS_URL`
2. Confirm that message bus redis entries are being sent to redis db 2
3. Confirm that Sidekiq redis entries are being sent to redis db 1

With Redis namespaces
1. Boot porta without setting `MESSAGE_BUS_REDIS_URL`, but setting `REDIS_NAMESPACE=sidekiq` and `MESSAGE_BUS_REDIS_NAMESPACE=mbus`
2. Confirm that both Sidekiq and message bus redis entries are being sent to redis db 1
3. Confirm that message bus redis entries are all prefixed `mbus:`
4. Confirm that Sidekiq redis entries are all prefixed `sidekiq:`