### PR TITLE
Fix flow errors in .git dir

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 <PROJECT_ROOT>/vendor/.*
 <PROJECT_ROOT>/node_modules/.*
+<PROJECT_ROOT>/.git/.*
 
 [include]
 


### PR DESCRIPTION
After merging https://github.com/3scale/porta/pull/904 flow is checking `.dir` directory and failing. 

    Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ .git/refs/heads/3scale-2.6.0-ER1-Update-package-lock.json:1:1

    Unexpected identifier

     1│ af757b0bce4ebc38fd8486f8ef7f848fdd8d5536
     2│

This PR adds `.git` folder to ignored list