### PR TITLE
[Contract] smart counter cache

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -134,6 +134,7 @@ gem 'acts-as-taggable-on', '~> 4.0'
 gem 'whenever', '~> 0.9.7', require: false
 gem 'will_paginate', '~> 3.1.0'
 gem 'browser'
+gem 'counter_culture'
 
 gem 'rack-x_served_by', '~> 0.1.1'
 gem 'deadlock_retry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,9 @@ GEM
       activerecord (>= 3.0.0)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    after_commit_action (1.1.0)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
     after_commit_queue (1.1.0)
       rails (>= 3.0)
     aggregate_root (0.3.6)
@@ -267,6 +270,10 @@ GEM
       sprockets (< 4.0)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.1)
+    counter_culture (2.2.4)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      after_commit_action (~> 1.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -843,6 +850,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   colorize
   compass-rails (~> 3.0.2)
+  counter_culture
   cucumber (~> 2.0)
   cucumber-rails
   dalli (~> 2.7)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -116,6 +116,8 @@ class Account < ApplicationRecord
     end
   }
 
+  alias_method :deleted?, :scheduled_for_deletion?
+
   def destroy_features
     features.destroy_all
   end

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -5,7 +5,7 @@ class Cinstance < Contract
 
   delegate :backend_version, to: :service, allow_nil: true
 
-  belongs_to :plan, class_name: 'ApplicationPlan', foreign_key: :plan_id, inverse_of: :cinstances, counter_cache: :contracts_count
+  belongs_to :plan, class_name: 'ApplicationPlan', foreign_key: :plan_id, inverse_of: :cinstances
   alias application_plan plan
 
   # TODO: verify the comment is still true and we can't use inverse_of

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -22,8 +22,10 @@ class Contract < ApplicationRecord
   after_destroy :destroy_customized_plan
   after_commit :notify_plan_changed
 
-  belongs_to :plan, counter_cache: true
-  validate   :correct_plan_subclass?
+  belongs_to :plan
+  counter_culture :plan, column_name: proc { |object| object.counter_culture_enabled? ? :contracts_count : nil }, column_names: { true => :contracts_count }
+
+  validate :correct_plan_subclass?
   # this breaks nested saving of records, when validating there is no user_account yet, its new record
   # validates_presence_of :user_account
 
@@ -107,6 +109,10 @@ class Contract < ApplicationRecord
   end
 
   delegate :paid?, :to => :plan
+
+  def counter_culture_enabled?
+    !provider_account&.scheduled_for_deletion? && !issuer&.deleted?
+  end
 
   def messenger
     (self.class.name.to_s << "Messenger").constantize

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -184,7 +184,7 @@ class Plan < ApplicationRecord
   end
 
   def reset_contracts_counter
-    self.class.reset_counters(id, :contracts)
+    Contract.counter_culture_fix_counts(where: { id: id })
   end
 
   def can_be_destroyed?

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
       activerecord (>= 3.0.0)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    after_commit_action (1.1.0)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
     after_commit_queue (1.1.0)
       rails (>= 3.0)
     aggregate_root (0.3.6)
@@ -271,6 +274,10 @@ GEM
       sprockets (< 4.0)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.1)
+    counter_culture (2.2.4)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      after_commit_action (~> 1.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -848,6 +855,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   colorize
   compass-rails (~> 3.0.2)
+  counter_culture
   cucumber (~> 2.0)
   cucumber-rails
   dalli (~> 2.7)

--- a/test/integration/change_application_plan_test.rb
+++ b/test/integration/change_application_plan_test.rb
@@ -17,8 +17,8 @@ class ChangeApplicationPlanTest < ActionDispatch::IntegrationTest
     app     = FactoryBot.create(:cinstance, service: service, plan: plan_1)
 
     assert_equal plan_1.id, app.plan_id
-    assert_equal 1, plan_1.contracts_count
-    assert_equal 0, plan_2.contracts_count
+    assert_equal 1, plan_1.reload.contracts_count
+    assert_equal 0, plan_2.reload.contracts_count
 
     put change_plan_admin_buyers_application_path(id: app, cinstance: { plan_id: plan_2.id })
     assert_response :redirect


### PR DESCRIPTION
**What this PR does / why we need it**:

One of the most problematic query during tenant deletion is updating `contracts_count`.
```
*************************** 21. row ***************************
     Id: 30653
   User: systemdb
   Host: 10.128.226.31:15651
     db: preview01
Command: Query
   Time: 10
  State: updating
   Info: UPDATE `plans` SET `contracts_count` = COALESCE(`contracts_count`, 0) - 1 WHERE `plans`.`type` IN ('ApplicationPlan') AND `plans`.`id` = 957972
```

Since the whole account is being deleted, there's no need to update this attribute.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-2988

**Verification steps** 

> Replace this with a list of necessary steps to verify the PR meets your expectations.
> e.g. `1. Go to Admin Portal, make sure that ...`

**Special notes for your reviewer**:
