### PR TITLE
Ensure uniqueness of service_id + backend_api_id

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -36,11 +36,7 @@ class BackendApi < ApplicationRecord
 
   scope :not_used_by, -> do |service_id|
     where.has do
-      not_exists(
-        BackendApiConfig
-        .by_service(service_id)
-        .by_backend_api(BabySqueel[:backend_apis].id)
-      )
+      not_exists BackendApiConfig.by_service(service_id).by_backend_api(BabySqueel[:backend_apis].id).select(:id)
     end
   end
 

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -34,7 +34,7 @@ class BackendApi < ApplicationRecord
 
   scope :orphans, -> { where.has { id.not_in(BackendApiConfig.selecting { :backend_api_id }) } }
 
-  scope :without_service, -> do |service_id|
+  scope :not_used_by, -> do |service_id|
     where.has do
       not_exists(
         BackendApiConfig

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -34,6 +34,16 @@ class BackendApi < ApplicationRecord
 
   scope :orphans, -> { where.has { id.not_in(BackendApiConfig.selecting { :backend_api_id }) } }
 
+  scope :without_service, -> do |service_id|
+    where.has do
+      not_exists(
+        BackendApiConfig
+        .by_service(service_id)
+        .by_backend_api(BabySqueel[:backend_apis].id)
+      )
+    end
+  end
+
   scope :oldest_first, -> { order(created_at: :asc) }
   scope :accessible, -> { where.not(state: DELETED_STATE) }
 

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -34,11 +34,11 @@ class BackendApi < ApplicationRecord
 
   scope :orphans, -> { where.has { id.not_in(BackendApiConfig.selecting { :backend_api_id }) } }
 
-  scope :not_used_by, -> do |service_id|
+  scope :not_used_by, ->(service_id) {
     where.has do
       not_exists BackendApiConfig.by_service(service_id).by_backend_api(BabySqueel[:backend_apis].id).select(:id)
     end
-  end
+  }
 
   scope :oldest_first, -> { order(created_at: :asc) }
   scope :accessible, -> { where.not(state: DELETED_STATE) }

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -35,9 +35,22 @@ class BackendApi < ApplicationRecord
   scope :orphans, -> { where.has { id.not_in(BackendApiConfig.selecting { :backend_api_id }) } }
 
   scope :not_used_by, ->(service_id) {
-    where.has do
-      not_exists BackendApiConfig.by_service(service_id).by_backend_api(BabySqueel[:backend_apis].id).select(:id)
-    end
+    # TODO: Baby Squeel
+    # It used to be:
+    # where.has do
+    #   not_exists BackendApiConfig.by_service(service_id).by_backend_api(BabySqueel[:backend_apis].id).select(:id)
+    # end
+    # And that works for MySQL and Postgres but not Oracle
+    sql_query = <<~SQL
+      (
+        NOT EXISTS (
+          SELECT id
+          FROM backend_api_configs
+          WHERE service_id = ? AND backend_api_configs.backend_api_id = backend_apis.id
+        )
+      )
+    SQL
+    where(sql_query, service_id)
   }
 
   scope :oldest_first, -> { order(created_at: :asc) }

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -34,6 +34,25 @@ class BackendApi < ApplicationRecord
 
   scope :orphans, -> { where.has { id.not_in(BackendApiConfig.selecting { :backend_api_id }) } }
 
+  scope :not_used_by, ->(service_id) {
+    # TODO: Baby Squeel
+    # It should be:
+    # where.has do
+    #   not_exists BackendApiConfig.by_service(service_id).by_backend_api(BabySqueel[:backend_apis].id).select(:id)
+    # end
+    # And that works for MySQL and Postgres but not Oracle
+    sql_query = <<~SQL
+      (
+        NOT EXISTS (
+          SELECT id
+          FROM backend_api_configs
+          WHERE service_id = ? AND backend_api_configs.backend_api_id = backend_apis.id
+        )
+      )
+    SQL
+    where(sql_query, service_id)
+  }
+
   scope :oldest_first, -> { order(created_at: :asc) }
   scope :accessible, -> { where.not(state: DELETED_STATE) }
 
@@ -46,12 +65,6 @@ class BackendApi < ApplicationRecord
     end
 
     after_transition to: [DELETED_STATE], do: :schedule_deletion
-  end
-
-  def self.not_used_by(service_id)
-    where.has do
-      not_exists BackendApiConfig.by_service(service_id).by_backend_api(BabySqueel[:backend_apis].id).select(:id)
-    end
   end
 
   def self.default_api_backend

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -22,8 +22,8 @@ class BackendApiConfig < ApplicationRecord
   validates :path, uniqueness: { scope: :service_id, case_sensitive: false }
   validates :path, length: { in: 0..255, allow_nil: false }, path: true
 
-  scope :by_service,     ->(param_service_id)     { where.has { service_id     == param_service_id     } }
-  scope :by_backend_api, ->(param_backend_api_id) { where.has { backend_api_id == param_backend_api_id } }
+  scope :by_service,     ->(service_id)     { where.has { self.service_id     == service_id     } }
+  scope :by_backend_api, ->(backend_api_id) { where.has { self.backend_api_id == backend_api_id } }
 
   scope :with_subpath, -> do
     common_query = where.not(path: '/')

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -18,6 +18,7 @@ class BackendApiConfig < ApplicationRecord
   has_many :backend_api_metrics, through: :backend_api, source: :metrics
 
   validates :service_id, :backend_api_id, presence: true
+  validates :backend_api_id, uniqueness: { scope: :service_id }
   validates :path, uniqueness: { scope: :service_id, case_sensitive: false }
   validates :path, length: { in: 0..255, allow_nil: false }, path: true
 

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -22,6 +22,9 @@ class BackendApiConfig < ApplicationRecord
   validates :path, uniqueness: { scope: :service_id, case_sensitive: false }
   validates :path, length: { in: 0..255, allow_nil: false }, path: true
 
+  scope :by_service,     ->(param_service_id)     { where.has { service_id     == param_service_id     } }
+  scope :by_backend_api, ->(param_backend_api_id) { where.has { backend_api_id == param_backend_api_id } }
+
   scope :with_subpath, -> do
     common_query = where.not(path: '/')
     System::Database.oracle? ? common_query.where('path is NOT NULL') : common_query.where.not(path: '')

--- a/app/models/deleted_object.rb
+++ b/app/models/deleted_object.rb
@@ -8,14 +8,14 @@ class DeletedObject < ApplicationRecord
     scope scoped_class.to_s.underscore.pluralize.to_sym, -> { where(object_type: scoped_class) }
   end
 
-  scope(:deleted_owner, -> do
+  scope :deleted_owner, -> do
     join_sql = <<-SQL
       INNER JOIN deleted_objects deleted_owner
         ON deleted_objects.owner_type = deleted_owner.object_type
         AND deleted_objects.owner_id = deleted_owner.object_id
     SQL
     joins(join_sql)
-  end)
+  end
 
   scope :stale, -> { where.has { ((id.in DeletedObject.deleted_owner.select(:id)) | (object_type == Service.name)) & (created_at <= 1.week.ago) } }
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -100,7 +100,7 @@ class Service < ApplicationRecord
   scope :accessible, -> { where.not(state: DELETE_STATE) }
   scope :deleted, -> { where(state: DELETE_STATE) }
   scope :of_approved_accounts, -> { joins(:account).merge(Account.approved) }
-  scope(:permitted_for_user, ->(user) do
+  scope :permitted_for_user, ->(user) do
     # TODO: this is probably wrong...
     # how come if it does not have access_to_all_services but it can not use service_permissions,
     # then we allow them all?!!
@@ -110,7 +110,7 @@ class Service < ApplicationRecord
     else
       all
     end
-  end)
+  end
 
   validates :credit_card_support_email, format: { with: /.+@.+\..+/, allow_blank: true }
 

--- a/app/views/api/backend_api_configs/_form.html.slim
+++ b/app/views/api/backend_api_configs/_form.html.slim
@@ -2,7 +2,7 @@
   - persisted = @backend_api_config.persisted?
   = form.input :backend_api_id,
                 as: :select,
-                collection: current_account.backend_apis.without_service(@backend_api_config.service_id),
+                collection: current_account.backend_apis.not_used_by(@backend_api_config.service_id),
                 include_blank: false,
                 prompt: 'Select a Backend',
                 label: 'Backend',

--- a/app/views/api/backend_api_configs/_form.html.slim
+++ b/app/views/api/backend_api_configs/_form.html.slim
@@ -2,7 +2,7 @@
   - persisted = @backend_api_config.persisted?
   = form.input :backend_api_id,
                 as: :select,
-                collection: current_account.backend_apis,
+                collection: current_account.backend_apis.without_service(@backend_api_config.service_id),
                 include_blank: false,
                 prompt: 'Select a Backend',
                 label: 'Backend',

--- a/db/migrate/20190925133159_enforce_uniqueness_association_service_backend_api.rb
+++ b/db/migrate/20190925133159_enforce_uniqueness_association_service_backend_api.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class EnforceUniquenessAssociationServiceBackendApi < ActiveRecord::Migration
+  disable_ddl_transaction! if System::Database.postgres?
+
+  def change
+    index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+    add_index :backend_api_configs, %i[backend_api_id service_id], index_options.merge({unique: true})
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190920123906) do
+ActiveRecord::Schema.define(version: 20190925133159) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -228,6 +228,7 @@ ActiveRecord::Schema.define(version: 20190920123906) do
     t.integer  "tenant_id",      precision: 38
   end
 
