### PR TITLE
Fix Cuke Step: stub integration errors after signup and before login

### DIFF
--- a/features/step_definitions/provider_steps.rb
+++ b/features/step_definitions/provider_steps.rb
@@ -85,6 +85,8 @@ Given(/^a provider signs up and activates his account$/) do
   email = open_email(user.email, with_subject: 'Account Activation')
   click_first_link_in_email(email)
 
+  step 'stub integration errors dashboard'
+
   within login_form do
     fill_in 'Email', with: user.email
     fill_in 'Password', with: 'supersecret'


### PR DESCRIPTION
Fixes [this random cuke error in CircleCI](https://circleci.com/gh/3scale/porta/104931#tests/containers/18).

It doesn't happen always, but sometimes it fails in the step _a provider signs up and activates his account_ because it tries to fetch from the internet _the integration errors_ but CircleCI shouldn't try to access the internet so it is stubbed here using this:
https://github.com/3scale/porta/blob/434182f7f4889f04fe4efbdd26e052be22034f5b/test/test_helpers/backend.rb#L87-L91
https://github.com/3scale/porta/blob/434182f7f4889f04fe4efbdd26e052be22034f5b/features/step_definitions/provider_steps.rb#L142-L146

Just like we are currently doing for other steps before logging in:
https://github.com/3scale/porta/blob/434182f7f4889f04fe4efbdd26e052be22034f5b/features/step_definitions/provider_steps.rb#L148-L163
