### PR TITLE
3265 endpoint objects status

### DIFF
--- a/app/controllers/admin/api/base_controller.rb
+++ b/app/controllers/admin/api/base_controller.rb
@@ -33,6 +33,10 @@ class Admin::Api::BaseController < ApplicationController
 
   rescue_from ::Account::BillingAddress::AddressFormatError, with: :handle_billing_address_error
 
+  def accessible_services
+    (current_user || current_account).accessible_services
+  end
+
   protected
 
   def notification_center
@@ -70,10 +74,6 @@ class Admin::Api::BaseController < ApplicationController
   end
 
   private
-
-  def accessible_services
-    (current_user || current_account).accessible_services
-  end
 
   def accessible_application_plans
     current_account.application_plans.where(issuer: accessible_services)

--- a/app/controllers/admin/api/objects_controller.rb
+++ b/app/controllers/admin/api/objects_controller.rb
@@ -57,7 +57,7 @@ class Admin::Api::ObjectsController < Admin::Api::BaseController
   ##~ op = e.operations.add
   ##~ op.httpMethod = "GET"
   ##~ op.summary = "Object deletion status for objects that are deleted asynchronously"
-  ##~ op.description = "Returns an object status. (200/404). Useful for those objects that deleted asynchronously in order to know if the deletion has been completed(404) or not(200)"
+  ##~ op.description = "Returns an object status (200/404). Useful for those objects that are deleted asynchronously in order to know if the deletion has been completed(404) or not(200)."
   ##~ op.group = "objects"
   #
   ##~ op.parameters.add @parameter_access_token

--- a/app/controllers/admin/api/objects_controller.rb
+++ b/app/controllers/admin/api/objects_controller.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+class Admin::Api::ObjectsController < Admin::Api::BaseController
+
+  class AllowedStatusObject
+    attr_reader :controller, :status_object
+
+    def initialize(controller, status_object)
+      @controller = controller
+      @status_object = status_object
+    end
+
+    def authorize
+      raise NotImplementedError
+    end
+
+    private
+
+    def raise_access_denied
+      raise CanCan::AccessDenied
+    end
+  end
+
+  class BuyerAccountObject < AllowedStatusObject
+    def authorize
+      controller.authorize! :read, status_object
+    end
+  end
+
+  class ServiceObject < AllowedStatusObject
+    def authorize
+      raise_access_denied unless controller.accessible_services.exists?(service_id)
+    end
+
+    def service_id
+      controller.status_object_id
+    end
+  end
+
+  class ProxyObject < ServiceObject
+    delegate :service_id, to: :status_object
+  end
+
+  class BackendApiObject < AllowedStatusObject
+    def authorize
+      controller.provider_can_use!(:api_as_product)
+    end
+  end
+
+  ALLOWED_OBJECTS = %w[service buyer_account proxy backend_api].freeze
+
+  before_action :authorize_status_object_type
+
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/objects/status.json"
+  #
+  ##~ op = e.operations.add
+  ##~ op.httpMethod = "GET"
+  ##~ op.summary = "Object deletion status for objects that are deleted asynchronously"
+  ##~ op.description = "Returns an object status. (200/404). Useful for those objects that deleted asynchronously in order to know if the deletion has been completed(404) or not(200)"
+  ##~ op.group = "objects"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  ##~ op.parameters.add :dataType => "string", :required => true, :paramType => "query", :name => "object_type", :description => "Object type has to be service, buyer_account, proxy or backend_api."
+  ##~ op.parameters.add :dataType => "string", :required => true, :paramType => "query", :name => "object_id", :description => "Object ID."
+  def status
+    status_object = current_account.public_send(association_name).find(status_object_id)
+
+    authorize_status_object(status_object)
+
+    head :ok
+  end
+
+  def status_object_type
+    @status_object_type ||= params.fetch(:object_type).to_s
+  end
+
+  def status_object_id
+    @status_object_id ||= params.fetch(:object_id)
+  end
+
+  private
+
+  def association_name
+    status_object_type.pluralize
+  end
+
+  def authorize_status_object_type
+    raise(CanCan::AccessDenied) if ALLOWED_OBJECTS.exclude?(status_object_type)
+  end
+
+  def authorize_status_object(status_object)
+    "#{self.class}::#{status_object_type.classify}Object".constantize.new(self, status_object).authorize
+  end
+end

--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -360,11 +360,11 @@ module Logic
         klass.helper_method :provider_can_use?
       end
 
-      protected
-
       def provider_can_use!(feature)
         raise ActiveRecord::RecordNotFound unless provider_can_use?(feature)
       end
+
+      protected
 
       def provider_can_use?(fresh_feature)
         return false if Logic::RollingUpdates.skipped?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -487,6 +487,8 @@ without fake Core server your after commit callbacks will crash and you might ge
       # called from heroku deploy hook after heroku proxy deploy script
       post 'heroku-proxy/deployed', to: 'heroku_proxy#deployed', as: :heroku_proxy_deployed
 
