### PR TITLE
Promote to Staging button

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -34,6 +34,8 @@ class Api::IntegrationsController < Api::BaseController
       update_onboarding_mapping_bubble
       update_mapping_rules_position
 
+      return redirect_to admin_service_integration_path(@service) if apiap?
+
       if @proxy.send_api_test_request!
         api_backend = @proxy.api_backend
         onboarding.bubble_update('api')
@@ -41,7 +43,6 @@ class Api::IntegrationsController < Api::BaseController
         return redirect_to edit_path
       end
       render :edit
-
     else
       attrs = proxy_rules_attributes
       splitted = attrs.keys.group_by { |key| attrs[key]['_destroy'] == '1' }

--- a/app/presenters/api/integrations_show_presenter.rb
+++ b/app/presenters/api/integrations_show_presenter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Api::IntegrationsShowPresenter
 
   def initialize(proxy)
@@ -41,13 +43,15 @@ class Api::IntegrationsShowPresenter
   end
 
   def test_state_modifier
+    return 'is-untested' if @proxy.account.provider_can_use?(:api_as_product)
+
     case @proxy.api_test_success
     when true
-      'is-successful'.freeze
+      'is-successful'
     when false
-      'is-erroneous'.freeze
+      'is-erroneous'
     else
-      'is-untested'.freeze
+      'is-untested'
     end
   end
 

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -34,6 +34,13 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
         dt.u-dl-term Secret Token
         dd.u-dl-definition = @proxy.secret_token
 
+    div
+      = semantic_form_for @proxy, url: admin_service_integration_path(@service) do |f|
+        = f.buttons class: "buttons buttons-inline" do
+          = f.hidden_field :lock_version
+          = f.button "Promote v. #{@show_presenter.last_sandbox_config.version+1} to Staging",
+            button_html: {class: 'important-button PromoteButton', data: { disable_with: 'promoting…' }}
+
 - unless deployment_option_is_service_mesh?(@service)
   section style="margin-top: 48px;"
     h2 Environments

--- a/test/unit/presenters/api/integrations_show_presenter_test.rb
+++ b/test/unit/presenters/api/integrations_show_presenter_test.rb
@@ -50,6 +50,8 @@ class Api::IntegrationsShowPresenterTest < ActiveSupport::TestCase
   end
 
   def test_state_modifier
+    @proxy.account.stubs(:provider_can_use?).with(:api_as_product).returns(false)
+
     assert_equal 'is-untested', Presenter.new(@proxy).test_state_modifier
 
     @proxy.api_test_success = true
@@ -57,6 +59,18 @@ class Api::IntegrationsShowPresenterTest < ActiveSupport::TestCase
 
     @proxy.api_test_success = false
     assert_equal 'is-erroneous', Presenter.new(@proxy).test_state_modifier
+  end
+
+  test 'state_modifier for apiap' do
+    @proxy.account.stubs(:provider_can_use?).with(:api_as_product).returns(true)
+
+    assert_equal 'is-untested', Presenter.new(@proxy).test_state_modifier
+
+    @proxy.api_test_success = true
+    assert_equal 'is-untested', Presenter.new(@proxy).test_state_modifier
+
+    @proxy.api_test_success = false
+    assert_equal 'is-untested', Presenter.new(@proxy).test_state_modifier
   end
 
   def test_production_proxy_endpoint


### PR DESCRIPTION
![2019-09-27 17 56 37](https://user-images.githubusercontent.com/1842261/65783551-5323d000-e150-11e9-89f8-726dcc6d4087.gif)

**Special notes for your reviewer**
1. We will be able to hide the button once https://github.com/3scale/porta/pull/1244 gets merged. (Ideally also https://github.com/3scale/porta/pull/1235.)
2. We also need to solve a previous step when it's the first staging config to be generated. Right now we are pointing the user to the integration edit page where the "Save & test" is broken, apart from other fields that should not appear for APIAP-accounts.
3. We can easily improve the flash message shown after the config is promoted in https://github.com/3scale/porta/blob/95cf0c394bb8ee73131184080361e2be03d8f8a3/app/controllers/api/integrations_controller.rb#L33