### PR TITLE
[WIP][DO NOT MERGE] Debug why npm is failing compiling

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,8 +10,9 @@ default: &default
   # ['app/assets', 'engine/foo/app/assets']
   resolved_paths: ['app/javascript/src']
 
-  # Reload manifest.json on all requests so we reload latest compiled packs
+  # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false
+  webpack_compile_output: true
 
   extensions:
     - .coffee


### PR DESCRIPTION
A removal of node_modules in preview makes deployment failing
Strangely npm is not redirecting errors to STDERR, so enabling STDOUT logging

:warning: This should not be merged

Just to test out https://github.com/3scale/deploy/pull/582 and why deploying in preview is fails


```
BUNDLE_GEMFILE=gemfiles/prod/Gemfile ruby2.3 ./bin/rake assets:precompile --trace
** Invoke assets:precompile (first_time)
** Invoke assets:environment (first_time)
** Invoke assets:environment:factory_bot (first_time)
** Execute assets:environment:factory_bot
** Invoke assets:environment:observers (first_time)
** Execute assets:environment:observers
** Execute assets:environment
** Invoke environment (first_time)
** Execute environment
RAILS_ENV=preview environment is not defined in config/webpacker.yml, falling back to production environment
** Invoke webpacker:yarn_install (first_time)
** Execute webpacker:yarn_install
** Execute assets:precompile
** Invoke webpacker:compile (first_time)
** Invoke webpacker:verify_install (first_time)
** Invoke webpacker:check_node (first_time)
** Execute webpacker:check_node
** Invoke webpacker:check_yarn (first_time)
** Execute webpacker:check_yarn
** Invoke webpacker:check_binstubs (first_time)
** Execute webpacker:check_binstubs
** Execute webpacker:verify_install
** Invoke environment
** Execute webpacker:compile
Compiling…
Compilation failed:
```

😱 no errors in STDERR

Need to enable STDOUT output with this PR and:

```
ERROR in /mnt/cache/node_modules/&#64;patternfly/react-core/node_modules/&#64;patternfly/react-styles/css/components/Dropdown/dropdown.css (/mnt/cache/node_modules/css-loader!/mnt/cache/node_modules/sass-loader/lib/loader.js??ref--8-2!/mnt/cache/node_modules/&#64;patternfly/react-core/node_modules/&#64;patternfly/react-styles/css/components/Dropdown/dropdown.css)
Module build failed (from /mnt/cache/node_modules/sass-loader/lib/loader.js):
Error: ENOENT: no such file or directory, scandir '/mnt/cache/node_modules/node-sass/vendor'
    at Object.fs.readdirSync (fs.js:904:18)
    at Object.getInstalledBinaries (/mnt/cache/node_modules/node-sass/lib/extensions.js:131:13)
    at foundBinariesList (/mnt/cache/node_modules/node-sass/lib/errors.js:20:15)
    at foundBinaries (/mnt/cache/node_modules/node-sass/lib/errors.js:15:5)
    at Object.module.exports.missingBinary (/mnt/cache/node_modules/node-sass/lib/errors.js:45:5)
    at module.exports (/mnt/cache/node_modules/node-sass/lib/binding.js:15:30)
    at Object.<anonymous> (/mnt/cache/node_modules/node-sass/lib/index.js:14:35)
    at Module._compile (/mnt/cache/node_modules/webpack-cli/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (/mnt/cache/node_modules/webpack-cli/node_modules/v8-compile-cache/v8-compile-cache.js:161:20)
    at Object.sassLoader (/mnt/cache/node_modules/sass-loader/lib/loader.js:46:72)
 &#64; /mnt/cache/node_modules/&#64;patternfly/react-core/node_modules/&#64;patternfly/react-styles/css/components/Dropdown/dropdown.css 2:14-145
 &#64; /mnt/cache/node_modules/&#64;patternfly/react-core/node_modules/&#64;patternfly/react-styles/css/components/Dropdown/dropdown.js
 &#64; /mnt/cache/node_modules/&#64;patternfly/react-core/dist/esm/components/Dropdown/Dropdown.js
 &#64; /mnt/cache/node_modules/&#64;patternfly/react-core/dist/esm/components/Dropdown/index.js
 &#64; /mnt/cache/node_modules/&#64;patternfly/react-core/dist/esm/components/index.js
 &#64; /mnt/cache/node_modules/&#64;patternfly/react-core/dist/esm/index.js
 &#64; ./app/javascript/src/LoginPage/LoginPageWrapper.jsx
 &#64; ./app/javascript/src/LoginPage/index.js
 &#64; ./app/javascript/packs/LoginPage.js

ERROR in ./app/javascript/src/Policies/styles/policies.scss (/mnt/cache/node_modules/css-loader!/mnt/cache/node_modules/sass-loader/lib/loader.js??ref--8-2!./app/javascript/src/Policies/styles/policies.scss)
Module build failed (from /mnt/cache/node_modules/sass-loader/lib/loader.js):
Error: ENOENT: no such file or directory, scandir '/mnt/cache/node_modules/node-sass/vendor'
    at Object.fs.readdirSync (fs.js:904:18)
    at Object.getInstalledBinaries (/mnt/cache/node_modules/node-sass/lib/extensions.js:131:13)
    at foundBinariesList (/mnt/cache/node_modules/node-sass/lib/errors.js:20:15)
    at foundBinaries (/mnt/cache/node_modules/node-sass/lib/errors.js:15:5)
    at Object.module.exports.missingBinary (/mnt/cache/node_modules/node-sass/lib/errors.js:45:5)
    at module.exports (/mnt/cache/node_modules/node-sass/lib/binding.js:15:30)
    at Object.<anonymous> (/mnt/cache/node_modules/node-sass/lib/index.js:14:35)
    at Module._compile (/mnt/cache/node_modules/webpack-cli/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (/mnt/cache/node_modules/webpack-cli/node_modules/v8-compile-cache/v8-compile-cache.js:161:20)
    at Object.sassLoader (/mnt/cache/node_modules/sass-loader/lib/loader.js:46:72)
 &#64; ./app/javascript/src/Policies/styles/policies.scss 2:14-192
 &#64; ./app/javascript/src/Policies/components/CustomPolicy.jsx
 &#64; ./app/javascript/packs/custom_policy.js
```

So it seems some dependencies were not installed ...