### PR TITLE
Fixes spec for ApiFilter component

### DIFF
--- a/spec/javascripts/Dashboard/ApiFilter.spec.jsx
+++ b/spec/javascripts/Dashboard/ApiFilter.spec.jsx
@@ -23,11 +23,27 @@ it('should render itself', () => {
 })
 
 it('should filter APIs passed in props by name', () => {
-  // TODO
+  // remove / add mean class 'hidden' from DOM Element
+  const remove = jest.fn()
+  const add = jest.fn()
+  jest.spyOn(document, 'getElementById').mockReturnValue({
+    classList: { remove, add }
+  })
+
   const input = apiFilter.find('input')
+
+  // Filter first all apis
   input.simulate('change', { target: { value: 'api' } })
-  input.simulate('change', { target: { value: 'api 1' } })
+
+  expect(remove).toHaveBeenCalledTimes(apis.length)
+  expect(add).toHaveBeenCalledTimes(0)
+
+  remove.mockReset()
+  add.mockReset()
+
+  // Filter only last one
   input.simulate('change', { target: { value: 'api 11' } })
 
-  // expect...
+  expect(remove).toHaveBeenCalledTimes(1)
+  expect(add).toHaveBeenCalledTimes(2)
 })

--- a/spec/javascripts/Dashboard/ApiFilter.spec.jsx
+++ b/spec/javascripts/Dashboard/ApiFilter.spec.jsx
@@ -33,7 +33,7 @@ it('should filter APIs passed in props by name', () => {
   const input = apiFilter.find('input')
 
   // Filter first all apis
-  input.simulate('change', { target: { value: 'api' } })
+  input.props().onChange({ target: { value: 'api' } })
 
   expect(remove).toHaveBeenCalledTimes(apis.length)
   expect(add).toHaveBeenCalledTimes(0)
@@ -42,7 +42,7 @@ it('should filter APIs passed in props by name', () => {
   add.mockReset()
 
   // Filter only last one
-  input.simulate('change', { target: { value: 'api 11' } })
+  input.props().onChange({ target: { value: 'api 11' } })
 
   expect(remove).toHaveBeenCalledTimes(1)
   expect(add).toHaveBeenCalledTimes(2)

--- a/spec/javascripts/Dashboard/ApiFilter.spec.jsx
+++ b/spec/javascripts/Dashboard/ApiFilter.spec.jsx
@@ -22,7 +22,7 @@ it('should render itself', () => {
   expect(apiFilter.find('.ApiFilter').exists()).toBe(true)
 })
 
-it.skip('should filter APIs passed in props by name', () => {
+it('should filter APIs passed in props by name', () => {
   // TODO
   const input = apiFilter.find('input')
   input.simulate('change', { target: { value: 'api' } })


### PR DESCRIPTION
As part of #1058 the `ApiFilter` was refactored and some specs became outdated.

This PR makes sure ApiFilter has a proper coverage.