### PR TITLE
Include Rake task to destroy orphans backend apis

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -30,6 +30,8 @@ class BackendApi < ApplicationRecord
 
   has_system_name(uniqueness_scope: [:account_id])
 
+  scope :orphans, -> { joining { services.outer }.where { BabySqueel[:backend_api_configs].backend_api_id == nil } }
+
   scope :oldest_first, -> { order(created_at: :asc) }
 
   def self.default_api_backend

--- a/lib/tasks/backend_api.rake
+++ b/lib/tasks/backend_api.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :backend_api do
+  desc 'Destroy all orphan backend apis that does not belongs to any service when api_as_product is disabled'
+  task :destroy_orphans => :environment do
+    BackendApi.orphans.find_each { |backend_api| DeleteObjectHierarchyWorker.perform_later(backend_api) unless backend_api.account.provider_can_use?(:api_as_product) }
+  end
+end

--- a/test/models/backend_api_test.rb
+++ b/test/models/backend_api_test.rb
@@ -30,6 +30,18 @@ class BackendApiTest < ActiveSupport::TestCase
     assert @backend_api.valid?
   end
 
+  test '.orphans should return backend apis that do not belongs to any service' do
+    FactoryBot.create(:service)
+    service_to_delete = FactoryBot.create(:service)
+    orphan_backend_api = service_to_delete.backend_api_configs.first.backend_api
+
+    assert_equal [], BackendApi.orphans
+
+    service_to_delete.destroy!
+
+    assert_equal [orphan_backend_api], BackendApi.orphans
+  end
+
   test 'creates default metrics' do
     backend_api = FactoryBot.create(:backend_api)
     hits = backend_api.metrics.hits

--- a/test/unit/tasks/backend_api_test.rb
+++ b/test/unit/tasks/backend_api_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class Tasks::BackendApiTest < ActiveSupport::TestCase
+  setup do
+    @backend_api = FactoryBot.create(:backend_api)
+    FactoryBot.create(:backend_api_config, backend_api: @backend_api)
+    @orphan_backend_api = FactoryBot.create(:backend_api)
+  end
+
+  test 'destroy orphans when account can not use api as product' do
+    Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(@orphan_backend_api).once
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(@backend_api).never
+
+    execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
+  end
+
+  test 'does not destroy orphans when account can use api as product' do
+    Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(@orphan_backend_api).never
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(@backend_api).never
+
+    execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
+  end
+end


### PR DESCRIPTION
Although the deletion process of Services is async, even after
several hours or even days a given Service cannot be created again
using the same system_name from a previously deleted one. This
happens because the backend api is still created. Some customers
reported this bug.

This commit includes a Rake task to allow us to run this in cli
to destroy orphans backend apis