### PR TITLE
Fixes undefined method backend_version on OIDC::ProxyChangedEvent

### DIFF
--- a/app/events/oidc/proxy_changed_event.rb
+++ b/app/events/oidc/proxy_changed_event.rb
@@ -19,10 +19,8 @@ class OIDC::ProxyChangedEvent < BaseEventStoreEvent
 
   # :reek:NilCheck but backend_version_change just can be nil
   def self.valid?(proxy)
-    return unless proxy
-
-    service = proxy.service
-
+    service = proxy.try(:service)
+    return unless service
     service.backend_version.oauth? || service.backend_version_change&.include?('oauth')
   end
 end

--- a/test/events/oidc/proxy_changed_event_test.rb
+++ b/test/events/oidc/proxy_changed_event_test.rb
@@ -28,4 +28,13 @@ class OIDC::ProxyChangedEventTest < ActiveSupport::TestCase
     assert_equal 'http://example.com/auth/realm', zync[:oidc_endpoint]
     assert_equal proxy.service.id, zync[:service_id]
   end
+
+  test '#valid? when service has been deleted' do
+    proxy = FactoryBot.create(:simple_proxy, oidc_issuer_endpoint: 'http://example.com/auth/realm')
+    proxy.service.backend_version = 'oauth'
+    assert OIDC::ProxyChangedEvent.valid?(proxy)
+
+    proxy.stubs(service: nil)
+    refute OIDC::ProxyChangedEvent.valid?(proxy)
+  end
 end


### PR DESCRIPTION
Fixes NoMethodError: undefined method `backend_version' for nil:NilClass when proxy validity is checked while service has been deleted already.

Closes [THREESCALE-2917](https://issues.jboss.org/browse/THREESCALE-2917)