### PR TITLE
Fix flash message spacing

### DIFF
--- a/app/assets/stylesheets/provider/_flash.scss
+++ b/app/assets/stylesheets/provider/_flash.scss
@@ -1,7 +1,7 @@
 #flashWrapper {
   position: absolute;
-  right: 0;
-  top: line-height-times(0.5);
+  right: line-height-times(1);
+  top: line-height-times(1);
   text-align: right;
   @include animation(fadeInLeft 0.5s ease-in-out);
 }


### PR DESCRIPTION
**Note**
Due to scrollbar not being overlayed, the flash message is not aligned with the header icons anymore.

![Screen Shot 2019-06-19 at 12 50 47](https://user-images.githubusercontent.com/11672286/59759682-eb2c3680-9290-11e9-9c7b-d28978a122a5.png)
