### PR TITLE
Allow choosing between 3scale managed or self managed for on-premises

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -137,8 +137,7 @@ class Service < ApplicationRecord
     end
 
     def self.gateways
-      gateways = APICAST - (ThreeScale.config.apicast_custom_url ? %i(self_managed) : [])
-      gateways.map { |gateway| gateway.to_s.freeze }
+      APICAST.map { |gateway| gateway.to_s.freeze }
     end
 
     def self.service_mesh

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -650,6 +650,16 @@ class ServiceTest < ActiveSupport::TestCase
       refute_includes gateways, 'service_mesh_istio'
     end
 
+    def test_gateways_with_apicast_custom_url
+      ThreeScale.config.stubs(apicast_custom_url: true)
+      gateways = Service::DeploymentOption.gateways
+
+      assert_includes gateways, 'self_managed'
+      assert_includes gateways, 'hosted'
+      refute_includes gateways, 'plugin_ruby'
+      refute_includes gateways, 'service_mesh_istio'
+    end
+
     def test_plugins
       plugins = Service::DeploymentOption.plugins
 


### PR DESCRIPTION
Fixes THREESCALE-3001

Relates to https://github.com/3scale/Red_Hat_3scale_Documentation/pull/470

~Trying to fix the issues on a migration if possible (for existing services created on version 2.5)~

- [ ] ~What to set for currently existing Service, should it be self_managed or hosted?~
- [ ] ~What if APIcast is actually self managed but on the same OCP?~
  - [ ] ~On same THREESCALE_WILDCARD_DOMAIN and the route exists?~
  - [ ] ~On another domain, and the route exists?~
- [ ] ~What if APIcast is actually self managed but hosted somewhere else, so the route does not exist~
- [ ] ~What if actually the customers wants it to be `hosted` but sets a route in order to bypass the wildcard-router?~