### PR TITLE
Creates a separate test database for seeds test

### DIFF
--- a/config/examples/database.yml
+++ b/config/examples/database.yml
@@ -16,6 +16,10 @@ development:
 test:
   <<: *DEFAULT
   url: <%= "#{ENV['DATABASE_URL']}test" %>
+
+test_seed:
+  <<: *DEFAULT
+  url: <%= "#{ENV['DATABASE_URL']}test_seed" %>
 <% when /^postgresql/ %>
 default: &DEFAULT
   adapter: postgresql
@@ -32,6 +36,10 @@ development:
   <<: *DEFAULT
 
 test:
+  <<: *DEFAULT
+  url: <%= "#{ENV['DATABASE_URL']}#{ENV['TEST_ENV_NUMBER']}" %>
+
+test_seed:
   <<: *DEFAULT
   url: <%= "#{ENV['DATABASE_URL']}#{ENV['TEST_ENV_NUMBER']}" %>
 <% else; db_host = ENV.fetch('DB_PORT_3306_TCP_ADDR') { ENV['DB_PORT'] ? 'db' : ENV['DB_HOST'] } || '127.0.0.1' %>
@@ -51,4 +59,8 @@ development:
 test:
   <<: *DEFAULT
   url: <%= ENV.fetch('DATABASE_URL', "mysql2://root:@#{db_host}:3306/3scale_system_test") %><%=ENV['TEST_ENV_NUMBER']%>
+
+test_seed:
+  <<: *DEFAULT
+  url: <%= ENV.fetch('DATABASE_URL', "mysql2://root:@#{db_host}:3306/3scale_system_test_seed") %><%=ENV['TEST_ENV_NUMBER']%>
 <% end %>

--- a/test/unit/db/seeds_test.rb
+++ b/test/unit/db/seeds_test.rb
@@ -3,7 +3,36 @@
 require 'test_helper'
 
 class SeedsTest < ActiveSupport::TestCase
+  setup do
+    with_fake_env('test_seed') do
+      System::Application.load_tasks
+      Rake::Task['db:create'].invoke
+      Rake::Task['db:schema:load'].invoke
+    end
+
+  end
+
+  attr_reader :env
+
+  teardown do
+    with_fake_env('test_seed') { Rake::Task['db:drop'].invoke }
+  end
+
   test 'the seeds do not fail' do
+    ActiveRecord::Base.establish_connection(:test_seed)
     assert Rails.application.load_seed
+    ActiveRecord::Base.establish_connection(:test)
+  end
+
+  private
+
+  def with_fake_env(new_env)
+    old_env = Rails.env
+    begin
+      Rails.env = ENV['RAILS_ENV'] = new_env
+      yield
+    ensure
+      Rails.env = ENV['RAILS_ENV'] = old_env
+    end
   end
 end

--- a/test/unit/db/seeds_test.rb
+++ b/test/unit/db/seeds_test.rb
@@ -3,36 +3,33 @@
 require 'test_helper'
 
 class SeedsTest < ActiveSupport::TestCase
-  setup do
-    with_fake_env('test_seed') do
-      System::Application.load_tasks
-      Rake::Task['db:create'].invoke
-      Rake::Task['db:schema:load'].invoke
+  class SeedDatabaseConnection < ActiveRecord::Base
+    def self.abstract_class?
+      true
     end
-
   end
 
-  attr_reader :env
+  disable_transactional_fixtures!
 
-  teardown do
-    with_fake_env('test_seed') { Rake::Task['db:drop'].invoke }
+  setup do
+    @config = ActiveRecord::Base.configurations['test_seed']
+    adapter = ActiveRecord::Tasks::DatabaseTasks.send(:class_for_adapter, config['adapter']).new(config)
+    creation_options = adapter.send(:creation_options)
+    ActiveRecord::Base.connection.create_database config['database'], creation_options
+    ActiveRecord::Tasks::DatabaseTasks.load_schema_for(config)
+    SeedDatabaseConnection.establish_connection(:test_seed)
+  end
+
+  attr_reader :config
+
+  def after_teardown
+    super
+    SeedDatabaseConnection.connection.drop_database config['database']
   end
 
   test 'the seeds do not fail' do
-    ActiveRecord::Base.establish_connection(:test_seed)
-    assert Rails.application.load_seed
-    ActiveRecord::Base.establish_connection(:test)
-  end
-
-  private
-
-  def with_fake_env(new_env)
-    old_env = Rails.env
-    begin
-      Rails.env = ENV['RAILS_ENV'] = new_env
-      yield
-    ensure
-      Rails.env = ENV['RAILS_ENV'] = old_env
+    SeedDatabaseConnection.transaction(requires_new: true) do
+      assert Rails.application.load_seed
     end
   end
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It makes the seeds test to always run in its own database.

**Which issue(s) this PR fixes** 

Closes [THREESCALE-2854](https://issues.jboss.org/browse/THREESCALE-2854)

**Special notes for your reviewer**

For CircleCI only, an alternative could be not to run the seeds test among the others and create a separate job for it setting the `DATABASE_URL` of the test environment with a different and exclusive db, say by tweaking with `TEST_ENV_NUMBER`.

We could as well just clear the test database with `db:data:clear`, but I'm afraid that could mess with concurrent tests eventually pointing to the same db.