### PR TITLE
Fix show of backend usage routing paths in the integration page

### DIFF
--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -118,4 +118,13 @@ module Api::IntegrationsHelper
     options = PROMOTE_BUTTON_COMMON_OPTIONS.deep_merge(button_html: { class: 'PromoteButton disabled-button', disabled: true })
     ['Nothing to promote', options]
   end
+
+  def backend_routing_rule(backend_api_config)
+    path = StringUtils::StripSlash.strip_slash(backend_api_config.path.presence)
+    code = content_tag :code do
+      "/#{path} => "
+    end
+    endpoint = backend_api_config.backend_api.private_endpoint
+    code + endpoint
+  end
 end

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -14,9 +14,7 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
             ul
             - for backend_api_config in backend_api_configs
               li
-                code
-                  ' /#{backend_api_config.path.presence} =>
-                = backend_api_config.backend_api.private_endpoint
+                = backend_routing_rule(backend_api_config)
         - else
           dt.u-dl-term Private Base URL
           dd.u-dl-definition = @proxy.api_backend


### PR DESCRIPTION
This PR fixes a tiny regression bug in the UI after https://github.com/3scale/porta/pull/1308 was merged.

**Before**

![Screen Shot 2019-10-18 at 10 40 34 AM](https://user-images.githubusercontent.com/1842261/67083242-1705ed00-f19b-11e9-9534-0a9f955ba0bb.png)

**After**

![Screen Shot 2019-10-18 at 11 33 09 AM](https://user-images.githubusercontent.com/1842261/67083255-208f5500-f19b-11e9-9491-257dc7b679c3.png)
