### PR TITLE
Fix documentation of liquid email tag

### DIFF
--- a/doc/liquid/tags.md
+++ b/doc/liquid/tags.md
@@ -59,11 +59,11 @@ SMTP header for the message.
 
 __Example:__ Conditional blind carbon copy
 ```liquid
-{% email %}
-  {% if plan.system_name == 'enterprise' %}
+{% if plan.system_name == 'enterprise' %}
+  {% email %}
      {% bcc 'marketing@world-domination.org' %}
-  {% endif%}
-{% endemail %}
+  {% endemail %}
+{% endif%}
 ```
 
 __Example:__ Disabling emails at all
@@ -75,14 +75,16 @@ __Example:__ Disabling emails at all
 
 __Example:__ Signup email filter
 ```liquid
-{% email %}
-  {% if plan.system == 'enterprise' %}
+{% if plan.system == 'enterprise' %}
+  {% email %}
     {% subject = 'Greetings from Example company!' %}
     {% reply-to = 'support@example.com' %}
-  {% else %}
+  {% endemail %}
+{% else %}
+  {% email %}
     {% do_not_send %}
-  {% endif %}
-{% endemail %}
+  {% endemail %}
+{% endif %}
 ```
 # Tag 'flash'
 

--- a/features/old/emails.feature
+++ b/features/old/emails.feature
@@ -45,3 +45,147 @@ Scenario: Disable 'Waiting list confirmation' notification
 
     When I act as "Kirill"
     Then I should receive no email with subject "Waiting list confirmation"
+
+Scenario: Disable 'Waiting list confirmation' notification with truthy condition
+    Given a provider "foo.example.com" with default plans
+    And provider "foo.example.com" requires accounts to be approved
+    And provider "foo.example.com" has multiple applications enabled
+    And provider "foo.example.com" has email template "account_confirmed"
+    """
+    {% if true %}{% email %}{% do_not_send %}{% endemail %}{% endif %}
+    Dear More Things,
+
+    This email is to let you know that you own even more things.
+    """
+
+    When the current domain is foo.example.com
+    And I go to the sign up page
+    And I fill in the signup fields as "Kirill"
+    Then I should see the registration succeeded
+
+    When I follow the activation link in an email sent to "Kirill@example.com"
+    Then I should see "once your account is approved"
+
+    When I act as "Kirill"
+    Then I should receive no email with subject "Waiting list confirmation"
+
+Scenario: Disable 'Waiting list confirmation' notification with falsy condition
+    Given a provider "foo.example.com" with default plans
+    And provider "foo.example.com" requires accounts to be approved
+    And provider "foo.example.com" has multiple applications enabled
+    And provider "foo.example.com" has email template "account_confirmed"
+    """
+    {% if false %}{% email %}{% do_not_send %}{% endemail %}{% endif %}
+    Dear More Things,
+
+    This email is to let you know that you own even more things.
+    """
+
+    When the current domain is foo.example.com
+    And I go to the sign up page
+    And I fill in the signup fields as "Kirill"
+    Then I should see the registration succeeded
+
+    When I follow the activation link in an email sent to "Kirill@example.com"
+    Then I should see "once your account is approved"
+
+    When I act as "Kirill"
+    Then I should receive 1 email with subject "Waiting list confirmation"
+
+Scenario: Custom email subject with truthy condition
+    Given a provider "foo.example.com" with default plans
+    And provider "foo.example.com" requires accounts to be approved
+    And provider "foo.example.com" has multiple applications enabled
+    And provider "foo.example.com" has email template "account_confirmed"
+    """
+    {% if true %}
+      {% email %}
+        {% subject 'Your account has been confirmed' %}
+      {% endemail %}
+    {% else %}
+      {% email %}
+        {% subject 'Other custom subject' %}
+      {% endemail %}
+    {% endif %}
+    Dear More Things,
+
+    This email is to let you know that you own even more things.
+    """
+
+    When the current domain is foo.example.com
+    And I go to the sign up page
+    And I fill in the signup fields as "Kirill"
+    Then I should see the registration succeeded
+
+    When I follow the activation link in an email sent to "Kirill@example.com"
+    Then I should see "once your account is approved"
+
+    When I act as "Kirill"
+    Then I should receive no email with subject "Waiting list confirmation"
+    And I should receive no email with subject "Other custom subject"
+    Then I should receive 1 email with subject "Your account has been confirmed"
+
+Scenario: Custom email subject with falsy condition
+    Given a provider "foo.example.com" with default plans
+    And provider "foo.example.com" requires accounts to be approved
+    And provider "foo.example.com" has multiple applications enabled
+    And provider "foo.example.com" has email template "account_confirmed"
+    """
+    {% if false %}
+      {% email %}
+        {% subject 'Your account has been confirmed' %}
+      {% endemail %}
+    {% else %}
+      {% email %}
+        {% subject 'Other custom subject' %}
+      {% endemail %}
+    {% endif %}
+    Dear More Things,
+
+    This email is to let you know that you own even more things.
+    """
+
+    When the current domain is foo.example.com
+    And I go to the sign up page
+    And I fill in the signup fields as "Kirill"
+    Then I should see the registration succeeded
+
+    When I follow the activation link in an email sent to "Kirill@example.com"
+    Then I should see "once your account is approved"
+
+    When I act as "Kirill"
+    Then I should receive no email with subject "Waiting list confirmation"
+    And I should receive no email with subject "Your account has been confirmed"
+    Then I should receive 1 email with subject "Other custom subject"
+
+Scenario: Do not disable 'Waiting list confirmation' notification due to falsy condition but still change the subject
+    Given a provider "foo.example.com" with default plans
+    And provider "foo.example.com" requires accounts to be approved
+    And provider "foo.example.com" has multiple applications enabled
+    And provider "foo.example.com" has email template "account_confirmed"
+    """
+    {% if false %}
+      {% email %}
+        {% do_not_send %}
+      {% endemail %}
+    {% else %}
+      {% email %}
+        {% subject 'Your account has been confirmed' %}
+      {% endemail %}
+    {% endif %}
+    Dear More Things,
+
+    This email is to let you know that you own even more things.
+    """
+
+    When the current domain is foo.example.com
+    And I go to the sign up page
+    And I fill in the signup fields as "Kirill"
+    Then I should see the registration succeeded
+
+    When I follow the activation link in an email sent to "Kirill@example.com"
+    Then I should see "once your account is approved"
+
+    When I act as "Kirill"
+    Then I should receive no email with subject "Waiting list confirmation"
+    And I should receive 1 email with subject "Your account has been confirmed"

