### PR TITLE
always show apicast config for apiap

### DIFF
--- a/app/views/api/integrations/show.html.slim
+++ b/app/views/api/integrations/show.html.slim
@@ -6,14 +6,17 @@
   = render 'api/integrations/apicast/shared/deployment_options'
 
   .integration data-state="open"
-    - case @service.deployment_option
-    - when /^plugin_/
-      = render 'api/integrations/plugin/plugin'
-    - when /^service_mesh/
+    - if @apiap
       = render 'api/integrations/apicast/configuration_driven/apicast'
     - else
-      - if @show_presenter.any_sandbox_configs?
+      - case @service.deployment_option
+      - when /^plugin_/
+        = render 'api/integrations/plugin/plugin'
+      - when /^service_mesh/
         = render 'api/integrations/apicast/configuration_driven/apicast'
       - else
-        ' To get started with this service on APIcast,
-        = link_to "add the base URL of your API and save the configuration.", edit_admin_service_integration_path(@service), class: "important-button"
+        - if @show_presenter.any_sandbox_configs?
+          = render 'api/integrations/apicast/configuration_driven/apicast'
+        - else
+          ' To get started with this service on APIcast,
+          = link_to "add the base URL of your API and save the configuration.", edit_admin_service_integration_path(@service), class: "important-button"


### PR DESCRIPTION
Closes [THREESCALE-3575](https://issues.jboss.org/browse/THREESCALE-3575)

People on APIAP should always get the same config show  page.

This will lead to issues with people currently using plugins. To be continued. Hoping the tests will fail. 