### PR TITLE
Dashboard stream and email notifications are filtered according to the member permissions

### DIFF
--- a/app/events/applications/application_plan_change_requested_event.rb
+++ b/app/events/applications/application_plan_change_requested_event.rb
@@ -6,6 +6,7 @@ class Applications::ApplicationPlanChangeRequestedEvent < ApplicationRelatedEven
       account:        application.account,
       user:           user,
       current_plan:   application.plan,
+      service:        application.service,
       requested_plan: requested_plan,
       provider:       application.provider_account,
       metadata: {

--- a/config/abilities/provider_any.rb
+++ b/config/abilities/provider_any.rb
@@ -28,12 +28,18 @@ Ability.define do |user|
     if user.has_permission?(:finance)
       can [:show], BillingRelatedEvent
     end
+
     if user.has_permission?(:partners)
-      can [:show], AccountRelatedEvent
+      can [:show], AccountRelatedEvent do |event|
+        service_id = event.try(:service)&.id || event.try(:service_id)
+        !service_id || user.has_access_to_service?(service_id)
+      end
+
       can [:show], ServiceRelatedEvent do |event|
         user.has_access_to_service?(event.try(:service) || event.service_id)
       end
     end
+
     if user.has_permission?(:monitoring)
       can [:show], AlertRelatedEvent
     end

--- a/test/unit/abilities/provider_any_test.rb
+++ b/test/unit/abilities/provider_any_test.rb
@@ -10,23 +10,67 @@ class Abilities::ProviderAdminTest < ActiveSupport::TestCase
     @user = User.new({account: @account}, without_protection: true)
   end
 
-  def test_policies_allowed
-    @account.expects(:provider_can_use?).with(:policy_registry).returns(true)
-    @account.stubs(tenant?: true)
+  attr_reader :user, :account
 
-    assert_can Ability.new(@user), :manage, :policy_registry
+  def test_policies_allowed
+    account.expects(:provider_can_use?).with(:policy_registry).returns(true)
+    account.stubs(tenant?: true)
+
+    assert_can ability, :manage, :policy_registry
   end
 
   def test_policies_no_rolling_update
-    @account.expects(:provider_can_use?).with(:policy_registry).returns(false)
-    @account.stubs(tenant?: true)
+    account.expects(:provider_can_use?).with(:policy_registry).returns(false)
+    account.stubs(tenant?: true)
 
-    assert_cannot Ability.new(@user), :manage, :policy_registry
+    assert_cannot ability, :manage, :policy_registry
   end
 
   def test_policies_not_tenant
-    @account.stubs(tenant?: false)
+    account.stubs(tenant?: false)
 
-    assert_cannot Ability.new(@user), :manage, :policy_registry
+    assert_cannot ability, :manage, :policy_registry
+  end
+
+  test 'Cinstance/Application events can show if has :partners and access to the service if there is a service' do
+    cinstance = FactoryBot.create(:cinstance)
+    service = cinstance.service
+    cinstance_events = [
+      Cinstances::CinstanceExpiredTrialEvent.create(cinstance), Cinstances::CinstanceCancellationEvent.create(cinstance),
+      Cinstances::CinstancePlanChangedEvent.create(cinstance, user), Applications::ApplicationCreatedEvent.create(cinstance, user)
+    ]
+
+    user.stubs(:has_permission?)
+    user.stubs(:has_access_to_service?)
+
+    cinstance_events.each do |cinstance_event|
+      user.expects(:has_permission?).with(:partners).returns(true)
+      user.expects(:has_access_to_service?).with(service.id).returns(false)
+      assert_cannot ability, :show, cinstance_event
+
+      user.expects(:has_permission?).with(:partners).returns(false)
+      user.stubs(:has_access_to_service?).returns(true)
+      assert_cannot ability, :show, cinstance_event
+
+      user.expects(:has_permission?).with(:partners).returns(true)
+      user.expects(:has_access_to_service?).with(service.id).returns(true)
+      assert_can ability, :show, cinstance_event
+    end
+  end
+
+  test 'AccountRelatedEvent can show if has :partners and does not have a service' do
+    user.stubs(:has_permission?)
+
+    user.expects(:has_permission?).with(:partners).returns(true)
+    assert_can ability, :show, Accounts::AccountCreatedEvent.create(account, user)
+
+    user.expects(:has_permission?).with(:partners).returns(false)
+    assert_cannot ability, :show, Accounts::AccountCreatedEvent.create(account, user)
+  end
+
+  private
+
+  def ability
+    Ability.new(user)
   end
 end


### PR DESCRIPTION
Bug reproduced following the steps of the description in the Jira issue ([THREESCALE-629 - Dashboard stream and email notifications should be filtered according to the member permissions](https://issues.jboss.org/browse/THREESCALE-629))
In development I also use this code to reproduce it in the rails console quickly (you need sidekiq running 😄 ):

```ruby
def reproduce_bug
  tenant = Account.find(2)
  ('A'..'B').to_a.each do |letter|
    begin
      tenant.services.create!(name: "Service #{letter}")
    rescue ThreeScale::Core::APIClient::ConnectionError
    end
  end

  (1..2).to_a.each do |n|
    Service.find_by(name: 'Service B').application_plans.create!(name: "plan_#{n}")
    
    user = tenant.users.create!(role: :member, username: "member#{n}", email: "member#{n}@example.com", password: '123456')
    user.activate
  end

  cinstance = Account.find(3).buy!(ApplicationPlan.find_by(name: 'plan_1'))

  User.find_by(username: 'member1').update!({member_permission_ids: ['', 'partners', 'plans'], member_permission_service_ids: Service.where('name LIKE ?', 'Service ?').pluck(:id)})
  User.find_by(username: 'member2').update!({member_permission_ids: ['', 'partners', 'plans'], member_permission_service_ids: Service.where(name: 'Service A').pluck(:id)})
  
  cinstance.change_plan!(ApplicationPlan.find_by(name: 'plan_2'))
end
```
I also temporarily used this test:
```ruby
class SavingEventsTest < ActionMailer::TestCase
    disable_transactional_fixtures!

    def test_application_plan_changed_without_permissions
      tenant = FactoryBot.create(:simple_provider)
      services = FactoryBot.create_list(:simple_service, 2, account: tenant)
      application_plans = FactoryBot.create_list(:application_plan, 2, service: services.last)
      users = FactoryBot.create_list(:member, 2, account: tenant)
      users.each(&:activate!)
      developer = FactoryBot.create(:simple_buyer, provider_account: tenant)
      FactoryBot.create(:admin, account: developer) # To save a valid Cinstances::CinstancePlanChangedEvent
      cinstance = developer.buy!(application_plans.first)
      users.first.update!({member_permission_ids: %w[partners plans], member_permission_service_ids: services.map(&:id)})
      users.last.update!({member_permission_ids: %w[partners plans], member_permission_service_ids: [services.first.id]})

      assert_difference(EventStore::Event.where(event_type: Cinstances::CinstancePlanChangedEvent).method(:count)) do
        assert_difference(EventStore::Event.where(event_type: NotificationEvent).method(:count)) do

          assert_difference(users.first.notifications.method(:count)) do
            assert_no_difference(users.last.notifications.method(:count)) do
              Sidekiq::Testing.inline! { cinstance.change_plan!(application_plans.last) }
            end
          end
        end

      end

    end
end
```

Now the notifications are filtered in creation time according to the member permissions. And that applies to notifications for users in the Dashboard and email.