### PR TITLE
[INSTALL.md] Install sphinx from source

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -118,11 +118,11 @@ brew services start memcached postgresql
 
 #### Sphinx Search
 
-[Sphinx](http://sphinxsearch.com/) has to be installed with **mysql@5.7**:
+[Sphinx](http://sphinxsearch.com/) has to be installed with **mysql@5.7** and compiled from source:
 
 ```shell
 sed -i '' -e 's|depends_on "mysql"|depends_on "mysql@5.7"|g' /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/sphinx.rb
-brew install sphinx
+brew install --build-from-source sphinx
 ```
 
 #### Redis


### PR DESCRIPTION
BecauseHomebrew bottles are compiled with default environments
and with dynamic library of mysql pointing to  @@HOMEBREW_PREFIX@@/opt/mysql/lib/libmysqlclient.21.dylib

It needs to be build from source to take into account that we use mysql@5.7