### PR TITLE
[zync] Fixes issue when the Zync DB is reset, and Proxy can't be recreated

### DIFF
--- a/app/events/zync_event.rb
+++ b/app/events/zync_event.rb
@@ -5,7 +5,7 @@ class ZyncEvent < BaseEventStoreEvent
   # Create Zync Event
 
   def self.create(event, model = event)
-    metadata = event.metadata
+    metadata = event.metadata || {}
     provider_id = metadata.fetch(:provider_id) { model.tenant_id }
 
     attributes = {
@@ -19,7 +19,7 @@ class ZyncEvent < BaseEventStoreEvent
     new(
       metadata: {
         provider_id: provider_id,
-      },
+      }.reverse_merge(metadata),
       **attributes
     )
   end

--- a/test/events/zync_event_test.rb
+++ b/test/events/zync_event_test.rb
@@ -58,4 +58,15 @@ class ZyncEventTest < ActiveSupport::TestCase
 
     assert_equal application.class, event.model
   end
+
+  def test_merges_metadata
+    application = FactoryBot.build_stubbed(:simple_cinstance, tenant_id: 123)
+    date = Date.parse('2019-09-01')
+    Timecop.freeze(date) do
+      parent_event = RailsEventStore::Event.new metadata: {foo: :bar}
+
+      event = ZyncEvent.create(parent_event, application)
+      assert_equal({provider_id: application.tenant_id, foo: :bar, timestamp: date }, event.metadata)
+    end
+  end
 end


### PR DESCRIPTION
Closes THREESCALE-1526

Make sure that the metadata are kept in the successive events on ZyncEvent.create

Steps to reproduce:

1. Setup Porta and launch web server + Sidekiq with ZYNC_ENDPOINT=http://localhost:5000 ZYNC_AUTHENTICATON_TOKEN=foo
2. Setup Zync and launch web server with ZYNC_AUTHENTICATON_TOKEN=foo
3. Drop and recreate zync database: rails db:drop && ./bin/setup
4. Create an application (call it App1)
5. See in the Sidekiq Web UI that Proxy cannot be created and is stuck with UnprocessableEntityError

Expected result:

All the components needed in Zync (Tenant, Service, Proxy, Application) are created