### PR TITLE
Disabling submit button when policies endpoint is wrong

### DIFF
--- a/app/views/api/policies/edit.html.slim
+++ b/app/views/api/policies/edit.html.slim
@@ -3,5 +3,5 @@
 = semantic_form_for @proxy, url: admin_service_policies_path(@service) do |f|
   = render '/api/integrations/apicast/shared/policies', f: f
   = f.buttons do
-    = f.button t('formtastic.actions.policies.update'), button_html: {class: 'important-button update', name: 'update', value: '1',
-      id: 'policies-button-sav', title: 'Update Policies'} 
+    = f.button t('formtastic.actions.policies.update'), button_html: {class: "update #{@error ? 'disabled-button' : 'important-button'}", name: 'update', value: '1',
+      id: 'policies-button-sav', title: 'Update Policies', disabled: (@error ? true : nil) }


### PR DESCRIPTION
**What this PR does / why we need it**:

In Policies page (`apiconfig/services/<id>/policies/edit`), when fetch to policies endpoint fails for any reason, an error message is shown: "Failed to fetch APIcast policies from ...", but the submit button is enabled and the form can be submitted. This PR disables submit button when fetch APIcast policies fails.

Try with APIAP on. When APIAP off, the button is not displayed at all in the integration page.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3793

**Before:**
![before](https://user-images.githubusercontent.com/13486237/67467118-7d31ba80-f648-11e9-865a-94f436ff2d79.png)

**After:**
![after](https://user-images.githubusercontent.com/13486237/67467129-828f0500-f648-11e9-8427-fe4ad52a9ac1.png)
