### PR TITLE
Improve the tests of creating a backend api for each new tenant

### DIFF
--- a/test/unit/db/seeds_test.rb
+++ b/test/unit/db/seeds_test.rb
@@ -197,7 +197,7 @@ class SeedsTest < ActiveSupport::TestCase
     tenant_user = tenant_account.users.but_impersonation_admin.first!
     assert_equal ENV_VARIABLES['USER_LOGIN'], tenant_user.username
     assert_equal ENV_VARIABLES['USER_EMAIL'], tenant_user.email
-    assert(tenant_bought_cinstance = enant_account.bought_cinstance)
+    assert(tenant_bought_cinstance = tenant_account.bought_cinstance)
     assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['PROVIDER_PLAN']).id, tenant_bought_cinstance.plan_id
   end
 

--- a/test/unit/db/seeds_test.rb
+++ b/test/unit/db/seeds_test.rb
@@ -90,14 +90,14 @@ class SeedsTest < ActiveSupport::TestCase
       assert master_service.metrics.find_by(system_name: system_name, unit: 'hit', friendly_name: description)
     end
 
-    assert (tenant_app_plan = master_service.application_plans.default)
+    tenant_app_plan = master_service.application_plans.default
     assert_equal 'enterprise', tenant_app_plan.name
     assert_equal master_service.id, tenant_app_plan.issuer_id
 
-    assert (apicast = master_account.access_tokens.find_by(name: 'APIcast'))
+    apicast = master_account.access_tokens.find_by(name: 'APIcast')
     assert_equal 'ro', apicast.permission
     assert_equal %w[account_management], apicast.scopes
-    assert (master_token = master_account.access_tokens.find_by(name: 'Master Token'))
+    master_token = master_account.access_tokens.find_by(name: 'Master Token')
     assert_equal 'rw', master_token.permission
     assert_equal %w[account_management], master_token.scopes
 
@@ -208,9 +208,9 @@ class SeedsTest < ActiveSupport::TestCase
   private
 
   def assert_expected_backend_api
-    assert (service = Account.tenants.first!.default_service)
+    service = Account.tenants.first!.default_service
     assert_equal 1, service.backend_apis.count
-    assert (backend_api = service.backend_apis.accessible.first)
+    backend_api = service.backend_apis.accessible.first
     assert_equal BackendApi.default_api_backend, backend_api.private_endpoint
     assert_equal service.system_name, backend_api.system_name
     assert_equal "#{service.name} Backend", backend_api.name

--- a/test/unit/db/seeds_test.rb
+++ b/test/unit/db/seeds_test.rb
@@ -80,7 +80,8 @@ class SeedsTest < ActiveSupport::TestCase
     assert_equal master_service.id, master_app_plan.issuer_id
     assert_equal 'enterprise', master_app_plan.name
 
-    assert_equal ApplicationPlan.find_by(name: 'Master Plan').id, master_account.bought_cinstance&.plan.id
+    assert(master_bought_cinstance = master_account.bought_cinstance)
+    assert_equal ApplicationPlan.find_by(name: 'Master Plan').id, master_bought_cinstance.plan_id
 
     master_account_plan = master_account.default_account_plan
     assert_equal master_account.id, master_account_plan.issuer_id
@@ -113,8 +114,10 @@ class SeedsTest < ActiveSupport::TestCase
     assert tenant_account.sample_data.presence
     assert tenant_account.approved?
     assert tenant_account.state_changed_at.present?
-    assert_equal ApplicationPlan.find_by(name: 'enterprise').id, tenant_account.bought_cinstance&.plan.id
-    assert_equal 'API', tenant_account.default_service&.name
+    assert(tenant_bought_cinstance = tenant_account.bought_cinstance)
+    assert_equal ApplicationPlan.find_by(name: 'enterprise').id, tenant_bought_cinstance.plan_id
+    assert(tenant_service = tenant_account.default_service)
+    assert_equal 'API', tenant_service.name
 
     assert_equal 2, tenant_account.users.count
     tenant_user = tenant_account.users.but_impersonation_admin.first!
@@ -182,7 +185,8 @@ class SeedsTest < ActiveSupport::TestCase
     assert_equal ENV_VARIABLES['MASTER_SERVICE'], master_account.default_service.name
     assert(tenant_app_plan = master_account.default_service.application_plans.default)
     assert_equal ENV_VARIABLES['PROVIDER_PLAN'], tenant_app_plan.name
