### PR TITLE
3scale release migration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,6 +295,42 @@ commands: # reusable commands with parameters
       - *store-log-artifacts
       - *upload-coverage
 
+  install-openshift:
+    steps:
+      - run:
+          name: Install OpenShift Client Tools
+          working_directory: /tmp
+          command: |
+            curl --fail -L  https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz | tar -xzf-
+            sudo mv /tmp/openshift-origin-client-tools-*-linux-64bit/oc /usr/local/bin/
+            sudo mv /tmp/openshift-origin-client-tools-*-linux-64bit/kubectl /usr/local/bin/
+      - run:
+          name: Configure Docker
+          command: |
+            echo '{"insecure-registries": ["172.30.0.0/16"]}' | sudo tee --append /etc/docker/daemon.json
+            sudo systemctl restart docker
+      - run:
+          name: Start and Configure OpenShift Cluster
+          working_directory: /tmp/openshift
+          command: |
+            DOCKER_HOST_IP=$(docker run --net=host codenvy/che-ip)
+            oc cluster up --public-hostname=${DOCKER_HOST_IP} --enable=persistent-volumes \
+              --enable=registry --enable=router
+            oc login https://${DOCKER_HOST_IP}:8443 -u system:admin --insecure-skip-tls-verify=true > /dev/null
+            oc adm policy add-cluster-role-to-user cluster-admin developer > /dev/null
+            oc adm policy add-scc-to-group hostmount-anyuid system:serviceaccounts
+            oc login https://${DOCKER_HOST_IP}:8443 -u developer --insecure-skip-tls-verify=true > /dev/null
+
+            oc wait --timeout=90s --for=condition=available dc/docker-registry --namespace=default || oc rollout retry dc/docker-registry --namespace=default
+
+  oc-observe:
+    steps:
+      - run:
+          name: Observe OpenShift Pod changes
+          command: |
+            oc observe pods --maximum-errors=-1 --no-headers --object-env-var=OBJECT --type-env-var=TYPE -- jq -n --raw-output 'env.OBJECT | fromjson | "\(env.TYPE) \(.kind) \(.metadata.name) started at \(.status.startTime) (\(.status.phase)) \(.status.conditions // [] | map("\(.type): \(.status) @ \(.lastTransitionTime)") | join(", "))"'
+          background: true
+
 ##################################### CIRCLECI EXECUTORS ############################################
 
 executors:
@@ -905,10 +941,66 @@ jobs:
           path: tmp/capybara
           destination: capybara
 
+  simple-upgrade-test:
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true
+    resource_class: large
+    parameters:
+      threescale_release_version:
+        type: string
+        default: "2.6"
+    steps:
+      - install-openshift
+      - run:
+          name: Change to migration-test namespace
+          command: |
+            oc new-project migration-test
+      - oc-observe
+      - run:
+          name: Watch deployment configs
+          command: |
+            while true; do oc describe dc; sleep 600; done
+
+          background: true
+      - run:
+          name: Watch imagestreams
+          command: |
+            while true; do oc describe is; sleep 600; done
+
+          background: true
+      - run:
+          name: Deploy 3scale << parameters.threescale_release_version >> from amp-eval template
+          command: |
+            oc create -f https://raw.githubusercontent.com/3scale/3scale-operator/<< parameters.threescale_release_version >>-stable/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml
+            oc new-app 3scale-api-management-eval --param WILDCARD_DOMAIN=lvh.me
+            oc wait --for=condition=available --timeout=-1s $(oc get dc --output=name)
+          no_output_timeout: 30m
+      - checkout
+      - run:
+          name: Build system master image
+          command: |
+            oc create -f test/migration/build-system-master.json
+            oc start-build amp-system-master --wait --follow
+      - run:
+          name: Run upgrade from 3scale << parameters.threescale_release_version >> test
+          command: |
+            test/migration/run_migration_test.sh
+
 ##################################### CIRCLECI WORKFLOWS ############################################
 
 workflows:
   version: 2
+
+  upgrade_tests:
+    jobs:
+      - manual_approval: # <<< A job that will require manual approval in the CircleCI web application.
+          type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
+          # On approval of the `hold` job, any successive job that requires the `hold` job will run.
+      - simple-upgrade-test:
+          threescale_release_version: "2.6"
+          requires:
+            - manual_approval
 
   mysql_build:
     jobs:
@@ -1338,4 +1430,10 @@ workflows:
             - karma
             - jest
           <<: *only-master-filter
+    <<: *nightly-trigger
+
+  nightly_upgrade_tests:
+    jobs:
+      - simple-upgrade-test:
+          threescale_release_version: "2.6"
     <<: *nightly-trigger

