### PR TITLE
[do not merge] [wip] Hotfix: Do not disable promote to staging

### DIFF
--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -94,7 +94,8 @@ module Api::IntegrationsHelper
   end
 
   def promote_to_staging_button_options(proxy)
-    return disabled_promote_button_options if proxy.any_sandbox_configs? && !proxy.pending_affecting_changes?
+    # FIXME: Hot fix to https://issues.jboss.org/browse/THREESCALE-3760
+    # return disabled_promote_button_options if proxy.any_sandbox_configs? && !proxy.pending_affecting_changes?
 
     label = deployment_option_is_service_mesh?(proxy.service) ? 'Update Configuration' : "Promote v. #{proxy.next_sandbox_config_version} to Staging"
     promote_button_options(label)


### PR DESCRIPTION
We are unsure yet if the proxy config affecting change is fully complete

Fixes: https://issues.jboss.org/browse/THREESCALE-3760

Proposal is to quick fix it (because of ER2)

Then probably use in a later PR something like:

https://github.com/3scale/porta/blob/master/app/services/apicast_v2_deployment_service.rb#L13-L15