### PR TITLE
Don't display Backend APIs in menu if feature is off

### DIFF
--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -86,7 +86,8 @@ module MenuHelper
 
   def api_selector_services
     @api_selector_services ||= (site_account.provider? && logged_in? ? current_user.accessible_services : Service.none).decorate
-                                   .concat(current_user.account.backend_apis.decorate)
+    @api_selector_services.concat(current_user.account.backend_apis.decorate) if current_account.provider_can_use?(:api_as_product)
+    @api_selector_services
   end
 
   def audience_link


### PR DESCRIPTION


**What this PR does / why we need it**:

This commit fix the problem that we currently have that displays
the backend apis in the menu even if the rolling update is turned
off
