### PR TITLE
Create default 'hits' metric to backend API

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -26,6 +26,7 @@ class BackendApi < ApplicationRecord
   alias_attribute :api_backend, :private_endpoint
 
   before_validation :set_private_endpoint, :set_port_private_endpoint
+  after_create :create_default_metrics
 
   has_system_name(uniqueness_scope: [:account_id])
 
@@ -45,6 +46,10 @@ class BackendApi < ApplicationRecord
 
   def method_metrics
     metrics.where(parent: metrics.hits)
+  end
+
+  def create_default_metrics
+    metrics.create_default!(:hits)
   end
 
   private

--- a/test/integration/provider/admin/backend_apis/metrics_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/metrics_controller_test.rb
@@ -8,7 +8,7 @@ class Provider::Admin::BackendApis::MetricsControllerTest < ActionDispatch::Inte
     @service = @provider.first_service
     @backend_api = @service.backend_api
 
-    @hits = FactoryBot.create(:metric, service: nil, owner: @backend_api, system_name: 'hits')
+    @hits = @backend_api.metrics.hits
     @meth = FactoryBot.create(:metric, service: nil, owner: @backend_api, system_name: 'meth', parent: @hits)
     @ads = FactoryBot.create(:metric, service: nil, owner: @backend_api, system_name: 'ads')
 

--- a/test/models/backend_api_test.rb
+++ b/test/models/backend_api_test.rb
@@ -23,4 +23,10 @@ class BackendApiTest < ActiveSupport::TestCase
     @backend_api.private_endpoint = 'https://example.org:3/path'
     assert @backend_api.valid?
   end
+
+  test 'creates default metrics' do
+    backend_api = FactoryBot.create(:backend_api)
+    hits = backend_api.metrics.hits
+    assert hits.default? :hits
+  end
 end

--- a/test/unit/backend_api_logic/service_extension_test.rb
+++ b/test/unit/backend_api_logic/service_extension_test.rb
@@ -51,7 +51,7 @@ class ServiceExtensionTest < ActiveSupport::TestCase
     third_backend_api = FactoryBot.create(:backend_api, account: service.account)
     service.backend_api_configs.create(backend_api: second_backend_api, path: 'whatever')
 
-    related_metrics = [service.metrics.hits]
+    related_metrics = [service.metrics.hits, first_backend_api.metrics.hits, second_backend_api.metrics.hits]
     related_metrics << FactoryBot.create(:metric, service: service)
     related_metrics << FactoryBot.create(:metric, service: nil, owner: first_backend_api)
     related_metrics << FactoryBot.create(:metric, service: nil, owner: second_backend_api)

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -99,7 +99,7 @@ class MetricTest < ActiveSupport::TestCase
 
   test 'fill same owner as the parent' do
     backend_api = FactoryBot.create(:backend_api)
-    hits = FactoryBot.create(:metric, owner: backend_api, system_name: 'hits')
+    hits = backend_api.metrics.hits
     method = hits.children.create(system_name: 'meth1')
     assert_equal backend_api, method.owner
   end


### PR DESCRIPTION
Closes [THREESCALE-3355](https://issues.jboss.org/browse/THREESCALE-3355)