### PR TITLE
[Rolling updates] Make impersonation admin behave like normal admin

### DIFF
--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -347,30 +347,23 @@ module Logic
     end
 
     module Service
-      private
-
-      # This smells :reek:NilCheck
-      def provider_can_use?(fresh_feature)
-        provider&.provider_can_use?(fresh_feature)
-      end
+      delegate :provider_can_use?, to: :provider
+      private :provider_can_use?
     end
 
     module Controller
-      def self.included(klass)
-        klass.helper_method :provider_can_use?
+      extend ActiveSupport::Concern
+
+      included do
+        delegate :provider_can_use?, to: :current_account
+        helper_method :provider_can_use?
+        private :provider_can_use?
       end
 
-      protected
+      private
 
       def provider_can_use!(feature)
         raise ActiveRecord::RecordNotFound unless provider_can_use?(feature)
-      end
-
-      def provider_can_use?(fresh_feature)
-        return false if Logic::RollingUpdates.skipped?
-        return true if Logic::RollingUpdates.disabled?
-
-        current_user&.impersonation_admin? || current_account.provider_can_use?(fresh_feature)
       end
     end
   end

--- a/test/unit/logic/rolling_updates_test.rb
+++ b/test/unit/logic/rolling_updates_test.rb
@@ -106,21 +106,9 @@ class Logic::RollingUpdatesTest < ActiveSupport::TestCase
     provider.expects(:provider_can_use?).returns(false).once
     buyer.send(:provider_can_use?, :whatever)
   end
-
-  test "Controller: provider_can_use? return true if it is the impersonation admin user" do
-    controller_instance = mocked_controller
-
-    user = User.new(username: ThreeScale.config.impersonation_admin['username'])
-    controller_instance.expects(:current_user).returns(user).once
-
-    assert controller_instance.send(:provider_can_use?, :whatever)
-  end
-
+  
   test "Controller: provider_can_use? delegate to current_account" do
     controller_instance = mocked_controller
-
-    user = User.new
-    controller_instance.expects(:current_user).returns(user).once
 
     provider = Account.new
     provider.expects(:provider_can_use?).with(:whatever)
@@ -188,6 +176,10 @@ class Logic::RollingUpdatesTest < ActiveSupport::TestCase
     controller_class = Class.new do
       def self.helper_method(*); end
       include Logic::RollingUpdates::Controller
+
+      def current_account
+        Account.new
+      end
     end
 
     controller_class.new


### PR DESCRIPTION
Impersonation admin has the same role than any admin

Closes https://issues.jboss.org/browse/THREESCALE-3442

#### Why? 

**TL;DR It has become confusing when doing support and mess up with some live tests**

- We use impersonation administrator to investigate some support cases
  So the behaviour should be the same as any normal administrator of the tenant
- `provider_can_use?` has different meaning if it is used in the view as a helper,
  if it is used in the controller as method, or in the model as method
- Also the behaviour changes with skipped? and enabled? in the tests
- chaining different RU can be complex ....
- Does really anyone wants to test RU with impersonation admin? If we want to test a feature we just create an account and enable RU on this account
- It is also an old code (4 years) without really reasons explained for it
https://github.com/3scale/system/commit/de1f9f05616005268f088317a01404e4d198fa2f (probably to test the response codes feature only) and was forgottten to be removed or accepted as that.

The combinations of all those factors generates some mistake in production/development/test,
and also confused developers/QE/support as its behaviour is inconsistent.



### Notes

This is also a necessary part of making our tests cleaner with the  principle of least surprise as a goal.