### PR TITLE
Fix Random CircleCI failure: in 'test_custom_release' - Expected '4', got '2'

### DIFF
--- a/lib/system/deploy.rb
+++ b/lib/system/deploy.rb
@@ -28,7 +28,7 @@ module System
 
       class VersionParser
         attr_reader :segments
-        
+
         def initialize(release)
           @segments = release.to_s.split('.')
         end
@@ -69,9 +69,9 @@ module System
       [200, {'Content-Type' => 'application/json'}, [info.to_json]]
     end
 
-    def self.load_info!
-      self.info = Info.new(parse_deploy_info)
-    rescue => error
+    def self.load_info!(deploy_info = parse_deploy_info)
+      self.info = Info.new(deploy_info)
+    rescue StandardError => error
       self.info = InvalidInfo.new(error)
     end
   end

--- a/test/fixtures/deploy_info
+++ b/test/fixtures/deploy_info
@@ -1,0 +1,9 @@
+{
+  "revision": "a1b2c3d",
+  "release": "4.5.1-CR1",
+  "deployed_at": "2019-09-25 10:45:09 UTC",
+  "rails": "4.2.11.1",
+  "env": {
+    "PATH": "/home/user/production/porta"
+  }
+}

--- a/test/unit/deploy/basic_info_test.rb
+++ b/test/unit/deploy/basic_info_test.rb
@@ -1,11 +1,11 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class BasicInfoTest < ActiveSupport::TestCase
-
   test 'default release is 2.x' do
     System::Deploy.load_info!
     assert_equal '2.x', System::Deploy.info.release
-
   end
 
   test 'minor and major version taken from default release' do
@@ -15,7 +15,9 @@ class BasicInfoTest < ActiveSupport::TestCase
   end
 
   test 'custom release' do
-    System::Deploy.info.expects(:release).returns('4.5.1-CR1')
+    path = Rails.root.join('test', 'fixtures', 'deploy_info').expand_path
+    System::Deploy.load_info! ActiveSupport::JSON.decode(path.read)
+
     assert_equal '4', System::Deploy.info.major_version
     assert_equal '5', System::Deploy.info.minor_version
   end


### PR DESCRIPTION
Closes [THREESCALE-3621](https://issues.jboss.org/browse/THREESCALE-3621)

The problem is that we are memoizing at Module level, so when it runs tests, it keeps the memoized attributes of the previous tests, and this test only passes when it is executed the 1st one. It is ok to memoize for the real code because the `.deploy_info` won't change in execution time, but for the tests it is a problem.

A way to reproduce it locally would be, for example:
```ruby
test 'custom release' do
  System::Deploy.load_info!
  System::Deploy.info.major_version # So it loads all the memoized variables

  # From here the actual test
  System::Deploy.info.stubs(:release).returns('4.5.1-CR1')

  assert_equal '4', System::Deploy.info.major_version
  assert_equal '5', System::Deploy.info.minor_version
end
```

And an alternative way to make it work would be removing some variables, for example by removing only this one, it would work:
https://github.com/3scale/porta/blob/a1e47420cf7a0e56acfc93e6f8795709235f72f5/lib/system/deploy.rb#L46
