### PR TITLE
[apiap] Backend API metrics controller and index page

### DIFF
--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -5,13 +5,9 @@ class Api::MetricsController < Api::BaseController
   before_action :find_plan_and_service, only: [:toggle_visible, :toggle_limits_only_text, :toggle_enabled]
   before_action :find_metric, except: [:new, :create, :index]
   before_action :build_metric, only: [:new, :create]
-  before_action :activate_menu
 
+  activate_menu :serviceadmin, :integration, :methods_metrics
   sublayout 'api/service'
-
-  def activate_menu(*args)
-    super (@service&.acts_as_product? ? %i[backend_api] : %i[serviceadmin integration]) << :methods_metrics
-  end
 
   def index
     respond_to do |format|

--- a/app/controllers/provider/admin/backend_apis/metrics_controller.rb
+++ b/app/controllers/provider/admin/backend_apis/metrics_controller.rb
@@ -1,15 +1,25 @@
 # frozen_string_literal: true
 
 class Provider::Admin::BackendApis::MetricsController < Provider::Admin::BackendApis::BaseController
+  before_action :find_metric, except: [:new, :create, :index]
+  before_action :build_metric, only: [:new, :create]
+
   activate_menu :backend_api, :methods_metrics
   sublayout 'api/service'
 
   def index
     @metrics = @backend_api.metrics.top_level.includes(:proxy_rules)
-    @methods = @backend_api.method_metrics.includes(:proxy_rules)
-    @hits_metric = @backend_api.metrics.hits
+    @service = @backend_api.service # FIXME: This is needed because the page is still using a helper shared with the old metrics page (app/helpers/services_helper.rb:26)
+  end
 
-    render template: '/api/metrics/index'
+  def new
+    @service = @backend_api.service # FIXME: This is needed because the page is still pointing the form to the old metrics controller
+    render template: '/api/metrics/new'
+  end
+
+  def edit
+    @service = @backend_api.service # FIXME: This is needed because the page is still pointing the form to the old metrics controller
+    render template: '/api/metrics/edit'
   end
 
   helper_method :bubbles
@@ -17,5 +27,19 @@ class Provider::Admin::BackendApis::MetricsController < Provider::Admin::Backend
 
   def bubbles
     onboarding.persisted? ? onboarding.bubbles : []
+  end
+
+  private
+
+  def find_metric
+    @metric = @backend_api.metrics.find(params[:id])
+  end
+
+  def build_metric
+    @metric = if params[:metric_id]
+                @backend_api.metrics.find(params[:metric_id]).children
+              else
+                @backend_api.metrics
+              end.build(params[:metric] || {})
   end
 end

--- a/app/controllers/provider/admin/backend_apis/metrics_controller.rb
+++ b/app/controllers/provider/admin/backend_apis/metrics_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Provider::Admin::BackendApis::MetricsController < Provider::Admin::BackendApis::BaseController
+  activate_menu :backend_api, :methods_metrics
+  sublayout 'api/service'
+
+  def index
+    @metrics = @backend_api.metrics.top_level.includes(:proxy_rules)
+    @methods = @backend_api.method_metrics.includes(:proxy_rules)
+    @hits_metric = @backend_api.metrics.hits
+
+    render template: '/api/metrics/index'
+  end
+
+  helper_method :bubbles
+  delegate :onboarding, to: :current_account
+
+  def bubbles
+    onboarding.persisted? ? onboarding.bubbles : []
+  end
+end

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -248,7 +248,7 @@ module VerticalNavHelper
     sections = []
     return sections unless @backend_api
     sections << {id: :overview,         title: 'Overview',           path: provider_admin_backend_api_path(@backend_api)}
-    sections << {id: :methods_metrics,  title: 'Methods & Metrics',  path: admin_service_metrics_path(@backend_api.service)}
+    sections << {id: :methods_metrics,  title: 'Methods & Metrics',  path: provider_admin_backend_api_metrics_path(@backend_api)}
     sections << {id: :mapping_rules,    title: 'Mapping Rules',      path: provider_admin_backend_api_mapping_rules_path(@backend_api)}
   end
 