-    assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['MASTER_PLAN']).id, master_account.bought_cinstance&.plan.id
+    assert(master_bought_cinstance = master_account.bought_cinstance)
+    assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['MASTER_PLAN']).id, master_bought_cinstance.plan_id
 
     tenant_account = Account.tenants.first!
     assert_equal ENV_VARIABLES['PROVIDER_NAME'], tenant_account.name
@@ -193,7 +197,8 @@ class SeedsTest < ActiveSupport::TestCase
     tenant_user = tenant_account.users.but_impersonation_admin.first!
     assert_equal ENV_VARIABLES['USER_LOGIN'], tenant_user.username
     assert_equal ENV_VARIABLES['USER_EMAIL'], tenant_user.email
-    assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['PROVIDER_PLAN']).id, tenant_account.bought_cinstance&.plan.id
+    assert(tenant_bought_cinstance = enant_account.bought_cinstance)
+    assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['PROVIDER_PLAN']).id, tenant_bought_cinstance.plan_id
   end
 
   test 'done in a transaction: if it fails somewhere, it rollbacks' do
@@ -209,9 +214,9 @@ class SeedsTest < ActiveSupport::TestCase
   private
 
   def assert_expected_backend_api
-    assert (service = Account.tenants.first!.default_service)
+    assert(service = Account.tenants.first!.default_service)
     assert_equal 1, service.backend_apis.count
-    assert (backend_api = service.backend_apis.accessible.first)
+    assert(backend_api = service.backend_apis.accessible.first)
     assert_equal BackendApi.default_api_backend, backend_api.private_endpoint
     assert_equal service.system_name, backend_api.system_name
     assert_equal "#{service.name} Backend", backend_api.name

--- a/test/unit/db/seeds_test.rb
+++ b/test/unit/db/seeds_test.rb
@@ -80,8 +80,7 @@ class SeedsTest < ActiveSupport::TestCase
     assert_equal master_service.id, master_app_plan.issuer_id
     assert_equal 'enterprise', master_app_plan.name
 
-    assert (master_bought_cinstance = master_account.bought_cinstance)
-    assert_equal ApplicationPlan.find_by(name: 'Master Plan').id, master_bought_cinstance.plan_id
+    assert_equal ApplicationPlan.find_by(name: 'Master Plan').id, master_account.bought_cinstance.plan_id
 
     master_account_plan = master_account.default_account_plan
     assert_equal master_account.id, master_account_plan.issuer_id
@@ -114,10 +113,8 @@ class SeedsTest < ActiveSupport::TestCase
     assert tenant_account.sample_data.presence
     assert tenant_account.approved?
     assert tenant_account.state_changed_at.present?
-    assert (tenant_bought_cinstance = tenant_account.bought_cinstance)
-    assert_equal ApplicationPlan.find_by(name: 'enterprise').id, tenant_bought_cinstance.plan_id
-    assert (tenant_service = tenant_account.default_service)
-    assert_equal 'API', tenant_service.name
+    assert_equal ApplicationPlan.find_by(name: 'enterprise').id, tenant_account.bought_cinstance.plan_id
+    assert_equal 'API', tenant_account.default_service.name
 
     assert_equal 2, tenant_account.users.count
     tenant_user = tenant_account.users.but_impersonation_admin.first!
@@ -183,10 +180,8 @@ class SeedsTest < ActiveSupport::TestCase
     assert_equal ENV_VARIABLES['MASTER_ACCESS_CODE'], master_account.site_access_code
     assert_equal ENV_VARIABLES['MASTER_USER'], master_account.users.first!.username
     assert_equal ENV_VARIABLES['MASTER_SERVICE'], master_account.default_service.name
-    assert (tenant_app_plan = master_account.default_service.application_plans.default)
-    assert_equal ENV_VARIABLES['PROVIDER_PLAN'], tenant_app_plan.name
-    assert (master_bought_cinstance = master_account.bought_cinstance)
-    assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['MASTER_PLAN']).id, master_bought_cinstance.plan_id
+    assert_equal ENV_VARIABLES['PROVIDER_PLAN'], master_account.default_service.application_plans.default.name
+    assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['MASTER_PLAN']).id, master_account.bought_cinstance.plan_id
 
     tenant_account = Account.tenants.first!
     assert_equal ENV_VARIABLES['PROVIDER_NAME'], tenant_account.name
