### PR TITLE
Fix uninitialized constant Sidekiq::JobRetry

### DIFF
--- a/app/lib/three_scale/sidekiq_retry_support.rb
+++ b/app/lib/three_scale/sidekiq_retry_support.rb
@@ -15,7 +15,7 @@ module ThreeScale
           when Integer
             retry_option
           when true
-            Sidekiq::JobRetry::DEFAULT_MAX_RETRY_ATTEMPTS
+            Sidekiq::Middleware::Server::RetryJobs::DEFAULT_MAX_RETRY_ATTEMPTS
           else
             0
           end

--- a/app/lib/three_scale/sidekiq_retry_support.rb
+++ b/app/lib/three_scale/sidekiq_retry_support.rb
@@ -32,14 +32,14 @@ module ThreeScale
         retry_attempt.to_i >= retry_limit
       end
 
-      def with_retry_count
-        logger.info { "Running #{retry_identifier} (#{retry_attempt}/#{retry_limit})" }
+      def with_retry_log
+        logger.info "Running #{retry_identifier} (#{retry_attempt}/#{retry_limit})"
 
         yield
       rescue => exception
-        logger.info { "#{retry_identifier} attempt ##{retry_attempt} failed with #{exception}" }
+        logger.info "#{retry_identifier} attempt ##{retry_attempt} failed with #{exception}"
 
-        logger.info { "Retrying #{retry_identifier}" } unless last_attempt?
+        logger.info "Retrying #{retry_identifier}" unless last_attempt?
         raise exception
       end
 

--- a/app/workers/web_hook_worker.rb
+++ b/app/workers/web_hook_worker.rb
@@ -44,7 +44,7 @@ class WebHookWorker
   def perform(webhook_id, options)
     @webhook_id = webhook_id
 
-    with_retry_count do
+    with_retry_log do
       push(options.symbolize_keys.slice(:url, :xml, :content_type))
     end
   end

--- a/test/unit/three_scale/sidekiq_retry_support_test.rb
+++ b/test/unit/three_scale/sidekiq_retry_support_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ThreeScale::SidekiqRetrySupportTest < ActiveSupport::TestCase
+  class WorkerTest < ActiveSupport::TestCase
+    TestWorker = Class.new do
+      include Sidekiq::Worker
+      include ThreeScale::SidekiqRetrySupport::Worker
+    end
+
+    setup do
+      @worker = TestWorker.new
+    end
+
+    attr_reader :worker
+
+    test 'counts retry attempts' do
+      assert_equal 0, worker.retry_attempt
+    end
+
+    test 'fetches the retry limit from sidekiq options' do
+      assert_equal 25, worker.retry_limit
+
+      other_class = Class.new do
+        include Sidekiq::Worker
+        include ThreeScale::SidekiqRetrySupport::Worker
+
+        sidekiq_options retry: 10
+      end
+
+      assert_equal 10, other_class.retry_limit
+    end
+
+    test '#last_attempt?' do
+      refute worker.last_attempt?
+      worker.retry_attempt = 25
+      assert worker.last_attempt?
+    end
+
+    test 'retry log' do
+      TestException = Class.new(StandardError)
+
+      worker.stubs(retry_identifier: 'my-job')
+
+      worker.logger.expects(:info).with('Running my-job (0/25)')
+      worker.logger.expects(:info).with('my-job attempt #0 failed with error message')
+      worker.logger.expects(:info).with('Retrying my-job')
+
+      assert_raises(TestException) do
+        worker.with_retry_log { raise TestException, 'error message' }
+      end
+
+      worker.retry_attempt = 25
+
+      worker.logger.expects(:info).with('Running my-job (25/25)')
+      worker.logger.expects(:info).with('my-job attempt #25 failed with error message')
+
+      assert_raises(TestException) do
+        worker.with_retry_log { raise TestException, 'error message' }
+      end
+    end
+
+    test 'retry identifier' do
+      worker.stubs(jid: '1234')
+      assert_equal 'ThreeScale::SidekiqRetrySupportTest::WorkerTest::TestWorker-1234', worker.retry_identifier
+    end
+  end
+end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Fixes a reference to `Sidekiq::Middleware::Server::RetryJobs::DEFAULT_MAX_RETRY_ATTEMPTS` in `ThreeScale::SidekiqRetrySupport::Worker::retry_limit`.

`Sidekiq::JobRetry::DEFAULT_MAX_RETRY_ATTEMPTS` was introduced in Sidekiq 5: https://github.com/mperham/sidekiq/pull/3235

**Which issue(s) this PR fixes** 
![Screen Shot 2019-06-25 at 11 35 26 AM](https://user-images.githubusercontent.com/1842261/60188377-78dac980-982f-11e9-93d3-571f702b40f6.png)
