### PR TITLE
Fix empty or corrupted tenant_id

### DIFF
--- a/lib/tasks/multitenant/triggers.rake
+++ b/lib/tasks/multitenant/triggers.rake
@@ -38,6 +38,85 @@ namespace :multitenant do
     puts "Recreated #{triggers.size} triggers"
   end
 
+  desc 'Fix empty or corrupted tenant_id in accounts'
+  task :fix_corrupted_tenant_id_accounts, %i[batch_size sleep_time] => :environment do |_task, args|
+    batch_size = (args[:batch_size] || 100).to_i
+    sleep_time = (args[:sleep_time] || 1).to_i
+
+    ids = (Rails.application.simple_try_config_for(ENV['FILE']) || [])
+
+    ids.in_groups_of(batch_size).each do |group|
+      puts "Executing update for a batch of size: #{group.size}"
+      Account.buyers.where(id: group).update_all('tenant_id = provider_account_id') # rubocop:disable Rails/SkipsModelValidations
+      Account.providers.where(id: group).update_all('tenant_id = id') # rubocop:disable Rails/SkipsModelValidations
+      puts "Sleeping #{sleep_time} seconds"
+      sleep(sleep_time)
+    end
+  end
+
+  desc 'Fix empty or corrupted tenant_id for a table associated to account'
+  task :fix_corrupted_tenant_id_for_table_associated_to_account, %i[table_name time_start time_end batch_size sleep_time] => :environment do |_task, args|
+    sleep_time = args[:sleep_time]
+    master_id = Account.master.id
+
+    puts "------ Updating #{args[:table_name]} ------"
+    condition = condition_update_tenant_id(args[:time_start], args[:time_end])
+    args[:table_name].constantize.joining { account }.where.has(&condition).find_in_batches(batch_size: args[:batch_size].to_i) do |group|
+      puts "Executing update for a batch of size: #{group.size}"
+      group.each { |user| user.update_column(:tenant_id, user.account.tenant_id) if user.account_id != master_id } # rubocop:disable Rails/SkipsModelValidations
+      puts "Sleeping #{sleep_time} seconds"
+      sleep(sleep_time.to_i)
+    end
+  end
+
+  desc 'Fix empty or corrupted tenant_id for a table associated to user'
+  task :fix_corrupted_tenant_id_for_table_associated_to_user, %i[table_name time_start time_end batch_size sleep_time] => :environment do |_task, args|
+    sleep_time = args[:sleep_time]
+    master_id = Account.master.id
+
+    puts "------ Updating #{args[:table_name]} ------"
+    condition = condition_update_tenant_id(args[:time_start], args[:time_end])
+    args[:table_name].constantize.joining { user }.where.has(&condition).find_in_batches(batch_size: args[:batch_size].to_i) do |group|
+      puts "Executing update for a batch of size: #{group.size}"
+      group.each { |user| user.update_column(:tenant_id, user.account.tenant_id) if user.account_id != master_id } # rubocop:disable Rails/SkipsModelValidations
+      puts "Sleeping #{sleep_time} seconds"
+      sleep(sleep_time.to_i)
+    end
+  end
+
+  desc 'Fix empty tenant_id in access_tokens'
+  task :fix_empty_tenant_id_access_tokens, %i[batch_size sleep_time] => :environment do |_task, args|
+    batch_size = (args[:batch_size] || 100).to_i
+    sleep_time = (args[:sleep_time] || 1).to_i
+    master_id = Account.master.id
+
+    puts '------ Updating "access_tokens" ------'
+    AccessToken.joining { owner }.where.has { tenant_id == nil }.find_in_batches(batch_size: batch_size) do |group|
+      puts "Executing update for a batch of size: #{group.size}"
+      group.each do |access_token|
+        tenant_id = access_token.owner.tenant_id
+        access_token.update_column(:tenant_id, tenant_id) if tenant_id != master_id # rubocop:disable Rails/SkipsModelValidations
+      end
+      puts "Sleeping #{sleep_time} seconds"
+      sleep(sleep_time)
+    end
+  end
+
+  desc 'Restore all tenant_id in alerts'
+  task :restore_all_tenant_id_alerts, %i[batch_size sleep_time] => :environment do |_task, args|
+    batch_size = (args[:batch_size] || 100).to_i
+    sleep_time = (args[:sleep_time] || 1).to_i
+    master_id = Account.master.id
+
+    puts '------ Updating "alerts" ------'
+    Alert.joining { account }.find_in_batches(batch_size: batch_size) do |group|
+      puts "Executing update for a batch of size: #{group.size}"
+      group.each { |alert| alert.update_column(:tenant_id, alert.account.tenant_id) if alert.account_id != master_id } # rubocop:disable Rails/SkipsModelValidations
+      puts "Sleeping #{sleep_time} seconds"
+      sleep(sleep_time)
+    end
+  end
+
   desc 'Sets the tenant id on all relevant tables'
   task :set_tenant_id => :environment do
 
@@ -111,6 +190,10 @@ namespace :multitenant do
 
     # FIXME: This will not work when we have more than 1 oidc_configurable_type
     OIDConfiguration.update_all "tenant_id = (SELECT tenant_id FROM proxies WHERE id = oidc_configurable_id AND tenant_id <> #{MASTER_ID})"
+  end
+
+  def condition_update_tenant_id(time_start, time_end)
+    proc { |object| (object.tenant_id == nil) | ((object.created_at >= Time.strptime(time_start, '%m/%d/%Y %H:%M %Z')) & (object.created_at <= Time.strptime(time_end, '%m/%d/%Y %H:%M %Z'))) }
   end
 end
 


### PR DESCRIPTION
Closes [THREESCALE-2571 - Fix users without tenant_id set](https://issues.jboss.org/browse/THREESCALE-2571)

The code that we currently have to reset the `tenant_id` updates all records of the DB ([here](https://github.com/3scale/porta/blob/f591474f5e7b00b99ac41b026936616c237ca309/lib/tasks/multitenant/triggers.rake#L41-L115)), not only the ones that are NULL. Besides, it does not rely on indexes. This is not ideal. Just in case, I tried executing it in preview with ops supervision, and it did not went well indeed. I am not really considering refactoring though:
1. That would be a lot of work in comparison to what we need to close the issue
2. It's technically out of scope.
3. There is already a refactoring in progress in [this old PR](https://github.com/3scale/porta/pull/598) which should have its own Jira issue opened.

To sum up, I will just do a simple task from this to update only the records that we currently need (those that have `tenant_id` as `nil` or that were updated on 2019-01-24). For all relevant tables affected by this day.

This code is meant to be a one time execution, and it is optimised for it. The conclusions are in https://github.com/3scale/infrastructure/issues/693
We will execute it with these params:
```
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:fix_corrupted_tenant_id_accounts[1, 1]'
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:fix_corrupted_tenant_id_for_table_associated_to_account[User, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 1, 1]'
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:fix_corrupted_tenant_id_for_table_associated_to_account[Settings, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:fix_corrupted_tenant_id_for_table_associated_to_account[Profile, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:fix_corrupted_tenant_id_for_table_associated_to_account[PaymentDetail, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:fix_corrupted_tenant_id_for_table_associated_to_account[Policy, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:fix_corrupted_tenant_id_for_table_associated_to_user[NotificationPreferences, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:fix_corrupted_tenant_id_for_table_associated_to_user[SSOAuthorization, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:fix_empty_tenant_id_access_tokens[100, 1]'
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:restore_all_tenant_id_alerts[100, 1]'
```
