### PR TITLE
Fix empty Policy Chain list in policies/edit

### DIFF
--- a/app/javascript/src/Policies/middleware/PolicyChain.jsx
+++ b/app/javascript/src/Policies/middleware/PolicyChain.jsx
@@ -43,10 +43,10 @@ const loadChain = ({registry, storedChain, dispatch}: {registry: Array<RegistryP
   })
   if (errors > 0) {
     dispatch(loadChainError({})) // TODO: Define what to do with errors (unlikely now, just undefined path returned by Array.find)
-  } else {
-    dispatch(setOriginalPolicyChain(updatedChain))
-    dispatch(loadChainSuccess(updatedChain))
   }
+
+  dispatch(setOriginalPolicyChain(updatedChain))
+  dispatch(loadChainSuccess(updatedChain))
 }
 
 const policyChainMiddleware = ({ dispatch, getState }: { dispatch: Dispatch, getState: GetState }) => (next: any) => (action: PolicyChainMiddlewareAction) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

When there is any bogus policy in the policy chain the components dispatched an error, instead of updating the store, so the chain is kept empty.

However, dispatching an error does nothing because this is not implemented so the errors fall silently.

The proper behavior is that both things happen:
* if there are wrong policies it should dispatch an error and exclude them from the chain
* then it should update the chain with all the resting valid policies

**Which issue(s) this PR fixes** 

[THREESCALE-3229: Empty Policy Chain list after removal of custom policy from apicast](https://issues.jboss.org/browse/THREESCALE-3229)

**Verification steps** 

1. Using APIcast 2.7 add a HTTP Proxy policy
2. Change to APIcast 2.6 and go to policies/edit
3. The policy should not be there since it's not supported by 2.6

**In progress**
- [x] Fix 🐛 
- [x] Add tests