### PR TITLE
Fix Create Application wrong test

### DIFF
--- a/features/old/applications/providers/create_application.feature
+++ b/features/old/applications/providers/create_application.feature
@@ -78,6 +78,7 @@ Feature: Create application
    Scenario: The service of the selected application plans hasn´t service plan
      Given a service "second" of provider "foo.example.com"
        And a published application plan "second_app_plan" of service "second" of provider "foo.example.com"
+       And the service "second" does not have service plan
        And buyer "bob" is not subscribed to the default service of provider "foo.example.com"
        And I go to the provider side create application page for "bob"
       Then I should see "New Application"

--- a/features/step_definitions/service_steps.rb
+++ b/features/step_definitions/service_steps.rb
@@ -61,6 +61,10 @@ Given /^the service has been successfully tested$/ do
   @provider.default_service.proxy.update_column(:api_test_success, true)
 end
 
+Given(/^the service "([^"]*)" does not have service plan$/) do |name|
+  Service.find_by(name: name).service_plans.destroy_all
+end
+
 Given /^the service acts as product$/ do
   @provider.default_service.update_column(:act_as_product, true)
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

The test passes when it should not. In order to show "create new service plan" there has to be no service plans.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3390
