### PR TITLE
[API] Backend Usage 'show/read' + Representer returns service id & backend api id

### DIFF
--- a/app/controllers/admin/api/services/backend_api_configs_controller.rb
+++ b/app/controllers/admin/api/services/backend_api_configs_controller.rb
@@ -91,6 +91,24 @@ class Admin::Api::Services::BackendApiConfigsController < Admin::Api::Services::
     respond_with(backend_api_config)
   end
 
+  ##~ e = sapi.apis.add
+  ##~ e.path = "/admin/api/services/{service_id}/backend_apis/{id}.json"
+  ##~ e.responseClass = "backend_api_config"
+  #
+  ##~ op            = e.operations.add
+  ##~ op.httpMethod = "GET"
+  ##~ op.summary    = "Backend Usage Read"
+  ##~ op.description = "Show the usage of a Backend within the scope of the Service (Product)."
+  ##~ op.group = "backend_api_config"
+  #
+  ##~ op.parameters.add @parameter_access_token
+  ##~ op.parameters.add @parameter_service_id_by_id_name
+  ##~ op.parameters.add @parameter_backend_api_id_by_id
+  #
+  def show
+    respond_with(backend_api_config)
+  end
+
   private
 
   def backend_api_config

--- a/app/representers/backend_api_config_representer.rb
+++ b/app/representers/backend_api_config_representer.rb
@@ -4,6 +4,8 @@ module BackendApiConfigRepresenter
   include ThreeScale::JSONRepresenter
 
   property :path
+  property :service_id
+  property :backend_api_id, as: :id
 
   link :service do
     admin_api_service_url(service_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -672,7 +672,7 @@ without fake Core server your after commit callbacks will crash and you might ge
         end
 
         scope module: :services do # this api has a knack for inconsistency
-          resources :backend_apis, controller: :backend_api_configs, except: %i[new edit show], defaults: { format: :json }
+          resources :backend_apis, controller: :backend_api_configs, except: %i[new edit], defaults: { format: :json }
 
           resources :end_users, :only => [:show, :create, :destroy] do
             member do

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -6663,6 +6663,43 @@
       ]
     },
     {
+      "path": "/admin/api/services/{service_id}/backend_apis/{id}.json",
+      "responseClass": "backend_api_config",
+      "operations": [
+        {
+          "httpMethod": "GET",
+          "summary": "Backend Usage Read",
+          "description": "Show the usage of a Backend within the scope of the Service (Product).",
+          "group": "backend_api_config",
+          "parameters": [
+            {
+              "name": "access_token",
+              "description": "A personal Access Token",
+              "dataType": "string",
+              "required": true,
+              "paramType": "query",
+              "threescale_name": "access_token"
+            },
+            {
+              "name": "service_id",
+              "description": "ID of the service.",
+              "dataType": "int",
+              "required": true,
+              "paramType": "path",
+              "threescale_name": "service_ids"
+            },
+            {
+              "name": "id",
+              "description": "ID of the Backend.",
+              "dataType": "int",
+              "required": true,
+              "paramType": "path"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": "/admin/api/services/{service_id}/end_user_plans.xml",
       "responseClass": "List[end_user_plan]",
       "operations": [


### PR DESCRIPTION
As decided with QE, we add a show endpoint and return the service id and backend api id of all Backend API Usage endpoints and in Backend API read for its usage.

#### Show Endpoint
![image](https://user-images.githubusercontent.com/11318903/66297428-f5317e00-e8ef-11e9-9f23-e22cf4d6fbd9.png)
![image](https://user-images.githubusercontent.com/11318903/66297454-fe224f80-e8ef-11e9-9972-9ed671a62500.png)

- Request: `curl -v  -X GET "http://provider-admin.example.com.lvh.me:3000/admin/api/services/2/backend_apis/2.json?access_token=c32fc99008021a29babf962bb04bb30807f8f3310add73ac6f51377477f2486d"`

- Response:
```json
{
 "path": "",
 "service_id": 2,
 "id": 2,
 "links": [
  {
   "rel": "service",
   "href": "http://provider-admin.example.com/admin/api/services/2"
  },
  {
   "rel": "backend_api",
   "href": "http://provider-admin.example.com/admin/api/backend_apis/2"
  }
 ]
}
```