### PR TITLE
Change BackendApi#orphans to use not in instead of Left Join

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -32,7 +32,7 @@ class BackendApi < ApplicationRecord
 
   has_system_name(uniqueness_scope: [:account_id])
 
-  scope :orphans, -> { joining { services.outer }.where { BabySqueel[:backend_api_configs].backend_api_id == nil } }
+  scope :orphans, -> { where.has { id.not_in(BackendApiConfig.selecting { :backend_api_id }) } }
 
   scope :oldest_first, -> { order(created_at: :asc) }
   scope :accessible, -> { where.not(state: DELETED_STATE) }


### PR DESCRIPTION
We have a performance issue in our orphans method for BackendApi.
This commit changes it to use not in instead of a left join. This
reduced our query running from 80 seconds to 30 miliseconds in a
table with 37 thousands records.
