### PR TITLE
Do not allow access to edit or update IntegrationsController for apiap

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -4,6 +4,7 @@ class Api::IntegrationsController < Api::BaseController
   before_action :find_service
   before_action :find_proxy
   before_action :authorize
+  before_action :hide_for_apiap, only: :edit
 
   activate_menu :serviceadmin, :integration, :configuration
   sublayout 'api/service'
@@ -203,6 +204,10 @@ class Api::IntegrationsController < Api::BaseController
 
   def message_bus?(proxy)
     proxy.oidc? && ZyncWorker.config.message_bus
+  end
+
+  def hide_for_apiap
+    raise ActiveRecord::RecordNotFound if apiap?
   end
 
   def authorize

--- a/test/functional/api/integrations_controller_test.rb
+++ b/test/functional/api/integrations_controller_test.rb
@@ -123,6 +123,8 @@ class Api::IntegrationsControllerTest < ActionController::TestCase
   end
 
   test 'update custom public endpoint with proxy_pro enabled' do
+    rolling_updates_off
+    
     Proxy.any_instance.stubs(deploy: true)
     ProxyTestService.any_instance.stubs(:disabled?).returns(true)
 
@@ -136,6 +138,8 @@ class Api::IntegrationsControllerTest < ActionController::TestCase
   end
 
   test 'create proxy config with proxy_pro enabled' do
+    rolling_updates_off
+
     proxy = @provider.default_service.proxy
     proxy.update_column(:apicast_configuration_driven, true)
 

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -1,15 +1,13 @@
 require 'test_helper'
 
-class IntegrationsTest < ActionDispatch::IntegrationTest
+class IntegrationsControllerTest < ActionDispatch::IntegrationTest
 
   def setup
     @provider = FactoryBot.create(:provider_account)
 
-    login_provider @provider
-
     stub_apicast_registry
 
-    host! @provider.admin_domain
+    login! @provider
   end
 
   def test_index


### PR DESCRIPTION
[THREESCALE-3625](https://issues.jboss.org/browse/THREESCALE-3625)
APIAP-users should not have access to `/apiconfig/services/:service_id/integration/edit` and before this PR they do by typing the URL on the browser. This PR blocks access to the `edit` action of this controller for APIAP users.