### PR TITLE
[Do Not Merge] Fixes Metrics table header in Application Plan page

### DIFF
--- a/app/assets/stylesheets/provider/_commons.scss
+++ b/app/assets/stylesheets/provider/_commons.scss
@@ -200,3 +200,11 @@ hr, {
   color: $success-color;
   cursor: move;
 }
+
+tbody {
+  tr {
+    &.hidden {
+      visibility: collapse;
+    }
+  }
+}

--- a/app/assets/stylesheets/provider/_metrics.scss
+++ b/app/assets/stylesheets/provider/_metrics.scss
@@ -10,6 +10,12 @@ th[data-collapsible="true"] {
       padding-right: 3px;
     }
   }
+
+  &.collapsed {
+    i {
+      transform: rotate(-90deg);
+    }
+  }
 }
 
 table.contract_table {

--- a/app/assets/stylesheets/provider/_metrics.scss
+++ b/app/assets/stylesheets/provider/_metrics.scss
@@ -18,6 +18,20 @@ th[data-collapsible="true"] {
   }
 }
 
+table#metrics,
+table#backend_api_metrics {
+  table-layout: fixed;
+
+  thead {
+    th {
+      width: 70%;
+    }
+    th + th {
+      width: 10%;
+    }
+  }
+}
+
 table.contract_table {
 	width: 100%;
 	margin-bottom: line-height-times(1/2);

--- a/app/assets/stylesheets/provider/_metrics.scss
+++ b/app/assets/stylesheets/provider/_metrics.scss
@@ -2,6 +2,16 @@
   margin-top: line-height-times(2);
 }
 
+th[data-collapsible="true"] {
+  span {
+    cursor: pointer;
+
+    i {
+      padding-right: 3px;
+    }
+  }
+}
+
 table.contract_table {
 	width: 100%;
 	margin-bottom: line-height-times(1/2);

--- a/app/javascript/packs/plans-metrics.js
+++ b/app/javascript/packs/plans-metrics.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const span = th.querySelector('span')
         span.insertBefore(caret, span.firstChild)
         span.addEventListener('click', () => {
+          th.classList.toggle('collapsed')
           ids.forEach(id => document.getElementById(`metric_${id}`).classList.toggle('hidden'))
         })
       }

--- a/app/javascript/packs/plans-metrics.js
+++ b/app/javascript/packs/plans-metrics.js
@@ -1,21 +1,32 @@
 import { safeFromJsonString } from 'utilities/json-utils'
 
 document.addEventListener('DOMContentLoaded', () => {
+  function toggleMetricVisibility (id) {
+    document.getElementById(`metric_${id}`)
+      .classList
+      .toggle('hidden')
+  }
+
   document.querySelectorAll('th.backend_api_metric_title')
     .forEach(th => {
       const { collapsible, metrics } = th.dataset
       const ids = safeFromJsonString(metrics)
 
       if (collapsible) {
+        const toggleBackendAPI = () => {
+          th.classList.toggle('collapsed')
+          ids.forEach(toggleMetricVisibility)
+        }
+
         const caret = document.createElement('i')
         caret.classList.add('fa', 'fa-caret-down')
 
         const span = th.querySelector('span')
         span.insertBefore(caret, span.firstChild)
-        span.addEventListener('click', () => {
-          th.classList.toggle('collapsed')
-          ids.forEach(id => document.getElementById(`metric_${id}`).classList.toggle('hidden'))
-        })
+        span.addEventListener('click', toggleBackendAPI)
+
+        // First render with all metrics collapsed
+        toggleBackendAPI()
       }
     })
 })

--- a/app/javascript/packs/plans-metrics.js
+++ b/app/javascript/packs/plans-metrics.js
@@ -1,0 +1,20 @@
+import { safeFromJsonString } from 'utilities/json-utils'
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('th.backend_api_metric_title')
+    .forEach(th => {
+      const { collapsible, metrics } = th.dataset
+      const ids = safeFromJsonString(metrics)
+
+      if (collapsible) {
+        const caret = document.createElement('i')
+        caret.classList.add('fa', 'fa-caret-down')
+
+        const span = th.querySelector('span')
+        span.insertBefore(caret, span.firstChild)
+        span.addEventListener('click', () => {
+          ids.forEach(id => document.getElementById(`metric_${id}`).classList.toggle('hidden'))
+        })
+      }
+    })
+})

--- a/app/views/api/metrics/_backend_api.erb
+++ b/app/views/api/metrics/_backend_api.erb
@@ -1,6 +1,8 @@
 <tr>
-  <th colspan="7" class="backend_api_metric_title">
-    <%= backend_api.name %>
+  <th colspan="7" class="backend_api_metric_title"
+                  data-collapsible="<%= backend_api.top_level_metrics.any? %>"
+                  data-metrics="<%= backend_api.top_level_metrics.map &:id %>">
+    <span><%= backend_api.name %></span>
     (<%= link_to 'Define method or metric', provider_admin_backend_api_metrics_path(backend_api), title: 'Define Methods & Metrics for this Backend API' %>)
   </th>
 </tr>

--- a/app/views/api/plans/_metrics.html.erb
+++ b/app/views/api/plans/_metrics.html.erb
@@ -41,8 +41,6 @@
             show only icons and not text.</p>
           <% end %>
         </th>
-        <th class="operations">
-        </th>
       </tr>
     </thead>
 
@@ -88,8 +86,6 @@
             using text only (default) or using icons and text. Disabled methods will
             show only icons and not text.</p>
           <% end %>
-        </th>
-        <th class="operations">
         </th>
       </tr>
     </thead>

--- a/app/views/api/plans/_metrics.html.erb
+++ b/app/views/api/plans/_metrics.html.erb
@@ -6,6 +6,7 @@
       Metrics, Methods & Limits
     <% end %>
   </h2>
+
   <table id="metrics" class="contract_table">
     <thead>
       <tr>
@@ -105,5 +106,6 @@
       <% end -%>
     </tbody>
   </table>
+  <%= javascript_pack_tag 'plans-metrics' %>
   <% end -%>
 </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets table-layout to fixed so that both tables (metrics and backend_api_metrics) look aligned.

**Which issue(s) this PR fixes** 

[THREESCALE-3092: APIAP: Application plan > edit > Methods & Metrics - Fix header style](https://issues.jboss.org/browse/THREESCALE-3092)

**Before**:
<img width="927" alt="Screen Shot 2019-08-26 at 14 04 18" src="https://user-images.githubusercontent.com/11672286/63689595-ae3d6c80-c80a-11e9-87d6-ed58bed822ac.png">

**After**:
<img width="927" alt="Screen Shot 2019-08-26 at 14 03 09" src="https://user-images.githubusercontent.com/11672286/63689610-b5fd1100-c80a-11e9-9af8-cc6433783b2b.png">
