### PR TITLE
Remove react-hot-loader module from Policies

### DIFF
--- a/app/javascript/src/Policies/components/App.jsx
+++ b/app/javascript/src/Policies/components/App.jsx
@@ -5,24 +5,14 @@ import PoliciesWidget from 'Policies/components/PoliciesWidget'
 
 import type { Store } from 'Policies/types'
 
-// This is a class-based component because the current
-// version of hot reloading won't hot reload a stateless
-// component at the top-level.
-
 type Props = {
   store: Store
 }
 
-class App extends React.Component<Props, {}> {
-  render () {
-    const { store } = this.props
-
-    return (
-      <div>
-        <PoliciesWidget store={store} />
-      </div>
-    )
-  }
-}
+const App = ({ store }: Props) => (
+  <div>
+    <PoliciesWidget store={store} />
+  </div>
+)
 
 export default App

--- a/app/javascript/src/Policies/index.jsx
+++ b/app/javascript/src/Policies/index.jsx
@@ -8,7 +8,6 @@ import 'whatwg-fetch'
 
 import React from 'react'
 import { render } from 'react-dom'
-import { AppContainer } from 'react-hot-loader'
 import Root from 'Policies/components/Root'
 import configureStore from 'Policies/store/configureStore'
 import { initialState } from 'Policies/reducers/initialState'
@@ -26,24 +25,7 @@ const Policies = (store, elementId) => {
     return
   }
 
-  render(
-    <AppContainer>
-      <Root store={store} />
-    </AppContainer>,
-    element
-  )
-
-  if (module.hot) {
-    module.hot.accept('./components/Root', () => {
-      const NewRoot = require('./components/Root').default
-      render(
-        <AppContainer>
-          <NewRoot store={store} />
-        </AppContainer>,
-        element
-      )
-    })
-  }
+  render(<Root store={store} />, element)
 }
 
 type InitPolicies = {

--- a/app/javascript/src/Policies/store/configureStore.jsx
+++ b/app/javascript/src/Policies/store/configureStore.jsx
@@ -49,14 +49,6 @@ function configureStoreDev (initialState: State): Store {
     applyMiddleware(...middlewares)
   ))
 
-  if (module.hot) {
-    // Enable Webpack hot module replacement for reducers
-    module.hot.accept('../reducers', () => {
-      const nextReducer = require('../reducers').default // eslint-disable-line global-require
-      store.replaceReducer(nextReducer)
-    })
-  }
-
   // $FlowFixMe this is of type State
   return store
 }

--- a/app/javascript/src/Policies/store/index.jsx
+++ b/app/javascript/src/Policies/store/index.jsx
@@ -1,0 +1,3 @@
+// @flow
+
+export * from 'Policies/store/configureStore'

--- a/app/javascript/src/Types/libs/libdefs.js
+++ b/app/javascript/src/Types/libs/libdefs.js
@@ -1,12 +1,5 @@
 // @flow
 
-// TODO: remove this workaround, necessary for module.hot to work
-declare var module: {
-  hot: {
-    accept(path: string, callback: () => void): void
-  }
-}
-
 // TODO: remove these module declarations when not failing
 declare module 'whatwg-fetch' {
   declare type Options = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14519,30 +14519,6 @@
         "scheduler": "^0.15.0"
       }
     },
-    "react-hot-loader": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.12.tgz",
-      "integrity": "sha512-Tkd412j5yPKHoTRsJzZb+5UJNFKkPszm7QGKGYvt+jnzTkDS+qK0u3AYPlB0MmBlwzUKVHICqq5KH9Srzda7XA==",
-      "dev": true,
-      "requires": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
-      }
-    },
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
@@ -14566,12 +14542,12 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-redux": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
-      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
+      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.1.0",
+        "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4",
         "loose-envify": "^1.1.0",
         "prop-types": "^15.6.1",
@@ -15479,12 +15455,6 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "postcss-loader": "^3.0.0",
     "postcss-smart-import": "^0.7.6",
     "raf": "^3.4.1",
-    "react-hot-loader": "^4.6.3",
     "redux-immutable-state-invariant": "^2.1.0",
     "regenerator-runtime": "^0.13.1",
     "sass-loader": "^7.1.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

`react-hot-loader` is supposed to be used during development to "hot-load" react, that is to refresh the UI without reloading the page.

Since webpacker is configured to refresh the page after every change, it doesn't make sense and it is useless to have this module anymore.

**Verification steps**:
* `npm run update-dependencies`
* Navigate to `apiconfig/services/<id>/policies/edit`
* Policies widget should work as usual

**Note**:
This is part 1 of the refactorization of Policies:
[THREESCALE-2221: Policies: Normalise the use of policies schema and its types](https://issues.jboss.org/browse/THREESCALE-2221)

A follow-up PR will be created once this one is merged.