### PR TITLE
Include JSX files under Eslint coverage

### DIFF
--- a/app/javascript/src/Policies/types/index.jsx
+++ b/app/javascript/src/Policies/types/index.jsx
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable no-use-before-define */
 
 import type { State } from 'Policies/types/State'
 import type {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "update-dependencies": "npm run clean && npm i --no-progress",
     "check-dependencies": "npm ls --depth=0 || npm run update-dependencies",
     "flow:install": "flow-typed install",
-    "lint": "flow && eslint app/javascript spec/javascripts",
+    "lint": "flow && eslint --ext .js,.jsx app/javascript spec/javascripts",
     "test": "karma start --single-run",
     "jest": "jest",
     "jest:watch": "npm run-script jest -- --watch"

--- a/spec/javascripts/LoginPage/SignupPageWrapper.spec.jsx
+++ b/spec/javascripts/LoginPage/SignupPageWrapper.spec.jsx
@@ -24,5 +24,5 @@ it('should render itself', () => {
 
 it('should render <SignupForm/> child component', () => {
   const wrapper = mount(<SignupPage {...props}/>)
-  expect(wrapper.find(SignupPage).exists()).toEqual(true)
+  expect(wrapper.find(SignupForm).exists()).toEqual(true)
 })

--- a/spec/javascripts/Navigation/ContextSelector.spec.jsx
+++ b/spec/javascripts/Navigation/ContextSelector.spec.jsx
@@ -126,7 +126,7 @@ describe('When there are many services', () => {
 
   it('should render all APIs when input is empty', () => {
     const input = contextSelector.find('input')
-    expect(input.props().value).toBeUndefined
+    expect(input.props().value).toBeUndefined()
 
     const apiList = contextSelector.find('.PopNavigation-results').children()
     expect(apiList).toHaveLength(apis.length)

--- a/spec/javascripts/Policies/components/PolicyChain.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyChain.spec.jsx
@@ -46,10 +46,17 @@ describe('PolicyChain Components', () => {
   describe('SortableList', () => {
     function setup () {
       const props = {
-        items: policies.concat(
-          { id: '3', enabled: false, name: 'headers', humanName: 'Headers',
-            summary: 'Headers summary', description: 'Headers description',
-            version: 'builtin', configuration: {}, schema: {} }),
+        items: policies.concat({
+          id: '3',
+          enabled: false,
+          name: 'headers',
+          humanName: 'Headers',
+          summary: 'Headers summary',
+          description: 'Headers description',
+          version: 'builtin',
+          configuration: {},
+          schema: {}
+        }),
         visible: true,
         editPolicy: jest.fn()
       }

--- a/spec/javascripts/Policies/middleware/PolicyChain.spec.jsx
+++ b/spec/javascripts/Policies/middleware/PolicyChain.spec.jsx
@@ -6,10 +6,18 @@ const create = () => {
     { name: 'echo', configuration: {}, summary: 'ECHO', description: 'ECHO', humanName: 'ECHO', version: 'builtin' }
   ]
 
-  const chain = [
-    { name: 'cors', configuration: {}, summary: 'CORS', description: 'CORS', humanName: 'CORS', version: 'builtin',
-      data: {}, uuid: '007', enabled: true, removable: true }
-  ]
+  const chain = [{
+    name: 'cors',
+    configuration: {},
+    summary: 'CORS',
+    description: 'CORS',
+    humanName: 'CORS',
+    version: 'builtin',
+    data: {},
+    uuid: '007',
+    enabled: true,
+    removable: true
+  }]
 
   const store = {
     getState: jest.fn(() => ({registry, chain})),
@@ -52,8 +60,18 @@ describe('PolicyChain Middleware', () => {
   it('Dispatches the correct update when REMOVE_POLICY_FROM_CHAIN', () => {
     invoke({
       type: 'REMOVE_POLICY_FROM_CHAIN',
-      policy: { name: 'cors', configuration: {}, summary: 'CORS', description: 'CORS', humanName: 'CORS', version: 'builtin',
-        data: {}, uuid: '007', enabled: true, removable: true }
+      policy: {
+        name: 'cors',
+        configuration: {},
+        summary: 'CORS',
+        description: 'CORS',
+        humanName: 'CORS',
+        version: 'builtin',
+        data: {},
+        uuid: '007',
+        enabled: true,
+        removable: true
+      }
     })
 
     expect(store.dispatch).toHaveBeenCalledWith(updatePolicyChain([]))


### PR DESCRIPTION
`eslint` watches both **js** and **jsx** files when running webpack-dev. However it only includes **js** when running in CI.

This PR fixes the script `lint` for that purpose.

