### PR TITLE
Fix ApplicationControllerTest: modern browser test do requests before asserting

### DIFF
--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -15,6 +15,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     login! provider
 
     ApplicationController.any_instance.stubs(:browser_not_modern?).returns(false)
+    get admin_buyers_accounts_path
     assert_response :success
     assert flash[:error].blank?
 


### PR DESCRIPTION
I have the perception that the tests in https://github.com/3scale/porta/pull/1123/files#diff-5d113ecd6dff22e5dfd32ef384f7dd74R13 are lacking this request.