### PR TITLE
Do not create automatically create backend when creating a product

### DIFF
--- a/app/controllers/admin/api/services_controller.rb
+++ b/app/controllers/admin/api/services_controller.rb
@@ -46,7 +46,9 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add :name => " ", :dataType => "custom", :paramType => "query", :allowMultiple => true, :description => "Extra parameters"
   #
   def create
-    service = current_account.create_service(service_params)
+    service = current_account.services.build
+    create_service = ServiceCreator.new(service: service)
+    create_service.call!(service_params)
     service.reload if service.persisted? # It has been touched
     respond_with(service)
   end

--- a/app/controllers/admin/api/services_controller.rb
+++ b/app/controllers/admin/api/services_controller.rb
@@ -48,7 +48,7 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   def create
     service = current_account.services.build
     create_service = ServiceCreator.new(service: service)
-    create_service.call!(service_params)
+    create_service.call(service_params)
     service.reload if service.persisted? # It has been touched
     respond_with(service)
   end

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -35,8 +35,9 @@ class Api::IntegrationsController < Api::BaseController
       update_mapping_rules_position
 
       if @proxy.send_api_test_request!
+        api_backend = @proxy.api_backend
         onboarding.bubble_update('api')
-        done_step(:api_sandbox_traffic) if ApiClassificationService.test(@proxy.api_backend).real_api?
+        done_step(:api_sandbox_traffic) if api_backend.present? && ApiClassificationService.test(api_backend).real_api?
         return redirect_to edit_path
       end
       render :edit

--- a/app/forms/onboarding/request_form.rb
+++ b/app/forms/onboarding/request_form.rb
@@ -33,6 +33,7 @@ class Onboarding::RequestForm < Reform::Form
   end
 
   def uri
+    return unless model.api_backend
     URI.join(api_base_url, path || SLASH).to_s
   end
 

--- a/app/lib/backend_api_logic/proxy_extension.rb
+++ b/app/lib/backend_api_logic/proxy_extension.rb
@@ -20,11 +20,7 @@ module BackendApiLogic
     protected
 
     def validate_backend_api?
-      if account.provider_can_use?(:api_as_product)
-        backend_api.private_endpoint_changed?
-      else
-        true
-      end
+      !account.provider_can_use?(:api_as_product) || backend_api.private_endpoint_changed?
     end
 
     def save_backend_api

--- a/app/lib/backend_api_logic/proxy_extension.rb
+++ b/app/lib/backend_api_logic/proxy_extension.rb
@@ -5,24 +5,30 @@ module BackendApiLogic
     extend ActiveSupport::Concern
 
     included do
-      delegate :backend_api, to: :service, allow_nil: true
-      delegate :private_endpoint, :private_endpoint=, to: :backend_api, allow_nil: true, prefix: true
+      delegate :api_backend, :api_backend=, :backend_api, :backend_api_proxy, to: :service
+      delegate :private_endpoint, :private_endpoint=, to: :backend_api, prefix: true
       delegate :default_api_backend, to: 'BackendApi'
 
-      alias_method :api_backend, :backend_api_private_endpoint
-      alias_method :api_backend=, :backend_api_private_endpoint=
-
-      validates :backend_api, nested_association: {report: {private_endpoint: :api_backend}}, associated: true
       before_save :save_backend_api
 
       has_many :backend_api_configs, through: :service
       accepts_nested_attributes_for :backend_api_configs
+
+      validates :backend_api, nested_association: {report: {private_endpoint: :api_backend}}, associated: true, if: :validate_backend_api?
     end
 
     protected
 
+    def validate_backend_api?
+      if account.provider_can_use?(:api_as_product)
+        backend_api.private_endpoint_changed?
+      else
+        true
+      end
+    end
+
     def save_backend_api
-      backend_api.save
+      backend_api_private_endpoint && backend_api_proxy.update!(private_endpoint: backend_api_private_endpoint)
     end
   end
 end

--- a/app/lib/backend_api_logic/service_extension.rb
+++ b/app/lib/backend_api_logic/service_extension.rb
@@ -8,7 +8,8 @@ module BackendApiLogic
       has_many :backend_api_configs, inverse_of: :service, dependent: :destroy
       has_many :backend_apis, through: :backend_api_configs
 
-      alias_method :backend_api, :first_backend_api
+      delegate :backend_api, to: :backend_api_proxy
+      delegate :api_backend, :api_backend=, to: :backend_api
 
       has_many :backend_api_metrics, through: :backend_api_configs
 
@@ -17,6 +18,9 @@ module BackendApiLogic
       end, class_name: 'Metric'
     end
 
+    # TODO: This is used by db/migrate/20190716110520_create_the_backend_apis_of_services.rb
+    # We should Remove this after 2.7 is released
+    # https://issues.jboss.org/browse/THREESCALE-3517
     def first_backend_api
       @backend_api ||= find_or_create_first_backend_api!
     end
