### PR TITLE
Settings: Fix staging and production URL grayed out

### DIFF
--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -69,9 +69,13 @@ module Api::IntegrationsHelper
   end
 
   def apicast_custom_urls?
+    # the idea would be to keep this rolling update disabled for saas
+    Rails.application.config.three_scale.apicast_custom_url
+  end
+
+  def apicast_urls_readonly?
     # should always return true on prem (deployment option 'hosted') and only return true when self managed in saas (deployment option 'self_managed')
-    # so the idea would be to keep this rolling update disabled for saas
-    Rails.application.config.three_scale.apicast_custom_url || @service.proxy.self_managed?
+    !(apicast_custom_urls? || @service.proxy.self_managed?)
   end
 
   def custom_backend?

--- a/app/javascript/src/Settings/authentication-widget.jsx
+++ b/app/javascript/src/Settings/authentication-widget.jsx
@@ -31,6 +31,8 @@ const toggleDisabled = toggleAttrInSetting('disabled')
 
 const toggleReadOnly = toggleAttrInSetting('readonly')
 
+const resetValue = (isReadOnly) => isReadOnly ? toggleAttrInSetting('value')(false) : settings => settings
+
 export function initialize () {
   const authWrapper = document.getElementById(AUTH_WRAPPER_ID)
   const authSettingsWrapper = document.getElementById(AUTH_SETS_WRP_ID)
@@ -49,7 +51,7 @@ export function initialize () {
   }))
   integrations.forEach(i => i.addEventListener('click', () => {
     apicastSettings.forEach(s => toggle(toggleDisabled, toggleHiddenClass)(i.id === SERVICE_MESH_ID)(s))
-    proxyEndpoints.forEach(e => toggleReadOnly(!apicastCustomUrl && i.id !== SELF_MANAGED)(e))
+    proxyEndpoints.forEach(e => toggle(toggleReadOnly, resetValue)(!apicastCustomUrl && i.id !== SELF_MANAGED)(e))
     toggle(toggleDisabled, toggleHiddenClass)(i.id === SERVICE_MESH_ID && !oidc.checked)(authSettingsWrapper)
   }))
 }

--- a/app/javascript/src/Settings/authentication-widget.jsx
+++ b/app/javascript/src/Settings/authentication-widget.jsx
@@ -11,11 +11,25 @@ const INTEGRATION_METHODS_CLASS = 'integration-method'
 const SERVICE_MESH_ID = 'service_deployment_option_service_mesh_istio'
 const APICAST_SETTINGS_CLASS = 'apicast-only-settings'
 const OIDC_ID = 'service_proxy_authentication_method_oidc'
+const PROXY_ENDPOINT_CLASS = 'proxy-endpoint'
+const PROXY_ENDPOINTS_ID = 'proxy-endpoints'
+const SELF_MANAGED = 'service_deployment_option_self_managed'
 
