### PR TITLE
Sync backend API 'hits' metrics with apisonator as children of service 'hits'

### DIFF
--- a/app/lib/backend/model_extensions/metric.rb
+++ b/app/lib/backend/model_extensions/metric.rb
@@ -23,31 +23,19 @@ module Backend
 
       def sync_backend
         execute_per_service do |service|
-          ::BackendMetricWorker.perform_async(*args_to_backend_metric_worker(service))
+          ::BackendMetricWorker.perform_async(service.backend_id, id, system_name)
         end
       end
 
       def sync_backend!
         execute_per_service do |service|
-          ::BackendMetricWorker.new.perform(*args_to_backend_metric_worker(service))
+          ::BackendMetricWorker.new.perform(service.backend_id, id, system_name)
         end
       end
 
       def execute_per_service(&block)
         services = [*owner.try(:services), service].compact
         services.each(&block)
-      end
-
-      def args_to_backend_metric_worker(service)
-        [service.backend_id, id, system_name, parent_id_for_service(service)]
-      end
-
-      def parent_id_for_service(service)
-        if backend_api_metric? && hits?
-          service.metrics.hits&.id
-        else
-          parent_id
-        end
       end
     end
   end

--- a/app/lib/backend_api_logic/metric_extension.rb
+++ b/app/lib/backend_api_logic/metric_extension.rb
@@ -19,6 +19,14 @@ module BackendApiLogic
       owner_type == 'BackendApi'
     end
 
+    def parent_id_for_service(service)
+      if backend_api_metric? && hits?
+        service.metrics.hits&.id
+      else
+        parent_id
+      end
+    end
+
     module ClassMethods
       def hits_extended_system_name_as_sql
         Arel::Nodes::SqlLiteral.new("'hits#{SYSTEM_NAME_SUFFIX_SEPARATOR}' || #{quoted_table_name}.owner_id")

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -98,6 +98,10 @@ class Metric < ApplicationRecord
     end
   end
 
+  def hits?
+    default?(:hits)
+  end
+
   def child?
     parent_id.present?
   end

--- a/test/unit/backend/model_extensions/metric_test.rb
+++ b/test/unit/backend/model_extensions/metric_test.rb
@@ -20,7 +20,7 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
     metric.save!
 
     metric.system_name = 'bars'
-    BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.system_name, nil)
+    BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.system_name)
 
     metric.save!
   end
@@ -52,7 +52,7 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
   test 'sync backend metric data when metric is destroyed' do
     metric = FactoryBot.create(:metric)
 
-    BackendMetricWorker.expects(:perform_async).with(metric.service.backend_id, metric.id, metric.system_name, nil)
+    BackendMetricWorker.expects(:perform_async).with(metric.service.backend_id, metric.id, metric.system_name)
 
     metric.destroy
   end
@@ -69,7 +69,7 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
     metric = MetricWithFiber.create(service: service, friendly_name: 'My metric', unit: 'hits')
     metric_id = metric.id
 
-    ::BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric_id, metric.system_name, nil).twice
+    ::BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric_id, metric.system_name).twice
 
     metric_f1 = MetricWithFiber.find(metric_id)
     metric_f2 = MetricWithFiber.find(metric_id)
@@ -89,23 +89,10 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
     services.last.backend_api_configs.create(backend_api: backend_api, path: 'other') # other service using the same BackendApi
     metric = FactoryBot.build(:metric, service: nil, owner: backend_api)
 
-    services.each { |service| BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.system_name, nil) }
+    services.each { |service| BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.system_name) }
     metric.send :sync_backend
 
-    services.each { |service| BackendMetricWorker.any_instance.expects(:perform).with(service.backend_id, metric.id, metric.system_name, nil) }
-    metric.send :sync_backend!
-  end
-
-  test 'sync backend api hits metric with backend' do
-    services = FactoryBot.create_list(:simple_service, 2)
-    backend_api = services.first.first_backend_api
-    services.last.backend_api_configs.create(backend_api: backend_api, path: 'other') # other service using the same BackendApi
-    metric = backend_api.metrics.hits
-
-    services.each { |service| BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.system_name, service.metrics.hits.id) }
-    metric.send :sync_backend
-
-    services.each { |service| BackendMetricWorker.any_instance.expects(:perform).with(service.backend_id, metric.id, metric.system_name, service.metrics.hits.id) }
+    services.each { |service| BackendMetricWorker.any_instance.expects(:perform).with(service.backend_id, metric.id, metric.system_name) }
     metric.send :sync_backend!
   end
 end

--- a/test/unit/backend_api_logic/metric_extension_test.rb
+++ b/test/unit/backend_api_logic/metric_extension_test.rb
@@ -25,4 +25,23 @@ class MetricExtensionTest < ActiveSupport::TestCase
     service_metric = FactoryBot.create(:metric)
     refute service_metric.backend_api_metric?
   end
+
+  test '#parent_id_for_service' do
+    backend_hits = backend_api.metrics.hits
+    backend_method = FactoryBot.build(:metric, system_name: 'bmeth', service_id: nil, owner: @backend_api, parent: backend_hits)
+    backend_non_hits = metric
+
+    service = FactoryBot.create(:service, account: backend_api.account)
+    service_hits = service.metrics.hits
+    service_method = FactoryBot.build(:metric, system_name: 'foo', owner: service, parent: service_hits)
+    service_non_hits = FactoryBot.build(:metric, system_name: 'bar', owner: service)
+
+    assert_equal service_hits.id, backend_hits.parent_id_for_service(service)
+    assert_equal backend_hits.id, backend_method.parent_id_for_service(service)
+    refute backend_non_hits.parent_id_for_service(service)
+
+    refute service_hits.parent_id_for_service(service)
+    assert_equal service_hits.id, service_method.parent_id_for_service(service)
+    refute service_non_hits.parent_id_for_service(service)
+  end
 end

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -145,6 +145,16 @@ class MetricTest < ActiveSupport::TestCase
     refute metric.default?(:hits)
   end
 
+  test '#hits?' do
+    service = FactoryBot.create(:service)
+
+    hits_metric = service.metrics.hits
+    non_hits_metric = FactoryBot.create(:metric, owner: service, system_name: 'non-hits')
+
+    assert hits_metric.hits?
+    refute non_hits_metric.hits?
+  end
+
   context 'child metric' do
     setup do
       @service = FactoryBot.create(:service)


### PR DESCRIPTION
Closes [THREESCALE-3399](https://issues.jboss.org/browse/THREESCALE-3399)