### PR TITLE
[apiap] Polymorphic owner for ProxyRule

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -5,6 +5,8 @@ class BackendApi < ApplicationRecord
   include SystemName
   ECHO_API_HOST = 'echo-api.3scale.net'
 
+  has_many :proxy_rules, as: :owner, dependent: :destroy, inverse_of: :owner
+
   has_many :backend_api_configs, inverse_of: :backend_api, dependent: :destroy
   has_many :services, through: :backend_api_configs
   belongs_to :account, inverse_of: :backend_apis

--- a/app/models/proxy_rule.rb
+++ b/app/models/proxy_rule.rb
@@ -11,7 +11,7 @@ class ProxyRule < ApplicationRecord
   belongs_to :owner, polymorphic: true # FIXME: we should touch the owner here, but it will raise ActiveRecord::StaleObjectError
   belongs_to :metric
 
-  validates :http_method, :pattern, :proxy, :owner_id, :owner_type, :metric_id, presence: true
+  validates :http_method, :pattern, :owner_id, :owner_type, :metric_id, presence: true
   validates :owner_type, length: { maximum: 255 }
   validates :delta, numericality: { :only_integer => true, :greater_than => 0 }
 

--- a/app/models/proxy_rule.rb
+++ b/app/models/proxy_rule.rb
@@ -8,16 +8,20 @@ class ProxyRule < ApplicationRecord
   scope :ordered, -> { order(position: :asc) }
 
   belongs_to :proxy, touch: true
+  belongs_to :owner, polymorphic: true # FIXME: we should touch the owner here, but it will raise ActiveRecord::StaleObjectError
   belongs_to :metric
+
+  validates :http_method, :pattern, :proxy, :owner_id, :owner_type, :metric_id, presence: true
+  validates :owner_type, length: { maximum: 255 }
+  validates :delta, numericality: { :only_integer => true, :greater_than => 0 }
+
+  before_validation :fill_owner
 
   include ThreeScale::Search::Scopes
 
   self.allowed_sort_columns = %w[proxy_rules.http_method proxy_rules.pattern proxy_rules.last proxy_rules.position metrics.friendly_name]
   self.default_sort_column = :position
   self.default_sort_direction = :asc
-
-  validates :http_method, :pattern, :proxy, :metric_id, presence: true
-  validates :delta, numericality: { :only_integer => true, :greater_than => 0 }
 
   ALLOWED_HTTP_METHODS = %w( GET POST DELETE PUT PATCH HEAD OPTIONS ).freeze
 
@@ -140,4 +144,9 @@ class ProxyRule < ApplicationRecord
     end
   end
 
+  def fill_owner
+    return true if owner_type?
+    self.owner_id = proxy_id
+    self.owner_type = 'Proxy'
+  end
 end

--- a/db/migrate/20190801143026_add_owner_to_proxy_rules.rb
+++ b/db/migrate/20190801143026_add_owner_to_proxy_rules.rb
@@ -1,0 +1,11 @@
+class AddOwnerToProxyRules < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_column :proxy_rules, :owner_id, :integer, limit: 8
+    add_column :proxy_rules, :owner_type, :string
+
+    index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+    add_index :proxy_rules, [:owner_type, :owner_id], index_options
+  end
+end

--- a/db/migrate/20190801143259_backfill_proxy_rules_owners.rb
+++ b/db/migrate/20190801143259_backfill_proxy_rules_owners.rb
@@ -1,0 +1,10 @@
+class BackfillProxyRulesOwners < ActiveRecord::Migration
+  def up
+    say_with_time 'Updating proxy rules owners...' do
+      ProxyRule.reset_column_information
+      ProxyRule.find_each do |proxy_rule|
+        proxy_rule.update_columns(owner_id: proxy_rule.proxy_id, owner_type: 'Proxy') unless proxy_rule.owner_type?
+      end
+    end
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -1153,8 +1153,11 @@ ActiveRecord::Schema.define(version: 20190802133303) do
     t.text     "redirect_url"
     t.integer  "position",                       precision: 38
     t.boolean  "last",               limit: nil,                default: false
