### PR TITLE
Adjust width and height of colorbox modals

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -171,10 +171,15 @@
       $(this).on('ajax:complete', function(event, xhr, status){
         var form = $(this).closest('form');
         var width = form.data('width');
-        $.colorbox({ open:true, html: xhr.responseText, width: width });
+        $.colorbox({
+          open: true,
+          html: xhr.responseText,
+          width: width,
+          maxWidth: '85%',
+          maxHeight: '90%'
+        });
       })
     });
-
 
     $("a.fancybox, a.colorbox").live("click", function(e) {
       $(this).colorbox({ open:true });

--- a/app/assets/stylesheets/provider/_colorbox.scss
+++ b/app/assets/stylesheets/provider/_colorbox.scss
@@ -44,6 +44,10 @@
       }
     }
   }
+
+  table.data + form {
+    margin: line-height-times(1) 0;
+  }
 }
 
 #cboxOverlay{


### PR DESCRIPTION
**What this PR does / why we need it**:

Some modal windows are too wide:
![before](https://user-images.githubusercontent.com/13486237/67764197-ba7fb900-fa49-11e9-8737-81e9234c314e.png)

Setting some max width and height they looks better:
![after](https://user-images.githubusercontent.com/13486237/67774553-dee59080-fa5d-11e9-8c06-480c875b106d.png)


**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3807

**Verification steps** 

1. Login to SaaS master account
2. Go to Audience->Account->Listing and select an account
3. Under account details, select a plan and click on "Change plan" 

This branch is deployed in [preview](https://multitenant-admin.preview01.3scale.net/buyers/accounts/2445582823158)
