### PR TITLE
Application Plan "Methods & Metrics" collapsible table

### DIFF
--- a/app/assets/stylesheets/provider/_metrics.scss
+++ b/app/assets/stylesheets/provider/_metrics.scss
@@ -14,6 +14,23 @@ table#backend_api_metrics {
       width: 10%;
     }
   }
+
+th[data-collapsible="true"] {
+  span {
+    cursor: pointer;
+
+    i {
+      padding-right: 3px;
+    }
+  }
+
+  tbody {
+    tr {
+      &.hidden {
+        display: none;
+      }
+    }
+  } 
 }
 
 table.contract_table {

--- a/app/assets/stylesheets/provider/_metrics.scss
+++ b/app/assets/stylesheets/provider/_metrics.scss
@@ -14,6 +14,15 @@ table#backend_api_metrics {
       width: 10%;
     }
   }
+  
+  tbody {
+    tr {
+      &.hidden {
+        display: none;
+      }
+    }
+  } 
+}
 
 th[data-collapsible="true"] {
   span {
@@ -24,13 +33,11 @@ th[data-collapsible="true"] {
     }
   }
 
-  tbody {
-    tr {
-      &.hidden {
-        display: none;
-      }
+  &.collapsed {
+    i {
+      transform: rotate(-90deg);
     }
-  } 
+  }
 }
 
 table.contract_table {

--- a/app/assets/stylesheets/provider/_metrics.scss
+++ b/app/assets/stylesheets/provider/_metrics.scss
@@ -53,6 +53,10 @@ table.contract_table {
   th {
     padding-top: line-height-times(1/4);
     padding-bottom: line-height-times(1/4);
+    
+    &:first-child {
+      text-align: left;
+    }
   }
 
   td.selected strong {

--- a/app/assets/stylesheets/provider/_metrics.scss
+++ b/app/assets/stylesheets/provider/_metrics.scss
@@ -29,7 +29,7 @@ th[data-collapsible="true"] {
     cursor: pointer;
 
     i {
-      padding-right: 3px;
+      margin-right: line-height-times(1/4);
     }
   }
 

--- a/app/assets/stylesheets/provider/_metrics.scss
+++ b/app/assets/stylesheets/provider/_metrics.scss
@@ -14,17 +14,17 @@ table#backend_api_metrics {
       width: 10%;
     }
   }
-  
+
   tbody {
     tr {
       &.hidden {
         display: none;
       }
     }
-  } 
+  }
 }
 
-th[data-collapsible="true"] {
+th.collapsible {
   span {
     cursor: pointer;
 

--- a/app/javascript/packs/plans-metrics.js
+++ b/app/javascript/packs/plans-metrics.js
@@ -14,6 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const ids = safeFromJsonString(metrics)
 
     if (collapsible) {
+      th.classList.add('collapsible')
+
       const toggleBackendAPI = () => {
         th.classList.toggle('collapsed')
         ids.forEach(toggleMetricVisibility)

--- a/app/javascript/packs/plans-metrics.js
+++ b/app/javascript/packs/plans-metrics.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const span = th.querySelector('span')
         span.insertBefore(caret, span.firstChild)
         span.addEventListener('click', () => {
+          th.classList.toggle('collapsed')
           ids.forEach(id => document.getElementById(`metric_${id}`).classList.toggle('hidden'))
         })
       }

--- a/app/javascript/packs/plans-metrics.js
+++ b/app/javascript/packs/plans-metrics.js
@@ -1,21 +1,35 @@
 import { safeFromJsonString } from 'utilities/json-utils'
 
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('th.backend_api_metric_title')
-    .forEach(th => {
-      const { collapsible, metrics } = th.dataset
-      const ids = safeFromJsonString(metrics)
+  function toggleMetricVisibility (id) {
+    document.getElementById(`metric_${id}`)
+      .classList
+      .toggle('hidden')
+  }
 
-      if (collapsible) {
-        const caret = document.createElement('i')
-        caret.classList.add('fa', 'fa-caret-down')
+  const ths = document.querySelectorAll('th.backend_api_metric_title')
+  // NodeList.foreEach not supported in IE11
+  for (const th of ths) {
+    const { collapsible, metrics } = th.dataset
+    const ids = safeFromJsonString(metrics)
 
-        const span = th.querySelector('span')
-        span.insertBefore(caret, span.firstChild)
-        span.addEventListener('click', () => {
-          th.classList.toggle('collapsed')
-          ids.forEach(id => document.getElementById(`metric_${id}`).classList.toggle('hidden'))
-        })
+    if (collapsible) {
+      const toggleBackendAPI = () => {
+        th.classList.toggle('collapsed')
+        ids.forEach(toggleMetricVisibility)
       }
-    })
+
+      const caret = document.createElement('i')
+      // Multiple arguments for 'add' not supported in IE11
+      caret.classList.add('fa')
+      caret.classList.add('fa-caret-down')
+
+      const span = th.querySelector('span')
+      span.insertBefore(caret, span.firstChild)
+      span.addEventListener('click', toggleBackendAPI)
+
+      // First render with all metrics collapsed
+      toggleBackendAPI()
+    }
+  }
 })

--- a/app/javascript/packs/plans-metrics.js
+++ b/app/javascript/packs/plans-metrics.js
@@ -1,0 +1,20 @@
+import { safeFromJsonString } from 'utilities/json-utils'
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('th.backend_api_metric_title')
+    .forEach(th => {
+      const { collapsible, metrics } = th.dataset
+      const ids = safeFromJsonString(metrics)
+
+      if (collapsible) {
+        const caret = document.createElement('i')
+        caret.classList.add('fa', 'fa-caret-down')
+
+        const span = th.querySelector('span')
+        span.insertBefore(caret, span.firstChild)
+        span.addEventListener('click', () => {
+          ids.forEach(id => document.getElementById(`metric_${id}`).classList.toggle('hidden'))
+        })
+      }
+    })
+})

--- a/app/views/api/metrics/_backend_api.erb
+++ b/app/views/api/metrics/_backend_api.erb
@@ -1,7 +1,7 @@
 <tr>
   <th colspan="7" class="backend_api_metric_title"
                   data-collapsible="<%= backend_api.top_level_metrics.any? %>"
-                  data-metrics="<%= backend_api.top_level_metrics.map &:id %>">
+                  data-metrics="<%= backend_api.metrics.map &:id %>">
     <span><%= backend_api.name %></span>
     (<%= link_to 'Define method or metric', provider_admin_backend_api_metrics_path(backend_api), title: 'Define Methods & Metrics for this Backend API' %>)
   </th>

--- a/app/views/api/metrics/_backend_api.erb
+++ b/app/views/api/metrics/_backend_api.erb
@@ -1,6 +1,8 @@
 <tr>
-  <th colspan="7" class="backend_api_metric_title">
-    <%= backend_api.name %>
+  <th colspan="7" class="backend_api_metric_title"
+                  data-collapsible="<%= backend_api.top_level_metrics.any? %>"
+                  data-metrics="<%= backend_api.top_level_metrics.map &:id %>">
+    <span><%= backend_api.name %></span>
     (<%= link_to 'Define method or metric', provider_admin_backend_api_metrics_path(backend_api), title: 'Define Methods & Metrics for this Backend API' %>)
   </th>
 </tr>

--- a/app/views/api/plans/_metrics.html.erb
+++ b/app/views/api/plans/_metrics.html.erb
@@ -6,6 +6,7 @@
       Metrics, Methods & Limits
     <% end %>
   </h2>
+
   <table id="metrics" class="contract_table">
     <thead>
       <tr>
@@ -101,5 +102,6 @@
       <% end -%>
     </tbody>
   </table>
+  <%= javascript_pack_tag 'plans-metrics' %>
   <% end -%>
 </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a caret to the title and hides/shows the table.

![metrics](https://user-images.githubusercontent.com/11672286/63681013-28fb8d00-c7f5-11e9-8d9a-782ede0cbd55.gif)

**Which issue(s) this PR fixes** 

[THREESCALE-3093: APIAP: Application plan > edit > Methods & Metrics - Collapsible table](https://issues.jboss.org/browse/THREESCALE-3093)

**Tested in**:

- [x] Firefox
- [x] Chrome
- [x] Safari (although it jumps to the top when resizing the table 🐛)
- [x] IE11

**Verification steps** 

- Go to `apiconfig/application_plans/22/edit` and click on the names of each Backend API under _Metrics, Methods, Limits & Pricing Rules_
- Metrics from each particular API should collapse/expande
- The caret should rotate
- When no JS, there shouldn't any caret
- When no metrics, there shouldn't any caret either
