### PR TITLE
Add some padding to Header icons

### DIFF
--- a/app/assets/stylesheets/provider/_header.scss
+++ b/app/assets/stylesheets/provider/_header.scss
@@ -55,4 +55,12 @@ $master-ribbon-height: line-height-times(1);
   .pf-c-page__header-nav {
     align-self: center;
   }
+
+  .pf-c-page__header-tools {
+    text-align: center;
+    
+    i {
+      padding: line-height-times(1 / 2);
+    }
+  }
 }


### PR DESCRIPTION
By adding a padding the button has a wider clickable area.

Padding value of `line-height-times(1 / 2)` for a button's width of `line-height-times(3 / 2)`. Also aligns icons to the center.


![Screen Shot 2019-06-18 at 13 08 06](https://user-images.githubusercontent.com/11672286/59677436-231c7680-91ca-11e9-8ed4-dc5d1e2b5394.png)
