### PR TITLE
Fix redirect_url field in the proxy and backend_api/mapping rules

### DIFF
--- a/app/views/api/proxy_rules/index.html.slim
+++ b/app/views/api/proxy_rules/index.html.slim
@@ -2,4 +2,4 @@
 
 = render 'shared/proxy_rules/table', proxy_rules: @proxy_rules,
                                      new_rule_path: new_admin_service_proxy_rule_path(@service),
-                                     owner: @service
+                                     owner: @service, include_redirect: @service.using_proxy_pro?

--- a/app/views/api/proxy_rules/new.html.slim
+++ b/app/views/api/proxy_rules/new.html.slim
@@ -1,4 +1,5 @@
 = content_for :sublayout_title, 'New Mapping Rule'
 
 = semantic_form_for @proxy_rule, url: admin_service_proxy_rules_path(@service) do |form|
-  = render 'shared/proxy_rules/form', form: form, proxy_rule: @proxy_rule, metrics: @service.metrics
+  = render 'shared/proxy_rules/form', form: form, proxy_rule: @proxy_rule, metrics: @service.metrics,
+                                      include_redirect: @service.using_proxy_pro?

--- a/app/views/shared/proxy_rules/_form.html.slim
+++ b/app/views/shared/proxy_rules/_form.html.slim
@@ -1,7 +1,7 @@
 = form.inputs do
   = form.input :http_method, as: :select, collection: ProxyRule::ALLOWED_HTTP_METHODS, include_blank: false, label: 'Verb'
   = form.input :pattern
-  = form.input :redirect_url, as: :string if proxy_rule.owner.try(:using_proxy_pro?)
+  = form.input :redirect_url, as: :string if local_assigns[:include_redirect]
   = form.input :metric_id, as: :select, collection: metrics, include_blank: false, label: 'Metric or Method to increment'
   = form.input :delta, label: 'Increment by'
   = form.input :last, label: 'Last?'

--- a/app/views/shared/proxy_rules/_table.html.slim
+++ b/app/views/shared/proxy_rules/_table.html.slim
@@ -3,7 +3,7 @@ table#mapping_rules.data
     tr
       th = sortable('proxy_rules.http_method', 'Verb')
       th = sortable('proxy_rules.pattern', 'Pattern')
-      - if owner.try(:using_proxy_pro?)
+      - if local_assigns[:include_redirect]
         th Redirect
       th title="increment" +
       th = sortable('metrics.friendly_name', 'Metric or Method')
@@ -20,7 +20,7 @@ table#mapping_rules.data
           = rule.pattern
           - if rule.pattern == '/'
             span.fa.fa-exclamation-triangle.disabled#catch-all-warning title=(t('api.integrations.proxy.proxy_rule_catch_all_warning'))
-        - if owner.try(:using_proxy_pro?)
+        - if local_assigns[:include_redirect]
           td.redirect_url
             = rule.redirect_url
         td.delta

--- a/test/integration/api/proxy_rules_controller_test.rb
+++ b/test/integration/api/proxy_rules_controller_test.rb
@@ -15,7 +15,7 @@ class Api::ProxyRulesControllerTest < ActionDispatch::IntegrationTest
       @service = FactoryBot.create(:service, account: @provider)
     end
 
-    test 'index page list all proxy rules' do
+    test '#index page list all proxy rules' do
       proxy_rules = FactoryBot.create_list(:proxy_rule, 2, proxy: @service.proxy)
 
       get admin_service_proxy_rules_path(@service)
@@ -27,6 +27,37 @@ class Api::ProxyRulesControllerTest < ActionDispatch::IntegrationTest
         patterns.include?(pattern)
       end
     end
+
+    test '#index page should not return the Redirect header when not using proxy pro' do
+      Service.any_instance.stubs(:using_proxy_pro?).returns(false)
+      proxy_rules = FactoryBot.create(:proxy_rule, proxy: @service.proxy)
+
+      get admin_service_proxy_rules_path(@service)
+      refute_match /Redirect/, response.body
+    end
+
+    test '#index page should return the Redirect header when using proxy pro' do
+      Service.any_instance.stubs(:using_proxy_pro?).returns(true)
+      proxy_rules = FactoryBot.create(:proxy_rule, proxy: @service.proxy)
+
+      get admin_service_proxy_rules_path(@service)
+      assert_match /Redirect/, response.body
+    end
+
+    test '#new should not return the Redirect Url field when not using proxy pro' do
+      Service.any_instance.stubs(:using_proxy_pro?).returns(false)
+
+      get new_admin_service_proxy_rule_path(@service)
+      assert_select '#proxy_rule_redirect_url', false
+    end
+
+    test '#new should return the Redirect Url field when using proxy pro' do
+      Service.any_instance.stubs(:using_proxy_pro?).returns(true)
+
+      get new_admin_service_proxy_rule_path(@service)
+      assert_select '#proxy_rule_redirect_url'
+    end
+
 
     test '#create persists a new proxy rule' do
       proxy_rule_params = FactoryBot.attributes_for(:proxy_rule, proxy: @service.proxy, metric_id: @service.metrics.last.id)

--- a/test/integration/provider/admin/backend_apis/mapping_rules_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/mapping_rules_controller_test.rb
@@ -16,9 +16,9 @@ class Provider::Admin::BackendApis::MappingRulesControllerTest < ActionDispatch:
 
   test '#index' do
     get provider_admin_backend_api_mapping_rules_path(backend_api)
-    assert_response :success
 
-    assert_select 'table.data tr', count: backend_api.mapping_rules.count+1
+    assert_response :success
+    assert_select 'table.data tr', count: @backend_api.mapping_rules.count+1
     @backend_api.mapping_rules.each { |rule| assert_select 'table.data tr td', text: rule.pattern }
   end
 
@@ -39,5 +39,18 @@ class Provider::Admin::BackendApis::MappingRulesControllerTest < ActionDispatch:
 
     put provider_admin_backend_api_mapping_rule_path(backend_api, @backend_api.mapping_rules.first), {}
     assert_response :not_found
+  end
+
+  test '#index should not render the Redirect column in the table' do
+    get provider_admin_backend_api_mapping_rules_path(backend_api)
+
+    assert_response :success
+    refute_match /Redirect/, response.body
+  end
+
+  test '#new should not return the Redirect Url' do
+    get new_provider_admin_backend_api_mapping_rule_path(backend_api)
+
+    assert_select '#proxy_rule_redirect_url', false
   end
 end


### PR DESCRIPTION
We currently have a bug in
app/views/shared/proxy_rules/_form.html.slim page. To render the
redirect_url field, it relies on the owner to check if it is
using proxy pro. But this caller to owner is invalid. Owner for
ProxyRule can be a Proxy or BackendApi, not the Service (which we
expect to call the using_proxy_pro method).
