### PR TITLE
[wip] Fixes liquid tag do_not_send within control flow blocks

### DIFF
--- a/features/old/emails.feature
+++ b/features/old/emails.feature
@@ -45,3 +45,26 @@ Scenario: Disable 'Waiting list confirmation' notification
 
     When I act as "Kirill"
     Then I should receive no email with subject "Waiting list confirmation"
+
+  Scenario: Conditionally disable 'Waiting list confirmation' notification
+      Given a provider "foo.example.com" with default plans
+      And provider "foo.example.com" requires accounts to be approved
+      And provider "foo.example.com" has multiple applications enabled
+      And provider "foo.example.com" has email template "account_confirmed"
+      """
+      {% email %}{% if true %}{% do_not_send %}{% endif %}{% endemail %}
+      Dear More Things,
+
+      This email is to let you know that you own even more things.
+      """
+
+      When the current domain is foo.example.com
+      And I go to the sign up page
+      And I fill in the signup fields as "Kirill"
+      Then I should see the registration succeeded
+
+      When I follow the activation link in an email sent to "Kirill@example.com"
+      Then I should see "once your account is approved"
+
+      When I act as "Kirill"
+      Then I should receive no email with subject "Waiting list confirmation"

--- a/lib/developer_portal/config/initializers/liquid.rb
+++ b/lib/developer_portal/config/initializers/liquid.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'liquid'
 require 'liquid/url_helper_hacks'
+require 'liquid/backtracking_liquid_parsing'
 
 
 # allow calling present? in {% if %}

--- a/lib/developer_portal/lib/liquid/backtracking_liquid_parsing.rb
+++ b/lib/developer_portal/lib/liquid/backtracking_liquid_parsing.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Liquid
+  module BacktrackingLiquidParsing
+    module TagExtension
+      def self.prepended(_klass)
+        attr_accessor :previous_tag
+      end
+
+      module ClassMethods
+        def parse(tag_name, markup, tokens, options, previous_tag = nil)
+          tag = new(tag_name, markup, options)
+          tag.previous_tag = previous_tag
+          tag.parse(tokens)
+          tag
+        end
+      end
+    end
+
+    module BlockExtension
+      def parse(tokens)
+        @blank = true
+        @nodelist ||= []
+        @nodelist.clear
+
+        while token = tokens.shift
+          begin
+            unless token.empty?
+              case
+              when token.start_with?(Liquid::Block::TAGSTART)
+                if token =~ Liquid::Block::FullToken
+
+                  # if we found the proper block delimiter just end parsing here and let the outer block
+                  # proceed
+                  return if block_delimiter == $1
+
+                  # fetch the tag from registered blocks
+                  if tag = Liquid::Template.tags[$1]
+                    markup = token.is_a?(Liquid::Token) ? token.child($2) : $2
+                    new_tag = tag.parse($1, markup, tokens, @options, self)
+                    new_tag.line_number = token.line_number if token.is_a?(Liquid::Token)
+                    @blank &&= new_tag.blank?
+                    @nodelist << new_tag
+                  else
+                    # this tag is not registered with the system
+                    # pass it to the current block for special handling or error reporting
+                    unknown_tag($1, $2, tokens)
+                  end
+                else
+                  raise Liquid::SyntaxError.new(options[:locale].t("errors.syntax.tag_termination".freeze, :token => token, :tag_end => Liquid::TagEnd.inspect))
+                end
+              when token.start_with?(Liquid::Block::VARSTART)
+                new_var = create_variable(token)
+                new_var.line_number = token.line_number if token.is_a?(Liquid::Token)
+                @nodelist << new_var
+                @blank = false
+              else
+                @nodelist << token
+                @blank &&= (token =~ /\A\s*\z/)
+              end
+            end
+          rescue Liquid::SyntaxError => e
+            e.set_line_number_from_token(token)
+            raise
+          end
+        end
+
+        # Make sure that it's ok to end parsing in the current block.
+        # Effectively this method will throw an exception unless the current block is
+        # of type Document
+        assert_missing_delimitation!
+      end
+    end
+  end
+end
+
+Liquid::Tag.singleton_class.prepend Liquid::BacktrackingLiquidParsing::TagExtension::ClassMethods
+Liquid::Tag.prepend Liquid::BacktrackingLiquidParsing::TagExtension
+Liquid::Block.prepend Liquid::BacktrackingLiquidParsing::BlockExtension

