### PR TITLE
adds liquid check for admin role

### DIFF
--- a/lib/developer_portal/app/views/developer_portal/_users_menu.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/_users_menu.html.liquid
@@ -5,10 +5,14 @@
     </li>
 
     {% if provider.account_management_enabled? %}
-      {% include 'menu_item' with urls.users %}
+      {% if current_user.admin? %}
+        {% include 'menu_item' with urls.users %}
+      {% endif %}
 
       {% if provider.multiple_users_allowed? %}
-        {% include 'menu_item' with urls.invitations %}
+        {% if current_user.admin? %}
+          {% include 'menu_item' with urls.invitations %}
+        {% endif %}
       {% endif %}
     {% endif %}
 


### PR DESCRIPTION
Fixes [THREESCALE-1142](https://issues.jboss.org/browse/THREESCALE-1142)

404 Not Found error is returned for member users when they try to navigate to some of the presented menu items. These menu items shouldn't be rendered if the user is not an admin user and therefore restricted access is enforced whilst hiding those menus. 
