### PR TITLE
Fixing broken alignment text in Product overview page

### DIFF
--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -99,6 +99,8 @@ section class="service-widget"
             '  published) with a total of
             = pluralize service.contracts.service.size, 'contract'
             | .
+          
+      = render 'shared/service_access'
 
     section[name="activity"]
 
@@ -169,8 +171,6 @@ section class="service-widget"
               ul
                 - service.backend_apis.each do |backend_api|
                   li = link_to backend_api.name, provider_admin_backend_api_path(backend_api)
-
-= render 'shared/service_access'
 
 javascript:
   document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes text alignment issue in Product overview page

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3354

Go to **Your Product > Overview**

**Before:**

> ![before](https://user-images.githubusercontent.com/13486237/64016728-04baeb80-cb28-11e9-9df9-157908936047.png)

**After:**

> ![after](https://user-images.githubusercontent.com/13486237/64016733-097f9f80-cb28-11e9-8071-055be93e24d7.png)
