### PR TITLE
Integration Settings as Application Usage Rules

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -30,7 +30,8 @@ class Api::ServicesController < Api::BaseController
   end
 
   def settings
-    activate_menu :serviceadmin, :integration, :settings
+    activate_menu_args = current_account.provider_can_use?(:api_as_product) ? %i[serviceadmin applications usage_rules] : %i[serviceadmin integration settings]
+    activate_menu activate_menu_args
     @alert_limits = Alert::ALERT_LEVELS
   end
 

--- a/app/helpers/api/services_helper.rb
+++ b/app/helpers/api/services_helper.rb
@@ -56,4 +56,8 @@ module Api::ServicesHelper
     msg = t('api.services.forms.definition_settings.refresh_confirmation', name: h(service.name))
     action_link_to(:refresh, url, {data: { confirm: msg }, method: :put}.merge(options) )
   end
+
+  def page_title
+    current_account.provider_can_use?(:api_as_product) ? 'Usage Rules' : 'Settings'
+  end
 end

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -221,6 +221,7 @@ module VerticalNavHelper
     items = []
     items << {id: :listing,           title: 'Listing',           path: admin_service_applications_path(@service)}
     items << {id: :application_plans, title: 'Application Plans', path: admin_service_application_plans_path(@service)} if can?(:manage, :plans)
+    items << {id: :usage_rules,       title: 'Usage Rules',       path: settings_admin_service_path(@service)} if current_account.provider_can_use?(:api_as_product)
     items
   end
 
@@ -241,7 +242,8 @@ module VerticalNavHelper
     items << {id: :configuration,   title: 'Configuration',     path: path_to_service(@service)}
     items << {id: :methods_metrics, title: 'Methods & Metrics', path: admin_service_metrics_path(@service)}
     items << {id: :mapping_rules,   title: 'Mapping Rules',     path: admin_service_proxy_rules_path(@service)} if current_account.independent_mapping_rules_enabled?
-    items << {id: :settings,        title: 'Settings',          path: settings_admin_service_path(@service)}
+    items << {id: :settings,        title: 'Settings',          path: settings_admin_service_path(@service)} unless current_account.provider_can_use?(:api_as_product)
+    items
   end
 
   # Backend APIs

--- a/app/views/api/services/settings.html.slim
+++ b/app/views/api/services/settings.html.slim
@@ -1,4 +1,4 @@
-- content_for :sublayout_title, 'Settings'
+- content_for :sublayout_title, page_title
 
 - if (can? :manage, :service_plans) && !current_account.settings.service_plans_ui_visible?
   = form_tag polymorphic_path([:masterize, :admin, @service, ServicePlan]), :method => :post, :class => 'service autosubmit formtastic', :remote => true do

--- a/features/old/menu/api_menu.feature
+++ b/features/old/menu/api_menu.feature
@@ -38,6 +38,7 @@ Feature: API menu
 
   Scenario: Integration sub menu structure provider has api as product enabled
     Given the account has Service acting as Product
+    And I have api_as_product feature disabled
     When I follow "Overview"
     When I follow "Integration" within the main menu
     Then I should see menu items
@@ -47,6 +48,7 @@ Feature: API menu
     | Settings                  |
 
   Scenario: Integration sub menu structure when provider does not have api as product enabled
+    Given I have api_as_product feature disabled
     When I follow "Overview"
     And I follow "Integration" within the main menu
     Then I should see menu items
@@ -56,6 +58,7 @@ Feature: API menu
 
   Scenario: Integration sub menu structure for API as Product
     Given the account has Service acting as Product
+    And I have api_as_product feature disabled
     When I follow "Overview"
     And I follow "Integration" within the main menu
     Then I should see menu items

--- a/features/old/services/multiservice.feature
+++ b/features/old/services/multiservice.feature
@@ -41,6 +41,7 @@ Feature: Multiservice feature
   @javascript
   Scenario: Edit service
     Given I am logged in as provider "foo.example.com"
+      And all the rolling updates features are off
       And I am on the edit page for service "Fancy API" of provider "foo.example.com"
     When I fill in "Name" with "Less fancy API"
      And I press "Update Service"


### PR DESCRIPTION
**What this PR does / why we need it**:

The current Integration > Settings needs to be migrated to Applications > Usage Rules when rolling update `api_as_product` is enabled

**Which issue(s) this PR fixes** 

fixes https://issues.jboss.org/browse/THREESCALE-3471

**Verification steps** 

* With Rolling update on:
<img width="976" alt="Screen Shot 2019-09-19 at 09 13 25" src="https://user-images.githubusercontent.com/4183971/65243412-ae095780-dabe-11e9-80b2-3c813c187a00.png">

* With Rolling update off:
<img width="969" alt="Screen Shot 2019-09-19 at 09 14 50" src="https://user-images.githubusercontent.com/4183971/65243448-c24d5480-dabe-11e9-8242-d814313681be.png">

**Special notes for your reviewer**:
Mind the rolling update feature needs to be either `false` or an array with the provider_id (s)