### PR TITLE
Passing username from params to login form

### DIFF
--- a/app/javascript/src/LoginPage/LoginPageWrapper.jsx
+++ b/app/javascript/src/LoginPage/LoginPageWrapper.jsx
@@ -36,7 +36,10 @@ type Props = {
   providerPasswordPath: string,
   providerSessionsPath: string,
   redirectUrl: string,
-  show3scaleLoginForm: boolean
+  show3scaleLoginForm: boolean,
+  session: {
+    username: ?string
+  }
 }
 
 const formModeTuple: [string, string] = ['login', 'password-reset']
@@ -83,6 +86,7 @@ class SimpleLoginPage extends React.Component<Props, State> {
         { !enforceSSO &&
             <Login3scaleForm
               providerSessionsPath={this.props.providerSessionsPath}
+              session={this.props.session}
             />
         }
         { hasAuthenticationProviders &&

--- a/app/javascript/src/LoginPage/loginForms/Login3scaleForm.jsx
+++ b/app/javascript/src/LoginPage/loginForms/Login3scaleForm.jsx
@@ -17,7 +17,10 @@ import {
 } from '@patternfly/react-core'
 
 type Props = {
-  providerSessionsPath: string
+  providerSessionsPath: string,
+  session: {
+    username: ?string
+  }
 }
 
 type State = {
@@ -43,10 +46,10 @@ const PASSWORD_ATTRS = {
 
 class Login3scaleForm extends React.Component<Props, State> {
   state = {
-    username: '',
+    username: this.props.session.username || '',
     password: '',
     validation: {
-      username: undefined,
+      username: this.props.session.username ? true : undefined,
       password: undefined
     }
   }
@@ -72,7 +75,8 @@ class Login3scaleForm extends React.Component<Props, State> {
       label: USERNAME_ATTRS.label,
       isValid: validation.username,
       value: username,
-      onChange: this.handleInputChange
+      onChange: this.handleInputChange,
+      autoFocus: username ? false : 'autoFocus'
     }
     const passwordInputProps = {
       isRequired: true,
@@ -81,7 +85,8 @@ class Login3scaleForm extends React.Component<Props, State> {
       label: PASSWORD_ATTRS.label,
       isValid: validation.password,
       value: password,
-      onChange: this.handleInputChange
+      onChange: this.handleInputChange,
+      autoFocus: username ? 'autoFocus' : false
     }
     const formDisabled = Object.values(this.state.validation).some(value => value !== true)
     return (

--- a/app/views/provider/sessions/new.html.slim
+++ b/app/views/provider/sessions/new.html.slim
@@ -9,7 +9,8 @@ div#pf-login-page-container data-login-props={redirectUrl: (session[:return_to].
   providerSessionsPath: provider_sessions_path,
   providerLoginPath: provider_login_path,
   providerPasswordPath: provider_password_path,
-  providerAdminDashboardPath: provider_admin_dashboard_path}.to_json
+  providerAdminDashboardPath: provider_admin_dashboard_path,
+  session: {username: params[:username]} }.to_json
 
 #old-login-page-wrapper
   .box#old-login-page

--- a/spec/javascripts/LoginPage/Login3scaleForm.spec.jsx
+++ b/spec/javascripts/LoginPage/Login3scaleForm.spec.jsx
@@ -4,7 +4,8 @@ import {mount} from 'enzyme'
 import {Login3scaleForm, HiddenInputs} from 'LoginPage'
 
 const props = {
-  providerSessionsPath: 'sessions-path'
+  providerSessionsPath: 'sessions-path',
+  session: {username: ''}
 }
 
 it('should render itself with right props', () => {
@@ -51,6 +52,12 @@ describe('username', () => {
     expect(wrapper.state().username).toEqual('')
     expect(wrapper.state().validation.username).toEqual(false)
   })
+
+  it('should autofocus username input when username is not passed as param', () => {
+    const wrapper = mount(<Login3scaleForm {...props}/>)
+    expect(wrapper.find('input#session_username').props().autoFocus).toEqual('autoFocus')
+    expect(wrapper.find('input#session_password').props().autoFocus).toEqual(false)
+  })
 })
 
 describe('password', () => {
@@ -80,5 +87,12 @@ describe('password', () => {
     wrapper.find('input#session_password').props().onChange(event)
     expect(wrapper.state().password).toEqual('')
     expect(wrapper.state().validation.password).toEqual(false)
+  })
+
+  it('should autofocus password input when username is passed as param', () => {
+    const propsUsernameParams = {...props, session: {username: 'bob'}}
+    const wrapper = mount(<Login3scaleForm {...propsUsernameParams}/>)
+    expect(wrapper.find('input#session_password').props().autoFocus).toEqual('autoFocus')
+    expect(wrapper.find('input#session_username').props().autoFocus).toEqual(false)
   })
 })

--- a/spec/javascripts/LoginPage/LoginPageWrapper.spec.jsx
+++ b/spec/javascripts/LoginPage/LoginPageWrapper.spec.jsx
@@ -11,7 +11,8 @@ const props = {
   providerPasswordPath: 'password-path',
   providerSessionsPath: 'sessions-path',
   redirectUrl: 'redirect-url',
-  show3scaleLoginForm: true
+  show3scaleLoginForm: true,
+  session: {username: ''}
 }
 
 it('should render itself', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

When username is present in URL params it must be used to pre-fill username input


<img width="769" alt="Screenshot 2019-10-04 at 11 11 23" src="https://user-images.githubusercontent.com/13486237/66197607-09307200-e69b-11e9-9c5a-12792ac7eddd.png">

