### PR TITLE
Proxy config workflow

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -88,7 +88,6 @@ class Api::IntegrationsController < Api::BaseController
   end
 
   def show
-    @apiap = apiap?
     respond_to do |format|
       format.html do
         @show_presenter = Api::IntegrationsShowPresenter.new(@proxy)

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -33,6 +33,8 @@ class FrontendController < ApplicationController
     current_account.provider_can_use?(:api_as_product)
   end
 
+  helper_method :apiap?
+
   def do_nothing_if_head
     render head: :success, nothing: true if request.head?
   end

--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -92,4 +92,30 @@ module Api::IntegrationsHelper
     title = deployment_option_is_service_mesh?(service) ? 'Service Mesh' : 'APIcast'
     t(:edit_deployment_configuration, scope: :api_integrations_controller, deployment: title )
   end
+
+  def promote_to_staging_button_options(proxy)
+    return disabled_promote_button_options if proxy.any_sandbox_configs? && !proxy.pending_affecting_changes?
+
+    label = deployment_option_is_service_mesh?(proxy.service) ? 'Update Configuration' : "Promote v. #{proxy.next_sandbox_config_version} to Staging"
+    promote_button_options(label)
+  end
+
+  def promote_to_production_button_options(proxy)
+    return disabled_promote_button_options if proxy.environments_have_same_config?
+
+    label = "Promote v. #{proxy.next_production_config_version} to Production"
+    promote_button_options(label)
+  end
+
+  PROMOTE_BUTTON_COMMON_OPTIONS = { button_html: { class: 'PromoteButton', data: { disable_with: 'promoting…' } } }.freeze
+
+  def promote_button_options(label = 'Promote')
+    options = PROMOTE_BUTTON_COMMON_OPTIONS.deep_merge(button_html: { class: 'PromoteButton important-button' })
+    [label, options]
+  end
+
+  def disabled_promote_button_options
+    options = PROMOTE_BUTTON_COMMON_OPTIONS.deep_merge(button_html: { class: 'PromoteButton disabled-button', disabled: true })
+    ['Nothing to promote', options]
+  end
 end

--- a/app/lib/proxy_config_affecting_changes.rb
+++ b/app/lib/proxy_config_affecting_changes.rb
@@ -25,8 +25,6 @@ module ProxyConfigAffectingChanges
   module ProxyExtension
     extend ActiveSupport::Concern
 
-    PROXY_CONFIG_AFFECTING_ATTRIBUTES = %w[policies_config].freeze # TODO: add more attributes here
-
     included do
       has_one :proxy_config_affecting_change, dependent: :delete
       private :proxy_config_affecting_change
@@ -36,7 +34,7 @@ module ProxyConfigAffectingChanges
       after_commit :issue_proxy_affecting_change_events, on: :update
 
       def issue_proxy_affecting_change_events
-        return if previously_changed?(:created_at) || (previous_changes.keys & PROXY_CONFIG_AFFECTING_ATTRIBUTES).empty?
+        return if previously_changed?(:created_at) || (previous_changes.keys - %w[updated_at lock_version]).empty?
 
         issue_proxy_affecting_change_event(self)
       end

--- a/app/views/api/backend_api_configs/new.html.slim
+++ b/app/views/api/backend_api_configs/new.html.slim
@@ -7,7 +7,8 @@
                   collection: current_account.backend_apis.accessible.not_used_by(@backend_api_config.service_id),
                   include_blank: false,
                   prompt: 'Select a Backend',
-                  label: 'Backend'
+                  label: 'Backend',
+                  hint: link_to('Create a Backend that can be used by any Product', new_provider_admin_backend_api_path)
     = form.input :path
 
   = form.buttons do

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -1,5 +1,5 @@
 section.Configuration class=('Configuration--is-promoted' unless deployment_option_is_service_mesh?(@service)) class="Configuration--#{@show_presenter.test_state_modifier}"
