### PR TITLE
Hide AccountPlan from Account#show view unless it has permission, like in the nav

### DIFF
--- a/app/helpers/plans_helper.rb
+++ b/app/helpers/plans_helper.rb
@@ -1,5 +1,10 @@
 module PlansHelper
 
+  def account_plans_management_visible?
+    settings = current_account.settings
+    can?(:manage, :account_plans) && settings.account_plans.allowed? && settings.account_plans_ui_visible?
+  end
+
   def can_create_plan?(plan)
     case plan.new
     when AccountPlan

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -81,7 +81,7 @@ h1 data-hook="account-show"
         = render 'monthly_charging', account: @account
 
   .right_narrow
-    - if can?(:manage, :account_plans) && current_account.settings.account_plans.allowed? && current_account.settings.account_plans_ui_visible?
+    - if account_plans_management_visible?
       = render partial: 'account_plan',
                locals: { \
                  plan: @account.bought_account_plan,

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -81,7 +81,7 @@ h1 data-hook="account-show"
         = render 'monthly_charging', account: @account
 
   .right_narrow
-    - if can?(:manage, :account_plans)
+    - if can?(:manage, :account_plans) && current_account.settings.account_plans.allowed? && current_account.settings.account_plans_ui_visible?
       = render partial: 'account_plan',
                locals: { \
                  plan: @account.bought_account_plan,

--- a/app/views/shared/provider/navigation/audience/_accounts.html.slim
+++ b/app/views/shared/provider/navigation/audience/_accounts.html.slim
@@ -3,7 +3,7 @@
          title: 'Listing',
          path:  admin_buyers_accounts_path
 
-- if can?(:manage, :account_plans) && current_account.settings.account_plans.allowed? && current_account.settings.account_plans_ui_visible?
+- if account_plans_management_visible?
   =  vertical_nav_item,
        title: 'Account Plans',
        path:   admin_buyers_account_plans_path

--- a/app/views/shared/provider/navigation/audience/_accounts.html.slim
+++ b/app/views/shared/provider/navigation/audience/_accounts.html.slim
@@ -3,7 +3,7 @@
          title: 'Listing',
          path:  admin_buyers_accounts_path
 
-- if can?(:manage, :plans) && current_account.settings.account_plans.allowed? && current_account.settings.account_plans_ui_visible?
+- if can?(:manage, :account_plans) && current_account.settings.account_plans.allowed? && current_account.settings.account_plans_ui_visible?
   =  vertical_nav_item,
        title: 'Account Plans',
        path:   admin_buyers_account_plans_path

--- a/features/old/menu/audience_menu.feature
+++ b/features/old/menu/audience_menu.feature
@@ -12,6 +12,7 @@ Feature: Audience menu
 
   Scenario: Audience menu structure
     Then I should see menu items
+    | Accounts Sub Menu         |
     | Accounts                  |
     | Portal                    |
     | Messages                  |
@@ -20,6 +21,7 @@ Feature: Audience menu
   Scenario: Accounts sub menu structure
     When I follow "Accounts" within the main menu
     Then I should see menu items
+    | Accounts Sub Menu         |
     | Listing                   |
     | Usage Rules               |
     | Fields Definitions        |
@@ -27,6 +29,7 @@ Feature: Audience menu
   Scenario: Portal sub menu structure
     When I follow "Portal" within the main menu
     Then I should see menu items
+    | Accounts Sub Menu         |
     | Content                   |
     | Drafts                    |
     | Redirects                 |
@@ -43,6 +46,7 @@ Feature: Audience menu
   Scenario: Messages sub menu structure
     When I follow "Messages" within the main menu
     Then I should see menu items
+    | Accounts Sub Menu         |
     | Inbox                     |
     | Sent messages             |
     | Trash                     |
@@ -52,6 +56,7 @@ Feature: Audience menu
   Scenario: Forum sub menu structure
     When I follow "Forum" within the main menu
     Then I should see menu items
+    | Accounts Sub Menu         |
     | Threads                   |
     | Categories                |
     | My Threads                |
@@ -62,13 +67,23 @@ Feature: Audience menu
     And I go to the accounts admin page
     When I follow "Accounts" within the main menu
     Then I should see menu items
-    | Account Plans              |
+      | Accounts Sub Menu        |
+      | Account Plans            |
+
+  Scenario: Accounts sub menu structure with account plans disabled
+    When provider "foo.example.com" has "account_plans" denied
+    And I go to the accounts admin page
+    When I follow "Accounts" within the main menu
+    Then I should not see menu items
+      | Accounts Sub Menu        |
+      | Account Plans            |
 
   Scenario: Accounts sub menu structure with service plans enabled
     When provider "foo.example.com" has "service_plans" visible
     And I go to the accounts admin page
     When I follow "Accounts" within the main menu
     Then I should see menu items
+    | Accounts Sub Menu         |
     | Listing                   |
     | Subscriptions             |
     | Usage Rules               |
@@ -80,4 +95,5 @@ Feature: Audience menu
     And I follow "Accounts"
     When I follow "Portal" within the main menu
     Then I should see menu items
+    | Accounts Sub Menu         |
     | Groups                    |

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -15,6 +15,14 @@ Then /^I should see menu items$/ do |items|
   end
 end
 
+Then /^I should not see menu items$/ do |items|
+  items.rows.each do |item|
+    within '#mainmenu' do
+      assert has_no_css? 'li', :text => item[0]
+    end
+  end
+end
+
 
 Then /^there should be submenu items$/ do |items|
   items.rows.each do |item|

--- a/test/unit/helpers/plans_helper_test.rb
+++ b/test/unit/helpers/plans_helper_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class PlansHelperTest < ActionView::TestCase
+  include PlansHelper
 
   def test_can_create_plan
     stubs(:can?).with(:create, :account_plans).returns(true)
@@ -17,4 +18,28 @@ class PlansHelperTest < ActionView::TestCase
     assert can_create_plan?(AccountPlan)
   end
 
+  test 'account_plans_management_visible?' do
+    tenant = FactoryBot.create(:simple_provider)
+    stubs(current_account: tenant)
+
+    stubs(:can?).with(:manage, :account_plans).returns(true)
+    tenant.settings.allow_account_plans
+    tenant.settings.update_column(:account_plans_ui_visible, true)
+    assert account_plans_management_visible?
+
+    stubs(:can?).with(:manage, :account_plans).returns(false)
+    tenant.settings.allow_account_plans
+    tenant.settings.update_column(:account_plans_ui_visible, true)
+    refute account_plans_management_visible?
+
+    stubs(:can?).with(:manage, :account_plans).returns(true)
+    tenant.settings.deny_account_plans
+    tenant.settings.update_column(:account_plans_ui_visible, true)
+    refute account_plans_management_visible?
+
+    stubs(:can?).with(:manage, :account_plans).returns(true)
+    tenant.settings.allow_account_plans
+    tenant.settings.update_column(:account_plans_ui_visible, false)
+    refute account_plans_management_visible?
+  end
 end


### PR DESCRIPTION
Closes [THREESCALE-3005](https://issues.jboss.org/browse/THREESCALE-3005)

### Verification steps
Check `http://provider-admin.example.com.lvh.me:3000/buyers/accounts/3` locally
#### Before
![image](https://user-images.githubusercontent.com/11318903/61541950-e4841100-aa40-11e9-937c-7d3dfd7643eb.png)

#### After
![image](https://user-images.githubusercontent.com/11318903/61541938-de8e3000-aa40-11e9-81c8-3b0f3406003b.png)
