### PR TITLE
[cukes] Selenium client timeout waits longer

### DIFF
--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -84,7 +84,10 @@ Capybara.register_driver :headless_chrome do |app|
 
   options.add_preference(:browser, set_download_behavior: { behavior: 'allow' })
 
-  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.timeout = 120 # default 60
+
+  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client)
 
   driver
 end


### PR DESCRIPTION
Trying to fix the annoying `Net::ReadTimeout (Net::ReadTimeout)` that happens randomly in our cukes