### PR TITLE
Fix Cuke Master Step ensuring that master exists or creates it

### DIFF
--- a/features/step_definitions/master_steps.rb
+++ b/features/step_definitions/master_steps.rb
@@ -1,4 +1,5 @@
 Given(/^the master account allows signups$/) do
+  master_account # Ensure that the master account exists, otherwise it creates it
   step 'provider "master" has multiple applications disabled'
   step 'provider "master" has default service and account plan'
   step 'a default application plan "Base" of provider "master"'


### PR DESCRIPTION
Fixes the random failure [in CircleCI](https://circleci.com/gh/3scale/porta/105017#tests/containers/18) with title `failed The 404 page` and in `features/percy/provider.feature:5:in Given the master account allows signups`