### PR TITLE
Fixing ajv ErrorObject  error in circle ci

### DIFF
--- a/app/javascript/src/Policies/components/SchemaEditor.jsx
+++ b/app/javascript/src/Policies/components/SchemaEditor.jsx
@@ -7,6 +7,7 @@ import { fromJsonString, toJsonString } from 'utilities/json-utils'
 import 'codemirror/mode/javascript/javascript'
 import ApicastManifest from 'Policies/apicast-manifest'
 import Ajv from 'ajv'
+import type { ErrorObject } from 'ajv'
 import type { Schema } from 'Policies/types/Policies'
 
 const ajv = new Ajv().addSchema(ApicastManifest, 'ApicastManifest')
@@ -26,8 +27,9 @@ const CM_OPTIONS = {
   tabSize: 2
 }
 
-const validateSchema = (schema: Schema): Array<Error> => {
-  return (!ajv.validate('ApicastManifest', schema)) ? ajv.errors : []
+const validateSchema = (schema: Schema): Array<ErrorObject> => {
+  ajv.validate('ApicastManifest', schema)
+  return ajv.errors ? ajv.errors : []
 }
 
 const initialState = (schema: Schema) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

We have an issue with `flow`. Locally it doesn't find any errors, but in `circle ci` we are getting this:

```
Launching Flow server for /opt/app-root/src/project
Spawned flow server (pid=442)
Logs will go to /tmp/flow/zSoptzSapp-rootzSsrczSproject.log
Monitor logs will go to /tmp/flow/zSoptzSapp-rootzSsrczSproject.monitor_log
Error ---------------------------------------------------- app/javascript/src/Policies/components/SchemaEditor.jsx:30:10

Cannot return `!ajv.validate(...) ? ajv.errors : []` because:
 - undefined [1] is incompatible with array type [2].
 - `Error` [3] is incompatible with `$npm$ajv$ErrorObject` [4] in array element.
 - property `dataPath` is missing in `Error` [3] but exists in `$npm$ajv$ErrorObject` [4] in array element.
 - property `keyword` is missing in `Error` [3] but exists in `$npm$ajv$ErrorObject` [4] in array element.
 - property `params` is missing in `Error` [3] but exists in `$npm$ajv$ErrorObject` [4] in array element.
 - property `schemaPath` is missing in `Error` [3] but exists in `$npm$ajv$ErrorObject` [4] in array element.
 - undefined [5] is incompatible with string [6] in property `message` of array element.

   app/javascript/src/Policies/components/SchemaEditor.jsx:30:10
    30|   return (!ajv.validate('ApicastManifest', schema)) ? ajv.errors : []
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

References:
   flow-typed/npm/ajv_v6.x.x.js:111:14
   111|     errors?: Array<ErrorObject>;
                     ^^^^^^^^^^^^^^^^^^ [1]
   app/javascript/src/Policies/components/SchemaEditor.jsx:29:42
    29| const validateSchema = (schema: Schema): Array<Error> => {
                                                 ^^^^^^^^^^^^ [2]
   app/javascript/src/Policies/components/SchemaEditor.jsx:29:48
    29| const validateSchema = (schema: Schema): Array<Error> => {
                                                       ^^^^^ [3]
   flow-typed/npm/ajv_v6.x.x.js:111:20
   111|     errors?: Array<ErrorObject>;
                           ^^^^^^^^^^^ [4]
   flow-typed/npm/ajv_v6.x.x.js:35:13
    35|   message?: string,
                    ^^^^^^ [5]
   /tmp/flow/flowlib_3c3a2f54/core.js:436:14
   436|     message: string;
                     ^^^^^^ [6]
```

**Which issue(s) this PR fixes** 

> Replace this comment with references to related issues. This will ensure the issue(s) are closed automatically when the PR gets merged.
> e.g. `fixes #<issue number>(, fixes #<issue_number>, ...)`

**Verification steps** 


**Special notes for your reviewer**:
Importing the type from ajv fixes the issue