### PR TITLE
Zync UnprocessableEntityError hook in a Sidekiq batch

### DIFF
--- a/app/events/zync_event.rb
+++ b/app/events/zync_event.rb
@@ -53,6 +53,10 @@ class ZyncEvent < BaseEventStoreEvent
     end
   end
 
+  def create_dependencies
+    dependencies.map { |dependency| self.class.create(self, dependency) }
+  end
+
   def self.type_for(model)
     case model
     when Cinstance, ApplicationRelatedEvent then 'Application'

--- a/test/events/zync_event_test.rb
+++ b/test/events/zync_event_test.rb
@@ -18,6 +18,17 @@ class ZyncEventTest < ActiveSupport::TestCase
     assert_equal [ service = application.service, service.proxy ], event.dependencies
   end
 
+  def test_create_dependencies
+    application = FactoryBot.create(:simple_cinstance)
+    event = ZyncEvent.create(RailsEventStore::Event.new, application)
+
+    dependencies = [service = application.service, service.proxy]
+    event.expects(:dependencies).returns(dependencies)
+    dependencies.each { |dependency| ZyncEvent.expects(:create).with(event, dependency) }
+
+    event.create_dependencies
+  end
+
   def test_non_persisted_dependencies_for_application
     application = FactoryBot.build(:simple_cinstance, service: FactoryBot.create(:simple_service))
     assert event = ZyncEvent.create(Applications::ApplicationDeletedEvent.create(application), application)

--- a/test/workers/zync_worker_test.rb
+++ b/test/workers/zync_worker_test.rb
@@ -44,9 +44,137 @@ class ZyncWorkerTest < ActiveSupport::TestCase
     ZyncWorker::MessageBusPublisher.expects(:enabled).returns(false)
 
     assert_difference(zync_events.method(:count), +2) do
+      worker.perform(event.event_id, event.data.with_indifferent_access)
+    end
+  end
+
+  class UnprocessableEntityRetryTest < ActiveSupport::TestCase
+    disable_transactional_fixtures!
+
+    attr_reader :worker, :event, :application
+
+    setup do
+      EventStore::Repository.stubs(raise_errors: true)
+      ZyncWorker::MessageBusPublisher.any_instance.stubs(enabled?: false)
+
+      @worker = ZyncWorker.new
+      @application = FactoryBot.create(:simple_cinstance).reload # reload to get tenant_id
+      FactoryBot.create(:simple_admin, account: application.provider_account) # for the access token
+      @event = ZyncEvent.create(RailsEventStore::Event.new, application)
+
+      worker.config.stubs(endpoint: 'http://example.com') # so it makes http request
+      worker.publisher.call(event) # so it is later available to find
+
+      stub_request(:put, 'http://example.com/tenant').to_return(status: 200)
+      stub_request(:put, 'http://example.com/notification').to_return(status: 422).with(body: event.data.to_json) # causes UnprocessableEntityError to be raised
+    end
+
+    test 'sync event dependencies when it fails' do
+      worker.expects(:sync_dependencies).with(event.event_id).returns(true)
+      worker.perform(event.event_id, event.data.with_indifferent_access)
+    end
+
+    test 'raises the error when there is no dependency' do
+      worker.expects(:sync_dependencies).with(event.event_id).returns([])
       assert_raises ZyncWorker::UnprocessableEntityError do
         worker.perform(event.event_id, event.data.with_indifferent_access)
       end
