### PR TITLE
Adding Settings subheader to Application menu when APIAP is on

### DIFF
--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -221,7 +221,10 @@ module VerticalNavHelper
     items = []
     items << {id: :listing,           title: 'Listing',           path: admin_service_applications_path(@service)}
     items << {id: :application_plans, title: 'Application Plans', path: admin_service_application_plans_path(@service)} if can?(:manage, :plans)
-    items << {id: :usage_rules,       title: 'Usage Rules',       path: settings_admin_service_path(@service)} if current_account.provider_can_use?(:api_as_product)
+    if current_account.provider_can_use?(:api_as_product)
+      items << {                          title: 'Settings'}
+      items << {id: :usage_rules,       title: 'Usage Rules',       path: settings_admin_service_path(@service)}
+    end
     items
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**API > Applications > Settings** should have subheader in vertical nav, just like  **Audience > Accounts > Settings**

**Which issue(s) this PR fixes** 

[THREESCALE-3511](https://issues.jboss.org/browse/THREESCALE-3511)

**With APIAP on:**
![APIAP-on](https://user-images.githubusercontent.com/13486237/65321261-0bc39f80-dba4-11e9-9bc6-fdd0e9ab751d.png)

**With APIAP off:**
![APIAP-off](https://user-images.githubusercontent.com/13486237/65321249-08c8af00-dba4-11e9-93cb-e993f1ffdc80.png)