### PR TITLE
[DO NOT MERGE] Destroy backend apis belonging to the service when it is deleted

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -198,6 +198,7 @@ class Service < ApplicationRecord
 
     before_transition to: [:deleted], do: :deleted_by_state_machine
     after_transition to: [:deleted], do: :notify_deletion
+    after_transition to: [:deleted], do: :destroy_related_backend_apis
   end
 
   def using_proxy_pro?
@@ -515,6 +516,11 @@ class Service < ApplicationRecord
 
   def archive_as_deleted
     ::DeletedObject.create!(object: self, owner: account)
+  end
+
+  def destroy_related_backend_apis
+    return if act_as_product?
+    backend_api&.destroy
   end
 
   def deleted_by_state_machine

--- a/app/workers/destroy_all_deleted_objects_worker.rb
+++ b/app/workers/destroy_all_deleted_objects_worker.rb
@@ -1,7 +1,7 @@
 class DestroyAllDeletedObjectsWorker
   include Sidekiq::Worker
 
-  def perform(class_name)
-    class_name.constantize.deleted.find_each(&DeleteObjectHierarchyWorker.method(:perform_later))
+  def perform(class_name, method = :deleted)
+    class_name.constantize.public_send(method).find_each(&DeleteObjectHierarchyWorker.method(:perform_later))
   end
 end

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -361,9 +361,13 @@ class ServiceTest < ActiveSupport::TestCase
     assert_equal 'published', service_plan.state
   end
 
-  class DestroyingServiceTest < ActiveSupport::TestCase
+  class DestroyServiceTest < ActiveSupport::TestCase
 
     disable_transactional_fixtures!
+
+    def setup
+      Account.any_instance.stubs(:provider_can_use?).returns(true)
+    end
 
     test "destroying service destroys it's plans" do
       service          = FactoryBot.create(:service)
@@ -403,21 +407,6 @@ class ServiceTest < ActiveSupport::TestCase
       event = RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceDeletedEvent).last!
       assert_equal service_id, event.data['service_id']
     end
-  end
-
-  class CreateServiceTest < ActiveSupport::TestCase
-    disable_transactional_fixtures!
-
-    test 'creating service creates a related event' do
-      User.stubs(current: FactoryBot.create(:simple_user))
-      assert_difference(RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceCreatedEvent).method(:count)) do
-        FactoryBot.create(:simple_service)
-      end
-    end
-  end
-
-  class DestroyServiceTest < ActiveSupport::TestCase
-    disable_transactional_fixtures!
 
     test 'archive as deleted' do
       account = FactoryBot.create(:simple_provider)
@@ -430,6 +419,49 @@ class ServiceTest < ActiveSupport::TestCase
       assert_equal 'Service', deleted_object_entry.object_type
       assert_equal account.id, deleted_object_entry.owner_id
       assert_equal 'Account', deleted_object_entry.owner_type
+    end
+
+    test 'marking as deleted should not delete the associates Backend APIs if in rolling update and service acts as product' do
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
+      default_service = FactoryBot.create(:simple_service)
+      account = default_service.account
+      service_to_delete = FactoryBot.create(:simple_service, account: account, act_as_product: true)
+
+      assert_change of: lambda { BackendApi.count }, by: 0 do
+        service_to_delete.mark_as_deleted
+      end
+    end
+
+    test 'marking as deleted should delete the associates Backend APIs if not in rolling update and service acts as product' do
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+      default_service = FactoryBot.create(:simple_service)
+      account = default_service.account
+      service_to_delete = FactoryBot.create(:simple_service, account: account, act_as_product: true)
+
+      assert_change of: lambda { BackendApi.count }, by: -1 do
+        service_to_delete.mark_as_deleted
+      end
+    end
+
+    test 'marking as deleted should delete the associates Backend APIs if the service does not act as product' do
+      default_service = FactoryBot.create(:simple_service)
+      account = default_service.account
+      service_to_delete = FactoryBot.create(:simple_service, account: account, act_as_product: false)
+
+      assert_change of: lambda { BackendApi.count }, by: -1 do
+        service_to_delete.mark_as_deleted
+      end
+    end
+  end
+
+  class CreateServiceTest < ActiveSupport::TestCase
+    disable_transactional_fixtures!
+
+    test 'creating service creates a related event' do
+      User.stubs(current: FactoryBot.create(:simple_user))
+      assert_difference(RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceCreatedEvent).method(:count)) do
+        FactoryBot.create(:simple_service)
+      end
     end
   end
 

