### PR TITLE
[APIAP] Update Proxy public/staging urls from Integration -> Settings

### DIFF
--- a/app/lib/api_integration/settings_result.rb
+++ b/app/lib/api_integration/settings_result.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ApiIntegration::SettingsResult
+  extend ActiveModel::Naming
+  extend ActiveModel::Translation
+  class ServiceMismatchError < ActiveRecord::ActiveRecordError; end
+
+  def initialize(service:, proxy:)
+    raise ServiceMismatchError unless proxy.service == service
+    @service = service
+    @proxy = proxy
+  end
+
+  attr_reader :service, :proxy
+
+  def valid?
+    # It's done this way to get all the errors even if it is already known that is invalid
+    [service.valid?, proxy.valid?].all?
+  end
+
+  def update!(service_attributes: {}, proxy_attributes: {})
+    ActiveRecord::Base.transaction do
+      service.update!(service_attributes)
+      proxy.update!(proxy_attributes) unless service.deployment_option == 'hosted'
+    end
+    true
+  end
+
+  def update(service_attributes: {}, proxy_attributes: {})
+    update!(service_attributes: service_attributes, proxy_attributes: proxy_attributes)
+    # Done this way so it does the rollback
+  rescue ActiveRecord::RecordInvalid
+    false
+  end
+
+  def errors
+    errors = ActiveModel::Errors.new(self)
+    proxy.errors.full_messages.each    { |proxy_error|   errors.add(:proxy, proxy_error)     }
+    service.errors.full_messages.each  { |service_error| errors.add(:service, service_error) }
+    errors
+  end
+
+  private
+
+  # ActiveModel::Errors needs this method to read the errors correctly
+  def read_attribute_for_validation(attr)
+    public_send(attr)
+  end
+end

--- a/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
+++ b/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
@@ -1,0 +1,14 @@
+= f.inputs "API gateway" do
+  = f.input :sandbox_endpoint, label: "Staging Public Base URL",
+            input_html: { data: { default: (proxy.default_staging_endpoint unless proxy.self_managed?) },
+                          readonly: !apicast_custom_urls?,
+                          placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
+            hint: apicast_endpoint_input_hint(service, environment: 'staging')
+
+  = help_bubble( 'proxy_endpoint_bubble', t('api.integrations.proxy.proxy_endpoint_help_html'))
+  = f.input :endpoint, label: "Production Public Base URL",
+            input_html: { data: { default: (proxy.default_production_endpoint unless proxy.self_managed?) },
+                          readonly: !apicast_custom_urls?,
+                          placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
+            hint: apicast_endpoint_input_hint(service, environment: 'production')
+  = help_bubble( 'proxy_endpoint_bubble', t('api.integrations.proxy.proxy_endpoint_help_html'))

--- a/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
+++ b/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
@@ -1,4 +1,5 @@
-= f.inputs "API gateway" do
+- is_service_mesh = proxy.service_mesh_integration?
+= f.inputs "API gateway", class: "apicast-only-settings #{'hidden' if is_service_mesh}", disabled: is_service_mesh do
   = f.input :sandbox_endpoint, label: "Staging Public Base URL",
             input_html: { data: { default: (proxy.default_staging_endpoint unless proxy.self_managed?) },
                           readonly: !apicast_custom_urls?,

--- a/app/views/api/services/forms/_integration_settings_apiap.html.slim
+++ b/app/views/api/services/forms/_integration_settings_apiap.html.slim
@@ -1,10 +1,9 @@
 = javascript_pack_tag 'settings'
 
+- @service.deployment_option ||= 'hosted'
+
 #settings
   = form.inputs 'Deployment', id: 'integration-wrapper' do
-
-    - if @service.deployment_option == nil
-      - @service.deployment_option = 'hosted'
 
     = form.input :deployment_option,
             as: :radio,
@@ -25,3 +24,4 @@
 
     = form.semantic_fields_for :proxy do |f|
       = render 'api/services/forms/authentication_settings', f: f, oauth_hint: 'apicast_oauth'
+      = render 'api/integrations/apicast/shared/proxy_endpoints', f: f, service: @service, proxy: @service.proxy

--- a/test/functional/api/services_controller_test.rb
+++ b/test/functional/api/services_controller_test.rb
@@ -116,6 +116,6 @@ class Api::ServicesControllerTest < ActionController::TestCase
 
     put :update, id: @service.id, service: { name: 'Supetramp' }
 
-    assert_response 200
+    assert_response 302
   end
 end

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -30,10 +30,12 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'update the settings' do
+      service.update!(deployment_option: 'self_managed')
       put admin_service_path(service), update_params
       assert_equal 'Service information updated.', flash[:notice]
 
       update_service_params = update_params[:service]
+      update_proxy_params = update_service_params.delete(:proxy_attributes)
       expected_notification_settings = update_service_params[:notification_settings].transform_values { |notifications| notifications.map(&:to_i) }
       expected_buyer_plan_change_permission = update_service_params[:buyer_plan_change_permission]
       expected_signup_and_use = update_service_params
@@ -45,6 +47,11 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_equal expected_notification_settings, service.notification_settings
       assert_equal expected_buyer_plan_change_permission, service.buyer_plan_change_permission
       expected_signup_and_use.each { |attr_name, attr_value| assert_equal attr_value, service.public_send(attr_name) }
+
+      proxy = service.proxy
+      update_proxy_params.each do |field_name, expected_value|
+        assert_equal expected_value, proxy.public_send(field_name)
+      end
     end
 
     # This test can be removed once used deprecated attributes have been removed from the schema
@@ -80,6 +87,10 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
             email_provider: ['', '50', '100', '150'],
             web_buyer: ['', '50', '100', '150'],
             email_buyer: ['', '50', '100', '300']
+          },
+          proxy_attributes: {
+            endpoint: 'http://api.example.com:8080',
+            sandbox_endpoint: 'http://api.staging.example.com:8080'
           }
         }
       }