@@ -26,8 +30,6 @@ module BackendApiLogic
       config = backend_api_configs.first || create_first_backend_api_config!
       config.backend_api
     end
-
-    private
 
     def create_first_backend_api_config!
       backend_api = account.backend_apis.build(
@@ -39,6 +41,45 @@ module BackendApiLogic
       constructor = new_record? ? :build : :create!
       attrs = {backend_api: backend_api, path: ''}
       backend_api_configs.public_send(constructor, attrs)
+    end
+
+    class BackendApiProxy
+      attr_reader :service
+      delegate :account, :backend_apis, :backend_api_configs, to: :service
+      delegate :name, :system_name, to: :service, prefix: true
+
+      def initialize(service)
+        @service = service
+      end
+
+      def backend_api_config
+        @backend_api_config ||= backend_api_configs.first ||
+                                backend_api_configs.build(path: '', backend_api: backend_api)
+      end
+
+      def backend_api
+        @backend_api ||= backend_api_configs.first&.backend_api || account.backend_apis.build(system_name: service_system_name, name: "#{service_name} Backend API", description: "Backend API of #{service_name}")
+      end
+
+      def update!(attrs = {})
+        BackendApi.transaction do
+          backend_api_config.path = attrs[:path] if attrs.key?(:path)
+          backend_api_config.backend_api = backend_api
+          backend_api.private_endpoint = attrs[:private_endpoint] if attrs.key?(:private_endpoint)
+          backend_api.save!
+          backend_api_config.save!
+        end
+      end
+
+      def update(attrs = {})
+        update!(attrs)
+      rescue ActiveRecord::RecordInvalid
+        false
+      end
+    end
+
+    def backend_api_proxy
+      @backend_api_proxy ||= BackendApiProxy.new(self)
     end
   end
 end

--- a/app/lib/logic/provider_signup.rb
+++ b/app/lib/logic/provider_signup.rb
@@ -64,7 +64,7 @@ module Logic
           service_plan.create_contract_with! provider
           application_plan.create_contract_with! provider
 
-          provider.services.create! name: 'API'
+          ServiceCreator.new(service: provider.services.build(name: 'API')).call
         end
 
         if ThreeScale.config.onpremises

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -334,7 +334,7 @@ module Account::ProviderMethods
       plan.create_contract_with!(self)
     end
 
-    services.create! name: "API"
+    ServiceCreator.new(service: services.build(name: 'API')).call
   end
 
   def create_default_fields_definitions

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -59,6 +59,7 @@ class BackendApi < ApplicationRecord
   private
 
   def set_private_endpoint
+    return if account.provider_can_use?(:api_as_product)
     self.private_endpoint ||= default_api_backend
   end
 

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -102,8 +102,8 @@ class Proxy < ApplicationRecord
   alias_attribute :production_endpoint, :endpoint
   alias_attribute :staging_endpoint, :sandbox_endpoint
 
-  delegate :account, to: :service, allow_nil: true
-  delegate :provider_can_use?, to: :account, allow_nil: true
+  delegate :account, to: :service
+  delegate :provider_can_use?, to: :account
   delegate :backend_apis, :backend_api_configs, to: :service
 
   # This smells of :reek:NilCheck
@@ -139,10 +139,8 @@ class Proxy < ApplicationRecord
 
   def policy_chain
     # TODO: We need to remove this rolling update as it should be available for everyone using APIcast V2
-    return unless provider_can_use?(:policies)
-    raw_config = policies_config
-    return if raw_config.blank?
-    raw_config.each_with_object([]) do |config, chain|
+    return [] unless provider_can_use?(:policies)
+    (policies_config.presence || []).each_with_object([]) do |config, chain|
       chain << config.slice('name', 'version', 'configuration') if config['enabled']
     end
   end

--- a/app/representers/proxy_representer.rb
+++ b/app/representers/proxy_representer.rb
@@ -4,7 +4,7 @@ class ProxyRepresenter < ThreeScale::Representer
   property :service_id
   property :endpoint
   property :deployed_at
-  property :api_backend
+  property :api_backend, render_nil: true
   property :credentials_location
   property :auth_app_key
   property :auth_app_id

--- a/app/services/api_classification_service.rb
+++ b/app/services/api_classification_service.rb
@@ -11,6 +11,7 @@ class ApiClassificationService
   # @return [Symbol] either `:real` or `:test`
 
   def test(url)
+    return Category.new(uri: nil, test_api: false) unless url
     uri = URI(url)
 
     host = uri.host

--- a/app/services/service_creator.rb
+++ b/app/services/service_creator.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ServiceCreator
+
+  delegate :backend_api_configs, :backend_api_proxy, :account, to: :@service
+  delegate :provider_can_use?, to: :account
+
+  def initialize(service:, backend_api: nil)
+    @service     = service
+    @backend_api = backend_api
+  end
+
+  def call!(params = {})
+    @service.transaction do
+      backend_api_proxy_params = params.dup
+      service_params = backend_api_proxy_params.slice!(:path, :private_endpoint)
+      @service.attributes = service_params
+      save!(backend_api_proxy_params)
+    end
+  end
+
+  def call(params = {})
+    call!(params)
+  rescue ActiveRecord::RecordInvalid
+    false
+  end
+
+  private
+
+  def save!(params)
+    @service.save!
+    if @backend_api
+      save_assigned_backend_api(params)
+    else
+      save_default_backend_api(params)
+    end
+  end
+
+  def save_default_backend_api(params)
+    if provider_can_use?(:api_as_product)
+      return true if %i[path private_endpoint].none? { |key| params.key?(key) }
+      backend_api_proxy.update!(params)
+    else
+      backend_api_proxy.update!(private_endpoint: BackendApi.default_api_backend)
+    end
+  end
+
+  def save_assigned_backend_api(attrs)
+    config = backend_api_configs.find_by(backend_api_id: @backend_api.id) ||
+      backend_api_configs.build(backend_api: @backend_api)
+    config.path = path.to_s if attrs.key?(:path)
+    config.save!
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -69,7 +69,8 @@ ActiveRecord::Base.transaction do
   master_user.activate!
 
   # Creating the master service
-  master_service = Service.create!(account: master, name: master_service)
+  master_service = Service.new(account: master, name: master_service)
+  ServiceCreator.new(service: master_service).call!(private_endpoint: BackendApi.default_api_backend)
   master_service.service_plans.default!(ServicePlan.first!)
 
   # Master needs to be contracted with an ApplicationPlan

--- a/lib/signup/provider_account_manager.rb
+++ b/lib/signup/provider_account_manager.rb
@@ -28,7 +28,7 @@ class Signup::ProviderAccountManager < Signup::AccountManager
 
   def contract_plans_and_create_service(account, plans, defaults)
     create_contract_plans_for_account!(account, plans, defaults)
-    account.services.create! name: 'API'
+    ServiceCreator.new(service: account.services.build(name: 'API')).call
     set_switches_and_limits(account, plans.application_plan)
   end
 

--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -93,7 +93,7 @@ FactoryBot.define do
   end
 
 #TODO: rename this, it is actually buying plans!
-  factory(:provider_account_with_pending_users_signed_up_to_no_plan, :parent => :account) do
+  factory(:provider_account_with_pending_users_signed_up_to_no_plan, parent: :account) do
     sequence(:self_domain) { |n| "admin-domain-company#{n}.com" }
     site_access_code { '' }
     payment_gateway_type { :bogus }
@@ -145,6 +145,8 @@ FactoryBot.define do
         service_plans_ui_visible: true,
         end_user_plans_ui_visible: true
       )
