### PR TITLE
Fix sync of backend api metrics on create BackendApiConfig

### DIFF
--- a/app/lib/backend/model_extensions/backend_api_config.rb
+++ b/app/lib/backend/model_extensions/backend_api_config.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Backend
+  module ModelExtensions
+    module BackendApiConfig
+      extend ActiveSupport::Concern
+
+      included do
+        after_commit :sync_backend_api_metrics_with_backend, on: :create
+      end
+
+      def sync_backend_api_metrics_with_backend
+        backend_api.services.reset
+        backend_api.metrics.each { |metric| metric.send(:sync_backend) }
+      end
+    end
+  end
+end

--- a/app/lib/backend/model_extensions/backend_api_config.rb
+++ b/app/lib/backend/model_extensions/backend_api_config.rb
@@ -9,8 +9,7 @@ module Backend
       end
 
       def sync_backend_api_metrics_with_backend
-        backend_api.services.reset
-        backend_api.metrics.each { |metric| metric.send(:sync_backend) }
+        backend_api.metrics.each { |metric| metric.send(:sync_backend_for_service, service) }
       end
     end
   end

--- a/app/lib/backend/model_extensions/backend_api_config.rb
+++ b/app/lib/backend/model_extensions/backend_api_config.rb
@@ -9,7 +9,7 @@ module Backend
       end
 
       def sync_backend_api_metrics_with_backend
-        backend_api.metrics.each { |metric| metric.send(:sync_backend_for_service, service) }
+        backend_api.metrics.each { |metric| metric.sync_backend_for_service(service) }
       end
     end
   end

--- a/app/lib/backend/model_extensions/metric.rb
+++ b/app/lib/backend/model_extensions/metric.rb
@@ -15,12 +15,6 @@ module Backend
         end
       end
 
-      private
-
-      def cache_service_association
-        owner.account # just call it to cache it
-      end
-
       def sync_backend
         execute_per_service do |service|
           sync_backend_for_service(service)
@@ -39,6 +33,12 @@ module Backend
 
       def sync_backend_for_service!(service)
         ::BackendMetricWorker.new.perform(service.backend_id, id, attributes['system_name'])
+      end
+
+      private
+
+      def cache_service_association
+        owner.account # just call it to cache it
       end
 
       def execute_per_service(&block)

--- a/app/lib/backend/model_extensions/metric.rb
+++ b/app/lib/backend/model_extensions/metric.rb
@@ -23,14 +23,22 @@ module Backend
 
       def sync_backend
         execute_per_service do |service|
-          ::BackendMetricWorker.perform_async(service.backend_id, id, system_name)
+          sync_backend_for_service(service)
         end
       end
 
       def sync_backend!
         execute_per_service do |service|
-          ::BackendMetricWorker.new.perform(service.backend_id, id, system_name)
+          sync_backend_for_service!(service)
         end
+      end
+
+      def sync_backend_for_service(service)
+        ::BackendMetricWorker.perform_async(service.backend_id, id, attributes['system_name'])
+      end
+
+      def sync_backend_for_service!(service)
+        ::BackendMetricWorker.new.perform(service.backend_id, id, attributes['system_name'])
       end
 
       def execute_per_service(&block)

--- a/app/lib/backend/storage_rewrite.rb
+++ b/app/lib/backend/storage_rewrite.rb
@@ -38,7 +38,7 @@ module Backend
       end
 
       Metric.find_each do |metric|
-        metric.send(:sync_backend!)
+        metric.sync_backend!
         progress.call
       end
 
@@ -80,7 +80,7 @@ module Backend
       end
 
       metrics.find_each do |metric|
-        metric.send(:sync_backend!)
+        metric.sync_backend!
         progress.call
       end
 

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class BackendApiConfig < ApplicationRecord
+  include Backend::ModelExtensions::BackendApiConfig
 
   default_scope -> { order(id: :asc) }
   belongs_to :service, inverse_of: :backend_api_configs
