### PR TITLE
[Refactor][Test] Remove redundant test login methods

### DIFF
--- a/test/integration/admin/api/member_permissions_controller_test.rb
+++ b/test/integration/admin/api/member_permissions_controller_test.rb
@@ -105,7 +105,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
 
   test "member user can't update his own permissions" do
     @user.update_attribute :role, 'member'
-    provider_login @user
+    login! @provider, user: @user
     # allowed_sections%5B%5D=settings&allowed_service_ids%5B%5D
     params = { allowed_sections: ['settings'], allowed_service_ids: '' }
 

--- a/test/integration/master/api/finance/accounts/billing_jobs_controller_test.rb
+++ b/test/integration/master/api/finance/accounts/billing_jobs_controller_test.rb
@@ -113,7 +113,7 @@ class Master::Api::Finance::Accounts::BillingJobsControllerTest < ActionDispatch
     end
 
     test 'can create jobs without an access token if logged in' do
-      provider_login @master_admin
+      login! master_account, user: @master_admin
       post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08')
       assert_response :accepted
     end

--- a/test/integration/master/api/finance/billing_jobs_controller_test.rb
+++ b/test/integration/master/api/finance/billing_jobs_controller_test.rb
@@ -127,7 +127,7 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
     end
 
     test 'can create jobs without an access token if logged in' do
-      provider_login @master_admin
+      login! master_account, user: @master_admin
       post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08')
       assert_response :accepted
     end

--- a/test/integration/payment_gateways/braintree_blue_test.rb
+++ b/test/integration/payment_gateways/braintree_blue_test.rb
@@ -45,7 +45,7 @@ class BraintreeBlueTest < ActionDispatch::IntegrationTest
 
   test "invalid merchant id redirects to show" do
     PaymentGateways::BrainTreeBlueCrypt.any_instance.stubs(:try_find_customer).raises(Braintree::AuthenticationError)
-    buyer_login @buyer_account.admins.first
+    login_buyer @buyer_account
     get developer_portal.edit_admin_account_braintree_blue_path
     assert_redirected_to developer_portal.admin_account_braintree_blue_path
     assert_equal 'Invalid merchant id', flash[:error]

--- a/test/integration/provider/admin/keys_controller_test.rb
+++ b/test/integration/provider/admin/keys_controller_test.rb
@@ -103,14 +103,14 @@ class Provider::Admin::KeysControllerTest < ActionDispatch::IntegrationTest
   private
 
   def assert_only_qualified_members_have_access(verb, path, format)
-    provider_login(@member_user)
+    login! @member_user.account, user: @member_user
     public_send(verb, path, format)
     assert_response(
       :forbidden,
       "#{verb} #{path} should be forbidden for regular members"
     )
 
-    provider_login(@member_user_with_app_access)
+    login! @member_user_with_app_access.account, user: @member_user_with_app_access
     public_send(verb, path, format)
     assert_response(
       :success,

--- a/test/integration/sites/settings_controller_test.rb
+++ b/test/integration/sites/settings_controller_test.rb
@@ -19,7 +19,7 @@ class Sites::SettingsControllerTest < ActionDispatch::IntegrationTest
     member = FactoryBot.create(:simple_admin, account: master_account)
     member.activate!
 
-    provider_login member
+    login! master_account, user: member
 
     get edit_admin_site_emails_path
 

--- a/test/integration/stats/clients_test.rb
+++ b/test/integration/stats/clients_test.rb
@@ -19,7 +19,7 @@ class Stats::ClientsTest < ActionDispatch::IntegrationTest
   end
 
   test 'usage with invalid period' do
-    provider_login @provider_account.admins.first
+    login! @provider_account
     get "/stats/applications/#{@cinstance.id}/usage.json", :period => 'XSScript', :metric_name => @metric.system_name
     assert_response :bad_request
   end
@@ -35,7 +35,7 @@ class Stats::ClientsTest < ActionDispatch::IntegrationTest
 
     Timecop.freeze(Time.utc(2009, 12, 13))
 
-    provider_login @provider_account.admins.first
+    login! @provider_account
     @provider_account.update_attribute(:timezone, 'Madrid')
 
     get "/stats/applications/#{@cinstance.id}/usage.json", period:'month', metric_name: @metric.system_name, skip_change: false
@@ -74,7 +74,7 @@ class Stats::ClientsTest < ActionDispatch::IntegrationTest
 
     Timecop.freeze(Time.utc(2009, 12, 13))
 
-    provider_login @provider_account.admins.first
+    login! @provider_account
     @provider_account.update_attribute(:timezone, 'Madrid')
 
     get "/stats/applications/#{@cinstance.id}/usage_response_code.json", period:'month', response_code: 200

--- a/test/test_helpers/authentication.rb
+++ b/test/test_helpers/authentication.rb
@@ -42,24 +42,16 @@ ActionDispatch::IntegrationTest.class_eval do
   private
 
   def login!(provider, user: provider.admins.first)
-    provider_login user
     host! provider.self_domain
+    provider_login_with user.username, 'supersecret'
   end
 
   alias_method :login_provider, :login!
 
   def login_buyer(account)
     host! account.provider_account.domain
-    buyer_login(account.admins.first)
-  end
-
-  def buyer_login(user, password = 'supersecret')
-    login_with(user.username, password)
-  end
-
-  def provider_login(user, password = 'supersecret')
-    host! user.account.self_domain
-    provider_login_with user.username, password
+    user = account.admins.first
+    login_with user.username, 'supersecret'
   end
 
   def provider_login_with(username, password)


### PR DESCRIPTION
I encountered this while reviewing https://github.com/3scale/porta/pull/1008
We have several methods doing the same thing... besides, it was setting the `host` twice for all logins of providers.