### PR TITLE
[Cukes] 2 minor improvements from 2.6: A scenario doesn't need JS + fix warning

### DIFF
--- a/features/old/accounts/service_contracts.feature
+++ b/features/old/accounts/service_contracts.feature
@@ -21,7 +21,6 @@ Feature: Account service plans management
     Given a buyer "bob" signed up to provider "foo.example.com"
     Given current domain is the admin domain of provider "foo.example.com"
 
-  @javascript
   Scenario: Link to service contracts on account page in enterprise
     Given I am logged in as provider "foo.example.com"
     When I am on the buyer account page for "bob"

--- a/features/step_definitions/services/service_contract_steps.rb
+++ b/features/step_definitions/services/service_contract_steps.rb
@@ -1,5 +1,5 @@
 Given /^the following buyers with service subscriptions signed up to (provider "[^"]*"):$/ do |provider, table|
-  # table is a Cucumber::Ast::Table
+  # table is a Cucumber::MultilineArgument::DataTable
   table.map_column!(:plans) { |plans| plans.from_sentence.map{ |plan| Plan.find_by_name!(plan) } }
   table.map_column!(:name) { |name| FactoryBot.create :buyer_account, :provider_account => provider, :org_name => name }
   table.map_headers! { |header| header.to_sym }

--- a/features/step_definitions/stats/provider_charts.rb
+++ b/features/step_definitions/stats/provider_charts.rb
@@ -7,7 +7,7 @@ Then(/^there should be a c3 chart with the following data:$/) do |table|
 
   table.map_column!('total', &:to_i)
   page.document.synchronize(Capybara.default_max_wait_time,
-                            errors: [Cucumber::Ast::Table::Different, Selenium::WebDriver::Error::JavascriptError]) do
+                            errors: [Cucumber::MultilineArgument::DataTable::Different, Selenium::WebDriver::Error::JavascriptError]) do
     values = page.evaluate_script <<-JS
       (function(){
         var $chart = $("#{chart_selector}")
@@ -25,7 +25,7 @@ Then(/^there should be a c3 chart with the following data:$/) do |table|
     raise Selenium::WebDriver::Error::JavascriptError, 'Could not get values from c3' if values.blank?
 
     data = Cucumber::Core::Ast::DataTable.new(values, table.location)
-    series = Cucumber::Ast::Table.new(data)
+    series = Cucumber::MultilineArgument::DataTable.new(data)
     series.map_column!('start', false) { |start| Time.at(start/1000) if start }
 
     table.dup.diff!(series)

--- a/features/support/alerts.rb
+++ b/features/support/alerts.rb
@@ -29,7 +29,7 @@ module Alerts
 
     data = Cucumber::Core::Ast::DataTable.new(table, nil)
 
-    table = Cucumber::Ast::Table.new data
+    table = Cucumber::MultilineArgument::DataTable.new data
 
     # two byte non breaking space :/
     nbsp = ' '


### PR DESCRIPTION
Originally this PR was opened to investigate and test for the `Net::ReadTimeout` randomly appearing in CircleCI for the provider login, but since that has been fixed in https://github.com/3scale/porta/pull/930, this PR now only contains 2 minor improvements that I encountered when I was dealing with that error:
1. One of the scenarios of the feature _service contracts_ doesn't need JS 😄 
2. Fix deprecation warning: Ast::Table -> MultilineArgument::DataTable