### PR TITLE
Audit logs to stdout

### DIFF
--- a/app/lib/features/logging_config.rb
+++ b/app/lib/features/logging_config.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Features
+  class LoggingConfig < Config
+    def enabled?
+      config.present?
+    end
+  end
+end

--- a/config/examples/features.yml
+++ b/config/examples/features.yml
@@ -12,6 +12,8 @@ features: &default
     password: 'example-password'
     uri: 'https://gdpr.segment.com/graphql'
     workspace: 'example-workspace'
+  logging:
+    audits_to_stdout: true
 
 development:
   <<: *default

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-Features::AccountDeletionConfig.configure(Rails.configuration.three_scale.features.account_deletion)
-Features::SegmentDeletionConfig.configure(Rails.configuration.three_scale.features.segment_deletion)
+Rails.configuration.three_scale.features.each_key do |feature_name|
+  feature = "Features::#{feature_name.to_s.camelize}Config".constantize
+  feature.configure Rails.configuration.three_scale.features.public_send(feature_name)
+end

--- a/test/factories/audit.rb
+++ b/test/factories/audit.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:audit, class: Audited.audit_class) do
+    synchronous { true }
+
+    provider_id { build_stubbed(:simple_provider).id }
+
+    auditable_type { 'Account' }
+    auditable_id  { provider_id }
+
+    kind { auditable_type }
+
+    action { 'create' }
+    audited_changes { { 'org_name' => ['Previous', 'Current'] } }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+
+    user_id { User.current&.id }
+    user_type { 'User' if user_id }
+  end
+end

--- a/test/unit/audited_hacks_test.rb
+++ b/test/unit/audited_hacks_test.rb
@@ -25,4 +25,114 @@ class AuditedHacksTest < ActiveSupport::TestCase
     assert_equal User.current, audit.user
   end
 
+  class LoggingTest < ActiveSupport::TestCase
+    disable_transactional_fixtures!
+
+    setup do
+      @provider = FactoryBot.create(:simple_provider)
+      User.current = FactoryBot.create(:admin, account: provider)
+      
+      @audit_class = Audited.audit_class
+      @audit = FactoryBot.build(:audit, provider_id: provider.id)
+
+      audit_class.delete_all
+    end
+
+    attr_reader :provider, :audit_class, :audit
+
+    test '#logging_to_stdout?' do
+      Features::LoggingConfig.config.stubs(audits_to_stdout: false)
+      refute audit_class.logging_to_stdout?
+      refute audit.logging_to_stdout?
+
+      Features::LoggingConfig.config.stubs(audits_to_stdout: true)
+      assert audit_class.logging_to_stdout?
+      assert audit.logging_to_stdout?
+    end
+
+    test 'logging to stdout disabled' do
+      audit_class.stubs(:logging_to_stdout? => false)
+      audit_class.any_instance.expects(:log_to_stdout).never # I know, expecting a method never to be invoked sucks :/
+      assert audit.save!
+    end
+
+    test 'logging to stdout enabled' do
+      audit_class.stubs(:logging_to_stdout? => true)
+      audit_class.any_instance.expects(:log_to_stdout).once
+      assert audit.save!
+
+      audit.version = 2
+      audit_class.any_instance.expects(:log_to_stdout).never
+      assert audit.save!
+    end
+
+    test 'logging to stdout only on create' do
+      audit_class.stubs(:logging_to_stdout? => true)
+      audit_class.any_instance.expects(:log_to_stdout).once
+      assert audit.save!
+    end
+
+    test 'log to stdout' do
+      audit.stubs(log_trail: 'log message')
+      Rails.logger.expects(:info).with('log message')
+      audit.log_to_stdout
+    end
+
+    test 'safe hash for create action' do
+      assert_equal expected_hash_new_record, audit.send(:to_h_safe)
+
+      audit.save!
+
+      assert_equal expected_hash_persisted, audit.send(:to_h_safe)
+    end
+
+    test 'sahe hash for update action' do
+      audit = FactoryBot.build(:audit, action: 'update', provider_id: provider.id)
+      changed_attributes = { action: 'update', changed_attributes: ['org_name'] }.stringify_keys
+
+      assert_equal expected_hash_new_record(audit).merge(changed_attributes), audit.send(:to_h_safe)
+
+      audit.save!
+
+      assert_equal expected_hash_persisted(audit).merge(changed_attributes), audit.send(:to_h_safe)
+    end
+
+    test 'log trail' do
+      audit.save!
+      assert_equal expected_hash_persisted.to_json, audit.send(:log_trail)
+    end
+
+    test 'log trail without user' do
+      User.current = nil
+      audit = FactoryBot.create(:audit)
+      assert_equal expected_hash_persisted(audit).to_json, audit.send(:log_trail)
+    end
+
+    protected
+
+    def expected_hash_new_record(audit = @audit)
+      provider_id = audit.provider_id
+      expected_hash = {
+        auditable_type: 'Account',
+        auditable_id: provider_id,
+        action: 'create',
+        version: 1,
+        provider_id: provider_id,
+        user_id: nil,
+        user_type: nil,
+        request_uuid: audit.request_uuid,
+        remote_address: nil,
+        created_at: nil,
+        user_role: nil,
+        audit_id: nil
+      }
+      user = User.current
+      expected_hash.merge!(user_id: user.id, user_type: 'User', user_role: user.role) if user
+      expected_hash.stringify_keys
+    end
+
+    def expected_hash_persisted(audit = @audit)
+      expected_hash_new_record(audit).merge({ created_at: audit.created_at, audit_id: audit.id }.stringify_keys)
+    end
+  end
 end

