### PR TITLE
Prevent trailing slash in patterns of proxy rules of backend api configs with a path

### DIFF
--- a/app/decorators/proxy_rule_decorator.rb
+++ b/app/decorators/proxy_rule_decorator.rb
@@ -5,7 +5,10 @@ class ProxyRuleDecorator < ApplicationDecorator
 
   def pattern
     pattern_value = object.pattern
-    backend_api_path ? File.join('/', backend_api_path, pattern_value) : pattern_value
+    return pattern_value unless backend_api_path
+    parts = ['/', backend_api_path]
+    parts << pattern_value unless pattern_value == '/'
+    File.join(*parts)
   end
 
   def metric_system_name

--- a/test/decorators/proxy_rule_decorator_test.rb
+++ b/test/decorators/proxy_rule_decorator_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProxyRuleDecoratorTest < Draper::TestCase
+  setup do
+    @backend_api = FactoryBot.create(:backend_api)
+  end
+
+  attr_reader :backend_api, :service
+
+  test 'pattern for backend with path' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/hello')
+    decorator = proxy_rule.decorate(context: { backend_api_path: 'mybackend' })
+    assert_equal '/mybackend/hello', decorator.pattern
+  end
+
+  test 'pattern for backend without path' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/hello')
+    decorator = proxy_rule.decorate(context: { backend_api_path: '' })
+    assert_equal '/hello', decorator.pattern
+  end
+
+  test 'catch-all pattern for backend with path' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/')
+    decorator = proxy_rule.decorate(context: { backend_api_path: 'mybackend' })
+    assert_equal '/mybackend', decorator.pattern
+  end
+
+  test 'catch-all pattern for backend without path' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/')
+    decorator = proxy_rule.decorate(context: { backend_api_path: '' })
+    assert_equal '/', decorator.pattern
+  end
+end


### PR DESCRIPTION
This will make proxy rules whose pattern is the "catch-all" pattern `/` not to end with the slash if the pattern has been prepended by a backend api path.

**Example 1**
Backend path: `/mybackend`
Proxy rule pattern: `/`
Actual proxy rule pattern in the config: `/mybackend` (it used to be `/mybackend/` before this PR)

**Example 2**
Backend path: `/mybackend`
Proxy rule pattern: `/hello`
Actual proxy rule pattern in the config: `/mybackend/hello` (same as before)

**Example 3**
Backend path: `/`
Proxy rule pattern: `/`
Actual proxy rule pattern in the config: `/` (same as before)

**Example 4**
Backend path: `/`
Proxy rule pattern: `/hello`
Actual proxy rule pattern in the config: `/hello` (same as before)

----

Closes [THREESCALE-3833](https://issues.jboss.org/browse/THREESCALE-3833)