### PR TITLE
Detect dangerous migrations

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -18,6 +18,8 @@ gem 'protected_attributes', '~> 1.1.4'
 #gem 'protected_attributes_continued', '~> 1.3.0'
 gem 'rails-observers'
 
+gem 'strong_migrations'
+
 group :assets do
   gem 'coffee-rails', '~> 4.2'
   gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -741,6 +741,8 @@ GEM
       json (~> 1.8.1)
       mime-types (>= 1.25, < 3.0)
       rest-client (~> 1.4)
+    strong_migrations (0.3.1)
+      activerecord (>= 3.2.0)
     symbolize (4.5.2)
       activemodel (>= 3.2, < 5)
       activesupport (>= 3.2, < 5)
@@ -968,6 +970,7 @@ DEPENDENCIES
   state_machines-activerecord (~> 0.5.0)
   statsd-ruby
   stripe
+  strong_migrations
   swagger-ui_rails!
   swagger-ui_rails2!
   symbolize (~> 4.5)

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+StrongMigrations.start_after = 20190304222108

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -745,6 +745,8 @@ GEM
       json (~> 1.8.1)
       mime-types (>= 1.25, < 3.0)
       rest-client (~> 1.4)
+    strong_migrations (0.3.1)
+      activerecord (>= 3.2.0)
     symbolize (4.5.2)
       activemodel (>= 3.2, < 5)
       activesupport (>= 3.2, < 5)
@@ -973,6 +975,7 @@ DEPENDENCIES
   state_machines-activerecord (~> 0.5.0)
   statsd-ruby
   stripe
+  strong_migrations
   swagger-ui_rails!
   swagger-ui_rails2!
   symbolize (~> 4.5)


### PR DESCRIPTION
Closes [THREESCALE-1859 - Ability to detect dangerous migrations](https://issues.jboss.org/browse/THREESCALE-1859)

Install and use the Gem `strong_migrations` to detect dangerous migrations for new migrations from now on.

I think that it works well in the 3 DBs without doing anything else 🤔 

## Verification steps

### Adding a dangerous migration
I am doing some tests locally with this new temporary migration in `db/migrate/20190507145848_temporarily_remove_account_service_preffix.rb` :
```ruby
class TemporarilyRemoveAccountServicePreffix < ActiveRecord::Migration
  def change
    puts "\n------------------------\nUsing #{System::Database.adapter}\n------------------------\n"
    remove_column :accounts, :service_preffix
  end
end
```

#### MySQL
![image](https://user-images.githubusercontent.com/11318903/57311560-26611480-70ec-11e9-8ed7-b8077085dc81.png)

#### Postgres
![image](https://user-images.githubusercontent.com/11318903/57311531-1c3f1600-70ec-11e9-9200-cf65e4cd4bd5.png)

#### Oracle
![image](https://user-images.githubusercontent.com/11318903/57311630-4690d380-70ec-11e9-9bab-beb4f3c7364c.png)

### Simulating that it is already safe
The `Account` model has this change now to remove the column from the Rails cache programatically:
![image](https://user-images.githubusercontent.com/11318903/57312155-4cd37f80-70ed-11e9-8b82-fa42041d5b8d.png)

And simulating that it is already deployed to production, the same migration mentioned before now looks like this:
```ruby
class TemporarilyRemoveAccountServicePreffix < ActiveRecord::Migration
  def change
    puts "\n------------------------\nUsing #{System::Database.adapter}\n------------------------\n"
    safety_assured { remove_column :accounts, :service_preffix }
  end
end
```

#### MySQL
![image](https://user-images.githubusercontent.com/11318903/57312347-9fad3700-70ed-11e9-8d34-56a241236192.png)

#### Postgres
![image](https://user-images.githubusercontent.com/11318903/57312300-8b693a00-70ed-11e9-910b-153cd6a58720.png)

#### Oracle
![image](https://user-images.githubusercontent.com/11318903/57312373-ac318f80-70ed-11e9-864a-611ad531316a.png)

