### PR TITLE
[zync] publish events about provider domain changes [THREESCALE-2686]

### DIFF
--- a/app/events/domains/provider_domains_changed_event.rb
+++ b/app/events/domains/provider_domains_changed_event.rb
@@ -1,0 +1,19 @@
+class Domains::ProviderDomainsChangedEvent < BaseEventStoreEvent
+  def self.create(provider)
+    new(
+      provider:    provider,
+      admin_domains: [ provider.self_domain ],
+      developer_domains: [ provider.domain ],
+      metadata: {
+        provider_id: provider.id,
+        zync: {
+          tenant_id: provider.tenant_id || provider.id,
+        }
+      }
+    )
+  end
+
+  def self.valid?(account)
+    account.provider?
+  end
+end

--- a/app/events/domains/proxy_domains_changed_event.rb
+++ b/app/events/domains/proxy_domains_changed_event.rb
@@ -1,0 +1,29 @@
+require 'uri'
+
+class Domains::ProxyDomainsChangedEvent < BaseEventStoreEvent
+  def self.create(proxy)
+    new(
+      proxy:    proxy,
+      staging_domains: extract_domain(proxy.sandbox_endpoint),
+      production_domains: extract_domain(proxy.endpoint),
+
+      metadata: {
+        provider_id: (provider_id = proxy.provider&.id),
+        zync: {
+          tenant_id: proxy.tenant_id || proxy.provider&.tenant_id || provider_id,
+          service_id: proxy.service_id,
+        }
+      }
+    )
+  end
+
+  def self.valid?(proxy)
+    !!proxy # TODO: check if deployment_option or domains actually changed
+  end
+
+  def self.extract_domain(url)
+    [ URI(url.presence || '').host ].compact
+  rescue ArgumentError, URI::InvalidURIError
+    # nothing
+  end
+end

--- a/app/events/zync_event.rb
+++ b/app/events/zync_event.rb
@@ -31,6 +31,7 @@ class ZyncEvent < BaseEventStoreEvent
   def model
     case type
     when 'Application' then Cinstance
+    when 'Provider' then Account.providers
     else type.constantize
     end
   end
@@ -55,6 +56,7 @@ class ZyncEvent < BaseEventStoreEvent
   def self.type_for(model)
     case model
     when Cinstance, ApplicationRelatedEvent then 'Application'
+    when ->(object) { object.is_a?(Account) && object.provider? } then 'Provider'
     else model.model_name.name
     end
   end

--- a/app/lib/missing_model.rb
+++ b/app/lib/missing_model.rb
@@ -21,4 +21,5 @@ class MissingModel
   end
 
   class MissingApplication < MissingModel; end
+  class MissingProvider < MissingModel; end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -58,6 +58,7 @@ class Account < ApplicationRecord
   include CreditCard
   include Gateway
   include States
+  require_dependency 'account/domains'
   include Domains
 
   #TODO: this needs testing?

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -88,6 +88,7 @@ class Proxy < ApplicationRecord
 
   before_save :set_correct_endpoints, if: :set_correct_endpoints?
   after_save :publish_events
+  before_destroy :publish_events
 
   after_save :track_apicast_version_change, if: :apicast_configuration_driven_changed?
 
@@ -257,6 +258,8 @@ class Proxy < ApplicationRecord
 
   def publish_events
     OIDC::ProxyChangedEvent.create_and_publish!(self)
+    Domains::ProxyDomainsChangedEvent.create_and_publish!(self)
+    nil
   end
 
   DEPLOYMENT_OPTION_CHANGED = ->(record) { record.changed_attributes.key?(:deployment_option) }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -211,7 +211,7 @@ class Service < ApplicationRecord
 
   def publish_events
     OIDC::ServiceChangedEvent.create_and_publish!(self)
-    OIDC::ProxyChangedEvent.create_and_publish!(proxy) if backend_version_change&.include?('oauth')
+    OIDC::ProxyChangedEvent.create_and_publish!(proxy)
   end
 
   def backend_authentication_type

--- a/app/representers/proxy_representer.rb
+++ b/app/representers/proxy_representer.rb
@@ -32,6 +32,8 @@ class ProxyRepresenter < ThreeScale::Representer
   property :created_at
   property :updated_at
 
+  property :deployment_option
+
   # By sending the lock_version with the update call the record is updated only when matching that version.
   property :lock_version
 

--- a/app/subscribers/publish_zync_event_subscriber.rb
+++ b/app/subscribers/publish_zync_event_subscriber.rb
@@ -16,8 +16,9 @@ class PublishZyncEventSubscriber
            # When the app is deleted the event caries all the needed information
            when Cinstances::CinstanceCancellationEvent then ZyncEvent.create(event)
            when ApplicationRelatedEvent then ZyncEvent.create(event, event.application)
