### PR TITLE
Remove reference to old field Services#buyer_can_see_log_requests

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -45,7 +45,7 @@ class Service < ApplicationRecord
   end
 
   def self.columns
-    super.reject { |column| %w[buyer_can_see_log_requests tech_support_email admin_support_email].include?(column.name) }
+    super.reject { |column| %w[tech_support_email admin_support_email].include?(column.name) }
   end
 
   scope :of_account, ->(account) { where.has { account_id == account } }


### PR DESCRIPTION
It doesn't exist anymore since https://github.com/3scale/system/pull/8582 and it was also remove from SaaS/Production.
![image](https://user-images.githubusercontent.com/11318903/58484059-a87bb080-8161-11e9-9b71-d78506961370.png)

