### PR TITLE
[Apicast::ProxySource] inject backend API proxy rules

### DIFF
--- a/app/decorators/proxy_rule_decorator.rb
+++ b/app/decorators/proxy_rule_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ProxyRuleDecorator < ApplicationDecorator
+
+  self.include_root_in_json = false
+
+  def pattern
+    pattern_value = super
+    backend_api_path ? File.join('/', backend_api_path, pattern_value) : pattern_value
+  end
+
+  private
+
+  def backend_api_path
+    context[:backend_api_path]
+  end
+end

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -103,6 +103,7 @@ class Proxy < ApplicationRecord
 
   delegate :account, to: :service, allow_nil: true
   delegate :provider_can_use?, to: :account, allow_nil: true
+  delegate :backend_apis, :backend_api_configs, to: :service
 
   # This smells of :reek:NilCheck
   def authentication_method

--- a/app/services/apicast_v2_deployment_service.rb
+++ b/app/services/apicast_v2_deployment_service.rb
@@ -1,20 +1,27 @@
 class ApicastV2DeploymentService
-  attr_reader :proxy, :source
+  attr_reader :proxy
 
   def initialize(proxy)
     @proxy = proxy
-    @source = Apicast::ProxySource.new(proxy)
   end
 
   def call(environment:, user: User.current)
     default_params = { proxy: proxy, user: user, environment: environment }
     latest_config  = ProxyConfig.where(default_params).newest_first.first
-    new_config     = ProxyConfig.new(default_params.merge(content: source.to_json))
+    new_config     = ProxyConfig.new(default_params.merge(content: json_source))
 
     if new_config.differs_from?(latest_config)
       new_config.save && new_config
     else
       latest_config
     end
+  end
+
+  private
+
+  def json_source
+    proxy_source = Apicast::ProxySource.new(proxy).to_hash
+    proxy_source['proxy']['proxy_rules'] = Apicast::ProxyRulesSource.new(proxy).to_hash
+    proxy_source.to_json
   end
 end

--- a/lib/apicast/proxy_rules_source.rb
+++ b/lib/apicast/proxy_rules_source.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Apicast
+  class ProxyRulesSource
+    attr_reader :proxy
+
+    delegate :backend_api_configs, to: :proxy
+
+    def initialize(proxy)
+      @proxy = proxy
+    end
+
+    def to_hash
+      api_proxy_rules = proxy.proxy_rules
+
+      api_proxy_rules += backend_api_configs.flat_map do |config|
+        config.backend_api.proxy_rules.decorate(context: { backend_api_path: config.path })
+      end
+
+      api_proxy_rules.as_json(root: false)
+    end
+  end
+end

--- a/lib/apicast/proxy_source.rb
+++ b/lib/apicast/proxy_source.rb
@@ -18,9 +18,5 @@ module Apicast
     def to_hash
       service.as_json(Apicast::ProviderSource::SERVICE_SERIALIZE_OPTIONS.merge(root: false))
     end
-
-    def to_json
-      to_hash.to_json
-    end
   end
 end

--- a/test/unit/apicast/proxy_rules_source_test.rb
+++ b/test/unit/apicast/proxy_rules_source_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class Apicast::ProxyRulesSourceTest < ActiveSupport::TestCase
+
+  def test_to_hash
+    proxy = FactoryBot.create(:proxy)
+    rule_1 = FactoryBot.create(:proxy_rule, proxy: proxy, last: true)
+    rule_2 = FactoryBot.create(:proxy_rule, proxy: proxy)
+
+    backend_api_config = FactoryBot.create(:backend_api_config, service: proxy.service, path: '/test/path/')
+    rule_3 = FactoryBot.create(:proxy_rule, owner: backend_api_config.backend_api, pattern: '/create')
+
+    source = Apicast::ProxyRulesSource.new(proxy).to_hash
+    assert find_by_id_in_hash(rule_1.id, source)
+    assert find_by_id_in_hash(rule_2.id, source)
+    rule_hash_3 = find_by_id_in_hash(rule_3.id, source)
+    assert rule_hash_3
+    assert_equal '/test/path/create', rule_hash_3['pattern']
+  end
+
+  private
+
+  def find_by_id_in_hash(id, hash)
+    hash.find { |object| object['id'] == id }
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

It allows overriding from Product level the Proxy Rules defined in Backend API

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3325

