### PR TITLE
Fix Popup positioning in Safari

### DIFF
--- a/app/assets/stylesheets/provider/_header.scss
+++ b/app/assets/stylesheets/provider/_header.scss
@@ -4,6 +4,10 @@ $master-ribbon-height: line-height-times(1);
 .Header {
   height: $header-height;
 
+  .PopNavigation-list {
+    top: $header-height;
+  }
+
   &--master {
     height: $header-height + $master-ribbon-height;
     border-top: $master-ribbon-height solid $header-border-color;
@@ -13,6 +17,10 @@ $master-ribbon-height: line-height-times(1);
       position: absolute;
       top: 0;
       left: 50%;
+    }
+
+    .PopNavigation-list {
+      top: $header-height + $master-ribbon-height;
     }
   }
 

--- a/app/assets/stylesheets/provider/_pop_navigation.scss
+++ b/app/assets/stylesheets/provider/_pop_navigation.scss
@@ -1,10 +1,16 @@
 $link-padding: line-height-times(1 / 2);
+$pf4-sidebar-width: 18.125rem;
 
 .PopNavigation {
   color: $content-background;
 
   &--context {
     float: left;
+
+    .PopNavigation-list {
+      left: $pf4-sidebar-width;
+      margin-left: line-height-times(1 / 2);
+    }
   }
 
   &--session {
@@ -38,7 +44,6 @@ $link-padding: line-height-times(1 / 2);
     border-radius: $border-radius;
     display: none;
     margin-top: line-height-times(1 / 2, true);
-    margin-left: calc(-#{$link-padding} + -#{$border-width});
     max-width: line-height-times(10);
     min-width: line-height-times(4);
     overflow: hidden;


### PR DESCRIPTION
**What this PR does / why we need it**:

Set manually top/right/left values to PopNavigation so that it works properly in Safari.

This is Safari:
![Screen Shot 2019-06-27 at 14 48 46](https://user-images.githubusercontent.com/11672286/60269174-3f1cc800-98ee-11e9-8ee5-9f06a2784c92.png)

![Screen Shot 2019-06-27 at 14 50 33](https://user-images.githubusercontent.com/11672286/60269184-417f2200-98ee-11e9-9fff-4d8153587d14.png)


**Which issue(s) this PR fixes** 

[THREESCALE-2902: Adjust vertical position of pop ups at the top right in Safari](https://issues.jboss.org/browse/THREESCALE-2902)

**Verification steps** 

context-selector and help/session popups should look good in Chrome, Firefox, IE11 and Safari.
