### PR TITLE
[major_and_minor_version_path] unknown version 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -341,10 +341,13 @@ module ApplicationHelper
   def major_and_minor_version_path
     full_version = System::Deploy.info.release || '2.0.0'
     simple_version = /^(?:(\d+)\.)?(?:(\d+))/.match(full_version)
+
     if saas?
-      "red_hat_3scale/#{simple_version[1]}-saas"
+      version = simple_version ? simple_version[1] : full_version
+      "red_hat_3scale/#{version}-saas"
     else
-      "red_hat_3scale_api_management/#{simple_version[1]}.#{simple_version[2]}"
+      version = simple_version ? "#{simple_version[1]}.#{simple_version[2]}" ? full_version
+      "red_hat_3scale_api_management/#{version}"
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -339,15 +339,12 @@ module ApplicationHelper
   end
 
   def major_and_minor_version_path
-    full_version = System::Deploy.info.release || '2.0.0'
-    simple_version = /^(?:(\d+)\.)?(?:(\d+))/.match(full_version)
+    info = System::Deploy.info
 
     if saas?
-      version = simple_version ? simple_version[1] : full_version
-      "red_hat_3scale/#{version}-saas"
+      "red_hat_3scale/#{info.major_version}-saas"
     else
-      version = simple_version ? "#{simple_version[1]}.#{simple_version[2]}" ? full_version
-      "red_hat_3scale_api_management/#{version}"
+      "red_hat_3scale_api_management/#{info.minor_version}"
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -344,7 +344,7 @@ module ApplicationHelper
     if saas?
       "red_hat_3scale/#{info.major_version}-saas"
     else
-      "red_hat_3scale_api_management/#{info.minor_version}"
+      "red_hat_3scale_api_management/#{info.major_version}.#{info.minor_version}"
     end
   end
 

--- a/lib/system/deploy.rb
+++ b/lib/system/deploy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module System
   module Deploy
     mattr_accessor :info
@@ -15,9 +17,31 @@ module System
 
       def initialize(info)
         @revision = info.fetch('revision') { `git rev-parse HEAD 2> /dev/null`.strip }
-        @release = ENV['AMP_RELEASE'].presence
+        @release = info.fetch('release') { '2.0.0' }
         @deployed_at = info.fetch('deployed_at') { Time.now }
         @error = info.fetch(:error) if info.key?(:error)
+      end
+
+      def minor_version
+        version.segments[1]
+      end
+
+      def major_version
+        version.segments[0]
+      end
+
+      private
+
+      class UnknownVersion
+        def segments
+          %w[unknown unknown]
+        end
+      end
+
+      def version
+        @version ||= Gem::Version.new(release)
+      rescue ArgumentError
+        UnknownVersion.new
       end
     end
 

--- a/lib/system/deploy.rb
+++ b/lib/system/deploy.rb
@@ -45,7 +45,7 @@ module System
       end
 
       def version
-        @version ||= Gem::Version.new(release)
+        @version ||= VersionParser new(release)
       rescue ArgumentError
         UnknownVersion.new
       end

--- a/lib/system/deploy.rb
+++ b/lib/system/deploy.rb
@@ -47,7 +47,7 @@ module System
       def version
         @version ||= VersionParser new(release)
       rescue ArgumentError
-        UnknownVersion.new
+        VersionParser.new(release)
       end
     end
 

--- a/lib/system/deploy.rb
+++ b/lib/system/deploy.rb
@@ -32,7 +32,13 @@ module System
 
       private
 
-      class UnknownVersion
+      class VersionParser
+         attr_reader :segments
+        
+        def initialize(release)
+          segments = release.to_s.split('.')
+          @segments = [segments.shift, segments.join('.')]
+        end
         def segments
           %w[unknown unknown]
         end

--- a/lib/system/deploy.rb
+++ b/lib/system/deploy.rb
@@ -15,39 +15,35 @@ module System
       attr_reader :revision, :deployed_at
       attr_reader :release
 
