### PR TITLE
Fix ContextSelector position / alignment

### DIFF
--- a/app/assets/stylesheets/provider/_pop_navigation.scss
+++ b/app/assets/stylesheets/provider/_pop_navigation.scss
@@ -1,3 +1,5 @@
+$link-padding: line-height-times(1 / 2);
+
 .PopNavigation {
   color: $content-background;
 
@@ -35,7 +37,8 @@
     border: $border-width solid $border-color;
     border-radius: $border-radius;
     display: none;
-    margin: line-height-times(1 / 2, true) 0 0 0;
+    margin-top: line-height-times(3 / 2, true);
+    margin-left: calc(-#{$link-padding} + -#{$border-width});
     max-width: line-height-times(10);
     min-width: line-height-times(4);
     overflow: hidden;
@@ -77,7 +80,7 @@
   &-link {
     color: $font-color;
     display: block;
-    padding: line-height-times(1 / 2);
+    padding: $link-padding;
 
     &:hover {
       color: $link-color;


### PR DESCRIPTION
Moves `ContextSelector`'s dropdown menu down and also aligns icons vertically.

**Provider**
![context](https://user-images.githubusercontent.com/11672286/59700572-dd74a380-91f3-11e9-962c-0314bf7a2898.gif)

**Master**
![Screen Shot 2019-06-18 at 17 56 43](https://user-images.githubusercontent.com/11672286/59699782-74406080-91f2-11e9-99d1-64856bccf56e.png)

**Help menu**
![Screen Shot 2019-06-18 at 18 09 06](https://user-images.githubusercontent.com/11672286/59700698-2e849780-91f4-11e9-80c7-9e89354c7aa0.png)

