### PR TITLE
[Cukes] Follow 'Analytics' within the subsubmenu

### DIFF
--- a/features/provider/applications/stats.feature
+++ b/features/provider/applications/stats.feature
@@ -6,5 +6,5 @@ Feature: Application Stats
 
   Scenario: Stats access
     Given I'm on that application page
-    When I follow "Analytics"
+    When I follow "Analytics" within the subsubmenu
     Then I should see that application stats

--- a/features/support/selectors.rb
+++ b/features/support/selectors.rb
@@ -16,7 +16,7 @@ module HtmlSelectorsHelper
     when 'the first api dashboard widget'
       "#service_#{provider_first_service!.id}"
     when 'the subsubmenu'
-      '.secondary-nav-item-pf.active'
+      '.subsubmenu'
     when 'the user widget'
       '#user_widget'
     when 'the footer'


### PR DESCRIPTION
It tries to follow a link of Analytics but there are 2. This PR clarifies which one but also fixes the selector of the subsubmenu.