### PR TITLE
[settings] New integration settings component

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,4 +15,4 @@
 module.system.node.resolve_dirname=node_modules
 module.name_mapper.extension='scss' -> 'empty/object'
 module.system=haste
-module.name_mapper='\(Applications\|Dashboard\|LoginPage\|Navigation\|Onboarding\|Policies\|services\|Stats\|Types\|Users\|utilities\|NewService\)\(.*\)$' -> '<PROJECT_ROOT>/app/javascript/src/\1/\2'
+module.name_mapper='\(Applications\|Form\|Settings\|Dashboard\|LoginPage\|Navigation\|Onboarding\|Policies\|services\|Stats\|Types\|Users\|utilities\|NewService\)\(.*\)$' -> '<PROJECT_ROOT>/app/javascript/src/\1/\2'

--- a/app/javascript/packs/settingsPageStyles.js
+++ b/app/javascript/packs/settingsPageStyles.js
@@ -1,0 +1,1 @@
+import 'patternflyStyles/settingsPage'

--- a/app/javascript/src/Form/FormFieldset.jsx
+++ b/app/javascript/src/Form/FormFieldset.jsx
@@ -2,34 +2,23 @@
 // TODO: Replace this component when patternfly-react implements it.
 
 import * as React from 'react'
+// $FlowFixMe Flow has troubles with @patternfly modules
 import { FormContext } from '@patternfly/react-core/dist/js/components/Form/FormContext'
-// $FlowFixMe
+// $FlowFixMe Flow has troubles with @patternfly modules
 import styles from '@patternfly/react-styles/css/components/Form/form'
