### PR TITLE
[Refactor] Remove '@ajax' tag from cukes to be faster

### DIFF
--- a/features/old/accounts/bulk_operations.feature
+++ b/features/old/accounts/bulk_operations.feature
@@ -1,4 +1,4 @@
-@javascript @ajax
+@javascript
 Feature: Bulk operations
   In order to control a lot of applications
   As a provider

--- a/features/old/accounts/bulk_operations/change_plans.feature
+++ b/features/old/accounts/bulk_operations/change_plans.feature
@@ -1,4 +1,4 @@
-@javascript @ajax
+@javascript
 Feature: Bulk operations
   In order to transfer applications from one plan to another
   As a provider

--- a/features/old/accounts/notifications.feature
+++ b/features/old/accounts/notifications.feature
@@ -31,7 +31,7 @@ Feature: Notifications
       And the "Daily aggregate report" checkbox should not be checked
 
   # This scenario was unDRYed from an Outline due to performance reasons, it went from ~2 minutes to 20 seconds
-  @ajax @javascript
+  @javascript
   Scenario: Enable notification
     And current domain is the admin domain of provider "foo.example.com"
     When I log in as provider "foo.example.com"

--- a/features/old/accounts/service_contracts.feature
+++ b/features/old/accounts/service_contracts.feature
@@ -27,7 +27,7 @@ Feature: Account service plans management
      And I follow "Portal" in the main menu
     Then I should see "Service Subscription"
 
-  @javascript @ajax
+  @javascript
   Scenario: Subscribe to service with selected service plan
     Given current domain is the admin domain of provider "foo.example.com"
       And I am logged in as provider "foo.example.com"

--- a/features/old/api/end_user_plans.feature
+++ b/features/old/api/end_user_plans.feature
@@ -35,7 +35,7 @@ Feature: End User Plan creation
       And I am on the edit page for service "API" of provider "foo.example.com"
       Then there should not be any mention of end user plans
 
-  @javascript @ajax
+  @javascript
   Scenario: Selecting default End User Plan
     Given an end user plan "First" of provider "foo.example.com"
     Given an end user plan "Second" of provider "foo.example.com"

--- a/features/old/api/metrics/visibility.feature
+++ b/features/old/api/metrics/visibility.feature
@@ -31,7 +31,7 @@ Feature: Metric visibility
   #     And I go to the "app" application page
   #   Then I should see the metric "visible" in the plan widget
 
-  @javascript @ajax
+  @javascript
   Scenario: Hide metric
     And current domain is the admin domain of provider "foo.example.com"
     When I log in as provider "foo.example.com"
@@ -65,7 +65,7 @@ Feature: Metric visibility
     #   And I go to the "app" application page
     # Then I should see the metric "visible" limits as text in the plan widget
 
-  @javascript @ajax
+  @javascript
   Scenario: Metric limits shown with icon and text
     And current domain is the admin domain of provider "foo.example.com"
     When I log in as provider "foo.example.com"
@@ -82,7 +82,7 @@ Feature: Metric visibility
     #   And I go to the "app" application page
     # Then I should see the metric "visible" limits as icons and text in the plan widget
 
-  @javascript @ajax
+  @javascript
   Scenario: Metric limits with value 0 only show icons in icons and text mode
     And current domain is the admin domain of provider "foo.example.com"
     When I log in as provider "foo.example.com"
@@ -100,7 +100,7 @@ Feature: Metric visibility
     #   And I go to the "app" application page
     # Then I should see the metric "zeroed" limits as icons only in the plan widget
 
-  @javascript @ajax
+  @javascript
   Scenario: Metrics enabling and disabling
     Given current domain is the admin domain of provider "foo.example.com"
       And I log in as provider "foo.example.com"
@@ -115,7 +115,7 @@ Feature: Metric visibility
     Then I should see the metric "zeroed" is enabled
       But I should see the metric "visible" is disabled
 
