### PR TITLE
Fixing PF4 BG image in firefox

### DIFF
--- a/app/javascript/packs/LoginPage.js
+++ b/app/javascript/packs/LoginPage.js
@@ -12,10 +12,10 @@ import {safeFromJsonString} from 'utilities/json-utils'
 document.addEventListener('DOMContentLoaded', () => {
   const oldLoginWrapper = document.getElementById('old-login-page-wrapper')
   oldLoginWrapper.removeChild(document.getElementById('old-login-page'))
-  const loginPageContainer = document.getElementById('login-page-container')
+  const PFLoginPageContainer = document.getElementById('pf-login-page-container')
   if (isIE11) {
-    loginPageContainer.classList.add('isIe11', 'pf-c-page')
+    PFLoginPageContainer.classList.add('isIe11', 'pf-c-page')
   }
-  const loginPageProps = safeFromJsonString(loginPageContainer.dataset.loginProps)
-  LoginPageWrapper(loginPageProps, 'login-page-container')
+  const loginPageProps = safeFromJsonString(PFLoginPageContainer.dataset.loginProps)
+  LoginPageWrapper(loginPageProps, 'pf-login-page-container')
 })

--- a/app/javascript/packs/SignUpPage.js
+++ b/app/javascript/packs/SignUpPage.js
@@ -10,14 +10,16 @@ if (isIE11) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const signupPageContainer = document.getElementById('signup-page-container')
+  const loginPageContainer = document.getElementById('login-page-container')
   if (isIE11) {
-    signupPageContainer.classList.add('isIe11', 'pf-c-page')
+    loginPageContainer.classList.add('isIe11', 'pf-c-page')
   }
 
-  const loginLayout = document.querySelector('.login-layout')
-  loginLayout.removeChild(document.getElementById('old-signup-page-wrapper'))
+  let oldLoginWrapper = document.getElementById('old-login-page-wrapper')
+  if (oldLoginWrapper.parentNode) {
+    oldLoginWrapper.parentNode.removeChild(oldLoginWrapper)
+  }
 
-  const signupPageProps = safeFromJsonString(signupPageContainer.dataset.props)
-  SignupPageWrapper(signupPageProps, 'signup-page-container')
+  const signupPageProps = safeFromJsonString(loginPageContainer.dataset.signupProps)
+  SignupPageWrapper(signupPageProps, 'login-page-container')
 })

--- a/app/javascript/packs/SignUpPage.js
+++ b/app/javascript/packs/SignUpPage.js
@@ -10,9 +10,9 @@ if (isIE11) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const loginPageContainer = document.getElementById('login-page-container')
+  const PFLoginPageContainer = document.getElementById('pf-login-page-container')
   if (isIE11) {
-    loginPageContainer.classList.add('isIe11', 'pf-c-page')
+    PFLoginPageContainer.classList.add('isIe11', 'pf-c-page')
   }
 
   let oldLoginWrapper = document.getElementById('old-login-page-wrapper')
@@ -20,6 +20,6 @@ document.addEventListener('DOMContentLoaded', () => {
     oldLoginWrapper.parentNode.removeChild(oldLoginWrapper)
   }
 
-  const signupPageProps = safeFromJsonString(loginPageContainer.dataset.signupProps)
-  SignupPageWrapper(signupPageProps, 'login-page-container')
+  const signupPageProps = safeFromJsonString(PFLoginPageContainer.dataset.signupProps)
+  SignupPageWrapper(signupPageProps, 'pf-login-page-container')
 })

--- a/app/javascript/src/LoginPage/assets/styles/loginPage.scss
+++ b/app/javascript/src/LoginPage/assets/styles/loginPage.scss
@@ -19,7 +19,7 @@ $pf-black-500:  #8b8d8f; // $osloGray
 $--pf-global--danger-color--100: #c9190b;
 $--pf-global--info-color--200:	#004368;
 
-#login-page-container {
+#pf-login-page-container {
 
   .pf-c-background-image::before {
     filter: none;

--- a/app/views/provider/invitee_signups/show.html.erb
+++ b/app/views/provider/invitee_signups/show.html.erb
@@ -1,6 +1,6 @@
 <%= javascript_pack_tag 'SignUpPage' %>
 
-<%= tag("div", :id => "login-page-container", :"data-signup-props" => {:path => provider_invitee_signup_path(@invitation.token),
+<%= tag("div", :id => "pf-login-page-container", :"data-signup-props" => {:path => provider_invitee_signup_path(@invitation.token),
   :name => @invitation.account.name,
   :user => {
       :email => @user.email || "",

--- a/app/views/provider/invitee_signups/show.html.erb
+++ b/app/views/provider/invitee_signups/show.html.erb
@@ -1,6 +1,16 @@
 <%= javascript_pack_tag 'SignUpPage' %>
 
-<div id="old-signup-page-wrapper">
+<%= tag("div", :id => "login-page-container", :"data-signup-props" => {:path => provider_invitee_signup_path(@invitation.token),
+  :name => @invitation.account.name,
+  :user => {
+      :email => @user.email || "",
+      :username => @user.username || "",
+      :firstname => @user.first_name || "",
+      :lastname => @user.last_name || ""
+    }
+}.to_json) %>
+
+<div id="old-login-page-wrapper">
   <h2>Sign Up to <%= @invitation.account.name %></h2>
 
  
@@ -20,15 +30,4 @@
  <% end %>
 </div>
 
-<%= tag("div", :id => "signup-page-container", :data => {
-  :props => {
-    :user => {
-      :email => @user.email || "",
-      :username => @user.username || "",
-      :firstname => @user.first_name || "",
-      :lastname => @user.last_name || ""
-    },
-    :path => provider_invitee_signup_path(@invitation.token),
-    :name => @invitation.account.name
-  }
-}) %>
+

--- a/app/views/provider/sessions/new.html.slim
+++ b/app/views/provider/sessions/new.html.slim
@@ -1,7 +1,7 @@
 = javascript_pack_tag 'LoginPage'
 - authentication_providers = (@authentication_providers || []).map { |ap| {authorizeURL: ap.authorize_url, humanKind: ap.human_kind} }
 - flash_messages = (flash || []).map { |f| {type: f[0], message: f[1]}}
-div#login-page-container data-login-props={redirectUrl: (session[:return_to].nil? ? "null" : (request.protocol + request.host_with_port + session[:return_to])),
+div#pf-login-page-container data-login-props={redirectUrl: (session[:return_to].nil? ? "null" : (request.protocol + request.host_with_port + session[:return_to])),
   enforceSSO: false,
   authenticationProviders: authentication_providers,
   flashMessages: flash_messages,


### PR DESCRIPTION
**What this PR does / why we need it**:
In Firefox the BG image of PF4 Loginpage component is not rendering (in the signup form, with invitation email).

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-2991

**Verification steps** 

- Go to **Account Settings > Users > Invitations**
- Send an invitation
- Logout
- In the terminal, look for the link sent
- Go to the link in Firefox
