### PR TITLE
Remove white spaces when filtering backends in Safari

### DIFF
--- a/app/assets/stylesheets/provider/admin/_dashboard.scss
+++ b/app/assets/stylesheets/provider/admin/_dashboard.scss
@@ -16,12 +16,8 @@
   &--services {
     margin-top: line-height-times(1.4);
 
-    section.hidden {
+    .hidden {
       display: none;
-    }
-
-    tr.hidden {
-      visibility: collapse;
     }
   }
 

--- a/app/assets/stylesheets/provider/admin/_dashboard.scss
+++ b/app/assets/stylesheets/provider/admin/_dashboard.scss
@@ -19,6 +19,18 @@
     .hidden {
       display: none;
     }
+
+    #backends > table {
+      table-layout: fixed;
+
+      th {
+        text-align: left;
+
+        &:first-child {
+          width: 60%;
+        }
+      }
+    }
   }
 
   &-title {

--- a/app/javascript/src/Dashboard/components/ApiFilter.jsx
+++ b/app/javascript/src/Dashboard/components/ApiFilter.jsx
@@ -33,7 +33,12 @@ const ApiFilter = ({ apis, domClass, placeholder = 'All APIs' }: Props) => {
 
       const el = document.getElementById(`${domClass}_${id}`)
       if (el) {
-        el.classList.toggle('hidden', !isFilteredApi)
+        // Toggle method second argument not supported in IE11
+        if (isFilteredApi) {
+          el.classList.remove('hidden')
+        } else {
+          el.classList.add('hidden')
+        }
       }
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

* Removes white space from backends table when filtering in Safari
* Fixes name column width so that table doesn't change size when filtering

**Which issue(s) this PR fixes** 

[THREESCALE-3358: filtering backends should remove white space](https://issues.jboss.org/browse/THREESCALE-3358)

**Verification steps** 

1. Go to dashboard > Backends tab
2. Filter Backends. Make sure there are some with big names.

Verified in:

- [x] Safari
- [x] Chrome
- [x] Firefox
- [x] IE11