### PR TITLE
Do not check status codes from cucumber features

### DIFF
--- a/features/old/applications/buyers/referrer_filters/buyer_side_multiple_applications.feature
+++ b/features/old/applications/buyers/referrer_filters/buyer_side_multiple_applications.feature
@@ -98,7 +98,7 @@ Feature: Buyer's application referrer filters (multiple applications mode)
 
     When I log in as "alice"
     And I do POST to the referrer filters url for application "MegaWidget"
-    Then I should get 404
+    Then I should see "Not found"
 
   @security @allow-rescue
   Scenario: Deleting referrer filter is forbidden if not buyer of the application
@@ -109,4 +109,4 @@ Feature: Buyer's application referrer filters (multiple applications mode)
 
     When I log in as "alice"
     And I do DELETE to the "foo.example.org" referrer filter url for application "MegaWidget"
-    Then I should get 404
+    Then I should see "Not found"

--- a/features/old/applications/providers/referrer_filters.feature
+++ b/features/old/applications/providers/referrer_filters.feature
@@ -53,7 +53,7 @@ Feature: Providers's application referrer filters
      And current domain is the admin domain of provider "xyz.example.com"
     When I log in as provider "xyz.example.com"
      And I do POST to the referrer filters url for application "SpookyWidget"
-    Then I should get 404
+    Then I should see "Not found"
 
   @security @allow-rescue
   Scenario: Deleting referrer filter is forbidden if not provider of the application
@@ -65,4 +65,4 @@ Feature: Providers's application referrer filters
      And I log in as provider "bar.example.com"
 
     And I do DELETE to the "foo.example.org" referrer filter url for application "SpookyWidget"
-    Then I should get 404
+    Then I should see "Not found"

--- a/features/old/buyers/accounts/searching.feature
+++ b/features/old/buyers/accounts/searching.feature
@@ -203,6 +203,5 @@ Feature: Searching buyer accounts
     And I search for:
       | Group/Org. |
       | gorillas   |
-    Then I should get 503
-    And I should see "Search is temporarily offline. Please try again in few minutes."
+    Then I should see "Search is temporarily offline. Please try again in few minutes."
 

--- a/features/old/buyers/accounts/security.feature
+++ b/features/old/buyers/accounts/security.feature
@@ -78,13 +78,13 @@ Feature: Buyer accounts management security
     Then I should not see "bob"
 
     When I go to the buyer account edit page for "bob"
-    Then I should get 404
+    Then I should see "Not found"
 
     When I do a HTTP request to update buyer "bob" changing the organization name to "mike"
-    Then I should get 404
+    Then I should see "Not found"
     And there should be no buyer "mike"
     But there should be a buyer "bob"
 
     When I do a HTTP request to delete buyer "bob"
-    Then I should get 404
+    Then I should see "Not found"
     And there should be a buyer "bob"

--- a/features/old/buyers/invitations/security.feature
+++ b/features/old/buyers/invitations/security.feature
@@ -17,4 +17,4 @@ Feature: Security constraints to invite partners
   Scenario: Invitation interface on partners is restricted to users not admins of the provider account
     When I log in as "lolycat" on foo.example.com
     When I request the url of the invitations of the partner "lol cats"
-    Then I should get 404
+    Then I should see "Not found"

--- a/features/old/cms/advanced/groups_and_sections.feature
+++ b/features/old/cms/advanced/groups_and_sections.feature
@@ -31,7 +31,7 @@ Feature: Groups and Sections
     Given the current domain is "foo.example.com"
       And the section "Docs" of provider "foo.example.com" is access restricted
      When I request the url "/docs/first"
-     Then I should get 404
+     Then I should see "Not found"
 
 
   @allow-rescue
@@ -39,7 +39,7 @@ Feature: Groups and Sections
     Given the section "Docs" of provider "foo.example.com" is access restricted
       And I am logged in as "alice" on "foo.example.com"
      When I request the url "/docs/first"
-     Then I should get 404
+     Then I should see "Not found"
 
   Scenario: Access restricted sections are access granted to allowed users
     Given the section "Docs" of provider "foo.example.com" is access restricted

--- a/features/old/cms/advanced/multi-tenant/authorizations/groups_and_sections.feature
+++ b/features/old/cms/advanced/multi-tenant/authorizations/groups_and_sections.feature
@@ -42,7 +42,7 @@ Feature: Groups and permissions
   Scenario: Restricted sections are restricted even when there is another one public with same path that is public
     Given the current domain is "one.example.com"
     When I request the url "/first"
-    Then I should get 404
+    Then I should see "Not found"
 
   # logged users
   Scenario: sections are accessible to permitted buyers even when another provider has a restricted section with same path
@@ -54,7 +54,7 @@ Feature: Groups and permissions
   Scenario: sections are restricted to buyers even when another provider has a public section with same path
     Given I am logged in as "one_buyer" on one.example.com
     When I request the url "/first"
-    Then I should get 404
+    Then I should see "Not found"
 
   Scenario: Each one sees its contents
     Given I am logged in as "one_buyer" on two.example.com

--- a/features/old/cms/pages.feature
+++ b/features/old/cms/pages.feature
@@ -52,7 +52,8 @@ Feature: CMS Pages
       And I press "Hide" inside the dropdown
      Then I should see "Page has been hidden"
 
-     When I hit "/potato" on foo.example.com and looking at the request, I should get 404
+     When I hit "/potato" on foo.example.com
+     Then I should see "Not found"
 
   Scenario: Builtin page
     Given provider "foo.example.com" has all the templates setup

