### PR TITLE
Remove require_dependency for app/lib/csv

### DIFF
--- a/app/lib/stats/views/csv/top_applications.rb
+++ b/app/lib/stats/views/csv/top_applications.rb
@@ -1,4 +1,4 @@
-require 'csv/exporter'
+# frozen_string_literal: true
 
 module Stats
   module Views

--- a/app/lib/stats/views/csv/usage.rb
+++ b/app/lib/stats/views/csv/usage.rb
@@ -1,4 +1,4 @@
-require 'csv/exporter'
+# frozen_string_literal: true
 
 module Stats
   module Views

--- a/app/workers/data_exports_worker.rb
+++ b/app/workers/data_exports_worker.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
+
 require 'zip'
-require 'csv'
 
 class DataExportsWorker
   include Sidekiq::Worker


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit is one of some to move mostly of our lib/* to app/lib
in order to have eager loading on boot

This one removes the require_dependency for app/lib/csv