### PR TITLE
Fixes index view '/backend_apis'

### DIFF
--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -8,6 +8,7 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   layout 'provider'
 
   def index
+    activate_menu :dashboard
     @backend_apis = current_account.backend_apis
   end
 


### PR DESCRIPTION
Removes the empty vertical navigation showing up in `/backend_apis`.
Also fixes Context Selector `backend: undefined`.

**Before**:
<img width="934" alt="Screen Shot 2019-08-28 at 12 19 49" src="https://user-images.githubusercontent.com/11672286/63847668-8ecf4c80-c98e-11e9-95ff-8d83c36b1954.png">

**After**:
<img width="934" alt="Screen Shot 2019-08-28 at 12 19 36" src="https://user-images.githubusercontent.com/11672286/63847676-955dc400-c98e-11e9-854f-9423f3038db4.png">
