### PR TITLE
Fix Random Bug in Test: Order Services by ID before fetching the 2nd [Test Export to CSV]

### DIFF
--- a/test/unit/csv/applications_exporter_test.rb
+++ b/test/unit/csv/applications_exporter_test.rb
@@ -52,7 +52,7 @@ class Csv::ApplicationsExporterTest < ActiveSupport::TestCase
 
   test 'to_csv' do
     Timecop.freeze(Time.utc(2011,1,1)) do
-      cinstance = @provider.services[1].cinstances.first!
+      cinstance = @provider.services.order(:id).second.cinstances.first!
       cinstance.update_attributes(first_daily_traffic_at: '2016-03-03 00:00:00 UTC')
       exporter = Csv::ApplicationsExporter.new(@provider, {data: 'applications'})
       lines = exporter.to_csv.lines.to_a


### PR DESCRIPTION
The order in postgres changes depending on the execution, so if we fetch the `2nd` and the `2nd` changes for each execution, then sometimes it is going to raise an error because it does not fetch the one we want. So this PR just orders by ID before fetching, so it will always fetch the same one 😄 

Fixes [this random bug](https://circleci.com/gh/3scale/porta/101044?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

#### Verification steps
Run several times locally `DATABASE_URL="postgresql://postgres:@localhost:5433/systempdb" bundle exec m test/unit/csv/applications_exporter_test.rb:54`