+      backend_api = FactoryBot.create(:backend_api, account: account, name: 'API Backend API')
+      FactoryBot.create(:backend_api_config, service: account.services.first, backend_api: backend_api)
     end
   end
 
@@ -176,8 +178,13 @@ FactoryBot.define do
         username = account.org_name.gsub(/[^a-zA-Z0-9_\.]+/, '_')
         account.users << FactoryBot.create(:admin, :account_id => account.id, :username => username, :tenant_id => account.id)
       end
+    end
 
-      # account.admins.each(&:activate!)
+    trait(:with_default_backend_api) do
+      after(:create) do |account|
+        backend_api = FactoryBot.build(:backend_api, account: account)
+        FactoryBot.create(:backend_api_config, service: account.default_service, backend_api: backend_api)
+      end
     end
   end
 

--- a/test/factories/simple.rb
+++ b/test/factories/simple.rb
@@ -78,6 +78,13 @@ FactoryBot.define do
     after(:create) do |record|
       record.service_tokens.first_or_create!(value: 'token')
     end
+
+    trait :with_default_backend_api do
+      before(:create) do |record|
+        backend_api = FactoryBot.build(:backend_api, private_endpoint: 'https://echo-api.3scale.net')
+        FactoryBot.create(:backend_api_config, path: '', service: record, backend_api: backend_api)
+      end
+    end
   end
 
   factory(:simple_cinstance, :class => Cinstance) do

--- a/test/functional/api/integrations_controller_test.rb
+++ b/test/functional/api/integrations_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Api::IntegrationsControllerTest < ActionController::TestCase
 
   def setup
-    @provider = FactoryBot.create(:provider_account)
+    @provider = FactoryBot.create(:provider_account, :with_default_backend_api)
     @provider.default_service.service_tokens.create!(value: 'token')
 
     stub_apicast_registry
@@ -24,7 +24,7 @@ class Api::IntegrationsControllerTest < ActionController::TestCase
 
   test 'should have access' do
     rolling_updates_off
