### PR TITLE
Move creation of metric.owner_(id|type) before migration of existing backend APIs

### DIFF
--- a/db/migrate/20190716110000_add_owner_to_metrics.rb
+++ b/db/migrate/20190716110000_add_owner_to_metrics.rb
@@ -2,6 +2,8 @@ class AddOwnerToMetrics < ActiveRecord::Migration
   disable_ddl_transaction!
 
    def change
+    return if ActiveRecord::SchemaMigration.find_by(version: 20190805135730) # this migration was repositioned back
+
     add_column :metrics, :owner_id, :integer, limit: 8
     add_column :metrics, :owner_type, :string
 


### PR DESCRIPTION
**What this PR does / why we need it**

After https://github.com/3scale/porta/pull/1171, https://github.com/3scale/porta/commit/bbd7051d92cfc4f286f0c0ae28c04aa1d9bd65a2 became a requirement for https://github.com/3scale/porta/blob/8cecd33c61eed6e724ffcc2108effb89fd913ac0/db/migrate/20190716110520_create_the_backend_apis_of_services.rb.

**Which issue(s) this PR fixes**

Closes [THREESCALE-3485](https://issues.jboss.org/browse/THREESCALE-3485)

**Verification steps** 

```
git co c2204dcdf8cf3e5a9484e635df3bba7544e8b529~1 # right before the migration that breaks without this PR
bundle exec rake db:reset
git co fix/create-backend-apis-migration
bundle exec db:migrate
```

You should see no error

```
Migrating to CreateTheBackendApisOfServices (20190716110520)
== 20190716110520 CreateTheBackendApisOfServices: migrating ===================
-- Migrating proxies api_backend to slugs...
rake aborted!
StandardError: An error has occurred, all later migrations canceled:
undefined method `owner_type?' for #<Metric:0x0000000006b93858>
/opt/system/vendor/bundle/ruby/2.4.0/gems/activemodel-4.2.11.1/lib/active_model/attribute_methods.rb:433:in `method_missing'
/opt/system/app/models/metric.rb:251:in `fill_owner'
```

**Special notes to the reviewer**

_Alternative:_ Completely remove https://github.com/3scale/porta/blob/8cecd33c61eed6e724ffcc2108effb89fd913ac0/db/migrate/20190716110520_create_the_backend_apis_of_services.rb and make it a rake task to be executed only after finishing with all DLL migrations.