### PR TITLE
Does not send request to segment if disabled

### DIFF
--- a/app/lib/three_scale/analytics/user_tracking.rb
+++ b/app/lib/three_scale/analytics/user_tracking.rb
@@ -14,7 +14,7 @@ module ThreeScale
 
       class TrackingAdapter
         DELEGATED_METHODS = %i(flush track identify group).freeze
-        delegate(*DELEGATED_METHODS, to: :@adapter)
+        delegate(*DELEGATED_METHODS, to: :adapter)
 
         class NullAdapter
           def with_options(*)
@@ -31,11 +31,19 @@ module ThreeScale
         end
 
         def segment_configured?
-          defined?(::Segment)
+          config.enabled && defined?(::Segment)
         end
 
         def initialize(config = {})
-          @adapter = segment_configured? ? ::Segment::Analytics.new(config) : NullAdapter.new
+          @config = config
+        end
+
+        private
+
+        attr_reader :config
+
+        def adapter
+          @adapter ||= segment_configured? ? ::Segment::Analytics.new(config) : NullAdapter.new
         end
       end
 

--- a/test/unit/three_scale/analytics/user_tracking_test.rb
+++ b/test/unit/three_scale/analytics/user_tracking_test.rb
@@ -8,125 +8,178 @@ class ThreeScale::Analytics::UserTrackingTest < ActiveSupport::TestCase
     @user = FactoryBot.build_stubbed(:user, account: account, email: 'foo@example.net')
   end
 
-  def test_track_uses_segment
-    UserTracking::Segment.expects(:track).once
-    UserTracking.new(@user).track('foo')
+  def teardown
+    clean_segment_adapter
   end
 
-  def test_identify_uses_segment
-    UserTracking::Segment.expects(:identify).once
-    UserTracking.new(@user).identify(trait: 'value')
-  end
+  class SegmentEnabled < UserTrackingTest
+    def setup
+      super
+      System::Application.config.three_scale.segment.stubs(enabled: true)
+    end
 
-  def test_flush_uses_segment
-    UserTracking::Segment.expects(:flush).with().once
-    UserTracking.new(@user).flush
-  end
+    test 'track uses segment' do
+      UserTracking::Segment.expects(:track).once
+      UserTracking.new(@user).track('foo')
+    end
 
-  def test_group_uses_segment
-    UserTracking::Segment.expects(:group).once
-    UserTracking.new(@user).group
-  end
+    test 'identify uses segment' do
+      UserTracking::Segment.expects(:identify).once
+      UserTracking.new(@user).identify(trait: 'value')
+    end
 
-  def test_experiment
-    tracking = UserTracking.new(@user)
+    test 'flush uses segment' do
+      UserTracking::Segment.expects(:flush).once
+      UserTracking.new(@user).flush
+    end
 
-    UserTracking::Segment.expects(:identify)
-        .with(has_entry(traits: has_entry('Experiment: Some Name' => 'variant')))
-    UserTracking::Segment.expects(:track)
-        .with(has_entry(properties: { variation: 'variant'}))
+    test 'group uses segment' do
+      UserTracking::Segment.expects(:group).once
+      UserTracking.new(@user).group
+    end
 
-    tracking.experiment('Some Name', 'variant')
-  end
+    test 'experiment tracks and identify' do
+      tracking = UserTracking.new(@user)
 
-  def test_with_options
-    tracking = UserTracking.new(@user)
+      UserTracking::Segment.expects(:identify)
+          .with(has_entry(traits: has_entry('Experiment: Some Name' => 'variant')))
+      UserTracking::Segment.expects(:track)
+          .with(has_entry(properties: { variation: 'variant'}))
 
-    timestamp = 1.hour.from_now
+      tracking.experiment('Some Name', 'variant')
+    end
 
-    seq = sequence('segment')
+    test 'with options' do
+      tracking = UserTracking.new(@user)
 
-    UserTracking::Segment.expects(:identify).in_sequence(seq).with(has_entry(timestamp: timestamp))
+      timestamp = 1.hour.from_now
 
-    UserTracking::Segment.expects(:identify).in_sequence(seq).with(Not(has_key(:timestamp)))
+      seq = sequence('segment')
 
-    tracking.with_segment_options(timestamp: timestamp) do
+      UserTracking::Segment.expects(:identify).in_sequence(seq).with(has_entry(timestamp: timestamp))
+
+      UserTracking::Segment.expects(:identify).in_sequence(seq).with(Not(has_key(:timestamp)))
+
+      tracking.with_segment_options(timestamp: timestamp) do
+        tracking.identify
+      end
+
       tracking.identify
     end
 