--- a/app/views/provider/admin/backend_apis/mapping_rules/index.html.slim
+++ b/app/views/provider/admin/backend_apis/mapping_rules/index.html.slim
@@ -24,7 +24,7 @@ section.Section
             th
               ' Metric or Method
               | (
-              = link_to 'Define', admin_service_metrics_path(@backend_api.service), title: 'Define Methods & Metrics for this service'
+              = link_to 'Define', provider_admin_backend_api_metrics_path(@backend_api), title: 'Define Methods & Metrics for this service'
               | )
             th colspan="2"
               ' Last?

--- a/app/views/provider/admin/backend_apis/metrics/_form.html.slim
+++ b/app/views/provider/admin/backend_apis/metrics/_form.html.slim
@@ -1,0 +1,8 @@
+= form.inputs do
+  = form.input :friendly_name, hint: @metric.child? ? 'e.g. Create new user' : 'e.g. Transfer Out', input_html: { autofocus: true }
+  = form.input :system_name, hint: ( @metric.child? ? 'e.g. users/create or create_user' : 'e.g. transfer_out' ) + '. Spaces are not permitted.', input_html: { disabled: @metric.default?(:hits) }
+  = form.input :unit unless @metric.child?
+  = form.input :description, input_html: { rows: 3 }
+
+= form.buttons do
+  = form.commit_button "#{@metric.new_record? ? 'Create' : 'Update'} #{@metric.child? ? 'Method' : 'Metric'}"

--- a/app/views/provider/admin/backend_apis/metrics/_link_to_mapping_rules.slim
+++ b/app/views/provider/admin/backend_apis/metrics/_link_to_mapping_rules.slim
@@ -1,0 +1,5 @@
+= link_to provider_admin_backend_api_mapping_rules_path(@backend_api) do
+  - if metric.proxy_rules.any?
+    i.fa.fa-check
+  - else
+    | Add a mapping rule