-    
+
     member = FactoryBot.create(:member)
     member.member_permissions.create(admin_section: 'plans')
     @provider.users << member

--- a/test/integration/provider/admin/backend_apis/mapping_rules_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/mapping_rules_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class Provider::Admin::BackendApis::MappingRulesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @provider = FactoryBot.create(:provider_account)
+    @provider = FactoryBot.create(:provider_account, :with_default_backend_api)
     @backend_api = @provider.first_service.backend_api
 
     FactoryBot.create(:proxy_rule, proxy: nil, owner: @backend_api)
@@ -18,7 +18,7 @@ class Provider::Admin::BackendApis::MappingRulesControllerTest < ActionDispatch:
     get provider_admin_backend_api_mapping_rules_path(backend_api)
     assert_response :success
 
-    assert_select 'table.data tr', count: @backend_api.mapping_rules.count+1
+    assert_select 'table.data tr', count: backend_api.mapping_rules.count+1
     @backend_api.mapping_rules.each { |rule| assert_select 'table.data tr td', text: rule.pattern }
   end
 end

--- a/test/integration/provider/admin/backend_apis/metrics_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/metrics_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class Provider::Admin::BackendApis::MetricsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @provider = FactoryBot.create(:provider_account)
+    @provider = FactoryBot.create(:provider_account, :with_default_backend_api)
     @service = @provider.first_service
     @backend_api = @service.backend_api
 

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -46,7 +46,7 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
   end
 
   test 'system_name can be created but not updated' do
-    post provider_admin_backend_apis_path, { backend_api: {name: 'My Backend API', system_name: 'first-system-name'} }
+    post provider_admin_backend_apis_path, { backend_api: {name: 'My Backend API', system_name: 'first-system-name', private_endpoint: 'https://endpoint.com/p'} }
     backend_api = provider.backend_apis.last!
     assert_equal 'first-system-name', backend_api.system_name
 
@@ -55,18 +55,19 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
   end
 
   test 'delete a backend api with products' do
-    backend_api = @provider.backend_apis[0]
+    backend_api = @provider.backend_apis.first
+    FactoryBot.create(:backend_api_config, service: @provider.first_service, backend_api: backend_api)
     assert backend_api.backend_api_configs.any?
 
     delete provider_admin_backend_api_path(backend_api)
     assert BackendApi.exists? backend_api.id
     assert_equal 'Backend API could not be deleted', flash[:error]
   end
-  
+
   test 'delete a backend api without any products' do
-    backend_api = @provider.backend_apis[1]
+    backend_api = @provider.backend_apis.second
     assert_not backend_api.backend_api_configs.any?
-    
+
     delete provider_admin_backend_api_path(backend_api)
     assert_redirected_to provider_admin_dashboard_path
     assert_not BackendApi.exists? backend_api.id

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -55,7 +55,7 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
   end
 
   test 'delete a backend api with products' do
-    backend_api = @provider.backend_apis.first
+    backend_api = @provider.backend_apis.order(:id).first
     FactoryBot.create(:backend_api_config, service: @provider.first_service, backend_api: backend_api)
     assert backend_api.backend_api_configs.any?
 
@@ -65,7 +65,7 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
   end
 
   test 'delete a backend api without any products' do
-    backend_api = @provider.backend_apis.second
+    backend_api = @provider.backend_apis.order(:id).second
     assert_not backend_api.backend_api_configs.any?
 
     delete provider_admin_backend_api_path(backend_api)

--- a/test/models/backend_api_test.rb
+++ b/test/models/backend_api_test.rb
@@ -21,6 +21,7 @@ class BackendApiTest < ActiveSupport::TestCase
     @account.stubs(:provider_can_use?).with(:apicast_v1).returns(true)
     @account.stubs(:provider_can_use?).with(:apicast_v2).returns(true)
     @account.expects(:provider_can_use?).with(:proxy_private_base_path).at_least_once.returns(false)
+    @account.expects(:provider_can_use?).with(:api_as_product).at_least_once.returns(false)
     @backend_api.private_endpoint = 'https://example.org:3/path'
     @backend_api.valid?
     assert_equal [@backend_api.errors.generate_message(:private_endpoint, :invalid)], @backend_api.errors.messages[:private_endpoint]
@@ -31,8 +32,9 @@ class BackendApiTest < ActiveSupport::TestCase
   end
 
   test '.orphans should return backend apis that do not belongs to any service' do
-    FactoryBot.create(:service)
-    service_to_delete = FactoryBot.create(:service)
+    account = FactoryBot.create(:account)
+    FactoryBot.create(:service, account: account)
+    service_to_delete = FactoryBot.create(:simple_service, :with_default_backend_api, system_name: 'orphan_system', account: account)
     orphan_backend_api = service_to_delete.backend_api_configs.first.backend_api
 
     assert_equal [], BackendApi.orphans

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -779,6 +779,37 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal 0, ApplicationPlan.where(id: aps).count
   end
 
