### PR TITLE
Fix mapping rules link in Methods and Metrics page

### DIFF
--- a/app/helpers/api/mapping_rules_helper.rb
+++ b/app/helpers/api/mapping_rules_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api::MappingRulesHelper
+  def link_to_mapping_rules(service:)
+    path, data = if current_account.independent_mapping_rules_enabled?
+                   [admin_service_proxy_rules_path(service), {}]
+                 else
+                   [edit_admin_service_integration_path(service, anchor: 'mapping-rules'), { behavior: 'open-mapping-rules' }]
+                 end
+
+    link_to 'Mapping Rules', path, data: data
+  end
+end

--- a/app/views/api/metrics/index.html.slim
+++ b/app/views/api/metrics/index.html.slim
@@ -13,7 +13,7 @@ section.Section.u-toggleableBySettingsBox data-state="open"
     ' .
     - if show_mappings?
       ' A method needs to be mapped to one or more URL patterns in the
-      => link_to 'Mapping Rules', edit_admin_service_integration_path(@service, anchor: 'mapping-rules'), data: { behavior: 'open-mapping-rules' }
+      => link_to_mapping_rules(service: @service)
       ' section of the integration page so specific calls to your API up the count of specific methods.
     - else
       ' Make sure to call these methods from your code base so specific usage of your API up the count of specific methods.

--- a/test/helpers/api/mapping_rules_helper_test.rb
+++ b/test/helpers/api/mapping_rules_helper_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Api::MappingRulesHelperTest < ActionView::TestCase
+  def setup
+    @provider = FactoryBot.build(:provider_account)
+    @service  = FactoryBot.build_stubbed(:simple_service)
+  end
+
+  test 'links to the independent mapping rules page if enabled' do
+    @provider.stubs(:independent_mapping_rules_enabled?).returns(true)
+    link = link_to_mapping_rules(service: @service)
+    expected_path = admin_service_proxy_rules_path(@service)
+    assert_match(/#{expected_path}/, link)
+  end
+
+  test 'links to the mapping rules in the integration page if independent mapping rules is disabled' do
+    @provider.stubs(:independent_mapping_rules_enabled?).returns(false)
+    link = link_to_mapping_rules(service: @service)
+    expected_path = edit_admin_service_integration_path(@service, anchor: 'mapping-rules')
+    assert_match(/#{expected_path}/, link)
+    assert_match(/data-behavior="open-mapping-rules"/, link)
+  end
+
+  private
+
+  def current_account
+    @provider
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently our Methods and Metrics page have a link to mapping rules
link, but it is linking only to the mapping rules inside the integration
pages and it is not considering the independent mapping rules.

This commit fixes this behave by considering the independent mapping
rules to create the link.

**Which issue(s) this PR fixes** 

[THREESCALE-3719](https://issues.jboss.org/browse/THREESCALE-3719)

**Verification steps** 

1. Enable APIAP
2. Enter in `/apiconfig/services/SERVICE_ID/metrics` page
3. The link should redirect to the independent mapping rules page: `/apiconfig/services/SERVICE_ID/proxy_rules`
4. Disable APIAP
5. Enter in `/apiconfig/services/SERVICE_ID/metrics` page
6. The link should redirect to the integration page: `apiconfig/services/SERVICE_ID/integration/edit`
