### PR TITLE
Make independent mapping rules always enabled when APIAP is on

### DIFF
--- a/app/controllers/api/proxy_rules_controller.rb
+++ b/app/controllers/api/proxy_rules_controller.rb
@@ -44,7 +44,7 @@ class Api::ProxyRulesController < Api::BaseController
   private
 
   def authorize!
-    provider_can_use!(:independent_mapping_rules)
+    current_account.independent_mapping_rules_enabled? || raise(CanCan::AccessDenied)
   end
 
   def proxy

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -240,7 +240,7 @@ module VerticalNavHelper
     items = []
     items << {id: :configuration,   title: 'Configuration',     path: path_to_service(@service)}
     items << {id: :methods_metrics, title: 'Methods & Metrics', path: admin_service_metrics_path(@service)}
-    items << {id: :mapping_rules,   title: 'Mapping Rules',     path: admin_service_proxy_rules_path(@service)} if provider_can_use?(:independent_mapping_rules)
+    items << {id: :mapping_rules,   title: 'Mapping Rules',     path: admin_service_proxy_rules_path(@service)} if current_account.independent_mapping_rules_enabled?
     items << {id: :settings,        title: 'Settings',          path: settings_admin_service_path(@service)}
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -560,6 +560,10 @@ class Account < ApplicationRecord
     end
   end
 
+  def independent_mapping_rules_enabled?
+    provider_can_use?(:api_as_product) || provider_can_use?(:independent_mapping_rules)
+  end
+
   private
 
   def validate_timezone

--- a/app/views/api/integrations/apicast/shared/_mapping_rules.html.slim
+++ b/app/views/api/integrations/apicast/shared/_mapping_rules.html.slim
@@ -1,4 +1,4 @@
-- if current_account.provider_can_use?(:independent_mapping_rules)
+- if current_account.independent_mapping_rules_enabled?
   fieldset.inputs.independent_mapping_rules
     legend
       span

--- a/app/views/shared/provider/navigation/service/_integration.html.slim
+++ b/app/views/shared/provider/navigation/service/_integration.html.slim
@@ -7,7 +7,7 @@
          title: 'Methods & Metrics',
          path: admin_service_metrics_path(@service)
 
-- if current_account.provider_can_use?(:independent_mapping_rules)
+- if current_account.independent_mapping_rules_enabled?
   = render vertical_nav_item,
            title: 'Mapping Rules',
            path: admin_service_proxy_rules_path(@service)

--- a/features/old/menu/api_menu.feature
+++ b/features/old/menu/api_menu.feature
@@ -36,7 +36,9 @@ Feature: API menu
     | Listing                   |
     | Application Plans         |
 
-  Scenario: Integration sub menu structure
+  Scenario: Integration sub menu structure provider has api as product enabled
+    Given the account has Service acting as Product
+    When I follow "Overview"
     When I follow "Integration" within the main menu
     Then I should see menu items
     | Configuration             |
@@ -44,8 +46,7 @@ Feature: API menu
     | Mapping Rules             |
     | Settings                  |
 
-  Scenario: Integration sub menu structure without independent mapping rules
-    Given I have independent_mapping_rules feature disabled
+  Scenario: Integration sub menu structure when provider does not have api as product enabled
     When I follow "Overview"
     And I follow "Integration" within the main menu
     Then I should see menu items
@@ -61,16 +62,6 @@ Feature: API menu
     | Configuration             |
     | Methods & Metrics         |
     | Mapping Rules             |
-    | Settings                  |
-
-  Scenario: Integration sub menu structure for API as Product without independent mapping rules
-    Given the account has Service acting as Product
-    And I have independent_mapping_rules feature disabled
-    When I follow "Overview"
-    And I follow "Integration" within the main menu
-    Then I should see menu items
-    | Configuration             |
-    | Methods & Metrics         |
     | Settings                  |
 
   Scenario: API menu structure with service plans enabled

--- a/test/integration/api/proxy_rules_controller_test.rb
+++ b/test/integration/api/proxy_rules_controller_test.rb
@@ -4,17 +4,15 @@ require 'test_helper'
 
 class Api::ProxyRulesControllerTest < ActionDispatch::IntegrationTest
   def setup
-    Logic::RollingUpdates.stubs(enabled?: true)
-    Account.any_instance.stubs(:provider_can_use?).returns(true)
     @provider = FactoryBot.create(:provider_account)
-    @service  = FactoryBot.create(:service, account: @provider)
     login_provider @provider
   end
 
-  class WithFeatureEnabled < Api::ProxyRulesControllerTest
+  class WhenIndependentMappingRulesIsEnabled < Api::ProxyRulesControllerTest
     def setup
       super
-      Account.any_instance.stubs(:provider_can_use?).with(:independent_mapping_rules).returns(true).at_least_once
+      Account.any_instance.stubs(:independent_mapping_rules_enabled?).returns(true)
+      @service = FactoryBot.create(:service, account: @provider)
     end
 
     test 'index page list all proxy rules' do
@@ -61,22 +59,23 @@ class Api::ProxyRulesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  class WithFeatureDisabled < Api::ProxyRulesControllerTest
+  class WhenIndependentMappingRulesIsDisabled < Api::ProxyRulesControllerTest
     def setup
       super
-      Account.any_instance.stubs(:provider_can_use?).with(:independent_mapping_rules).returns(false).at_least_once
+      Account.any_instance.stubs(:independent_mapping_rules_enabled?).returns(false)
+      @service = FactoryBot.create(:service, account: @provider)
     end
 
     test 'cannot access index page' do
       get admin_service_proxy_rules_path(@service)
 
-      assert_response :not_found
+      assert_response :forbidden
     end
 
     test 'cannot access new page' do
       get new_admin_service_proxy_rule_path(@service)
 
-      assert_response :not_found
+      assert_response :forbidden
     end
 
     test 'cannot access edit page' do
@@ -84,13 +83,13 @@ class Api::ProxyRulesControllerTest < ActionDispatch::IntegrationTest
 
       get edit_admin_service_proxy_rule_path(@service, proxy_rule)
 
-      assert_response :not_found
+      assert_response :forbidden
     end
 
     test 'cannot create a proxy rule' do
       post admin_service_proxy_rules_path(@service), proxy_rule: FactoryBot.attributes_for(:proxy_rule, proxy: @service.proxy)
 
-      assert_response :not_found
+      assert_response :forbidden
     end
 
     test 'cannot update a proxy rule' do
@@ -98,7 +97,7 @@ class Api::ProxyRulesControllerTest < ActionDispatch::IntegrationTest
 
       patch admin_service_proxy_rule_path(@service, proxy_rule), proxy_rule: { pattern: '/testing' }
 
-      assert_response :not_found
+      assert_response :forbidden
     end
 
     test 'cannot delete a proxy rule' do
@@ -106,7 +105,7 @@ class Api::ProxyRulesControllerTest < ActionDispatch::IntegrationTest
 
       delete admin_service_proxy_rule_path(@service, proxy_rule)
 
-      assert_response :not_found
+      assert_response :forbidden
     end
   end
 end

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -316,7 +316,7 @@ class ServiceTest < ActiveSupport::TestCase
     service.account.settings.service_plans_ui_visible = true
 
     service.save!
-    
+
     service_plan = service.service_plans.first!
     assert_equal 'hidden', service_plan.state
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to make independent_mapping_rules always enabled for
services acting as product.

**Which issue(s) this PR fixes** 

[THREESCALE-3341](https://issues.jboss.org/browse/THREESCALE-3341)

Depends on https://github.com/3scale/porta/pull/1156