-  @javascript @ajax
+  @javascript
     Scenario: Metric cannot be disabled
       Given current domain is the admin domain of provider "foo.example.com"
         And I log in as provider "foo.example.com"

--- a/features/old/api/usage_limits.feature
+++ b/features/old/api/usage_limits.feature
@@ -1,4 +1,4 @@
-@javascript @ajax
+@javascript
 Feature: Usage limits
   In order to prevent my users to send uncontrolable amount of traffic to my API
   As a provider

--- a/features/old/applications/buyers/application_management.feature
+++ b/features/old/applications/buyers/application_management.feature
@@ -22,7 +22,7 @@ Feature: Buyer's application management
       And I go to the "SomeApp" application page
     Then I should not see the application keys
 
-  @javascript @ajax
+  @javascript
   Scenario: Can select a plan when creating a new application
     Given a service "Travelling" of provider "foo.example.com"
       And service "Travelling" allows to choose plan on app creation

--- a/features/old/applications/providers/bulk_operations.feature
+++ b/features/old/applications/providers/bulk_operations.feature
@@ -1,4 +1,4 @@
-@javascript @ajax
+@javascript
 Feature: Bulk operations
   In order to control a lot of applications
   As a provider

--- a/features/old/applications/providers/keys.feature
+++ b/features/old/applications/providers/keys.feature
@@ -34,7 +34,6 @@ Feature: Applications details
      And I press "Set Custom Key"
     Then I should see "Invalid key"
 
-  @ajax
   Scenario: Remove and add keys
     Given provider "foo.example.com" uses backend v2 in his default service
       And I am logged in as provider "foo.example.com"

--- a/features/old/cms/changes.feature
+++ b/features/old/cms/changes.feature
@@ -12,7 +12,7 @@ Feature: CMS Changes
       And I go to the CMS changes
      Then I should see 2 CMS changes
 
-  @javascript @ajax
+  @javascript
   Scenario: Revert page
     Given I have changed CMS page "page"
      When I go to the CMS changes

--- a/features/old/emails.feature
+++ b/features/old/emails.feature
@@ -1,4 +1,4 @@
-@emails @javascript @ajax
+@emails @javascript
 Feature: Emails
   As a provider
   I want to control email notifications like a boss

--- a/features/old/liquid/active_docs.feature
+++ b/features/old/liquid/active_docs.feature
@@ -1,4 +1,4 @@
-@javascript @ajax @selenium
+@javascript @selenium
 Feature: ActiveDocs
   In order to rule the world
   As a provider

--- a/features/old/services/subscriptions/bulk_operations.feature
+++ b/features/old/services/subscriptions/bulk_operations.feature
@@ -1,4 +1,4 @@
-@javascript @ajax
+@javascript
 Feature: Bulk operations
   In order to control a lot of subscibed services
   As a provider

--- a/features/step_definitions/api/end_user_plan_steps.rb
+++ b/features/step_definitions/api/end_user_plan_steps.rb
@@ -4,6 +4,7 @@ Given /^an end user plan "(.+?)" of (provider ".+?")$/ do |name, provider|
 end
 
 Then /^"(.*?)" should be default end user plan for service "(.*?)"$/ do |plan_name, service_name|
+  wait_for_requests
   service = Service.where(name: service_name).first
   plan    = EndUserPlan.where(name: plan_name).first
   assert_equal service.default_end_user_plan, plan

--- a/features/step_definitions/applications/keys_steps.rb
+++ b/features/step_definitions/applications/keys_steps.rb
@@ -102,12 +102,14 @@ def limit_warning
 end
 
 Then /^I should see application keys limit reached error$/ do
