### PR TITLE
Master Member gets permissions for provider_plans

### DIFF
--- a/app/controllers/master/providers/plans_controller.rb
+++ b/app/controllers/master/providers/plans_controller.rb
@@ -9,7 +9,7 @@ class Master::Providers::PlansController < Master::Providers::BaseController
 
   def update
     authorize! :update, :provider_plans
-    raise CanCan::AccessDenied unless current_user.has_access_to_service?(@new_plan.issuer_id)
+    authorize! :update, @new_plan.issuer
 
     @provider.force_upgrade_to_provider_plan!(@new_plan)
   end

--- a/app/controllers/master/providers/plans_controller.rb
+++ b/app/controllers/master/providers/plans_controller.rb
@@ -8,6 +8,9 @@ class Master::Providers::PlansController < Master::Providers::BaseController
   end
 
   def update
+    authorize! :update, :provider_plans
+    raise CanCan::AccessDenied unless current_user.has_access_to_service?(@new_plan.issuer_id)
+
     @provider.force_upgrade_to_provider_plan!(@new_plan)
   end
 

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -74,7 +74,7 @@ h1 data-hook="account-show"
                                method: :post,
                                data: { confirm: 'Are you sure?', disable_with: 'resuming…' },
                                class: 'action resume'
-    - if can?(:update, :provider_plans) && current_user.has_access_to_service?(@account.bought_cinstance.service_id)
+    - if can?(:update, :provider_plans) && can?(:update, @account.bought_cinstance.service)
       = render 'master/providers/plans/widget', provider: @account
     - if can?(:manage, :finance)
       .dashboard_bubble.round

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -74,7 +74,7 @@ h1 data-hook="account-show"
                                method: :post,
                                data: { confirm: 'Are you sure?', disable_with: 'resuming…' },
                                class: 'action resume'
-    - if can?(:update, :provider_plans)
+    - if can?(:update, :provider_plans) && current_user.has_access_to_service?(@account.bought_cinstance.service_id)
       = render 'master/providers/plans/widget', provider: @account
     - if can?(:manage, :finance)
       .dashboard_bubble.round

--- a/config/abilities/master_member.rb
+++ b/config/abilities/master_member.rb
@@ -20,7 +20,9 @@ Ability.define do |user|
 
     if user.has_permission?(:partners)
       can :manage, :partners
-      can :manage, :provider_plans
+
+      can :manage, :provider_plans unless ThreeScale.config.onpremises
+
       if user.account.provider_can_use?(:service_permissions)
         can :resume, Account
         can(:update, Account) { |account| !account.scheduled_for_deletion? }

--- a/config/abilities/master_member.rb
+++ b/config/abilities/master_member.rb
@@ -17,13 +17,14 @@ Ability.define do |user|
     end
 
     can(:create, Account, &:signup_provider_possible?)
+
     if user.has_permission?(:partners)
       can :manage, :partners
+      can :manage, :provider_plans
       if user.account.provider_can_use?(:service_permissions)
         can :resume, Account
         can(:update, Account) { |account| !account.scheduled_for_deletion? }
       end
-
     end
 
   end

--- a/test/integration/master/providers/plans_controller_test.rb
+++ b/test/integration/master/providers/plans_controller_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Master::Api::PlansControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @master_member = FactoryBot.create(:member, account: master_account, state: 'active')
+    @service = master_account.default_service
+    @tenant = FactoryBot.create(:simple_provider, provider_account: master_account)
+    @old_plan, @new_plan = FactoryBot.create_list(:application_plan, 2, service: service)
+    @tenant.buy! old_plan
+  end
+
+  attr_reader :tenant, :old_plan, :new_plan, :master_member, :service
+
+  test '#update from an unauthenticated user' do
+    host! master_account.self_domain
+
+    put master_provider_plan_path(tenant), plan_id: new_plan.id, format: :js
+
+    assert_response :redirect
+    assert_equal [old_plan.id], tenant.bought_application_plans.pluck(:id)
+  end
+
+  test '#update for an admin' do
+    login! master_account
+
+    put master_provider_plan_path(tenant), plan_id: new_plan.id, format: :js
+
+    assert_response :success
+    assert_equal [new_plan.id], tenant.bought_application_plans.pluck(:id)
+  end
+
+  test '#update for a member with permission partners and the service' do
+    master_member.update!({member_permission_ids: ['partners'], member_permission_service_ids: [service.id]})
+    login! master_account, user: master_member
+
+    put master_provider_plan_path(tenant), plan_id: new_plan.id, format: :js
+
+    assert_response :success
+    assert_equal [new_plan.id], tenant.bought_application_plans.pluck(:id)
+  end
+
+  test '#update for a member without permission partners but with the service' do
+    master_member.update!({member_permission_ids: [], member_permission_service_ids: [service.id]})
+    login! master_account, user: master_member
+
+    put master_provider_plan_path(tenant), plan_id: new_plan.id, format: :js
+
+    assert_response :forbidden
+    assert_equal [old_plan.id], tenant.bought_application_plans.pluck(:id)
+  end
+
+  test '#update for a member with permission partners but without the service' do
+    master_member.update!({member_permission_ids: ['partners'], member_permission_service_ids: '[]'})
+    login! master_account, user: master_member
+
+    put master_provider_plan_path(tenant), plan_id: new_plan.id, format: :js
+
+    assert_response :forbidden
+    assert_equal [old_plan.id], tenant.bought_application_plans.pluck(:id)
+  end
+end

