### PR TITLE
THREESCALE-2542 Ability to configure JWT Claim with ClientID

### DIFF
--- a/app/controllers/admin/api/services/proxies_controller.rb
+++ b/app/controllers/admin/api/services/proxies_controller.rb
@@ -6,7 +6,7 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
   represents :json, entity: ::ProxyRepresenter::JSON
   represents :xml, entity: ::ProxyRepresenter::XML
 
-  wrap_parameters ::Proxy, include: Proxy.attribute_names + %w[api_backend]
+  wrap_parameters ::Proxy, include: Proxy.attribute_names + %w[api_backend] + GatewayConfiguration::ATTRIBUTES
 
   ##~ e = sapi.apis.add
   ##~ e.path = "/admin/api/services/{service_id}/proxy.xml"
@@ -59,6 +59,8 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
   ##~ op.parameters.add name: "oidc_issuer_endpoint", description: "Location of your OpenID Provider.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "oidc_issuer_type", description: "Type of your OpenID Provider.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "sandbox_endpoint", description: "Sandbox endpoint.", dataType: "string", paramType: "query", required: false
+  ##~ op.parameters.add name: "jwt_claim_with_client_id", description: "JWT Claim With ClientId Location.", dataType: "string", paramType: "query", required: false
+  ##~ op.parameters.add name: "jwt_claim_with_client_id_type", description: "JWT Claim With ClientId Type. Either `plain` or `liquid`", dataType: "string", paramType: "query", required: false
   #
   def update
     if proxy.update_attributes(proxy_params)
@@ -82,6 +84,7 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
                           error_status_no_match error_headers_no_match secret_token hostname_rewrite
                           oauth_login_url api_test_path oidc_issuer_endpoint oidc_issuer_type error_status_limits_exceeded
                           error_headers_limits_exceeded error_limits_exceeded]
