### PR TITLE
[Cukes] Fix feature public site access

### DIFF
--- a/features/old/public_site_access.feature
+++ b/features/old/public_site_access.feature
@@ -20,15 +20,6 @@ Feature: Public site access
     When I follow "Admin" in the user widget
     Then the current domain should be the master domain
 
-  #@javascript
-  Scenario: View Site takes to the public side
-    Given I log in as "foo.example.com" on the admin domain of provider "foo.example.com"
-    When I navigate to the accounts page
-     And I follow "Portal" within the main menu
-     And I follow "Visit Portal"
-    Then the current domain should be foo.example.com
-     And I should be on the homepage
-
   @wip
   Scenario: View site on a non-standard port
     Given current domain is the admin domain of provider "foo.example.com"
@@ -42,7 +33,7 @@ Feature: Public site access
     Given provider "foo.example.com" has site access code "foobar"
       And current domain is the admin domain of provider "foo.example.com"
      When I log in as provider "foo.example.com"
-      And I navigate to the accounts page
+      And I follow "Developer Portal"
       And I follow "Visit Portal"
      Then the current domain should be foo.example.com
       And I should not see field "Access code"

--- a/features/step_definitions/url_steps.rb
+++ b/features/step_definitions/url_steps.rb
@@ -24,6 +24,7 @@ When /^current domain is the admin domain of (provider "[^"]*")$/ do |provider|
 end
 
 Then /^the current domain should(?: still)? be ([^\s]+)$/ do |domain|
+  page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
   uri = URI.parse(current_url)
   assert_equal domain, uri.host
 end

--- a/test/functional/developer_portal/access_codes_controller_test.rb
+++ b/test/functional/developer_portal/access_codes_controller_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class DeveloperPortal::AccessCodesControllerTest < ActionController::TestCase
-end


### PR DESCRIPTION
Fix features from `features/old/public_site_access.feature` by removing moving to a new wingow due to the `target: "_blank"`
Remove empty test
Remove redundant cucumber scenario