### PR TITLE
Fixes Header on small screen setup

### DIFF
--- a/app/assets/stylesheets/provider/_patternfly_ie11.scss
+++ b/app/assets/stylesheets/provider/_patternfly_ie11.scss
@@ -282,8 +282,8 @@ button:-moz-focusring,
   -ms-grid-row-span: 1;
   grid-row: 2 / 3;
   min-width: 0;
-  padding-left: 0;
-  background-color: transparent;
+  padding-left: 0 !important; // Need to override styles introduced by PF React
+  background-color: transparent !important; // Need to override styles introduced by PF React
 }
 
 .pf-c-page__header-nav > .pf-c-nav {


### PR DESCRIPTION
**What this PR does / why we need it**:

After introducing PF4 React in vert nav, the header is showing some weird styles due to Patternfly variables.

In order to fix this, it is required to use `!important` in our `_patternfly_ie11.scss`.

Before:
![header](https://user-images.githubusercontent.com/11672286/61120071-6651c880-a49c-11e9-8daa-5cf1461f8200.gif)

After:
![header_after](https://user-images.githubusercontent.com/11672286/61120084-6eaa0380-a49c-11e9-8844-3290c4e119b3.gif)


**Which issue(s) this PR fixes** 
[THREESCALE-3013: Header changes color when on small screen setup](https://issues.jboss.org/browse/THREESCALE-3013)

**Verification steps** 
* Go to a screen where there's a Vertical Navigation (e.g. Audience)
* Shrink browser and look at the Header's nav component. Background and margins should stay unchanged.
