### PR TITLE
Removing https://support.3scale.net/api_docs/track.json request

### DIFF
--- a/app/views/layouts/provider.html.slim
+++ b/app/views/layouts/provider.html.slim
@@ -9,8 +9,6 @@ html[lang="en"]
     = render 'provider/theme'
     = render 'provider/analytics'
     = javascript_include_tag 'provider/layout/provider'
-    - if Rails.env.production? or Rails.env.preview?
-      script[src="https://support.3scale.net/api_docs/track.json?callback=$.noop" async="true"]
     = yield :javascripts
 
   body

--- a/app/views/layouts/provider/suspended.html.slim
+++ b/app/views/layouts/provider/suspended.html.slim
@@ -8,8 +8,6 @@ html[lang="en"]
     = stylesheet_link_tag "provider/themes/wizard.css"
     = render 'provider/analytics'
     = javascript_include_tag 'provider/layout/provider'
-    - if Rails.env.production? or Rails.env.preview?
-      script[src="https://support.3scale.net/api_docs/track.json?callback=$.noop" async="true"]
       = yield :javascripts
 
   body

--- a/app/views/layouts/wizard.html.slim
+++ b/app/views/layouts/wizard.html.slim
@@ -9,8 +9,6 @@ html[lang="en"]
     = stylesheet_link_tag "provider/themes/wizard.css"
     = render 'provider/analytics'
     = javascript_include_tag 'provider/layout/provider'
-    - if Rails.env.production? or Rails.env.preview?
-      script[src="https://support.3scale.net/api_docs/track.json?callback=$.noop" async="true"]
     = yield :javascripts
 
   body


### PR DESCRIPTION
**What this PR does / why we need it**:

All pages in the app are doing a request to `https://support.3scale.net/api_docs/track.json?callback=$.noop`:

![track](https://user-images.githubusercontent.com/13486237/67575435-dda22400-f73c-11e9-8051-7b30889a258d.png)

It looks like an outdated/unused tracking script.
The commit is old (it comes from System in 2015)

**Which issue(s) this PR fixes** 

There are some tickets asking to remove it:
https://issues.jboss.org/browse/THREESCALE-661
https://issues.jboss.org/browse/THREESCALE-870


**Verification steps** 

The branch is deployed in preview, please check that everything works normally
https://multitenant-admin.preview01.3scale.net/p/admin/dashboard
