### PR TITLE
List products used by backend and disable delete link

### DIFF
--- a/app/assets/stylesheets/provider/_commons.scss
+++ b/app/assets/stylesheets/provider/_commons.scss
@@ -74,6 +74,12 @@ ul, p, ol, dl {
   padding: 0;
 }
 
+p + ul {
+  list-style: none;
+  margin-top: line-height-times(-2/3);
+  padding-left: line-height-times(2/3);
+}
+
 %dl {
   padding: 0;
   margin-top: line-height-times(1/2);

--- a/app/views/provider/admin/backend_apis/forms/_delete.html.slim
+++ b/app/views/provider/admin/backend_apis/forms/_delete.html.slim
@@ -6,7 +6,7 @@
   p
     ' Deleting this backend API will
     strong> irreversibly
-    ' destroy all methods & metrics and mapping rules of this backend API and remove it from all products currently using the backend API.
+    ' destroy all methods & metrics and mapping rules of this backend API.
     ' It will also delete in the the application plans all limits and pricing rules set on methods & metrics of this backend API.
 
   p
@@ -14,8 +14,18 @@
     ' Proxy configurations of products using this backend API (staging and production) will not update automatically after deleting the backend API.
     ' You need to perform this action on each product using the backend, manually via UI or 3scale API.
 
-  p
-    - msg = t('api.backend_apis.edit.delete_confirmation', name: h(backend_api.name))
-    - delete_options = { data: { confirm: msg }, method: :delete, label: "I understand the consequences, proceed to delete '#{h(backend_api.name)}' backend" }
-    = delete_link_for(provider_admin_backend_api_path(backend_api), delete_options)
+  - if backend_api.backend_api_configs.any?
+    p The following products are using this backend API:
+    ul
+      - for service in backend_api.services
+        li = link_to service.name, admin_service_path(service)
+
+    p
+      ' Before deleting this backend API, make sure none of the products above is using it.
+
+  - else
+    p
+      - msg = t('api.backend_apis.edit.delete_confirmation', name: h(backend_api.name))
+      - delete_options = { data: { confirm: msg }, method: :delete, label: "I understand the consequences, proceed to delete '#{h(backend_api.name)}' backend" }
+      = delete_link_for(provider_admin_backend_api_path(backend_api), delete_options)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* List the list of products used by backend
* If there's any, disable the delete link

<img width="918" alt="Screen Shot 2019-08-29 at 15 55 52" src="https://user-images.githubusercontent.com/11672286/63946520-8f8ede00-ca75-11e9-9721-85080ecb5c6f.png">

<img width="918" alt="Screen Shot 2019-08-29 at 15 56 12" src="https://user-images.githubusercontent.com/11672286/63946527-9158a180-ca75-11e9-839c-afd9b399b439.png">

**Which issue(s) this PR fixes** 

[THREESCALE-3344: Provide Feedback when there are Products used by a Backend](https://issues.jboss.org/browse/THREESCALE-3344)

**Verification steps** 

Go to a Backend API edit page and try to delete it.
