### PR TITLE
UI BackendAPI Controller allows system_name for create but not for update

### DIFF
--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -18,7 +18,7 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   end
 
   def create
-    @backend_api = current_account.backend_apis.build(backend_api_params)
+    @backend_api = current_account.backend_apis.build(create_params)
     if @backend_api.save
       redirect_to provider_admin_backend_api_path(@backend_api), notice: 'Backend API created'
     else
@@ -33,7 +33,7 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   def edit; end
 
   def update
-    if @backend_api.update_attributes(backend_api_params)
+    if @backend_api.update_attributes(update_params)
       redirect_to provider_admin_backend_api_path(@backend_api), notice: 'Backend API updated'
     else
       flash.now[:error] = 'Backend API could not be updated'
@@ -52,12 +52,19 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
 
   protected
 
+  DEFAULT_PARAMS = %i[name description private_endpoint].freeze
+  private_constant :DEFAULT_PARAMS
+
   def find_backend_api
     @backend_api = current_account.backend_apis.find(params[:id])
   end
 
-  def backend_api_params
-    params.require(:backend_api).permit(:name, :system_name, :description, :private_endpoint)
+  def create_params
+    params.require(:backend_api).permit(DEFAULT_PARAMS | %i[system_name])
+  end
+
+  def update_params
+    params.require(:backend_api).permit(DEFAULT_PARAMS)
   end
 
   def authorize

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -54,6 +54,15 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
     assert_equal 'https://new-endpoint.com:443/p', backend_api.reload.private_endpoint
   end
 
+  test 'system_name can be created but not updated' do
+    post provider_admin_backend_apis_path, { backend_api: {name: 'My Backend API', system_name: 'first-system-name'} }
+    backend_api = provider.backend_apis.last!
+    assert_equal 'first-system-name', backend_api.system_name
+
+    put provider_admin_backend_api_path(backend_api, { backend_api: {name: 'My Backend API', system_name: 'my-new-backend-api'} })
+    assert_equal 'first-system-name', backend_api.reload.system_name
+  end
+
   test 'delete a backend api with products' do
     backend_api = @provider.backend_apis[0]
     assert backend_api.backend_api_configs.any?


### PR DESCRIPTION
Done for the Controller 👍 

For the UI it is already correct:
https://github.com/3scale/porta/blob/dd5c49fd0bc9903d3f6f88b1f0e0d98b4d2962ac/app/views/provider/admin/backend_apis/edit.html.slim#L4
https://github.com/3scale/porta/blob/dd5c49fd0bc9903d3f6f88b1f0e0d98b4d2962ac/app/views/provider/admin/backend_apis/forms/_naming.html.slim#L3
Just like we do for the rest of models, for example for service:
https://github.com/3scale/porta/blob/dd5c49fd0bc9903d3f6f88b1f0e0d98b4d2962ac/app/views/api/services/forms/_naming.html.slim#L3
