### PR TITLE
Avoid Empty paths for BackendApiConfig

### DIFF
--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -43,6 +43,10 @@ module BackendApiLogic
           @config = config
         end
 
+        def config_path
+          @config_path ||= ConfigPath.new(path)
+        end
+
         def as_json
           return if private_endpoint.blank?
           {
@@ -51,24 +55,16 @@ module BackendApiLogic
               operations: [
                 match: :path,
                 op: :matches,
-                value: path_to_regex
+                value: config_path.to_regex
               ]
             }
           }.merge(replace_path)
         end
 
-        def path_to_regex
-          if path.to_s.empty?
-            "/.*"
-          else
-            "/#{path}/.*|/#{path}/?"
-          end
-        end
-
         def replace_path
-          return {} if path.blank?
+          return {} if config_path.blank?
 
-          { replace_path: "{{original_request.path | remove_first: '/#{path}'}}" }
+          { replace_path: "{{original_request.path | remove_first: '#{config_path.path}'}}" }
         end
       end
       private_constant :Rule

--- a/app/lib/backend_api_logic/service_extension.rb
+++ b/app/lib/backend_api_logic/service_extension.rb
@@ -29,7 +29,7 @@ module BackendApiLogic
 
       def backend_api_config
         @backend_api_config ||= backend_api_configs.first ||
-                                backend_api_configs.build(path: '', backend_api: backend_api)
+                                backend_api_configs.build(path: '/', backend_api: backend_api)
       end
 
       def backend_api

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -14,22 +14,17 @@ class BackendApiConfig < ApplicationRecord
   self.default_sort_column = 'backend_apis.name'
   self.default_sort_direction = :asc
 
-  attribute :path, ActiveRecord::Type::StringNotNil.new
-
   has_many :backend_api_metrics, through: :backend_api, source: :metrics
 
   validates :service_id, :backend_api_id, presence: true
   validates :backend_api_id, uniqueness: { scope: :service_id }
   validates :path, uniqueness: { scope: :service_id, case_sensitive: false }
-  validates :path, length: { in: 0..255, allow_nil: false }, path: true
+  validates :path, length: { in: 1..255, allow_nil: false }, path: true
 
   scope :by_service,     ->(service_id)     { where.has { self.service_id     == service_id     } }
   scope :by_backend_api, ->(backend_api_id) { where.has { self.backend_api_id == backend_api_id } }
 
-  scope :with_subpath, -> do
-    common_query = where.not(path: '/')
-    System::Database.oracle? ? common_query.where('path is NOT NULL') : common_query.where.not(path: '')
-  end
+  scope :with_subpath, -> { where.not(path: ConfigPath::EMPTY_PATH) }
 
   scope :accessible, -> do
     joining { service }.where.has { (service.state != ::Service::DELETE_STATE) }
@@ -38,6 +33,6 @@ class BackendApiConfig < ApplicationRecord
   delegate :private_endpoint, to: :backend_api
 
   def path=(value)
-    super(StringUtils::StripSlash.strip_slash(value))
+    super(ConfigPath.new(value).path)
   end
 end

--- a/app/models/config_path.rb
+++ b/app/models/config_path.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ConfigPath
+  EMPTY_PATH = '/'
+
+  attr_reader :path
+
+  def initialize(value)
+    self.path = value
+  end
+
+  def to_regex
+    return '/.*' if empty?
+
+    "#{path}/.*|#{path}/?"
+  end
+
+  def empty?
+    path == EMPTY_PATH
+  end
+
+  private
+
+  def path=(value)
+    @path = EMPTY_PATH + StringUtils::StripSlash.strip_slash(value)
+  end
+end

--- a/app/services/service_creator.rb
+++ b/app/services/service_creator.rb
@@ -47,7 +47,7 @@ class ServiceCreator
 
   def save_assigned_backend_api(attrs)
     config = backend_api_configs.find_by(backend_api_id: @backend_api.id) ||
-      backend_api_configs.build(backend_api: @backend_api)
+             backend_api_configs.build(backend_api: @backend_api, path: '/')
     config.path = path.to_s if attrs.key?(:path)
     config.save!
   end

--- a/app/validators/path_validator.rb
+++ b/app/validators/path_validator.rb
@@ -8,6 +8,7 @@ class PathValidator < ActiveModel::EachValidator
   protected
 
   def path?(value)
+    value = StringUtils::StripSlash.strip_slash(value)
     uri = URI.parse(value)
     uri.path == value
   rescue URI::InvalidURIError

--- a/lib/tasks/data_migration/fix_backend_config_path.rb
+++ b/lib/tasks/data_migration/fix_backend_config_path.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :data_migration do
+  desc 'Backfill Paths for Backend Api Configs'
+  task :fix_backend_config_path do
+    query = System::Database.oracle? ? BackendApiConfig.where('path is NULL') : BackendApiConfig.where(path: '')
+    progress = ProgressCounter.new(query.count)
+    BackendApiConfig.transaction do
+      query.select(:id).find_in_batches(batch_size: 200) do |records|
+        BackendApiConfig.where(id: records.map(&:id)).update_all(path: '/')
+        progress.call(increment: records.size)
+      end
+    end
+  end
+end

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -31,7 +31,7 @@ namespace :services do
               private_endpoint: service.proxy&.[]('api_backend')
             )
 
