### PR TITLE
[Bugfix][Oracle] Remove experimental test

### DIFF
--- a/test/workers/delete_object_hierarchy_worker_test.rb
+++ b/test/workers/delete_object_hierarchy_worker_test.rb
@@ -179,10 +179,8 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
     def save_queries(&block)
       queries = []
 
-      counter_f = ->(name, started, finished, unique_id, payload) {
-        unless %w[ CACHE SCHEMA ].include?(payload[:name])
-          queries << payload
-        end
+      counter_f = ->(_name, _start, _finish, _id, payload) {
+        queries << payload if payload[:name].eql?('SQL')
       }
 
       ActiveSupport::Notifications.subscribed(

--- a/test/workers/delete_object_hierarchy_worker_test.rb
+++ b/test/workers/delete_object_hierarchy_worker_test.rb
@@ -173,37 +173,4 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
       end
     end
   end
-
-  class DeleteProviderQueryCounterTest < ActiveSupport::TestCase
-
-    def save_queries(&block)
-      queries = []
-
-      counter_f = ->(_name, _start, _finish, _id, payload) {
-        queries << payload if payload[:name].eql?('SQL')
-      }
-
-      ActiveSupport::Notifications.subscribed(
-        counter_f,
-        "sql.active_record",
-        &block
-      )
-
-      queries
-    end
-
-    def setup
-      @provider = FactoryBot.create(:provider_account)
-      @provider.schedule_for_deletion!
-
-      SystemOperation::DEFAULTS.keys.each do |name|
-        @provider.mail_dispatch_rules.create!(system_operation: SystemOperation.for(name))
-      end
-    end
-
-    def test_queries
-      queries = save_queries{ DeleteObjectHierarchyWorker.perform_now(@provider) }
-      assert_equal 2, queries.count
-    end
-  end
 end


### PR DESCRIPTION
Bugfix in test for CircleCI/locally in Oracle.
When I run `spring m test/workers/delete_object_hierarchy_worker_test.rb:208` (now `204`), I see:
![image](https://user-images.githubusercontent.com/11318903/58428485-f5e51880-80a2-11e9-9653-72eec8f3e574.png)

Example of this: https://circleci.com/gh/3scale/porta/54953#tests/containers/3

This is blocking any PR that needs to run the tests for all DBs.

Depends on https://github.com/3scale/porta/pull/823