### PR TITLE
[WIP][Outdated]When deleting in parallel, try once to unstore credit card before destroying the buyer

### DIFF
--- a/app/models/account/payment_details.rb
+++ b/app/models/account/payment_details.rb
@@ -4,7 +4,7 @@ module Account::PaymentDetails
   extend ActiveSupport::Concern
 
   included do
-    has_one :payment_detail, -> { order id: :desc }, autosave: true
+    has_one :payment_detail, -> { order id: :desc }, autosave: true, dependent: :delete
 
     CREDIT_CARD_ATTRIBUTES = [
       :credit_card_auth_code,

--- a/app/workers/delete_account_hierarchy_worker.rb
+++ b/app/workers/delete_account_hierarchy_worker.rb
@@ -21,4 +21,8 @@ class DeleteAccountHierarchyWorker < DeleteObjectHierarchyWorker
     end
   end
 
+  def destroyable_associations
+    super.select { |reflection| reflection.class_name != Account.name }
+  end
+
 end

--- a/app/workers/delete_object_hierarchy_worker.rb
+++ b/app/workers/delete_object_hierarchy_worker.rb
@@ -130,6 +130,8 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
         DeleteAccountHierarchyWorker
       when Service.name
         DeleteServiceHierarchyWorker
+      when PaymentGatewaySetting.name
+        DeletePaymentSettingHierarchyWorker
       else
         DeleteObjectHierarchyWorker
       end

--- a/app/workers/delete_payment_setting_hierarchy_worker.rb
+++ b/app/workers/delete_payment_setting_hierarchy_worker.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class DeletePaymentSettingHierarchyWorker < DeleteObjectHierarchyWorker
+  alias payment_setting object
+
+  def delete_associations
+    destroy_users_of_provider(payment_setting.account) if called_from_provider_hierarchy?
+
+    super
+  end
+
+  private
+
+  def called_from_provider_hierarchy?
+    caller_worker_hierarchy.include?("Hierarchy-Account-#{payment_setting.account_id}")
+  end
+
+  def destroy_users_of_provider(provider)
+    provider.buyer_account_ids.each do |associated_object_id|
+      associated_object = Account.new
+      associated_object.id = associated_object_id
+      DeleteAccountHierarchyWorker.perform_later(associated_object, caller_worker_hierarchy)
+    end
+  end
+
+end


### PR DESCRIPTION
Closes [THREESCALE-3637](https://issues.jboss.org/browse/THREESCALE-3637)
Remove all buyers (+ unstore credit cards) before the PaymentSetting

**VERY WIP**