### PR TITLE
Fixes test by making assertion case insensitive

### DIFF
--- a/features/step_definitions/dashboard_steps.rb
+++ b/features/step_definitions/dashboard_steps.rb
@@ -7,14 +7,14 @@ def service_for_name (name)
   page.find("#service_#{service_id}")
 end
 
-def hits_for_name (name)
+def hits_for_name (name, opts = {})
   service_id = service_id_for_name(name)
-  page.find_by_id("dashboard-widget-service_id-#{service_id}service_hits")
+  page.find_by_id("dashboard-widget-service_id-#{service_id}service_hits", opts)
 end
 
-def top_traffic_for_name (name)
+def top_traffic_for_name (name, opts = {})
   service_id = service_id_for_name(name)
-  page.find_by_id("dashboard-widget-service_id-#{service_id}service_top_traffic")
+  page.find_by_id("dashboard-widget-service_id-#{service_id}service_top_traffic", opts)
 end
 
 When(/^service "([^"]*)" is (folded|unfolded)$/) do |service_name, state|
@@ -25,8 +25,8 @@ When(/^service "([^"]*)" is (folded|unfolded)$/) do |service_name, state|
 end
 
 Then(/^I should not see "([^"]*)" overview data$/) do |service_name|
-  hits = hits_for_name(service_name)
-  top_traffic = top_traffic_for_name(service_name)
+  hits = hits_for_name(service_name, visible: false)
+  top_traffic = top_traffic_for_name(service_name, visible: false)
 
   assert_not hits.visible?
   assert_not top_traffic.visible?

--- a/features/step_definitions/dashboard_steps.rb
+++ b/features/step_definitions/dashboard_steps.rb
@@ -1,5 +1,5 @@
 def service_id_for_name (name)
-  page.find_by_id('apis').find('section', :text => name)[:id][/\d+/]
+  page.find_by_id('apis').find('section', :text => %r{#{name}}i)[:id][/\d+/]
 end
 
 def service_for_name (name)


### PR DESCRIPTION
Some title in system are upper case and Capybara is case-sensitive by default. Adding a regex with the flag `/i` fixes this issue.

Error:
```
failed Folded services have no overview data

    Scenario: Folded services have no overview data

And service "Fancy API" is folded

Message:

    Unable to find visible css "section" with text "Fancy API" within #<Capybara::Node::Element tag="section" path="/html/body/div[1]/div/main/div/div[1]/section[2]"> (Capybara::ElementNotFound)
```

EDIT
And also it's required to specify `visible: false` so that the element is found and asserted.
Using `visible: :hidden` could make the test throw an error, which would be also valid but not so elegant.