### PR TITLE
Rename AuthenticationProvider module to AuthenticationProviders

### DIFF
--- a/app/lib/service_discovery/authentication_provider_support.rb
+++ b/app/lib/service_discovery/authentication_provider_support.rb
@@ -11,6 +11,6 @@ module ServiceDiscovery::AuthenticationProviderSupport
   end
 
   def service_discovery_authentication_provider
-    @service_discovery_authentication_provider ||= ::AuthenticationProvider::ServiceDiscoveryProvider.build(account: self)
+    @service_discovery_authentication_provider ||= ::AuthenticationProviders::ServiceDiscoveryProvider.build(account: self)
   end
 end

--- a/app/models/authentication_provider/custom.rb
+++ b/app/models/authentication_provider/custom.rb
@@ -1,3 +1,0 @@
-class AuthenticationProvider::Custom < AuthenticationProvider
-  self.authorization_scope = :iam_tools
-end

--- a/app/models/authentication_providers/auth0.rb
+++ b/app/models/authentication_providers/auth0.rb
@@ -1,4 +1,6 @@
-class AuthenticationProvider::Auth0 < AuthenticationProvider
+# frozen_string_literal: true
+
+class AuthenticationProviders::Auth0 < AuthenticationProvider
   self.authorization_scope = :iam_tools
   self.oauth_config_required = true
 

--- a/app/models/authentication_providers/custom.rb
+++ b/app/models/authentication_providers/custom.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AuthenticationProviders::Custom < AuthenticationProvider
+  self.authorization_scope = :iam_tools
+end

--- a/app/models/authentication_providers/github.rb
+++ b/app/models/authentication_providers/github.rb
@@ -1,4 +1,6 @@
-class AuthenticationProvider::GitHub < AuthenticationProvider
+# frozen_string_literal: true
+
+class AuthenticationProviders::GitHub < AuthenticationProvider
   self.authorization_scope = :branding
 
   after_initialize :set_defaults, unless: :persisted?
@@ -50,11 +52,12 @@ class AuthenticationProvider::GitHub < AuthenticationProvider
   def credentials
     case branding_state.to_sym
     when :threescale_branded
-        config = ThreeScale::OAuth2.config.fetch(kind, {}).symbolize_keys
+      config = ThreeScale::OAuth2.config.fetch(kind, {}).symbolize_keys
 
-        AuthenticationProvider::Credentials.new(config.fetch(:client_id) { client_id.presence },
-                                                config.fetch(:client_secret) { client_secret.presence })
-    else super
+      AuthenticationProvider::Credentials.new(config.fetch(:client_id) { client_id.presence },
+                                              config.fetch(:client_secret) { client_secret.presence })
+    else
+      super
     end
   end
 end

--- a/app/models/authentication_providers/keycloak.rb
+++ b/app/models/authentication_providers/keycloak.rb
@@ -1,4 +1,6 @@
-class AuthenticationProvider::Keycloak < AuthenticationProvider
+# frozen_string_literal: true
+
+class AuthenticationProviders::Keycloak < AuthenticationProvider
   self.authorization_scope = :iam_tools
   self.oauth_config_required = true
 

--- a/app/models/authentication_providers/redhat_customer_portal.rb
+++ b/app/models/authentication_providers/redhat_customer_portal.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AuthenticationProvider::RedhatCustomerPortal < AuthenticationProvider::Keycloak
+class AuthenticationProviders::RedhatCustomerPortal < AuthenticationProviders::Keycloak
 
   CONFIG_ATTRIBUTES = %i[client_id client_secret realm system_name skip_ssl_certificate_verification].freeze
   private_constant :CONFIG_ATTRIBUTES

--- a/app/models/authentication_providers/service_discovery_provider.rb
+++ b/app/models/authentication_providers/service_discovery_provider.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AuthenticationProvider::ServiceDiscoveryProvider < AuthenticationProvider
+class AuthenticationProviders::ServiceDiscoveryProvider < AuthenticationProvider
   attr_accessible :account, :token_url, :authorize_url, :user_info_url, :client_id, :client_secret, :system_name,
                   :kind, :skip_ssl_certificate_verification
 

--- a/features/support/transforms.rb
+++ b/features/support/transforms.rb
@@ -254,6 +254,6 @@ Transform /^authentication provider "([^\"]+)"$/ do |authentication_provider_nam
               }
             )
 
-  authentication_provider_class = "AuthenticationProvider::#{authentication_provider_name}".constantize
+  authentication_provider_class = "AuthenticationProviders::#{authentication_provider_name}".constantize
   authentication_provider_class.create(options)
 end

--- a/lib/redhat_customer_portal_support.rb
+++ b/lib/redhat_customer_portal_support.rb
@@ -10,7 +10,7 @@ module RedhatCustomerPortalSupport
   end
 
   def redhat_customer_authentication_provider
