### PR TITLE
create_and_publish returns the event

### DIFF
--- a/app/events/base_event_store_event.rb
+++ b/app/events/base_event_store_event.rb
@@ -23,7 +23,7 @@ class BaseEventStoreEvent < RailsEventStore::Event
 
       event = create(*args)
 
-      PUBLISHER.call(event)
+      PUBLISHER.call(event) && event
     end
 
     protected

--- a/test/events/applications/application_deleted_event_test.rb
+++ b/test/events/applications/application_deleted_event_test.rb
@@ -16,8 +16,7 @@ class Applications::ApplicationDeletedEventTest < ActiveSupport::TestCase
     application.service.delete
     application.provider_account.delete
 
-    event = Applications::ApplicationDeletedEvent.create(application.reload)
-    Rails.application.config.event_store.publish_event(event)
+    event = Applications::ApplicationDeletedEvent.create_and_publish!(application.reload)
 
     event_stored = EventStore::Repository.find_event!(event.event_id)
     assert_equal provider_id, event_stored.metadata[:provider_id]

--- a/test/events/base_event_store_event_test.rb
+++ b/test/events/base_event_store_event_test.rb
@@ -35,6 +35,11 @@ class BaseEventStoreEventTest < ActiveSupport::TestCase
     DummieEvent.create_and_publish!(provider, nil, 1)
   end
 
+  test 'create_and_publish returns the event if is persisted, otherwise nil' do
+    assert_instance_of DummieEvent, DummieEvent.create_and_publish!(provider, 'Alex', 1)
+    assert_nil DummieEvent.create_and_publish!(provider, nil, 1)
+  end
+
   def test_create
     assert_raise NotImplementedError do
       NoCreateMethodEvent.create_and_publish!('Alex')

--- a/test/events/domains/provider_domains_changed_event_test.rb
+++ b/test/events/domains/provider_domains_changed_event_test.rb
@@ -5,8 +5,7 @@ require 'test_helper'
 class Domains::ProviderDomainsChangedEventTest < ActiveSupport::TestCase
   test 'can be persisted' do
     provider = FactoryBot.create(:simple_provider)
-    event = Domains::ProviderDomainsChangedEvent.create(provider)
-    Rails.application.config.event_store.publish_event(event)
+    event = Domains::ProviderDomainsChangedEvent.create_and_publish!(provider)
 
     assert EventStore::Repository.find_event(event.event_id)
   end

--- a/test/events/domains/proxy_domains_changed_event_test.rb
+++ b/test/events/domains/proxy_domains_changed_event_test.rb
@@ -4,19 +4,10 @@ require 'test_helper'
 
 class Domains::ProxyDomainsChangedEventTest < ActiveSupport::TestCase
   test 'deserialises correctly when the Proxy is deleted' do
-    proxy = FactoryBot.create(:proxy)
-    event = Domains::ProxyDomainsChangedEvent.create(proxy)
-    Rails.application.config.event_store.publish_event(event)
+    proxy = FactoryBot.create(:simple_proxy)
+    event = Domains::ProxyDomainsChangedEvent.create_and_publish!(proxy)
 
     proxy.delete
-
-    assert EventStore::Repository.find_event(event.event_id)
-  end
-
-  test 'can be persisted' do
-    proxy = FactoryBot.create(:simple_proxy)
-    event = Domains::ProxyDomainsChangedEvent.create(proxy)
-    Rails.application.config.event_store.publish_event(event)
 
     assert EventStore::Repository.find_event(event.event_id)
   end

--- a/test/events/oidc/proxy_changed_event_test.rb
+++ b/test/events/oidc/proxy_changed_event_test.rb
@@ -15,7 +15,7 @@ class OIDC::ProxyChangedEventTest < ActiveSupport::TestCase
     refute OIDC::ProxyChangedEvent.create_and_publish!(proxy), 'service is not oauth'
 
     proxy.service.backend_version = 'oauth'
-    assert_equal :ok, OIDC::ProxyChangedEvent.create_and_publish!(proxy),'event should be created for OAuth service'
+    assert OIDC::ProxyChangedEvent.create_and_publish!(proxy),'event should be created for OAuth service'
   end
 
   def test_create

--- a/test/events/oidc/service_changed_event_test.rb
+++ b/test/events/oidc/service_changed_event_test.rb
@@ -3,19 +3,11 @@
 require 'test_helper'
 
 class OIDC::ServiceChangedEventTest < ActiveSupport::TestCase
-
-  def setup
-    EventStore::Repository.stubs(raise_errors: true)
-    @event_store = Rails.application.config.event_store
-  end
-
-  attr_reader :event_store
-
   def test_create
+    EventStore::Repository.stubs(raise_errors: true)
+
     service = FactoryBot.create(:simple_service)
 
