### PR TITLE
Proxy config affecting change events

### DIFF
--- a/app/events/proxy_configs/affecting_object_changed_event.rb
+++ b/app/events/proxy_configs/affecting_object_changed_event.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ProxyConfigs::AffectingObjectChangedEvent < ServiceRelatedEvent
+  def self.create(proxy, object)
+    new(
+      proxy_id: proxy.id,
+      object_id: object.id,
+      object_type: object.class.name,
+      metadata: {
+        service_id: proxy.service_id,
+        provider_id: proxy.account.id
+      }
+    )
+  end
+end

--- a/app/lib/event_store/repository.rb
+++ b/app/lib/event_store/repository.rb
@@ -164,6 +164,7 @@ module EventStore
       subscribe_event(UserEventSubscriber.new, Users::UserDeletedEvent)
       subscribe_event(ServiceDeletionSubscriber.new, Services::ServiceScheduledForDeletionEvent)
       subscribe_event(ServiceDeletedSubscriber.new, Services::ServiceDeletedEvent)
+      subscribe_event(ProxyConfigEventSubscriber.new, ProxyConfigs::AffectingObjectChangedEvent)
       subscribe_event(ZyncSubscriber.new, ZyncEvent)
     end
 

--- a/app/lib/proxy_config_affecting_changes.rb
+++ b/app/lib/proxy_config_affecting_changes.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module ProxyConfigAffectingChanges
+  module ProxyRuleExtension
+    extend ActiveSupport::Concern
+
+    included do
+      include ProxyConfigAffectingChanges
+
+      after_commit :issue_proxy_affecting_change_events
+
+      def issue_proxy_affecting_change_events
+        case owner
+        when Proxy
+          issue_proxy_affecting_change_event(owner)
+        when BackendApi
+          owner.proxies.each(&method(:issue_proxy_affecting_change_event))
+        end
+      end
+    end
+  end
+
+  module ProxyExtension
+    extend ActiveSupport::Concern
+
+    PROXY_CONFIG_AFFECTING_ATTRIBUTES = %w[policies_config].freeze # TODO: add more attributes here
+
+    included do
+      include ProxyConfigAffectingChanges
+
+      after_commit :issue_proxy_affecting_change_events, on: :update
+
+      def issue_proxy_affecting_change_events
+        changes_attributes = previous_changes.keys
+        return if changes_attributes.include?('created_at') || (changes_attributes & PROXY_CONFIG_AFFECTING_ATTRIBUTES).empty?
+        issue_proxy_affecting_change_event(self)
+      end
+    end
+  end
+
+  def issue_proxy_affecting_change_event(proxy)
+    ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy, self)
+  end
+end

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -11,6 +11,8 @@ class BackendApi < ApplicationRecord
 
   has_many :backend_api_configs, inverse_of: :backend_api, dependent: :destroy
   has_many :services, through: :backend_api_configs
+  has_many :proxies, through: :services
+
   belongs_to :account, inverse_of: :backend_apis
 
   delegate :provider_can_use?, to: :account, allow_nil: true

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -6,6 +6,7 @@ class Proxy < ApplicationRecord
   include BackendApiLogic::ProxyExtension
   prepend BackendApiLogic::RoutingPolicy
   include GatewaySettings::ProxyExtension
+  include ProxyConfigAffectingChanges::ProxyExtension
 
   DEFAULT_POLICY = { 'name' => 'apicast', 'humanName' => 'APIcast policy', 'description' => 'Main functionality of APIcast.',
                      'configuration' => {}, 'version' => 'builtin', 'enabled' => true, 'removable' => false, 'id' => 'apicast-policy'  }.freeze

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -20,6 +20,9 @@ class Proxy < ApplicationRecord
 
   validates :error_status_no_match, :error_status_auth_missing, :error_status_auth_failed, :error_status_limits_exceeded, presence: true
 
+  has_one :proxy_config_affecting_change, dependent: :delete
+  private :proxy_config_affecting_change
+
   uri_pattern = URI::DEFAULT_PARSER.pattern
 
   URI_OPTIONAL_PORT = /\Ahttps?:\/\/[a-zA-Z0-9._-]*(:\d+)?\Z/
@@ -513,6 +516,19 @@ class Proxy < ApplicationRecord
 
   def service_mesh_integration?
     Service::DeploymentOption.service_mesh.include?(deployment_option)
