### PR TITLE
Adding pristinejs to validate forms

### DIFF
--- a/app/javascript/src/LoginPage/loginForms/FormGroup.jsx
+++ b/app/javascript/src/LoginPage/loginForms/FormGroup.jsx
@@ -25,7 +25,7 @@ const getFormGroupProps = (type: string) => {
   const inputTypes = ['text', 'password', 'email', 'text', 'email', 'text', 'text', 'password', 'password']
   const labels = ['Email or Username', 'Password', 'Email address', 'Username', 'Email', 'First name', 'Last name', 'Password', 'Password confirmation']
   const fieldIDs = ['session_username', 'session_password', 'email', 'user_username', 'user_email', 'user_first_name', 'user_last_name', 'user_password', 'user_password_confirmation']
-  const helperTextInvalids = ['Email or username is mandatory', 'Password is mandatory', 'A valid email address is mandatory', 'Username is mandatory', 'A valid email is mandatory', '', '', 'Password is mandatory', 'Password and Password confirmation must match']
+  const helperTextInvalids = ['Email or username is mandatory', 'Password is mandatory', 'A valid email address is mandatory', 'Username is mandatory', 'A valid email is mandatory', '', '', 'Password is mandatory', 'Password confirmation is mandatory']
   const tabIndexs = ['1', '2', '1', null, null, null, null, null, null]
   return {
     label: labels[typeIndex],

--- a/app/javascript/src/LoginPage/loginForms/Login3scaleForm.jsx
+++ b/app/javascript/src/LoginPage/loginForms/Login3scaleForm.jsx
@@ -4,12 +4,18 @@ import React from 'react'
 import type { Node } from 'react'
 
 import {HiddenInputs, FormGroup} from 'LoginPage'
+import Pristine from 'pristinejs'
 
 import {
   Form,
   ActionGroup,
   Button
 } from '@patternfly/react-core'
+
+const idsToStateKeys = {
+  'session_username': 'isValidUsername',
+  'session_password': 'isValidPassword'
+}
 
 type Props = {
   providerSessionsPath: string
@@ -22,42 +28,56 @@ type State = {
   isValidPassword: ?boolean
 }
 
+type Error = {
+  input: {
+    id: string
+  },
+  errors: string[]
+}
+
 class Login3scaleForm extends React.Component<Props, State> {
-  constructor (props: Props) {
-    super(props)
-    this.state = {
-      username: '',
-      password: '',
-      isValidUsername: undefined,
-      isValidPassword: undefined
+  pristine: any
+
+  state = {
+    username: '',
+    password: '',
+    isValidUsername: undefined,
+    isValidPassword: undefined
+  }
+
+  componentDidMount () {
+    const formElement = document.getElementById('new_session')
+    this.pristine = new Pristine(formElement)
+  }
+
+  handleTextInputUsername = (username: string, event: SyntheticEvent<HTMLInputElement>) => {
+    this.setState({username})
+    this.validateFormfield(event.currentTarget.id)
+  }
+
+  handleTextInputPassword = (password: string, event: SyntheticEvent<HTMLInputElement>) => {
+    this.setState({password})
+    this.validateFormfield(event.currentTarget.id)
+  }
+
+  setInvalidFields = (errors: Array<Error>) => {
+    for (const error of errors) {
+      (error) => this.setState({[idsToStateKeys[error.input.id]]: false})
     }
   }
 
-  setIsValidUsername = () => {
-    this.setState({isValidUsername: this.state.username !== ''})
-  }
-
-  handleTextInputUsername = (username: string) => {
-    this.setState({ username }, this.setIsValidUsername)
-  }
-
-  setIsValidPassword = () => {
-    this.setState({isValidPassword: this.state.password !== ''})
-  }
-
-  handleTextInputPassword = (password: string) => {
-    this.setState({ password }, this.setIsValidPassword)
+  validateFormfield = (id: string) => {
+    const field = document.getElementById(id)
+    const isFieldValid = this.pristine.validate(field)
+    this.setState({[idsToStateKeys[id]]: isFieldValid}) 
   }
 
   validateForm = (event: SyntheticEvent<HTMLInputElement>) => {
-    this.setIsValidUsername()
-    this.setIsValidPassword()
-    const isFormDisabled = this.state.username === '' ||
-      this.state.password === '' ||
-      this.state.isValidUsername === false ||
-      this.state.isValidPassword === false
-    if (isFormDisabled) {
+    const valid = this.pristine.validate()
+    const errors = this.pristine.getErrors()
+    if (!valid) {
       event.preventDefault()
+      this.setInvalidFields(errors)
     }
   }
 
@@ -76,15 +96,15 @@ class Login3scaleForm extends React.Component<Props, State> {
       inputIsValid: isValidPassword
     }
     return (
-      <Form
+      <Form noValidate={true}
         action={this.props.providerSessionsPath}
         id='new_session'
         acceptCharset='UTF-8'
         method='post'
       >
         <HiddenInputs/>
-        <FormGroup type='username' labelIsValid={isValidUsername} inputProps={usernameInputProps} />
-        <FormGroup type='password' labelIsValid={isValidPassword} inputProps={passwordInputProps} />
+        <FormGroup isRequired type='username' labelIsValid={isValidUsername} inputProps={usernameInputProps} />
+        <FormGroup isRequired type='password' labelIsValid={isValidPassword} inputProps={passwordInputProps} />
         <ActionGroup>
           <Button
             className='pf-c-button pf-m-primary pf-m-block'

--- a/app/javascript/src/LoginPage/loginForms/SignupForm.jsx
+++ b/app/javascript/src/LoginPage/loginForms/SignupForm.jsx
@@ -9,6 +9,14 @@ import {
   HiddenInputs,
   FormGroup
 } from 'LoginPage'
+import Pristine from 'pristinejs'
+
+const idsToStateKeys = {
+  'user_username': 'isValidUsername',
+  'user_email': 'isValidEmailAddress',
+  'user_password': 'isValidPassword',
+  'user_password_confirmation': 'isValidPasswordConfirmation'
+}
 
 type Props = {
   path: string,
@@ -27,12 +35,19 @@ type State = {
   lastname: string,
   password: string,
   passwordConfirmation: string,
-  isFilledUsername: ?boolean,
-  isFilledEmailAddress: ?boolean,
-  isFilledFirstname: boolean,
-  isFilledLastname: boolean,
-  isFilledPassword: ?boolean,
-  isFilledPasswordConfirmation: ?boolean
+  isValidUsername: ?boolean,
+  isValidEmailAddress: ?boolean,
+  isValidFirstname: boolean,
+  isValidLastname: boolean,
+  isValidPassword: ?boolean,
+  isValidPasswordConfirmation: ?boolean
+}
+
+type Error = {
+  input: {
+    id: string
+  },
+  errors: string[]
 }
 
 const InputFormGroup = (props) => {
@@ -53,68 +68,97 @@ const InputFormGroup = (props) => {
 }
 
 class SignupForm extends Component<Props, State> {
-  constructor (props: Props) {
-    super(props)
-    this.state = {
-      username: this.props.user.username,
-      emailAddress: this.props.user.email,
-      firstname: this.props.user.firstname,
-      lastname: this.props.user.lastname,
-      password: '',
-      passwordConfirmation: '',
-      isFilledUsername: undefined,
-      isFilledEmailAddress: undefined,
-      isFilledFirstname: true,
-      isFilledLastname: true,
-      isFilledPassword: undefined,
-      isFilledPasswordConfirmation: undefined
-    }
+  pristine: any
+
+  state = {
+    username: this.props.user.username,
+    emailAddress: this.props.user.email,
+    firstname: this.props.user.firstname,
+    lastname: this.props.user.lastname,
+    password: '',
+    passwordConfirmation: '',
+    isValidUsername: undefined,
+    isValidEmailAddress: undefined,
+    isValidFirstname: true,
+    isValidLastname: true,
+    isValidPassword: undefined,
+    isValidPasswordConfirmation: undefined
   }
 
-  handleTextInputUsername = (username: string) =>
-    this.setState({ username, isFilledUsername: username !== '' })
+  componentDidMount () {
+    const formElement = document.getElementById('signup_form')
+    this.pristine = new Pristine(formElement)
+  }
 
-  handleTextInputEmail = (emailAddress: string) =>
-    this.setState({ emailAddress, isFilledEmailAddress: emailAddress !== '' })
+  handleTextInputUsername = (username: string, event: SyntheticEvent<HTMLInputElement>) => {
+    this.setState({ username })
+    this.validateFormfield(event.currentTarget.id)
+  }
 
-  handleTextInputFirstname = (firstname: string) => this.setState({ firstname })
+  handleTextInputEmail = (emailAddress: string, event: SyntheticEvent<HTMLInputElement>) => {
+    this.setState({ emailAddress })
+    this.validateFormfield(event.currentTarget.id)
+  }
+
+  handleTextInputFirstname = (firstname: string) => {
+    this.setState({ firstname })
+  }
 
   handleTextInputLastname = (lastname: string) => this.setState({ lastname })
 
-  handleTextInputPassword = (password: string) =>
-    this.setState({
-      password,
-      isFilledPassword: password !== '',
-      isFilledPasswordConfirmation: this.state.passwordConfirmation === password
-    })
+  handleTextInputPassword = (password: string, event: SyntheticEvent<HTMLInputElement>) => {
+    this.setState({ password })
+    this.validateFormfield(event.currentTarget.id)
+  }
 
-  handleTextInputPasswordConfirmation = (passwordConfirmation: string) =>
-    this.setState({
-      passwordConfirmation,
-      isFilledPasswordConfirmation: passwordConfirmation !== '' && passwordConfirmation === this.state.password
-    })
+  handleTextInputPasswordConfirmation = (passwordConfirmation: string, event: SyntheticEvent<HTMLInputElement>) => {
+    this.setState({ passwordConfirmation })
+    this.validateFormfield(event.currentTarget.id)
+  }
+
+  setInvalidFields = (errors: Array<Error>) => {
+    errors.forEach(
+      (error) => this.setState({[idsToStateKeys[error.input.id]]: false})
+    )
+  }
+
+  validateFormfield = (id: string) => {
+    const field = document.getElementById(id)
+    const isFieldValid = this.pristine.validate(field)
+    this.setState({[idsToStateKeys[id]]: isFieldValid})
+  }
+
+  validateForm = (event: SyntheticEvent<HTMLInputElement>) => {
+    const valid = this.pristine.validate()
+    const errors = this.pristine.getErrors()
+    if (!valid) {
+      event.preventDefault()
+      this.setInvalidFields(errors)
+    }
+  }
 
   render () {
-    const { username, isFilledUsername, emailAddress, isFilledEmailAddress, firstname, isFilledFirstname, lastname, isFilledLastname, password, isFilledPassword, passwordConfirmation, isFilledPasswordConfirmation } = this.state
+    const { username, isValidUsername, emailAddress, isValidEmailAddress, firstname, isValidFirstname, lastname, isValidLastname, password, isValidPassword, passwordConfirmation, isValidPasswordConfirmation } = this.state
     return (
-      <Form noValidate={false}
+      <Form noValidate={true}
         action={this.props.path}
         id='signup_form'
         acceptCharset='UTF-8'
         method='post'
       >
         <HiddenInputs />
-        <InputFormGroup isRequired type='user[username]' value={username} isValid={isFilledUsername} onChange={this.handleTextInputUsername} />
-        <InputFormGroup isRequired type='user[email]' value={emailAddress} isValid={isFilledEmailAddress} onChange={this.handleTextInputEmail} />
-        <InputFormGroup isRequired={false} type='user[first_name]' value={firstname} isValid={isFilledFirstname} onChange={this.handleTextInputFirstname} />
-        <InputFormGroup isRequired={false} type='user[last_name]' value={lastname} isValid={isFilledLastname} onChange={this.handleTextInputLastname} />
-        <InputFormGroup isRequired type='user[password]' value={password} isValid={isFilledPassword} onChange={this.handleTextInputPassword} />
-        <InputFormGroup isRequired type='user[password_confirmation]' value={passwordConfirmation} isValid={isFilledPasswordConfirmation} onChange={this.handleTextInputPasswordConfirmation} />
+        <InputFormGroup isRequired type='user[username]' value={username} isValid={isValidUsername} onChange={this.handleTextInputUsername} />
+        <InputFormGroup isRequired type='user[email]' value={emailAddress} isValid={isValidEmailAddress} onChange={this.handleTextInputEmail} />
+        <InputFormGroup isRequired={false} type='user[first_name]' value={firstname} isValid={isValidFirstname} onChange={this.handleTextInputFirstname} />
+        <InputFormGroup isRequired={false} type='user[last_name]' value={lastname} isValid={isValidLastname} onChange={this.handleTextInputLastname} />
+        <InputFormGroup isRequired type='user[password]' value={password} isValid={isValidPassword} onChange={this.handleTextInputPassword} />
+        <InputFormGroup isRequired type='user[password_confirmation]' value={passwordConfirmation} isValid={isValidPasswordConfirmation} onChange={this.handleTextInputPasswordConfirmation} />
         <ActionGroup>
           <input type="submit"
             name="commit"
             value="Sign up"
             className="pf-m-primary pf-c-button pf-m-primary pf-m-block"
+            onClick={this.validateForm}
           />
         </ActionGroup>
       </Form>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16613,6 +16613,11 @@
         }
       }
     },
+    "pristinejs": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/pristinejs/-/pristinejs-0.1.6.tgz",
+      "integrity": "sha512-M+LVKROrOLtxKduSC8Y5M+iCa7X2GCPGvbBCW5O4eN80mt4d0uqlFygcSvM3Kfsu14blT9IhlbPLPnjzorXL9Q=="
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "node-sass": "^4.9.4",
     "numeral": "^2.0.6",
     "pluralize": "^7.0.0",
+    "pristinejs": "^0.1.6",
     "prop-types": "^15.7.2",
     "react": "^16.8.5",
     "react-codemirror2": "^5.1.0",

--- a/spec/javascripts/LoginPage/Login3scaleForm.spec.jsx
+++ b/spec/javascripts/LoginPage/Login3scaleForm.spec.jsx
@@ -29,16 +29,26 @@ it('should render HiddenInputs component', () => {
 
 it('should set username state', () => {
   const wrapper = mount(<Login3scaleForm {...props}/>)
+  const event = {
+    currentTarget: {
+      id: 'session_username'
+    }
+  }
   jest.spyOn(wrapper.instance(), 'handleTextInputUsername')
-  wrapper.instance().handleTextInputUsername('foo')
+  wrapper.instance().handleTextInputUsername('foo', event)
   expect(wrapper.instance().handleTextInputUsername).toHaveBeenCalled()
   expect(wrapper.state().username).toEqual('foo')
 })
 
 it('should set password state', () => {
   const wrapper = mount(<Login3scaleForm {...props}/>)
+  const event = {
+    currentTarget: {
+      id: 'session_password'
+    }
+  }
   jest.spyOn(wrapper.instance(), 'handleTextInputPassword')
-  wrapper.instance().handleTextInputPassword('bar')
+  wrapper.instance().handleTextInputPassword('bar', event)
   expect(wrapper.instance().handleTextInputPassword).toHaveBeenCalled()
   expect(wrapper.state().password).toEqual('bar')
 })

--- a/spec/javascripts/LoginPage/RequestPasswordForm.spec.jsx
+++ b/spec/javascripts/LoginPage/RequestPasswordForm.spec.jsx
@@ -31,8 +31,13 @@ it('should render HiddenInputs component', () => {
 
 it('should set emailAddress state', () => {
   const wrapper = mount(<RequestPasswordForm {...props}/>)
+  const event = {
+    currentTarget: {
+      id: 'email'
+    }
+  }
   jest.spyOn(wrapper.instance(), 'handleTextInputEmail')
-  wrapper.instance().handleTextInputEmail('foo')
+  wrapper.instance().handleTextInputEmail('foo@bar.com', event)
   expect(wrapper.instance().handleTextInputEmail).toHaveBeenCalled()
-  expect(wrapper.state().emailAddress).toEqual('foo')
+  expect(wrapper.state().emailAddress).toEqual('foo@bar.com')
 })

--- a/spec/javascripts/LoginPage/SignupForm.spec.jsx
+++ b/spec/javascripts/LoginPage/SignupForm.spec.jsx
@@ -33,8 +33,13 @@ describe('Username', () => {
   })
   it('should set username state', () => {
     const wrapper = mount(<SignupForm {...props} />)
+    const event = {
+      currentTarget: {
+        id: 'user_username'
+      }
+    }
     jest.spyOn(wrapper.instance(), 'handleTextInputUsername')
-    wrapper.instance().handleTextInputUsername('Bob')
+    wrapper.instance().handleTextInputUsername('Bob', event)
     expect(wrapper.instance().handleTextInputUsername).toHaveBeenCalled()
     expect(wrapper.state().username).toEqual('Bob')
   })
@@ -47,8 +52,13 @@ describe('Email', () => {
   })
   it('should set emailAddress state', () => {
     const wrapper = mount(<SignupForm {...props} />)
+    const event = {
+      currentTarget: {
+        id: 'user_email'
+      }
+    }
     jest.spyOn(wrapper.instance(), 'handleTextInputEmail')
-    wrapper.instance().handleTextInputEmail('bob@sponge.com')
+    wrapper.instance().handleTextInputEmail('bob@sponge.com', event)
     expect(wrapper.instance().handleTextInputEmail).toHaveBeenCalled()
     expect(wrapper.state().emailAddress).toEqual('bob@sponge.com')
   })
@@ -89,8 +99,13 @@ describe('Password', () => {
   })
   it('should set password state', () => {
     const wrapper = mount(<SignupForm {...props} />)
+    const event = {
+      currentTarget: {
+        id: 'user_password'
+      }
+    }
     jest.spyOn(wrapper.instance(), 'handleTextInputPassword')
-    wrapper.instance().handleTextInputPassword('gary1234')
+    wrapper.instance().handleTextInputPassword('gary1234', event)
     expect(wrapper.instance().handleTextInputPassword).toHaveBeenCalled()
     expect(wrapper.state().password).toEqual('gary1234')
   })
@@ -103,8 +118,13 @@ describe('Password confirmation', () => {
   })
   it('should set passwordConfirmation state', () => {
     const wrapper = mount(<SignupForm {...props} />)
+    const event = {
+      currentTarget: {
+        id: 'user_password_confirmation'
+      }
+    }
     jest.spyOn(wrapper.instance(), 'handleTextInputPasswordConfirmation')
-    wrapper.instance().handleTextInputPasswordConfirmation('gary1234')
+    wrapper.instance().handleTextInputPasswordConfirmation('gary1234', event)
     expect(wrapper.instance().handleTextInputPasswordConfirmation).toHaveBeenCalled()
     expect(wrapper.state().passwordConfirmation).toEqual('gary1234')
   })

--- a/spec/javascripts/LoginPage/SignupPageWrapper.spec.jsx
+++ b/spec/javascripts/LoginPage/SignupPageWrapper.spec.jsx
@@ -24,5 +24,5 @@ it('should render itself', () => {
 
 it('should render <SignupForm/> child component', () => {
   const wrapper = mount(<SignupPage {...props}/>)
-  expect(wrapper.find(SignupPage).exists()).toEqual(true)
+  expect(wrapper.find(SignupForm).exists()).toEqual(true)
 })

--- a/spec/javascripts/__mocks__/pristinejs.js
+++ b/spec/javascripts/__mocks__/pristinejs.js
@@ -1,0 +1,7 @@
+export const mockValidate = jest.fn()
+
+const mock = jest.fn().mockImplementation(() => {
+  return {validate: mockValidate}
+})
+
+export default mock


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds form validation to PF4/React forms

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-2993

**Special notes for your reviewer**:

We are using [PF4 react form](https://patternfly-react.surge.sh/patternfly-4/components/form/) elements. PF doesn't provide any kind of validation, it only expects you to pass a boolean prop to the input fields and an error message to show the corresponding styles.

We should choose a validation library (or craft our own). I've been testing some libraries and I think we could use [Pristine](https://github.com/sha256/Pristine).

**Pros:**
- Small (~4kb minified)
- No additional dependencies
- Non-intrusive (It can only return a simple boolean, or an errors object. It has an option to add styled -error messages, but it's totally optional)
- Active project (last commit  4 Mar, 2019)

**Cons:**
- Early development stage (`"pristinejs": "^0.1.6"`)
- No license (is that an issue?)
- Only 2 contributors