### PR TITLE
Extract apiap data migrations to rake tasks

### DIFF
--- a/app/lib/backend_api_logic/service_extension.rb
+++ b/app/lib/backend_api_logic/service_extension.rb
@@ -18,31 +18,6 @@ module BackendApiLogic
       end, class_name: 'Metric'
     end
 
-    # TODO: This is used by db/migrate/20190716110520_create_the_backend_apis_of_services.rb
-    # We should Remove this after 2.7 is released
-    # https://issues.jboss.org/browse/THREESCALE-3517
-    def first_backend_api
-      @backend_api ||= find_or_create_first_backend_api!
-    end
-
-    def find_or_create_first_backend_api!
-      return unless account
-      config = backend_api_configs.first || create_first_backend_api_config!
-      config.backend_api
-    end
-
-    def create_first_backend_api_config!
-      backend_api = account.backend_apis.build(
-        system_name: system_name,
-        name: "#{name} Backend",
-        description: "Backend of #{name}",
-        private_endpoint: proxy&.[]('api_backend')
-      )
-      constructor = new_record? ? :build : :create!
-      attrs = {backend_api: backend_api, path: ''}
-      backend_api_configs.public_send(constructor, attrs)
-    end
-
     class BackendApiProxy
       attr_reader :service
       delegate :account, :backend_apis, :backend_api_configs, to: :service

--- a/db/migrate/20190716110520_create_the_backend_apis_of_services.rb
+++ b/db/migrate/20190716110520_create_the_backend_apis_of_services.rb
@@ -4,6 +4,8 @@ require 'progress_counter'
 
 class CreateTheBackendApisOfServices < ActiveRecord::Migration
   def change
+    return puts "Nothing to do, this migration should not be executed" # Moved to lib/tasks/services.rake:create_backend_apis
+
     say_with_time 'Migrating proxies api_backend to slugs...' do
       reversible do |dir|
         dir.up do

--- a/db/migrate/20190801143259_backfill_proxy_rules_owners.rb
+++ b/db/migrate/20190801143259_backfill_proxy_rules_owners.rb
@@ -2,6 +2,8 @@ require 'progress_counter'
 
 class BackfillProxyRulesOwners < ActiveRecord::Migration
   def up
+    return puts "Nothing to do, this migration should not be executed" # Moved to lib/tasks/proxy.rake:update_proxy_rule_owners
+
     say_with_time 'Updating proxy rules owners...' do
       ProxyRule.reset_column_information
       progress = ProgressCounter.new(ProxyRule.count)

--- a/db/migrate/20190805135829_backfill_metric_owners.rb
+++ b/db/migrate/20190805135829_backfill_metric_owners.rb
@@ -2,6 +2,8 @@ require 'progress_counter'
 
 class BackfillMetricOwners < ActiveRecord::Migration
   def up
+    return puts "Nothing to do, this migration should not be executed" # Moved to lib/tasks/service.rake:update_metric_owners
+
     say_with_time 'Updating metric owners...' do
       Metric.reset_column_information
       progress = ProgressCounter.new(Metric.count)

--- a/lib/tasks/proxy.rake
+++ b/lib/tasks/proxy.rake
@@ -1,3 +1,8 @@
+# frozen_string_literal: true
+
+require 'benchmark'
+require 'progress_counter'
+
 namespace :proxy do
   desc "create proxies for every service"
   task :create_proxies => :environment do
@@ -31,5 +36,18 @@ namespace :proxy do
   desc 'Fixing nil endpoint for hosted'
   task :set_correct_endpoint_hosted => :environment do
     Service.includes(:proxy).where(proxies: {endpoint: nil}, deployment_option: 'hosted').find_each(&:deployment_option_changed)
+  end
+
+  desc 'Update proxy rules owners'
+  task update_proxy_rule_owners: :environment do
+    puts 'Updating proxy rules owners...'
+    duration = Benchmark.measure do
+      progress = ProgressCounter.new(ProxyRule.count)
+      ProxyRule.find_each do |proxy_rule|
+        proxy_rule.update_columns(owner_id: proxy_rule.proxy_id, owner_type: 'Proxy') unless proxy_rule.owner_type?
+        progress.call
+      end
+    end
+    puts "Finished in #{format('%.1fs', duration.real)}\n\t"
   end
 end

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'benchmark'
+require 'progress_counter'
+
 namespace :services do
   desc 'Create test contract for each existing service'
   task :create_test_contracts => :environment do
@@ -8,5 +11,44 @@ namespace :services do
 
   task :destroy_marked_as_deleted => :environment do
     DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
+  end
+
+  desc 'Migrate proxies api_backend to backend api configs.'
+  task create_backend_apis: :environment do
+    puts 'Migrating proxies api_backend to backend api configs...'
+    duration = Benchmark.measure do
+      Service.transaction do
+        progress = ProgressCounter.new(Service.count)
+        Service.includes(:backend_api_configs).find_each(batch_size: 100) do |service|
+          progress.call do
+            next if service.backend_api_configs.any?
+
+            service_name = service.name
+            backend_api = service.account.backend_apis.create(
+              system_name: service.system_name,
+              name: "#{service_name} Backend",
+              description: "Backend of #{service_name}",
+              private_endpoint: service.proxy&.[]('api_backend')
+            )
+
+            service.backend_api_configs.create(backend_api: backend_api, path: '')
+          end
+        end
+      end
+    end
+    puts "Finished in #{format('%.1fs', duration.real)}\n\t"
+  end
+
+  desc 'Update metric owners'
+  task update_metric_owners: :environment do
+    puts 'Updating metric owners...'
+    duration = Benchmark.measure do
+      progress = ProgressCounter.new(Metric.count)
+      Metric.find_each do |metric|
+        metric.update_columns(owner_id: metric.service_id, owner_type: 'Service') unless metric.owner_type?
+        progress.call
+      end
+    end
+    puts "Finished in #{format('%.1fs', duration.real)}\n\t"
   end
 end