-  - unless @apiap
+  - unless apiap?
     = link_to edit_deployment_option_title(@service), edit_admin_service_integration_path(@service), class: 'SettingsBox-toggle'
 
   article.Configuration-summary data-state="open" class=("Environment--#{@show_presenter.test_state_modifier}" unless deployment_option_is_service_mesh?(@service))
@@ -34,12 +34,12 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
         dt.u-dl-term Secret Token
         dd.u-dl-definition = @proxy.secret_token
 
-    div
-      = semantic_form_for @proxy, url: admin_service_integration_path(@service) do |f|
-        = f.buttons class: "buttons buttons-inline" do
-          = f.hidden_field :lock_version
-          = f.button "Promote v. #{@show_presenter.last_sandbox_config.version+1} to Staging",
-            button_html: {class: 'important-button PromoteButton', data: { disable_with: 'promoting…' }}
+    - if apiap?
+      div
+        = semantic_form_for @proxy, url: admin_service_integration_path(@service) do |f|
+          = f.buttons class: "buttons buttons-inline" do
+            = f.hidden_field :lock_version
+            = f.button *promote_to_staging_button_options(@show_presenter)
 
 - unless deployment_option_is_service_mesh?(@service)
   section style="margin-top: 48px;"
@@ -54,11 +54,11 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
           .ConfigurationVersion
             ' v.
             = @show_presenter.last_sandbox_config.version
-        - unless @show_presenter.environments_have_same_config?
           = semantic_form_for @proxy, url: promote_to_production_admin_service_integration_path(@service, anchor: 'production'), html: { class: 'PromoteForm' } do |f|
             = f.buttons class: "buttons buttons-inline" do
-              = f.button "Promote v. #{@show_presenter.last_sandbox_config.version} to Production",
-                button_html: {class: 'important-button PromoteButton', data: { disable_with: 'promoting…' }}
+              = f.button *promote_to_production_button_options(@show_presenter)
+        - else
+          | no configuration has been saved for the staging environment yet
 
     .SettingsBox.Environment
       - if @show_presenter.any_production_configs?
@@ -67,9 +67,8 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
         h3.Environment-title Production Environment
         - if @show_presenter.any_production_configs?
           = @show_presenter.production_proxy_endpoint
-        - else
-          | no configuration has been saved for the production environment yet
-        .ConfigurationVersion
-          - if @show_presenter.any_production_configs?
+          .ConfigurationVersion
             ' v.
             = @show_presenter.last_production_config.version
+        - else
+          | no configuration has been saved for the production environment yet

--- a/app/views/api/integrations/apicast/shared/_deployment_options.html.slim
+++ b/app/views/api/integrations/apicast/shared/_deployment_options.html.slim
@@ -1,5 +1,5 @@
 .SettingsBox
-  - unless @apiap
+  - unless apiap?
     a href="" class="IntegrationSettingsBox-toggle" data-state="open" edit integration settings
     article.IntegrationSettingsBox-summary data-state="open"
       - if can_toggle_apicast_version?

--- a/app/views/api/integrations/show.html.slim
+++ b/app/views/api/integrations/show.html.slim
@@ -12,8 +12,12 @@
     - when /^service_mesh/
       = render 'api/integrations/apicast/configuration_driven/apicast'
     - else
-      - if @show_presenter.any_sandbox_configs?
+      - if @show_presenter.apicast_config_ready?
         = render 'api/integrations/apicast/configuration_driven/apicast'
       - else
-        ' To get started with this service on APIcast,
-        = link_to "add the base URL of your API and save the configuration.", edit_admin_service_integration_path(@service), class: "important-button"
+        - if apiap?
+          ' To get started with this product on APIcast,
+          = link_to "add a Backend and promote the configuration.", new_admin_service_backend_api_config_path(@service), class: "important-button"
+        - else
+          ' To get started with this service on APIcast,
+          = link_to "add the base URL of your API and save the configuration.", edit_admin_service_integration_path(@service), class: "important-button"

