### PR TITLE
[Usage Rules] Separated view and route

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -12,7 +12,7 @@ class Api::ServicesController < Api::BaseController
   load_and_authorize_resource :service, through: :current_user,
     through_association: :accessible_services, except: [:create]
 
-  with_options only: %i[edit update settings] do |actions|
+  with_options only: %i[edit update settings usage_rules] do |actions|
     actions.sublayout 'api/service'
   end
 
@@ -30,8 +30,13 @@ class Api::ServicesController < Api::BaseController
   end
 
   def settings
-    activate_menu_args = current_account.provider_can_use?(:api_as_product) ? %i[serviceadmin applications usage_rules] : %i[serviceadmin integration settings]
-    activate_menu activate_menu_args
+    activate_menu :serviceadmin, :integration, :settings
+    @alert_limits = Alert::ALERT_LEVELS
+  end
+
+  def usage_rules
+    raise ActiveRecord::RecordNotFound unless provider_can_use?(:api_as_product)
+    activate_menu :serviceadmin, :applications, :usage_rules
     @alert_limits = Alert::ALERT_LEVELS
   end
 

--- a/app/helpers/api/services_helper.rb
+++ b/app/helpers/api/services_helper.rb
@@ -56,8 +56,4 @@ module Api::ServicesHelper
     msg = t('api.services.forms.definition_settings.refresh_confirmation', name: h(service.name))
     action_link_to(:refresh, url, {data: { confirm: msg }, method: :put}.merge(options) )
   end
-
-  def page_title
-    current_account.provider_can_use?(:api_as_product) ? 'Usage Rules' : 'Settings'
-  end
 end

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -222,8 +222,8 @@ module VerticalNavHelper
     items << {id: :listing,           title: 'Listing',           path: admin_service_applications_path(@service)}
     items << {id: :application_plans, title: 'Application Plans', path: admin_service_application_plans_path(@service)} if can?(:manage, :plans)
     if current_account.provider_can_use?(:api_as_product)
-      items << {                          title: 'Settings'}
-      items << {id: :usage_rules,       title: 'Usage Rules',       path: settings_admin_service_path(@service)}
+      items << {title: 'Settings'}
+      items << {id: :usage_rules, title: 'Usage Rules', path: usage_rules_admin_service_path(@service)}
     end
     items
   end

--- a/app/views/api/services/forms/_usage_rules.html.slim
+++ b/app/views/api/services/forms/_usage_rules.html.slim
@@ -1,0 +1,55 @@
+= form.inputs current_account.multiple_applications_allowed? ? 'Application Requirements' : 'Signup & Use' do
+
+  - unless current_account.multiple_applications_allowed?
+    // TODO remove this and make it an extra_field? Or how about just remove it?
+    = form.input :intentions_required
+
+  = form.input :buyers_manage_apps
+
+  - if @service.backend_version.app_keys_allowed?
+    = form.input :buyers_manage_keys
+
+  = form.input :referrer_filters_required, as: :boolean
+
+  = form.input :custom_keys_enabled
+
+  - if @service.backend_version == "2"
+    = form.input :buyer_key_regenerate_enabled
+    = form.input :mandatory_app_key
+
+- if can?(:see, :end_users) and @service.end_users_allowed?
+  = form.inputs 'End Users Requirements' do
+    = form.input :end_user_registration_required, input_html: { :disabled => @service.end_user_plans.default.nil? }
+
+= form.inputs "Application Plans" do
+  = form.input  :buyer_can_select_plan
+
+  = form.inputs "Application Plan Changing" do
+
+    = render 'shared/plan_change_settings', form: form, permission: :buyer_plan_change_permission, label: ''
+
+= form.inputs 'Alerts' do
+  li.full-width
+    p.inline-hints
+      ' Here you can set at which utilization levels you want to trigger alerts, whom you want to send these alerts to (admins and/or developers) and by which means (web and/or email).
+      em In order for an application to trigger usage alerts, usage limit(s) need to be set up in the Application Plan to which the application is subscribed.
+
+  li.full-width
+    table id="notification-settings-table" class="data notification-settings"
+      thead
+        tr
+          th
+          - @alert_limits.each do |level|
+            th
+              = level
+              | %
+
+      tbody
+        = row_for_alert_levels 'Show Web Alerts to Admins of this Account', :web_provider
+        = row_for_alert_levels 'Send Email Alerts to Admins of this Account', :email_provider
+      thead
+        tr
+          th.spacer colspan="9"
+      tbody
+        = row_for_alert_levels 'Show Web Alerts to Admins of the Developer Account', :web_buyer
+        = row_for_alert_levels 'Send Email Alerts to Admins of the Developer Account', :email_buyer

--- a/app/views/api/services/usage_rules.html.slim
+++ b/app/views/api/services/usage_rules.html.slim
@@ -1,4 +1,5 @@
-- content_for :sublayout_title, 'Settings'
+- # TODO: When APIAP is default, adjust the old settings cukes to usage rules
+- content_for :sublayout_title, 'Usage Rules', flush: true
 
 - if (can? :manage, :service_plans) && !current_account.settings.service_plans_ui_visible?
   = form_tag polymorphic_path([:masterize, :admin, @service, ServicePlan]), :method => :post, :class => 'service autosubmit formtastic', :remote => true do
@@ -16,6 +17,6 @@
             p.inline-hints Please create a service plan first.
 
 = semantic_form_for @service, :url => admin_service_path(@service) do |form|
-  = render :partial => 'api/services/forms/settings', :locals => { :form => form }
+  = render :partial => 'api/services/forms/usage_rules', :locals => { :form => form }
   = form.buttons do
     = form.commit_button

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -775,6 +775,7 @@ without fake Core server your after commit callbacks will crash and you might ge
         resources :services, except: :index do
           member do
             get :settings
+            get :usage_rules
           end
           resource :support, :only => [:edit, :update]
           resource :content, :only => [:edit, :update]


### PR DESCRIPTION
**What this PR does / why we need it**:
This aims to enhance the previous https://github.com/3scale/porta/pull/1202, making it a bit easier to tackle https://issues.jboss.org/browse/THREESCALE-3451

**Which issue(s) this PR fixes** 

Improves  https://issues.jboss.org/browse/THREESCALE-3471

**Special notes for your reviewer**:
This is an enhancement of the previous https://github.com/3scale/porta/pull/1202

* The views are duplicated, but it's needed in order to get independence for method
settings
* In the future, we just adjust the cukes to Usage Rules instead of old
Settings, and we can safely remove the old settings
* Clean, no conditionals