### PR TITLE
Remove require dependency from account

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -192,7 +192,7 @@ class Account < ApplicationRecord
   end
 
   def forum!
-    forum || fail(ActiveRecord::RecordNotFound, "buyer accounts can't have forum")
+    forum || raise(ActiveRecord::RecordNotFound, "buyer accounts can't have forum")
   end
 
   def build_forum(attributes = {})
@@ -283,11 +283,11 @@ class Account < ApplicationRecord
   end
 
   def self.master
-    find_by_master!(true)
+    find_by!(master: true)
   end
 
   def self.provider
-    find_by_provider!(true)
+    find_by!(provider: true)
   end
 
   def self.master?
@@ -304,9 +304,9 @@ class Account < ApplicationRecord
 
   def country=(country_name)
     self.country_id = if country_name.is_a? Country
-      country_name.id
+                        country_name.id
                       elsif country_name
-      Country.find_by_name(country_name).try!(:id)
+                        Country.find_by(name: country_name)&.id
                       end
   end
 
@@ -318,7 +318,7 @@ class Account < ApplicationRecord
   # database lookup if possible (uses cache), so it is super fast.
   def self.id_from_api_key(api_key)
     Rails.cache.fetch("account_ids/#{api_key}") do
-      Account.find_by_provider_key!(api_key).id
+      Account.find_by_provider_key!(api_key).id # rubocop:disable Rails/DynamicFindBy
     end
   end
 
@@ -362,13 +362,13 @@ class Account < ApplicationRecord
   # currency and further to DEFAULT_CURRENCY.
   #
   def currency
-    billing_strategy.try!(:currency) || country.try!(:currency) || DEFAULT_CURRENCY
+    billing_strategy&.currency || country&.currency || DEFAULT_CURRENCY
   end
 
   # Tax rate associated with this account. It is taken from it's country of
   # residence.
   def tax_rate
-    country && country.tax_rate || 0.0
+    country&.tax_rate || 0.0
   end
 
   # Return country name
@@ -458,7 +458,7 @@ class Account < ApplicationRecord
   end
 
   def backend_object
-    fail 'backend_object is only for provider accounts' unless provider?
+    raise 'backend_object is only for provider accounts' unless provider?
 
     @backend_object ||= BackendClient::Connection.new.provider(self)
   end
@@ -509,9 +509,7 @@ class Account < ApplicationRecord
         bought_plans.to_xml(builder: xml, root: 'plans')
         users.to_xml(builder: xml, root: 'users')
 
-        if options[:with_apps]
-          bought_cinstances.to_xml(builder: xml, root: 'applications')
-        end
+        bought_cinstances.to_xml(builder: xml, root: 'applications') if options[:with_apps]
       end
     end
 
@@ -540,21 +538,16 @@ class Account < ApplicationRecord
   # Grabs the support_email if defined, otherwise falls back to the email of first admin. Dog.
   def support_email
     se = self[:support_email]
-    se.present? ? se : admins.first.try!(:email)
+    se.presence || admins.first&.email
   end
 
   def finance_support_email
-    fse = self[:finance_support_email]
-    if fse.present?
-      fse
-    else
-      support_email
-    end
+    self[:finance_support_email].presence || support_email
   end
 
   def provider_id_for_audits
     if buyer?
-      provider_account.try!(:provider_id_for_audits)
+      provider_account&.provider_id_for_audits
     else
       id
     end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_dependency 'backend_client'
-
 class Account < ApplicationRecord
   # Hack to remove all the attributes with names matching the regex from @attributes
   # It is enough for rails not persisting them in actual columns.
@@ -58,8 +56,7 @@ class Account < ApplicationRecord
   include CreditCard
   include Gateway
   include States
-  require_dependency 'account/domains'
-  include Domains
+  include ProviderDomains
 
   #TODO: this needs testing?
   scope :providers, -> { where(provider: true) }

--- a/app/models/account/provider_domains.rb
+++ b/app/models/account/provider_domains.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Account::ProviderDomains
   extend ActiveSupport::Concern
 
@@ -28,10 +30,10 @@ module Account::ProviderDomains
 
     end
 