-            service.backend_api_configs.create(backend_api: backend_api, path: '')
+            service.backend_api_configs.create(backend_api: backend_api, path: '/')
           end
         end
       end

--- a/test/factories/backend_api.rb
+++ b/test/factories/backend_api.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
   end
 
   factory :backend_api_config do
-    sequence(:path) { |n| "path#{n}" }
+    sequence(:path) { |n| "/path#{n}" }
     association :service
     association :backend_api
   end

--- a/test/fixtures/backend_api_configs.yml
+++ b/test/fixtures/backend_api_configs.yml
@@ -1,0 +1,7 @@
+empty_path:
+  id: 1
+  path: ''
+
+with_path:
+  id: 2
+  path: '/some/path'

--- a/test/integration/admin/api/services/backend_api_configs_controller_test.rb
+++ b/test/integration/admin/api/services/backend_api_configs_controller_test.rb
@@ -18,7 +18,7 @@ class Admin::API::Services::BackendApiConfigsControllerTest < ActionDispatch::In
       assert_response :created
     end
     backend_api_config = service.backend_api_configs.order(:id).last!
-    assert_equal 'foo/bar', backend_api_config.path
+    assert_equal '/foo/bar', backend_api_config.path
     assert_equal service.id, backend_api_config.service_id
     assert_equal backend_api.id, backend_api_config.backend_api_id
   end
@@ -51,7 +51,7 @@ class Admin::API::Services::BackendApiConfigsControllerTest < ActionDispatch::In
 
     assert_response :success
     backend_api_config.reload
-    assert_equal 'foo/bar/updated', backend_api_config.path
+    assert_equal '/foo/bar/updated', backend_api_config.path
     assert_equal backend_api.id, backend_api_config.backend_api_id
   end
 

--- a/test/integration/api/backend_api_configs_controller_test.rb
+++ b/test/integration/api/backend_api_configs_controller_test.rb
@@ -59,7 +59,7 @@ class Api::BackendApiConfigsControllerTest < ActionDispatch::IntegrationTest
       }
       assert_redirected_to admin_service_backend_api_configs_path(service)
       assert_equal 'Backend added to Product.', flash[:notice]
-      assert_equal backend_api, service.backend_api_configs.find_by(path: 'foo').backend_api
+      assert_equal backend_api, service.backend_api_configs.find_by(path: '/foo').backend_api
     end
   end
 
@@ -102,7 +102,7 @@ class Api::BackendApiConfigsControllerTest < ActionDispatch::IntegrationTest
     put admin_service_backend_api_config_path(service, config), backend_api_config: { path: 'bar' }
     assert_redirected_to admin_service_backend_api_configs_path(service)
     assert_equal 'Backend usage was updated.', flash[:notice]
-    assert_equal 'bar', config.reload.path
+    assert_equal '/bar', config.reload.path
   end
 
   test 'cannot change backend_api' do

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -28,7 +28,7 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
     backend_api = @provider.backend_apis.last
 
     services = FactoryBot.create_list(:simple_service, 3, account: @provider)
-    services.each { |service| service.backend_api_configs.create(backend_api: backend_api) }
+    services.each { |service| service.backend_api_configs.create(backend_api: backend_api, path: '/') }
     accessible_services = services.take(2)
     non_accessible_service = services.last
     non_accessible_service.update_column(:state, 'deleted')

--- a/test/unit/backend_api_logic/routing_policy_test.rb
+++ b/test/unit/backend_api_logic/routing_policy_test.rb
@@ -45,12 +45,12 @@ module BackendApiLogic
 
       test '#replace_path' do
         [
-          [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: '' }, nil],
-          [{ private_endpoint: 'https://safe-second-api.io', path: '' }, nil],
-          [{ private_endpoint: 'https://safe-second-api.io/v2', path: '' }, nil],
-          [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: 'hey' }, "{{original_request.path | remove_first: '/hey'}}"],
-          [{ private_endpoint: 'https://safe-second-api.io', path: 'ho' }, "{{original_request.path | remove_first: '/ho'}}"],
-          [{ private_endpoint: 'https://safe-second-api.io/v2', path: 'lets-go' }, "{{original_request.path | remove_first: '/lets-go'}}"]
+          [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: '/' }, nil],
+          [{ private_endpoint: 'https://safe-second-api.io', path: '/' }, nil],
+          [{ private_endpoint: 'https://safe-second-api.io/v2', path: '/' }, nil],
+          [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: '/hey' }, "{{original_request.path | remove_first: '/hey'}}"],
+          [{ private_endpoint: 'https://safe-second-api.io', path: '/ho' }, "{{original_request.path | remove_first: '/ho'}}"],
+          [{ private_endpoint: 'https://safe-second-api.io/v2', path: '/lets-go' }, "{{original_request.path | remove_first: '/lets-go'}}"]
         ].each do |config, replace_path_value|
           expected_replace_path = replace_path_value ? { replace_path: replace_path_value } : {}
           assert_equal expected_replace_path, rule_class.new(stub(config)).replace_path