-    tracking.identify
+    test 'basic traits' do
+      traits = UserTracking.new(nil).basic_traits
+      assert_equal Hash.new, traits
+
+      traits = UserTracking.new(@user).basic_traits
+
+      assert_equal traits.slice(:email), email: @user.email
+    end
+
+    test 'identify' do
+      tracking = UserTracking.new(nil)
+      refute tracking.identify
+
+      tracking = UserTracking.new(@user)
+      assert tracking.identify
+
+      @user.account.provider = false
+      refute tracking.identify
+    end
+
+    test 'track' do
+      tracking = UserTracking.new(nil)
+      refute tracking.track('Event')
+
+      tracking = UserTracking.new(@user)
+      assert tracking.track('Event')
+
+      @user.account.provider = false
+      refute tracking.track('Event')
+    end
+
+    test 'group' do
+      tracking = UserTracking.new(nil)
+      refute tracking.group
+
+      tracking = UserTracking.new(@user)
+      assert tracking.group
+
+      @user.account.provider = false
+      refute tracking.group
+    end
+
+    test 'group traits' do
+      tracking = UserTracking.new(nil)
+      assert_equal Hash.new, tracking.group_traits
+
+      tracking = UserTracking.new(@user)
+      @user.account.stubs(bought_plan: Plan.new(name: 'fooplan', cost_per_month: 42), state: 'suspended')
+
+      assert_equal({name: @user.account.name,
+                    plan: 'fooplan',
+                    monthly_spend: 42.0,
+                    license_mrr: 42.0,
+                    state: 'suspended',
+                   }, tracking.group_traits)
+    end
+
+    test 'can_send?' do
+      refute UserTracking.new(nil).can_send?
+      assert UserTracking.new(@user).can_send?
+    end
+
+    test 'only track providers' do
+      @user.account.provider = false
+      refute UserTracking.new(@user).can_send?
+    end
+
+    test 'do not track impersonation admins' do
+      @user.username = ThreeScale.config.impersonation_admin['username']
+      refute UserTracking.new(@user).can_send?
+    end
   end
 
-  def test_basic_traits
-    traits = UserTracking.new(nil).basic_traits
-    assert_equal Hash.new, traits
+  class SegmentDisabled < UserTrackingTest
+    def setup
+      super
+      System::Application.config.three_scale.segment.stubs(enabled: false)
+    end
 
-    traits = UserTracking.new(@user).basic_traits
+    test 'does not track' do
+      expect_not_contact_segment(:track)
 
-    assert_equal traits.slice(:email), email: @user.email
+      UserTracking.new(@user).track('foo')
+    end
+
+    test 'does not flush' do
+      expect_not_contact_segment(:flush)
+
+      UserTracking.new(@user).flush
+    end
+
+    test 'does not identify' do
+      expect_not_contact_segment(:identify)
+
+      UserTracking.new(@user).identify
+    end
+
+    test 'does not group' do
+      expect_not_contact_segment(:group)
+
+      UserTracking.new(@user).group
+    end
+
+    private
+
+    def expect_not_contact_segment(action_name)
+      UserTracking::TrackingAdapter::NullAdapter.any_instance.expects(action_name)
+    end
   end
 
-  def test_identify
-    tracking = UserTracking.new(nil)
-    refute tracking.identify
+  private
 
-    tracking = UserTracking.new(@user)
-    assert tracking.identify
-
-    @user.account.provider = false
-    refute tracking.identify
-  end
-
-
-  def test_track
-    tracking = UserTracking.new(nil)
-    refute tracking.track('Event')
-
-    tracking = UserTracking.new(@user)
-    assert tracking.track('Event')
-
-    @user.account.provider = false
-    refute tracking.track('Event')
-  end
-
-  def test_group
-    tracking = UserTracking.new(nil)
-    refute tracking.group
-
-    tracking = UserTracking.new(@user)
-    assert tracking.group
-
-    @user.account.provider = false
-    refute tracking.group
-  end
-
-  def test_group_traits
-    tracking = UserTracking.new(nil)
-    assert_equal Hash.new, tracking.group_traits
-
-    tracking = UserTracking.new(@user)
-    @user.account.stubs(bought_plan: Plan.new(name: 'fooplan', cost_per_month: 42), state: 'suspended')
-
-    assert_equal({name: @user.account.name,
-                  plan: 'fooplan',
-                  monthly_spend: 42.0,
-                  license_mrr: 42.0,
-                  state: 'suspended',
-                 }, tracking.group_traits)
-  end
-
-  def test_can_send?
-    refute UserTracking.new(nil).can_send?
-    assert UserTracking.new(@user).can_send?
-  end
-
-  def test_only_track_providers
-    @user.account.provider = false
-    refute UserTracking.new(@user).can_send?
-  end
-
-  def test_do_not_track_impersonation_admins
-    @user.username = ThreeScale.config.impersonation_admin['username']
-    refute UserTracking.new(@user).can_send?
+  def clean_segment_adapter
+    ThreeScale::Analytics::UserTracking::Segment.instance_variable_set(:@adapter, nil)
   end
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

3scale on-prem tries to send requests to segment.io and fails when it
is not reachable. This commit creates a section to toggle segment at
features.yml and it avoids sending requests to segment.io if it is
disabled.

**Which issue(s) this PR fixes** 

Closes [THREESCALE-2572](https://issues.jboss.org/browse/THREESCALE-2572)
