### PR TITLE
Fix Pricing Rules and Limits endpoints to accept metrics from BackendApi

### DIFF
--- a/app/controllers/admin/api/application_plan_metric_limits_controller.rb
+++ b/app/controllers/admin/api/application_plan_metric_limits_controller.rb
@@ -108,7 +108,7 @@ class Admin::Api::ApplicationPlanMetricLimitsController < Admin::Api::BaseContro
 
   def metric
     # if service_id were passed in the url service.metrics would be ok
-    @metric ||= application_plan.service.metrics.find(params[:metric_id])
+    @metric ||= application_plan.all_metrics.find(params[:metric_id])
   end
 
   def usage_limits

--- a/app/controllers/admin/api/application_plan_metric_pricing_rules_controller.rb
+++ b/app/controllers/admin/api/application_plan_metric_pricing_rules_controller.rb
@@ -52,7 +52,7 @@ class Admin::Api::ApplicationPlanMetricPricingRulesController < Admin::Api::Base
   end
 
   def metric
-    @metric ||= application_plan.service.metrics.find(params[:metric_id])
+    @metric ||= application_plan.all_metrics.find(params[:metric_id])
   end
 
   def pricing_rules

--- a/test/functional/admin/api/application_plan_metric_pricing_rules_controller_test.rb
+++ b/test/functional/admin/api/application_plan_metric_pricing_rules_controller_test.rb
@@ -29,6 +29,25 @@ class Admin::Api::ApplicationPlanMetricPricingRulesControllerTest < ActionContro
     assert_equal 1, xml_elements_by_key(@response.body, 'pricing_rule').count
   end
 
+  def test_returns_success_if_backend_is_used_by_the_product
+    backend = FactoryBot.create(:backend_api)
+    metric  = FactoryBot.create(:metric, owner: backend)
+    FactoryBot.create(:backend_api_config, backend_api: backend, service: @plan.service)
+
+    get :index, application_plan_id: @plan.id, metric_id: metric.id, format: :json
+
+    assert_response :success
+  end
+
+  def test_returns_not_found_if_backend_is_not_used_by_the_product
+    backend = FactoryBot.create(:backend_api)
+    metric  = FactoryBot.create(:metric, owner: backend)
+
+    get :index, application_plan_id: @plan.id, metric_id: metric.id, format: :json
+
+    assert_response :not_found
+  end
+
   def test_create_json
     post :create, application_plan_id: @plan.id, metric_id: @metric.id,
       pricing_rule: { min: 10, max: 20, cost_per_unit: 20.0553 }, format: :json

--- a/test/integration/user-management-api/application_plan_metric_limits_test.rb
+++ b/test/integration/user-management-api/application_plan_metric_limits_test.rb
@@ -60,6 +60,27 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
                           :metric_id => @metric.id })
   end
 
+  test 'application_plan_metric_limits_index with a backend api used by service returns success' do
+    backend = FactoryBot.create(:backend_api)
+    metric  = FactoryBot.create(:metric, owner: backend)
+    FactoryBot.create(:backend_api_config, backend_api: backend, service: @app_plan.service)
+
+    get(admin_api_application_plan_metric_limits_path(@app_plan, metric),
+             :provider_key => @provider.api_key, :format => :xml)
+
+    assert_response :success
+  end
+
+  test 'application_plan_metric_limits_index with a backend api not used by service returns not found' do
+    backend = FactoryBot.create(:backend_api)
+    metric  = FactoryBot.create(:metric, owner: backend)
+
+    get(admin_api_application_plan_metric_limits_path(@app_plan, metric),
+             :provider_key => @provider.api_key, :format => :xml)
+
+    assert_response :not_found
+  end
+
   test 'application_plan_metric_limit_show' do
     get(admin_api_application_plan_metric_limit_path(@app_plan, @metric, @limit),
              :provider_key => @provider.api_key, :format => :xml)


### PR DESCRIPTION
[THREESCALE-3746](https://issues.jboss.org/browse/THREESCALE-3746)
Currently when the user tries to create/update/delete limits or pricing
rules for a Backend API metric in a plan it fails with 404.

This commit fixes it by making the controller consider the backend api
metrics using the `all_metrics` method from the plan.