+    t.integer  "owner_id",                       precision: 38
+    t.string   "owner_type"
   end
 
+  add_index "proxy_rules", ["owner_type", "owner_id"], name: "index_proxy_rules_on_owner_type_and_owner_id"
   add_index "proxy_rules", ["proxy_id"], name: "index_proxy_rules_on_proxy_id"
 
   create_table "referrer_filters", force: :cascade do |t|

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -1154,8 +1154,11 @@ ActiveRecord::Schema.define(version: 20190802133303) do
     t.text     "redirect_url"
     t.integer  "position"
     t.boolean  "last",                           default: false
+    t.integer  "owner_id",           limit: 8
+    t.string   "owner_type"
   end
 
+  add_index "proxy_rules", ["owner_type", "owner_id"], name: "index_proxy_rules_on_owner_type_and_owner_id", using: :btree
   add_index "proxy_rules", ["proxy_id"], name: "index_proxy_rules_on_proxy_id", using: :btree
 
   create_table "referrer_filters", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1155,8 +1155,11 @@ ActiveRecord::Schema.define(version: 20190802133303) do
     t.text     "redirect_url",       limit: 65535
     t.integer  "position",           limit: 4
     t.boolean  "last",                             default: false
+    t.integer  "owner_id",           limit: 8
+    t.string   "owner_type",         limit: 255
   end
 
+  add_index "proxy_rules", ["owner_type", "owner_id"], name: "index_proxy_rules_on_owner_type_and_owner_id", using: :btree
   add_index "proxy_rules", ["proxy_id"], name: "index_proxy_rules_on_proxy_id", using: :btree
 
   create_table "referrer_filters", force: :cascade do |t|

--- a/test/unit/proxy_rule_test.rb
+++ b/test/unit/proxy_rule_test.rb
@@ -141,4 +141,19 @@ class ProxyRuleTest < ActiveSupport::TestCase
 
     proxy_rule.save!
   end
+
+  test 'fill owner' do
+    provider = FactoryBot.create(:simple_provider)
+
+    proxy = FactoryBot.create(:service, account: provider).proxy
+    proxy_proxy_rule = FactoryBot.build(:proxy_rule, proxy: proxy)
+    refute proxy_proxy_rule.owner
+    assert proxy_proxy_rule.valid?
+    assert_equal proxy, proxy_proxy_rule.owner
+
+    backend_api = BackendApi.create(name: 'API', system_name: 'api', account: provider)
+    backend_proxy_rule = FactoryBot.build(:proxy_rule, owner: backend_api)
+    assert_equal backend_api, backend_proxy_rule.owner
+    assert backend_proxy_rule.valid?
+  end
 end

--- a/test/unit/proxy_rule_test.rb
+++ b/test/unit/proxy_rule_test.rb
@@ -152,7 +152,7 @@ class ProxyRuleTest < ActiveSupport::TestCase
     assert_equal proxy, proxy_proxy_rule.owner
 
     backend_api = BackendApi.create(name: 'API', system_name: 'api', account: provider)
-    backend_proxy_rule = FactoryBot.build(:proxy_rule, owner: backend_api)
+    backend_proxy_rule = FactoryBot.build(:proxy_rule, proxy: nil, owner: backend_api)
     assert_equal backend_api, backend_proxy_rule.owner
     assert backend_proxy_rule.valid?
   end


### PR DESCRIPTION
This is step 1 of migrating mapping rules from the proxies to the backend APIs. Next step will be removing `proxy_id` and using only the new polymorphic owner.

Closes [THREESCALE-3157](https://issues.jboss.org/browse/THREESCALE-3157)

**Special notes for your reviewer**
It contains commits of https://github.com/3scale/porta/pull/1059