+    permitted_params += GatewayConfiguration::ATTRIBUTES
 
     params.require(:proxy).permit(permitted_params)
   end

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -223,6 +223,7 @@ class Api::IntegrationsController < Api::BaseController
   def proxy_params
     basic_fields = [
       :lock_version,
+
       :auth_app_id, :auth_app_key, :api_backend, :hostname_rewrite, :oauth_login_url,
       :secret_token, :credentials_location, :auth_user_key, :error_status_auth_failed,
       :error_headers_auth_failed, :error_auth_failed, :error_status_auth_missing,
@@ -242,6 +243,8 @@ class Api::IntegrationsController < Api::BaseController
     if provider_can_use?(:apicast_oidc)
       basic_fields << :oidc_issuer_endpoint
       basic_fields << :oidc_issuer_type
+      basic_fields << :jwt_claim_with_client_id
+      basic_fields << :jwt_claim_with_client_id_type
     end
 
     basic_fields << { backend_api_configs_attributes: %i[_destroy id path] } if provider_can_use?(:api_as_product)

--- a/app/lib/gateway_settings/proxy_extension.rb
+++ b/app/lib/gateway_settings/proxy_extension.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module GatewaySettings
+  module ProxyExtension
+    extend ActiveSupport::Concern
+    included do
+      has_one :gateway_configuration, dependent: :delete, inverse_of: :proxy, autosave: true
+      # TODO: In the future, stop using columns and put all configuration to this class
+      delegate(*GatewayConfiguration.accessors, to: :gateway_configuration)
+    end
+
+    def gateway_configuration
+      super || build_gateway_configuration
+    end
+  end
+end

--- a/app/models/gateway_configuration.rb
+++ b/app/models/gateway_configuration.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class GatewayConfiguration < ApplicationRecord
+  JWT_CLAIM_ATTRIBUTES = %i[jwt_claim_with_client_id jwt_claim_with_client_id_type].freeze
+  ATTRIBUTES = JWT_CLAIM_ATTRIBUTES
+
+  JWT_CLAIM_WITH_CLIENT_ID_TYPES = %w[plain liquid].freeze
+
+  belongs_to :proxy, inverse_of: :gateway_configuration, touch: true
+  store :settings, accessors: ATTRIBUTES, coder: JSON
+
+  validates :jwt_claim_with_client_id_type, inclusion: { in: JWT_CLAIM_WITH_CLIENT_ID_TYPES, allow_nil: true}
+  validates :jwt_claim_with_client_id, :jwt_claim_with_client_id_type, presence: {if: :jwt_claim_any?}
+
+  def self.accessors
+    ATTRIBUTES.flat_map {|attr| [attr, "#{attr}="] }
+  end
+
+  protected
+
+  def jwt_claim_any?
+    JWT_CLAIM_ATTRIBUTES.any? { |attr| public_send(attr).present? }
+  end
+end

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -5,6 +5,7 @@ class Proxy < ApplicationRecord
   include AfterCommitQueue
   include BackendApiLogic::ProxyExtension
   prepend BackendApiLogic::RoutingPolicy
+  include GatewaySettings::ProxyExtension
 
   DEFAULT_POLICY = { 'name' => 'apicast', 'humanName' => 'APIcast policy', 'description' => 'Main functionality of APIcast.',
                      'configuration' => {}, 'version' => 'builtin', 'enabled' => true, 'removable' => false, 'id' => 'apicast-policy'  }.freeze

--- a/app/representers/proxy_representer.rb
+++ b/app/representers/proxy_representer.rb
@@ -41,8 +41,11 @@ class ProxyRepresenter < ThreeScale::Representer
   # By sending the lock_version with the update call the record is updated only when matching that version.
   property :lock_version
 
-  property :oidc_issuer_endpoint, if: ->(*) {  oidc?   }
-  property :oidc_issuer_type, if: ->(*) {  oidc?   }
+  property :oidc_issuer_endpoint, if: ->(*) { oidc? }
+  property :oidc_issuer_type, if: ->(*) { oidc? }
+
+  property :jwt_claim_with_client_id, if: ->(*) { oidc? }
+  property :jwt_claim_with_client_id_type, if: ->(*) { oidc? }
 
   class JSON < ProxyRepresenter
     include Roar::JSON

--- a/app/views/api/integrations/apicast/shared/_authentication_settings.html.slim
+++ b/app/views/api/integrations/apicast/shared/_authentication_settings.html.slim
@@ -1,22 +1,23 @@
 = f.toggled_inputs 'Authentication Settings' do
+  //= f.inputs "Specific for the Authentication Type" do
   - if @service.oidc?
     = render 'api/integrations/apicast/shared/oidc', f: f
-
   - elsif @service.oauth?
     = f.input :oauth_login_url, label: "OAuth Authorization Endpoint", input_html: { placeholder: "https://#{parameterized_org_name_of_the_current_account}.com/authorize" },  hint: t("formtastic.hints.proxy.#{oauth_hint}")
-
-  = f.input :hostname_rewrite, label: "Host Header"
-  = f.input :secret_token, label: "Secret Token"
-
-  = f.input :credentials_location, as: :radio,
-    collection: Proxy.credentials_collection
-
   - case @service.backend_version
   - when '1'
-    = f.input :auth_user_key
+    = f.inputs "API Key (user_key) Basics" do
+      = f.input :auth_user_key
   - when '2'
-    = f.input :auth_app_id
-    = f.input :auth_app_key
+    = f.inputs "App_ID and App_key Pair Basics" do
+      = f.input :auth_app_id
+      = f.input :auth_app_key
+  = f.inputs "Credentials Location" do
+    = f.input :credentials_location, as: :radio,
+      collection: Proxy.credentials_collection
+  = f.inputs "Security" do
+    = f.input :hostname_rewrite, label: "Host Header"
+    = f.input :secret_token, label: "Secret Token"
 
 = f.toggled_inputs 'Gateway Response' do
   = f.inputs "Authentication Failed Error" do

--- a/app/views/api/integrations/apicast/shared/_oidc.html.slim
+++ b/app/views/api/integrations/apicast/shared/_oidc.html.slim
@@ -5,3 +5,6 @@
   = f.semantic_fields_for :oidc_configuration do |config|
     - OIDCConfiguration::Config::FLOWS.each do |flow|
       = config.input flow, :as => :boolean
+= f.inputs "JWT Claim with ClientID" do |config|
+  = f.input :jwt_claim_with_client_id_type, include_blank: false, label: 'JWT Claim with ClientId Type', collection: GatewayConfiguration::JWT_CLAIM_WITH_CLIENT_ID_TYPES, as: :select
+  = f.input :jwt_claim_with_client_id, input_html: {placeholder: 'azp', value: f.object.jwt_claim_with_client_id.presence || 'azp'}, hint: true, label: 'JWT Claim with ClientID Location'

--- a/app/views/api/integrations/apicast/shared/_oidc.html.slim
+++ b/app/views/api/integrations/apicast/shared/_oidc.html.slim
@@ -1,10 +1,11 @@
-= f.input :oidc_issuer_type, hint: true, as: :select,
-    collection: Proxy.oidc_issuer_types, selected: @proxy.oidc_issuer_type || Proxy.column_defaults['oidc_issuer_type']
-= f.input :oidc_issuer_endpoint, hint: true, input_html: { placeholder: "https://sso.example.com/auth/realms/gateway" }
+= f.inputs "OpenID Connect (OIDC) Basics" do
+  = f.input :oidc_issuer_type, hint: true, as: :select,
+      collection: Proxy.oidc_issuer_types, selected: @proxy.oidc_issuer_type || Proxy.column_defaults['oidc_issuer_type']
+  = f.input :oidc_issuer_endpoint, hint: true, input_html: { placeholder: "https://sso.example.com/auth/realms/gateway" }
 = f.inputs "OIDC Authorization flow" do
   = f.semantic_fields_for :oidc_configuration do |config|
     - OIDCConfiguration::Config::FLOWS.each do |flow|
       = config.input flow, :as => :boolean
-= f.inputs "JWT Claim with ClientID" do |config|
-  = f.input :jwt_claim_with_client_id_type, include_blank: false, label: 'JWT Claim with ClientId Type', collection: GatewayConfiguration::JWT_CLAIM_WITH_CLIENT_ID_TYPES, as: :select
-  = f.input :jwt_claim_with_client_id, input_html: {placeholder: 'azp', value: f.object.jwt_claim_with_client_id.presence || 'azp'}, hint: true, label: 'JWT Claim with ClientID Location'
+= f.inputs "JSON Web Token (JWT) Claim with ClientID" do |config|
+  = f.input :jwt_claim_with_client_id_type, include_blank: false, label: 'ClientID Token Claim Type', collection: GatewayConfiguration::JWT_CLAIM_WITH_CLIENT_ID_TYPES, as: :select, hint: true
+  = f.input :jwt_claim_with_client_id, input_html: {placeholder: 'azp', value: f.object.jwt_claim_with_client_id.presence || 'azp'}, hint: true, label: 'ClientID Token Claim'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1246,6 +1246,8 @@ en:
         secret_token: |
           Enables you to block any direct developer requests to your API backend; each 3scale API gateway call to your API backend contains a request header called <code>X-3scale-proxy-secret-token</code>.
           The value of this header can be set by you here. It's up to you ensure your backend only allows calls with this secret header.
+        jwt_claim_with_client_id: |
+          Location of the ClientID in the JWT token. Example: azp
 
 
       service:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1246,8 +1246,10 @@ en:
         secret_token: |
           Enables you to block any direct developer requests to your API backend; each 3scale API gateway call to your API backend contains a request header called <code>X-3scale-proxy-secret-token</code>.
           The value of this header can be set by you here. It's up to you ensure your backend only allows calls with this secret header.
+        jwt_claim_with_client_id_type: |
+          Process the ClientID Token Claim value as a string or as a liquid template. When set to 'Liquid' you can define more complex rules. e.g. If 'some_claim' is an array you can select the first value this like {{ some_claim | first }}. 
         jwt_claim_with_client_id: |
-          Location of the ClientID in the JWT token. Example: azp
+          The Token Claim that contains the clientID. Defaults to 'azp'.
 
 
       service:

--- a/db/migrate/20190920123906_create_gateway_configurations.rb
+++ b/db/migrate/20190920123906_create_gateway_configurations.rb
@@ -1,0 +1,12 @@
+class CreateGatewayConfigurations < ActiveRecord::Migration
+  def change
+    create_table :gateway_configurations do |t|
+      t.text :settings
+      t.belongs_to :proxy, limit: 8
+      t.integer :tenant_id, limit: 8
+
+      t.timestamps null: false
+    end
+    add_index :gateway_configurations, [:proxy_id], unique: true
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190904144157) do
+ActiveRecord::Schema.define(version: 20190920123906) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -585,6 +585,16 @@ ActiveRecord::Schema.define(version: 20190904144157) do
 
   add_index "forums", ["permalink"], name: "index_forums_on_site_id_and_permalink"
   add_index "forums", ["position"], name: "index_forums_on_position_and_site_id"