+  end
+
+  def find_or_create_proxy_config_affecting_change
+    proxy_config_affecting_change || create_proxy_config_affecting_change
+  end
+  alias affecting_change_history find_or_create_proxy_config_affecting_change
+  private :find_or_create_proxy_config_affecting_change
+
+  def pending_affecting_changes?
+    return unless apicast_configuration_driven?
+    config = proxy_configs.sandbox.newest_first.first
+    return false unless config
+    config.created_at < affecting_change_history.updated_at
   end
 
   protected

--- a/app/models/proxy_config_affecting_change.rb
+++ b/app/models/proxy_config_affecting_change.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ProxyConfigAffectingChange < ApplicationRecord
+  belongs_to :proxy
+end

--- a/app/models/proxy_rule.rb
+++ b/app/models/proxy_rule.rb
@@ -11,6 +11,8 @@ class ProxyRule < ApplicationRecord
   belongs_to :owner, polymorphic: true # FIXME: we should touch the owner here, but it will raise ActiveRecord::StaleObjectError
   belongs_to :metric
 
+  include ProxyConfigAffectingChanges::ProxyRuleExtension
+
   validates :http_method, :pattern, :owner_id, :owner_type, :metric_id, presence: true
   validates :owner_type, length: { maximum: 255 }
   validates :delta, numericality: { :only_integer => true, :greater_than => 0 }

--- a/app/subscribers/proxy_config_event_subscriber.rb
+++ b/app/subscribers/proxy_config_event_subscriber.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ProxyConfigEventSubscriber
+  def call(event)
+    case event
+    when ProxyConfigs::AffectingObjectChangedEvent then ProxyConfigAffectingChangeWorker.perform_later(event.event_id)
+    else raise "Unknown event type #{event.class}"
+    end
+  end
+end

--- a/app/workers/proxy_config_affecting_change_worker.rb
+++ b/app/workers/proxy_config_affecting_change_worker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ProxyConfigAffectingChangeWorker < ActiveJob::Base # rubocop:disable Rails/ApplicationJob
+  def perform(event_id)
+    event = EventStore::Repository.find_event!(event_id)
+    proxy = Proxy.find(event.proxy_id)
+    proxy.affecting_change_history.touch
+  rescue ActiveRecord::RecordNotFound
+  end
+end

--- a/db/migrate/20190925152107_create_proxy_config_affecting_changes.rb
+++ b/db/migrate/20190925152107_create_proxy_config_affecting_changes.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateProxyConfigAffectingChanges < ActiveRecord::Migration
+  disable_ddl_transaction! if System::Database.postgres?
+
+  def change
+    create_table :proxy_config_affecting_changes do |t|
+      t.references :proxy, null: false
+      t.timestamps null: false
+    end
+
+    index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+    add_index :proxy_config_affecting_changes, :proxy_id, index_options.merge(unique: true)
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190925133159) do
+ActiveRecord::Schema.define(version: 20190925152107) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   precision: 38,                  null: false
@@ -1132,6 +1132,14 @@ ActiveRecord::Schema.define(version: 20190925133159) do
 
   add_index "proxies", ["service_id"], name: "index_proxies_on_service_id"
   add_index "proxies", ["staging_domain", "production_domain"], name: "index_proxies_on_staging_domain_and_production_domain"
+
+  create_table "proxy_config_affecting_changes", force: :cascade do |t|
+    t.integer  "proxy_id",   precision: 38, null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "proxy_config_affecting_changes", ["proxy_id"], name: "index_proxy_config_affecting_changes_on_proxy_id", unique: true
 
   create_table "proxy_configs", force: :cascade do |t|
     t.integer  "proxy_id",                 precision: 38,             null: false

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190925133159) do
+ActiveRecord::Schema.define(version: 20190925152107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1133,6 +1133,14 @@ ActiveRecord::Schema.define(version: 20190925133159) do
 
   add_index "proxies", ["service_id"], name: "index_proxies_on_service_id", using: :btree
   add_index "proxies", ["staging_domain", "production_domain"], name: "index_proxies_on_staging_domain_and_production_domain", using: :btree
+
+  create_table "proxy_config_affecting_changes", force: :cascade do |t|
+    t.integer  "proxy_id",   null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "proxy_config_affecting_changes", ["proxy_id"], name: "index_proxy_config_affecting_changes_on_proxy_id", unique: true, using: :btree
 
   create_table "proxy_configs", force: :cascade do |t|
     t.integer  "proxy_id",    limit: 8,                null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190925133159) do
