### PR TITLE
Remove duplicated method Liquid::Drop::Provider#logo_url

### DIFF
--- a/lib/developer_portal/lib/liquid/drops/provider.rb
+++ b/lib/developer_portal/lib/liquid/drops/provider.rb
@@ -111,12 +111,6 @@ module Liquid
         @model.settings.multiple_applications.visible?
       end
 
-      def logo_url
-        if logo = @model.profile.logo
-          logo.url(:large)
-        end
-      end
-
       desc """*True* if your 3scale plan allows you to manage multiple APIs
                as separate [services][support-terminology-service].
            """


### PR DESCRIPTION
This method is duplicated.

I've removed this one:
https://github.com/3scale/porta/blob/09ea71b4ca22de7b27fef10d15e648462d189e37/lib/developer_portal/lib/liquid/drops/provider.rb#L114-L118
And I've kept this one:
https://github.com/3scale/porta/blob/09ea71b4ca22de7b27fef10d15e648462d189e37/lib/developer_portal/lib/liquid/drops/provider.rb#L193-L201
