### PR TITLE
Don't display backends in master account

### DIFF
--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -300,6 +300,10 @@ module Logic
       end
 
       class ApiAsProduct < Base
+        def enabled?
+          super && !master?
+        end
+
         def missing_config
           false
         end


### PR DESCRIPTION
**What this PR does / why we need it**:

Revert Master Account to 2.7 functionality by putting it behind the rolling update `api_as_product`.

**Which issue(s) this PR fixes** 

[THREESCALE-3786: Don't display backends in master account](https://issues.jboss.org/browse/THREESCALE-3786)

**Verification steps** 

Master account should work like a non-APIAP account.