+  add_index "backend_api_configs", ["backend_api_id", "service_id"], name: "index_backend_api_configs_on_backend_api_id_and_service_id", unique: true
   add_index "backend_api_configs", ["path", "service_id"], name: "index_backend_api_configs_on_path_and_service_id", unique: true
   add_index "backend_api_configs", ["service_id"], name: "index_backend_api_configs_on_service_id"
 

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190920123906) do
+ActiveRecord::Schema.define(version: 20190925133159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -227,6 +227,7 @@ ActiveRecord::Schema.define(version: 20190920123906) do
     t.integer  "tenant_id",      limit: 8
   end
 
+  add_index "backend_api_configs", ["backend_api_id", "service_id"], name: "index_backend_api_configs_on_backend_api_id_and_service_id", unique: true, using: :btree
   add_index "backend_api_configs", ["path", "service_id"], name: "index_backend_api_configs_on_path_and_service_id", unique: true, using: :btree
   add_index "backend_api_configs", ["service_id"], name: "index_backend_api_configs_on_service_id", using: :btree
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190920123906) do
+ActiveRecord::Schema.define(version: 20190925133159) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -228,6 +228,7 @@ ActiveRecord::Schema.define(version: 20190920123906) do
     t.integer  "tenant_id",      limit: 8
   end
 
