### PR TITLE
Bump faraday version to 0.12.2

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -105,7 +105,8 @@ end
 gem 'nokogiri', '>= 1.6.8'
 gem 'dalli', '~> 2.7'
 gem 'secure_headers', '~> 2.2'
-gem 'faraday_middleware'
+gem 'faraday', '~> 0.12.0'
+gem 'faraday_middleware', '~> 0.12.0'
 
 gem 'rails_event_store', '~> 0.9.0'
 gem 'paperclip', '~> 5.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,10 +333,10 @@ GEM
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
     fakefs (0.18.0)
-    faraday (0.9.2)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.1)
-      faraday (>= 0.7.4, < 0.10)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.10.0)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
@@ -454,7 +454,7 @@ GEM
     multi_json (1.13.1)
     multi_test (0.1.2)
     multi_xml (0.5.5)
-    multipart-post (2.0.0)
+    multipart-post (2.1.0)
     mustache (1.1.0)
     mysql2 (0.3.18)
     net-http-digest_auth (1.4)
@@ -873,7 +873,8 @@ DEPENDENCIES
   factory_bot_rails (~> 4.11.1)
   fakefs (~> 0.18.0)
   fakeweb!
-  faraday_middleware
+  faraday (~> 0.12.0)
+  faraday_middleware (~> 0.12.0)
   font-awesome-rails (~> 4.7.0.4)
   font_assets!
   formtastic (~> 1.2.4)

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -337,10 +337,10 @@ GEM
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
     fakefs (0.18.0)
-    faraday (0.9.2)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.1)
-      faraday (>= 0.7.4, < 0.10)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.10.0)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
@@ -458,7 +458,7 @@ GEM
     multi_json (1.13.1)
     multi_test (0.1.2)
     multi_xml (0.5.5)
-    multipart-post (2.0.0)
+    multipart-post (2.1.0)
     mustache (1.1.0)
     mysql2 (0.3.18)
     net-http-digest_auth (1.4)
@@ -878,7 +878,8 @@ DEPENDENCIES
   factory_bot_rails (~> 4.11.1)
   fakefs (~> 0.18.0)
   fakeweb!
-  faraday_middleware
+  faraday (~> 0.12.0)
+  faraday_middleware (~> 0.12.0)
   font-awesome-rails (~> 4.7.0.4)
   font_assets!
   formtastic (~> 1.2.4)

--- a/test/test_helpers/backend.rb
+++ b/test/test_helpers/backend.rb
@@ -85,7 +85,7 @@ module TestHelpers
     MockCore.mock_core!
 
     def stub_core_integration_errors(service_id: )
-      MockCore.stubs.get("/internal/services/#{service_id}/errors/", {'User-Agent' => 'Faraday v0.9.2'}) do
+      MockCore.stubs.get("/internal/services/#{service_id}/errors/", {'User-Agent' => 'Faraday v0.12.2'}) do
         [ 200, {'content-type'=>'application/json'}, { errors: [] }.to_json ]
       end
     end

--- a/test/test_helpers/backend.rb
+++ b/test/test_helpers/backend.rb
@@ -85,7 +85,7 @@ module TestHelpers
     MockCore.mock_core!
 
     def stub_core_integration_errors(service_id: )
-      MockCore.stubs.get("/internal/services/#{service_id}/errors/", {'User-Agent' => 'Faraday v0.12.2'}) do
+      MockCore.stubs.get("/internal/services/#{service_id}/errors/") do
         [ 200, {'content-type'=>'application/json'}, { errors: [] }.to_json ]
       end
     end


### PR DESCRIPTION
**What this PR does / why we need it**
It updates the version of the faraday gem in use to v0.12.2.

**Which issue(s) this PR fixes**
This is expected to include support to no_proxy env var in the HTTP requests performed using the gem, such as connections to backend, segment and some requests performed by Sidekiq.

Closes [THREESCALE-1739](https://issues.jboss.org/browse/THREESCALE-1739)