### PR TITLE
Inject Routing policy for Backend API upstreams (THREESCALE-3311)

### DIFF
--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -17,7 +17,7 @@ module BackendApiLogic
       end
 
       def to_a
-        rules = backend_api_configs.each_with_object([]) do |config, rules|
+        rules = backend_api_configs.reorder(path: :desc).each_with_object([]) do |config, rules|
           rule = Rule.new(config).as_json
           rules << rule if rule
         end

--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -57,7 +57,7 @@ module BackendApiLogic
           if path.empty?
             "/.*"
           else
-          "/#{path}/.*|/#{path}/?"
+            "/#{path}/.*|/#{path}/?"
           end
         end
       end

--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module BackendApiLogic
+  module RoutingPolicy
+    def policy_chain
+      chain = super
+      return chain unless service.act_as_product?
+      Builder.new(service).to_a.concat(chain)
+    end
+
+    class Builder
+      delegate :proxy, :backend_api_configs, to: :@service
+      delegate :policies_config, to: :proxy
+
+      def initialize(service)
+        @service = service
+      end
+
+      def to_a
+        rules = backend_api_configs.each_with_object([]) do |config, rules|
+          rule = Rule.new(config).as_json
+          rules << rule if rule
+        end
+        return [] if rules.empty?
+        [{
+          name: "routing",
+          version: "builtin",
+          enabled: true,
+          configuration: {
+            rules: rules
+          }
+        }].as_json
+      end
+
+      class Rule
+        delegate :private_endpoint, :path, to: :@config
+
+        def initialize(config)
+          @config = config
+        end
+
+        def as_json
+          return if private_endpoint.blank?
+          {
+            url: private_endpoint,
+            condition: {
+              operations: [
+                match: :path,
+                op: :matches,
+                value: path_to_regex
+              ]
+            }
+          }
+        end
+
+        def path_to_regex
+          if path.empty?
+            "/.*"
+          else
+          "/#{path}/.*|/#{path}/?"
+          end
+        end
+      end
+      private_constant :Rule
+    end
+    private_constant :Builder
+
+  end
+end

--- a/app/lib/string_utils/strip_slash.rb
+++ b/app/lib/string_utils/strip_slash.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module StringUtils
+  # Might be good to add it to String but I do not like that
+  module StripSlash
+    module_function
+
+    def strip_slash(value)
+      value.to_s.gsub(/(^\/+)|(\/+$)/,'')
+    end
+  end
+end

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -13,6 +13,6 @@ class BackendApiConfig < ApplicationRecord
   end
 
   def path=(value)
-    super(value.to_s.reverse.chomp("/").reverse.chomp("/"))
+    super(value.to_s.gsub(/(^\/+)|(\/+$)/,''))
   end
 end

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -12,6 +12,8 @@ class BackendApiConfig < ApplicationRecord
     backend_api.metrics.each { |metric| metric.send(:sync_backend) }
   end
 
+  delegate :private_endpoint, to: :backend_api
+
   def path=(value)
     super(StringUtils::StripSlash.strip_slash(value))
   end

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -13,6 +13,6 @@ class BackendApiConfig < ApplicationRecord
   end
 
   def path=(value)
-    super(value.to_s.gsub(/(^\/+)|(\/+$)/,''))
+    super(StringUtils::StripSlash.strip_slash(value))
   end
 end

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -4,6 +4,7 @@ require 'resolv'
 class Proxy < ApplicationRecord
   include AfterCommitQueue
   include BackendApiLogic::ProxyExtension
+  prepend BackendApiLogic::RoutingPolicy
 
   DEFAULT_POLICY = { 'name' => 'apicast', 'humanName' => 'APIcast policy', 'description' => 'Main functionality of APIcast.',
                      'configuration' => {}, 'version' => 'builtin', 'enabled' => true, 'removable' => false, 'id' => 'apicast-policy'  }.freeze
@@ -136,6 +137,7 @@ class Proxy < ApplicationRecord
   end
 
   def policy_chain
+    # TODO: We need to remove this rolling update as it should be available for everyone using APIcast V2
     return unless provider_can_use?(:policies)
     raw_config = policies_config
     return if raw_config.blank?

--- a/test/models/backend_api_config_test.rb
+++ b/test/models/backend_api_config_test.rb
@@ -15,7 +15,7 @@ class BackendApiConfigTest < ActiveSupport::TestCase
     @config.path = 'hello/my/name/is/'
     assert_equal 'hello/my/name/is', @config.path
 
-    @config.path = '/hello/my/name/is/john/'
+    @config.path = '//hello/my/name/is/john//'
     assert_equal 'hello/my/name/is/john', @config.path
   end
 

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -86,14 +86,14 @@ class ProxyTest < ActiveSupport::TestCase
       backend_api2 = FactoryBot.create(:backend_api, account: account, private_endpoint: 'https://private-2.example.com')
       FactoryBot.create(:backend_api_config, path: '/null', backend_api: null_backend_api, service: service)
       FactoryBot.create(:backend_api_config, path: '/foo', backend_api: backend_api1, service: service)
-      FactoryBot.create(:backend_api_config, path: '/bar', backend_api: backend_api2, service: service)
+      FactoryBot.create(:backend_api_config, path: '/foo/bar', backend_api: backend_api2, service: service)
       policy_chain =  [
         {"name"=>"routing", "version"=>"builtin", "enabled"=>true,
           "configuration"=>{
             "rules"=>[
-              {"url"=>"https://echo-api.3scale.net:443", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/.*"}]}},
+              {"url"=>"https://private-2.example.com:443", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/bar/.*|/foo/bar/?"}]}},
               {"url"=>"https://private-1.example.com:443", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/.*|/foo/?"}]}},
-              {"url"=>"https://private-2.example.com:443", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/bar/.*|/bar/?"}]}}
+              {"url"=>"https://echo-api.3scale.net:443", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/.*"}]}}
             ]
           }
         },


### PR DESCRIPTION
So the request is properly mapped to the correct upstream

Closes https://issues.jboss.org/browse/THREESCALE-3311