-    scope :by_domain, lambda { |domain| where(domain: domain) }
-    scope :by_self_domain, lambda { |domain| where(self_domain: domain) }
+    scope :by_domain, ->(domain) { where(domain: domain) }
+    scope :by_self_domain, ->(domain) { where(self_domain: domain) }
     scope :by_admin_domain, lambda { |domain|
-      table = self.table_name
+      table = table_name
       where("(#{table}.self_domain = :domain) OR (#{table}.self_domain IS NULL AND provider_accounts_accounts.domain = :domain)",
             { :domain => domain })
       .joins(:provider_account)
@@ -50,12 +52,12 @@ module Account::ProviderDomains
     end
 
     def find_by_domain!(domain)
-      find_by_domain(domain) ||
-      raise(ActiveRecord::RecordNotFound, "Couldn't find #{name} with domain=#{domain.inspect}")
+      find_by_domain(domain) || # rubocop:disable Rails/DynamicFindBy
+        raise(ActiveRecord::RecordNotFound, "Couldn't find #{name} with domain=#{domain.inspect}")
     end
 
     def is_domain?(domain)
-      return unless domain.present?
+      return if domain.blank?
       providers.where(:domain => domain).exists?
     end
 
@@ -96,11 +98,11 @@ module Account::ProviderDomains
     domain.present? && self_domain.present?
   end
 
-  def subdomain= name
+  def subdomain=(name)
     self.domain = if name.present?
-      [name, superdomain].join('.')
+                    [name, superdomain].join('.')
                   else
-      name
+                    name
                   end
   end
 
@@ -118,7 +120,7 @@ module Account::ProviderDomains
   end
 
   def dedicated_domain
-    superdomain = provider_account.try!(:superdomain)
+    superdomain = provider_account&.superdomain
 
     if superdomain && !domain.nil? && domain.ends_with?(superdomain)
       nil
@@ -129,11 +131,11 @@ module Account::ProviderDomains
 
   attr_writer :dedicated_domain
 
-  def self_subdomain= name
+  def self_subdomain=(name)
     self.self_domain = if name.present?
-      [name, superdomain].join('.')
+                         [name, superdomain].join('.')
                        else
-      name
+                         name
                        end
   end
 
@@ -155,7 +157,7 @@ module Account::ProviderDomains
   private
 
   def validate_domains?
-    provider? and not master?
+    provider? and !master?
   end
 
   def subdomain_from(domain)

--- a/app/models/account/provider_domains.rb
+++ b/app/models/account/provider_domains.rb
@@ -1,4 +1,4 @@
-module Account::Domains
+module Account::ProviderDomains
   extend ActiveSupport::Concern
 
   included do
@@ -173,7 +173,7 @@ module Account::Domains
 
   def unique?(attr, val = self[attr])
     scope = new_record? ? Account.all : Account.where.not(id: id)
-    Account::Domains.unique?(attr: attr, val: val, scope: scope)
+    Account::ProviderDomains.unique?(attr: attr, val: val, scope: scope)
   end
 
   def domain_uniqueness

--- a/test/unit/account/provider_domains_test.rb
+++ b/test/unit/account/provider_domains_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
+require 'test_helper'
 
-class Account::DomainsTest < ActiveSupport::TestCase
+class Account::ProviderDomainsTest < ActiveSupport::TestCase
   test '#domain must be downcase' do
     account_one = FactoryBot.create(:simple_provider)
     account_one.subdomain = 'FOO'

--- a/test/unit/account/provider_domains_test.rb
+++ b/test/unit/account/provider_domains_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Account::ProviderDomainsTest < ActiveSupport::TestCase
@@ -63,7 +65,7 @@ class Account::ProviderDomainsTest < ActiveSupport::TestCase
 
   test 'find_by_domain! raises an exception if domain is blank' do
     assert_raise ActiveRecord::RecordNotFound do
-      Account.find_by_domain!(nil)
+      Account.find_by_domain!(nil) # rubocop:disable Rails/DynamicFindBy
     end
   end
 
@@ -71,13 +73,13 @@ class Account::ProviderDomainsTest < ActiveSupport::TestCase
     Account.create!(:org_name => 'foo', :domain => '')
 
     assert_raise ActiveRecord::RecordNotFound do
-      Account.find_by_domain!(nil)
+      Account.find_by_domain!(nil) # rubocop:disable Rails/DynamicFindBy
     end
   end
 
   test 'find_by_domain! finds account by domain' do
     account = FactoryBot.create(:simple_account, :domain => 'example.net')
-    assert_equal account, Account.find_by_domain!('example.net')
+    assert_equal account, Account.find_by_domain!('example.net') # rubocop:disable Rails/DynamicFindBy
   end
 
   test '#generate_domains generates correctly default for provider' do


### PR DESCRIPTION

**What this PR does / why we need it**:

    Remove the usage of require_dependency in Account models
    
    This commit is one of some to move mostly of our lib/* to app/lib
    in order to have eager loading on boot
    
    - This one removes the needing of require_dependency
    'account/domains'. To this, we needed to rename the
    Account::Domains concern to be Account::ProviderDomains in order
    to not have naming clashes with the other Domains module.
    - Remove the backend_client require_dependency from Account class.