### PR TITLE
Fix infinite lazy initialization when the object will be destroyed

### DIFF
--- a/app/lib/cms/settings.rb
+++ b/app/lib/cms/settings.rb
@@ -5,7 +5,7 @@ module CMS
     DEFAULT_MODE = 'published'
 
     def initialize(settings, session)
-      @settings = settings
+      @settings = settings || ::Settings.new
       @session  = session
     end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -207,7 +207,7 @@ class Account < ApplicationRecord
   # profile is using acts_as_audited and it will not work if :dependent => :destroy
   has_one :profile, dependent: :delete
   has_one :settings, dependent: :destroy, inverse_of: :account, autosave: true
-  lazy_initialization_for :profile, :settings
+  lazy_initialization_for :profile, :settings, if: :should_not_be_deleted?
   accepts_nested_attributes_for :profile
 
   belongs_to :country

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -495,8 +495,10 @@ class Account < ApplicationRecord
         fields_to_xml(xml)
         extra_fields_to_xml(xml)
 
-        xml.monthly_billing_enabled settings&.monthly_billing_enabled
-        xml.monthly_charging_enabled settings&.monthly_charging_enabled
+        unless should_be_deleted?
+          xml.monthly_billing_enabled settings.monthly_billing_enabled
+          xml.monthly_charging_enabled settings.monthly_charging_enabled
+        end
 
         xml.credit_card_stored credit_card_stored?
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -495,8 +495,8 @@ class Account < ApplicationRecord
         fields_to_xml(xml)
         extra_fields_to_xml(xml)
 
-        xml.monthly_billing_enabled settings.monthly_billing_enabled
-        xml.monthly_charging_enabled settings.monthly_charging_enabled
+        xml.monthly_billing_enabled settings&.monthly_billing_enabled
+        xml.monthly_charging_enabled settings&.monthly_charging_enabled
 
         xml.credit_card_stored credit_card_stored?
 

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -18,7 +18,7 @@ module Account::ProviderMethods
     has_one :provider_constraints, foreign_key: 'provider_id'
 
     has_one :forum
-    lazy_initialization_for :forum, if: :provider?
+    lazy_initialization_for :forum, if: :initialize_forum?
 
     has_one  :web_hook, inverse_of: :account
     has_many :alerts
@@ -173,6 +173,10 @@ module Account::ProviderMethods
   # Only timezones with whole hour shift are allowed
   #
   ALLOWED_TIMEZONES = ActiveSupport::TimeZone.all.reject { |z| z.utc_offset % 3600 != 0 }.freeze
+
+  def initialize_forum?
+    provider? && should_not_be_deleted?
+  end
 
   # Returns all alerts for all the apps of this provider buyers minus his own with (master) 3scale
   #

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -129,6 +129,10 @@ module Account::States
     def should_be_deleted?
       scheduled_for_deletion? || suspended? || (buyer? && provider_account.try(:should_be_deleted?))
     end
+
+    def should_not_be_deleted?
+      !should_be_deleted?
+    end
   end
 
   module ClassMethods

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -551,8 +551,9 @@ class Service < ApplicationRecord
   end
 
   def default_service_plan_state
-    return if !account || !account.provider_can_use?(:published_service_plan_signup) || !(settings = account.settings)
-    settings.service_plans_ui_visible? ? 'hidden'.freeze : 'published'.freeze
+    return unless account && account.provider_can_use?(:published_service_plan_signup)
+    return if account.should_be_deleted?
+    account.settings.service_plans_ui_visible? ? 'hidden'.freeze : 'published'.freeze
   end
 
   def update_notification_settings

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -551,8 +551,8 @@ class Service < ApplicationRecord
   end
 
   def default_service_plan_state
-    return unless account.try(:provider_can_use?, :published_service_plan_signup)
-    account.settings.service_plans_ui_visible? ? 'hidden'.freeze : 'published'.freeze
+    return if !account || !account.provider_can_use?(:published_service_plan_signup) || !(settings = account.settings)
+    settings.service_plans_ui_visible? ? 'hidden'.freeze : 'published'.freeze
   end
 
   def update_notification_settings

--- a/app/representers/account_representer.rb
+++ b/app/representers/account_representer.rb
@@ -65,6 +65,5 @@ module AccountRepresenter
     credit_card_stored?
   end
 
-  delegate :monthly_charging_enabled, to: :settings
-  delegate :monthly_billing_enabled, to: :settings
+  delegate :monthly_charging_enabled, :monthly_billing_enabled, to: :settings, allow_nil: true
 end

--- a/lib/developer_portal/app/views/shared/_footer.html.erb
+++ b/lib/developer_portal/app/views/shared/_footer.html.erb
@@ -7,14 +7,16 @@
     </li>
     <% end %>
 
-    <% settings = site_account.settings %>
+    <% unless site_account.should_be_deleted? %>
+      <% settings = site_account.settings %>
 
-    <% if settings&.privacy_policy.present? %>
-      <li><%= link_to 'Privacy policy', settings_privacy_path %></li>
-    <% end %>
+      <% if settings.privacy_policy.present? %>
+        <li><%= link_to 'Privacy policy', settings_privacy_path %></li>
+      <% end %>
 