+      get 'objects/status' => 'objects#status', as: :objects_status, controller: :objects
+
       namespace :personal, defaults: { format: :json } do
         resources :access_tokens, except: %i[new edit]
       end

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -5645,6 +5645,41 @@
       ]
     },
     {
+      "path": "/admin/api/objects/status.json",
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "summary": "Object deletion status for objects that are deleted asynchronously",
+          "description": "Returns an object status. (200/404). Useful for those objects that deleted asynchronously in order to know if the deletion has been completed(404) or not(200)",
+          "group": "objects",
+          "parameters": [
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            },
+            {
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "name": "object_type",
+              "description": "Object type has to be service, account, proxy or backend_api."
+            },
+            {
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "name": "object_id",
+              "description": "Object ID."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": "/admin/api/personal/access_tokens.json",
       "responseClass": "access_token",
       "operations": [

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -5650,7 +5650,7 @@
         {
           "httpMethod": "GET",
           "summary": "Object deletion status for objects that are deleted asynchronously",
-          "description": "Returns an object status. (200/404). Useful for those objects that deleted asynchronously in order to know if the deletion has been completed(404) or not(200)",
+          "description": "Returns an object status (200/404). Useful for those objects that deleted asynchronously in order to know if the deletion has been completed(404) or not(200)",
           "group": "objects",
           "parameters": [
             {

--- a/test/integration/admin/api/objects_controller_test.rb
+++ b/test/integration/admin/api/objects_controller_test.rb
@@ -1,0 +1,80 @@
+require 'test_helper'
+
+class Admin::Api::ObjectsControllerTest < ActionDispatch::IntegrationTest
+
+  CONTROLLER = Admin::Api::ObjectsController
+
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+
+    host! @provider.admin_domain
+
+    login_provider @provider
+  end
+
+  def test_status_404
+    get admin_api_objects_status_path(object_type: 'service', object_id: 1)
+    assert_response 404
+  end
+
+  def test_status_200
+    service = FactoryBot.create(:service, account: @provider)
+    CONTROLLER::ServiceObject.any_instance.stubs(:authorize).returns(true)
+    get admin_api_objects_status_path(object_type: 'service', object_id: service.id)
+    assert_response 200
+  end
+
+  def test_status_403
+    get admin_api_objects_status_path(object_type: 'code-injection', object_id: 1)
+    assert_response 403
+  end
+
+  def test_status_service
+    service = FactoryBot.create(:service, account: @provider)
+    CONTROLLER.any_instance.expects(:accessible_services).returns(Service.none)
+    get admin_api_objects_status_path(object_type: 'service', object_id: service.id)
+    assert_response 403
+
+    CONTROLLER.any_instance.expects(:accessible_services).returns(Service.all)
+    get admin_api_objects_status_path(object_type: 'service', object_id: service.id)
+    assert_response 200
+
+    service.destroy!
+    get admin_api_objects_status_path(object_type: 'service', object_id: service.id)
+    assert_response 404
+  end
+
+  def test_status_buyer_account
+    account = FactoryBot.create(:simple_buyer, provider_account: @provider)
+    CONTROLLER.any_instance.expects(:authorize!).raises(CanCan::AccessDenied)
+    get admin_api_objects_status_path(object_type: 'buyer_account', object_id: account.id)
+    assert_response 403
+
+    CONTROLLER.any_instance.expects(:authorize!).returns(true)
+    get admin_api_objects_status_path(object_type: 'buyer_account', object_id: account.id)
+    assert_response 200
+  end
+
+  def test_status_proxy
+    service = FactoryBot.create(:service, account: @provider)
+    CONTROLLER.any_instance.expects(:accessible_services).returns(Service.none)
+    get admin_api_objects_status_path(object_type: 'proxy', object_id: service.proxy.id)
+    assert_response 403
+
+    CONTROLLER.any_instance.expects(:accessible_services).returns(Service.all)
+    get admin_api_objects_status_path(object_type: 'proxy', object_id: service.proxy.id)
+    assert_response 200
+  end
+
+  def test_status_backend_api
+    Logic::RollingUpdates.stubs(:enabled?).returns(true)
+    backend_api = FactoryBot.create(:backend_api, account: @provider, name: 'API Backend')
+    @provider.stubs(:provider_can_use?).with(:api_as_product).returns(false)
+    get admin_api_objects_status_path(object_type: 'backend_api', object_id: backend_api.id)
+    assert_response 404
+
+    Logic::RollingUpdates.stubs(:enabled?).returns(false)
+    get admin_api_objects_status_path(object_type: 'backend_api', object_id: backend_api.id)
+    assert_response 200
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

API endpoint: object deletion status for objects that are deleted asynchronously

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3265
