### PR TITLE
Styling Updates -> Services>New and Index Pages

### DIFF
--- a/lib/developer_portal/app/views/developer_portal/css/default.css
+++ b/lib/developer_portal/app/views/developer_portal/css/default.css
@@ -202,6 +202,11 @@ fieldset:first-of-type {
 }
 
 /* tables & table panels */
+th, td{
+  padding: 10px;
+  text-align: left;
+}
+
 .table thead > tr > th, .table tbody > tr > th, .table tfoot > tr > th, .table thead > tr > td, .table tbody > tr > td, .table tfoot > tr > td {
   border-top: none;
   border-bottom: none;
@@ -582,6 +587,12 @@ pre.message {
 
 dl + dl {
   margin-top: 60px;
+}
+
+ul, ol {
+  margin-top: 0;
+  margin-bottom: 10px;
+  list-style: none;
 }
 
 /* SSO */

--- a/lib/developer_portal/app/views/developer_portal/services/index.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/services/index.html.liquid
@@ -1,82 +1,63 @@
-<div class="full">
-  <div class="container" >
-    <div class="row">
-      <div class="col-md-10">
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <table class="table">
-              <thead>
-                <tr>
-                  <th style="width:20%">Name</th>
-                  <th>Description</th>
-                  <th>Plan</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for service in provider.services %}
-                  <tr class="service">
-                    {% if service.subscribable? %}
-                      {% assign subscription = service.subscription %}
-                      <td>
-                        {{ service.name }}
-                      </td>
-                      <td>
-                        <p>
-                          {{ service.description }}
-                        </p>
-                      </td>
-
-                      <td>
-                        {% if subscription %}
-                          {{ subscription.plan.name  }}
-                          {% unless subscription.live? %}
-                            ({{ subscription.state }})
-                          {% endunless %}
-                        {% endif %}
-                      </td>
-
-                      <td>
-                        {% if subscription %}
-                            {% if subscription.can.change_plan? %}
-                               <a href="#" id="choose-plan-{{subscription.id}}" class="btn btn-default">Review/Change</a>
-
-                               {{ "plans_widget.js" | javascript_include_tag }}
-                               {{ "plans_widget.css" | stylesheet_link_tag }}
-
-                                <script type="text/javascript">
-                                  //<![CDATA[
-                                  $(document).ready(function() {
-                                    $("#choose-plan-{{ subscription.id }}").click(function(){
-                                      var planID = '{{ subscription.plan.id }}';
-                                      var contractID = '{{ subscription.id }}';
-                                      var url = '{{ subscription.change_plan_url }}';
-
-                                      function plan_chosen_callback(name, planID){
-                                      }
-
-                                      PlanWidget.loadPreview(planID, plan_chosen_callback, url, contractID );
-
-                                      return false;
-                                    });
-                                  });
-                                  //]]>
-                                </script>
-
-                            {% endif %}
-                       {% else %}
-                         {{ "Subscribe to " | append: service.name | link_to: service.subscribe_url }}
-                       {% endif %}
-                      </td>
-                      {% endif %}
-                  </tr>
-                 {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+<div class="row">
+   <div class="col-md-10">
+      <table class="panel panel-default">
+         <thread class="panel-heading">
+         <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Plan</th>
+            <th></th>
+         </tr>
+         </thead>
+         <tbody="panel-body">
+         {% for service in provider.services %}
+         <tr class="service">
+            {% if service.subscribable? %}
+            {% assign subscription = service.subscription %}
+            <td>
+               {{ service.name }}
+            </td>
+            <td>
+               {{ service.description }}
+            </td>
+            <td>
+               {% if subscription %}
+               {{ subscription.plan.name  }}
+               {% unless subscription.live? %}
+               ({{ subscription.state }})
+               {% endunless %}
+               {% endif %}
+            </td>
+            <td>
+               {% if subscription %}
+               {% if subscription.can.change_plan? %}
+               <a href="#" id="choose-plan-{{subscription.id}}" class="btn btn-default">Review/Change</a>
+               {{ "plans_widget.js" | javascript_include_tag }}
+               {{ "plans_widget.css" | stylesheet_link_tag }}
+               <script type="text/javascript">
+                  //<![CDATA[
+                  $(document).ready(function() {
+                    $("#choose-plan-{{ subscription.id }}").click(function(){
+                      var planID = '{{ subscription.plan.id }}';
+                      var contractID = '{{ subscription.id }}';
+                      var url = '{{ subscription.change_plan_url }}';
+                      function plan_chosen_callback(name, planID){
+                      }
+                      PlanWidget.loadPreview(planID, plan_chosen_callback, url, contractID );
+                      return false;
+                    });
+                  });
+                  //]]>
+               </script>
+               {% endif %}
+               {% else %}
+               {{ "Subscribe to " | append: service.name | link_to: service.subscribe_url }}
+               {% endif %}
+            </td>
+            {% endif %}
+         </tr>
+         {% endfor %}
+         </tbody>
+      </table>
+   </div>
 </div>
-

--- a/lib/developer_portal/app/views/developer_portal/services/new.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/services/new.html.liquid
@@ -4,7 +4,7 @@
   <p>Please choose a service and plan you which to subscribe to.</p>
 
   <fieldset class="inputs" name="">
-    <ol>
+    <ul>
       <li class="plan_selector required" id="service_contract_plan_input">
         <label for="service_contract_plan_id">Plan<abbr title="required">*</abbr></label>
         <select id="service_contract_plan_id" name="service_contract[plan_id]">
@@ -26,17 +26,17 @@
         </select>
         <p class="inline-hints">Choose a plan you want to subscribe to.</p>
       </li>
-    </ol>
+    </ul>
   </fieldset>
 
   {% include 'service_subscription_licence' %}
 
   <fieldset class="buttons">
-    <ol>
+    <ul>
       <li class="commit">
         <input class="important-button create" name="commit" type="submit" value="Subscribe">
       </li>
-    </ol>
+    </ul>
   </fieldset>
 
 {% endform %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

This PR fixes alignment and styling in Services > Index and New Pages 

**Note**: As per comment on PR https://github.com/3scale/porta/pull/777, creating this separate PR for styling updates.

**Which issue(s) this PR fixes** 

This fixes just alignment and styling of the developer portal views, so there is no issue logged for this.

**Verification steps** 

Scenario 1: Go to default Developer portal > Services > Verify the table alignment is correct.

**Note**: To test the below scenario, we need to first create/update API, with more than one service plans.

Scenario 2: Go to default Developer portal > Services > Choose a service which has more than one Service Plan, then it will take you to a view to Subscribe to a service with a plan - Make sure everything looks good(removed the numbering which is not required)

**Special notes for your reviewer**:
**Scenario 1:** 
Services Before Changes:
![Styling-Services View-Before](https://user-images.githubusercontent.com/45026747/57806613-1a490880-7725-11e9-84ca-e1c7d0b269e2.png)

Services View After Changes:
![Styling-Services View-After](https://user-images.githubusercontent.com/45026747/57806656-351b7d00-7725-11e9-8828-17de18a629ca.png)

**Scenario 2:**
Subscribe to a Service View Before changes:
![Styling-Subscribe-To-Service-Before](https://user-images.githubusercontent.com/45026747/57806755-672cdf00-7725-11e9-94f4-056864550b47.png)

Subscribe to a Service View After changes
![Styling-Subscribe-To-Service-After](https://user-images.githubusercontent.com/45026747/57806766-6e53ed00-7725-11e9-9b0c-9e02d90bb380.png)