--- a/test/migration/build-system-master.json
+++ b/test/migration/build-system-master.json
@@ -1,0 +1,104 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "ruby-24-centos7",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "amp-system-master"
+                },
+                "annotations": {
+                    "openshift.io/generated-by": "OpenShiftNewApp"
+                }
+            },
+            "spec": {
+                "lookupPolicy": {
+                    "local": false
+                },
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/imported-from": "centos/ruby-24-centos7"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "centos/ruby-24-centos7"
+                        },
+                        "generation": null,
+                        "importPolicy": {},
+                        "referencePolicy": {
+                            "type": ""
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "dockerImageRepository": ""
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "amp-system-master",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "amp-system-master"
+                },
+                "annotations": {
+                    "openshift.io/generated-by": "OpenShiftNewApp"
+                }
+            },
+            "spec": {
+                "lookupPolicy": {
+                    "local": false
+                }
+            },
+            "status": {
+                "dockerImageRepository": ""
+            }
+        },
+        {
+            "kind": "BuildConfig",
+            "apiVersion": "build.openshift.io/v1",
+            "metadata": {
+                "name": "amp-system-master",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "amp-system-master"
+                },
+                "annotations": {
+                    "openshift.io/generated-by": "OpenShiftNewApp"
+                }
+            },
+            "spec": {
+                "source": {
+                    "type": "Git",
+                    "git": {
+                        "uri": "https://github.com/3scale/porta.git"
+                    }
+                },
+                "strategy": {
+                    "type": "Docker",
+                    "dockerStrategy": {
+                        "contextDir": "/",
+                        "dockerfilePath": "openshift/system/Dockerfile.on_prem",
+                        "forcePull": true
+                    }
+                },
+                "output": {
+                    "to": {
+                        "kind": "ImageStreamTag",
+                        "name": "amp-system-master:latest"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/test/migration/build_testpod_template.rb
+++ b/test/migration/build_testpod_template.rb
@@ -1,0 +1,55 @@
+require 'yaml'
+require 'json'
+require 'uri'
+require 'time'
+require 'net/http'
+require 'pathname'
+
+TEMPLATE = 'https://raw.githubusercontent.com/3scale/3scale-operator/master/pkg/3scale/amp/auto-generated-templates/amp/amp-eval.yml'
+
+def read_url(resource)
+  Net::HTTP.get(URI.parse(resource))
+end
+
+def system_dc(template)
+  dc = template.fetch('objects').find do |obj|
+    obj.fetch('kind') == 'DeploymentConfig' && obj.dig('metadata', 'name') == 'system-app'
+  end
+  raise "system deployment config not found from #{TEMPLATE}" if dc.nil?
+
+  dc
+end
+
+def pre_hook(template)
+  system_dc(template).dig('spec', 'strategy', 'rollingParams', 'pre')
+end
+
+def pre_hook_command(template)
+  pre_hook(template).dig('execNewPod', 'command')
+end
+
+def pre_hook_env(template)
+  pre_hook(template).dig('execNewPod', 'env')
+end
+
+POD_NAME = ARGV[0]
+IMAGE = ARGV[1]
+
+amp_template = YAML.safe_load(read_url(TEMPLATE))
+
+pod_template = {
+  apiVersion: 'v1',
+  spec: {
+    containers: [
+      {
+        name: POD_NAME,
+        image: IMAGE,
+        tty: true,
+        command: pre_hook_command(amp_template),
+        env: pre_hook_env(amp_template)
+      }
+    ]
+  }
+}
+
+puts pod_template.to_json

--- a/test/migration/run_migration_test.sh
+++ b/test/migration/run_migration_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Exit script if you try to use an uninitialized variable.
+set -o nounset
+# Exit script if a statement returns a non-true return value.
+set -o errexit
+# Use the error status of the first failure, rather than that of the last item in a pipeline.
+set -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+POD_NAME=system-migration
+
+system_image() {
+  oc get is amp-system-master -o=go-template='{{ .status.dockerImageRepository }}'
+}
+
+POD_IMAGE=$(system_image)
+echo "IMAGE: ${POD_IMAGE}"
+
+build_pod_spec() {
+  ruby $DIR/build_testpod_template.rb ${POD_NAME} ${POD_IMAGE}
+}
+
+oc run ${POD_NAME} --rm -ti --image ${POD_IMAGE} --restart=Never --wait=true --overrides="$(build_pod_spec)"


### PR DESCRIPTION
**What this PR does / why we need it**:

A test to validate 3scale release upgrade procedure is needed. High level, the test does the following:
* Installs previous 3scale release
* Run migration / upgrade procedure
* Check migration has been successful

Implemented as a CircleCi test to validate 3scale release upgrade procedure. The test goes as follows:

* installs _previous_ 3scale release. Previous release is set as job parameter to be easily changed when a new version is released. Currently, previous release is *2.6*
* builds current master release of porta image
* Run the `system-app` prehook command (defined in templates/operator) from recently built porta master image.
* Test will pass if prehook command returns successfully (exit code is 0). 

Currently the test is quite simple. IMO, it could be improved in, at least, two ways:
* Installed 3scale _previous_ release contains just initial data. It could be interesting adding some kind of data (like proxy info, backend info, product info, whatever...) that could lead to edge cases to test upgrade procedure.
* Test will pass if prehook command returns successfully (exit code is 0). This could lead to false positives. For instance, the migration process misses upgrading some table. The upgrade procedure will still succeed, but the migration process is clearly failing to be complete.

Those enhancements, though, could be added later in other PR's. 

**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3808

Data model and actual data migration process can be broken and nobody notices it. 

**Verification steps** 

**Special notes for your reviewer**:
