### PR TITLE
Remove associations from BackendApiConfig

### DIFF
--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -6,13 +6,6 @@ class BackendApiConfig < ApplicationRecord
   belongs_to :service, inverse_of: :backend_api_configs
   belongs_to :backend_api, inverse_of: :backend_api_configs
 
-  has_many :metrics, through: :service
-  has_many :top_level_metrics, through: :service, class_name: 'Metric'
-  has_one :proxy, through: :service
-  has_many :proxy_rules, through: :proxy
-
-  alias mapping_rules proxy_rules
-
   validates :path, length: { in: 0..255, allow_nil: false }, path: true
 
   def path=(value)


### PR DESCRIPTION
Remove a few no longer used associations from BackendApiConfig
* metrics (through service)
* proxy_rules (through proxy > service)
* aliases and related methods