### PR TITLE
Fix apicast replace_path to use remove

### DIFF
--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -68,8 +68,7 @@ module BackendApiLogic
         def replace_path
           return {} if path.blank?
 
-          private_base_path = StringUtils::StripSlash.strip_slash(URI.parse(private_endpoint).path)
-          { replace_path: "{{original_request.path | replace: '/#{path}', '/#{private_base_path}'}}" }
+          { replace_path: "{{original_request.path | remove_first: '/#{path}'}}" }
         end
       end
       private_constant :Rule

--- a/test/unit/backend_api_logic/routing_policy_test.rb
+++ b/test/unit/backend_api_logic/routing_policy_test.rb
@@ -23,7 +23,7 @@ module BackendApiLogic
 
     test '#policy_chain' do
       injected_rules = [
-        { url: backend_apis.last.private_endpoint,  condition: { operations: [match: :path, op: :matches, value: '/foo/.*|/foo/?'] }, replace_path: "{{original_request.path | replace: '/foo', '/'}}" },
+        { url: backend_apis.last.private_endpoint,  condition: { operations: [match: :path, op: :matches, value: '/foo/.*|/foo/?'] }, replace_path: "{{original_request.path | remove_first: '/foo'}}" },
         { url: backend_apis.first.private_endpoint, condition: { operations: [match: :path, op: :matches, value: '/.*'] } }
       ]
       apicast_policy = { name: 'apicast', 'version': 'builtin', 'configuration': {} }
@@ -48,9 +48,9 @@ module BackendApiLogic
           [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: '' }, nil],
           [{ private_endpoint: 'https://safe-second-api.io', path: '' }, nil],
           [{ private_endpoint: 'https://safe-second-api.io/v2', path: '' }, nil],
-          [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: 'hey' }, "{{original_request.path | replace: '/hey', '/ns'}}"],
-          [{ private_endpoint: 'https://safe-second-api.io', path: 'ho' }, "{{original_request.path | replace: '/ho', '/'}}"],
-          [{ private_endpoint: 'https://safe-second-api.io/v2', path: 'lets-go' }, "{{original_request.path | replace: '/lets-go', '/v2'}}"]
+          [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: 'hey' }, "{{original_request.path | remove_first: '/hey'}}"],
+          [{ private_endpoint: 'https://safe-second-api.io', path: 'ho' }, "{{original_request.path | remove_first: '/ho'}}"],
+          [{ private_endpoint: 'https://safe-second-api.io/v2', path: 'lets-go' }, "{{original_request.path | remove_first: '/lets-go'}}"]
         ].each do |config, replace_path_value|
           expected_replace_path = replace_path_value ? { replace_path: replace_path_value } : {}
           assert_equal expected_replace_path, rule_class.new(stub(config)).replace_path

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -91,8 +91,8 @@ class ProxyTest < ActiveSupport::TestCase
         {"name"=>"routing", "version"=>"builtin", "enabled"=>true,
           "configuration"=>{
             "rules"=>[
-              {"url"=>"https://private-2.example.com:443", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/bar/.*|/foo/bar/?"}]}, 'replace_path'=>"{{original_request.path | replace: '/foo/bar', '/'}}"},
-              {"url"=>"https://private-1.example.com:443", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/.*|/foo/?"}]}, 'replace_path'=>"{{original_request.path | replace: '/foo', '/'}}"},
+              {"url"=>"https://private-2.example.com:443", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/bar/.*|/foo/bar/?"}]}, 'replace_path'=>"{{original_request.path | remove_first: '/foo/bar'}}"},
+              {"url"=>"https://private-1.example.com:443", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/.*|/foo/?"}]}, 'replace_path'=>"{{original_request.path | remove_first: '/foo'}}"},
               {"url"=>"https://echo-api.3scale.net:443", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/.*"}]}}
             ]
           }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It changes the routing policies injected into the proxy config for the backends of a product so they use the `replace_path` rule with `remove_first` instead of with `replace`.

**Which issue(s) this PR fixes** 

Porta is currently generating proxy configs for products containing backends with paths with the following attribute in the corresponding injected routing policy:

```
"replace_path": "{{original_request.path | replace: '/the-path', '/'}}"
```

This is causing apicast to route the incoming traffic, for example, from `<public-domain>/the-path/actual-backend-path`, to `<private-domain>//actual-backend-path`. The correct backend endpoint would be `<private-domain>/actual-backend-path`.

We should use instead in the routing policy injected for the backend:

```
{{original_request.path | remove_first: '/the-path' }}
```

Closes [THREESCALE-3593](https://issues.jboss.org/browse/THREESCALE-3593)

**Verification steps** 

1. Create a product containing at least 2 backends
2. Generate the proxy config
3. Confirm in the json file of the proxy config that the `routing` policies injected in the chain for the backends with path include a `replace_path` rule in the following format:
    ```
    "replace_path": "{{original_request.path | remove_first: '/the-path'}}"
    ```

**Example of part of a real proxy config generated using this PR**

<img width="786" alt="Screen Shot 2019-10-02 at 3 11 23 PM" src="https://user-images.githubusercontent.com/1842261/66046920-0d3b8300-e527-11e9-94be-ea457aa2b3d3.png">

**Special notes to the reviewer**

Related to https://github.com/3scale/APIcast/pull/1122
