### PR TITLE
[Cuke] Fix navigation to 'Invoices'

### DIFF
--- a/features/old/menu/account_menu.feature
+++ b/features/old/menu/account_menu.feature
@@ -34,7 +34,7 @@ Feature: Menu of the Account screen
     Given provider "foo.example.com" has "finance" switch denied
     When I go to the provider dashboard
      And I follow "Account"
-    Then I should see "3scale Invoices"
+     And I follow "Billing"
      And I follow "3scale Invoices"
     Then I should be on my invoices from 3scale page
 
@@ -42,6 +42,7 @@ Feature: Menu of the Account screen
     Given master is billing tenants
     When I go to the provider dashboard
      And I follow "Account"
+     And I follow "Billing"
     Then I should see "3scale Invoices"
 
   Scenario: Account menu when master is not billing


### PR DESCRIPTION
This PR is similar to https://github.com/3scale/porta/pull/834

The way to navigate to "Invoices" is not "Account" -> "Invoices" from the Dashboard. Because "Invoices" is under "Billing":
![image](https://user-images.githubusercontent.com/11318903/58817401-ec702900-862b-11e9-8fa2-90c3549f217b.png)

The reason why it was working anyway is because it is under the same HTML:
![image](https://user-images.githubusercontent.com/11318903/58817445-07429d80-862c-11e9-8afa-b1e23be492a2.png)

But as soon as we add the tag `@javascript`, it won't work because it isn't the real navigation.
With this PR it works both with and without the `@javascript` tag.
