### PR TITLE
Fixes API search in non-APIAP dashboards

### DIFF
--- a/app/assets/stylesheets/provider/admin/_dashboard.scss
+++ b/app/assets/stylesheets/provider/admin/_dashboard.scss
@@ -15,6 +15,14 @@
 
   &--services {
     margin-top: line-height-times(1.4);
+
+    section.hidden {
+      display: none;
+    }
+
+    tr.hidden {
+      visibility: collapse;
+    }
   }
 
   &-title {
@@ -427,14 +435,3 @@ a:hover .u-notice {
   }
 }
 
-#products {
-  .hidden {
-    display: none;
-  }
-}
-
-#backends {
-  .hidden {
-    visibility: collapse;
-  }
-}

--- a/app/javascript/packs/services_search_bar.js
+++ b/app/javascript/packs/services_search_bar.js
@@ -1,0 +1,11 @@
+// TODO: remove this pack when apiap rolling updated is removed
+import { ApiFilterWrapper as ApiFilter } from 'Dashboard/components/ApiFilter'
+
+import { safeFromJsonString } from 'utilities/json-utils'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const id = 'api_filter'
+  const { apis, domClass } = document.getElementById(id).dataset
+
+  ApiFilter({ apis: safeFromJsonString(apis), domClass }, id)
+})

--- a/app/views/provider/admin/dashboards/_services_filter.html.slim
+++ b/app/views/provider/admin/dashboards/_services_filter.html.slim
@@ -1,24 +1,7 @@
 - if current_user.multiple_accessible_services?
-  #api_filter
+  - apis = @services.as_json(root: false, only: [:id, :name]).to_json
+  #api_filter data-apis=apis data-dom-class='service'
+    = javascript_pack_tag 'services_search_bar'
 
-    javascript:
-      document.addEventListener('DOMContentLoaded', function () {
-        var allApis = #{ json @services.as_json(root: false, only: [:id, :name]) }
-
-        var displayApis = function(filteredApis) {
-          allApis.forEach(function(api) {
-            var isFilteredApi = filteredApis.some(function(filteredApi) {
-              return filteredApi.id === api.id
-            });
-
-            document.getElementById("service_" + api.id).style.display = isFilteredApi ? "inline": "none";
-          })
-        }
-
-        window.ApiFilter({
-          apis: allApis,
-          displayApis: displayApis
-        }, 'api_filter')
-      })
 - else
   h1.DashboardSection-title APIs


### PR DESCRIPTION
🐛
`ApiFilter` is not working when APIAP is disabled, this was introduced in #1058 .

Fixes:
- Create a pack for services searchbar (to be consistent with #1058) that is loaded when APIAP rolling update is off
- Adjust style `.hidden` to affect both service sections and product/backend sections