### PR TITLE
[WIP] Fix Links decoration

### DIFF
--- a/app/assets/stylesheets/provider/_links.scss
+++ b/app/assets/stylesheets/provider/_links.scss
@@ -1,9 +1,10 @@
 p a {
-  text-decoration: underline;
   color: $font-color;
+  text-decoration: underline;
 
   &:hover {
     color: $link-color;
+    text-decoration: underline;
   }
 }
 

--- a/app/assets/stylesheets/provider/_menu.scss
+++ b/app/assets/stylesheets/provider/_menu.scss
@@ -55,6 +55,7 @@ ul.login-form-links {
 
       &:hover {
         color: $menu-hover-color;
+        text-decoration: underline;
       }
     }
   }
@@ -92,6 +93,7 @@ ul.login-form-links {
 
     &:hover {
       color: $menu-hover-color;
+      text-decoration: underline;
     }
   }
 }

--- a/app/assets/stylesheets/provider/_services.scss
+++ b/app/assets/stylesheets/provider/_services.scss
@@ -104,11 +104,12 @@
       }
 
       a {
-        text-decoration: underline;
         color: $link-hover-color;
+        text-decoration: underline;
 
         &:hover {
-          color: $link-color
+          color: $link-color;
+          text-decoration: underline;
         }
       }
     }

--- a/app/assets/stylesheets/provider/_settings_box.scss
+++ b/app/assets/stylesheets/provider/_settings_box.scss
@@ -19,6 +19,7 @@
 
     &:hover {
       color: $link-hover-color;
+      text-decoration: underline;
     }
 
     &--inline {

--- a/app/assets/stylesheets/provider/stats/_base.scss
+++ b/app/assets/stylesheets/provider/stats/_base.scss
@@ -57,6 +57,7 @@ $stats-menu-help-color: $label-color;
     &:hover,
     &.is-selected {
       color: $stats-menu-link-color-selected;
+      text-decoration: underline;
     }
   }
 

--- a/app/javascript/packs/pf4BaseStyles.js
+++ b/app/javascript/packs/pf4BaseStyles.js
@@ -5,3 +5,5 @@
 /* selective pf4 base styles */
 import '@patternfly/patternfly/patternfly-variables.css'
 import '@patternfly/patternfly/patternfly-globals.css'
+
+import 'utilities/override-pf-styles.scss'

--- a/app/javascript/src/utilities/override-pf-styles.scss
+++ b/app/javascript/src/utilities/override-pf-styles.scss
@@ -1,0 +1,3 @@
+a:hover {
+  text-decoration: inherit;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the introduction to Patternfly4 React in the Vertical Navigation, links styles are overridden. These new styles are added inline and in a the last place (after all rails stylesheets have been loaded).

Therefore the best solution is to use `!important` os that our style has the priority. Eventually when we fully implement PF4 it will be as simple as removing this very line.

![link](https://user-images.githubusercontent.com/11672286/60960457-50ac9980-a30a-11e9-9900-3e65b0a2e060.gif)


**Which issue(s) this PR fixes** 
[THREESCALE-2994: links in dashboard and popup menu's shouldn't underline on hover](https://issues.jboss.org/browse/THREESCALE-2994)

**Verification steps** 

* In Vertical Navigation: titles, but not subtitles, should have an underline.
* In the rest of the UI: no link should have an underline.

