### PR TITLE
[Rolling Updates] On-premises, defaults are merged to extra configs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -184,7 +184,7 @@ module System
     config.three_scale.payments.enabled = false
     config.three_scale.active_merchant_mode ||= Rails.env.production? ? :production : :test
 
-    config.three_scale.rolling_updates.features = try_config_for(:rolling_updates)
+    config.three_scale.rolling_updates.features = try_config_for(:rolling_updates).deep_merge(try_config_for(:"extra-rolling_updates") || {})
 
     config.three_scale.service_discovery = ActiveSupport::OrderedOptions.new
     config.three_scale.service_discovery.enabled = false

--- a/openshift/system/entrypoint.sh
+++ b/openshift/system/entrypoint.sh
@@ -2,10 +2,19 @@
 
 EXTRA_CONFIGS_DIR=${EXTRA_CONFIGS_DIR:-/opt/system-extra-configs}
 BASE_CONFIGS_DIR=${BASE_CONFIGS:-/opt/system/config}
+
 if [ -d "${EXTRA_CONFIGS_DIR}" ]; then
     for configfile in ${EXTRA_CONFIGS_DIR}/*.yml; do
         baseconfigfile=$(basename "$configfile")
-        ln -sf "${configfile}" "${BASE_CONFIGS_DIR}/${baseconfigfile}"
+
+        case $baseconfigfile in
+            rolling_updates.yml)
+                ln -sf "${configfile}" "${BASE_CONFIGS_DIR}/extra-${baseconfigfile}"
+                ;;
+            *)
+                ln -sf "${configfile}" "${BASE_CONFIGS_DIR}/${baseconfigfile}"
+                ;;
+        esac
     done
 fi
 


### PR DESCRIPTION
This PR makes the default rolling updates in `openshift/system/config/rolling_updates.yml`
to be merged with `config/extra-rolling_updates.yml`

Blocks: https://github.com/3scale/porta/pull/744