### PR TITLE
Revert Prevent trailing slash in patterns of proxy rules of backend api configs with a path

### DIFF
--- a/app/decorators/proxy_rule_decorator.rb
+++ b/app/decorators/proxy_rule_decorator.rb
@@ -6,9 +6,7 @@ class ProxyRuleDecorator < ApplicationDecorator
   def pattern
     pattern_value = object.pattern
     return pattern_value unless backend_api_path
-    parts = ['/', backend_api_path]
-    parts << pattern_value unless pattern_value == '/'
-    File.join(*parts)
+    File.join('/', backend_api_path, pattern_value)
   end
 
   def metric_system_name

--- a/test/decorators/proxy_rule_decorator_test.rb
+++ b/test/decorators/proxy_rule_decorator_test.rb
@@ -9,27 +9,66 @@ class ProxyRuleDecoratorTest < Draper::TestCase
 
   attr_reader :backend_api, :service
 
-  test 'pattern for backend with path' do
+  test '#pattern' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/hello')
+    decorator = proxy_rule.decorate
+    assert_equal '/hello', decorator.pattern
+  end
+
+  test 'catch-all pattern' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/')
+    decorator = proxy_rule.decorate
+    assert_equal '/', decorator.pattern
+  end
+
+  test '#pattern for backend with simple path' do
     proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/hello')
     decorator = proxy_rule.decorate(context: { backend_api_path: 'mybackend' })
     assert_equal '/mybackend/hello', decorator.pattern
   end
 
-  test 'pattern for backend without path' do
+  test '#pattern for backend with complex path' do
     proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/hello')
-    decorator = proxy_rule.decorate(context: { backend_api_path: '' })
-    assert_equal '/hello', decorator.pattern
+    decorator = proxy_rule.decorate(context: { backend_api_path: '/mybackend/v2' })
+    assert_equal '/mybackend/v2/hello', decorator.pattern
   end
 
-  test 'catch-all pattern for backend with path' do
+  test '#pattern with trailing slash' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/hello/')
+    decorator = proxy_rule.decorate(context: { backend_api_path: 'mybackend' })
+    assert_equal '/mybackend/hello/', decorator.pattern
+  end
+
+  test 'catch-all pattern for backend with simple path' do
     proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/')
     decorator = proxy_rule.decorate(context: { backend_api_path: 'mybackend' })
-    assert_equal '/mybackend', decorator.pattern
+    assert_equal '/mybackend/', decorator.pattern
   end
 
-  test 'catch-all pattern for backend without path' do
-    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: '/')
-    decorator = proxy_rule.decorate(context: { backend_api_path: '' })
-    assert_equal '/', decorator.pattern
+  test 'complex patterns' do
+    patterns = %w(
+      /foo/{bar}/baz/{foo}/quux
+      /foo/{whatever}.json
+      /foo/bar.json
+      /foo.ext1/bar.ext2
+      /v1/word/{word}.json?app_id={app_id}&app_key={app_key}
+      /foo$
+      /foo$?bar=baz
+      /$
+      /TWAPData;{StartDateTime};{EndDateTime};{CurrencyPair},{ResponseType},{UserName},{Password}
+      /service1.svc/securejson/getdata/Tick;16122016100000;16122016100001;GBPJPY;,JSON,Username,Password
+      /business-central/rest/runtime/com.redhat.demos:BuildEntAppIn60Min:3.0/withvars/process/project1.SummitDemo/start
+      /TWAPDATA;{startDateTime};{endDateTime};{currencyPair},{responseType}
+      /optaplanner-webexamples-6.5.0.Final-redhat-2/rest/vehiclerouting/solution/solve
+      /optaplanner-webexamples-6.5.0.final-redhat-2/rest/vehiclerouting/solution/solve
+      /foo{lal}/
+      /foo/{bar}k/baz/{p}/quux
+      /http://www.url.com/something.asmx/
+    )
+    patterns.each do |pattern|
+      proxy_rule = FactoryBot.build_stubbed(:proxy_rule, owner: backend_api, pattern: pattern)
+      decorator = proxy_rule.decorate
+      assert_equal pattern, decorator.pattern
+    end
   end
 end


### PR DESCRIPTION
This PR reverts https://github.com/3scale/porta/pull/1394 and introduces new tests to the proxy rule decorator.
It goes in the opposite direction of https://github.com/3scale/porta/pull/1400, which should be closed in case we decide to move on with this one.

Related to [THREESCALE-3833](https://issues.jboss.org/browse/THREESCALE-3833).

Closes [THREESCALE-3872](https://issues.jboss.org/browse/THREESCALE-3872).

The Jira reported as a bug a scenario where two requests with and without a trailing slash, targeting a mapping rule of a backend whose pattern was `/` (AKA the "catch-all" mapping rule pattern), were treated differently. According to the description of the bug, one would expect those things to be trated equally. But this is not correct. Requests with and without the trailing slash _should_ be trated as different request.

First reason is that, even though some web servers and web clients may treat those cases as equal, it's also a valid interpretation the a URL that does not end with a slash targets a resource, while the same URL with a slash appended to the end triggers additional semantics to the request. The resource pointed can be a file or a directory or even represent a soft parameter coded in the URL; without a trailing slash, the request is asking for the resource. If a trailing is added, then the resource cannot be a file and if it's a directory can instruct a web server to look for a possible `index.html` file in that directory, for example.

It also adds some confusion the fact that, following the RFC, user agents (e.g. curl) sometimes add a slash to the path, but that is a _leading_ slash, not a _trailing_ slash. In APIAP terms, when the catch-all mapping rule is defined at the backend level and that backend has a routing path at the product level, then the trailing slash is NOT optional. The user can still make it optional if wanted, by creating a product-level mapping rule with the same pattern as the routing path of the backend and no trailing slash.

Another reason why we should not remove the trailing slash is that system will allow the definition of two distinct mapping rules, where one coincides exactly to the pattern of the other but adds a trailing slash. The users assume those two mapping rules to be used for different cases. Yet after https://github.com/3scale/porta/pull/1394 ans specially if https://github.com/3scale/porta/pull/1400 gets merged, we could be injecting both mapping rules with the exact same pattern.

Finally, as there are some semantics involved behind the meaning of requests with and without a trailing slash, better not to try "fixing" what the customer defined.