### PR TITLE
ProxyDomainsChangedEvent saves the ProxyID instead of the globalID

### DIFF
--- a/app/events/domains/proxy_domains_changed_event.rb
+++ b/app/events/domains/proxy_domains_changed_event.rb
@@ -3,7 +3,7 @@ require 'uri'
 class Domains::ProxyDomainsChangedEvent < BaseEventStoreEvent
   def self.create(proxy)
     new(
-      proxy:    proxy,
+      proxy: MissingModel::MissingProxy.new(id: proxy.id),
       staging_domains: extract_domain(proxy.sandbox_endpoint),
       production_domains: extract_domain(proxy.endpoint),
 

--- a/app/lib/missing_model.rb
+++ b/app/lib/missing_model.rb
@@ -22,4 +22,5 @@ class MissingModel
 
   class MissingApplication < MissingModel; end
   class MissingProvider < MissingModel; end
+  class MissingProxy < MissingModel; end
 end

--- a/test/events/domains/proxy_domains_changed_event_test.rb
+++ b/test/events/domains/proxy_domains_changed_event_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Domains::ProxyDomainsChangedEventTest < ActiveSupport::TestCase
+  test 'deserialises correctly when the Proxy is deleted' do
+    proxy = FactoryBot.create(:proxy)
+    event = Domains::ProxyDomainsChangedEvent.create(proxy)
+    Rails.application.config.event_store.publish_event(event)
+
+    proxy.delete
+
+    assert EventStore::Repository.find_event(event.event_id)
+  end
+end


### PR DESCRIPTION
Fixes a bugsnag error 😄 The problem we have is when we destroy a service and destroy its proxy, this happens:
https://github.com/3scale/porta/blob/041ccb6cf322d9f278dbaf52a47388738d289180/app/models/proxy.rb#L91
https://github.com/3scale/porta/blob/041ccb6cf322d9f278dbaf52a47388738d289180/app/models/proxy.rb#L261
https://github.com/3scale/porta/blob/041ccb6cf322d9f278dbaf52a47388738d289180/app/events/domains/proxy_domains_changed_event.rb#L6
So the event is saved correctly but when it tries to use it, it tries to deserialise and it fails here because the proxy doesn't exist anymore:
https://github.com/3scale/porta/blob/041ccb6cf322d9f278dbaf52a47388738d289180/app/lib/event_store/event.rb#L13

So I have done the same as we are doing for [ApplicationDeletedEvent](https://github.com/3scale/porta/blob/041ccb6cf322d9f278dbaf52a47388738d289180/app/events/applications/application_deleted_event.rb#L8) which is also used for Zync 😄 