### PR TITLE
Improve Tabs in Dashboard

### DIFF
--- a/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
+++ b/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
@@ -53,13 +53,6 @@
         user-select: none;
       }
 
-      &:not(.pf-m-current):hover {
-        // FIXME: after not working!
-        .pf-c-tabs__button::after {
-          border-top: 2px solid #737679; //var(--pf-c-tabs__item--m-current--BorderTopWidth) solid var(--pf-c-tabs__item--hover--Color);
-        }
-      }
-
       &.pf-m-current {
         .pf-c-tabs__button::before {
           border-bottom-width: 0;
@@ -79,7 +72,18 @@
           right: 0;
           top: 0;
         }
-      }
+      }   
+    }
+
+    .pf-c-tabs__item:not(pf-m-current):hover .pf-c-tabs__button::after {
+      border-top: 2px solid #737679; //var(--pf-c-tabs__item--m-current--BorderTopWidth) solid var(--pf-c-tabs__item--hover--Color);
+      bottom: 0;
+      content: '';
+      left: 0;
+      margin-left: 1px;
+      position: absolute;
+      right: 0;
+      top: 0;
     }
 
     .pf-c-tabs__item:last-of-type {

--- a/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
+++ b/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
@@ -1,0 +1,88 @@
+/**
+ * This are styles to fake Tab component without using PF4 css.
+ *
+ * It is wrapped around pf-c-tabs to avoid possible issues with other
+ * styles in the project. Properties values are hardcoded to meet the exact
+ * ones from PF4.
+ *
+ * It is to be removed completely once using PF4 css files.
+ */
+.pf-c-tabs {
+  ul {
+    list-style: none;
+  }
+
+  button {
+    font-size: 100%;
+    line-height: 24px; //var(--pf-global--LineHeight--md);
+    height: unset;
+    cursor: pointer;
+  }
+
+  .pf-c-tabs__list {
+    display: flex;
+    max-width: 100%;
+    overflow-x: auto;
+    position: relative;
+
+    .pf-c-tabs__item {
+      .pf-c-tabs__button::before {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        content: "";
+        border-color: #d2d2d2; //var(--pf-c-tabs__item--BorderColor)
+        border-style: solid;
+        border-width: 1px 0 1px 1px; //var(--pf-c-tabs__item--BorderWidth) 0 var(--pf-c-tabs__item--BorderWidth) var(--pf-c-tabs__item--BorderWidth);
+      }
+
+      .pf-c-tabs__button {
+        background: transparent; //var(--pf-c-tabs__button--Background);
+        border: 0;
+        color: rgb(21, 21, 21); //var(--pf-c-tabs__item--m-current--Color);
+        display: inline-block;
+        font-weight: 400; //var(--pf-c-tabs__button--FontWeight)
+        outline-offset: calc(-1 * 0.25rem); //var(--pf-c-tabs__button--OutlineOffset);
+        padding: 8px; //var(--pf-c-tabs__button--PaddingTop) var(--pf-c-tabs__button--PaddingRight) var(--pf-c-tabs__button--PaddingBottom) var(--pf-c-tabs__button--PaddingLeft)
+        position: relative;
+        user-select: none;
+      }
+
+      &:not(.pf-m-current):hover {
+        // FIXME: after not working!
+        .pf-c-tabs__button::after {
+          border-top: 2px solid #737679; //var(--pf-c-tabs__item--m-current--BorderTopWidth) solid var(--pf-c-tabs__item--hover--Color);
+        }
+      }
+
+      &.pf-m-current {
+        .pf-c-tabs__button::before {
+          border-bottom-width: 0px;
+        }
+
+        .pf-c-tabs__button {
+          color: rgb(0, 102, 204); //var(--pf-c-tabs__item--m-current--Color);
+        }
+
+        .pf-c-tabs__button::after {
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          margin-left: 1px; //var(--pf-c-tabs__item--BorderWidth);
+          content: "";
+          border-top: 2px solid #06c; //var(--pf-c-tabs__item--m-current--BorderTopWidth) solid var(--pf-c-tabs__item--m-current--Color);
+        }
+      }
+    }
+
+    .pf-c-tabs__item:last-of-type {
+      .pf-c-tabs__button::before {
+        border-right-width: 1px;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
+++ b/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
@@ -1,3 +1,5 @@
+// scss-lint:disable SelectorFormat
+
 /**
  * This are styles to fake Tab component without using PF4 css.
  *
@@ -7,16 +9,17 @@
  *
  * It is to be removed completely once using PF4 css files.
  */
+
 .pf-c-tabs {
   ul {
     list-style: none;
   }
 
   button {
-    font-size: 100%;
-    line-height: 24px; //var(--pf-global--LineHeight--md);
-    height: unset;
     cursor: pointer;
+    font-size: 100%;
+    height: unset;
+    line-height: 24px; //var(--pf-global--LineHeight--md);
   }
 
   .pf-c-tabs__list {
@@ -27,15 +30,15 @@
 
     .pf-c-tabs__item {
       .pf-c-tabs__button::before {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        content: "";
         border-color: #d2d2d2; //var(--pf-c-tabs__item--BorderColor)
         border-style: solid;
         border-width: 1px 0 1px 1px; //var(--pf-c-tabs__item--BorderWidth) 0 var(--pf-c-tabs__item--BorderWidth) var(--pf-c-tabs__item--BorderWidth);
+        bottom: 0;
+        content: '';
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
       }
 
       .pf-c-tabs__button {
@@ -44,7 +47,7 @@
         color: rgb(21, 21, 21); //var(--pf-c-tabs__item--m-current--Color);
         display: inline-block;
         font-weight: 400; //var(--pf-c-tabs__button--FontWeight)
-        outline-offset: calc(-1 * 0.25rem); //var(--pf-c-tabs__button--OutlineOffset);
+        outline-offset: calc(-1 * .25rem); //var(--pf-c-tabs__button--OutlineOffset);
         padding: 8px; //var(--pf-c-tabs__button--PaddingTop) var(--pf-c-tabs__button--PaddingRight) var(--pf-c-tabs__button--PaddingBottom) var(--pf-c-tabs__button--PaddingLeft)
         position: relative;
         user-select: none;
@@ -59,7 +62,7 @@
 
       &.pf-m-current {
         .pf-c-tabs__button::before {
-          border-bottom-width: 0px;
+          border-bottom-width: 0;
         }
 
         .pf-c-tabs__button {
@@ -67,14 +70,14 @@
         }
 
         .pf-c-tabs__button::after {
-          position: absolute;
-          top: 0;
-          right: 0;
+          border-top: 2px solid #06c; //var(--pf-c-tabs__item--m-current--BorderTopWidth) solid var(--pf-c-tabs__item--m-current--Color);
           bottom: 0;
+          content: '';
           left: 0;
           margin-left: 1px; //var(--pf-c-tabs__item--BorderWidth);
-          content: "";
-          border-top: 2px solid #06c; //var(--pf-c-tabs__item--m-current--BorderTopWidth) solid var(--pf-c-tabs__item--m-current--Color);
+          position: absolute;
+          right: 0;
+          top: 0;
         }
       }
     }

--- a/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
+++ b/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
@@ -11,6 +11,7 @@
  */
 
 .pf-c-tabs {
+
   ul {
     list-style: none;
   }
@@ -19,7 +20,7 @@
     cursor: pointer;
     font-size: 100%;
     height: unset;
-    line-height: 24px; //var(--pf-global--LineHeight--md);
+    line-height: line-height-times(1); //var(--pf-global--LineHeight--md);
   }
 
   .pf-c-tabs__list {
@@ -48,7 +49,7 @@
         display: inline-block;
         font-weight: 400; //var(--pf-c-tabs__button--FontWeight)
         outline-offset: calc(-1 * .25rem); //var(--pf-c-tabs__button--OutlineOffset);
-        padding: 8px; //var(--pf-c-tabs__button--PaddingTop) var(--pf-c-tabs__button--PaddingRight) var(--pf-c-tabs__button--PaddingBottom) var(--pf-c-tabs__button--PaddingLeft)
+        padding: line-height-times(1 / 4) line-height-times(1); //var(--pf-c-tabs__button--PaddingTop) var(--pf-c-tabs__button--PaddingRight) var(--pf-c-tabs__button--PaddingBottom) var(--pf-c-tabs__button--PaddingLeft)
         position: relative;
         user-select: none;
       }
@@ -92,4 +93,38 @@
       }
     }
   }
+}
+
+/**
+ * Overrides
+ *
+ * This styles are not PF4 compatibe, were added to make tabs match our dashboard design
+ */
+
+ .DashboardSection--tabs-title {
+    color: #393f44;
+    cursor: pointer;
+    float: left;
+    font-size: 100%;
+    font-weight: 700;
+    line-height: line-height-times(1);
+    margin-right: 0.75rem;
+    margin: 0 0 0 0;
+    padding-top: 8px;
+ }
+
+.pf-tabs-header {
+  border-bottom: 1px solid white;
+  float: right;
+  line-height: line-height-times(1);
+  position: relative;
+  top: 2px;
+}
+
+.pf-c-tabs .pf-c-tabs__list .pf-c-tabs__item .pf-c-tabs__button {
+  text-transform: uppercase;
+}
+
+.pf-c-tabs .pf-c-tabs__list .pf-c-tabs__item.pf-m-current .pf-c-tabs__button::before {
+  border-bottom: 1px solid white;
 }

--- a/app/assets/stylesheets/provider/_theme.scss
+++ b/app/assets/stylesheets/provider/_theme.scss
@@ -107,3 +107,4 @@
 @import 'provider/print';
 
 @import 'provider/vertical_nav';
+@import 'provider/patternfly_tabs_fake';

--- a/app/assets/stylesheets/provider/admin/_dashboard.scss
+++ b/app/assets/stylesheets/provider/admin/_dashboard.scss
@@ -429,14 +429,17 @@ a:hover .u-notice {
   }
 
   &--content {
-    & > input,
-    #products,
-    #backends {
+    & > input {
       display: none;
     }
 
-    & > input:checked ~ #products,
-    & > input:checked ~ #backends {
+    & > #products,
+    & > #backends {
+      display: none;
+    }
+
+    & > #products.active,
+    & > #backends.active {
       display: block;
     }
 

--- a/app/assets/stylesheets/provider/admin/_dashboard.scss
+++ b/app/assets/stylesheets/provider/admin/_dashboard.scss
@@ -31,10 +31,6 @@
         }
       }
     }
