### PR TITLE
Show "service access" message only when there are no accessible services

### DIFF
--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -99,7 +99,8 @@ section class="service-widget"
             '  published) with a total of
             = pluralize service.contracts.service.size, 'contract'
             | .
-          
+
+    - if current_user.accessible_services.empty?
       = render 'shared/service_access'
 
     section[name="activity"]

--- a/app/views/buyers/applications/index.html.slim
+++ b/app/views/buyers/applications/index.html.slim
@@ -10,6 +10,8 @@
       ' on service
       = @service.name
 
-= render 'listing'
-= render 'shared/service_access'
+- if current_user.accessible_services.empty?
+  = render 'shared/service_access'
+- else
+  = render 'listing'
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It checks if the current user as no accessible services, if so it renders the message instead of the list.

Currently the message is always shown 🐛.

**Which issue(s) this PR fixes** 

[THREESCALE-3595: Message shown incorrectly in applications listing page](https://issues.jboss.org/browse/THREESCALE-3595)

**Visual verification**:
![Screen Shot 2019-10-03 at 12 34 17](https://user-images.githubusercontent.com/11672286/66120238-b8594480-e5da-11e9-8898-465d1661f8f3.png)

![Screen Shot 2019-10-03 at 12 35 56](https://user-images.githubusercontent.com/11672286/66120240-babb9e80-e5da-11e9-928d-aa5783afc2d3.png)

![Screen Shot 2019-10-03 at 12 37 57](https://user-images.githubusercontent.com/11672286/66120243-bbeccb80-e5da-11e9-81df-38a5a773c69f.png)

