### PR TITLE
[apiap] Remove Backend API default slug

### DIFF
--- a/app/presenters/backend_api_presenter.rb
+++ b/app/presenters/backend_api_presenter.rb
@@ -18,10 +18,6 @@ class BackendApiPresenter
     "Backend API of #{service.name}"
   end
 
-  def default_product_slug
-    nil
-  end
-
   alias_method :to_param, :system_name
 
   delegate :proxy, to: :service

--- a/app/presenters/services/backend_api_presenter.rb
+++ b/app/presenters/services/backend_api_presenter.rb
@@ -1,5 +1,5 @@
 class Services::BackendApiPresenter < BackendApiPresenter
   def product_slug
-    nil || default_product_slug
+    nil
   end
 end

--- a/app/views/provider/admin/backend_apis/show.html.slim
+++ b/app/views/provider/admin/backend_apis/show.html.slim
@@ -13,9 +13,6 @@ section.Section
         dd.u-dl-definition == description
       dt.u-dl-term Private Base URL
       dd.u-dl-definition == @backend_api.private_url
-      - if (default_product_slug = @backend_api.default_product_slug.presence)
-        dt.u-dl-term Default Product Slug
-        dd.u-dl-definition == default_product_slug
 
 section class="service-widget"
   div.content-service


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Removes Backend API default product slug, not need since it was decided that a product may include one (and only one) Backend API without any slug at all.