### PR TITLE
Use the image built by circleci on system-builder/ruby24 branch merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ system-builder-latest: &system-builder-latest
 
 system-builder-ruby24: &system-builder-ruby24
   <<: *system-builder-latest
-  image: quay.io/3scale/system-builder:ruby2.4
+  image: quay.io/3scale/system-builder:ruby24
 
 mysql-container: &mysql-container
   image: circleci/mysql:5.7-ram


### PR DESCRIPTION
So it is automatized

The build is triggered in quay for the tag `ruby24` on the branch `ruby24`