### PR TITLE
Display a deprecated message when Service uses plugin deployment

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -521,6 +521,18 @@ class Service < ApplicationRecord
     proxy.apicast_configuration_driven && !proxy.service_mesh_integration?
   end
 
+  # TODO: Remove this when no one use plugins
+  def plugin_deployment?
+    deployment = self[:deployment_option]
+    DeploymentOption.plugins.include?(deployment)
+  end
+
+  # TODO: Remove this when no one use plugins
+  def deployment_option
+    return 'hosted' if plugin_deployment?
+    super
+  end
+
   private
 
   def archive_as_deleted

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -523,14 +523,7 @@ class Service < ApplicationRecord
 
   # TODO: Remove this when no one use plugins
   def plugin_deployment?
-    deployment = self[:deployment_option]
-    DeploymentOption.plugins.include?(deployment)
-  end
-
-  # TODO: Remove this when no one use plugins
-  def deployment_option
-    return 'hosted' if plugin_deployment?
-    super
+    DeploymentOption.plugins.include?(deployment_option)
   end
 
   private

--- a/app/views/api/services/settings_apiap.html.slim
+++ b/app/views/api/services/settings_apiap.html.slim
@@ -1,4 +1,5 @@
 - content_for :sublayout_title, 'Settings'
+
 = semantic_form_for @service, :url => admin_service_path(@service) do |form|
   = render :partial => 'api/services/forms/integration_settings_apiap', :locals => {:form => form}
   = form.buttons do

--- a/app/views/layouts/api/_service.html.slim
+++ b/app/views/layouts/api/_service.html.slim
@@ -2,6 +2,7 @@
   h1
     = yield :sublayout_title
 
+/ TODO: Remove this when no one use plugins
 = render 'shared/service/deprecated_plugin_warning'
 
 = yield

--- a/app/views/layouts/api/_service.html.slim
+++ b/app/views/layouts/api/_service.html.slim
@@ -2,4 +2,6 @@
   h1
     = yield :sublayout_title
 
+= render 'shared/service/deprecated_plugin_warning'
+
 = yield

--- a/app/views/shared/service/_deprecated_plugin_warning.html.slim
+++ b/app/views/shared/service/_deprecated_plugin_warning.html.slim
@@ -1,9 +1,7 @@
 - if @service&.plugin_deployment?
-  = semantic_form_for @service, :url => admin_service_path(@service) do |form|
+  = form_for @service, :url => admin_service_path(@service) do |form|
     .deprecated_plugin_message
       p.InfoBox--notice.InfoBox
-        'Your product currently uses plugin as deployment option. We no longer support plugins. Please update your settings.
-        = form.input :deployment_option,
-                as: :hidden
-        = form.buttons do
-          = form.commit_button 'Ok'
+        i This Product currently uses a plugin as the deployment option. Your integration will keep on working but we no longer support plugins.
+        = form.hidden_field :deployment_option
+        = form.submit 'Ok', class: 'button next outline-button-thin outline-button-thin--positive'

--- a/app/views/shared/service/_deprecated_plugin_warning.html.slim
+++ b/app/views/shared/service/_deprecated_plugin_warning.html.slim
@@ -1,7 +1,4 @@
 - if @service&.plugin_deployment?
-  = form_for @service, :url => admin_service_path(@service) do |form|
-    .deprecated_plugin_message
-      p.InfoBox--notice.InfoBox
-        i This Product currently uses a plugin as the deployment option. Your integration will keep on working but we no longer support plugins.
-        = form.hidden_field :deployment_option
-        = form.submit 'Ok', class: 'button next outline-button-thin outline-button-thin--positive'
+  .deprecated_plugin_message
+    p.InfoBox--notice.InfoBox
+      i This Product currently uses a plugin as the deployment option. Your integration will keep on working but we no longer support plugins.

--- a/app/views/shared/service/_deprecated_plugin_warning.html.slim
+++ b/app/views/shared/service/_deprecated_plugin_warning.html.slim
@@ -1,0 +1,9 @@
+- if @service&.plugin_deployment?
+  = semantic_form_for @service, :url => admin_service_path(@service) do |form|
+    .deprecated_plugin_message
+      p.InfoBox--notice.InfoBox
+        'Your product currently uses plugin as deployment option. We no longer support plugins. Please update your settings.
+        = form.input :deployment_option,
+                as: :hidden
+        = form.buttons do
+          = form.commit_button 'Ok'

--- a/test/unit/helpers/services_helper_test.rb
+++ b/test/unit/helpers/services_helper_test.rb
@@ -7,8 +7,5 @@ class ServicesHelperTest < ActionView::TestCase
 
     @service.deployment_option = 'hosted'
     assert show_mappings?
-
-    @service.deployment_option = 'plugin_java'
-    refute show_mappings?
   end
 end

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -318,6 +318,22 @@ class ServiceTest < ActiveSupport::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { service.reload }
   end
 
+  test '#plugin_deployment? returns true when using a plugin as deployment option' do
+    service = FactoryBot.build(:service, deployment_option: 'plugin_ruby')
+
+    assert service.plugin_deployment?
+
+    service = FactoryBot.build(:service, deployment_option: 'hosted')
+
+    refute service.plugin_deployment?
+  end
+
+  test '#deployment_option should default to hosted if using plugin as deployment option' do
+    service = FactoryBot.build(:service, deployment_option: 'plugin_ruby')
+
+    assert_equal 'hosted', service.deployment_option
+  end
+
   def test_default_service_plan
     service = FactoryBot.build(:simple_service)
     service.account.settings.service_plans_ui_visible = true

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -328,12 +328,6 @@ class ServiceTest < ActiveSupport::TestCase
     refute service.plugin_deployment?
   end
 
-  test '#deployment_option should default to hosted if using plugin as deployment option' do
-    service = FactoryBot.build(:service, deployment_option: 'plugin_ruby')
-
-    assert_equal 'hosted', service.deployment_option
-  end
-
   def test_default_service_plan
     service = FactoryBot.build(:simple_service)
     service.account.settings.service_plans_ui_visible = true


### PR DESCRIPTION
[THREESCALE-2395](https://issues.jboss.org/browse/THREESCALE-2395)

Our plugin deployment option is deprecated. To avoid needing some data migration in database, this commit sets the deployment option as hosted if the current option is set to plugins and also displays a message to the user to update their configuration.

<img width="1403" alt="Screenshot 2019-11-04 21 12 35" src="https://user-images.githubusercontent.com/54224/68154606-28dfe200-ff48-11e9-999c-17c596278953.png">
