### PR TITLE
Fix missing configs in Custom Policies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -940,15 +940,6 @@
         "regenerator-runtime": "^0.13.2"
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
-      "integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -11509,6 +11500,11 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
+    "lodash.topath": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
+      "integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak="
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -12085,11 +12081,6 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-    },
-    "nanoid": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.0.tgz",
-      "integrity": "sha512-g5WwS+p6Cm+zQhO2YOpRbQThZVnNb7DDq74h8YDCLfAGynrEOrbx2E16dc8ciENiP1va5sqaAruqn2sN+xpkWg=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -14558,18 +14549,15 @@
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
     },
     "react-jsonschema-form": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/react-jsonschema-form/-/react-jsonschema-form-1.8.0.tgz",
-      "integrity": "sha512-3rZZ1tCG+vtXRXEdX751t5L1c1TUGk1pvSY/4LzBrUo5FlwulnwJpkosE4BqwSRxvfMckP8YoHFQV4KjzaHGgQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-jsonschema-form/-/react-jsonschema-form-1.3.0.tgz",
+      "integrity": "sha512-WrlQh0urJGkR4Sb9hMJLwsTkVYVYbpgtofZ+JxiI9FSFXAIfCiCwhZ7R0zEKFADlah3KrN3qC6VFE6HtFk6aZg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.4.5",
         "ajv": "^6.7.0",
+        "babel-runtime": "^6.26.0",
         "core-js": "^2.5.7",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.5.8",
-        "react-is": "^16.8.4",
-        "react-lifecycles-compat": "^3.0.4",
-        "shortid": "^2.2.14"
+        "lodash.topath": "^4.5.2",
+        "prop-types": "^15.5.8"
       }
     },
     "react-lifecycles-compat": {
@@ -15527,14 +15515,6 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
-    },
-    "shortid": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
-      "integrity": "sha512-4UnZgr9gDdA1kaKj/38IiudfC3KHKhDc1zi/HSxd9FQDR0VLwH3/y79tZJLsVYPsJgIjeHjqIWaWVRJUj9qZOQ==",
-      "requires": {
-        "nanoid": "^2.0.0"
-      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "react": "^16.8.5",
     "react-codemirror2": "^5.1.0",
     "react-dom": "^16.8.3",
-    "react-jsonschema-form": "^1.3.0",
+    "react-jsonschema-form": "1.3.0",
     "react-redux": "^5.0.6",
     "react-sortable-hoc": "^1.6.1",
     "redux": "^4.0.1",


### PR DESCRIPTION
NPM silently installed `react-jsonschema-form@1.8.0` which has a change in their `Form` component that breaks our implementation.

Since we rely on `1.3.0`, let's install that _exact_ version.

fixes https://issues.jboss.org/browse/THREESCALE-3475

- [ ] check if this was shipped in 2.6 (i guess not but would be good to be sure)