--- a/test/workers/destroy_all_deleted_objects_worker_test.rb
+++ b/test/workers/destroy_all_deleted_objects_worker_test.rb
@@ -4,27 +4,44 @@ require 'test_helper'
 
 class DestroyAllDeletedObjectsWorkerTest < ActiveSupport::TestCase
 
-  def test_perform_destroys_message_recipient
-    message = FactoryBot.create(:received_message, deleted_at: DateTime.yesterday)
-    Sidekiq::Testing.inline! do
-      assert_difference(MessageRecipient.method(:count), -1) do
-        DestroyAllDeletedObjectsWorker.perform_async('MessageRecipient')
+  class DestroyingService < DestroyAllDeletedObjectsWorkerTest
+    test 'perform destroys message recipient' do
+      message = FactoryBot.create(:received_message, deleted_at: DateTime.yesterday)
+      Sidekiq::Testing.inline! do
+        assert_difference(MessageRecipient.method(:count), -1) do
+          DestroyAllDeletedObjectsWorker.perform_async('MessageRecipient')
+        end
+        assert_raise(ActiveRecord::RecordNotFound) { message.reload }
       end
-      assert_raise(ActiveRecord::RecordNotFound) { message.reload }
+    end
+
+    test 'perform enqueues delete object hierarchy worker jobs' do
+      provider = FactoryBot.create(:simple_provider)
+      services = FactoryBot.create_list(:simple_service, 2, account: provider)
+      services.first.mark_as_deleted!
+
+      DeleteObjectHierarchyWorker.expects(:perform_later).once.with do |object, _hierarchy|
+        object.id == services.first.id
+      end
+
+      Sidekiq::Testing.inline! do
+        DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
+      end
     end
   end
 
-  def test_perform_enqueues_delete_object_hierarchy_worker_jobs
-    provider = FactoryBot.create(:simple_provider)
-    services = FactoryBot.create_list(:simple_service, 2, account: provider)
-    services.first.mark_as_deleted!
+  class DestroyingBackendApi < DestroyAllDeletedObjectsWorkerTest
+    test 'perform destroys all oprhans backend apis' do
+      backend_api = FactoryBot.create(:backend_api_config).backend_api
+      orphan_backend_api = FactoryBot.create(:backend_api_config).backend_api
+      orphan_backend_api.services.destroy_all
 
-    DeleteObjectHierarchyWorker.expects(:perform_later).once.with do |object, _hierarchy|
-      object.id == services.first.id
-    end
-
-    Sidekiq::Testing.inline! do
-      DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
+      Sidekiq::Testing.inline! do
+        assert_difference(BackendApi.method(:count), -1) do
+          DestroyAllDeletedObjectsWorker.perform_async('BackendApi', :orphans)
+        end
+        assert_raise(ActiveRecord::RecordNotFound) { orphan_backend_api.reload }
+      end
     end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we have some orphans backend apis in the database caused
by deleting a service. This generates some problems for some
clients when they tries to recreate the service with the same name
and it fails because an already existent backend api with the same
name already exists. This commit changes this behave to delete
all related backend apis when deleting a service when the client
is in the rolling update.

This also adds a rake task to clear orphans backend apis.


**Which issue(s) this PR fixes** 

[THREESCALE-3317](https://issues.jboss.org/browse/THREESCALE-3317)

**Verification steps** 

1. Create a service.
2. It will create a service and a backend api belonging to it.
3. Destroy the service.
4. It should also destroy the backend api related to it.
5. Try to create a service with the same name.
6. It should create with success.

:warning: Blocked by [ [THREESCALE-3343](https://issues.jboss.org/browse/THREESCALE-3343) | [#1144](https://github.com/3scale/porta/pull/1144) ]