### PR TITLE
Include PF4 styles for settings page

### DIFF
--- a/app/javascript/packs/settingsPageStyles.js
+++ b/app/javascript/packs/settingsPageStyles.js
@@ -1,0 +1,1 @@
+import 'patternflyStyles/settingsPage'

--- a/app/javascript/src/patternflyStyles/settingsPage.css
+++ b/app/javascript/src/patternflyStyles/settingsPage.css
@@ -1,0 +1,7 @@
+@import '~@patternfly/patternfly/components/Button/button.css';
+@import '~@patternfly/patternfly/components/Check/check.css';
+@import '~@patternfly/patternfly/components/Form/form.css';
+@import '~@patternfly/patternfly/components/FormControl/form-control.css';
+@import '~@patternfly/patternfly/components/InputGroup/input-group.css';
+@import '~@patternfly/patternfly/components/Radio/radio.css';
+@import '~@patternfly/patternfly/components/Select/select.css';

--- a/app/views/layouts/provider.html.slim
+++ b/app/views/layouts/provider.html.slim
@@ -9,6 +9,7 @@ html[lang="en"]
     = javascript_pack_tag 'PF4Styles/base'
     = render 'provider/theme'
     = render 'provider/analytics'
+    = javascript_pack_tag 'settingsPageStyles'
     = javascript_include_tag 'provider/layout/provider'
     = yield :javascripts
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The new integration settings component https://github.com/3scale/porta/pull/1315 is missing PF4 styles.
Since https://github.com/3scale/porta/pull/1019 we should import explicitly all PF4 styles required. This was a recommendation from PF4 team: https://github.com/patternfly/patternfly-react-seed/wiki/Disable-Patternfly-React-Auto-Style-Injection.


**Which issue(s) this PR fixes** 

https://issues.jboss.org/browse/THREESCALE-3563

**Verification steps** 

run `bundle exec rake webpack:compile && bundle exec rake assets:precompile`

**Special notes for your reviewer**:
Apply this patch to make it work:
```
diff --git a/app/javascript/packs/settings.js b/app/javascript/packs/settings.js
index e9bb1a69..0bfeb4b6 100644
--- a/app/javascript/packs/settings.js
+++ b/app/javascript/packs/settings.js
@@ -1,5 +1,5 @@
-import { initialize as authenticationWidget } from 'Settings/authentication-widget'
+import { initSettings as settingsWidgets } from 'Settings/index'

 document.addEventListener('DOMContentLoaded', () => {
-  authenticationWidget()
+  settingsWidgets({elementId: 'settings'})
 })
```