### PR TITLE
Simplify policy lists header and its styles

### DIFF
--- a/app/javascript/src/Policies/components/HeaderButton.jsx
+++ b/app/javascript/src/Policies/components/HeaderButton.jsx
@@ -1,0 +1,37 @@
+// @flow
+
+import * as React from 'react'
+
+import type { ThunkAction } from 'Policies/types'
+
+type Props = {
+  type: 'add' | 'cancel',
+  onClick: () => ThunkAction,
+  children?: React.Node
+}
+
+const getIcon = type => {
+  switch (type) {
+    case 'add':
+      return 'fa fa-plus-circle'
+    case 'cancel':
+      return 'fa fa-times-circle'
+  }
+}
+
+const getClass = type => {
+  switch (type) {
+    case 'add':
+      return 'PolicyChain-addPolicy'
+    case 'cancel':
+      return 'PolicyChain-addPolicy--cancel'
+  }
+}
+
+const HeaderButton = ({ type, onClick, children }: Props) => (
+  <div className={getClass(type)} onClick={onClick}>
+    <i className={getIcon(type)} />{children}
+  </div>
+)
+
+export { HeaderButton }

--- a/app/javascript/src/Policies/components/HeaderButton.jsx
+++ b/app/javascript/src/Policies/components/HeaderButton.jsx
@@ -10,27 +10,19 @@ type Props = {
   children?: React.Node
 }
 
