### PR TITLE
Remove activerecord-nulldb-adapter gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,4 @@ USER root
 RUN sed -i 's/compile: true/compile: false/' config/webpacker.yml
 
 RUN bash -c "bundle install && bundle exec rake tmp:create"
-RUN bash -c "npm install && rake assets:precompile && DATABASE_URL=nulldb://nohost rake webpacker:compile"
+RUN bash -c "npm install && rake assets:precompile"

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -88,7 +88,6 @@ gem '3scale_client', '~> 2.6.1', require: false
 gem 'analytics-ruby', require: false
 
 group :development, :test do
-  gem 'activerecord-nulldb-adapter'
   gem 'bootsnap', '~> 1.3'
 
   platform :mri_23, :mri_24, :mri_25 do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,8 +162,6 @@ GEM
       activemodel (= 4.2.11.1)
       activesupport (= 4.2.11.1)
       arel (~> 6.0)
-    activerecord-nulldb-adapter (0.4.0)
-      activerecord (>= 2.0.0)
     activerecord-oracle_enhanced-adapter (1.6.9)
     activesupport (4.2.11.1)
       i18n (~> 0.7)
@@ -817,7 +815,6 @@ DEPENDENCIES
   active-docs!
   active_merchant-adyen12!
   activemerchant (~> 1.77.0)
-  activerecord-nulldb-adapter
   activerecord-oracle_enhanced-adapter (~> 1.6.0)
   acts-as-taggable-on (~> 4.0)
   acts_as_list (~> 0.9.17)

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -163,8 +163,6 @@ GEM
       activemodel (= 4.2.11.1)
       activesupport (= 4.2.11.1)
       arel (~> 6.0)
-    activerecord-nulldb-adapter (0.4.0)
-      activerecord (>= 2.0.0)
     activerecord-oracle_enhanced-adapter (1.6.9)
     activesupport (4.2.11.1)
       i18n (~> 0.7)
@@ -821,7 +819,6 @@ DEPENDENCIES
   active-docs!
   active_merchant-adyen12!
   activemerchant (~> 1.77.0)
-  activerecord-nulldb-adapter
   activerecord-oracle_enhanced-adapter (~> 1.6.0)
   acts-as-taggable-on (~> 4.0)
   acts_as_list (~> 0.9.17)


### PR DESCRIPTION
**What this PR does / why we need it**:

Changing the Dockerfile to not run webpacker:compile (because
assets:precompile already do it) we could remove the gem
activerecord-nulldb-adapter from the application. It was only used
to avoid webpacker:compile fail with a database connection error.

You can verify it  by trying to run the app with docker-compose locally:

```
make dev-setup
make dev-start
```
