### PR TITLE
Adding validation to request password form when pristine

### DIFF
--- a/app/javascript/src/LoginPage/loginForms/RequestPasswordForm.jsx
+++ b/app/javascript/src/LoginPage/loginForms/RequestPasswordForm.jsx
@@ -30,7 +30,9 @@ type State = {
 class RequestPasswordForm extends React.Component<Props, State> {
   state = {
     email: '',
-    validation: {}
+    validation: {
+      email: undefined
+    }
   }
 
   handleTextInputEmail = (email: string, event: SyntheticEvent<HTMLInputElement>) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding validation to request password form when pristine
In https://github.com/3scale/porta/pull/1005 form validation was added.
But I missed the pristine state of email input in request password form

**Pristine:**
![empty](https://user-images.githubusercontent.com/13486237/64513584-2b77df80-d2e9-11e9-95da-c27bab4e0828.png)

**Dirty:**
![filled](https://user-images.githubusercontent.com/13486237/64513590-2f0b6680-d2e9-11e9-8dd3-46e133caea38.png)
