### PR TITLE
Sets correct min-height to element dd

### DIFF
--- a/app/assets/stylesheets/provider/_commons.scss
+++ b/app/assets/stylesheets/provider/_commons.scss
@@ -102,7 +102,7 @@ p + ul {
 }
 
 %dd {
-  min-height: line-height-times(1);
+  min-height: line-height-times(2);
   padding: line-height-times(1/2) 0 line-height-times(1/2) 40%;
   border-bottom: $border-width solid $border-color;
   list-style: none;


### PR DESCRIPTION
**Which issue(s) this PR fixes** 

[THREESCALE-3585: When product has no mapping rules, show page looks weird](https://issues.jboss.org/browse/THREESCALE-3585)

**Before:**
![Screen Shot 2019-10-01 at 12 42 23](https://user-images.githubusercontent.com/11672286/65955970-98464b80-e449-11e9-9163-a57906b55fde.png)

**After:**
![Screen Shot 2019-10-01 at 12 42 14](https://user-images.githubusercontent.com/11672286/65955984-9ed4c300-e449-11e9-8ae3-96f8028fb15f.png)