--- a/lib/developer_portal/lib/liquid/tags/email.rb
+++ b/lib/developer_portal/lib/liquid/tags/email.rb
@@ -22,11 +22,11 @@ module Liquid::Tags
     }
 
     example 'Conditional blind carbon copy', %{
-       {% email %}
-         {% if plan.system_name == 'enterprise' %}
+       {% if plan.system_name == 'enterprise' %}
+         {% email %}
             {% bcc 'marketing@world-domination.org' %}
-         {% endif%}
-       {% endemail %}
+         {% endemail %}
+       {% endif%}
      }
 
     example 'Disabling emails at all', %{
@@ -36,14 +36,16 @@ module Liquid::Tags
     }
 
     example 'Signup email filter', %{
-        {% email %}
-          {% if plan.system == 'enterprise' %}
+        {% if plan.system == 'enterprise' %}
+          {% email %}
             {% subject = 'Greetings from Example company!' %}
             {% reply-to = 'support@example.com' %}
-          {% else %}
+          {% endemail %}
+        {% else %}
+          {% email %}
             {% do_not_send %}
-          {% endif %}
-        {% endemail %}
+          {% endemail %}
+        {% endif %}
      }
 
     AssignSyntax = /(#{Liquid::QuotedFragment}+)?\s*=?\s*(#{Liquid::QuotedFragment}+)/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It fixes the liquid documentation about how to use the `email` tag in
combination of conditional blocks.

**Which issue(s) this PR fixes** 

Close [THREESCALE-2226](https://issues.jboss.org/browse/THREESCALE-2226)