-           when OIDC::ProxyChangedEvent then ZyncEvent.create(event, event.proxy)
+           when OIDC::ProxyChangedEvent, Domains::ProxyDomainsChangedEvent then ZyncEvent.create(event, event.proxy)
            when OIDC::ServiceChangedEvent then ZyncEvent.create(event, event.service)
+           when Domains::ProviderDomainsChangedEvent then  ZyncEvent.create(event, event.provider)
            else raise "Unknown event type #{event.class}"
            end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -80,6 +80,7 @@ master_service.update_attribute(:default_application_plan, application_plan)
 range = [0] | Alert::ALERT_LEVELS
 master_service.notification_settings = { web_buyer: range, email_buyer: range, web_provider: range, email_provider: range}
 master_service.save!
+
 application_plan.create_contract_with! master
 
 # Setting the default account plan for master (plan to which provider will subscribe)
@@ -91,6 +92,7 @@ master.save!
 provider_plan = ENV.fetch('PROVIDER_PLAN', 'enterprise')
 plan = ApplicationPlan.create!(issuer: master_service, name: provider_plan)
 master_service.application_plans.default!(plan)
+master_service.update_columns(deployment_option: 'self_managed')
 
 # Enable account_plans / service_plans and end_users plans for Master
 %i(end_users account_plans service_plans).each do |setting|

--- a/spec/acceptance/api/proxy_spec.rb
+++ b/spec/acceptance/api/proxy_spec.rb
@@ -19,6 +19,7 @@ resource 'Proxy' do
   json(:resource) do
     let(:root) { 'proxy' }
     it { should include('credentials_location' => resource.credentials_location) }
+    it { should include('deployment_option' => resource.deployment_option.to_s) }
     it { should have_links('mapping_rules', 'service', 'self') }
   end
 end

--- a/test/unit/provider_test.rb
+++ b/test/unit/provider_test.rb
@@ -2,16 +2,34 @@ require 'test_helper'
 
 class ProviderTest < ActiveSupport::TestCase
   def setup
-    master_account
+    FactoryBot.create(:simple_master)
   end
 
   def test_find
-    provider = Account.create!(org_name: 'Mr. Provider') {|p| p.provider = true }
+    provider = FactoryBot.create(:simple_provider)
 
     assert_equal provider, Provider.find(provider.id)
   end
 
   def test_find_with_master
     assert_equal master_account, Provider.find(master_account.id)
+  end
+
+  test 'publishes domain events when changed' do
+    provider = FactoryBot.create(:simple_provider)
+
+    Domains::ProviderDomainsChangedEvent.expects(:create).with(provider)
+
+    provider.domain = 'example.com'
+
+    assert provider.save!
+  end
+
+  test 'publishes domain events when removed' do
+    provider = FactoryBot.create(:simple_provider)
+
+    Domains::ProviderDomainsChangedEvent.expects(:create).with(provider)
+
+    provider.destroy
   end
 end

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -537,6 +537,38 @@ class ProxyTest < ActiveSupport::TestCase
     assert_equal policy_config2, @proxy.find_policy_config_by(name: 'my-other-policy', version: '0.5.0')
   end
 
+  test 'domain changes events on update of hosted proxy' do
+    @proxy.service.deployment_option = 'hosted'
+
+    Domains::ProxyDomainsChangedEvent.expects(:create).with(@proxy).once
+
+    @proxy.update_attributes(staging_endpoint: 'http://example.com')
+  end
+
+  test 'domain changes events on update of self managed proxy' do
+    @proxy.service.deployment_option = 'self_managed'
+
+    Domains::ProxyDomainsChangedEvent.expects(:create).with(@proxy).once
+
+    @proxy.update_attributes(staging_endpoint: 'http://example.com')
+  end
+
+  test 'domain changes events on destroy of hosted proxy' do
+    @proxy.service.deployment_option = 'hosted'
+
+    Domains::ProxyDomainsChangedEvent.expects(:create).with(@proxy).once
+
+    @proxy.destroy
+  end
+
+  test 'domain changes events on destroy of self managed' do
+    @proxy.service.deployment_option = 'self_managed'
+
+    Domains::ProxyDomainsChangedEvent.expects(:create).with(@proxy).once
+
+    @proxy.destroy
+  end
+
   def analytics
     ThreeScale::Analytics::UserTracking.any_instance
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

Publish events to Zync when Provider or a Proxy changes domain (that includes when a provider/proxy is created and deleted).

Depends on https://github.com/3scale/zync/pull/199 