+    end
+
+    test '#create_dependency_events' do
+      event_id = event.event_id
+      EventStore::Repository.expects(:find_event!).with(event_id).returns(event)
+      event.expects(:create_dependencies)
+      worker.create_dependency_events(event_id)
+    end
+
+    test '#sync_dependencies publishes events and enqueues jobs' do
+      event_id = event.event_id
+      dependency_events = event.create_dependencies
+
+      worker.expects(:create_dependency_events).with(event_id).returns(dependency_events)
+      worker.expects(:publish_dependency_events).with(dependency_events)
+
+      worker.sync_dependencies(event_id)
+    end
+
+    test '#publish_dependency_events enqueues the jobs' do
+      %w[Proxy Service].each { |dependent_type| ZyncWorker.expects(:perform_async).with(anything, has_entry(:type, dependent_type)) }
+      worker.publish_dependency_events(event.create_dependencies)
+    end
+
+    test 'on batch complete' do
+      event_id = event.event_id
+      klass = worker.class
+      klass.expects(:perform_async).with(event_id, anything, 1)
+      klass.new.on_complete(1, {'event_id' => event_id, 'manual_retry_count' => 0})
+    end
+
+    test 'number of attempts' do
+      event_id = event.event_id
+      retry_limit = worker.retry_limit
+
+      dependency_events = []
+      retry_limit.times { dependency_events << event.create_dependencies }
+
+      dependency_events.flatten.each do |dependent_event|
+        stub_request(:put, 'http://example.com/notification').to_return(status: 200).with(body: dependent_event.data.to_json)
+      end
+
+      Sidekiq::Testing.inline! do
+        assert_raises(ZyncWorker::UnprocessableEntityError) do
+          (retry_limit + 1).times do |attempt|
+            worker.stubs(retry_attempt: attempt)
+            worker.expects(:create_dependency_events).with(event_id).returns(dependency_events[attempt]) if attempt < retry_limit
+            worker.perform(event_id, event.data.with_indifferent_access)
+          end
+        end
+      end
+    end
+
+    test 'batch callback without manual retry count' do
+      event_id = event.event_id
+      worker.stubs(update_tenant: [ { id: event.tenant_id }, application.provider_account ])
+      worker.expects(:http_put).raises(ZyncWorker::UnprocessableEntityError.new(mock(status: 422, as_json: {})))
+
+      Sidekiq::Batch.any_instance.expects(:on).with(:complete, ZyncWorker, { 'event_id' => event_id, 'manual_retry_count' => nil })
+      worker.perform(event_id, event.data.with_indifferent_access)
+    end
+
+    test 'batch callback with manual retry count' do
+      event_id = event.event_id
+      worker.stubs(update_tenant: [ { id: event.tenant_id }, application.provider_account ])
+      worker.expects(:http_put).raises(ZyncWorker::UnprocessableEntityError.new(mock(status: 422, as_json: {})))
+
+      Sidekiq::Batch.any_instance.expects(:on).with(:complete, ZyncWorker, { 'event_id' => event_id, 'manual_retry_count' => 5 })
+      worker.perform(event_id, event.data.with_indifferent_access, 5)
+    end
+
+    test 'batch callback with manual retry count and sidekiq retry count' do
+      event_id = event.event_id
+      event_data = event.data.with_indifferent_access
+      worker.stubs(update_tenant: [ { id: event.tenant_id }, application.provider_account ])
+      worker.expects(:http_put).raises(ZyncWorker::UnprocessableEntityError.new(mock(status: 422, as_json: {})))
+
+      worker.retry_attempt = 2
+
+      Sidekiq::Batch.any_instance.expects(:on).with(:complete, ZyncWorker, { 'event_id' => event_id, 'manual_retry_count' => 5 })
+      worker.perform(event_id, event_data, 5)
+      refute worker.last_attempt?
+    end
+
+    test 'batch callback with manual retry count and sidekiq retry count summing last attempt' do
+      event_id = event.event_id
+      event_data = event.data.with_indifferent_access
+      worker.stubs(update_tenant: [ { id: event.tenant_id }, application.provider_account ])
+      worker.expects(:http_put).raises(ZyncWorker::UnprocessableEntityError.new(mock(status: 422, as_json: {})))
+
+      worker.retry_attempt = 2
+
+      worker.expects(:sync_dependencies).never
+      Sidekiq::Batch.any_instance.expects(:on).with(:complete, ZyncWorker, { 'event_id' => event_id, 'manual_retry_count' => 23 }).never
+      assert_raises(ZyncWorker::UnprocessableEntityError) { worker.perform(event_id, event_data, 23) }
+      assert worker.last_attempt?
     end
   end
 
@@ -67,9 +195,7 @@ class ZyncWorkerTest < ActiveSupport::TestCase
 
     zync_event = EventStore::Event.where(event_type: ZyncEvent).last!
     assert_difference(EventStore::Event.where(event_type: ZyncEvent).method(:count), +1) do
-      assert_raises ZyncWorker::UnprocessableEntityError do
-        Sidekiq::Testing.inline! { ZyncWorker.perform_async(zync_event.event_id, zync_event.data) }
-      end
+      Sidekiq::Testing.inline! { ZyncWorker.perform_async(zync_event.event_id, zync_event.data) }
     end
 
     stub_request(:put, 'http://example.com/notification').to_return(status: 200)


### PR DESCRIPTION
**What this PR does / why we need it**

TLDR – Reverts 3scale/porta#846 + a couple fixes, including one after https://github.com/3scale/porta/pull/927 was merged

This PR modifies the way the hook on the `UnprocessableEntityError` exceptions in the Zync worker behaves.

Right now in master, whenever a zync job fails with a `UnprocessableEntityError`, we hook into the error to publish zync events for the possible dependent objects that are assumed to be missing in Zync and therefore make it to return a 422. Right after publishing those dependency zync events, it raises the error in the current job and all zync jobs concur to be processed in parallel by Sidekiq – the one that failed and the ones just created as "dependencies".

This PR makes the current job to wait for the dependency jobs to be performed to only then re-enqueue itself. So instead of making the job to concur with its dependencies right away, it waits until there are no missing dependencies in Zync and therefore no reason for another 422.

This was implemented using Sidekiq batches. When `UnprocessableEntityError` happens, the job opens a batch, add the dependency jobs to the batch and programs itself to be re-enqueued in the batch callback (`on_complete`).

**Verification steps** 
1. Quiet Sidekiq all processes
2. Create a new API in the Admin Portal
3. In the Sidekiq Web Console, delete the zync job meant to create the `Service` in zync (and keep the one to create the `Proxy`)
4. Redeploy `system-sidekiq`

Expected behavior:
- The Zync job to create the `Proxy` will get performed and fail with `UnprocessableEntityError` (although it shows up as a success in the logs)
- Since it’s not the “last_attempt”, the job will invoke `ZyncWorker#sync_dependencies` which creates a new zync job for the `Service` (deleted in step 3 above) in a batch
- The batch only contains that job for the `Service` and in its callback (`on_complete`) the first job (the one for the `Proxy`) is re-enqueued
- After the batch is finished (and therefore the `Service` is created in zync), the callback is invoked, the job for the `Proxy` enqueued and processed

Example:
![Screen Shot 2019-06-25 at 6 09 11 PM](https://user-images.githubusercontent.com/1842261/60116451-5043c880-9778-11e9-91d8-9566accce226.png)

**Special notes for your reviewer**
Contains commits of https://github.com/3scale/porta/pull/947