+
+  create_table "gateway_configurations", force: :cascade do |t|
+    t.text     "settings"
+    t.integer  "proxy_id",   precision: 38
+    t.integer  "tenant_id",  precision: 38
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "gateway_configurations", ["proxy_id"], name: "index_gateway_configurations_on_proxy_id", unique: true
 
   create_table "go_live_states", force: :cascade do |t|
     t.integer  "account_id",             precision: 38

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190904144157) do
+ActiveRecord::Schema.define(version: 20190920123906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -584,6 +584,16 @@ ActiveRecord::Schema.define(version: 20190904144157) do
 
   add_index "forums", ["permalink"], name: "index_forums_on_site_id_and_permalink", using: :btree
   add_index "forums", ["position"], name: "index_forums_on_position_and_site_id", using: :btree
+
+  create_table "gateway_configurations", force: :cascade do |t|
+    t.text     "settings"
+    t.integer  "proxy_id",   limit: 8
+    t.integer  "tenant_id",  limit: 8
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+  end
+
+  add_index "gateway_configurations", ["proxy_id"], name: "index_gateway_configurations_on_proxy_id", unique: true, using: :btree
 
   create_table "go_live_states", force: :cascade do |t|
     t.integer  "account_id", limit: 8

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190904144157) do
+ActiveRecord::Schema.define(version: 20190920123906) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -585,6 +585,16 @@ ActiveRecord::Schema.define(version: 20190904144157) do
 
   add_index "forums", ["permalink"], name: "index_forums_on_site_id_and_permalink", using: :btree
   add_index "forums", ["position"], name: "index_forums_on_position_and_site_id", using: :btree
