### PR TITLE
Ignore hidden elements in Capybara to avoid false positives

### DIFF
--- a/features/old/accounts/buyers/personal_details.feature
+++ b/features/old/accounts/buyers/personal_details.feature
@@ -39,8 +39,6 @@ Feature: Personal Details
     And I follow "Settings"
     Then I should not see "Personal Details"
 
-
-  @javascript
   Scenario: User Fields
     Given provider "foo.example.com" has the following fields defined for "User":
       | name                 | required | read_only | hidden |

--- a/features/old/proxy.feature
+++ b/features/old/proxy.feature
@@ -66,15 +66,14 @@ Feature: Proxy integration
     Given I'm using a custom API Backend
     Then I should be able to switch back to using the default API Backend
 
-
-  @javascript
+  @javascript @selenium
   Scenario: Got some fancy policy chain
     And I go to the integration show page for service "one"
     And I press "Start using the latest APIcast"
     When I have policies feature enabled
     And I go to the integration page for service "one"
+    And I toggle "Policies"
     Then I should see the Policy Chain
-
 
   Scenario: Got error message when APIcast registry is not setup properly
     And apicast registry is undefined
@@ -96,6 +95,6 @@ Feature: Proxy integration
     And I save the proxy config
     Then the mapping rules should be in the following order:
       | http_method | pattern | delta | metric |
-      | PUT         | /mixers | 1     | hits   |
-      | GET         | /       | 1     | hits   |
       | POST        | /beers  | 2     | hits   |
+      | GET         | /       | 1     | hits   |
+      | PUT         | /mixers | 1     | hits   |

--- a/features/step_definitions/applications/keys_steps.rb
+++ b/features/step_definitions/applications/keys_steps.rb
@@ -98,7 +98,7 @@ Then /^I should see all keys of the application of (buyer "[^"]*")$/ do |buyer|
 end
 
 def limit_warning
-  find("#app-keys-limit-warning")
+  find("#app-keys-limit-warning", visible: :any)
 end
 
 Then /^I should see application keys limit reached error$/ do

--- a/features/step_definitions/buyer_steps.rb
+++ b/features/step_definitions/buyer_steps.rb
@@ -214,7 +214,7 @@ Given('the provider has a buyer') do
     click_on 'Sign in'
   end
 
-  page.should have_content('Signed in successfully')
+  page.should have_content(/Signed in successfully/i)
 
   @buyer = @provider.buyers.last!
 end

--- a/features/step_definitions/buyers_management/user_steps.rb
+++ b/features/step_definitions/buyers_management/user_steps.rb
@@ -19,13 +19,13 @@ Then /^I should see button to delete buyer (user "[^"]*")$/ do |user|
 end
 
 Then /^I should not see button to delete buyer (user "[^"]*")$/ do |user|
-  user_rm_form = "//form[@action='#{admin_buyers_account_user_path(user.account, user)}'][@method='post']//input[@name='_method'][@value='delete']"
-  assert has_no_xpath?(user_rm_form)
+  user_rm_form = "//form[@action='#{admin_buyers_account_user_path(user.account, user)}'][@method='post']//input[@name='_method'][@value='delete'][@type='hidden']"
+  assert has_no_xpath?(user_rm_form, visible: true)
 end
 
 Then /^I should see button to delete (user "[^"]*")$/ do |user|
-  user_rm_form = "//form[@action='#{provider_admin_account_user_path(user)}'][@method='post']//input[@name='_method'][@value='delete']"
-  assert has_xpath?(user_rm_form)
+  user_rm_form = "//form[@action='#{provider_admin_account_user_path(user)}'][@method='post']//input[@name='_method'][@value='delete'][@type='hidden']"
+  assert has_xpath?(user_rm_form, visible: :hidden)
 end
 
 Then /^I should not see button to delete (user "[^"]*")$/ do |user|

--- a/features/step_definitions/capcha_steps.rb
+++ b/features/step_definitions/capcha_steps.rb
@@ -7,7 +7,7 @@ Then /^I should not see the captcha$/ do
 end
 
 Then /^I should see the captcha$/ do
