### PR TITLE
[Refactor & Bugfix] Task update corrupted or empty tenant_id

### DIFF
--- a/lib/tasks/multitenant/tenants.rake
+++ b/lib/tasks/multitenant/tenants.rake
@@ -19,5 +19,64 @@ namespace :multitenant do
       query.find_each(&:suspend)
       puts(query.any? ? 'Some of the tenants haven\t been suspended' : 'All the right tenants have been suspended')
     end
+
+    desc 'Fix empty or corrupted tenant_id in accounts'
+    task :fix_corrupted_tenant_id_accounts, %i[batch_size sleep_time] => :environment do |_task, args|
+      batch_size = (args[:batch_size] || 100).to_i
+      sleep_time = (args[:sleep_time] || 1).to_i
+
+      ids = Rails.application.simple_try_config_for(ENV['FILE']) || []
+
+      ids.in_groups_of(batch_size).each do |group|
+        puts "Executing update for a batch of size: #{group.size}"
+        Account.buyers.where(id: group).update_all('tenant_id = provider_account_id') # rubocop:disable Rails/SkipsModelValidations
+        Account.providers.where(id: group).update_all('tenant_id = id') # rubocop:disable Rails/SkipsModelValidations
+        puts "Sleeping #{sleep_time} seconds"
+        sleep(sleep_time)
+      end
+    end
+
+    desc 'Fix empty or corrupted tenant_id for a table associated to account'
+    task :fix_corrupted_tenant_id_for_table_associated_to_account, %i[table_name time_start time_end batch_size sleep_time] => :environment do |_task, args|
+      update_tenant_ids(proc { |object| object.account.tenant_id }, proc { account }, condition_update_tenant_id(args[:time_start], args[:time_end]), args.to_hash)
+    end
+
+    desc 'Fix empty or corrupted tenant_id for a table associated to user'
+    task :fix_corrupted_tenant_id_for_table_associated_to_user, %i[table_name time_start time_end batch_size sleep_time] => :environment do |_task, args|
+      update_tenant_ids(proc { |object| object.user.tenant_id }, proc { user }, condition_update_tenant_id(args[:time_start], args[:time_end]), args.to_hash)
+    end
+
+    desc 'Fix empty tenant_id in access_tokens'
+    task :fix_empty_tenant_id_access_tokens, %i[batch_size sleep_time] => :environment do |_task, args|
+      update_tenant_ids(proc { |object| object.owner.tenant_id }, proc { owner }, proc { tenant_id == nil }, args.to_hash.merge({table_name: 'AccessToken'}))
+    end
+
+    desc 'Restore all tenant_id in alerts'
+    task :restore_all_tenant_id_alerts, %i[batch_size sleep_time] => :environment do |_task, args|
+      update_tenant_ids(proc { |object| object.account.tenant_id }, proc { account }, false, args.to_hash.merge({table_name: 'Alert'}))
+    end
+
+    def update_tenant_ids(tenant_id_block, association_block, condition, **args)
+      query = args[:table_name].constantize.joining(&association_block)
+      query = query.where.has(&condition) if condition
+      puts "------ Updating #{args[:table_name]} ------"
+      find_each_with_sleep(query, *args.slice(:batch_size, :sleep_time).values) do |record|
+        tenant_id = tenant_id_block.call(record)
+        record.update_column(:tenant_id, tenant_id) if tenant_id != Account.master.id # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+
+    def find_each_with_sleep(query, batch_size, sleep_time)
+      query.find_in_batches(batch_size: batch_size.to_i) do |group|
+        puts "Executing update for a batch of size: #{group.size}"
+        group.each { |record| yield record }
+        puts "Sleeping #{sleep_time} seconds"
+        sleep(sleep_time.to_i)
+      end
+    end
+
+    def condition_update_tenant_id(time_start, time_end)
+      proc { |object| (object.tenant_id == nil) | ((object.created_at >= Time.strptime(time_start, '%m/%d/%Y %H:%M %Z')) & (object.created_at <= Time.strptime(time_end, '%m/%d/%Y %H:%M %Z'))) }
+    end
   end
 end

--- a/test/unit/tasks/multitenant/tenants_test.rb
+++ b/test/unit/tasks/multitenant/tenants_test.rb
@@ -3,6 +3,84 @@
 require 'test_helper'
 
 class Tasks::Multitenant::TenantsTest < ActiveSupport::TestCase
