### PR TITLE
Refactor types in module Policies

### DIFF
--- a/app/javascript/src/Policies/actions/OriginalPolicyChain.jsx
+++ b/app/javascript/src/Policies/actions/OriginalPolicyChain.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type { ChainPolicy } from 'Policies/types/Policies'
+import type { ChainPolicy } from 'Policies/types'
 
 export type SetOriginalPolicyChainAction = { type: 'SET_ORIGINAL_POLICY_CHAIN', payload: Array<ChainPolicy> }
 export function setOriginalPolicyChain (payload: Array<ChainPolicy>): SetOriginalPolicyChainAction {

--- a/app/javascript/src/Policies/actions/PolicyChain.jsx
+++ b/app/javascript/src/Policies/actions/PolicyChain.jsx
@@ -2,8 +2,7 @@
 
 import { RSAA } from 'redux-api-middleware'
 
-import type { RSSAAction } from 'Policies/types/index'
-import type { RegistryPolicy, ChainPolicy, StoredChainPolicy } from 'Policies/types/Policies'
+import type { RSSAAction, RegistryPolicy, ChainPolicy, StoredChainPolicy } from 'Policies/types'
 
 export type AddPolicyToChainAction = { type: 'ADD_POLICY_TO_CHAIN', policy: RegistryPolicy }
 export function addPolicyToChain (policy: RegistryPolicy): AddPolicyToChainAction {

--- a/app/javascript/src/Policies/actions/PolicyChain.jsx
+++ b/app/javascript/src/Policies/actions/PolicyChain.jsx
@@ -39,13 +39,13 @@ export function loadChainSuccess (payload: Array<ChainPolicy>): LoadChainSuccess
   return { type: 'LOAD_CHAIN_SUCCESS', payload }
 }
 
-export type LoadChainErrorAction = { type: 'LOAD_CHAIN_ERROR', payload: Object }
-export function loadChainError (payload: Object): LoadChainErrorAction {
+export type LoadChainErrorAction = { type: 'LOAD_CHAIN_ERROR', payload: {} }
+export function loadChainError (payload: {}): LoadChainErrorAction {
   return { type: 'LOAD_CHAIN_ERROR', payload }
 }
 
 export type FetchChainSuccessAction = { type: 'FETCH_CHAIN_SUCCESS', payload: Array<ChainPolicy> }
-export type FetchChainErrorAction = { type: 'FETCH_CHAIN_ERROR', payload: Object }
+export type FetchChainErrorAction = { type: 'FETCH_CHAIN_ERROR', payload: {} }
 
 const REQUEST = { type: 'FETCH_CHAIN_REQUEST' }
 const SUCCESS = { type: 'FETCH_CHAIN_SUCCESS' }

--- a/app/javascript/src/Policies/actions/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/actions/PolicyConfig.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type { ChainPolicy } from 'Policies/types/Policies'
+import type { ChainPolicy } from 'Policies/types'
 
 export type UpdatePolicyConfigAction = { type: 'UPDATE_POLICY_CONFIG', policyConfig: ChainPolicy }
 export function updatePolicyConfig (policyConfig: ChainPolicy): UpdatePolicyConfigAction {

--- a/app/javascript/src/Policies/actions/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/actions/PolicyRegistry.jsx
@@ -5,7 +5,7 @@ import { RSAA } from 'redux-api-middleware'
 import type { RSSAAction, RawRegistry } from 'Policies/types'
 
 export type FetchRegistrySuccessAction = { type: 'FETCH_REGISTRY_SUCCESS', payload: RawRegistry, meta: ?{} }
-export type FetchRegistryErrorAction = { type: 'FETCH_REGISTRY_ERROR', payload: Object, error: boolean, meta: ?{} }
+export type FetchRegistryErrorAction = { type: 'FETCH_REGISTRY_ERROR', payload: {}, error: boolean, meta: ?{} }
 
 const REQUEST = { type: 'FETCH_REGISTRY_REQUEST' }
 const SUCCESS = { type: 'FETCH_REGISTRY_SUCCESS' }

--- a/app/javascript/src/Policies/actions/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/actions/PolicyRegistry.jsx
@@ -1,8 +1,8 @@
 // @flow
 
 import { RSAA } from 'redux-api-middleware'
-import type { RSSAAction } from 'Policies/types/index'
-import type { RawRegistry } from 'Policies/types/Policies'
+
+import type { RSSAAction, RawRegistry } from 'Policies/types'
 
 export type FetchRegistrySuccessAction = { type: 'FETCH_REGISTRY_SUCCESS', payload: RawRegistry, meta: ?{} }
 export type FetchRegistryErrorAction = { type: 'FETCH_REGISTRY_ERROR', payload: Object, error: boolean, meta: ?{} }

--- a/app/javascript/src/Policies/actions/index.jsx
+++ b/app/javascript/src/Policies/actions/index.jsx
@@ -15,10 +15,7 @@ import {
 import { updatePolicyConfig } from 'Policies/actions/PolicyConfig'
 
 import type { UIComponent } from 'Policies/actions/UISettings'
-import type { SortPolicyChainAction } from 'Policies/actions/PolicyChain'
-import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
-import type { Dispatch, ThunkAction } from 'Policies/types/index'
-import type { RawRegistry, RegistryPolicy, ChainPolicy, StoredChainPolicy } from 'Policies/types/Policies'
+import type { Dispatch, RawRegistry, RegistryPolicy, ChainPolicy, StoredChainPolicy, IPoliciesActions, ThunkAction } from 'Policies/types'
 
 const chainComponent: UIComponent = 'chain'
 const registryComponent: UIComponent = 'registry'
@@ -91,19 +88,6 @@ function closePolicyConfig (): ThunkAction {
   return function (dispatch: Dispatch) {
     dispatch(uiComponentTransition({hide: policyConfigComponent, show: chainComponent}))
   }
-}
-
-export interface IPoliciesActions {
-  openPolicyRegistry: () => ThunkAction,
-  editPolicy: ChainPolicy => ThunkAction,
-  sortPolicyChain: Array<ChainPolicy> => SortPolicyChainAction,
-  submitPolicyConfig: (ChainPolicy) => ThunkAction,
-  removePolicyFromChain: (ChainPolicy) => ThunkAction,
-  closePolicyConfig: () => ThunkAction,
-  addPolicy: RegistryPolicy => ThunkAction,
-  closePolicyRegistry: () => ThunkAction,
-  populatePolicies: (serviceId: string, chain?: Array<StoredChainPolicy>, registry?: RawRegistry) => ThunkAction,
-  updatePolicyConfig: (ChainPolicy) => UpdatePolicyConfigAction
 }
 
 export const actions: IPoliciesActions = {

--- a/app/javascript/src/Policies/components/CustomPolicies.jsx
+++ b/app/javascript/src/Policies/components/CustomPolicies.jsx
@@ -2,8 +2,10 @@
 
 import * as React from 'react'
 import {PolicyList} from 'Policies/components/PolicyList'
+
 import 'Policies/styles/policies.scss'
-import type {ShallowPolicy} from 'Policies/types/Policies'
+
+import type {ShallowPolicy} from 'Policies/types'
 
 const CustomPolicies = ({policies = []}: {policies: Array<ShallowPolicy>}): React.Node => {
   const ADD_POLICY_HREF = '/p/admin/registry/policies/new'

--- a/app/javascript/src/Policies/components/CustomPolicy.jsx
+++ b/app/javascript/src/Policies/components/CustomPolicy.jsx
@@ -4,13 +4,12 @@ import * as React from 'react'
 import { useState } from 'react'
 import SchemaForm from 'react-jsonschema-form'
 import { SchemaEditor } from 'Policies/components/SchemaEditor'
-import type { Policy, Schema } from 'Policies/types/Policies'
-import type {InputEvent} from 'Policies/types'
+import { CSRFToken } from 'utilities/utils'
+
 import 'codemirror/mode/javascript/javascript'
 import 'Policies/styles/policies.scss'
-import {CSRFToken} from 'utilities/utils'
 
-type OnChange = (InputEvent) => void
+import type { Policy, Schema } from 'Policies/types'
 
 const POLICY_TEMPLATE: Policy = {
   schema: {
@@ -33,7 +32,13 @@ const POLICY_TEMPLATE: Policy = {
   id: 0
 }
 
-function CustomPolicyForm ({policy, onChange, win = window}: {policy: Policy, onChange: OnChange, win?: Window}) {
+type CustomPolicyFormProps = {
+  policy: Policy,
+  onChange: SyntheticInputEvent<> => void,
+  win?: Window
+}
+
+function CustomPolicyForm ({ policy, onChange, win = window }: CustomPolicyFormProps) {
   const isNewPolicy = !policy.id
   const [method, setMethod] = useState(isNewPolicy ? 'post' : 'put')
   const action = (isNewPolicy) ? '/p/admin/registry/policies/' : `/p/admin/registry/policies/${policy.id}`
@@ -85,7 +90,7 @@ function CustomPolicyForm ({policy, onChange, win = window}: {policy: Policy, on
 function CustomPolicyEditor ({initialPolicy}: {initialPolicy: Policy}) {
   const [policy, setPolicy] = useState(initialPolicy)
   const onSchemaEdited = (schema: Schema) => setPolicy(prevPolicy => ({ ...prevPolicy, ...{ schema } }))
-  const handleChange = (ev: InputEvent) => {
+  const handleChange = (ev: SyntheticInputEvent<>) => {
     ev.persist()
     return setPolicy(prevPolicy => ({ ...prevPolicy, ...{ [ev.target.name]: ev.target.value } }))
   }

--- a/app/javascript/src/Policies/components/PoliciesForm.jsx
+++ b/app/javascript/src/Policies/components/PoliciesForm.jsx
@@ -5,8 +5,7 @@ import Form from 'react-jsonschema-form'
 
 import { isNotApicastPolicy } from 'Policies/components/util'
 
-import type { ThunkAction } from 'Policies/types/index'
-import type { ChainPolicy } from 'Policies/types/Policies'
+import type { ThunkAction, ChainPolicy } from 'Policies/types'
 import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
 
 class PolicyForm extends Form {

--- a/app/javascript/src/Policies/components/PoliciesWidget.jsx
+++ b/app/javascript/src/Policies/components/PoliciesWidget.jsx
@@ -10,10 +10,7 @@ import { PolicyChainHiddenInput } from 'Policies/components/PolicyChainHiddenInp
 import { connect } from 'react-redux'
 import { isPolicyChainChanged } from 'Policies/util'
 
-import type { ChainPolicy } from 'Policies/types/Policies'
-import type { State, RegistryState, ChainState, UIState } from 'Policies/types/State'
-import type { Dispatch } from 'Policies/types/index'
-import type { IPoliciesActions } from 'Policies/actions'
+import type { ChainPolicy, State, RegistryState, ChainState, UIState, Dispatch, IPoliciesActions } from 'Policies/types'
 
 type Props = {
   registry: RegistryState,

--- a/app/javascript/src/Policies/components/PolicyChain.jsx
+++ b/app/javascript/src/Policies/components/PolicyChain.jsx
@@ -9,8 +9,7 @@ import {
 } from 'react-sortable-hoc'
 import { PolicyTile } from 'Policies/components/PolicyTile'
 
-import type { ThunkAction } from 'Policies/types/index'
-import type { ChainPolicy } from 'Policies/types/Policies'
+import type { ThunkAction, ChainPolicy } from 'Policies/types'
 import type { SortPolicyChainAction } from 'Policies/actions/PolicyChain'
 
 type Props = {

--- a/app/javascript/src/Policies/components/PolicyChainHiddenInput.jsx
+++ b/app/javascript/src/Policies/components/PolicyChainHiddenInput.jsx
@@ -1,5 +1,8 @@
+// @flow
+
 import React from 'react'
-import type { ChainPolicy, StoredChainPolicy } from 'Policies/types/Policies'
+
+import type { ChainPolicy, StoredChainPolicy } from 'Policies/types'
 
 const filteredPolicyKeys = ['configuration', 'name', 'version', 'enabled']
 
@@ -7,6 +10,7 @@ function filterPolicyKeys (policy: ChainPolicy): StoredChainPolicy {
   return Object.keys(policy)
     .filter(policyKey => filteredPolicyKeys.includes(policyKey))
     .reduce((filteredPolicy, key) => {
+      // $FlowFixMe: refactor this method
       filteredPolicy[key] = policy[key]
       return filteredPolicy
     }, {})

--- a/app/javascript/src/Policies/components/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/components/PolicyConfig.jsx
@@ -4,8 +4,7 @@ import React from 'react'
 
 import { PoliciesForm } from 'Policies/components/PoliciesForm'
 
-import type { ThunkAction } from 'Policies/types/index'
-import type { ChainPolicy } from 'Policies/types/Policies'
+import type { ThunkAction, ChainPolicy } from 'Policies/types'
 import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
 
 type Props = {

--- a/app/javascript/src/Policies/components/PolicyList.jsx
+++ b/app/javascript/src/Policies/components/PolicyList.jsx
@@ -2,12 +2,14 @@
 
 import * as React from 'react'
 import { PolicyTile } from 'Policies/components/PolicyTile'
+
+import type {ShallowPolicy} from 'Policies/types'
+
 import 'Policies/styles/policies.scss'
-import type {ShallowPolicy} from 'Policies/types/Policies'
 
 const policyEditLink = (id: number): string => `/p/admin/registry/policies/${id}/edit`
 
-const navigateToEditPolicy = (url: string, win: any = window) => {
+const navigateToEditPolicy = (url: string, win: Window = window) => {
   win.location.href = url
   win.history.pushState({}, '', url)
 }

--- a/app/javascript/src/Policies/components/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/components/PolicyRegistry.jsx
@@ -2,10 +2,10 @@
 
 import React from 'react'
 
-import type { RegistryPolicy } from 'Policies/types/Policies'
-import type { ThunkAction } from 'Policies/types/index'
 import { isNotApicastPolicy } from 'Policies/components/util'
 import { PolicyTile } from 'Policies/components/PolicyTile'
+
+import type { RegistryPolicy, ThunkAction } from 'Policies/types'
 
 type Props = {
   visible: boolean,
@@ -23,7 +23,7 @@ const CloseRegistryButton = ({closePolicyRegistry}) => {
 }
 
 const PolicyRegistryItem = ({value, addPolicy}: {value: RegistryPolicy, addPolicy: (RegistryPolicy) => ThunkAction}) => {
-  const addToChain = () => addPolicy(value)
+  const addToChain = () => void addPolicy(value)
   return (
     <li className="Policy">
       <PolicyTile policy={value} onClick={addToChain} title='Add this Policy.'/>

--- a/app/javascript/src/Policies/components/PolicyTile.jsx
+++ b/app/javascript/src/Policies/components/PolicyTile.jsx
@@ -1,13 +1,13 @@
 // @flow
 
 import * as React from 'react'
-import type { ShallowPolicy } from 'Policies/types/Policies'
-import type { Dispatch } from 'Policies/types'
+
+import type { ShallowPolicy } from 'Policies/types'
 
 type Props = {
   policy: ShallowPolicy,
   title?: string,
-  onClick: Dispatch | (number) => {}
+  onClick: () => void
 }
 
 const PolicyTile = function ({policy, onClick, title = 'Edit this Policy'}: Props): React.Node {

--- a/app/javascript/src/Policies/components/Root.jsx
+++ b/app/javascript/src/Policies/components/Root.jsx
@@ -2,7 +2,6 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-
 import { Provider } from 'react-redux'
 
 import App from 'Policies/components/App'

--- a/app/javascript/src/Policies/components/SchemaEditor.jsx
+++ b/app/javascript/src/Policies/components/SchemaEditor.jsx
@@ -3,12 +3,15 @@
 import * as React from 'react'
 import { useState } from 'react'
 import { UnControlled as CodeMirror } from 'react-codemirror2'
-import { fromJsonString, toJsonString } from 'utilities/json-utils'
-import 'codemirror/mode/javascript/javascript'
-import ApicastManifest from 'Policies/apicast-manifest'
 import Ajv from 'ajv'
+
+import { fromJsonString, toJsonString } from 'utilities/json-utils'
+import ApicastManifest from 'Policies/apicast-manifest'
+
+import 'codemirror/mode/javascript/javascript'
+
 import type { ErrorObject } from 'ajv'
-import type { Schema } from 'Policies/types/Policies'
+import type { Schema } from 'Policies/types'
 
 const ajv = new Ajv().addSchema(ApicastManifest, 'ApicastManifest')
 

--- a/app/javascript/src/Policies/components/util.jsx
+++ b/app/javascript/src/Policies/components/util.jsx
@@ -1,6 +1,7 @@
 // @flow
 
-import type { RegistryPolicy, ChainPolicy } from 'Policies/types/Policies'
+import type { RegistryPolicy, ChainPolicy } from 'Policies/types'
+
 type Policy = RegistryPolicy | ChainPolicy
 
 function isNotApicastPolicy (policy: Policy): boolean {

--- a/app/javascript/src/Policies/index.jsx
+++ b/app/javascript/src/Policies/index.jsx
@@ -13,7 +13,7 @@ import configureStore from 'Policies/store/configureStore'
 import { initialState } from 'Policies/reducers/initialState'
 import { actions } from 'Policies/actions/index'
 
-import type { RawRegistry, StoredChainPolicy } from 'Policies/types/Policies'
+import type { RawRegistry, StoredChainPolicy } from 'Policies/types'
 
 import 'Policies/styles/policies.scss'
 

--- a/app/javascript/src/Policies/middleware/PolicyChain.jsx
+++ b/app/javascript/src/Policies/middleware/PolicyChain.jsx
@@ -48,7 +48,7 @@ const loadChain = ({registry, storedChain, dispatch}: {registry: Array<RegistryP
   }
 }
 
-const policyChainMiddleware = ({ dispatch, getState }: { dispatch: Dispatch, getState: GetState }) => (next: any) => (action: PolicyChainMiddlewareAction) => {
+const policyChainMiddleware = ({ dispatch, getState }: { dispatch: Dispatch, getState: GetState }) => (next: Dispatch) => (action: PolicyChainMiddlewareAction) => {
   const state = getState()
   switch (action.type) {
     case 'LOAD_CHAIN':

--- a/app/javascript/src/Policies/middleware/PolicyChain.jsx
+++ b/app/javascript/src/Policies/middleware/PolicyChain.jsx
@@ -1,11 +1,10 @@
 // @flow
 
-import type { RegistryPolicy, ChainPolicy, StoredChainPolicy } from 'Policies/types/Policies'
-import type { Dispatch, GetState, PolicyChainMiddlewareAction } from 'Policies/types/index'
-
 import { generateGuid } from 'Policies/util'
 import { loadChainSuccess, loadChainError, updatePolicyChain } from 'Policies/actions/PolicyChain'
 import { setOriginalPolicyChain } from 'Policies/actions/OriginalPolicyChain'
+
+import type { RegistryPolicy, ChainPolicy, StoredChainPolicy, Dispatch, GetState, PolicyChainMiddlewareAction } from 'Policies/types'
 
 function findRegistryPolicy (registry: Array<RegistryPolicy>, storedPolicy: StoredChainPolicy): RegistryPolicy | typeof undefined {
   return registry.find(policy => (policy.name === storedPolicy.name && policy.version === storedPolicy.version))

--- a/app/javascript/src/Policies/reducers/OriginalPolicyChain.jsx
+++ b/app/javascript/src/Policies/reducers/OriginalPolicyChain.jsx
@@ -2,17 +2,16 @@
 
 import { initialState } from 'Policies/reducers/initialState'
 import { createReducer, updateArray } from 'Policies/util'
-import type { ChainState } from 'Policies/types/State'
+
+import type { ChainState } from 'Policies/types'
 import type { SetOriginalPolicyChainAction } from 'Policies/actions/OriginalPolicyChain'
 
 function setOriginalPolicyChain (state: ChainState, action: SetOriginalPolicyChainAction): ChainState {
   return updateArray(state, action.payload)
 }
 
-// eslint-disable-next-line space-infix-ops
-// const ChainReducer = createReducer<ChainState>(initialState.chain, {
-// $FlowFixMe TODO: in order to fully type createReducer, set UIState and re-enable flow. (use lines above)
-const OriginalChainReducer = createReducer(initialState.originalChain, {
+// TODO: use combineReducers instead of createReducer
+const OriginalChainReducer = createReducer<ChainState>(initialState.originalChain, {
   'SET_ORIGINAL_POLICY_CHAIN': setOriginalPolicyChain
 })
 

--- a/app/javascript/src/Policies/reducers/PolicyChain.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyChain.jsx
@@ -2,8 +2,8 @@
 
 import { initialState } from 'Policies/reducers/initialState'
 import { createReducer, generateGuid, updateArray } from 'Policies/util'
-import type { ChainState } from 'Policies/types/State'
-import type { ChainPolicy, RegistryPolicy } from 'Policies/types/Policies'
+
+import type { ChainState, ChainPolicy, RegistryPolicy } from 'Policies/types'
 import type {
   AddPolicyToChainAction,
   FetchChainSuccessAction,
@@ -29,10 +29,8 @@ function updatePolicies (state: ChainState, action: UpdateChainPolicies): ChainS
   return updateArray(state, action.payload)
 }
 
-// eslint-disable-next-line space-infix-ops
-// const ChainReducer = createReducer<ChainState>(initialState.chain, {
-// $FlowFixMe TODO: in order to fully type createReducer, set UIState and re-enable flow. (use lines above)
-const ChainReducer = createReducer(initialState.chain, {
+// TODO: use combineReducers instead of createReducer
+const ChainReducer = createReducer<ChainState>(initialState.chain, {
   'ADD_POLICY_TO_CHAIN': addPolicy,
   'SORT_POLICY_CHAIN': updatePolicies,
   'LOAD_CHAIN_SUCCESS': updatePolicies,

--- a/app/javascript/src/Policies/reducers/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyConfig.jsx
@@ -1,19 +1,17 @@
 // @flow
 
-import type { ChainPolicy } from 'Policies/types/Policies'
-import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
-
 import { initialState } from 'Policies/reducers/initialState'
 import { updateObject, createReducer } from 'Policies/util'
+
+import type { ChainPolicy } from 'Policies/types'
+import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
 
 function updatePolicyConfig (state: ChainPolicy, action: UpdatePolicyConfigAction): ChainPolicy {
   return updateObject(state, action.policyConfig)
 }
 
-// eslint-disable-next-line space-infix-ops
-// const PolicyConfigReducer = createReducer<ChainPolicy>(initialState.policyConfig, {
-// $FlowFixMe TODO: in order to fully type createReducer, set UIState and re-enable flow. (use lines above)
-const PolicyConfigReducer = createReducer(initialState.policyConfig, {
+// TODO: use combineReducers instead of createReducer
+const PolicyConfigReducer = createReducer<ChainPolicy>(initialState.policyConfig, {
   'UPDATE_POLICY_CONFIG': updatePolicyConfig
 })
 

--- a/app/javascript/src/Policies/reducers/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyRegistry.jsx
@@ -3,17 +3,15 @@
 import { initialState } from 'Policies/reducers/initialState'
 import { createReducer, updateArray, parsePolicies } from 'Policies/util'
 
-import type { RegistryState } from 'Policies/types/State'
+import type { RegistryState } from 'Policies/types'
 import type { FetchRegistrySuccessAction } from 'Policies/actions/PolicyRegistry'
 
 function updateRegistry (state: RegistryState, action: FetchRegistrySuccessAction): RegistryState {
   return updateArray(state, parsePolicies(action.payload))
 }
 
-// eslint-disable-next-line space-infix-ops
-// const RegistryReducer = createReducer<RegistryState>(initialState.registry, {
-// $FlowFixMe TODO: in order to fully type createReducer, set UIState and re-enable flow. (use lines above)
-const RegistryReducer = createReducer(initialState.registry, {
+// TODO: use combineReducers instead of createReducer
+const RegistryReducer = createReducer<RegistryState>(initialState.registry, {
   'LOAD_REGISTRY_SUCCESS': updateRegistry,
   'FETCH_REGISTRY_SUCCESS': updateRegistry
 })

--- a/app/javascript/src/Policies/reducers/UISettings.jsx
+++ b/app/javascript/src/Policies/reducers/UISettings.jsx
@@ -3,15 +3,15 @@
 import { initialState } from 'Policies/reducers/initialState'
 import { createReducer, updateError, updateObject } from 'Policies/util'
 
-import type { State, UIState } from 'Policies/types'
+import type { UIState } from 'Policies/types'
 import type { UIComponentTransitionAction } from 'Policies/actions/UISettings'
 
-function updateComponentTransition (state: State, action: UIComponentTransitionAction): State {
+function updateComponentTransition (state: UIState, action: UIComponentTransitionAction): UIState {
   return updateObject(state, {[action.hide]: false, [action.show]: true})
 }
 
 function updateRequestsCounter (number: number) {
-  return function (state) {
+  return function (state: UIState): UIState {
     return updateObject(state, {requests: state.requests + number})
   }
 }

--- a/app/javascript/src/Policies/reducers/UISettings.jsx
+++ b/app/javascript/src/Policies/reducers/UISettings.jsx
@@ -3,7 +3,7 @@
 import { initialState } from 'Policies/reducers/initialState'
 import { createReducer, updateError, updateObject } from 'Policies/util'
 
-import type { State } from 'Policies/types/State'
+import type { State, UIState } from 'Policies/types'
 import type { UIComponentTransitionAction } from 'Policies/actions/UISettings'
 
 function updateComponentTransition (state: State, action: UIComponentTransitionAction): State {
@@ -16,10 +16,8 @@ function updateRequestsCounter (number: number) {
   }
 }
 
-// eslint-disable-next-line space-infix-ops
-// const UISettingsReducer = createReducer<UIState>(initialState.ui, {
-// $FlowFixMe TODO: in order to fully type createReducer, set UIState and re-enable flow. (use lines above)
-const UISettingsReducer = createReducer(initialState.ui, {
+// TODO: use combineReducers instead of createReducer
+const UISettingsReducer = createReducer<UIState>(initialState.ui, {
   'UI_COMPONENT_TRANSITION': updateComponentTransition,
   'FETCH_CHAIN_ERROR': updateError,
   'FETCH_REGISTRY_ERROR': updateError,

--- a/app/javascript/src/Policies/reducers/index.jsx
+++ b/app/javascript/src/Policies/reducers/index.jsx
@@ -8,7 +8,7 @@ import PolicyConfigReducer from 'Policies/reducers/PolicyConfig'
 import ChainReducer from 'Policies/reducers/PolicyChain'
 import OriginalChainReducer from 'Policies/reducers/OriginalPolicyChain'
 
-// $FlowFixMe: Redux types should work out of the box
+// $FlowFixMe: provide type for State, Action after removing createReducer
 const rootReducer = combineReducers({
   chain: ChainReducer,
   originalChain: OriginalChainReducer,

--- a/app/javascript/src/Policies/reducers/initialState.jsx
+++ b/app/javascript/src/Policies/reducers/initialState.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type {State} from 'Policies/types/State'
+import type { State } from 'Policies/types'
 
 export const initialState: State = {
   registry: [],

--- a/app/javascript/src/Policies/store/configureStore.jsx
+++ b/app/javascript/src/Policies/store/configureStore.jsx
@@ -7,8 +7,7 @@ import { apiMiddleware } from 'redux-api-middleware'
 import { policyChainMiddleware } from 'Policies/middleware/PolicyChain'
 import rootReducer from 'Policies/reducers'
 
-import type {State} from 'Policies/types/State'
-import type {Store} from 'Policies/types'
+import type { State, Store } from 'Policies/types'
 
 function configureStoreProd (initialState: State): Store {
   const middlewares = [
@@ -43,7 +42,7 @@ function configureStoreDev (initialState: State): Store {
   ]
 
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose // add support for Redux dev tools
-  // $FlowFixMe
+
   const store = createStore(rootReducer, initialState, composeEnhancers(
     // $FlowFixMe
     applyMiddleware(...middlewares)

--- a/app/javascript/src/Policies/types/Actions.jsx
+++ b/app/javascript/src/Policies/types/Actions.jsx
@@ -1,0 +1,59 @@
+// @flow
+
+import type {
+  AddPolicyToChainAction,
+  RemovePolicyFromChainAction,
+  SortPolicyChainAction,
+  UpdatePolicyInChainAction,
+  FetchChainErrorAction,
+  LoadChainAction,
+  LoadChainSuccessAction,
+  LoadChainErrorAction,
+  UpdatePolicyChainAction
+} from 'Policies/actions/PolicyChain'
+import type { SetOriginalPolicyChainAction } from 'Policies/actions/OriginalPolicyChain'
+import type { UIComponentTransitionAction } from 'Policies/actions/UISettings'
+import type {
+  FetchRegistrySuccessAction,
+  FetchRegistryErrorAction,
+  LoadRegistrySuccessAction
+} from 'Policies/actions/PolicyRegistry'
+import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
+import type { Dispatch, GetState, RawRegistry, RegistryPolicy, ChainPolicy, StoredChainPolicy } from 'Policies/types'
+
+export interface IAction {
+  type: string
+}
+
+type PolicyChainAction = AddPolicyToChainAction | SortPolicyChainAction | LoadChainSuccessAction | LoadChainErrorAction | UpdatePolicyChainAction
+type PolicyRegistryAction = FetchRegistrySuccessAction | FetchRegistryErrorAction | LoadRegistrySuccessAction
+type PolicyConfigAction = UpdatePolicyConfigAction
+
+export type ThunkAction = (dispatch: Dispatch, getState: GetState) => void
+export type PolicyChainMiddlewareAction = UpdatePolicyInChainAction | RemovePolicyFromChainAction | LoadChainAction
+export type Action = PolicyConfigAction | PolicyRegistryAction | PolicyChainAction | UIComponentTransitionAction | PolicyChainMiddlewareAction | SetOriginalPolicyChainAction
+
+export interface IPoliciesActions {
+  openPolicyRegistry: () => ThunkAction,
+  editPolicy: ChainPolicy => ThunkAction,
+  sortPolicyChain: Array<ChainPolicy> => SortPolicyChainAction,
+  submitPolicyConfig: (ChainPolicy) => ThunkAction,
+  removePolicyFromChain: (ChainPolicy) => ThunkAction,
+  closePolicyConfig: () => ThunkAction,
+  addPolicy: RegistryPolicy => ThunkAction,
+  closePolicyRegistry: () => ThunkAction,
+  populatePolicies: (serviceId: string, chain?: Array<StoredChainPolicy>, registry?: RawRegistry) => ThunkAction,
+  updatePolicyConfig: (ChainPolicy) => UpdatePolicyConfigAction
+}
+
+export type RSSAAction = {
+  [string]: {
+    endpoint: string,
+    method: string,
+    credentials: string,
+    types: []
+  }
+}
+
+export type FetchErrorAction = FetchChainErrorAction | FetchRegistryErrorAction
+export type PromiseAction = Promise<Action>

--- a/app/javascript/src/Policies/types/Policies.jsx
+++ b/app/javascript/src/Policies/types/Policies.jsx
@@ -1,5 +1,8 @@
 // @flow
 
+// eslint-disable-next-line flowtype/no-weak-types
+export type Configuration = Object
+
 export type RawPolicy = {
   $schema?: string,
   id: number,
@@ -7,7 +10,7 @@ export type RawPolicy = {
   version: string,
   description?: string,
   summary?: string,
-  configuration: {}
+  configuration: Configuration
 }
 
 export type RawRegistry = {
@@ -16,7 +19,7 @@ export type RawRegistry = {
 
 export type RegistryPolicy = & RawPolicy & {
   humanName: string,
-  data?: {}
+  data?: Configuration
 }
 
 export type ChainPolicy = & RegistryPolicy & {
@@ -28,7 +31,7 @@ export type ChainPolicy = & RegistryPolicy & {
 export type StoredChainPolicy = {
   name: string,
   version: string,
-  configuration: {},
+  configuration: Configuration,
   enabled: boolean
 }
 
@@ -43,7 +46,7 @@ export type Schema = {
   version: string,
   summary: string,
   description: string,
-  configuration: {}
+  configuration: Configuration
 }
 export type Policy = {
   id: number,

--- a/app/javascript/src/Policies/types/Policies.jsx
+++ b/app/javascript/src/Policies/types/Policies.jsx
@@ -7,7 +7,7 @@ export type RawPolicy = {
   version: string,
   description?: string,
   summary?: string,
-  configuration: Object
+  configuration: {}
 }
 
 export type RawRegistry = {
@@ -16,7 +16,7 @@ export type RawRegistry = {
 
 export type RegistryPolicy = & RawPolicy & {
   humanName: string,
-  data?: Object
+  data?: {}
 }
 
 export type ChainPolicy = & RegistryPolicy & {
@@ -28,7 +28,7 @@ export type ChainPolicy = & RegistryPolicy & {
 export type StoredChainPolicy = {
   name: string,
   version: string,
-  configuration: Object,
+  configuration: {},
   enabled: boolean
 }
 
@@ -38,7 +38,13 @@ export type ShallowPolicy = {
   humanName: string,
   summary?: string
 }
-export type Schema = Object
+export type Schema = {
+  name: string,
+  version: string,
+  summary: string,
+  description: string,
+  configuration: {}
+}
 export type Policy = {
   id: number,
   schema: Schema,

--- a/app/javascript/src/Policies/types/State.jsx
+++ b/app/javascript/src/Policies/types/State.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type { RegistryPolicy, ChainPolicy } from 'Policies/types/Policies'
+import type { RegistryPolicy, ChainPolicy } from 'Policies/types'
 
 export type UIState = {
   +registry: boolean,

--- a/app/javascript/src/Policies/types/index.jsx
+++ b/app/javascript/src/Policies/types/index.jsx
@@ -1,61 +1,10 @@
 // @flow
-/* eslint-disable no-use-before-define */
 
-import type { State } from 'Policies/types/State'
-import type {
-  AddPolicyToChainAction,
-  RemovePolicyFromChainAction,
-  SortPolicyChainAction,
-  UpdatePolicyInChainAction,
-  FetchChainErrorAction,
-  LoadChainAction,
-  LoadChainSuccessAction,
-  LoadChainErrorAction,
-  UpdatePolicyChainAction
-} from 'Policies/actions/PolicyChain'
-import type { SetOriginalPolicyChainAction } from 'Policies/actions/OriginalPolicyChain'
-import type { UIComponentTransitionAction } from 'Policies/actions/UISettings'
-import type {
-  FetchRegistrySuccessAction,
-  FetchRegistryErrorAction,
-  LoadRegistrySuccessAction
-} from 'Policies/actions/PolicyRegistry'
-import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
-import type { IPoliciesActions } from 'Policies/actions'
+import type { State, IPoliciesActions, IAction, Action, ThunkAction, PromiseAction, RSSAAction } from 'Policies/types'
 
-type PolicyChainAction = AddPolicyToChainAction | SortPolicyChainAction
-  | LoadChainSuccessAction | LoadChainErrorAction | UpdatePolicyChainAction
-
-type PolicyRegistryAction = FetchRegistrySuccessAction
-  | FetchRegistryErrorAction | LoadRegistrySuccessAction
-
-type PolicyConfigAction = UpdatePolicyConfigAction
-
-export type RSSAAction = {
-  [string]: {
-    endpoint: string,
-    method: string,
-    credentials: string,
-    types: []
-  }
-}
-
-export type PolicyChainMiddlewareAction = UpdatePolicyInChainAction
-  | RemovePolicyFromChainAction | LoadChainAction
-export type FetchErrorAction = FetchChainErrorAction | FetchRegistryErrorAction
-// Actions
-export interface IAction {
-  type: string
-}
-
-export type Action = PolicyConfigAction | PolicyRegistryAction
-  | PolicyChainAction | UIComponentTransitionAction | PolicyChainMiddlewareAction
-  | SetOriginalPolicyChainAction
-
-export type PromiseAction = Promise<Action>
 export type GetState = () => State
-export type Dispatch = (action: Action | ThunkAction | PromiseAction | RSSAAction) => any
-export type ThunkAction = (dispatch: Dispatch, getState: GetState) => any
+
+export type Dispatch = (action: Action | ThunkAction | PromiseAction | RSSAAction) => Action | ThunkAction | PromiseAction | RSSAAction
 
 export type Reducer<S> = (state?: S, action: IAction) => S
 
@@ -64,8 +13,6 @@ export type Store = State & {
   dispatch: Dispatch
 }
 
-export type ElementEventTemplate<E> = {
-  target: E
-} & Event & SyntheticEvent<>
-
-export type InputEvent = ElementEventTemplate<HTMLInputElement>
+export * from 'Policies/types/Actions'
+export * from 'Policies/types/Policies'
+export * from 'Policies/types/State'

--- a/app/javascript/src/Policies/util.jsx
+++ b/app/javascript/src/Policies/util.jsx
@@ -2,15 +2,20 @@
 
 import type { Reducer, UIState, FetchErrorAction, RawPolicy, RawRegistry, RegistryPolicy, ChainPolicy, IAction } from 'Policies/types'
 
-function updateObject (oldObject: Object, newValues: Object): Object {
+// Needs to be any, since it's a subset of T
+// eslint-disable-next-line flowtype/no-weak-types
+function updateObject<T> (oldObject: T, newValues: any): T {
   return {...oldObject, ...newValues}
 }
 
-function updateArray (oldArray: any, newValues: any): Array<any> {
+function updateArray<T> (oldArray: Array<T>, newValues: Array<T>): Array<T> {
+  // $FlowFixMe: it does return an array, flow types are incorrect here
   return Object.assign([], oldArray, newValues)
 }
 
-function createReducer<S> (initialState: S, handlers: any): Reducer<S> {
+// TODO: refactor Action types, create a common interface and remove 'any' from here
+// eslint-disable-next-line flowtype/no-weak-types
+function createReducer<S> (initialState: S, handlers: {[string]: (S, any) => S}): Reducer<S> {
   return function reducer (state: S = initialState, action: IAction) {
     if (handlers.hasOwnProperty(action.type)) {
       return handlers[action.type](state, action)

--- a/app/javascript/src/Policies/util.jsx
+++ b/app/javascript/src/Policies/util.jsx
@@ -1,8 +1,6 @@
 // @flow
 
-import type { UIState } from 'Policies/types/State'
-import type { FetchErrorAction, Reducer } from 'Policies/types/index'
-import type { RawPolicy, RawRegistry, RegistryPolicy, ChainPolicy } from 'Policies/types/Policies'
+import type { Reducer, UIState, FetchErrorAction, RawPolicy, RawRegistry, RegistryPolicy, ChainPolicy, IAction } from 'Policies/types'
 
 function updateObject (oldObject: Object, newValues: Object): Object {
   return {...oldObject, ...newValues}
@@ -13,7 +11,7 @@ function updateArray (oldArray: any, newValues: any): Array<any> {
 }
 
 function createReducer<S> (initialState: S, handlers: any): Reducer<S> {
-  return function reducer (state = initialState, action) {
+  return function reducer (state: S = initialState, action: IAction) {
     if (handlers.hasOwnProperty(action.type)) {
       return handlers[action.type](state, action)
     } else {

--- a/app/javascript/src/Types/libs/libdefs.js
+++ b/app/javascript/src/Types/libs/libdefs.js
@@ -1,5 +1,8 @@
 // @flow
 
+// Disabling all weak-type checks since this file is a workaround for missing types
+/* eslint-disable flowtype/no-weak-types */
+
 // TODO: remove these module declarations when not failing
 declare module 'whatwg-fetch' {
   declare type Options = {
@@ -24,5 +27,4 @@ declare module 'core-js/fn/symbol' {
 
 }
 
-// eslint-disable-next-line flowtype/no-weak-types
 export type Window = any


### PR DESCRIPTION
**What this PR does / why we need it**:

Clean-up and refactoring of Types inside Policies.

* Unify imports by creating an index inside each of the types' folder
* Remove as many weak types: `any` and `Object` as possible
* Rearrange import order (first libs, then modules, types and lastly css)
* Remove as many `$FixFlowMe` comments as possible

**Verification steps**:
* `npm run update-dependencies`
* Navigate to `apiconfig/services/<id>/policies/edit`
* Policies widget should work as usual

**Note**:
This is part 3 of the refactorization of Policies:
[THREESCALE-2221: Policies: Normalise the use of policies schema and its types](https://issues.jboss.org/browse/THREESCALE-2221)

Previous step #1340.

A follow-up PR will be created once this one is merged.