### PR TITLE
Running jest test with maxWorkers option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,7 +577,7 @@ jobs:
       - run:
           name: Jest specs
           command: |
-            npm run-script jest
+            npm run-script jest --maxWorkers=2
       - *upload-coverage
 
   unit:


### PR DESCRIPTION
This is needed for 2.6 ER1.
Jest tests were failing with
```
console.error node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/virtual-console.js:29
    Error: Uncaught [Error: ENOMEM: not enough memory, read]
```
This will prevent that memory over comsumption 