### PR TITLE
Give stripe elements form less width so submit button sits at right edge

### DIFF
--- a/app/views/payment_gateways/_stripe_elements.html.erb
+++ b/app/views/payment_gateways/_stripe_elements.html.erb
@@ -18,7 +18,7 @@
 
     <fieldset>
       <legend>Credit card details </legend>
-      <div id="card-element">
+      <div id="card-element col-md-10">
         <!-- a Stripe Element will be inserted here. -->
       </div>
 
@@ -139,4 +139,3 @@
     });
 
 </script>
-


### PR DESCRIPTION
stripe elements form is taking more width than it should. This pr fixes that.