-  page.should have_selector(RECAPTCHA_SCRIPT)
+  page.should have_selector(RECAPTCHA_SCRIPT, visible: false)
 end
 
 When /^I leave the captcha empty$/ do

--- a/features/step_definitions/cms/email_template_steps.rb
+++ b/features/step_definitions/cms/email_template_steps.rb
@@ -27,6 +27,5 @@ Then /^I should see default content of email template "(.+?)"$/ do |name|
   t = CMS::EmailTemplate.dup.extend(CMS::EmailTemplate::ProviderAssociationExtension)
 
   content = t.find_default_by_name(name).published
-
-  page.find :xpath, XPath.descendant(:textarea)[XPath.text.is(content)]
+  page.find :xpath, XPath.descendant(:textarea)[XPath.text.is(content)], visible: :hidden
 end

--- a/features/step_definitions/credit_card_steps.rb
+++ b/features/step_definitions/credit_card_steps.rb
@@ -109,6 +109,6 @@ When(/^I fill in the braintree credit card iframe$/) do
   if @javascript
     page.evaluate_script("document.querySelector('#braintree_nonce').value = 'some_braintree_nonce'")
   else
-    find(:css, '#braintree_nonce').set('some_braintree_nonce')
+    find(:css, '#braintree_nonce', visible: :hidden).set('some_braintree_nonce')
   end
 end

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -295,7 +295,7 @@ end
 toggled_input_selector = '[data-behavior="toggle-inputs"] legend'
 
 And(/^I toggle "([^"]*)"$/) do |name|
-  find(toggled_input_selector, text: name).click
+  find(toggled_input_selector, text: /#{name}/i).click
 end
 
 When(/^I toggle all inputs$/) do

--- a/features/step_definitions/fields_steps.rb
+++ b/features/step_definitions/fields_steps.rb
@@ -1,7 +1,7 @@
 Then /^fields should be required:$/ do |table|
   table.rows.each do |row|
     field = row.first
-    assert page.has_xpath?("//label[normalize-space(text())='#{field}']/abbr[@title='required']"),
+    assert page.has_xpath?("//label[normalize-space(text())='#{field}']/abbr[@title='required']", visible: false),
            "Field #{field.first} is not required"
   end
 end

--- a/features/step_definitions/liquid_steps.rb
+++ b/features/step_definitions/liquid_steps.rb
@@ -50,7 +50,7 @@ Then /^the html body should contain "(.*?)"$/ do |html|
 end
 
 Then /^the html head should contain "(.*?)"$/ do |html|
-  page.find('head').native.to_s.should match(html)
+  page.find('head', visible: :all).native.to_s.should match(html)
 end
 
 Then /^the html should contain the SSO data$/ do

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -10,7 +10,7 @@ When /^I navigate to the page of the partner "([^\"]*)"$/ do |partner|
 end
 
 When 'I navigate to the accounts page' do
-  click_link(text: /\A\d Accounts?\z/)
+  click_link href: admin_buyers_accounts_path
 end
 
 When /^I navigate to a topic in (the forum of "[^\"]*")$/ do |forum|

--- a/features/step_definitions/personal_details_steps.rb
+++ b/features/step_definitions/personal_details_steps.rb
@@ -1,21 +1,19 @@
 # encoding: UTF-8
 
 Then(/^I should see the personal details form$/) do
-
   should have_css('form#edit_personal_details.formtastic.personal_details')
   within('form#edit_personal_details') do
 
-
-    should have_xpath('//input[@name="origin" and @type="hidden"]')
+    should have_xpath('//input[@name="origin" and @type="hidden"]', visible: :hidden)
     within(:xpath, '//div[@style="margin:0;padding:0;display:inline"]') do
 
       #
       # correct: ✓
       # incorrect: √
       #
-      should have_xpath("//input[@name='utf8' and @type='hidden' and @value='✓']")
-      should have_xpath("//input[@name='authenticity_token' and @type='hidden']")
-      should have_xpath("//input[@name='_method' and @type='hidden' and @value='put']")
+      should have_xpath("//input[@name='utf8' and @type='hidden' and @value='✓']", visible: :hidden)
+      should have_xpath("//input[@name='authenticity_token' and @type='hidden']", visible: :hidden)
+      should have_xpath("//input[@name='_method' and @type='hidden' and @value='put']", visible: :hidden)
     end
   end
 

--- a/features/step_definitions/proxy_steps.rb
+++ b/features/step_definitions/proxy_steps.rb
@@ -53,8 +53,7 @@ Then(/^I should see the Policy Chain$/) do
   page.should have_css(".PolicyChain")
   page.should have_css(".Policy")
   page.should have_text("APIcast policy")
-  page.should have_css(".PolicyRegistryList.is-hidden")
-
+  page.should have_css(".PolicyRegistryList.is-hidden", visible: :hidden)
 end
 
 

--- a/features/step_definitions/spam_protection_steps.rb
+++ b/features/step_definitions/spam_protection_steps.rb
@@ -1,5 +1,5 @@
 When /^I check hidden spam checkbox$/ do
-  id = find(".boolean.required[id*='confirmation_input'] input[name*='[confirmation]'][type=checkbox]")[:id]
+  id = find(".boolean.required[id*='confirmation_input'] input[name*='[confirmation]'][type=checkbox]", visible: :hidden)[:id]
   page.evaluate_script <<-JS
     document.getElementById("#{id}").checked = true
   JS

--- a/features/step_definitions/stats/application_steps.rb
+++ b/features/step_definitions/stats/application_steps.rb
@@ -13,7 +13,7 @@ When(/^the provider is logged in and visits the "(.*?)" application stats$/) do 
     And I log in as provider "foo.example.com"
   }
 
