### PR TITLE
Fix Reflection Account-ProvidedAccessTokens through Users

### DIFF
--- a/app/lib/service_discovery/authentication_provider_support.rb
+++ b/app/lib/service_discovery/authentication_provider_support.rb
@@ -6,7 +6,7 @@ module ServiceDiscovery::AuthenticationProviderSupport
 
   def self.included(base)
     base.class_eval do
-      has_many :provided_access_tokens, through: :user
+      has_many :provided_access_tokens, through: :users
     end
   end
 


### PR DESCRIPTION
Error discovered by @guicassolato in https://github.com/3scale/porta/pull/982#discussion_r301696933 and explained in https://github.com/3scale/porta/pull/982#discussion_r301845050

Before this PR:
![image](https://user-images.githubusercontent.com/11318903/60931785-3ac3b800-a2bb-11e9-80b6-a764cc6517b1.png)
After this PR:
![image](https://user-images.githubusercontent.com/11318903/60931795-47e0a700-a2bb-11e9-9b6a-d18aea22599e.png)