### PR TITLE
Improve error message when the apicast registry url is not present + 'Start by'

### DIFF
--- a/app/services/policies/policies_list_service.rb
+++ b/app/services/policies/policies_list_service.rb
@@ -58,14 +58,15 @@ class Policies::PoliciesListService
     begin
       response = ::JSONClient.get(apicast_registry_url)
     rescue *HTTP_ERRORS => error
-      raise_policies_list_error(error.message)
+      error_message = 'Please provide an apicast registry url in your configuration.' if apicast_registry_url.blank?
+      raise_policies_list_error(error_message || error.message)
     end
     raise_policies_list_error(response.content) unless response.ok?
     response.body['policies']
   end
 
   def raise_policies_list_error(error)
-    raise PoliciesListServiceError, I18n.t('errors.messages.apicast_not_found', url: apicast_registry_url, error: error)
+    raise PoliciesListServiceError, I18n.t('errors.messages.apicast_not_found', url: apicast_registry_url.presence || ' ', error: error)
   end
 
   def policies_from_account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -567,7 +567,7 @@ en:
           /foo/bar/baz requests.</p>
         curl:
           no_application_plan:
-            Start with creating an application plan.
+            Start by creating an application plan.
           no_application:
             In order to send a valid test request, please create an application that subscribes to an application plan of this service.
 


### PR DESCRIPTION
Before this PR:
![image](https://user-images.githubusercontent.com/11318903/65950194-e2c1cb00-e43d-11e9-86ff-8d981b321bc0.png)
![image](https://user-images.githubusercontent.com/11318903/65950365-316f6500-e43e-11e9-98ba-52fa86193c64.png)


After this PR:
![image](https://user-images.githubusercontent.com/11318903/65950224-f0775080-e43d-11e9-9fac-5b9b01d8ac3e.png)
![image](https://user-images.githubusercontent.com/11318903/65950395-40eeae00-e43e-11e9-9c57-1967f22695fc.png)

