### PR TITLE
Fixes proxy rule positioning by changing scope to "owner"

### DIFF
--- a/app/models/proxy_rule.rb
+++ b/app/models/proxy_rule.rb
@@ -3,7 +3,7 @@
 require 'addressable/template'
 
 class ProxyRule < ApplicationRecord
-  acts_as_list scope: :proxy, add_new_at: :bottom
+  acts_as_list scope: :owner, add_new_at: :bottom
   scope :ordered, -> { order(position: :asc) }
 
   belongs_to :proxy, touch: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes list scope from `:proxy` to `:owner` in order to fix mapping rules positioning among backend apis.

**Which issue(s) this PR fixes** 

[THREESCALE-3569: Position of backend API mapping rules leak to other backends](https://issues.jboss.org/browse/THREESCALE-3569)

**Verification steps** 

1. Go to Backend API "A" > mapping rules > add new mapping rule with position 1
2. Go to Backend API "B" > mapping rules > add new mapping rule with position 1
3. Go back to Backend API "A" > mapping rules > position should still be 1, not 2
