### PR TITLE
Issue proxy affecting change on backend api private endpoint update

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -2,6 +2,7 @@
 
 class BackendApi < ApplicationRecord
   include SystemName
+  include ProxyConfigAffectingChanges::BackendApiExtension
 
   DELETED_STATE = :deleted
   ECHO_API_HOST = 'echo-api.3scale.net'


### PR DESCRIPTION
This is an alternative to https://github.com/3scale/porta/pull/1352. Instead of always enabling the "Promote to staging" button, it makes `BackendApi` to issue a `ProxyConfigs::AffectingObjectChangedEvent` whenever `private_endpoint` is updated. The former is a broader "fix" that prevents from any other (yet unkown) flaws of the proxy affecting changes mechanism. This is a more specific approach addressing the issue reported in https://issues.jboss.org/browse/THREESCALE-3760.