### PR TITLE
Zync domain events cascade

### DIFF
--- a/app/events/base_event_store_event.rb
+++ b/app/events/base_event_store_event.rb
@@ -10,6 +10,10 @@ class BaseEventStoreEvent < RailsEventStore::Event
     end
   end
 
+  def publish
+    PUBLISHER.call(self)
+  end
+
   include Categorizable
 
   class << self

--- a/app/workers/process_domain_events_worker.rb
+++ b/app/workers/process_domain_events_worker.rb
@@ -1,0 +1,49 @@
+class ProcessDomainEventsWorker
+  include Sidekiq::Worker
+
+  class_attribute :publisher
+  self.publisher = ->(*args) { Rails.application.config.event_store.publish_event(*args) }
+
+  def perform(event)
+    events = find_providers(event).map { |provider| Domains::ProviderDomainsChangedEvent.create(provider, event) }
+    events += find_proxies(event).map { |proxy| Domains::ProxyDomainsChangedEvent.create(proxy, event) }
+
+    events.each(&publisher.method(:call))
+  end
+
+
+  def find_providers(event)
+    domains = event.domains
+    providers = Account.providers
+
+    providers = case event
+                when Domains::ProviderDomainsChangedEvent
+                  providers.where.not(id: event.provider.id)
+                else
+                  providers
+                end
+
+    providers.where.has { domain.in(domains).or self_domain.in(domains) }
+  end
+
+  def find_proxies(event)
+    domains = event.domains
+    proxies = Proxy
+
+    proxies = case event
+              when Domains::ProxyDomainsChangedEvent
+                proxies.where.not(id: event.proxy.id)
+              else
+                proxies
+              end
+
+    proxies.where.has { production_domain.in(domains).or staging_domain.in(domains) }
+  end
+
+  def self.enqueue(event)
+    return unless ThreeScale.config.onpremises
+    return if event.parent_event?
+
+    super
+  end
+end

--- a/app/workers/process_domain_events_worker.rb
+++ b/app/workers/process_domain_events_worker.rb
@@ -1,14 +1,11 @@
 class ProcessDomainEventsWorker
   include Sidekiq::Worker
 
-  class_attribute :publisher
-  self.publisher = ->(*args) { Rails.application.config.event_store.publish_event(*args) }
-
   def perform(event)
     events = find_providers(event).map { |provider| Domains::ProviderDomainsChangedEvent.create(provider, event) }
     events += find_proxies(event).map { |proxy| Domains::ProxyDomainsChangedEvent.create(proxy, event) }
 
-    events.each(&publisher.method(:call))
+    events.each(&:publish)
   end
 
 

--- a/db/migrate/20190722114341_add_proxy_domains.rb
+++ b/db/migrate/20190722114341_add_proxy_domains.rb
@@ -1,9 +1,12 @@
 class AddProxyDomains < ActiveRecord::Migration
+  disable_ddl_transaction! if System::Database.postgres?
+
   def change
     add_column :proxies, :staging_domain, :string
     add_column :proxies, :production_domain, :string
 
-    add_index :proxies, [ :staging_domain, :production_domain ]
+    index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+    add_index :proxies, [ :staging_domain, :production_domain ], index_options
 
     reversible do |dir|
       dir.up do

--- a/db/migrate/20190722114341_add_proxy_domains.rb
+++ b/db/migrate/20190722114341_add_proxy_domains.rb
@@ -12,10 +12,8 @@ class AddProxyDomains < ActiveRecord::Migration
       dir.up do
         Proxy.reset_column_information
 
-        Proxy.select(:id, :sandbox_endpoint, :endpoint).find_in_batches(batch_size: 1000) do |batch|
-          batch.each do |proxy|
-            proxy.update_columns proxy.update_domains
-          end
+        Proxy.select(:id, :sandbox_endpoint, :endpoint).find_each do |proxy|
+          proxy.update_columns proxy.update_domains
         end
       end
     end

--- a/db/migrate/20190722114341_add_proxy_domains.rb
+++ b/db/migrate/20190722114341_add_proxy_domains.rb
@@ -1,0 +1,20 @@
+class AddProxyDomains < ActiveRecord::Migration
+  def change
+    add_column :proxies, :staging_domain, :string
+    add_column :proxies, :production_domain, :string
+
+    add_index :proxies, [ :staging_domain, :production_domain ]
+
+    reversible do |dir|
+      dir.up do
+        Proxy.reset_column_information
+
+        Proxy.select(:id, :sandbox_endpoint, :endpoint).find_in_batches(batch_size: 1000) do |batch|
+          batch.each do |proxy|
+            proxy.update_columns proxy.update_domains
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190627103617) do
+ActiveRecord::Schema.define(version: 20190722114341) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -1084,9 +1084,12 @@ ActiveRecord::Schema.define(version: 20190627103617) do
     t.string   "error_headers_limits_exceeded",                             default: "text/plain; charset=us-ascii"
     t.integer  "error_status_limits_exceeded",               precision: 38, default: 429
     t.string   "error_limits_exceeded",                                     default: "Usage limit exceeded"
+    t.string   "staging_domain"
+    t.string   "production_domain"
   end
 
   add_index "proxies", ["service_id"], name: "index_proxies_on_service_id"
