### PR TITLE
BackendApiConfig as an affecting object of Proxy config

### DIFF
--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -2,6 +2,7 @@
 
 class BackendApiConfig < ApplicationRecord
   include Backend::ModelExtensions::BackendApiConfig
+  include ProxyConfigAffectingChanges::BackendApiConfigExtension
 
   default_scope -> { order(id: :asc) }
   belongs_to :service, inverse_of: :backend_api_configs

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -21,9 +21,6 @@ class Proxy < ApplicationRecord
 
   validates :error_status_no_match, :error_status_auth_missing, :error_status_auth_failed, :error_status_limits_exceeded, presence: true
 
-  has_one :proxy_config_affecting_change, dependent: :delete
-  private :proxy_config_affecting_change
-
   uri_pattern = URI::DEFAULT_PARSER.pattern
 
   URI_OPTIONAL_PORT = /\Ahttps?:\/\/[a-zA-Z0-9._-]*(:\d+)?\Z/
@@ -517,19 +514,6 @@ class Proxy < ApplicationRecord
 
   def service_mesh_integration?
     Service::DeploymentOption.service_mesh.include?(deployment_option)
-  end
-
-  def find_or_create_proxy_config_affecting_change
-    proxy_config_affecting_change || create_proxy_config_affecting_change
-  end
-  alias affecting_change_history find_or_create_proxy_config_affecting_change
-  private :find_or_create_proxy_config_affecting_change
-
-  def pending_affecting_changes?
-    return unless apicast_configuration_driven?
-    config = proxy_configs.sandbox.newest_first.first
-    return false unless config
-    config.created_at < affecting_change_history.updated_at
   end
 
   protected

--- a/test/models/backend_api_config_test.rb
+++ b/test/models/backend_api_config_test.rb
@@ -129,4 +129,20 @@ class BackendApiConfigTest < ActiveSupport::TestCase
     assert_includes     accessible_backend_api_config_ids, backend_api_configs[1].id
     assert_not_includes accessible_backend_api_config_ids, backend_api_configs[0].id
   end
+
+  class ProxyConfigAffectingChangesTest < ActiveSupport::TestCase
+    disable_transactional_fixtures!
+
+    test 'proxy config affecting changes' do
+      backend_api = FactoryBot.create(:backend_api)
+      product = FactoryBot.create(:simple_service, account: backend_api.account)
+      backend_api_config = product.backend_api_configs.build(backend_api: backend_api)
+
+      ProxyConfigs::AffectingObjectChangedEvent.expects(:create_and_publish!).with(product.proxy, backend_api_config).times(3)
+
+      backend_api_config.save!
+      backend_api_config.update_attributes(path: '/a-path')
+      backend_api_config.destroy!
+    end
+  end
 end

--- a/test/unit/proxy_rule_test.rb
+++ b/test/unit/proxy_rule_test.rb
@@ -160,22 +160,28 @@ class ProxyRuleTest < ActiveSupport::TestCase
   class ProxyConfigAffectingChangesTest < ActiveSupport::TestCase
     disable_transactional_fixtures!
 
-    test 'proxy config affecting changes of object owner by proxy' do
+    test 'proxy config affecting changes of object owned by proxy' do
       proxy = FactoryBot.create(:proxy)
-      proxy_rule = FactoryBot.build(:proxy_rule, owner: proxy)
-      ProxyConfigs::AffectingObjectChangedEvent.expects(:create_and_publish!).with(proxy, proxy_rule).twice
+      proxy_rule = FactoryBot.build(:proxy_rule, owner: proxy, pattern: '/some-pattern')
+
+      ProxyConfigs::AffectingObjectChangedEvent.expects(:create_and_publish!).with(proxy, proxy_rule).times(3)
+
       proxy_rule.save!
       proxy_rule.update_attributes(pattern: '/new-pattern')
+      proxy_rule.destroy!
     end
 
-    test 'proxy config affecting changes of object owner by backend_api' do
+    test 'proxy config affecting changes of object owned by backend_api' do
       backend_api = FactoryBot.create(:backend_api)
       products = FactoryBot.create_list(:simple_service, 2)
-      proxy_rule = FactoryBot.build(:proxy_rule, owner: backend_api)
+      proxy_rule = FactoryBot.build(:proxy_rule, owner: backend_api, pattern: '/some-pattern')
       products.each { |product| product.backend_api_configs.create(backend_api: backend_api) }
-      products.each { |product| ProxyConfigs::AffectingObjectChangedEvent.expects(:create_and_publish!).with(product.proxy, proxy_rule).twice }
+
+      products.each { |product| ProxyConfigs::AffectingObjectChangedEvent.expects(:create_and_publish!).with(product.proxy, proxy_rule).times(3) }
+
       proxy_rule.save!
       proxy_rule.update_attributes(pattern: '/new-pattern')
+      proxy_rule.destroy!
     end
   end
 end


### PR DESCRIPTION
Currently `BackendApiConfig` object are not signalling a proxy config affecting change. They should. So we show the exclamation mark to the user whenever a backend is added to a product, edited ot removed.