### PR TITLE
Rake task to issue domain changed events to all providers

### DIFF
--- a/lib/tasks/zync.rake
+++ b/lib/tasks/zync.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+namespace :zync do
+  namespace :resync do
+    def each_with_progress(scope)
+      total_count = scope.count
+      batch_size = 100
+      index = 0
+
+      progress = -> do
+        break unless (index % batch_size) == 0
+        percent = (index / total_count.to_f) * 100.0
+        puts "#{percent.round(2)}% completed"
+      end
+
+      scope.find_each(batch_size: batch_size) do |object|
+        index += 1
+        yield object
+        progress.call
+      end
+    end
+
+    desc 'Resync provider domains with zync'
+    task provider_domains: :environment do
+      accounts = Account.providers_with_master
+      if (provider_id = ENV["PROVIDER_ID"])
+        accounts = accounts.where(id: provider_id)
+      end
+      each_with_progress(accounts) { |account| Domains::ProviderDomainsChangedEvent.create_and_publish!(account) }
+    end
+
+    desc 'Resync proxy domains with zync'
+    task proxy_domains: :environment do
+      services = Service.includes(:proxy)
+      if (provider_id = ENV["PROVIDER_ID"])
+        services = services.where(account_id: provider_id)
+      end
+      each_with_progress(services) { |service| Domains::ProxyDomainsChangedEvent.create_and_publish!(service.proxy) }
+    end
+
+    desc 'Resync all domains with zync'
+    task domains: [:provider_domains, :proxy_domains]
+  end
+end

--- a/test/unit/tasks/zync_test.rb
+++ b/test/unit/tasks/zync_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class Tasks::ZyncTest < ActiveSupport::TestCase
+  setup do
+    FactoryBot.create(:provider_account)
+  end
+
+  test 'resync provider domains' do
+    Account.providers_with_master.each { |account| Domains::ProviderDomainsChangedEvent.expects(:create_and_publish!).with(account) }
+    execute_rake_task 'zync.rake', 'zync:resync:provider_domains'
+  end
+
+  test 'resync proxy domains' do
+    Service.all.each { |service| Domains::ProxyDomainsChangedEvent.expects(:create_and_publish!).with(service.proxy) }
+    execute_rake_task 'zync.rake', 'zync:resync:proxy_domains'
+  end
+end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It implements a set of rake tasks to issue domain changed events of
providers and proxies. This will make Zync to resync Openshift routes
eventually managed.

**Which issue(s) this PR fixes** 

Related to [THREESCALE-2841](https://issues.jboss.org/browse/THREESCALE-2841)

**Verification steps** 

Provider domains:
```
bundle exec rake zync:resync:provider_domains
```

Proxy domains:
```
bundle exec rake zync:resync:proxy_domains
```

Both provider and proxy domains:
```
bundle exec rake zync:resync:domains
```