### PR TITLE
Fix broken integration page links when apiap is on

### DIFF
--- a/app/views/api/metrics/_link_to_mapping_rules.slim
+++ b/app/views/api/metrics/_link_to_mapping_rules.slim
@@ -1,4 +1,4 @@
-= link_to edit_admin_service_integration_path(@service, anchor: 'mapping-rules'), data: { behavior: 'open-mapping-rules', bubble: 'mapping' } do
+= link_to (apiap? ? new_admin_service_proxy_rule_path(@service) : edit_admin_service_integration_path(@service, anchor: 'mapping-rules')), data: { behavior: 'open-mapping-rules', bubble: 'mapping' } do
   - if metric.proxy_rules.any?
     i.fa.fa-check
   - else

--- a/app/views/api/metrics/index.html.slim
+++ b/app/views/api/metrics/index.html.slim
@@ -13,7 +13,7 @@ section.Section.u-toggleableBySettingsBox data-state="open"
     ' .
     - if show_mappings?
       ' A method needs to be mapped to one or more URL patterns in the
-      => link_to 'Mapping Rules', edit_admin_service_integration_path(@service, anchor: 'mapping-rules'), data: { behavior: 'open-mapping-rules' }
+      => link_to 'Mapping Rules', ( apiap? ? admin_service_proxy_rules_path : edit_admin_service_integration_path(@service, anchor: 'mapping-rules')), data: { behavior: 'open-mapping-rules' }
       ' section of the integration page so specific calls to your API up the count of specific methods.
     - else
       ' Make sure to call these methods from your code base so specific usage of your API up the count of specific methods.
@@ -69,7 +69,7 @@ section.Section.u-toggleableBySettingsBox data-state="open"
     ' <em>Hits</em> is the built-in metric to which all methods report. Additional top-level metrics can be added here in order to track other usage that shouldn't increase the hit count.
     - if show_mappings?
       ' A metric needs to be mapped to one or more URL patterns in the
-      => link_to 'Mapping Rules', edit_admin_service_integration_path(@service, anchor: 'mapping-rules'), data: { behavior: 'open-mapping-rules' }
+      => link_to 'Mapping Rules', ( apiap? ? admin_service_proxy_rules_path : edit_admin_service_integration_path(@service, anchor: 'mapping-rules')), data: { behavior: 'open-mapping-rules' }
       ' section of the integration page so specific calls to your API up the count of specific metrics.
     - else
       ' Make sure to call these metrics from your code base so specific calls to your API up the count of specific metrics.

--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -122,16 +122,18 @@ section class="service-widget"
           - if service.deployment_option.present?
             - deployment_option_phrased = t(service.proxy.deployment_option, scope: "deployment_options.phrased")
           - unless service.has_traffic?
-            li.item.integration
+            li class=("item integration #{'is-hidden' if apiap?}")
               - case service.proxy.deployment_option.presence
               - when 'hosted'
-                p On the #{link_to( 'Integration page', edit_admin_service_integration_path(service, :anchor => 'staging') )}, add your <em>API base URL</em> to the <em>Private Base URL</em> field in the staging box and hit <strong>Update & Test</strong>. Once the staging box is green, hit <strong>Deploy</strong> in the production box and you have completed a basic integration.
-                = important_icon_link "Configure #{deployment_option_phrased}",
-                  'hdd-o', edit_admin_service_integration_path(service, :anchor => 'staging'), :class => "outline-button next"
+                - unless apiap?
+                  p On the #{link_to( 'Integration page', edit_admin_service_integration_path(service, :anchor => 'staging') )}, add your <em>API base URL</em> to the <em>Private Base URL</em> field in the staging box and hit <strong>Update & Test</strong>. Once the staging box is green, hit <strong>Deploy</strong> in the production box and you have completed a basic integration.
+                  = important_icon_link "Configure #{deployment_option_phrased}",
+                    'hdd-o', edit_admin_service_integration_path(service, :anchor => 'staging'), :class => "outline-button next"
               - when 'self_managed'
-                p On the #{link_to( 'Integration page', edit_admin_service_integration_path(service, :anchor => 'staging') )}, add your <em>API base URL</em> to the <em>Private Base URL</em> field in the staging box and hit <strong>Update & Test</strong>. Once the staging box is green, proceed to download the NGINX config files for your On-premises NGINX reverse proxy server. Once you've added these config files to your Nginx server you have completed a basic integration.
-                = important_icon_link "Configure #{deployment_option_phrased}",
-                  'hdd-o', edit_admin_service_integration_path(service, :anchor => 'staging'), :class => "outline-button next"
+                - unless apiap?
+                  p On the #{link_to( 'Integration page', edit_admin_service_integration_path(service, :anchor => 'staging') )}, add your <em>API base URL</em> to the <em>Private Base URL</em> field in the staging box and hit <strong>Update & Test</strong>. Once the staging box is green, proceed to download the NGINX config files for your On-premises NGINX reverse proxy server. Once you've added these config files to your Nginx server you have completed a basic integration.
+                  = important_icon_link "Configure #{deployment_option_phrased}",
+                    'hdd-o', edit_admin_service_integration_path(service, :anchor => 'staging'), :class => "outline-button next"
               - when 'plugin_rest'
                 p Follow the instructions on the #{link_to('Integration page', path_to_service(service))} to integrate your API using #{deployment_option_phrased} the against 3scale Service Management API endpoints.
                 = important_icon_link "Get started with #{deployment_option_phrased}",

--- a/app/views/provider/admin/dashboards/widgets/_service_top_traffic.html.slim
+++ b/app/views/provider/admin/dashboards/widgets/_service_top_traffic.html.slim
@@ -24,9 +24,9 @@ article.DashboardWidget id = widget.id
       p
         ' In order to show Top Applications you need to have at least one application sending traffic to the #{friendly_service_name(service)}.
       p
-        ' Consider
-        => link_to 'making some test calls', edit_admin_service_integration_path(widget_service_id, :anchor => 'staging')
-        | from the Integration page to get a feel for what you'd see here.
+          ' Consider
+          => link_to 'making some test calls', (apiap? ? admin_service_integration_path(widget_service_id) : edit_admin_service_integration_path(widget_service_id, :anchor => 'staging'))
+          | to get a feel for what you’d see here.
 
   - else
     = widget.spinner

--- a/features/provider/onboarding/wizard.feature
+++ b/features/provider/onboarding/wizard.feature
@@ -9,6 +9,7 @@ Feature: Onboarding Wizard
   @emails
   Scenario: Provider goes through the wizard
     Given a provider signs up and activates his account
+     And I have rolling updates "api_as_product" disabled
     When user starts the onboarding wizard
      And adds the echo api
      And sends the test request


### PR DESCRIPTION
**What this PR does / why we need it**:

In API overview page, links to Integration page `/apiconfig/services/<id>/integration/edit` should not shown when APIAP is on.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3705

**APIAP ON:**
![apiap-on](https://user-images.githubusercontent.com/13486237/67017453-1e28ee80-f0fa-11e9-9505-b4f8553052a1.png)

**APIAP OFF:**
![apiap-off](https://user-images.githubusercontent.com/13486237/67017490-297c1a00-f0fa-11e9-89d8-9f756613fb32.png)