@@ -197,8 +192,7 @@ class SeedsTest < ActiveSupport::TestCase
     tenant_user = tenant_account.users.but_impersonation_admin.first!
     assert_equal ENV_VARIABLES['USER_LOGIN'], tenant_user.username
     assert_equal ENV_VARIABLES['USER_EMAIL'], tenant_user.email
-    assert (tenant_bought_cinstance = tenant_account.bought_cinstance)
-    assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['PROVIDER_PLAN']).id, tenant_bought_cinstance.plan_id
+    assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['PROVIDER_PLAN']).id, tenant_account.bought_cinstance.plan_id
   end
 
   test 'done in a transaction: if it fails somewhere, it rollbacks' do

--- a/test/unit/db/seeds_test.rb
+++ b/test/unit/db/seeds_test.rb
@@ -80,7 +80,7 @@ class SeedsTest < ActiveSupport::TestCase
     assert_equal master_service.id, master_app_plan.issuer_id
     assert_equal 'enterprise', master_app_plan.name
 
-    assert(master_bought_cinstance = master_account.bought_cinstance)
+    assert (master_bought_cinstance = master_account.bought_cinstance)
     assert_equal ApplicationPlan.find_by(name: 'Master Plan').id, master_bought_cinstance.plan_id
 
     master_account_plan = master_account.default_account_plan
@@ -91,14 +91,14 @@ class SeedsTest < ActiveSupport::TestCase
       assert master_service.metrics.find_by(system_name: system_name, unit: 'hit', friendly_name: description)
     end
 
-    assert(tenant_app_plan = master_service.application_plans.default)
+    assert (tenant_app_plan = master_service.application_plans.default)
     assert_equal 'enterprise', tenant_app_plan.name
     assert_equal master_service.id, tenant_app_plan.issuer_id
 
-    assert(apicast = master_account.access_tokens.find_by(name: 'APIcast'))
+    assert (apicast = master_account.access_tokens.find_by(name: 'APIcast'))
     assert_equal 'ro', apicast.permission
     assert_equal %w[account_management], apicast.scopes
-    assert(master_token = master_account.access_tokens.find_by(name: 'Master Token'))
+    assert (master_token = master_account.access_tokens.find_by(name: 'Master Token'))
     assert_equal 'rw', master_token.permission
     assert_equal %w[account_management], master_token.scopes
 
@@ -114,9 +114,9 @@ class SeedsTest < ActiveSupport::TestCase
     assert tenant_account.sample_data.presence
     assert tenant_account.approved?
     assert tenant_account.state_changed_at.present?
-    assert(tenant_bought_cinstance = tenant_account.bought_cinstance)
+    assert (tenant_bought_cinstance = tenant_account.bought_cinstance)
     assert_equal ApplicationPlan.find_by(name: 'enterprise').id, tenant_bought_cinstance.plan_id
-    assert(tenant_service = tenant_account.default_service)
+    assert (tenant_service = tenant_account.default_service)
     assert_equal 'API', tenant_service.name
 
     assert_equal 2, tenant_account.users.count
@@ -183,9 +183,9 @@ class SeedsTest < ActiveSupport::TestCase
     assert_equal ENV_VARIABLES['MASTER_ACCESS_CODE'], master_account.site_access_code
     assert_equal ENV_VARIABLES['MASTER_USER'], master_account.users.first!.username
     assert_equal ENV_VARIABLES['MASTER_SERVICE'], master_account.default_service.name
-    assert(tenant_app_plan = master_account.default_service.application_plans.default)
+    assert (tenant_app_plan = master_account.default_service.application_plans.default)
     assert_equal ENV_VARIABLES['PROVIDER_PLAN'], tenant_app_plan.name
-    assert(master_bought_cinstance = master_account.bought_cinstance)
+    assert (master_bought_cinstance = master_account.bought_cinstance)
     assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['MASTER_PLAN']).id, master_bought_cinstance.plan_id
 
     tenant_account = Account.tenants.first!
@@ -197,7 +197,7 @@ class SeedsTest < ActiveSupport::TestCase
     tenant_user = tenant_account.users.but_impersonation_admin.first!
     assert_equal ENV_VARIABLES['USER_LOGIN'], tenant_user.username
     assert_equal ENV_VARIABLES['USER_EMAIL'], tenant_user.email
