### PR TITLE
[Cukes] Fix: features/old/buyers/users.feature

### DIFF
--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -216,7 +216,7 @@ end
 #     </tr>
 #   </table>
 Then /^(.*) within the "([^"]*)" row$/ do |action, content|
-  within(%(tr:contains("#{content}"))) do
+  within(:xpath, "//*[text()[contains(.,'#{content}')]]/ancestor::tr") do
     step action
   end
 end

--- a/features/step_definitions/user_management/common_steps.rb
+++ b/features/step_definitions/user_management/common_steps.rb
@@ -17,7 +17,7 @@ When /^I check "([^"]*)" in the user permission field$/ do |permission|
 end
 
 Then /^I should not see the user role field$/ do
-  assert has_no_css?('fieldset:contains("Role")')
+  refute has_xpath?("//fieldset[text()[contains(.,'Role')]]")
 end
 
 Then /^I should see "([^\"]*)" for (user "[^\"]*")$/ do |text, user|


### PR DESCRIPTION
Fix all cukes for `features/old/buyers/users.feature`. It works for the current master branch as well.
In `PF3-Login-Page` branch, it relies on the `@javascript` tag to work anyway 😄 