### PR TITLE
Fixes update buttons in new Policies page

### DIFF
--- a/app/javascript/src/Policies/components/PoliciesWidget.jsx
+++ b/app/javascript/src/Policies/components/PoliciesWidget.jsx
@@ -53,7 +53,7 @@ const PolicyList = ({ registry, chain, originalChain, policyConfig, ui, boundAct
     closePolicyRegistry: boundActionCreators.closePolicyRegistry
   }
 
-  const buttonsFieldset = document.querySelector('fieldset.buttons')
+  const buttonsFieldset = document.querySelector('[id^="edit_proxy_"] > fieldset.buttons')
   if (buttonsFieldset) {
     // classList.toggle second argument is not supported in IE11
     if (ui.chain) {
@@ -64,7 +64,7 @@ const PolicyList = ({ registry, chain, originalChain, policyConfig, ui, boundAct
   }
 
   // HACK: enable the submit button after any change is made
-  const submitButton = document.querySelector('input#policies-button-sav')
+  const submitButton = document.querySelector('#policies-button-sav')
   if (submitButton) {
     // classList.toggle second argument is not supported in IE11
     if (isPolicyChainChanged(chain, originalChain)) {

--- a/app/views/api/policies/edit.html.slim
+++ b/app/views/api/policies/edit.html.slim
@@ -2,5 +2,6 @@
 
 = semantic_form_for @proxy, url: admin_service_policies_path(@service) do |f|
   = render '/api/integrations/apicast/shared/policies', f: f
-  = f.button t('formtastic.actions.policies.update'), button_html: {class: 'important-button update', name: 'update', value: '1',
-    id: 'policies-button-sav', title: 'Update Policies'} 
+  = f.buttons do
+    = f.button t('formtastic.actions.policies.update'), button_html: {class: 'important-button update', name: 'update', value: '1',
+      id: 'policies-button-sav', title: 'Update Policies'} 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes broken logic regarding update buttons in Policies:
* Move button into a fieldset
* Changes query from `input#id` to simply the id.

**Verification steps** 

![update](https://user-images.githubusercontent.com/11672286/65944337-c324a580-e431-11e9-8456-329ac0c3766b.gif)

