### PR TITLE
Enable APIAP on On-premises

### DIFF
--- a/openshift/system/config/rolling_updates.yml
+++ b/openshift/system/config/rolling_updates.yml
@@ -18,7 +18,7 @@ base: &default
   policy_registry: true
   proxy_private_base_path: true
   service_mesh_integration: true
-  api_as_product: false
+  api_as_product: true
 
 production:
   <<: *default


### PR DESCRIPTION
So it is the default behaviour for on premises builds