-    @redhat_customer_authentication_provider ||= AuthenticationProvider::RedhatCustomerPortal.build(account: self)
+    @redhat_customer_authentication_provider ||= AuthenticationProviders::RedhatCustomerPortal.build(account: self)
   end
 
   def redhat_account_recently_verified?

--- a/test/factories/authentication_provider.rb
+++ b/test/factories/authentication_provider.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     account_type { AuthenticationProvider.account_types[:developer] }
   end
 
-  factory(:self_authentication_provider, class: AuthenticationProvider::Auth0) do
+  factory(:self_authentication_provider, class: AuthenticationProviders::Auth0) do
     sequence(:name) { |n| "self-name-#{n}" }
     sequence(:system_name) { |n| "self-system_name_#{n}" }
     association :account, factory: :simple_provider
@@ -30,23 +30,23 @@ FactoryBot.define do
 
   factory(:auth0_authentication_provider,
                     parent: :authentication_provider,
-                    class: AuthenticationProvider::Auth0)
+                    class: AuthenticationProviders::Auth0)
 
   factory(:github_authentication_provider,
                     parent: :authentication_provider,
-                    class: AuthenticationProvider::GitHub) do
+                    class: AuthenticationProviders::GitHub) do
     branding_state { 'threescale_branded' }
   end
 
   factory(:keycloak_authentication_provider,
                     parent: :authentication_provider,
-                    class: AuthenticationProvider::Keycloak) do
+                    class: AuthenticationProviders::Keycloak) do
     kind { 'keycloak' }
   end
 
   factory(:redhat_customer_portal_authentication_provider,
                     parent: :authentication_provider,
-                    class: AuthenticationProvider::RedhatCustomerPortal) do
+                    class: AuthenticationProviders::RedhatCustomerPortal) do
     kind { 'redhat_customer_portal' }
   end
 end

--- a/test/integration/admin/api/account/authentication_providers_controller_test.rb
+++ b/test/integration/admin/api/account/authentication_providers_controller_test.rb
@@ -141,10 +141,10 @@ class Admin::Api::Account::AuthenticationProvidersControllerTest < ActionDispatc
   end
 
   private
-  
+
   def create_authentication_provider
-    AuthenticationProvider::Auth0.create!(client_id: 'firstClientId', client_secret: 'firstClientSecret',
-                                          site: 'http://example.net', account_type: AuthenticationProvider.account_types[:provider], account: @provider)
+    AuthenticationProviders::Auth0.create!(client_id: 'firstClientId', client_secret: 'firstClientSecret',
+                                           site: 'http://example.net', account_type: AuthenticationProvider.account_types[:provider], account: @provider)
   end
 
   def authentication_provider_params(different_attributes: {})

--- a/test/integration/admin/api/authentication_providers_controller_test.rb
+++ b/test/integration/admin/api/authentication_providers_controller_test.rb
@@ -68,7 +68,7 @@ class Admin::Api::AuthenticationProvidersControllerTest < ActionDispatch::Integr
       post admin_api_authentication_providers_path(authentication_provider_params(different_attributes: {kind: 'unknown'}))
       assert_response :created
       authentication_provider = provider.authentication_providers.find_by!(kind: 'unknown')
-      assert_equal AuthenticationProvider::Custom.name, authentication_provider.type
+      assert_equal AuthenticationProviders::Custom.name, authentication_provider.type
     end
   end
 

--- a/test/unit/account/provider_test.rb
+++ b/test/unit/account/provider_test.rb
@@ -14,7 +14,7 @@ class Account::ProviderTest < ActiveSupport::TestCase
     end
 
     should 'authentication_providers build_kind' do
-      (AuthenticationProvider.available(AuthenticationProvider.account_types[:developer]) + [AuthenticationProvider::Custom]).each do |authentication_provider_class|
+      (AuthenticationProvider.available(AuthenticationProvider.account_types[:developer]) + [AuthenticationProviders::Custom]).each do |authentication_provider_class|
         kind_name = authentication_provider_class.to_s.demodulize
         authentication_provider = @account.authentication_providers.build_kind(kind: kind_name, client_id: 'id', client_secret: 'secret', site: 'http://example.com')
         assert_equal authentication_provider_class, authentication_provider.class

--- a/test/unit/authentication_provider_test.rb
+++ b/test/unit/authentication_provider_test.rb
@@ -56,7 +56,7 @@ class AuthenticationProviderTest < ActiveSupport::TestCase
 
   test 'callback_account' do
       auth_provider = FactoryBot.build_stubbed(:authentication_provider)
-          .becomes(AuthenticationProvider::GitHub)
+          .becomes(AuthenticationProviders::GitHub)
       master = FactoryBot.build_stubbed(:master_account)
 
       auth_provider.branding_state = 'threescale_branded'
