### PR TITLE
[wip] Remove uniqueness from index on metrics(service_id, system_name)

### DIFF
--- a/db/migrate/20190822141551_remove_uniqueness_from_index_on_metrics_service_system_name.rb
+++ b/db/migrate/20190822141551_remove_uniqueness_from_index_on_metrics_service_system_name.rb
@@ -1,0 +1,14 @@
+class RemoveUniquenessFromIndexOnMetricsServiceSystemName < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def self.up
+    remove_index :metrics, [:service_id, :system_name]
+
+    index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+    add_index :metrics, [:service_id, :system_name], index_options.merge(unique: false)
+  end
+
+  def self.down
+    # This is not reversible, but it does not matter.
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190805135829) do
+ActiveRecord::Schema.define(version: 20190822141551) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -829,7 +829,7 @@ ActiveRecord::Schema.define(version: 20190805135829) do
 
   add_index "metrics", ["owner_type", "owner_id", "system_name"], name: "index_metrics_on_owner_type_and_owner_id_and_system_name", unique: true
   add_index "metrics", ["owner_type", "owner_id"], name: "index_metrics_on_owner_type_and_owner_id"
-  add_index "metrics", ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", unique: true
+  add_index "metrics", ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name"
   add_index "metrics", ["service_id"], name: "index_metrics_on_service_id"
 
   create_table "moderatorships", force: :cascade do |t|

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190805135829) do
+ActiveRecord::Schema.define(version: 20190822141551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -828,7 +828,7 @@ ActiveRecord::Schema.define(version: 20190805135829) do
 
   add_index "metrics", ["owner_type", "owner_id", "system_name"], name: "index_metrics_on_owner_type_and_owner_id_and_system_name", unique: true, using: :btree
   add_index "metrics", ["owner_type", "owner_id"], name: "index_metrics_on_owner_type_and_owner_id", using: :btree
-  add_index "metrics", ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", unique: true, using: :btree
+  add_index "metrics", ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", using: :btree
   add_index "metrics", ["service_id"], name: "index_metrics_on_service_id", using: :btree
 
   create_table "moderatorships", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190805135829) do
+ActiveRecord::Schema.define(version: 20190822141551) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -829,7 +829,7 @@ ActiveRecord::Schema.define(version: 20190805135829) do
 
   add_index "metrics", ["owner_type", "owner_id", "system_name"], name: "index_metrics_on_owner_type_and_owner_id_and_system_name", unique: true, using: :btree
   add_index "metrics", ["owner_type", "owner_id"], name: "index_metrics_on_owner_type_and_owner_id", using: :btree
-  add_index "metrics", ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", unique: true, using: :btree
+  add_index "metrics", ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", using: :btree
   add_index "metrics", ["service_id"], name: "index_metrics_on_service_id", using: :btree
 
   create_table "moderatorships", force: :cascade do |t|


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It removes the uniqueness constraint from the index on `metrics(service_id, system_name)`. The reason is because now a metric may belong to a backend API and not to a service. Without this PR, two different backend APIs each one holding a metric with the same `system_name` would cause a uniqueness constraint violation in the DB due to `NULL` `service_id` in both of them.