### PR TITLE
[WIP] Factory metric without having to pass service_id: nil

### DIFF
--- a/app/lib/api_docs/provider_data.rb
+++ b/app/lib/api_docs/provider_data.rb
@@ -62,7 +62,7 @@ module ApiDocs
     end
 
     def metrics
-      @metrics ||= @account.metrics.includes(:service).top_level
+      @metrics ||= @account.top_level_metrics.includes(:owner)
     end
 
     METRIC_NAME = ->(metric) { "#{metric.friendly_name} | #{metric.service.name}" }

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -45,7 +45,7 @@ module Account::ProviderMethods
     end
 
     def metrics
-      Metric.where(service_id: Service.where(account_id: id))
+      Metric.where(owner_id: Service.where(account_id: id), owner_type: Service.name)
     end
 
     def top_level_metrics

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -28,8 +28,6 @@ module Account::ProviderMethods
     has_many :provider_audits, foreign_key: :provider_id, class_name: Audited.audit_class.name
 
     has_many :usage_limits, through: :services
-    has_many :metrics, through: :services
-    has_many :top_level_metrics, through: :services
     has_many :proxies, through: :services
     has_many :proxy_rules, through: :proxies
     has_many :proxy_logs, foreign_key: :provider_id
@@ -44,6 +42,14 @@ module Account::ProviderMethods
         complete_attributes = attributes.merge(account: build.account).reverse_merge(where_values_hash).symbolize_keys!
         build_by_kind(kind: kind, account_type: AuthenticationProvider.account_types[:provider], **complete_attributes)
       end
+    end
+
+    def metrics
+      Metric.where(service_id: Service.where(account_id: id))
+    end
+
+    def top_level_metrics
+      metrics.top_level
     end
 
     has_many :backend_apis, inverse_of: :account, dependent: :destroy

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -32,10 +32,7 @@ class Metric < ApplicationRecord
   validate :only_hits_has_children
 
   alias service= owner=
-
-  def service
-    Service.find_by(id: service_id)
-  end
+  alias service owner
 
   def service_id
     service_id = super

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -31,6 +31,8 @@ class Metric < ApplicationRecord
 
   validate :only_hits_has_children
 
+  alias service= owner=
+
   def service
     Service.find_by(id: service_id)
   end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -32,9 +32,7 @@ class Metric < ApplicationRecord
   validate :only_hits_has_children
 
   def service
-    service = super
-    service ||= owner if backend_api_metric?
-    service
+    Service.find_by(id: service_id)
   end
 
   def service_id

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -92,7 +92,7 @@ class Service < ApplicationRecord
 
   has_many :features, as: :featurable, dependent: :destroy
 
-  has_many :metrics, dependent: :destroy
+  has_many :metrics, dependent: :destroy, as: :owner, inverse_of: :owner
   has_many :top_level_metrics, -> { includes(:children).top_level }, class_name: 'Metric'
 
   has_many :service_tokens, inverse_of: :service, dependent: :destroy

--- a/test/factories/other.rb
+++ b/test/factories/other.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
   end
 
   factory(:metric) do
-    association :service
+    association(:owner, factory: :service)
     sequence(:friendly_name) { |n| "Metric #{n}" }
     sequence(:unit) { |m| "metric_#{m}" }
   end

--- a/test/integration/admin/api/backend_apis/metrics_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metrics_controller_test.rb
@@ -15,7 +15,7 @@ class Admin::API::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
   test 'index' do
     FactoryBot.create(:metric, owner: backend_api, parent: backend_api.metrics.hits)
 
-    FactoryBot.create(:metric, owner: FactoryBot.create(:backend_api, account: tenant), service_id: nil)
+    FactoryBot.create(:metric, owner: FactoryBot.create(:backend_api, account: tenant))
     FactoryBot.create(:metric, service: FactoryBot.create(:service, account: tenant))
 
     get admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value)

--- a/test/integration/provider/admin/backend_apis/metrics_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/metrics_controller_test.rb
@@ -9,8 +9,8 @@ class Provider::Admin::BackendApis::MetricsControllerTest < ActionDispatch::Inte
     @backend_api = @service.backend_api
 
     @hits = @backend_api.metrics.hits
