### PR TITLE
Do not use inline module in Tasks unit test

### DIFF
--- a/test/unit/tasks/backend_api_test.rb
+++ b/test/unit/tasks/backend_api_test.rb
@@ -1,25 +1,27 @@
 require 'test_helper'
 
-class Tasks::BackendApiTest < ActiveSupport::TestCase
-  setup do
-    @backend_api = FactoryBot.create(:backend_api)
-    FactoryBot.create(:backend_api_config, backend_api: @backend_api)
-    @orphan_backend_api = FactoryBot.create(:backend_api)
-  end
+module Tasks
+  class BackendApiTest < ActiveSupport::TestCase
+    setup do
+      @backend_api = FactoryBot.create(:backend_api)
+      FactoryBot.create(:backend_api_config, backend_api: @backend_api)
+      @orphan_backend_api = FactoryBot.create(:backend_api)
+    end
 
-  test 'destroy orphans when account can not use api as product' do
-    Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-    DeleteObjectHierarchyWorker.expects(:perform_later).with(@orphan_backend_api).once
-    DeleteObjectHierarchyWorker.expects(:perform_later).with(@backend_api).never
+    test 'destroy orphans when account can not use api as product' do
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+      DeleteObjectHierarchyWorker.expects(:perform_later).with(@orphan_backend_api).once
+      DeleteObjectHierarchyWorker.expects(:perform_later).with(@backend_api).never
 
-    execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
-  end
+      execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
+    end
 
-  test 'does not destroy orphans when account can use api as product' do
-    Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
-    DeleteObjectHierarchyWorker.expects(:perform_later).with(@orphan_backend_api).never
-    DeleteObjectHierarchyWorker.expects(:perform_later).with(@backend_api).never
+    test 'does not destroy orphans when account can use api as product' do
+      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
+      DeleteObjectHierarchyWorker.expects(:perform_later).with(@orphan_backend_api).never
+      DeleteObjectHierarchyWorker.expects(:perform_later).with(@backend_api).never
 
-    execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
+      execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
+    end
   end
 end

--- a/test/unit/tasks/backend_test.rb
+++ b/test/unit/tasks/backend_test.rb
@@ -1,23 +1,25 @@
 require 'test_helper'
 
-class Tasks::BackendTest < ActiveSupport::TestCase
-  test 'storage:rewrite' do
-    provider = FactoryBot.create(:provider_account)
-    buyer    = FactoryBot.create(:buyer_account, provider_account: provider)
-    app      = FactoryBot.create(:cinstance, user_account: buyer)
-    key, filter = nil
+module Tasks
+  class BackendTest < ActiveSupport::TestCase
+    test 'storage:rewrite' do
+      provider = FactoryBot.create(:provider_account)
+      buyer    = FactoryBot.create(:buyer_account, provider_account: provider)
+      app      = FactoryBot.create(:cinstance, user_account: buyer)
+      key, filter = nil
 
-    BackendClient::ToggleBackend.without_backend do
-      key    = FactoryBot.create(:application_key, application: app)
-      filter = FactoryBot.create(:referrer_filter, application: app)
+      BackendClient::ToggleBackend.without_backend do
+        key    = FactoryBot.create(:application_key, application: app)
+        filter = FactoryBot.create(:referrer_filter, application: app)
+      end
+
+      expect_backend_create_key(app, key.value)
+      expect_backend_create_referrer_filter(app, filter.value)
+
+      Rails.env.stubs(test?: false)
+      System::Application.config.three_scale.core.expects(fake_server: false)
+
+      execute_rake_task 'backend.rake', 'backend:storage:rewrite'
     end
-
-    expect_backend_create_key(app, key.value)
-    expect_backend_create_referrer_filter(app, filter.value)
-
-    Rails.env.stubs(test?: false)
-    System::Application.config.three_scale.core.expects(fake_server: false)
-
-    execute_rake_task 'backend.rake', 'backend:storage:rewrite'
   end
 end

--- a/test/unit/tasks/cms/cms_test.rb
+++ b/test/unit/tasks/cms/cms_test.rb
@@ -1,23 +1,25 @@
 require 'test_helper'
 
-class Tasks::Cms::CmsTest < ActiveSupport::TestCase
+module Tasks
+  class CmsTest < ActiveSupport::TestCase
 
-  def setup
-    @page = FactoryBot.build(:cms_partial, system_name: 'shared/pagination',
-      published: '<p>Title</p><a href="{{ part.link }}">Supertramp</a>')
+    def setup
+      @page = FactoryBot.build(:cms_partial, system_name: 'shared/pagination',
+        published: '<p>Title</p><a href="{{ part.link }}">Supertramp</a>')
 
-    @page.save(validate: false)
-  end
+      @page.save(validate: false)
+    end
 
-  def test_fix_pagination_href
-    assert_equal true,  @page.published.include?('{{ part.link }}')
-    assert_equal false, @page.published.include?('{{ part.url }}')
+    def test_fix_pagination_href
+      assert_equal true,  @page.published.include?('{{ part.link }}')
+      assert_equal false, @page.published.include?('{{ part.url }}')
 
-    execute_rake_task 'cms/cms.rake', 'cms:fix:pagination_href'
+      execute_rake_task 'cms/cms.rake', 'cms:fix:pagination_href'
 
-    @page.reload
+      @page.reload
 
-    assert_equal true,  @page.published.include?('{{ part.url }}')
-    assert_equal false, @page.published.include?('{{ part.link }}')
+      assert_equal true,  @page.published.include?('{{ part.url }}')
+      assert_equal false, @page.published.include?('{{ part.link }}')
+    end
   end
 end

