### PR TITLE
Error message when fails to fetch policies

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -13,6 +13,11 @@ class Api::IntegrationsController < Api::BaseController
   rescue_from ActiveRecord::StaleObjectError, with: :edit_stale
 
   def edit
+    begin
+      @registry_policies = Policies::PoliciesListService.call!(current_account)
+    rescue RuntimeError, Errno::ECONNREFUSED => error
+      @error = error
+    end
     @latest_lua = current_account.proxy_logs.first
     @deploying =  ThreeScale::TimedValue.get(deploying_hosted_proxy_key)
     @ever_deployed_hosted = current_account.hosted_proxy_deployed_at.present?

--- a/app/views/api/integrations/apicast/shared/_policies.html.slim
+++ b/app/views/api/integrations/apicast/shared/_policies.html.slim
@@ -1,13 +1,18 @@
-- content_for :javascripts do
-  = javascript_pack_tag 'policies'
-
-= f.toggled_inputs 'policies', cookie_name: 'policies-rules' , legend: "Policies", id: "policies-container" do
+= f.toggled_inputs 'policies', cookie_name: 'policies-rules', legend: "Policies", id: "policies-container" do
   div#policies
 
-javascript:
-  document.addEventListener('DOMContentLoaded', function () {
-    var registry = #{json Policies::PoliciesListService.call(current_account)}
-    var chain = #{json @proxy.policies_config}
-    var serviceId = #{json @service.id}
-    initPolicies({element: 'policies', registry: registry, chain: chain, serviceId: serviceId})
-  })
+  - if @error.nil?
+    - content_for :javascripts do
+      = javascript_pack_tag 'policies'
+
+    javascript:
+      document.addEventListener('DOMContentLoaded', function () {
+        var registry = #{json @registry_policies}
+        var chain = #{json @proxy.policies_config}
+        var serviceId = #{json @service.id}
+        initPolicies({element: 'policies', registry: registry, chain: chain, serviceId: serviceId})
+      })
+  - else
+    div
+      h3 A valid APIcast Policies endpoint must be provided
+      p = @error.message

--- a/features/old/proxy.feature
+++ b/features/old/proxy.feature
@@ -75,6 +75,15 @@ Feature: Proxy integration
     And I go to the integration page for service "one"
     Then I should see the Policy Chain
 
+
+  Scenario: Got error message when APIcast registry is not setup properly
+    And apicast registry is undefined
+    And I go to the integration show page for service "one"
+    And I press "Start using the latest APIcast"
+    When I have policies feature enabled
+    And I go to the integration page for service "one"
+    Then I should see "A valid APIcast Policies endpoint must be provided"
+
   @javascript
   Scenario: Sorting mapping rules
     And I go to the integration show page for service "one"

--- a/features/old/proxy.feature
+++ b/features/old/proxy.feature
@@ -13,6 +13,7 @@ Feature: Proxy integration
     And the service "one" of provider "foo.example.com" has deployment option "self_managed"
     And current domain is the admin domain of provider "foo.example.com"
     And I log in as provider "foo.example.com"
+    And apicast registry is stubbed
     And I go to the integration show page for service "one"
     And I press "Revert to the old APIcast"
 
@@ -71,7 +72,6 @@ Feature: Proxy integration
     And I go to the integration show page for service "one"
     And I press "Start using the latest APIcast"
     When I have policies feature enabled
-    And apicast registry is stubbed
     And I go to the integration page for service "one"
     Then I should see the Policy Chain
 

--- a/features/provider/integration/edit.feature
+++ b/features/provider/integration/edit.feature
@@ -6,6 +6,7 @@ Feature: Edit Integration
   Background:
     Given a provider is logged in
      And all the rolling updates features are off
+     And apicast registry is stubbed
 
   Scenario: Edit a tested integration has a link to the analytics usage
     Given the service has been successfully tested

--- a/features/provider/integration/staging_environment.feature
+++ b/features/provider/integration/staging_environment.feature
@@ -6,6 +6,7 @@ Feature: Staging Environment
   Background:
     Given a provider is logged in
     And all the rolling updates features are off
+    And apicast registry is stubbed
 
   @javascript
   Scenario: Save staging environment with errors

--- a/test/functional/api/integrations_controller_test.rb
+++ b/test/functional/api/integrations_controller_test.rb
@@ -6,6 +6,8 @@ class Api::IntegrationsControllerTest < ActionController::TestCase
     @provider = FactoryBot.create(:provider_account)
     @provider.default_service.service_tokens.create!(value: 'token')
 
+    stub_apicast_registry
+
     host! @provider.admin_domain
     login_provider @provider
   end

--- a/test/integration/api/integration_test.rb
+++ b/test/integration/api/integration_test.rb
@@ -7,6 +7,8 @@ class IntegrationsTest < ActionDispatch::IntegrationTest
 
     login_provider @provider
 
+    stub_apicast_registry
+
     host! @provider.admin_domain
   end
 

--- a/test/test_helpers/proxy.rb
+++ b/test/test_helpers/proxy.rb
@@ -1,0 +1,10 @@
+def stub_apicast_registry
+  url = 'http://apicast.alaska/policies'
+  stubbed_registry = { policies: { apicast: [JSON.parse(file_fixture('policies/apicast-policy.json').read)] } }.to_json
+  ThreeScale.config.sandbox_proxy.stubs(apicast_registry_url: url)
+
+  stub_request(:get, url)
+      .with(headers: { 'Accept' => '*/*' })
+      .to_return(status: 200, body: stubbed_registry,
+                 headers: { 'Content-Type' => 'application/json' })
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Renders an error message when it fails to fetch the APIcast policy registry

It currently looks like this:
![Screenshot 2019-05-30 at 15 22 00](https://user-images.githubusercontent.com/4183971/58636130-e4dd1700-82ef-11e9-81fd-45de16196ae6.png)
![Screenshot 2019-05-30 at 15 27 55](https://user-images.githubusercontent.com/4183971/58636131-e575ad80-82ef-11e9-8006-00adc2109a80.png)


**Which issue(s) this PR fixes** 

fixes https://issues.jboss.org/browse/THREESCALE-2312

**Verification steps** 

Easy way to test this is in dev mode, start a rails server with `APICAST_REGISTRY_URL` env with nothing or a random URL. Then visit the Service integration page, under policies you should see an error message.

**Special notes for your reviewer**:
TO DO:
* [x] Better Styling cc: @thomasmaas 
* [x] Tests