### PR TITLE
Remove cucumber step to make http requests (non-UI step)

### DIFF
--- a/features/old/accounts/users.feature
+++ b/features/old/accounts/users.feature
@@ -103,9 +103,6 @@ Feature: User management
     And I go to the provider users page
     Then I should not see "delete" for user "foo.example.com"
 
-    When I do a HTTP request to delete user "foo.example.com"
-    Then I should be denied the access
-
   Scenario: Admin cannot edit his/her own role
     And current domain is the admin domain of provider "foo.example.com"
     When I log in as provider "foo.example.com"
@@ -113,9 +110,6 @@ Feature: User management
     And I follow "foo.example.com"
     Then I should see "Personal details"
     Then I should not see "Role"
-
-    When I do a HTTP request to change role of user "foo.example.com" to "member"
-    Then user "foo.example.com" should have role "admin"
 
   @security
   Scenario: User management requires login

--- a/features/step_definitions/user_management/common_steps.rb
+++ b/features/step_definitions/user_management/common_steps.rb
@@ -31,12 +31,3 @@ end
 When /^I request the url of users of "([^\"]*)"$/ do |provider|
   visit "http://#{provider}/account/users"
 end
-
-When /^I do a HTTP request to delete (user "[^"]*")$/ do |user|
-  page.driver.browser.process :delete, provider_admin_account_user_path(user)
-end
-
-When /^I do a HTTP request to change role of (user "[^"]*") to "([^"]*)"$/ do |user, role|
-  page.driver.put provider_admin_account_user_path(user), :user => {:role => role}
-  page.driver.browser.follow_redirect!
-end

--- a/test/integration/provider/admin/account/users_controller_test.rb
+++ b/test/integration/provider/admin/account/users_controller_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Provider::Admin::Account::UsersControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    login! provider
+  end
+
+  attr_reader :provider
+
+  test 'admin deletes another admin' do
+    user = FactoryBot.create(:admin, account: provider)
+
+    delete provider_admin_account_user_path(user.id)
+
+    assert_raises(ActiveRecord::RecordNotFound) { user.reload }
+  end
+
+  test 'admin cannot delete himself' do
+    user = provider.admin_users.first!
+
+    delete provider_admin_account_user_path(user.id)
+
+    assert user.reload
+  end
+
+  test 'admin changes role of another admin' do
+    user = FactoryBot.create(:admin, account: provider)
+
+    put provider_admin_account_user_path(user), user: {role: 'member'}
+
+    assert user.reload.member?
+  end
+
+  test 'admin cannot edit his own role' do
+    user = provider.admin_users.first!
+
+    put provider_admin_account_user_path(user), user: {role: 'member'}
+
+    assert user.reload.admin?
+  end
+end


### PR DESCRIPTION
This step is problematic because it does not exist for `Chrome::Driver` (which is the driver used when we have the tag `@javascript`) and it does not belong to cucumber to make this tests anyway, because it is not UI-related. It must be in `test/integration` 😄 