+  wait_for_requests
   within '#application_keys' do
     limit_warning.should be_visible
   end
 end
 
 Then /^I should(?:n't| not) see application keys limit reached error$/ do
+  wait_for_requests
   within '#application_keys' do
     limit_warning.should_not be_visible
   end

--- a/features/step_definitions/confirm_dialog_steps.rb
+++ b/features/step_definitions/confirm_dialog_steps.rb
@@ -3,6 +3,7 @@ Then /^(.+) and I confirm dialog box(?: "(.*)")?$/ do |original, text|
     accept_confirm(text) do
       step original
     end
+    wait_for_requests
   else # :rack_test but should not work if it relies on some JS
     step original
   end

--- a/features/step_definitions/metric_steps.rb
+++ b/features/step_definitions/metric_steps.rb
@@ -65,6 +65,7 @@ When /^I (?:enable|disable) the (metric "[^\"]*")$/ do |metric|
 end
 
 Then /^I should see the (metric "[^"]*") is (visible|hidden)$/ do |metric, visible|
+  wait_for_requests
   assert find(:xpath, "//span[@id='metric_#{metric.id}_visible']")[:class] == visible
 end
 
@@ -141,6 +142,7 @@ Then /^I should see the (metric "[^\"]*") limits as text in the plan widget$/ do
 end
 
 Then /^I should see the (metric "[^\"]*") limits show as icons and text$/ do |metric|
+  wait_for_requests
   assert find(:xpath, "//span[@id='metric_#{metric.id}_icons']")[:class] == 'icon'
 end
 
@@ -149,11 +151,13 @@ Then /^I should see the (metric "[^\"]*") limits as icons and text in the plan w
 end
 
 Then /^I should see the (metric "[^\"]*") limits as icons only in the plan widget$/ do |metric|
+  wait_for_requests
   assert find(:xpath, "//tr[@id='metric_#{metric.id}_limits']/td").text.strip.empty?
   assert has_xpath?("//tr[@id='metric_#{metric.id}_limits']/td/img")
 end
 
 Then /^I should see the (metric "[^\"]*") is (enabled|disabled)$/ do |metric, status|
+  wait_for_requests
   assert find(:xpath, "//span[@id='metric_#{metric.id}_status']")[:class] == status
 end
 

--- a/features/step_definitions/new_cms/changes_steps.rb
+++ b/features/step_definitions/new_cms/changes_steps.rb
@@ -21,6 +21,7 @@ Then /^I should see (\d+) CMS changes$/ do |count|
 end
 
 Then /^the CMS page "(.*?)" should be reverted$/ do |name|
+  wait_for_requests
   page = CMS::Page.find_by_system_name!(name)
   page.draft.should be_nil
   cms_changes.should_not have_css("#cms_page_#{page.id}_change")

--- a/features/step_definitions/notification_steps.rb
+++ b/features/step_definitions/notification_steps.rb
@@ -1,4 +1,5 @@
 Then /^I should have the notification "([^"]*)" (enabled|disabled)$/ do |name, status|
+  wait_for_requests
   notification = current_account.mail_dispatch_rules.find_by_system_operation_id(SystemOperation.find_by_name(name).id)
 
   case status

--- a/features/step_definitions/usage_limit_steps.rb
+++ b/features/step_definitions/usage_limit_steps.rb
@@ -58,6 +58,7 @@ Then /^I should not see hourly usage limit for (metric "[^"]*" on application pl
 end
 
 Then /^(.*?plan ".+?") should have a usage limit of (\d+) for metric "(.+?)" per "(.+?)"$/ do |plan, value, metric_name, period|
+  wait_for_requests
   metric = plan.service.metrics.find_by_system_name!(metric_name)
   assert_not_nil plan.usage_limits.find_by_metric_id_and_period_and_value(metric.id, period, value)
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -90,10 +90,6 @@ AfterStep '@javascript', '@alert', '~@selenium' do
   stub_javascript_alert
 end
 
-AfterStep '@javascript', '@ajax' do
-  wait_for_requests
-end
-
 Before '@javascript' do
   @javascript = true
 end


### PR DESCRIPTION
As spoken in https://github.com/3scale/porta/pull/986/files#r304486361, the goal is to remove this `@ajax` tag and make wait only in those steps when it is necessary, so it will be faster. 