### PR TITLE
Revert "Try Zync dependency chain in a Sidekiq batch on UnprocessableEntityError"

### DIFF
--- a/app/events/zync_event.rb
+++ b/app/events/zync_event.rb
@@ -52,10 +52,6 @@ class ZyncEvent < BaseEventStoreEvent
     end
   end
 
-  def create_dependencies
-    dependencies.map { |dependency| ZyncEvent.create(self, dependency) }
-  end
-
   def self.type_for(model)
     case model
     when Cinstance, ApplicationRelatedEvent then 'Application'

--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -4,8 +4,6 @@ require 'httpclient/include_client'
 
 class ZyncWorker
   include Sidekiq::Worker
-  include ThreeScale::SidekiqRetrySupport::Worker
-
   extend ::HTTPClient::IncludeClient
 
   class_attribute :publisher
@@ -222,7 +220,8 @@ class ZyncWorker
       http_put(notification_url, notification, event_id)
     end
   rescue UnprocessableEntityError
-    raise if last_attempt? || sync_dependencies(event_id).blank?
+    publish_dependencies_events(event_id)
+    raise
   end
 
   def valid?(event_id)
@@ -234,43 +233,15 @@ class ZyncWorker
     true
   end
 
-  def sync_dependencies(event_id)
-    dependency_events = []
+  def publish_dependencies_events(event_id)
+    event = EventStore::Repository.find_event!(event_id)
 
-    enqueue_dependency_batch(event_id) do
-      dependency_events = create_dependency_events(event_id)
-      publish_dependency_events(dependency_events)
+    dependencies = event.dependencies.map do |dependency|
+      ZyncEvent.create(event, dependency)
     end
 
-    dependency_events
+    dependencies.each { |dependency| publisher.call(dependency, 'zync') }
   end
-
-  def enqueue_dependency_batch(event_id, &block)
-    batch = Sidekiq::Batch.new
-    batch.description = "[ZyncWorker] Syncing dependencies first"
-    batch.on(:complete, self.class, { 'event_id' => event_id })
-    batch.jobs &block
-  end
-
-  def create_dependency_events(event_id)
-    EventStore::Repository.find_event!(event_id).create_dependencies
-  end
-
-  def publish_dependency_events(dependency_events)
-    dependency_events.each do |dependent_event|
-      publisher.call(dependent_event, 'zync')
-    end
-  end
-
-  def on_complete(_bid, options)
-    event = EventStore::Repository.find_event!(options['event_id'])
-
-    # A batch is only created after a UnprocessableEntityError has been raised, so retry the same event
-    # The number of retries is controlled at the origin of the failure using ThreeScale::SidekiqRetrySupport::Worker#last_attempt?
-    perform_async(event.event_id, event.data)
-  end
-
-  delegate :perform_async, to: :class
 
   def update_tenant(event_id)
     event = EventStore::Repository.find_event!(event_id)

--- a/test/events/zync_event_test.rb
+++ b/test/events/zync_event_test.rb
@@ -18,17 +18,6 @@ class ZyncEventTest < ActiveSupport::TestCase
     assert_equal [ service = application.service, service.proxy ], event.dependencies
   end
 
-  def test_create_dependencies
-    application = FactoryBot.create(:simple_cinstance)
-    event = ZyncEvent.create(RailsEventStore::Event.new, application)
-
-    dependencies = [service = application.service, service.proxy]
-    event.expects(:dependencies).returns(dependencies)
-    dependencies.each { |dependency| ZyncEvent.expects(:create).with(event, dependency) }
-
-    event.create_dependencies
-  end
-
   def test_non_persisted_dependencies_for_application
     application = FactoryBot.build(:simple_cinstance, service: FactoryBot.create(:simple_service))
     assert event = ZyncEvent.create(Applications::ApplicationDeletedEvent.create(application), application)

--- a/test/workers/zync_worker_test.rb
+++ b/test/workers/zync_worker_test.rb
@@ -44,97 +44,8 @@ class ZyncWorkerTest < ActiveSupport::TestCase
     ZyncWorker::MessageBusPublisher.expects(:enabled).returns(false)
 
     assert_difference(zync_events.method(:count), +2) do
