### PR TITLE
Create an independent page to manage Mapping Rules

### DIFF
--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -261,6 +261,15 @@ table#metrics {
   }
 }
 
+table#mapping_rules {
+  tr th a, tr td.actions a {
+    display: inline-block;
+  }
+  tr td.actions a {
+    margin-left: line-height-times(1/2);
+  }
+}
+
 td.thhead h3 {
   margin-top: 0;
   padding-right: line-height-times(2/3);

--- a/app/assets/stylesheets/provider/admin/apiconfig/services/_proxies.scss
+++ b/app/assets/stylesheets/provider/admin/apiconfig/services/_proxies.scss
@@ -8,6 +8,10 @@ $integration-tab-warning-color: darken($dirty-color, 60%);
   max-width: 100%;
 }
 
+#integration-tabs fieldset.independent_mapping_rules {
+  margin-left: 0;
+}
+
 #integration-tabs form.formtastic fieldset > ol > li.radio--iconic fieldset ol,
 form.formtastic fieldset > ol > li.radio--iconic fieldset ol {
   margin: line-height-times(4) 0;

--- a/app/controllers/api/proxy_rules_controller.rb
+++ b/app/controllers/api/proxy_rules_controller.rb
@@ -1,0 +1,70 @@
+class Api::ProxyRulesController < Api::BaseController
+  include ThreeScale::Search::Helpers
+
+  before_action :authorize!, :find_service, :find_proxy
+  before_action :find_proxy_rule, only: %i[edit update destroy]
+
+  activate_menu :serviceadmin, :integration, :mapping_rules
+
+  sublayout 'api/service'
+
+  def index
+    @proxy_rules = @proxy.proxy_rules.order_by(params[:sort], params[:direction])
+                                     .includes(:metric).ordered.paginate(page: params[:page])
+  end
+
+  def new
+    last_position = @proxy.proxy_rules.maximum(:position) || 0
+    next_position = last_position + 1
+    @proxy_rule = @proxy.proxy_rules.build(position: next_position, delta: 1)
+  end
+
+  def create
+    @proxy_rule = @proxy.proxy_rules.build(proxy_rule_params)
+    if @proxy_rule.save
+      redirect_to admin_service_proxy_rules_path(@service), notice: 'Mapping rule was created.'
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @proxy_rule.update_attributes(proxy_rule_params)
+      redirect_to admin_service_proxy_rules_path(@service), notice: 'Mapping rule was updated.'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @proxy_rule.destroy
+      flash[:notice] = 'The mapping rule was deleted'
+    else
+      flash[:error] = 'The mapping rule cannot be deleted'
+    end
+
+    redirect_to admin_service_proxy_rules_path(@service)
+  end
+
+  private
+
+  def authorize!
+    provider_can_use!(:independent_mapping_rules)
+  end
+
+  def find_proxy
+    @proxy = @service.proxy
+  end
+
+  def find_proxy_rule
+    @proxy_rule = @proxy.proxy_rules.find(params[:id])
+  end
+
+  def find_service
+    @service = current_user.accessible_services.find(params[:service_id])
+  end
+
+  def proxy_rule_params
+    params.require(:proxy_rule).permit(%i[http_method pattern delta metric_id position last redirect_url])
+  end
+end

--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -129,6 +129,12 @@ module Logic
         end
       end
 
+      class IndependentMappingRules < Base
+        def missing_config
+          false
+        end
+      end
+
       class InstantBillPlanChange < Base
         def missing_config
           false

--- a/app/models/proxy_rule.rb
+++ b/app/models/proxy_rule.rb
@@ -10,6 +10,12 @@ class ProxyRule < ApplicationRecord
   belongs_to :proxy, touch: true
   belongs_to :metric
 
+  include ThreeScale::Search::Scopes
+
+  self.allowed_sort_columns = %w{ proxy_rules.http_method proxy_rules.pattern proxy_rules.last proxy_rules.position metrics.friendly_name }
+  self.default_sort_column = :position
+  self.default_sort_direction = :asc
+
   validates :http_method, :pattern, :proxy, :metric_id, presence: true
   validates :delta, numericality: { :only_integer => true, :greater_than => 0 }
 

--- a/app/views/api/integrations/apicast/shared/_mapping_rules.html.slim
+++ b/app/views/api/integrations/apicast/shared/_mapping_rules.html.slim
@@ -1,4 +1,10 @@
-= f.toggled_inputs 'mapping_rules', cookie_name: 'mapping-rules' , legend: "Mapping Rules", id: "mapping-rules" do
+- if current_account.provider_can_use?(:independent_mapping_rules)
+  fieldset.inputs.independent_mapping_rules
+    legend
+      span
+        = link_to 'Mapping Rules', admin_service_proxy_rules_path(@service), target: '_blank'
+- else
+  = f.toggled_inputs 'mapping_rules', cookie_name: 'mapping-rules' , legend: 'Mapping Rules', id: "mapping-rules" do
 
     = help_bubble( 'proxy_rule_bubble', t('api.integrations.proxy.proxy_rule_help_html'))
     table#proxy-rules
@@ -30,35 +36,35 @@
           th colspan=(@service.using_proxy_pro? ? '7' : '6')
             = link_to "Add Mapping Rule", '#add-proxy-rule', class: 'action add', id: 'add-proxy-rule'
 
-javascript:
-  jQuery('#proxy-rules .metric select[data-selected]').each(function () {
-    jQuery(this).val(jQuery(this).data('selected'))
-  })
-  jQuery(function () {
-    var PIXEL_CORRECTOR = 4
-    var tdWidths = jQuery.map(jQuery('.ui-sortable-item').first().children(), function (td, _i) {
-      return td.offsetWidth + PIXEL_CORRECTOR
+  javascript:
+    jQuery('#proxy-rules .metric select[data-selected]').each(function () {
+      jQuery(this).val(jQuery(this).data('selected'))
     })
     jQuery(function () {
-      jQuery('#sortable').sortable({
-        cursor: 'move',
-        containment: '#mapping-rules',
-        items: 'tr:not(#new-proxy-rule-template)',
-        start: function (event, ui) {
-          jQuery.each(ui.item.children(), function (i, td) {
-            jQuery(td).css({ width: tdWidths[i] })
-          })
-        },
-        stop: function () {
-          $('tr:not(#new-proxy-rule-template)', this).each(function (index, mappingRule) {
-            if (!$(mappingRule).hasClass('deleted')) {
-              $(mappingRule).find('select,input:not(.destroyer)').removeAttr('disabled')
-              $(mappingRule).find('span.fa-exclamation-triangle').removeClass('disabled')
-            }
-            $(mappingRule).find('.position').val(index + 1)
-          })
-        }
+      var PIXEL_CORRECTOR = 4
+      var tdWidths = jQuery.map(jQuery('.ui-sortable-item').first().children(), function (td, _i) {
+        return td.offsetWidth + PIXEL_CORRECTOR
       })
-      jQuery('tr, td').disableSelection()
+      jQuery(function () {
+        jQuery('#sortable').sortable({
+          cursor: 'move',
+          containment: '#mapping-rules',
+          items: 'tr:not(#new-proxy-rule-template)',
+          start: function (event, ui) {
+            jQuery.each(ui.item.children(), function (i, td) {
+              jQuery(td).css({ width: tdWidths[i] })
+            })
+          },
+          stop: function () {
+            $('tr:not(#new-proxy-rule-template)', this).each(function (index, mappingRule) {
+              if (!$(mappingRule).hasClass('deleted')) {
+                $(mappingRule).find('select,input:not(.destroyer)').removeAttr('disabled')
+                $(mappingRule).find('span.fa-exclamation-triangle').removeClass('disabled')
+              }
+              $(mappingRule).find('.position').val(index + 1)
+            })
+          }
+        })
+        jQuery('tr, td').disableSelection()
+      })
     })
-  })

--- a/app/views/api/proxy_rules/_form.html.slim
+++ b/app/views/api/proxy_rules/_form.html.slim
@@ -1,0 +1,10 @@
+= form.inputs do
+  = form.input :http_method, as: :select, collection: ProxyRule::ALLOWED_HTTP_METHODS, include_blank: false, label: 'Verb'
+  = form.input :pattern
+  = form.input :metric_id, as: :select, collection: service.metrics, include_blank: false, label: 'Metric or Method to increment'
+  = form.input :delta, label: 'Increment by'
+  = form.input :last, label: 'Last?'
+  = form.input :position
+
+= form.buttons do
+  = form.commit_button "#{proxy_rule.new_record? ? 'Create' : 'Update'} Mapping Rule"

--- a/app/views/api/proxy_rules/edit.html.slim
+++ b/app/views/api/proxy_rules/edit.html.slim
@@ -1,0 +1,4 @@
+= content_for :sublayout_title, 'Edit Mapping Rule'
+
+= semantic_form_for @proxy_rule, url: admin_service_proxy_rule_path(@service, @proxy_rule) do |form|
+  = render 'form', form: form, proxy_rule: @proxy_rule, service: @service

--- a/app/views/api/proxy_rules/index.html.slim
+++ b/app/views/api/proxy_rules/index.html.slim
@@ -1,0 +1,46 @@
+- content_for :sublayout_title, 'Mapping Rules'
+
+table#mapping_rules.data
+  thead
+    tr
+      th = sortable('proxy_rules.http_method', 'Verb')
+      th = sortable('proxy_rules.pattern', 'Pattern')
+      - if @service.using_proxy_pro?
+        th Redirect
+      th title="increment" +
+      th
+        = sortable('metrics.friendly_name', 'Metric or Method')
+        |  (
+        = link_to 'Define', admin_service_metrics_path(@service), title: 'Define Methods & Metrics for this service'
+        | )
+      th = sortable('proxy_rules.last', 'Last?')
+      th = sortable('proxy_rules.position', 'Position')
+      th.actions
+        = link_to 'Add Mapping Rule', new_admin_service_proxy_rule_path(@service), class: 'action add'
+  tbody
+    - @proxy_rules.each do |rule|
+      tr
+        td.http_method
+          = rule.http_method
+        td.pattern
+          = rule.pattern
+          - if rule.pattern == '/'
+            span.fa.fa-exclamation-triangle.disabled#catch-all-warning title=(t('api.integrations.proxy.proxy_rule_catch_all_warning'))
+        - if @service.using_proxy_pro?
+          td.redirect_url
+            = rule.redirect_url
+        td.delta
+          = rule.delta
+        td.metric
+          = rule.metric_system_name
+        td.last_called_and_position
+          = rule.last
+        td.position
+          = rule.position
+        td.actions
+          = link_to '', edit_admin_service_proxy_rule_path(@service, rule.id), class: 'action edit'
+          = link_to '', admin_service_proxy_rule_path(@service, rule.id), class: 'action delete', data: {confirm: 'Are you sure?'}, method: :delete
+
+  tfoot
+
+= will_paginate(@proxy_rules)

--- a/app/views/api/proxy_rules/new.html.slim
+++ b/app/views/api/proxy_rules/new.html.slim
@@ -1,0 +1,4 @@
+= content_for :sublayout_title, 'New Mapping Rule'
+
+= semantic_form_for @proxy_rule, url: admin_service_proxy_rules_path(@service) do |form|
+  = render 'form', form: form, proxy_rule: @proxy_rule, service: @service

--- a/app/views/shared/provider/navigation/service/_integration.html.slim
+++ b/app/views/shared/provider/navigation/service/_integration.html.slim
@@ -6,6 +6,11 @@
          title: 'Methods & Metrics',
          path: admin_service_metrics_path(@service)
 
+- if current_account.provider_can_use?(:independent_mapping_rules)
+  = render vertical_nav_item,
+           title: 'Mapping Rules',
+           path: admin_service_proxy_rules_path(@service)
+
 = render vertical_nav_item,
      title: 'Settings',
      path: settings_admin_service_path(@service)

--- a/config/examples/rolling_updates.yml
+++ b/config/examples/rolling_updates.yml
@@ -16,6 +16,7 @@ base: &default
   policy_registry: true
   proxy_private_base_path: true
   service_mesh_integration: false
+  independent_mapping_rules: false
 
 development:
   <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -825,6 +825,7 @@ without fake Core server your after commit callbacks will crash and you might ge
           end
           resources :proxy_logs, :only => [:index, :show ]
           resources :proxy_configs, only: %i(index show)
+          resources :proxy_rules, except: %i(show)
         end
 
         resources :alerts, :only => [:index, :destroy] do

--- a/features/old/menu/api_menu.feature
+++ b/features/old/menu/api_menu.feature
@@ -40,6 +40,7 @@ Feature: API menu
     Then I should see menu items
     | Configuration             |
     | Methods & Metrics         |
+    | Mapping Rules             |
     | Settings                  |
 
   Scenario: API menu structure with service plans enabled

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -8,7 +8,7 @@ Then /^I should see the partners submenu$/ do
 end
 
 Then /^I should see menu items$/ do |items|
-  items.rows.each do |item|
+  items.raw.each do |item|
     within '#mainmenu' do
       assert has_css? 'li', :text => item[0]
     end

--- a/test/integration/api/proxy_rules_controller_test.rb
+++ b/test/integration/api/proxy_rules_controller_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Api::ProxyRulesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    Logic::RollingUpdates.stubs(enabled?: true)
+    Account.any_instance.stubs(:provider_can_use?).returns(true)
+    @provider = FactoryBot.create(:provider_account)
+    @service  = FactoryBot.create(:service, account: @provider)
+    login_provider @provider
+  end
+
+  class WithFeatureEnabled < Api::ProxyRulesControllerTest
+    def setup
+      super
+      Account.any_instance.stubs(:provider_can_use?).with(:independent_mapping_rules).returns(true).at_least_once
+    end
+
+    test 'index page list all proxy rules' do
+      proxy_rules = FactoryBot.create_list(:proxy_rule, 2, proxy: @service.proxy)
+
+      get admin_service_proxy_rules_path(@service)
+      page = Nokogiri::HTML::Document.parse(response.body)
+      patterns = page.xpath('//*[@id="proxy-rules"]/tbody/tr/td[2]').text
+
+      assert_response :ok
+      proxy_rules.map(&:pattern).each do |pattern|
+        patterns.include?(pattern)
+      end
+    end
+
+    test '#create persists a new proxy rule' do
+      proxy_rule_params = FactoryBot.attributes_for(:proxy_rule, proxy: @service.proxy, metric_id: @service.metrics.last.id)
+
+      assert_difference -> { @service.proxy.proxy_rules.count }, 1 do
+        post admin_service_proxy_rules_path(@service), proxy_rule: proxy_rule_params
+      end
+    end
+
+    test '#update saves the new attributes' do
+      proxy_rule = FactoryBot.create(:proxy_rule, proxy: @service.proxy)
+
+      patch admin_service_proxy_rule_path(@service, proxy_rule), proxy_rule: { pattern: '/testing' }
+      follow_redirect!
+      proxy_rule.reload
+
+      assert_response :ok
+      assert_equal '/testing', proxy_rule.pattern
+    end
+
+    test '#destroy deletes the proxy rule' do
+      proxy_rule = FactoryBot.create(:proxy_rule, proxy: @service.proxy)
+
+      assert_difference -> { @service.proxy.proxy_rules.count }, -1 do
+        delete admin_service_proxy_rule_path(@service, proxy_rule)
+        follow_redirect!
+
+        assert_response :success
+      end
+    end
+  end
+
+  class WithFeatureDisabled < Api::ProxyRulesControllerTest
+    def setup
+      super
+      Account.any_instance.stubs(:provider_can_use?).with(:independent_mapping_rules).returns(false).at_least_once
+    end
+
+    test 'cannot access index page' do
+      get admin_service_proxy_rules_path(@service)
+
+      assert_response :not_found
+    end
+
+    test 'cannot access new page' do
+      get new_admin_service_proxy_rule_path(@service)
+
+      assert_response :not_found
+    end
+
+    test 'cannot access edit page' do
+      proxy_rule = FactoryBot.create(:proxy_rule, proxy: @service.proxy)
+
+      get edit_admin_service_proxy_rule_path(@service, proxy_rule)
+
+      assert_response :not_found
+    end
+
+    test 'cannot create a proxy rule' do
+      post admin_service_proxy_rules_path(@service), proxy_rule: FactoryBot.attributes_for(:proxy_rule, proxy: @service.proxy)
+
+      assert_response :not_found
+    end
+
+    test 'cannot update a proxy rule' do
+      proxy_rule = FactoryBot.create(:proxy_rule, proxy: @service.proxy)
+
+      patch admin_service_proxy_rule_path(@service, proxy_rule), proxy_rule: { pattern: '/testing' }
+
+      assert_response :not_found
+    end
+
+    test 'cannot delete a proxy rule' do
+      proxy_rule = FactoryBot.create(:proxy_rule, proxy: @service.proxy)
+
+      delete admin_service_proxy_rule_path(@service, proxy_rule)
+
+      assert_response :not_found
+    end
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Our current page that manages the mapping rules don't have
pagination, causing a timeout if you have a lot of rules.

This commit creates a new independent page to manage Mapping rules
with a paginated list of itens.


**Which issue(s) this PR fixes** 

[THREESCALE-3002](https://issues.jboss.org/browse/THREESCALE-3002)

![independent_mapping_rules](https://user-images.githubusercontent.com/771411/62502600-a91a6e00-b7c6-11e9-83bd-1e0bfaaeb403.gif)
