### PR TITLE
Fix Cuke Given Step to Signup Buyer: Do not approve when already approved

### DIFF
--- a/features/step_definitions/buyer_steps.rb
+++ b/features/step_definitions/buyer_steps.rb
@@ -93,7 +93,7 @@ Given /^an approved buyer "([^\"]*)" signed up to provider "([^\"]*)"$/ do |acco
   step %(a pending buyer "#{account_name}" signed up to provider "#{provider_account_name}")
 
   @buyer = Account.find_by_org_name!(account_name)
-  @buyer.approve!
+  @buyer.approve! unless @buyer.approved?
 end
 
 Given /^a rejected buyer "([^\"]*)" signed up to provider "([^\"]*)"$/ do |account_name, provider_account_name|


### PR DESCRIPTION
Fixes this random CircleCI bug: https://circleci.com/gh/3scale/porta/78331#tests/containers/31