### PR TITLE
Fix Policies when having twice of the same type

### DIFF
--- a/app/javascript/src/Policies/components/PoliciesForm.jsx
+++ b/app/javascript/src/Policies/components/PoliciesForm.jsx
@@ -20,7 +20,6 @@ class PolicyForm extends Form {
 
 type Props = {
   schema?: string,
-  visible: boolean,
   policy: ChainPolicy,
   submitForm: (ChainPolicy) => ThunkAction,
   removePolicy: (ChainPolicy) => ThunkAction,
@@ -29,7 +28,7 @@ type Props = {
 }
 
 function PoliciesForm ({
-  visible, policy, submitForm, updatePolicy, removePolicy,
+  policy, submitForm, updatePolicy, removePolicy,
   closePolicyConfig}: Props) {
   const onSubmit = (policy) => {
     return ({formData, schema}) => {
@@ -43,7 +42,7 @@ function PoliciesForm ({
   const cancel = () => closePolicyConfig()
 
   return (
-    <section className={`PolicyConfiguration ${hiddenClass(visible)}`}>
+    <section className="PolicyConfiguration">
       <header className="PolicyConfiguration-header">
         <h2 className="PolicyConfiguration-title">Edit Policy</h2>
         <div onClick={cancel} className="PolicyConfiguration-cancel"><i className="fa fa-times-circle"></i> Cancel</div>

--- a/app/javascript/src/Policies/components/PoliciesWidget.jsx
+++ b/app/javascript/src/Policies/components/PoliciesWidget.jsx
@@ -90,11 +90,12 @@ const PolicyList = ({ registry, chain, originalChain, policyConfig, ui, boundAct
         visible={ui.registry}
         actions={policyRegistryActions}
       />
-      <PolicyConfig
-        visible={ui.policyConfig}
-        policy={policyConfig}
-        actions={policyConfigActions}
-      />
+      {ui.policyConfig &&
+        <PolicyConfig
+          policy={policyConfig}
+          actions={policyConfigActions}
+        />
+      }
       <PolicyChainHiddenInput policies={chain} />
     </div>
   )

--- a/app/javascript/src/Policies/components/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/components/PolicyConfig.jsx
@@ -9,7 +9,6 @@ import type { ChainPolicy } from 'Policies/types/Policies'
 import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
 
 type Props = {
-  visible: boolean,
   policy: ChainPolicy,
   actions: {
     submitPolicyConfig: (ChainPolicy) => ThunkAction,
@@ -19,9 +18,8 @@ type Props = {
   }
 }
 
-const PolicyConfig = ({visible, policy, actions}: Props) => {
+const PolicyConfig = ({policy, actions}: Props) => {
   return (<PoliciesForm
-    visible={visible}
     policy={policy}
     submitForm={actions.submitPolicyConfig}
     removePolicy={actions.removePolicyFromChain}

--- a/app/javascript/src/Policies/reducers/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyConfig.jsx
@@ -4,10 +4,10 @@ import type { ChainPolicy } from 'Policies/types/Policies'
 import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
 
 import { initialState } from 'Policies/reducers/initialState'
-import { updateObject, createReducer } from 'Policies/util'
+import { createReducer } from 'Policies/util'
 
 function updatePolicyConfig (state: ChainPolicy, action: UpdatePolicyConfigAction): ChainPolicy {
-  return updateObject(state, action.policyConfig)
+  return action.policyConfig
 }
 
 // eslint-disable-next-line space-infix-ops

--- a/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
@@ -46,7 +46,6 @@ describe('PolicyConfig Component', () => {
     }
 
     const props = {
-      visible: true,
       policy: policyConfig,
       actions: {
         submitPolicyConfig: jest.fn(),
@@ -68,9 +67,6 @@ describe('PolicyConfig Component', () => {
   it('should render self', () => {
     const {policyConfigWrapper} = setup()
     expect(policyConfigWrapper.find('section').hasClass('PolicyConfiguration')).toBe(true)
-
-    const registryProps = policyConfigWrapper.props()
-    expect(registryProps.visible).toBe(true)
     expect(policyConfigWrapper.find('.PolicyConfiguration-name').text()).toBe('Caching policy')
     expect(policyConfigWrapper.find('.PolicyConfiguration-version').text()).toBe('builtin')
     expect(policyConfigWrapper.find('.PolicyConfiguration-summary').text()).toBe('Caching')
@@ -135,7 +131,6 @@ describe('PolicyConfig APIcast policy', () => {
     }
 
     const props = {
-      visible: true,
       policy: policyConfig,
       actions: {
         submitPolicyConfig: jest.fn(),
@@ -157,9 +152,6 @@ describe('PolicyConfig APIcast policy', () => {
   it('should display the APIcast policy name and summary', () => {
     const {policyConfigWrapper} = setup()
     expect(policyConfigWrapper.find('section').hasClass('PolicyConfiguration')).toBe(true)
-
-    const registryProps = policyConfigWrapper.props()
-    expect(registryProps.visible).toBe(true)
     expect(policyConfigWrapper.find('.PolicyConfiguration-name').text()).toBe('APIcast')
     expect(policyConfigWrapper.find('.PolicyConfiguration-summary').text()).toBe('Main function...')
   })


### PR DESCRIPTION
**What this PR does / why we need it**:

When having 2 policies of the same type, clicking between one and the other wasn't updating the UI.

This happens because React is not detecting a change in `PolicyConfig` props and therefore the view isn't updated. The fix is to render/destroy the detailed view when it's supposed to be displayed/hidden by css.

**Which issue(s) this PR fixes** 

[THREESCALE-1924: When adding a 2nd URL rewriting policy the UI doesn't work as expected](https://issues.jboss.org/browse/THREESCALE-1924)

**Verification steps** 

1. Go to Integration > Policies
2. Add 2 policies of the same kind, i.e. _Upstream_
3. Open the first one, edit its config, click on _Update Policy_
4. Open the second one, its config should be empty.

Alternative:
Having 2 policies of the same kind with different configs:
1. Open 1, close it.
2. Open the other, configs should change.