### PR TITLE
Use create_or_find_by instead of find_or_create_by with retry

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -400,7 +400,7 @@ class Account < ApplicationRecord
 
   # @param [SystemOperation] operation
   def fetch_dispatch_rule(operation)
-    MailDispatchRule.fetch_with_retry!(system_operation: operation, account: self) do |m|
+    MailDispatchRule.create_or_find_by!(system_operation: operation, account: self) do |m|
       m.dispatch = false if %w[weekly_reports daily_reports new_forum_post].include?(operation.ref)
       m.emails = emails.first
     end

--- a/app/models/mail_dispatch_rule.rb
+++ b/app/models/mail_dispatch_rule.rb
@@ -6,18 +6,10 @@ class MailDispatchRule < ApplicationRecord
 
   scope :enabled, -> { where(dispatch: true) }
 
-  def self.fetch_with_retry!(options, &block)
-    retries = 0
-
-    begin
-      MailDispatchRule.find_or_create_by!(options, &block)
-    rescue ActiveRecord::RecordNotUnique
-      if retries > 10
-        raise
-      else
-        retries += 1
-        retry
-      end
-    end
+  # This is copied from Rails 6 source. We should remove it soon as we move to Rails 6.
+  def self.create_or_find_by!(options, &block)
+    transaction(requires_new: true) { create!(options, &block) }
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(options, &block)
   end
 end

--- a/test/unit/mail_dispatch_rule_test.rb
+++ b/test/unit/mail_dispatch_rule_test.rb
@@ -2,14 +2,24 @@ require 'test_helper'
 
 class MailDispatchRuleTest < ActiveSupport::TestCase
 
-  def test_fetch_with_retry
-    expected = nil
-    rule = MailDispatchRule.fetch_with_retry!(account_id: 1, system_operation_id: 1) do |rule|
-      expected = rule.dup
-      expected.save!
-    end
+  def test_create_or_find_by
+    assert_nil MailDispatchRule.find_by(account_id: 1, system_operation_id: 1)
 
-    assert_equal expected , rule
+    dispatch_rule = MailDispatchRule.create!(account_id: 1, system_operation_id: 1)
+
+    assert_equal dispatch_rule, MailDispatchRule.create_or_find_by!(account_id: 1, system_operation_id: 1)
+    assert_not_equal dispatch_rule, MailDispatchRule.create_or_find_by!(account_id: 1, system_operation_id: 2)
+  end
+
+  def test_create_or_find_by_within_transaction
+    assert_nil MailDispatchRule.find_by(account_id: 1, system_operation_id: 1)
+
+    dispatch_rule = MailDispatchRule.create!(account_id: 1, system_operation_id: 1)
+
+    MailDispatchRule.transaction do
+      assert_equal dispatch_rule, MailDispatchRule.create_or_find_by!(account_id: 1, system_operation_id: 1)
+      assert_not_equal dispatch_rule, MailDispatchRule.create_or_find_by!(account_id: 1, system_operation_id: 2)
+    end
   end
 
   test 'is unique' do


### PR DESCRIPTION
[THREESCALE-3785](https://issues.jboss.org/browse/THREESCALE-3785)
We have a problem in MailDispatchRule that can be from a Race Condition.
There are some RecordNotUnique errors exploding when the
DeleteObjectHierarchy Worker runs. This commit changes this to first try
to insert in the database, if it fails, we execute the find by.