### PR TITLE
Create a BackendAPI for new tenant by /p/signup

### DIFF
--- a/app/controllers/provider/signups_controller.rb
+++ b/app/controllers/provider/signups_controller.rb
@@ -47,8 +47,6 @@ class Provider::SignupsController < Provider::BaseController
 
     return render :show unless signup
 
-    ServiceCreator.new(service: @provider.default_service).call(private_endpoint: BackendApi.default_api_backend)
-
     session[:success_data] = { first_name: @user.first_name, email: @user.email }
 
     tracking = ThreeScale::Analytics.user_tracking(@user)

--- a/app/controllers/provider/signups_controller.rb
+++ b/app/controllers/provider/signups_controller.rb
@@ -47,6 +47,8 @@ class Provider::SignupsController < Provider::BaseController
 
     return render :show unless signup
 
+    ServiceCreator.new(service: @provider.default_service).call(private_endpoint: BackendApi.default_api_backend)
+
     session[:success_data] = { first_name: @user.first_name, email: @user.email }
 
     tracking = ThreeScale::Analytics.user_tracking(@user)

--- a/app/lib/logic/provider_signup.rb
+++ b/app/lib/logic/provider_signup.rb
@@ -64,7 +64,7 @@ module Logic
           service_plan.create_contract_with! provider
           application_plan.create_contract_with! provider
 
-          ServiceCreator.new(service: provider.services.build(name: 'API')).call
+          ServiceCreator.new(service: provider.services.build(name: 'API')).call(private_endpoint: BackendApi.default_api_backend)
         end
 
         if ThreeScale.config.onpremises

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -791,7 +791,7 @@ class AccountTest < ActiveSupport::TestCase
       user.password = user.password_confirmation = "foobar"
       user.email = "foo@example.com"
     end
-    assert_nil @provider.first_service.api_backend
+    assert_not_nil @provider.first_service.api_backend
   end
 
 


### PR DESCRIPTION
Closes [THREESCALE-3687](https://issues.jboss.org/browse/THREESCALE-3687)

:warning: blocks https://github.com/3scale/porta/pull/1304

This is just a "make it ugly, make it work" because it must be merged soon. The proper alternative is in https://github.com/3scale/porta/pull/1324 but I didn't have time to finish it.