### PR TITLE
Include Postgres schema dumping into make schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ C:\\nppdf32Log\\debuglog.txt
 .zeus.sock
 .deploy
 .s3cfg
+.tool-versions
 
 # Bundler Stuff
 .bundle

--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,11 @@ oracle-db-setup: oracle-database
 	MASTER_PASSWORD=p USER_PASSWORD=p ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" bundle exec rake db:drop db:create db:setup
 
 schema: ## Runs db schema migrations. Run this when you have changes to your database schema that you have added as new migrations.
+schema: POSTGRES_DATABASE_URL ?= "postgresql://postgres:@localhost:5433/3scale_system_development"
+schema:
 	bundle exec rake db:migrate db:schema:dump
 	MASTER_PASSWORD=p USER_PASSWORD=p ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" bundle exec rake db:migrate db:schema:dump
+	DATABASE_URL=$(POSTGRES_DATABASE_URL) bundle exec rake db:migrate
 
 oracle-database: ## Starts Oracle database container
 oracle-database: ORACLE_DATA_DIR ?= $(HOME)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

After making some change in the database we need to regenerate the
schema for Postgres. This changes the `make schema` command to
accept a env var `POSTGRES_DATABASE_URL` and uses it to migrate
the database and updates the schema after the migration

**Verification steps** 
Start your postgres database and create the data.

to simulate a non-executed migration in postgres you can run:
`DATABASE_URL="YOUR_PG_URL" bundle exec rake db:rollback db:schema:dump`

the db/postgres_schema.rb should have been changed with some columns being removed.

Now you can run `POSTGRES_DATABASE_URL="YOUR_PG_URL" make schema` (it will run the migration and redump the schema) and your
db/postgres_schema.rb should have no difference (it will be the same as git since we regenerated the schema)
