### PR TITLE
Fixes "create new service plan" link in New Application form

### DIFF
--- a/app/helpers/buyers/applications_helper.rb
+++ b/app/helpers/buyers/applications_helper.rb
@@ -6,6 +6,7 @@ module Buyers::ApplicationsHelper
       data-services_contracted='#{ services_contracted(buyer) }'
       data-service_plan_contracted_for_service='#{ service_plan_contracted_for_service(buyer) }'
       data-relation_service_and_service_plans='#{ relation_service_and_service_plans(provider) }'
+      data-create_service_plan_path='#{ create_service_plan_path }'
       data-relation_plans_services= '#{ relation_plans_services(provider) }' >".html_safe
 
   end
@@ -39,6 +40,10 @@ module Buyers::ApplicationsHelper
     provider.application_plans.includes(:service).each_with_object({}) do |application_plan, hash|
       hash[application_plan.id] = application_plan.service.id
     end.to_json
+  end
+
+  def create_service_plan_path
+    admin_service_service_plans_path ':service_id'
   end
 
   def last_traffic(cinstance)

--- a/app/javascript/src/Applications/create_application.js
+++ b/app/javascript/src/Applications/create_application.js
@@ -47,6 +47,14 @@ export class CreateApplication {
     return this.relationPlansServices[this.selectedPlan]
   }
 
+  get createServicePlanPath (): string {
+    return this.metadata.data('create_service_plan_path')
+  }
+
+  getCreateServicePlanPathForService (serviceId: number): string {
+    return this.createServicePlanPath.replace(':service_id', String(serviceId))
+  }
+
   checkSelectedPlan () {
     const service = this.serviceOfSelectedPlan
     const servicePlans = this.getServicePlansForService(service)
@@ -64,6 +72,7 @@ export class CreateApplication {
         this.setSelectOptions(servicePlans)
       } else {
         $('#cinstance_service_plan_id').html('<option> No service plan for the application plan </option>')
+        $('#link-help-new-application-service').attr('href', this.getCreateServicePlanPathForService(service))
         this.disableForm()
       }
     }

--- a/app/views/buyers/applications/new.html.erb
+++ b/app/views/buyers/applications/new.html.erb
@@ -19,8 +19,12 @@
                           :default_plan => @plans.respond_to?(:default) ? @plans.default : @plans.first %>
 
     <% if current_account.settings.service_plans.allowed? %>
-      <%= form.input :service_plan_id, as: :select, collection: [], label: ServicePlan.model_name.human,
-        hint: link_to('Create a service plan', admin_services_path, id: 'link-help-new-application-service') %>
+      <%= form.input :service_plan_id, as: :select,
+                                       collection: [],
+                                       label: ServicePlan.model_name.human,
+                                       hint: link_to('Create a service plan',
+                                       nil,
+                                       id: 'link-help-new-application-service') %>
     <% end %>
     <%= form.user_defined_form %>
   <% end %>


### PR DESCRIPTION
**What this PR does / why we need it**:

In Create Application form, when there isn't any Service Plan associated with a Service, a link is shown "create a new service plan". Currently that link is broken, now this PR sets the `href` of such element with the appropriate URL to the service _Service Plans_ page.

**Verification steps** 

1. Go to New Application
2. Make sure you have a service with no service plans, select a plan from that service
3. Click on "create a new service plan" below the _Service Plan" dropdown and verify it goes to the proper page