### PR TITLE
[oracle] Fix PDB name for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ oracle-db-container: &oracle-db-container
   environment:
     ORACLE_CHARACTERSET: 'AL32UTF8'
     ORACLE_SID: 'threescale'
-    ORACLE_PDB: 'systempdb'
+    ORACLE_PDB: 'systempdbtest'
     ORACLE_PWD: 'threescalepass'
   command: |
     bash -c "sed -i.bak 's|2048|6144|g' /opt/oracle/dbca.rsp.tmpl && exec /opt/oracle/runOracle.sh"


### PR DESCRIPTION
Relates to #924

In #924 we use systempdb systempdbtest and systempdbproduction in [config/database.yml](https://github.com/3scale/porta/commit/1d371059a5491422608a5aebe9ce3d1d2610d614#diff-23ee76661959fed8a0ed82075a4b5468)

But in circleci we only create [systempdb](https://github.com/3scale/porta/blob/3d6c398a64eec8842bbedd2c00d14c02d9a8091e/.circleci/config.yml#L113) though it should be systempdbtest as `RAILS_ENV=test`