### PR TITLE
Filter sensitive information in Sidekiq logging

### DIFF
--- a/app/lib/three_scale/sidekiq_logging_middleware.rb
+++ b/app/lib/three_scale/sidekiq_logging_middleware.rb
@@ -3,7 +3,8 @@ module ThreeScale
     def call(worker_class, msg, *)
       yield
     ensure
-      Rails.logger.info "Enqueued #{worker_class}##{msg['jid']} with args: #{msg['args']}"
+      filtered_args = FilterArguments.new(msg['args']).filter
+      Rails.logger.info "Enqueued #{worker_class}##{msg['jid']} with args: #{filtered_args}"
     end
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -73,7 +73,7 @@ class Account < ApplicationRecord
 
   scope :not_master, -> { where(master: [false, nil]) }
 
-  audited allow_mass_assignment: true, sensitive_attributes: %i[site_access_code credit_card_partial_number credit_card_expires_on credit_card_auth_code payment_gateway_options credit_card_authorize_net_payment_profile_token]
+  audited allow_mass_assignment: true
 
   # this is done in a callback because we want to do this AFTER the account is deleted
   # otherwise the before_destroy admin check in the user will stop the deletion

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -4,7 +4,7 @@ class Contract < ApplicationRecord
   # https://github.com/collectiveidea/audited/blob/f03c5b5d1717f2ebec64032d269316dc74476056/lib/audited/auditor.rb#L305-L311
   self.table_name = 'cinstances'
 
-  audited allow_mass_assignment: true, sensitive_attributes: %i[user_key]
+  audited allow_mass_assignment: true
   include ::ThreeScale::MethodTracing
 
   # FIXME: This class should be an abstract class I think, but doing so makes plenty of tests fail

--- a/app/models/payment_detail.rb
+++ b/app/models/payment_detail.rb
@@ -10,7 +10,7 @@ class PaymentDetail < ApplicationRecord
 
   belongs_to :account
 
-  audited allow_mass_assignment: true, sensitive_attributes: %i[payment_service_reference credit_card_partial_number credit_card_expires_on]
+  audited allow_mass_assignment: true
 
   attr_protected :account_id, :audit_ids
 

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -3,7 +3,7 @@ require 'simple_layout'
 class Settings < ApplicationRecord
   belongs_to :account, inverse_of: :settings
 
-  audited allow_mass_assignment: true, sensitive_attributes: %i[janrain_api_key cms_token sso_key]
+  audited allow_mass_assignment: true
 
   attr_protected :account_id, :tenant_id, :product, :audit_ids, :sso_key, :heroku_id, :heroku_name
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
   include Permissions
   include ProvidedAccessTokens
 
-  audited sensitive_attributes: %i[crypted_password salt activation_code lost_password_token password_digest]
+  audited
 
   before_validation :trim_white_space_from_username
   before_destroy :can_be_destroyed?

--- a/config/application.rb
+++ b/config/application.rb
@@ -221,7 +221,11 @@ module System
     config.cms_files_path = ':url_root/:date_partition/:basename-:random_secret.:extension'
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password, :credit_card]
+    config.filter_parameters += %i[activation_code cms_token credit_card credit_card_auth_code
+                                   credit_card_authorize_net_payment_profile_token credit_card_expires_on
+                                   credit_card_partial_number crypted_password janrain_api_key lost_password_token
+                                   password password_digest payment_gateway_options payment_service_reference salt
+                                   site_access_code sso_key user_key]
 
     require 'three_scale/middleware/multitenant'
     require 'three_scale/middleware/dev_domain'

--- a/lib/three_scale/filter_arguments.rb
+++ b/lib/three_scale/filter_arguments.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ThreeScale
+  # This class is used to filter sensitive parameters from hashes inside an array of
+  # arguments. It depends on ActionDispatch::Http::ParameterFilter.
+  #
+  # ActionDispatch::Http::ParameterFilter will be removed in Rails 6.1. After we need to change to
+  # ActiveSupport::ParameterFilter
+  class FilterArguments
+    FILTER = ActionDispatch::Http::ParameterFilter.new(Rails.configuration.filter_parameters)
+
+    def initialize(arguments = [])
+      @arguments = arguments.dup
+    end
+
+    def filter
+      return FILTER.filter(@arguments) if @arguments.is_a?(Hash)
+
+      @arguments.map { |argument| argument.is_a?(Enumerable) ? FILTER.filter(argument) : argument }
+    end
+  end
+end

--- a/test/unit/audited_hacks_test.rb
+++ b/test/unit/audited_hacks_test.rb
@@ -98,13 +98,12 @@ class AuditedHacksTest < ActiveSupport::TestCase
 
     test 'obfuscated audit' do
       provider_id = provider.id
-      Settings.stubs(sensitive_attributes: %i[sso_key])
       settings = Settings.new(account_id: provider_id)
       audit = FactoryBot.build(:audit, auditable_type: settings.class.name, auditable_id: 123, provider_id: provider_id, audited_changes: { 'welcome_text' => 'hello', 'sso_key' => 'sensitive' })
       audit_obfuscated = audit.obfuscated
       assert_not_equal audit.object_id, audit_obfuscated.object_id
       assert_equal({ 'welcome_text' => 'hello', 'sso_key' => 'sensitive' }, audit.audited_changes)
-      assert_equal({ 'welcome_text' => 'hello', 'sso_key' => '[FILTERED]'.to_sym }, audit_obfuscated.audited_changes)
+      assert_equal({ 'welcome_text' => 'hello', 'sso_key' => '[FILTERED]' }, audit_obfuscated.audited_changes)
     end
 
     protected

--- a/test/unit/sidekiq_logging_middleware_test.rb
+++ b/test/unit/sidekiq_logging_middleware_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class SidekiqLoggingMiddlewareTest < ActiveSupport::TestCase
+  test 'filter sensitive arguments' do
+    middleware = ThreeScale::SidekiqLoggingMiddleware.new
+    msg = {
+      'jid' => 123,
+      'args' => [
+        {
+          "some_arg": "value",
+          "user_key": "secret_value"
+        }
+      ]
+    }
+
+    Rails.logger.expects(:info).with('Enqueued DummyWorker#123 with args: [{:some_arg=>"value", :user_key=>"[FILTERED]"}]')
+
+    middleware.call('DummyWorker', msg) { nil }
+  end
+end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

The SidekiqLoggingMiddleware was missing to filter the sensitive
parameters when AuditedWorker was enqueued.

This commit moved all specific sensitive attributes to a global scope
and filtered these attributes in regular and Sidekiq logging.

**Which issue(s) this PR fixes** 

[THREESCALE-2985](https://issues.jboss.org/browse/THREESCALE-2985)

**Verification steps** 

- Create an account
- Sidekiq arguments should be filtered like the Audited one

<img width="1652" alt="Screen Shot 2019-07-25 at 16 12 42" src="https://user-images.githubusercontent.com/771411/61902910-9f0c8b80-aef9-11e9-85e2-c919d18379eb.png">

**Special notes for your reviewer**:

I decided to move all specific sensitive attributes (like `user_key`) into Rails `filter_parameters` configuration. This way it will be filtered even on the Rails logging itself. Also, it will filter future models that possibly include this attributes. If this is not a desire behave, I can return it into specific classes and pass it to the  FilterArguments.

The decision to create the FilterArguments was to reuse the filtering into other places. It acts as a dispatcher to the Rails ParamsFilter itself. It can be easily replaced for a custom implementation if needed,