### PR TITLE
PatternFly React: Our own FormFieldset and FormLegend components

### DIFF
--- a/app/javascript/src/Form/FormFieldset.jsx
+++ b/app/javascript/src/Form/FormFieldset.jsx
@@ -1,0 +1,68 @@
+// @flow
+// TODO: Replace this component when patternfly-react implements it.
+
+import * as React from 'react'
+import { FormContext } from '@patternfly/react-core/dist/js/components/Form/FormContext'
+// $FlowFixMe
+import styles from '@patternfly/react-styles/css/components/Form/form'
+// $FlowFixMe
+import { css, getModifier } from '@patternfly/react-styles'
+
+type Props = {
+  children?: React.Node,
+  className?: string,
+  label?: React.Node,
+  isRequired?: boolean,
+  isValid?: boolean,
+  isInline?: boolean,
+  helperText?: React.Node,
+  helperTextInvalid?: React.Node,
+  fieldId: string
+}
+
+const FormFieldset = ({
+  children,
+  className = '',
+  label,
+  isRequired = false,
+  isValid = true,
+  isInline = false,
+  helperText,
+  helperTextInvalid,
+  fieldId,
+  ...props
+}: Props) => (
+  <FormContext.Consumer>
+    {({ isHorizontal }: { isHorizontal: boolean }) => (
+      <fieldset
+        {...props}
+        className={css(styles.formFieldset, isInline ? getModifier(styles, 'inline', className) : className)}
+      >
+        {label && (
+          <label className={css(styles.formLabel)} htmlFor={fieldId}>
+            <span className={css(styles.formLabelText)}>{label}</span>
+            {isRequired && (
+              <span className={css(styles.formLabelRequired)} aria-hidden="true">
+                {'*'}
+              </span>
+            )}
+          </label>
+        )}
+        {isHorizontal ? <div className={css(styles.formHorizontalGroup)}>{children}</div> : children}
+        {((isValid && helperText) || (!isValid && helperTextInvalid)) && (
+          <div
+            className={css(styles.formHelperText, !isValid ? getModifier(styles, 'error') : '')}
+            id={`${fieldId}-helper`}
+            aria-live="polite"
+          >
+            {isValid ? helperText : helperTextInvalid}
+          </div>
+        )}
+      </fieldset>
+    )}
+  </FormContext.Consumer>
+)
+
+export {
+  FormFieldset
+}

--- a/app/javascript/src/Form/FormLegend.jsx
+++ b/app/javascript/src/Form/FormLegend.jsx
@@ -1,0 +1,23 @@
+// @flow
+// TODO: Replace this component when patternfly-react implements it.
+
+import * as React from 'react'
+
+type Props = {
+  children?: React.Node,
+  className?: string
+}
+
+const FormLegend = ({
+  children,
+  className = '',
+  ...props
+}: Props) => (
+  <legend {...props} className={`pf-c-form__legend ${className}`}>
+    {children}
+  </legend>
+)
+
+export {
+  FormLegend
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,9 @@ module.exports = {
     '<rootDir>/spec/javascripts/setupTests.js',
     '<rootDir>/spec/javascripts/__mocks__/global-mocks.js'
   ],
+  snapshotSerializers: [
+    'enzyme-to-json/serializer'
+  ],
   moduleDirectories: [
     'node_modules',
     'app/javascript/src'
@@ -23,6 +26,9 @@ module.exports = {
     // https://github.com/facebook/jest/issues/2663#issuecomment-369040789
     '.+\\.(png|svg)$': 'jest-transform-stub'
   },
+  modulePathIgnorePatterns: [
+    '__snapshots__'
+  ],
   testURL: 'http://localhost',
   testRegex: '.*.spec.jsx',
   verbose: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -5666,6 +5666,15 @@
         "semver": "^5.6.0"
       }
     },
