### PR TITLE
[Bugfix] Assure safety for strong_migrations in Openshift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ ENV PATH="./node_modules/.bin:$PATH:/usr/local/nginx/sbin/" \
     TZ=:/etc/localtime \
     LD_LIBRARY_PATH=/opt/oracle/instantclient_12_2/ \
     ORACLE_HOME=/opt/oracle/instantclient_12_2/ \
-    DB=$DB
+    DB=$DB \
+    SAFETY_ASSURED=1
 
 WORKDIR /opt/system/
 

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -41,7 +41,8 @@ COPY openshift/system/contrib/scl_enable /opt/system/etc/
 ENV BASH_ENV=/opt/system/etc/scl_enable \
     ENV=/opt/system/etc/scl_enable \
     PROMPT_COMMAND=". /opt/system/etc/scl_enable" \
-    RAILS_ENV=production
+    RAILS_ENV=production \
+    SAFETY_ASSURED=1
 
 RUN export ${BUNDLER_ENV} >/dev/null \
     && source /opt/system/etc/scl_enable \

--- a/openshift/system/Dockerfile.on_prem
+++ b/openshift/system/Dockerfile.on_prem
@@ -41,7 +41,8 @@ COPY openshift/system/contrib/scl_enable ./etc/
 ENV BASH_ENV=/opt/system/etc/scl_enable \
     ENV=/opt/system/etc/scl_enable \
     PROMPT_COMMAND=". /opt/system/etc/scl_enable" \
-    RAILS_ENV=production
+    RAILS_ENV=production \
+    SAFETY_ASSURED=1
 
 RUN export ${BUNDLER_ENV} >/dev/null\
     && source /opt/system/etc/scl_enable \


### PR DESCRIPTION
Closes [THREESCALE-2504 - Add SAFETY_ASSURED=1 for on-prem and QE nightly builds](https://issues.jboss.org/browse/THREESCALE-2504)