### PR TITLE
Fix wrong popup message when deleting method or metric

### DIFF
--- a/app/views/api/metrics/edit.html.erb
+++ b/app/views/api/metrics/edit.html.erb
@@ -1,11 +1,9 @@
-<% if @metric.child? %>
-  <% content_for :sublayout_title, "Edit Method" %>
-<% else %>
-  <% content_for :sublayout_title, "Edit Metric" %>
-<% end %>
+<% method_or_metric = @metric.child? ? "method" : "metric" %>
+<% content_for :sublayout_title, "Edit #{method_or_metric.capitalize}" %>
+
 <%= semantic_form_for @metric, :url => admin_service_metric_path(@service, @metric) do |form| %>
   <%= render 'form', :form => form %>
 <% end %>
 <% unless @metric.default?(:hits) %>
-  <%= delete_button_for admin_service_metric_path(@service, @metric), data: {:confirm => "Removing this metric will affect all plans that contain this metric. Are you sure? "} %>
+  <%= delete_button_for admin_service_metric_path(@service, @metric), data: {:confirm => "Removing this #{method_or_metric} will affect all plans that contain this #{method_or_metric}, all associated mapping rules will be deleted too. Are you sure? "} %>
 <% end %>

--- a/app/views/provider/admin/backend_apis/metrics/edit.html.erb
+++ b/app/views/provider/admin/backend_apis/metrics/edit.html.erb
@@ -1,8 +1,9 @@
-<% content_for :sublayout_title, @metric.child? ? "Edit Method" : "Edit Metric" %>
+<% method_or_metric = @metric.child? ? "method" : "metric" %>
+<% content_for :sublayout_title, "Edit #{method_or_metric.capitalize}" %>
 
 <%= semantic_form_for @metric, :url => provider_admin_backend_api_metric_path(@backend_api, @metric) do |form| %>
   <%= render 'form', :form => form %>
 <% end %>
 <% unless @metric.default?(:hits) %>
-  <%= delete_button_for provider_admin_backend_api_metric_path(@backend_api, @metric), data: {:confirm => "Removing this metric will affect all plans that contain this metric. Are you sure? "} %>
+  <%= delete_button_for provider_admin_backend_api_metric_path(@backend_api, @metric), data: {:confirm => "Removing this #{method_or_metric} will affect all plans that contain this #{method_or_metric}, all associated mapping rules will be deleted too. Are you sure? "} %>
 <% end %>


### PR DESCRIPTION
**What this PR does / why we need it**:

When deleting a method, a popup window notify that you are deleting a metric but you are currently deleting a method.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3738

**Product (Method):**
<img width="969" alt="product-method" src="https://user-images.githubusercontent.com/13486237/67106828-a1664500-f1cb-11e9-8432-91386ed1b86a.png">

**Product (Metric):**
<img width="958" alt="product-metric" src="https://user-images.githubusercontent.com/13486237/67106836-a5926280-f1cb-11e9-8678-13d0afdb52c3.png">

**Backend (Method):**
<img width="965" alt="backend-method" src="https://user-images.githubusercontent.com/13486237/67106850-aa571680-f1cb-11e9-97e1-c4b6cfd0b741.png">

**Backend (Metric):**
<img width="963" alt="backend-metric" src="https://user-images.githubusercontent.com/13486237/67106854-ae833400-f1cb-11e9-8cc7-11454f6397e3.png">
