### PR TITLE
[WIP][2.7 ER1]Remove tech_support_email and admin_support_email fields from the DB

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -15,7 +15,7 @@ class Service < ApplicationRecord
 
   has_system_name uniqueness_scope: :account_id
 
-  attr_readonly :system_name, :admin_support_email, :tech_support_email
+  attr_readonly :system_name
 
   validates :backend_version, inclusion: { in: ->(service) { BackendVersion.usable_versions(service: service) }}
 
@@ -42,10 +42,6 @@ class Service < ApplicationRecord
     service.has_many :application_plans, as: :issuer, &DefaultPlanProxy
     service.has_many :end_user_plans, &DefaultPlanProxy
     service.has_many :api_docs_services, class_name: 'ApiDocs::Service'
-  end
-
-  def self.columns
-    super.reject { |column| %w[tech_support_email admin_support_email].include?(column.name) }
   end
 
   scope :of_account, ->(account) { where.has { account_id == account } }

--- a/db/migrate/20190528133015_remove_service_support_emails.rb
+++ b/db/migrate/20190528133015_remove_service_support_emails.rb
@@ -1,0 +1,6 @@
+class RemoveServiceSupportEmails < ActiveRecord::Migration
+  def change
+    safety_assured { remove_column :services, :tech_support_email, :string }
+    safety_assured { remove_column :services, :admin_support_email, :string }
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190527104222) do
+ActiveRecord::Schema.define(version: 20190528133015) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -1172,8 +1172,6 @@ ActiveRecord::Schema.define(version: 20190527104222) do
     t.text     "infobar"
     t.text     "terms"
     t.boolean  "display_provider_keys",          limit: nil,                default: false
-    t.string   "tech_support_email"
-    t.string   "admin_support_email"
     t.string   "credit_card_support_email"
     t.boolean  "buyers_manage_apps",             limit: nil,                default: true
     t.boolean  "buyers_manage_keys",             limit: nil,                default: true

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190527104222) do
+ActiveRecord::Schema.define(version: 20190528133015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1173,8 +1173,6 @@ ActiveRecord::Schema.define(version: 20190527104222) do
     t.text     "infobar"
     t.text     "terms"
     t.boolean  "display_provider_keys",                      default: false
-    t.string   "tech_support_email",             limit: 255
-    t.string   "admin_support_email",            limit: 255
     t.string   "credit_card_support_email",      limit: 255
     t.boolean  "buyers_manage_apps",                         default: true
     t.boolean  "buyers_manage_keys",                         default: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190527104222) do
+ActiveRecord::Schema.define(version: 20190528133015) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -1174,8 +1174,6 @@ ActiveRecord::Schema.define(version: 20190527104222) do
     t.text     "infobar",                        limit: 65535
     t.text     "terms",                          limit: 65535
     t.boolean  "display_provider_keys",                        default: false
-    t.string   "tech_support_email",             limit: 255
-    t.string   "admin_support_email",            limit: 255
     t.string   "credit_card_support_email",      limit: 255
     t.boolean  "buyers_manage_apps",                           default: true
     t.boolean  "buyers_manage_keys",                           default: true

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -42,24 +42,6 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     expected_signup_and_use.each { |attr_name, attr_value| assert_equal attr_value, service.public_send(attr_name) }
   end
 
-  # This test can be removed once used deprecated attributes have been removed from the schema
-  test 'deprecated attributes should not be updated' do
-    new_tech_support_email = 'foo.tech.support@example.com'
-    new_admin_support_email = 'foo.admin.support@example.com'
-
-    deprecated_update_params = { service:
-                                 { tech_support_email: new_tech_support_email,
-                                   admin_support_email: new_admin_support_email }
-                               }
-
-    put admin_service_path(service), deprecated_update_params
-
-    service.reload
-
-    assert_not_equal service.tech_support_email, new_tech_support_email
-    assert_not_equal service.admin_support_email, new_admin_support_email
-  end
-
   private
 
   def update_params


### PR DESCRIPTION
Closes [THREESCALE-2480 - Remove tech_support_email and admin_support_email fields from the DB](https://issues.jboss.org/browse/THREESCALE-2480).
I need this PR to test https://github.com/3scale/deploy/pull/574 in preview, so I won't notify to ops/infra yet 😄 
Depends on https://github.com/3scale/porta/pull/822 and https://github.com/3scale/porta/pull/825