-    @meth = FactoryBot.create(:metric, service: nil, owner: @backend_api, system_name: 'meth', parent: @hits)
-    @ads = FactoryBot.create(:metric, service: nil, owner: @backend_api, system_name: 'ads')
+    @meth = FactoryBot.create(:metric, owner: @backend_api, system_name: 'meth', parent: @hits)
+    @ads = FactoryBot.create(:metric, owner: @backend_api, system_name: 'ads')
 
     login_provider @provider
   end

--- a/test/unit/backend/model_extensions/backend_api_config_test.rb
+++ b/test/unit/backend/model_extensions/backend_api_config_test.rb
@@ -8,7 +8,7 @@ class Backend::ModelExtensions::BackendApiConfigTest < ActiveSupport::TestCase
   test 'sync backend api metrics with backend' do
     service = FactoryBot.create(:service)
     backend_api = FactoryBot.create(:backend_api, account: service.account)
-    other_metric = FactoryBot.create(:metric, owner: backend_api, system_name: 'other', service_id: nil)
+    other_metric = FactoryBot.create(:metric, owner: backend_api, system_name: 'other')
 
     backend_api.metrics.each { |metric| metric.expects(:sync_backend_for_service).with(service) }
     service.backend_api_configs.create(backend_api: backend_api, path: 'foo')

--- a/test/unit/backend/model_extensions/metric_test.rb
+++ b/test/unit/backend/model_extensions/metric_test.rb
@@ -87,7 +87,7 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
     services = FactoryBot.create_list(:simple_service, 2)
     backend_api = services.first.first_backend_api
     services.last.backend_api_configs.create(backend_api: backend_api, path: 'other') # other service using the same BackendApi
-    metric = FactoryBot.build(:metric, service: nil, owner: backend_api)
+    metric = FactoryBot.build(:metric, owner: backend_api)
 
     services.each { |service| BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.attributes['system_name']) }
     metric.sync_backend

--- a/test/unit/backend_api_logic/metric_extension_test.rb
+++ b/test/unit/backend_api_logic/metric_extension_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class MetricExtensionTest < ActiveSupport::TestCase
   setup do
     @backend_api = FactoryBot.create(:backend_api)
-    @metric = FactoryBot.build(:metric, system_name: 'whatever', service_id: nil, owner: @backend_api)
+    @metric = FactoryBot.build(:metric, system_name: 'whatever', owner: @backend_api)
   end
 
   attr_reader :backend_api, :metric
@@ -28,7 +28,7 @@ class MetricExtensionTest < ActiveSupport::TestCase
 
   test '#parent_id_for_service' do
     backend_hits = backend_api.metrics.hits
-    backend_method = FactoryBot.build(:metric, system_name: 'bmeth', service_id: nil, owner: @backend_api, parent: backend_hits)
+    backend_method = FactoryBot.build(:metric, system_name: 'bmeth', owner: @backend_api, parent: backend_hits)
     backend_non_hits = metric
 
     service = FactoryBot.create(:service, account: backend_api.account)

--- a/test/unit/backend_api_logic/service_extension_test.rb
+++ b/test/unit/backend_api_logic/service_extension_test.rb
@@ -53,9 +53,9 @@ class ServiceExtensionTest < ActiveSupport::TestCase
 
     related_metrics = [service.metrics.hits, first_backend_api.metrics.hits, second_backend_api.metrics.hits]
     related_metrics << FactoryBot.create(:metric, service: service)
-    related_metrics << FactoryBot.create(:metric, service: nil, owner: first_backend_api)
-    related_metrics << FactoryBot.create(:metric, service: nil, owner: second_backend_api)
-    unrelated_metric = FactoryBot.create(:metric, service: nil, owner: third_backend_api)
+    related_metrics << FactoryBot.create(:metric, owner: first_backend_api)
+    related_metrics << FactoryBot.create(:metric, owner: second_backend_api)
+    unrelated_metric = FactoryBot.create(:metric, owner: third_backend_api)
 
     service_all_metrics = service.all_metrics
 


### PR DESCRIPTION
Otherwise when we create a metric for a backend api, it creates a service anyway, and we could simply pass `service: nil` but it is not very intuitive then.