### PR TITLE
Upgrade bcrypt-ruby to 3.1.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       activerecord (>= 4.2.0)
       join_dependency (~> 0.1.2)
       polyamorous (~> 1.3)
-    bcrypt (3.1.11)
+    bcrypt (3.1.13)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootsnap (1.3.2)

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       activerecord (>= 4.2.0)
       join_dependency (~> 0.1.2)
       polyamorous (~> 1.3)
-    bcrypt (3.1.11)
+    bcrypt (3.1.13)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootsnap (1.3.2)


### PR DESCRIPTION
bcrypt-ruby 3.1.11 is broken on Fedora 28 as these both issues
shows: https://github.com/codahale/bcrypt-ruby/issues/165
https://github.com/codahale/bcrypt-ruby/issues/170