### PR TITLE
[DO NOT MERGE] Prevents deployment when updating Proxy in APIAP

### DIFF
--- a/app/controllers/admin/api/services/proxies_controller.rb
+++ b/app/controllers/admin/api/services/proxies_controller.rb
@@ -63,7 +63,7 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
   ##~ op.parameters.add name: "jwt_claim_with_client_id_type", description: "JWT Claim With ClientId Type. Either `plain` or `liquid`", dataType: "string", paramType: "query", required: false
   #
   def update
-    if proxy.update_attributes(proxy_params)
+    if proxy.update_attributes(proxy_params) && !apiap?
       if proxy.service_mesh_integration?
         proxy.deploy!
       elsif proxy.apicast_configuration_driven

--- a/app/controllers/admin/api/services/proxies_controller.rb
+++ b/app/controllers/admin/api/services/proxies_controller.rb
@@ -33,7 +33,7 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
   ##~ op            = e.operations.add
   ##~ op.httpMethod = "PATCH"
   ##~ op.summary    = "Proxy Update"
-  ##~ op.description = "Changes the Proxy settings. This will create a new APIcast configuration version for the Staging environment with the updated settings."
+  ##~ op.description = "Changes the Proxy settings. This will create a new APIcast configuration version for the Staging environment with the updated settings. For servcice mesh, it will also create one for the Production environment"
   ##~ op.group = "proxy"
   #
   ##~ op.parameters.add @parameter_access_token

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -296,4 +296,8 @@ class ApplicationController < ActionController::Base
       res
     end
   end
+
+  def apiap?
+    current_account.provider_can_use?(:api_as_product)
+  end
 end

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -29,10 +29,6 @@ class FrontendController < ApplicationController
 
   private
 
-  def apiap?
-    current_account.provider_can_use?(:api_as_product)
-  end
-
   helper_method :apiap?
 
   def do_nothing_if_head

--- a/test/integration/user-management-api/services/proxies_test.rb
+++ b/test/integration/user-management-api/services/proxies_test.rb
@@ -49,15 +49,13 @@ class Admin::Api::Services::ProxiesTest < ActionDispatch::IntegrationTest
     params = provider_key_params.merge(proxy: { endpoint: 'https://alaska.wild' })
 
     Proxy.update_all(apicast_configuration_driven: false)
-    Proxy.any_instance.expects(:deploy_v2).never
-    assert_difference @service.proxy.proxy_configs.production.method(:count), 0 do
+    assert_no_difference @service.proxy.proxy_configs.sandbox.method(:count) do
       put(admin_api_service_proxy_path(params))
     end
     assert_response :success
 
     Proxy.update_all(apicast_configuration_driven: true)
-    Proxy.any_instance.expects(:deploy_v2).once
-    assert_difference @service.proxy.proxy_configs.production.method(:count), 1 do
+    assert_difference @service.proxy.proxy_configs.sandbox.method(:count), 1 do
       put(admin_api_service_proxy_path(params))
     end
     assert_response :success
@@ -70,15 +68,13 @@ class Admin::Api::Services::ProxiesTest < ActionDispatch::IntegrationTest
     params = provider_key_params.merge(proxy: { endpoint: 'https://alaska.wild' })
 
     Proxy.update_all(apicast_configuration_driven: false)
-    Proxy.any_instance.expects(:deploy_v2).never
-    assert_difference @service.proxy.proxy_configs.production.method(:count), 0 do
+    assert_no_difference @service.proxy.proxy_configs.sandbox.method(:count) do
       put(admin_api_service_proxy_path(params))
     end
     assert_response :success
 
     Proxy.update_all(apicast_configuration_driven: true)
-    Proxy.any_instance.expects(:deploy_v2).once
-    assert_difference @service.proxy.proxy_configs.production.method(:count), 0 do
+    assert_no_difference @service.proxy.proxy_configs.sandbox.method(:count) do
       put(admin_api_service_proxy_path(params))
     end
     assert_response :success
@@ -87,16 +83,18 @@ class Admin::Api::Services::ProxiesTest < ActionDispatch::IntegrationTest
   def test_update_for_service_mesh
     rolling_updates_on
     rolling_update(:api_as_product, enabled: false)
-    
+
     params = provider_key_params.merge(proxy: { credentials_location: 'headers' })
     @service.update_column :deployment_option, 'service_mesh_istio'
-    
-    assert_difference @service.proxy.proxy_configs.production.method(:count), 1 do
-      put(admin_api_service_proxy_path(params))
+
+    assert_difference @service.proxy.proxy_configs.sandbox.method(:count), 1 do
+      assert_difference @service.proxy.proxy_configs.production.method(:count), 1 do
+        put(admin_api_service_proxy_path(params))
+      end
     end
     assert_response :success
   end
-  
+
   def test_update_for_service_mesh_with_apiap
     rolling_updates_on
     rolling_update(:api_as_product, enabled: true)
@@ -104,8 +102,10 @@ class Admin::Api::Services::ProxiesTest < ActionDispatch::IntegrationTest
     params = provider_key_params.merge(proxy: { credentials_location: 'headers' })
     @service.update_column :deployment_option, 'service_mesh_istio'
 
-    assert_difference @service.proxy.proxy_configs.production.method(:count), 0 do
-      put(admin_api_service_proxy_path(params))
+    assert_no_difference @service.proxy.proxy_configs.sandbox.method(:count) do
+      assert_no_difference @service.proxy.proxy_configs.production.method(:count) do
+        put(admin_api_service_proxy_path(params))
+      end
     end
     assert_response :success
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `apiap?` condition when updating so that it isn't deployed. This way there is no proxy_config created.

**JIRA**:

[THREESCALE-3626: Proxy configs for products that do not have any backend (API)](https://issues.jboss.org/browse/THREESCALE-3626)
