### PR TITLE
[not needed now][wip] PatternFly4 Input Builder

### DIFF
--- a/app/javascript/src/FormBuilder/InputBuilder.jsx
+++ b/app/javascript/src/FormBuilder/InputBuilder.jsx
@@ -1,0 +1,66 @@
+//@flow
+
+import { switchCase, filterKeys } from 'utilities/fp'
+import React from 'react'
+import {
+  FormGroup,
+  TextInput,
+  FormSelectionOption,
+  FormSelect,
+  Checkbox,
+  Radio
+} from '@patternfly/react-core'
+
+type Type = 'text' | 'select' | 'radio' | 'checkbox' | 'hidden'
+type Options = {[string]: string}
+type Props = {
+  settings: {
+    label?: string,
+    name?: string,
+    type?: Type,
+    collection?: Options[],
+    onChange?: void,
+    className?: string,
+    isDisabled?: boolean,
+    isRequired?: boolean,
+    helperText?: string
+  },
+  value?: string
+}
+
+const SettingsTemplate = {
+  type: 'text',
+  label: '',
+  fieldId: ''
+}
+
+const COMMON_KEYS: string[] = ['id', 'type', 'onChange', 'value', 'className', 'isDisabled']
+const GROUP_KEYS: string[] = ['label', 'isRequired', 'fieldId', 'helperText']
+const SELECT_KEYS: string[] = [...COMMON_KEYS, ...['helperText']]
+const SELECT_OPTION_KEYS: string[] = ['value', 'label', 'isDisabled', 'key']
+const CHECKERS_KEYS: string[] = [...COMMON_KEYS, ...['isChecked', 'name']]
+
+
+const InputBuilder = ({settings = SettingsTemplate, value = ''}: Props) => {
+  const { type, collection } = settings
+  return (
+    <FormGroup {...filterKeys(settings)(GROUP_KEYS)}>
+      {switchCase({
+        'text': () => (<TextInput {...filterKeys({...settings, ...{value}})(COMMON_KEYS)}/>),
+        'select': () => (
+          <FormSelect {...filterKeys({...settings, ...{value}})(SELECT_KEYS)}>
+            {collection && collection.map((option, index) =>
+              <FormSelectionOption {...filterKeys({...option, ...{key: index}})(SELECT_OPTION_KEYS)} />
+            )}
+          </FormSelect>
+        ),
+        'checkbox': () => (<Checkbox {...filterKeys(settings)(CHECKERS_KEYS)} />),
+        'radio': () => (<Radio {...filterKeys(settings)(CHECKERS_KEYS)} />)
+      })(() => {})(type)()}
+    </FormGroup>
+  )
+}
+
+export {
+  InputBuilder
+}

--- a/app/javascript/src/utilities/fp.js
+++ b/app/javascript/src/utilities/fp.js
@@ -1,0 +1,13 @@
+const switchCase = cases => defaultCase => key =>
+  cases.hasOwnProperty(key) ? cases[key] : defaultCase
+
+const filterKeys = (source) => (allowed) => Object.keys(source)
+  .filter(key => allowed.includes(key))
+  .reduce((obj, key) => {
+    obj[key] = source[key]
+    return obj
+  }, {})
+export {
+  switchCase,
+  filterKeys
+}

--- a/spec/javascripts/FormBuilder/InputBuilder.spec.jsx
+++ b/spec/javascripts/FormBuilder/InputBuilder.spec.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import {
+  TextInput,
+  FormSelect,
+  Checkbox,
+  Radio
+} from '@patternfly/react-core'
+
+import { InputBuilder } from 'FormBuilder/InputBuilder'
+
+it('should return the correct PF4 component given a type', () => {
+  const props = {
+    text: {
+      type: 'text',
+      fieldId: 'baz',
+      id: 'bar'
+    },
+    select: {
+      type: 'select',
+      fieldId: 'foo',
+      collection: [
+        {value: 'foo', label: 'Foo'}
+      ]
+    },
+    checkbox: {
+      fieldId: 'check',
+      type: 'checkbox',
+      id: 'checkthisout'
+    },
+    radio: {
+      fieldId: 'rad',
+      type: 'radio',
+      id: 'checkthisoutornot',
+      name: 'tvontheradio'
+    }
+  }
+
+  const expected = {
+    text: TextInput,
+    select: FormSelect,
+    checkbox: Checkbox,
+    radio: Radio
+  }
+
+  Object.keys(props).forEach(k => {
+    const wrapper = shallow(<InputBuilder settings={props[k]} />)
+    expect(wrapper.find(expected[k]).exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Ease the process of crafting form inputs with PF4 magic when are migrated from formtastic with options coming from Rails.

**Which issue(s) this PR fixes** 
Needed for https://github.com/3scale/porta/pull/1315/

**Special notes for your reviewer**:
This is a helper only, this doesn't aim to replace PF4, nor solutions like react-json-form or anything of the like. We should keep it simple.