### PR TITLE
Improve out-of-date config ux

### DIFF
--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -242,7 +242,7 @@ module VerticalNavHelper
 
   def service_integration_items
     items = []
-    items << {id: :configuration,       title: 'Configuration',     path: path_to_service(@service)}
+    items << {id: :configuration,       title: 'Configuration',     path: path_to_service(@service),    outOfDateConfig: has_out_of_date_configuration?(@service)}
     items << {id: :methods_metrics,     title: 'Methods & Metrics', path: admin_service_metrics_path(@service)}
     items << {id: :mapping_rules,       title: 'Mapping Rules',     path: admin_service_proxy_rules_path(@service)} if current_account.independent_mapping_rules_enabled?
     if current_account.provider_can_use?(:api_as_product)

--- a/app/javascript/src/Navigation/components/PF4NavProxy.jsx
+++ b/app/javascript/src/Navigation/components/PF4NavProxy.jsx
@@ -8,13 +8,13 @@ const Nav = ({id, children}) => (
   </nav>
 )
 
-const OutdatedIcon = ({title}) => {
-  const isVisibleIcon = title === 'Integration'
-  return isVisibleIcon ? <i className='fa fa-exclamation-triangle' title='The Integration is out of date, promote!'></i> : null
-}
+const OutdatedIcon = () => (
+  <i className='fa fa-exclamation-triangle' title='The Integration is out of date, promote!'></i>
+)
 
 const NavExpandable = ({id, title, isExpanded, isActive, children, outOfDateConfig}) => {
   const [expanded, setExpanded] = useState(isExpanded)
+  const integrationOutOfDateConfig = !expanded && outOfDateConfig
 
   function onItemClick () {
     setExpanded(expanded => !expanded)
@@ -24,7 +24,7 @@ const NavExpandable = ({id, title, isExpanded, isActive, children, outOfDateConf
     <li className={`pf-c-nav__item pf-m-expandable ${expanded ? 'pf-m-expanded' : ''} ${isActive ? 'pf-m-current' : ''}`}>
       <a href="#" className="pf-c-nav__link" id={id} aria-expanded="true" onClick={onItemClick}>
         {title}
-        { outOfDateConfig && <OutdatedIcon title={title} /> }
+        { integrationOutOfDateConfig && <OutdatedIcon /> }
         <span className="pf-c-nav__toggle">
           {Caret}
         </span>
@@ -44,10 +44,11 @@ const Caret = (
   </svg>
 )
 
-const NavItem = ({to, isActive, target, children}) => (
+const NavItem = ({to, isActive, target, children, outOfDateConfig}) => (
   <li className="pf-c-nav__item">
     <a href={to} className={`pf-c-nav__link ${isActive ? 'pf-m-current' : ''}`} aria-current="page" target={target}>
       {children}
+      { outOfDateConfig && <OutdatedIcon /> }
     </a>
   </li>
 )

--- a/app/javascript/src/Navigation/components/VerticalNav.jsx
+++ b/app/javascript/src/Navigation/components/VerticalNav.jsx
@@ -8,7 +8,8 @@ type Item = {
   id: string,
   title: string,
   path: ?string,
-  target: ?string
+  target: ?string,
+  outOfDateConfig: ?boolean
 }
 
 type Section = Item & {
@@ -39,9 +40,9 @@ const VerticalNav = ({ sections, activeSection, activeItem }: Props) => (
 const NavSection = ({title, isSectionActive, activeItem, items, outOfDateConfig}) => {
   return (
     <NavExpandable title={title} isActive={isSectionActive} isExpanded={isSectionActive} outOfDateConfig={outOfDateConfig}>
-      {items.map(({id, title, path, target}) => (
+      {items.map(({id, title, path, target, outOfDateConfig}) => (
         path
-          ? <NavItem to={path} isActive={isSectionActive && activeItem === id} target={target} key={title} >{title}</NavItem>
+          ? <NavItem to={path} isActive={isSectionActive && activeItem === id} target={target} key={title} outOfDateConfig={outOfDateConfig} >{title}</NavItem>
           : <NavGroup title={title} className='vertical-nav-label' key={title}></NavGroup>
       ))}
     </NavExpandable>

--- a/app/views/shared/provider/navigation/_vertical_nav_item.html.slim
+++ b/app/views/shared/provider/navigation/_vertical_nav_item.html.slim
@@ -2,7 +2,6 @@
 - path = section[:path]
 - items = section[:items]
 - is_section_active = active_section == section[:id]
-- integration_out_of_date = section[:outOfDateConfig]
 
 - if items == nil
   li.pf-c-nav__item class=('pf-m-current' if is_section_active)
@@ -13,12 +12,14 @@
   li.pf-c-nav__item class='pf-m-expandable pf-m-expanded' class=('pf-m-current' if is_section_active)
     a.pf-c-nav__link href='#!'
       = title
-      - if integration_out_of_date
-        i.fa.fa-exclamation-triangle
+      
     section.pf-c-nav__subnav
       ul.pf-c-nav__simple-list
         - items.each do |item|
           - is_item_active = is_section_active && active_item == item[:id]
+          - is_item_config_out_of_date = item[:outOfDateConfig]
           li.pf-c-nav__item class=('pf-m-current' if is_item_active)
             = link_to item[:path], class: 'pf-c-nav__link', target: item[:target] do
               = item[:title]
+              - if is_item_config_out_of_date
+                i.fa.fa-exclamation-triangle


### PR DESCRIPTION
**What this PR does / why we need it**:

When config is outdated, Integration menu shows an exclamation mark.
If collapsed, the icon must shown at top level, if expanded the icon must shown in submenu.
When JS is off, the icon is placed in the submenu (no collapse/expand is available)

**Closes:** https://issues.jboss.org/browse/THREESCALE-3660

JS on:

![submenu](https://user-images.githubusercontent.com/13486237/66569549-156d7100-eb6c-11e9-8bc4-f43382a3b70b.gif)

JS off:
![js-off](https://user-images.githubusercontent.com/13486237/66569564-1f8f6f80-eb6c-11e9-89d3-660c7a28b955.png)


