### PR TITLE
Setting login password minimum length to 1

### DIFF
--- a/app/javascript/src/LoginPage/utils/formValidation.js
+++ b/app/javascript/src/LoginPage/utils/formValidation.js
@@ -14,7 +14,7 @@ const constraintsTypes = {
   },
   password: {
     presence: true,
-    length: {minimum: 6}
+    length: {minimum: 1}
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting login password minimum length to 1, to avoid conflicts with our seeds that currently accepts 1 char.
