### PR TITLE
Include analytics script only when analytics are enabled

### DIFF
--- a/app/views/provider/_analytics.html.erb
+++ b/app/views/provider/_analytics.html.erb
@@ -1,27 +1,27 @@
 <%= yield :analytics %>
 
 <%= analytics do |enabled| %>
-  <script type="text/javascript">
-    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
-      <%- if enabled %>
-        analytics.load("<%= segment.write_key %>");
-      <%- end %>
-    }}();
-  </script>
+  <%- if enabled %>
+    <script type="text/javascript">
+      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
+          analytics.load("<%= segment.write_key %>");
+      }}();
+    </script>
 
-  <script type="text/javascript">
-    <%- while (event = analytics_session.shift) -%>
-    <%- name, *args = event -%>
-    analytics[<%= json name %>].apply(analytics, <%= json args %>);
-    <%- end -%>
+    <script type="text/javascript">
+      <%- while (event = analytics_session.shift) -%>
+      <%- name, *args = event -%>
+      analytics[<%= json name %>].apply(analytics, <%= json args %>);
+      <%- end -%>
 
-    analytics.identify(<%= json current_user.try(:id) %>, <%= json analytics_identity_data %>);
-    analytics.page(<%= json @analytics_page %>);
+      analytics.identify(<%= json current_user.try(:id) %>, <%= json analytics_identity_data %>);
+      analytics.page(<%= json @analytics_page %>);
 
-    <%- if current_user && current_user.account.users.but_impersonation_admin.size > 1  -%>
-    analytics.group(<%= current_user.account.id %>, {
-      name: <%= json current_user.account.org_name %>
-    });
-    <%- end -%>
-  </script>
+      <%- if current_user && current_user.account.users.but_impersonation_admin.size > 1  -%>
+      analytics.group(<%= current_user.account.id %>, {
+        name: <%= json current_user.account.org_name %>
+      });
+      <%- end -%>
+    </script>
+  <%- end %>
 <% end %>


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently analytics scripts are loaded even when analytics are not enabled, simply `load()` method is not called but the script is loaded.
Scripts must be loaded only when analytics are enabled.