-    assert event = OIDC::ServiceChangedEvent.create(service)
-
-    assert_equal :ok, event_store.publish_event(event)
+    assert_instance_of OIDC::ServiceChangedEvent, OIDC::ServiceChangedEvent.create_and_publish!(service)
   end
 end

--- a/test/events/services/service_deleted_event_test.rb
+++ b/test/events/services/service_deleted_event_test.rb
@@ -41,8 +41,7 @@ class Services::ServiceDeletedEventTest < ActiveSupport::TestCase
     provider_id = provider.id
     provider.delete
 
-    event = Services::ServiceDeletedEvent.create(service.reload)
-    Rails.application.config.event_store.publish_event(event)
+    event = Services::ServiceDeletedEvent.create_and_publish!(service.reload)
 
     event_stored = EventStore::Repository.find_event!(event.event_id)
     assert_equal provider_id, event_stored.metadata.fetch(:provider_id)

--- a/test/events/services/service_token_deleted_event_test.rb
+++ b/test/events/services/service_token_deleted_event_test.rb
@@ -23,9 +23,7 @@ class ServiceTokenDeletedEventTest < ActiveSupport::TestCase
     assert provider_id = service_token.service.account.id
     service_token.service.delete
 
-    event = ServiceTokenDeletedEvent.create(service_token.reload)
-
-    Rails.application.config.event_store.publish_event(event)
+    event = ServiceTokenDeletedEvent.create_and_publish!(service_token.reload)
 
     event_stored = EventStore::Repository.find_event!(event.event_id)
     assert_equal provider_id, event_stored.metadata.fetch(:provider_id)

--- a/test/events/users/user_deleted_event_test.rb
+++ b/test/events/users/user_deleted_event_test.rb
@@ -15,8 +15,7 @@ class Users::UserDeletedEventTest < ActiveSupport::TestCase
     developer_account = FactoryBot.create(:simple_buyer, provider_account: tenant_account)
     developer_user = FactoryBot.create(:user, account: developer_account)
 
-    event = Users::UserDeletedEvent.create(developer_user.reload)
-    Rails.application.config.event_store.publish_event(event)
+    event = Users::UserDeletedEvent.create_and_publish!(developer_user.reload)
 
     event_stored = EventStore::Repository.find_event!(event.event_id)
     assert_equal tenant_account.id, event_stored.metadata[:provider_id]
@@ -29,8 +28,7 @@ class Users::UserDeletedEventTest < ActiveSupport::TestCase
 
     tenant_account.delete
 
-    event = Users::UserDeletedEvent.create(developer_user.reload)
-    Rails.application.config.event_store.publish_event(event)
+    event = Users::UserDeletedEvent.create_and_publish!(developer_user.reload)
 
     event_stored = EventStore::Repository.find_event!(event.event_id)
     assert_equal tenant_id, event_stored.metadata[:provider_id]
@@ -39,8 +37,7 @@ class Users::UserDeletedEventTest < ActiveSupport::TestCase
   test 'it is saved with the right data when user is a tenant and its account is still persisted' do
     tenant_user = FactoryBot.create(:user, account: tenant_account)
 
-    event = Users::UserDeletedEvent.create(tenant_user.reload)
-    Rails.application.config.event_store.publish_event(event)
+    event = Users::UserDeletedEvent.create_and_publish!(tenant_user.reload)
 
     event_stored = EventStore::Repository.find_event!(event.event_id)
     assert_equal tenant_account.id, event_stored.metadata[:provider_id]
@@ -51,8 +48,7 @@ class Users::UserDeletedEventTest < ActiveSupport::TestCase
 
     tenant_account.delete
 
-    event = Users::UserDeletedEvent.create(tenant_user.reload)
-    Rails.application.config.event_store.publish_event(event)
+    event = Users::UserDeletedEvent.create_and_publish!(tenant_user.reload)
 
     event_stored = EventStore::Repository.find_event!(event.event_id)
     assert_equal tenant_account.id, event_stored.metadata[:provider_id]

--- a/test/workers/backend_delete_end_users_worker_test.rb
+++ b/test/workers/backend_delete_end_users_worker_test.rb
@@ -5,8 +5,7 @@ require 'test_helper'
 class BackendDeleteEndUsersWorkerTest < ActiveSupport::TestCase
   def setup
     @service = FactoryBot.create(:simple_service)
-    @event = Services::ServiceDeletedEvent.create(service)
-    Rails.application.config.event_store.publish_event(event)
+    @event = Services::ServiceDeletedEvent.create_and_publish!(service)
   end
 
   attr_reader :service, :event

--- a/test/workers/backend_delete_service_token_worker_test.rb
+++ b/test/workers/backend_delete_service_token_worker_test.rb
@@ -10,8 +10,7 @@ class BackendDeleteServiceTokenWorkerTest < ActiveSupport::TestCase
 
   test 'destroy service token' do
     service_token = FactoryBot.create(:service_token)
