### PR TITLE
Cleaning some npm/babel/eslint warnings

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,6 +12,7 @@
       "@babel/preset-env",
       {
         "useBuiltIns": "entry",
+        "corejs": "2",
         "targets": {
           "node": "current",
           "ie": "11",

--- a/.eslintrc
+++ b/.eslintrc
@@ -75,6 +75,9 @@
     "flowtype/valid-syntax": 1
   },
   "settings": {
+    "react": {
+      "version": "detect"
+    },
     "flowtype": {
       "onlyFilesWithFlowAnnotation": true
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds some missing configuration to our build process, to prevent warnings like:
> WARNING: We noticed you're using the `useBuiltIns` option without declaring a core-js version...

Or:
> Warning: React version not specified in eslint-plugin-react settings
    
