### PR TITLE
[Bugfix][Oracle] path order in routing_policy working for null/empty values

### DIFF
--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -17,7 +17,7 @@ module BackendApiLogic
       end
 
       def to_a
-        rules = backend_api_configs.reorder(path: :desc).each_with_object([]) do |config, rules|
+        rules = backend_api_configs.reordering { sift(:path_desc) }.each_with_object([]) do |config, rules|
           rule = Rule.new(config).as_json
           rules << rule if rule
         end
@@ -54,7 +54,7 @@ module BackendApiLogic
         end
 
         def path_to_regex
-          if path.empty?
+          if path.to_s.empty?
             "/.*"
           else
             "/#{path}/.*|/#{path}/?"

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -14,6 +14,10 @@ class BackendApiConfig < ApplicationRecord
     backend_api.metrics.each { |metric| metric.send(:sync_backend) }
   end
 
+  sifter :path_desc do
+    System::Database.oracle? ? 'path DESC NULLS LAST' : {path: :desc}
+  end
+
   delegate :private_endpoint, to: :backend_api
 
   def path=(value)


### PR DESCRIPTION
Test it locally with oracle DB for the test: `test/unit/proxy_test.rb:103`
For Oracle the empty string is saved as `NULL`.