+  class UpdateTenantIdTest < ActiveSupport::TestCase
+    test 'fix_corrupted_tenant_id_accounts fixes buyers with tenant_id = provider_account_id' do
+      provider = FactoryBot.create(:simple_provider)
+      buyers_to_update = FactoryBot.create_list(:simple_buyer, 2, provider_account: provider, tenant_id: nil)
+      buyer_not_to_update = FactoryBot.create(:simple_buyer, provider_account: provider, tenant_id: nil)
+      [buyers_to_update, buyer_not_to_update].flatten.each { |account| account.update_column(:tenant_id, -1) }
+
+      Rails.application.expects(:simple_try_config_for).with('corrupted_accounts').returns(YAML.load(buyers_to_update.map(&:id).to_yaml))
+
+      ENV['FILE'] = 'corrupted_accounts'
+      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_accounts', '1', '1'
+
+      buyers_to_update.each { |buyer| assert_equal provider.id, buyer.reload.tenant_id }
+      assert_equal -1, buyer_not_to_update.reload.tenant_id
+    end
+
+    test 'fix_corrupted_tenant_id_accounts fixes providers with tenant_id = id' do
+      providers_to_update = FactoryBot.create_list(:simple_provider, 2, provider_account: master_account)
+      provider_not_to_update = FactoryBot.create(:simple_provider, provider_account: master_account)
+      [providers_to_update, provider_not_to_update].flatten.each { |account| account.update_column(:tenant_id, -1) }
+
+      Rails.application.expects(:simple_try_config_for).with('corrupted_accounts').returns(YAML.load(providers_to_update.map(&:id).to_yaml))
+
+      ENV['FILE'] = 'corrupted_accounts'
+      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_accounts', '1', '1'
+
+      providers_to_update.each { |provider| assert_equal provider.id, provider.reload.tenant_id }
+      assert_equal -1, provider_not_to_update.reload.tenant_id
+    end
+
+    test 'fix_corrupted_tenant_id_for_table_associated_to_account for a date range or nil' do
+      account = FactoryBot.create(:simple_provider)
+      users = FactoryBot.create_list(:simple_user, 4, account: account)
+      account.update_column(:tenant_id, account.id)
+      User.where(id: users[0..1].map(&:id)).update_all(tenant_id: nil)
+      User.where(id: users[2..3].map(&:id)).update_all(tenant_id: -1, created_at: Time.strptime('01/24/2019 11:00 UTC', '%m/%d/%Y %H:%M %Z'))
+
+      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_account', 'User', '01/24/2019 08:00 UTC', '01/24/2019 16:30 UTC', '3', '1'
+
+      users.each { |user| assert_equal account.reload.tenant_id, user.reload.tenant_id }
+    end
+
+    test 'fix_corrupted_tenant_id_for_table_associated_to_user for a date range or nil' do
+      user = FactoryBot.create(:simple_user, account: FactoryBot.create(:simple_provider))
+      sso_authorizations = FactoryBot.create_list(:sso_authorization, 4, user: user)
+      user.update_column(:tenant_id, user.account.id)
+      SSOAuthorization.where(id: sso_authorizations[0..1].map(&:id)).update_all(tenant_id: nil)
+      SSOAuthorization.where(id: sso_authorizations[2..3].map(&:id)).update_all(tenant_id: -1, created_at: Time.strptime('01/24/2019 11:00 UTC', '%m/%d/%Y %H:%M %Z'))
+
+      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_user', 'SSOAuthorization', '01/24/2019 08:00 UTC', '01/24/2019 16:30 UTC', '3', '1'
+
+      sso_authorizations.each { |sso_authorization| assert_equal user.reload.tenant_id, sso_authorization.reload.tenant_id }
+    end
+
+    test 'fix_empty_tenant_id_access_tokens' do
+      user = FactoryBot.create(:simple_user, account: FactoryBot.create(:simple_provider))
+      access_tokens = FactoryBot.create_list(:access_token, 3, owner: user)
+      user.update_column(:tenant_id, user.account.id)
+      AccessToken.where(id: access_tokens.map(&:id)).update_all(tenant_id: nil)
+
+      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_empty_tenant_id_access_tokens', '3', '1'
+
+      access_tokens.each { |access_token| assert_equal user.reload.tenant_id, access_token.reload.tenant_id }
+    end
+
+    test 'restore_all_tenant_id_alerts' do
+      account = FactoryBot.create(:simple_provider)
+      alerts = FactoryBot.create_list(:limit_alert, 4, account: account)
+      account.update_column(:tenant_id, account.id)
+      Alert.where(id: alerts[0..1].map(&:id)).update_all(tenant_id: nil)
+      Alert.where(id: alerts[2..3].map(&:id)).update_all(tenant_id: -1)
+
+      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:restore_all_tenant_id_alerts', '3', '1'
+
+      alerts.each { |alert| assert_equal account.reload.tenant_id, alert.reload.tenant_id }
+    end
+  end
+
   class ExportOrgNamesYamlTest < Tasks::Multitenant::TenantsTest
     setup do
       FactoryBot.create_list(:simple_provider, 5)


### PR DESCRIPTION
Refactor and Bugfix from https://github.com/3scale/porta/pull/813, closes [THREESCALE-2571](https://issues.jboss.org/browse/THREESCALE-2571)

### Tasks
1. Fix bug: For those tables associated to user, it was doing `record.account` instead of `record.user`
2. Move to `tenants` to be able to add tests (in `triggers` it doesn't work)
3. Add tests
4. A bit of DRY
5. Divide alerts between empty and not empty

### Plan to execute it
#### Already executed
```
RAILS_ENV=production FILE=corrupted_accounts bundle exec rake 'multitenant:tenants:fix_corrupted_tenant_id_accounts[1, 1]'
RAILS_ENV=production bundle exec rake 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_account[User, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 1, 1]'
RAILS_ENV=production bundle exec rake 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_account[Settings, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production bundle exec rake 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_account[PaymentDetail, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production bundle exec rake 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_account[Policy, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production bundle exec rake 'multitenant:tenants:fix_empty_tenant_id_access_tokens[100, 1]'
```
#### To be executed
```
RAILS_ENV=production bundle exec rake 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_user[NotificationPreferences, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production bundle exec rake 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_user[SSOAuthorization, 01/24/2019 08:00 UTC, 01/24/2019 16:30 UTC, 100, 1]'
RAILS_ENV=production bundle exec rake 'multitenant:tenants:restore_existing_tenant_id_alerts[100, 1]'
RAILS_ENV=production bundle exec rake 'multitenant:tenants:restore_empty_tenant_id_alerts[100, 1]'
```