### PR TITLE
Implement search by pattern for Mapping Rules

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -121,7 +121,7 @@ gem 'redis', '~> 3.3.5', require: ['redis', 'redis/connection/hiredis']
 gem 'redis-namespace', '~> 1.5.2'
 gem 'rest-client', '~> 2.0.2'
 gem 'httpclient', github: 'mikz/httpclient', branch: 'ssl-env-cert'
-gem 'thinking-sphinx', '~> 3.2.0'
+gem 'thinking-sphinx', '~> 3.0'
 gem 'ts-datetime-delta', require: 'thinking_sphinx/deltas/datetime_delta'
 gem 'diff-lcs', '~> 1.2'
 gem 'acts-as-taggable-on', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,7 +437,7 @@ GEM
     mimemagic (0.3.2)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.12.0)
     minitest-reporters (1.3.8)
       ansi
       builder
@@ -599,7 +599,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (2.0.2)
-    riddle (1.5.12)
+    riddle (2.4.0)
     rinku (1.7.3)
     rmagick (2.15.3)
     roar (1.0.4)
@@ -745,13 +745,13 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thinking-sphinx (3.2.0)
+    thinking-sphinx (3.4.2)
       activerecord (>= 3.1.0)
       builder (>= 2.1.2)
       innertube (>= 1.0.2)
       joiner (>= 0.2.0)
       middleware (>= 0.1.0)
