### PR TITLE
New page for Backend APIs

### DIFF
--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -12,7 +12,8 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   end
 
   def new
-    # TODO
+    activate_menu :dashboard
+    @backend_api = collection.build params[:backend_api]
   end
 
   def create
@@ -54,5 +55,9 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
 
   def authorize
     authorize! :manage, BackendApi
+  end
+
+  def collection
+    current_account.backend_apis
   end
 end

--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -17,12 +17,13 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   end
 
   def create
-    backend_api = current_account.backend_apis.build(backend_api_params)
-    if backend_api.save
-      redirect_to provider_admin_backend_api_path(backend_api), notice: 'Backend API created'
+    @backend_api = current_account.backend_apis.build(backend_api_params)
+    if @backend_api.save
+      redirect_to provider_admin_backend_api_path(@backend_api), notice: 'Backend API created'
     else
       flash.now[:error] = 'Backend API could not be created'
-      render :edit
+      activate_menu :dashboard
+      render :new
     end
   end
 

--- a/app/views/provider/admin/backend_apis/new.html.slim
+++ b/app/views/provider/admin/backend_apis/new.html.slim
@@ -1,0 +1,6 @@
+h2 New Backend API
+
+= semantic_form_for @backend_api, url: provider_admin_backend_apis_path do |form|
+  = render partial: 'provider/admin/backend_apis/forms/naming', locals: { form: form }
+  = form.buttons do
+    = form.commit_button

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -20,6 +20,11 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
     end
   end
 
+  test '#new' do
+    get new_provider_admin_backend_api_path
+    assert_response :success
+  end
+
   test '#show' do
     backend_api = @provider.backend_apis.last
     get provider_admin_backend_api_path(backend_api)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the view for creating a new Backend API.

<img width="934" alt="Screen Shot 2019-08-28 at 10 44 27" src="https://user-images.githubusercontent.com/11672286/63840138-d64edc00-c980-11e9-8e60-bf4eb9c7dd35.png">


**Which issue(s) this PR fixes** 

[THREESCALE-3322: APIAP: New page for backend APIs](https://issues.jboss.org/browse/THREESCALE-3322)

**Verification steps** 

1. Go to backend_apis/new
2. Try to create a new one