### PR TITLE
Fix Test for BackendApisController

### DIFF
--- a/test/integration/admin/api/backend_apis_controller_test.rb
+++ b/test/integration/admin/api/backend_apis_controller_test.rb
@@ -2,13 +2,13 @@
 
 require 'test_helper'
 
-class Admin::API::AccountsControllerTest < ActionDispatch::IntegrationTest
+class Admin::API::BackendApisControllerTest < ActionDispatch::IntegrationTest
   def setup
     @provider = FactoryBot.create(:provider_account)
     host! @provider.admin_domain
   end
 
-  attr_reader :provider, :access_token_value
+  attr_reader :provider
 
   test 'show' do
     get admin_api_backend_api_path(backend_api, access_token: access_token_value)


### PR DESCRIPTION
Fixes the tests:
- The name contains the proper name
- Removed a repeated method

It was originally fixed as part of https://github.com/3scale/porta/pull/1178 but that PR is not in master yet because it pointed to another PR waiting for the blockers.

It needs to be fixed now because it is failing tests in oracle (integration) for this.
The tests in oracle for cucumber are fixed in another PR 😉 