### PR TITLE
Create a new tenant through 'master-domain/p/signup' does not create a backend api

### DIFF
--- a/app/lib/logic/provider_signup.rb
+++ b/app/lib/logic/provider_signup.rb
@@ -64,7 +64,7 @@ module Logic
           service_plan.create_contract_with! provider
           application_plan.create_contract_with! provider
 
-          ServiceCreator.new(service: provider.services.build(name: 'API')).call
+          ServiceCreator.new(service: provider.services.build(name: 'API')).call(private_endpoint: BackendApi.default_api_backend)
         end
 
         if ThreeScale.config.onpremises

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -791,7 +791,7 @@ class AccountTest < ActiveSupport::TestCase
       user.password = user.password_confirmation = "foobar"
       user.email = "foo@example.com"
     end
-    assert_nil @provider.first_service.api_backend
+    assert_equal BackendApi.default_api_backend, @provider.first_service.api_backend
   end
 
 


### PR DESCRIPTION
Closes [THREESCALE-3687](https://issues.jboss.org/browse/THREESCALE-3687)

:warning: blocks https://github.com/3scale/porta/pull/1304