### PR TITLE
[API] Backend API with deletion in background through state

### DIFF
--- a/app/controllers/admin/api/backend_apis_controller.rb
+++ b/app/controllers/admin/api/backend_apis_controller.rb
@@ -46,7 +46,7 @@ class Admin::Api::BackendApisController < Admin::Api::BaseController
   ##
   #
   def index
-    respond_with(current_account.backend_apis.oldest_first.paginate(pagination_params))
+    respond_with(current_account.backend_apis.accessible.oldest_first.paginate(pagination_params))
   end
 
   ##~ e = sapi.apis.add
@@ -121,7 +121,7 @@ class Admin::Api::BackendApisController < Admin::Api::BaseController
   ##~ op.parameters.add @parameter_backend_api_id_by_id
   #
   def destroy
-    backend_api.destroy
+    backend_api.mark_as_deleted
     respond_with(backend_api)
   end
 
@@ -135,7 +135,7 @@ class Admin::Api::BackendApisController < Admin::Api::BaseController
   end
 
   def backend_api
-    @backend_api ||= current_account.backend_apis.find(params[:id])
+    @backend_api ||= current_account.backend_apis.accessible.find(params[:id])
   end
 
   def create_params


### PR DESCRIPTION
Implements this improvement: https://github.com/3scale/porta/pull/1065/files#r320805090
Which is the API side of what we currently have in https://github.com/3scale/porta/pull/1144 (where this PR is pointing at 😉 )