-    assert(tenant_bought_cinstance = tenant_account.bought_cinstance)
+    assert (tenant_bought_cinstance = tenant_account.bought_cinstance)
     assert_equal ApplicationPlan.find_by(name: ENV_VARIABLES['PROVIDER_PLAN']).id, tenant_bought_cinstance.plan_id
   end
 
@@ -214,9 +214,9 @@ class SeedsTest < ActiveSupport::TestCase
   private
 
   def assert_expected_backend_api
-    assert(service = Account.tenants.first!.default_service)
+    assert (service = Account.tenants.first!.default_service)
     assert_equal 1, service.backend_apis.count
-    assert(backend_api = service.backend_apis.accessible.first)
+    assert (backend_api = service.backend_apis.accessible.first)
     assert_equal BackendApi.default_api_backend, backend_api.private_endpoint
     assert_equal service.system_name, backend_api.system_name
     assert_equal "#{service.name} Backend", backend_api.name

--- a/test/unit/signup/account_manager_test.rb
+++ b/test/unit/signup/account_manager_test.rb
@@ -126,22 +126,28 @@ class Signup::AccountManagerTest < ActiveSupport::TestCase
       assert_equal 'API', account.first_service!.name
     end
 
-    test 'creating a provider will create default Backend if api_as_product is disabled' do
+    test 'creating a provider will create default Backend regardless of api_as_product' do
       Account.any_instance.stubs(:provider_can_use?).returns(false)
       Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false)
       account = signup_account_manager.create(signup_params).account
-      assert_equal BackendApi.default_api_backend, account.default_service.api_backend
+      assert_expected_backend_api(account)
     end
 
     test 'creating a provider will create default Backend if api_as_product is enabled' do
       Account.any_instance.stubs(:provider_can_use?).returns(false)
       Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true)
       account = signup_account_manager.create(signup_params).account
-      assert account.backend_apis.first
-      assert_equal BackendApi.default_api_backend, account.default_service.api_backend
+      assert_expected_backend_api(account)
     end
 
     private
+
+    def assert_expected_backend_api(account)
+      assert_equal 1, account.backend_apis.count
+      assert(service = account.default_service)
+      assert_equal 1, service.backend_apis.count
+      assert_equal BackendApi.default_api_backend, service.api_backend
+    end
 
     def manager_account
       @manager_account ||= master_account

--- a/test/unit/signup/account_manager_test.rb
+++ b/test/unit/signup/account_manager_test.rb
@@ -126,28 +126,32 @@ class Signup::AccountManagerTest < ActiveSupport::TestCase
       assert_equal 'API', account.first_service!.name
     end
 
-    test 'creating a provider will create default Backend regardless of api_as_product' do
+    test 'first service has a private endpoint in order to be functional for non-APIAP accounts' do
       Account.any_instance.stubs(:provider_can_use?).returns(false)
       Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false)
+
       account = signup_account_manager.create(signup_params).account
-      assert_expected_backend_api(account)
+      assert_equal 1, account.first_service!.backend_apis.count
+      assert_equal BackendApi.default_api_backend, account.first_service!.backend_apis.first!.private_endpoint
     end
 
-    test 'creating a provider will create default Backend if api_as_product is enabled' do
+    test 'first service has a complete backend api for APIAP accounts' do
       Account.any_instance.stubs(:provider_can_use?).returns(false)
       Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true)
+
       account = signup_account_manager.create(signup_params).account
-      assert_expected_backend_api(account)
+      assert_equal 1, account.backend_apis.count
+      assert (service = account.default_service)
+      assert_equal 1, service.backend_apis.count
+      assert (backend_api = service.backend_apis.accessible.first)
+      assert_equal BackendApi.default_api_backend, backend_api.private_endpoint
+      assert_equal service.system_name, backend_api.system_name
+      assert_equal "#{service.name} Backend", backend_api.name
+      assert_equal "Backend of #{service.name}", backend_api.description
+      assert_equal service.account_id, backend_api.account_id
     end
 
     private
-
-    def assert_expected_backend_api(account)
-      assert_equal 1, account.backend_apis.count
-      assert(service = account.default_service)
-      assert_equal 1, service.backend_apis.count
-      assert_equal BackendApi.default_api_backend, service.api_backend
-    end
 
     def manager_account
       @manager_account ||= master_account


### PR DESCRIPTION
Improves tests of https://github.com/3scale/porta/pull/1292 according to the reviews.