+  test '#signup provider with api_as_product' do
+    master_account.account_plans.default!(master_account.account_plans.first)
+    master_account.signup_provider(master_account.application_plans.first) do |provider, user|
+      provider.stubs(:provider_can_use?).returns(false)
+      provider.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
+      @provider, @user = provider, user
+      provider.subdomain = "foo"
+      provider.org_name = "bar"
+      provider.sample_data = false
+      user.password = user.password_confirmation = "foobar"
+      user.email = "foo@example.com"
+    end
+    assert_nil @provider.first_service.api_backend
+  end
+
+
+  test '#signup provider without api_as_product' do
+    master_account.account_plans.default!(master_account.account_plans.first)
+    master_account.signup_provider(master_account.application_plans.first) do |provider, user|
+      @provider, @user = provider, user
+      provider.stubs(:provider_can_use?).returns(false)
+      provider.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+      provider.subdomain = "foo"
+      provider.org_name = "bar"
+      provider.sample_data = false
+      user.password = user.password_confirmation = "foobar"
+      user.email = "foo@example.com"
+    end
+    assert_equal BackendApi.default_api_backend, @provider.first_service.api_backend
+  end
+
   test 'onboarding builds object if not already created' do
     account = FactoryBot.build(:account)
 

--- a/test/unit/apicast/provider_nginx_generator_test.rb
+++ b/test/unit/apicast/provider_nginx_generator_test.rb
@@ -50,12 +50,9 @@ class Apicast::ProviderNginxGeneratorTest < ActiveSupport::TestCase
 
   def test_service_conf
     provider_key = 'foobar'
-    service = Service.new
-    service.account_id = 42
-    service.id = 21
-    service.proxy = proxy = Proxy.new
-    service.backend_version = 2
-    proxy.oauth_login_url = 'http://example.com/login'
+    account = FactoryBot.build(:account, id: 42)
+    proxy   = FactoryBot.build(:proxy, oauth_login_url: 'http://example.com/login')
+    service = FactoryBot.build(:service, id: 21, account: account, proxy: proxy, backend_version: 2)
 
     subject = @generator.service_conf(service, provider_key)
 

--- a/test/unit/backend/model_extensions/metric_test.rb
+++ b/test/unit/backend/model_extensions/metric_test.rb
@@ -84,8 +84,8 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
   end
 
   test 'sync backend api metric for multiple services' do
-    services = FactoryBot.create_list(:simple_service, 2)
-    backend_api = services.first.first_backend_api
+    services = FactoryBot.create_list(:simple_service, 2, :with_default_backend_api)
+    backend_api = services.first.backend_api
     services.last.backend_api_configs.create(backend_api: backend_api, path: 'other') # other service using the same BackendApi
     metric = FactoryBot.build(:metric, service: nil, owner: backend_api)
 

--- a/test/unit/backend_api_logic/routing_policy_test.rb
+++ b/test/unit/backend_api_logic/routing_policy_test.rb
@@ -6,8 +6,9 @@ module BackendApiLogic
   class RoutingPolicyTest < ActiveSupport::TestCase
     setup do
       @service = FactoryBot.create(:simple_service)
+      first_backend_api = FactoryBot.create(:backend_api_config, path: '', service: @service).backend_api
       other_backend_api = FactoryBot.create(:backend_api, system_name: 'foo')
-      @backend_apis = [service.first_backend_api, other_backend_api]
+      @backend_apis = [first_backend_api, other_backend_api]
       @service.backend_api_configs.create(backend_api: other_backend_api, path: 'foo')
     end
 

--- a/test/unit/backend_api_logic/service_extension_test.rb
+++ b/test/unit/backend_api_logic/service_extension_test.rb
@@ -70,4 +70,19 @@ class ServiceExtensionTest < ActiveSupport::TestCase
     assert_same_elements service_all_metrics, related_metrics
     assert_not_includes service_all_metrics, unrelated_metric
   end
+
+  class BackendApiProxy < ActiveSupport::TestCase
+    test '#backend_api_config builds a new backend api config if does not exist' do
+      service = FactoryBot.create(:simple_service)
+
+      refute service.backend_api_proxy.backend_api_config.persisted?
+    end
+
+    test '#backend_api_config returns the already existent backend api config for the service' do
+      service = FactoryBot.create(:simple_service)
+      backend_api_config = FactoryBot.create(:backend_api_config, service: service)
+
+      assert_equal backend_api_config, service.backend_api_proxy.backend_api_config
+    end
+  end
 end

--- a/test/unit/backend_api_logic/service_extension_test.rb
+++ b/test/unit/backend_api_logic/service_extension_test.rb
@@ -3,50 +3,58 @@
 require 'test_helper'
 
 class ServiceExtensionTest < ActiveSupport::TestCase