-// $FlowFixMe
+// $FlowFixMe Flow has troubles with @patternfly modules
 import { css, getModifier } from '@patternfly/react-styles'
 
 type Props = {
   children?: React.Node,
   className?: string,
-  label?: React.Node,
-  isRequired?: boolean,
-  isValid?: boolean,
-  isInline?: boolean,
-  helperText?: React.Node,
-  helperTextInvalid?: React.Node,
-  fieldId: string
+  isInline?: boolean
 }
 
 const FormFieldset = ({
   children,
   className = '',
-  label,
-  isRequired = false,
-  isValid = true,
   isInline = false,
-  helperText,
-  helperTextInvalid,
-  fieldId,
   ...props
 }: Props) => (
   <FormContext.Consumer>
@@ -38,26 +27,7 @@ const FormFieldset = ({
         {...props}
         className={css(styles.formFieldset, isInline ? getModifier(styles, 'inline', className) : className)}
       >
-        {label && (
-          <label className={css(styles.formLabel)} htmlFor={fieldId}>
-            <span className={css(styles.formLabelText)}>{label}</span>
-            {isRequired && (
-              <span className={css(styles.formLabelRequired)} aria-hidden="true">
-                {'*'}
-              </span>
-            )}
-          </label>
-        )}
         {isHorizontal ? <div className={css(styles.formHorizontalGroup)}>{children}</div> : children}
-        {((isValid && helperText) || (!isValid && helperTextInvalid)) && (
-          <div
-            className={css(styles.formHelperText, !isValid ? getModifier(styles, 'error') : '')}
-            id={`${fieldId}-helper`}
-            aria-live="polite"
-          >
-            {isValid ? helperText : helperTextInvalid}
-          </div>
-        )}
       </fieldset>
     )}
   </FormContext.Consumer>

--- a/app/javascript/src/Form/index.jsx
+++ b/app/javascript/src/Form/index.jsx
@@ -1,0 +1,4 @@
+// @flow
+
+export * from 'Form/FormFieldset'
+export * from 'Form/FormLegend'

--- a/app/javascript/src/Settings/components/AuthenticationSettingsFieldset.jsx
+++ b/app/javascript/src/Settings/components/AuthenticationSettingsFieldset.jsx
@@ -1,0 +1,47 @@
+// @flow
+
+import * as React from 'react'
+import { FormFieldset, FormLegend } from 'Form'
+import { FormCollection, TextInputGroup } from 'Settings/components/Common'
+import { OidcFieldset } from 'Settings/components/OidcFieldset'
+import type { FieldGroupProps, TypeItemProps } from 'Settings/types'
+
+const OIDC_AUTH_METHOD = 'oidc'
+const API_KEY_METHOD = '1'
+const APP_ID_KEY_METHOD = '2'
+
+type Props = {
+  isServiceMesh: boolean,
+  authenticationMethod: string,
+  apiKeySettings: FieldGroupProps,
+  appIdKeyPairSettings: FieldGroupProps[],
+  oidcSettings: {
+    basicSettings: TypeItemProps,
+    flowSettings: FieldGroupProps[],
+    jwtSettings: TypeItemProps
+  }
+}
+
+const AuthenticationSettingsFieldset = ({
+  isServiceMesh,
+  authenticationMethod,
+  apiKeySettings,
+  appIdKeyPairSettings,
+  oidcSettings
+}: Props) => {
+  const isOidc = authenticationMethod === OIDC_AUTH_METHOD
+  const isApiKey = authenticationMethod === API_KEY_METHOD
+  const isAppIdKey = authenticationMethod === APP_ID_KEY_METHOD
+  return (
+    (!isServiceMesh || isOidc) && <FormFieldset id='fieldset-AuthenticationSettings'>
+      <FormLegend>Authentication Settings</FormLegend>
+      { isApiKey && <FormCollection collection={[apiKeySettings]} ItemComponent={TextInputGroup} legend='API KEY (USER_KEY) BASICS' /> }
+      { isAppIdKey && <FormCollection collection={appIdKeyPairSettings} ItemComponent={TextInputGroup} legend='APP_ID AND APP_KEY PAIR BASICS' /> }
+      { isOidc && <OidcFieldset {...oidcSettings} isServiceMesh={isServiceMesh} /> }
+    </FormFieldset>
+  )
+}
+
+export {
+  AuthenticationSettingsFieldset
+}

--- a/app/javascript/src/Settings/components/Common/FormCollection.jsx
+++ b/app/javascript/src/Settings/components/Common/FormCollection.jsx
@@ -1,0 +1,24 @@
+// @flow
+
+import * as React from 'react'
+import { FormFieldset, FormLegend } from 'Form'
+import type { FieldGroupProps } from 'Settings/types'
+
+type Props = {
+  collection: FieldGroupProps[],
+  ItemComponent: (FieldGroupProps) => React.Element<empty>,
+  legend: string
+}
+
+const FormCollection = ({collection, ItemComponent, legend}: Props) => {
+  return (
+    <FormFieldset id={`fieldset-${legend.replace(/\s+/g, '')}`}>
+      <FormLegend>{legend}</FormLegend>
+      { collection.map(itemProps => <ItemComponent {...itemProps} key={itemProps.name} />) }
+    </FormFieldset>
+  )
+}
+
+export {
+  FormCollection
+}

--- a/app/javascript/src/Settings/components/Common/RadioFieldset.jsx
+++ b/app/javascript/src/Settings/components/Common/RadioFieldset.jsx
@@ -1,0 +1,50 @@
+// @flow
+
+import * as React from 'react'
+import { useState } from 'react'
+import { FormFieldset, FormLegend } from 'Form'
+import { Radio } from '@patternfly/react-core'
+import type { FieldGroupProps, FieldCatalogProps } from 'Settings/types'
+
+type CheckEvent = SyntheticEvent<HTMLButtonElement>
+
+type Props = FieldGroupProps & FieldCatalogProps
+
+const useSelectedOnChange = (value, onChange) => (
+  typeof onChange === 'function'
+    ? [value, onChange]
+    : useState(value).map(x => typeof x === 'function' ? (_c, e: CheckEvent) => x(e.currentTarget.value) : x)
+)
+
+const RadioFieldset = ({
+  children,
+  legend,
+  name,
+  value,
+  catalog,
+  onChange,
+  ...props
+}: Props) => {
+  const [selectedOnChange, setSelectedOnChange] = useSelectedOnChange(value, onChange)
+  return (
+    <FormFieldset id={`fieldset-${name}`} {...props} >
+      <FormLegend>{legend}</FormLegend>
+      {Object.keys(catalog).map(key => (
+        <Radio
+          key={key}
+          value={key}
+          isChecked={selectedOnChange === key}
+          name={`service[${name}]`}
+          onChange={setSelectedOnChange}
+          label={catalog[key]}
+          id={`service_method_${name}_${key}`}
+        />
+      ))}
+      {children}
+    </FormFieldset>
+  )
+}
+
+export {
+  RadioFieldset
+}

--- a/app/javascript/src/Settings/components/Common/SelectGroup.jsx
+++ b/app/javascript/src/Settings/components/Common/SelectGroup.jsx
@@ -1,0 +1,44 @@
+// @flow
+
+import * as React from 'react'
+import { useState } from 'react'
+import { FormGroup, Select, SelectOption } from '@patternfly/react-core'
+import type { FieldGroupProps, FieldCatalogProps } from 'Settings/types'
+
+type Props = FieldGroupProps & FieldCatalogProps
+
+const SelectGroup = ({
+  label,
+  name,
+  hint,
+  value,
+  catalog
+}: Props) => {
+  const [ selectedValue, setSelectedValue ] = useState(value)
+  const [ isExpanded, setIsExpanded ] = useState(false)
+  const onSelect = (_e, selection) => {
+    setIsExpanded(false)
+    setSelectedValue(selection.key)
+  }
+
+  return (
+    <FormGroup label={label} fieldId={`service_proxy_attributes_${name}_select`} helperText={hint}>
+      <input name={`service[proxy_attributes][${name}]`} type='hidden' value={selectedValue} />
+      <Select
+        selections={catalog[selectedValue]}
+        onToggle={setIsExpanded}
+        onSelect={onSelect}
+        isExpanded={isExpanded}
+        id={`service_proxy_attributes_${name}_select`}
+      >
+        {Object.keys(catalog).map(key => (
+          <SelectOption key={catalog[key]} value={{ key, toString: () => catalog[key] }} />
+        ))}
+      </Select>
+    </FormGroup>
+  )
+}
+
+export {
+  SelectGroup
+}

--- a/app/javascript/src/Settings/components/Common/TextInputGroup.jsx
+++ b/app/javascript/src/Settings/components/Common/TextInputGroup.jsx
@@ -1,0 +1,38 @@
+// @flow
+
+import * as React from 'react'
+import { useState } from 'react'
+import { FormGroup, TextInput } from '@patternfly/react-core'
+import type { FieldGroupProps } from 'Settings/types'
+
+const TextInputGroup = ({
+  defaultValue,
+  placeholder,
+  label,
+  name,
+  hint,
+  value,
+  isDefaultValue = false,
+  readOnly = false,
+  inputType = 'text'
+}: FieldGroupProps) => {
+  const [ inputValue, setInputValue ] = useState(value)
+  const onChange = (value, _e) => setInputValue(value)
+  return (
+    <FormGroup label={label} fieldId={`service_proxy_attributes_${name}_input`} helperText={hint}>
+      <TextInput
+        id={`service_proxy_attributes_${name}_input`}
+        name={`service[proxy_attributes][${name}]`}
+        placeholder={placeholder}
+        value={isDefaultValue ? defaultValue : inputValue}
+        type={inputType}
+        onChange={onChange}
+        isReadOnly={readOnly}
+      />
+    </FormGroup>
+  )
+}
+
+export {
+  TextInputGroup
+}

--- a/app/javascript/src/Settings/components/Common/TypeItemCombo.jsx
+++ b/app/javascript/src/Settings/components/Common/TypeItemCombo.jsx
@@ -1,0 +1,26 @@
+// @flow
+
+import * as React from 'react'
+import { FormFieldset, FormLegend } from 'Form'
+import { TextInputGroup, SelectGroup } from 'Settings/components/Common'
+import type { FieldGroupProps, FieldCatalogProps } from 'Settings/types'
+
+type Props = {
+  type: FieldCatalogProps & FieldGroupProps,
+  item: FieldGroupProps,
+  legend: string
+}
+
+const TypeItemCombo = ({ type, item, legend }: Props) => {
+  return (
+    <FormFieldset id={`fieldset-${legend.replace(/\s+/g, '')}`}>
+      <FormLegend>{legend}</FormLegend>
+      <SelectGroup {...type} />
+      <TextInputGroup {...item} />
+    </FormFieldset>
+  )
+}
+
+export {
+  TypeItemCombo
+}

--- a/app/javascript/src/Settings/components/Common/index.jsx
+++ b/app/javascript/src/Settings/components/Common/index.jsx
@@ -1,0 +1,7 @@
+// @flow
+
+export * from 'Settings/components/Common/FormCollection'
+export * from 'Settings/components/Common/SelectGroup'
+export * from 'Settings/components/Common/TextInputGroup'
+export * from 'Settings/components/Common/RadioFieldset'
+export * from 'Settings/components/Common/TypeItemCombo'

--- a/app/javascript/src/Settings/components/Form.jsx
+++ b/app/javascript/src/Settings/components/Form.jsx
@@ -1,0 +1,58 @@
+// @flow
+
+import * as React from 'react'
+import { useState } from 'react'
+import { FormFieldset, FormLegend } from 'Form'
+import { FormCollection, TextInputGroup, RadioFieldset } from 'Settings/components/Common'
+import { AuthenticationSettingsFieldset } from 'Settings/components/AuthenticationSettingsFieldset'
+import type { SettingsProps as Props } from 'Settings/types'
+
+const SERVICE_MESH_INTEGRATION = 'service_mesh_istio'
+const PROXY_HOSTED_INTEGRATION = 'hosted'
+
+const Form = ({
+  isProxyCustomUrlActive,
+  integrationMethod,
+  authenticationMethod,
+  proxyEndpoints,
+  authenticationSettings,
+  credentialsLocation,
+  security,
+  gatewayResponse
+}: Props) => {
+  const [ selectedIntegrationMethod, setSelectedIntegrationMethod ] = useState(integrationMethod.value)
+  const [ selectedAuthenticationMethod, setSelectedAuthenticationMethod ] = useState(authenticationMethod.value)
+  const onChange = (setState) => (_checked, e) => setState(e.currentTarget.value)
+  const isServiceMesh = selectedIntegrationMethod === SERVICE_MESH_INTEGRATION
+  const isProxyHosted = selectedIntegrationMethod === PROXY_HOSTED_INTEGRATION
+  const isProxyUrlsReadOnly = !isProxyCustomUrlActive && isProxyHosted
+  const customProxyEndpoints = proxyEndpoints.map(endpoint =>
+    ({ ...endpoint, readOnly: isProxyUrlsReadOnly, isDefaultValue: isProxyUrlsReadOnly }))
+
+  return (
+    <React.Fragment>
+      <RadioFieldset {...integrationMethod} onChange={onChange(setSelectedIntegrationMethod)} value={selectedIntegrationMethod} legend='Integration' />
+      { !isServiceMesh && <FormCollection collection={customProxyEndpoints} ItemComponent={TextInputGroup} legend='API gateway' /> }
+      <RadioFieldset {...authenticationMethod} onChange={onChange(setSelectedAuthenticationMethod)} value={selectedAuthenticationMethod} legend='Authentication' />
+      <AuthenticationSettingsFieldset
+        isServiceMesh={isServiceMesh}
+        authenticationMethod={selectedAuthenticationMethod}
+        {...authenticationSettings}
+      />
+      { !isServiceMesh && <React.Fragment>
+        <RadioFieldset {...credentialsLocation} legend='Credentials Location' />
+        <FormCollection collection={security} ItemComponent={TextInputGroup} legend='Security' />
+        <FormFieldset id='fieldset-GatewayResponse'>
+          <FormLegend>Gateway Response</FormLegend>
+          {gatewayResponse.map(settings => (
+            <FormCollection key={settings.legend} collection={settings.collection} ItemComponent={TextInputGroup} legend={settings.legend} />
+          ))}
+        </FormFieldset>
+      </React.Fragment> }
+    </React.Fragment>
+  )
+}
+
+export {
+  Form
+}

--- a/app/javascript/src/Settings/components/OidcFieldset.jsx
+++ b/app/javascript/src/Settings/components/OidcFieldset.jsx
@@ -1,0 +1,53 @@
+// @flow
+
+import React, {useState} from 'react'
+import { FormFieldset, FormLegend } from 'Form'
+import { Checkbox } from '@patternfly/react-core'
+import { FormCollection, TypeItemCombo } from 'Settings/components/Common'
+import type { TypeItemProps, FieldGroupProps } from 'Settings/types'
+
+const Basics = (props: TypeItemProps) => (
+  <TypeItemCombo {...props} legend='OIDC BASICS' inputType='url' />
+)
+
+const JsonWebToken = (props: TypeItemProps) => (
+  <TypeItemCombo {...props} legend='JSON Web Token (JWT) Claim with ClientID' inputType='text' />
+)
+
+const FlowItem = ({name, label, checked}: FieldGroupProps) => {
+  const [ isChecked, setIsChecked ] = useState(checked)
+  const onChange = (check, _e) => setIsChecked(check)
+  return (
+    <Checkbox
+      id={`service_proxy_attributes_oidc_configuration_attributes_${name}_input`}
+      name={`service[proxy_attributes][oidc_configuration_attributes][${name}]`}
+      label={label}
+      isChecked={isChecked}
+      onChange={onChange}
+    />
+  )
+}
+
+const AuthorizationFlow = (props: {collection: FieldGroupProps[]}) => (
+  <FormCollection {...props} ItemComponent={FlowItem} legend='OIDC Authorization flow' />
+)
+
+type Props = {
+  isServiceMesh: boolean,
+  basicSettings: TypeItemProps,
+  jwtSettings: TypeItemProps,
+  flowSettings: FieldGroupProps[]
+}
+
+const OidcFieldset = ({isServiceMesh, basicSettings, jwtSettings, flowSettings}: Props) => (
+  <FormFieldset id='fieldset-Oidc'>
+    <FormLegend>OPENID CONNECT (OIDC)</FormLegend>
+    <Basics {...basicSettings} />
+    { !isServiceMesh && <AuthorizationFlow collection={flowSettings} /> }
+    { !isServiceMesh && <JsonWebToken {...jwtSettings} /> }
+  </FormFieldset>
+)
+
+export {
+  OidcFieldset
+}

--- a/app/javascript/src/Settings/defaults.jsx
+++ b/app/javascript/src/Settings/defaults.jsx
@@ -1,0 +1,263 @@
+const INTEGRATION_METHOD_DEFAULTS = {
+  value: 'hosted',
+  name: 'deployment_option',
+  catalog: {
+    hosted: 'APIcast 3scale managed',
+    self_managed: 'APIcast self-managed',
+    service_mesh_istio: 'Istio'
+  }
+}
+const AUTHENTICATION_METHOD_DEFAULTS = {
+  value: '1',
+  name: 'proxy_authentication_method',
+  catalog: {
+    '1': 'API Key (user_key)',
+    '2': 'App_ID and App_Key Pair',
+    oidc: 'OpenID Connect'
+  }
+}
+
+const PROXY_ENDPOINTS_DEFAULTS = [
+  {
+    defaultValue: 'https://api-2.staging.apicast.com',
+    placeholder: 'https://api.provider-name.com',
+    label: 'Staging Public Base URL',
+    name: 'sandbox_endpoint',
+    hint: 'Public address of your API gateway in the staging environment.',
+    value: 'https://custom.api.staging.provider-name.com',
+    inputType: 'url'
+  },
+  {
+    defaultValue: 'https://api-2.apicast.com',
+    placeholder: 'https://api.provider-name.com',
+    label: 'Staging Public Base URL',
+    name: 'endpoint',
+    hint: 'Public address of your API gateway in the production environment.',
+    value: 'https://custom.api.provider-name.com',
+    inputType: 'url'
+  }
+]
+
+const API_KEY_SETTINGS_DEFAULT = {
+  label: 'Auth user key',
+  name: 'auth_user_key',
+  value: 'user_key'
+}
+
+const APP_ID_KEY_PAIR_SETTINGS_DEFAULT = [
+  {
+    label: 'App ID parameter',
+    name: 'auth_app_id',
+    hint: 'Public address of your API gateway in the staging environment.',
+    value: 'app_id'
+  },
+  {
+    label: 'App Key parameter',
+    name: 'auth_app_key',
+    value: 'app_key'
+  }
+]
+
+const OIDC_BASICS_SETTINGS_DEFAULTS = {
+  type: {
+    value: 'keycloak',
+    name: 'oidc_issuer_type',
+    label: 'OpenID Connect Issuer Type',
+    catalog: {
+      keycloak: 'Red Hat Single Sign-On',
+      rest: 'REST API'
+    }
+  },
+  item: {
+    value: '',
+    name: 'oidc_issuer_endpoint',
+    label: 'OpenID Connect Issuer',
+    placeholder: 'https://sso.example.com/auth/realms/gateway',
+    hint: 'Location of your OpenID Provider. The format of this endpoint is determined on your OpenID Provider setup. A common guidance would be "https://CLIENT_ID:CLIENT_SECRET@HOST:PORT/auth/realms/REALM_NAME".'
+  }
+}
+
+const OIDC_FLOW_SETTINGS_DEFAULTS = [
+  { name: 'service_accounts_enabled', label: 'Service Accounts Flow', checked: false },
+  { name: 'standard_flow_enabled', label: 'Authorization Code Flow', checked: false },
+  { name: 'implicit_flow_enabled', label: 'Implicit Flow', checked: false },
+  { name: 'direct_access_grants_enabled', label: 'Direct Access Grant Flow', checked: false }
+]
+
+const OIDC_JWT_SETTINGS_DEFAULTS = {
+  type: {
+    value: 'plain',
+    name: 'jwt_claim_with_client_id_type',
+    label: 'ClientID Token Claim Type',
+    hint: 'Process the ClientID Token Claim value as a string or as a liquid template. When set to "Liquid" you can define more complex rules. e.g. If "some_claim" is an array you can select the first value this like {{ some_claim | first }}.',
+    catalog: {
+      plain: 'plain',
+      liquid: 'liquid'
+    }
+  },
+  item: {
+    value: 'azp',
+    name: 'jwt_claim_with_client_id',
+    label: 'ClientID Token Claim',
+    placeholder: 'azp',
+    hint: 'The Token Claim that contains the clientID. Defaults to "azp".'
+  }
+}
+
+const OIDC_SETTINGS_DEFAULTS = {
+  basicSettings: OIDC_BASICS_SETTINGS_DEFAULTS,
+  flowSettings: OIDC_FLOW_SETTINGS_DEFAULTS,
+  jwtSettings: OIDC_JWT_SETTINGS_DEFAULTS
+}
+
+const CREDENTIALS_LOCATION_DEFAULTS = {
+  value: 'headers',
+  name: 'credentials_location',
+  catalog: {
+    headers: 'As HTTP Headers',
+    query: 'As query parameters (GET) or body parameters (POST/PUT/DELETE)',
+    authorization: 'As HTTP Basic Authentication'
+  }
+}
+
+const SECURITY_DEFAULTS = [
+  {
+    defaultValue: '',
+    placeholder: 'https://api.provider-name.com',
+    label: 'Host Header',
+    name: 'hostname_rewrite',
+    hint: 'Lets you define a custom Host request header. This is needed if your API backend only accepts traffic from a specific host.',
+    value: '',
+    readOnly: false
+  },
+  {
+    defaultValue: '',
+    placeholder: 'https://api.provider-name.com',
+    label: 'Secret Token',
+    name: 'secret_token',
+    hint: 'Enables you to block any direct developer requests to your API backend; each 3scale API gateway call to your API backend contains a request header called X-3scale-proxy-secret-token. The value of this header can be set by you here. It\'s up to you ensure your backend only allows calls with this secret header.',
+    value: '',
+    readOnly: false
+  }
+]
+
+const GATEWAY_RESPONSE_DEFAULT = [
+  {
+    legend: 'Authentication Failed Error',
+    collection: [
+      {
+        label: 'Response Code',
+        name: 'error_status_auth_failed',
+        value: '403',
+        inputType: 'number'
+      },
+      {
+        label: 'Content-type',
+        name: 'error_headers_auth_failed',
+        value: 'text/plain; charset=us-ascii',
+        inputType: 'text'
+      },
+      {
+        label: 'Response Body',
+        name: 'error_auth_failed',
+        value: 'Authentication failed',
+        inputType: 'text'
+      }
+    ]
+  },
+  {
+    legend: 'Authentication Missing Error',
+    collection: [
+      {
+        label: 'Response Code',
+        name: 'error_status_auth_missing',
+        value: '403',
+        inputType: 'number'
+      },
+      {
+        label: 'Content-type',
+        name: 'error_headers_auth_missing',
+        value: 'text/plain; charset=us-ascii',
+        inputType: 'text'
+      },
+      {
+        label: 'Response Body',
+        name: 'error_auth_missing',
+        value: 'Authentication parameters missing',
+        inputType: 'text'
+      }
+    ]
+  },
+  {
+    legend: 'Match Error',
+    collection: [
+      {
+        label: 'Response Code',
+        name: 'error_status_no_match',
+        value: '404',
+        inputType: 'number'
+      },
+      {
+        label: 'Content-type',
+        name: 'error_headers_no_match',
+        value: 'text/plain; charset=us-ascii',
+        inputType: 'text'
+      },
+      {
+        label: 'Response Body',
+        name: 'error_no_match',
+        value: 'No Mapping Rule matched',
+        inputType: 'text'
+      }
+    ]
+  },
+  {
+    legend: 'Usage limit exceeded error',
+    collection: [
+      {
+        label: 'Response Code',
+        name: 'error_status_limits_exceeded',
+        value: '429',
+        inputType: 'number'
+      },
+      {
+        label: 'Content-type',
+        name: 'error_headers_limits_exceeded',
+        value: 'text/plain; charset=us-ascii',
+        inputType: 'text'
+      },
+      {
+        label: 'Response Body',
+        name: 'error_limits_exceeded',
+        value: 'Usage limit exceeded',
+        inputType: 'text'
+      }
+    ]
+  }
+]
+
+const AUTHENTICATION_SETTINGS_DEFAULT = {
+  oidcSettings: OIDC_SETTINGS_DEFAULTS,
+  appIdKeyPairSettings: APP_ID_KEY_PAIR_SETTINGS_DEFAULT,
+  apiKeySettings: API_KEY_SETTINGS_DEFAULT
+}
+
+const SETTINGS_DEFAULT = {
+  isProxyCustomUrlActive: false,
+  integrationMethod: INTEGRATION_METHOD_DEFAULTS,
+  authenticationMethod: AUTHENTICATION_METHOD_DEFAULTS,
+  proxyEndpoints: PROXY_ENDPOINTS_DEFAULTS,
+  authenticationSettings: AUTHENTICATION_SETTINGS_DEFAULT,
+  credentialsLocation: CREDENTIALS_LOCATION_DEFAULTS,
+  security: SECURITY_DEFAULTS,
+  gatewayResponse: GATEWAY_RESPONSE_DEFAULT
+}
+
+export {
+  INTEGRATION_METHOD_DEFAULTS,
+  PROXY_ENDPOINTS_DEFAULTS,
+  AUTHENTICATION_METHOD_DEFAULTS,
+  AUTHENTICATION_SETTINGS_DEFAULT,
+  OIDC_SETTINGS_DEFAULTS,
+  SETTINGS_DEFAULT
+}

--- a/app/javascript/src/Settings/index.jsx
+++ b/app/javascript/src/Settings/index.jsx
@@ -1,0 +1,21 @@
+// @flow
+
+import * as React from 'react'
+import { createReactWrapper } from 'utilities/createReactWrapper'
+import { Form } from 'Settings/components/Form'
+import { SETTINGS_DEFAULT } from 'Settings/defaults'
+import type { SettingsProps } from 'Settings/types'
+
+type Props = {
+  settings: SettingsProps,
+  elementId: string
+}
+
+const initSettings = ({
+  settings = SETTINGS_DEFAULT,
+  elementId
+}: Props) => createReactWrapper(<Form {...settings} />, elementId)
+
+export {
+  initSettings
+}

--- a/app/javascript/src/Settings/types/index.jsx
+++ b/app/javascript/src/Settings/types/index.jsx
@@ -1,0 +1,50 @@
+// @flow
+
+import * as React from 'react'
+
+export type FieldGroupProps = {
+  name: string,
+  value: string,
+  label: string,
+  children?: React.Node,
+  legend?: string,
+  checked?: string,
+  hint?: string,
+  placeholder?: string,
+  defaultValue?: string,
+  readOnly?: boolean,
+  inputType?: string,
+  isDefaultValue?: boolean,
+  onChange?: (value: string, event: SyntheticEvent<HTMLButtonElement>) => void
+}
+
+export type FieldCatalogProps = { catalog: { [string]: string } }
+
+export type TypeItemProps = {
+  type: FieldGroupProps & FieldCatalogProps,
+  item: FieldGroupProps
+}
+
+export type LegendCollectionProps = {
+  legend: string,
+  collection: FieldGroupProps[]
+}
+
+export type SettingsProps = {
+  isProxyCustomUrlActive: boolean,
+  integrationMethod: FieldGroupProps & FieldCatalogProps,
+  authenticationMethod: FieldGroupProps & FieldCatalogProps,
+  proxyEndpoints: FieldGroupProps[],
+  authenticationSettings: {
+    appIdKeyPairSettings: FieldGroupProps[],
+    apiKeySettings: FieldGroupProps,
+    oidcSettings: {
+      basicSettings: TypeItemProps,
+      flowSettings: FieldGroupProps[],
+      jwtSettings: TypeItemProps
+    }
+  },
+  credentialsLocation: FieldGroupProps & FieldCatalogProps,
+  security: FieldGroupProps[],
+  gatewayResponse: LegendCollectionProps[]
+}

--- a/app/javascript/src/patternflyStyles/settingsPage.css
+++ b/app/javascript/src/patternflyStyles/settingsPage.css
@@ -1,0 +1,7 @@
+@import '~@patternfly/patternfly/components/Button/button.css';
+@import '~@patternfly/patternfly/components/Check/check.css';
+@import '~@patternfly/patternfly/components/Form/form.css';
+@import '~@patternfly/patternfly/components/FormControl/form-control.css';
+@import '~@patternfly/patternfly/components/InputGroup/input-group.css';
+@import '~@patternfly/patternfly/components/Radio/radio.css';
+@import '~@patternfly/patternfly/components/Select/select.css';

--- a/app/views/layouts/provider.html.slim
+++ b/app/views/layouts/provider.html.slim
@@ -9,6 +9,7 @@ html[lang="en"]
     = javascript_pack_tag 'PF4Styles/base'
     = render 'provider/theme'
     = render 'provider/analytics'
+    = javascript_pack_tag 'settingsPageStyles'
     = javascript_include_tag 'provider/layout/provider'
     = yield :javascripts
 

--- a/spec/javascripts/Form/FormFieldset.spec.jsx
+++ b/spec/javascripts/Form/FormFieldset.spec.jsx
@@ -5,7 +5,7 @@ import { FormFieldset } from 'Form/FormFieldset'
 describe('FormFieldset', () => {
   it('should render default form fieldset variant', () => {
     const view = mount(
-      <FormFieldset fieldId="label-id">
+      <FormFieldset>
         <input id="input-id" />
       </FormFieldset>
     )
@@ -14,43 +14,16 @@ describe('FormFieldset', () => {
 
   it('should render inline form fieldset variant', () => {
     const view = mount(
-      <FormFieldset isInline fieldId="label-id">
+      <FormFieldset isInline>
         <input id="input-id" />
       </FormFieldset>
     )
     expect(view).toMatchSnapshot()
   })
 
-  it('should render form fieldset variant with node label and help text', () => {
+  it('should render form fieldset with custom class names', () => {
     const view = mount(
-      <FormFieldset fieldId="id" label={<span>Label</span>} helperText="this is helper text" >
-        <input aria-label="input" />
-      </FormFieldset>
-    )
-    expect(view).toMatchSnapshot()
-  })
-
-  it('should render form fieldset variant with node helperText', () => {
-    const view = mount(
-      <FormFieldset label="Label" fieldId="label-id" helperText={<span>Help text!</span>}>
-        <input id="input-id" />
-      </FormFieldset>
-    )
-    expect(view).toMatchSnapshot()
-  })
-
-  it('should render form fieldset required variant', () => {
-    const view = mount(
-      <FormFieldset isRequired label="label" fieldId="id">
-        <input id="input-id" />
-      </FormFieldset>
-    )
-    expect(view).toMatchSnapshot()
-  })
-
-  it('should render form fieldset invalid variant', () => {
-    const view = mount(
-      <FormFieldset label="label" fieldId="label-id" isValid={false} helperTextInvalid="Invalid FormFieldset">
+      <FormFieldset className='extra-class another-class'>
         <input id="input-id" />
       </FormFieldset>
     )

--- a/spec/javascripts/Form/__snapshots__/FormFieldset.spec.jsx.snap
+++ b/spec/javascripts/Form/__snapshots__/FormFieldset.spec.jsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormFieldset should render default form fieldset variant 1`] = `
-<FormFieldset
-  fieldId="label-id"
->
+<FormFieldset>
   <fieldset
     className="pf-c-form__fieldset"
   >
@@ -14,153 +12,22 @@ exports[`FormFieldset should render default form fieldset variant 1`] = `
 </FormFieldset>
 `;
 
-exports[`FormFieldset should render form fieldset invalid variant 1`] = `
+exports[`FormFieldset should render form fieldset with custom class names 1`] = `
 <FormFieldset
-  fieldId="label-id"
-  helperTextInvalid="Invalid FormFieldset"
-  isValid={false}
-  label="label"
+  className="extra-class another-class"
 >
   <fieldset
-    className="pf-c-form__fieldset"
+    className="pf-c-form__fieldset extra-class another-class"
   >
-    <label
-      className="pf-c-form__label"
-      htmlFor="label-id"
-    >
-      <span
-        className="pf-c-form__label-text"
-      >
-        label
-      </span>
-    </label>
     <input
       id="input-id"
     />
-    <div
-      aria-live="polite"
-      className="pf-c-form__helper-text pf-m-error"
-      id="label-id-helper"
-    >
-      Invalid FormFieldset
-    </div>
-  </fieldset>
-</FormFieldset>
-`;
-
-exports[`FormFieldset should render form fieldset required variant 1`] = `
-<FormFieldset
-  fieldId="id"
-  isRequired={true}
-  label="label"
->
-  <fieldset
-    className="pf-c-form__fieldset"
-  >
-    <label
-      className="pf-c-form__label"
-      htmlFor="id"
-    >
-      <span
-        className="pf-c-form__label-text"
-      >
-        label
-      </span>
-      <span
-        aria-hidden="true"
-        className="pf-c-form__label-required"
-      >
-        *
-      </span>
-    </label>
-    <input
-      id="input-id"
-    />
-  </fieldset>
-</FormFieldset>
-`;
-
-exports[`FormFieldset should render form fieldset variant with node helperText 1`] = `
-<FormFieldset
-  fieldId="label-id"
-  helperText={
-    <span>
-      Help text!
-    </span>
-  }
-  label="Label"
->
-  <fieldset
-    className="pf-c-form__fieldset"
-  >
-    <label
-      className="pf-c-form__label"
-      htmlFor="label-id"
-    >
-      <span
-        className="pf-c-form__label-text"
-      >
-        Label
-      </span>
-    </label>
-    <input
-      id="input-id"
-    />
-    <div
-      aria-live="polite"
-      className="pf-c-form__helper-text"
-      id="label-id-helper"
-    >
-      <span>
-        Help text!
-      </span>
-    </div>
-  </fieldset>
-</FormFieldset>
-`;
-
-exports[`FormFieldset should render form fieldset variant with node label and help text 1`] = `
-<FormFieldset
-  fieldId="id"
-  helperText="this is helper text"
-  label={
-    <span>
-      Label
-    </span>
-  }
->
-  <fieldset
-    className="pf-c-form__fieldset"
-  >
-    <label
-      className="pf-c-form__label"
-      htmlFor="id"
-    >
-      <span
-        className="pf-c-form__label-text"
-      >
-        <span>
-          Label
-        </span>
-      </span>
-    </label>
-    <input
-      aria-label="input"
-    />
-    <div
-      aria-live="polite"
-      className="pf-c-form__helper-text"
-      id="id-helper"
-    >
-      this is helper text
-    </div>
   </fieldset>
 </FormFieldset>
 `;
 
 exports[`FormFieldset should render inline form fieldset variant 1`] = `
 <FormFieldset
-  fieldId="label-id"
   isInline={true}
 >
   <fieldset

--- a/spec/javascripts/Settings/components/AuthenticationSettingsFieldset.spec.jsx
+++ b/spec/javascripts/Settings/components/AuthenticationSettingsFieldset.spec.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { AuthenticationSettingsFieldset } from 'Settings/components/AuthenticationSettingsFieldset'
+import { AUTHENTICATION_SETTINGS_DEFAULTS } from 'Settings/defaults'
+
+function setup (customProps = {}) {
+  const props = {
+    ...AUTHENTICATION_SETTINGS_DEFAULTS,
+    ...{
+      isServiceMesh: false,
+      authenticationMethod: '1'
+    },
+    ...customProps
+  }
+
+  const view = shallow(<AuthenticationSettingsFieldset {...props} />)
+
+  return { view, props }
+}
+
+it('should render correctly', () => {
+  const { view } = setup()
+  expect(view).toMatchSnapshot()
+})
+
+it('should not render when Service Mesh is active', () => {
+  const customProps = { isServiceMesh: true }
+  const { view } = setup(customProps)
+  expect(view).toMatchSnapshot()
+})
+
+it('should render only OIDC when Service Mesh is active and Oidc method is selected', () => {
+  const customProps = { isServiceMesh: true, authenticationMethod: 'oidc' }
+  const { view } = setup(customProps)
+  expect(view).toMatchSnapshot()
+})

--- a/spec/javascripts/Settings/components/Common/FormCollection.spec.jsx
+++ b/spec/javascripts/Settings/components/Common/FormCollection.spec.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { FormCollection } from 'Settings/components/Common'
+
+it('should render correctly', () => {
+  const GoodBand = ({name}) => <span>{name} rocks!</span>
+
+  const props = {
+    legend: 'Some Good Bands',
+    ItemComponent: GoodBand,
+    collection: [
+      { name: 'The Rolling Stones' },
+      { name: 'The Brian Jonestown Massacre' },
+      { name: 'Radiohead' },
+      { name: 'Blur' },
+      { name: 'The Clash' }
+    ]
+  }
+
+  const view = shallow(<FormCollection {...props} />)
+  expect(view).toMatchSnapshot()
+})

--- a/spec/javascripts/Settings/components/Common/RadioFieldset.spec.jsx
+++ b/spec/javascripts/Settings/components/Common/RadioFieldset.spec.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { RadioFieldset } from 'Settings/components/Common'
+
+it('should render correctly', () => {
+  const props = {
+    legend: 'Foo Fighters',
+    value: 'pat',
+    name: 'foo_fighters',
+    catalog: {
+      dave: 'Grohl',
+      pat: 'Smear'
+    },
+    onChange: jest.fn()
+  }
+
+  const view = shallow(<RadioFieldset {...props}><span>My Hero</span></RadioFieldset>)
+  expect(view).toMatchSnapshot()
+})

--- a/spec/javascripts/Settings/components/Common/SelectGroup.spec.jsx
+++ b/spec/javascripts/Settings/components/Common/SelectGroup.spec.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+
+import { SelectGroup } from 'Settings/components/Common'
+
+const setup = () => {
+  const props = {
+    label: 'Jukebox',
+    name: 'jukebox',
+    hint: 'Pick your favourite',
+    value: 'nick_cave',
+    catalog: {
+      the_libertines: 'The Libertines',
+      tame_impala: 'Tame Impala',
+      massive_attack: 'Massive Attack',
+      nick_cave: 'Nick Cave'
+    }
+  }
+  const tree = mount(<SelectGroup {...props} />)
+  return { props, tree }
+}
+
+it('should render correctly', () => {
+  const { tree } = setup()
+  expect(tree).toMatchSnapshot()
+})
+
+it('should change the hidden input value as expected', () => {
+  const { tree } = setup()
+  const selectProps = tree.find('Select').props()
+  expect(tree.find('input[type="hidden"]').prop('value')).toBe('nick_cave')
+
+  act(() => selectProps.onSelect({}, { key: 'massive_attack', toString: jest.fn() }))
+  tree.update()
+
+  expect(tree.find('input[type="hidden"]').prop('value')).toBe('massive_attack')
+})

--- a/spec/javascripts/Settings/components/Common/TextInputGroup.spec.jsx
+++ b/spec/javascripts/Settings/components/Common/TextInputGroup.spec.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { TextInputGroup } from 'Settings/components/Common'
+
+const setup = (custom = {}) => {
+  const props = {
+    placeholder: 'You Favourite Dooz Kawa',
+    name: 'dooz_kawa_chanson',
+    hint: 'Enter your favourite Dooz Kawa tune',
+    value: 'Me Faire La Belle',
+    defaultValue: 'Le Monstre',
+    ...custom
+  }
+  const view = shallow(<TextInputGroup {...props} />)
+  return { props, view }
+}
+
+it('should render correctly', () => {
+  const { view } = setup()
+  expect(view).toMatchSnapshot()
+})
+
+it('should default value when indicated', () => {
+  const { view } = setup({isDefaultValue: true})
+  expect(view.find('TextInput').prop('value')).toBe('Le Monstre')
+})

--- a/spec/javascripts/Settings/components/Common/TypeItemCombo.spec.jsx
+++ b/spec/javascripts/Settings/components/Common/TypeItemCombo.spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { TypeItemCombo } from 'Settings/components/Common'
+
+it('should render correctly', () => {
+  const props = {
+    type: {
+      value: 'run_the_jewels_3',
+      name: 'run_the_jewels_album',
+      label: 'Your RTJ favourite album',
+      catalog: {
+        run_the_jewels_1: 'Run The Jewels I',
+        run_the_jewels_2: 'Run The Jewels II',
+        run_the_jewels_3: 'Run The Jewels III'
+      }
+    },
+    item: {
+      value: 'Thursday in the Danger Room',
+      name: 'song_name',
+      label: 'Your favourite song from the album above ^',
+      placeholder: 'Oh Mama',
+      hint: 'Enter your favourite song from the album selected'
+    },
+    legend: 'Legend has it!'
+  }
+  const view = shallow(<TypeItemCombo {...props} />)
+  expect(view).toMatchSnapshot()
+})

--- a/spec/javascripts/Settings/components/Common/__snapshots__/FormCollection.spec.jsx.snap
+++ b/spec/javascripts/Settings/components/Common/__snapshots__/FormCollection.spec.jsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<FormFieldset
+  id="fieldset-SomeGoodBands"
+>
+  <FormLegend>
+    Some Good Bands
+  </FormLegend>
+  <GoodBand
+    key="The Rolling Stones"
+    name="The Rolling Stones"
+  />
+  <GoodBand
+    key="The Brian Jonestown Massacre"
+    name="The Brian Jonestown Massacre"
+  />
+  <GoodBand
+    key="Radiohead"
+    name="Radiohead"
+  />
+  <GoodBand
+    key="Blur"
+    name="Blur"
+  />
+  <GoodBand
+    key="The Clash"
+    name="The Clash"
+  />
+</FormFieldset>
+`;

--- a/spec/javascripts/Settings/components/Common/__snapshots__/RadioFieldset.spec.jsx.snap
+++ b/spec/javascripts/Settings/components/Common/__snapshots__/RadioFieldset.spec.jsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<FormFieldset
+  id="fieldset-foo_fighters"
+>
+  <FormLegend>
+    Foo Fighters
+  </FormLegend>
+  <Radio
+    className=""
+    id="service_method_foo_fighters_dave"
+    isChecked={false}
+    isDisabled={false}
+    isValid={true}
+    key="dave"
+    label="Grohl"
+    name="service[foo_fighters]"
+    onChange={[MockFunction]}
+    value="dave"
+  />
+  <Radio
+    className=""
+    id="service_method_foo_fighters_pat"
+    isChecked={true}
+    isDisabled={false}
+    isValid={true}
+    key="pat"
+    label="Smear"
+    name="service[foo_fighters]"
+    onChange={[MockFunction]}
+    value="pat"
+  />
+  <span>
+    My Hero
+  </span>
+</FormFieldset>
+`;

--- a/spec/javascripts/Settings/components/Common/__snapshots__/SelectGroup.spec.jsx.snap
+++ b/spec/javascripts/Settings/components/Common/__snapshots__/SelectGroup.spec.jsx.snap
@@ -1,0 +1,192 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<SelectGroup
+  catalog={
+    Object {
+      "massive_attack": "Massive Attack",
+      "nick_cave": "Nick Cave",
+      "tame_impala": "Tame Impala",
+      "the_libertines": "The Libertines",
+    }
+  }
+  hint="Pick your favourite"
+  label="Jukebox"
+  name="jukebox"
+  value="nick_cave"
+>
+  <FormGroup
+    fieldId="service_proxy_attributes_jukebox_select"
+    helperText="Pick your favourite"
+    label="Jukebox"
+  >
+    <div
+      className="pf-c-form__group"
+    >
+      <label
+        className="pf-c-form__label"
+        htmlFor="service_proxy_attributes_jukebox_select"
+      >
+        <span
+          className="pf-c-form__label-text"
+        >
+          Jukebox
+        </span>
+      </label>
+      <input
+        name="service[proxy_attributes][jukebox]"
+        type="hidden"
+        value="nick_cave"
+      />
+      <Select
+        aria-label=""
+        ariaLabelClear="Clear all"
+        ariaLabelRemove="Remove"
+        ariaLabelToggle="Options menu"
+        ariaLabelTypeAhead=""
+        ariaLabelledBy=""
+        className=""
+        id="service_proxy_attributes_jukebox_select"
+        isDisabled={false}
+        isExpanded={false}
+        isGrouped={false}
+        isPlain={false}
+        onClear={[Function]}
+        onSelect={[Function]}
+        onToggle={[Function]}
+        placeholderText=""
+        selections="Nick Cave"
+        toggleId={null}
+        variant="single"
+        width=""
+      >
+        <div
+          className="pf-c-select"
+          style={
+            Object {
+              "width": "",
+            }
+          }
+        >
+          <SelectToggle
+            ariaLabelToggle="Options menu"
+            ariaLabelledBy=" pf-toggle-id-0"
+            className=""
+            handleTypeaheadKeys={[Function]}
+            id="pf-toggle-id-0"
+            isActive={false}
+            isDisabled={false}
+            isExpanded={false}
+            isFocused={false}
+            isHovered={false}
+            isPlain={false}
+            onClose={[Function]}
+            onEnter={[Function]}
+            onToggle={[Function]}
+            parentRef={
+              Object {
+                "current": <div
+                  class="pf-c-select"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-labelledby=" pf-toggle-id-0"
+                    class="pf-c-select__toggle"
+                    id="pf-toggle-id-0"
+                    type="button"
+                  >
+                    <div
+                      class="pf-c-select__toggle-wrapper"
+                    >
+                      <span
+                        class="pf-c-select__toggle-text"
+                      >
+                        Nick Cave
+                      </span>
+                    </div>
+                    <svg
+                      aria-hidden="true"
+                      class="pf-c-select__toggle-arrow"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </button>
+                </div>,
+              }
+            }
+            type="button"
+            variant="single"
+          >
+            <button
+              aria-expanded={false}
+              aria-haspopup="listbox"
+              aria-labelledby=" pf-toggle-id-0"
+              className="pf-c-select__toggle"
+              disabled={false}
+              id="pf-toggle-id-0"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              type="button"
+            >
+              <div
+                className="pf-c-select__toggle-wrapper"
+              >
+                <span
+                  className="pf-c-select__toggle-text"
+                >
+                  Nick Cave
+                </span>
+              </div>
+              <CaretDownIcon
+                className="pf-c-select__toggle-arrow"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+                title={null}
+              >
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  className="pf-c-select__toggle-arrow"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </CaretDownIcon>
+            </button>
+          </SelectToggle>
+        </div>
+      </Select>
+      <div
+        aria-live="polite"
+        className="pf-c-form__helper-text"
+        id="service_proxy_attributes_jukebox_select-helper"
+      >
+        Pick your favourite
+      </div>
+    </div>
+  </FormGroup>
+</SelectGroup>
+`;

--- a/spec/javascripts/Settings/components/Common/__snapshots__/TextInputGroup.spec.jsx.snap
+++ b/spec/javascripts/Settings/components/Common/__snapshots__/TextInputGroup.spec.jsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<FormGroup
+  fieldId="service_proxy_attributes_dooz_kawa_chanson_input"
+  helperText="Enter your favourite Dooz Kawa tune"
+>
+  <TextInput
+    aria-label={null}
+    className=""
+    id="service_proxy_attributes_dooz_kawa_chanson_input"
+    isDisabled={false}
+    isReadOnly={false}
+    isRequired={false}
+    isValid={true}
+    name="service[proxy_attributes][dooz_kawa_chanson]"
+    onChange={[Function]}
+    placeholder="You Favourite Dooz Kawa"
+    type="text"
+    value="Me Faire La Belle"
+  />
+</FormGroup>
+`;

--- a/spec/javascripts/Settings/components/Common/__snapshots__/TypeItemCombo.spec.jsx.snap
+++ b/spec/javascripts/Settings/components/Common/__snapshots__/TypeItemCombo.spec.jsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<FormFieldset
+  id="fieldset-Legendhasit!"
+>
+  <FormLegend>
+    Legend has it!
+  </FormLegend>
+  <SelectGroup
+    catalog={
+      Object {
+        "run_the_jewels_1": "Run The Jewels I",
+        "run_the_jewels_2": "Run The Jewels II",
+        "run_the_jewels_3": "Run The Jewels III",
+      }
+    }
+    label="Your RTJ favourite album"
+    name="run_the_jewels_album"
+    value="run_the_jewels_3"
+  />
+  <TextInputGroup
+    hint="Enter your favourite song from the album selected"
+    label="Your favourite song from the album above ^"
+    name="song_name"
+    placeholder="Oh Mama"
+    value="Thursday in the Danger Room"
+  />
+</FormFieldset>
+`;

--- a/spec/javascripts/Settings/components/Form.spec.jsx
+++ b/spec/javascripts/Settings/components/Form.spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { Form } from 'Settings/components/Form'
+import {
+  SETTINGS_DEFAULT,
+  INTEGRATION_METHOD_DEFAULTS
+} from 'Settings/defaults'
+
+function setup (customProps = {}) {
+  const props = {
+    ...SETTINGS_DEFAULT,
+    ...customProps
+  }
+
+  const view = shallow(<Form {...props} />)
+
+  return { view, props }
+}
+
+it('should render correctly', () => {
+  const { view } = setup()
+  expect(view).toMatchSnapshot()
+})
+
+it('should not render Auth Settings, Security, Credential Locations and API Gateway when Istio is selected', () => {
+  const customProps = { integrationMethod: {...INTEGRATION_METHOD_DEFAULTS, value: 'service_mesh_istio'} }
+  const { view } = setup(customProps)
+  expect(view).toMatchSnapshot()
+})

--- a/spec/javascripts/Settings/components/OidcFieldset.spec.jsx
+++ b/spec/javascripts/Settings/components/OidcFieldset.spec.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { OidcFieldset } from 'Settings/components/OidcFieldset'
+import { OIDC_SETTINGS_DEFAULTS } from 'Settings/defaults'
+
+function setup (customProps = {}) {
+  const props = {
+    ...OIDC_SETTINGS_DEFAULTS,
+    isServiceMesh: false,
+    ...customProps
+  }
+
+  const view = shallow(<OidcFieldset {...props} />)
+
+  return { view, props }
+}
+
+it('should render correctly', () => {
+  const { view } = setup()
+  expect(view).toMatchSnapshot()
+})
+
+it('should render only Basics  when Service Mesh is active', () => {
+  const customProps = { isServiceMesh: true }
+  const { view } = setup(customProps)
+  expect(view).toMatchSnapshot()
+})

--- a/spec/javascripts/Settings/components/__snapshots__/AuthenticationSettingsFieldset.spec.jsx.snap
+++ b/spec/javascripts/Settings/components/__snapshots__/AuthenticationSettingsFieldset.spec.jsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should not render when Service Mesh is active 1`] = `""`;
+
+exports[`should render correctly 1`] = `
+<FormFieldset
+  id="fieldset-AuthenticationSettings"
+>
+  <FormLegend>
+    Authentication Settings
+  </FormLegend>
+  <FormCollection
+    ItemComponent={[Function]}
+    collection={
+      Array [
+        undefined,
+      ]
+    }
+    legend="API KEY (USER_KEY) BASICS"
+  />
+</FormFieldset>
+`;
+
+exports[`should render only OIDC when Service Mesh is active and Oidc method is selected 1`] = `
+<FormFieldset
+  id="fieldset-AuthenticationSettings"
+>
+  <FormLegend>
+    Authentication Settings
+  </FormLegend>
+  <OidcFieldset
+    isServiceMesh={true}
+  />
+</FormFieldset>
+`;

--- a/spec/javascripts/Settings/components/__snapshots__/Form.spec.jsx.snap
+++ b/spec/javascripts/Settings/components/__snapshots__/Form.spec.jsx.snap
@@ -1,0 +1,424 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should not render Auth Settings, Security, Credential Locations and API Gateway when Istio is selected 1`] = `
+<Fragment>
+  <RadioFieldset
+    catalog={
+      Object {
+        "hosted": "APIcast 3scale managed",
+        "self_managed": "APIcast self-managed",
+        "service_mesh_istio": "Istio",
+      }
+    }
+    legend="Integration"
+    name="deployment_option"
+    onChange={[Function]}
+    value="service_mesh_istio"
+  />
+  <RadioFieldset
+    catalog={
+      Object {
+        "1": "API Key (user_key)",
+        "2": "App_ID and App_Key Pair",
+        "oidc": "OpenID Connect",
+      }
+    }
+    legend="Authentication"
+    name="proxy_authentication_method"
+    onChange={[Function]}
+    value="1"
+  />
+  <AuthenticationSettingsFieldset
+    apiKeySettings={
+      Object {
+        "label": "Auth user key",
+        "name": "auth_user_key",
+        "value": "user_key",
+      }
+    }
+    appIdKeyPairSettings={
+      Array [
+        Object {
+          "hint": "Public address of your API gateway in the staging environment.",
+          "label": "App ID parameter",
+          "name": "auth_app_id",
+          "value": "app_id",
+        },
+        Object {
+          "label": "App Key parameter",
+          "name": "auth_app_key",
+          "value": "app_key",
+        },
+      ]
+    }
+    authenticationMethod="1"
+    isServiceMesh={true}
+    oidcSettings={
+      Object {
+        "basicSettings": Object {
+          "item": Object {
+            "hint": "Location of your OpenID Provider. The format of this endpoint is determined on your OpenID Provider setup. A common guidance would be \\"https://CLIENT_ID:CLIENT_SECRET@HOST:PORT/auth/realms/REALM_NAME\\".",
+            "label": "OpenID Connect Issuer",
+            "name": "oidc_issuer_endpoint",
+            "placeholder": "https://sso.example.com/auth/realms/gateway",
+            "value": "",
+          },
+          "type": Object {
+            "catalog": Object {
+              "keycloak": "Red Hat Single Sign-On",
+              "rest": "REST API",
+            },
+            "label": "OpenID Connect Issuer Type",
+            "name": "oidc_issuer_type",
+            "value": "keycloak",
+          },
+        },
+        "flowSettings": Array [
+          Object {
+            "checked": false,
+            "label": "Service Accounts Flow",
+            "name": "service_accounts_enabled",
+          },
+          Object {
+            "checked": false,
+            "label": "Authorization Code Flow",
+            "name": "standard_flow_enabled",
+          },
+          Object {
+            "checked": false,
+            "label": "Implicit Flow",
+            "name": "implicit_flow_enabled",
+          },
+          Object {
+            "checked": false,
+            "label": "Direct Access Grant Flow",
+            "name": "direct_access_grants_enabled",
+          },
+        ],
+        "jwtSettings": Object {
+          "item": Object {
+            "hint": "The Token Claim that contains the clientID. Defaults to \\"azp\\".",
+            "label": "ClientID Token Claim",
+            "name": "jwt_claim_with_client_id",
+            "placeholder": "azp",
+            "value": "azp",
+          },
+          "type": Object {
+            "catalog": Object {
+              "liquid": "liquid",
+              "plain": "plain",
+            },
+            "hint": "Process the ClientID Token Claim value as a string or as a liquid template. When set to \\"Liquid\\" you can define more complex rules. e.g. If \\"some_claim\\" is an array you can select the first value this like {{ some_claim | first }}.",
+            "label": "ClientID Token Claim Type",
+            "name": "jwt_claim_with_client_id_type",
+            "value": "plain",
+          },
+        },
+      }
+    }
+  />
+</Fragment>
+`;
+
+exports[`should render correctly 1`] = `
+<Fragment>
+  <RadioFieldset
+    catalog={
+      Object {
+        "hosted": "APIcast 3scale managed",
+        "self_managed": "APIcast self-managed",
+        "service_mesh_istio": "Istio",
+      }
+    }
+    legend="Integration"
+    name="deployment_option"
+    onChange={[Function]}
+    value="hosted"
+  />
+  <FormCollection
+    ItemComponent={[Function]}
+    collection={
+      Array [
+        Object {
+          "defaultValue": "https://api-2.staging.apicast.com",
+          "hint": "Public address of your API gateway in the staging environment.",
+          "inputType": "url",
+          "isDefaultValue": true,
+          "label": "Staging Public Base URL",
+          "name": "sandbox_endpoint",
+          "placeholder": "https://api.provider-name.com",
+          "readOnly": true,
+          "value": "https://custom.api.staging.provider-name.com",
+        },
+        Object {
+          "defaultValue": "https://api-2.apicast.com",
+          "hint": "Public address of your API gateway in the production environment.",
+          "inputType": "url",
+          "isDefaultValue": true,
+          "label": "Staging Public Base URL",
+          "name": "endpoint",
+          "placeholder": "https://api.provider-name.com",
+          "readOnly": true,
+          "value": "https://custom.api.provider-name.com",
+        },
+      ]
+    }
+    legend="API gateway"
+  />
+  <RadioFieldset
+    catalog={
+      Object {
+        "1": "API Key (user_key)",
+        "2": "App_ID and App_Key Pair",
+        "oidc": "OpenID Connect",
+      }
+    }
+    legend="Authentication"
+    name="proxy_authentication_method"
+    onChange={[Function]}
+    value="1"
+  />
+  <AuthenticationSettingsFieldset
+    apiKeySettings={
+      Object {
+        "label": "Auth user key",
+        "name": "auth_user_key",
+        "value": "user_key",
+      }
+    }
+    appIdKeyPairSettings={
+      Array [
+        Object {
+          "hint": "Public address of your API gateway in the staging environment.",
+          "label": "App ID parameter",
+          "name": "auth_app_id",
+          "value": "app_id",
+        },
+        Object {
+          "label": "App Key parameter",
+          "name": "auth_app_key",
+          "value": "app_key",
+        },
+      ]
+    }
+    authenticationMethod="1"
+    isServiceMesh={false}
+    oidcSettings={
+      Object {
+        "basicSettings": Object {
+          "item": Object {
+            "hint": "Location of your OpenID Provider. The format of this endpoint is determined on your OpenID Provider setup. A common guidance would be \\"https://CLIENT_ID:CLIENT_SECRET@HOST:PORT/auth/realms/REALM_NAME\\".",
+            "label": "OpenID Connect Issuer",
+            "name": "oidc_issuer_endpoint",
+            "placeholder": "https://sso.example.com/auth/realms/gateway",
+            "value": "",
+          },
+          "type": Object {
+            "catalog": Object {
+              "keycloak": "Red Hat Single Sign-On",
+              "rest": "REST API",
+            },
+            "label": "OpenID Connect Issuer Type",
+            "name": "oidc_issuer_type",
+            "value": "keycloak",
+          },
+        },
+        "flowSettings": Array [
+          Object {
+            "checked": false,
+            "label": "Service Accounts Flow",
+            "name": "service_accounts_enabled",
+          },
+          Object {
+            "checked": false,
+            "label": "Authorization Code Flow",
+            "name": "standard_flow_enabled",
+          },
+          Object {
+            "checked": false,
+            "label": "Implicit Flow",
+            "name": "implicit_flow_enabled",
+          },
+          Object {
+            "checked": false,
+            "label": "Direct Access Grant Flow",
+            "name": "direct_access_grants_enabled",
+          },
+        ],
+        "jwtSettings": Object {
+          "item": Object {
+            "hint": "The Token Claim that contains the clientID. Defaults to \\"azp\\".",
+            "label": "ClientID Token Claim",
+            "name": "jwt_claim_with_client_id",
+            "placeholder": "azp",
+            "value": "azp",
+          },
+          "type": Object {
+            "catalog": Object {
+              "liquid": "liquid",
+              "plain": "plain",
+            },
+            "hint": "Process the ClientID Token Claim value as a string or as a liquid template. When set to \\"Liquid\\" you can define more complex rules. e.g. If \\"some_claim\\" is an array you can select the first value this like {{ some_claim | first }}.",
+            "label": "ClientID Token Claim Type",
+            "name": "jwt_claim_with_client_id_type",
+            "value": "plain",
+          },
+        },
+      }
+    }
+  />
+  <RadioFieldset
+    catalog={
+      Object {
+        "authorization": "As HTTP Basic Authentication",
+        "headers": "As HTTP Headers",
+        "query": "As query parameters (GET) or body parameters (POST/PUT/DELETE)",
+      }
+    }
+    legend="Credentials Location"
+    name="credentials_location"
+    value="headers"
+  />
+  <FormCollection
+    ItemComponent={[Function]}
+    collection={
+      Array [
+        Object {
+          "defaultValue": "",
+          "hint": "Lets you define a custom Host request header. This is needed if your API backend only accepts traffic from a specific host.",
+          "label": "Host Header",
+          "name": "hostname_rewrite",
+          "placeholder": "https://api.provider-name.com",
+          "readOnly": false,
+          "value": "",
+        },
+        Object {
+          "defaultValue": "",
+          "hint": "Enables you to block any direct developer requests to your API backend; each 3scale API gateway call to your API backend contains a request header called X-3scale-proxy-secret-token. The value of this header can be set by you here. It's up to you ensure your backend only allows calls with this secret header.",
+          "label": "Secret Token",
+          "name": "secret_token",
+          "placeholder": "https://api.provider-name.com",
+          "readOnly": false,
+          "value": "",
+        },
+      ]
+    }
+    legend="Security"
+  />
+  <FormFieldset
+    id="fieldset-GatewayResponse"
+  >
+    <FormLegend>
+      Gateway Response
+    </FormLegend>
+    <FormCollection
+      ItemComponent={[Function]}
+      collection={
+        Array [
+          Object {
+            "inputType": "number",
+            "label": "Response Code",
+            "name": "error_status_auth_failed",
+            "value": "403",
+          },
+          Object {
+            "inputType": "text",
+            "label": "Content-type",
+            "name": "error_headers_auth_failed",
+            "value": "text/plain; charset=us-ascii",
+          },
+          Object {
+            "inputType": "text",
+            "label": "Response Body",
+            "name": "error_auth_failed",
+            "value": "Authentication failed",
+          },
+        ]
+      }
+      key="Authentication Failed Error"
+      legend="Authentication Failed Error"
+    />
+    <FormCollection
+      ItemComponent={[Function]}
+      collection={
+        Array [
+          Object {
+            "inputType": "number",
+            "label": "Response Code",
+            "name": "error_status_auth_missing",
+            "value": "403",
+          },
+          Object {
+            "inputType": "text",
+            "label": "Content-type",
+            "name": "error_headers_auth_missing",
+            "value": "text/plain; charset=us-ascii",
+          },
+          Object {
+            "inputType": "text",
+            "label": "Response Body",
+            "name": "error_auth_missing",
+            "value": "Authentication parameters missing",
+          },
+        ]
+      }
+      key="Authentication Missing Error"
+      legend="Authentication Missing Error"
+    />
+    <FormCollection
+      ItemComponent={[Function]}
+      collection={
+        Array [
+          Object {
+            "inputType": "number",
+            "label": "Response Code",
+            "name": "error_status_no_match",
+            "value": "404",
+          },
+          Object {
+            "inputType": "text",
+            "label": "Content-type",
+            "name": "error_headers_no_match",
+            "value": "text/plain; charset=us-ascii",
+          },
+          Object {
+            "inputType": "text",
+            "label": "Response Body",
+            "name": "error_no_match",
+            "value": "No Mapping Rule matched",
+          },
+        ]
+      }
+      key="Match Error"
+      legend="Match Error"
+    />
+    <FormCollection
+      ItemComponent={[Function]}
+      collection={
+        Array [
+          Object {
+            "inputType": "number",
+            "label": "Response Code",
+            "name": "error_status_limits_exceeded",
+            "value": "429",
+          },
+          Object {
+            "inputType": "text",
+            "label": "Content-type",
+            "name": "error_headers_limits_exceeded",
+            "value": "text/plain; charset=us-ascii",
+          },
+          Object {
+            "inputType": "text",
+            "label": "Response Body",
+            "name": "error_limits_exceeded",
+            "value": "Usage limit exceeded",
+          },
+        ]
+      }
+      key="Usage limit exceeded error"
+      legend="Usage limit exceeded error"
+    />
+  </FormFieldset>
+</Fragment>
+`;

--- a/spec/javascripts/Settings/components/__snapshots__/OidcFieldset.spec.jsx.snap
+++ b/spec/javascripts/Settings/components/__snapshots__/OidcFieldset.spec.jsx.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<FormFieldset
+  id="fieldset-Oidc"
+>
+  <FormLegend>
+    OPENID CONNECT (OIDC)
+  </FormLegend>
+  <Basics
+    item={
+      Object {
+        "hint": "Location of your OpenID Provider. The format of this endpoint is determined on your OpenID Provider setup. A common guidance would be \\"https://CLIENT_ID:CLIENT_SECRET@HOST:PORT/auth/realms/REALM_NAME\\".",
+        "label": "OpenID Connect Issuer",
+        "name": "oidc_issuer_endpoint",
+        "placeholder": "https://sso.example.com/auth/realms/gateway",
+        "value": "",
+      }
+    }
+    type={
+      Object {
+        "catalog": Object {
+          "keycloak": "Red Hat Single Sign-On",
+          "rest": "REST API",
+        },
+        "label": "OpenID Connect Issuer Type",
+        "name": "oidc_issuer_type",
+        "value": "keycloak",
+      }
+    }
+  />
+  <AuthorizationFlow
+    collection={
+      Array [
+        Object {
+          "checked": false,
+          "label": "Service Accounts Flow",
+          "name": "service_accounts_enabled",
+        },
+        Object {
+          "checked": false,
+          "label": "Authorization Code Flow",
+          "name": "standard_flow_enabled",
+        },
+        Object {
+          "checked": false,
+          "label": "Implicit Flow",
+          "name": "implicit_flow_enabled",
+        },
+        Object {
+          "checked": false,
+          "label": "Direct Access Grant Flow",
+          "name": "direct_access_grants_enabled",
+        },
+      ]
+    }
+  />
+  <JsonWebToken
+    item={
+      Object {
+        "hint": "The Token Claim that contains the clientID. Defaults to \\"azp\\".",
+        "label": "ClientID Token Claim",
+        "name": "jwt_claim_with_client_id",
+        "placeholder": "azp",
+        "value": "azp",
+      }
+    }
+    type={
+      Object {
+        "catalog": Object {
+          "liquid": "liquid",
+          "plain": "plain",
+        },
+        "hint": "Process the ClientID Token Claim value as a string or as a liquid template. When set to \\"Liquid\\" you can define more complex rules. e.g. If \\"some_claim\\" is an array you can select the first value this like {{ some_claim | first }}.",
+        "label": "ClientID Token Claim Type",
+        "name": "jwt_claim_with_client_id_type",
+        "value": "plain",
+      }
+    }
+  />
+</FormFieldset>
+`;
+
+exports[`should render only Basics  when Service Mesh is active 1`] = `
+<FormFieldset
+  id="fieldset-Oidc"
+>
+  <FormLegend>
+    OPENID CONNECT (OIDC)
+  </FormLegend>
+  <Basics
+    item={
+      Object {
+        "hint": "Location of your OpenID Provider. The format of this endpoint is determined on your OpenID Provider setup. A common guidance would be \\"https://CLIENT_ID:CLIENT_SECRET@HOST:PORT/auth/realms/REALM_NAME\\".",
+        "label": "OpenID Connect Issuer",
+        "name": "oidc_issuer_endpoint",
+        "placeholder": "https://sso.example.com/auth/realms/gateway",
+        "value": "",
+      }
+    }
+    type={
+      Object {
+        "catalog": Object {
+          "keycloak": "Red Hat Single Sign-On",
+          "rest": "REST API",
+        },
+        "label": "OpenID Connect Issuer Type",
+        "name": "oidc_issuer_type",
+        "value": "keycloak",
+      }
+    }
+  />
+</FormFieldset>
+`;


### PR DESCRIPTION
**What this PR does / why we need it**:

The new integration settings page needed a good refactor, it was crafted in a hacky fashion for 2.7 ER1

**Which issue(s) this PR fixes** 

fixes https://issues.jboss.org/browse/THREESCALE-3563

**Verification Steps**
Apply this patch to make it work:
```
diff --git a/app/javascript/packs/settings.js b/app/javascript/packs/settings.js
index e9bb1a69..0bfeb4b6 100644
--- a/app/javascript/packs/settings.js
+++ b/app/javascript/packs/settings.js
@@ -1,5 +1,5 @@
-import { initialize as authenticationWidget } from 'Settings/authentication-widget'
+import { initSettings as settingsWidgets } from 'Settings/index'

 document.addEventListener('DOMContentLoaded', () => {
-  authenticationWidget()
+  settingsWidgets({elementId: 'settings'})
 })
```

 
**TODO**
* [x] Tests
* [x] Fix Styles
* [x] Create issue for "Rails Helper" https://issues.jboss.org/browse/THREESCALE-3822
* [x] Create issue for "Remove old implementation" https://issues.jboss.org/browse/THREESCALE-3823 

