### PR TITLE
[Gemfile] Remove ruby requirements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-ruby File.read('.ruby-version', mode: 'rb').chomp.prepend('~> ')
-
 eval_gemfile 'Gemfile.base'
 gem 'pg', '~> 0.21.0'
 gem 'sidekiq-batch', '~> 0.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -994,8 +994,5 @@ DEPENDENCIES
   yard
   zip-zip
 
-RUBY VERSION
-   ruby 2.3.6p384
-
 BUNDLED WITH
    1.17.3

--- a/gemfiles/prod/Gemfile
+++ b/gemfiles/prod/Gemfile
@@ -1,5 +1,3 @@
-ruby '~> 2.3.0'
-
 eval_gemfile '../../Gemfile.base'
 
 source 'https://gems.contribsys.com/' do

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -999,8 +999,5 @@ DEPENDENCIES
   yard
   zip-zip
 
-RUBY VERSION
-   ruby 2.3.6p384
-
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
So that we can run tests for ruby 2.3, 2.4 and 2.5 at the same time