### PR TITLE
[DeleteObjectHierarchyWorker] destroy delete_all associations on back…

### DIFF
--- a/app/workers/delete_service_hierarchy_worker.rb
+++ b/app/workers/delete_service_hierarchy_worker.rb
@@ -8,9 +8,8 @@ class DeleteServiceHierarchyWorker < DeleteObjectHierarchyWorker
   # TODO: when we remove the Rolling Update, we must remove this whole method and not only the conditional
   def destroyable_associations
     return super if service.account.provider_can_use?(:api_as_product)
-
     object.class.reflect_on_all_associations.select do |reflection|
-      reflection.options[:dependent] == :destroy || reflection.name == :backend_apis
+      destroyable_association?(reflection.options[:dependent]) || reflection.name == :backend_apis
     end
   end
 end

--- a/test/workers/delete_object_hierarchy_worker_test.rb
+++ b/test/workers/delete_object_hierarchy_worker_test.rb
@@ -17,13 +17,13 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
 
   def test_success_callback_method
     caller_worker_hierarchy = %w[HTestClass123 HTestClass1123]
-    DeletePlainObjectWorker.expects(:perform_later).with(object, caller_worker_hierarchy)
+    DeletePlainObjectWorker.expects(:perform_later).with(object, caller_worker_hierarchy, 'destroy')
     hierarchy_worker.new.on_success(1, {'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => caller_worker_hierarchy})
   end
 
   def test_complete_callback_method
     caller_worker_hierarchy = %w[HTestClass123 HTestClass1123]
-    DeletePlainObjectWorker.expects(:perform_later).with(object, caller_worker_hierarchy)
+    DeletePlainObjectWorker.expects(:perform_later).with(object, caller_worker_hierarchy, 'destroy')
     hierarchy_worker.new.on_complete(1, {'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => caller_worker_hierarchy})
   end
 
@@ -69,7 +69,7 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
       DeleteObjectHierarchyWorker.new.on_success(1, {'object_global_id' => object.to_global_id, 'caller_worker_hierarchy' => %w[Hierarchy-TestClass-123]})
     end
   end
-
+  
   class DeletePlanTest < DeleteObjectHierarchyWorkerTest
     setup do
       # ApplicationPlan setup
@@ -85,8 +85,8 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
     def perform_expectations
       DeletePlainObjectWorker.stubs(:perform_later)
       DeleteObjectHierarchyWorker.stubs(:perform_later)
-      DeleteObjectHierarchyWorker.expects(:perform_later).with(Contract.new({ id: contract.id }, without_protection: true), anything)
-      DeleteObjectHierarchyWorker.expects(:perform_later).with(Plan.new({ id: customized_plan.id }, without_protection: true), anything)
+      DeleteObjectHierarchyWorker.expects(:perform_later).with(Contract.new({ id: contract.id }, without_protection: true), anything, 'destroy')
+      DeleteObjectHierarchyWorker.expects(:perform_later).with(Plan.new({ id: customized_plan.id }, without_protection: true), anything, 'destroy')
     end
 
     class AccountPlanTest < DeletePlanTest

--- a/test/workers/delete_plain_object_worker_test.rb
+++ b/test/workers/delete_plain_object_worker_test.rb
@@ -34,6 +34,28 @@ class DeletePlainObjectWorkerTest < ActiveSupport::TestCase
         DeletePlainObjectWorker.perform_now(object, %w[HTestClass123])
       end
     end
+
+    def test_destroy_method_destroy
+      object_1 = objects.first
+      object_2 = objects.second
+
+      object_1.expects(:destroy).once
+      DeletePlainObjectWorker.perform_now(object_1, %w[HTestClass123 HTestClass1123], 'destroy')
+
+      object_1.expects(:destroy!).once
+      DeletePlainObjectWorker.perform_now(object_1, [], 'destroy')
+    end
+
+    def test_destroy_method_delete
+      object_1 = objects.first
+      object_2 = objects.second
+
+      object_1.expects(:delete).once
+      DeletePlainObjectWorker.perform_now(object_1, %w[HTestClass123 HTestClass1123], 'delete')
+
+      object_1.expects(:delete).once
+      DeletePlainObjectWorker.perform_now(object_1, [], 'delete')
+    end
   end
 
   class UndestroyableObjectsTest < DeletePlainObjectWorkerTest

--- a/test/workers/delete_service_hierarcy_worker_test.rb
+++ b/test/workers/delete_service_hierarcy_worker_test.rb
@@ -12,13 +12,13 @@ class DeleteServiceHierarchyWorkerTest < ActiveSupport::TestCase
 
   test 'complete success method' do
     caller_worker_hierarchy = %w[HTestClass123 HTestClass1123]
-    DeletePlainObjectWorker.expects(:perform_later).with(service, caller_worker_hierarchy)
+    DeletePlainObjectWorker.expects(:perform_later).with(service, caller_worker_hierarchy, 'destroy')
     DeleteServiceHierarchyWorker.new.on_success(1, {'object_global_id' => service.to_global_id, 'caller_worker_hierarchy' => caller_worker_hierarchy})
   end
 
   test 'complete callback method' do
     caller_worker_hierarchy = %w[HTestClass123 HTestClass1123]
-    DeletePlainObjectWorker.expects(:perform_later).with(service, caller_worker_hierarchy)
+    DeletePlainObjectWorker.expects(:perform_later).with(service, caller_worker_hierarchy, 'destroy')
     DeleteServiceHierarchyWorker.new.on_complete(1, {'object_global_id' => service.to_global_id, 'caller_worker_hierarchy' => caller_worker_hierarchy})
   end
 
@@ -32,9 +32,9 @@ class DeleteServiceHierarchyWorkerTest < ActiveSupport::TestCase
 
     Sidekiq::Testing.inline! do
       [service_plan, application_plan, end_user_plan].each do |association|
-        DeleteObjectHierarchyWorker.expects(:perform_later).with(association, anything)
+        DeleteObjectHierarchyWorker.expects(:perform_later).with(association, anything, 'destroy')
       end
-      metrics.each { |metric| DeleteObjectHierarchyWorker.expects(:perform_later).with(metric, anything) }
+      metrics.each { |metric| DeleteObjectHierarchyWorker.expects(:perform_later).with(metric, anything, 'destroy') }
 
       DeleteServiceHierarchyWorker.perform_now(service)
     end
@@ -46,8 +46,8 @@ class DeleteServiceHierarchyWorkerTest < ActiveSupport::TestCase
     backend_api = FactoryBot.create(:backend_api, account: service.account)
     FactoryBot.create(:backend_api_config, service: service, backend_api: backend_api)
 
-    DeleteObjectHierarchyWorker.expects(:perform_later).with(service.backend_api_configs.first!, anything).once
-    DeleteObjectHierarchyWorker.expects(:perform_later).with(backend_api, anything).never
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(service.backend_api_configs.first!, anything, 'destroy').once
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(backend_api, anything, 'destroy').never
 
     Sidekiq::Testing.inline! { DeleteServiceHierarchyWorker.perform_now(service) }
 
@@ -60,8 +60,8 @@ class DeleteServiceHierarchyWorkerTest < ActiveSupport::TestCase
     backend_api = FactoryBot.create(:backend_api, account: service.account)
     FactoryBot.create(:backend_api_config, service: service, backend_api: backend_api)
 
-    DeleteObjectHierarchyWorker.expects(:perform_later).with(service.backend_api_configs.first!, anything).once
-    DeleteObjectHierarchyWorker.expects(:perform_later).with(backend_api, anything).once
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(service.backend_api_configs.first!, anything, 'destroy').once
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(backend_api, anything, '').once
 
     Sidekiq::Testing.inline! { DeleteServiceHierarchyWorker.perform_now(service) }
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

Lot's of CMS related associations are being deleted as `delete_all` once `Account` is being deleted. This way these associations would be deleted one by one on the background. 

**Which issue(s) this PR fixes** 

[THREESCALE-2988](https://issues.jboss.org/browse/THREESCALE-2988)