-const getIcon = type => {
-  switch (type) {
-    case 'add':
-      return 'fa fa-plus-circle'
-    case 'cancel':
-      return 'fa fa-times-circle'
-  }
+const classNames = {
+  add: 'PolicyChain-addPolicy',
+  cancel: 'PolicyChain-addPolicy--cancel'
 }
 
-const getClass = type => {
-  switch (type) {
-    case 'add':
-      return 'PolicyChain-addPolicy'
-    case 'cancel':
-      return 'PolicyChain-addPolicy--cancel'
-  }
+const icons = {
+  add: 'fa fa-plus-circle',
+  cancel: 'fa fa-times-circle'
 }
 
 const HeaderButton = ({ type, onClick, children }: Props) => (
-  <div className={getClass(type)} onClick={onClick}>
-    <i className={getIcon(type)} />{children}
+  <div className={classNames[type]} onClick={onClick}>
+    <i className={icons[type]} />{children}
   </div>
 )
 

--- a/app/javascript/src/Policies/components/PoliciesForm.jsx
+++ b/app/javascript/src/Policies/components/PoliciesForm.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import Form from 'react-jsonschema-form'
 
 import { isNotApicastPolicy } from 'Policies/components/util'
+import { HeaderButton } from 'Policies/components/HeaderButton'
 
 import type { ThunkAction, ChainPolicy } from 'Policies/types'
 import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
@@ -44,9 +45,11 @@ function PoliciesForm ({
 
   return (
     <section className="PolicyConfiguration">
-      <header className="PolicyConfiguration-header">
-        <h2 className="PolicyConfiguration-title">Edit Policy</h2>
-        <div onClick={cancel} className="PolicyConfiguration-cancel"><i className="fa fa-times-circle"></i> Cancel</div>
+      <header>
+        <h2>Edit Policy</h2>
+        <HeaderButton type='cancel' onClick={cancel}>
+          Cancel
+        </HeaderButton>
       </header>
       <h2 className="PolicyConfiguration-name">{policy.humanName}</h2>
       <p className="PolicyConfiguration-version-and-summary">

--- a/app/javascript/src/Policies/components/PolicyChain.jsx
+++ b/app/javascript/src/Policies/components/PolicyChain.jsx
@@ -8,6 +8,7 @@ import {
   arrayMove
 } from 'react-sortable-hoc'
 import { PolicyTile } from 'Policies/components/PolicyTile'
+import { HeaderButton } from 'Policies/components/HeaderButton'
 
 import type { ThunkAction, ChainPolicy } from 'Policies/types'
 import type { SortPolicyChainAction } from 'Policies/actions/PolicyChain'
@@ -48,14 +49,6 @@ const SortableList = SortableContainer(({ items, editPolicy }) => {
   )
 })
 
-const AddPolicyButton = ({openPolicyRegistry}: {openPolicyRegistry: () => ThunkAction}) => {
-  return (
-    <div className="PolicyChain-addPolicy" onClick={openPolicyRegistry}>
-      <i className="fa fa-plus-circle" /> Add Policy
-    </div>
-  )
-}
-
 const PolicyChain = ({chain, actions}: Props) => {
   const onSortEnd = ({oldIndex, newIndex}) => {
     const sortedChain = arrayMove(chain, oldIndex, newIndex)
@@ -64,9 +57,11 @@ const PolicyChain = ({chain, actions}: Props) => {
 
   return (
     <section className="PolicyChain">
-      <header className="PolicyChain-header">
-        <h2 className="PolicyChain-title">Policy Chain</h2>
-        <AddPolicyButton openPolicyRegistry={actions.openPolicyRegistry} />
+      <header>
+        <h2>Policy Chain</h2>
+        <HeaderButton type='add' onClick={actions.openPolicyRegistry}>
+          Add policy
+        </HeaderButton>
       </header>
       <SortableList
         items={chain}
@@ -82,6 +77,5 @@ export {
   PolicyChain,
   SortableList,
   SortableItem,
-  AddPolicyButton,
   DragHandle
 }

--- a/app/javascript/src/Policies/components/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/components/PolicyRegistry.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 
 import { isNotApicastPolicy } from 'Policies/components/util'
 import { PolicyTile } from 'Policies/components/PolicyTile'
+import { HeaderButton } from 'Policies/components/HeaderButton'
 
 import type { RegistryPolicy, ThunkAction } from 'Policies/types'
 
@@ -13,12 +14,6 @@ type Props = {
     addPolicy: (RegistryPolicy) => ThunkAction,
     closePolicyRegistry: () => ThunkAction
   }
-}
-
-const CloseRegistryButton = ({closePolicyRegistry}) => {
-  return (
-    <div className="PolicyChain-addPolicy--cancel" onClick={closePolicyRegistry}><i className="fa fa-times-circle"/> Cancel</div>
-  )
 }
 
 const PolicyRegistryItem = ({value, addPolicy}: {value: RegistryPolicy, addPolicy: (RegistryPolicy) => ThunkAction}) => {
@@ -33,9 +28,11 @@ const PolicyRegistryItem = ({value, addPolicy}: {value: RegistryPolicy, addPolic
 const PolicyRegistry = ({ items, actions }: Props) => {
   return (
     <section className="PolicyRegistryList">
-      <header className="PolicyRegistryList-header">
-        <h2 className="PolicyRegistryList-title">Select a Policy</h2>
-        <CloseRegistryButton closePolicyRegistry={actions.closePolicyRegistry} />
+      <header>
+        <h2>Select a Policy</h2>
+        <HeaderButton type='cancel' onClick={actions.closePolicyRegistry}>
+        Cancel
+        </HeaderButton>
       </header>
       <ul className="list-group">
         {items.filter(policy => isNotApicastPolicy(policy)).map((policy, index) => (

--- a/app/javascript/src/Policies/styles/policies.scss
+++ b/app/javascript/src/Policies/styles/policies.scss
@@ -4,6 +4,7 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 }
 
 $color: #464646;
+$disabledColor: #8b8d8f;
 $goColor: #4a90e2;
 $doColor: #54b45d;
 $dontColor: #ca4a4b;
@@ -15,43 +16,37 @@ $error-color: #c00;
   line-height: 1.5;
   padding-bottom: 2rem;
 
-  .PolicyChain, .PolicyRegistryList, .PolicyConfiguration {
+  section {
     width: 510px;
     margin: 0 auto;
-  }
 
-
-  .PolicyChain {
-    $PolicyChain-color: #464646;
-    $PolicyChain-goColor: #4a90e2;
-    $PolicyChain-doColor: #54b45d;
-    $PolicyChain-dontColor: #ca4a4b;
-    $PolicyChain-subtleColor: #ddd;
-
-    display: flex;
-    flex-flow: column nowrap;
-
-    &-header {
+    header {
       display: flex;
       flex-flow: row nowrap;
       align-items: baseline;
       justify-content: flex-start;
       margin-bottom: 1rem;
-      border-bottom: 1px solid $PolicyChain-subtleColor;
+      border-bottom: 1px solid $subtleColor;
     }
 
-    &-title {
+    h2 {
       margin-top: 0;
       font-size: 1rem;
+      font-weight: bold; // Overrides Bootstrap's h2
     }
+  }
 
-    &-addPolicy {
+  .PolicyChain {
+    display: flex;
+    flex-flow: column nowrap;
+
+    &-addPolicy,
+    &-addPolicy--cancel {
       @extend .u-do;
       margin-left: auto;
 
-      &--cancel {
-        @extend .u-do;
-        margin-left: auto;
+      i {
+        padding-right: 3px;
       }
     }
 
@@ -61,26 +56,6 @@ $error-color: #c00;
   }
 
   .PolicyConfiguration {
-    $PolicyConfiguration-color: #464646;
-    $PolicyConfiguration-goColor: #4a90e2;
-    $PolicyConfiguration-doColor: #54b45d;
-    $PolicyConfiguration-dontColor: #ca4a4b;
-    $PolicyConfiguration-subtleColor: #ddd;
-
-    &-header {
-      display: flex;
-      flex-flow: row wrap;
-      align-items: baseline;
-      justify-content: flex-start;
-      margin-bottom: 1rem;
-      border-bottom: 1px solid $PolicyConfiguration-subtleColor;
-    }
-
-    &-title {
-      margin-top: 0;
-      font-size: 1rem;
-    }
-
     &-name {
       margin: 0 0 0 0;
       padding: 0.5rem 0 0 0;
@@ -100,8 +75,8 @@ $error-color: #c00;
 
     &-remove {
       background-color: white;
-      color: $PolicyConfiguration-dontColor;
-      border-color: $PolicyConfiguration-dontColor;
+      color: $dontColor;
+      border-color: $dontColor;
     }
 
     &-description {
@@ -110,8 +85,8 @@ $error-color: #c00;
     }
 
     .btn-info {
-      background-color: $PolicyConfiguration-doColor;
-      border-color: $PolicyConfiguration-doColor;
+      background-color: $doColor;
+      border-color: $doColor;
       width: 33.33%;
       float: right;
       padding-left: 6px;
@@ -125,7 +100,7 @@ $error-color: #c00;
     .array-item {
       clear: both;
       float: left;
-      border-bottom: 1px dashed $PolicyConfiguration-subtleColor;
+      border-bottom: 1px dashed $subtleColor;
       display: block;
       width: 100%;
       margin-bottom: 2rem;
@@ -136,7 +111,7 @@ $error-color: #c00;
 
       &> .form-group {
         padding-bottom: 2rem;
-        border-bottom: 1px dashed $PolicyConfiguration-subtleColor;
+        border-bottom: 1px dashed $subtleColor;
       }
     }
 
@@ -167,40 +142,15 @@ $error-color: #c00;
       display: none;
     }
   }
-
-  .PolicyRegistryList {
-
-    &-header {
-      display: flex;
-      flex-flow: row nowrap;
-      align-items: baseline;
-      justify-content: flex-start;
-      margin-bottom: 1rem;
-      border-bottom: 1px solid $subtleColor;
-    }
-
-    &-title {
-      margin-top: 0;
-      font-size: 1rem;
-    }
-  }
 }
 
 .PoliciesWidget .Policy,
 .Policy {
-  $Policy-color: #464646;
-  $Policy-disabledColor: #8b8d8f;
-  $Policy-goColor: #4a90e2;
-  $Policy-doColor: #54b45d;
-  $Policy-dontColor: #ca4a4b;
-  $Policy-subtleColor: #ddd;
-
-
   display: flex;
   flex-flow: row nowrap;
   justify-content: space-between;
   align-items: baseline;
-  border-bottom: 1px solid $Policy-subtleColor;
+  border-bottom: 1px solid $subtleColor;
   padding: 0.5rem 0;
   user-select: none;
   text-align: left;
@@ -210,7 +160,7 @@ $error-color: #c00;
     .Policy-name,
     .Policy-summary,
     .Policy-version {
-      color: $Policy-disabledColor;
+      color: $disabledColor;
       text-decoration: line-through;
     }
   }
@@ -218,12 +168,12 @@ $error-color: #c00;
   &-sortHandle {
     order: 4;
     cursor: move;
-    color: $Policy-subtleColor;
+    color: $subtleColor;
     padding: 1rem;
     margin: -1rem -1rem 0 0;
 
     &:hover {
-      color: $Policy-doColor;
+      color: $doColor;
     }
   }
 
@@ -260,12 +210,12 @@ $error-color: #c00;
 
   &-summary {
     line-height: 1.5;
-    color: $Policy-color;
+    color: $color;
   }
 
   &-version {
     line-height: 1.5;
-    color: $Policy-color;
+    color: $color;
   }
 
   &:hover {
@@ -288,7 +238,7 @@ $error-color: #c00;
     border: none;
     background-color: transparent;
     font-weight: normal;
-    color: $Policy-dontColor;
+    color: $dontColor;
     opacity: 0.3;
     display: none;
 
@@ -301,8 +251,8 @@ $error-color: #c00;
     display: block;
     width: 100%;
     margin: 1rem 0;
-    border-bottom: 1px solid $Policy-subtleColor;
-    border-top: 1px solid $Policy-subtleColor;
+    border-bottom: 1px solid $subtleColor;
+    border-top: 1px solid $subtleColor;
   }
 }
 

--- a/app/javascript/src/Policies/styles/policies.scss
+++ b/app/javascript/src/Policies/styles/policies.scss
@@ -75,8 +75,8 @@ $error-color: #c00;
 
     &-remove {
       background-color: white;
-      color: $dontColor;
       border-color: $dontColor;
+      color: $dontColor;
     }
 
     &-description {
@@ -109,7 +109,7 @@ $error-color: #c00;
     &-form {
       clear: both;
 
-      &> .form-group {
+      & > .form-group {
         padding-bottom: 2rem;
         border-bottom: 1px dashed $subtleColor;
       }
@@ -119,7 +119,7 @@ $error-color: #c00;
       justify-content: flex-end !important;
     }
 
-    button[type=submit] {
+    button[type="submit"] {
       margin-bottom: 2rem;
     }
 
@@ -156,7 +156,6 @@ $error-color: #c00;
   text-align: left;
 
   &.Policy--disabled {
-
     .Policy-name,
     .Policy-summary,
     .Policy-version {

--- a/spec/javascripts/Policies/components/HeaderButton.spec.jsx
+++ b/spec/javascripts/Policies/components/HeaderButton.spec.jsx
@@ -1,0 +1,29 @@
+// @flow
+
+import React from 'react'
+import { mount } from 'enzyme'
+
+import { HeaderButton } from 'Policies/components/HeaderButton'
+
+it('should render itself', () => {
+  const wrapper = mount(<HeaderButton type='add' onClick={jest.fn()} />)
+  expect(wrapper.find(HeaderButton).exists()).toBe(true)
+})
+
+it('should handle clicks', () => {
+  const spy = jest.fn()
+  const wrapper = mount(<HeaderButton type='add' onClick={spy} />)
+
+  wrapper.props().onClick()
+  expect(spy).toHaveBeenCalled()
+})
+
+it('should have different stules for each type', () => {
+  const wrapper = mount(<HeaderButton type='add' onClick={jest.fn()} />)
+  expect(wrapper.find('.PolicyChain-addPolicy').exists()).toBe(true)
+  expect(wrapper.find('.fa-plus-circle').exists()).toBe(true)
+
+  wrapper.setProps({ type: 'cancel' })
+  expect(wrapper.find('.PolicyChain-addPolicy--cancel').exists()).toBe(true)
+  expect(wrapper.find('.fa-times-circle').exists()).toBe(true)
+})

--- a/spec/javascripts/Policies/components/HeaderButton.spec.jsx
+++ b/spec/javascripts/Policies/components/HeaderButton.spec.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { mount } from 'enzyme'
+import { render, mount } from 'enzyme'
 
 import { HeaderButton } from 'Policies/components/HeaderButton'
 
@@ -18,12 +18,12 @@ it('should handle clicks', () => {
   expect(spy).toHaveBeenCalled()
 })
 
-it('should have different styles for each type', () => {
-  const wrapper = mount(<HeaderButton type='add' onClick={jest.fn()} />)
-  expect(wrapper.find('.PolicyChain-addPolicy').exists()).toBe(true)
-  expect(wrapper.find('.fa-plus-circle').exists()).toBe(true)
+it('should be able to render an "add" button variant', () => {
+  const wrapper = render(<HeaderButton type='add' onClick={jest.fn()} />)
+  expect(wrapper).toMatchSnapshot()
+})
 
-  wrapper.setProps({ type: 'cancel' })
-  expect(wrapper.find('.PolicyChain-addPolicy--cancel').exists()).toBe(true)
-  expect(wrapper.find('.fa-times-circle').exists()).toBe(true)
+it('should be able to render a "cancel" button variant', () => {
+  const wrapper = render(<HeaderButton type='cancel' onClick={jest.fn()} />)
+  expect(wrapper).toMatchSnapshot()
 })

--- a/spec/javascripts/Policies/components/HeaderButton.spec.jsx
+++ b/spec/javascripts/Policies/components/HeaderButton.spec.jsx
@@ -18,7 +18,7 @@ it('should handle clicks', () => {
   expect(spy).toHaveBeenCalled()
 })
 
-it('should have different stules for each type', () => {
+it('should have different styles for each type', () => {
   const wrapper = mount(<HeaderButton type='add' onClick={jest.fn()} />)
   expect(wrapper.find('.PolicyChain-addPolicy').exists()).toBe(true)
   expect(wrapper.find('.fa-plus-circle').exists()).toBe(true)

--- a/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
@@ -84,11 +84,12 @@ describe('PolicyConfig Component', () => {
 
   it('should have a close button', () => {
     const {policyConfigWrapper, props} = setup()
-    const closeConfigButton = policyConfigWrapper.find('.PolicyConfiguration-cancel')
-    expect(closeConfigButton.text()).toBe(' Cancel')
+    const closeConfigButton = policyConfigWrapper.find('HeaderButton')
+    expect(closeConfigButton.find('.PolicyChain-addPolicy--cancel').exists()).toBe(true)
+    expect(closeConfigButton.text()).toBe('Cancel')
 
-    closeConfigButton.simulate('click')
-    expect(props.actions.closePolicyConfig.mock.calls.length).toBe(1)
+    closeConfigButton.props().onClick()
+    expect(props.actions.closePolicyConfig).toHaveBeenCalledTimes(1)
   })
 
   it('should have a remove button', () => {
@@ -97,7 +98,7 @@ describe('PolicyConfig Component', () => {
     expect(removePolicyButton.exists()).toBe(true)
 
     removePolicyButton.simulate('click')
-    expect(props.actions.removePolicyFromChain.mock.calls.length).toBe(1)
+    expect(props.actions.removePolicyFromChain).toHaveBeenCalledTimes(1)
   })
 
   it('should have a submit button', () => {
@@ -110,7 +111,7 @@ describe('PolicyConfig Component', () => {
     const {policyConfigWrapper, props} = setup()
     const policyConfigFormProps = policyConfigWrapper.find('.PolicyConfiguration-form').first().props()
     policyConfigFormProps.onSubmit({formData: {}, schema: {}})
-    expect(props.actions.submitPolicyConfig.mock.calls.length).toBe(1)
+    expect(props.actions.submitPolicyConfig).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/spec/javascripts/Policies/components/PolicyRegistry.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyRegistry.spec.jsx
@@ -55,8 +55,8 @@ describe('PolicyRegistry Components', () => {
 
     it('should have a close button', () => {
       const {registryWrapper, props} = setup()
-      const closeRegistryButton = registryWrapper.find('CloseRegistryButton div')
-      expect(closeRegistryButton.hasClass('PolicyChain-addPolicy--cancel')).toBe(true)
+      const closeRegistryButton = registryWrapper.find('HeaderButton')
+      expect(closeRegistryButton.find('.PolicyChain-addPolicy--cancel').exists()).toBe(true)
       closeRegistryButton.simulate('click')
       expect(props.actions.closePolicyRegistry.mock.calls.length).toBe(1)
     })

--- a/spec/javascripts/Policies/components/__snapshots__/HeaderButton.spec.jsx.snap
+++ b/spec/javascripts/Policies/components/__snapshots__/HeaderButton.spec.jsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should be able to render a "cancel" button variant 1`] = `
+<div
+  class="PolicyChain-addPolicy--cancel"
+>
+  <i
+    class="fa fa-times-circle"
+  />
+</div>
+`;
+
+exports[`should be able to render an "add" button variant 1`] = `
+<div
+  class="PolicyChain-addPolicy"
+>
+  <i
+    class="fa fa-plus-circle"
+  />
+</div>
+`;


### PR DESCRIPTION
**What this PR does / why we need it**:

Policy lists are the chain and the registry. Form also shares the same header.
* Extracts a `HeaderButton` component
* Simplifie styles, removing some classes and combining repeated things.

**Verification steps**:
* `npm run update-dependencies`
* Navigate to `apiconfig/services/<id>/policies/edit`
* At Policy Chain button should be 'add':
![Screen Shot 2019-11-18 at 12 54 12](https://user-images.githubusercontent.com/11672286/69050570-a6085e00-0a02-11ea-990d-7506e8da7aa0.png)
* At Edit Policy or Select a Policy shuold be "cancel":
![Screen Shot 2019-11-18 at 12 54 18](https://user-images.githubusercontent.com/11672286/69050624-c0dad280-0a02-11ea-8b63-8da02af85a8e.png)


**Note**:
This is part 7 of the refactorization of Policies:
[THREESCALE-2221: Policies: Normalise the use of policies schema and its types](https://issues.jboss.org/browse/THREESCALE-2221)

Previous step #1408.