--- a/test/unit/features/logging_config_test.rb
+++ b/test/unit/features/logging_config_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Features
+  class LoggingConfigTest < ActiveSupport::TestCase
+    def setup
+      @valid_config = { 'audits_to_stdout' => true }
+    end
+
+    attr_reader :valid_config
+
+    class EnabledDisabledTest < LoggingConfigTest
+      test 'disabled when blank' do
+        refute logging_config('').enabled?
+        refute logging_config({}).enabled?
+      end
+
+      test 'enabled when present' do
+        assert logging_config.enabled?
+        assert logging_config('any_logging_type' => false).enabled?
+      end
+    end
+
+    class AuditLogsToStdoutTest < LoggingConfigTest
+      test 'enabled' do
+        assert logging_config.config.audits_to_stdout
+      end
+
+      test 'disabled when missing, empty or false' do
+        ['', {}, { 'audits_to_stdout' => false }].each { |config| refute logging_config(config).config.audits_to_stdout }
+      end
+    end
+
+    private
+
+    def logging_config(config = valid_config)
+      Features::LoggingConfig.new(config)
+    end
+  end
+end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

- It defines a global feature `logging` where types of logging can be configured at the deployment level
- It defines a logging configuration `audit_to_stdout` that when enabled prints a simplified representation of a recently created audit record to the standard output

Example:
<img width="1370" alt="Screen Shot 2019-06-06 at 11 36 22 AM" src="https://user-images.githubusercontent.com/1842261/59023238-a1cef680-884f-11e9-8d51-edd113326709.png">

**Which issue(s) this PR fixes** 

Close [THREESCALE-2593](https://issues.jboss.org/browse/THREESCALE-2593)

**Verification steps** 

1. Activate `audits_to_stdout` in `config/features.yml:logging` (enabled by default on OpenShift once https://github.com/3scale/porta/pull/851 gets merged)
2. Create any audited record such as an account, application contract, etc
3. Make sure Sidekiq is running and audit jobs have been processed
4. Check the audits of the object created in (2)
5. Check in the Sidekiq logs a message printed that matches the audit observed in (4) (as a simplified representation of it)