### PR TITLE
Nullify api_backend when APIAP routing policy is used

### DIFF
--- a/app/services/apicast_v2_deployment_service.rb
+++ b/app/services/apicast_v2_deployment_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApicastV2DeploymentService
   attr_reader :proxy
 
@@ -22,6 +24,7 @@ class ApicastV2DeploymentService
   def json_source
     proxy_source = Apicast::ProxySource.new(proxy).to_hash
     proxy_source['proxy']['proxy_rules'] = Apicast::ProxyRulesSource.new(proxy).to_hash
+    proxy_source['proxy']['api_backend'] = nil if proxy.with_subpaths?
     proxy_source.to_json
   end
 end

--- a/test/unit/services/apicast_v2_deployment_service_test.rb
+++ b/test/unit/services/apicast_v2_deployment_service_test.rb
@@ -58,9 +58,11 @@ class ApicastV2DeploymentServiceTest < ActiveSupport::TestCase
   end
 
   test 'api_backend is nil when product has multiple backends' do
-    # Service has more than 1 backend
+    @proxy.stubs(with_subpaths?: true)
+
     config = Service.new(@proxy).call(environment: ProxyConfig::ENVIRONMENTS.first)
-    api_backend = JSON.parse(config.content, symbolize_names: true)[:proxy][:api_backend]
+    json_content = JSON.parse(config.content, symbolize_names: true)
+    api_backend = json_content.dig(:proxy, :api_backend)
 
     assert_equal api_backend, nil
   end

--- a/test/unit/services/apicast_v2_deployment_service_test.rb
+++ b/test/unit/services/apicast_v2_deployment_service_test.rb
@@ -64,6 +64,6 @@ class ApicastV2DeploymentServiceTest < ActiveSupport::TestCase
     json_content = JSON.parse(config.content, symbolize_names: true)
     api_backend = json_content.dig(:proxy, :api_backend)
 
-    assert_equal api_backend, nil
+    assert_nil api_backend
   end
 end

--- a/test/unit/services/apicast_v2_deployment_service_test.rb
+++ b/test/unit/services/apicast_v2_deployment_service_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ApicastV2DeploymentServiceTest < ActiveSupport::TestCase
@@ -16,7 +18,6 @@ class ApicastV2DeploymentServiceTest < ActiveSupport::TestCase
     Service.new(@proxy).call(environment: ProxyConfig::ENVIRONMENTS.first)
     assert_match policies.first.to_json, @proxy.proxy_configs.last.content
   end
-
 
   def test_save_proxy_rules_with_position
     @proxy.proxy_rules.destroy_all
@@ -56,6 +57,11 @@ class ApicastV2DeploymentServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test 'api_backend is nil when product has multiple backends' do
+    # Service has more than 1 backend
+    config = Service.new(@proxy).call(environment: ProxyConfig::ENVIRONMENTS.first)
+    api_backend = JSON.parse(config.content, symbolize_names: true)[:proxy][:api_backend]
 
+    assert_equal api_backend, nil
+  end
 end
-


### PR DESCRIPTION
**What this PR does / why we need it**:

When a product is using multiple backend, system still injects the old api_backend attribute into the proxy configuration. With this PR, `api_backend` is set to `nil` for new proxy configs when there are more than 1 backend.

**Which issue(s) this PR fixes** 

[THREESCALE-3775: Nullify old api_backend attribute when APIAP routing policy is used](https://issues.jboss.org/browse/THREESCALE-3775)
