### PR TITLE
[api#ednpoint] objects status endpoint

### DIFF
--- a/app/controllers/admin/api/objects_controller.rb
+++ b/app/controllers/admin/api/objects_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class Admin::Api::ObjectsController < Admin::Api::BaseController
+  clear_respond_to
+  respond_to :json
+
+  ALLOWED_OBJECTS = %w[service account proxy backend_api].freeze
+
+  before_action :authorize!
+
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/objects/status.json"
+  #
+  ##~ op = e.operations.add
+  ##~ op.httpMethod = "GET"
+  ##~ op.summary = "Object deletion status for objects that are deleted asynchronously"
+  ##~ op.description = "Returns an object status. (200/404). Useful for those objects that deleted asynchronously in order to know if the deletion has been completed(404) or not(200)"
+  ##~ op.group = "objects"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  ##~ op.parameters.add :dataType => "string", :required => true, :paramType => "query", :name => "object_type", :description => "Object type has to be service, account, proxy or backend_api."
+  ##~ op.parameters.add :dataType => "string", :required => true, :paramType => "query", :name => "object_id", :description => "Object ID."
+  def status
+    status_object = status_object_type.classify.constantize.unscoped.find(status_object_id)
+
+    authorize_tenant!(status_object)
+
+    head(:ok)
+  end
+
+  private
+
+  def status_object_type
+    @status_object_type ||= params.fetch(:object_type).to_s
+  end
+
+  def status_object_id
+    @status_object_id ||= params.fetch(:object_id)
+  end
+
+  def authorize_tenant!(status_object)
+    raise_access_denied if !current_account.master? && current_account.tenant_id != status_object.tenant_id
+  end
+
+  def authorize!
+    raise_access_denied if unknown_status_object || current_user_not_admin
+  end
+
+  def unknown_status_object
+    ALLOWED_OBJECTS.exclude?(status_object_type)
+  end
+
+  def current_user_not_admin
+    !current_user&.admin?
+  end
+
+  def raise_access_denied
+    raise CanCan::AccessDenied
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -487,6 +487,8 @@ without fake Core server your after commit callbacks will crash and you might ge
       # called from heroku deploy hook after heroku proxy deploy script
       post 'heroku-proxy/deployed', to: 'heroku_proxy#deployed', as: :heroku_proxy_deployed
 
+      get 'objects/status' => 'objects#status', as: :objects_status, controller: :objects, defaults: { format: :json }
+
       namespace :personal, defaults: { format: :json } do
         resources :access_tokens, except: %i[new edit]
       end

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -5645,6 +5645,41 @@
       ]
     },
     {
+      "path": "/admin/api/objects/status.json",
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "summary": "Object deletion status for objects that are deleted asynchronously",
+          "description": "Returns an object status. (200/404). Useful for those objects that deleted asynchronously in order to know if the deletion has been completed(404) or not(200)",
+          "group": "objects",
+          "parameters": [
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            },
+            {
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "name": "object_type",
+              "description": "Object type has to be service, account, proxy or backend_api."
+            },
+            {
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "name": "object_id",
+              "description": "Object ID."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": "/admin/api/personal/access_tokens.json",
       "responseClass": "access_token",
       "operations": [

--- a/test/integration/admin/api/objects_controller_test.rb
+++ b/test/integration/admin/api/objects_controller_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class Admin::Api::ObjectsControllerTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    @service = @provider.default_service
+
+    host! @provider.admin_domain
+
+    login_provider @provider
+  end
+
+  def test_status_object_not_found
+    get admin_api_objects_status_path(object_type: 'service', object_id: 'abc123')
+    assert_response 404
+  end
+
+  def test_status_object_found
+    get admin_api_objects_status_path(object_type: 'service', object_id: @service.id)
+    assert_response 200
+  end
+
+  def test_status_object_type_not_valid
+    get admin_api_objects_status_path(object_type: 'code-injection', object_id: 1)
+    assert_response 403
+  end
+
+  def test_status_no_tenant_id
+    @service.update_column(:tenant_id, nil)
+    get admin_api_objects_status_path(object_type: 'service', object_id: @service.id)
+    assert_response 403
+  end
+
+  def test_status_not_admin
+    User.any_instance.expects(:admin?).returns(false)
+    get admin_api_objects_status_path(object_type: 'service', object_id: @service.id)
+    assert_response 403
+  end
+
+  def test_status_no_current_user
+    Admin::Api::ObjectsController.any_instance.expects(:current_user).returns(nil).at_least_once
+    get admin_api_objects_status_path(object_type: 'service', object_id: @service.id)
+    assert_response 403
+  end
+
+  def test_status_different_tenant
+    another_provider = FactoryBot.create(:provider_account)
+    get admin_api_objects_status_path(object_type: 'service', object_id: another_provider.default_service.id)
+    assert_response 403
+
+    Account.any_instance.expects(:master?).returns(true)
+    get admin_api_objects_status_path(object_type: 'service', object_id: another_provider.default_service.id)
+    assert_response 200
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

API endpoint: object deletion status for objects that are deleted asynchronously

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3265
