### PR TITLE
Add an option to mark that the Service acts as product

### DIFF
--- a/app/javascript/src/NewService/components/FormElements/BackendApiSelect.jsx
+++ b/app/javascript/src/NewService/components/FormElements/BackendApiSelect.jsx
@@ -1,0 +1,43 @@
+// @flow
+
+import React, {useState} from 'react'
+import {Label} from 'NewService/components/FormElements'
+import type {Api} from 'Types/Api'
+
+type Props = {
+  backendApis: Api[]
+}
+
+const BackendApiSelect = ({backendApis}: Props) => {
+  const [actAsProduct, setActAsProduct] = useState(false)
+
+  const toggleActAsProduct = (event: SyntheticInputEvent<HTMLInputElement>) => {
+    setActAsProduct(event.currentTarget.checked)
+  }
+
+  return (
+    <React.Fragment>
+      <li id="service_act_as_product_input">
+        <label htmlFor='act_as_product'>
+          <input id="act_as_product" name="service[act_as_product]" type="checkbox" onChange={toggleActAsProduct} />
+          Act as product
+        </label>
+      </li>
+
+      {actAsProduct &&
+        <li id="service_backend_api_input">
+          <Label
+            htmlFor='service_backend_api'
+            label='Backend API'
+          />
+          <select name="service[backend_api]" id="service_backend_api">
+            <option key='new' value=''>Create a new Backend API</option>
+            {backendApis.map(({id, name}) => <option key={id} value={id}>{name}</option>)}
+          </select>
+        </li>
+      }
+    </React.Fragment>
+  )
+}
+
+export {BackendApiSelect}

--- a/app/javascript/src/NewService/components/FormElements/index.jsx
+++ b/app/javascript/src/NewService/components/FormElements/index.jsx
@@ -5,5 +5,6 @@ export {HiddenServiceDiscoveryInput} from 'NewService/components/FormElements/Hi
 export {Label} from 'NewService/components/FormElements/Label'
 export {Select} from 'NewService/components/FormElements/Select'
 export {ErrorMessage} from 'NewService/components/FormElements/ErrorMessage'
+export {BackendApiSelect} from 'NewService/components/FormElements/BackendApiSelect'
 export {ServiceDiscoveryListItems} from 'NewService/components/FormElements/ServiceDiscoveryListItems'
 export {ServiceManualListItems} from 'NewService/components/FormElements/ServiceManualListItems'

--- a/app/javascript/src/NewService/components/NewServiceForm.jsx
+++ b/app/javascript/src/NewService/components/NewServiceForm.jsx
@@ -4,18 +4,21 @@ import React, {useState} from 'react'
 
 import {ServiceSourceForm, ServiceDiscoveryForm, ServiceManualForm} from 'NewService'
 import {createReactWrapper} from 'utilities/createReactWrapper'
+import type {Api} from 'Types/Api'
 
 type Props = {
   isServiceDiscoveryAccessible: boolean,
   isServiceDiscoveryUsable: boolean,
   serviceDiscoveryAuthenticateUrl: string,
   providerAdminServiceDiscoveryServicesPath: string,
-  adminServicesPath: string
+  adminServicesPath: string,
+  apiap: boolean,
+  backendApis: Api[]
 }
 
 const NewServiceForm = (props: Props) => {
   const {isServiceDiscoveryAccessible, isServiceDiscoveryUsable, serviceDiscoveryAuthenticateUrl,
-    providerAdminServiceDiscoveryServicesPath, adminServicesPath} = props
+    providerAdminServiceDiscoveryServicesPath, adminServicesPath, apiap, backendApis} = props
 
   const [formMode, setFormMode] = useState('manual')
   const [loadingProjects, setLoadingProjects] = useState(false)
@@ -24,8 +27,8 @@ const NewServiceForm = (props: Props) => {
     setFormMode(event.currentTarget.value)
   }
 