--- a/lib/developer_portal/lib/liquid/tags/email.rb
+++ b/lib/developer_portal/lib/liquid/tags/email.rb
@@ -68,31 +68,6 @@ module Liquid::Tags
 
     private
 
-    def unknown_tag(name, params, tokens)
-      if name == 'do_not_send'
-        @do_not_send = true
-      else
-        case params =~ AssignSyntax && name
-          # when there are two arguments - $1 is first and $2 is second
-          # when there is just one - it is $2
-        when 'subject'
-          @subject = unquote($2)
-        when 'header'
-          @headers[unquote($1)] = unquote($2)
-        when 'bcc'
-          @bcc = unquote_array( params.scan(AssignSyntax) )
-        when 'cc'
-          @cc = unquote_array( params.scan(AssignSyntax) )
-        when 'reply_to', 'reply-to'
-          @reply_to = unquote($2)
-        when 'from'
-          @from = unquote($2)
-        else
-          super
-        end
-      end
-    end
-
     # removes leading and trailing ' or "
     def unquote(content)
       content =~ QuotedFragmentContent and $1
@@ -143,5 +118,33 @@ module Liquid::Tags
       mail.headers @headers
     end
 
+    module UnknownEmailTag
+      def unknown_tag(tag, params, tokens)
+        if tag == 'do_not_send'
+          @do_not_send = true
+        else
+          case params =~ AssignSyntax && tag
+            # when there are two arguments - $1 is first and $2 is second
+            # when there is just one - it is $2
+          when 'subject'
+            @subject = unquote($2)
+          when 'header'
+            @headers[unquote($1)] = unquote($2)
+          when 'bcc'
+            @bcc = unquote_array( params.scan(AssignSyntax) )
+          when 'cc'
+            @cc = unquote_array( params.scan(AssignSyntax) )
+          when 'reply_to', 'reply-to'
+            @reply_to = unquote($2)
+          when 'from'
+            @from = unquote($2)
+          else
+            super
+          end
+        end
+      end
+    end
+
+    self.superclass.prepend Liquid::Tags::Email::UnknownEmailTag
   end
 end

--- a/test/unit/liquid/tags/email_test.rb
+++ b/test/unit/liquid/tags/email_test.rb
@@ -32,6 +32,12 @@ class Liquid::Tags::EmailTest < ActiveSupport::TestCase
     assert_equal '', @email.render(context)
   end
 
+  test "do_not_send within control flow blocks" do
+    context = stub(:registers => {})
+    subject.parse('email', '', ['{% if true %}', '{% do_not_send %}', '{% endif %}', @end], {})
+    assert_equal '', @email.render(context)
+  end
+
   test "assign all tags to message" do
     message = stub_everything('message')
     headers = stub_everything('headers')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It injects the fallback for unknown liquid tags of the custom-defined `Liquid::Tags::Email` into its superclass `Liquid::Block`.

Even though those email tags (`header`, `bcc`, `do_not_send`, etc) are meant to be used only within the scope of an `email...endemail` block, missing them in the uper level implicates control flow blocks not allowed to be used within the email block. Furthermore, having the email tags known in `Liquid::Block` is currently a no-op if used other than within an `email...endemail` block.

### Examples

Without this PR, the following liquid template fails:

```
{% email %}
  {% if true %}
    {% do_not_send %}
  {% endif %}
{% endemail %}
```

while the following succeeds:

```
{% if true %}
  {% email %}
    {% do_not_send %}
  {% endemail %}
{% endif %}
```

With this PR, all the above succeeds and the following ones are no
no-op:

```
{% if true %}
  {% do_not_send %}
{% endif %}
```

```
{% do_not_send %}
```

**Which issue(s) this PR fixes** 

Closes [THREESCALE-2226](https://issues.jboss.org/browse/THREESCALE-2226)

**Verification steps** 

1. Choose an event type that would result in an email being sent to a buyer (e.g. charging an invoice).
2. Trigger the event and confirms that an email was sent to the buyer.
3. Edit the corresponding email template of the event chosen adding the following to the beginning of the template:
```
{% email %}
  {% if true %}
    {% do_not_send %}
  {% endif %}
{% endemail %}
```
4. Trigger again the corresponding event that previously resulted in the email being sent.
5. Confirm that this time the email was intercepted and not sent.