### PR TITLE
[Refactor] Remove unused Account::Gateway#payment_gateway_unconfigured?

### DIFF
--- a/app/models/account/gateway.rb
+++ b/app/models/account/gateway.rb
@@ -26,10 +26,6 @@ module Account::Gateway
     gateway_setting.persisted? && gateway_setting.configured?
   end
 
-  def payment_gateway_unconfigured?
-    !payment_gateway_configured?
-  end
-
   # MIGRATION use separate table over columns in same table
   # Accessors for backward compatibility
   # There is an issue, build_association will automatically save the association on parent save

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/adyen12_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/adyen12_controller.rb
@@ -22,7 +22,7 @@ module DeveloperPortal::Admin::Account
 
     # Catch exception from ActiveMerchant::AdyenGateway Argument error
     # This is likely because the provider has chosen adyen
-    # but did not fill in required fields aka payment_gateway_unconfigured?
+    # but did not fill in required fields aka payment_gateway_configured? is false
     def authorize_recurring_and_store_card_details
       gateway_client.authorize_recurring_and_store_card_details(params['adyen-encrypted-data'], ip: request.remote_ip)
     rescue ArgumentError => e

--- a/test/unit/account/gateway_test.rb
+++ b/test/unit/account/gateway_test.rb
@@ -88,13 +88,10 @@ class Account::GatewayTest  < ActiveSupport::TestCase
     account.gateway_setting.stubs(configured?: false)
 
     refute account.payment_gateway_configured?
-    assert account.payment_gateway_unconfigured?
 
     account.gateway_setting.stubs(configured?: true)
 
     assert account.payment_gateway_configured?
-    refute account.payment_gateway_unconfigured?
-
   end
 
 end

--- a/test/unit/invoice_test.rb
+++ b/test/unit/invoice_test.rb
@@ -476,7 +476,8 @@ class InvoiceTest < ActiveSupport::TestCase
 
   test '#charge! failed if provider payment_gateway is unconfigured' do
     @buyer.expects(:charge!).never
-    @provider.stubs(:payment_gateway_unconfigured?).returns(true)
+    @provider.stubs(:payment_gateway_configured?).returns(false)
+    @billing.create_line_item!(name: 'Fake', cost: 1.233, description: 'really', quantity: 1)
     @invoice.update_attribute(:state, 'pending')
 
     refute @invoice.charge!, 'Invoice should not charge!'


### PR DESCRIPTION
Removes a method that was only used from tests and now it is not used from anywhere else:
![image](https://user-images.githubusercontent.com/11318903/60437476-bb751b00-9c0e-11e9-8617-b3478cf19cf5.png)

I encountered this while working on another task 😄 