### PR TITLE
[PR JUST TO UNBLOCK QE!][DO NOT REVIEW OR MERGE!] API to relate Services with BackendAPI

### DIFF
--- a/app/controllers/admin/api/backend_apis/services_controller.rb
+++ b/app/controllers/admin/api/backend_apis/services_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class Admin::Api::BackendApis::ServicesController < Admin::Api::BackendApis::BaseController
+  wrap_parameters Service, include: Service.attribute_names | %w[state_event]
+  representer Service
+
+  # TODO: ActiveDocs
+  # TODO: Refactor
+  # TODO: should it all be called product instead of service?
+  # TODO: paginate
+
+  def index
+    services = backend_api.services.accessible
+    respond_with(services)
+  end
+
+  def create
+    service = current_account.services.build
+    create_service = ServiceCreator.new(service: service, backend_api: backend_api)
+    create_service.call(service_params)
+    service.reload if service.persisted? # It has been touched # TODO: Add test for this
+    respond_with(service)
+  end
+
+  def show
+    respond_with(service)
+  end
+
+  def update
+    service.update(service_params)
+    respond_with(service)
+  end
+
+  def destroy
+    service.mark_as_deleted
+    respond_with(service)
+  end
+
+  private
+
+  def service
+    @service ||= backend_api.services.accessible.find(params[:id])
+  end
+
+  def service_params
+    permitted_params = [:name, :system_name, :description, :support_email, :deployment_option, :backend_version,
+                        :intentions_required, :buyers_manage_apps, :referrer_filters_required,
+                        :buyer_can_select_plan, :buyer_plan_change_permission, :buyers_manage_keys,
+                        :buyer_key_regenerate_enabled, :mandatory_app_key, :custom_keys_enabled, :state_event,
+                        :txt_support, :terms,
+                        {notification_settings: [web_provider: [], email_provider: [], web_buyer: [], email_buyer: []]}]
+    params.require(:service).permit(*permitted_params)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -530,6 +530,7 @@ without fake Core server your after commit callbacks will crash and you might ge
             resources :methods, controller: 'metric_methods', except: %i[new edit]
           end
           resources :mapping_rules, except: %i[new edit]
+          resources :services, except: %i[new edit]
         end
       end
 

--- a/test/integration/admin/api/backend_apis/services_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/services_controller_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Admin::API::BackendApis::ServicesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @tenant = FactoryBot.create(:provider_account)
+    host! @tenant.admin_domain
+    @access_token_value = FactoryBot.create(:access_token, owner: @tenant.admin_users.first!, scopes: %w[account_management], permission: 'rw').value
+    @backend_api = FactoryBot.create(:backend_api, account: @tenant)
+  end
+
+  attr_reader :backend_api, :access_token_value, :tenant
+
+  test 'index' do
+    FactoryBot.create(:service, account: tenant)
+    tenant.services.each { |service| FactoryBot.create(:backend_api_config, backend_api: backend_api, service: service) }
+    expected_service_ids = tenant.services.pluck(:id)
+
+    deleted_service = FactoryBot.create(:service, account: tenant, state: :deleted)
+    FactoryBot.create(:backend_api_config, backend_api: backend_api, service: deleted_service)
+
+    service_without_backend_api = FactoryBot.create(:service, account: tenant)
+
+    service_with_another_backend_api = FactoryBot.create(:service, account: tenant)
+    another_backend_api = FactoryBot.create(:backend_api, account: tenant)
+    FactoryBot.create(:backend_api_config, backend_api: another_backend_api, service: service_with_another_backend_api)
+
+    get admin_api_backend_api_services_path(backend_api_id: backend_api.id, access_token: access_token_value)
+
+    assert_response :success
+    assert(response_collection = JSON.parse(response.body)['services'])
+    service_ids = response_collection.map { |response_service| response_service.dig('service', 'id') }
+
+    assert_equal expected_service_ids, service_ids
+  end
+
+  test 'create' do
+    assert_difference(backend_api.services.method(:count)) do
+      post admin_api_backend_api_services_path(backend_api_id: backend_api.id, access_token: access_token_value), service_params
+      assert_response :created
+    end
+    @service = backend_api.services.order(:id).last!
+    assert_equal service.id, JSON.parse(response.body).dig('service', 'id')
+  end
+
+  test 'create with errors in the model' do
+    assert_no_difference(backend_api.services.method(:count)) do
+      post admin_api_backend_api_services_path(backend_api_id: backend_api.id, access_token: access_token_value), service_params.merge({backend_version: 'fake'})
+      assert_response :unprocessable_entity
+    end
+    assert_contains JSON.parse(response.body).dig('errors', 'backend_version'), 'is not included in the list'
+  end
+
+  test 'show' do
+    get admin_api_backend_api_service_path(backend_api_id: backend_api.id, access_token: access_token_value, id: service.id)
+    assert_response :success
+    assert_equal service.id, JSON.parse(response.body).dig('service', 'id')
+  end
+
+  test 'update' do
+    put admin_api_backend_api_service_path(backend_api_id: backend_api.id, access_token: access_token_value, id: service.id), {name: 'new name'}
+    assert_response :success
+    assert_equal 'new name', service.reload.name
+  end
+
+  test 'update with errors in the model' do
+    old_backend_version = service.backend_version
+    put admin_api_backend_api_service_path(backend_api_id: backend_api.id, access_token: access_token_value, id: service.id), {backend_version: 'fake'}
+    assert_response :unprocessable_entity
+    assert_contains JSON.parse(response.body).dig('errors', 'backend_version'), 'is not included in the list'
+    assert_equal old_backend_version, service.reload.backend_version
+  end
+
+  test 'destroy' do
+    assert_change(of: -> { service.reload.deleted? }, from: false, to: true) do
+      delete admin_api_backend_api_service_path(backend_api_id: backend_api.id, access_token: access_token_value, id: service.id)
+      assert_response :ok
+    end
+  end
+
+  private
+
+  def service
+    @service ||= begin
+      service = FactoryBot.create(:service, account: tenant)
+      FactoryBot.create(:backend_api_config, backend_api: backend_api, service: service)
+      service
+    end
+  end
+
+  def service_params
+    @service_params = {name: 'the name', description: 'hello'}
+  end
+end


### PR DESCRIPTION
Just for QE to be able to relate BackendAPIs with Products/Services and undo it.
The real PR is in https://github.com/3scale/porta/pull/1214 but this one is just for QE and not meant to be ever merged.