### PR TITLE
[zync] Move Zync worker to its own queue

### DIFF
--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -9,7 +9,7 @@ class ZyncWorker
   class_attribute :publisher
   self.publisher = ->(*args) { Rails.application.config.event_store.publish_event(*args) }
 
-  sidekiq_options retry: 3, dead: false, queue: :low
+  sidekiq_options retry: 3, dead: false, queue: :zync
 
   def self.config
     Rails.configuration.zync

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,5 +1,0 @@
-"messages,web_hooks,*": 1
-"heroku_sync,signup,*": 1
-"audited,events,report_traffic,*": 1
-"billing": 4
-"backend_sync,heroku_sync,signup,web_hooks,messages,events,audited,report_traffic": 1

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -18,7 +18,7 @@ namespace :sidekiq do
 
     args = []
     args.push(['--index', ENV.fetch('INDEX', '0')])
-    args.push(%w[backend_sync billing critical default events low priority web_hooks].flat_map { |queue| ['--queue', queue] })
+    args.push(%w[backend_sync billing critical default events low priority web_hooks zync].flat_map { |queue| ['--queue', queue] })
 
     exec(envs, 'sidekiq', *args.flatten)
   end


### PR DESCRIPTION
Relates to: https://github.com/3scale/deploy/pull/567

We need Zync Workers to be confined, not running on the _low_ queue

Otherwise if we want to "throttle" calls to Zync we are throttling all jobs in the _low_ queue