+  add_index "proxies", ["staging_domain", "production_domain"], name: "index_proxies_on_staging_domain_and_production_domain"
 
   create_table "proxy_configs", force: :cascade do |t|
     t.integer  "proxy_id",                 precision: 38,             null: false

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190627103617) do
+ActiveRecord::Schema.define(version: 20190722114341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1085,9 +1085,12 @@ ActiveRecord::Schema.define(version: 20190627103617) do
     t.string   "error_headers_limits_exceeded",              default: "text/plain; charset=us-ascii"
     t.integer  "error_status_limits_exceeded",               default: 429
     t.string   "error_limits_exceeded",                      default: "Usage limit exceeded"
+    t.string   "staging_domain"
+    t.string   "production_domain"
   end
 
   add_index "proxies", ["service_id"], name: "index_proxies_on_service_id", using: :btree
+  add_index "proxies", ["staging_domain", "production_domain"], name: "index_proxies_on_staging_domain_and_production_domain", using: :btree
 
   create_table "proxy_configs", force: :cascade do |t|
     t.integer  "proxy_id",    limit: 8,                null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190627103617) do
+ActiveRecord::Schema.define(version: 20190722114341) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -1086,9 +1086,12 @@ ActiveRecord::Schema.define(version: 20190627103617) do
     t.string   "error_headers_limits_exceeded", limit: 255,   default: "text/plain; charset=us-ascii"
     t.integer  "error_status_limits_exceeded",  limit: 4,     default: 429
     t.string   "error_limits_exceeded",         limit: 255,   default: "Usage limit exceeded"
+    t.string   "staging_domain",                limit: 255
+    t.string   "production_domain",             limit: 255
   end
 
   add_index "proxies", ["service_id"], name: "index_proxies_on_service_id", using: :btree
+  add_index "proxies", ["staging_domain", "production_domain"], name: "index_proxies_on_staging_domain_and_production_domain", using: :btree
 
   create_table "proxy_configs", force: :cascade do |t|
     t.integer  "proxy_id",    limit: 8,                    null: false

--- a/lib/generators/subscriber/subscriber_generator.rb
+++ b/lib/generators/subscriber/subscriber_generator.rb
@@ -12,7 +12,7 @@ class SubscriberGenerator < Rails::Generators::NamedBase
   end
 
   def enable_subscribe
-    insert_into_file 'lib/event_store/repository.rb',
+    insert_into_file 'app/lib/event_store/repository.rb',
                      "  @client.subscribe(#{class_name}Subscriber.new, [#{class_name}Event])\n  ",
                      after: /@client.subscribe.+\n\s+(?=end)/
   end

--- a/test/events/domains/provider_domains_changed_event_test.rb
+++ b/test/events/domains/provider_domains_changed_event_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Domains::ProviderDomainsChangedEventTest < ActiveSupport::TestCase
+  test 'can be persisted' do
+    provider = FactoryBot.create(:simple_provider)
+    event = Domains::ProviderDomainsChangedEvent.create(provider)
+    Rails.application.config.event_store.publish_event(event)
+
+    assert EventStore::Repository.find_event(event.event_id)
+  end
+end

--- a/test/events/domains/proxy_domains_changed_event_test.rb
+++ b/test/events/domains/proxy_domains_changed_event_test.rb
@@ -12,4 +12,12 @@ class Domains::ProxyDomainsChangedEventTest < ActiveSupport::TestCase
 
     assert EventStore::Repository.find_event(event.event_id)
   end
+
+  test 'can be persisted' do
+    proxy = FactoryBot.create(:simple_proxy)
+    event = Domains::ProxyDomainsChangedEvent.create(proxy)
+    Rails.application.config.event_store.publish_event(event)
+
+    assert EventStore::Repository.find_event(event.event_id)
+  end
 end

--- a/test/workers/process_domain_events_worker_test.rb
+++ b/test/workers/process_domain_events_worker_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class ProcessDomainEventsWorkerTest < ActiveSupport::TestCase
+  def test_proxy_domain_changed_event
+    provider = FactoryBot.create(:simple_provider)
+    proxy = FactoryBot.create(:simple_proxy)
+    proxy.update_attributes!(endpoint: "http://#{provider.admin_domain}")
+    event = Domains::ProxyDomainsChangedEvent.create(proxy)
+
+    provider_domains_changed = EventStore::Repository.adapter.where(event_type: 'Domains::ProviderDomainsChangedEvent')
+
+    assert_difference provider_domains_changed.method(:count) do
+      ProcessDomainEventsWorker.new.perform(event)
+    end
+  end
+
+  def test_provider_domain_changed_event
+    provider = FactoryBot.create(:simple_provider)
+    proxy = FactoryBot.create(:simple_proxy)
+    proxy.update_attributes!(endpoint: "http://#{provider.admin_domain}")
+    event = Domains::ProviderDomainsChangedEvent.create(provider)
+
+    proxy_domains_changed = EventStore::Repository.adapter.where(event_type: 'Domains::ProxyDomainsChangedEvent')
+
+    assert_difference proxy_domains_changed.method(:count) do
+      ProcessDomainEventsWorker.new.perform(event)
+    end
+  end
+end


### PR DESCRIPTION
Create domain changed events for all proxies/providers matching the same domain. 
So for example when it is no longer used it can be recreated by zync for another provider/proxy.