### PR TITLE
Fix random test failure in test_raises_if_trying_to_upgrade_to_enterprise

### DIFF
--- a/test/unit/logic/provider_upgrade_test.rb
+++ b/test/unit/logic/provider_upgrade_test.rb
@@ -18,7 +18,8 @@ class Logic::ProviderUpgradeTest < ActiveSupport::TestCase
     @pro.plan_rule.stubs(:limits).returns(PlanRule::Limit.new(max_services: 3, max_users: 5))
     @pro.plan_rule.stubs(:rank).returns(19)
     @enterprise = FactoryBot.create(:published_plan, :system_name => 'super_enterprise2020xl', :issuer => service)
-    @enterprise.plan_rule.stubs(:metadata).returns({cannot_automatically_be_upgraded_to: true})
+    @enterprise.plan_rule.stubs(:rank).returns(28)
+    @enterprise.plan_rule.metadata = {cannot_automatically_be_upgraded_to: true}
     @enterprise.plan_rule.stubs(:switches).returns(
         %i[finance multiple_applications branding require_cc_on_signup account_plans multiple_users groups end_users
         multiple_services service_plans skip_email_engagement_footer web_hooks iam_tools]
@@ -62,8 +63,9 @@ class Logic::ProviderUpgradeTest < ActiveSupport::TestCase
     assert_raises(RuntimeError) { @provider.upgrade_to_provider_plan!(@power1M) }
   end
 
-  test 'raises if trying to upgrade to enterprise' do
+  test 'raises if trying to upgrade to enterprise for the cannot_automatically_be_upgraded_to' do
     @provider.stubs(:credit_card_stored?).returns(true)
+
     assert_raises(RuntimeError) { @provider.upgrade_to_provider_plan!(@enterprise) }
   end
 

--- a/test/unit/logic/provider_upgrade_test.rb
+++ b/test/unit/logic/provider_upgrade_test.rb
@@ -17,14 +17,6 @@ class Logic::ProviderUpgradeTest < ActiveSupport::TestCase
     )
     @pro.plan_rule.stubs(:limits).returns(PlanRule::Limit.new(max_services: 3, max_users: 5))
     @pro.plan_rule.stubs(:rank).returns(19)
-    @enterprise = FactoryBot.create(:published_plan, :system_name => 'super_enterprise2020xl', :issuer => service)
-    @enterprise.plan_rule.stubs(:rank).returns(28)
-    @enterprise.plan_rule.metadata = {cannot_automatically_be_upgraded_to: true}
-    @enterprise.plan_rule.stubs(:switches).returns(
-        %i[finance multiple_applications branding require_cc_on_signup account_plans multiple_users groups end_users
-        multiple_services service_plans skip_email_engagement_footer web_hooks iam_tools]
-    )
-    @enterprise.plan_rule.stubs(:limits).returns(PlanRule::Limit.new(max_services: nil, max_users: nil))
     @base = FactoryBot.create(:published_plan, :system_name => 'base', :issuer => service)
     @base.plan_rule.stubs(:limits).returns(PlanRule::Limit.new(max_services: 1, max_users: 1))
   end
@@ -50,32 +42,25 @@ class Logic::ProviderUpgradeTest < ActiveSupport::TestCase
     assert @provider.settings.finance.visible?, 'Finance should be visible on Power1M'
   end
 
-  test 'upgrade from base to enterprise' do
+  test 'upgrade through force_upgrade_to_provider_plan! bypasses can_upgrade?' do
     @provider.stubs(:credit_card_stored?).returns(true)
-    @provider.force_upgrade_to_provider_plan!(@enterprise)
-
-    assert_equal 'super_enterprise2020xl', @provider.reload.bought_cinstance.plan.system_name
-    assert_equal 'enterprise', @provider.settings.product
+    PlanRulesCollection.stubs(can_upgrade?: false) do
+      @provider.force_upgrade_to_provider_plan!(@power1M)
+    end
   end
 
   test 'raises if not credit_card_stored?' do
     @provider.stubs(:credit_card_stored?).returns(false)
