### PR TITLE
Fixes TypeError: json is null in CMS

### DIFF
--- a/app/assets/javascripts/provider/cms/sidebar.js.coffee
+++ b/app/assets/javascripts/provider/cms/sidebar.js.coffee
@@ -125,10 +125,12 @@ class Sidebar
       .on 'mouseenter mouseleave', '.cms-sidebar-listing li > a', (event) ->
         $(this).parent().toggleClass('ui-state-hover')
 
-
   highlight: (path) ->
     @element.find("a.#{HIGHLIGHT_CLASS}").removeClass(HIGHLIGHT_CLASS)
     @element.find("a[href='#{path}']").addClass(HIGHLIGHT_CLASS)
+
+  error_empty: ->
+    @element.find('#cms-sidebar-error-empty')
 
   content: ->
     @element.find('#cms-sidebar-content')
@@ -150,6 +152,9 @@ class Sidebar
     if filter? then items.filter(filter) else items
 
   update: (json) ->
+    unless json
+      @error_empty().show()
+      return
     @groups = @group(json)
     @json = json
 
@@ -159,7 +164,6 @@ class Sidebar
     portlets = @render_portlets(@json.portlets)
 
     $ =>
-
       @content().html(content)
       @layouts().html(layouts)
       @partials().html(partials)
@@ -199,7 +203,6 @@ class Sidebar
       partials: @json.partials
 
     @template.partials(data)
-
 
   render_content: (section) =>
     section_id = section.id
@@ -280,7 +283,6 @@ class SidebarToolbar
         element.removeClass(ACTIVE)
         all.addClass(ACTIVE)
 
-
   process_origin: (event) =>
     element = $(event.currentTarget)
     origin = element.data('filter-origin')
@@ -313,7 +315,6 @@ class SidebarFilter
 
     if query = @status.query
       $ => $(INPUT).val(query)
-
 
   save: ->
     SidebarFilter.save(@status)
@@ -488,7 +489,6 @@ class SidebarTemplates
   layouts: @template(@layouts)
   portlets: @template(@portlets)
   partials: @template(@partials)
-
 
 ## Exporting variables
 window.ThreeScale.Sidebar = Sidebar

--- a/app/assets/stylesheets/provider/admin/cms/_sidebar.scss
+++ b/app/assets/stylesheets/provider/admin/cms/_sidebar.scss
@@ -73,12 +73,11 @@
   .fa-folder-open-o {
     color: $brand-blue;
 
-
     &:hover {
       color: $brand-blue;
     }
 
-    &+ a {
+    & + a {
       //text-indent: line-height-times(1);
       //vertical-align: top;
     }
@@ -91,7 +90,8 @@
     vertical-align: middle;
     width: 100%;
 
-    &:hover,  &.current {
+    &:hover,
+    &.current {
       color: $link-color;
     }
   }
@@ -131,6 +131,11 @@
       }
     }
   }
+}
+
+#cms-sidebar-error-empty {
+  display: none;
+  margin: line-height-times(1/2);
 }
 
 @import 'provider/admin/cms/sidebar/filter';

--- a/app/views/layouts/_cms.html.erb
+++ b/app/views/layouts/_cms.html.erb
@@ -25,6 +25,7 @@
   <div id="cms-sidebar-layouts" class="cms-sidebar-listing"></div>
   <div id="cms-sidebar-partials" class="cms-sidebar-listing"></div>
   <div id="cms-sidebar-portlets" class="cms-sidebar-listing"></div>
+  <p id="cms-sidebar-error-empty">The folder tree could not load. Please retry.</p>
 </div>
 
 <div id="tab-content">

--- a/app/views/layouts/_cms.html.erb
+++ b/app/views/layouts/_cms.html.erb
@@ -25,7 +25,7 @@
   <div id="cms-sidebar-layouts" class="cms-sidebar-listing"></div>
   <div id="cms-sidebar-partials" class="cms-sidebar-listing"></div>
   <div id="cms-sidebar-portlets" class="cms-sidebar-listing"></div>
-  <p id="cms-sidebar-error-empty">The folder tree could not load. Please retry.</p>
+  <p id="cms-sidebar-error-empty">Something went wrong, please refresh the page.</p>
 </div>
 
 <div id="tab-content">


### PR DESCRIPTION
**What this PR does / why we need it**:

Catches when json is `null` and shows an error message.

Also minor lint fixes.

**Which issue(s) this PR fixes** 

https://app.bugsnag.com/3scale-networks-sl/system/errors/5d9ba1d604b3fe0019229e5d?event_id=5d9ba1d60050a3b0d87f0000&i=sk&m=nw

**Verification steps** 
1. Override AJAX call so it returns `null`
2. There should be no error in the console
3. An error message should be shown in the sidebar