-  test 'first_backend_api is nil when the service does not have an account' do
-    service = FactoryBot.build(:simple_service, account: nil)
-    assert_nil service.first_backend_api
-  end
+  class WithApiAsProduct < ActiveSupport::TestCase
 
-  test 'first_backend_api when the service is not persisted but has an account' do
-    service = FactoryBot.build(:simple_service)
-    assert(backend_api = service.first_backend_api)
-    assert_equal service.account_id, backend_api.account_id
-    refute backend_api.persisted?
-  end
+    def setup
+      Account.any_instance.stubs(:provider_can_use?).returns(false)
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false)
+    end
 
-  test 'first_backend_api default values' do
-    service = FactoryBot.build(:simple_service, system_name: nil)
-    assert(backend_api = service.first_backend_api)
-    assert_equal "#{service.name} Backend API", backend_api.name
-    assert_equal  "Backend API of #{service.name}", backend_api.description
-  end
+    test 'first_backend_api is nil when the service does not have an account' do
+      service = FactoryBot.build(:simple_service, account: nil)
+      assert_nil service.first_backend_api
+    end
 
-  test 'first_backend_api when the service its own system_name' do
-    service = FactoryBot.build(:simple_service, system_name: 'example-system-name')
-    assert_equal service.system_name, service.first_backend_api.system_name
-  end
+    test 'first_backend_api when the service is not persisted but has an account' do
+      service = FactoryBot.build(:simple_service)
+      assert(backend_api = service.first_backend_api)
+      assert_equal service.account_id, backend_api.account_id
+      refute backend_api.persisted?
+    end
 
-  test 'first_backend_api when the service is persisted' do
-    service = FactoryBot.create(:simple_service)
-    assert(backend_api = service.first_backend_api)
-    assert backend_api.persisted?
-    assert_equal service.account_id, backend_api.account_id
-    assert backend_api.id, service.reload.first_backend_api.id # It finds it bcz it was previously created instead of creating a new one
-    assert_not_nil backend_api.system_name # it is generated although service.system_name is nil
-    assert_equal BackendApi.default_api_backend, backend_api.private_endpoint # because service does not have a proxy so it takes the default api_backend
-  end
+    test 'first_backend_api default values' do
+      service = FactoryBot.build(:simple_service, system_name: nil)
+      assert(backend_api = service.first_backend_api)
+      assert_equal "#{service.name} Backend API", backend_api.name
+      assert_equal  "Backend API of #{service.name}", backend_api.description
+    end
 
-  test 'first_backend_api when the service has a proxy with its api_backend' do
-    proxy = FactoryBot.create(:proxy)
-    backend_api = proxy.service.first_backend_api
-    assert_equal proxy.api_backend, backend_api.private_endpoint
-    assert_not_equal BackendApi.default_api_backend, backend_api.private_endpoint
+    test 'first_backend_api when the service its own system_name' do
+      service = FactoryBot.build(:simple_service, system_name: 'example-system-name')
+      assert_equal service.system_name, service.first_backend_api.system_name
+    end
+
+    test 'first_backend_api when the service is persisted' do
+      service = FactoryBot.create(:simple_service)
+      assert(backend_api = service.first_backend_api)
+      assert backend_api.persisted?
+      assert_equal service.account_id, backend_api.account_id
+      assert backend_api.id, service.reload.first_backend_api.id # It finds it bcz it was previously created instead of creating a new one
+      assert_not_nil backend_api.system_name # it is generated although service.system_name is nil
+      assert_equal BackendApi.default_api_backend, backend_api.private_endpoint # because service does not have a proxy so it takes the default api_backend
+    end
+
+    test 'first_backend_api when the service has a proxy with its api_backend' do
+      proxy = FactoryBot.create(:proxy)
+      backend_api = proxy.service.first_backend_api
+      assert_equal proxy.api_backend, backend_api.private_endpoint
+      assert_not_equal BackendApi.default_api_backend, backend_api.private_endpoint
+    end
   end
 
   test '#all_metrics' do
-    service = FactoryBot.create(:simple_service)
-    first_backend_api = service.first_backend_api
+    service = FactoryBot.create(:simple_service, :with_default_backend_api)
+    first_backend_api = service.backend_api
     second_backend_api = FactoryBot.create(:backend_api, account: service.account)
     third_backend_api = FactoryBot.create(:backend_api, account: service.account)
     service.backend_api_configs.create(backend_api: second_backend_api, path: 'whatever')

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -40,8 +40,8 @@ class MetricTest < ActiveSupport::TestCase
   end
 
   test 'index uniq of system_name in owner scope' do
