### PR TITLE
Add mysql2 ld flags instructions in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -148,6 +148,20 @@ Run [Bundler](https://bundler.io/) to install all required Ruby gems:
 bundle install
 ```
 
+If the `mysql2` gem installation fail with the error:
+
+```
+ld: library not found for -lssl
+```
+
+you can fix it setting the flags:
+
+```shell
+bundle config --local build.mysql2 "--with-ldflags=-L/usr/local/opt/openssl/lib --with-cppflags=-I/usr/local/opt/openssl/include"
+```
+
+and run `bundle install` again.
+
 #### NPM
 
 Run [NPM](https://www.npmjs.com/) to install all the required Node modules:
@@ -175,6 +189,6 @@ bundle exec rake db:reset # This will drop and setup the database
 ### Run Porta
 Start up the rails server by running the following command:
 ```bash
-$ UNICORN_WORKERS=2 rails server -b 0.0.0.0 # Runs the server, available at localhost:3000
+$ env UNICORN_WORKERS=2 rails server -b 0.0.0.0 # Runs the server, available at localhost:3000
 ```
 > The number of unicorn workers is variable and sometimes it will need more than 2. In case the server is slow or start suffering from timeouts, try restarting porta with a higher number like 8.


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes the mysql2 gem installation fails with an error telling that
the library was not found for linking. This commit adds the instruction
to configure it for bundler.

It also modifies the `Run Porta` instruction to use `env` to set the
`UNICORN_WORKERS` environment variable allowing it to works fine in
fish shell along with bash and zsh.
