### PR TITLE
[BackgroundDeletion] module

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -58,6 +58,27 @@ class Account < ApplicationRecord
   include States
   include ProviderDomains
 
+  self.background_deletion = [
+    :users,
+    :mail_dispatch_rules,
+    :api_docs_services,
+    :services,
+    :contracts,
+    :account_plans,
+    [:settings, { action: :destroy, has_many: false }],
+    [:payment_detail, { action: :destroy, has_many: false }],
+    [:buyer_accounts, { action: :destroy, class_name: 'Account' }],
+    [:payment_gateway_setting, { action: :destroy, has_many: false }],
+    [:profile, { action: :delete, has_many: false }],
+    [:templates, { action: :delete }],
+    [:sections, { action: :delete, class_name: 'CMS::Section' }],
+    [:provided_sections, { action: :delete, class_name: 'CMS::Section' }],
+    [:redirects, { action: :delete }],
+    [:files, { action: :delete }],
+    [:builtin_pages, { action: :delete }],
+    [:provided_groups, { action: :delete }]
+  ]
+
   #TODO: this needs testing?
   scope :providers, -> { where(provider: true) }
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,6 +3,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  include BackgroundDeletion
 
   def self.user_attribute_names
     attribute_names

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -4,6 +4,8 @@ class BackendApi < ApplicationRecord
   include SystemName
   include ProxyConfigAffectingChanges::BackendApiExtension
 
+  self.background_deletion = %i[proxy_rules metrics backend_api_configs]
+
   DELETED_STATE = :deleted
   ECHO_API_HOST = 'echo-api.3scale.net'
 

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -3,6 +3,8 @@ class Cinstance < Contract
   # Maximum number of cinstances permitted between provider and buyer
   MAX = 10
 
+  self.background_deletion = [:referrer_filters, :application_keys, [:alerts, { action: :delete }]]
+
   delegate :backend_version, to: :service, allow_nil: true
 
   belongs_to :plan, class_name: 'ApplicationPlan', foreign_key: :plan_id, inverse_of: :cinstances

--- a/app/models/concerns/background_deletion.rb
+++ b/app/models/concerns/background_deletion.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module BackgroundDeletion
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :background_deletion, default: [], instance_writer: false
+  end
+
+  class Reflection
+
+    DEFAULT_DESTROY_METHOD = 'destroy'
+    DEFAULT_HAS_MANY_OPTION = true
+
+    attr_reader :name, :options
+
+    def initialize(association_config)
+      config = Array(association_config)
+
+      @name = config[0]
+      @options = config[1].presence || {}
+    end
+
+    def many?
+      options.fetch(:has_many) { DEFAULT_HAS_MANY_OPTION }
+    end
+
+    def class_name
+      options[:class_name].presence || name.to_s.singularize.classify
+    end
+
+    def background_destroy_method
+      options[:action].to_s.presence || DEFAULT_DESTROY_METHOD
+    end
+  end
+end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,5 +1,7 @@
 class Feature < ApplicationRecord
 
+  self.background_deletion = [:features_plans]
+
   audited :allow_mass_assignment => true
 
   #TODO: these need tests

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -5,6 +5,8 @@ class Metric < ApplicationRecord
   include ArchiveDeletionBelongingToService
   include BackendApiLogic::MetricExtension
 
+  self.background_deletion = %i[pricing_rules usage_limits plan_metrics proxy_rules]
+
   before_destroy :destroyable?
   before_validation :associate_to_service_of_parent, :fill_owner
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -12,6 +12,9 @@ class Plan < ApplicationRecord
   include SystemName
   include Logic::MetricVisibility::Plan
 
+  self.background_deletion = [:cinstances, :contracts, :plan_metrics, :pricing_rules,
+                              :usage_limits, [:customizations, { action: :destroy, class_name: 'Plan' }]]
+
   has_system_name :uniqueness_scope => [ :type, :issuer_id, :issuer_type ]
 
   audited :allow_mass_assignment => true

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -8,6 +8,8 @@ class Proxy < ApplicationRecord
   include GatewaySettings::ProxyExtension
   include ProxyConfigAffectingChanges::ProxyExtension
 
+  self.background_deletion = [:proxy_rules, [:proxy_configs, { action: :delete }], [:oidc_configuration, { action: :delete, has_many: false }]]
+
   DEFAULT_POLICY = { 'name' => 'apicast', 'humanName' => 'APIcast policy', 'description' => 'Main functionality of APIcast.',
                      'configuration' => {}, 'version' => 'builtin', 'enabled' => true, 'removable' => false, 'id' => 'apicast-policy'  }.freeze
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -12,6 +12,9 @@ class Service < ApplicationRecord
   extend System::Database::Scopes::IdOrSystemName
   include ServiceDiscovery::ModelExtensions::Service
 
+  self.background_deletion = [:service_plans, :application_plans, :end_user_plans, :api_docs_services,
+                              :backend_apis, :backend_api_configs, :metrics, [:proxy, { action: :destroy, has_many: false }]]
+
   DELETE_STATE = 'deleted'.freeze
 
   has_system_name uniqueness_scope: :account_id