--- a/app/views/provider/admin/backend_apis/edit.html.slim
+++ b/app/views/provider/admin/backend_apis/edit.html.slim
@@ -3,6 +3,6 @@ h2 Edit Backend
 = semantic_form_for @backend_api, url: provider_admin_backend_api_path(@backend_api) do |form|
   = render partial: 'provider/admin/backend_apis/forms/naming', locals: { form: form }
   = form.buttons do
-    = form.commit_button
+    = form.commit_button 'Update Backend'
 
 = render partial: 'provider/admin/backend_apis/forms/delete', locals: { backend_api: @backend_api }

--- a/app/views/provider/admin/backend_apis/new.html.slim
+++ b/app/views/provider/admin/backend_apis/new.html.slim
@@ -3,4 +3,4 @@ h2 New Backend
 = semantic_form_for @backend_api, url: provider_admin_backend_apis_path do |form|
   = render partial: 'provider/admin/backend_apis/forms/naming', locals: { form: form }
   = form.buttons do
-    = form.commit_button
+    = form.commit_button 'Create Backend'

--- a/app/views/provider/admin/dashboards/_service_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_service_navigation.html.slim
@@ -65,7 +65,7 @@ nav.DashboardNavigation
                                         icon_name: 'wrench'
 
         - else
-          = dashboard_navigation_link 'Integrate this API',
+          = dashboard_navigation_link "Integrate this #{apiap? ? 'Product' : 'API'}",
                                       path_to_service(service),
                                       icon_name: 'wrench',
                                       notice: true

--- a/app/views/provider/admin/dashboards/_service_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_service_navigation.html.slim
@@ -51,7 +51,7 @@ nav.DashboardNavigation
     // Integration
     - if can?(:manage, :plans)
       li.DashboardNavigation-list-item
-        - if service.has_traffic?
+        - if service.has_traffic? || (apiap? && service.proxy.proxy_configs.sandbox.any?)
           - if has_out_of_date_configuration?(service)
             = dashboard_navigation_link 'Integration',
                                         path_to_service(service),

--- a/features/old/api/settings.feature
+++ b/features/old/api/settings.feature
@@ -46,6 +46,7 @@ Feature: API Settings
 
   Scenario: API settings don't crash when APICAST_REGISTRY_URL is undefined
     Given apicast registry is undefined
+    And I have rolling update api_as_product disabled
     When I log in as provider "foo.example.com"
     And I go to the integration show page for service "API" of provider "foo.example.com"
     And I follow "add the base URL of your API and save the configuration."

--- a/features/old/menu/dashboard.feature
+++ b/features/old/menu/dashboard.feature
@@ -5,11 +5,11 @@ Feature: Dashboard
 
   Background:
     Given a provider "foo.example.com"
-      And current domain is the admin domain of provider "foo.example.com"
-      And I log in as provider "foo.example.com"
+    And current domain is the admin domain of provider "foo.example.com"
 
   Scenario: Audience widget
-    When I go to the provider dashboard
+    When I log in as provider "foo.example.com"
+    And I go to the provider dashboard
     Then I should see "Audience" in the audience dashboard widget
     And I should see the link "0 Accounts" in the audience dashboard widget
     And I should see the link "Portal" in the audience dashboard widget
@@ -17,7 +17,8 @@ Feature: Dashboard
     And I should see the link "0 Messages" in the audience dashboard widget
 
   Scenario: APIs widget
-    When I go to the provider dashboard
+    When I log in as provider "foo.example.com"
+    And I go to the provider dashboard
     Then I should see "APIs" in the apis dashboard widget
     And I should see "Products" in the apis dashboard widget
     And I should see "Backends" in the apis dashboard widget
@@ -30,6 +31,16 @@ Feature: Dashboard
     And I should see the link "0 Mapping Rules" in the apis dashboard backends tabs section
 
   Scenario: first API widget