+  add_index "backend_api_configs", ["backend_api_id", "service_id"], name: "index_backend_api_configs_on_backend_api_id_and_service_id", unique: true, using: :btree
   add_index "backend_api_configs", ["path", "service_id"], name: "index_backend_api_configs_on_path_and_service_id", unique: true, using: :btree
   add_index "backend_api_configs", ["service_id"], name: "index_backend_api_configs_on_service_id", using: :btree
 

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -58,7 +58,7 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
 
   test 'delete a backend api with products' do
     backend_api = @provider.backend_apis.order(:id).first
-    FactoryBot.create(:backend_api_config, service: @provider.first_service, backend_api: backend_api)
+    FactoryBot.create(:backend_api_config, backend_api: backend_api)
     assert backend_api.backend_api_configs.any?
 
     delete provider_admin_backend_api_path(backend_api)

--- a/test/models/backend_api_config_test.rb
+++ b/test/models/backend_api_config_test.rb
@@ -89,4 +89,34 @@ class BackendApiConfigTest < ActiveSupport::TestCase
     assert @config.valid?
     assert_empty @config.errors[:backend_api_id]
   end
+
+  test '.by_service returns the configs related to that service' do
+    account = FactoryBot.create(:simple_account)
+    services = FactoryBot.create_list(:service, 3, account: account)
+    backend_apis = FactoryBot.create_list(:backend_api, 3, account: account)
+
+    configs = 2.times.map do |index|
+      FactoryBot.create(:backend_api_config, backend_api: backend_apis[index], service: services[index])
+    end
+    configs << FactoryBot.create(:backend_api_config, service: services[0])
+
+    assert_same_elements configs.values_at(0, -1).map(&:id), BackendApiConfig.by_service(services[0]).pluck(:id)
+    assert_equal [configs[1].id], BackendApiConfig.by_service(services[1]).pluck(:id)
+    assert_empty BackendApiConfig.by_service(services[2]).pluck(:id)
+  end
+
+  test '.by_backend_api returns the configs related to that backend_api' do
+    account = FactoryBot.create(:simple_account)
+    services = FactoryBot.create_list(:service, 3, account: account)
+    backend_apis = FactoryBot.create_list(:backend_api, 3, account: account)
+
+    configs = 2.times.map do |index|
+      FactoryBot.create(:backend_api_config, backend_api: backend_apis[index], service: services[index])
+    end
+    configs << FactoryBot.create(:backend_api_config, backend_api: backend_apis[0])
+
+    assert_same_elements configs.values_at(0, -1).map(&:id), BackendApiConfig.by_backend_api(backend_apis[0]).pluck(:id)
+    assert_equal [configs[1].id], BackendApiConfig.by_backend_api(backend_apis[1]).pluck(:id)
+    assert_empty BackendApiConfig.by_backend_api(backend_apis[2]).pluck(:id)
+  end
 end

