### PR TITLE
Stop using service_prefix column from Account

### DIFF
--- a/app/lib/backend/model_extensions/service.rb
+++ b/app/lib/backend/model_extensions/service.rb
@@ -8,7 +8,7 @@ module Backend
       end
 
       def backend_id
-        preffix_key
+        prefix_key
       end
 
       def update_backend_service

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -6,7 +6,7 @@ class Account < ApplicationRecord
   # Hack to remove all the attributes with names matching the regex from @attributes
   # It is enough for rails not persisting them in actual columns.
   def self.columns
-    super.reject {|column| /\Apayment_gateway_(type|options)|deleted_at|first_admin_id\Z/ =~ column.name }
+    super.reject {|column| /\Apayment_gateway_(type|options)|deleted_at|service_preffix|first_admin_id\Z/ =~ column.name }
   end
 
   # need to reset column information to clear column_names and such
@@ -87,11 +87,9 @@ class Account < ApplicationRecord
   before_validation(on: :create, if: :provider?) { generate_domains }
   before_create :generate_site_access_code
 
-  attr_protected :master, :provider, :buyer, :from_email, :vat_rate, :sample_data,
-                 :default_service_id, :provider_account_id, :service_preffix, :s3_prefix,
-                 :paid_at, :paid, :signs_legal_terms, :tenant_id,
-                 :default_account_plan_id, :default_service_id,
-                 :domain, :subdomain, :self_subdomain, :self_domain, :audit_ids, :partner,
+  attr_protected :master, :provider, :buyer, :from_email, :vat_rate, :sample_data, :default_service_id, :s3_prefix,
+                 :provider_account_id, :paid_at, :paid, :signs_legal_terms, :tenant_id, :default_account_plan_id,
+                 :default_service_id, :domain, :subdomain, :self_subdomain, :self_domain,:audit_ids, :partner,
                  :hosted_proxy_deployed_at
 
   belongs_to :partner
@@ -254,9 +252,8 @@ class Account < ApplicationRecord
             :billing_address_name, :billing_address_address1, :billing_address_address2, :billing_address_city,
             :billing_address_state, :billing_address_country, :billing_address_zip, :billing_address_phone,
             :org_legaladdress_cont, :city, :state_region, :state, :timezone, :from_email, :primary_business,
-            :business_category, :zip, :self_domain,
-            :service_preffix, :s3_prefix, :proxy_configs_file_name, :support_email, :finance_support_email,
-            :billing_address_first_name, :billing_address_last_name, :proxy_configs_conf_file_name,
+            :business_category, :zip, :self_domain, :s3_prefix, :proxy_configs_file_name, :support_email,
+            :finance_support_email, :billing_address_first_name, :billing_address_last_name, :proxy_configs_conf_file_name,
             :proxy_configs_conf_content_type, :po_number, :vat_code, :fiscal_code, :proxy_configs_content_type,
             length: { maximum: 255 }
 

--- a/app/models/backend/transaction.rb
+++ b/app/models/backend/transaction.rb
@@ -134,7 +134,7 @@ module Backend
     end
 
     def self.storage_key(service_id, id)
-      ::Service.find(service_id).preffix_key "transactions/#{id}"
+      ::Service.find(service_id).prefix_key "transactions/#{id}"
     end
 
     def to_param
@@ -163,7 +163,7 @@ module Backend
     end
 
     def generate_id
-      storage.incr(Service.find(@service_id).preffix_key('transactions/counter'))
+      storage.incr(Service.find(@service_id).prefix_key('transactions/counter'))
     end
 
     def cinstance_data

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -517,7 +517,7 @@ class Cinstance < Contract
 
   def generate_key
     #FIXME: service is not accessible here yet
-    plan.issuer.preffix_key(SecureRandom.hex(16))
+    plan.issuer.prefix_key(SecureRandom.hex(16))
   end
 
   def end_users_switch

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -204,13 +204,6 @@ class Service < ApplicationRecord
     provider_can_use?(:proxy_pro) && proxy.self_managed?
   end
 
-  def preffix
-    @service_preffix ||= (provider&.service_preffix || '')
-  end
-
-  # by GrammarNazi
-  alias prefix preffix
-
   def publish_events
     OIDC::ServiceChangedEvent.create_and_publish!(self)
     OIDC::ProxyChangedEvent.create_and_publish!(proxy)
@@ -261,8 +254,8 @@ class Service < ApplicationRecord
     BackendVersion.new(super)
   end
 
-  def preffix_key(key = id)
-    [preffix.presence, key].compact.join
+  def prefix_key(key = id)
+    key.to_s
   end
 
   def published_plans


### PR DESCRIPTION


**What this PR does / why we need it**:

At first we thought that we needed this for the backend_id of a
Service, but if we are not using the service_prefix as it seems
from the SaaS DB, then the backend_id of the service by default
is just its id.

**Which issue(s) this PR fixes** 

[THREESCALE-2025](https://issues.jboss.org/browse/THREESCALE-2025)