### PR TITLE
Removing box-shadow in nested forms in integration page

### DIFF
--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -575,18 +575,17 @@ li.hidden {
     box-shadow: none;
     margin: 0;
     padding: 0;
+
+    &.staging-settings {
+      @include white-box-shadow;
+      padding: line-height-times(1);
+    }
   }
 
   form.formtastic.u-inline {
     display: inline-block;
   }
 
-  .integration {
-    form.formtastic {
-      @include white-box-shadow;
-      padding: line-height-times(1);
-    }
-  }
 }
 
 form#liquid-settings > fieldset {


### PR DESCRIPTION
**What this PR does / why we need it**:

Some nested forms in configuration page are showing box-shadow.

**Before:**
![before](https://user-images.githubusercontent.com/13486237/67267824-63ab3a00-f4b3-11e9-9ff9-f717babbc8cd.png)


**After:**
![after](https://user-images.githubusercontent.com/13486237/67268094-f21fbb80-f4b3-11e9-9cc7-372e19fa3228.png)

**NO APIAP**

**Integration page:**
![no-apiap-integration-page](https://user-images.githubusercontent.com/13486237/67270036-1c737800-f4b8-11e9-9c7c-7f37b465b3f3.png)

**Configuration page:**
![no-apiap-configuration-page](https://user-images.githubusercontent.com/13486237/67270064-29906700-f4b8-11e9-81aa-6d7f0cd32313.png)