-  const formToRender = () => formMode === 'manual' || !isServiceDiscoveryAccessible
-    ? <ServiceManualForm formActionPath={adminServicesPath}/>
+  const formToRender = () => formMode === 'manual'
+    ? <ServiceManualForm formActionPath={adminServicesPath} apiap={apiap} backendApis={backendApis} />
     : <ServiceDiscoveryForm formActionPath={providerAdminServiceDiscoveryServicesPath} setLoadingProjects={setLoadingProjects} />
 
   return (

--- a/app/javascript/src/NewService/components/ServiceManualForm.jsx
+++ b/app/javascript/src/NewService/components/ServiceManualForm.jsx
@@ -1,10 +1,19 @@
 // @flow
 
 import React from 'react'
-import {FormWrapper, ServiceManualListItems} from 'NewService/components/FormElements'
+import {BackendApiSelect, FormWrapper, ServiceManualListItems} from 'NewService/components/FormElements'
 import type {FormProps} from 'NewService/types'
+import type {Api} from 'Types/Api'
 
-const ServiceManualForm = ({formActionPath}: {formActionPath: string}) => {
+type Props = {
+  formActionPath: string,
+  apiap: boolean,
+  backendApis: Api[]
+}
+
+const ServiceManualForm = (props: Props) => {
+  const {formActionPath, apiap, backendApis} = props
+
   const formProps: FormProps = {
     id: 'new_service',
     formActionPath,
@@ -14,6 +23,7 @@ const ServiceManualForm = ({formActionPath}: {formActionPath: string}) => {
   return (
     <FormWrapper {...formProps}>
       <ServiceManualListItems/>
+      {apiap && <BackendApiSelect backendApis={backendApis} />}
     </FormWrapper>
   )
 }

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -8,6 +8,10 @@ class BackendApiConfig < ApplicationRecord
 
   validates :path, length: { in: 0..255, allow_nil: false }, path: true
 
+  after_create do
+    backend_api.metrics.each { |metric| metric.send(:sync_backend) }
+  end
+
   def path=(value)
     super(value.to_s.reverse.chomp("/").reverse.chomp("/"))
   end

--- a/app/views/api/services/new.html.slim
+++ b/app/views/api/services/new.html.slim
@@ -4,4 +4,6 @@
                                              isServiceDiscoveryUsable: service_discovery_usable?,
                                              serviceDiscoveryAuthenticateUrl: service_discovery_presenter.authorize_url,
                                              providerAdminServiceDiscoveryServicesPath: provider_admin_service_discovery_services_path,
-                                             adminServicesPath: admin_services_path }.to_json
+                                             adminServicesPath: admin_services_path,
+                                             apiap: current_account.provider_can_use?(:api_as_product),
+                                             backendApis: current_account.backend_apis.as_json(only: [:id, :name], root: false) }.to_json

--- a/spec/javascripts/NewService/NewServiceForm.spec.jsx
+++ b/spec/javascripts/NewService/NewServiceForm.spec.jsx
@@ -5,6 +5,7 @@ import Enzyme, {mount} from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
 import {NewServiceForm, ServiceManualForm, ServiceDiscoveryForm} from 'NewService'
+import {BackendApiSelect} from 'NewService/components/FormElements'
 
 import * as utils from 'utilities/utils'
 jest.spyOn(utils, 'CSRFToken')
@@ -17,7 +18,9 @@ const props = {
   isServiceDiscoveryUsable: true,
   serviceDiscoveryAuthenticateUrl: 'authenticate-url',
   providerAdminServiceDiscoveryServicesPath: 'my-path',
-  adminServicesPath: 'my-other-path'
+  adminServicesPath: 'my-other-path',
+  apiap: false,
+  backendApis: []
 }
 
 it('should render itself', () => {
@@ -41,6 +44,11 @@ it('should render the correct form depending on which mode is selected', () => {
   expect(wrapper.find(ServiceDiscoveryForm).exists()).toEqual(false)
 })
 
+it('should not render BackendApiSelect by default', () => {
+  const wrapper = mount(<NewServiceForm {...props}/>)
+  expect(wrapper.find(BackendApiSelect).exists()).toEqual(false)
+})
+
 describe('when Service Discovery is not accessible', () => {
   beforeAll(() => {
     props.isServiceDiscoveryAccessible = false
@@ -58,5 +66,16 @@ describe('when Service Discovery is not accessible', () => {
     expect(wrapper.find('ServiceManualForm').exists()).toEqual(true)
     expect(wrapper.find('form#new_service').exists()).toEqual(true)
     expect(wrapper.find('form#service_source').exists()).toEqual(false)
+  })
+})
+
+describe('when Api as Product is enabled', () => {
+  beforeAll(() => {
+    props.apiap = true
+  })
+
+  it('should render BackendApiSelect', () => {
+    const wrapper = mount(<NewServiceForm {...props}/>)
+    expect(wrapper.find(BackendApiSelect).exists()).toEqual(true)
   })
 })

--- a/spec/javascripts/NewService/formElements/BackendApiSelect.spec.jsx
+++ b/spec/javascripts/NewService/formElements/BackendApiSelect.spec.jsx
@@ -1,0 +1,40 @@
+// @flow
+
+import React from 'react'
+import {act} from 'react-dom/test-utils'
+import Enzyme, {shallow} from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+import {BackendApiSelect} from 'NewService/components/FormElements'
+import { BASE_PATH } from 'NewService'
+
+Enzyme.configure({adapter: new Adapter()})
+
+const props = {
+  backendApis: []
+}
+
+it('should render itself', () => {
+  const wrapper = shallow(<BackendApiSelect {...props} />)
+  expect(wrapper.find('#service_act_as_product_input').exists()).toEqual(true)
+})
+
+it('should render Act as Product checkbox', () => {
+  const wrapper = shallow(<BackendApiSelect {...props} />)
+  expect(wrapper.find('input[name="service[act_as_product]"]').exists()).toEqual(true)
+})
+
+it('should not render select element when Act as Product checkbox is unchecked', () => {
+  const wrapper = shallow(<BackendApiSelect {...props} />)
+  expect(wrapper.find('select[name="service[backend_api]"]').exists()).toEqual(false)
+})
+
+it('should render select element when Act as Product checkbox is checked', () => {
+  const wrapper = shallow(<BackendApiSelect {...props} />)
+  expect(wrapper.find('select[name="service[backend_api]"]').exists()).toEqual(false)
+  const eventObj = {currentTarget: {checked: true}}
+  act(() => {
+    wrapper.find('input[name="service[act_as_product]"]').simulate('change', eventObj)
+  })
+  expect(wrapper.find('select[name="service[backend_api]"]').exists()).toEqual(true)
+})

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -5,79 +5,152 @@ require 'test_helper'
 class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
 
   setup do
-    provider = FactoryBot.create(:provider_account)
-    @service = provider.default_service
-    login! provider
+    @provider = FactoryBot.create(:provider_account)
+    @service = @provider.default_service
+    login! @provider
   end
 
   attr_reader :service
 
-  test 'settings renders the right template and contains the right sections' do
-    get settings_admin_service_path(service)
-    assert_response :success
-    page = Nokogiri::HTML::Document.parse(response.body)
+  class SettingsTest < Api::ServicesControllerTest
+    test 'settings renders the right template and contains the right sections' do
+      get settings_admin_service_path(service)
+      assert_response :success
+      page = Nokogiri::HTML::Document.parse(response.body)
 
-    assert_template 'api/services/settings'
-    section_titles = page.xpath("//fieldset[@class='inputs']/legend").text
-    ['Signup & Use', 'Application Plans', 'Application Plan Changing','Alerts'].each do |expected_title|
-      section_titles.include? expected_title
+      assert_template 'api/services/settings'
+      section_titles = page.xpath("//fieldset[@class='inputs']/legend").text
+      ['Signup & Use', 'Application Plans', 'Application Plan Changing','Alerts'].each do |expected_title|
+        section_titles.include? expected_title
+      end
     end
-  end
 
-  test 'update the settings' do
-    put admin_service_path(service), update_params
-    assert_equal 'Service information updated.', flash[:notice]
+    test 'update the settings' do
+      put admin_service_path(service), update_params
+      assert_equal 'Service information updated.', flash[:notice]
 
-    update_service_params = update_params[:service]
-    expected_notification_settings = update_service_params[:notification_settings].transform_values { |notifications| notifications.map(&:to_i) }
-    expected_buyer_plan_change_permission = update_service_params[:buyer_plan_change_permission]
-    expected_signup_and_use = update_service_params
+      update_service_params = update_params[:service]
+      expected_notification_settings = update_service_params[:notification_settings].transform_values { |notifications| notifications.map(&:to_i) }
+      expected_buyer_plan_change_permission = update_service_params[:buyer_plan_change_permission]
+      expected_signup_and_use = update_service_params
                                   .slice(:intentions_required, :buyers_manage_apps, :referrer_filters_required, :custom_keys_enabled, :buyer_can_select_plan)
                                   .transform_values { |value| (value.to_i == 1) }
 
-    service.reload
+      service.reload
 
-    assert_equal expected_notification_settings, service.notification_settings
-    assert_equal expected_buyer_plan_change_permission, service.buyer_plan_change_permission
-    expected_signup_and_use.each { |attr_name, attr_value| assert_equal attr_value, service.public_send(attr_name) }
+      assert_equal expected_notification_settings, service.notification_settings
+      assert_equal expected_buyer_plan_change_permission, service.buyer_plan_change_permission
+      expected_signup_and_use.each { |attr_name, attr_value| assert_equal attr_value, service.public_send(attr_name) }
+    end
+
+    # This test can be removed once used deprecated attributes have been removed from the schema
+    test 'deprecated attributes should not be updated' do
+      new_tech_support_email = 'foo.tech.support@example.com'
+      new_admin_support_email = 'foo.admin.support@example.com'
+
+      deprecated_update_params = { service:
+                                   { tech_support_email: new_tech_support_email,
+                                     admin_support_email: new_admin_support_email }
+                                 }
+
+      put admin_service_path(service), params: deprecated_update_params
+
+      service.reload
+
+      assert_not_equal service.tech_support_email, new_tech_support_email
+      assert_not_equal service.admin_support_email, new_admin_support_email
+    end
+
+    private
+
+    def update_params
+      @update_params ||= { service:
+        { intentions_required: '0',
+          buyers_manage_apps: '0',
+          referrer_filters_required: '1',
+          custom_keys_enabled: '1',
+          buyer_can_select_plan: '1',
+          buyer_plan_change_permission: 'direct',
+          notification_settings:
+          { web_provider: ['', '50', '100', '300'],
+            email_provider: ['', '50', '100', '150'],
+            web_buyer: ['', '50', '100', '150'],
+            email_buyer: ['', '50', '100', '300']
+          }
+        }
+      }
+    end
   end
 
-  # This test can be removed once used deprecated attributes have been removed from the schema
-  test 'deprecated attributes should not be updated' do
-    new_tech_support_email = 'foo.tech.support@example.com'
-    new_admin_support_email = 'foo.admin.support@example.com'
+  class ActAsProduct < Api::ServicesControllerTest
+    def setup
+      super
+      Logic::RollingUpdates.stubs(enabled?: true)
+      Account.any_instance.stubs(:provider_can_use?).returns(true)
+      @provider.settings.allow_multiple_services!
+    end
 
-    deprecated_update_params = { service:
-                                 { tech_support_email: new_tech_support_email,
-                                   admin_support_email: new_admin_support_email }
-                               }
+    test 'should mark that service will act as product if feature is enabled' do
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
 
-    put admin_service_path(service), deprecated_update_params
+      assert_change of: -> { Service.count } do
+        post admin_services_path, service: {
+          system_name: 'my_new_product',
+          name: 'My new Product',
+          description: 'This will act as product',
+          act_as_product: true
+        }
+      end
+      assert Service.last.act_as_product
+      assert_equal 1, Service.last.backend_api_configs.count
+    end
 
-    service.reload
+    test 'should not mark that service will act as product if feature is not enabled' do
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
 
-    assert_not_equal service.tech_support_email, new_tech_support_email
-    assert_not_equal service.admin_support_email, new_admin_support_email
+      assert_change of: -> { Service.count } do
+        post admin_services_path, service: {
+          system_name: 'my_new_product',
+          name: 'My new Product',
+          description: 'This will act as product',
+          act_as_product: true
+        }
+      end
+      refute Service.last.act_as_product
+      assert_equal 1, Service.last.backend_api_configs.count
+    end
+
+    test 'should create a new Backend API if none was selected' do
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
+
+      assert_change of: -> { BackendApi } do
+        post admin_services_path, service: {
+          system_name: 'my_new_product',
+          name: 'My new Product',
+          description: 'This will act as product',
+          act_as_product: true
+        }
+      end
+
+      assert_equal 1, Service.last.backend_api_configs.count
+    end
+
+    test 'should reuse the same Backend API if it was selected' do
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
+      backend_api = FactoryBot.create(:backend_api, account: @provider)
+
+      assert_change of: -> { BackendApi }, by: 0 do
+        post admin_services_path, service: {
+          system_name: 'my_new_product',
+          name: 'My new Product',
+          description: 'This will act as product',
+          act_as_product: true,
+          backend_api: backend_api.id
+        }
+      end
+
+      assert_equal backend_api, Service.last.backend_api
+      assert_equal 1, Service.last.backend_api_configs.count
+    end
   end
-
-  private
-
-  def update_params
-    @update_params ||= { service:
-                             { intentions_required: '0',
-                               buyers_manage_apps: '0',
-                               referrer_filters_required: '1',
-                               custom_keys_enabled: '1',
-                               buyer_can_select_plan: '1',
-                               buyer_plan_change_permission: 'direct',
-                               notification_settings:
-                                   { web_provider: ['', '50', '100', '300'],
-                                     email_provider: ['', '50', '100', '150'],
-                                     web_buyer: ['', '50', '100', '150'],
-                                     email_buyer: ['', '50', '100', '300']
-                                   }
-                             }
-    }
-  end
-
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds a new option in the screen to create a service
to inform if it will act as product. If this options is checked, it will
present a select to choose which backend api it will be attached
or if it will create a new one.

This is when you create a Service without checking act as product:
![act_as_product_1](https://user-images.githubusercontent.com/771411/63549996-0b35db80-c508-11e9-9a3d-324ded89bd96.gif)

This is when you create a Service checking act as product and let it create a new Backend API:
![act_as_product_2](https://user-images.githubusercontent.com/771411/63550103-53ed9480-c508-11e9-9f19-dee911acb965.gif)

This is when you create a Service checking act as product and select an already existent Backend API:
![act_as_product_3](https://user-images.githubusercontent.com/771411/63550117-5fd95680-c508-11e9-87d7-6ade63a8318e.gif)


**Which issue(s) this PR fixes** 

[THREESCALE-3294](https://issues.jboss.org/browse/THREESCALE-3294)

**Verification steps** 

1. Go to the screen to create a new Service
2. Create a new service without checking `act as product` checkbox.
3. It should create a new service without attaching any backend api into it.
4. Go to the screen to create a new Service
5. Create a new service checking `act as product` checkbox and selecting `New Backend API` in the Backend API combo box.
6. It should create a new service with a freshly created backend api for this service.
7. Go to the screen to create a new Service
8. Create a new service checking `act as product` checkbox and selecting some already created backend api in the Backend API combo box.
9. It should create a new service with an already existent backend api for this service.