+    "enzyme-to-json": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.4.2.tgz",
+      "integrity": "sha512-tlzvJPPONTaTR2eKrWTt/pxknTjXgcNbxcYkxNfB0CwC8Pfc5xmSycaTwaQ1HXpN1zv6A7lAhnMV58HOIXTkFg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.12"
+      }
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "empty": "^0.10.1",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.10.0",
+    "enzyme-to-json": "^3.4.2",
     "eslint": "^6.0.1",
     "eslint-config-standard": "^7.1.0",
     "eslint-loader": "^2.1.1",

--- a/spec/javascripts/Form/FormFieldset.spec.jsx
+++ b/spec/javascripts/Form/FormFieldset.spec.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { FormFieldset } from 'Form/FormFieldset'
+
+describe('FormFieldset', () => {
+  it('should render default form fieldset variant', () => {
+    const view = mount(
+      <FormFieldset fieldId="label-id">
+        <input id="input-id" />
+      </FormFieldset>
+    )
+    expect(view).toMatchSnapshot()
+  })
+
+  it('should render inline form fieldset variant', () => {
+    const view = mount(
+      <FormFieldset isInline fieldId="label-id">
+        <input id="input-id" />
+      </FormFieldset>
+    )
+    expect(view).toMatchSnapshot()
+  })
+
+  it('should render form fieldset variant with node label and help text', () => {
+    const view = mount(
+      <FormFieldset fieldId="id" label={<span>Label</span>} helperText="this is helper text" >
+        <input aria-label="input" />
+      </FormFieldset>
+    )
+    expect(view).toMatchSnapshot()
+  })
+
+  it('should render form fieldset variant with node helperText', () => {
+    const view = mount(
+      <FormFieldset label="Label" fieldId="label-id" helperText={<span>Help text!</span>}>
+        <input id="input-id" />
+      </FormFieldset>
+    )
+    expect(view).toMatchSnapshot()
+  })
+
+  it('should render form fieldset required variant', () => {
+    const view = mount(
+      <FormFieldset isRequired label="label" fieldId="id">
+        <input id="input-id" />
+      </FormFieldset>
+    )
+    expect(view).toMatchSnapshot()
+  })
+
+  it('should render form fieldset invalid variant', () => {
+    const view = mount(
+      <FormFieldset label="label" fieldId="label-id" isValid={false} helperTextInvalid="Invalid FormFieldset">
+        <input id="input-id" />
+      </FormFieldset>
+    )
+    expect(view).toMatchSnapshot()
+  })
+})

--- a/spec/javascripts/Form/FormLegend.spec.jsx
+++ b/spec/javascripts/Form/FormLegend.spec.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { FormLegend } from 'Form/FormLegend'
+
+test('FormLegend', () => {
+  const view = shallow(<FormLegend>I am Legendary</FormLegend>)
+  expect(view).toMatchSnapshot()
+})
+
+test('FormLegend with additional class name', () => {
+  const view = shallow(<FormLegend className="first-class">I am Legendary</FormLegend>)
+  expect(view).toMatchSnapshot()
+})
+
+test('FormLegend with additional class name and props', () => {
+  const view = shallow(
+    <FormLegend className="first-class" id="legendary" data-label-name="Legendary">
+      I am Legendary
+    </FormLegend>
+  )
+  expect(view).toMatchSnapshot()
+})

