### PR TITLE
[LOW PRIORITY][Fix] Escaped HTML entities in edit API page

### DIFF
--- a/app/helpers/api/services_helper.rb
+++ b/app/helpers/api/services_helper.rb
@@ -46,7 +46,7 @@ module Api::ServicesHelper
   end
 
   def delete_service_link(service, options = {})
-    msg = t('api.services.forms.definition_settings.delete_confirmation', name: h(service.name))
+    msg = t('api.services.forms.definition_settings.delete_confirmation', name: j(service.name))
     delete_link_for(admin_service_path(service), {data: { confirm: msg }, method: :delete}.merge(options) )
   end
 

--- a/app/helpers/cinstances_helper.rb
+++ b/app/helpers/cinstances_helper.rb
@@ -53,7 +53,7 @@ Are you sure?}
   end
 
   def delete_application_link(application)
-    msg = t('api.applications.edit.delete_confirmation', name: h(application.name))
+    msg = t('api.applications.edit.delete_confirmation', name: j(application.name))
     delete_link_for(admin_buyers_application_path(application), confirm: msg, title: 'Delete Application')
   end
 end

--- a/app/views/api/services/_delete.html.slim
+++ b/app/views/api/services/_delete.html.slim
@@ -9,4 +9,4 @@
     ' all applications, application plans, metrics, pricing rules, features, service plans and subscriptions of this service. Therefore all authorization and reporting calls for this service will no longer be valid.
 
   p
-    = delete_service_link(service, label: "I understand the consequences, proceed to delete '#{h(service.name)}' service")
+    = delete_service_link(service, label: "I understand the consequences, proceed to delete '#{j(service.name)}' service")

--- a/app/views/provider/admin/backend_apis/forms/_delete.html.slim
+++ b/app/views/provider/admin/backend_apis/forms/_delete.html.slim
@@ -25,6 +25,6 @@
 
   - else
     p
-      - msg = t('api.backend_apis.edit.delete_confirmation', name: h(backend_api.name))
-      - delete_options = { data: { confirm: msg }, method: :delete, label: "I understand the consequences, proceed to delete '#{h(backend_api.name)}' backend" }
+      - msg = t('api.backend_apis.edit.delete_confirmation', name: j(backend_api.name))
+      - delete_options = { data: { confirm: msg }, method: :delete, label: "I understand the consequences, proceed to delete '#{j(backend_api.name)}' backend" }
       = delete_link_for(provider_admin_backend_api_path(backend_api), delete_options)


### PR DESCRIPTION
Closes [THREESCALE-2547](https://issues.jboss.org/browse/THREESCALE-2547)

![image](https://user-images.githubusercontent.com/11318903/65910581-4a8afe00-e3cb-11e9-8fc5-fdb052ccfb42.png)

Not sure if it is a good idea but I am escaping JSON instead of HTML to obtain this. For this:
https://github.com/rails/rails/blob/a273da7619ac6a2b2f98532a5610238c68ad219b/activesupport/lib/active_support/core_ext/string/output_safety.rb#L10-L11
