### PR TITLE
Fix broken bubbles

### DIFF
--- a/app/assets/javascripts/help.js.erb
+++ b/app/assets/javascripts/help.js.erb
@@ -20,19 +20,30 @@ if(typeof Help == 'undefined'){
         var layerTopPos  = 10,
             layerLeftPos = 10;
 
+        var textRight = $image.offset().left + $helperLayer.width();
 
         var offset = (function(i, l){
-            var top  = i.offset().top - (i.offset().top - i.position().top) + i.height() - 1,
-                left = i.offset().left - (i.offset().left - i.position().left);
+            var top  = i.offset().top - (i.offset().top - i.position().top) + i.height() - 1;
+            var left = i.offset().left - (i.offset().left - i.position().left);
 
+            if (textRight > $(window).width()) {
+             left = left - l.width();
+            }
             return {top:top, left:left};
         })($image, $helperLayer);
 
   			$helperLayer.css({zIndex:99999});
         $helperLayer.show();
-        $helperLayer.css({top: offset.top + 'px', left:offset.left + "px" });
+        $helperLayer.css({top: offset.top + 'px', left: offset.left + 'px' });
+        if (textRight > $(window).width()) {
+          $helperLayer.css({
+            borderTopRightRadius: 0,
+            borderTopLeftRadius: '0.1875rem'
+          })
+        }
         image.src = '<%= asset_path('provider/icons/questionClose.png') %>';
         image.style.zIndex = 100000;
+        
       }
     }
   };

--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -149,10 +149,6 @@ form.formtastic fieldset.inputs > ol > li.select select {
   border-radius: $border-radius;
 }
 
-form.formtastic fieldset.inputs > ol > li.select select {
-
-}
-
 form.formtastic fieldset.buttons {
   border-top: $border-width solid $border-color;
   text-align: right;
@@ -203,6 +199,15 @@ form + form .action.delete {
 
 form.formtastic ol > li#api_docs_service_body_input {
     max-width: 100%;
+}
+
+form.formtastic {
+  #settings,
+  #staging {
+    .inputs ol {
+      position: relative;
+    }
+  }
 }
 
 form.formtastic ol > li {

--- a/app/assets/stylesheets/provider/_inline_helper.scss
+++ b/app/assets/stylesheets/provider/_inline_helper.scss
@@ -25,6 +25,6 @@
 
 .formtastic .helpButton {
   position: absolute;
-  right: line-height-times(-1/4);
+  right: 0;
   top: 0;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Some popup bubbles are broken, sometimes showing a space between the icon (?) and the text box, and sometimes are displayed at the right (outside the browser window).

**Before:**
![before](https://user-images.githubusercontent.com/13486237/67961443-ffe3e800-fbfb-11e9-88d8-81945b18af0d.png)

**After:**
![after](https://user-images.githubusercontent.com/13486237/67961479-0b371380-fbfc-11e9-9395-313814426119.png)

**Brach deployed to preview**: https://multitenant-admin.preview01.3scale.net/p/admin/dashboard

**Note:** Bubbles needs a whole refactor, this is just a quick-fix
New task created for 2.8 release https://issues.jboss.org/browse/THREESCALE-3854