+    When I log in as provider "foo.example.com"
+    And I should see "API" in the first api dashboard widget
+    And I should see the link "Overview" in the first api dashboard widget
+    And I should see the link "Analytics" in the first api dashboard widget
+    And I should see the link "Integrate this Product" in the first api dashboard widget
+    And I should see the link "0 ActiveDocs" in the first api dashboard widget
+
+  Scenario: first API widget without APIAP
+    Given I have rolling update api_as_product disabled
+    When I log in as provider "foo.example.com"
     And I should see "API" in the first api dashboard widget
     And I should see the link "Overview" in the first api dashboard widget
     And I should see the link "Analytics" in the first api dashboard widget
@@ -39,12 +50,14 @@ Feature: Dashboard
   Scenario: Audience widget with Finance enabled
     Given provider "foo.example.com" is charging
     And provider "foo.example.com" has "finance" switch allowed
-    When I go to the provider dashboard
+    When I log in as provider "foo.example.com"
+    And I go to the provider dashboard
     Then I should see the link "Billing" in the audience dashboard widget
 
   Scenario: API Widget with Service plans enabled and more than 1 service plan
     Given a service "Another one" of provider "foo.example.com"
     And provider "foo.example.com" has "service_plans" switch allowed
     And a service plan "second" of provider "foo.example.com"
-    When I go to the provider dashboard
+    When I log in as provider "foo.example.com"
+    And I go to the provider dashboard
     Then I should see the link "0 Subscriptions" in the first api dashboard widget

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -650,13 +650,13 @@ class ProxyTest < ActiveSupport::TestCase
       service = FactoryBot.create(:simple_service, account: provider)
       proxy = service.proxy
 
-      # Updating policies_config is an affecting change
-      ProxyConfigs::AffectingObjectChangedEvent.expects(:create_and_publish!).with(proxy, proxy)
-      proxy.update_attributes(policies_config: [{ name: '1', version: 'b', configuration: {} }])
+      ProxyConfigs::AffectingObjectChangedEvent.expects(:create_and_publish!).with(proxy, proxy).twice
 
-      # Not all attributes of Proxy are considered potential affecting changes
-      ProxyConfigs::AffectingObjectChangedEvent.expects(:create_and_publish!).with(proxy, proxy).never
+      proxy.update_attributes(policies_config: [{ name: '1', version: 'b', configuration: {} }])
       proxy.update_attributes(deployed_at: Time.utc(2019, 9, 26, 12, 20))
+
+      # A stale update is not an affecting change
+      proxy.update_attributes(updated_at: Time.utc(2019, 9, 26, 12, 20))
     end
   end
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It implements the new workflow for generating/promoting proxy configs on APIAP, mostly changing the UI.

_Non-APIAP_

![non-apiap](https://user-images.githubusercontent.com/1842261/65964599-96868300-e45d-11e9-864e-6121990390c4.gif)

_APIAP_

![apiap](https://user-images.githubusercontent.com/1842261/65964623-a605cc00-e45d-11e9-84c4-0c989e5eb703.gif)


**Which issue(s) this PR fixes** 

Closes
- [THREESCALE-3581](https://issues.jboss.org/browse/THREESCALE-3581)
- [THREESCALE-3575](https://issues.jboss.org/browse/THREESCALE-3575)
- [THREESCALE-3539](https://issues.jboss.org/browse/THREESCALE-3539)

**TODOs**
- [x] Fix promote buttons for APIAP vs non-APIAP
- [x] Fix promote buttons for service mesh integration (See https://github.com/3scale/porta/pull/1274)
- [x] Enable more attributes of `Proxy` to trigger `AffectingObjectChangesEvent`
- [x] Fix "Integrate this API" -> "Integrate this Product" in the Dashboard
- [x] Add "Create a backend" link in "Add Backend to Product" page (create BackendApiConfig)
- [ ] Write 🥒 for the new scenarios
- [ ] ~Make it impossible to generate proxy config if product has no backend api config~ (separate PR)
- [ ] ~Throw 404 when apiap-user tries to access `/apiconfig/services/2/integration/edit`~ (separate PR)