@@ -9,10 +10,6 @@ class BackendApiConfig < ApplicationRecord
   has_many :backend_api_metrics, through: :backend_api, source: :metrics
 
   validates :path, length: { in: 0..255, allow_nil: false }, path: true
-
-  after_create do
-    backend_api.metrics.each { |metric| metric.send(:sync_backend) }
-  end
 
   scope :with_subpath, -> { common_query = where.not(path: '/'); System::Database.oracle? ? common_query.where('path is NOT NULL') : common_query.where.not(path: '') }
 

--- a/app/workers/backend_metric_worker.rb
+++ b/app/workers/backend_metric_worker.rb
@@ -45,7 +45,7 @@ class BackendMetricWorker
       new_metric_attributes = {
         service_id: service_backend_id,
         id: metric_id,
-        name: metric.system_name,
+        name: metric.attributes['system_name'],
         parent_id: metric.parent_id_for_service(service)
       }
       ThreeScale::Core::Metric.save(new_metric_attributes)

--- a/test/unit/backend/model_extensions/backend_api_config_test.rb
+++ b/test/unit/backend/model_extensions/backend_api_config_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Backend::ModelExtensions::BackendApiConfigTest < ActiveSupport::TestCase
+  disable_transactional_fixtures!
+
+  test 'sync backend api metrics with backend' do
+    service = FactoryBot.create(:service)
+    backend_api = FactoryBot.create(:backend_api, account: service.account)
+    other_metric = FactoryBot.create(:metric, owner: backend_api, system_name: 'other', service_id: nil)
+
+    backend_api.metrics.each { |metric| metric.expects(:sync_backend_for_service).with(service) }
+    service.backend_api_configs.create(backend_api: backend_api, path: 'foo')
+  end
+end

--- a/test/unit/backend/model_extensions/metric_test.rb
+++ b/test/unit/backend/model_extensions/metric_test.rb
@@ -89,11 +89,11 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
     services.last.backend_api_configs.create(backend_api: backend_api, path: 'other') # other service using the same BackendApi
     metric = FactoryBot.build(:metric, service: nil, owner: backend_api)
 
-    services.each { |service| BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.system_name) }
-    metric.send :sync_backend
+    services.each { |service| BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.attributes['system_name']) }
+    metric.sync_backend
 
-    services.each { |service| BackendMetricWorker.any_instance.expects(:perform).with(service.backend_id, metric.id, metric.system_name) }
-    metric.send :sync_backend!
+    services.each { |service| BackendMetricWorker.any_instance.expects(:perform).with(service.backend_id, metric.id, metric.attributes['system_name']) }
+    metric.sync_backend!
   end
 
   test 'sync metric for single service' do

--- a/test/workers/backend_metric_worker_test.rb
+++ b/test/workers/backend_metric_worker_test.rb
@@ -64,10 +64,10 @@ class BackendMetricWorkerTest < ActiveSupport::TestCase
     worker = BackendMetricWorker.new
 
     metric_attributes = [
-      { id: service_hits.id, name: service_hits.system_name, parent_id: nil },
-      { id: service_other.id, name: service_other.system_name, parent_id: nil },
-      { id: backend_hits.id, name: backend_hits.system_name, parent_id: service_hits.id },
-      { id: backend_other.id, name: backend_other.system_name, parent_id: nil }
+      { id: service_hits.id, name: service_hits.attributes['system_name'], parent_id: nil },
+      { id: service_other.id, name: service_other.attributes['system_name'], parent_id: nil },
+      { id: backend_hits.id, name: backend_hits.attributes['system_name'], parent_id: service_hits.id },
+      { id: backend_other.id, name: backend_other.attributes['system_name'], parent_id: nil }
     ]
     metric_attributes.each do |attrs|
       ThreeScale::Core::Metric.expects(:save).with(attrs.merge(service_id: service_backend_id))


### PR DESCRIPTION
Whenever a new `BackendApiConfig` is created, we need to synchronize all existing metrics that belong to the `backend_api` as if they were owned by the `service` (product), but because of ActiveRecord caching of model associations, we are not really achieving that.

Also, there's no need to synchronize again for all services; only for the one service (product) of the config.