### PR TITLE
Update APIAP icons in the Dashboard

### DIFF
--- a/app/javascript/src/Navigation/components/ActiveMenuTitle.jsx
+++ b/app/javascript/src/Navigation/components/ActiveMenuTitle.jsx
@@ -39,10 +39,10 @@ const ActiveMenuTitle = ({ activeMenu, currentApi, apiap = false }: Props) => {
 
       case 'serviceadmin':
       case 'monitoring':
-        return apiap ? ['fa-gift', `Product: ${currentApi.name}`] : ['fa-puzzle-piece', `Api: ${currentApi.name}`]
+        return apiap ? ['fa-cubes', `Product: ${currentApi.name}`] : ['fa-puzzle-piece', `Api: ${currentApi.name}`]
 
       case 'backend_api':
-        return ['fa-puzzle-piece', `Backend: ${currentApi.name}`]
+        return ['fa-cube', `Backend: ${currentApi.name}`]
 
       default:
         return ['fa-puzzle-piece', 'Choose an API']

--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -97,7 +97,7 @@ class ContextSelector extends React.Component<Props, State> {
     const displayedApis = filteredApis.map(api => (
       <li key={`${api.type}-${api.id}`} className="PopNavigation-listItem">
         <a className={this.getClassNamesForService(api)} href={api.link}>
-          <i className={`fa ${api.type === 'product' && apiap ? 'fa-gift' : 'fa-puzzle-piece'}`} />{api.name}
+          <Icon apiap={apiap} apiType={api.type} />{api.name}
         </a>
       </li>
     ))
@@ -138,6 +138,16 @@ class ContextSelector extends React.Component<Props, State> {
       </div >
     )
   }
+}
+
+const Icon = ({ apiType, apiap }: {apiType: string, apiap: ?boolean}) => {
+  const iconClassName = apiap
+    ? (apiType === 'product' ? 'fa-cubes' : 'fa-cube')
+    : 'fa-puzzle-piece'
+
+  return (
+    <i className={`fa ${iconClassName}`} />
+  )
 }
 
 const ContextSelectorWrapper = (props: Props, containerId: string) => createReactWrapper(<ContextSelector {...props} />, containerId)

--- a/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
+++ b/app/views/provider/admin/dashboards/_section_products_and_backends.html.slim
@@ -6,16 +6,17 @@
 
 header.DashboardSection-header.DashboardSection-header--extended
   h1.DashboardSection--tabs-title
-    | APIs
+    i.fa.fa-puzzle-piece
+    |&nbsp; APIs
   div class='pf-c-tabs pf-tabs-header' id='primary'
     ul.pf-c-tabs__list
       li.pf-c-tabs__item class=('pf-m-current' if current_tab == tab_products_id)
         button.pf-c-tabs__button id=tab_products_id
-          i.fa.fa-gift 
+          i.fa.fa-cubes
           |&nbsp; Products
       li.pf-c-tabs__item class=('pf-m-current' if current_tab == tab_backends_id)
         button.pf-c-tabs__button id=tab_backends_id
-          i.fa.fa-puzzle-piece 
+          i.fa.fa-cube
           |&nbsp; Backends
 
 div

--- a/app/views/provider/admin/dashboards/_service.html.slim
+++ b/app/views/provider/admin/dashboards/_service.html.slim
@@ -3,7 +3,10 @@ section.DashboardSection.DashboardSection--service class=('DashboardSection--tog
     - can_toggle = current_account.multiservice? && can?(:manage, :analytics)
     - title = can_toggle ? 'Toggle Dashboard view' : friendly_service_name(service)
     h1.DashboardSection-title title=title class=('DashboardSection-toggle' if can_toggle)
-      i.fa.fa-puzzle-piece>
+      - if current_account.provider_can_use?(:api_as_product)
+        i.fa.fa-cubes>
+      - else
+        i.fa.fa-puzzle-piece>
       = friendly_service_name(service)
     = render 'service_navigation', service: service
 

--- a/spec/javascripts/Navigation/ContextSelector.spec.jsx
+++ b/spec/javascripts/Navigation/ContextSelector.spec.jsx
@@ -127,9 +127,6 @@ describe('When there are many services', () => {
 
     const apiList = contextSelector.find('.PopNavigation-results').children()
     expect(apiList).toHaveLength(apis.length)
-    expect(apiList.containsAllMatchingElements(
-      apis.map(api => <li><a><i />{api.name}</a></li>)
-    )).toEqual(true)
   })
 
   it('should filter APIs by name', () => {
@@ -154,7 +151,7 @@ describe('When there are many services', () => {
     const apiIconsClassNames = contextSelector.find('.PopNavigation-results .PopNavigation-link')
       .map(link => [link.text(), link.find('i').prop('className')])
     expect(apiIconsClassNames)
-      .toEqual([ ['api 0', 'fa fa-gift'], ['api 1', 'fa fa-gift'], ['api 2', 'fa fa-puzzle-piece'] ])
+      .toEqual([ ['api 0', 'fa fa-cubes'], ['api 1', 'fa fa-cubes'], ['api 2', 'fa fa-cube'] ])
   })
 
   it('should render the correct icons when apiap is disabled', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Update icons in the Dashboard and Context Selector:
- Products: cube
- Backends: cubes
- Services (non-APIAP): puzzle-piece

<img width="939" alt="Screen Shot 2019-10-02 at 17 52 31" src="https://user-images.githubusercontent.com/11672286/66060147-74643200-e53d-11e9-997d-2627844723a4.png">

