### PR TITLE
Cannot destroy a BackendApi used by Services

### DIFF
--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -37,7 +37,7 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   end
 
   def destroy
-    if @backend_api.services.empty? && @backend_api.mark_as_deleted
+    if @backend_api.mark_as_deleted
       redirect_to provider_admin_dashboard_path, notice: 'Backend will be deleted shortly.'
     else
       flash[:error] = 'Backend could not be deleted'

--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -40,7 +40,7 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
     if @backend_api.mark_as_deleted
       redirect_to provider_admin_dashboard_path, notice: 'Backend will be deleted shortly.'
     else
-      flash[:error] = 'Backend could not be deleted'
+      flash[:error] = @backend_api.errors.full_messages.to_sentence
       render :edit
     end
   end

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -31,9 +31,7 @@ class BackendApiConfig < ApplicationRecord
   end
 
   scope :accessible, -> do
-    joining { [service, backend_api] }.where.has do
-      (service.state != ::Service::DELETE_STATE) & (backend_api.state != ::BackendApi::DELETED_STATE)
-    end
+    joining { service }.where.has { (service.state != ::Service::DELETE_STATE) }
   end
 
   delegate :private_endpoint, to: :backend_api

--- a/app/representers/backend_api_representer.rb
+++ b/app/representers/backend_api_representer.rb
@@ -13,6 +13,7 @@ module BackendApiRepresenter
   property :account_id
   property :created_at
   property :updated_at
+  property :usage, decorator: BackendApiConfigsRepresenter
 
   link :metrics do
     admin_api_backend_api_metrics_path(backend_api_id: id)
@@ -20,5 +21,9 @@ module BackendApiRepresenter
 
   link :mapping_rules do
     admin_api_backend_api_mapping_rules_path(backend_api_id: id)
+  end
+
+  def usage
+    backend_api_configs.accessible.order(:id)
   end
 end

--- a/app/views/provider/admin/backend_apis/forms/_delete.html.slim
+++ b/app/views/provider/admin/backend_apis/forms/_delete.html.slim
@@ -28,4 +28,3 @@
       - msg = t('api.backend_apis.edit.delete_confirmation', name: h(backend_api.name))
       - delete_options = { data: { confirm: msg }, method: :delete, label: "I understand the consequences, proceed to delete '#{h(backend_api.name)}' backend" }
       = delete_link_for(provider_admin_backend_api_path(backend_api), delete_options)
-

--- a/app/workers/delete_service_hierarchy_worker.rb
+++ b/app/workers/delete_service_hierarchy_worker.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 class DeleteServiceHierarchyWorker < DeleteObjectHierarchyWorker
-  def perform(*)
-    # TODO: when we remove the Rolling Update, we must remove this whole line and not only the conditional
-    purge_backend_apis unless service.account.provider_can_use?(:api_as_product)
-    super
-  end
-
   private
 
   alias service object
 
-  def purge_backend_apis
-    service.backend_apis.accessible.find_each(&:mark_as_deleted!)
+  # TODO: when we remove the Rolling Update, we must remove this whole method and not only the conditional
+  def destroyable_associations
+    return super if service.account.provider_can_use?(:api_as_product)
+
+    object.class.reflect_on_all_associations.select do |reflection|
+      reflection.options[:dependent] == :destroy || reflection.name == :backend_apis
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -857,6 +857,8 @@ en:
                 'wildcards' - words inside curly brackets ('{}')
         backend_api:
           attributes:
+            base:
+              cannot_be_destroyed_with_products: cannot be deleted because it is used by at least one Product
             private_endpoint:
               invalid: "the accepted format is 'http(s)://address(:port)(/path)'"
         proxy:
@@ -1247,7 +1249,7 @@ en:
           Enables you to block any direct developer requests to your API backend; each 3scale API gateway call to your API backend contains a request header called <code>X-3scale-proxy-secret-token</code>.
           The value of this header can be set by you here. It's up to you ensure your backend only allows calls with this secret header.
         jwt_claim_with_client_id_type: |
-          Process the ClientID Token Claim value as a string or as a liquid template. When set to 'Liquid' you can define more complex rules. e.g. If 'some_claim' is an array you can select the first value this like {{ some_claim | first }}. 
+          Process the ClientID Token Claim value as a string or as a liquid template. When set to 'Liquid' you can define more complex rules. e.g. If 'some_claim' is an array you can select the first value this like {{ some_claim | first }}.
         jwt_claim_with_client_id: |
           The Token Claim that contains the clientID. Defaults to 'azp'.
 

--- a/spec/acceptance/api/backend_api_spec.rb
+++ b/spec/acceptance/api/backend_api_spec.rb
@@ -9,8 +9,9 @@ resource 'BackendApi' do
   json(:resource) do
     let(:root) { 'backend_api' }
 
-    it { subject.should have_properties(expected_properties).from(resource) }
+    it { should have_properties(expected_properties).from(resource) }
     it { should have_links('metrics', 'mapping_rules') }
+    it { should have_properties('usage') }
   end
 
   json(:collection) do

--- a/test/integration/admin/api/backend_apis_controller_test.rb
+++ b/test/integration/admin/api/backend_apis_controller_test.rb
@@ -38,6 +38,14 @@ class Admin::API::BackendApisControllerTest < ActionDispatch::IntegrationTest
     assert backend_api.reload.deleted?
   end
 
+  test 'destroy with errors' do
+    BackendApiConfig.create!(service: provider.default_service, backend_api: backend_api)
+
+    delete admin_api_backend_api_path(backend_api, access_token: access_token_value)
+    refute backend_api.reload.deleted?
+    assert_contains JSON.parse(response.body).dig('errors', 'base'), 'cannot be deleted because it is used by at least one Product'
+  end
+
   test 'update' do
     put admin_api_backend_api_path(backend_api, access_token: access_token_value), permitted_params.merge(forbidden_params)
     assert_response :success