+ActiveRecord::Schema.define(version: 20190925152107) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id",   limit: 8,                      null: false
@@ -1134,6 +1134,14 @@ ActiveRecord::Schema.define(version: 20190925133159) do
 
   add_index "proxies", ["service_id"], name: "index_proxies_on_service_id", using: :btree
   add_index "proxies", ["staging_domain", "production_domain"], name: "index_proxies_on_staging_domain_and_production_domain", using: :btree
+
+  create_table "proxy_config_affecting_changes", force: :cascade do |t|
+    t.integer  "proxy_id",   limit: 4, null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+  end
+
+  add_index "proxy_config_affecting_changes", ["proxy_id"], name: "index_proxy_config_affecting_changes_on_proxy_id", unique: true, using: :btree
 
   create_table "proxy_configs", force: :cascade do |t|
     t.integer  "proxy_id",    limit: 8,                    null: false

--- a/test/events/proxy_configs/affecting_object_changed_event_test.rb
+++ b/test/events/proxy_configs/affecting_object_changed_event_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProxyConfigs::AffectingObjectChangedEventTest < ActiveSupport::TestCase
+  test 'create' do
+    proxy = FactoryBot.create(:proxy)
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
+    event = ProxyConfigs::AffectingObjectChangedEvent.create(proxy, proxy_rule)
+
+    assert_equal proxy.id, event.proxy_id
+    assert_equal proxy_rule.id, event.object_id
+    assert_equal 'ProxyRule', event.object_type
+  end
+end

--- a/test/subscribers/proxy_config_event_subscriber_test.rb
+++ b/test/subscribers/proxy_config_event_subscriber_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProxyConfigEventSubscriberTest < ActiveSupport::TestCase
+  test 'create' do
+    proxy = FactoryBot.create(:proxy)
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
+    event = ProxyConfigs::AffectingObjectChangedEvent.create(proxy, proxy_rule)
+
+    ProxyConfigAffectingChangeWorker.expects(:perform_later).with(event.event_id)
+
+    ProxyConfigEventSubscriber.new.call(event)
+  end
+end

--- a/test/workers/proxy_config_affecting_change_worker_test.rb
+++ b/test/workers/proxy_config_affecting_change_worker_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProxyConfigAffectingChangeWorkerTest < ActiveSupport::TestCase
+  setup do
+    @worker = ProxyConfigAffectingChangeWorker.new
+    EventStore::Repository.stubs(raise_errors: true)
+  end
+
+  attr_reader :worker
+
+  test '#perform' do
+    proxy = FactoryBot.create(:proxy)
+    event = ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy, mock(id: 123))
+
+    affecting_change_history = mock
+    Proxy.any_instance.expects(:create_proxy_config_affecting_change).returns(affecting_change_history)
+    affecting_change_history.expects(:touch)
+
+    worker.perform(event.event_id)
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

It defines a new event to be issued whenever an object that is part of a proxy config changes (or gets created, or destroyed). This event will asynchronously touch a tracking record in a separate table, also introduced, that holds a 1-1 relationship with proxy.

**Which issue(s) this PR fixes** 

This will make possible for the UI to highlight for the user a potential outdated proxy config, thus being relevant to https://github.com/3scale/porta/pull/1235.

Closes [THREESCALE-3555](https://issues.jboss.org/browse/THREESCALE-3555)

**TODOs**
- [x] Create table to store the change history on proxy config affecting objects
- [x] Generate the schema for Oracle and PostgreSQL
- [x] Define a new type of event to be issued whenever a proxy config affecting change occurs (plus subscriber and worker)
- [x] Issue the event on every model of proxy config affecting object (in a `after_commit`, for each proxy potentially affected)
  - `ProxyRule` (`Metric` deletion will kick `ProxyRule` deletion, so already covered)
  - ~`Policy`~
  - `Proxy` (Maybe only a few attributes – `policies_config`)
  - `GatewayConfiguration`

**Special notes for your reviewer**
Not sure if we should issue one event per proxy (passing proxy and affecting object) or just one event per change, passing only the affecting object and let the creation of the event to handle the logics of triggering one background job per proxy. In the latter case, the event would have to be aware of the different types of affecting objects (so it can get to the proxies).

To sum up (very roughly exemplifying):

*Option A*
```
# where the event is triggered (many places in the code) 
Event.new(object)

# what the event does
for each proxy using object
  Notifier.new(proxy, object)
```

*Option B*
```
# where the event is triggered (many places in the code) 
for each proxy using object
  Event.new(proxy, object)

# what the event does
Notifier.new(proxy, object)
```

_Update:_ going with Option B.

----

I won't tag this as APIAP-only because I think this can be used for non-APIAP accounts as well.