### PR TITLE
Implements basic deletion of Backend APIs

### DIFF
--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -42,7 +42,12 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   end
 
   def destroy
-    # TODO
+    if @backend_api.services.empty? && @backend_api.destroy
+      redirect_to provider_admin_dashboard_path, notice: 'Backend API deleted'
+    else
+      flash[:error] = 'Backend API could not be deleted'
+      render :edit
+    end
   end
 
   protected

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -53,4 +53,23 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
     assert_response :redirect
     assert_equal 'https://new-endpoint.com:443/p', backend_api.reload.private_endpoint
   end
+
+  test 'delete a backend api with products' do
+    backend_api = @provider.backend_apis[0]
+    assert backend_api.backend_api_configs.any?
+
+    delete provider_admin_backend_api_path(backend_api)
+    assert BackendApi.exists? backend_api.id
+    assert_equal 'Backend API could not be deleted', flash[:error]
+  end
+  
+  test 'delete a backend api without any products' do
+    backend_api = @provider.backend_apis[1]
+    assert_not backend_api.backend_api_configs.any?
+    
+    delete provider_admin_backend_api_path(backend_api)
+    assert_redirected_to provider_admin_dashboard_path
+    assert_not BackendApi.exists? backend_api.id
+    assert_equal 'Backend API deleted', flash[:notice]
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements `destroy` method of Backend APIs. It checks whether the backend is used by any product: if so, it can't be destroyed; otherwise it is destroyed and user is redirected to the Dashboard.

**Which issue(s) this PR fixes** 

[THREESCALE-3342: Implement basic deletion for Backend API](https://issues.jboss.org/browse/THREESCALE-3342)

**Verification steps** 

1. Go to a Backend API and click on 'edit'
2. At the bottom there's the delete button, confirm the alert and
    * if backend is used by any product: it redirects to edit page and shows an error message
    * if backend is **not** used by any product: it redirects to dashboard and backend is deleted

**TODO**:

- [x] Fix tests