--- a/test/models/backend_api_config_test.rb
+++ b/test/models/backend_api_config_test.rb
@@ -73,4 +73,20 @@ class BackendApiConfigTest < ActiveSupport::TestCase
     @config.path = 'bar'
     assert @config.valid?
   end
+
+  test 'validates uniqueness of backend_api within service' do
+    service = FactoryBot.create(:simple_service)
+    backend_api = FactoryBot.create(:backend_api, account: service.account)
+    FactoryBot.create(:backend_api_config, service: service, backend_api: backend_api)
+
+    @config.service = service
+    @config.backend_api = backend_api
+    @config.path = 'another_path'
+    refute @config.valid?
+    assert_includes @config.errors[:backend_api_id], 'has already been taken'
+
+    @config.backend_api = FactoryBot.create(:backend_api, account: service.account)
+    assert @config.valid?
+    assert_empty @config.errors[:backend_api_id]
+  end
 end

--- a/test/models/backend_api_test.rb
+++ b/test/models/backend_api_test.rb
@@ -44,23 +44,23 @@ class BackendApiTest < ActiveSupport::TestCase
     assert_equal [orphan_backend_api], BackendApi.orphans
   end
 
-  test '.without_service returns the backend apis that are not related to that service' do
+  test '.not_used_by returns the backend apis that are not related to that service' do
     account = FactoryBot.create(:simple_provider)
-    backend_api_without_service = FactoryBot.create(:backend_api, account: account)
-    backend_api_with_one_service = FactoryBot.create(:backend_api, account: account)
-    backend_api_with_two_services = FactoryBot.create(:backend_api, account: account)
+    backend_api_not_used_by_any_service = FactoryBot.create(:backend_api, account: account)
+    backend_api_using_one_service = FactoryBot.create(:backend_api, account: account)
+    backend_api_using_two_services = FactoryBot.create(:backend_api, account: account)
 
     services = FactoryBot.create_list(:service, 4, account: account)
 
     configs = []
-    configs << services[0].backend_api_configs.create!(backend_api: backend_api_with_one_service, path: 'foo')
-    configs << services[1].backend_api_configs.create!(backend_api: backend_api_with_two_services, path: 'foo')
-    configs << services[2].backend_api_configs.create!(backend_api: backend_api_with_two_services, path: 'bar')
+    configs << services[0].backend_api_configs.create!(backend_api: backend_api_using_one_service, path: 'foo')
+    configs << services[1].backend_api_configs.create!(backend_api: backend_api_using_two_services, path: 'foo')
+    configs << services[2].backend_api_configs.create!(backend_api: backend_api_using_two_services, path: 'bar')
 
-    assert_same_elements [backend_api_without_service, backend_api_with_two_services].map(&:id), BackendApi.without_service(services[0].id).pluck(:id)
-    assert_same_elements [backend_api_without_service, backend_api_with_one_service].map(&:id), BackendApi.without_service(services[1].id).pluck(:id)
-    assert_same_elements [backend_api_without_service, backend_api_with_one_service].map(&:id), BackendApi.without_service(services[2].id).pluck(:id)
-    assert_same_elements [backend_api_without_service, backend_api_with_one_service, backend_api_with_two_services].map(&:id), BackendApi.without_service(services[3].id).pluck(:id)
+    assert_same_elements [backend_api_not_used_by_any_service, backend_api_using_two_services].map(&:id), BackendApi.not_used_by(services[0].id).pluck(:id)
+    assert_same_elements [backend_api_not_used_by_any_service, backend_api_using_one_service].map(&:id), BackendApi.not_used_by(services[1].id).pluck(:id)
+    assert_same_elements [backend_api_not_used_by_any_service, backend_api_using_one_service].map(&:id), BackendApi.not_used_by(services[2].id).pluck(:id)
+    assert_same_elements [backend_api_not_used_by_any_service, backend_api_using_one_service, backend_api_using_two_services].map(&:id), BackendApi.not_used_by(services[3].id).pluck(:id)
   end
 
   test 'creates default metrics' do


### PR DESCRIPTION
We need this for now for the API. Because we are hiding the 'backend api config' from the customer, so we are not returning its ID, so without this PR, the only way to identify a backend api config in `/admin/api/services/:service_id/backend_apis/` to update it or destroy it is by the field path, which is clearly a bad idea because it would be part of the path of the request and because it can be empty.
Which this PR, it is just the ID of the backend_api :smile: 