### PR TITLE
Simplify and improve performance of HiddenInput

### DIFF
--- a/app/javascript/src/Policies/components/PolicyChainHiddenInput.jsx
+++ b/app/javascript/src/Policies/components/PolicyChainHiddenInput.jsx
@@ -2,31 +2,17 @@
 
 import React from 'react'
 
-import type { ChainPolicy, StoredChainPolicy } from 'Policies/types'
+import type { ChainPolicy } from 'Policies/types'
 
-const filteredPolicyKeys = ['configuration', 'name', 'version', 'enabled']
-
-function filterPolicyKeys (policy: ChainPolicy): StoredChainPolicy {
-  return Object.keys(policy)
-    .filter(policyKey => filteredPolicyKeys.includes(policyKey))
-    .reduce((filteredPolicy, key) => {
-      // $FlowFixMe: refactor this method
-      filteredPolicy[key] = policy[key]
-      return filteredPolicy
-    }, {})
+type Props = {
+  policies: ChainPolicy[]
 }
 
-// TODO: Next iteration see if we can store the config as data field in Rails
-function parsePolicy (policy: ChainPolicy): StoredChainPolicy {
-  return {...filterPolicyKeys(policy), ...{configuration: policy.data}}
-}
+const PolicyChainHiddenInput = ({ policies }: Props) => {
+  // TODO: Next iteration see if we can store the config as data field in Rails
+  const parsedPolicies = policies.map(({ data, name, version, enabled }) => ({ configuration: data, name, version, enabled }))
+  const data = JSON.stringify(parsedPolicies)
 
-function parsePolicies (policies: Array<ChainPolicy>) {
-  return policies.map(policy => parsePolicy(policy))
-}
-
-const PolicyChainHiddenInput = ({policies}: {policies: Array<ChainPolicy>}) => {
-  let data = JSON.stringify(parsePolicies(policies))
   return (
     <input
       type='hidden'

--- a/spec/javascripts/Policies/components/PolicyChainHiddenInput.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyChainHiddenInput.spec.jsx
@@ -1,27 +1,37 @@
+// @flow
+
 import React from 'react'
+
 import { mount } from 'enzyme'
 import { PolicyChainHiddenInput } from 'Policies/components/PolicyChainHiddenInput'
 
-describe('PolicyRegistry Components', () => {
-  const policyChain = [
-    {id: '1', enabled: true, name: 'cors', humanName: 'CORS', description: 'CORS headers', version: '1.0.0', configuration: {}, $schema: '', data: {}},
-    {id: '2', enabled: true, name: 'echo', humanName: 'Echo', description: 'Echoes the request', version: '1.0.0', configuration: {}, $schema: '', data: {}}
-  ]
-  function setup () {
-    const props = {
-      policies: policyChain
-    }
+import type { ChainPolicy } from 'Policies/types'
 
-    const inputWrapper = mount(<PolicyChainHiddenInput {...props} />)
+const policies: ChainPolicy[] = [
+  { id: 1, enabled: true, name: 'cors', humanName: 'CORS', description: 'CORS headers', version: '1.0.0', configuration: {}, $schema: '', data: {} },
+  { id: 2, enabled: true, name: 'echo', humanName: 'Echo', description: 'Echoes the request', version: '1.0.0', configuration: {}, $schema: '', data: {} }
+]
 
-    return {
-      props,
-      inputWrapper
-    }
+it('should render itself', () => {
+  const wrapper = mount(<PolicyChainHiddenInput policies={policies} />)
+
+  const input = wrapper.find('input')
+  expect(input.prop('id')).toBe('proxy[policies_config]')
+  expect(input.prop('type')).toBe('hidden')
+})
+
+it('should render an input with the parsed policies as value', () => {
+  const wrapper = mount(<PolicyChainHiddenInput policies={policies} />)
+
+  const value = wrapper.find('input').prop('value')
+  const data = JSON.parse(value)
+
+  expect(data).toHaveLength(policies.length)
+
+  for (const policy of data) {
+    expect(policy).toHaveProperty('configuration', {})
+    expect(policy).toHaveProperty('name')
+    expect(policy).toHaveProperty('version', '1.0.0')
+    expect(policy).toHaveProperty('enabled', true)
   }
-  it('should render the input with filtered chain', () => {
-    const {inputWrapper} = setup()
-    expect(inputWrapper.find('input').get(0).props.value)
-      .toEqual('[{"enabled":true,"name":"cors","version":"1.0.0","configuration":{}},{"enabled":true,"name":"echo","version":"1.0.0","configuration":{}}]')
-  })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Simplify logic and improve performance of `PolicyChainHiddenInput`. It is currently a bit convoluted (and heavy).

Performance comparison: http://jsben.ch/4fWbF.

**Verification steps**:
* `npm run update-dependencies`
* Navigate to `apiconfig/services/<id>/policies/edit`
* Policies widget should work as usual

**Note**:
This is part 5 of the refactorization of Policies:
[THREESCALE-2221: Policies: Normalise the use of policies schema and its types](https://issues.jboss.org/browse/THREESCALE-2221)

Previous step #1399.