### PR TITLE
Make registry_policies available for Edit and Update actions

### DIFF
--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -52,11 +52,11 @@ module Api::IntegrationsHelper
   end
 
   def currently_deploying?(proxy)
-    @deploying
+    deploying
   end
 
   def deployed?(proxy)
-    @ever_deployed_hosted
+    ever_deployed_hosted
   end
 
   def apicast_configuration_driven?
@@ -91,5 +91,15 @@ module Api::IntegrationsHelper
   def edit_deployment_option_title(service)
     title = deployment_option_is_service_mesh?(service) ? 'Service Mesh' : 'APIcast'
     t(:edit_deployment_configuration, scope: :api_integrations_controller, deployment: title )
+  end
+
+  private
+
+  def deploying
+    @deploying ||= ThreeScale::TimedValue.get(current_account.deploying_hosted_proxy_key)
+  end
+
+  def ever_deployed_hosted
+    @ever_deployed_hosted ||= current_account.hosted_proxy_deployed_at.present?
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -167,6 +167,10 @@ class Account < ApplicationRecord
     users.admins.but_impersonation_admin
   end
 
+  def deploying_hosted_proxy_key
+    "#{id}/deploying_hosted"
+  end
+
   def first_admin
     @_first_admin ||= admins.first
   end


### PR DESCRIPTION
Currently when something happens when trying to update something
in the integration page, it fails and the registry_policies is
not called because it is only set in the edit action. This commit
changes it and makes it available as a helper method and the view
only calls the method instead of relying on a variable saved in
the action.