### PR TITLE
MetricsController in API must behave the same way for BackendApi as for Service

### DIFF
--- a/app/controllers/admin/api/backend_apis/metrics_controller.rb
+++ b/app/controllers/admin/api/backend_apis/metrics_controller.rb
@@ -118,10 +118,10 @@ class Admin::Api::BackendApis::MetricsController < Admin::Api::BackendApis::Base
   end
 
   def create_params
-    params.require(:metric).permit(DEFAULT_PARAMS | %i[system_name])
+    params.fetch(:metric).permit(DEFAULT_PARAMS | %i[system_name])
   end
 
   def update_params
-    params.require(:metric).permit(DEFAULT_PARAMS)
+    params.fetch(:metric).permit(DEFAULT_PARAMS)
   end
 end

--- a/test/integration/admin/api/backend_apis/metric_methods_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metric_methods_controller_test.rb
@@ -136,6 +136,15 @@ class Admin::API::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
     assert_response :not_found
   end
 
+  test 'when no params are sent, the error message is the same as in the other metrics endpoint' do
+    post admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value), {}
+    assert_response :unprocessable_entity
+    assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
+
+    put admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id), {}
+    assert_response :success
+  end
+
   private
 
   def metric_method

--- a/test/integration/admin/api/backend_apis/metrics_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metrics_controller_test.rb
@@ -135,6 +135,16 @@ class Admin::API::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
     assert_response :not_found
   end
 
+  test 'when no params are sent, the error message is the same as in the other metrics endpoint' do
+    post admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value), {}
+    assert_response :unprocessable_entity
+    assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
+    assert_contains JSON.parse(response.body).dig('errors', 'unit'), 'can\'t be blank'
+
+    put admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id), {}
+    assert_response :success
+  end
+
   private
 
   def metric


### PR DESCRIPTION
Fixes [this inconsistency reported by QE](https://issues.jboss.org/browse/THREESCALE-3209?focusedCommentId=13790191&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13790191).