### PR TITLE
[Migrate] Service with field to act as product

### DIFF
--- a/db/migrate/20190731092006_add_acts_as_product_to_service.rb
+++ b/db/migrate/20190731092006_add_acts_as_product_to_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddActsAsProductToService < ActiveRecord::Migration
+  def up
+    add_column :services, :act_as_product, :boolean
+    change_column_default :services, :act_as_product, false
+  end
+
+  def down
+    remove_column :services, :act_as_product
+  end
+end

--- a/db/migrate/20190731092338_backfill_add_acts_as_product_to_service.rb
+++ b/db/migrate/20190731092338_backfill_add_acts_as_product_to_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BackfillAddActsAsProductToService < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    Service.find_in_batches(batch_size: 200) do |records|
+      Service.where(id: records.map(&:id)).update_all act_as_product: false
+      sleep(0.5)
+    end
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -1233,6 +1233,7 @@ ActiveRecord::Schema.define(version: 20190805135829) do
     t.boolean  "referrer_filters_required",      limit: nil,                default: false
     t.string   "deployment_option",                                         default: "hosted"
     t.string   "kubernetes_service_link"
+    t.boolean  "act_as_product",                 limit: nil,                default: false
   end
 
   add_index "services", ["account_id"], name: "idx_account_id"

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -1234,6 +1234,7 @@ ActiveRecord::Schema.define(version: 20190805135829) do
     t.boolean  "referrer_filters_required",                  default: false
     t.string   "deployment_option",              limit: 255, default: "hosted"
     t.string   "kubernetes_service_link",        limit: 255
+    t.boolean  "act_as_product",                             default: false
   end
 
   add_index "services", ["account_id"], name: "idx_account_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1235,6 +1235,7 @@ ActiveRecord::Schema.define(version: 20190805135829) do
     t.boolean  "referrer_filters_required",                    default: false
     t.string   "deployment_option",              limit: 255,   default: "hosted"
     t.string   "kubernetes_service_link",        limit: 255
+    t.boolean  "act_as_product",                               default: false
   end
 
   add_index "services", ["account_id"], name: "idx_account_id", using: :btree


### PR DESCRIPTION
Extracted from https://github.com/3scale/porta/pull/1008 to make the PR smaller and it is actually part of https://github.com/3scale/porta/pull/1041

The way to do this PR has been making a new branch from master, reset the DBs (mysql, postgres and oracle) and setup, then rollback all of them with STEP=7 (just in case 😄 ), add these 2 migrations, and migrate the 3 DBs 😎 