-
-    .pf-c-tabs {
-      padding-bottom: 1rem;
-    }
   }
 
   &-title {

--- a/app/assets/stylesheets/provider/admin/_dashboard.scss
+++ b/app/assets/stylesheets/provider/admin/_dashboard.scss
@@ -31,6 +31,10 @@
         }
       }
     }
+
+    .pf-c-tabs {
+      padding-bottom: 1rem;
+    }
   }
 
   &-title {

--- a/app/javascript/src/Dashboard/tabs-widget.jsx
+++ b/app/javascript/src/Dashboard/tabs-widget.jsx
@@ -9,7 +9,8 @@ export function initialize () {
     i.addEventListener('change', toggleCurrentTab)
   }
 
-  function toggleCurrentTab () {
+  function toggleCurrentTab (e: any) {
+    document.cookie = `dashboard_current_tab=${e.currentTarget.id}`
     for (const t of tabs) {
       t.classList.toggle('current-tab')
     }

--- a/app/javascript/src/Dashboard/tabs-widget.jsx
+++ b/app/javascript/src/Dashboard/tabs-widget.jsx
@@ -6,6 +6,13 @@ function updateActiveTab (activeTab, inactiveTab) {
   inactiveTab.classList.remove('active')
 }
 
+function setCurrentTab (currentTab, currentInput, notCurrentTab, notCurrentInput) {
+  currentTab.parentElement.classList.add('pf-m-current')
+  currentInput.setAttribute('checked', true)
+  notCurrentTab.parentElement.classList.remove('pf-m-current')
+  notCurrentInput.removeAttribute('checked')
+}
+
 export function initialize () {
   const productsInput = document.querySelector(`.DashboardNavigation-tabs--content > input#${TAB_PRODUCTS}`)
   const backendsInput = document.querySelector(`.DashboardNavigation-tabs--content > input#${TAB_BACKENDS}`)
@@ -13,25 +20,16 @@ export function initialize () {
   const backendsContainer = document.querySelector(`.DashboardNavigation-tabs--content #backends`)
   const tabsBar = document.querySelector('.DashboardSection--services > .pf-c-tabs')
   const productsTab = tabsBar.querySelector(`button#${TAB_PRODUCTS}`)
+
   productsTab.addEventListener('click', () => {
-    productsTab.parentElement.classList.add('pf-m-current')
-    productsInput.setAttribute('checked', true)
-
-    backendsTab.parentElement.classList.remove('pf-m-current')
-    backendsInput.removeAttribute('checked')
-
+    setCurrentTab(productsTab, productsInput, backendsTab, backendsInput)
     document.cookie = `dashboard_current_tab=${TAB_PRODUCTS}`
     updateActiveTab(productsContainer, backendsContainer)
   })
 
   const backendsTab = tabsBar.querySelector(`button#${TAB_BACKENDS}`)
   backendsTab.addEventListener('click', () => {
-    backendsTab.parentElement.classList.add('pf-m-current')
-    backendsInput.setAttribute('checked', true)
-
-    productsTab.parentElement.classList.remove('pf-m-current')
-    productsInput.removeAttribute('checked')
-
+    setCurrentTab(backendsTab, backendsInput, productsTab, productsInput)
     document.cookie = `dashboard_current_tab=${TAB_BACKENDS}`
     updateActiveTab(backendsContainer, productsContainer)
   })

--- a/app/javascript/src/Dashboard/tabs-widget.jsx
+++ b/app/javascript/src/Dashboard/tabs-widget.jsx
@@ -1,18 +1,45 @@
-// @flow
+const TAB_PRODUCTS = 'tab-products'
+const TAB_BACKENDS = 'tab-backends'
 
 export function initialize () {
-  const tabs = document.querySelectorAll('label[for^="tab-"]')
-  const inputs = document.querySelectorAll('input[name="apiap-tabs"]')
+  const productsInput = document.querySelector(`.DashboardNavigation-tabs--content > input#${TAB_PRODUCTS}`)
+  const backendsInput = document.querySelector(`.DashboardNavigation-tabs--content > input#${TAB_BACKENDS}`)
 
-  // NodeList.foreEach not supported in IE11
-  for (const i of inputs) {
-    i.addEventListener('change', toggleCurrentTab)
-  }
+  const tabsBar = document.querySelector('.DashboardSection--services > .pf-c-tabs')
+  const productsTab = tabsBar.querySelector(`button#${TAB_PRODUCTS}`)
+  productsTab.addEventListener('click', () => {
+    productsTab.parentElement.classList.add('pf-m-current')
+    productsInput.setAttribute('checked', true)
 
-  function toggleCurrentTab (e: any) {
-    document.cookie = `dashboard_current_tab=${e.currentTarget.id}`
-    for (const t of tabs) {
-      t.classList.toggle('current-tab')
-    }
-  }
+    backendsTab.parentElement.classList.remove('pf-m-current')
+    backendsInput.removeAttribute('checked')
+
+    document.cookie = `dashboard_current_tab=${TAB_PRODUCTS}`
+  })
+
+  const backendsTab = tabsBar.querySelector(`button#${TAB_BACKENDS}`)
+  backendsTab.addEventListener('click', () => {
+    backendsTab.parentElement.classList.add('pf-m-current')
+    backendsInput.setAttribute('checked', true)
+
+    productsTab.parentElement.classList.remove('pf-m-current')
+    productsInput.removeAttribute('checked')
+
+    document.cookie = `dashboard_current_tab=${TAB_BACKENDS}`
+  })
+
+  // const tabs = document.querySelectorAll('label[for^="tab-"]')
+  // const inputs = document.querySelectorAll('input[name="apiap-tabs"]')
+
+  // // NodeList.foreEach not supported in IE11
+  // for (const i of inputs) {
+  //   i.addEventListener('change', toggleCurrentTab)
+  // }
+
+  // function toggleCurrentTab (e: any) {
+  //   document.cookie = `dashboard_current_tab=${e.currentTarget.id}`
+  //   for (const t of tabs) {
+  //     t.classList.toggle('current-tab')
+  //   }
+  // }
 }

--- a/app/javascript/src/Dashboard/tabs-widget.jsx
+++ b/app/javascript/src/Dashboard/tabs-widget.jsx
@@ -18,7 +18,7 @@ export function initialize () {
   const backendsInput = document.querySelector(`.DashboardNavigation-tabs--content > input#${TAB_BACKENDS}`)
   const productsContainer = document.querySelector(`.DashboardNavigation-tabs--content #products`)
   const backendsContainer = document.querySelector(`.DashboardNavigation-tabs--content #backends`)
-  const tabsBar = document.querySelector('.DashboardSection--services > .pf-c-tabs')
+  const tabsBar = document.querySelector('.DashboardSection-header .pf-c-tabs')
   const productsTab = tabsBar.querySelector(`button#${TAB_PRODUCTS}`)
 
   productsTab.addEventListener('click', () => {

--- a/app/javascript/src/Dashboard/tabs-widget.jsx
+++ b/app/javascript/src/Dashboard/tabs-widget.jsx
@@ -1,10 +1,16 @@
 const TAB_PRODUCTS = 'tab-products'
 const TAB_BACKENDS = 'tab-backends'
 
+function updateActiveTab (activeTab, inactiveTab) {
+  activeTab.classList.add('active')
+  inactiveTab.classList.remove('active')
+}
+
 export function initialize () {
   const productsInput = document.querySelector(`.DashboardNavigation-tabs--content > input#${TAB_PRODUCTS}`)
   const backendsInput = document.querySelector(`.DashboardNavigation-tabs--content > input#${TAB_BACKENDS}`)
-
+  const productsContainer = document.querySelector(`.DashboardNavigation-tabs--content #products`)
+  const backendsContainer = document.querySelector(`.DashboardNavigation-tabs--content #backends`)
   const tabsBar = document.querySelector('.DashboardSection--services > .pf-c-tabs')
   const productsTab = tabsBar.querySelector(`button#${TAB_PRODUCTS}`)
   productsTab.addEventListener('click', () => {
@@ -15,6 +21,7 @@ export function initialize () {
     backendsInput.removeAttribute('checked')
 
     document.cookie = `dashboard_current_tab=${TAB_PRODUCTS}`
+    updateActiveTab(productsContainer, backendsContainer)
   })
 
   const backendsTab = tabsBar.querySelector(`button#${TAB_BACKENDS}`)
@@ -26,20 +33,6 @@ export function initialize () {
     productsInput.removeAttribute('checked')
 
     document.cookie = `dashboard_current_tab=${TAB_BACKENDS}`
+    updateActiveTab(backendsContainer, productsContainer)
   })
-
-  // const tabs = document.querySelectorAll('label[for^="tab-"]')
-  // const inputs = document.querySelectorAll('input[name="apiap-tabs"]')
-
-  // // NodeList.foreEach not supported in IE11
-  // for (const i of inputs) {
-  //   i.addEventListener('change', toggleCurrentTab)
-  // }
-
-  // function toggleCurrentTab (e: any) {
-  //   document.cookie = `dashboard_current_tab=${e.currentTarget.id}`
-  //   for (const t of tabs) {
-  //     t.classList.toggle('current-tab')
-  //   }
-  // }
 }

--- a/app/views/provider/admin/dashboards/_apiap_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_apiap_navigation.html.slim
@@ -1,6 +1,8 @@
+- current_tab = cookies[:dashboard_current_tab]
+
 nav.DashboardNavigation.DashboardNavigation-tabs
   ul.DashboardNavigation-list
     li.DashboardNavigation-list-item
-      = dashboard_apiap_tab_label 'tab-products', 'Product', @services, icon_name: 'gift', current_tab: true
+      = dashboard_apiap_tab_label 'tab-products', 'Product', @services, icon_name: 'gift', current_tab: current_tab == 'tab-products'
     li.DashboardNavigation-list-item
-      = dashboard_apiap_tab_label 'tab-backends', 'Backend', current_account.backend_apis, icon_name: 'puzzle-piece'
+      = dashboard_apiap_tab_label 'tab-backends', 'Backend', current_account.backend_apis, icon_name: 'puzzle-piece', current_tab: current_tab == 'tab-backends'

--- a/app/views/provider/admin/dashboards/_apiap_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_apiap_navigation.html.slim
@@ -1,8 +1,0 @@
-- current_tab = cookies[:dashboard_current_tab]
-
-nav.DashboardNavigation.DashboardNavigation-tabs
-  ul.DashboardNavigation-list
-    li.DashboardNavigation-list-item
-      = dashboard_apiap_tab_label 'tab-products', 'Product', @services, icon_name: 'gift', current_tab: current_tab == 'tab-products'
-    li.DashboardNavigation-list-item
-      = dashboard_apiap_tab_label 'tab-backends', 'Backend', current_account.backend_apis, icon_name: 'puzzle-piece', current_tab: current_tab == 'tab-backends'

--- a/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
+++ b/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
@@ -1,5 +1,6 @@
 / TODO: workaround until backend_apis/new form is implemented
 - new_admin_backend_api_path = "backend_apis/new"
+- current_tab = cookies[:dashboard_current_tab]
 
 header.DashboardSection-header.DashboardSection-header--extended
   h1.DashboardSection-title
@@ -8,7 +9,7 @@ header.DashboardSection-header.DashboardSection-header--extended
 
 div
   div.DashboardNavigation-tabs--content
-    input#tab-products name='apiap-tabs' type='radio' checked='checked' autocomplete='off'
+    input#tab-products name='apiap-tabs' type='radio' autocomplete='omff' checked=('checked' if current_tab == 'tab-products')
     div#products
       = render 'apiap_search_bar', collection: @services, placeholder: 'Find a Product', id: 'products_search'
       = render 'new_api_button', text: 'New Product', path: new_admin_service_path
@@ -18,7 +19,7 @@ div
                cache_options: { expires_in: 1.hour }
 
   div.DashboardNavigation-tabs--content
-    input#tab-backends name='apiap-tabs' type='radio' autocomplete='off'
+    input#tab-backends name='apiap-tabs' type='radio' autocomplete='off' checked=('checked' if current_tab == 'tab-backends')
     div#backends
       = render 'apiap_search_bar', collection: current_account.backend_apis, placeholder: 'Find a Backend', id: 'backends_search'
       = render 'new_api_button', text: 'New Backend', path: new_admin_backend_api_path

--- a/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
+++ b/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
@@ -1,15 +1,21 @@
 / TODO: workaround until backend_apis/new form is implemented
 - new_admin_backend_api_path = "backend_apis/new"
 - current_tab = cookies[:dashboard_current_tab]
+- tab_products_id = 'tab-products'
+- tab_backends_id = 'tab-backends'
 
-header.DashboardSection-header.DashboardSection-header--extended
-  h1.DashboardSection-title
-    | APIs
-  = render 'apiap_navigation'  
+div class='pf-c-tabs' id='primary'
+  ul.pf-c-tabs__list
+    li.pf-c-tabs__item class=('pf-m-current' if current_tab == tab_products_id)
+      button.pf-c-tabs__button id=tab_products_id
+        |Products
+    li.pf-c-tabs__item class=('pf-m-current' if current_tab == tab_backends_id)
+      button.pf-c-tabs__button id=tab_backends_id
+        |Backends
 
 div
   div.DashboardNavigation-tabs--content
-    input#tab-products name='apiap-tabs' type='radio' autocomplete='omff' checked=('checked' if current_tab == 'tab-products')
+    input#tab-products name='apiap-tabs' type='radio' autocomplete='omff' checked=('checked' if current_tab == tab_products_id)
     div#products
       = render 'apiap_search_bar', collection: @services, placeholder: 'Find a Product', id: 'products_search'
       = render 'new_api_button', text: 'New Product', path: new_admin_service_path
@@ -19,7 +25,7 @@ div
                cache_options: { expires_in: 1.hour }
 
   div.DashboardNavigation-tabs--content
-    input#tab-backends name='apiap-tabs' type='radio' autocomplete='off' checked=('checked' if current_tab == 'tab-backends')
+    input#tab-backends name='apiap-tabs' type='radio' autocomplete='off' checked=('checked' if current_tab == tab_backends_id)
     div#backends
       = render 'apiap_search_bar', collection: current_account.backend_apis, placeholder: 'Find a Backend', id: 'backends_search'
       = render 'new_api_button', text: 'New Backend', path: new_admin_backend_api_path

--- a/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
+++ b/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
@@ -2,7 +2,7 @@
 - new_admin_backend_api_path = "backend_apis/new"
 - tab_products_id = 'tab-products'
 - tab_backends_id = 'tab-backends'
-- current_tab = cookies[:dashboard_current_tab]
+- current_tab = cookies[:dashboard_current_tab] || tab_products_id
 
 div class='pf-c-tabs' id='primary'
   ul.pf-c-tabs__list

--- a/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
+++ b/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
@@ -4,14 +4,19 @@
 - tab_backends_id = 'tab-backends'
 - current_tab = cookies[:dashboard_current_tab] || tab_products_id
 
-div class='pf-c-tabs' id='primary'
-  ul.pf-c-tabs__list
-    li.pf-c-tabs__item class=('pf-m-current' if current_tab == tab_products_id)
-      button.pf-c-tabs__button id=tab_products_id
-        |Products
-    li.pf-c-tabs__item class=('pf-m-current' if current_tab == tab_backends_id)
-      button.pf-c-tabs__button id=tab_backends_id
-        |Backends
+header.DashboardSection-header.DashboardSection-header--extended
+  h1.DashboardSection--tabs-title
+    | APIs
+  div class='pf-c-tabs pf-tabs-header' id='primary'
+    ul.pf-c-tabs__list
+      li.pf-c-tabs__item class=('pf-m-current' if current_tab == tab_products_id)
+        button.pf-c-tabs__button id=tab_products_id
+          i.fa.fa-gift 
+          |&nbsp; Products
+      li.pf-c-tabs__item class=('pf-m-current' if current_tab == tab_backends_id)
+        button.pf-c-tabs__button id=tab_backends_id
+          i.fa.fa-puzzle-piece 
+          |&nbsp; Backends
 
 div
   div.DashboardNavigation-tabs--content

--- a/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
+++ b/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
@@ -1,8 +1,8 @@
 / TODO: workaround until backend_apis/new form is implemented
 - new_admin_backend_api_path = "backend_apis/new"
-- current_tab = cookies[:dashboard_current_tab]
 - tab_products_id = 'tab-products'
 - tab_backends_id = 'tab-backends'
+- current_tab = cookies[:dashboard_current_tab]
 
 div class='pf-c-tabs' id='primary'
   ul.pf-c-tabs__list
@@ -15,8 +15,8 @@ div class='pf-c-tabs' id='primary'
 
 div
   div.DashboardNavigation-tabs--content
-    input#tab-products name='apiap-tabs' type='radio' autocomplete='omff' checked=('checked' if current_tab == tab_products_id)
-    div#products
+    input#tab-products name='apiap-tabs' type='radio' autocomplete='off' checked=('checked' if current_tab == tab_products_id)
+    div#products class=('active' if current_tab == tab_products_id)
       = render 'apiap_search_bar', collection: @services, placeholder: 'Find a Product', id: 'products_search'
       = render 'new_api_button', text: 'New Product', path: new_admin_service_path
       = render collection: @services,
@@ -26,7 +26,7 @@ div
 
   div.DashboardNavigation-tabs--content
     input#tab-backends name='apiap-tabs' type='radio' autocomplete='off' checked=('checked' if current_tab == tab_backends_id)
-    div#backends
+    div#backends class=('active' if current_tab == tab_backends_id)
       = render 'apiap_search_bar', collection: current_account.backend_apis, placeholder: 'Find a Backend', id: 'backends_search'
       = render 'new_api_button', text: 'New Backend', path: new_admin_backend_api_path
       = render 'list_backends'

--- a/features/old/authorization/provider_plans_section.feature
+++ b/features/old/authorization/provider_plans_section.feature
@@ -20,7 +20,8 @@ Feature: Provider plans section authorization
     Given current domain is the admin domain of provider "foo.example.com"
      When I log in as provider "foo.example.com"
      When I go to the provider dashboard
-     Then I should see "apis" in the apis dashboard widget
+     Then I should see "Products" in the apis dashboard widget
+     Then I should see "Backends" in the apis dashboard widget
 
     When I go to the <page> page
     Then I should be at url for the <page> page
@@ -41,7 +42,8 @@ Feature: Provider plans section authorization
      And current domain is the admin domain of provider "foo.example.com"
      When I log in as provider "member"
       And I go to the provider dashboard
-    Then I should see "apis" in the apis dashboard widget
+    Then I should see "Products" in the apis dashboard widget
+    Then I should see "Backends" in the apis dashboard widget
 
     When I request the url of the '<page>' page then I should see an exception
 
@@ -64,7 +66,8 @@ Feature: Provider plans section authorization
       And current domain is the admin domain of provider "foo.example.com"
      When I log in as provider "member"
       And I go to the provider dashboard
-     Then I should see "apis" in the apis dashboard widget
+     Then I should see "Products" in the apis dashboard widget
+     Then I should see "Backends" in the apis dashboard widget
 
     When I go to the <page> page
     Then I should be at url for the <page> page

--- a/features/old/authorization/provider_plans_section.feature
+++ b/features/old/authorization/provider_plans_section.feature
@@ -20,6 +20,7 @@ Feature: Provider plans section authorization
     Given current domain is the admin domain of provider "foo.example.com"
      When I log in as provider "foo.example.com"
      When I go to the provider dashboard
+     Then I should see "APIs" in the apis dashboard widget
      Then I should see "Products" in the apis dashboard widget
      Then I should see "Backends" in the apis dashboard widget
 
@@ -42,6 +43,7 @@ Feature: Provider plans section authorization
      And current domain is the admin domain of provider "foo.example.com"
      When I log in as provider "member"
       And I go to the provider dashboard
+    Then I should see "APIs" in the apis dashboard widget
     Then I should see "Products" in the apis dashboard widget
     Then I should see "Backends" in the apis dashboard widget
 
@@ -66,6 +68,7 @@ Feature: Provider plans section authorization
       And current domain is the admin domain of provider "foo.example.com"
      When I log in as provider "member"
       And I go to the provider dashboard
+     Then I should see "APIs" in the apis dashboard widget
      Then I should see "Products" in the apis dashboard widget
      Then I should see "Backends" in the apis dashboard widget
 

--- a/features/old/menu/dashboard.feature
+++ b/features/old/menu/dashboard.feature
@@ -18,14 +18,15 @@ Feature: Dashboard
 
   Scenario: APIs widget
     When I go to the provider dashboard
-    Then I should see "APIs" in the apis dashboard widget
-    And I should see "1 Product" in the apis dashboard widget
-    And I should see "1 Backend" in the apis dashboard widget
-    And I should see the link "0 ActiveDocs" in the apis dashboard widget
-    And I should see the link "New Backend" in the apis dashboard widget
-    And I should see the link "API Backend API" in the apis dashboard widget
-    And I should see the link "0 Methods" in the apis dashboard widget
-    And I should see the link "0 Mapping Rules" in the apis dashboard widget
+    And I should see "Products" in the apis dashboard widget
+    And I should see "Backends" in the apis dashboard widget
+    And I should see "API" in the apis dashboard products tabs section
+    And I should see the link "New Product" in the apis dashboard products tabs section
+    And I should see the link "0 ActiveDocs" in the apis dashboard products tabs section
+    And I should see the link "New Backend" in the apis dashboard backends tabs section
+    And I should see the link "API Backend API" in the apis dashboard backends tabs section
+    And I should see the link "0 Methods" in the apis dashboard backends tabs section
+    And I should see the link "0 Mapping Rules" in the apis dashboard backends tabs section
 
   Scenario: first API widget
     And I should see "API" in the first api dashboard widget

--- a/features/old/menu/dashboard.feature
+++ b/features/old/menu/dashboard.feature
@@ -18,6 +18,7 @@ Feature: Dashboard
 
   Scenario: APIs widget
     When I go to the provider dashboard
+    Then I should see "APIs" in the apis dashboard widget
     And I should see "Products" in the apis dashboard widget
     And I should see "Backends" in the apis dashboard widget
     And I should see "API" in the apis dashboard products tabs section

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -231,6 +231,7 @@ When /^(.*) within ([^:"]+)$/ do |lstep, scope|
 end
 
 [ 'the audience dashboard widget', 'the apis dashboard widget',
+  'the apis dashboard products tabs section', 'the apis dashboard backends tabs section',
   'the first api dashboard widget',
   'the main menu',
   'the subsubmenu','the user widget',

--- a/features/support/selectors.rb
+++ b/features/support/selectors.rb
@@ -13,6 +13,10 @@ module HtmlSelectorsHelper
       '#audience'
     when 'the apis dashboard widget', :apis_dashboard_widget
       '#apis'
+    when 'the apis dashboard products tabs section'
+      '#products'
+    when 'the apis dashboard backends tabs section'
+      '#backends'
     when 'the first api dashboard widget'
       "#service_#{provider_first_service!.id}"
     when 'the subsubmenu'


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Remember what tab is selected
- [x] Replace current tabs with PF4 ones
- [x] Fix hover style

![after](https://user-images.githubusercontent.com/13486237/65255475-43780c00-dafe-11e9-9f91-daf531e6895e.png)

~⚠️**PF4 Styles**⚠️ There's still an issue with the hover style. For some reason I can't get the [::after style](https://github.com/3scale/porta/pull/1190/files#diff-b04944eeb7c91095409e39e62cf6cf8cR54) work, despite the fact that it works for `.pf-m-current`.~


**Which issue(s) this PR fixes** 

[THREESCALE-3357: Improve product and backend tabs on dashboard](https://issues.jboss.org/browse/THREESCALE-3357)

**Verification steps** 

* Feels and looks like [PF4 tabs](https://pf4.patternfly.org/components/Tabs/examples/)
* After refreshing the page, same tab is selected (it doesn't show Products by default)
