### PR TITLE
[wip] [Bugfix] ProxyRule pattern in the response should not strip slashes

### DIFF
--- a/app/decorators/proxy_rule_decorator.rb
+++ b/app/decorators/proxy_rule_decorator.rb
@@ -4,9 +4,8 @@ class ProxyRuleDecorator < ApplicationDecorator
   self.include_root_in_json = false
 
   def pattern
-    path_joined_parts = ['/', backend_api_path, object.pattern].join('/')
-    path_without_duplicated_slashes = path_joined_parts.gsub(%r{\/{2,}}, '/')
-    path_without_duplicated_slashes.chomp('/').presence || '/'
+    parts = [backend_api_path, object.pattern].compact
+    '/' + parts.map { |part| StringUtils::StripSlash.strip_slash(part).presence }.compact.join('/')
   end
 
   def metric_system_name

--- a/app/decorators/proxy_rule_decorator.rb
+++ b/app/decorators/proxy_rule_decorator.rb
@@ -4,11 +4,9 @@ class ProxyRuleDecorator < ApplicationDecorator
   self.include_root_in_json = false
 
   def pattern
-    pattern_value = object.pattern
-    return pattern_value unless backend_api_path
-    parts = ['/', backend_api_path]
-    parts << pattern_value unless pattern_value == '/'
-    File.join(*parts)
+    path_joined_parts = ['/', backend_api_path, object.pattern].join('/')
+    path_without_duplicated_slashes = path_joined_parts.gsub(%r{\/{2,}}, '/')
+    path_without_duplicated_slashes.chomp('/').presence || '/'
   end
 
   def metric_system_name

--- a/test/decorators/proxy_rule_decorator_test.rb
+++ b/test/decorators/proxy_rule_decorator_test.rb
@@ -9,27 +9,66 @@ class ProxyRuleDecoratorTest < Draper::TestCase
 
   attr_reader :backend_api, :service
 
-  test 'pattern for backend with path' do
+  test '#pattern' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/hello')
+    decorator = proxy_rule.decorate
+    assert_equal '/hello', decorator.pattern
+  end
+
+  test 'catch-all pattern' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/')
+    decorator = proxy_rule.decorate
+    assert_equal '/', decorator.pattern
+  end
+
+  test '#pattern for backend with simple path' do
     proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/hello')
     decorator = proxy_rule.decorate(context: { backend_api_path: 'mybackend' })
     assert_equal '/mybackend/hello', decorator.pattern
   end
 
-  test 'pattern for backend without path' do
+  test '#pattern for backend with complex path' do
     proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/hello')
-    decorator = proxy_rule.decorate(context: { backend_api_path: '' })
-    assert_equal '/hello', decorator.pattern
+    decorator = proxy_rule.decorate(context: { backend_api_path: '/mybackend/v2' })
+    assert_equal '/mybackend/v2/hello', decorator.pattern
   end
 
-  test 'catch-all pattern for backend with path' do
+  test '#pattern with trailing slash' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/hello/')
+    decorator = proxy_rule.decorate(context: { backend_api_path: 'mybackend' })
+    assert_equal '/mybackend/hello', decorator.pattern
+  end
+
+  test 'catch-all pattern for backend with simple path' do
     proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/')
     decorator = proxy_rule.decorate(context: { backend_api_path: 'mybackend' })
     assert_equal '/mybackend', decorator.pattern
   end
 
-  test 'catch-all pattern for backend without path' do
-    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/')
-    decorator = proxy_rule.decorate(context: { backend_api_path: '' })
-    assert_equal '/', decorator.pattern
+  test 'complex patterns' do
+    patterns = %w(
+      /foo/{bar}/baz/{foo}/quux
+      /foo/{whatever}.json
+      /foo/bar.json
+      /foo.ext1/bar.ext2
+      /v1/word/{word}.json?app_id={app_id}&app_key={app_key}
+      /foo$
+      /foo$?bar=baz
+      /$
+      /TWAPData;{StartDateTime};{EndDateTime};{CurrencyPair},{ResponseType},{UserName},{Password}
+      /service1.svc/securejson/getdata/Tick;16122016100000;16122016100001;GBPJPY;,JSON,Username,Password
+      /business-central/rest/runtime/com.redhat.demos:BuildEntAppIn60Min:3.0/withvars/process/project1.SummitDemo/start
+      /TWAPDATA;{startDateTime};{endDateTime};{currencyPair},{responseType}
+      /optaplanner-webexamples-6.5.0.Final-redhat-2/rest/vehiclerouting/solution/solve
+      /optaplanner-webexamples-6.5.0.final-redhat-2/rest/vehiclerouting/solution/solve
+      /foo{lal}/
+      /foo/{bar}k/baz/{p}/quux
+      /http://www.url.com/something.asmx/
+    )
+    patterns.each do |pattern|
+      proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: pattern)
+      decorator = proxy_rule.decorate
+      assert_equal (pattern.ends_with?('/') ? pattern[0...-1] : pattern), decorator.pattern
+    end
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-3872](https://issues.jboss.org/browse/THREESCALE-3872)

1. [Refactor] ProxyRuleDecorator#pattern without using 'File'.
2. [Bugfix] ProxyRuleDecorator#pattern should not strip slashes.
