### PR TITLE
[Refactor] InviteeSignups redirect if logged in flash message using i18n

### DIFF
--- a/app/controllers/provider/invitee_signups_controller.rb
+++ b/app/controllers/provider/invitee_signups_controller.rb
@@ -36,10 +36,7 @@ class Provider::InviteeSignupsController < FrontendController
   end
 
   def redirect_if_logged_in
-    if logged_in?
-      flash[:notice] = 'You are already signed up. Log out if you want to sign up again.'
-      redirect_to provider_admin_dashboard_url
-    end
+    redirect_to provider_admin_dashboard_url, notice: I18n.t('flash.signups.already_logged_in') if logged_in?
   end
 
   def find_invitation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1130,6 +1130,7 @@ en:
     signups:
       create:
         notice: "Thanks for signing up! You can now sign in."
+      already_logged_in: 'You are already signed up. Log out if you want to sign up again.'
 
   proxy:
     credentials_location:

--- a/test/integration/provider/invitee_signups_controller_test.rb
+++ b/test/integration/provider/invitee_signups_controller_test.rb
@@ -56,7 +56,7 @@ class Provider::InviteeSignupsControllerTest < ActionDispatch::IntegrationTest
 
     get provider_invitee_signup_path(invitation_token: 'abc123')
 
-    assert_equal 'You are already signed up. Log out if you want to sign up again.', flash[:notice] # TODO: i18n, after the 2.6 ER1
+    assert_equal I18n.t('flash.signups.already_logged_in'), flash[:notice]
     assert_redirected_to provider_admin_dashboard_url
   end
 


### PR DESCRIPTION
It was a small pending _TODO_ since https://github.com/3scale/porta/commit/d38138949dd374823d51117a11f43ef02e4cf65a#diff-31f104d42ede0161621ab77154eaf31bR59