### PR TITLE
[Cuke] Fix 'element not interactable' for 'I navigate to the forum admin page'

### DIFF
--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -20,6 +20,7 @@ end
 
 When /^I navigate to the forum admin page$/ do
   click_link 'Messages'
+  click_link 'Forum'
   click_link 'Threads'
 end
 


### PR DESCRIPTION
This step was wrong 😄 This is our real UI:
![image](https://user-images.githubusercontent.com/11318903/58809065-8380b500-861b-11e9-96ab-a6b4c95bfca4.png)

From `Messages` it is impossible to access directly to `Threads`. The real path is from the Dashboard to `Messages`, then to `Forum` and finally to `Threads`.

It was working anyway because it is in the same HTML:
![image](https://user-images.githubusercontent.com/11318903/58809173-b7f47100-861b-11e9-9aa5-f0c700f67dd7.png)

But as soon as we want to add the `@javascript` tag to any cucumber with this step, it would work. But after this PR, it works both with or without the tag 😄 

I discovered this problem thanks to https://github.com/3scale/porta/pull/761
