### PR TITLE
[APIAP][API Endpoints] Set the flag of a service to 'act as product'

### DIFF
--- a/app/controllers/admin/api/services_controller.rb
+++ b/app/controllers/admin/api/services_controller.rb
@@ -113,12 +113,14 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   end
 
   def service_params
-    params.require(:service).permit(:name, :system_name, :description, :support_email, :deployment_option, :backend_version,
-                                    :intentions_required, :buyers_manage_apps, :referrer_filters_required,
-                                    :buyer_can_select_plan, :buyer_plan_change_permission, :buyers_manage_keys,
-                                    :buyer_key_regenerate_enabled, :mandatory_app_key, :custom_keys_enabled, :state_event,
-                                    :txt_support, :terms,
-                                    notification_settings: [web_provider: [], email_provider: [], web_buyer: [], email_buyer: []])
+    permitted_params = [:name, :system_name, :description, :support_email, :deployment_option, :backend_version,
+                        :intentions_required, :buyers_manage_apps, :referrer_filters_required,
+                        :buyer_can_select_plan, :buyer_plan_change_permission, :buyers_manage_keys,
+                        :buyer_key_regenerate_enabled, :mandatory_app_key, :custom_keys_enabled, :state_event,
+                        :txt_support, :terms,
+                        {notification_settings: [web_provider: [], email_provider: [], web_buyer: [], email_buyer: []]}]
+    permitted_params += [:act_as_product] if provider_can_use?(:api_as_product)
+    params.require(:service).permit(*permitted_params)
   end
 
   def service

--- a/test/integration/admin/api/services_controller_test.rb
+++ b/test/integration/admin/api/services_controller_test.rb
@@ -62,6 +62,7 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       host! provider.admin_domain
       @service = FactoryBot.create(:service, account: provider)
       Account.any_instance.stubs(can_create_service?: true)
+      Logic::RollingUpdates.stubs(enabled?: true)
     end
 
     attr_reader :provider, :service
@@ -128,6 +129,40 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
 
       put admin_api_service_path(service, access_token: access_token_value, format: :json), permitted_params.merge({state_event: 'publish'})
       assert_equal 'published', service.reload.state
+    end
+
+    test 'create accepts act_as_product when the rolling update is enabled' do
+      Logic::RollingUpdates::Features::ApiAsProduct.any_instance.stubs(:enabled?).returns(true)
+
+      assert_difference(provider.services.method(:count)) do
+        post admin_api_services_path(access_token: access_token_value, format: :json), permitted_params.merge({act_as_product: true})
+      end
+      assert provider.services.last!.act_as_product
+    end
+
+    test 'create does not accept act_as_product when the rolling update is disabled' do
+      Logic::RollingUpdates::Features::ApiAsProduct.any_instance.stubs(:enabled?).returns(false)
+
+      assert_difference(provider.services.method(:count)) do
+        post admin_api_services_path(access_token: access_token_value, format: :json), permitted_params.merge({act_as_product: true})
+      end
+      refute provider.services.last!.act_as_product
+    end
+
+    test 'update accepts act_as_product when the rolling update is enabled' do
+      Logic::RollingUpdates::Features::ApiAsProduct.any_instance.stubs(:enabled?).returns(true)
+
+      put admin_api_service_path(service, access_token: access_token_value, format: :json), permitted_params.merge({act_as_product: true})
+      assert_response :success
+      assert service.reload.act_as_product
+    end
+
+    test 'update does not accept act_as_product when the rolling update is disabled' do
+      Logic::RollingUpdates::Features::ApiAsProduct.any_instance.stubs(:enabled?).returns(false)
+
+      put admin_api_service_path(service, access_token: access_token_value, format: :json), permitted_params.merge({act_as_product: true})
+      assert_response :success
+      refute service.reload.act_as_product
     end
 
     private


### PR DESCRIPTION
Closes [THREESCALE-3210](https://issues.jboss.org/browse/THREESCALE-3210)
Depends on https://github.com/3scale/porta/pull/1078 and https://github.com/3scale/porta/pull/1068