--- a/features/old/forums/categories.feature
+++ b/features/old/forums/categories.feature
@@ -79,9 +79,6 @@ Feature: Forum categories
     When I log in as "alice" on foo.example.com
     And I go to the forum page
     Then I should not see button "New category"
-    When I do a HTTP request to create new category "Fake"
-    Then I should get 404
-    And the forum of "foo.example.com" should not have category "Fake"
 
   @security @allow-rescue
   Scenario: User can't edit a category
@@ -91,16 +88,9 @@ Feature: Forum categories
     And I go to the forum page
     Then I should not see link "Edit" for category "Security"
 
-    When I do a HTTP request to update category "Security"
-    Then I should get 404
-
   @security @allow-rescue
   Scenario: User can't delete a category
     Given the forum of "foo.example.com" has category "Security"
-
     When I log in as "alice" on foo.example.com
     And I go to the forum page
     Then I should not see button "Delete" for category "Security"
-
-    When I do a HTTP request to delete category "Security"
-    Then I should get 404

--- a/features/old/forums/searching.feature
+++ b/features/old/forums/searching.feature
@@ -68,6 +68,5 @@ Feature: Forum searching
     When I log in as "bob" on foo.example.com
     And I go to the forum page
     And I search for "plutonium"
-    Then I should get 503
-    And I should see "Search is temporarily offline. Please try again in few minutes."
+    Then I should see "Search is temporarily offline. Please try again in few minutes."
 

--- a/features/old/home_page.feature
+++ b/features/old/home_page.feature
@@ -22,4 +22,4 @@ Feature: Home page
     Given there is no provider with domain "bar.example.com"
     When the current domain is "bar.example.com"
     And I go to the homepage
-    Then I should get 404
+    Then I should see "Not found"

--- a/features/old/signup/with_invitation.feature
+++ b/features/old/signup/with_invitation.feature
@@ -38,7 +38,7 @@ Feature: Signup with invitation
   Scenario: Attempting to sign up with invalid invitation token
     When current domain is the admin domain of provider "foo.example.com"
     When I go to the provider user signup page with invalid invitation token
-    Then I should get 404
+    Then I should see "Not found"
 
   # buyer
   Scenario: Attempting to sign up with invalid invitation token

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -113,17 +113,6 @@ Then /^the "([^"]*)" button should be hidden$/ do |label|
   assert has_css?('button', :text => label, :visible => false)
 end
 
-Then /^I should get (\d+)$/ do |code|
-  assert_equal code.to_i, page.status_code
-end
-
-When /^(.+) and looking at the request, I should get (\d+)$/ do |pre_step, code|
-  requests = inspect_requests do
-    step pre_step
-  end
-  assert_equal code.to_i, requests.first.status_code
-end
-
 Then /^I should see the fields contain:$/ do |table|
   table.rows_hash.each do |field, value|
     step %{the "#{field}" field should contain "#{value}"}

--- a/features/step_definitions/forum/category_steps.rb
+++ b/features/step_definitions/forum/category_steps.rb
@@ -39,15 +39,3 @@ When /^I should not see (link|button) "([^"]*)" for category "([^"]*)"$/ do |wid
 
   assert has_no_css?(%(#categories td:contains("#{name}") ~ td #{element}:contains("#{label}")))
 end
-
-When /^I do a HTTP request to create new category "([^"]*)"$/ do |name|
-  page.driver.post admin_forum_categories_path, :topic_category => {:name => name}
-end
-
-When /^I do a HTTP request to update (category "[^"]*")$/ do |category|
-  page.driver.put admin_forum_category_path(category)
-end
-
-When /^I do a HTTP request to delete (category "[^"]*")$/ do |category|
-  page.driver.delete admin_forum_category_path(category)
-end

--- a/test/functional/forums/admin/categories_controller_test.rb
+++ b/test/functional/forums/admin/categories_controller_test.rb
@@ -1,4 +1,0 @@
-require File.expand_path(File.dirname(__FILE__) + '/../../../test_helper')
-
-class Forums::Admin::CategoriesControllerTest < ActionController::TestCase
-end

--- a/test/integration/developer_portal/forums/admin/categories_controller_test.rb
+++ b/test/integration/developer_portal/forums/admin/categories_controller_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DeveloperPortal::Forums::Admin::CategoriesControllerTest < ActionDispatch::IntegrationTest
+  include DeveloperPortal::Engine.routes.url_helpers
+
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    provider.settings.allow_multiple_applications!
+    provider.settings.show_multiple_applications!
+    provider.settings.update_column(:forum_enabled, true)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+    @category = provider.forum.categories.create!(name: 'Security')
+    login_buyer buyer
+  end
+
+  attr_reader :provider, :buyer, :category
+
+  test '#create' do
+    assert_raises(ActionController::RoutingError) { post admin_forum_categories_path({topic_category: {name: 'fake'}}) }
+  end
+
+  test '#update' do
+    assert_raises(ActionController::RoutingError) { put admin_forum_category_path(category) }
+  end
+
+  test '#delete' do
+    assert_raises(ActionController::RoutingError) { delete admin_forum_category_path(category) }
+  end
+end


### PR DESCRIPTION
Checking status codes from cucumber does not work from `Chrome::Driver`, which is the browser used when we have the tag `@javascript`. This way it works anyway.
And either way it is wrong to test status codes from HTTP requests from Cucumber. Cucumber should do only UI related actions and assert from the UI.