### PR TITLE
Fix alignment in service discovery error message

### DIFF
--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -540,8 +540,8 @@ li.hidden {
 #new_service_wrapper {
   .errorMessage {
     color: $error-color;
-    margin-bottom: line-height-times(1/2);
-    margin-top: -#{$fieldset-margin-bottom};
+    margin: 0;
+    padding: 0 line-height-times(1);
   }
 
   .new-service-source-input {
@@ -550,6 +550,20 @@ li.hidden {
 }
 
 // Overrides
+.new-service-form {
+  @include white-box-shadow;
+
+  form.formtastic {
+    box-shadow: none;
+    margin: 0;
+
+    fieldset {
+      margin-bottom: 0;
+    }
+  }
+}
+
+
 .dashboard_bubble form.formtastic {
   box-shadow: none;
   margin: 0;

--- a/app/javascript/src/NewService/components/NewServiceForm.jsx
+++ b/app/javascript/src/NewService/components/NewServiceForm.jsx
@@ -35,16 +35,18 @@ const NewServiceForm = (props: Props) => {
   return (
     <React.Fragment>
       <h1>{title}</h1>
-      {isServiceDiscoveryAccessible &&
-        <ServiceSourceForm
-          isServiceDiscoveryUsable={isServiceDiscoveryUsable}
-          serviceDiscoveryAuthenticateUrl={serviceDiscoveryAuthenticateUrl}
-          handleFormsVisibility={handleFormsVisibility}
-          loadingProjects={loadingProjects}
-          apiap={apiap}
-        />
-      }
-      {formToRender()}
+      <div className="new-service-form">
+        {isServiceDiscoveryAccessible &&
+          <ServiceSourceForm
+            isServiceDiscoveryUsable={isServiceDiscoveryUsable}
+            serviceDiscoveryAuthenticateUrl={serviceDiscoveryAuthenticateUrl}
+            handleFormsVisibility={handleFormsVisibility}
+            loadingProjects={loadingProjects}
+            apiap={apiap}
+          />
+        }
+        {formToRender()}
+      </div>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

After merging https://github.com/3scale/porta/pull/1182, error message for service discovery is missaligned

**Before:**
![before](https://user-images.githubusercontent.com/13486237/67089550-36574700-f1a8-11e9-9b92-393f021d91fa.png)

**After (no error):**
![no-error](https://user-images.githubusercontent.com/13486237/67097831-3dd41b80-f1bb-11e9-863a-62d0e1415bf4.png)

**After (error):**
![error](https://user-images.githubusercontent.com/13486237/67097844-44629300-f1bb-11e9-9aff-47bd491e3b97.png)