+
+  create_table "gateway_configurations", force: :cascade do |t|
+    t.text     "settings",   limit: 65535
+    t.integer  "proxy_id",   limit: 8
+    t.integer  "tenant_id",  limit: 8
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
+  add_index "gateway_configurations", ["proxy_id"], name: "index_gateway_configurations_on_proxy_id", unique: true, using: :btree
 
   create_table "go_live_states", force: :cascade do |t|
     t.integer  "account_id", limit: 8

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -7261,6 +7261,20 @@
               "dataType": "string",
               "paramType": "query",
               "required": false
+            },
+            {
+              "name": "jwt_claim_with_client_id",
+              "description": "JWT Claim With ClientId Location.",
+              "dataType": "string",
+              "paramType": "query",
+              "required": false
+            },
+            {
+              "name": "jwt_claim_with_client_id_type",
+              "description": "JWT Claim With ClientId Type. Either `plain` or `liquid`",
+              "dataType": "string",
+              "paramType": "query",
+              "required": false
             }
           ]
         }

--- a/lib/apicast/provider_source.rb
+++ b/lib/apicast/provider_source.rb
@@ -22,7 +22,7 @@ module Apicast
           except: [:policies_config],
           methods: [
             :oauth_login_url, :hostname_rewrite_for_sandbox, :endpoint_port, :api_backend, :valid?, :service_backend_version,
-            :hosts, :backend, :policy_chain
+            :hosts, :backend, :policy_chain, *GatewayConfiguration::ATTRIBUTES
           ],
           include: [
             proxy_rules: {

--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -546,6 +546,12 @@ System::Database::MySQL.define do
     SQL
   end
 
+  trigger 'gateway_configurations' do
+    <<~SQL
+      SET NEW.tenant_id = (SELECT tenant_id FROM proxies WHERE id = NEW.proxy_id AND tenant_id <> master_id);
+    SQL
+  end
+
   procedure 'sp_invoices_friendly_id', invoice_id: 'bigint' do
     <<~SQL
       BEGIN

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -562,6 +562,12 @@ System::Database::Oracle.define do
     SQL
   end
 
+  trigger 'gateway_configurations' do
+    <<~SQL
+      SELECT tenant_id INTO :new.tenant_id FROM proxies WHERE id = :new.proxy_id AND tenant_id <> master_id;
+    SQL
+  end
+
   procedure 'sp_invoices_friendly_id', invoice_id: 'NUMBER' do
     <<~SQL
         v_provider_account_id NUMBER;

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -561,6 +561,12 @@ System::Database::Postgres.define do
     SQL
   end
 
+  trigger 'gateway_configurations' do
+    <<~SQL
+      SELECT tenant_id INTO NEW.tenant_id FROM proxies WHERE id = NEW.proxy_id AND tenant_id <> master_id;
+    SQL
+  end
+
   procedure 'sp_invoices_friendly_id', invoice_id: 'numeric' do
     <<~SQL
       DECLARE

--- a/spec/acceptance/api/proxy_spec.rb
+++ b/spec/acceptance/api/proxy_spec.rb
@@ -12,23 +12,51 @@ resource 'Proxy' do
     put '/admin/api/services/:service_id/proxy.:format', action: :update do
       parameter :credentials_location, 'Credentials Location'
       parameter :api_backend, 'Private endpoint'
+      parameter :jwt_claim_with_client_id, 'JWT Claim with ClientID Location'
+      parameter :jwt_claim_with_client_id_type, 'JWT Claim with ClientID Type'
 
       let(:credentials_location) { 'headers' }
       let(:api_backend) { 'https://private.example.com:443' }
+      let(:jwt_claim_with_client_id) { 'azp' }
+      let(:jwt_claim_with_client_id_type) { 'plain' }
 
       request 'should change api_backend' do
         resource.reload
         resource.api_backend.should eq(api_backend)
+      end
+
+      request 'should change jwt_claim_with_client_id_type' do
+        resource.reload
+        resource.jwt_claim_with_client_id_type.should eq(jwt_claim_with_client_id_type)
+      end
+
+      request 'should change jwt_claim_with_client_id' do
+        resource.reload
+        resource.jwt_claim_with_client_id.should eq(jwt_claim_with_client_id)
       end
     end
   end
 
   json(:resource) do
     let(:root) { 'proxy' }
+
+    parameter :api_backend, 'Private endpoint'
+
+    let(:api_backend) { 'https://private.example.com:443' }
+
     it { should include('credentials_location' => resource.credentials_location) }
     it { should include('deployment_option' => resource.deployment_option.to_s) }
     it { should have_links('mapping_rules', 'service', 'self') }
     it { should include('api_backend' => resource.api_backend) }
+
+    context 'OIDC' do
+      before do
+        resource.update!(authentication_method: :oidc, jwt_claim_with_client_id_type: 'plain', jwt_claim_with_client_id: 'azp')
+      end
+
+      it { should include('jwt_claim_with_client_id' => 'azp') }
+      it { should include('jwt_claim_with_client_id_type' => 'plain') }
+    end
   end
 end
 

--- a/test/models/gateway_configuration_test.rb
+++ b/test/models/gateway_configuration_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class GatewayConfigurationTest < ActiveSupport::TestCase
+
+  test 'a nil column always creates a valid settings' do
+    config = GatewayConfiguration.new
+    config.save!
+    config.update_column :settings, nil
+    config.reload
+    assert config.valid?
+    assert_equal Hash.new, config.settings
+  end
+
+  test 'saves changes to the configuration' do
+    proxy = FactoryBot.create(:proxy, jwt_claim_with_client_id_type: 'plain', jwt_claim_with_client_id: 'azp')
+    config = proxy.gateway_configuration
+    assert config.persisted?
+    config.reload
+    proxy.reload
+    assert_equal 'plain', proxy.jwt_claim_with_client_id_type
+    assert_equal 'azp', config.jwt_claim_with_client_id
+    assert_equal 'plain', config.jwt_claim_with_client_id_type
+    assert_equal 'azp', config.jwt_claim_with_client_id
+  end
+
+  test 'JWT Claims with CliendID all or none specified' do
+    config = GatewayConfiguration.new
+    assert config.valid?
+    config.jwt_claim_with_client_id_type = 'plain'
+    assert config.invalid?
+    config.jwt_claim_with_client_id = 'azp'
+    assert config.valid?
+    config.jwt_claim_with_client_id_type = nil
+    assert config.invalid?
+  end
+end

--- a/test/unit/apicast/provider_source_test.rb
+++ b/test/unit/apicast/provider_source_test.rb
@@ -22,6 +22,7 @@ class Apicast::ProviderSourceTest < ActiveSupport::TestCase
 
   def test_services
     proxy = FactoryBot.build_stubbed(:proxy)
+    proxy.stubs(jwt_claim_with_client_id_type: 'plain', jwt_claim_with_client_id: 'azp')
     service = FactoryBot.build_stubbed(:simple_service, proxy: proxy)
 
     @account.stubs(services: [ service ])
@@ -30,11 +31,14 @@ class Apicast::ProviderSourceTest < ActiveSupport::TestCase
     assert_equal @account.services.size, services.size
 
     service.stubs(updated_at: Time.now)
-    assert_equal service.updated_at, @source.attributes_for_proxy['services'][0]['updated_at']
+    service_attributes =  @source.attributes_for_proxy['services'][0]
+    assert_equal service.updated_at, service_attributes['updated_at']
 
     assert proxy_attributes = services.first.proxy
 
     assert_equal proxy.hosts, proxy_attributes.hosts
+    assert_equal 'azp', service_attributes['proxy']['jwt_claim_with_client_id']
+    assert_equal 'plain', service_attributes['proxy']['jwt_claim_with_client_id_type']
   end
 
   def test_policies_with_default_apicast_policy


### PR DESCRIPTION
Closes THREESCALE-2542

### What it does

Ability to configure through API and UI the JWT Claim With ClientID
By default in the UI they are pre-filled to `plain` and `azp` if OIDC is chosen as authentication methid, so customers are not confused.

In the API they are not set as the default in APIcast no values means `plain` and `azp` anyway


### Notes

This  PR introduces a new storage for the Proxy model: GatewayConfiguration
Instead of using columns, configurations are stored into a JSON field through `ActiveRecord::Base::store` method

It will be more flexible in the future, no need of migration (proxies table is quite core in the project)

Also we could migrate probably the old columns to that one but no need for now.