@@ -58,7 +58,7 @@ module BackendApiLogic
       end
 
       test 'replace_path config only included when the config has a path' do
-        refute rule_class.new(stub(private_endpoint: 'http://whatever', path: '')).as_json.has_key?(:replace_path)
+        refute rule_class.new(stub(private_endpoint: 'http://whatever', path: '/')).as_json.has_key?(:replace_path)
         assert rule_class.new(stub(private_endpoint: 'http://whatever', path: 'foo')).as_json.has_key?(:replace_path)
       end
     end

--- a/test/unit/config_path_test.rb
+++ b/test/unit/config_path_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class ConfigPathTest < ActiveSupport::TestCase
+  test 'includes initial slash in path if not present' do
+    config_path = ConfigPath.new('hello')
+    assert_equal '/hello', config_path.path
+
+    config_path = ConfigPath.new('/hello')
+    assert_equal '/hello', config_path.path
+  end
+
+  test '#empty? returns true if path is equal /' do
+    assert ConfigPath.new('/').empty?
+  end
+
+  test '#empty? returns false if path is not equal /' do
+    refute ConfigPath.new('/somepath').empty?
+  end
+
+  test '#to_regex returns "/.*" if path is not informed' do
+    assert_equal '/.*', ConfigPath.new('/').to_regex
+  end
+
+  test '#to_regex returns the regex for the path if it is informed' do
+    assert_equal '/some/path/.*|/some/path/?', ConfigPath.new('/some/path').to_regex
+  end
+end

--- a/test/unit/proxy_rule_test.rb
+++ b/test/unit/proxy_rule_test.rb
@@ -175,7 +175,7 @@ class ProxyRuleTest < ActiveSupport::TestCase
       backend_api = FactoryBot.create(:backend_api)
       products = FactoryBot.create_list(:simple_service, 2)
       proxy_rule = FactoryBot.build(:proxy_rule, owner: backend_api, pattern: '/some-pattern')
-      products.each { |product| product.backend_api_configs.create(backend_api: backend_api) }
+      products.each { |product| product.backend_api_configs.create(backend_api: backend_api, path: '/') }
 
       products.each { |product| ProxyConfigs::AffectingObjectChangedEvent.expects(:create_and_publish!).with(product.proxy, proxy_rule).times(3) }
 

--- a/test/unit/tasks/data_migration/fix_backend_config_path_test.rb
+++ b/test/unit/tasks/data_migration/fix_backend_config_path_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class Tasks::FixBackendConfigPathTest < ActiveSupport::TestCase
+  fixtures :backend_api_configs
+
+  setup do
+    @config_without_path = backend_api_configs(:empty_path)
+    @config_with_path    = backend_api_configs(:with_path)
+  end
+
+  test 'migrates all configs with empty path to have a backslash on it' do
+    assert @config_without_path.path.blank?
+    assert_equal '/some/path', @config_with_path.path
+
+    execute_rake_task 'data_migration/fix_backend_config_path.rb', 'data_migration:fix_backend_config_path'
+
+    assert_equal '/', @config_without_path.reload.path
+    assert_equal '/some/path', @config_with_path.reload.path
+  end
+end

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -15,7 +15,7 @@ class Tasks::ServicesTest < ActiveSupport::TestCase
     services.each { |service| service.proxy.update_column(:api_backend, 'https://api.example.com') }
 
     # 1st service already has backend api
-    services.first.backend_api_configs.create(backend_api: FactoryBot.create(:backend_api, account: provider))
+    services.first.backend_api_configs.create(backend_api: FactoryBot.create(:backend_api, account: provider), path: '/')
 
     # 2nd and 3rd services don't have backend_api but neither their proxy have a private_endpoint
     services[1..2].each { |service| service.proxy.update_column(:api_backend, nil) }


### PR DESCRIPTION
**What this PR does / why we need it**:

MySQL and Postgres saves `''` as empty string, but Oracle saves it as null.
Now for the first service of each tenant, we link it to a new backend api, with empty string path in the backend api config. The problem is that we are checking the uniqueness of service_id and path for backend_api_config but for Oracle, it searches by empty string although it is saved as null, so it does not find it by Rails and it tries to save it but raises an error.
We also have this problem if we try to use `where(path: '')` or a `find_by`, that it tries to search by `''` but it is saved as null so it does not find it although it is there. 

This commit changes this behave to make the application to save `'/'` instead of the empty string. 

**Which issue(s) this PR fixes** 

[THREESCALE-3631](https://issues.jboss.org/browse/THREESCALE-3631)