### PR TITLE
Fixes used backends list at Service overview

### DIFF
--- a/app/assets/stylesheets/provider/_services.scss
+++ b/app/assets/stylesheets/provider/_services.scss
@@ -89,10 +89,11 @@
         column-rule: $border-width solid $border-color;
         list-style: none;
         padding: line-height-times(2 / 3) line-height-times(1 / 2);
+
         li {
           border-bottom: none;
           display: inline-block;
-          padding: line-height-times(1 / 4) 0;
+          padding-top: 0;
           width: 100%;
         }
       }


### PR DESCRIPTION
When many items, padding gets weird. The problem is the styles targeting first, nth and last li-children.

**Before:**
<img width="396" alt="Screen Shot 2019-08-21 at 19 17 38" src="https://user-images.githubusercontent.com/11672286/63453568-3c9ba200-c449-11e9-9f93-14fc0016fc1a.png">

**After:**
<img width="396" alt="Screen Shot 2019-08-21 at 19 16 23" src="https://user-images.githubusercontent.com/11672286/63453600-52a96280-c449-11e9-9c5c-81f687b90a68.png">