--- a/app/views/provider/admin/backend_apis/metrics/index.html.slim
+++ b/app/views/provider/admin/backend_apis/metrics/index.html.slim
@@ -1,0 +1,108 @@
+- content_for :sublayout_title, 'Methods & Metrics'
+
+= javascript_include_tag 'vendor/jquery/extensions/jquery.cookie.js'
+
+- content_for :javascripts do
+  = javascript_pack_tag 'bubbles'
+
+section.Section.u-toggleableBySettingsBox data-state="open"
+  h2 Methods
+  p
+    ' Add the methods of this Backend API to get data on their individual usage once part of a Product. Method calls trigger the built-in Hits-metric. Usage limits and pricing rules for individual methods are defined under context of a Product Application Plan.
+    ' .
+    - if show_mappings?
+      ' A method needs to be mapped to one or more URL patterns in the
+      => link_to 'Mapping Rules', provider_admin_backend_api_mapping_rules_path(@backend_api)
+      ' of this Backend API.
+    - else
+      ' Make sure to call these methods from your code base so specific usage of your API up the count of specific methods.
+
+  - cache ['v1', 'methods', @backend_api] do
+    table#metrics.data class=(show_mappings? ? 'u-sixEqualColumns' : 'u-fiveEqualColumns')
+      thead
+        tr
+          th Method
+          th System Name
+          th Unit
+          th Description
+          - if show_mappings?
+            th Mapped
+          th.actions
+            = link_to 'New method',
+                      new_provider_admin_backend_api_metric_child_path(@backend_api, @backend_api.metrics.hits),
+                      class:'action add' if @backend_api.metrics.hits
+
+      tbody
+        - if @backend_api.method_metrics.any?
+          - @backend_api.method_metrics.each do |method|
+            tr
+              td
+                = link_to method.friendly_name,
+                  edit_provider_admin_backend_api_metric_path(@backend_api, method)
+              td = method.system_name
+              td = method.unit
+              td = method.description
+              - if show_mappings?
+                td
+                  = render 'link_to_mapping_rules', metric: method
+              td.actions
+
+          javascript:
+            document.addEventListener('DOMContentLoaded', function () {
+              showBubble(#{json bubbles.take(1).as_json})
+            })
+            $(document).on('click', 'a[data-behavior~=open-mapping-rules]', function(event){
+              // Unfold the mapping section of the integration page by
+              // setting the cookie value that controls it
+              $.cookie( 'mapping-rules', true, {expires: 30, path: '/'});
+            });
+
+        - else
+          tr
+            td colspan=(show_mappings? ? '6' : '5')
+              = t('provider.admin.messages.no_methods')
+
+section.Section.u-toggleableBySettingsBox data-state="open"
+  h2 Metrics
+  p
+    ' <em>Hits</em> is the built-in metric to which all methods report. Additional top-level metrics can be added here in order to track other usage that shouldn't increase the hit count.
+    - if show_mappings?
+      ' A metric needs to be mapped to one or more URL patterns in the
+      => link_to 'Mapping Rules', provider_admin_backend_api_mapping_rules_path(@backend_api)
+      ' of this Backend API
+    - else
+      ' Make sure to call these metrics from your code base so specific calls to your API up the count of specific metrics.
+
+  - cache ['v1', 'metrics', @backend_api] do
+    table#metrics.data class=(show_mappings? ? 'u-sixEqualColumns' : 'u-fiveEqualColumns')
+      thead
+        tr
+          th Metric
+          th System Name
+          th Unit
+          th Description
+          - if show_mappings?
+            th Mapped
+          th.actions
+            = link_to 'New metric',
+                      new_provider_admin_backend_api_metric_path(@backend_api),
+                      class:'action add'
+
+      tbody
+        - if @backend_api.top_level_metrics.any?
+          - @backend_api.top_level_metrics.each do |metric|
+            tr
+              td
+                = link_to metric.friendly_name, edit_provider_admin_backend_api_metric_path(@backend_api, metric)
+              td = metric.system_name
+              td = metric.unit
+              td = metric.description
+              - if show_mappings?
+                td
+                  = render 'link_to_mapping_rules', metric: metric
+              td.actions
+
+        - else
+          tr
+            td colspan=(show_mappings? ? '6' : '5')
+              = t('provider.admin.messages.no_metrics')

--- a/app/views/provider/admin/backend_apis/show.html.slim
+++ b/app/views/provider/admin/backend_apis/show.html.slim
@@ -28,6 +28,6 @@ section class="service-widget"
       h2 Methods & Mapping Rules
       ul.application-plans
         li.item
-          = link_to pluralize(@backend_api.method_metrics.size, 'method'), admin_service_metrics_path(@backend_api.service)
+          = link_to pluralize(@backend_api.method_metrics.size, 'method'), provider_admin_backend_api_metrics_path(@backend_api)
         li.item
           = link_to pluralize(@backend_api.mapping_rules.size, 'mapping rule'), provider_admin_backend_api_mapping_rules_path(@backend_api)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,6 +205,7 @@ without fake Core server your after commit callbacks will crash and you might ge
     namespace :admin do
       resources :backend_apis do
         scope module: :backend_apis do
+          resources :metrics
           resources :mapping_rules
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,7 +205,9 @@ without fake Core server your after commit callbacks will crash and you might ge
     namespace :admin do
       resources :backend_apis do
         scope module: :backend_apis do
-          resources :metrics
+          resources :metrics, :except => [:show] do
+            resources :children, :controller => 'metrics', :only => [:new, :create]
+          end
           resources :mapping_rules
         end
       end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Creates a separate controller for Backend API metrics and methods.

For the moment it still renders the index page based on the old template (`/api/metrics/index`).

![Screen Shot 2019-07-12 at 12 38 28 PM](https://user-images.githubusercontent.com/1842261/61122395-fe9e7c00-a4a1-11e9-9ae6-ae32f4ce9c76.png)


**Special notes for your reviewer**:

Contains commits of https://github.com/3scale/porta/pull/995