### PR TITLE
Set ZyncWorker number of retries to Sidekiq default

### DIFF
--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -9,7 +9,7 @@ class ZyncWorker
   class_attribute :publisher
   self.publisher = ->(*args) { Rails.application.config.event_store.publish_event(*args) }
 
-  sidekiq_options retry: 3, dead: false, queue: :zync
+  sidekiq_options queue: :zync
 
   def self.config
     Rails.configuration.zync


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It sets ZyncWorker number of retry attempts to Sidekiq default (25) and
makes the job to go to the dead set in case it still exhausts the number of
attempts.

**Which issue(s) this PR fixes** 

Closes [THREESCALE-2843](https://issues.jboss.org/browse/THREESCALE-2843)