@@ -69,21 +69,21 @@ class AuthenticationProviderTest < ActiveSupport::TestCase
   end
 
   test 'find_kind' do
-    assert_equal AuthenticationProvider::Keycloak, AuthenticationProvider.find_kind('keycloak')
-    assert_equal AuthenticationProvider::Auth0, AuthenticationProvider.find_kind('auth0')
-    assert_equal AuthenticationProvider::GitHub, AuthenticationProvider.find_kind('github')
+    assert_equal AuthenticationProviders::Keycloak, AuthenticationProvider.find_kind('keycloak')
+    assert_equal AuthenticationProviders::Auth0, AuthenticationProvider.find_kind('auth0')
+    assert_equal AuthenticationProviders::GitHub, AuthenticationProvider.find_kind('github')
   end
 
   test 'self.kind' do
-    assert_equal 'github', AuthenticationProvider::GitHub.kind
-    assert_equal 'auth0', AuthenticationProvider::Auth0.kind
-    assert_equal 'keycloak', AuthenticationProvider::Keycloak.kind
+    assert_equal 'github', AuthenticationProviders::GitHub.kind
+    assert_equal 'auth0', AuthenticationProviders::Auth0.kind
+    assert_equal 'keycloak', AuthenticationProviders::Keycloak.kind
   end
 
   test 'kind' do
-    assert_equal 'github', AuthenticationProvider::GitHub.new.kind
-    assert_equal 'auth0', AuthenticationProvider::Auth0.new.kind
-    assert_equal 'keycloak', AuthenticationProvider::Keycloak.new.kind
+    assert_equal 'github', AuthenticationProviders::GitHub.new.kind
+    assert_equal 'auth0', AuthenticationProviders::Auth0.new.kind
+    assert_equal 'keycloak', AuthenticationProviders::Keycloak.new.kind
   end
 
   test 'branded_available?' do
@@ -102,11 +102,11 @@ class AuthenticationProviderTest < ActiveSupport::TestCase
 
   test 'initial state github' do
     AuthenticationProvider.stubs(branded_available?: false)
-    github = AuthenticationProvider::GitHub.new
+    github = AuthenticationProviders::GitHub.new
     assert_equal github.branding_state, 'custom_branded'
 
     AuthenticationProvider.stubs(branded_available?: true)
-    github = AuthenticationProvider::GitHub.new
+    github = AuthenticationProviders::GitHub.new
     assert_equal github.branding_state, 'threescale_branded'
   end
 
@@ -129,20 +129,20 @@ class AuthenticationProviderTest < ActiveSupport::TestCase
   end
 
   test '#published: github not branded on new record' do
-    AuthenticationProvider::GitHub.stubs(:branded_available?).returns(false)
-    auth = AuthenticationProvider::GitHub.new(published: true)
+    AuthenticationProviders::GitHub.stubs(:branded_available?).returns(false)
+    auth = AuthenticationProviders::GitHub.new(published: true)
     assert auth.published
   end
 
   test '#published: github branded on new record' do
-    AuthenticationProvider::GitHub.stubs(:branded_available?).returns(true)
-    auth = AuthenticationProvider::GitHub.new(published: false)
+    AuthenticationProviders::GitHub.stubs(:branded_available?).returns(true)
+    auth = AuthenticationProviders::GitHub.new(published: false)
     assert auth.published
   end
 
   test '#published: github not branded on existing record can publish it' do
-    AuthenticationProvider::GitHub.stubs(:branded_available?).returns(false)
-    auth = AuthenticationProvider::GitHub.create!(published: false, client_id: '12345', client_secret: '12345')
+    AuthenticationProviders::GitHub.stubs(:branded_available?).returns(false)
+    auth = AuthenticationProviders::GitHub.create!(published: false, client_id: '12345', client_secret: '12345')
     refute auth.published
     auth.published = true
     auth.save!
@@ -151,8 +151,8 @@ class AuthenticationProviderTest < ActiveSupport::TestCase
   end
 
   test '#published: github branded on existing record can unpublish it' do
-    AuthenticationProvider::GitHub.stubs(:branded_available?).returns(true)
-    auth = AuthenticationProvider::GitHub.create!(client_id: '12345', client_secret: '12345')
+    AuthenticationProviders::GitHub.stubs(:branded_available?).returns(true)
+    auth = AuthenticationProviders::GitHub.create!(client_id: '12345', client_secret: '12345')
     assert auth.published
     auth.published = false
     auth.save!

--- a/test/unit/liquid/drops/authentication_provider_drop_test.rb
+++ b/test/unit/liquid/drops/authentication_provider_drop_test.rb
@@ -23,7 +23,7 @@ class Liquid::Drops::AuthenticationProviderDropTest < ActiveSupport::TestCase
   test '#client_id' do
     assert_equal @authentication_provider.client_id, @drop.client_id
 
