### PR TITLE
[ruby] Upgrade to ruby 2.4 on 2.5-stable branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ attach-to-workspace: &attach-to-workspace
   attach_workspace:
     at: .
 
-system-builder: &system-builder
+system-builder-latest: &system-builder-latest
   image: quay.io/3scale/system-builder:latest
   environment:
     BUNDLE_FROZEN: true
@@ -84,6 +84,10 @@ system-builder: &system-builder
     MASTER_PASSWORD: p
     USER_PASSWORD: p
     LC_ALL: en_US.UTF-8
+
+system-builder-ruby24: &system-builder-ruby24
+  <<: *system-builder-latest
+  image: quay.io/3scale/system-builder:ruby2.4
 
 mysql-container: &mysql-container
   image: circleci/mysql:5.7-ram
@@ -127,6 +131,12 @@ only-master-filter: &only-master-filter
   filters:
     branches:
       only: master
+
+nightly-trigger: &nightly-trigger
+  triggers:
+    - schedule:
+        cron: "0 0 * * *"
+        <<: *only-master-filter
 
 build-envs:
   mysql: &build-envs-mysql
@@ -263,8 +273,8 @@ commands: # reusable commands with parameters
       - run:
           name: Run Rails tests
           command: |
-            shopt -s extglob
-            TESTS=$(bundle exec rake "test:files:${CIRCLE_JOB%-@(postgres|oracle)}" | circleci tests split --split-by=timings)
+            taskname=$(echo $CIRCLE_JOB | sed -e 's/-\(postgres\|oracle\|[0-9]\)//g')
+            TESTS=$(bundle exec rake "test:files:${taskname}" | circleci tests split --split-by=timings)
             bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace
       - upload-artifacts
 
@@ -292,67 +302,162 @@ commands: # reusable commands with parameters
 ##################################### CIRCLECI EXECUTORS ############################################
 
 executors:
-  builder:
+  builder-latest: &builder-latest
     parameters:
       database:
         type: string
         default: mysql
     docker:
-      - *system-builder
+      - *system-builder-latest
     environment:
       DB: << parameters.database >>
     working_directory: /opt/app-root/src/project
 
-  builder-with-mysql:
+  builder-with-mysql-latest: &builder-with-mysql-latest
     resource_class: small
     docker:
-      - *system-builder
+      - *system-builder-latest
       - *mysql-container
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
     <<: *build-envs-mysql
 
-  builder-with-postgres:
+  builder-with-postgres-latest: &builder-with-postgres-latest
     resource_class: small
     docker:
-      - *system-builder
+      - *system-builder-latest
       - *postgres-container
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
     <<: *build-envs-postgresql
 
-  builder-with-oracle:
+  builder-with-oracle-latest: &builder-with-oracle-latest
     resource_class: large
     docker:
-      - *system-builder
+      - *system-builder-latest
       - *oracle-db-container
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
     <<: *build-envs-oracle
 
