### PR TITLE
Fix proxy fields not being updated

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -81,7 +81,7 @@ class Api::ServicesController < Api::BaseController
                         :buyer_can_select_plan, :buyer_plan_change_permission, :buyers_manage_keys,
                         :buyer_key_regenerate_enabled, :mandatory_app_key, :custom_keys_enabled, :state_event,
                         :txt_support, :terms,
-                        {notification_settings: [web_provider: [], email_provider: [], web_buyer: [], email_buyer: []], proxy: Proxy.user_attribute_names}
+                        {notification_settings: [web_provider: [], email_provider: [], web_buyer: [], email_buyer: []], proxy_attributes: Proxy.user_attribute_names}
     ]
     params.require(:service).permit(permitted_params)
   end


### PR DESCRIPTION
Currently, if we edit some service's proxy field at
/apiconfig/services/:id/settings, the value is not being saved.
This commit fixes this problem, making the controller to accept
the right attributes sent from the UI.
