### PR TITLE
DomainsChangedEvent not issued on Saas

### DIFF
--- a/app/subscribers/publish_zync_event_subscriber.rb
+++ b/app/subscribers/publish_zync_event_subscriber.rb
@@ -12,13 +12,20 @@ class PublishZyncEventSubscriber
 
   # @param [ZyncEvent] event
   def call(event)
+    unless ThreeScale.config.onpremises
+      case event
+      when Domains::ProxyDomainsChangedEvent, Domains::ProviderDomainsChangedEvent
+        return
+      end
+    end
+
     zync = case event
            # When the app is deleted the event caries all the needed information
            when Cinstances::CinstanceCancellationEvent then ZyncEvent.create(event)
            when ApplicationRelatedEvent then ZyncEvent.create(event, event.application)
            when OIDC::ProxyChangedEvent, Domains::ProxyDomainsChangedEvent then ZyncEvent.create(event, event.proxy)
            when OIDC::ServiceChangedEvent then ZyncEvent.create(event, event.service)
-           when Domains::ProviderDomainsChangedEvent then  ZyncEvent.create(event, event.provider)
+           when Domains::ProviderDomainsChangedEvent then ZyncEvent.create(event, event.provider)
            else raise "Unknown event type #{event.class}"
            end
 

--- a/test/subscribers/publish_zync_event_subscriber_test.rb
+++ b/test/subscribers/publish_zync_event_subscriber_test.rb
@@ -8,7 +8,48 @@ class PublishZyncEventSubscriberTest < ActiveSupport::TestCase
   def test_create
     application = FactoryBot.build_stubbed(:simple_cinstance, tenant_id: 1)
     event = Applications::ApplicationCreatedEvent.new(application: application)
-
     assert @subscriber.call(event)
+  end
+
+  class DomainEventsTest < ActiveSupport::TestCase
+    setup do
+      @subscriber = PublishZyncEventSubscriber.new
+      ThreeScale.config.stubs(onpremises: true)
+    end
+
+    attr_reader :subscriber
+
+    test 'proxy domains event' do
+      proxy = FactoryBot.build_stubbed(:proxy)
+      event = Domains::ProxyDomainsChangedEvent.create proxy
+      assert subscriber.call(event)
+    end
+
+    test 'provider domains event' do
+      provider = FactoryBot.build_stubbed(:simple_provider)
+      event = Domains::ProviderDomainsChangedEvent.create provider
+      assert subscriber.call(event)
+    end
+  end
+
+  class NotOnpremDomainEventsTest < ActiveSupport::TestCase
+    setup do
+      @subscriber = PublishZyncEventSubscriber.new
+      ThreeScale.config.stubs(onpremises: false)
+    end
+
+    attr_reader :subscriber
+
+    test 'proxy domains event' do
+      proxy = FactoryBot.build_stubbed(:proxy)
+      event = Domains::ProxyDomainsChangedEvent.create proxy
+      refute subscriber.call(event)
+    end
+
+    test 'provider domains event' do
+      provider = FactoryBot.build_stubbed(:simple_provider)
+      event = Domains::ProviderDomainsChangedEvent.create provider
+      refute subscriber.call(event)
+    end
   end
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Makes `ProviderDomainsChangedEvent` and `ProxyDomainsChangedEvent` not to be issued on Saas