### PR TITLE
Reorganization of APIcast configuration view for APIAP

### DIFF
--- a/app/assets/stylesheets/provider/_settings_box.scss
+++ b/app/assets/stylesheets/provider/_settings_box.scss
@@ -95,6 +95,22 @@
     position: relative;
   }
 
+  &-backend-summary {
+    border-left: line-height-times(1/4) solid $border-color;
+    margin: line-height-times(1) 0 line-height-times(2);
+    padding-left: line-height-times(1);
+    dt.u-dl-term {
+      width: calc(40% - #{line-height-times(3/4)});
+    }
+    dd.u-dl-definition {
+      padding-left: calc(40% - #{line-height-times(3/4)});
+    }
+  }
+
+  &-promote-button {
+    border-top: $border-width solid $border-color;
+  }
+
   &-title {
     margin: 0 !important;
   }

--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -221,10 +221,17 @@ module Api::IntegrationsHelper
 
   def backend_routing_rule(backend_api_config)
     path = StringUtils::StripSlash.strip_slash(backend_api_config.path.presence)
-    code = content_tag :code do
-      "/#{path} => "
+    content_tag :code do
+      "/#{path} => #{backend_api_config.backend_api.private_endpoint}"
     end
-    endpoint = backend_api_config.backend_api.private_endpoint
-    code + endpoint
+  end
+
+  def proxy_rules_preview(proxy_rules, path: nil)
+    last_rule = proxy_rules.last
+    return 'None' unless last_rule
+    code = content_tag(:code) { "#{path}#{last_rule.pattern} => #{last_rule.metric.name}" }
+    rules_size = proxy_rules.size
+    more = rules_size > 1 ? " and #{rules_size - 1} more." : ''
+    code + more
   end
 end

--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -21,7 +21,7 @@ module BackendApiLogic
       end
 
       def to_a
-        rules = backend_api_configs.reordering { sift(:desc, :path) }.each_with_object([]) do |config, collection|
+        rules = backend_api_configs.sorted_for_proxy_config.each_with_object([]) do |config, collection|
           rule = Rule.new(config).as_json
           collection << rule if rule
         end

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -30,6 +30,8 @@ class BackendApiConfig < ApplicationRecord
     joining { service }.where.has { (service.state != ::Service::DELETE_STATE) }
   end
 
+  scope :sorted_for_proxy_config, -> { reordering { sift(:desc, :path) } }
+
   delegate :private_endpoint, to: :backend_api
 
   def path=(value)

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -6,36 +6,40 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
     h3.Configuration-title = deployment_option_is_service_mesh?(@service) ? 'Service mesh Configuration' : 'APIcast Configuration'
 
     dl.u-dl
-      - unless deployment_option_is_service_mesh?(@service)
-        - if current_account.provider_can_use?(:api_as_product)
-          - backend_api_configs = @service.backend_api_configs
-          dt.u-dl-term Private Base #{'URL'.pluralize backend_api_configs.count}
-          dd.u-dl-definition
-            ul
-            - for backend_api_config in backend_api_configs
-              li
-                = backend_routing_rule(backend_api_config)
-        - else
-          dt.u-dl-term Private Base URL
-          dd.u-dl-definition = @proxy.api_backend
+      - if apiap?
+        dt.u-dl-term
+          h4
+            => icon('cubes')
+            = @service.name
+        dd.u-dl-definition
+      - elsif !deployment_option_is_service_mesh?(@service)
+        dt.u-dl-term Private Base URL
+        dd.u-dl-definition = @proxy.api_backend
 
       dt.u-dl-term Mapping rules
-      dd.u-dl-definition
-        - if (last_rule = @proxy.proxy_rules.last)
-          code
-            ' #{last_rule.pattern} => #{last_rule.metric.name}
-        - if (rules_size = @proxy.proxy_rules.size) > 1
-          | and #{rules_size - 1} more.
+      dd.u-dl-definition = proxy_rules_preview(@proxy.proxy_rules)
+
       - unless deployment_option_is_service_mesh?(@service)
         dt.u-dl-term Credential Location
         dd.u-dl-definition = @proxy.credentials_location
         dt.u-dl-term Secret Token
         dd.u-dl-definition = @proxy.secret_token
 
-
       - if apiap?
+        - unless deployment_option_is_service_mesh?(@service)
+          - @service.backend_api_configs.sorted_for_proxy_config.includes(:backend_api).each do |backend_api_config|
+            - backend_api = backend_api_config.backend_api
+            div.Configuration-backend-summary
+              dt.u-dl-term
+                h4
+                  => icon('cube')
+                  = backend_api.name
+              dd.u-dl-definition = backend_routing_rule(backend_api_config)
+              dt.u-dl-term Mapping rules
+              dd.u-dl-definition = proxy_rules_preview(backend_api.proxy_rules, path: backend_api_config.path)
+
         dt.u-dl-term Promote
-        dd.u-dl-definition
+        dd.u-dl-definition.Configuration-promote-button
           = semantic_form_for @proxy, url: admin_service_integration_path(@service) do |f|
             = f.hidden_field :lock_version
             = f.button *promote_to_staging_button_options(@show_presenter)


### PR DESCRIPTION
It reorganizes how APIcast Configuration info is displayed for APIAP accounts, making it more clear that Backends are composing parts of Products, they also bring their own mapping rules to the configuration.

It also now shows the backends in the same order as they will be injected into the routing policy rules.

![Screen Shot 2019-10-25 at 5 19 26 PM](https://user-images.githubusercontent.com/1842261/67583490-febe4100-f74b-11e9-94c4-9a5607b5143b.png)

Related to [THREESCALE-3781](https://issues.jboss.org/browse/THREESCALE-3781) (although it doesn't really show the full list of mapping rules, but it already communicates better to the user)