### PR TITLE
Give Master Admin permission to see Backend API

### DIFF
--- a/config/abilities/master_admin.rb
+++ b/config/abilities/master_admin.rb
@@ -48,6 +48,11 @@ Ability.define do |user|
     can :manage, :authentication_providers
     can :manage, :web_hooks
 
+    if user.account.provider_can_use?(:api_as_product)
+      can :manage, BackendApi
+      can :manage, BackendApiConfig
+    end
+
     #COPY these come from forum.rb
     can :manage, TopicCategory do |category|
       category.forum.account = user.account

--- a/test/unit/abilities/master_admin_test.rb
+++ b/test/unit/abilities/master_admin_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module Abilities
@@ -64,7 +66,6 @@ module Abilities
       assert_cannot ability, :manage, :service_plans
     end
 
-
     def test_plans
       ThreeScale.config.stubs(onpremises: false)
       assert_can ability, :manage, :plans
@@ -93,6 +94,26 @@ module Abilities
         ThreeScale.config.stubs(onpremises: onpremises)
         assert_cannot ability, :manage, :portal
       end
+    end
+
+    test 'backend apis' do
+      Account.any_instance.stubs(:provider_can_use?).returns(true)
+
+      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
+      assert_can ability, :manage, BackendApi
+
+      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+      assert_cannot ability, :manage, BackendApi
+    end
+
+    test 'backend api configs' do
+      Account.any_instance.stubs(:provider_can_use?).returns(true)
+
+      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
+      assert_can ability, :manage, BackendApiConfig
+
+      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+      assert_cannot ability, :manage, BackendApiConfig
     end
 
     private

--- a/test/unit/abilities/provider_admin_test.rb
+++ b/test/unit/abilities/provider_admin_test.rb
@@ -83,17 +83,21 @@ module Abilities
     end
 
     test 'backend apis' do
+      Account.any_instance.stubs(:provider_can_use?).returns(true)
+
+      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
       assert_can ability, :manage, BackendApi
 
-      Account.any_instance.stubs(:provider_can_use?).returns(true)
       Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
       assert_cannot ability, :manage, BackendApi
     end
 
     test 'backend api configs' do
+      Account.any_instance.stubs(:provider_can_use?).returns(true)
+
+      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
       assert_can ability, :manage, BackendApiConfig
 
-      Account.any_instance.stubs(:provider_can_use?).returns(true)
       Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
       assert_cannot ability, :manage, BackendApiConfig
     end


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds permissions for master tenant to see Backend APIs.

**Which issue(s) this PR fixes** 

[THREESCALE-3725: In master tenant, master backend service overview page shows access denied](https://issues.jboss.org/browse/THREESCALE-3725)

**Verification steps** 

1. Open the master tenant
2. Go to "Master Service Backend API" (from the context selector)

**Special notes for your reviewer**:
Some permissions might be still missing.