### PR TITLE
Fixes styles for "Metrics" tables

### DIFF
--- a/app/assets/stylesheets/provider/_metrics.scss
+++ b/app/assets/stylesheets/provider/_metrics.scss
@@ -2,28 +2,6 @@
   margin-top: line-height-times(2);
 }
 
-table#metrics,
-table#backend_api_metrics {
-  table-layout: fixed;
-
-  thead {
-    th {
-      width: 70%;
-    }
-    th + th {
-      width: 10%;
-    }
-  }
-
-  tbody {
-    tr {
-      &.hidden {
-        display: none;
-      }
-    }
-  }
-}
-
 th.collapsible {
   span {
     cursor: pointer;
@@ -44,7 +22,48 @@ table.contract_table {
 	width: 100%;
 	margin-bottom: line-height-times(1/2);
 	border-collapse: collapse;
-	border-spacing: 0;
+  border-spacing: 0;
+
+  &#features {
+    table-layout: fixed;
+
+    thead {
+      th:first-child,
+      th:nth-child(2) {
+        width: 35%;
+      }
+
+      th:nth-child(3) {
+        width: 10%;
+      }
+
+      th:last-child {
+        width: 20%;
+      }
+    }
+  }
+  
+  &#metrics,
+  &#backend_api_metrics {
+    table-layout: fixed;
+
+    thead {
+      th {
+        width: 70%;
+      }
+      th + th {
+        width: 10%;
+      }
+    }
+
+    tbody {
+      tr {
+        &.hidden {
+          display: none;
+        }
+      }
+    }
+  }
 
   tr {
     border-bottom: $border-width solid $border-color;
@@ -63,7 +82,6 @@ table.contract_table {
     background: $light-background-color;
     padding: line-height-times(1/8);
   }
-
 
   table.usage_table {
     th, td {


### PR DESCRIPTION
Some styles introduced in #1121 affects other tables. This PR makes those more accurate.
**Before** (Methods & Metrics):
<img width="836" alt="Screen Shot 2019-08-28 at 12 44 07" src="https://user-images.githubusercontent.com/11672286/63849268-06eb4180-c992-11e9-9eca-1b75d4451f9c.png">

**After** (Methods & Metrics):
<img width="836" alt="Screen Shot 2019-08-28 at 12 43 12" src="https://user-images.githubusercontent.com/11672286/63849302-18344e00-c992-11e9-8892-90172880b3a2.png">

It also aligns `enable` column between tables at Application Plan's page:

**Before** (app plan page):
<img width="851" alt="Screen Shot 2019-08-28 at 12 45 14" src="https://user-images.githubusercontent.com/11672286/63849421-56ca0880-c992-11e9-89d3-8a27b4ad9555.png">


**After** (app plan page):
<img width="851" alt="Screen Shot 2019-08-28 at 12 44 39" src="https://user-images.githubusercontent.com/11672286/63849426-5af62600-c992-11e9-9f01-f6d973418d06.png">

