### PR TITLE
Share logic between the 2 pages to manage Mapping Rules

### DIFF
--- a/app/controllers/provider/admin/backend_apis/mapping_rules_controller.rb
+++ b/app/controllers/provider/admin/backend_apis/mapping_rules_controller.rb
@@ -1,14 +1,39 @@
 # frozen_string_literal: true
 
 class Provider::Admin::BackendApis::MappingRulesController < Provider::Admin::BackendApis::BaseController
+  include ThreeScale::Search::Helpers
+  include ProxyRuleSharedController
+
   activate_menu :backend_api, :mapping_rules
 
-  include ThreeScale::Search::Helpers
+  delegate :proxy_rules, to: :@backend_api
 
-  def index
-    @mapping_rules = @backend_api.mapping_rules
-                                 .order_by(params[:sort], params[:direction])
-                                 .includes(:metric)
-                                 .paginate(pagination_params)
+  def create
+    @proxy_rule = proxy_rules.build(proxy_rule_params)
+    if @proxy_rule.save
+      redirect_to provider_admin_backend_api_mapping_rules_path(@backend_api), notice: 'Mapping rule was created.'
+    else
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @proxy_rule.update_attributes(proxy_rule_params)
+      redirect_to provider_admin_backend_api_mapping_rules_path(@backend_api), notice: 'Mapping rule was updated.'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @proxy_rule.destroy
+      flash[:notice] = 'The mapping rule was deleted'
+    else
+      flash[:error] = 'The mapping rule cannot be deleted'
+    end
+
+    redirect_to provider_admin_backend_api_mapping_rules_path(@backend_api)
   end
 end

--- a/app/controllers/proxy_rule_shared_controller.rb
+++ b/app/controllers/proxy_rule_shared_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# This module is used to share behavior between the 2 different Mapping rules controller that we have
+# (1 for BackendApi and another one to the Proxy).
+# The controller that uses this class should implement the `proxy_rules` method that returns a relation containing all
+# the mapping rules for the resource.
+module ProxyRuleSharedController
+  def self.included(base)
+    base.class_eval do
+      before_action :find_proxy_rule, only: %i[edit update destroy]
+    end
+  end
+
+  def index
+    @proxy_rules = proxy_rules.order_by(params[:sort], params[:direction])
+                              .includes(:metric)
+                              .paginate(pagination_params)
+  end
+
+  def new
+    last_position = proxy_rules.maximum(:position) || 0
+    next_position = last_position + 1
+    @proxy_rule   = proxy_rules.build(position: next_position, delta: 1)
+  end
+
+  private
+
+  def find_proxy_rule
+    @proxy_rule = proxy_rules.find(params[:id])
+  end
+
+  def proxy_rule_params
+    params.require(:proxy_rule).permit(%i[http_method pattern delta metric_id position last redirect_url])
+  end
+end

--- a/app/helpers/proxy_rules_helper.rb
+++ b/app/helpers/proxy_rules_helper.rb
@@ -1,0 +1,12 @@
+module ProxyRulesHelper
+  def proxy_rule_path_for(proxy_rule, edit: false)
+    owner = proxy_rule.owner
+    collection = case owner
+                 when Proxy
+                   [:admin, owner.service, :proxy_rule]
+                 when BackendApi
+                   [:provider, :admin, owner, :mapping_rule]
+                 end
+    public_send (edit ? :edit_polymorphic_path : :polymorphic_path), collection, id: proxy_rule
+  end
+end

--- a/app/views/api/proxy_rules/edit.html.slim
+++ b/app/views/api/proxy_rules/edit.html.slim
@@ -1,4 +1,4 @@
 = content_for :sublayout_title, 'Edit Mapping Rule'
 
 = semantic_form_for @proxy_rule, url: admin_service_proxy_rule_path(@service, @proxy_rule) do |form|
-  = render 'form', form: form, proxy_rule: @proxy_rule, service: @service
+  = render 'shared/proxy_rules/form', form: form, proxy_rule: @proxy_rule, metrics: @service.metrics

--- a/app/views/api/proxy_rules/index.html.slim
+++ b/app/views/api/proxy_rules/index.html.slim
@@ -1,46 +1,5 @@
 - content_for :sublayout_title, 'Mapping Rules'
 
