### PR TITLE
When deleting in parallel, try once to unstore credit card before destroying the buyer

### DIFF
--- a/app/models/account/payment_details.rb
+++ b/app/models/account/payment_details.rb
@@ -4,7 +4,7 @@ module Account::PaymentDetails
   extend ActiveSupport::Concern
 
   included do
-    has_one :payment_detail, -> { order id: :desc }, autosave: true
+    has_one :payment_detail, -> { order id: :desc }, autosave: true, dependent: :destroy
 
     CREDIT_CARD_ATTRIBUTES = [
       :credit_card_auth_code,

--- a/app/workers/delete_account_hierarchy_worker.rb
+++ b/app/workers/delete_account_hierarchy_worker.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class DeleteAccountHierarchyWorker < DeleteObjectHierarchyWorker
-
   def perform(*)
     return unless account.should_be_deleted?
     super
@@ -21,4 +20,11 @@ class DeleteAccountHierarchyWorker < DeleteObjectHierarchyWorker
     end
   end
 
+  def destroyable_association?(reflection)
+    if called_from_provider_hierarchy? && account.gateway_setting.persisted?
+      super && reflection.class_name != Account.name
+    else
+      super
+    end
+  end
 end

--- a/app/workers/delete_payment_setting_hierarchy_worker.rb
+++ b/app/workers/delete_payment_setting_hierarchy_worker.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class DeletePaymentSettingHierarchyWorker < DeleteObjectHierarchyWorker
+  private
+
+  alias payment_setting object
+
+  def delete_associations
+    super
+
+    return unless called_from_provider_hierarchy?
+
+    reflection_buyers_of_provider = Account.reflect_on_all_associations.find { |reflection| reflection.name == :buyer_accounts }
+    ReflectionDestroyer.new(payment_setting.account, reflection_buyers_of_provider, caller_worker_hierarchy).destroy_later
+  end
+end

--- a/app/workers/delete_service_hierarchy_worker.rb
+++ b/app/workers/delete_service_hierarchy_worker.rb
@@ -5,11 +5,8 @@ class DeleteServiceHierarchyWorker < DeleteObjectHierarchyWorker
 
   alias service object
 
-  # TODO: when we remove the Rolling Update, we must remove this whole method and not only the conditional
-  def destroyable_associations
-    return super if service.account.provider_can_use?(:api_as_product)
-    object.class.reflect_on_all_associations.select do |reflection|
-      destroyable_association?(reflection.options[:dependent]) || reflection.name == :backend_apis
-    end
+  # TODO: when we remove the Rolling Update, we must remove this whole method
+  def destroyable_association?(reflection)
+    super || (reflection.name == :backend_apis && !service.account.provider_can_use?(:api_as_product))
   end
 end

--- a/test/integration/service_not_deleted_test.rb
+++ b/test/integration/service_not_deleted_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 require 'sidekiq/testing'
 
-class ServiceNotDeletoedTest < ActionDispatch::IntegrationTest
+class ServiceNotDeletedTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
   disable_transactional_fixtures!

--- a/test/workers/delete_account_hierarchy_worker_test.rb
+++ b/test/workers/delete_account_hierarchy_worker_test.rb
@@ -3,10 +3,11 @@
 require 'test_helper'
 
 class DeleteAccountHierarchyWorkerTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
 
   def setup
-    @provider = FactoryBot.create(:provider_account)
-    @provider.schedule_for_deletion!
+    @provider = FactoryBot.create(:provider_account, provider_account: master_account)
+    provider.schedule_for_deletion!
   end
 
   attr_reader :provider
@@ -24,14 +25,12 @@ class DeleteAccountHierarchyWorkerTest < ActiveSupport::TestCase
     FactoryBot.create(:application_contract, user_account: provider)
     contracts = provider.reload.contracts
 
-    buyers = FactoryBot.create_list(:buyer_account, 2, provider_account: provider)
     users = provider.users
     cms_sections = provider.sections
 
     DeleteObjectHierarchyWorker.stubs(:perform_later)
     users.each { |user| DeleteObjectHierarchyWorker.expects(:perform_later).with(user, anything, 'destroy') }
     services.each { |service| DeleteServiceHierarchyWorker.expects(:perform_later).with(service, anything, 'destroy') }
-    buyers.each { |buyer| DeleteAccountHierarchyWorker.expects(:perform_later).with(buyer, anything, 'destroy').once }
     contracts.each do |contract|
       DeleteObjectHierarchyWorker.expects(:perform_later).with(Contract.new({ id: contract.id }, without_protection: true), anything, 'destroy')
     end
@@ -39,20 +38,78 @@ class DeleteAccountHierarchyWorkerTest < ActiveSupport::TestCase
     cms_sections.each do |cms_section|
       DeleteObjectHierarchyWorker.expects(:perform_later).with(CMS::Section.new({ id: cms_section.id }, without_protection: true), anything, 'delete')
     end
+    DeletePaymentSettingHierarchyWorker.expects(:perform_later).with(provider.payment_gateway_setting, anything, 'destroy')
 
-    Sidekiq::Testing.inline! { DeleteAccountHierarchyWorker.perform_now(provider) }
+    perform_enqueued_jobs { DeleteAccountHierarchyWorker.perform_now(provider) }
   end
 
   test 'does not perform if wrong state' do
     provider.update_column(:state, 'approved')
-    DeleteObjectHierarchyWorker.expects(:perform_later).never
 
-    Sidekiq::Testing.inline! { DeleteAccountHierarchyWorker.perform_now(provider) }
+    perform_enqueued_jobs { DeleteAccountHierarchyWorker.perform_now(provider) }
+
+    assert provider.reload
   end
 
   test 'the account ends up destroyed after the hierarchy' do
-    Sidekiq::Testing.inline! { DeleteAccountHierarchyWorker.perform_now(provider) }
+    perform_enqueued_jobs { DeleteAccountHierarchyWorker.perform_now(provider) }
 
     assert_raises(ActiveRecord::RecordNotFound) { provider.reload }
+  end
+
+  class DeleteBuyersTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
+    disable_transactional_fixtures!
+
+    def setup
+      @provider = FactoryBot.create(:provider_account, provider_account: master_account)
+      provider.schedule_for_deletion!
+      @buyers = FactoryBot.create_list(:simple_buyer, 2, provider_account: provider)
+    end
+
+    attr_reader :provider, :buyers
+
+    test 'buyers are not destroyed through the tenant if the hierarchy comes from the tenant' do
+      expect_buyers_perform_later(requested_times: :never)
+
+      tenant_hierarchy_worker.perform(provider)
+    end
+
+    test 'buyers are destroyed through the tenant if it does not have a payment gateway setting' do
+      provider.payment_gateway_setting.delete
+
+      expect_buyers_perform_later(requested_times: :once)
+
+      tenant_hierarchy_worker.perform(provider)
+    end
+
+    test 'buyers are destroyed through regular hierarchy if it is not called from the tenant' do
+      buyers.each { |buyer| buyer.payment_detail.save! && DeleteObjectHierarchyWorker.expects(:perform_later).with(buyer.payment_detail, anything, 'destroy') }
+
+      buyers.each { |buyer| perform_enqueued_jobs { DeleteAccountHierarchyWorker.perform_now(buyer) } }
+
+      buyers.each { |buyer| assert_raises(ActiveRecord::RecordNotFound) { buyer.reload } }
+    end
+
+    private
+
+    def tenant_hierarchy_worker
+      @tenant_hierarchy_worker ||= begin
+        worker = DeleteAccountHierarchyWorker.new
+        worker.instance_variable_set(:@caller_worker_hierarchy, ["Hierarchy-Account-#{provider.id}"])
+        worker.instance_variable_set(:@object, provider)
+        worker
+      end
+    end
+
+    def expect_buyers_perform_later(requested_times:)
+      buyers.each do |buyer|
+        DeleteAccountHierarchyWorker.expects(:perform_later)
+          .with(buyer, ["Hierarchy-Account-#{provider.id}"], 'destroy')
+          .public_send(requested_times)
+      end
+    end
+
   end
 end

--- a/test/workers/delete_payment_setting_hierarchy_worker_test.rb
+++ b/test/workers/delete_payment_setting_hierarchy_worker_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DeletePaymentSettingHierarchyWorkerTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+  
+  def setup
+    tenant = FactoryBot.create(:simple_provider)
+    tenant.schedule_for_deletion!
+    @payment_gateway_setting = FactoryBot.create(:payment_gateway_setting, account: tenant, tenant_id: tenant.id)
+    @buyers = FactoryBot.create_list(:simple_buyer, 2, provider_account: tenant)
+  end
+
+  attr_reader :payment_gateway_setting, :buyers
+
+  test 'it performs for the buyers is it is destroyed by the provider association' do
+    perform_enqueued_jobs do
+      DeletePaymentSettingHierarchyWorker.perform_now(payment_gateway_setting,
+        ["Hierarchy-Account-#{payment_gateway_setting.tenant_id}"])
+    end
+
+    buyers.each { |buyer| assert_raises(ActiveRecord::RecordNotFound) { buyer.reload } }
+  end
+
+  test 'it does not perform for the buyers if it is not destroyed by the provider association' do
+    perform_enqueued_jobs { DeletePaymentSettingHierarchyWorker.perform_now(payment_gateway_setting, []) }
+
+    buyers.each { |buyer| assert buyer.reload }
+  end
+end


### PR DESCRIPTION
Closes [THREESCALE-3637](https://issues.jboss.org/browse/THREESCALE-3637)

### Tasks
- [X] Delete provider buyers before payment setting
- [X] Do not work the hierarchy for buyers twice
- [X] Delete PaymentDetail before its Account

### Verification Steps
I tested also in preview to be more realistic and the way to test it there is:
1. Get a some tenants scheduled for deletion. Some of them big ones. For example by doing: `tenants = Account.tenants.scheduled_for_deletion.first(10)`
2. Do the deletion in Background: `tenants.each { |tenant| DeleteAccountHierarchyWorker.perform_later(tenant) }`
3. Keep track of what's going on in the UI by the URL `/sidekiq/queues` , and check which ones are destroyed by doing in the terminal: `tenants.map { |tenant| Account.exists?(tenant.id) }`. That until all of them are completely destroyed.
4. Download the Sidekiq logs and search there for the order of how everything has been destroyed. For example, this is the format of the data you are looking for:
```json
"arguments": [
  {"_aj_globalid": "gid://system/Settings/3"},
  ["Hierarchy-Account-1", "Hierarchy-PaymentGatewaySetting-4", "Hierarchy-Account-2", "Hierarchy-Settings-2"],
  "destroy"
]
```