-    @authentication_provider = @authentication_provider.becomes(AuthenticationProvider::GitHub)
+    @authentication_provider = @authentication_provider.becomes(AuthenticationProviders::GitHub)
     @authentication_provider.brand_as_threescale(false)
 
     @drop = Drops::AuthenticationProvider.new(@authentication_provider)

--- a/test/unit/models_test.rb
+++ b/test/unit/models_test.rb
@@ -19,9 +19,9 @@ class ModelsTest < ActiveSupport::TestCase
       'CMS::EmailTemplate' => %w[content_type], 'CMS::Builtin' => %w[title], 'CMS::Builtin::StaticPage' => %w[title], 'CMS::Builtin::Page' => %w[title content_type],
       'CMS::Builtin::Partial' => %w[title content_type], 'CMS::Portlet' => %w[content_type], 'CMS::Builtin::LegalTerm' => %w[title content_type],
       'CMS::PortletTest::CustomPortlet' => :all, 'CMS::Portlet::Base' => %w[content_type], 'ExternalRssFeedPortlet' => %w[content_type],
-      'LatestForumPostsPortlet' => %w[content_type], 'TableOfContentsPortlet' => %w[content_type], 'AuthenticationProvider::GitHub' => %w[branding_state account_type],
-      'AuthenticationProvider::Keycloak' => %w[account_type], 'AuthenticationProvider::Auth0' => %w[account_type], 'AuthenticationProvider::Custom' => %w[account_type],
-      'AuthenticationProvider::ServiceDiscoveryProvider' => %w[account_type], 'AuthenticationProvider::RedhatCustomerPortal' => %w[account_type],
+      'LatestForumPostsPortlet' => %w[content_type], 'TableOfContentsPortlet' => %w[content_type], 'AuthenticationProviders::GitHub' => %w[branding_state account_type],
+      'AuthenticationProviders::Keycloak' => %w[account_type], 'AuthenticationProviders::Auth0' => %w[account_type], 'AuthenticationProviders::Custom' => %w[account_type],
+      'AuthenticationProviders::ServiceDiscoveryProvider' => %w[account_type], 'AuthenticationProviders::RedhatCustomerPortal' => %w[account_type],
       'Account' => %w[credit_card_auth_code credit_card_authorize_net_payment_profile_token credit_card_partial_number],
       'DeadlockTest::Model' => :all, 'ThreeScale::SearchTest::Model' => :all
     }

--- a/test/unit/presenters/provider_oauth_flow_presenter_test.rb
+++ b/test/unit/presenters/provider_oauth_flow_presenter_test.rb
@@ -4,7 +4,7 @@ class ProviderOAuthFlowPresenterTest < ActiveSupport::TestCase
 
   setup do
     provider = FactoryBot.build_stubbed(:simple_provider, self_domain: 'example.com')
-    authentication_provider = AuthenticationProvider::Auth0.new(account: provider, kind: 'auth0', system_name: 'auth0_abc123')
+    authentication_provider = AuthenticationProviders::Auth0.new(account: provider, kind: 'auth0', system_name: 'auth0_abc123')
 
     request = stubs(:request)
     request.stubs(scheme: 'http')

--- a/test/unit/redhat_customer_portal_test.rb
+++ b/test/unit/redhat_customer_portal_test.rb
@@ -1,19 +1,19 @@
 require 'test_helper'
 
-class AuthenticationProvider::RedHatCustomerPortalTest < ActiveSupport::TestCase
+class AuthenticationProviders::RedHatCustomerPortalTest < ActiveSupport::TestCase
 
   test 'authentication provider is frozen' do
-    assert AuthenticationProvider::RedhatCustomerPortal.build.frozen?
+    assert AuthenticationProviders::RedhatCustomerPortal.build.frozen?
   end
 
   test 'authentication provider preserves eventual config attributes passed' do
     ThreeScale.config.redhat_customer_portal.stubs(realm: 'default-realm')
 
-    authentication_provider = AuthenticationProvider::RedhatCustomerPortal.build(realm: 'my-custom-realm')
+    authentication_provider = AuthenticationProviders::RedhatCustomerPortal.build(realm: 'my-custom-realm')
     assert_equal 'my-custom-realm', authentication_provider.realm
   end
 
   test 'authentication provider is readonly' do
-    assert AuthenticationProvider::RedhatCustomerPortal.build.readonly?
+    assert AuthenticationProviders::RedhatCustomerPortal.build.readonly?
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit renames the module AuthenticationProvider to 
AuthenticationProviders to avoid clashing it with the already existent 
class with the same name. With this, we can safely drop the 
`require_dependency` for each authentication provider.