--- a/test/unit/tasks/data_migration/fix_backend_config_path_test.rb
+++ b/test/unit/tasks/data_migration/fix_backend_config_path_test.rb
@@ -1,20 +1,22 @@
 require 'test_helper'
 
-class Tasks::FixBackendConfigPathTest < ActiveSupport::TestCase
-  fixtures :backend_api_configs
+module Tasks
+  class FixBackendConfigPathTest < ActiveSupport::TestCase
+    fixtures :backend_api_configs
 
-  setup do
-    @config_without_path = backend_api_configs(:empty_path)
-    @config_with_path    = backend_api_configs(:with_path)
-  end
+    setup do
+      @config_without_path = backend_api_configs(:empty_path)
+      @config_with_path    = backend_api_configs(:with_path)
+    end
 
-  test 'migrates all configs with empty path to have a backslash on it' do
-    assert @config_without_path.path.blank?
-    assert_equal '/some/path', @config_with_path.path
+    test 'migrates all configs with empty path to have a backslash on it' do
+      assert @config_without_path.path.blank?
+      assert_equal '/some/path', @config_with_path.path
 
-    execute_rake_task 'data_migration/fix_backend_config_path.rake', 'data_migration:fix_backend_config_path'
+      execute_rake_task 'data_migration/fix_backend_config_path.rake', 'data_migration:fix_backend_config_path'
 
-    assert_equal '/', @config_without_path.reload.path
-    assert_equal '/some/path', @config_with_path.reload.path
+      assert_equal '/', @config_without_path.reload.path
+      assert_equal '/some/path', @config_with_path.reload.path
+    end
   end
 end

--- a/test/unit/tasks/deleted_objects_test.rb
+++ b/test/unit/tasks/deleted_objects_test.rb
@@ -2,31 +2,33 @@
 
 require 'test_helper'
 
-class Tasks::DeletedObjectsTest < ActiveSupport::TestCase
-  test 'destroy_deleted_objects_with_owner_service_destroyed' do
+module Tasks
+  class DeletedObjectsTest < ActiveSupport::TestCase
+    test 'destroy_deleted_objects_with_owner_service_destroyed' do
 
-    # Metric Object destroyed with Service owner persisted
-    service = FactoryBot.create(:simple_service)
-    metric = FactoryBot.create(:metric, service: service)
-    DeletedObject.create!(object: metric, owner: service)
-    metric.delete
+      # Metric Object destroyed with Service owner persisted
+      service = FactoryBot.create(:simple_service)
+      metric = FactoryBot.create(:metric, service: service)
+      DeletedObject.create!(object: metric, owner: service)
+      metric.delete
 
-    # Metric Object destroyed with Service owner destroyed (without its own DeletedObject)
-    service = FactoryBot.create(:simple_service)
-    metric = FactoryBot.create(:metric, service: service)
-    object_with_service_owner_destroyed = DeletedObject.create!(object: metric, owner: service)
-    metric.delete
-    service.delete
+      # Metric Object destroyed with Service owner destroyed (without its own DeletedObject)
+      service = FactoryBot.create(:simple_service)
+      metric = FactoryBot.create(:metric, service: service)
+      object_with_service_owner_destroyed = DeletedObject.create!(object: metric, owner: service)
+      metric.delete
+      service.delete
 
-    # Service Object destroyed
-    service = FactoryBot.create(:simple_service)
-    DeletedObject.create!(object: service, owner: service.account)
-    service.delete
+      # Service Object destroyed
+      service = FactoryBot.create(:simple_service)
+      DeletedObject.create!(object: service, owner: service.account)
+      service.delete
 
 
-    assert_difference(DeletedObject.method(:count), -1) do
-      execute_rake_task 'deleted_objects.rake', 'deleted_objects:destroy_deleted_objects_with_owner_service_destroyed'
+      assert_difference(DeletedObject.method(:count), -1) do
+        execute_rake_task 'deleted_objects.rake', 'deleted_objects:destroy_deleted_objects_with_owner_service_destroyed'
+      end
+      assert_raise(ActiveRecord::RecordNotFound) { object_with_service_owner_destroyed.reload }
     end
-    assert_raise(ActiveRecord::RecordNotFound) { object_with_service_owner_destroyed.reload }
   end
 end

--- a/test/unit/tasks/forum/migrate_forum_test.rb
+++ b/test/unit/tasks/forum/migrate_forum_test.rb
@@ -1,43 +1,45 @@
 require 'test_helper'
 
-class Tasks::ForumTest < ActiveSupport::TestCase
+module Tasks
+  class ForumTest < ActiveSupport::TestCase
 
-  def test_migrate_forum
-    admin_1, admin_2 = FactoryBot.create_list(:simple_user, 2)
-    account = FactoryBot.create(:simple_account, users: [admin_2])
-    forum_1 = FactoryBot.create(:forum)
-    forum_2 = FactoryBot.create(:forum, account: account)
+    def test_migrate_forum
+      admin_1, admin_2 = FactoryBot.create_list(:simple_user, 2)
+      account = FactoryBot.create(:simple_account, users: [admin_2])
+      forum_1 = FactoryBot.create(:forum)
+      forum_2 = FactoryBot.create(:forum, account: account)
 
-    FactoryBot.create(:post, user: admin_1, forum: forum_1,
-      topic: FactoryBot.create(:topic, user: admin_1, forum: forum_1))
-    FactoryBot.create(:post, user: admin_1, forum: forum_1,
-      topic: FactoryBot.create(:topic, user: admin_1, forum: forum_1))
+      FactoryBot.create(:post, user: admin_1, forum: forum_1,
+        topic: FactoryBot.create(:topic, user: admin_1, forum: forum_1))
+      FactoryBot.create(:post, user: admin_1, forum: forum_1,
+        topic: FactoryBot.create(:topic, user: admin_1, forum: forum_1))
 