-    service = FactoryBot.create(:service)
-    owners = [service, service.first_backend_api]
+    service = FactoryBot.create(:simple_service, :with_default_backend_api)
+    owners = [service, service.backend_api]
     owners.each do |owner|
       owner_attributes = { service: (owner.is_a?(Service) ? owner : nil), owner: owner }
       metric_one = FactoryBot.create(:metric, **owner_attributes, system_name: 'frags')
@@ -91,7 +91,7 @@ class MetricTest < ActiveSupport::TestCase
     assert service_metric.valid?
     assert_equal service, service_metric.owner
 
-    backend_api = BackendApi.create(name: 'API', system_name: 'api', account: service.provider)
+    backend_api = FactoryBot.create(:backend_api, name: 'API', system_name: 'api', account: service.provider)
     backend_metric = FactoryBot.build(:metric, owner: backend_api)
     assert_equal backend_api, backend_metric.owner
     assert backend_metric.valid?

--- a/test/unit/provider_test.rb
+++ b/test/unit/provider_test.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 
 class ProviderTest < ActiveSupport::TestCase
-  def setup
-    FactoryBot.create(:simple_master)
-  end
-
   def test_find
     provider = FactoryBot.create(:simple_provider)
 

--- a/test/unit/proxy_rule_test.rb
+++ b/test/unit/proxy_rule_test.rb
@@ -151,7 +151,7 @@ class ProxyRuleTest < ActiveSupport::TestCase
     assert proxy_proxy_rule.valid?
     assert_equal proxy, proxy_proxy_rule.owner
 
-    backend_api = BackendApi.create(name: 'API', system_name: 'api', account: provider)
+    backend_api = FactoryBot.create(:backend_api, name: 'API', system_name: 'api', account: provider)
     backend_proxy_rule = FactoryBot.build(:proxy_rule, proxy: nil, owner: backend_api)
     assert_equal backend_api, backend_proxy_rule.owner
     assert backend_proxy_rule.valid?

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -79,7 +79,7 @@ class ProxyTest < ActiveSupport::TestCase
       rolling_updates_on
 
       account = FactoryBot.create(:simple_provider)
-      service = FactoryBot.create(:simple_service, account: account)
+      service = FactoryBot.create(:simple_service, :with_default_backend_api, account: account)
       null_backend_api = FactoryBot.create(:backend_api, account: account, private_endpoint: 'https://foo.baz')
       null_backend_api.update_columns(private_endpoint: '')
       backend_api1 = FactoryBot.create(:backend_api, account: account, private_endpoint: 'https://private-1.example.com')
@@ -240,8 +240,8 @@ class ProxyTest < ActiveSupport::TestCase
     assert_equal 1, @proxy.proxy_rules.size
   end
 
-  test 'api_backend defaults to echo API' do
-    assert_equal 'https://echo-api.3scale.net:443', @proxy.api_backend
+  test 'api_backend defaults to nil if there is no backend api' do
+    assert_nil @proxy.api_backend
   end
 
   test 'proxy api backend formats ok' do
@@ -255,6 +255,7 @@ class ProxyTest < ActiveSupport::TestCase
     @account.stubs(:provider_can_use?).with(:apicast_v1).returns(true)
     @account.stubs(:provider_can_use?).with(:apicast_v2).returns(true)
     @account.expects(:provider_can_use?).with(:proxy_private_base_path).at_least_once.returns(false)
+    @account.expects(:provider_can_use?).with(:api_as_product).at_least_once.returns(false)
     backend_api = @proxy.backend_api
     backend_api.stubs(account: @account)
     @proxy.api_backend = 'https://example.org:3/path'

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -11,6 +11,21 @@ class ServiceTest < ActiveSupport::TestCase
     assert_not_nil service.proxy
   end
 
+  def test_create_with_default_private_endpoint
+    ::Account.any_instance.stubs(:provider_can_use?).returns(false)
+    rolling_update :api_as_product, enabled: false
+    account = FactoryBot.build(:provider_account)
+    account.save!
+    service = account.default_service
+    assert_equal BackendApi.default_api_backend, service.api_backend
+
+    rolling_update :api_as_product, enabled: true
+    account = FactoryBot.build(:provider_account)
+    account.save!
+    service = account.default_service
+    assert_nil service.api_backend
+  end
+
   def test_backend_version=
     service = FactoryBot.build_stubbed(:simple_service)
     service.backend_version = 'oauth'

--- a/test/unit/services/provider_proxy_deployment_service_test.rb
+++ b/test/unit/services/provider_proxy_deployment_service_test.rb
@@ -16,7 +16,7 @@ class ProviderProxyDeploymentServiceTest < ActiveSupport::TestCase
   end
 
   def test_deploy_success
-    proxy = FactoryBot.create(:proxy, api_test_success: true)
+    proxy = FactoryBot.create(:proxy, service: @provider.first_service, api_test_success: true)
 
     stub_request(:get, "http://test.proxy/deploy/TEST?provider_id=#{@provider.id}")
         .to_return(status: 200)
