### PR TITLE
Remove 'is-hidden' class used in Policies in favor of conditional rendering

### DIFF
--- a/app/javascript/src/Policies/components/PoliciesForm.jsx
+++ b/app/javascript/src/Policies/components/PoliciesForm.jsx
@@ -40,6 +40,8 @@ function PoliciesForm ({
   const remove = () => removePolicy(policy)
   const cancel = () => closePolicyConfig()
 
+  const isPolicyVisible = isNotApicastPolicy(policy)
+
   return (
     <section className="PolicyConfiguration">
       <header className="PolicyConfiguration-header">
@@ -53,33 +55,35 @@ function PoliciesForm ({
         <span className="PolicyConfiguration-summary">{policy.summary}</span>
       </p>
       <p className="PolicyConfiguration-description">{policy.description}</p>
-      <label className={`${hiddenClass(isNotApicastPolicy(policy))} Policy-status`} htmlFor="policy-enabled">
-        <input
-          id="policy-enabled" name="policy-enabled" type="checkbox"
-          checked={policy.enabled}
-          onChange={togglePolicy}
-        />
-        {' '} Enabled
-      </label>
-      <PolicyForm
-        className={`PolicyConfiguration-form ${hiddenClass(isNotApicastPolicy(policy))}`}
-        schema={policy.configuration}
-        formData={policy.data}
-        onSubmit={onSubmit(policy)}
-      >
-        <button className='btn btn-info' type="submit">Update Policy</button>
-      </PolicyForm>
-      <div
-        className={`PolicyConfiguration-remove btn btn-danger btn-sm ${hiddenClass(policy.removable)}`}
-        onClick={remove}>
-        <i className="fa fa-trash"></i> Remove
-      </div>
+      {isPolicyVisible &&
+        <label className="Policy-status" htmlFor="policy-enabled">
+          <input
+            id="policy-enabled" name="policy-enabled" type="checkbox"
+            checked={policy.enabled}
+            onChange={togglePolicy}
+          />
+          {' '} Enabled
+        </label>
+      }
+      {isPolicyVisible &&
+        <PolicyForm
+          className="PolicyConfiguration-form"
+          schema={policy.configuration}
+          formData={policy.data}
+          onSubmit={onSubmit(policy)}
+        >
+          <button className='btn btn-info' type="submit">Update Policy</button>
+        </PolicyForm>
+      }
+      {policy.removable &&
+        <div
+          className="PolicyConfiguration-remove btn btn-danger btn-sm"
+          onClick={remove}>
+          <i className="fa fa-trash"></i> Remove
+        </div>
+      }
     </section>
   )
-}
-
-function hiddenClass (bool?: boolean): string {
-  return bool ? '' : 'is-hidden'
 }
 
 export { PolicyForm, PoliciesForm }

--- a/app/javascript/src/Policies/components/PoliciesWidget.jsx
+++ b/app/javascript/src/Policies/components/PoliciesWidget.jsx
@@ -77,22 +77,9 @@ const PolicyList = ({ registry, chain, originalChain, policyConfig, ui, boundAct
 
   return (
     <div className="PoliciesWidget">
-      <PolicyChain
-        chain={chain}
-        visible={ui.chain}
-        actions={chainActions}
-      />
-      <PolicyRegistry
-        items={registry}
-        visible={ui.registry}
-        actions={policyRegistryActions}
-      />
-      {ui.policyConfig &&
-        <PolicyConfig
-          policy={policyConfig}
-          actions={policyConfigActions}
-        />
-      }
+      {ui.chain && <PolicyChain chain={chain} actions={chainActions} />}
+      {ui.registry && <PolicyRegistry items={registry} actions={policyRegistryActions} />}
+      {ui.policyConfig && <PolicyConfig policy={policyConfig} actions={policyConfigActions} />}
       <PolicyChainHiddenInput policies={chain} />
     </div>
   )

--- a/app/javascript/src/Policies/components/PolicyChain.jsx
+++ b/app/javascript/src/Policies/components/PolicyChain.jsx
@@ -13,7 +13,6 @@ import type { ThunkAction, ChainPolicy } from 'Policies/types'
 import type { SortPolicyChainAction } from 'Policies/actions/PolicyChain'
 
 type Props = {
-  visible: boolean,
   chain: Array<ChainPolicy>,
   actions: {
     openPolicyRegistry: () => ThunkAction,
@@ -34,9 +33,9 @@ const SortableItem = SortableElement(({value, editPolicy, index}) => {
   )
 })
 
-const SortableList = SortableContainer(({items, visible, editPolicy}) => {
+const SortableList = SortableContainer(({ items, editPolicy }) => {
   return (
-    <ul className={(visible ? 'list-group' : 'is-hidden list-group')}>
+    <ul className="list-group">
       {items.map((policy, index) => (
         <SortableItem
           key={`item-${index}`}
@@ -57,7 +56,7 @@ const AddPolicyButton = ({openPolicyRegistry}: {openPolicyRegistry: () => ThunkA
   )
 }
 
-const PolicyChain = ({chain, visible, actions}: Props) => {
+const PolicyChain = ({chain, actions}: Props) => {
   const onSortEnd = ({oldIndex, newIndex}) => {
     const sortedChain = arrayMove(chain, oldIndex, newIndex)
     actions.sortPolicyChain(sortedChain)
@@ -65,13 +64,12 @@ const PolicyChain = ({chain, visible, actions}: Props) => {
 
   return (
     <section className="PolicyChain">
-      <header className={(visible ? 'PolicyChain-header' : 'is-hidden PolicyChain-header')}>
+      <header className="PolicyChain-header">
         <h2 className="PolicyChain-title">Policy Chain</h2>
         <AddPolicyButton openPolicyRegistry={actions.openPolicyRegistry} />
       </header>
       <SortableList
         items={chain}
-        visible={visible}
         onSortEnd={onSortEnd}
         useDragHandle={true}
         editPolicy={actions.editPolicy}

--- a/app/javascript/src/Policies/components/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/components/PolicyRegistry.jsx
@@ -8,7 +8,6 @@ import { PolicyTile } from 'Policies/components/PolicyTile'
 import type { RegistryPolicy, ThunkAction } from 'Policies/types'
 
 type Props = {
-  visible: boolean,
   items: Array<RegistryPolicy>,
   actions: {
     addPolicy: (RegistryPolicy) => ThunkAction,
@@ -31,9 +30,9 @@ const PolicyRegistryItem = ({value, addPolicy}: {value: RegistryPolicy, addPolic
   )
 }
 
-const PolicyRegistry = ({items, visible, actions}: Props) => {
+const PolicyRegistry = ({ items, actions }: Props) => {
   return (
-    <section className={(visible ? 'PolicyRegistryList' : 'PolicyRegistryList is-hidden')}>
+    <section className="PolicyRegistryList">
       <header className="PolicyRegistryList-header">
         <h2 className="PolicyRegistryList-title">Select a Policy</h2>
         <CloseRegistryButton closePolicyRegistry={actions.closePolicyRegistry} />

--- a/app/javascript/src/Policies/styles/policies.scss
+++ b/app/javascript/src/Policies/styles/policies.scss
@@ -55,10 +55,6 @@ $error-color: #c00;
       }
     }
 
-    &.is-hidden {
-      display: none;
-    }
-
     .list-group {
       margin-bottom: 0;
     }
@@ -170,10 +166,6 @@ $error-color: #c00;
     #root__title {
       display: none;
     }
-
-    &.is-hidden {
-      display: none;
-    }
   }
 
   .PolicyRegistryList {
@@ -190,10 +182,6 @@ $error-color: #c00;
     &-title {
       margin-top: 0;
       font-size: 1rem;
-    }
-
-    &.is-hidden {
-      display: none;
     }
   }
 }
@@ -307,10 +295,6 @@ $error-color: #c00;
     &:hover {
       opacity: 1;
     }
-  }
-
-  .is-hidden {
-    display: none;
   }
 
   &-status {

--- a/features/step_definitions/proxy_steps.rb
+++ b/features/step_definitions/proxy_steps.rb
@@ -53,7 +53,7 @@ Then(/^I should see the Policy Chain$/) do
   page.should have_css(".PolicyChain")
   page.should have_css(".Policy")
   page.should have_text("APIcast policy")
-  page.should have_css(".PolicyRegistryList", visible: :hidden)
+  page.should_not have_css(".PolicyRegistryList")
 end
 
 

--- a/features/step_definitions/proxy_steps.rb
+++ b/features/step_definitions/proxy_steps.rb
@@ -53,7 +53,7 @@ Then(/^I should see the Policy Chain$/) do
   page.should have_css(".PolicyChain")
   page.should have_css(".Policy")
   page.should have_text("APIcast policy")
-  page.should have_css(".PolicyRegistryList.is-hidden", visible: :hidden)
+  page.should have_css(".PolicyRegistryList", visible: :hidden)
 end
 
 

--- a/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
@@ -159,7 +159,7 @@ describe('PolicyConfig APIcast policy', () => {
   it('should hide the APIcast policy form', () => {
     const {policyConfigWrapper} = setup()
 
-    expect(policyConfigWrapper.find(PolicyForm).hasClass('is-hidden')).toBe(true)
+    expect(policyConfigWrapper.find(PolicyForm).exists()).toBe(false)
   })
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In React, the recommended way to hide components is to not render them at all, this is achieved by means of conditional rendering.
* Remove repeated class definitions of `is-hidden` class in policies.scss
* Remove parameters `visible`
* Use local parameters to conditional render components 

**Verification steps**:
* `npm run update-dependencies`
* Navigate to `apiconfig/services/<id>/policies/edit`
* Policies widget should work as usual

**Note**:
This is part 6 of the refactorization of Policies:
[THREESCALE-2221: Policies: Normalise the use of policies schema and its types](https://issues.jboss.org/browse/THREESCALE-2221)

Previous step #1403.