### PR TITLE
Adding IE11 styles

### DIFF
--- a/app/javascript/packs/LoginPage.js
+++ b/app/javascript/packs/LoginPage.js
@@ -1,5 +1,11 @@
 import '@babel/polyfill'
 import 'core-js/es7/object'
+
+const isIE11 = !!navigator.userAgent.match(/Trident\/7\./)
+if (isIE11) {
+    import('LoginPage/assets/styles/ie11-pf4BaseStyles.css')
+}
+
 import {LoginPageWrapper} from 'LoginPage'
 import {safeFromJsonString} from 'utilities/json-utils'
 
@@ -7,6 +13,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const oldLoginWrapper = document.getElementById('old-login-page-wrapper')
   oldLoginWrapper.removeChild(document.getElementById('old-login-page'))
   const loginPageContainer = document.getElementById('login-page-container')
+  if (isIE11) {
+    loginPageContainer.classList.add('isIe11', 'pf-c-page')
+  }
   const loginPageProps = safeFromJsonString(loginPageContainer.dataset.loginProps)
   LoginPageWrapper(loginPageProps, 'login-page-container')
 })

--- a/app/javascript/src/LoginPage/LoginPageWrapper.jsx
+++ b/app/javascript/src/LoginPage/LoginPageWrapper.jsx
@@ -99,13 +99,13 @@ class SimpleLoginPage extends React.Component<Props, State> {
   render (): Node {
     return (
       <LoginPage
-        footerListVariants='inline'
         brandImgSrc={brandImg}
         brandImgAlt='Red Hat 3scale API Management'
         backgroundImgSrc={PF4DownstreamBG}
         backgroundImgAlt='Red Hat 3scale API Management'
         loginTitle={this.state.loginTitle}
         forgotCredentials={this.showForgotCredentials()}
+        footer={null}
       >
         {
           this.props.flashMessages &&

--- a/app/javascript/src/LoginPage/assets/styles/ie11-pf4BaseStyles.css
+++ b/app/javascript/src/LoginPage/assets/styles/ie11-pf4BaseStyles.css
@@ -1,0 +1,233 @@
+@charset "UTF-8";
+
+a {
+    color: #0066CC;
+}
+
+.pf-c-background-image {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #151515;
+  text-rendering: optimizeLegibility;
+}
+
+.pf-c-background-image::before {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  content: "";
+  background-color: #151515;
+  background-image: url("../images/PF4DownstreamBG.svg");
+  -webkit-filter: url("#image_overlay");
+  filter: url("#image_overlay");
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.pf-c-login__header {
+  width: 40%;
+  float: right;
+}
+
+@media (max-width: 576px) {
+  .pf-c-login__header {
+    padding-right: 1rem;
+    padding-left: 1rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .pf-c-login__header {
+    margin-top: 4rem;
+  }
+}
+
+.pf-c-login__header .pf-c-brand {
+  margin-bottom: 3rem;
+}
+
+.pf-c-login__main {
+  background-color: #fff;
+}
+
+@media (max-width: 1200px) {
+  .pf-c-login__main {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.pf-c-login__main-header {
+  align-items: center;
+  padding: 3rem 3rem 1rem 3rem;
+}
+
+.pf-c-login__main-body {
+  padding-right: 3rem;
+  padding-bottom: 2rem;
+  padding-left: 3rem;
+}
+
+.pf-c-login__main-body .pf-c-form__helper-text {
+  display: flex;
+  align-items: center;
+}
+
+.pf-c-login__main-body .pf-c-form__helper-text .pf-c-form__helper-text-icon {
+  margin-right: 0.5rem;
+  font-size: 1.125rem;
+}
+
+.pf-c-login__main-footer-band {
+  padding: 1.5rem 1rem 1.5rem 1rem;
+  text-align: center;
+  background-color: #ededed;
+}
+
+.pf-c-login__main-footer-band>*+* {
+  padding-top: 1rem;
+}
+
+.pf-c-brand {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #151515;
+  text-rendering: optimizeLegibility;
+}
+
+.pf-c-title.pf-m-4xl {
+  font-size: 2.25rem;
+  font-weight: 400;
+  line-height: 1.3;
+}
+
+.pf-c-title.pf-m-3xl {
+  font-size: 1.75rem;
+  font-weight: 400;
+  line-height: 1.3;
+}
+
+.pf-c-title.pf-m-2xl {
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 1.3;
+}
+
+.pf-c-title.pf-m-xl {
+  font-size: 1.3125rem;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.pf-c-title.pf-m-lg {
+  font-size: 1.125rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.pf-c-title.pf-m-md {
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.pf-c-form {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #151515;
+  text-rendering: optimizeLegibility;
+}
+
+.pf-c-form-control {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #151515;
+  text-rendering: optimizeLegibility;
+}
+
+.pf-c-form__group.pf-m-action {
+  margin-top: 2rem;
+}
+
+.pf-c-form__group .pf-c-form__label {
+  padding-bottom: 0.5rem;
+}
+
+.pf-c-form__group .pf-c-form__helper-text {
+  margin-top: 0.25rem;
+}
+
+.pf-c-form__label {
+  display: inline-block;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.3;
+  color: #72767b;
+}
+
+.pf-c-form__label-required {
+  margin-left: 0.25rem;
+  font-size: 0.875rem;
+  line-height: 0;
+  color: #c9190b;
+}
+
+.pf-c-form__helper-text {
+  font-size: 0.875rem;
+}
+
+.pf-c-form__helper-text:not(.pf-m-error) {
+  color: #151515;
+}
+
+.pf-c-form__helper-text.pf-m-error {
+  color: #c9190b;
+}
+
+.pf-c-form__helper-text.pf-m-inactive {
+  display: none;
+  visibility: hidden;
+}
+
+.pf-c-form__helper-text.pf-m-hidden {
+  visibility: hidden;
+  opacity: 0;
+}
+
+.pf-c-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: calc(0.5rem * -1);
+  margin-right: calc(0.5rem * -1);
+  margin-bottom: calc(0.5rem * -1);
+  margin-left: calc(0.5rem * -1);
+  overflow: hidden;
+}
+
+.pf-c-form__actions>* {
+  margin-top: 0.5rem;
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+  margin-left: 0.5rem;
+}
+
+.pf-c-form-control {
+  color: #151515;
+  position: relative;
+  width: 100%;
+  padding: calc(0.375rem - 1px) 0.5rem calc(0.375rem - 1px) 0.5rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  background-color: #fff;
+  border: 1px solid;
+  border-color: #ededed #ededed #8b8d8f #ededed;
+  border-radius: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+}

--- a/app/javascript/src/LoginPage/assets/styles/loginPage.scss
+++ b/app/javascript/src/LoginPage/assets/styles/loginPage.scss
@@ -37,7 +37,6 @@ $--pf-global--info-color--200:	#004368;
     }
   }
 
-
   .providers-separator {
     margin-top: 1rem;
     text-align: center;
@@ -55,5 +54,57 @@ $--pf-global--info-color--200:	#004368;
 
   .pf-m-notice {
     color: $--pf-global--info-color--200;
+  }
+}
+
+/****** Override styles for IE 11  ******/
+.isIe11 {
+  .pf-c-login {
+    .pf-c-login__container {
+      display: block;
+      padding-right: 6.125rem;
+      padding-left: 6.125rem;
+      width: 90%;
+      padding: 10% 5%;
+
+      .pf-c-login__main {
+        display: block;
+        width: 45%;
+        float: left;
+
+        .pf-c-login__main-body {
+          .pf-c-form {
+            .pf-c-form__group {
+              .pf-c-form__actions {
+                .pf-c-button.pf-m-primary {
+                  background-color: #06c;
+                  border-radius: 3px;
+                  color: #fff;
+                  padding: 6px 16px;
+                }
+              }
+            }
+          }
+        }
+      }
+      .pf-c-login__header {
+        display: block;
+        width: 45%;
+        float: right;
+      }
+
+      @media (max-width: 768px) {
+        .pf-c-login__main {
+          display: block;
+          width: 100%;
+          float: left;
+        }
+        .pf-c-login__header {
+          display: block;
+          width: 100%;
+          float: left;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds styles for PF4 Login page in IE 11, copying some rules from PF4 Base Styles and overriding some others

**Screenshots:**
![VirtualBox_IE11 - Win81_18_06_2019_10_45_45](https://user-images.githubusercontent.com/13486237/59667055-5ead4580-91b6-11e9-8543-8a0caf56eaa0.png)
![VirtualBox_IE11 - Win81_18_06_2019_10_45_21](https://user-images.githubusercontent.com/13486237/59667060-61a83600-91b6-11e9-8557-19ee31e169ce.png)