@@ -34,7 +34,7 @@ class ProviderProxyDeploymentServiceTest < ActiveSupport::TestCase
   end
 
   def test_deploy_failure
-    proxy = FactoryBot.create(:proxy, api_test_success: true)
+    proxy = FactoryBot.create(:proxy, service: @provider.first_service, api_test_success: true)
 
     stub_request(:get, "http://test.proxy/deploy/TEST?provider_id=#{@provider.id}")
         .to_return(status: 500)

--- a/test/unit/services/service_creator_test.rb
+++ b/test/unit/services/service_creator_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class ServiceCreatorTest < ActiveSupport::TestCase
+  test 'service creation without path and endpoint' do
+    service = FactoryBot.build(:service)
+    creator = ServiceCreator.new(service: service)
+    creator.call
+    assert service.persisted?
+    assert service.backend_api_proxy.backend_api.new_record?
+  end
+
+  test 'service creation with path and private_endpoint' do
+    service = FactoryBot.build(:service)
+    creator = ServiceCreator.new(service: service)
+    creator.call(path: 'foo', private_endpoint: 'http://example.com')
+
+    assert service.persisted?
+    backend_api = service.backend_api_proxy.backend_api
+    backend_api_config = service.backend_api_proxy.backend_api_config
+    assert backend_api.persisted?
+    assert backend_api_config.persisted?
+  end
+
+  test 'service creation with invalid private_endpoint' do
+    service = FactoryBot.build(:service)
+    creator = ServiceCreator.new(service: service)
+    creator.call(path: 'foo')
+
+    refute service.persisted?
+    backend_api = service.backend_api_proxy.backend_api
+    backend_api_config = service.backend_api_proxy.backend_api_config
+    refute backend_api.persisted?
+    refute backend_api_config.persisted?
+  end
+
+  test 'service with assigned backend api' do
+    backend_api = FactoryBot.create(:backend_api)
+    account = backend_api.account
+    service = FactoryBot.build(:service, account: account)
+    creator = ServiceCreator.new(service: service, backend_api: backend_api)
+    creator.call
+    backend_api = service.backend_api_proxy.backend_api
+    backend_api_config = service.backend_api_proxy.backend_api_config
+    assert service.persisted?
+    assert backend_api.persisted?
+    assert backend_api_config.persisted?
+  end
+end

--- a/test/unit/services/service_discovery/import_cluster_definitions_service_test.rb
+++ b/test/unit/services/service_discovery/import_cluster_definitions_service_test.rb
@@ -93,6 +93,7 @@ module ServiceDiscovery
       @account.stubs(:provider_can_use?).with(:apicast_v1).returns(true)
       @account.stubs(:provider_can_use?).with(:apicast_v2).returns(true)
       @account.stubs(:provider_can_use?).with(:proxy_private_base_path).returns(false)
+      @account.expects(:provider_can_use?).with(:api_as_product).at_least_once.returns(false)
       @service.backend_api.stubs(account: @account)
 
       System::ErrorReporting.expects(:report_error).with(responds_with(:message, 'Could not save API backend URL'), any_parameters)

--- a/test/unit/signup/account_manager_test.rb
+++ b/test/unit/signup/account_manager_test.rb
@@ -126,6 +126,20 @@ class Signup::AccountManagerTest < ActiveSupport::TestCase
       assert_equal 'API', account.first_service!.name
     end
 
+    test 'creating a provider will create default Backend API if api_as_product is disabled' do
+      Account.any_instance.stubs(:provider_can_use?).returns(false)
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false)
+      account = signup_account_manager.create(signup_params).account
+      assert_equal BackendApi.default_api_backend, account.default_service.api_backend
+    end
+
+    test 'creating a provider will not create default Backend API if api_as_product is enabled' do
+      Account.any_instance.stubs(:provider_can_use?).returns(false)
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true)
+      account = signup_account_manager.create(signup_params).account
+      assert_nil account.default_service.api_backend
+    end
+
     private
 
     def manager_account

--- a/test/workers/backend_metric_worker_test.rb
+++ b/test/workers/backend_metric_worker_test.rb
@@ -52,7 +52,7 @@ class BackendMetricWorkerTest < ActiveSupport::TestCase
   end
 
   test 'syncs metrics with the right parent_id' do
-    service = FactoryBot.create(:service)
+    service = FactoryBot.create(:simple_service, :with_default_backend_api)
     service_hits = service.metrics.hits
     service_other = FactoryBot.create(:metric, owner: service, system_name: 'other-metric-of-service')
     service_backend_id = service.backend_id


### PR DESCRIPTION
Do not create backend_api automatically when create a Service

It is extracted from https://github.com/3scale/porta/pull/1168

- Keeping only changes in the backend, not in the UI
- Normally we do not have to touch the UI