### PR TITLE
set rubocop lambda style to literal

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,9 @@ Style/TrailingCommaInHashLiteral:
 Style/TrailingCommaInArrayLiteral:
   Enabled: false
 
+Style/Lambda:
+  EnforcedStyle: literal
+
 Metrics/LineLength:
   Max: 99
   Enabled: false

--- a/app/lib/backend/storage_rewrite.rb
+++ b/app/lib/backend/storage_rewrite.rb
@@ -9,7 +9,7 @@ module Backend
       progress_each = 100
       index = 0
 
-      progress = lambda do
+      progress = -> do
         index += 1
         break unless (index % progress_each) == 0
         percent = (index / total_count.to_f) * 100.0
@@ -66,7 +66,7 @@ module Backend
       total_count = services.size + cinstances.size + metrics.size + usage_limits.size + bought_cinstances.size
 
       index = 0
-      progress = lambda do
+      progress = -> do
         percent = ((index + 1) / total_count.to_f) * 100.0
         yield percent if block_given?
         index += 1
@@ -89,7 +89,7 @@ module Backend
         progress.call
       end
 
-      update_cinstance = lambda do |cinstance|
+      update_cinstance = ->(cinstance) do
         cinstance.send(:update_backend_application)
         cinstance.send(:update_backend_user_key_to_application_id_mapping)
         if cinstance.provider_account

--- a/app/lib/logic/contracting.rb
+++ b/app/lib/logic/contracting.rb
@@ -11,7 +11,7 @@ module Logic
 
         # Has to have default or published application plan
         # so this method should be called only in this scope
