### PR TITLE
stop breaking words at random places in table content

### DIFF
--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -137,11 +137,6 @@ table.list {
   th {
     border-bottom: $border-width solid $border-color;
     font-weight: $font-weight-normal;
-    word-break: break-all;
-
-    &:nth-child(3) {
-      word-break: normal;
-    }
   }
 }
 


### PR DESCRIPTION
<img width="300" alt="Screenshot 2019-10-09 11 50 53" src="https://user-images.githubusercontent.com/54224/66471112-12e71a80-ea8b-11e9-8951-c52229333eb9.png">

This just isn't acceptable. (saw during demo of Andreu to UXD team)
