### PR TITLE
APIAP check returns false in the Wizard

### DIFF
--- a/app/controllers/provider/admin/onboarding/wizard/base_controller.rb
+++ b/app/controllers/provider/admin/onboarding/wizard/base_controller.rb
@@ -3,17 +3,11 @@ class Provider::Admin::Onboarding::Wizard::BaseController < FrontendController
 
   delegate :onboarding, to: :current_account
 
-  helper_method :apiap?
-
   def track_step(step)
     analytics.track('Wizard Step', step: step.to_s)
   end
 
   protected
-
-  def apiap?
-    site_account.provider_can_use? :api_as_product
-  end
 
   def service
     current_account.first_service!


### PR DESCRIPTION
**What this PR does / why we need it**:

The check was using `site_account` in case there was no provider available, which was a wrong assumption.

**Verification steps** 

> Wizard should feature instructions for Product and Backend
