### PR TITLE
Remove the usage of require_dependency for app/lib/authentication

### DIFF
--- a/app/lib/authentication/strategy/base.rb
+++ b/app/lib/authentication/strategy/base.rb
@@ -1,5 +1,3 @@
-require_dependency 'authentication/strategy'
-
 module Authentication
   module Strategy
     class Procedure

--- a/app/lib/authentication/strategy/oauth2.rb
+++ b/app/lib/authentication/strategy/oauth2.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_dependency 'authentication/strategy'
-
 module Authentication
   module Strategy
     class Oauth2 < Authentication::Strategy::Oauth2Base

--- a/app/lib/authentication/strategy/oauth2_base.rb
+++ b/app/lib/authentication/strategy/oauth2_base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_dependency 'authentication/strategy'
-
 module Authentication
   module Strategy
     class Oauth2Base < Authentication::Strategy::Internal

--- a/app/lib/authentication/strategy/provider_oauth2.rb
+++ b/app/lib/authentication/strategy/provider_oauth2.rb
@@ -1,5 +1,3 @@
-require_dependency 'authentication/strategy'
-
 module Authentication
   module Strategy
     class ProviderOauth2 < Authentication::Strategy::Oauth2Base


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit is one of some to move mostly of our lib/* to app/lib
in order to have eager loading on boot

- This one removes the needing of require_dependency for
app/lib/authentication