### PR TITLE
Do not allow blank plan in service subscription

### DIFF
--- a/app/controllers/buyers/service_contracts_controller.rb
+++ b/app/controllers/buyers/service_contracts_controller.rb
@@ -139,6 +139,6 @@ private
   end
 
   def service_plan(plan_id = params[:service_contract][:plan_id])
-    @service_plan ||= service.service_plans.find(plan_id)
+    @service_plan ||= service.service_plans.find_by(id: plan_id)
   end
 end

--- a/app/views/buyers/service_contracts/new.html.erb
+++ b/app/views/buyers/service_contracts/new.html.erb
@@ -1,8 +1,8 @@
 <h1>New service subscription</h1>
 
 <%= semantic_form_for @service_contract,
-  :url => admin_buyers_account_service_contracts_path(@account, :service_id => @service.id),
-  :html => { :'data-remote' => true } do |form| %>
+  url: admin_buyers_account_service_contracts_path(@account, service_id: @service.id),
+  html: { data: { remote: true } } do |form| %>
 
   <%= form.inputs do %>
 
@@ -11,11 +11,11 @@
       <p><%= h @service.name %></p>
     </li>
 
-    <%= form.input :plan, :collection => @service_plans, :include_blank => !@service_contract.plan_id? %>
+    <!--  It will prompt only if there is no default service plan selected -->
+    <%= form.input :plan, collection: @service_plans, prompt: !@service_contract.plan_id? %>
   <% end %>
 
   <%= form.buttons do %>
-    <%= form.commit_button 'Create subscription', :button_html => {:'data-disable-with' => 'Creating subscription...' } %>
+    <%= form.commit_button 'Create subscription', button_html: { data: { disable_with: 'Creating subscription...' } } %>
   <%-end%>
 <%-end %>
-

--- a/test/integration/buyers/service_contracts_controller_test.rb
+++ b/test/integration/buyers/service_contracts_controller_test.rb
@@ -15,11 +15,10 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
     @buyer1.buy! @application_plan
     @buyer2.buy! @application_plan
 
-    host! @provider.admin_domain
-    provider_login_with @provider.admins.first.username, 'supersecret'
+    login! @provider
   end
 
-  def test_can_unsubscribe_from_service_contract
+  test 'can unsubscribe from service contract' do
     get admin_buyers_account_service_contracts_path(account_id: @buyer1.id)
 
     assert_response :success
@@ -30,7 +29,7 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
     assert page.xpath("//a[@data-method='delete']").text =~ /Unsubscribe/
   end
 
-  def test_unsubscribe_developers_from_service_with_suspended_application
+  test 'unsubscribe developers from service with suspended application' do
     apps = @buyer1.bought_cinstances.by_service_id(@service_contract.service_id)
     apps.update_all state: 'suspended'
 
@@ -47,7 +46,7 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, @buyer2.bought_cinstances.by_service_id(@service_contract.service_id).count
   end
 
-  def test_unsubscribe_developers_from_service_with_one_not_suspended_application
+  test 'unsubscribe developers from service with one not suspended application' do
     apps = @buyer1.bought_cinstances.by_service_id(@service_contract.service_id)
 
     assert_no_difference(-> {apps.count})  do
@@ -61,7 +60,7 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_unsubscribe_developers_from_service_with_two_no_suspended_applications
+  test 'unsubscribe developers from service with two not suspended applications' do
     application_plan2 = FactoryBot.create(:application_plan, issuer: @service)
 
     @buyer1.buy! application_plan2
@@ -74,10 +73,26 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
     assert_match I18n.t('service_contracts.unsubscribe_failure'), flash[:error]
   end
 
-  def test_unauthorized_access_master_on_premises
+  test 'unauthorized access master_on_premises' do
     login! master_account
     ThreeScale.stubs(master_on_premises?: true)
     get admin_buyers_account_service_contracts_path(account_id: @provider.id)
     assert_response :forbidden
+  end
+
+  test 'renders a prompt if there is no default service plan' do
+    get new_admin_buyers_account_service_contract_path(account_id: @buyer1.id, service_id: @service.id)
+
+    page = Nokogiri::HTML::Document.parse(response.body)
+    assert page.xpath("//select[@id='service_contract_plan_id']/option").map(&:text).include?('Please select')
+  end
+
+  test 'does not render a prompt if there is a default service plan' do
+    @service.update_attributes(default_service_plan: @service_plan)
+      
+    get new_admin_buyers_account_service_contract_path(account_id: @buyer1.id, service_id: @service.id)
+
+    page = Nokogiri::HTML::Document.parse(response.body)
+    assert page.xpath("//select[@id='service_contract_plan_id']/option").map(&:text).exclude?('Please select')
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently when you try to subscribe in some service, the plan listing is 
blank and when you try to submit it, it explodes an exception and it 
renders a weird 404 page.

This commit validates if the service plan exists

![idea2](https://user-images.githubusercontent.com/771411/62075722-389aac80-b21c-11e9-9f80-63a680269f7d.gif)


**Which issue(s) this PR fixes** 

[THREESCALE-2944](https://issues.jboss.org/browse/THREESCALE-2944)

**Verification steps** 

- Create user and application
- Create at least 2 services 
- Go to Accounts->Listing and choose created account
- Go to Service Subscriptions tab and try to add one available service subscription
- It should not have a blank option in the listing
