### PR TITLE
[proxy] introduce OIDC integration types [THREESCALE-2665]

### DIFF
--- a/app/controllers/admin/api/services/proxies_controller.rb
+++ b/app/controllers/admin/api/services/proxies_controller.rb
@@ -54,6 +54,7 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
   ##~ op.parameters.add name: "error_status_no_match", description: "Status code when no mapping rule is matched.", dataType: "int", paramType: "query", required: false
   ##~ op.parameters.add name: "error_headers_no_match", description: "Content-Type header when no mapping rule is matched.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "oidc_issuer_endpoint", description: "Location of your OpenID Provider.", dataType: "string", paramType: "query", required: false
+  ##~ op.parameters.add name: "oidc_issuer_type", description: "Type of your OpenID Provider.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "sandbox_endpoint", description: "Sandbox endpoint.", dataType: "string", paramType: "query", required: false
   #
   def update
@@ -76,7 +77,7 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
                           error_status_auth_failed error_status_auth_failed error_headers_auth_failed
                           error_status_auth_missing error_headers_auth_missing error_no_match
                           error_status_no_match error_headers_no_match secret_token hostname_rewrite
-                          oauth_login_url api_test_path oidc_issuer_endpoint]
+                          oauth_login_url api_test_path oidc_issuer_endpoint oidc_issuer_type]
     params.require(:proxy).permit(permitted_params)
   end
 

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -233,7 +233,10 @@ class Api::IntegrationsController < Api::BaseController
 
     basic_fields << :endpoint if @service.using_proxy_pro? || @proxy.saas_script_driven_apicast_self_managed?
 
-    basic_fields << :oidc_issuer_endpoint if provider_can_use?(:apicast_oidc)
+    if provider_can_use?(:apicast_oidc)
+      basic_fields << :oidc_issuer_endpoint
+      basic_fields << :oidc_issuer_type
+    end
 
     params.require(:proxy).permit(*basic_fields)
   end

--- a/app/representers/proxy_representer.rb
+++ b/app/representers/proxy_representer.rb
@@ -36,6 +36,7 @@ class ProxyRepresenter < ThreeScale::Representer
   property :lock_version
 
   property :oidc_issuer_endpoint, if: ->(*) {  oidc?   }
+  property :oidc_issuer_type, if: ->(*) {  oidc?   }
 
   class JSON < ProxyRepresenter
     include Roar::JSON

--- a/app/views/api/integrations/apicast/shared/_authentication_settings.html.slim
+++ b/app/views/api/integrations/apicast/shared/_authentication_settings.html.slim
@@ -1,5 +1,7 @@
 = f.toggled_inputs 'Authentication Settings' do
   - if @service.oidc?
+    = f.input :oidc_issuer_type, hint: true, as: :select,
+        collection: Proxy.oidc_issuer_types, selected: @proxy.oidc_issuer_type || Proxy.column_defaults['oidc_issuer_type']
     = f.input :oidc_issuer_endpoint, hint: true, input_html: { placeholder: "https://sso.example.com/auth/realms/gateway" }
     = f.inputs "OIDC Authorization flow" do
       = f.semantic_fields_for :oidc_configuration do |config|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1072,6 +1072,7 @@ en:
         hosted_proxy_endpoint: "Public Base URL"
         production_endpoint: "Public Base URL"
         oidc_issuer_endpoint: "OpenID Connect Issuer"
+        oidc_issuer_type: "OpenID Connect Issuer Type"
 
       profile:
         company_url: URL
@@ -1124,7 +1125,9 @@ en:
       headers: "As HTTP Headers"
       query: "As query parameters (GET) or body parameters (POST/PUT/DELETE)"
       authorization: "As HTTP Basic Authentication"
-
+    oidc_issuer_type:
+      keycloak: 'Red Hat Single Sign-On'
+      rest: 'REST API'
   formtastic:
     hints:
       user:

--- a/db/migrate/20190530065503_add_proxies_oidc_issuer_type.rb
+++ b/db/migrate/20190530065503_add_proxies_oidc_issuer_type.rb
@@ -1,0 +1,15 @@
+class AddProxiesOIDCIssuerType < ActiveRecord::Migration
+  def change
+    add_column :proxies, :oidc_issuer_type, :string, default: nil
+
+    reversible do |dir|
+      dir.up do
+        Proxy.where.not(oidc_issuer_endpoint: nil).select(:id).find_in_batches(batch_size: 10_000) do |batch|
+          Proxy.where(id: batch).update_all(oidc_issuer_type: 'keycloak')
+        end
+
+        change_column_default :proxies, :oidc_issuer_type, 'keycloak'
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190527104222) do
+ActiveRecord::Schema.define(version: 20190530065503) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -1082,6 +1082,7 @@ ActiveRecord::Schema.define(version: 20190527104222) do
     t.integer  "lock_version",                 limit: 8,     default: 0,                                   null: false
     t.string   "authentication_method",        limit: 255
     t.text     "policies_config",              limit: 65535
+    t.string   "oidc_issuer_type",             limit: 255,   default: "keycloak"
   end
 
   add_index "proxies", ["service_id"], name: "index_proxies_on_service_id", using: :btree

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -505,6 +505,7 @@ class ProxyTest < ActiveSupport::TestCase
 
     assert_difference proxy_changed_events.method(:count) do
       @proxy.oidc_issuer_endpoint = 'http://example.com'
+      @proxy.oidc_issuer_type = 'keycloak'
       @proxy.save!
     end
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a select box for user chose if they are using Keycloak or Generic HTTP adapter for the OIDC sync integration.