-    ENV.stubs(:[])
-    ENV.stubs(:[]).with('CURRENT_FORUM_ID').returns(forum_1.id)
-    ENV.stubs(:[]).with('NEW_FORUM_ID').returns(forum_2.id)
+      ENV.stubs(:[])
+      ENV.stubs(:[]).with('CURRENT_FORUM_ID').returns(forum_1.id)
+      ENV.stubs(:[]).with('NEW_FORUM_ID').returns(forum_2.id)
 
-    assert_equal 2, forum_1.topics.count
-    assert_equal 0, forum_2.topics.count
-    assert_equal 4, forum_1.posts.count
-    assert_equal 0, forum_2.posts.count
+      assert_equal 2, forum_1.topics.count
+      assert_equal 0, forum_2.topics.count
+      assert_equal 4, forum_1.posts.count
+      assert_equal 0, forum_2.posts.count
 
-    (forum_1.topics.to_a + forum_1.posts.to_a).each do |object|
-      assert_equal object.user_id, admin_1.id
-    end
+      (forum_1.topics.to_a + forum_1.posts.to_a).each do |object|
+        assert_equal object.user_id, admin_1.id
+      end
 
-    execute_rake_task 'forum/migrate_forum.rake', 'forum:migrate_forum'
+      execute_rake_task 'forum/migrate_forum.rake', 'forum:migrate_forum'
 
-    forum_1.reload
-    forum_2.reload
+      forum_1.reload
+      forum_2.reload
 
-    assert_equal 0, forum_1.topics.count
-    assert_equal 2, forum_2.topics.count
-    assert_equal 0, forum_1.posts.count
-    assert_equal 4, forum_2.posts.count
+      assert_equal 0, forum_1.topics.count
+      assert_equal 2, forum_2.topics.count
+      assert_equal 0, forum_1.posts.count
+      assert_equal 4, forum_2.posts.count
 
-    (forum_2.topics.to_a + forum_2.posts.to_a).each do |object|
-      assert_equal object.user_id, admin_2.id
+      (forum_2.topics.to_a + forum_2.posts.to_a).each do |object|
+        assert_equal object.user_id, admin_2.id
+      end
     end
   end
 end

--- a/test/unit/tasks/impersonation_admin_user_test.rb
+++ b/test/unit/tasks/impersonation_admin_user_test.rb
@@ -2,24 +2,26 @@
 
 require 'test_helper'
 
-class Tasks::ImpersonationAdminUserTest < ActiveSupport::TestCase
-  setup do
-    3.times do
-      FactoryBot.create(:active_admin,
-                            username: '3scaleadmin',
-                            account: FactoryBot.create(:simple_provider, provider_account: master_account)
-                          )
+module Tasks
+  class ImpersonationAdminUserTest < ActiveSupport::TestCase
+    setup do
+      3.times do
+        FactoryBot.create(:active_admin,
+                              username: '3scaleadmin',
+                              account: FactoryBot.create(:simple_provider, provider_account: master_account)
+                            )
+      end
+      FactoryBot.create_list(:active_admin, 2)
     end
-    FactoryBot.create_list(:active_admin, 2)
-  end
 
-  test 'update' do
-    execute_rake_task 'impersonation_admin_user.rake', 'impersonation_admin_user:update', 'example-username', 'domain.example.com'
+    test 'update' do
+      execute_rake_task 'impersonation_admin_user.rake', 'impersonation_admin_user:update', 'example-username', 'domain.example.com'
 
-    users = User.where(username: 'example-username')
-    assert_equal 0, User.where(username: '3scaleadmin').count
-    assert_equal 3, users.count
-    assert_equal 3, User.where('username <> \'3scaleadmin\'').where('username <> \'example-username\'').count
-    users.each { |user| assert_match /\Aexample\-username\+#{user.account.self_domain}@domain\.example\.com\z/, user.email }
+      users = User.where(username: 'example-username')
+      assert_equal 0, User.where(username: '3scaleadmin').count
+      assert_equal 3, users.count
+      assert_equal 3, User.where('username <> \'3scaleadmin\'').where('username <> \'example-username\'').count
+      users.each { |user| assert_match /\Aexample\-username\+#{user.account.self_domain}@domain\.example\.com\z/, user.email }
+    end
   end
 end

--- a/test/unit/tasks/multitenant/tenants_test.rb
+++ b/test/unit/tasks/multitenant/tenants_test.rb
@@ -2,162 +2,166 @@
 
 require 'test_helper'
 
-class Tasks::Multitenant::TenantsTest < ActiveSupport::TestCase
-  class UpdateTenantIdTest < ActiveSupport::TestCase
-    test 'fix_corrupted_tenant_id_accounts fixes buyers with tenant_id = provider_account_id' do
-      provider = FactoryBot.create(:simple_provider)
-      buyers_to_update = FactoryBot.create_list(:simple_buyer, 2, provider_account: provider, tenant_id: nil)
-      buyer_not_to_update = FactoryBot.create(:simple_buyer, provider_account: provider, tenant_id: nil)
-      [buyers_to_update, buyer_not_to_update].flatten.each { |account| account.update_column(:tenant_id, -1) }
+module Tasks
+  module Multitenant
+    class TenantsTest < ActiveSupport::TestCase
+      class UpdateTenantIdTest < ActiveSupport::TestCase
+        test 'fix_corrupted_tenant_id_accounts fixes buyers with tenant_id = provider_account_id' do
+          provider = FactoryBot.create(:simple_provider)
+          buyers_to_update = FactoryBot.create_list(:simple_buyer, 2, provider_account: provider, tenant_id: nil)
+          buyer_not_to_update = FactoryBot.create(:simple_buyer, provider_account: provider, tenant_id: nil)
+          [buyers_to_update, buyer_not_to_update].flatten.each { |account| account.update_column(:tenant_id, -1) }
 
-      Rails.application.expects(:simple_try_config_for).with('corrupted_accounts').returns(YAML.load(buyers_to_update.map(&:id).to_yaml))
+          Rails.application.expects(:simple_try_config_for).with('corrupted_accounts').returns(YAML.load(buyers_to_update.map(&:id).to_yaml))
 
-      ENV['FILE'] = 'corrupted_accounts'
-      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_accounts', '1', '1'
+          ENV['FILE'] = 'corrupted_accounts'
+          execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_accounts', '1', '1'
 
-      buyers_to_update.each { |buyer| assert_equal provider.id, buyer.reload.tenant_id }
-      assert_equal -1, buyer_not_to_update.reload.tenant_id
-    end
+          buyers_to_update.each { |buyer| assert_equal provider.id, buyer.reload.tenant_id }
+          assert_equal -1, buyer_not_to_update.reload.tenant_id
+        end
 
-    test 'fix_corrupted_tenant_id_accounts fixes providers with tenant_id = id' do
-      providers_to_update = FactoryBot.create_list(:simple_provider, 2, provider_account: master_account)
-      provider_not_to_update = FactoryBot.create(:simple_provider, provider_account: master_account)
-      [providers_to_update, provider_not_to_update].flatten.each { |account| account.update_column(:tenant_id, -1) }
+        test 'fix_corrupted_tenant_id_accounts fixes providers with tenant_id = id' do
+          providers_to_update = FactoryBot.create_list(:simple_provider, 2, provider_account: master_account)
+          provider_not_to_update = FactoryBot.create(:simple_provider, provider_account: master_account)
+          [providers_to_update, provider_not_to_update].flatten.each { |account| account.update_column(:tenant_id, -1) }
 
-      Rails.application.expects(:simple_try_config_for).with('corrupted_accounts').returns(YAML.load(providers_to_update.map(&:id).to_yaml))
+          Rails.application.expects(:simple_try_config_for).with('corrupted_accounts').returns(YAML.load(providers_to_update.map(&:id).to_yaml))
 
-      ENV['FILE'] = 'corrupted_accounts'
-      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_accounts', '1', '1'
+          ENV['FILE'] = 'corrupted_accounts'
+          execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_accounts', '1', '1'
 
-      providers_to_update.each { |provider| assert_equal provider.id, provider.reload.tenant_id }
-      assert_equal -1, provider_not_to_update.reload.tenant_id
-    end
+          providers_to_update.each { |provider| assert_equal provider.id, provider.reload.tenant_id }
+          assert_equal -1, provider_not_to_update.reload.tenant_id
+        end
 
-    test 'fix_corrupted_tenant_id_for_table_associated_to_account for a date range or nil' do
-      account = FactoryBot.create(:simple_provider)
-      users = FactoryBot.create_list(:simple_user, 4, account: account)
-      account.update_column(:tenant_id, account.id)
-      User.where(id: users[0..1].map(&:id)).update_all(tenant_id: nil)
-      User.where(id: users[2..3].map(&:id)).update_all(tenant_id: -1, created_at: Time.strptime('01/24/2019 11:00 UTC', '%m/%d/%Y %H:%M %Z'))
+        test 'fix_corrupted_tenant_id_for_table_associated_to_account for a date range or nil' do
+          account = FactoryBot.create(:simple_provider)
+          users = FactoryBot.create_list(:simple_user, 4, account: account)
+          account.update_column(:tenant_id, account.id)
+          User.where(id: users[0..1].map(&:id)).update_all(tenant_id: nil)
+          User.where(id: users[2..3].map(&:id)).update_all(tenant_id: -1, created_at: Time.strptime('01/24/2019 11:00 UTC', '%m/%d/%Y %H:%M %Z'))
 
-      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_account', 'User', '01/24/2019 08:00 UTC', '01/24/2019 16:30 UTC', '3', '1'
+          execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_account', 'User', '01/24/2019 08:00 UTC', '01/24/2019 16:30 UTC', '3', '1'
 
-      users.each { |user| assert_equal account.reload.tenant_id, user.reload.tenant_id }
-    end
+          users.each { |user| assert_equal account.reload.tenant_id, user.reload.tenant_id }
+        end
 
-    test 'fix_corrupted_tenant_id_for_table_associated_to_user for a date range or nil' do
-      user = FactoryBot.create(:simple_user, account: FactoryBot.create(:simple_provider))
-      sso_authorizations = FactoryBot.create_list(:sso_authorization, 4, user: user)
-      user.update_column(:tenant_id, user.account.id)
-      SSOAuthorization.where(id: sso_authorizations[0..1].map(&:id)).update_all(tenant_id: nil)
-      SSOAuthorization.where(id: sso_authorizations[2..3].map(&:id)).update_all(tenant_id: -1, created_at: Time.strptime('01/24/2019 11:00 UTC', '%m/%d/%Y %H:%M %Z'))
+        test 'fix_corrupted_tenant_id_for_table_associated_to_user for a date range or nil' do
+          user = FactoryBot.create(:simple_user, account: FactoryBot.create(:simple_provider))
+          sso_authorizations = FactoryBot.create_list(:sso_authorization, 4, user: user)
+          user.update_column(:tenant_id, user.account.id)
+          SSOAuthorization.where(id: sso_authorizations[0..1].map(&:id)).update_all(tenant_id: nil)
+          SSOAuthorization.where(id: sso_authorizations[2..3].map(&:id)).update_all(tenant_id: -1, created_at: Time.strptime('01/24/2019 11:00 UTC', '%m/%d/%Y %H:%M %Z'))
 
-      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_user', 'SSOAuthorization', '01/24/2019 08:00 UTC', '01/24/2019 16:30 UTC', '3', '1'
+          execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_corrupted_tenant_id_for_table_associated_to_user', 'SSOAuthorization', '01/24/2019 08:00 UTC', '01/24/2019 16:30 UTC', '3', '1'
 
-      sso_authorizations.each { |sso_authorization| assert_equal user.reload.tenant_id, sso_authorization.reload.tenant_id }
-    end
+          sso_authorizations.each { |sso_authorization| assert_equal user.reload.tenant_id, sso_authorization.reload.tenant_id }
+        end
 
-    test 'fix_empty_tenant_id_access_tokens' do
-      user = FactoryBot.create(:simple_user, account: FactoryBot.create(:simple_provider))
-      access_tokens = FactoryBot.create_list(:access_token, 3, owner: user)
-      user.update_column(:tenant_id, user.account.id)
-      AccessToken.where(id: access_tokens.map(&:id)).update_all(tenant_id: nil)
+        test 'fix_empty_tenant_id_access_tokens' do
+          user = FactoryBot.create(:simple_user, account: FactoryBot.create(:simple_provider))
+          access_tokens = FactoryBot.create_list(:access_token, 3, owner: user)
+          user.update_column(:tenant_id, user.account.id)
+          AccessToken.where(id: access_tokens.map(&:id)).update_all(tenant_id: nil)
 
-      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_empty_tenant_id_access_tokens', '3', '1'
+          execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:fix_empty_tenant_id_access_tokens', '3', '1'
 
-      access_tokens.each { |access_token| assert_equal user.reload.tenant_id, access_token.reload.tenant_id }
-    end
+          access_tokens.each { |access_token| assert_equal user.reload.tenant_id, access_token.reload.tenant_id }
+        end
 
-    test 'restore_existing_tenant_id_alerts' do
-      account = FactoryBot.create(:simple_provider)
-      alerts_empty = FactoryBot.create_list(:limit_alert, 2, account: account)
-      alerts_with_tenant_id = FactoryBot.create_list(:limit_alert, 2, account: account)
-      account.update_column(:tenant_id, account.id)
-      Alert.where(id: alerts_empty.map(&:id)).update_all(tenant_id: nil)
-      Alert.where(id: alerts_with_tenant_id.map(&:id)).update_all(tenant_id: -1)
+        test 'restore_existing_tenant_id_alerts' do
+          account = FactoryBot.create(:simple_provider)
+          alerts_empty = FactoryBot.create_list(:limit_alert, 2, account: account)
+          alerts_with_tenant_id = FactoryBot.create_list(:limit_alert, 2, account: account)
+          account.update_column(:tenant_id, account.id)
+          Alert.where(id: alerts_empty.map(&:id)).update_all(tenant_id: nil)
+          Alert.where(id: alerts_with_tenant_id.map(&:id)).update_all(tenant_id: -1)
 
-      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:restore_existing_tenant_id_alerts', '3', '1'
+          execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:restore_existing_tenant_id_alerts', '3', '1'
 
-      alerts_with_tenant_id.each { |alert| assert_equal account.reload.tenant_id, alert.reload.tenant_id }
-      alerts_empty.each { |alert| assert_nil alert.reload.tenant_id }
-    end
+          alerts_with_tenant_id.each { |alert| assert_equal account.reload.tenant_id, alert.reload.tenant_id }
+          alerts_empty.each { |alert| assert_nil alert.reload.tenant_id }
+        end
 
-    test 'restore_empty_tenant_id_alerts' do
-      account = FactoryBot.create(:simple_provider)
-      alerts_empty = FactoryBot.create_list(:limit_alert, 2, account: account)
-      alerts_with_tenant_id = FactoryBot.create_list(:limit_alert, 2, account: account)
-      account.update_column(:tenant_id, account.id)
-      Alert.where(id: alerts_empty.map(&:id)).update_all(tenant_id: nil)
-      Alert.where(id: alerts_with_tenant_id.map(&:id)).update_all(tenant_id: -1)
+        test 'restore_empty_tenant_id_alerts' do
+          account = FactoryBot.create(:simple_provider)
+          alerts_empty = FactoryBot.create_list(:limit_alert, 2, account: account)
+          alerts_with_tenant_id = FactoryBot.create_list(:limit_alert, 2, account: account)
+          account.update_column(:tenant_id, account.id)
+          Alert.where(id: alerts_empty.map(&:id)).update_all(tenant_id: nil)
+          Alert.where(id: alerts_with_tenant_id.map(&:id)).update_all(tenant_id: -1)
 
-      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:restore_empty_tenant_id_alerts', '3', '1'
+          execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:restore_empty_tenant_id_alerts', '3', '1'
 
-      alerts_empty.each { |alert| assert_equal account.reload.tenant_id, alert.reload.tenant_id }
-      alerts_with_tenant_id.each { |alert| assert_equal -1, alert.reload.tenant_id }
-    end
-  end
+          alerts_empty.each { |alert| assert_equal account.reload.tenant_id, alert.reload.tenant_id }
+          alerts_with_tenant_id.each { |alert| assert_equal -1, alert.reload.tenant_id }
+        end
+      end
 
-  class ExportOrgNamesYamlTest < Tasks::Multitenant::TenantsTest
-    setup do
-      FactoryBot.create_list(:simple_provider, 5)
-      FactoryBot.create_list(:simple_buyer, 2)
-    end
+      class ExportOrgNamesYamlTest < Multitenant::TenantsTest
+        setup do
+          FactoryBot.create_list(:simple_provider, 5)
+          FactoryBot.create_list(:simple_buyer, 2)
+        end
 
-    teardown do
-      file_name = 'tenants_organization_names.yml'
-      File.delete(file_name) if File.exist?(file_name)
-    end
+        teardown do
+          file_name = 'tenants_organization_names.yml'
+          File.delete(file_name) if File.exist?(file_name)
+        end
 
-    test 'export_org_names_to_yaml' do
-      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:export_org_names_to_yaml'
+        test 'export_org_names_to_yaml' do
+          execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:export_org_names_to_yaml'
 
-      assert_equal Account.providers.order(:id).pluck(:org_name), YAML.load_file('tenants_organization_names.yml')
-    end
-  end
+          assert_equal Account.providers.order(:id).pluck(:org_name), YAML.load_file('tenants_organization_names.yml')
+        end
+      end
 
-  class SuspendEnterpriseScheduledForDeletionTest < Tasks::Multitenant::TenantsTest
-    setup do
-      config = {'account_suspension' => 2, 'account_inactivity' => 3, 'contract_unpaid_time' => 4, disabled_for_app_plans: ['enterprise']}
-      Features::AccountDeletionConfig.configure(config)
-      Features::AccountDeletionConfig.stubs(enabled?: true)
+      class SuspendEnterpriseScheduledForDeletionTest < Multitenant::TenantsTest
+        setup do
+          config = {'account_suspension' => 2, 'account_inactivity' => 3, 'contract_unpaid_time' => 4, disabled_for_app_plans: ['enterprise']}
+          Features::AccountDeletionConfig.configure(config)
+          Features::AccountDeletionConfig.stubs(enabled?: true)
 
-      enterprise_plan = FactoryBot.create(:application_plan, system_name: 'enterprise', issuer: master_account.default_service)
-      pro_plan = FactoryBot.create(:application_plan, system_name: 'pro', issuer: master_account.default_service)
+          enterprise_plan = FactoryBot.create(:application_plan, system_name: 'enterprise', issuer: master_account.default_service)
+          pro_plan = FactoryBot.create(:application_plan, system_name: 'pro', issuer: master_account.default_service)
 
-      @tenant_with_enterprise = FactoryBot.create(:simple_provider, state: 'scheduled_for_deletion')
-      FactoryBot.create(:cinstance, user_account: @tenant_with_enterprise, plan: enterprise_plan)
+          @tenant_with_enterprise = FactoryBot.create(:simple_provider, state: 'scheduled_for_deletion')
+          FactoryBot.create(:cinstance, user_account: @tenant_with_enterprise, plan: enterprise_plan)
 
-      @tenant_with_pro = FactoryBot.create(:simple_provider, state: 'scheduled_for_deletion')
-      FactoryBot.create(:cinstance, user_account: @tenant_with_pro, plan: pro_plan)
+          @tenant_with_pro = FactoryBot.create(:simple_provider, state: 'scheduled_for_deletion')
+          FactoryBot.create(:cinstance, user_account: @tenant_with_pro, plan: pro_plan)
 
-      @tenant_with_enterprise_and_pro = FactoryBot.create(:simple_provider, state: 'scheduled_for_deletion')
-      FactoryBot.create(:cinstance, user_account: @tenant_with_enterprise_and_pro, plan: enterprise_plan)
-      FactoryBot.create(:cinstance, user_account: @tenant_with_enterprise_and_pro, plan: pro_plan)
+          @tenant_with_enterprise_and_pro = FactoryBot.create(:simple_provider, state: 'scheduled_for_deletion')
+          FactoryBot.create(:cinstance, user_account: @tenant_with_enterprise_and_pro, plan: enterprise_plan)
+          FactoryBot.create(:cinstance, user_account: @tenant_with_enterprise_and_pro, plan: pro_plan)
 
-      @tenant_without_any_cinstance = FactoryBot.create(:simple_provider, state: 'scheduled_for_deletion')
+          @tenant_without_any_cinstance = FactoryBot.create(:simple_provider, state: 'scheduled_for_deletion')
 
-      @developer_with_enterprise = FactoryBot.create(:simple_buyer, state: 'scheduled_for_deletion')
-      cinstance = FactoryBot.create(:cinstance, user_account: @developer_with_enterprise)
-      cinstance.plan.update_column(:system_name, 'enterprise')
-    end
+          @developer_with_enterprise = FactoryBot.create(:simple_buyer, state: 'scheduled_for_deletion')
+          cinstance = FactoryBot.create(:cinstance, user_account: @developer_with_enterprise)
+          cinstance.plan.update_column(:system_name, 'enterprise')
+        end
 
-    test 'it suspends only the tenants with a enterprise cinstance' do
-      execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:suspend_forbidden_plans_scheduled_for_deletion'
+        test 'it suspends only the tenants with a enterprise cinstance' do
+          execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:suspend_forbidden_plans_scheduled_for_deletion'
 
-      assert @tenant_with_enterprise.reload.suspended?
-      assert @tenant_with_enterprise_and_pro.reload.suspended?
-      assert @tenant_with_pro.reload.scheduled_for_deletion?
-      assert @tenant_without_any_cinstance.reload.scheduled_for_deletion?
-      assert @developer_with_enterprise.reload.scheduled_for_deletion?
-    end
+          assert @tenant_with_enterprise.reload.suspended?
+          assert @tenant_with_enterprise_and_pro.reload.suspended?
+          assert @tenant_with_pro.reload.scheduled_for_deletion?
+          assert @tenant_without_any_cinstance.reload.scheduled_for_deletion?
+          assert @developer_with_enterprise.reload.scheduled_for_deletion?
+        end
 
-    test 'it does nothing with the config is disabled' do
-      Features::AccountDeletionConfig.stubs(enabled?: false)
-      assert @tenant_with_enterprise.reload.scheduled_for_deletion?
-      assert @tenant_with_enterprise_and_pro.reload.scheduled_for_deletion?
-      assert @tenant_with_pro.reload.scheduled_for_deletion?
-      assert @tenant_without_any_cinstance.reload.scheduled_for_deletion?
-      assert @developer_with_enterprise.reload.scheduled_for_deletion?
+        test 'it does nothing with the config is disabled' do
+          Features::AccountDeletionConfig.stubs(enabled?: false)
+          assert @tenant_with_enterprise.reload.scheduled_for_deletion?
+          assert @tenant_with_enterprise_and_pro.reload.scheduled_for_deletion?
+          assert @tenant_with_pro.reload.scheduled_for_deletion?
+          assert @tenant_without_any_cinstance.reload.scheduled_for_deletion?
+          assert @developer_with_enterprise.reload.scheduled_for_deletion?
+        end
+      end
     end
   end
 end

--- a/test/unit/tasks/proxy_test.rb
+++ b/test/unit/tasks/proxy_test.rb
@@ -2,13 +2,15 @@
 
 require 'test_helper'
 
-class Tasks::ProxyTest < ActiveSupport::TestCase
-  test 'update_proxy_rule_owners' do
-    proxy_rules = FactoryBot.create_list(:proxy_rule, 3)
-    ProxyRule.where(id: proxy_rules.map(&:id)).update_all(owner_id: nil, owner_type: nil)
-    FactoryBot.create(:proxy_rule, proxy_id: nil, owner: FactoryBot.create(:backend_api))
-    assert_change of: ->{ ProxyRule.where(owner_type: 'Proxy').count }, by: 3 do
-      execute_rake_task 'proxy.rake', 'proxy:update_proxy_rule_owners'
+module Tasks
+  class ProxyTest < ActiveSupport::TestCase
+    test 'update_proxy_rule_owners' do
+      proxy_rules = FactoryBot.create_list(:proxy_rule, 3)
+      ProxyRule.where(id: proxy_rules.map(&:id)).update_all(owner_id: nil, owner_type: nil)
+      FactoryBot.create(:proxy_rule, proxy_id: nil, owner: FactoryBot.create(:backend_api))
+      assert_change of: ->{ ProxyRule.where(owner_type: 'Proxy').count }, by: 3 do
+        execute_rake_task 'proxy.rake', 'proxy:update_proxy_rule_owners'
+      end
     end
   end
 end

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -2,35 +2,37 @@
 
 require 'test_helper'
 
-class Tasks::ServicesTest < ActiveSupport::TestCase
-  test 'destroy_marked_as_deleted' do
-    DestroyAllDeletedObjectsWorker.expects(:perform_async).once.with('Service')
+module Tasks
+  class ServicesTest < ActiveSupport::TestCase
+    test 'destroy_marked_as_deleted' do
+      DestroyAllDeletedObjectsWorker.expects(:perform_async).once.with('Service')
 
-    execute_rake_task 'services.rake', 'services:destroy_marked_as_deleted'
-  end
-
-  test 'create_backend_apis' do
-    provider = FactoryBot.create(:simple_provider)
-    services = FactoryBot.create_list(:simple_service, 7, account: provider)
-    services.each { |service| service.proxy.update_column(:api_backend, 'https://api.example.com') }
-
-    # 1st service already has backend api
-    services.first.backend_api_configs.create(backend_api: FactoryBot.create(:backend_api, account: provider), path: '/')
-
-    # 2nd and 3rd services don't have backend_api but neither their proxy have a private_endpoint
-    services[1..2].each { |service| service.proxy.update_column(:api_backend, nil) }
-
-    assert_change of: ->{ provider.backend_apis.count }, by: 4 do
-      execute_rake_task 'services.rake', 'services:create_backend_apis'
+      execute_rake_task 'services.rake', 'services:destroy_marked_as_deleted'
     end
-  end
 
-  test 'update_metric_owners' do
-    metrics = FactoryBot.create_list(:metric, 3)
-    Metric.where(id: metrics.map(&:id)).update_all(owner_id: nil, owner_type: nil)
-    FactoryBot.create(:metric, service_id: nil, owner: FactoryBot.create(:backend_api))
-    assert_change of: ->{ Metric.where(owner_type: 'Service').count }, by: 3 do
-      execute_rake_task 'services.rake', 'services:update_metric_owners'
+    test 'create_backend_apis' do
+      provider = FactoryBot.create(:simple_provider)
+      services = FactoryBot.create_list(:simple_service, 7, account: provider)
+      services.each { |service| service.proxy.update_column(:api_backend, 'https://api.example.com') }
+
+      # 1st service already has backend api
+      services.first.backend_api_configs.create(backend_api: FactoryBot.create(:backend_api, account: provider), path: '/')
+
+      # 2nd and 3rd services don't have backend_api but neither their proxy have a private_endpoint
+      services[1..2].each { |service| service.proxy.update_column(:api_backend, nil) }
+
+      assert_change of: ->{ provider.backend_apis.count }, by: 4 do
+        execute_rake_task 'services.rake', 'services:create_backend_apis'
+      end
+    end
+
+    test 'update_metric_owners' do
+      metrics = FactoryBot.create_list(:metric, 3)
+      Metric.where(id: metrics.map(&:id)).update_all(owner_id: nil, owner_type: nil)
+      FactoryBot.create(:metric, service_id: nil, owner: FactoryBot.create(:backend_api))
+      assert_change of: ->{ Metric.where(owner_type: 'Service').count }, by: 3 do
+        execute_rake_task 'services.rake', 'services:update_metric_owners'
+      end
     end
   end
 end

--- a/test/unit/tasks/sidekiq_test.rb
+++ b/test/unit/tasks/sidekiq_test.rb
@@ -2,19 +2,21 @@
 
 require 'test_helper'
 
-class Tasks::SidekiqTest < ActiveSupport::TestCase
-  test 'sidekiq:worker' do
-    Rails.application.eager_load!
-    active_job_classes = ActiveJob::Base.descendants
-    sidekiq_classes = ObjectSpace.each_object(Class).select { |c| c.included_modules.include? Sidekiq::Worker }
+module Tasks
+  class SidekiqTest < ActiveSupport::TestCase
+    test 'sidekiq:worker' do
+      Rails.application.eager_load!
+      active_job_classes = ActiveJob::Base.descendants
+      sidekiq_classes = ObjectSpace.each_object(Class).select { |c| c.included_modules.include? Sidekiq::Worker }
 
-    active_job_queues = active_job_classes.map { |c| c.try(:queue_name)&.to_s }.compact.to_set
-    sidekiq_queues = sidekiq_classes.map { |c| (c.try(:get_sidekiq_options) || {})['queue']&.to_s }.compact.to_set
-    all_queues = active_job_queues.merge(sidekiq_queues)
+      active_job_queues = active_job_classes.map { |c| c.try(:queue_name)&.to_s }.compact.to_set
+      sidekiq_queues = sidekiq_classes.map { |c| (c.try(:get_sidekiq_options) || {})['queue']&.to_s }.compact.to_set
+      all_queues = active_job_queues.merge(sidekiq_queues)
 
-    sorted_and_formatted_queues = %w[--index 0] + all_queues.to_a.sort.flat_map { |queue| ['--queue', queue] }
+      sorted_and_formatted_queues = %w[--index 0] + all_queues.to_a.sort.flat_map { |queue| ['--queue', queue] }
 
-    Object.any_instance.expects(:exec).with({'RAILS_MAX_THREADS'=>'1'}, 'sidekiq', *sorted_and_formatted_queues.flatten)
-    execute_rake_task 'sidekiq.rake', 'sidekiq:worker'
+      Object.any_instance.expects(:exec).with({'RAILS_MAX_THREADS'=>'1'}, 'sidekiq', *sorted_and_formatted_queues.flatten)
+      execute_rake_task 'sidekiq.rake', 'sidekiq:worker'
+    end
   end
 end

--- a/test/unit/tasks/swagger_test.rb
+++ b/test/unit/tasks/swagger_test.rb
@@ -1,15 +1,17 @@
 require 'test_helper'
 
-class Tasks::SwaggerTest < ActiveSupport::TestCase
-  setup do
-    accounts = FactoryBot.create_list(:simple_account, 2)
-    accounts.each { |account| account.api_docs_services.create!(name: 'The Foo API', body: '{"basePath":"http://example.com", "apis":[]}') }
-    accounts.first.delete
-    assert_equal 2, ApiDocs::Service.count
-  end
+module Tasks
+  class SwaggerTest < ActiveSupport::TestCase
+    setup do
+      accounts = FactoryBot.create_list(:simple_account, 2)
+      accounts.each { |account| account.api_docs_services.create!(name: 'The Foo API', body: '{"basePath":"http://example.com", "apis":[]}') }
+      accounts.first.delete
+      assert_equal 2, ApiDocs::Service.count
+    end
 
-  test 'destroy_orphans' do
-    DeleteObjectHierarchyWorker.expects(:perform_later).once.with { |swagger| swagger.account.blank? }
-    execute_rake_task 'swagger.rake', 'swagger:destroy_orphans'
+    test 'destroy_orphans' do
+      DeleteObjectHierarchyWorker.expects(:perform_later).once.with { |swagger| swagger.account.blank? }
+      execute_rake_task 'swagger.rake', 'swagger:destroy_orphans'
+    end
   end
 end

--- a/test/unit/tasks/zync_test.rb
+++ b/test/unit/tasks/zync_test.rb
@@ -1,17 +1,19 @@
 require 'test_helper'
 
-class Tasks::ZyncTest < ActiveSupport::TestCase
-  setup do
-    FactoryBot.create(:provider_account)
-  end
+module Tasks
+  class ZyncTest < ActiveSupport::TestCase
+    setup do
+      FactoryBot.create(:provider_account)
+    end
 
-  test 'resync provider domains' do
-    Account.providers_with_master.each { |account| Domains::ProviderDomainsChangedEvent.expects(:create_and_publish!).with(account) }
-    execute_rake_task 'zync.rake', 'zync:resync:provider_domains'
-  end
+    test 'resync provider domains' do
+      Account.providers_with_master.each { |account| Domains::ProviderDomainsChangedEvent.expects(:create_and_publish!).with(account) }
+      execute_rake_task 'zync.rake', 'zync:resync:provider_domains'
+    end
 
-  test 'resync proxy domains' do
-    Service.all.each { |service| Domains::ProxyDomainsChangedEvent.expects(:create_and_publish!).with(service.proxy) }
-    execute_rake_task 'zync.rake', 'zync:resync:proxy_domains'
+    test 'resync proxy domains' do
+      Service.all.each { |service| Domains::ProxyDomainsChangedEvent.expects(:create_and_publish!).with(service.proxy) }
+      execute_rake_task 'zync.rake', 'zync:resync:proxy_domains'
+    end
   end
 end


### PR DESCRIPTION
This commit adds all tests from Tasks unit tests inside a module instead
of using inline modules.