### PR TITLE
Align vertically APIs title in Dashboard

### DIFF
--- a/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
+++ b/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
@@ -98,7 +98,7 @@
  */
 
  .DashboardSection--tabs-title {
-    bottom: line-height-times(-1 / 3);
+    bottom: line-height-times(-1 / 4);
     color: #393f44;
     cursor: pointer;
     float: left;


### PR DESCRIPTION
**What this PR does / why we need it**:

APIs title in dashboard is a bit vertically misaligned.

**Before:**
![before](https://user-images.githubusercontent.com/13486237/67269314-cbaf4f80-f4b6-11e9-9f69-35a2e2b27a55.png)

After:
![after](https://user-images.githubusercontent.com/13486237/67269319-d10c9a00-f4b6-11e9-8cde-ec9bd20aab09.png)
