### PR TITLE
Remove Deprecated & Unused Cuke Step for partners to select plan

### DIFF
--- a/features/step_definitions/applications/configuration_steps.rb
+++ b/features/step_definitions/applications/configuration_steps.rb
@@ -6,10 +6,3 @@ Given /^the (provider "[^\"]*") does not allow its partners to manage applicatio
   provider.default_service.update_attribute :buyers_manage_apps, true
   provider.default_service.update_attribute :buyers_manage_keys, false
 end
-
-
-Given /^the (provider "[^\"]*") allows its partners to select a plan$/ do |provider|
-  ActiveSupport::Deprecation.warn('Use "service NAME allows to choose plan on app creation"')
-  provider.default_service.update_attribute :buyer_can_select_plan, true
-end
-


### PR DESCRIPTION
I accidentally found this while working on another issue and I saw that [it was deprecated 8 years ago](https://github.com/3scale/system/commit/e8dced76d30b3094aff6803a9102f979690e724a).