### PR TITLE
List all backend API endpoints inside the APIcast config

### DIFF
--- a/app/assets/stylesheets/provider/_commons.scss
+++ b/app/assets/stylesheets/provider/_commons.scss
@@ -99,6 +99,7 @@ ul, p, ol, dl {
   min-height: line-height-times(1);
   padding: line-height-times(1/2) 0 line-height-times(1/2) 40%;
   border-bottom: $border-width solid $border-color;
+  list-style: none;
 }
 
 .u-dl {

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -7,8 +7,11 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
 
     dl.u-dl
       - unless deployment_option_is_service_mesh?(@service)
-        dt.u-dl-term Private Base URL
-        dd.u-dl-definition = @proxy.api_backend
+        dt.u-dl-term Backends
+        dd.u-dl-definition
+          ul
+          - for backend in @service.backend_apis
+            li = link_to backend.name, provider_admin_backend_api_path(backend)
       dt.u-dl-term Mapping rules
       dd.u-dl-definition
         - if (last_rule = @proxy.proxy_rules.last)

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -7,11 +7,19 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
 
     dl.u-dl
       - unless deployment_option_is_service_mesh?(@service)
-        dt.u-dl-term Backends
-        dd.u-dl-definition
-          ul
-          - for backend in @service.backend_apis
-            li = link_to backend.name, provider_admin_backend_api_path(backend)
+        - if @service.act_as_traditional_service?
+          dt.u-dl-term Private Base URL
+          dd.u-dl-definition = @proxy.api_backend
+        - else
+          - backend_api_configs = @service.backend_api_configs
+          dt.u-dl-term Private Base #{'URL'.pluralize backend_api_configs.count}
+          dd.u-dl-definition
+            ul
+            - for backend_api_config in backend_api_configs
+              li
+                code
+                  ' /#{backend_api_config.path.presence} =>
+                = backend_api_config.backend_api.private_endpoint
       dt.u-dl-term Mapping rules
       dd.u-dl-definition
         - if (last_rule = @proxy.proxy_rules.last)


### PR DESCRIPTION
**What this PR does / why we need it**:

Renders a list of endpoints of all `@service.backend_api_config` instead of a single "Private Base URL".

Without API as Product (still like this for all services that do not act as product):
<img width="1680" alt="Screen Shot 2019-08-23 at 1 59 55 PM" src="https://user-images.githubusercontent.com/1842261/63591309-ab464000-c5ae-11e9-9e75-aedd4e5ea9d5.png">

With API as Product:
<img width="1680" alt="Screen Shot 2019-08-23 at 1 59 25 PM" src="https://user-images.githubusercontent.com/1842261/63591346-cca72c00-c5ae-11e9-97e7-85f2ad4d371d.png">

"Private Base URL" will inflect automatically depending on the number of `backend_api_config` of the service.

**Which issue(s) this PR fixes** 

[THREESCALE-3282: APIAP: list all backend API endpoints in the proxy config show page](https://issues.jboss.org/browse/THREESCALE-3282)

**Notes for reviewers**:
Go to `/apiconfig/services/<id>/integration`
Either have an APIcast running or create a `service_token` and a `proxy_configs`:
```ruby
# in the rails console
s = Service.find(<id>)
s.service_tokens.create!(value: 'token')
s.proxy.proxy_configs.create(content: { proxy: { hosts: ['foo.com']}}.to_json, environment: 'sandbox').save!
```