--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 class ServicePlan < Plan
   include ::ThreeScale::MethodTracing

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,9 @@ class User < ApplicationRecord
   include Permissions
   include ProvidedAccessTokens
 
+  self.background_deletion = [:user_sessions, :access_tokens, [:sso_authorizations, { action: :delete }],
+                              [:moderatorships, { action: :delete }], [:notifications, { action: :delete }],
+                              [:notification_preferences, { action: :delete, has_many: false }]]
   audited
 
   before_validation :trim_white_space_from_username

--- a/app/workers/delete_account_hierarchy_worker.rb
+++ b/app/workers/delete_account_hierarchy_worker.rb
@@ -20,9 +20,9 @@ class DeleteAccountHierarchyWorker < DeleteObjectHierarchyWorker
     end
   end
 
-  def destroyable_association?(reflection)
+  def destroyable_association?(association)
     if called_from_provider_hierarchy? && account.gateway_setting.persisted?
-      super && reflection.class_name != Account.name
+      association != :buyer_accounts
     else
       super
     end

--- a/app/workers/delete_payment_setting_hierarchy_worker.rb
+++ b/app/workers/delete_payment_setting_hierarchy_worker.rb
@@ -5,12 +5,12 @@ class DeletePaymentSettingHierarchyWorker < DeleteObjectHierarchyWorker
 
   alias payment_setting object
 
-  def delete_associations
+  def destroy_and_delete_associations
     super
 
     return unless called_from_provider_hierarchy?
 
-    reflection_buyers_of_provider = Account.reflect_on_all_associations.find { |reflection| reflection.name == :buyer_accounts }
-    ReflectionDestroyer.new(payment_setting.account, reflection_buyers_of_provider, caller_worker_hierarchy).destroy_later
+    reflection = BackgroundDeletion::Reflection.new([:buyer_accounts, { action: :destroy, class_name: 'Account' }])
+    ReflectionDestroyer.new(object.account, reflection, caller_worker_hierarchy).destroy_later
   end
 end

--- a/app/workers/delete_service_hierarchy_worker.rb
+++ b/app/workers/delete_service_hierarchy_worker.rb
@@ -6,7 +6,12 @@ class DeleteServiceHierarchyWorker < DeleteObjectHierarchyWorker
   alias service object
 
   # TODO: when we remove the Rolling Update, we must remove this whole method
-  def destroyable_association?(reflection)
-    super || (reflection.name == :backend_apis && !service.account.provider_can_use?(:api_as_product))
+  def destroy_and_delete_associations
+    super
+
+    return unless service.account.provider_can_use?(:api_as_product)
+
+    reflection = BackgroundDeletion::Reflection.new(:backend_apis)
+    ReflectionDestroyer.new(object, reflection, caller_worker_hierarchy).destroy_later
   end
 end

--- a/test/unit/concerns/background_deletion_test.rb
+++ b/test/unit/concerns/background_deletion_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class Concerns::BackgroundDeletionTest < ActiveSupport::TestCase
+
+  class DoubleObject
+    include BackgroundDeletion
+    self.background_deletion = [:services, [:users, { action: :delete }]]
+  end
+
+  class DoubleActiveRecordObject < ApplicationRecord
+    self.table_name = 'access_tokens'
+
+    include BackgroundDeletion
+    self.background_deletion = [[:owner, { action: :destroy, has_many: false }]]
+
+    belongs_to :owner, class_name: 'User', dependent: :destroy
+  end
+
+  def test_destroy_integration
+    user = FactoryBot.create(:simple_user)
+    double_object = DoubleActiveRecordObject.create!(owner: user, value: 'abc123', name: 'super-token', permission: 'rw')
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(user, anything, 'destroy').once
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(user, anything, 'delete').never
+    DeleteObjectHierarchyWorker.perform_now(double_object)
+  end
+
+  class SecondDoubleActiveRecordObject < DoubleActiveRecordObject
+    self.background_deletion = [[:owner, { action: :delete, has_many: false }]]
+  end
+
+  def test_delete_integration
+    user = FactoryBot.create(:simple_user)
+    double_object = SecondDoubleActiveRecordObject.create!(owner: user, value: 'abc123', name: 'super-token', permission: 'rw')
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(user, anything, 'delete').once
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(user, anything, 'destroy').never
+    DeleteObjectHierarchyWorker.perform_now(double_object)
+  end
+end

--- a/test/workers/delete_service_hierarcy_worker_test.rb
+++ b/test/workers/delete_service_hierarcy_worker_test.rb
@@ -63,7 +63,7 @@ class DeleteServiceHierarchyWorkerTest < ActiveSupport::TestCase
     FactoryBot.create(:backend_api_config, service: service, backend_api: backend_api)
 
     DeleteObjectHierarchyWorker.expects(:perform_later).with(service.backend_api_configs.first!, anything, 'destroy').once
-    DeleteObjectHierarchyWorker.expects(:perform_later).with(backend_api, anything, '').once
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(backend_api, anything, 'destroy').once
 
     perform_enqueued_jobs { DeleteServiceHierarchyWorker.perform_now(service) }
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

Association that should be deleted on the background should be defined manually, instead of taking them by the `depenend` option from the association.

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3702