--- a/spec/javascripts/Form/__snapshots__/FormFieldset.spec.jsx.snap
+++ b/spec/javascripts/Form/__snapshots__/FormFieldset.spec.jsx.snap
@@ -1,0 +1,174 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormFieldset should render default form fieldset variant 1`] = `
+<FormFieldset
+  fieldId="label-id"
+>
+  <fieldset
+    className="pf-c-form__fieldset"
+  >
+    <input
+      id="input-id"
+    />
+  </fieldset>
+</FormFieldset>
+`;
+
+exports[`FormFieldset should render form fieldset invalid variant 1`] = `
+<FormFieldset
+  fieldId="label-id"
+  helperTextInvalid="Invalid FormFieldset"
+  isValid={false}
+  label="label"
+>
+  <fieldset
+    className="pf-c-form__fieldset"
+  >
+    <label
+      className="pf-c-form__label"
+      htmlFor="label-id"
+    >
+      <span
+        className="pf-c-form__label-text"
+      >
+        label
+      </span>
+    </label>
+    <input
+      id="input-id"
+    />
+    <div
+      aria-live="polite"
+      className="pf-c-form__helper-text pf-m-error"
+      id="label-id-helper"
+    >
+      Invalid FormFieldset
+    </div>
+  </fieldset>
+</FormFieldset>
+`;
+
+exports[`FormFieldset should render form fieldset required variant 1`] = `
+<FormFieldset
+  fieldId="id"
+  isRequired={true}
+  label="label"
+>
+  <fieldset
+    className="pf-c-form__fieldset"
+  >
+    <label
+      className="pf-c-form__label"
+      htmlFor="id"
+    >
+      <span
+        className="pf-c-form__label-text"
+      >
+        label
+      </span>
+      <span
+        aria-hidden="true"
+        className="pf-c-form__label-required"
+      >
+        *
+      </span>
+    </label>
+    <input
+      id="input-id"
+    />
+  </fieldset>
+</FormFieldset>
+`;
+
+exports[`FormFieldset should render form fieldset variant with node helperText 1`] = `
+<FormFieldset
+  fieldId="label-id"
+  helperText={
+    <span>
+      Help text!
+    </span>
+  }
+  label="Label"
+>
+  <fieldset
+    className="pf-c-form__fieldset"
+  >
+    <label
+      className="pf-c-form__label"
+      htmlFor="label-id"
+    >
+      <span
+        className="pf-c-form__label-text"
+      >
+        Label
+      </span>
+    </label>
+    <input
+      id="input-id"
+    />
+    <div
+      aria-live="polite"
+      className="pf-c-form__helper-text"
+      id="label-id-helper"
+    >
+      <span>
+        Help text!
+      </span>
+    </div>
+  </fieldset>
+</FormFieldset>
+`;
+
+exports[`FormFieldset should render form fieldset variant with node label and help text 1`] = `
+<FormFieldset
+  fieldId="id"
+  helperText="this is helper text"
+  label={
+    <span>
+      Label
+    </span>
+  }
+>
+  <fieldset
+    className="pf-c-form__fieldset"
+  >
+    <label
+      className="pf-c-form__label"
+      htmlFor="id"
+    >
+      <span
+        className="pf-c-form__label-text"
+      >
+        <span>
+          Label
+        </span>
+      </span>
+    </label>
+    <input
+      aria-label="input"
+    />
+    <div
+      aria-live="polite"
+      className="pf-c-form__helper-text"
+      id="id-helper"
+    >
+      this is helper text
+    </div>
+  </fieldset>
+</FormFieldset>
+`;
+
+exports[`FormFieldset should render inline form fieldset variant 1`] = `
+<FormFieldset
+  fieldId="label-id"
+  isInline={true}
+>
+  <fieldset
+    className="pf-c-form__fieldset pf-m-inline"
+  >
+    <input
+      id="input-id"
+    />
+  </fieldset>
+</FormFieldset>
+`;

--- a/spec/javascripts/Form/__snapshots__/FormLegend.spec.jsx.snap
+++ b/spec/javascripts/Form/__snapshots__/FormLegend.spec.jsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormLegend 1`] = `
+<legend
+  className="pf-c-form__legend "
+>
+  I am Legendary
+</legend>
+`;
+
+exports[`FormLegend with additional class name 1`] = `
+<legend
+  className="pf-c-form__legend first-class"
+>
+  I am Legendary
+</legend>
+`;
+
+exports[`FormLegend with additional class name and props 1`] = `
+<legend
+  className="pf-c-form__legend first-class"
+  data-label-name="Legendary"
+  id="legendary"
+>
+  I am Legendary
+</legend>
+`;


### PR DESCRIPTION
**What this PR does / why we need it**:

the patternfly-react lib hasn't implemented still the components for fieldset and legend, so these ones are the ones we will be using until they release their own.

Needed for https://github.com/3scale/porta/pull/1315
**Which issue(s) this PR fixes** 


**Verification steps** 

**Special notes for your reviewer**:
These components will be removed when patternfly team release the official ones.