-      riddle (>= 1.5.11)
+      riddle (>= 2.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -960,7 +960,7 @@ DEPENDENCIES
   swagger-ui_rails2!
   symbolize (~> 4.5)
   thin
-  thinking-sphinx (~> 3.2.0)
+  thinking-sphinx (~> 3.0)
   timecop (~> 0.9)
   ts-datetime-delta
   uglifier

--- a/app/controllers/api/proxy_rules_controller.rb
+++ b/app/controllers/api/proxy_rules_controller.rb
@@ -54,4 +54,8 @@ class Api::ProxyRulesController < Api::BaseController
   def service
     @service ||= current_user.accessible_services.find(params[:service_id])
   end
+
+  def owner_id
+    proxy.id
+  end
 end

--- a/app/controllers/provider/admin/backend_apis/mapping_rules_controller.rb
+++ b/app/controllers/provider/admin/backend_apis/mapping_rules_controller.rb
@@ -36,4 +36,10 @@ class Provider::Admin::BackendApis::MappingRulesController < Provider::Admin::Ba
 
     redirect_to provider_admin_backend_api_mapping_rules_path(@backend_api)
   end
+
+  private
+
+  def owner_id
+    @backend_api.id
+  end
 end

--- a/app/controllers/proxy_rule_shared_controller.rb
+++ b/app/controllers/proxy_rule_shared_controller.rb
@@ -12,9 +12,11 @@ module ProxyRuleSharedController
   end
 
   def index
-    @proxy_rules = proxy_rules.order_by(params[:sort], params[:direction])
-                              .includes(:metric)
-                              .paginate(pagination_params)
+    @search = ThreeScale::Search.new(params[:search])
+    query   = ProxyRuleQuery.new(owner_type: params[:owner_type], owner_id: owner_id,
+                                 direction: params[:direction], sort: params[:sort], per_page: per_page)
+    @proxy_rules = query.search_for(@search['query'], proxy_rules)
+                        .paginate(pagination_params)
   end
 
   def new

--- a/app/indices/proxy_rules_index.rb
+++ b/app/indices/proxy_rules_index.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+ThinkingSphinx::Index.define(:proxy_rule, with: :real_time) do
+  indexes :pattern
+
+  has owner_id, as: :owner_id, type: :integer
+  has owner_type, as: :owner_type, type: :string
+
+  set_property min_infix_len: 1
+end

--- a/app/models/proxy_rule.rb
+++ b/app/models/proxy_rule.rb
@@ -3,7 +3,6 @@
 require 'addressable/template'
 
 class ProxyRule < ApplicationRecord
-
   acts_as_list scope: :proxy, add_new_at: :bottom
   scope :ordered, -> { order(position: :asc) }
 
@@ -16,6 +15,8 @@ class ProxyRule < ApplicationRecord
   validates :delta, numericality: { :only_integer => true, :greater_than => 0 }
 
   before_validation :fill_owner
+
+  after_commit { IndexProxyRuleWorker.perform_later(id) }
 
   include ThreeScale::Search::Scopes
 

--- a/app/queries/proxy_rule_query.rb
+++ b/app/queries/proxy_rule_query.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ProxyRuleQuery
+  def initialize(owner_type:, owner_id:, sort: nil, direction: nil, per_page: ThreeScale::Search::Helpers::MAX_PER_PAGE)
+    @direction  = direction
+    @owner_type = owner_type
+    @owner_id   = owner_id
+    @per_page   = per_page.to_i
+    @sort       = sort
+  end
+
+  def search_for(query, scope = ProxyRule.all)
+    scope = scope.order_by(@sort, @direction).includes(:metric)
+    return scope if query.blank?
+    options = {
+      ids_only: true, star: true, per_page: @per_page, ignore_scopes: true,
+      with: { owner_type: @owner_type, owner_id: @owner_id }
+    }
+    ids = ProxyRule.search(ThinkingSphinx::Query.escape(query), options)
+    scope.where(id: ids, owner_type: @owner_type, owner_id: @owner_id)
+  end
+end

--- a/app/views/shared/proxy_rules/_table.html.slim
+++ b/app/views/shared/proxy_rules/_table.html.slim
@@ -11,6 +11,13 @@ table#mapping_rules.data
       th = sortable('proxy_rules.position', 'Position')
       th.actions
         = link_to 'Add Mapping Rule', new_rule_path, class: 'action add'
+    tr.search
+      = search_form do |s|
+        th
+        th colspan="3"
+          = s.text_field :query, size: 20, class: :query, placeholder: 'Search for Pattern'
+        th colspan="4"
+          = s.submit 'Search'
   tbody
     - proxy_rules.each do |rule|
       tr

--- a/app/workers/application_job.rb
+++ b/app/workers/application_job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/workers/index_proxy_rule_worker.rb
+++ b/app/workers/index_proxy_rule_worker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class IndexProxyRuleWorker < ApplicationJob
+  def perform(proxy_rule_id)
+    proxy_rule = ProxyRule.find(proxy_rule_id)
+    ThinkingSphinx::RealTime::Callbacks::RealTimeCallbacks.new(
+      :proxy_rule
+    ).after_save(proxy_rule)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,7 +208,7 @@ without fake Core server your after commit callbacks will crash and you might ge
           resources :metrics, :except => [:show] do
             resources :children, :controller => 'metrics', :only => [:new, :create]
           end
-          resources :mapping_rules, except: %i[show]
+          resources :mapping_rules, except: %i[show], defaults: { owner_type: 'BackendApi' }
         end
       end
 
@@ -846,7 +846,7 @@ without fake Core server your after commit callbacks will crash and you might ge
           end
           resources :proxy_logs, :only => [:index, :show ]
           resources :proxy_configs, only: %i(index show)
-          resources :proxy_rules, except: %i[show]
+          resources :proxy_rules, except: %i[show], defaults: { owner_type: 'Proxy' }
         end
 
         resources :alerts, :only => [:index, :destroy] do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -36,6 +36,10 @@ non_transactional = %w[
 
 transactional = non_transactional.map {|t| "~#{t}" }
 
+Before do
+  IndexProxyRuleWorker.stubs(:perform_later)
+end
+
 Before transactional.join(' or ') do
   Cucumber::Rails::Database.before_js if Cucumber::Rails::Database.autorun_database_cleaner
 end

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -441,7 +441,7 @@ GEM
     mimemagic (0.3.2)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.12.0)
     minitest-reporters (1.3.8)
       ansi
       builder
@@ -603,7 +603,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (2.0.2)
-    riddle (1.5.12)
+    riddle (2.4.0)
     rinku (1.7.3)
     rmagick (2.15.3)
     roar (1.0.4)
@@ -749,13 +749,13 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thinking-sphinx (3.2.0)
+    thinking-sphinx (3.4.2)
       activerecord (>= 3.1.0)
       builder (>= 2.1.2)
       innertube (>= 1.0.2)
       joiner (>= 0.2.0)
       middleware (>= 0.1.0)
-      riddle (>= 1.5.11)
+      riddle (>= 2.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -965,7 +965,7 @@ DEPENDENCIES
   swagger-ui_rails2!
   symbolize (~> 4.5)
   thin
-  thinking-sphinx (~> 3.2.0)
+  thinking-sphinx (~> 3.0)
   timecop (~> 0.9)
   ts-datetime-delta
   uglifier

--- a/test/integration/provider/admin/backend_apis/mapping_rules_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/mapping_rules_controller_test.rb
@@ -18,7 +18,7 @@ class Provider::Admin::BackendApis::MappingRulesControllerTest < ActionDispatch:
     get provider_admin_backend_api_mapping_rules_path(backend_api)
 
     assert_response :success
-    assert_select 'table.data tr', count: @backend_api.mapping_rules.count+1
+    assert_select 'table.data tr', count: @backend_api.mapping_rules.count+2
     @backend_api.mapping_rules.each { |rule| assert_select 'table.data tr td', text: rule.pattern }
   end
 

--- a/test/integration/service_not_deleted_test.rb
+++ b/test/integration/service_not_deleted_test.rb
@@ -3,7 +3,9 @@
 require 'test_helper'
 require 'sidekiq/testing'
 
-class ServiceNotDeletedTest < ActionDispatch::IntegrationTest
+class ServiceNotDeletoedTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   disable_transactional_fixtures!
 
   def setup
@@ -14,7 +16,7 @@ class ServiceNotDeletedTest < ActionDispatch::IntegrationTest
   def test_not_deleted
     @provider.settings.allow_multiple_services!
 
-    Sidekiq::Testing.inline! do
+    perform_enqueued_jobs(except: IndexProxyRuleWorker) do
       (ENV['BRUTOFORCE'].present? ? 2000 : 1).times do |i|
         service_name = "service foo #{i}"
         post(admin_api_services_path, provider_key: @provider.api_key, format: :json, name: service_name)

--- a/test/monkey_patches/active_job_test_helper.rb
+++ b/test/monkey_patches/active_job_test_helper.rb
@@ -1,0 +1,109 @@
+require 'active_job/test_helper'
+require 'active_job/queue_adapters/test_adapter'
+
+# TODO: Remove this Monkey patch after we move to Rails 5.
+# This is used to ensure that we run only a specific job in a Test.
+# It was extracted from
+# https://github.com/rails/rails/blob/fc5dd0b85189811062c85520fd70de8389b55aeb/activejob/lib/active_job/test_helper.rb#L368
+module ActiveJob
+  module QueueAdapters
+    class TestAdapter
+      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject, :queue, :at)
+      attr_writer(:enqueued_jobs, :performed_jobs)
+
+      def enqueued_jobs
+        @enqueued_jobs ||= []
+      end
+
+      def performed_jobs
+        @performed_jobs ||= []
+      end
+
+      def enqueue(job) #:nodoc:
+        return if filtered?(job)
+
+        job_data = job_to_hash(job)
+        perform_or_enqueue(perform_enqueued_jobs, job, job_data)
+      end
+
+      def enqueue_at(job, timestamp) #:nodoc:
+        return if filtered?(job)
+
+        job_data = job_to_hash(job, at: timestamp)
+        perform_or_enqueue(perform_enqueued_at_jobs, job, job_data)
+      end
+
+      private
+
+      def job_to_hash(job, extras = {})
+        { job: job.class, args: job.serialize.fetch("arguments"), queue: job.queue_name }.merge!(extras)
+      end
+
+      def perform_or_enqueue(perform, job, job_data)
+        if perform
+          performed_jobs << job_data
+          Base.execute job.serialize
+        else
+          enqueued_jobs << job_data
+        end
+      end
+
+      def filtered?(job)
+        filtered_queue?(job) || filtered_job_class?(job) || filtered_time?(job)
+      end
+
+      def filtered_time?(job)
+        job.scheduled_at > at.to_f if at && job.scheduled_at
+      end
+
+      def filtered_queue?(job)
+        if queue
+          job.queue_name != queue.to_s
+        end
+      end
+
+      def filtered_job_class?(job)
+        if filter
+          !filter_as_proc(filter).call(job)
+        elsif reject
+          filter_as_proc(reject).call(job)
+        end
+      end
+
+      def filter_as_proc(filter)
+        return filter if filter.is_a?(Proc)
+
+        ->(job) { Array(filter).include?(job.class) }
+      end
+    end
+  end
+
+  module TestHelper
+    class << self
+      def included(base)
+        base.class_eval do
+          def perform_enqueued_jobs(only: nil, except: nil)
+            raise ArgumentError, "Cannot specify both `:only` and `:except` options." if only && except
+            old_perform_enqueued_jobs = queue_adapter.perform_enqueued_jobs
+            old_perform_enqueued_at_jobs = queue_adapter.perform_enqueued_at_jobs
+            old_filter = queue_adapter.filter
+            old_reject = queue_adapter.reject
+
+            begin
+              queue_adapter.perform_enqueued_jobs = true
+              queue_adapter.perform_enqueued_at_jobs = true
+              queue_adapter.filter = only
+              queue_adapter.reject = except
+              yield
+            ensure
+              queue_adapter.perform_enqueued_jobs = old_perform_enqueued_jobs
+              queue_adapter.perform_enqueued_at_jobs = old_perform_enqueued_at_jobs
+              queue_adapter.filter = old_filter
+              queue_adapter.reject = old_reject
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,7 @@ WebMock.enable!
 
 WebMock.disable_net_connect!
 
-
+require 'monkey_patches/active_job_test_helper'
 class ActiveSupport::TestCase
   self.use_transactional_fixtures = true
   self.use_instantiated_fixtures  = false

--- a/test/unit/proxy_rule_test.rb
+++ b/test/unit/proxy_rule_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
-class ProxyRuleTest < ActiveSupport::TestCase
 
+class ProxyRuleTest < ActiveSupport::TestCase
   test 'patterns' do
     proxy_rule = FactoryBot.build_stubbed(:proxy_rule)
 

--- a/test/unit/queries/proxy_rule_query_test.rb
+++ b/test/unit/queries/proxy_rule_query_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class ProxyRuleTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  disable_transactional_fixtures!
+
+  test '#search_for uses sphinx if query given' do
+    ThinkingSphinx::Test.run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('test')
+      end
+    end
+  end
+
+  test '#search_for reuses the scope if given' do
+    ThinkingSphinx::Test.run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule   = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test1', position: 1)
+        proxy_rule2  = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test2', position: 2)
+        query        = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+        scope        = ProxyRule.where(position: 2)
+
+        assert_equal [proxy_rule2], query.search_for('test', scope)
+      end
+    end
+  end
+
+  test '#search_for order result if sort/direction parameters given' do
+    ThinkingSphinx::Test.run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule   = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test1', position: 1)
+        proxy_rule2  = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test2', position: 2)
+        query        = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id,
+                                          sort: :position, direction: :desc)
+
+        assert_equal [proxy_rule2, proxy_rule], query.search_for('test')
+      end
+    end
+  end
+
+  test '#search_for does not use sphinx if no query given' do
+    ThinkingSphinx::Test.run do
+      ThinkingSphinx::Search.expects(:new).never
+      query = ProxyRuleQuery.new(owner_type: 'BackendApi', owner_id: 1)
+
+      assert_equal [], query.search_for('')
+    end
+  end
+end


### PR DESCRIPTION
This commit implements a search by pattern for mapping rules. It
includes a search field in the mapping rules page for both Backend
APIs and Services. It also adds an index for ProxyRule class using
Sphinx.