--- a/test/unit/backend_api_logic/service_extension_test.rb
+++ b/test/unit/backend_api_logic/service_extension_test.rb
@@ -3,55 +3,6 @@
 require 'test_helper'
 
 class ServiceExtensionTest < ActiveSupport::TestCase
-  class WithApiAsProduct < ActiveSupport::TestCase
-
-    def setup
-      Account.any_instance.stubs(:provider_can_use?).returns(false)
-      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false)
-    end
-
-    test 'first_backend_api is nil when the service does not have an account' do
-      service = FactoryBot.build(:simple_service, account: nil)
-      assert_nil service.first_backend_api
-    end
-
-    test 'first_backend_api when the service is not persisted but has an account' do
-      service = FactoryBot.build(:simple_service)
-      assert(backend_api = service.first_backend_api)
-      assert_equal service.account_id, backend_api.account_id
-      refute backend_api.persisted?
-    end
-
-    test 'first_backend_api default values' do
-      service = FactoryBot.build(:simple_service, system_name: nil)
-      assert(backend_api = service.first_backend_api)
-      assert_equal "#{service.name} Backend", backend_api.name
-      assert_equal  "Backend of #{service.name}", backend_api.description
-    end
-
-    test 'first_backend_api when the service its own system_name' do
-      service = FactoryBot.build(:simple_service, system_name: 'example-system-name')
-      assert_equal service.system_name, service.first_backend_api.system_name
-    end
-
-    test 'first_backend_api when the service is persisted' do
-      service = FactoryBot.create(:simple_service)
-      assert(backend_api = service.first_backend_api)
-      assert backend_api.persisted?
-      assert_equal service.account_id, backend_api.account_id
-      assert backend_api.id, service.reload.first_backend_api.id # It finds it bcz it was previously created instead of creating a new one
-      assert_not_nil backend_api.system_name # it is generated although service.system_name is nil
-      assert_equal BackendApi.default_api_backend, backend_api.private_endpoint # because service does not have a proxy so it takes the default api_backend
-    end
-
-    test 'first_backend_api when the service has a proxy with its api_backend' do
-      proxy = FactoryBot.create(:proxy)
-      backend_api = proxy.service.first_backend_api
-      assert_equal proxy.api_backend, backend_api.private_endpoint
-      assert_not_equal BackendApi.default_api_backend, backend_api.private_endpoint
-    end
-  end
-
   test '#all_metrics' do
     service = FactoryBot.create(:simple_service, :with_default_backend_api)
     first_backend_api = service.backend_api

--- a/test/unit/tasks/proxy_test.rb
+++ b/test/unit/tasks/proxy_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Tasks::ProxyTest < ActiveSupport::TestCase
+  test 'update_proxy_rule_owners' do
+    proxy_rules = FactoryBot.create_list(:proxy_rule, 3)
+    ProxyRule.where(id: proxy_rules.map(&:id)).update_all(owner_id: nil, owner_type: nil)
+    FactoryBot.create(:proxy_rule, proxy_id: nil, owner: FactoryBot.create(:backend_api))
+    assert_change of: ->{ ProxyRule.where(owner_type: 'Proxy').count }, by: 3 do
+      execute_rake_task 'proxy.rake', 'proxy:update_proxy_rule_owners'
+    end
+  end
+end

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -8,4 +8,29 @@ class Tasks::ServicesTest < ActiveSupport::TestCase
 
     execute_rake_task 'services.rake', 'services:destroy_marked_as_deleted'
   end
+
+  test 'create_backend_apis' do
+    provider = FactoryBot.create(:simple_provider)
+    services = FactoryBot.create_list(:simple_service, 7, account: provider)
+    services.each { |service| service.proxy.update_column(:api_backend, 'https://api.example.com') }
+
+    # 1st service already has backend api
+    services.first.backend_api_configs.create(backend_api: FactoryBot.create(:backend_api, account: provider))
+
+    # 2nd and 3rd services don't have backend_api but neither their proxy have a private_endpoint
+    services[1..2].each { |service| service.proxy.update_column(:api_backend, nil) }
+
+    assert_change of: ->{ provider.backend_apis.count }, by: 4 do
+      execute_rake_task 'services.rake', 'services:create_backend_apis'
+    end
+  end
+
+  test 'update_metric_owners' do
+    metrics = FactoryBot.create_list(:metric, 3)
+    Metric.where(id: metrics.map(&:id)).update_all(owner_id: nil, owner_type: nil)
+    FactoryBot.create(:metric, service_id: nil, owner: FactoryBot.create(:backend_api))
+    assert_change of: ->{ Metric.where(owner_type: 'Service').count }, by: 3 do
+      execute_rake_task 'services.rake', 'services:update_metric_owners'
+    end
+  end
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Rails migrations should not really contain changing-state DML code (INSERT, UPDATE, DELETE), as they are not sufficiently tested and tend not to follow changes in the code.

**Which issue(s) this PR fixes** 

Closes [THREESCALE-3556](https://issues.jboss.org/browse/THREESCALE-3556)
 
**Verification steps** 

Try upgrade 3scale from 2.6 to a newer version. You should see no migration exceptions.

**Missing**
- [ ] Add tests