--- a/test/integration/admin/api/backend_apis_controller_test.rb
+++ b/test/integration/admin/api/backend_apis_controller_test.rb
@@ -11,9 +11,25 @@ class Admin::API::BackendApisControllerTest < ActionDispatch::IntegrationTest
   attr_reader :provider
 
   test 'show' do
+    backend_api_configs = FactoryBot.create_list(:backend_api_config, 2, backend_api: backend_api)
+
     get admin_api_backend_api_path(backend_api, access_token: access_token_value)
+
     assert_response :success
-    assert_equal backend_api.id, JSON.parse(response.body).dig('backend_api', 'id')
+    backend_api_response = JSON.parse(response.body)
+    assert_equal backend_api.id, backend_api_response.dig('backend_api', 'id')
+
+    usage_response = backend_api_response.dig('backend_api', 'usage') || []
+    assert_equal backend_api_configs.size, usage_response.length
+    backend_api_configs.each_with_index do |backend_api_config, index|
+      response_item = usage_response[index]
+      assert_equal backend_api_config.path, response_item['path']
+      links = response_item.fetch('links', {})
+      assert_equal 'service', links[0]['rel']
+      assert_equal admin_api_service_url(backend_api_config.service), links[0]['href']
+      assert_equal 'backend_api', links[1]['rel']
+      assert_equal admin_api_backend_api_url(backend_api), links[1]['href']
+    end
   end
 
   test 'destroy' do

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -81,4 +81,15 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
       assert_equal 'Backend will be deleted shortly.', flash[:notice]
     end
   end
+
+  test 'delete a backend api with products shows the correct error message' do
+    backend_api = @provider.backend_apis.order(:id).first!
+    assert backend_api.backend_api_configs.any?
+
+    perform_enqueued_jobs do
+      delete provider_admin_backend_api_path(backend_api)
+      assert backend_api.reload.published?
+      assert_equal 'cannot be deleted because it is used by at least one Product', flash[:error]
+    end
+  end
 end

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -70,16 +70,6 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
     assert_equal 'first-system-name', backend_api.reload.system_name
   end
 
-  test 'delete a backend api with products' do
-    backend_api = @provider.backend_apis.order(:id).first
-    FactoryBot.create(:backend_api_config, backend_api: backend_api)
-    assert backend_api.backend_api_configs.any?
-
-    delete provider_admin_backend_api_path(backend_api)
-    assert BackendApi.exists? backend_api.id
-    assert_equal 'Backend could not be deleted', flash[:error]
-  end
-
   test 'delete a backend api without any products will schedule to delete in background' do
     backend_api = @provider.backend_apis.order(:id).second
     assert_not backend_api.backend_api_configs.any?

--- a/test/models/backend_api_config_test.rb
+++ b/test/models/backend_api_config_test.rb
@@ -119,4 +119,14 @@ class BackendApiConfigTest < ActiveSupport::TestCase
     assert_equal [configs[1].id], BackendApiConfig.by_backend_api(backend_apis[1]).pluck(:id)
     assert_empty BackendApiConfig.by_backend_api(backend_apis[2]).pluck(:id)
   end
+
+  test 'accessible' do
+    backend_api_configs = FactoryBot.create_list(:backend_api_config, 2)
+    services = backend_api_configs.map(&:service)
+    services[0].mark_as_deleted!
+
+    accessible_backend_api_config_ids = BackendApiConfig.accessible.pluck(:id)
+    assert_includes     accessible_backend_api_config_ids, backend_api_configs[1].id
+    assert_not_includes accessible_backend_api_config_ids, backend_api_configs[0].id
+  end
 end

--- a/test/models/backend_api_test.rb
+++ b/test/models/backend_api_test.rb
@@ -77,4 +77,19 @@ class BackendApiTest < ActiveSupport::TestCase
     assert_includes accessible_backend_apis, backend_api_published.id
     assert_not_includes accessible_backend_apis, backend_api_deleted.id
   end
+
+  test 'can be destroyed or marked as deleted only if it is destroyed by association or does not have backend api configs' do
+    backend_api = FactoryBot.create(:backend_api)
+    assert backend_api.mark_as_deleted
+    backend_api.destroy
+    refute BackendApi.exists? backend_api.id
+
+    backend_api = FactoryBot.create(:backend_api_config).backend_api
+    refute backend_api.mark_as_deleted
+    backend_api.destroy
+    assert BackendApi.exists? backend_api.id
+
+    assert backend_api.account.destroy
+    refute BackendApi.exists? backend_api.id
+  end
 end


### PR DESCRIPTION
Closes [THREESCALE-3571](https://issues.jboss.org/browse/THREESCALE-3571)

- [X] Cannot destroy a BackendApi with BackendApiConfigs (except for destroy by association) is validated from the model and automatically applied to all our controllers and deletion workers. This includes the same condition for changing the state to 'deleted' and to destroy for real.
- [X] BackendApiConfig.accessible does not have to check anymore the state of its backend apis because all of its backend apis will be accessible now.
- [X] BackendApiRepresenter returns its usage.

![image](https://user-images.githubusercontent.com/11318903/65779864-d9d4af00-e148-11e9-9fa3-31503373747b.png)

![image](https://user-images.githubusercontent.com/11318903/65779904-ed801580-e148-11e9-869b-630b0471515b.png)

- [X] When tries to destroy via the controller of the UI (skipping the UI itself), it shows an accurate and understandable error message.
![image](https://user-images.githubusercontent.com/11318903/65877600-5d321280-e38c-11e9-8d29-3dff18280416.png)