-    event = ServiceTokenDeletedEvent.create(service_token)
-    Rails.application.config.event_store.publish_event(event)
+    event = ServiceTokenDeletedEvent.create_and_publish!(service_token)
 
     Sidekiq::Testing.inline! do
       ThreeScale::Core::ServiceToken.expects(:delete).with([{ service_token: service_token.value, service_id: service_token.service_id }])

--- a/test/workers/backend_delete_service_worker_test.rb
+++ b/test/workers/backend_delete_service_worker_test.rb
@@ -5,8 +5,7 @@ require 'test_helper'
 class BackendDeleteServiceWorkerTest < ActiveSupport::TestCase
   test 'perform' do
     service = FactoryBot.create(:simple_service)
-    event = Services::ServiceDeletedEvent.create(service)
-    Rails.application.config.event_store.publish_event(event)
+    event = Services::ServiceDeletedEvent.create_and_publish!(service)
 
     BackendDeleteEndUsersWorker.expects(:perform_async).with { |param| param == event.event_id }
     BackendDeleteStatsWorker.expects(:perform_async).with { |param| param == event.event_id }

--- a/test/workers/backend_delete_stats_worker_test.rb
+++ b/test/workers/backend_delete_stats_worker_test.rb
@@ -10,8 +10,7 @@ class BackendDeleteStatsWorkerTest < ActiveSupport::TestCase
     @metrics = FactoryBot.create_list(:metric, 3)
     metrics.each { |metric| DeletedObject.create(owner: service, object: metric) }
 
-    @event = Services::ServiceDeletedEvent.create(service)
-    Rails.application.config.event_store.publish_event(event)
+    @event = Services::ServiceDeletedEvent.create_and_publish!(service)
   end
 
   attr_reader :service, :applications, :metrics, :event

--- a/test/workers/create_service_token_worker_test.rb
+++ b/test/workers/create_service_token_worker_test.rb
@@ -43,8 +43,7 @@ class CreateServiceTokenWorkerTest < ActiveSupport::TestCase
     def setup
       @service = FactoryBot.create(:simple_service)
       @user = FactoryBot.create(:simple_user)
-      @event = Services::ServiceCreatedEvent.create(service, user)
-      Rails.application.config.event_store.publish_event(event)
+      @event = Services::ServiceCreatedEvent.create_and_publish!(service, user)
     end
 
     attr_reader :service, :user, :event

--- a/test/workers/segment_delete_user_worker_test.rb
+++ b/test/workers/segment_delete_user_worker_test.rb
@@ -90,9 +90,7 @@ class SegmentDeleteUserWorkerTest < ActiveSupport::TestCase
   def user_deleted_event
     @user_deleted_event ||= begin
       user = FactoryBot.create(:admin, account: provider, tenant_id: provider.id)
-      event = Users::UserDeletedEvent.create(user)
-      Rails.application.config.event_store.publish_event(event)
-      event
+      Users::UserDeletedEvent.create_and_publish!(user)
     end
   end
 

--- a/test/workers/zync_worker_test.rb
+++ b/test/workers/zync_worker_test.rb
@@ -16,10 +16,8 @@ class ZyncWorkerTest < ActiveSupport::TestCase
   test 'perform does not crash when the event exists but the provider is destroyed' do
     worker = ZyncWorker.new
     application = FactoryBot.create(:simple_cinstance)
-    app_event = Applications::ApplicationDeletedEvent.create(application)
-    Rails.application.config.event_store.publish_event(app_event)
-    zync_event = ZyncEvent.create(app_event, application)
-    Rails.application.config.event_store.publish_event(zync_event)
+    app_event = Applications::ApplicationDeletedEvent.create_and_publish!(application)
+    zync_event = ZyncEvent.create_and_publish!(app_event, application)
     worker.stubs(valid?: true)
     worker.stubs(endpoint: 'http://example.com')
     stub_request(:put, "http://example.com/notification").to_return(status: 200)


### PR DESCRIPTION
Otherwise it is counterintuitive and problematic, and this way it simplifies the code and it is also easier for any newcomer.

Outside the tests, it is used in the following places, all of them will keep working after this because the only expect a truthy value if it worked and a falsy value and if it didn't:

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/contract/states.rb#L63-L65

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/service_token.rb#L15-L17

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/proxy.rb#L259-L263

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/cinstance.rb#L269-L271

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/account/states.rb#L146-L149

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/application_key.rb#L130-L132

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/service.rb#L212-L215

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/service.rb#L558-L564

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/service.rb#L605-L607

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/user.rb#L417-L419

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/models/account/domains.rb#L81-L84

https://github.com/3scale/porta/blob/af47f5f0f34b856571eb0c3a4227ba5f17ed7849/app/observers/message_observer.rb#L27-L36