-const toggleActive = (setting, active) => {
-  active ? setting.classList.add('hidden') : setting.classList.remove('hidden')
-  active ? setting.setAttribute('disabled', true) : setting.removeAttribute('disabled')
+const toggle = (...toggleFns) => active => setting => toggleFns.map(toggle => toggle(active)).reduce((s, t) => t(s), setting)
+
+const toggleAttrInSetting = (attr) => (active) => (setting) => {
+  active ? setting.setAttribute(attr, attr) : setting.removeAttribute(attr)
+  return setting
 }
+
+const toggleHiddenClass = (active) => (setting) => {
+  active ? setting.classList.add('hidden') : setting.classList.remove('hidden')
+  return setting
+}
+
+const toggleDisabled = toggleAttrInSetting('disabled')
+
+const toggleReadOnly = toggleAttrInSetting('readonly')
 
 export function initialize () {
   const authWrapper = document.getElementById(AUTH_WRAPPER_ID)
@@ -24,15 +38,18 @@ export function initialize () {
   const [...settings] = authWrapper.getElementsByClassName(AUTH_SETS_CLASS)
   const [...integrations] = document.getElementById(INTEGRATION_WRAPPER_ID).getElementsByClassName(INTEGRATION_METHODS_CLASS)
   const [...apicastSettings] = document.getElementsByClassName(APICAST_SETTINGS_CLASS)
+  const [...proxyEndpoints] = document.getElementsByClassName(PROXY_ENDPOINT_CLASS)
+  const apicastCustomUrl = document.getElementById(PROXY_ENDPOINTS_ID).dataset.apicastCustomUrls === 'true'
   const oidc = document.getElementById(OIDC_ID)
   const serviceMesh = document.getElementById(SERVICE_MESH_ID)
 
   methods.forEach(m => m.addEventListener('click', () => {
-    toggleActive(authSettingsWrapper, serviceMesh.checked && !oidc.checked)
-    settings.forEach(s => toggleActive(s, s.id !== `${m.id}_settings`))
+    toggle(toggleDisabled, toggleHiddenClass)(serviceMesh.checked && !oidc.checked)(authSettingsWrapper)
+    settings.forEach(s => toggle(toggleDisabled, toggleHiddenClass)(s.id !== `${m.id}_settings`)(s))
   }))
   integrations.forEach(i => i.addEventListener('click', () => {
-    apicastSettings.forEach(s => toggleActive(s, i.id === SERVICE_MESH_ID))
-    toggleActive(authSettingsWrapper, i.id === SERVICE_MESH_ID && !oidc.checked)
+    apicastSettings.forEach(s => toggle(toggleDisabled, toggleHiddenClass)(i.id === SERVICE_MESH_ID)(s))
+    proxyEndpoints.forEach(e => toggleReadOnly(!apicastCustomUrl && i.id !== SELF_MANAGED)(e))
+    toggle(toggleDisabled, toggleHiddenClass)(i.id === SERVICE_MESH_ID && !oidc.checked)(authSettingsWrapper)
   }))
 }

--- a/app/javascript/src/Settings/authentication-widget.jsx
+++ b/app/javascript/src/Settings/authentication-widget.jsx
@@ -31,7 +31,11 @@ const toggleDisabled = toggleAttrInSetting('disabled')
 
 const toggleReadOnly = toggleAttrInSetting('readonly')
 
-const resetValue = (isReadOnly) => isReadOnly ? toggleAttrInSetting('value')(false) : settings => settings
+const setValue = (el, val) => {
+  el.value = val
+  return el
+}
+const setInputValue = (val) => (isReadOnly) => isReadOnly ? setting => setValue(setting, val) : setting => setting
 
 export function initialize () {
   const authWrapper = document.getElementById(AUTH_WRAPPER_ID)
@@ -51,7 +55,7 @@ export function initialize () {
   }))
   integrations.forEach(i => i.addEventListener('click', () => {
     apicastSettings.forEach(s => toggle(toggleDisabled, toggleHiddenClass)(i.id === SERVICE_MESH_ID)(s))
-    proxyEndpoints.forEach(e => toggle(toggleReadOnly, resetValue)(!apicastCustomUrl && i.id !== SELF_MANAGED)(e))
+    proxyEndpoints.forEach(e => toggle(toggleReadOnly, setInputValue(e.dataset.default))(!apicastCustomUrl && i.id !== SELF_MANAGED)(e))
     toggle(toggleDisabled, toggleHiddenClass)(i.id === SERVICE_MESH_ID && !oidc.checked)(authSettingsWrapper)
   }))
 }

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -190,6 +190,11 @@ class Proxy < ApplicationRecord
 
     def default_production_endpoint; end
 
+    def default_staging_endpoint_apiap; end
+
+    def default_production_endpoint_apiap; end
+
+
     protected
 
     delegate :provider, to: :service