-table#mapping_rules.data
-  thead
-    tr
-      th = sortable('proxy_rules.http_method', 'Verb')
-      th = sortable('proxy_rules.pattern', 'Pattern')
-      - if @service.using_proxy_pro?
-        th Redirect
-      th title="increment" +
-      th
-        = sortable('metrics.friendly_name', 'Metric or Method')
-        |  (
-        = link_to 'Define', admin_service_metrics_path(@service), title: 'Define Methods & Metrics for this service'
-        | )
-      th = sortable('proxy_rules.last', 'Last?')
-      th = sortable('proxy_rules.position', 'Position')
-      th.actions
-        = link_to 'Add Mapping Rule', new_admin_service_proxy_rule_path(@service), class: 'action add'
-  tbody
-    - @proxy_rules.each do |rule|
-      tr
-        td.http_method
-          = rule.http_method
-        td.pattern
-          = rule.pattern
-          - if rule.pattern == '/'
-            span.fa.fa-exclamation-triangle.disabled#catch-all-warning title=(t('api.integrations.proxy.proxy_rule_catch_all_warning'))
-        - if @service.using_proxy_pro?
-          td.redirect_url
-            = rule.redirect_url
-        td.delta
-          = rule.delta
-        td.metric
-          = rule.metric_system_name
-        td.last_called_and_position
-          = rule.last
-        td.position
-          = rule.position
-        td.actions
-          = link_to '', edit_admin_service_proxy_rule_path(@service, rule.id), class: 'action edit'
-          = link_to '', admin_service_proxy_rule_path(@service, rule.id), class: 'action delete', data: {confirm: 'Are you sure?'}, method: :delete
-
-  tfoot
-
-= will_paginate(@proxy_rules)
+= render 'shared/proxy_rules/table', proxy_rules: @proxy_rules,
+                                     new_rule_path: new_admin_service_proxy_rule_path(@service),
+                                     owner: @service

--- a/app/views/api/proxy_rules/new.html.slim
+++ b/app/views/api/proxy_rules/new.html.slim
@@ -1,4 +1,4 @@
 = content_for :sublayout_title, 'New Mapping Rule'
 
 = semantic_form_for @proxy_rule, url: admin_service_proxy_rules_path(@service) do |form|
-  = render 'form', form: form, proxy_rule: @proxy_rule, service: @service
+  = render 'shared/proxy_rules/form', form: form, proxy_rule: @proxy_rule, metrics: @service.metrics

--- a/app/views/provider/admin/backend_apis/mapping_rules/edit.html.slim
+++ b/app/views/provider/admin/backend_apis/mapping_rules/edit.html.slim
@@ -1,0 +1,4 @@
+h2 Edit Mapping Rule
+
+= semantic_form_for @proxy_rule, url: provider_admin_backend_api_mapping_rule_path(@backend_api, @proxy_rule) do |form|
+  = render 'shared/proxy_rules/form', form: form, proxy_rule: @proxy_rule, metrics: @backend_api.metrics

--- a/app/views/provider/admin/backend_apis/mapping_rules/index.html.slim
+++ b/app/views/provider/admin/backend_apis/mapping_rules/index.html.slim
@@ -1,41 +1,5 @@
 h2 Mapping Rules
 
-table#mapping_rules.data
-  thead
-    tr
-      th = sortable('proxy_rules.http_method', 'Verb')
-      th = sortable('proxy_rules.pattern', 'Pattern')
-      th title="increment" +
-      th
-        = sortable('metrics.friendly_name', "Metric or Method")
-        |  (
-        = link_to 'Define', provider_admin_backend_api_metrics_path(@backend_api), title: 'Define Methods & Metrics for this service'
-        | )
-      th = sortable('proxy_rules.last', 'Last?')
-      th title="position" = sortable('proxy_rules.position', 'P')
-      th.actions
-        = link_to 'New Mapping Rule',
-                  new_provider_admin_backend_api_mapping_rule_path(@backend_api),
-                  class:'action add'
-
-  tbody
-    - @mapping_rules.each do |rule|
-      tr
-        td
-          = rule.http_method
-        td
-          = rule.pattern
-        td
-          = rule.delta
-        td
-          = rule.metric.friendly_name
-        td
-          - if rule.last
-            i.fa.fa-check
-        td
-          = rule.position
-        td.actions
-          = link_to '', edit_provider_admin_backend_api_mapping_rule_path(@backend_api, rule), class: 'action edit'
-          = link_to '', provider_admin_backend_api_mapping_rule_path(@backend_api, rule), class: 'action delete', method: :destroy, remote: true, data: { confirm: 'Are you sure?' }
-
-= will_paginate @mapping_rules
+= render 'shared/proxy_rules/table', proxy_rules: @proxy_rules,
+                                     new_rule_path: new_provider_admin_backend_api_mapping_rule_path(@backend_api),
+                                     owner: @backend_api

