### PR TITLE
Allow inclusion of special chars in App ID/KEY as defined in RFC 6749

### DIFF
--- a/app/models/application_key.rb
+++ b/app/models/application_key.rb
@@ -2,8 +2,6 @@ class ApplicationKey < ApplicationRecord
 
   KEYS_LIMIT = 5
 
-  APP_KEY_FORMAT = /[a-z\d][a-z\d\-\_]*[a-z\d]/i.freeze
-
 
   belongs_to :application, :class_name => 'Cinstance', :inverse_of => :application_keys
 
@@ -11,7 +9,7 @@ class ApplicationKey < ApplicationRecord
 
   validates :application, presence: true
   # letters, numbers, dash, cannot stat with dash, case insensitive
-  validates :value, format: { with: /\A#{APP_KEY_FORMAT}\Z/ },
+  validates :value, format: { with: /\A[\x20-\x7E]+\Z/ },
                     length: { within: 5..255 },
                     uniqueness: { scope: :application_id }
 

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -110,7 +110,6 @@ class Cinstance < Contract
 
   validate :same_service, on: :update, if: :plan_id_changed?
 
-  APP_ID_FORMAT = /[\w-]+/.freeze
   # letter, number, underscore (_), hyphen-minus (-), dot (.), base64 format
   # In base64 encoding, the character set is [A-Z,a-z,0-9,and + /], if rest length is less than 4, fill of '=' character.
   # ^([A-Za-z0-9+/]{4})* means the String start with 0 time or more base64 group.
@@ -118,8 +117,7 @@ class Cinstance < Contract
   # matches also the non 64B case with (\A[\w\-\.]+\Z)
   USER_KEY_FORMAT = /(([\w\-\.]+)|([A-Za-z0-9+\/]{4})*([A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}==))/
 
-  # Arbitrary limit, increase don't broke anything.
-  validates :application_id, format: { with: /\A#{APP_ID_FORMAT}\Z/ }, length: { in: 4..140 }
+  validates :application_id, format: { with: /\A[\x20-\x7E]+\Z/ }, length: { in: 4..255 }
 
 
   validates :user_key, format: { with: /\A#{USER_KEY_FORMAT}\Z/ }, length: { maximum: 256 },

--- a/test/unit/application_keys_test.rb
+++ b/test/unit/application_keys_test.rb
@@ -162,4 +162,12 @@ class ApplicationKeysTest < ActiveSupport::TestCase
 
   end
 
+  test 'Value can include special characters as defined in the RFC 6749' do
+    generate_random_key_with_all_chars_of_rfc_6749 = -> { ("\x20".."\x7e").to_a.shuffle.join }
+    app_key = FactoryBot.build(:application_key, value: (value = generate_random_key_with_all_chars_of_rfc_6749.call))
+
+    assert app_key.save
+    assert value, app_key.reload.value
+  end
+
 end

--- a/test/unit/backend/model_extensions/cinstance_test.rb
+++ b/test/unit/backend/model_extensions/cinstance_test.rb
@@ -23,25 +23,6 @@ class Backend::ModelExtensions::CinstanceTest < ActiveSupport::TestCase
     assert_equal 'custom_app_id', cinstance.application_id
   end
 
-  test 'application_id is properly validated' do
-    cinstance = Cinstance.new(:plan => FactoryBot.create(:application_plan), :user_account   => FactoryBot.create(:buyer_account))
-
-    cinstance.application_id = "1"
-    assert !cinstance.valid?
-
-    cinstance.application_id = "asd"
-    assert !cinstance.valid?
-
-    cinstance.application_id = "6f76704d-14fc-40ab-bd2a-1a1442dc6b91"
-    assert cinstance.valid?
-
-    cinstance.application_id = "sdfsd-*"
-    assert !cinstance.valid?
-
-    cinstance.application_id = "valid"
-    assert cinstance.valid?
-  end
-
   test 'application_id is immutable' do
     cinstance = FactoryBot.create(:simple_cinstance)
 

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -1038,4 +1038,28 @@ class CinstanceTest < ActiveSupport::TestCase
     assert_not_includes ids_cinstances_like_list, id_cinstance_with_another_plan
     assert_not_includes ids_cinstances_like_list, id_service_contract_with_enterprise_plan
   end
+
+  test 'App ID can include special characters as defined in the RFC 6749' do
+    generate_random_key_with_all_chars_of_rfc_6749 = -> { ("\x20".."\x7e").to_a.shuffle.join }
+    cinstance = FactoryBot.build(:cinstance, application_id: (app_id = generate_random_key_with_all_chars_of_rfc_6749.call))
+
+    assert cinstance.save
+    assert app_id, cinstance.reload.application_id
+  end
+
+  test 'App ID length is validated to be between 4 and 255 characters' do
+    cinstance = FactoryBot.build(:cinstance)
+
+    cinstance.application_id = ''
+    refute cinstance.valid?
+
+    cinstance.application_id = 'a' * 3
+    refute cinstance.valid?
+
+    cinstance.application_id = 'a' * 4
+    assert cinstance.valid?
+
+    cinstance.application_id = 'a' * 255
+    assert cinstance.valid?
+  end
 end


### PR DESCRIPTION
Closes [THREESCALE-1451](https://issues.jboss.org/browse/THREESCALE-1451)