@@ -227,6 +232,13 @@ class Proxy < ApplicationRecord
       production_endpoint = proxy.apicast_configuration_driven ? :apicast_production_endpoint : :hosted_proxy_endpoint
       generate(production_endpoint)
     end
+    def default_staging_endpoint_apiap
+      default_staging_endpoint
+    end
+
+    def default_production_endpoint_apiap
+      default_production_endpoint
+    end
   end
 
   # @return DeploymentStrategy
@@ -237,6 +249,10 @@ class Proxy < ApplicationRecord
                end
 
     strategy.try!(:new, self)
+  end
+
+  def deployment_strategy_apiap
+    HostedAPIcast.new self
   end
 
   def oidc?
@@ -470,6 +486,9 @@ class Proxy < ApplicationRecord
 
   delegate :default_production_endpoint, :default_staging_endpoint,
            to: :deployment_strategy, allow_nil: true
+
+  delegate :default_production_endpoint_apiap, :default_staging_endpoint_apiap,
+           to: :deployment_strategy_apiap, allow_nil: true
 
   delegate :backend_version, to: :service, prefix: true
 

--- a/app/views/api/integrations/apicast/configuration_driven/_configuration.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_configuration.html.slim
@@ -32,14 +32,14 @@
       = f.inputs "API gateway" do
         = f.input :sandbox_endpoint, label: "Staging Public Base URL",
                   input_html: { data: { default: (@proxy.default_staging_endpoint unless @proxy.self_managed?) },
-                                readonly: !apicast_custom_urls?,
+                                readonly: apicast_urls_readonly?,
                                 placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
                   hint: apicast_endpoint_input_hint(@service, environment: 'staging')
 
         = help_bubble( 'proxy_endpoint_bubble', t('api.integrations.proxy.proxy_endpoint_help_html'))
         = f.input :endpoint, label: "Production Public Base URL",
                   input_html: { data: { default: (@proxy.default_production_endpoint unless @proxy.self_managed?) },
-                                readonly: !apicast_custom_urls?,
+                                readonly: apicast_urls_readonly?,
                                 placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
                   hint: apicast_endpoint_input_hint(@service, environment: 'production')
         = help_bubble( 'proxy_endpoint_bubble', t('api.integrations.proxy.proxy_endpoint_help_html'))

--- a/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
+++ b/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
@@ -1,15 +1,19 @@
 - is_service_mesh = proxy.service_mesh_integration?
-= f.inputs "API gateway", class: "apicast-only-settings #{'hidden' if is_service_mesh}", disabled: is_service_mesh do
+- is_self_managed = proxy.self_managed?
+- is_read_only = !apicast_custom_urls? && !is_self_managed
+= f.inputs "API gateway", id: 'proxy-endpoints', data: {apicast_custom_urls: apicast_custom_urls?}, class: "apicast-only-settings #{'hidden' if is_service_mesh}", disabled: is_service_mesh do
   = f.input :sandbox_endpoint, label: "Staging Public Base URL",
-            input_html: { data: { default: (proxy.default_staging_endpoint unless proxy.self_managed?) },
-                          readonly: !apicast_custom_urls?,
+            input_html: { class: 'proxy-endpoint',
+                          data: { default: (proxy.default_staging_endpoint unless proxy.self_managed?) },
+                          readonly: is_read_only,
                           placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
             hint: apicast_endpoint_input_hint(service, environment: 'staging')
 
   = help_bubble( 'proxy_endpoint_bubble', t('api.integrations.proxy.proxy_endpoint_help_html'))
   = f.input :endpoint, label: "Production Public Base URL",
-            input_html: { data: { default: (proxy.default_production_endpoint unless proxy.self_managed?) },
-                          readonly: !apicast_custom_urls?,
+            input_html: { class: 'proxy-endpoint',
+                          data: { default: (proxy.default_production_endpoint unless proxy.self_managed?) },
+                          readonly: is_read_only,
                           placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
             hint: apicast_endpoint_input_hint(service, environment: 'production')
   = help_bubble( 'proxy_endpoint_bubble', t('api.integrations.proxy.proxy_endpoint_help_html'))

--- a/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
+++ b/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
@@ -4,7 +4,7 @@
 = f.inputs "API gateway", id: 'proxy-endpoints', data: {apicast_custom_urls: apicast_custom_urls?}, class: "apicast-only-settings #{'hidden' if is_service_mesh}", disabled: is_service_mesh do
   = f.input :sandbox_endpoint, label: "Staging Public Base URL",
             input_html: { class: 'proxy-endpoint',
-                          data: { default: (proxy.default_staging_endpoint unless proxy.self_managed?) },
+                          data: { default: (proxy.default_staging_endpoint_apiap ) },
                           readonly: apicast_urls_readonly?,
                           placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
             hint: apicast_endpoint_input_hint(service, environment: 'staging')
@@ -12,7 +12,7 @@
   = help_bubble( 'proxy_endpoint_bubble', t('api.integrations.proxy.proxy_endpoint_help_html'))
   = f.input :endpoint, label: "Production Public Base URL",
             input_html: { class: 'proxy-endpoint',
-                          data: { default: (proxy.default_production_endpoint unless proxy.self_managed?) },
+                          data: { default: (proxy.default_production_endpoint_apiap ) },
                           readonly: apicast_urls_readonly?,
                           placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
             hint: apicast_endpoint_input_hint(service, environment: 'production')

--- a/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
+++ b/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
@@ -1,11 +1,11 @@
 - is_service_mesh = proxy.service_mesh_integration?
 - is_self_managed = proxy.self_managed?
-- is_read_only = !apicast_custom_urls? && !is_self_managed
+
 = f.inputs "API gateway", id: 'proxy-endpoints', data: {apicast_custom_urls: apicast_custom_urls?}, class: "apicast-only-settings #{'hidden' if is_service_mesh}", disabled: is_service_mesh do
   = f.input :sandbox_endpoint, label: "Staging Public Base URL",
             input_html: { class: 'proxy-endpoint',
                           data: { default: (proxy.default_staging_endpoint unless proxy.self_managed?) },
-                          readonly: is_read_only,
+                          readonly: apicast_urls_readonly?,
                           placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
             hint: apicast_endpoint_input_hint(service, environment: 'staging')
 
@@ -13,7 +13,7 @@
   = f.input :endpoint, label: "Production Public Base URL",
             input_html: { class: 'proxy-endpoint',
                           data: { default: (proxy.default_production_endpoint unless proxy.self_managed?) },
-                          readonly: is_read_only,
+                          readonly: apicast_urls_readonly?,
                           placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
             hint: apicast_endpoint_input_hint(service, environment: 'production')
   = help_bubble( 'proxy_endpoint_bubble', t('api.integrations.proxy.proxy_endpoint_help_html'))


### PR DESCRIPTION
With `ENABLE_APICAST_CUSTOM_URL=1`
![with-custom-url](https://user-images.githubusercontent.com/4183971/67179657-34d48b80-f401-11e9-86f7-28fc9e37f4ab.gif)

With `ENABLE_APICAST_CUSTOM_URL=0`
![without-custom-url](https://user-images.githubusercontent.com/4183971/67179990-571ad900-f402-11e9-91bd-576069cffbd8.gif)

Default Hosted APIcast url behaviour:
![updated_default_behaviour](https://user-images.githubusercontent.com/4183971/67204842-96fcb300-f438-11e9-9d99-f11b94ba0371.gif)


**What this PR does / why we need it**:

Fixes a bug with proxy staging and production URLs and integration method selected.

**Which issue(s) this PR fixes** 

Fixes https://issues.jboss.org/browse/THREESCALE-3753

** Notes **
Missing cuke for feature. https://issues.jboss.org/browse/THREESCALE-3762