+      delegate :minor_version, :major_version, to: :version
+
       def initialize(info)
         @revision = info.fetch('revision') { `git rev-parse HEAD 2> /dev/null`.strip }
-        @release = info.fetch('release') { '2.0.0' }
+        @release = info.fetch('release') { '2.x' }
         @deployed_at = info.fetch('deployed_at') { Time.now }
         @error = info.fetch(:error) if info.key?(:error)
-      end
-
-      def minor_version
-        version.segments[1]
-      end
-
-      def major_version
-        version.segments[0]
       end
 
       private
 
       class VersionParser
-         attr_reader :segments
+        attr_reader :segments
         
         def initialize(release)
-          segments = release.to_s.split('.')
-          @segments = [segments.shift, segments.join('.')]
+          @segments = release.to_s.split('.')
         end
-        def segments
-          %w[unknown unknown]
+
+        def minor_version
+          segments[1]
+        end
+
+        def major_version
+          segments[0]
         end
       end
 
       def version
-        @version ||= VersionParser new(release)
-      rescue ArgumentError
-        VersionParser.new(release)
+        @version ||= VersionParser.new(release)
       end
     end
 

--- a/test/unit/deploy/basic_info_test.rb
+++ b/test/unit/deploy/basic_info_test.rb
@@ -2,20 +2,21 @@ require 'test_helper'
 
 class BasicInfoTest < ActiveSupport::TestCase
 
-  test 'default release is 2.0.0' do
+  test 'default release is 2.x' do
     System::Deploy.load_info!
-    assert_equal '2.0.0', System::Deploy.info.release
+    assert_equal '2.x', System::Deploy.info.release
+
   end
 
   test 'minor and major version taken from default release' do
     System::Deploy.load_info!
-    assert_equal 2, System::Deploy.info.major_version
-    assert_equal 0, System::Deploy.info.minor_version
+    assert_equal '2', System::Deploy.info.major_version
+    assert_equal 'x', System::Deploy.info.minor_version
   end
 
   test 'custom release' do
     System::Deploy.info.expects(:release).returns('4.5.1-CR1')
-    assert_equal 4, System::Deploy.info.major_version
-    assert_equal 5, System::Deploy.info.minor_version
+    assert_equal '4', System::Deploy.info.major_version
+    assert_equal '5', System::Deploy.info.minor_version
   end
 end

--- a/test/unit/deploy/basic_info_test.rb
+++ b/test/unit/deploy/basic_info_test.rb
@@ -2,26 +2,20 @@ require 'test_helper'
 
 class BasicInfoTest < ActiveSupport::TestCase
 
-  test 'env empty' do
-    ENV['AMP_RELEASE'] = nil
-    System::Deploy.load_info!
-    assert_nil System::Deploy.info.release
-  end
-
-  test 'env not empty' do
-    ENV['AMP_RELEASE'] = '2.0.0'
+  test 'default release is 2.0.0' do
     System::Deploy.load_info!
     assert_equal '2.0.0', System::Deploy.info.release
   end
 
-  test 'info is invalid' do
-    ENV['AMP_RELEASE'] = '2.0.0'
+  test 'minor and major version taken from default release' do
     System::Deploy.load_info!
-    assert_equal '2.0.0', System::Deploy.info.release
-
-    System::Deploy.expects(:parse_deploy_info).raises(StandardError.new)
-    System::Deploy.load_info!
-    assert_equal '2.0.0', System::Deploy.info.release
+    assert_equal 2, System::Deploy.info.major_version
+    assert_equal 0, System::Deploy.info.minor_version
   end
 
+  test 'custom release' do
+    System::Deploy.info.expects(:release).returns('4.5.1-CR1')
+    assert_equal 4, System::Deploy.info.major_version
+    assert_equal 5, System::Deploy.info.minor_version
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

`major_and_minor_version_path` does not work for "upstream" release name

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-2250
