### PR TITLE
[bugfix] Keycloak client must have openid scope

### DIFF
--- a/app/lib/three_scale/oauth2/keycloak_client.rb
+++ b/app/lib/three_scale/oauth2/keycloak_client.rb
@@ -43,6 +43,10 @@ module ThreeScale
         }
       end
 
+      def scopes
+        'openid'
+      end
+
       private
 
       class RedirectUri

--- a/test/unit/three_scale/oauth2/keycloak_client_test.rb
+++ b/test/unit/three_scale/oauth2/keycloak_client_test.rb
@@ -59,6 +59,10 @@ class ThreeScale::OAuth2::KeycloakClientTest < ActiveSupport::TestCase
     assert_equal expected_data, @oauth2.user_data.to_h
   end
 
+  test '#scopes' do
+    assert_equal 'openid', @oauth2.scopes
+  end
+
   class RedirectUriTest < ActiveSupport::TestCase
 
     RedirectUri = ThreeScale::OAuth2::KeycloakClient::RedirectUri


### PR DESCRIPTION
Closes THREESCALE-2909
In order to use OpenID Connect as specified in https://openid.net/specs/openid-connect-basic-1_0.html#Scopes

The scope `openid` is REQUIRED otherwise

REQUIRED. Informs the Authorization Server that the Client is making an OpenID Connect request. If the openid scope value is not present, the behavior is entirely unspecified.