### PR TITLE
[apiap] Polymorphic owner for Metric

### DIFF
--- a/app/lib/backend/model_extensions/metric.rb
+++ b/app/lib/backend/model_extensions/metric.rb
@@ -22,10 +22,12 @@ module Backend
       end
 
       def sync_backend
+        return unless service # FIXME: We also need to sync BackendApi metrics
         ::BackendMetricWorker.sync(service.backend_id, id, system_name)
       end
 
       def sync_backend!
+        return unless service # FIXME: We also need to sync BackendApi metrics
         ::BackendMetricWorker.new.perform(service.backend_id, id, system_name)
       end
     end

--- a/app/lib/backend/model_extensions/metric.rb
+++ b/app/lib/backend/model_extensions/metric.rb
@@ -22,13 +22,20 @@ module Backend
       end
 
       def sync_backend
-        return unless service # FIXME: We also need to sync BackendApi metrics
-        ::BackendMetricWorker.sync(service.backend_id, id, system_name)
+        execute_per_service do |service|
+          ::BackendMetricWorker.sync(service.backend_id, id, system_name)
+        end
       end
 
       def sync_backend!
-        return unless service # FIXME: We also need to sync BackendApi metrics
-        ::BackendMetricWorker.new.perform(service.backend_id, id, system_name)
+        execute_per_service do |service|
+          ::BackendMetricWorker.new.perform(service.backend_id, id, system_name)
+        end
+      end
+
+      def execute_per_service(&block)
+        services = [*owner.try(:services), service].compact
+        services.each(&block)
       end
     end
   end

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -6,6 +6,7 @@ class BackendApi < ApplicationRecord
   ECHO_API_HOST = 'echo-api.3scale.net'
 
   has_many :proxy_rules, as: :owner, dependent: :destroy, inverse_of: :owner
+  has_many :metrics, as: :owner, dependent: :destroy, inverse_of: :owner
 
   has_many :backend_api_configs, inverse_of: :backend_api, dependent: :destroy
   has_many :services, through: :backend_api_configs

--- a/db/migrate/20190805135730_add_owner_to_metrics.rb
+++ b/db/migrate/20190805135730_add_owner_to_metrics.rb
@@ -1,0 +1,12 @@
+class AddOwnerToMetrics < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+   def change
+    add_column :metrics, :owner_id, :integer, limit: 8
+    add_column :metrics, :owner_type, :string
+
+    index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+    add_index :metrics, [:owner_type, :owner_id], index_options
+    add_index :metrics, [:owner_type, :owner_id, :system_name], index_options.merge(unique: true)
+  end
+end

--- a/db/migrate/20190805135829_backfill_metric_owners.rb
+++ b/db/migrate/20190805135829_backfill_metric_owners.rb
@@ -1,0 +1,10 @@
+class BackfillMetricOwners < ActiveRecord::Migration
+  def up
+    say_with_time 'Updating metric owners...' do
+      Metric.reset_column_information
+      Metric.find_each do |metric|
+        metric.update_columns(owner_id: metric.service_id, owner_type: 'Service') unless metric.owner_type?
+      end
+    end
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190802133303) do
+ActiveRecord::Schema.define(version: 20190805135829) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -823,8 +823,12 @@ ActiveRecord::Schema.define(version: 20190802133303) do
     t.string   "friendly_name"
     t.integer  "parent_id",     precision: 38
     t.integer  "tenant_id",     precision: 38
+    t.integer  "owner_id",      precision: 38
+    t.string   "owner_type"
   end
 
+  add_index "metrics", ["owner_type", "owner_id", "system_name"], name: "index_metrics_on_owner_type_and_owner_id_and_system_name", unique: true
+  add_index "metrics", ["owner_type", "owner_id"], name: "index_metrics_on_owner_type_and_owner_id"
   add_index "metrics", ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", unique: true
   add_index "metrics", ["service_id"], name: "index_metrics_on_service_id"
 

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190802133303) do
+ActiveRecord::Schema.define(version: 20190805135829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -822,8 +822,12 @@ ActiveRecord::Schema.define(version: 20190802133303) do
     t.string   "friendly_name", limit: 255
     t.integer  "parent_id",     limit: 8
     t.integer  "tenant_id",     limit: 8
+    t.integer  "owner_id",      limit: 8
+    t.string   "owner_type"
   end
 
+  add_index "metrics", ["owner_type", "owner_id", "system_name"], name: "index_metrics_on_owner_type_and_owner_id_and_system_name", unique: true, using: :btree
+  add_index "metrics", ["owner_type", "owner_id"], name: "index_metrics_on_owner_type_and_owner_id", using: :btree
   add_index "metrics", ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", unique: true, using: :btree
   add_index "metrics", ["service_id"], name: "index_metrics_on_service_id", using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190802133303) do
+ActiveRecord::Schema.define(version: 20190805135829) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -823,8 +823,12 @@ ActiveRecord::Schema.define(version: 20190802133303) do
     t.string   "friendly_name", limit: 255
     t.integer  "parent_id",     limit: 8
     t.integer  "tenant_id",     limit: 8
+    t.integer  "owner_id",      limit: 8
+    t.string   "owner_type",    limit: 255
   end
 
+  add_index "metrics", ["owner_type", "owner_id", "system_name"], name: "index_metrics_on_owner_type_and_owner_id_and_system_name", unique: true, using: :btree
+  add_index "metrics", ["owner_type", "owner_id"], name: "index_metrics_on_owner_type_and_owner_id", using: :btree
   add_index "metrics", ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", unique: true, using: :btree
   add_index "metrics", ["service_id"], name: "index_metrics_on_service_id", using: :btree
 


### PR DESCRIPTION
This is step 1 of migrating metrics from the services to the backend APIs. Next step will be removing `service_id` and using only the new polymorphic owner.

Closes [THREESCALE-3158](https://issues.jboss.org/browse/THREESCALE-3158)

**Special notes for your reviewer**
It contains commits of https://github.com/3scale/porta/pull/1059