### PR TITLE
Slightly improve loading Stats screen

### DIFF
--- a/app/assets/stylesheets/provider/stats/_base.scss
+++ b/app/assets/stylesheets/provider/stats/_base.scss
@@ -138,19 +138,12 @@ $stats-chart-tooltip-color: $label-color;
 
 .StatsChart-container {
   &.is-loading {
+    background-image: image-url('spinner.svg');
+    background-position: center;
+    background-repeat: no-repeat;
+    content: '';
+    height: 320px; // Fixed value, comes from stats package
     opacity: .5;
-
-    &::before {
-      background-image: image-url('spinner.svg');
-      background-position: center;
-      background-repeat: no-repeat;
-      bottom: 50%;
-      content: '';
-      height: line-height-times(2);
-      left: 50%;
-      position: absolute;
-      width: line-height-times(2);
-    }
   }
 
   .c3 svg {


### PR DESCRIPTION
Slightly improves Stats screen since introduction of PF4 by adding blank space. This size is exactly `320px` as it's the height of the chart rendered by the stats package.

**Before**
![stats-2](https://user-images.githubusercontent.com/11672286/59847812-e1273800-9363-11e9-91ad-a686b29d2d43.gif)

**Now**
![stats](https://user-images.githubusercontent.com/11672286/59847818-e3899200-9363-11e9-9412-7cb55a17eb58.gif)
