### PR TITLE
Avoid IndexProxyRuleWorker to raise Record not found

### DIFF
--- a/app/workers/index_proxy_rule_worker.rb
+++ b/app/workers/index_proxy_rule_worker.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class IndexProxyRuleWorker < ApplicationJob
+  # TODO: Rails 5 -> discard_on ActiveRecord::RecordNotFound
+  rescue_from(ActiveRecord::RecordNotFound) do |exception|
+    Rails.logger.info exception.message
+  end
+
   def perform(proxy_rule_id)
     proxy_rule = ProxyRule.find(proxy_rule_id)
     ThinkingSphinx::RealTime::Callbacks::RealTimeCallbacks.new(

--- a/test/workers/index_proxy_rule_worker_test.rb
+++ b/test/workers/index_proxy_rule_worker_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class IndexProxyRuleWorkerTest < ActiveSupport::TestCase
+  test 'it does not raises RecordNotFound if id does not exist' do
+    assert_nothing_raised ActiveRecord::RecordNotFound do
+      IndexProxyRuleWorker.perform_now(42)
+    end
+  end
+
+  test 'indexes the proxy rule in Sphinx if record exists' do
+    proxy_rule = FactoryBot.create(:proxy_rule)
+    ThinkingSphinx::RealTime::Callbacks::RealTimeCallbacks.any_instance
+      .expects(:after_save)
+
+    IndexProxyRuleWorker.perform_now(proxy_rule.id)
+  end
+end


### PR DESCRIPTION
[THREESCALE-3639](https://issues.jboss.org/browse/THREESCALE-3639)
IndexProxyRuleWorker raises ActiveRecord::RecordNotFound: Couldn't find
ProxyRule with id X when ProxyRule id "X" no longer exists.

This commit changes the worker to rescue this error and logs instead
of making it raising the error.

