### PR TITLE
Fixes wrong feature for Branding

### DIFF
--- a/features/old/switches/branding.feature
+++ b/features/old/switches/branding.feature
@@ -4,7 +4,7 @@ Feature: Branding switch
   Controls the Branding feature
 
   Background:
-    Given an application plan "plus" of provider "master"
+    Given a published application plan "plus" of provider "master"
     And a provider "foo.example.com"
       And current domain is the admin domain of provider "foo.example.com"
 

--- a/features/step_definitions/switches_steps.rb
+++ b/features/step_definitions/switches_steps.rb
@@ -19,7 +19,7 @@ Given /^the provider has ("(?:.+?)"(?: switch)? visible)$/ do |sentence|
 end
 
 Then /^I should see the invitation to upgrade my plan$/ do
-  assert has_content?("Upgrade")
+  assert find(:css, 'a#change-plan.important-button')&.has_content?('Upgrade')
 end
 
 Then /^I should see upgrade notice for "(.+?)"$/ do |switch|

--- a/features/step_definitions/switches_steps.rb
+++ b/features/step_definitions/switches_steps.rb
@@ -19,7 +19,7 @@ Given /^the provider has ("(?:.+?)"(?: switch)? visible)$/ do |sentence|
 end
 
 Then /^I should see the invitation to upgrade my plan$/ do
-  assert find(:css, 'a#change-plan.important-button')&.has_content?('Upgrade')
+  assert find('a#change-plan.important-button', text: 'Upgrade to')
 end
 
 Then /^I should see upgrade notice for "(.+?)"$/ do |switch|


### PR DESCRIPTION
**What this PR does / why we need it**:

The test is using this screen in the test:
![Screen Shot 2019-09-06 at 12 24 56](https://user-images.githubusercontent.com/11672286/64437421-8da4ca80-d0c6-11e9-9f0d-32a26fb355fa.png)

But it should display an "Upgrade" button.

The test only passes because the assertion is too broad:
```
assert has_content?("Upgrade")
```
And it finds the word _Upgrade_ in the page `<title>` so that it falsely passes.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3390

**Verification steps** 
```
cuke features/old/switches/branding.feature:12
```
should pass.