+  builder-ruby24:
+    <<: *builder-latest
+    docker:
+      - *system-builder-ruby24
+
+  builder-with-mysql-ruby24:
+    <<: *builder-with-mysql-latest
+    docker:
+      - *system-builder-ruby24
+      - *mysql-container
+      - *memcached-container
+      - *redis-container
+
+
+  builder-with-postgres-ruby24:
+    <<: *builder-with-postgres-latest
+    docker:
+      - *system-builder-ruby24
+      - *postgres-container
+      - *memcached-container
+      - *redis-container
+
+  builder-with-oracle-ruby24:
+    <<: *builder-with-oracle-latest
+    docker:
+      - *system-builder-ruby24
+      - *oracle-db-container
+      - *memcached-container
+      - *redis-container
+
+  cucumber-with-mysql-latest: &cucumber-with-mysql-latest
+    resource_class: small
+    docker:
+      - *system-builder-latest
+      - *dnsmasq-container
+      - *mysql-container
+      - *memcached-container
+      - *redis-container
+
+  cucumber-with-postgres-latest: &cucumber-with-postgres-latest
+    resource_class: small
+    docker:
+      - *system-builder-latest
+      - *dnsmasq-container
+      - *postgres-container
+      - *memcached-container
+      - *redis-container
+
+  cucumber-with-oracle-latest: &cucumber-with-oracle-latest
+    resource_class: large
+    docker:
+      - *system-builder-latest
+      - *dnsmasq-container
+      - *oracle-db-container
+      - *memcached-container
+      - *redis-container
+
+  cucumber-with-mysql-ruby24:
+    <<: *cucumber-with-mysql-latest
+    docker:
+      - *system-builder-ruby24
+      - *dnsmasq-container
+      - *mysql-container
+      - *memcached-container
+      - *redis-container
+
+  cucumber-with-postgres-ruby24:
+    <<: *cucumber-with-postgres-latest
+    docker:
+      - *system-builder-ruby24
+      - *dnsmasq-container
+      - *postgres-container
+      - *memcached-container
+      - *redis-container
+
+  cucumber-with-oracle-ruby24:
+    <<: *cucumber-with-oracle-latest
+    docker:
+      - *system-builder-ruby24
+      - *dnsmasq-container
+      - *oracle-db-container
+      - *memcached-container
+      - *redis-container
 ##################################### CIRCLECI JOBS ############################################
 
 jobs:
   dependencies_bundler:
+    parameters:
+      executor:
+        type: string
+        default: builder-latest
     executor:
-      name: builder
+      name: << parameters.executor >>
       database: mysql
     steps:
       - install-gem-dependencies
 
   deps_bundler_postgres:
+    parameters:
+      executor:
+        type: string
+        default: builder-latest
     executor:
-      name: builder
+      name: << parameters.executor >>
       database: postgresql
     steps:
       - install-gem-dependencies
 
   deps_bundler_oracle:
+    parameters:
+      executor:
+        type: string
+        default: builder-latest
     executor:
-      name: builder
+      name: << parameters.executor >>
       database: oracle
     steps:
       - install-gem-dependencies:
@@ -360,7 +465,12 @@ jobs:
             - clone-oracle-libraries
 
   dependencies_npm:
-    executor: builder
+    parameters:
+      executor:
+        type: string
+        default: builder-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - checkout-with-submodules
       - *restore-npm-cache
@@ -376,7 +486,12 @@ jobs:
             - ./node_modules
 
   assets_precompile:
-    executor: builder
+    parameters:
+      executor:
+        type: string
+        default: builder-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - checkout-with-submodules
       - *attach-to-workspace