-    <% if settings&.refund_policy.present? %>
-      <li><%= link_to 'Refund policy', settings_refunds_path %></li>
+      <% if settings.refund_policy.present? %>
+        <li><%= link_to 'Refund policy', settings_refunds_path %></li>
+      <% end %>
     <% end %>
 
     <li class="last">

--- a/lib/developer_portal/app/views/shared/_footer.html.erb
+++ b/lib/developer_portal/app/views/shared/_footer.html.erb
@@ -7,11 +7,13 @@
     </li>
     <% end %>
 
-    <% if site_account.settings.privacy_policy.present? %>
+    <% settings = site_account.settings %>
+
+    <% if settings&.privacy_policy.present? %>
       <li><%= link_to 'Privacy policy', settings_privacy_path %></li>
     <% end %>
 
-    <% if site_account.settings.refund_policy.present? %>
+    <% if settings&.refund_policy.present? %>
       <li><%= link_to 'Refund policy', settings_refunds_path %></li>
     <% end %>
 

--- a/test/unit/pdf/dispatch_test.rb
+++ b/test/unit/pdf/dispatch_test.rb
@@ -28,8 +28,9 @@ class Pdf::DispatchTest < ActiveSupport::TestCase
   end
 
   test 'not enqueue report for non approved accounts' do
-    account = FactoryBot.create(:simple_provider, state: 'suspended')
+    account = FactoryBot.create(:simple_provider)
     FactoryBot.create(:simple_service, account: account)
+    account.suspend!
 
     # Only master is reported
     assert_difference PdfReportWorker.jobs.method(:count), 1 do

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -608,8 +608,9 @@ class ServiceTest < ActiveSupport::TestCase
   end
 
   test 'of_approved_account' do
-    account = FactoryBot.create(:simple_provider, state: 'suspended')
+    account = FactoryBot.create(:simple_provider)
     service = FactoryBot.create(:simple_service, account: account)
+    account.suspend!
     assert_not_includes Service.of_approved_accounts, service
   end
 

--- a/test/workers/delete_account_hierarchy_worker_test.rb
+++ b/test/workers/delete_account_hierarchy_worker_test.rb
@@ -44,4 +44,10 @@ class DeleteAccountHierarchyWorkerTest < ActiveSupport::TestCase
 
     Sidekiq::Testing.inline! { DeleteAccountHierarchyWorker.perform_now(provider) }
   end
+
+  test 'the account ends up destroyed after the hierarchy' do
+    Sidekiq::Testing.inline! { DeleteAccountHierarchyWorker.perform_now(provider) }
+
+    assert_raises(ActiveRecord::RecordNotFound) { provider.reload }
+  end
 end

--- a/test/workers/delete_account_hierarchy_worker_test.rb
+++ b/test/workers/delete_account_hierarchy_worker_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DeleteAccountHierarchyWorkerTest < ActiveSupport::TestCase
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    provider.schedule_for_deletion!
+  end
+
+  attr_reader :provider
+
+  test 'perform destroys the associations in background' do
+    DeleteObjectHierarchyWorker.stubs(:perform_later)
+
+    non_default_service = FactoryBot.create(:service, account: provider)
+    non_default_service.stubs(:default?).returns(false)
+    services = [provider.services.default, non_default_service]
+    account_plan = provider.account_plans.default
+
+    FactoryBot.create(:service_contract, user_account: provider)
+    FactoryBot.create(:account_contract, user_account: provider)
+    FactoryBot.create(:application_contract, user_account: provider)
+    contracts = provider.reload.contracts
+
+    buyers = FactoryBot.create_list(:buyer_account, 2, provider_account: provider)
+    users = provider.users
+
+    DeleteObjectHierarchyWorker.stubs(:perform_later)
+    users.each { |user| DeleteObjectHierarchyWorker.expects(:perform_later).with(user, anything) }
+    services.each { |service| DeleteServiceHierarchyWorker.expects(:perform_later).with(service, anything) }
+    buyers.each { |buyer| DeleteAccountHierarchyWorker.expects(:perform_later).with(buyer, anything).once }
+    contracts.each do |contract|
+      DeleteObjectHierarchyWorker.expects(:perform_later).with(Contract.new({ id: contract.id }, without_protection: true), anything)
+    end
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(account_plan, anything)
+
+    Sidekiq::Testing.inline! { DeleteAccountHierarchyWorker.perform_now(provider) }
+  end
+
+  test 'does not perform if wrong state' do
+    provider.update_column(:state, 'approved')
+    DeleteObjectHierarchyWorker.expects(:perform_later).never
+
+    Sidekiq::Testing.inline! { DeleteAccountHierarchyWorker.perform_now(provider) }
+  end
+end


### PR DESCRIPTION
Without this fix, this is what the DeleteObjectHierarchyWorker (and its children) receive in the test I wrote:
![image](https://user-images.githubusercontent.com/11318903/66466879-bc2a1280-ea83-11e9-945a-fd49034f377e.png)

With this fix:
![image](https://user-images.githubusercontent.com/11318903/66466919-ce0bb580-ea83-11e9-9900-0d2d4a483486.png)