--- a/test/unit/abilities/master_member_test.rb
+++ b/test/unit/abilities/master_member_test.rb
@@ -56,10 +56,16 @@ class Abilities::MasterMemberTest < ActiveSupport::TestCase
   def test_provider_plans
     @member.stubs(:has_permission?)
 
+    ThreeScale.config.stubs(onpremises: false)
+
     @member.expects(:has_permission?).with(:partners).returns(true)
     assert_can ability, :manage, :provider_plans
 
     @member.expects(:has_permission?).with(:partners).returns(false)
+    assert_cannot ability, :manage, :provider_plans
+
+    ThreeScale.config.stubs(onpremises: true)
+    @member.expects(:has_permission?).with(:partners).returns(true)
     assert_cannot ability, :manage, :provider_plans
   end
 

--- a/test/unit/abilities/master_member_test.rb
+++ b/test/unit/abilities/master_member_test.rb
@@ -53,6 +53,16 @@ class Abilities::MasterMemberTest < ActiveSupport::TestCase
     assert_can ability, :create, Account
   end
 
+  def test_provider_plans
+    @member.stubs(:has_permission?)
+
+    @member.expects(:has_permission?).with(:partners).returns(true)
+    assert_can ability, :manage, :provider_plans
+
+    @member.expects(:has_permission?).with(:partners).returns(false)
+    assert_cannot ability, :manage, :provider_plans
+  end
+
   private
 
   def ability


### PR DESCRIPTION
Closes [THREESCALE-1733 - Multitenant member user with appropriate rights doesn't have access to application plans](https://issues.jboss.org/browse/THREESCALE-1733).

### Verification steps

Locally, if you have the default DB from the seeds, follow this steps 😄 

1. Put in `config/plan_rules.yml`:

```yaml
plan_rules: &default
  base:
    rank: 1
    limits:
      max_users: 1
      max_services: 1
    switches: []
    metadata: {}
  2015_plus_copy_14540190951550343:
    rank: 3
    limits:
      max_users: 1
      max_services: 1
    switches: []
    metadata:
      trial: true
  plus:
    rank: 8
    limits:
      max_users: 1
      max_services: 1
    switches:
    - finance
    - multiple_applications
    - branding
    - require_cc_on_signup
    metadata: {}
  master_plan:
    rank: 50
    limits:
      max_users:
      max_services:
    switches:
      - finance
      - multiple_applications
      - branding
      - require_cc_on_signup
      - account_plans
      - multiple_users
      - groups
      - end_users
      - multiple_services
      - service_plans
      - skip_email_engagement_footer
      - web_hooks
      - iam_tools
  enterprise:
      rank: 27
      limits:
        max_users:
        max_services:
      switches:
      - finance
      - multiple_applications
      - branding
      - require_cc_on_signup
      - account_plans
      - multiple_users
      - groups
      - end_users
      - multiple_services
      - service_plans
      - skip_email_engagement_footer
      - web_hooks
      - iam_tools

development:
  <<: *default
```

2. Create and activate a new member user for the master account. It can be done through the rails console:

```ruby
user = Account.master.users.create!({username: 'member', password: '123456', email: 'member@example.com', role: :member})
user.activate!
```

3. Give the user the member_permissions `partners` and access to the service.
```
user.update!({member_permission_ids: ['partners'], member_permission_service_ids: [Account.master.default_service.id]})
```

4. Run the rails server, and visit `http://master-account.example.com.lvh.me:3000/buyers/accounts/2`. You will need to log in from this newly created member user.
You will now see at the bottom of the page:
![image](https://user-images.githubusercontent.com/11318903/58101222-7c9b8080-7bdf-11e9-92b2-89cd359ff44a.png)

5. `Change plan` to `Master Plan`. And it gets done:
![image](https://user-images.githubusercontent.com/11318903/58101467-fb90b900-7bdf-11e9-8b0a-b2972f55755e.png)

### Tasks

1. Master member user with permissions `partners` and permission for the service, can update the application of the provider.
2. Ensure permissions to render the widget and to update in the controller.

### TODO for following PRs/Issues

There are a couple of improvements that could be done, but later on, in different Jira issues.
1. Changing this `unless ThreeScale.config.onpremises` for a Rolling Update. Imo it should be part of [THREESCALE-1022 - Saas vs On-premises differences](https://issues.jboss.org/browse/THREESCALE-1022) so I didn't create a new Jira issue for this specific line.
2. Having one ability to manage the cinstance directly, as suggested [in this comment](https://github.com/3scale/porta/pull/808#discussion_r286469412), instead of checking for 2 different accesses (`update provider_plans` and `update the service`). I will create a Jira issue for this one.