### PR TITLE
[Rolling Updates] Plugin deployment option are deprecated

### DIFF
--- a/app/helpers/services_helper.rb
+++ b/app/helpers/services_helper.rb
@@ -36,19 +36,6 @@ module ServicesHelper
   end
 
   def deployment_options
-    options = Service.deployment_options(current_account)
-    {}.merge(options['Gateway'])
-        .merge(service_mesh_active? ? options['Service Mesh'] : {})
-        .merge(plugins_active? ? options['Plugin'] : {})
-  end
-
-  private
-
-  def service_mesh_active?
-    current_account.provider_can_use?(:service_mesh_integration)
-  end
-
-  def plugins_active?
-    false
+    Service.deployment_options(current_account).values.reduce(&:merge)
   end
 end

--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -315,6 +315,13 @@ module Logic
         end
       end
 
+      # Plugins are deprecated
+      # This is to make the transition easier
+      class PluginDeploymentOption < Base
+        def missing_config
+          true
+        end
+      end
       class Unknown < Base
         def missing_config
           false

--- a/app/views/api/services/forms/_integration_settings.html.slim
+++ b/app/views/api/services/forms/_integration_settings.html.slim
@@ -127,13 +127,14 @@ javascript:
               value_as_class: true,
               hint: t('formtastic.hints.deployment_option_service_mesh')
 
-    = form.input :deployment_option,
-      as: :radio,
-      collection: Service.deployment_options(current_account)['Plugin'],
-      label: 'Or Plugin',
-      wrapper_html: { class: "radio--iconic plugin" },
-      value_as_class: true,
-      hint: t("formtastic.hints.deployment_option_plugin")
+    - if current_account.provider_can_use?(:plugin_deployment_option)
+      = form.input :deployment_option,
+        as: :radio,
+        collection: Service.deployment_options(current_account)['Plugin'],
+        label: 'Or Plugin',
+        wrapper_html: { class: "radio--iconic plugin" },
+        value_as_class: true,
+        hint: t("formtastic.hints.deployment_option_plugin")
 
   = form.inputs "Authentication" do
     = form.input :proxy_authentication_method,

--- a/app/views/api/services/forms/_integration_settings_apiap.html.slim
+++ b/app/views/api/services/forms/_integration_settings_apiap.html.slim
@@ -1,6 +1,5 @@
 = javascript_pack_tag 'settings'
-
-- @service.deployment_option ||= 'hosted'
+- @service.deployment_option = 'hosted' if @service.deployment_option.blank?
 
 #settings
   = form.inputs 'Deployment', id: 'integration-wrapper' do

--- a/openshift/system/config/rolling_updates.yml
+++ b/openshift/system/config/rolling_updates.yml
@@ -21,6 +21,7 @@ base: &default
   proxy_private_base_path: true
   service_mesh_integration: true
   api_as_product: true
+  plugin_deployment_option: false
 
 production:
   <<: *default

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -75,11 +75,31 @@ class ServiceTest < ActiveSupport::TestCase
   end
 
   def test_deployment_options
-    deployment_options = Service.deployment_options
+    account = Account.new
+
+    # All
+    account.stubs(:provider_can_use?).with(:plugin_deployment_option).returns(true)
+    account.stubs(:provider_can_use?).with(:service_mesh_integration).returns(true)
+
+    deployment_options = Service.deployment_options(account)
 
     assert_includes deployment_options, 'Gateway'
     assert_includes deployment_options, 'Plugin'
     assert_includes deployment_options, 'Service Mesh'
+
+    # Service Mesh
+    account.stubs(:provider_can_use?).with(:service_mesh_integration).returns(false)
+
+    deployment_options = Service.deployment_options(account)
+
+    refute_includes deployment_options, 'Service Mesh'
+
+    # Plugin
+    account.stubs(:provider_can_use?).with(:plugin_deployment_option).returns(false)
+
+    deployment_options = Service.deployment_options(account)
+
+    refute_includes deployment_options, 'Plugin'
   end
 
   # Now the last remaining service cannot be destroyed


### PR DESCRIPTION
We want to deprecate Plugins
This is the first step to do it, on-prem they should not be shown anymore

We still need to think of what to do with customers that use it.
My suggestion is not to have a migration path, either they use APIcast V2 or nothing

Partially closes THREESCALE-2395