### PR TITLE
[stats] Fix moment-range and timezone

### DIFF
--- a/app/javascript/src/Stats/lib/csv_link.jsx
+++ b/app/javascript/src/Stats/lib/csv_link.jsx
@@ -1,7 +1,6 @@
 /** @jsx StatsUI.dom */
 import 'core-js/fn/symbol/iterator' // make Symbol work on IE 11
-import moment from 'moment'
-import 'moment-timezone'
+import moment from 'moment-timezone'
 
 import {StatsUI} from 'Stats/lib/ui'
 
@@ -51,7 +50,7 @@ export class StatsCSVLink extends StatsUI {
   }
 
   _parseTimeColumn (columns) {
-    columns[0] = columns[0].map((value, key) => (key > 0) ? moment(value).utc().tz(this.data._period.timezone).format(TIMESTAMP_FORMAT) : 'datetime')
+    columns[0] = columns[0].map((value, key) => (key > 0) ? moment.tz(value, this.data._period.timezone).format(TIMESTAMP_FORMAT) : 'datetime')
     return columns
   }
 

--- a/app/javascript/src/Stats/lib/methods_table.jsx
+++ b/app/javascript/src/Stats/lib/methods_table.jsx
@@ -1,7 +1,6 @@
 /** @jsx StatsUI.dom */
 import numeral from 'numeral'
-import moment from 'moment'
-import 'moment-timezone'
+import moment from 'moment-timezone'
 
 import {StatsUI} from 'Stats/lib/ui'
 
@@ -36,10 +35,10 @@ export class StatsMethodsTable extends StatsUI {
                     {methodDetails.name}
                   </td>
                   <td className="StatsMethodsTable-since">
-                    {moment(methodDetails.period.since).utc().tz(methodDetails.period.timezone).format(TIMESTAMP_FORMAT)}
+                    {moment.tz(methodDetails.period.since, methodDetails.period.timezone).format(TIMESTAMP_FORMAT)}
                   </td>
                   <td className="StatsMethodsTable-until">
-                    {moment(methodDetails.period.until).utc().tz(methodDetails.period.timezone).format(TIMESTAMP_FORMAT)}
+                    {moment.tz(methodDetails.period.until, methodDetails.period.timezone).format(TIMESTAMP_FORMAT)}
                   </td>
                   <td className="StatsMethodsTable-total u-amount u-tabular-number">
                     {numeral(methodDetails.total).format('0,0').toUpperCase()}

--- a/app/javascript/src/Stats/lib/series.jsx
+++ b/app/javascript/src/Stats/lib/series.jsx
@@ -64,7 +64,7 @@ export class StatsSeries {
     const granularity = period.granularity
     const timeInterval = `${period.since}/${period.until}`
     const range = Array.from(moment.range(timeInterval).by(granularity))
-    return range.map(m => m.tz(period.timezone).format(CHART_TIMESTAMP_FORMAT))
+    return range.map(m => moment.tz(m, period.timezone).format(CHART_TIMESTAMP_FORMAT))
   }
 
   _sortResponses (responses) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is important since it was breaking the Analytics/Usage and Response Codes with
```
Uncaught (in promise) TypeError: t.tz is not a function
```
In preview/production environments after the Babel/Webpack update and dropped of `npm ci` in deploy process.
**

**Which issue(s) this PR fixes** 