-    assert_raises(RuntimeError) { @provider.upgrade_to_provider_plan!(@power1M) }
+    PlanRulesCollection.stubs(can_upgrade?: true) do
+      assert_raises(RuntimeError) { @provider.upgrade_to_provider_plan!(@power1M) }
+    end
   end
 
-  test 'raises if trying to upgrade to enterprise for the cannot_automatically_be_upgraded_to' do
+  test 'raises unless can_upgrade?' do
     @provider.stubs(:credit_card_stored?).returns(true)
-
-    assert_raises(RuntimeError) { @provider.upgrade_to_provider_plan!(@enterprise) }
-  end
-
-  test 'upgrade to inferior plans fails' do
-    @provider.stubs(:credit_card_stored?).returns(true)
-
-    @app = @provider.bought_cinstance
-    @app.plan.update_attribute(:system_name, 'power1M')
-
-    assert_raises(RuntimeError) { @provider.upgrade_to_provider_plan!(@base) }
+    PlanRulesCollection.stubs(can_upgrade?: false) do
+      assert_raises(RuntimeError) { @provider.upgrade_to_provider_plan!(@power1M) }
+    end
   end
 
   test 'can call force_upgrade_to_provider_plan! with a master plan system_name' do


### PR DESCRIPTION
Closes [THREESCALE-2144 - Fix random test failure in test_raises_if_trying_to_upgrade_to_enterprise](https://issues.jboss.org/browse/THREESCALE-2144)

### Background/History
The goal of this test, from very old commits, when everything was inside `ProviderUpgrade`, was to check that it was not possible to upgrade through `enterprise` by `upgrade_to_provider_plan!`.

https://github.com/3scale/system/blob/d18418385555e96094cb3346db3724aedcef7993/test/unit/logic/provider_upgrade_test.rb#L62-L65

https://github.com/3scale/system/blob/0696c85a78f8e63369d8808e1a05a8f32b4d9181/app/lib/logic/provider_upgrade.rb#L176-L190

Later we extracted a lot of this code into `PlanRule`, `PlanRuleCollection`, and made it configurable by `plan_rules.yml`. The `enterprise` was not hardcoded anymore and we added the metadata option `cannot_automatically_be_upgraded_to` for that.

This means that the goal of this test would be, at this point, checking that it can not be upgraded through `upgrade_to_provider_plan!` to a plan with the metadata `cannot_automatically_be_upgraded_to` to `true`.

### Problems

1. When I tested this locally, it was raising the error as expected and desired, but for the wrong reasons... what was happening was it was loading with `rank` to `0` and it returned that it couldn't upgrade because the original plan and the desired plan had the same rank, not for the `cannot_automatically_be_upgraded_to` which was not even stubbed correctly 😞 

2. For the random failure, apparently there was a conflict for testing the same class variable/method (`PlanRulesCollection::PLAN_RULES_BY_NAME`, used by `PlanRulesCollection.plan_rules_by_name`) from `Logic::ProviderUpgradeTest` and `PlanRulesCollectionTest`. So if by the time a test was running, it had the wrong configuration, then it returns a wrong value.

### Tasks to fix the problems
In the 1st commit I added the `rank` and the `cannot_automatically_be_upgraded_to` to `enterprise` in   `Logic::ProviderUpgradeTest`, but in the 2nd commit, I changed some tests of this same file according to our new code, and by that I mean that we shouldn't test configuration but business logic... the fact that `enterprise` has `cannot_automatically_be_upgraded_to` is configuration and not business logic, and this business logic is already tested in `PlanRulesCollectionTest`, except the specific methods of `ProviderUpgrade` which is what is being tested now, stubbing what is already tested in  `PlanRulesCollectionTest` for how we want it to behave in these cases.
