### PR TITLE
[DO NOT MERGE YET] Drop service_prefix column from Accounts table

### DIFF
--- a/db/migrate/20190913002814_remove_service_preffix_from_accounts.rb
+++ b/db/migrate/20190913002814_remove_service_preffix_from_accounts.rb
@@ -1,0 +1,5 @@
+class RemoveServicePreffixFromAccounts < ActiveRecord::Migration
+  def change
+    safety_assured { remove_column :accounts, :service_preffix, :string }
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190805135829) do
+ActiveRecord::Schema.define(version: 20190913002814) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -76,7 +76,6 @@ ActiveRecord::Schema.define(version: 20190805135829) do
     t.string   "credit_card_authorize_net_payment_profile_token"
     t.integer  "tenant_id",                                                   precision: 38
     t.string   "self_domain"
-    t.string   "service_preffix"
     t.string   "s3_prefix"
     t.integer  "prepared_assets_version",                                     precision: 38
     t.boolean  "sample_data",                                     limit: nil

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190805135829) do
+ActiveRecord::Schema.define(version: 20190913002814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,7 +79,6 @@ ActiveRecord::Schema.define(version: 20190805135829) do
     t.string   "credit_card_authorize_net_payment_profile_token", limit: 255
     t.integer  "tenant_id",                                       limit: 8
     t.string   "self_domain",                                     limit: 255
-    t.string   "service_preffix",                                 limit: 255
     t.string   "s3_prefix",                                       limit: 255
     t.integer  "prepared_assets_version"
     t.boolean  "sample_data"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190805135829) do
+ActiveRecord::Schema.define(version: 20190913002814) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -76,7 +76,6 @@ ActiveRecord::Schema.define(version: 20190805135829) do
     t.string   "credit_card_authorize_net_payment_profile_token", limit: 255
     t.integer  "tenant_id",                                       limit: 8
     t.string   "self_domain",                                     limit: 255
-    t.string   "service_preffix",                                 limit: 255
     t.string   "s3_prefix",                                       limit: 255
     t.integer  "prepared_assets_version",                         limit: 4
     t.boolean  "sample_data"


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the second part of this issue. In the first part
https://github.com/3scale/porta/pull/1134 we stopped to use this
column in the code. This commit now removes it from the database
since we are not using it anymore.


**Which issue(s) this PR fixes** 

[THREESCALE-2025](https://issues.jboss.org/browse/THREESCALE-2025)