-        scope :can_create_application_contract, lambda {
+        scope :can_create_application_contract, -> {
           query = joining { application_plans.outer }.uniq
           .where.has {
             default_application_plan_id.not_eq(nil) |

--- a/app/lib/three_scale/analytics/user_tracking.rb
+++ b/app/lib/three_scale/analytics/user_tracking.rb
@@ -8,7 +8,7 @@ module ThreeScale
   module Analytics
     class UserTracking
 
-      error_handler = lambda do |status, error|
+      error_handler = ->(status, error) do
         System::ErrorReporting.report_error(error_message: error, parameters: { status: status })
       end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -105,7 +105,7 @@ class Account < ApplicationRecord
 
   scope :free, ->(free_date) { where.has { not_exists Contract.have_paid_on(free_date).by_account(BabySqueel[:accounts].id).select(:id) } }
 
-  scope :lacks_cinstance_with_plan_system_name, lambda { |system_names|
+  scope :lacks_cinstance_with_plan_system_name, ->(system_names) {
     where.has do
       not_exists Cinstance.by_account(BabySqueel[:accounts].id).by_plan_system_name(system_names).select(:id)
     end

--- a/app/models/account/credit_card.rb
+++ b/app/models/account/credit_card.rb
@@ -9,7 +9,7 @@ module Account::CreditCard
 
     before_destroy :unstore_credit_card!
 
-    scope :expired_credit_card, lambda { |time|
+    scope :expired_credit_card, ->(time) {
       expired_credit_card = joins(:payment_detail).where.has do
         (credit_card_expires_on == time) | (payment_detail.credit_card_expires_on == time)
       end

--- a/app/models/account/master_methods.rb
+++ b/app/models/account/master_methods.rb
@@ -7,11 +7,11 @@ module Account::MasterMethods
     has_many :provider_accounts, -> { providers }, :class_name  => 'Account', :foreign_key => 'provider_account_id'
     alias_method :providers, :provider_accounts
 
-    scope :by_provider_key, lambda { |provider_key|
+    scope :by_provider_key, ->(provider_key) {
       includes(:bought_cinstances).references(:bought_cinstances).merge(Cinstance.by_user_key(provider_key))
     }
 
-    scope :by_service_token, lambda { |service_token|
+    scope :by_service_token, ->(service_token) {
       includes(:service_tokens).where(service_tokens: { value: service_token })
     }
 

--- a/app/models/account/provider_domains.rb
+++ b/app/models/account/provider_domains.rb
@@ -32,7 +32,7 @@ module Account::ProviderDomains
 
     scope :by_domain, ->(domain) { where(domain: domain) }
     scope :by_self_domain, ->(domain) { where(self_domain: domain) }
-    scope :by_admin_domain, lambda { |domain|
+    scope :by_admin_domain, ->(domain) {
       table = table_name
       where("(#{table}.self_domain = :domain) OR (#{table}.self_domain IS NULL AND provider_accounts_accounts.domain = :domain)",
             { :domain => domain })

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -74,7 +74,7 @@ class Alert < ApplicationRecord
     end
   end
 
-  scope :by_application, lambda { |cinstance|
+  scope :by_application, ->(cinstance) {
     return all if cinstance == :all || cinstance.nil?
 
     where(:cinstance_id => cinstance.id)

--- a/app/models/application_plan.rb
+++ b/app/models/application_plan.rb
@@ -12,7 +12,7 @@ class ApplicationPlan < Plan
 
   validate :end_users_switch
 
-  scope :provided_by, lambda { |provider|
+  scope :provided_by, ->(provider) {
     if provider == :all || provider.blank?
       {}
     else

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -21,10 +21,10 @@ class BackendApiConfig < ApplicationRecord
   validates :path, uniqueness: { scope: :service_id, case_sensitive: false }
   validates :path, length: { in: 0..255, allow_nil: false }, path: true
 
-  scope :with_subpath, (lambda do
+  scope :with_subpath, -> do
     common_query = where.not(path: '/')
     System::Database.oracle? ? common_query.where('path is NOT NULL') : common_query.where.not(path: '')
-  end)
+  end
 
   delegate :private_endpoint, to: :backend_api
 

--- a/app/models/cms/template.rb
+++ b/app/models/cms/template.rb
@@ -3,9 +3,9 @@ class CMS::Template < ApplicationRecord
   include CMS::Filtering
 
   scope :with_draft, ->{ where(['draft IS NOT NULL'])}
-  scope :for_rails_view, lambda { |path| where(rails_view_path: path.to_s) }
+  scope :for_rails_view, ->(path) { where(rails_view_path: path.to_s) }
 
-  scope :but, lambda { | *klasses | where{ type.not_in klasses.map(&:to_s) } }
+  scope :but, ->(*klasses) { where{ type.not_in klasses.map(&:to_s) } }
   scope :recents, -> { order(updated_at: :desc).where.has { updated_at != created_at } }
   attr_accessible :provider, :draft, :liquid_enabled, :handler
 

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -63,22 +63,22 @@ class Contract < ApplicationRecord
   end
 
   # Return contracts bought by given account.
-  scope :bought_by, lambda { |account|
+  scope :bought_by, ->(account) {
     where({:user_account_id => account.id})
   }
 
   scope :with_account, -> { includes([:user_account])}
 
-  scope :by_type, lambda { |contract_type|
+  scope :by_type, ->(contract_type) {
     where({ :type => contract_type.to_s })
   }
 
   # SEARCH SCOPES
-  scope :by_plan_id, lambda { |plan_id|
+  scope :by_plan_id, ->(plan_id) {
     where(plan_id: plan_id.to_i)
   }
 
-  scope :by_name, lambda { |text|
+  scope :by_name, ->(text) {
     # replace start and end of string with % unless already has %
     pattern = text.sub(/(^[^%])/, '%\\1').sub( /([^%]$)/, '\\1%')
     collate = { oracle: 'GENERIC_M_CI', postgres: '"und-x-icu"', mysql: 'UTF8_GENERAL_CI' }.fetch(System::Database.adapter.to_sym)
@@ -86,7 +86,7 @@ class Contract < ApplicationRecord
   }
 
   scope :by_account, ->(account) { where.has { user_account_id == account } }
-  scope :by_account_query, lambda { |query| where( { :user_account_id => Account.buyers.search_ids(query) } ) }
+  scope :by_account_query, ->(query) { where( { :user_account_id => Account.buyers.search_ids(query) } ) }
 
   scope :have_paid_on, ->(paid_date) { where.has { (paid_until >= paid_date) | (variable_cost_paid_until >= paid_date) } }
 

--- a/app/models/deleted_object.rb
+++ b/app/models/deleted_object.rb
@@ -8,7 +8,7 @@ class DeletedObject < ApplicationRecord
     scope scoped_class.to_s.underscore.pluralize.to_sym, -> { where(object_type: scoped_class) }
   end
 
-  scope(:deleted_owner, lambda do
+  scope(:deleted_owner, -> do
     join_sql = <<-SQL
       INNER JOIN deleted_objects deleted_owner
         ON deleted_objects.owner_type = deleted_owner.object_type

--- a/app/models/fields_definition.rb
+++ b/app/models/fields_definition.rb
@@ -20,9 +20,9 @@ class FieldsDefinition < ApplicationRecord
   belongs_to :account, :inverse_of => :fields_definitions
   acts_as_list :scope => :account, :column => :pos
 
-  scope :by_provider,  lambda {|provider| where(['account_id = ?', provider.id]) }
-  scope :by_target, lambda { |class_name| where(['target = ?', class_name])}
-  scope :by_name, lambda { |name| where(['name = ?', name])}
+  scope :by_provider,  ->(provider) { where(['account_id = ?', provider.id]) }
+  scope :by_target, ->(class_name) { where(['target = ?', class_name])}
+  scope :by_name, ->(name) { where(['name = ?', name])}
   scope :required, -> { where({ :required => true })}
 
   def self.editable_by(user)

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -21,7 +21,7 @@ class LineItem < ApplicationRecord
   end
 
   # REFACTOR: REMOVE!
-  scope :by_period_including, lambda { |time|
+  scope :by_period_including, ->(time) {
       where(["#{table_name}.created_at <= ? AND #{table_name}.finished_at >= ?", time, time])
   }
 

--- a/app/models/message_recipient.rb
+++ b/app/models/message_recipient.rb
@@ -49,7 +49,7 @@ class MessageRecipient < ApplicationRecord
   scope :deleted,      -> { where.not(deleted_at: nil) }
   scope :hidden,       -> { not_deleted.where.not(hidden_at: nil) }
   scope :of_account,   ->(account) { where(receiver: account) }
-  scope :not_system,   lambda {
+  scope :not_system,   -> {
     includes(:message).where(messages: { system_operation_id: nil }).references(:message)
   }
 

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -42,7 +42,7 @@ class Metric < ApplicationRecord
   # depend on the database implementation. In order to ensure that behavior, use User.order(:id).first instead.
   #
   default_scope -> { order(:id) }
-  scope :top_level, lambda { where(parent_id: nil) }
+  scope :top_level, -> { where(parent_id: nil) }
   scope :order_by_unit, -> { order('unit') }
 
   # Create one of the predefined, default metrics.

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -112,9 +112,9 @@ class Plan < ApplicationRecord
 
   scope :latest, -> { limit(5).order(created_at: :desc) }
 
-  scope :by_state, lambda { |state|  where({:state => state.to_s})}
+  scope :by_state, ->(state) {  where({:state => state.to_s})}
 
-  scope :by_type, lambda { |type| where({ :type => type.to_s })}
+  scope :by_type, ->(type) { where({ :type => type.to_s })}
 
   # Customzied plans
   scope :customized, -> { where("#{table_name}.original_id <> 0") }

--- a/app/models/pricing_rule.rb
+++ b/app/models/pricing_rule.rb
@@ -21,7 +21,7 @@ class PricingRule < ApplicationRecord
   validates :cost_per_unit, numericality: true
   validates :cost_per_unit, format: { with: /\A\d+\.?\d{0,#{DECIMALS}}\z/, message: "maximum decimals is #{DECIMALS}." }
 
-  scope :for_metric, lambda { |metric| where(:metric_id => metric.to_param) }
+  scope :for_metric, ->(metric) { where(:metric_id => metric.to_param) }
 
   delegate :service, :to => :plan
 

--- a/app/models/proxy_config.rb
+++ b/app/models/proxy_config.rb
@@ -2,7 +2,7 @@ class ProxyConfig < ApplicationRecord
   class InvalidEnvironmentError < StandardError; end
   ENVIRONMENTS = %w(sandbox production).freeze
 
-  ENVIRONMENT_CHECK = lambda do |env|
+  ENVIRONMENT_CHECK = ->(env) do
     ENVIRONMENTS.include?(env) ? env : raise(InvalidEnvironmentError, env)
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -100,7 +100,7 @@ class Service < ApplicationRecord
   scope :accessible, -> { where.not(state: DELETE_STATE) }
   scope :deleted, -> { where(state: DELETE_STATE) }
   scope :of_approved_accounts, -> { joins(:account).merge(Account.approved) }
-  scope(:permitted_for_user, lambda do |user|
+  scope(:permitted_for_user, ->(user) do
     # TODO: this is probably wrong...
     # how come if it does not have access_to_all_services but it can not use service_permissions,
     # then we allow them all?!!
@@ -466,7 +466,7 @@ class Service < ApplicationRecord
     system_name.to_s.parameterize.tr('_','-')
   end
 
-  APPLY_I18N = lambda do |args|
+  APPLY_I18N = ->(args) do
     args.map do |opt|
       [
         I18n.t(opt, scope: :deployment_options, raise: ActionView::Base.raise_on_missing_translations),

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -39,11 +39,11 @@ class Topic < ApplicationRecord
   validates :body, presence: { :on => :create }
   validates :title, :permalink, length: { maximum: 255 }
 
-  scope :order_by, lambda {|param|
+  scope :order_by, ->(param) {
                      joins('INNER JOIN posts ON topics.last_post_id = posts.id')
                                    .order((param && ['hits', 'posts_count'].include?(param)) ? "#{param} desc" : 'posts.created_at desc')
                    }
-  scope :for_category, lambda { |*args| where(['topic_category_id = ?', args.first || nil]) }
+  scope :for_category, ->(*args) { where(['topic_category_id = ?', args.first || nil]) }
 
   scope :with_latest_post, -> { joins('INNER JOIN posts ON topics.last_post_id = posts.id')}
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,7 +78,7 @@ class User < ApplicationRecord
 
   #TODO: this needs tests
   validates :password, length: { :minimum => 6, :allow_blank => true,
-                      :if => lambda{ |u| u.validate_password? and not u.send(:provider_requires_strong_passwords?) } }
+                      :if => ->(u){ u.validate_password? and not u.send(:provider_requires_strong_passwords?) } }
 
   validates :extra_fields, length: { maximum: 65535 }
   validates :crypted_password, :salt, :remember_token, :activation_code,
@@ -127,9 +127,9 @@ class User < ApplicationRecord
     %w(pending active)
   end
 
-  scope :without_ids, lambda { |id| id ? where(['users.id <> ?', id]) : where({}) }
+  scope :without_ids, ->(id) { id ? where(['users.id <> ?', id]) : where({}) }
 
-  scope :by_email, lambda { |email| where(:email => email) }
+  scope :by_email, ->(email) { where(:email => email) }
 
   scope :latest, -> {limit(5).order(created_at: :desc)}
 

--- a/app/models/user/roles.rb
+++ b/app/models/user/roles.rb
@@ -9,7 +9,7 @@ module User::Roles
     symbolize :role
     before_save :set_role
 
-    scope :by_role, lambda { |role| where({:role => role.to_s})}
+    scope :by_role, ->(role) { where({:role => role.to_s})}
 
     ROLES.each do |role|
       #adds method admin? to check whether user role is admin (other roles too)

--- a/app/representers/cms/layout_representer.rb
+++ b/app/representers/cms/layout_representer.rb
@@ -10,7 +10,7 @@ module CMS::LayoutRepresenter
   property :content_type
   property :handler, render_nil: true
 
-  with_options(if: lambda {|options| options[:short] == false }) do |p|
+  with_options(if: ->(options) { options[:short] == false }) do |p|
     p.property :published, render_nil: true
     p.property :draft, render_nil: true
   end

--- a/app/representers/cms/page_representer.rb
+++ b/app/representers/cms/page_representer.rb
@@ -5,7 +5,7 @@ module CMS::PageRepresenter
 
   property :id
 
-  with_options(if: lambda {|options| options[:short] == false }) do |p|
+  with_options(if: ->(options) { options[:short] == false }) do |p|
     p.property :draft, render_nil: true
     p.property :published, render_nil: true
   end

--- a/app/representers/cms/partial_representer.rb
+++ b/app/representers/cms/partial_representer.rb
@@ -6,7 +6,7 @@ module CMS::PartialRepresenter
   property :id
   property :system_name
 
-  with_options(if: lambda {|options| options[:short] == false }) do |p|
+  with_options(if: ->(options) { options[:short] == false }) do |p|
     p.property :published, render_nil: true
     p.property :draft, render_nil: true
   end

--- a/app/representers/cms/portlet_representer.rb
+++ b/app/representers/cms/portlet_representer.rb
@@ -10,7 +10,7 @@ module CMS::PortletRepresenter
   property :name
   property :description
 
-  with_options(if: lambda {|options| options[:short] == false }) do |p|
+  with_options(if: ->(options) { options[:short] == false }) do |p|
     p.property :draft
     p.property :published
   end

--- a/config/abilities/buyer_any.rb
+++ b/config/abilities/buyer_any.rb
@@ -39,7 +39,7 @@ Ability.define do |user|
       can :manage, :applications
     end
 
-    new_app_condition = lambda do
+    new_app_condition = -> do
       (provider.settings.multiple_applications_visible? ||
           !provider.settings.multiple_applications_visible? &&
               account.bought_cinstances.count.zero?)

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module System
   module AssociationExtension
     def self.included(base)
       base.define_singleton_method(:to_proc) do
-        lambda { |_| include base }
+        ->(_) { include base }
       end
     end
   end

--- a/config/docker/unicorn.rb
+++ b/config/docker/unicorn.rb
@@ -17,7 +17,7 @@ rescue
   warn "WARNING: Caught exception: #{$!}"
 end
 
-detect_unicorn_workers = lambda do
+detect_unicorn_workers = -> do
   workers = ENV['UNICORN_WORKERS']
   return Integer(workers) if workers.to_i.positive?
 

--- a/config/initializers/clear_after_commit_on_destroy_queue.rb
+++ b/config/initializers/clear_after_commit_on_destroy_queue.rb
@@ -1,1 +1,1 @@
-ActionDispatch::Callbacks.after(lambda{ThreeScale::AfterCommitOnDestroy.clear!})
+ActionDispatch::Callbacks.after(->{ThreeScale::AfterCommitOnDestroy.clear!})

--- a/config/initializers/debug_callbacks.rb
+++ b/config/initializers/debug_callbacks.rb
@@ -6,7 +6,7 @@ if ENV['DEBUG']
     end
 
     def debug_callback(callback)
-      lambda do |target, *args, &block|
+      ->(target, *args, &block) do
         begin
           result = callback.call(target, *args, &block)
         rescue => e

--- a/config/initializers/message_bus.rb
+++ b/config/initializers/message_bus.rb
@@ -11,7 +11,7 @@ end
 
 ThreeScale::MessageBusConfig.new(Rails.configuration.three_scale.message_bus).configure_message_bus!
 
-authenticated_request = lambda do |env|
+authenticated_request = ->(env) do
   ActiveRecord::Base.connection_pool.with_connection do
     (env['authenticated_request'] ||= AuthenticatedSystem::Request.new(ActionDispatch::Request.new(env)))
   end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -3,5 +3,5 @@ Time::DATE_FORMATS[:db_month] = '%Y-%m'
 Date::DATE_FORMATS[:db_month] = '%Y-%m'
 
 # This is like the :number, but with trailing zeroes removed.
-Time::DATE_FORMATS[:compact] = lambda { |time| time.to_s(:number).sub(/0{0,6}$/, '') }
+Time::DATE_FORMATS[:compact] = ->(time) { time.to_s(:number).sub(/0{0,6}$/, '') }
 Date::DATE_FORMATS[:compact] = Date::DATE_FORMATS[:number]

--- a/features/step_definitions/cms/pages_steps.rb
+++ b/features/step_definitions/cms/pages_steps.rb
@@ -71,7 +71,7 @@ end
 
 Then /^going to the page "([^\"]*)" should raise "([^"]*)"$/ do |title, e|
   path = Page.find_by_title(title).path
-  lambda { visit(path) }.should raise_error(e.constantize)
+  -> { visit(path) }.should raise_error(e.constantize)
 end
 
 Then /^the page "([^"]*)" should exist$/ do |name|

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -182,7 +182,7 @@ end
 Then /^I should see the following definition list:$/ do |table|
   # Not quite sure why single #next is not enought, possibly because
   # the first next sibling is just a text node?
-  table.diff!(extract_table('dl', 'dt', lambda { |dt| [dt, dt.next.next] }))
+  table.diff!(extract_table('dl', 'dt', ->(dt) { [dt, dt.next.next] }))
 end
 
 Then /^I should not see "([^"]*)" column$/ do |text|

--- a/features/step_definitions/exceptions_handling_steps.rb
+++ b/features/step_definitions/exceptions_handling_steps.rb
@@ -20,14 +20,14 @@ end
 
 #OPTIMIZE: remove exception from step signature and make it less code aware
 When /^I request the url of the '([^\']*)' page then I should see a "([^"]*)" exception$/ do |page, e|
-  lambda { visit path_to("the #{page} page") }
+  -> { visit path_to("the #{page} page") }
     .should raise_error(e.constantize)
 end
 
 
 #TODO: dry this with the other steps
 Then /^I request the url of the (page "[^\"]*") an exception should be raised$/ do |page|
-  lambda { visit page.path }
+  -> { visit page.path }
     .should raise_error(ActiveRecord::RecordNotFound)
 end
 

--- a/features/step_definitions/site/alerts_steps.rb
+++ b/features/step_definitions/site/alerts_steps.rb
@@ -23,7 +23,7 @@ When /^default service of (provider ".+?") has allowed following alerts:$/ do |p
 end
 
 Then /^I should see alert settings:$/ do |table|
-  body = extract_table 'table#notification-settings-table',  'tbody tr', lambda { |tr|
+  body = extract_table 'table#notification-settings-table',  'tbody tr', ->(tr) {
     [tr.text, tr.all(:xpath, '*').map{ |td| td.all(:xpath, '*').map{|input| input['value'] }.join } ].flatten
   }
   table.diff! body

--- a/lib/signup/developer_account_manager.rb
+++ b/lib/signup/developer_account_manager.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Signup::DeveloperAccountManager < Signup::AccountManager
-  self.account_builder = lambda do |account|
+  self.account_builder = ->(account) do
     account.buyer = true
     account
   end

--- a/lib/signup/provider_account_manager.rb
+++ b/lib/signup/provider_account_manager.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Signup::ProviderAccountManager < Signup::AccountManager
-  self.account_builder = lambda do |account|
+  self.account_builder = ->(account) do
     account.provider = true
     account.sample_data = true
     account.email_all_users = true

--- a/lib/system/error_reporting.rb
+++ b/lib/system/error_reporting.rb
@@ -4,7 +4,7 @@ module System
   module ErrorReporting
     module_function
 
-    OPTIONS = lambda do |parameters, rack_env = nil|
+    OPTIONS = ->(parameters, rack_env = nil) do
       options = parameters.present? ? { parameters: parameters } : {}
 
       options[:rack_env] = rack_env if rack_env

--- a/lib/tasks/backend.rake
+++ b/lib/tasks/backend.rake
@@ -95,7 +95,7 @@ END
     # FIXME: delete non-existing keys too
     #
 
-    rewrite_progress = lambda do |percent|
+    rewrite_progress = ->(percent) do
       puts "#{percent.round(2)}% completed"
     end
 
@@ -131,7 +131,7 @@ END
       cinstances = accounts.flat_map{|p| p.bought_cinstances }
       total_count = cinstances.size
       index = 0
-      progress = lambda do
+      progress = -> do
         percent = ((index + 1) / total_count.to_f) * 100.0
         puts "#{percent.round(2)}% completed"
         index += 1
@@ -148,7 +148,7 @@ END
       cinstances = Cinstance.find(:all, :conditions => "user_key like 'clean-%'")
       total_count = cinstances.size
       index = 0
-      progress = lambda do
+      progress = -> do
         percent = ((index + 1) / total_count.to_f) * 100.0
         puts "#{percent.round(2)}% completed"
         index += 1

--- a/lib/tasks/fields_definitions.rake
+++ b/lib/tasks/fields_definitions.rake
@@ -12,7 +12,7 @@ namespace :fields_definitions do
     diff = (provider_fields.keys - master_fields.keys).group_by{|tuple| tuple.shift}
     diff.values.each{|arr| arr.flatten! }
 
-    reduce = lambda do |objects|
+    reduce = ->(objects) do
       objects.map do |object|
         existing = object.class.builtin_fields.map do |field|
           field if object.send(field).present?

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -291,7 +291,7 @@ namespace :fixes do
 
     logger = ActiveSupport::Logger.new('log/fixes_account_contract_states.log')
 
-    exec_batch = lambda do |label, scope, states|
+    exec_batch = ->(label, scope, states) do
       total = scope.count
       counter = 0
       scope.find_in_batches do |records|

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -12,7 +12,7 @@ namespace :integrate do
 
   orchestration_helpers = Module.new do
     def self.print_banner_around
-      lambda do |line|
+      ->(line) do
         puts
         puts "=" * 40
         puts "== #{Color::BOLD}#{line}#{Color::CLEAR}"

--- a/lib/three_scale/rake/remove_dup_usage_limits.rb
+++ b/lib/three_scale/rake/remove_dup_usage_limits.rb
@@ -33,7 +33,7 @@ module ThreeScale
 
       def run!
         index = 0
-        progress = lambda do
+        progress = -> do
           index += 1
           break unless (index % PROGRESS_EACH) == 0
           percent = (index / @total_count.to_f) * 100.0

--- a/test/functional/provider/domains_controller_test.rb
+++ b/test/functional/provider/domains_controller_test.rb
@@ -12,7 +12,7 @@ class Provider::DomainsControllerTest < ActionController::TestCase
   test 'email list of domains' do
     @request.host = Account.master.domain
 
-    assert_change :of => lambda { ActionMailer::Base.deliveries.count } do
+    assert_change :of => -> { ActionMailer::Base.deliveries.count } do
       post :recover, :email => @provider1.emails.first
     end
     assert_response :success

--- a/test/integration/proxy_example_test.rb
+++ b/test/integration/proxy_example_test.rb
@@ -124,7 +124,7 @@ class ProxyExampleTest < ActiveSupport::TestCase
   end
 
   def wait_for(port, seconds = 10)
-    opened = lambda do
+    opened = -> do
       begin
         TCPSocket.new('127.0.0.1', port)
       rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED

--- a/test/integration/user-management-api/buyers_users_test.rb
+++ b/test/integration/user-management-api/buyers_users_test.rb
@@ -297,7 +297,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
   end
 
   test "create sends no email" do
-    assert_no_change :of => lambda { ActionMailer::Base.deliveries.count } do
+    assert_no_change :of => -> { ActionMailer::Base.deliveries.count } do
       post(admin_api_account_users_path(:account_id => @buyer.id,
                                              :format => :xml),
                 :username => 'chuck',
@@ -591,7 +591,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'activate sends no email' do
     chuck = FactoryBot.create :user, :account => @buyer
-    assert_no_change :of => lambda { ActionMailer::Base.deliveries.count } do
+    assert_no_change :of => -> { ActionMailer::Base.deliveries.count } do
       put "/admin/api/accounts/#{@buyer.id}/users/#{chuck.id}/activate.xml?provider_key=#{@provider.api_key}"
     end
     assert_response :success

--- a/test/integration/user-management-api/users_test.rb
+++ b/test/integration/user-management-api/users_test.rb
@@ -289,7 +289,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   test "create sends no email" do
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    assert_no_change :of => lambda { ActionMailer::Base.deliveries.count } do
+    assert_no_change :of => -> { ActionMailer::Base.deliveries.count } do
       post(admin_api_users_path(:format => :xml),
                 :username => 'chuck',
                 :email => 'chuck@norris.us',
@@ -351,7 +351,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   end
 
   test "create forbidden if multiple_users is not allowed" do
-    assert_no_change :of => lambda { ActionMailer::Base.deliveries.count } do
+    assert_no_change :of => -> { ActionMailer::Base.deliveries.count } do
       post(admin_api_users_path(:format => :xml),
                 :username => 'chuck',
                 :email => 'chuck@norris.us',
@@ -547,7 +547,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   test 'activate sends no email' do
     chuck = FactoryBot.create :user, :account => @provider
-    assert_no_change :of => lambda { ActionMailer::Base.deliveries.count } do
+    assert_no_change :of => -> { ActionMailer::Base.deliveries.count } do
       put "/admin/api/users/#{chuck.id}/activate.xml?provider_key=#{@provider.api_key}"
     end
     assert_response :success

--- a/test/test_helpers/backend.rb
+++ b/test/test_helpers/backend.rb
@@ -135,7 +135,7 @@ module TestHelpers
                        :since  => options[:since]}
 
       change_options = options.slice(:from, :to, :by)
-      change_options[:of] = lambda { stats.total(stats_options) }
+      change_options[:of] = -> { stats.total(stats_options) }
 
       assert_change change_options, &block
     end

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -58,7 +58,7 @@ class Account::StatesTest < ActiveSupport::TestCase
   test 'approve! transitions from pending to approved' do
     account = FactoryBot.create(:pending_account)
 
-    assert_change :of   => lambda { account.state },
+    assert_change :of   => -> { account.state },
                   :from => "pending",
                   :to   => "approved" do
       account.approve!
@@ -69,7 +69,7 @@ class Account::StatesTest < ActiveSupport::TestCase
     account = FactoryBot.create(:pending_account)
     account.reject!
 
-    assert_change :of   => lambda { account.state },
+    assert_change :of   => -> { account.state },
                   :from => "rejected",
                   :to   => "approved" do
       account.approve!

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -388,7 +388,7 @@ class AccountTest < ActiveSupport::TestCase
   test 'forum is lazily created for providers' do
     account = nil
 
-    assert_no_change :of => lambda { Forum.count } do
+    assert_no_change :of => -> { Forum.count } do
       account = FactoryBot.create(:simple_provider)
     end
 
@@ -606,7 +606,7 @@ class AccountTest < ActiveSupport::TestCase
     buyer_account = FactoryBot.create(:simple_buyer, provider_account: provider_account)
     buyer_account.buy!(plan)
 
-    assert_change :of => lambda { Account.providers.count }, :by => -1 do
+    assert_change :of => -> { Account.providers.count }, :by => -1 do
       provider_account.destroy
     end
   end

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -308,7 +308,7 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test 'by_active_since returns cinstances based on first_daily_traffic_at' do
-    days_to_time_format = lambda{ |x| x.days.ago.to_time.strftime("%Y-%m-%d") }
+    days_to_time_format = ->(x){ x.days.ago.to_time.strftime("%Y-%m-%d") }
 
     app1 = FactoryBot.create(:cinstance, first_daily_traffic_at: 3.days.ago.to_time)
     app2 = FactoryBot.create(:cinstance, first_daily_traffic_at: 1.day.ago.to_time)

--- a/test/unit/invitation_test.rb
+++ b/test/unit/invitation_test.rb
@@ -102,7 +102,7 @@ class InvitationTest < ActiveSupport::TestCase
     invitation = @provider.invitations.create!(:email => 'bob@example.com')
 
     Timecop.freeze(Time.utc(2010, 3, 12)) do
-      assert_change :of => lambda { invitation.accepted? }, :from => false, :to => true do
+      assert_change :of => -> { invitation.accepted? }, :from => false, :to => true do
         invitation.accept!
       end
 
@@ -115,7 +115,7 @@ class InvitationTest < ActiveSupport::TestCase
     invitation.accept!
 
     Timecop.travel(2.days.from_now) do
-      assert_no_change :of => lambda { invitation.accepted_at } do
+      assert_no_change :of => -> { invitation.accepted_at } do
         invitation.accept!
       end
     end
@@ -125,7 +125,7 @@ class InvitationTest < ActiveSupport::TestCase
     invitation = @provider.invitations.create!(:email => 'bob@example.net')
     user = invitation.make_user(:username => 'bob', :password => 'monkey')
 
-    assert_change :of => lambda { invitation.accepted? }, :from => false, :to => true do
+    assert_change :of => -> { invitation.accepted? }, :from => false, :to => true do
       user.save!
       invitation.reload
     end

--- a/test/unit/models_test.rb
+++ b/test/unit/models_test.rb
@@ -29,7 +29,7 @@ class ModelsTest < ActiveSupport::TestCase
     Rails.application.eager_load!
     models = ActiveRecord::Base.descendants - [BackendApi, Service, Proxy]
 
-    validate_columns_for = lambda do |model, options = {}|
+    validate_columns_for = ->(model, options = {}) do
       exception_attributes = exceptions.fetch(model.name, [])
       next if exception_attributes == :all
       model.columns.each do |column|

--- a/test/unit/stats/aggregation_test.rb
+++ b/test/unit/stats/aggregation_test.rb
@@ -21,7 +21,7 @@ class Stats::AggregationTest < ActiveSupport::TestCase
     key = "stats/{service:#{@service.backend_id}}/metric:#{@metric.id}/day:20091122"
     @storage.set(key, 1024)
 
-    assert_change :of => lambda { @storage.get(key) }, :from => '1024', :to => '1025' do
+    assert_change :of => -> { @storage.get(key) }, :from => '1024', :to => '1025' do
       Aggregation.aggregate(transaction)
     end
   end
@@ -32,7 +32,7 @@ class Stats::AggregationTest < ActiveSupport::TestCase
     key = "stats/{service:#{@service.backend_id}}/metric:#{@metric.id}/hour:2009112218"
     @storage.set(key, 7)
 
-    assert_change :of => lambda { @storage.get(key) }, :from => '7', :to => '8' do
+    assert_change :of => -> { @storage.get(key) }, :from => '7', :to => '8' do
       Aggregation.aggregate(transaction)
     end
   end
@@ -40,7 +40,7 @@ class Stats::AggregationTest < ActiveSupport::TestCase
   test 'Aggregation.aggregate does not update set of services' do
     transaction = build_transaction_at(Time.zone.now)
 
-    assert_no_change :of => lambda { @storage.smembers('stats/services') } do
+    assert_no_change :of => -> { @storage.smembers('stats/services') } do
       Aggregation.aggregate(transaction)
     end
   end
@@ -51,7 +51,7 @@ class Stats::AggregationTest < ActiveSupport::TestCase
     key = "stats/{service:#{@service.backend_id}}/cinstance:#{@cinstance.id}/metric:#{@metric.id}/day:20091122"
     @storage.set(key, 19)
 
-    assert_change :of => lambda { @storage.get(key) }, :from => '19', :to => '20' do
+    assert_change :of => -> { @storage.get(key) }, :from => '19', :to => '20' do
       Aggregation.aggregate(transaction)
     end
   end
@@ -62,7 +62,7 @@ class Stats::AggregationTest < ActiveSupport::TestCase
     key = "stats/{service:#{@service.backend_id}}/cinstance:#{@cinstance.id}/metric:#{@metric.id}/month:20091101"
     @storage.set(key, 243)
 
-    assert_change :of => lambda { @storage.get(key) }, :from => '243', :to => '244' do
+    assert_change :of => -> { @storage.get(key) }, :from => '243', :to => '244' do
       Aggregation.aggregate(transaction)
     end
   end
@@ -73,7 +73,7 @@ class Stats::AggregationTest < ActiveSupport::TestCase
     key = "stats/{service:#{@service.backend_id}}/cinstance:#{@cinstance.id}/metric:#{@metric.id}/year:20090101"
     @storage.set(key, 4981)
 
-    assert_change :of => lambda { @storage.get(key) }, :from => '4981', :to => '4982' do
+    assert_change :of => -> { @storage.get(key) }, :from => '4981', :to => '4982' do
       Aggregation.aggregate(transaction)
     end
   end
@@ -84,7 +84,7 @@ class Stats::AggregationTest < ActiveSupport::TestCase
     key = "stats/{service:#{@service.backend_id}}/cinstance:#{@cinstance.id}/metric:#{@metric.id}/eternity"
     @storage.set(key, 7008)
 
-    assert_change :of => lambda { @storage.get(key) }, :from => '7008', :to => '7009' do
+    assert_change :of => -> { @storage.get(key) }, :from => '7008', :to => '7009' do
       Aggregation.aggregate(transaction)
     end
   end
@@ -95,7 +95,7 @@ class Stats::AggregationTest < ActiveSupport::TestCase
 
     key = "stats/{service:#{@service.backend_id}}/cinstances"
 
-    assert_change :of => lambda { @storage.smembers(key) },
+    assert_change :of => -> { @storage.smembers(key) },
                   :from => [], :to => [@cinstance.id.to_s] do
       Aggregation.aggregate(transaction)
     end

--- a/test/unit/stats/service_test.rb
+++ b/test/unit/stats/service_test.rb
@@ -126,7 +126,7 @@ class Stats::ServiceTest < ActiveSupport::TestCase
     cinstance2 = FactoryBot.create(:cinstance, :plan => plan, :name => 'cinstance2')
     cinstance3 = FactoryBot.create(:cinstance, :plan => plan)
 
-    key = lambda do |cinstance|
+    key = ->(cinstance) do
       "stats/{service:#{@service.backend_id}}/cinstance:#{cinstance.application_id}/metric:#{@metric.id}/month:20091201"
     end
 
@@ -234,7 +234,7 @@ class Stats::ServiceTest < ActiveSupport::TestCase
     gb = Country.find_or_create_by!(:code => 'GB', :name => 'United Kingdom')
     es = Country.find_or_create_by!(:code => 'ES', :name => 'Spain')
 
-    key = lambda do |code|
+    key = ->(code) do
       "stats/{service:#{@service.backend_id}}/country:#{code}/metric:#{@metric.id}/month:20091201"
     end
 

--- a/test/unit/three_scale/middleware/dev_domain_test.rb
+++ b/test/unit/three_scale/middleware/dev_domain_test.rb
@@ -6,7 +6,7 @@ class ThreeScale::Middleware::DevDomainTest < ActiveSupport::TestCase
     env = {}
     res = [200, {}, [Object.new.freeze]]
 
-    app = lambda do |e|
+    app = ->(e) do
       assert_equal env, e
       assert_equal env.object_id, e.object_id
 
@@ -24,7 +24,7 @@ class ThreeScale::Middleware::DevDomainTest < ActiveSupport::TestCase
       'HTTP_X_FORWARDED_HOST' => 'foobar.example.com'
     }
     res = [200, {}, [Object.new.freeze]]
-    app = lambda do |e|
+    app = ->(e) do
       assert_equal({
                      'HTTP_HOST' => 'api.example.net',
                      'HTTP_X_FORWARDED_HOST' => 'foobar.example.com,api.example.net',
@@ -41,7 +41,7 @@ class ThreeScale::Middleware::DevDomainTest < ActiveSupport::TestCase
   end
 
   def test_redirect
-    app = lambda do |env|
+    app = ->(env) do
       [ 301, {'Location' => 'http://api.foo.example.com/path' }, [] ]
     end
     middleware = ThreeScale::Middleware::DevDomain.new(app, /\.foo\./)

--- a/test/unit/user/roles_test.rb
+++ b/test/unit/user/roles_test.rb
@@ -105,7 +105,7 @@ class User::RolesTest < ActiveSupport::TestCase
   test 'role is not mass assignable' do
     user = FactoryBot.create(:user)
 
-    assert_no_change :of => lambda { user.role } do
+    assert_no_change :of => -> { user.role } do
       user.update_attributes(:role => :admin)
     end
   end


### PR DESCRIPTION
So

```ruby
scope :blah, (lambda do |param|
  # ...
  param...
  #...
  # ...
end)
```

can be written 

```ruby
scope :blah, ->(param) do
  # ...
  param...
  #...
  # ...
end
```

See https://github.com/rubocop-hq/rubocop/issues/1520