--- a/test/unit/lib/api_integration/settings_result_test.rb
+++ b/test/unit/lib/api_integration/settings_result_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApiIntegration::SettingsResultTest < ActiveSupport::TestCase
+  test 'raises ServiceMismatchError in initialize when then parameter service is different than the proxy service' do
+    assert_raise ApiIntegration::SettingsResult::ServiceMismatchError do
+      ApiIntegration::SettingsResult.new(proxy: proxy, service: FactoryBot.create(:simple_service))
+    end
+  end
+
+  test '#valid? returns true if both are valid' do
+    assert service.valid?
+    assert proxy.valid?
+    assert settings_result.valid?
+  end
+
+  test '#valid? returns false if the service is invalid' do
+    service.name = ''
+    refute service.valid?
+    refute settings_result.valid?
+  end
+
+  test '#valid? returns false if the proxy is invalid' do
+    proxy.error_status_no_match = ''
+    refute proxy.valid?
+    refute settings_result.valid?
+  end
+
+  test '#update! updates both when they are valid' do
+    assert settings_result.update!(attributes)
+    service_attributes.each { |field_name, value| assert_equal value, service.public_send(field_name) }
+    proxy_attributes.each   { |field_name, value| assert_equal value, proxy.public_send(field_name)   }
+  end
+
+  test '#update! raises ActiveRecord::RecordInvalid and does not save any change when the proxy attributes are invalid' do
+    old_service_attributes = service.attributes.slice(service_attributes.keys)
+    old_proxy_attributes   = proxy.attributes.slice(proxy_attributes.keys)
+
+    proxy_attributes[:error_headers_auth_failed] = ''
+    assert_raises(ActiveRecord::RecordInvalid) { settings_result.update!(attributes) }
+    old_service_attributes.each { |field_name, value| assert_equal value, service.public_send(field_name) }
+    old_proxy_attributes.each   { |field_name, value| assert_equal value, proxy.public_send(field_name)   }
+  end
+
+  test '#update! raises ActiveRecord::RecordInvalid and does not save any change when the service attributes are invalid' do
+    old_service_attributes = service.attributes.slice(service_attributes.keys)
+    old_proxy_attributes   = proxy.attributes.slice(proxy_attributes.keys)
+
+    service_attributes[:name] = ''
+    assert_raises(ActiveRecord::RecordInvalid) { settings_result.update!(attributes) }
+    old_service_attributes.each { |field_name, value| assert_equal value, service.public_send(field_name) }
+    old_proxy_attributes.each   { |field_name, value| assert_equal value, proxy.public_send(field_name)   }
+  end
+
+  test '#update updates both when they are valid' do
+    assert settings_result.update(attributes)
+    service_attributes.each { |field_name, value| assert_equal value, service.public_send(field_name) }
+    proxy_attributes.each   { |field_name, value| assert_equal value, proxy.public_send(field_name)   }
+  end
+
+  test '#update returns false and does not save when the proxy attributes are invalid and #errors returns the errors' do
+    old_service_attributes = service.attributes.slice(service_attributes.keys)
+    old_proxy_attributes   = proxy.attributes.slice(proxy_attributes.keys)
+
+    proxy_attributes[:error_headers_auth_failed] = ''
+    refute settings_result.update(attributes)
+    old_service_attributes.each { |field_name, value| assert_equal value, service.public_send(field_name) }
+    old_proxy_attributes.each   { |field_name, value| assert_equal value, proxy.public_send(field_name)   }
+
+    assert_equal 'Error headers auth failed invalid', settings_result.errors[:proxy].to_sentence
+    assert_empty settings_result.errors[:service]
+  end
+
+  test '#update returns false and does not save when the service attributes are invalid and #errors returns the errors' do
+    old_service_attributes = service.attributes.slice(service_attributes.keys)
+    old_proxy_attributes   = proxy.attributes.slice(proxy_attributes.keys)
+
+    service_attributes[:name] = ''
+    refute settings_result.update(attributes)
+    old_service_attributes.each { |field_name, value| assert_equal value, service.public_send(field_name) }
+    old_proxy_attributes.each   { |field_name, value| assert_equal value, proxy.public_send(field_name)   }
+
+    assert_equal 'Name can\'t be blank', settings_result.errors[:service].to_sentence
+    assert_empty settings_result.errors[:proxy]
+  end
+
+  test '#update and #update! for deployment_option "hosted"' do
+    service.update!(deployment_option: 'self_managed') unless service.deployment_option == 'self_managed'
+    proxy.update!(endpoint: 'http://prod.example.com:80', staging_endpoint: 'http://staging.example.com:80')
+
+    service_attributes[:deployment_option] = 'hosted'
+    assert settings_result.update(attributes)
+    assert_equal 'hosted', service.deployment_option
+    assert_equal "http://#{service.system_name}-#{service.account_id}.apicast.dev:8080", proxy.endpoint
+    assert_equal "http://#{service.system_name}-#{service.account_id}.staging.apicast.dev:8080", proxy.staging_endpoint
+  end
+
+  private
+
+  def proxy
+    @proxy ||= FactoryBot.create(:simple_proxy, service: service)
+  end
+
+  def service
+    @service ||= FactoryBot.create(:simple_service, deployment_option: 'self_managed')
+  end
+
+  def settings_result
+    @settings_result ||= ApiIntegration::SettingsResult.new(service: service, proxy: proxy)
+  end
+
+  def service_attributes
+    @service_attributes ||= {name: 'new name'}
+  end
+
+  def proxy_attributes
+    @proxy_attributes ||= {endpoint: 'http://myapi.example.com:8123'}
+  end
+
+  def attributes
+    {service_attributes: service_attributes, proxy_attributes: proxy_attributes}
+  end
+end


### PR DESCRIPTION
Closes [THREESCALE-3576](https://issues.jboss.org/browse/THREESCALE-3576)

### Verification Steps
1. In `config/rolling_updates.yml` you will need `api_as_product: true`
2. In `config/settings.yml` you will need `apicast_custom_url: http://example.com.lvh.me` for this:
https://github.com/3scale/porta/blob/17d259fa26abe0bbbfc710c869cc3bf7c3a26470/app/helpers/api/integrations_helper.rb#L71-L75
3. Run the server with `UNICORN_WORKERS=8 bundle exec rails server -b 0.0.0.0`
4. Through the browser, go to `http://provider-admin.example.com.lvh.me:3000/apiconfig/services/:service_id/settings`
![image](https://user-images.githubusercontent.com/11318903/65986121-8a152100-e483-11e9-8159-a59fd4bf0cb2.png)
5. Change that data and update :dancer: 