-      worker.perform(event.event_id, event.data.with_indifferent_access)
-    end
-  end
-
-  class UnprocessableEntityRetryTest < ActiveSupport::TestCase
-    disable_transactional_fixtures!
-
-    attr_reader :worker, :event, :application
-
-    setup do
-      EventStore::Repository.stubs(raise_errors: true)
-
-      @worker = ZyncWorker.new
-      @application = FactoryBot.create(:simple_cinstance).reload # reload to get tenant_id
-      FactoryBot.create(:simple_admin, account: application.provider_account) # for the access token
-      @event = ZyncEvent.create(RailsEventStore::Event.new, application)
-
-      worker.config.stubs(endpoint: 'http://example.com') # so it makes http request
-      worker.publisher.call(event) # so it is later available to find
-
-      stub_request(:put, 'http://example.com/tenant').to_return(status: 200)
-      stub_request(:put, 'http://example.com/notification').to_return(status: 422).with(body: event.data.to_json) # causes UnprocessableEntityError to be raised
-    end
-
-    test 'sync event dependencies when it fails' do
-      worker.expects(:sync_dependencies).with(event.event_id).returns(true)
-      worker.perform(event.event_id, event.data.with_indifferent_access)
-    end
-
-    test 'raises the error when there is no dependency' do
-      worker.expects(:sync_dependencies).with(event.event_id).returns([])
       assert_raises ZyncWorker::UnprocessableEntityError do
         worker.perform(event.event_id, event.data.with_indifferent_access)
-      end
-    end
-
-    test '#create_dependency_events' do
-      EventStore::Repository.expects(:find_event!).returns(event)
-      event.expects(:create_dependencies)
-      worker.create_dependency_events(event.event_id)
-    end
-
-    test '#sync_dependencies publishes events and enqueues jobs' do
-      event_id = event.event_id
-      dependency_events = event.create_dependencies
-
-      worker.expects(:create_dependency_events).with(event_id).returns(dependency_events)
-      worker.expects(:publish_dependency_events).with(dependency_events)
-
-      worker.sync_dependencies(event_id)
-    end
-
-    test '#publish_dependency_events enqueues the jobs' do
-      event_id = event.event_id
-      dependency_events = event.create_dependencies
-
-      %w[Proxy Service].each { |dependent_type| ZyncWorker.expects(:perform_async).with(anything, has_entry(:type, dependent_type)) }
-      worker.publish_dependency_events(dependency_events)
-    end
-
-    test 'on batch complete' do
-      event_id = event.event_id
-      klass = worker.class
-      klass.expects(:perform_async).with(event_id, anything)
-      klass.new.on_complete(1, {'event_id' => event_id})
-    end
-
-    test 'number of attempts' do
-      ZyncWorker::MessageBusPublisher.any_instance.stubs(enabled?: false)
-
-      retry_limit = worker.retry_limit
-
-      dependency_events = {}
-      retry_limit.times { |i| dependency_events[i] = event.create_dependencies }
-
-      dependency_events.values.flatten.each do |dependent_event|
-        stub_request(:put, 'http://example.com/notification').to_return(status: 200).with(body: dependent_event.data.to_json)
-      end
-
-      worker.expects(:create_dependency_events).with(event.event_id).times(3)
-            .returns(dependency_events[0])
-            .then.returns(dependency_events[1])
-            .then.returns(dependency_events[2])
-
-      Sidekiq::Testing.inline! do
-        assert_raises(ZyncWorker::UnprocessableEntityError) do
-          (retry_limit + 1).times do |attempt|
-            worker.retry_attempt = attempt
-            worker.perform(event.event_id, event.data.with_indifferent_access)
-          end
-        end
       end
     end
   end
@@ -156,7 +67,9 @@ class ZyncWorkerTest < ActiveSupport::TestCase
 
     zync_event = EventStore::Event.where(event_type: ZyncEvent).last!
     assert_difference(EventStore::Event.where(event_type: ZyncEvent).method(:count), +1) do
-      Sidekiq::Testing.inline! { ZyncWorker.perform_async(zync_event.event_id, zync_event.data) }
+      assert_raises ZyncWorker::UnprocessableEntityError do
+        Sidekiq::Testing.inline! { ZyncWorker.perform_async(zync_event.event_id, zync_event.data) }
+      end
     end
 
     stub_request(:put, 'http://example.com/notification').to_return(status: 200)


### PR DESCRIPTION
Reverts 3scale/porta#809. `ThreeScale::SidekiqRetrySupport::Worker#last_attempt?` doesn't really work the way it has been used here.