### PR TITLE
Aligning APIs tabs title in Dashboard

### DIFF
--- a/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
+++ b/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
@@ -98,6 +98,7 @@
  */
 
  .DashboardSection--tabs-title {
+    bottom: line-height-times(-1 / 3);
     color: #393f44;
     cursor: pointer;
     float: left;
@@ -106,7 +107,7 @@
     line-height: line-height-times(1);
     margin-right: 0.75rem;
     margin: 0 0 0 0;
-    padding-top: 8px;
+    position: relative;
  }
 
 .pf-tabs-header {


### PR DESCRIPTION
**What this PR does / why we need it**:

Aligning "APIs" title of tabs section, to match with "AUDIENCE" spacing (moving it down)

![tabs](https://user-images.githubusercontent.com/13486237/66927115-8ced4580-f02f-11e9-97a1-8f5fb74ce671.png)

