### PR TITLE
[Bugfix] DeleteObjectHierarchyWorker raise URI::GID::MissingModelIdError

### DIFF
--- a/app/workers/delete_object_hierarchy_worker.rb
+++ b/app/workers/delete_object_hierarchy_worker.rb
@@ -53,7 +53,7 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
   def build_batch
     batch = Sidekiq::Batch.new
     batch.description = batch_description
-    batch_callbacks(batch) { batch.jobs { delete_associations(object) } }
+    batch_callbacks(batch) { batch.jobs { delete_associations } }
     batch
   end
 
@@ -74,7 +74,7 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
     end
   end
 
-  def delete_associations(object)
+  def delete_associations
     object.class.reflect_on_all_associations.each do |reflection|
       next unless reflection.options[:dependent] == :destroy
       ReflectionDestroyer.new(object, reflection, caller_worker_hierarchy).destroy_later

--- a/app/workers/delete_object_hierarchy_worker.rb
+++ b/app/workers/delete_object_hierarchy_worker.rb
@@ -106,13 +106,13 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
       main_object.public_send("#{reflection.name.to_s.singularize}_ids").each do |associated_object_id|
         associated_object = reflection.class_name.constantize.new
         associated_object.id = associated_object_id
-        delete_associated_object_later(associated_object)
+        delete_associated_object_later(associated_object) if associated_object.id
       end
     end
 
     def destroy_has_one_association
       associated_object = main_object.public_send(reflection.name)
-      delete_associated_object_later(associated_object) if associated_object
+      delete_associated_object_later(associated_object) if associated_object.try(:id)
     end
 
     def delete_associated_object_later(associated_object)

--- a/app/workers/delete_object_hierarchy_worker.rb
+++ b/app/workers/delete_object_hierarchy_worker.rb
@@ -106,17 +106,17 @@ class DeleteObjectHierarchyWorker < ActiveJob::Base
       main_object.public_send("#{reflection.name.to_s.singularize}_ids").each do |associated_object_id|
         associated_object = reflection.class_name.constantize.new
         associated_object.id = associated_object_id
-        delete_associated_object_later(associated_object) if associated_object.id
+        delete_associated_object_later(associated_object)
       end
     end
 
     def destroy_has_one_association
       associated_object = main_object.public_send(reflection.name)
-      delete_associated_object_later(associated_object) if associated_object.try(:id)
+      delete_associated_object_later(associated_object)
     end
 
     def delete_associated_object_later(associated_object)
-      association_delete_worker.perform_later(associated_object, caller_worker_hierarchy)
+      association_delete_worker.perform_later(associated_object, caller_worker_hierarchy) if associated_object.try(:id)
     end
 
     def association_delete_worker


### PR DESCRIPTION
I've seen that we have this error while I was working on https://github.com/3scale/porta/pull/981
I separate it because it is unrelated and also more urgent.