### PR TITLE
Fix wrong page rendering in Service Settings page

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -31,14 +31,12 @@ class Api::ServicesController < Api::BaseController
 
   def settings
     activate_menu :serviceadmin, :integration, :settings
-    @alert_limits = Alert::ALERT_LEVELS
-    settings_apiap if apiap?
+    render settings_page
   end
 
   def usage_rules
     raise ActiveRecord::RecordNotFound unless apiap?
     activate_menu :serviceadmin, :applications, :usage_rules
-    @alert_limits = Alert::ALERT_LEVELS
   end
 
   def create
@@ -63,7 +61,7 @@ class Api::ServicesController < Api::BaseController
       onboarding.bubble_update('deployment') if integration_method_changed? && !integration_method_self_managed?
       redirect_back_or_to :action => :settings
     else
-      render :action => :edit # edit page is only page with free form fields. other forms are less probable to have errors
+      render action: params[:update_settings].present? ? settings_page : :edit # edit page is only page with free form fields. other forms are less probable to have errors
     end
   end
 
@@ -87,8 +85,8 @@ class Api::ServicesController < Api::BaseController
   end
 
   # This will be the default 'settings' when apiap is live
-  def settings_apiap
-    render :settings_apiap
+  def settings_page
+    apiap? ? :settings_apiap : :settings
   end
 
   protected

--- a/app/helpers/alerts_helper.rb
+++ b/app/helpers/alerts_helper.rb
@@ -19,7 +19,7 @@ module AlertsHelper
 
   def row_for_alert_levels(label, key, hash = nil, levels = nil)
     hash ||= @service.notification_settings
-    levels ||= @alert_limits
+    levels ||= alert_limits
 
     content_tag :tr, id: key do
       hidden_field_tag("service[notification_settings][#{key}][]", "") +
@@ -28,6 +28,10 @@ module AlertsHelper
           content_tag(:td, check_box_tag("service[notification_settings][#{key}][]", level, checked, title: "#{label} at #{level}% usage"))
         end.join.html_safe
     end
+  end
+
+  def alert_limits
+    @alert_limits ||= Alert::ALERT_LEVELS
   end
 
 end

--- a/app/views/api/services/forms/_settings.html.slim
+++ b/app/views/api/services/forms/_settings.html.slim
@@ -39,7 +39,7 @@
       thead
         tr
           th
-          - @alert_limits.each do |level|
+          - alert_limits.each do |level|
             th
               = level
               | %

--- a/app/views/api/services/forms/_usage_rules.html.slim
+++ b/app/views/api/services/forms/_usage_rules.html.slim
@@ -39,7 +39,7 @@
       thead
         tr
           th
-          - @alert_limits.each do |level|
+          - alert_limits.each do |level|
             th
               = level
               | %

--- a/app/views/api/services/settings_apiap.html.slim
+++ b/app/views/api/services/settings_apiap.html.slim
@@ -2,4 +2,4 @@
 = semantic_form_for @service, :url => admin_service_path(@service) do |form|
   = render :partial => 'api/services/forms/integration_settings_apiap', :locals => {:form => form}
   = form.buttons do
-    = form.commit_button
+    = form.commit_button(button_html: { name: 'update_settings' })


### PR DESCRIPTION
Fixes [THREESCALE-3588](https://issues.jboss.org/browse/THREESCALE-3588)

Currently if we try to save a service settings with wrong value,
it renders the service edit page instead of the service settings
page. This commit fixes this