@@ -395,7 +510,12 @@ jobs:
             - ./config/*.yml
 
   lint:
-    executor: builder
+    parameters:
+      executor:
+        type: string
+        default: builder-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - checkout-with-submodules
       - *attach-to-workspace
@@ -427,7 +547,12 @@ jobs:
           destination: active_docs
 
   karma:
-    executor: builder
+    parameters:
+      executor:
+        type: string
+        default: builder-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - checkout-with-submodules
       - *attach-to-workspace
@@ -440,7 +565,12 @@ jobs:
       - *upload-coverage
 
   jest:
-    executor: builder
+    parameters:
+      executor:
+        type: string
+        default: builder-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - checkout-with-submodules
       - *attach-to-workspace
@@ -452,19 +582,34 @@ jobs:
 
   unit:
     parallelism: 8
-    executor: builder-with-mysql
+    parameters:
+      executor:
+        type: string
+        default: builder-with-mysql-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rails-tests
 
   unit-postgres:
     parallelism: 8
-    executor: builder-with-postgres
+    parameters:
+      executor:
+        type: string
+        default: builder-with-postgres-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rails-tests
 
   unit-oracle:
     parallelism: 6
-    executor: builder-with-oracle
+    parameters:
+      executor:
+        type: string
+        default: builder-with-oracle-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rails-tests:
           extra-deps:
@@ -472,19 +617,34 @@ jobs:
 
   functional:
     parallelism: 2
-    executor: builder-with-mysql
+    parameters:
+      executor:
+        type: string
+        default: builder-with-mysql-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rails-tests
 
   functional-postgres:
     parallelism: 2
-    executor: builder-with-postgres
+    parameters:
+      executor:
+        type: string
+        default: builder-with-postgres-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rails-tests
 
   functional-oracle:
     parallelism: 2
-    executor: builder-with-oracle
+    parameters:
+      executor:
+        type: string
+        default: builder-with-oracle-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rails-tests:
           extra-deps:
@@ -492,19 +652,34 @@ jobs:
 
   integration:
     parallelism: 8
-    executor: builder-with-mysql
+    parameters:
+      executor:
+        type: string
+        default: builder-with-mysql-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rails-tests
 
   integration-postgres:
     parallelism: 8
-    executor: builder-with-postgres
+    parameters:
+      executor:
+        type: string
+        default: builder-with-postgres-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rails-tests
 
   integration-oracle:
     parallelism: 6
-    executor: builder-with-oracle
+    parameters:
+      executor:
+        type: string
+        default: builder-with-oracle-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rails-tests:
           extra-deps:
@@ -512,19 +687,34 @@ jobs:
 
   rspec:
     parallelism: 3
-    executor: builder-with-mysql
+    parameters:
+      executor:
+        type: string
+        default: builder-with-mysql-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rspec-tests
 
   rspec-postgres:
     parallelism: 3
-    executor: builder-with-postgres
+    parameters:
+      executor:
+        type: string
+        default: builder-with-postgres-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rspec-tests
 
   rspec-oracle:
     parallelism: 4
-    executor: builder-with-oracle
+    parameters:
+      executor:
+        type: string
+        default: builder-with-oracle-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - rspec-tests:
           extra-deps:
@@ -533,39 +723,36 @@ jobs:
   cucumber:
     <<: *build-envs-mysql
     parallelism: 40
-    resource_class: small
-    docker:
-      - *system-builder
-      - *dnsmasq-container
-      - *mysql-container
-      - *memcached-container
-      - *redis-container
+    parameters:
+      executor:
+        type: string
+        default: cucumber-with-mysql-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - cucumber-tests
 
   cucumber-postgres:
     <<: *build-envs-postgresql
     parallelism: 40
-    resource_class: small
-    docker:
-      - *system-builder
-      - *dnsmasq-container
-      - *postgres-container
-      - *memcached-container
-      - *redis-container
+    parameters:
+      executor:
+        type: string
+        default: cucumber-with-postgres-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - cucumber-tests
 
   cucumber-oracle:
     <<: *build-envs-oracle
     parallelism: 30
-    resource_class: large
-    docker:
-      - *system-builder
-      - *dnsmasq-container
-      - *oracle-db-container
-      - *memcached-container
-      - *redis-container
+    parameters:
+      executor:
+        type: string
+        default: cucumber-with-oracle-latest
+    executor:
+      name: << parameters.executor >>
     steps:
       - cucumber-tests:
           extra-deps:
@@ -694,7 +881,7 @@ jobs:
     parallelism: 1
     resource_class: small
     docker:
-      - *system-builder
+      - *system-builder-latest
       - image: quay.io/mikz/dnsmasq
         command:
           - --no-poll
@@ -948,3 +1135,207 @@ workflows:
           requires:
             - assets_precompile
           <<: *only-master-filter
+
+
+######## Nightly workflows
+
+
+  mysql_build_ruby24:
+    jobs:
+      - notify_start:
+          <<: *only-master-filter
+      - dependencies_bundler:
+          executor: builder-ruby24
+      - dependencies_npm:
+          executor: builder-ruby24
+      - docker-build:
+          context: org-global
+      - assets_precompile:
+          executor: builder-ruby24
+          requires:
+            - dependencies_bundler
+            - dependencies_npm
+      - unit:
+          executor: builder-with-mysql-ruby24
+          requires:
+            - dependencies_bundler
+      - functional:
+          executor: builder-with-mysql-ruby24
+          requires:
+            - assets_precompile
+      - integration:
+          executor: builder-with-mysql-ruby24
+          requires:
+            - assets_precompile
+      - rspec:
+          executor: builder-with-mysql-ruby24
+          requires:
+            - dependencies_bundler
+      - cucumber:
+          executor: cucumber-with-mysql-ruby24
+          requires:
+            - assets_precompile
+      - notify_success:
+          requires:
+            - rspec
+            - unit
+            - cucumber
+            - integration
+            - functional
+          <<: *only-master-filter
+      - notify_failure:
+          requires:
+            - rspec
+            - unit
+            - cucumber
+            - integration
+            - functional
+          <<: *only-master-filter
+    <<: *nightly-trigger
+
+  postgres_build_ruby24:
+    jobs:
+      - notify_start:
+          <<: *only-master-filter
+      - deps_bundler_postgres:
+          executor: builder-ruby24
+      - dependencies_npm:
+          executor: builder-ruby24
+      - docker-build:
+          context: org-global
+      - assets_precompile:
+          executor: builder-ruby24
+          requires:
+            - deps_bundler_postgres
+            - dependencies_npm
+      - unit-postgres:
+          executor: builder-with-postgres-ruby24
+          requires:
+            - deps_bundler_postgres
+      - functional-postgres:
+          executor: builder-with-postgres-ruby24
+          requires:
+            - assets_precompile
+      - integration-postgres:
+          executor: builder-with-postgres-ruby24
+          requires:
+            - assets_precompile
+      - rspec-postgres:
+          executor: builder-with-postgres-ruby24
+          requires:
+            - deps_bundler_postgres
+      - cucumber-postgres:
+          executor: cucumber-with-postgres-ruby24
+          requires:
+            - assets_precompile
+      - notify_success:
+          requires:
+            - rspec-postgres
+            - unit-postgres
+            - cucumber-postgres
+            - integration-postgres
+            - functional-postgres
+          <<: *only-master-filter
+      - notify_failure:
+          requires:
+            - rspec-postgres
+            - unit-postgres
+            - cucumber-postgres
+            - integration-postgres
+            - functional-postgres
+          <<: *only-master-filter
+    <<: *nightly-trigger
+
+  oracle_build_ruby24:
+    jobs:
+      - notify_start:
+          <<: *only-master-filter
+      - deps_bundler_oracle:
+          executor: builder-ruby24
+      - dependencies_npm:
+          executor: builder-ruby24
+      - docker-build:
+          context: org-global
+      - assets_precompile:
+          executor: builder-ruby24
+          requires:
+            - deps_bundler_oracle
+            - dependencies_npm
+
+      - unit-oracle:
+          executor: builder-with-oracle-ruby24
+          requires:
+            - deps_bundler_oracle
+      - functional-oracle:
+          executor: builder-with-oracle-ruby24
+          requires:
+            - assets_precompile
+      - integration-oracle:
+          executor: builder-with-oracle-ruby24
+          requires:
+            - assets_precompile
+      - rspec-oracle:
+          executor: builder-with-oracle-ruby24
+          requires:
+            - deps_bundler_oracle
+      - cucumber-oracle:
+          executor: cucumber-with-oracle-ruby24
+          requires:
+            - assets_precompile
+      - notify_success:
+          requires:
+            - rspec-oracle
+            - unit-oracle
+            - cucumber-oracle
+            - integration-oracle
+            - functional-oracle
+          <<: *only-master-filter
+
+      - notify_failure:
+          requires:
+            - rspec-oracle
+            - unit-oracle
+            - cucumber-oracle
+            - integration-oracle
+            - functional-oracle
+          <<: *only-master-filter
+    <<: *nightly-trigger
+
+  javascript_tests_ruby24:
+    jobs:
+      - notify_start:
+          <<: *only-master-filter
+      - dependencies_bundler:
+          executor: builder-ruby24
+      - dependencies_npm:
+          executor: builder-ruby24
+      - assets_precompile:
+          executor: builder-ruby24
+          requires:
+            - dependencies_bundler
+            - dependencies_npm
+      - lint:
+          executor: builder-ruby24
+          requires:
+            - assets_precompile
+      - karma:
+          executor: builder-ruby24
+          requires:
+            - dependencies_npm
+      - jest:
+          executor: builder-ruby24
+          requires:
+            - dependencies_npm
+      - notify_success:
+          requires:
+            - lint
+            - karma
+            - jest
+          <<: *only-master-filter
+      - notify_failure:
+          requires:
+            - lint
+            - karma
+            - jest
+          <<: *only-master-filter
+    <<: *nightly-trigger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ attach-to-workspace: &attach-to-workspace
     at: .
 
 system-builder-latest: &system-builder-latest
-  image: quay.io/3scale/system-builder:latest
+  image: quay.io/3scale/system-builder:ruby2.4
   environment:
     BUNDLE_FROZEN: true
     BUNDLE_PATH: 'vendor/bundle'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-ruby File.read('.ruby-version', mode: 'rb').chomp.prepend('~> ')
-
 eval_gemfile 'Gemfile.base'
 gem 'pg', '~> 0.21.0'
 gem 'sidekiq-batch', '~> 0.1.1'

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -207,7 +207,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'email_spec', require: false
   gem 'fakefs', '~>0.18.0', require: 'fakefs/safe'
-  gem 'fakeweb', git: 'https://github.com/3scale/fakeweb.git', ref: '6c9392c03879b85b06b0d8f6dbabe75e69b7abb7', require: false
+  gem 'fakeweb', git: 'https://github.com/3scale/fakeweb.git', ref: 'ad11ea7b290c85b572e0b30e8c6201460d8bf2d8', require: false
   gem 'webmock', '~> 2.3.2'
   gem 'launchy'
   gem 'mechanize'

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -56,7 +56,7 @@ gem 'sidekiq-prometheus-exporter'
 gem 'activemerchant', '~> 1.77.0'
 gem 'active_merchant-adyen12', github: '3scale/active_merchant-adyen12'
 gem 'money', '6.7.1' # Lock to this version we use in production
-gem 'stripe' # we need the stripe gem because activemerchant can not generate Stripe's "customers"
+gem 'stripe', '~> 1.58.0' # we need the stripe gem because activemerchant can not generate Stripe's "customers"
 gem 'audited'
 
 # Rails 4.1: this should not be needed, maybe replace it with enum -- http://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html
@@ -82,7 +82,7 @@ gem 'analytics-ruby', require: false
 group :development, :test do
   gem 'bootsnap', '~> 1.3'
 
-  platform :mri_20, :mri_21, :mri_22, :mri_23 do
+  platform :mri_23, :mri_24, :mri_25 do
     # we want to disable byebug for capybara because it hangs
     # see: https://github.com/deivid-rodriguez/byebug/issues/115
     # the issue is tracked as https://github.com/deivid-rodriguez/pry-byebug/issues/69
@@ -116,7 +116,7 @@ gem 'recaptcha', '4.13.1', require: 'recaptcha/rails'
 gem 'hiredis', '~>0.6.0'
 gem 'redis', '~> 3.3.5', require: ['redis', 'redis/connection/hiredis']
 gem 'redis-namespace', '~> 1.5.2'
-gem 'rest-client', '~>1.6'
+gem 'rest-client', '~> 2.0.2'
 gem 'httpclient', github: 'mikz/httpclient', branch: 'ssl-env-cert'
 gem 'thinking-sphinx', '~> 3.2.0'
 gem 'ts-datetime-delta', require: 'thinking_sphinx/deltas/datetime_delta'

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -208,7 +208,7 @@ group :test do
   gem 'email_spec', require: false
   gem 'fakefs', '~>0.18.0', require: 'fakefs/safe'
   gem 'fakeweb', git: 'https://github.com/3scale/fakeweb.git', ref: '6c9392c03879b85b06b0d8f6dbabe75e69b7abb7', require: false
-  gem 'webmock', '~> 1.21', require: false
+  gem 'webmock', '~> 2.3.2'
   gem 'launchy'
   gem 'mechanize'
   gem 'parallel_tests', '~> 2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -978,8 +978,5 @@ DEPENDENCIES
   yard
   zip-zip
 
-RUBY VERSION
-   ruby 2.3.6p384
-
 BUNDLED WITH
    1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
       activerecord (>= 3.0)
     acts_as_tree (1.4.0)
       activerecord (>= 3.0.0)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     after_commit_queue (1.1.0)
       rails (>= 3.0)
@@ -364,7 +364,7 @@ GEM
     has_scope (0.7.1)
       actionpack (>= 4.1, < 5.2)
       activesupport (>= 4.1, < 5.2)
-    hashdiff (0.3.0)
+    hashdiff (0.3.9)
     hashie (3.4.4)
     hiredis (0.6.0)
     htmlentities (4.3.4)
@@ -650,7 +650,7 @@ GEM
     rubyzip (1.2.2)
     rufus-scheduler (3.0.9)
       tzinfo
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     sanitize (2.1.1)
       nokogiri (>= 1.4.4)
     sass (3.4.25)
@@ -788,7 +788,7 @@ GEM
     url (0.3.2)
     user_agent_parser (2.2.0)
     uuidtools (2.1.5)
-    webmock (1.24.6)
+    webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -968,7 +968,7 @@ DEPENDENCIES
   uglifier
   unicorn
   unicorn-rails
-  webmock (~> 1.21)
+  webmock (~> 2.3.2)
   webpacker (~> 3.3)
   whenever (~> 0.9.7)
   will_paginate (~> 3.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,8 @@ GIT
 
 GIT
   remote: https://github.com/3scale/fakeweb.git
-  revision: 6c9392c03879b85b06b0d8f6dbabe75e69b7abb7
-  ref: 6c9392c03879b85b06b0d8f6dbabe75e69b7abb7
+  revision: ad11ea7b290c85b572e0b30e8c6201460d8bf2d8
+  ref: ad11ea7b290c85b572e0b30e8c6201460d8bf2d8
   specs:
     fakeweb (1.3.0.3scale.pre.2)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,7 +303,7 @@ GEM
       representable (>= 2.2.3, < 2.4.0)
       uber
     docile (1.1.5)
-    domain_name (0.5.20160310)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
@@ -373,7 +373,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 1.0.1)
       http_parser.rb (~> 0.6.0)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     http-form_data (1.0.3)
     http_parser.rb (0.6.0)
@@ -591,10 +591,10 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    rest-client (1.8.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (2.0.2)
     riddle (1.5.12)
     rinku (1.7.3)
@@ -737,10 +737,8 @@ GEM
       activerecord (>= 4.1, < 5.2)
       state_machines-activemodel (>= 0.5.0)
     statsd-ruby (1.4.0)
-    stripe (1.16.0)
-      json (~> 1.8.1)
-      mime-types (>= 1.25, < 3.0)
-      rest-client (~> 1.4)
+    stripe (1.58.0)
+      rest-client (>= 1.4, < 4.0)
     symbolize (4.5.2)
       activemodel (>= 3.2, < 5)
       activesupport (>= 3.2, < 5)
@@ -778,7 +776,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.6)
     unicode-display_width (1.3.0)
     unicorn (5.1.0)
       kgio (~> 2.6)
@@ -921,7 +919,7 @@ DEPENDENCIES
   redis (~> 3.3.5)
   redis-namespace (~> 1.5.2)
   reform (~> 2.0.3)
-  rest-client (~> 1.6)
+  rest-client (~> 2.0.2)
   rmagick (~> 2.15.3)
   roar-rails
   rspec-html-matchers!
@@ -959,7 +957,7 @@ DEPENDENCIES
   state_machines (~> 0.5.0)
   state_machines-activerecord (~> 0.5.0)
   statsd-ruby
-  stripe
+  stripe (~> 1.58.0)
   swagger-ui_rails!
   swagger-ui_rails2!
   symbolize (~> 4.5)

--- a/app/lib/three_scale/spam_protection/checks/timestamp.rb
+++ b/app/lib/three_scale/spam_protection/checks/timestamp.rb
@@ -2,7 +2,7 @@ module ThreeScale::SpamProtection
   module Checks
 
     class Timestamp < Base
-      DEFAULT_SECRET_KEY = -> { Rails.application.key_generator.generate_key('spam-protection-checks-timestamp') }
+      DEFAULT_SECRET_KEY = -> { Rails.application.key_generator.generate_key('spam-protection-checks-timestamp', 32) }
 
       def initialize(config)
         super

--- a/gemfiles/prod/Gemfile
+++ b/gemfiles/prod/Gemfile
@@ -1,5 +1,3 @@
-ruby '~> 2.3.0'
-
 eval_gemfile '../../Gemfile.base'
 
 source 'https://gems.contribsys.com/' do

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -983,8 +983,5 @@ DEPENDENCIES
   yard
   zip-zip
 
-RUBY VERSION
-   ruby 2.3.6p384
-
 BUNDLED WITH
    1.17.3

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
       activerecord (>= 3.0)
     acts_as_tree (1.4.0)
       activerecord (>= 3.0.0)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     after_commit_queue (1.1.0)
       rails (>= 3.0)
@@ -368,7 +368,7 @@ GEM
     has_scope (0.7.1)
       actionpack (>= 4.1, < 5.2)
       activesupport (>= 4.1, < 5.2)
-    hashdiff (0.3.0)
+    hashdiff (0.3.9)
     hashie (3.4.4)
     hiredis (0.6.0)
     htmlentities (4.3.4)
@@ -654,7 +654,7 @@ GEM
     rubyzip (1.2.2)
     rufus-scheduler (3.0.9)
       tzinfo
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     sanitize (2.1.1)
       nokogiri (>= 1.4.4)
     sass (3.4.25)
@@ -792,7 +792,7 @@ GEM
     url (0.3.2)
     user_agent_parser (2.2.0)
     uuidtools (2.1.5)
-    webmock (1.24.6)
+    webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -973,7 +973,7 @@ DEPENDENCIES
   uglifier
   unicorn
   unicorn-rails
-  webmock (~> 1.21)
+  webmock (~> 2.3.2)
   webpacker (~> 3.3)
   whenever (~> 0.9.7)
   will_paginate (~> 3.1.0)

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -14,8 +14,8 @@ GIT
 
 GIT
   remote: https://github.com/3scale/fakeweb.git
-  revision: 6c9392c03879b85b06b0d8f6dbabe75e69b7abb7
-  ref: 6c9392c03879b85b06b0d8f6dbabe75e69b7abb7
+  revision: ad11ea7b290c85b572e0b30e8c6201460d8bf2d8
+  ref: ad11ea7b290c85b572e0b30e8c6201460d8bf2d8
   specs:
     fakeweb (1.3.0.3scale.pre.2)
 

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
       representable (>= 2.2.3, < 2.4.0)
       uber
     docile (1.1.5)
-    domain_name (0.5.20160310)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
@@ -377,7 +377,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 1.0.1)
       http_parser.rb (~> 0.6.0)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     http-form_data (1.0.3)
     http_parser.rb (0.6.0)
@@ -595,10 +595,10 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    rest-client (1.8.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (2.0.2)
     riddle (1.5.12)
     rinku (1.7.3)
@@ -741,10 +741,8 @@ GEM
       activerecord (>= 4.1, < 5.2)
       state_machines-activemodel (>= 0.5.0)
     statsd-ruby (1.4.0)
-    stripe (1.16.0)
-      json (~> 1.8.1)
-      mime-types (>= 1.25, < 3.0)
-      rest-client (~> 1.4)
+    stripe (1.58.0)
+      rest-client (>= 1.4, < 4.0)
     symbolize (4.5.2)
       activemodel (>= 3.2, < 5)
       activesupport (>= 3.2, < 5)
@@ -782,7 +780,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.6)
     unicode-display_width (1.3.0)
     unicorn (5.1.0)
       kgio (~> 2.6)
@@ -926,7 +924,7 @@ DEPENDENCIES
   redis (~> 3.3.5)
   redis-namespace (~> 1.5.2)
   reform (~> 2.0.3)
-  rest-client (~> 1.6)
+  rest-client (~> 2.0.2)
   rmagick (~> 2.15.3)
   roar-rails
   rspec-html-matchers!
@@ -964,7 +962,7 @@ DEPENDENCIES
   state_machines (~> 0.5.0)
   state_machines-activerecord (~> 0.5.0)
   statsd-ruby
-  stripe
+  stripe (~> 1.58.0)
   swagger-ui_rails!
   swagger-ui_rails2!
   symbolize (~> 4.5)

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/ruby-23-centos7
+FROM centos/ruby-24-centos7
 
 USER root
 

--- a/openshift/system/Dockerfile.on_prem
+++ b/openshift/system/Dockerfile.on_prem
@@ -1,4 +1,4 @@
-FROM centos/ruby-23-centos7
+FROM centos/ruby-24-centos7
 
 USER root
 

--- a/openshift/system/contrib/scl_enable
+++ b/openshift/system/contrib/scl_enable
@@ -1,4 +1,4 @@
 # This file contains automatic SCL enablement.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-ruby23
+source scl_source enable rh-ruby24
 source scl_source enable $NODEJS_SCL

--- a/test/unit/active_merchant/stripe_fix_test.rb
+++ b/test/unit/active_merchant/stripe_fix_test.rb
@@ -6,7 +6,8 @@ class StripeFixTest < ActiveSupport::TestCase
     System::Application.config.three_scale.payments.stubs(enabled: true)
     stripe = ActiveMerchant::Billing::StripeGateway.new login: 'apitoken'
 
-    request = stub_request(:delete, "https://apitoken:@api.stripe.com/v1/customers/credit_card_auth_code").
+    auth = Base64.strict_encode64('apitoken:')
+    request = stub_request(:delete, "https://api.stripe.com/v1/customers/credit_card_auth_code").with(headers: {Authorization: "Basic #{auth}"}).
       to_return(:status => 200, :body => '{}', :headers => {})
     stripe.threescale_unstore('credit_card_auth_code')
 

--- a/test/unit/array_test.rb
+++ b/test/unit/array_test.rb
@@ -2,22 +2,37 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 class ArrayTest < ActiveSupport::TestCase
   context '#to_xml method' do
+    setup do
+      @version = Gem::Version.new(RUBY_VERSION)
+      @ruby_24 = Gem::Version.new('2.4.0')
+    end
+
     should 'not add the attr params as default' do
       xml = Nokogiri::XML::Document.parse([1,2].to_xml)
 
-      assert xml.xpath("//fixnums[@type]").empty?
+      if @version < @ruby_24
+        assert xml.xpath("//fixnums[@type]").empty?
+      else
+        assert xml.xpath("//integers[@type]").empty?
+      end
     end
 
     should 'not add the attr params if skip_types => true is passed' do
       xml = Nokogiri::XML::Document.parse([1,2].to_xml(:skip_types => true))
-
-      assert xml.xpath("//fixnums[@type]").empty?
+      if @version < @ruby_24
+        assert xml.xpath("//fixnums[@type]").empty?
+      else
+        assert xml.xpath("//integers[@type]").empty?
+      end
     end
 
     should 'add the attr params if skip_types => false is passed' do
       xml = Nokogiri::XML::Document.parse([1,2].to_xml(:skip_types => false))
-
-      assert !xml.xpath("//fixnums[@type]").empty?
+      if @version < @ruby_24
+        assert !xml.xpath("//fixnums[@type]").empty?
+      else
+        assert !xml.xpath("//integers[@type]").empty?
+      end
     end
   end
 end

--- a/test/unit/backend_client/connection_test.rb
+++ b/test/unit/backend_client/connection_test.rb
@@ -50,7 +50,8 @@ class BackendClient::ConnectionTest < ActiveSupport::TestCase
     @connection.post('/stuff.xml', :type => 'warpdrive')
 
     assert_equal 'POST',           FakeWeb.last_request.method
-    assert_equal 'type=warpdrive', FakeWeb.last_request.body.to_s
+    stream = FakeWeb.last_request.body_stream.instance_variable_get :@stream
+    assert_equal 'type=warpdrive', stream.string
   end
 
   test 'loads configuration from a file' do


### PR DESCRIPTION
Now the 2.5 stable branch is using ruby 2.4
It will be the case on the master branch soon, for some technical reasons, it is not possible for now.

Closes https://issues.jboss.org/browse/THREESCALE-2064