### PR TITLE
Fix Products' search bar in Dashboard

### DIFF
--- a/app/assets/stylesheets/provider/admin/_dashboard.scss
+++ b/app/assets/stylesheets/provider/admin/_dashboard.scss
@@ -17,10 +17,6 @@
     border-top: 0;
     margin-top: line-height-times(1.4);
 
-    .hidden {
-      display: none;
-    }
-
     #backends > table {
       border-width: 0;
       box-shadow: none;
@@ -459,6 +455,7 @@ a:hover .u-notice {
       border-top: 0;
       display: block;
       margin: 1px 0 0 1px;
+      min-height: line-height-times(28 / 3);
       padding: line-height-times(1);
     }
 
@@ -466,6 +463,11 @@ a:hover .u-notice {
     & > #backends.active .ApiFilter {
       margin-left: 0;
       padding: 1px;
+    }
+
+    & > #products.active .hidden,
+    & > #backends.active .hidden {
+      display: none;
     }
 
     .DashboardWidget {

--- a/features/provider/dashboard/tabs.feature
+++ b/features/provider/dashboard/tabs.feature
@@ -1,0 +1,36 @@
+Feature: Dashboard search bar
+  In order to navigate easily to products and backends
+  As a provider
+  I want to be able to filter them by name
+
+  Background:
+    Given a provider is logged in
+    And a service "My Fancy Product"
+    And a service "My Regular Product"
+    And a backend api "My Fancy Backend API"
+    And a backend api "My Regular Backend API"
+    And I go to the provider dashboard
+
+  @javascript
+  Scenario: Filtering products
+    When I select the products tab
+    And I should see "My Fancy Product" in the apis dashboard products tabs section
+    And I should see "My Regular Product" in the apis dashboard products tabs section
+    Then I search for "My Fan" using the products search bar
+    And I should see "My Fancy Product" in the apis dashboard products tabs section
+    And I should not see "My Regular Product" in the apis dashboard products tabs section
+    Then I search for "My Foo Foo" using the products search bar
+    And I should not see "My Fancy Product" in the apis dashboard products tabs section
+    And I should not see "My Regular Product" in the apis dashboard products tabs section
+
+  @javascript
+  Scenario: Filtering backends
+    When I select the backends tab
+    And I should see "My Fancy Backend API" in the apis dashboard backends tabs section
+    And I should see "My Regular Backend API" in the apis dashboard backends tabs section
+    Then I search for "My Fan" using the backends search bar
+    And I should see "My Fancy Backend API" in the apis dashboard backends tabs section
+    And I should not see "My Regular Backend API" in the apis dashboard backends tabs section
+    Then I search for "My Foo Foo" using the backends search bar
+    And I should not see "My Fancy Backend API" in the apis dashboard backends tabs section
+    And I should not see "My Regular Backend API" in the apis dashboard backends tabs section

--- a/features/step_definitions/dashboard_steps.rb
+++ b/features/step_definitions/dashboard_steps.rb
@@ -1,18 +1,20 @@
-def service_id_for_name (name)
-  page.find_by_id('apis').find('section', :text => %r{#{name}}i)[:id][/\d+/]
+# frozen_string_literal: true
+
+def service_id_for_name(name)
+  page.find_by_id('apis').find('section', text: /#{name}/i)[:id][/\d+/]
 end
 
-def service_for_name (name)
+def service_for_name(name)
   service_id = service_id_for_name(name)
   page.find("#service_#{service_id}")
 end
 
-def hits_for_name (name, opts = {})
+def hits_for_name(name, opts = {})
   service_id = service_id_for_name(name)
   page.find_by_id("dashboard-widget-service_id-#{service_id}service_hits", opts)
 end
 
-def top_traffic_for_name (name, opts = {})
+def top_traffic_for_name(name, opts = {})
   service_id = service_id_for_name(name)
   page.find_by_id("dashboard-widget-service_id-#{service_id}service_top_traffic", opts)
 end
@@ -41,8 +43,18 @@ When(/^overview data of "([^"]*)" is displayed$/) do |service_name|
 end
 
 When(/^I (fold|unfold) service "([^"]*)"$/) do |action, service_name|
-  step %{service "#{service_name}" is #{action == 'fold' ? 'unfolded' : 'folded'}}
+  step %(service "#{service_name}" is #{action == 'fold' ? 'unfolded' : 'folded'})
 
   service = service_for_name(service_name)
   service.find('.DashboardSection-toggle').click
+end
+
+When(/^I select the (products|backends) tab$/) do |tab|
+  find('button', id: "tab-#{tab}").click
+end
+
+
+When (/^I search for "([^"]*)" using the (products|backends) search bar/) do |query, tab|
+  search_bar = find("##{tab}_search").find('input[type="search"]')
+  search_bar.send_keys query
 end

--- a/features/step_definitions/service_steps.rb
+++ b/features/step_definitions/service_steps.rb
@@ -2,6 +2,14 @@ Given /^a service "([^"]*)" of (provider "[^"]*")$/ do |name, provider|
   provider.services.create! :name => name, :mandatory_app_key => false
 end
 
+Given /^a backend api "([^"]*)"$/ do |name|
+  @provider.backend_apis.create!(name: name, private_endpoint: 'https://foo')
+end
+
+Given /^a service "([^"]*)"$/ do |name|
+  @provider.services.create!(name: name, mandatory_app_key: false)
+end
+
 Given /^(?:a )?default service of (provider "[^"]*") has name "([^"]*)"$/ do |provider, name|
   provider.first_service!.update_attribute(:name, name)
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Css rule `display: none;` was being overridden by `display: table`.

* Moved `hidden` definition to a higher priority place so that it overrides `display: table`
* Sets min-height so that the card doesn't collapse

![products](https://user-images.githubusercontent.com/11672286/68470285-0980d780-021c-11ea-9622-ebd8e51d72bf.gif)


**Which issue(s) this PR fixes** 

[THREESCALE-3871: Products search bar in Dashboard not working](https://issues.jboss.org/browse/THREESCALE-3871)

**Verification steps** 

1. Open the dashboard, Products tab
2. Use the search bar: products should hide and show accordingly with the search query

**Special notes for your reviewer**:
Todo:
- [ ] Add tests