-  click_on(text: /\d Apps?/, match: :first)
+  click_on(text: /\d Applications?/i, match: :first)
 
   within '.cinstances' do
     click_on developer_app_name, match: :one

--- a/features/step_definitions/stats_steps.rb
+++ b/features/step_definitions/stats_steps.rb
@@ -22,7 +22,7 @@ end
 Then /^I should see a list of metrics:$/ do |table|
   table.hashes.each_with_index do |row, index|
     within(".StatsSelector-container") do
-      assert_text row['Buyer']
+      assert_text :all, row['Buyer']
     end
   end
 end

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -14,7 +14,6 @@ DEFAULT_JS_DRIVER = :headless_chrome
 Capybara.default_driver = :rack_test
 Capybara.javascript_driver = DEFAULT_JS_DRIVER
 Capybara.default_selector    = :css
-Capybara.ignore_hidden_elements = false
 
 # see http://www.elabs.se/blog/60-introducing-capybara-2-1
 Capybara.configure do |config|
@@ -22,7 +21,6 @@ Capybara.configure do |config|
   config.javascript_driver = DEFAULT_JS_DRIVER
   config.raise_server_errors = true
   config.match = :prefer_exact
-  config.ignore_hidden_elements = false
   config.always_include_port = true
   config.default_max_wait_time = 10
 end

--- a/features/support/current_user.rb
+++ b/features/support/current_user.rb
@@ -7,7 +7,7 @@ helper = Module.new do
     # HACK: I can't access session variables easily, but there are other ways how to get what I want :)
     begin
       # provider side
-      username = find(:css, '#user_widget .username').text(:all).strip
+      username = find(:css, '#user_widget .username', visible: :all).text(:all).strip
     rescue Capybara::ElementNotFound
       # buyer side
       username = find('#sign-out-button')[:title].gsub('Sign Out','').strip

--- a/features/support/helpers/messages_helpers.rb
+++ b/features/support/helpers/messages_helpers.rb
@@ -2,7 +2,7 @@ module MessagesHelpers
   def find_delete_button_in_row(label, *cells)
     forms = find(:xpath, selector_for_table_row_with_cells(*cells)).all('td form')
     forms = forms.select do |form|
-      form[:method] == 'post' && form.has_css?('input[name = "_method"][value = "delete"]')
+      form[:method] == 'post' && form.has_css?('input[name="_method"][value="delete"][type="hidden"]', visible: :hidden)
     end
 
     forms.first.find_button(label).tap do |button|


### PR DESCRIPTION
Some elements are found in even when the are _not visible_, resulting in false positives.