### PR TITLE
[Doc] Add missing ')' in Contributing for the right format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ To sign your commits, you only need to follow these steps:
 
 #### **Do you have questions about the source code?**
 
-* Ask any question by [raising an issue](https://issues.jboss.org/secure/CreateIssueDetails!init.jspa?pid=12318224&issuetype=3&components=12325241&priority=4. Maintainers could always use more help, so they'll be happy to assist you, no matter how silly you might think your question is. 
+* Ask any question by [raising an issue](https://issues.jboss.org/secure/CreateIssueDetails!init.jspa?pid=12318224&issuetype=3&components=12325241&priority=4). Maintainers could always use more help, so they'll be happy to assist you, no matter how silly you might think your question is. 
 
 Thanks for reading this far!! 
 


### PR DESCRIPTION
This is how it looks before this PR:
![image](https://user-images.githubusercontent.com/11318903/64952118-cfc8cb80-d87f-11e9-9cab-ea7d19577b25.png)

This is how it looks like after this PR:
![image](https://user-images.githubusercontent.com/11318903/64952150-e111d800-d87f-11e9-9650-a4f23b5aee83.png)
