### PR TITLE
Shorten labels auth options for apiap

### DIFF
--- a/app/javascript/src/Settings/styles/authentication.scss
+++ b/app/javascript/src/Settings/styles/authentication.scss
@@ -2,7 +2,8 @@
   display: none !important;
 }
 
-#service_deployment_option_input {
+#service_deployment_option_input,
+#service_proxy_authentication_method_input {
   label span,
   .inline-hints {
     display: none;


### PR DESCRIPTION
before:
<img width="834" alt="Screenshot 2019-10-24 10 29 23" src="https://user-images.githubusercontent.com/54224/67467521-309aaf00-f649-11e9-873b-472d5a815252.png">


after:
<img width="344" alt="Screenshot 2019-10-23 09 44 29" src="https://user-images.githubusercontent.com/54224/67467256-ba964800-f648-11e9-95fe-4fe83384c869.png">
