### PR TITLE
Deprecate Adyen payment gateway

### DIFF
--- a/app/models/payment_gateway.rb
+++ b/app/models/payment_gateway.rb
@@ -15,7 +15,7 @@ class PaymentGateway
     PaymentGateway.new(:braintree_blue, public_key: 'Public Key', merchant_id: 'Merchant ID', private_key: 'Private Key'),
     PaymentGateway.new(:ogone, deprecated: true, login: 'PSPID', password: 'Password', user: 'User Id', signature: "SHA-IN Pass phrase", signature_out: "SHA-OUT Pass phrase"),
     PaymentGateway.new(:stripe, login: "Secret Key", publishable_key: "Publishable Key"),
-    PaymentGateway.new(:adyen12, login: 'Login', password: 'Secret Password', public_key: "Client Encryption Public Key", merchantAccount: 'Merchant ID', encryption_js_url: "Library location")
+    PaymentGateway.new(:adyen12, deprecated: true, login: 'Login', password: 'Secret Password', public_key: "Client Encryption Public Key", merchantAccount: 'Merchant ID', encryption_js_url: "Library location")
   ].freeze
 
   def self.bogus_enabled?

--- a/features/step_definitions/credit_card_steps.rb
+++ b/features/step_definitions/credit_card_steps.rb
@@ -49,7 +49,7 @@ Given /^(provider "[^"]*") manages payments with "([^"]*)"$/ do |provider, payme
 end
 
 Given /^the provider has unconfigured payment gateway$/ do
-  @provider.payment_gateway_type = 'adyen12'
+  @provider.payment_gateway_type = 'stripe'
   @provider.payment_gateway_options = { login: '3Scale'}
   @provider.save!
 end

--- a/test/functional/developer_portal/admin/account/adyen12_controller_test.rb
+++ b/test/functional/developer_portal/admin/account/adyen12_controller_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class DeveloperPortal::Admin::Account::Adyen12ControllerTest < DeveloperPortal::AbstractPaymentGatewaysControllerTest
+class DeveloperPortal::Admin::Account::Adyen12ControllerTest < DeveloperPortal::DeprecatedPaymentGatewaysControllerTest
   include ActiveMerchantTestHelpers
   include ActiveMerchantTestHelpers::Adyen12
 

--- a/test/functional/finance/provider/settings_controller_test.rb
+++ b/test/functional/finance/provider/settings_controller_test.rb
@@ -49,7 +49,7 @@ class Finance::Provider::SettingsControllerTest < ActionController::TestCase
 
       values = page.xpath(".//select[@id='account_payment_gateway_type']/*").map { |o| o['value'] }
 
-      assert_equal(['', 'braintree_blue', 'stripe', 'adyen12', 'bogus'], values)
+      assert_equal(['', 'braintree_blue', 'stripe', 'bogus'], values)
     end
 
     should 'contain deprectaed gateway if in use' do
@@ -64,7 +64,7 @@ class Finance::Provider::SettingsControllerTest < ActionController::TestCase
 
       values = page.xpath(".//select[@id='account_payment_gateway_type']/*").map { |o| o['value'] }
 
-      assert_same_elements(['', 'braintree_blue', 'ogone', 'stripe', 'adyen12', 'bogus'], values)
+      assert_same_elements(['', 'braintree_blue', 'ogone', 'stripe', 'bogus'], values)
     end
   end # gateway options
 end

--- a/test/helpers/payment_details_helper_test.rb
+++ b/test/helpers/payment_details_helper_test.rb
@@ -2,12 +2,12 @@ require 'test_helper'
 
 class PaymentDetailsHelperTest < DeveloperPortal::ActionView::TestCase
   test '#payment_details_path' do
-    account = Account.new(payment_gateway_type: :adyen12)
-    assert_equal '/admin/account/adyen12?foo=bar&hello=world', payment_details_path(account, {foo: 'bar', hello: 'world'})
+    account = Account.new(payment_gateway_type: :stripe)
+    assert_equal '/admin/account/stripe?foo=bar&hello=world', payment_details_path(account, {foo: 'bar', hello: 'world'})
   end
 
   test '#edit_payment_details_path' do
-    account = Account.new(payment_gateway_type: :adyen12)
-    assert_equal "#{@request.scheme}://#{@request.host}/admin/account/adyen12/edit", edit_payment_details(account)
+    account = Account.new(payment_gateway_type: :stripe)
+    assert_equal "#{@request.scheme}://#{@request.host}/admin/account/stripe/edit", edit_payment_details(account)
   end
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Deprecate Adyen payment gateway and remove the option for choosing it in Billing Settings page. It will continue active for accounts already using it but they won't be able to switch back if they change it.

Update Account Management API to remove Adyen references.

**Which issue(s) this PR fixes** 

Closes [THREESCALE-2769](https://issues.jboss.org/browse/THREESCALE-2769)

**Verification steps** 

1. Access the Admin Portal with a Provider that has `Adyen` configured as the payment gateway. 
2. It should keep `Adyen` as the provider's gateway but alert it with a deprecated message:

![image](https://user-images.githubusercontent.com/771411/59459772-fea05300-8df3-11e9-8424-de0bd78d93c7.png)

3. Change the gateway to another one and hit `Save Changes`. 
4. It should change the provider's gateway and don't list `Adyen` in the list.

![image](https://user-images.githubusercontent.com/771411/59459878-3a3b1d00-8df4-11e9-80b9-6dc2e29ece3b.png)