--- a/app/views/provider/admin/backend_apis/mapping_rules/new.html.slim
+++ b/app/views/provider/admin/backend_apis/mapping_rules/new.html.slim
@@ -1,0 +1,4 @@
+h2 New Mapping Rule
+
+= semantic_form_for @proxy_rule, url: provider_admin_backend_api_mapping_rules_path(@backend_api) do |form|
+  = render 'shared/proxy_rules/form', form: form, proxy_rule: @proxy_rule, metrics: @backend_api.metrics

--- a/app/views/shared/proxy_rules/_form.html.slim
+++ b/app/views/shared/proxy_rules/_form.html.slim
@@ -1,7 +1,8 @@
 = form.inputs do
   = form.input :http_method, as: :select, collection: ProxyRule::ALLOWED_HTTP_METHODS, include_blank: false, label: 'Verb'
   = form.input :pattern
-  = form.input :metric_id, as: :select, collection: service.metrics, include_blank: false, label: 'Metric or Method to increment'
+  = form.input :redirect_url, as: :string if proxy_rule.owner.try(:using_proxy_pro?)
+  = form.input :metric_id, as: :select, collection: metrics, include_blank: false, label: 'Metric or Method to increment'
   = form.input :delta, label: 'Increment by'
   = form.input :last, label: 'Last?'
   = form.input :position

--- a/app/views/shared/proxy_rules/_table.html.slim
+++ b/app/views/shared/proxy_rules/_table.html.slim
@@ -1,0 +1,38 @@
+table#mapping_rules.data
+  thead
+    tr
+      th = sortable('proxy_rules.http_method', 'Verb')
+      th = sortable('proxy_rules.pattern', 'Pattern')
+      - if owner.try(:using_proxy_pro?)
+        th Redirect
+      th title="increment" +
+      th = sortable('metrics.friendly_name', 'Metric or Method')
+      th = sortable('proxy_rules.last', 'Last?')
+      th = sortable('proxy_rules.position', 'Position')
+      th.actions
+        = link_to 'Add Mapping Rule', new_rule_path, class: 'action add'
+  tbody
+    - proxy_rules.each do |rule|
+      tr
+        td.http_method
+          = rule.http_method
+        td.pattern
+          = rule.pattern
+          - if rule.pattern == '/'
+            span.fa.fa-exclamation-triangle.disabled#catch-all-warning title=(t('api.integrations.proxy.proxy_rule_catch_all_warning'))
+        - if owner.try(:using_proxy_pro?)
+          td.redirect_url
+            = rule.redirect_url
+        td.delta
+          = rule.delta
+        td.metric
+          = rule.metric_system_name
+        td.last_called_and_position
+          = rule.last
+        td.position
+          = rule.position
+        td.actions
+          = link_to '', proxy_rule_path_for(rule, edit: true), class: 'action edit'
+          = link_to '', proxy_rule_path_for(rule), class: 'action delete', data: {confirm: 'Are you sure?'}, method: :delete
+
+= will_paginate(@proxy_rules)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,7 +208,7 @@ without fake Core server your after commit callbacks will crash and you might ge
           resources :metrics, :except => [:show] do
             resources :children, :controller => 'metrics', :only => [:new, :create]
           end
-          resources :mapping_rules
+          resources :mapping_rules, except: %i[show]
         end
       end
 

--- a/test/helpers/proxy_rules_helper_test.rb
+++ b/test/helpers/proxy_rules_helper_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class ProxyRulesHelperTest < ActionView::TestCase
+  test 'generates the right path when it is a Proxy Rule with a Proxy' do
+    proxy      = FactoryBot.build_stubbed(:proxy)
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: proxy)
+
+    path = proxy_rule_path_for(proxy_rule)
+
+    assert_equal(admin_service_proxy_rule_path(proxy_rule.owner.service, proxy_rule), path)
+  end
+
+  test 'generates the right path when it is a Proxy Rule with a Backend Api' do
+    backend_api = FactoryBot.build_stubbed(:backend_api)
+    proxy_rule  = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api)
+
+    path = proxy_rule_path_for(proxy_rule)
+
+    assert_equal(provider_admin_backend_api_mapping_rule_path(backend_api, proxy_rule), path)
+  end
+
+  test 'generates the right path when it is for edit' do
+    backend_api = FactoryBot.build_stubbed(:backend_api)
+    proxy_rule  = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api)
+
+    path = proxy_rule_path_for(proxy_rule, edit: true)
+
+    assert_equal(edit_provider_admin_backend_api_mapping_rule_path(backend_api, proxy_rule), path)
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Now we have 2 pages to manage mapping rules, 1 for backend apis
and another for the service itself, and some code are being
duplicated between both. This commit tries to reuse some logics
and views for both pages.