### PR TITLE
[Cukes] Fix steps that require accepting alerts

### DIFF
--- a/features/old/accounts/invitations.feature
+++ b/features/old/accounts/invitations.feature
@@ -103,7 +103,7 @@ Feature: Invitations
     And current domain is the admin domain of provider "foo.example.com"
     When I log in as provider "foo.example.com"
     And I go to the provider sent invitations page
-    And I press "Delete" for an invitation from account "foo.example.com" for "alice@foo.example.com"
+    And I press "Delete" for an invitation from account "foo.example.com" for "alice@foo.example.com" and I confirm dialog box
     Then I should not see invitation for "alice@foo.example.com"
 
   Scenario: Managing sent invitations disabled when multiple_users switch denied

--- a/features/old/api/metrics/deletion.feature
+++ b/features/old/api/metrics/deletion.feature
@@ -13,7 +13,7 @@ Feature: Metric deletion
     When I log in as provider "foo.example.com"
     And I go to the service definition page
     And I follow "transfer"
-    And I press "Delete"
+    And I press "Delete" and I confirm dialog box
     Then I should not see metric "transfer"
     And provider "foo.example.com" should not have metric "transfer"
 

--- a/features/old/buyers/invitations/for_admins.feature
+++ b/features/old/buyers/invitations/for_admins.feature
@@ -51,7 +51,7 @@ Feature: Invitations on partner accounts for admins
   Scenario: Destroying invitations
     Given an invitation sent to "alice@lolcats.com" to join account "lol cats"
     When I navigate to the page of the invitations of the partner "lol cats"
-      And I delete the invitation for "alice@lolcats.com"
+    And I press "Delete" for an invitation from account "lol cats" for "alice@lolcats.com" and I confirm dialog box
     Then I should not see invitation for "alice@lolcats.com"
 
 

--- a/features/old/cms/groups.feature
+++ b/features/old/cms/groups.feature
@@ -22,5 +22,5 @@ Feature: CMS groups
       Then I should be on the groups page
        And I should see "le java enterprisers"
 
-      When I follow "Delete"
+      When I follow "Delete" and I confirm dialog box
       Then I should see "Group deleted"

--- a/features/old/services/subscriptions/bulk_operations/change_states.feature
+++ b/features/old/services/subscriptions/bulk_operations/change_states.feature
@@ -29,8 +29,7 @@ Feature: Bulk operations
 
     Then I should see "Accept, suspend or resume selected subscriptions"
 
-    When I select "Accept" from "Action"
-     And I will confirm dialog box
+    When I select "Accept" from "Action" and I confirm dialog box
      And I press "Change state" within fancybox
 
     Then I should see "Action completed successfully"
@@ -52,8 +51,7 @@ Feature: Bulk operations
 
     Then I should see "Accept, suspend or resume selected subscriptions"
 
-    When I select "Suspend" from "Action"
-     And I will confirm dialog box
+    When I select "Suspend" from "Action" and I confirm dialog box
      And I press "Change state" within fancybox
 
     Then I should see "Action completed successfully"
@@ -75,8 +73,7 @@ Feature: Bulk operations
 
     Then I should see "Accept, suspend or resume selected subscriptions"
 
-    When I select "Resume" from "Action"
-     And I will confirm dialog box
+    When I select "Resume" from "Action" and I confirm dialog box
      And I press "Change state" within fancybox
 
     Then I should see "Action completed successfully"

--- a/features/step_definitions/confirm_dialog_steps.rb
+++ b/features/step_definitions/confirm_dialog_steps.rb
@@ -1,8 +1,3 @@
-When 'I will confirm dialog box' do
-  warn Cucumber::Term::ANSIColor.red('DEPRECATION WARNING: "I will confirm dialog box" step is deprecated. Please use "(step) and I confirm dialog box"')
-  bypass_confirm_dialog
-end
-
 Then /^(.+) and I confirm dialog box(?: "(.*)")?$/ do |original, text|
   if [:webkit, :selenium, :webkit_debug, :headless_chrome, :chrome, :headless_firefox, :firefox].include? Capybara.current_driver
     accept_confirm(text) do

--- a/features/step_definitions/invitations_steps.rb
+++ b/features/step_definitions/invitations_steps.rb
@@ -37,11 +37,6 @@ When(/^I press "([^"]*)" for an invitation from (account "[^"]*") for "([^"]*)"$
   step %(I follow "#{label}" within "##{dom_id(invitation)}")
 end
 
-When(/^I delete the invitation for "([^\"]*)"$/) do |address|
-  invitation = Invitation.find_by_email!(address)
-  step %(I follow "Delete" within "##{dom_id(invitation)}")
-end
-
 When(/^I resend the invitation to "([^\"]*)"$/) do |email|
   # these ivars are preparing for the expectation steps that follow
   invitation = Invitation.find_by_email email


### PR DESCRIPTION
Fixes the following scenarios:

![image](https://user-images.githubusercontent.com/11318903/59036125-fdf54300-886e-11e9-85d2-469557db1012.png)

![image](https://user-images.githubusercontent.com/11318903/59038712-c5a43380-8873-11e9-9b99-130678987ce7.png)

![image](https://user-images.githubusercontent.com/11318903/59038768-e076a800-8873-11e9-8e8b-6cf2fee9a8ba.png)

![image](https://user-images.githubusercontent.com/11318903/59038816-eec4c400-8873-11e9-94ce-71d07eae79b8.png)

And for `features/old/cms/groups.feature:26`:
![image](https://user-images.githubusercontent.com/11318903/59038900-0ef48300-8874-11e9-829a-2032dd25de4f.png)





