### PR TITLE
Moving Login Providers to bottom

### DIFF
--- a/app/javascript/src/LoginPage/LoginPageWrapper.jsx
+++ b/app/javascript/src/LoginPage/LoginPageWrapper.jsx
@@ -78,20 +78,17 @@ class SimpleLoginPage extends React.Component<Props, State> {
     const enforceSSO = this.props.enforceSSO
     return (
       <React.Fragment>
-        { hasAuthenticationProviders &&
-          <AuthenticationProviders
-            authenticationProviders={this.props.authenticationProviders}
-          />
-        }
-        { (hasAuthenticationProviders && !enforceSSO) &&
-          <div className='providers-separator'>
-            {'or sign in with your 3scale credentials:'}
-          </div>
-        }
         { !enforceSSO &&
             <Login3scaleForm
               providerSessionsPath={this.props.providerSessionsPath}
             />
+        }
+        { hasAuthenticationProviders &&
+          <div className='providers-separator'>
+            <AuthenticationProviders
+              authenticationProviders={this.props.authenticationProviders}
+            />
+          </div>
         }
       </React.Fragment>
     )

--- a/app/javascript/src/LoginPage/assets/styles/loginPage.scss
+++ b/app/javascript/src/LoginPage/assets/styles/loginPage.scss
@@ -12,14 +12,17 @@ $--pf-global--info-color--200:	#004368;
     font-family: 'Open Sans';
   }
 
-  a.authentication-link:hover {
-    text-decoration: none;
+  .login-provider {
+    padding: 0.3rem 0;
+
+    .login-provider-link:hover {
+      text-decoration: none;
+    }
   }
 
+
   .providers-separator {
-    color: $pf-black-500;
-    border-bottom: 1px solid $pf-black-500;
-    margin: 2rem 0;
+    margin-top: 1rem;
     text-align: center;
   }
 

--- a/app/javascript/src/LoginPage/loginForms/AuthenticationProviders.jsx
+++ b/app/javascript/src/LoginPage/loginForms/AuthenticationProviders.jsx
@@ -1,8 +1,6 @@
 // @flow
 
 import React from 'react'
-
-import { Card, CardBody } from '@patternfly/react-core'
 import { KeyIcon, LessThanIcon, GreaterThanIcon } from '@patternfly/react-icons'
 
 type ProvidersProps = {
@@ -16,14 +14,12 @@ type Props = {
 
 const Provider = ({authorizeURL, humanKind}: {authorizeURL: string, humanKind: string}) => {
   return (
-    <Card>
-      <CardBody>
-        <a className='authentication-link' href={authorizeURL}>
-          <KeyIcon/>{' Authenticate through '}
-          <LessThanIcon/><GreaterThanIcon/>{humanKind}
-        </a>
-      </CardBody>
-    </Card>
+    <p className='login-provider'>
+      <a className='login-provider-link' href={authorizeURL}>
+        <KeyIcon/>{' Authenticate through '}
+        <LessThanIcon/><GreaterThanIcon/>{humanKind}
+      </a>
+    </p>
   )
 }
 
@@ -35,7 +31,6 @@ const AuthenticationProviders = (props: Props) => {
 
   return (
     <React.Fragment>
-      <h3>Please use your single sign-on LDAP credentials</h3>
       <div className='providers-list'>
         {providersList}
       </div>

--- a/spec/javascripts/LoginPage/AuthenticationProviders.spec.jsx
+++ b/spec/javascripts/LoginPage/AuthenticationProviders.spec.jsx
@@ -22,9 +22,12 @@ const props = {
 it('should render itself', () => {
   const wrapper = mount(<AuthenticationProviders {...props} />)
   expect(wrapper.find('.providers-list').exists()).toEqual(true)
-  expect(wrapper.find('.authentication-link').length).toEqual(2)
-  expect(wrapper.find('.authentication-link').first().props().href).toEqual('fake-provider-1')
-  expect(wrapper.find('.authentication-link').first().contains('Fake human kind 1')).toEqual(true)
-  expect(wrapper.find('.authentication-link').last().props().href).toEqual('fake-provider-2')
-  expect(wrapper.find('.authentication-link').last().contains('Fake human kind 2')).toEqual(true)
+  expect(wrapper.find('.login-provider').length).toEqual(2)
+  expect(wrapper.find('.login-provider-link').length).toEqual(2)
+
+  expect(wrapper.find('.login-provider-link').first().props().href).toEqual('fake-provider-1')
+  expect(wrapper.find('.login-provider-link').first().contains('Fake human kind 1')).toEqual(true)
+
+  expect(wrapper.find('.login-provider-link').last().props().href).toEqual('fake-provider-2')
+  expect(wrapper.find('.login-provider-link').last().contains('Fake human kind 2')).toEqual(true)
 })


### PR DESCRIPTION
Moving Login Providers to bottom, for https://github.com/3scale/porta/pull/761