### PR TITLE
Remove comment about proxy association in Service Factory

### DIFF
--- a/test/factories/other.rb
+++ b/test/factories/other.rb
@@ -27,7 +27,6 @@ FactoryBot.define do
 
   factory(:service) do
     mandatory_app_key { false }
-    #  association :proxy, :factory => :proxy
     sequence(:name) { |n| "service#{n}" }
     association(:account, :factory => :provider_account)
     after(:create) do |record|


### PR DESCRIPTION
This comment has been there since `28 Nov 2013` in a [wip commit](https://github.com/3scale/system/commit/cf1f0d1c5cc959ad1cc389ae4fab580e4ba81fee#diff-5ff39f52de683ee8bae9f36d8bde5a69R36), and I find it just confusing instead of helpful 😕 
The proxy is created anyway with this factory and the tests are relying on that.