### PR TITLE
Fix Backend API mapping rules injected into the proxy config

### DIFF
--- a/app/decorators/proxy_rule_decorator.rb
+++ b/app/decorators/proxy_rule_decorator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ProxyRuleDecorator < ApplicationDecorator
-
   self.include_root_in_json = false
 
   def pattern
@@ -9,10 +8,14 @@ class ProxyRuleDecorator < ApplicationDecorator
     backend_api_path ? File.join('/', backend_api_path, pattern_value) : pattern_value
   end
 
+  def metric_system_name
+    object.metric.attributes['system_name']
+  end
+
   private
 
   def delegatable?(method)
-    return false if method.to_sym == :pattern
+    return false if self.class.instance_methods(false).include?(method.to_sym)
     object.respond_to?(method)
   end
 

--- a/app/decorators/proxy_rule_decorator.rb
+++ b/app/decorators/proxy_rule_decorator.rb
@@ -5,11 +5,16 @@ class ProxyRuleDecorator < ApplicationDecorator
   self.include_root_in_json = false
 
   def pattern
-    pattern_value = super
+    pattern_value = object.pattern
     backend_api_path ? File.join('/', backend_api_path, pattern_value) : pattern_value
   end
 
   private
+
+  def delegatable?(method)
+    return false if method.to_sym == :pattern
+    object.respond_to?(method)
+  end
 
   def backend_api_path
     context[:backend_api_path]

--- a/test/unit/apicast/proxy_rules_source_test.rb
+++ b/test/unit/apicast/proxy_rules_source_test.rb
@@ -8,14 +8,23 @@ class Apicast::ProxyRulesSourceTest < ActiveSupport::TestCase
     rule_2 = FactoryBot.create(:proxy_rule, proxy: proxy)
 
     backend_api_config = FactoryBot.create(:backend_api_config, service: proxy.service, path: '/test/path/')
-    rule_3 = FactoryBot.create(:proxy_rule, owner: backend_api_config.backend_api, pattern: '/create')
+    backend_api = backend_api_config.backend_api
+    metric = FactoryBot.create(:metric, owner: backend_api, description: 'My awesome metric', system_name: 'my-metric')
+    rule_3 = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/create')
+    rule_4 = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/delete', metric: metric)
 
     source = Apicast::ProxyRulesSource.new(proxy).to_hash
+
     assert find_by_id_in_hash(rule_1.id, source)
     assert find_by_id_in_hash(rule_2.id, source)
+
     rule_hash_3 = find_by_id_in_hash(rule_3.id, source)
-    assert rule_hash_3
+    rule_hash_4 = find_by_id_in_hash(rule_4.id, source)
+
+    assert rule_hash_3 && rule_hash_4
     assert_equal '/test/path/create', rule_hash_3['pattern']
+    assert_equal '/test/path/delete', rule_hash_4['pattern']
+    assert_equal metric['system_name'], rule_hash_4['metric_system_name']
   end
 
   private


### PR DESCRIPTION
**Which issue(s) this PR fixes** 

Backend api mapping rules injected in the proxy config have two problems:
1. It does not prepend the backend API config path to the pattern of the proxy rule
2. It does not inject the full `system_name` of the metric but only the part without the `.#{backend_api.id}` suffix

First problem is due to draper's `delegate_all` method used in https://github.com/3scale/porta/blob/ccc776ca84d1acb04694f8762c405eed5bdf4137/app/decorators/application_decorator.rb#L4. This method makes the decorator class to dynamically define delegations of the decorated object's instance methods to the object itself, thus making `ProxyRuleDecorator#pattern` to execute only once and then always be delegated to the object.

See https://github.com/drapergem/draper/issues/818

The second problem is because of https://github.com/3scale/porta/blob/ccc776ca84d1acb04694f8762c405eed5bdf4137/app/lib/backend_api_logic/metric_extension.rb#L13-L15

**What this PR does**
- [x] Fix `path` of Backend API mapping rules injected into the proxy config
- [x] Fix `system_name` of Backend API mapping rules injected into the proxy config

**Verification steps** 

1. Generate a json proxy config file of a product using 2+ backend APIs containing proxy rules
2. Verify that all backend API proxy rules include the proper backend api config's path prepended to the rule's pattern
3. Verify that all backend API proxy rules have the `.#{backend_api.id}` suffix appended to the end of `metric_system_name`

<img width="733" alt="Screen Shot 2019-09-16 at 8 18 51 PM" src="https://user-images.githubusercontent.com/1842261/64982755-3d481c80-d8bf-11e9-9eaa-38ddc8b7c957.png">
