### PR TITLE
Removing box shadows from nested cards in APIAP intengration page

### DIFF
--- a/app/assets/stylesheets/provider/_settings_box.scss
+++ b/app/assets/stylesheets/provider/_settings_box.scss
@@ -1,6 +1,13 @@
+.SettingsBox {
+  @include white-box-shadow;
+}
+
+#integration-tabs .integration .SettingsBox {
+  box-shadow: none;
+}
+
 .SettingsBox,
 .IntegrationSettingsBox {
-  @include white-box-shadow;
   position: relative;
 
   &-toggle {
@@ -43,6 +50,7 @@
   & + .integration {
     @include white-box-shadow;
     margin-top: line-height-times(1);
+    overflow: hidden;
     padding: line-height-times(1);
   }
 
@@ -90,8 +98,7 @@
   }
 
   &-summary {
-    @include white-box-shadow;
-    border: $border-width-lg solid transparent;
+    border: $border-width-lg solid $border-color;
     min-height: line-height-times(2);
     padding: line-height-times(1);
     position: relative;


### PR DESCRIPTION
**What this PR does / why we need it**:

Nested cards in APIAP integration page are showing box-shadow, but it must be there only for not-nested cards, also the vertical line should not overflow outside container.

**Before:**
![before](https://user-images.githubusercontent.com/13486237/67939101-23de0400-fbd1-11e9-99a8-eb9cd2cfa6b3.png)

**After:**
![after](https://user-images.githubusercontent.com/13486237/67939116-2b9da880-fbd1-11e9-81ae-fc8abdb0d8ff.png)
