### PR TITLE
[npm] Fix https-proxy-agent vulnerability (MitM)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8518,9 +8518,9 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",


### PR DESCRIPTION
* https://snyk.io/vuln/SNYK-JS-HTTPSPROXYAGENT-469131

**What this PR does / why we need it**:

Npm reported a vulnerability in one of our dependencies: `https-proxy-agent` 

**Which issue(s) this PR fixes** 

No issue associated.

**Verification steps** 

Run `npm install` after checkout and instead of warnings, the notice `found 0 vulnerabilities` should be shown