### PR TITLE
Mitigates ActiveRecord::StaleObjectError on proxy update

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -194,7 +194,6 @@ class Proxy < ApplicationRecord
 
     def default_production_endpoint_apiap; end
 
-
     protected
 
     delegate :provider, to: :service
@@ -533,6 +532,11 @@ class Proxy < ApplicationRecord
 
   def service_mesh_integration?
     Service::DeploymentOption.service_mesh.include?(deployment_option)
+  end
+
+  def update_attributes(*)
+    reload # helps to prevent ActiveRecord::StaleObjectError. Using pessimistic locking wouldcould be an alternative.
+    super
   end
 
   protected

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -683,4 +683,26 @@ class ProxyTest < ActiveSupport::TestCase
       proxy.update_attributes(updated_at: Time.utc(2019, 9, 26, 12, 20))
     end
   end
+
+  class StaleObjectErrorTest < ActiveSupport::TestCase
+    test 'proxy reloads before updating attributes' do
+      class ProxyWithFiber < ::Proxy
+        def update_attributes(*)
+          Fiber.yield
+          super
+        end
+      end
+
+      proxy_id = FactoryBot.create(:proxy).id
+
+      fiber_update = Fiber.new { ProxyWithFiber.find(proxy_id).update_attributes(error_auth_failed: 'new auth error msg') }
+      fiber_touch = Fiber.new { Proxy.find(proxy_id).touch }
+
+      fiber_update.resume
+      assert_nothing_raised(ActiveRecord::StaleObjectError) do
+        fiber_touch.resume
+        fiber_update.resume
+      end
+    end
+  end
 end


### PR DESCRIPTION
Concurrent updates of a proxy record, particularly when one of the threads is trying to "touch" the object, can cause ActiveRecord to raise an `ActiveRecord::StaleObjectError`. When initiated in the scope of an HTTP request, the update may end up rejected with a `409 Conflict` response due to this race condition.

Example of recently introduced background operations now touching the proxy object at a much higher frequency than before:

https://github.com/3scale/porta/blob/42779a0ae2f7bf3060550b2e34aaeb2e0aeb2497/app/workers/proxy_config_affecting_change_worker.rb#L7
https://github.com/3scale/porta/blob/42779a0ae2f7bf3060550b2e34aaeb2e0aeb2497/app/models/proxy_config_affecting_change.rb#L4

Closes [THREESCALE-3772](https://issues.jboss.org/browse/THREESCALE-3772)

**Special notes to the reviewer**
An alternative approach would be enforcing pessimist locking on the proxy update, though Rails 4 is known to have issues with ActiveRecord locking and touch operations: https://github.com/rails/rails/commit/9721b45b40c045a132b7177f0e86b0f5d567a2df.