### PR TITLE
Redefine Policies types

### DIFF
--- a/app/javascript/src/Policies/actions/PolicyChain.jsx
+++ b/app/javascript/src/Policies/actions/PolicyChain.jsx
@@ -2,7 +2,7 @@
 
 import { RSAA } from 'redux-api-middleware'
 
-import type { RSSAAction, RegistryPolicy, ChainPolicy, StoredChainPolicy } from 'Policies/types'
+import type { RSSAAction, RegistryPolicy, ChainPolicy, PolicyConfig } from 'Policies/types'
 
 export type AddPolicyToChainAction = { type: 'ADD_POLICY_TO_CHAIN', policy: RegistryPolicy }
 export function addPolicyToChain (policy: RegistryPolicy): AddPolicyToChainAction {
@@ -29,9 +29,9 @@ export function updatePolicyChain (payload: Array<ChainPolicy>): UpdatePolicyCha
   return { type: 'UPDATE_POLICY_CHAIN', payload }
 }
 
-export type LoadChainAction = { type: 'LOAD_CHAIN', storedChain: Array<StoredChainPolicy> }
-export function loadChain (storedChain: Array<StoredChainPolicy>): LoadChainAction {
-  return { type: 'LOAD_CHAIN', storedChain }
+export type LoadChainAction = { type: 'LOAD_CHAIN', policiesConfig: Array<PolicyConfig> }
+export function loadChain (policiesConfig: Array<PolicyConfig>): LoadChainAction {
+  return { type: 'LOAD_CHAIN', policiesConfig }
 }
 
 export type LoadChainSuccessAction = { type: 'LOAD_CHAIN_SUCCESS', payload: Array<ChainPolicy> }

--- a/app/javascript/src/Policies/actions/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/actions/PolicyConfig.jsx
@@ -2,7 +2,7 @@
 
 import type { ChainPolicy } from 'Policies/types'
 
-export type UpdatePolicyConfigAction = { type: 'UPDATE_POLICY_CONFIG', policyConfig: ChainPolicy }
-export function updatePolicyConfig (policyConfig: ChainPolicy): UpdatePolicyConfigAction {
-  return { type: 'UPDATE_POLICY_CONFIG', policyConfig }
+export type UpdatePolicyConfigAction = { type: 'UPDATE_POLICY_CONFIG', policy: ChainPolicy }
+export function updatePolicyConfig (policy: ChainPolicy): UpdatePolicyConfigAction {
+  return { type: 'UPDATE_POLICY_CONFIG', policy }
 }

--- a/app/javascript/src/Policies/actions/index.jsx
+++ b/app/javascript/src/Policies/actions/index.jsx
@@ -15,21 +15,21 @@ import {
 import { updatePolicyConfig } from 'Policies/actions/PolicyConfig'
 
 import type { UIComponent } from 'Policies/actions/UISettings'
-import type { Dispatch, RawRegistry, RegistryPolicy, ChainPolicy, StoredChainPolicy, IPoliciesActions, ThunkAction } from 'Policies/types'
+import type { Dispatch, RawRegistry, RegistryPolicy, ChainPolicy, PolicyConfig, IPoliciesActions, ThunkAction } from 'Policies/types'
 
 const chainComponent: UIComponent = 'chain'
 const registryComponent: UIComponent = 'registry'
 const policyConfigComponent: UIComponent = 'policyConfig'
 
 // Policies action creators
-function loadSavedPolicies (chain: Array<StoredChainPolicy>, registry: RawRegistry): ThunkAction {
+function loadSavedPolicies (chain: Array<PolicyConfig>, registry: RawRegistry): ThunkAction {
   return function (dispatch: Dispatch) {
     dispatch(loadRegistrySuccess(registry))
     dispatch(loadChain(chain))
   }
 }
 
-function populatePolicies (serviceId: string, chain?: Array<StoredChainPolicy>, registry?: RawRegistry): ThunkAction {
+function populatePolicies (serviceId: string, chain?: Array<PolicyConfig>, registry?: RawRegistry): ThunkAction {
   return function (dispatch: Dispatch) {
     if (registry && chain) {
       dispatch(loadSavedPolicies(chain, registry))

--- a/app/javascript/src/Policies/components/PoliciesWidget.jsx
+++ b/app/javascript/src/Policies/components/PoliciesWidget.jsx
@@ -10,12 +10,12 @@ import { PolicyChainHiddenInput } from 'Policies/components/PolicyChainHiddenInp
 import { connect } from 'react-redux'
 import { isPolicyChainChanged } from 'Policies/util'
 
-import type { ChainPolicy, State, RegistryState, ChainState, UIState, Dispatch, IPoliciesActions } from 'Policies/types'
+import type { ChainPolicy, State, RegistryPolicy, UIState, Dispatch, IPoliciesActions } from 'Policies/types'
 
 type Props = {
-  registry: RegistryState,
-  chain: ChainState,
-  originalChain: ChainState,
+  registry: Array<RegistryPolicy>,
+  chain: Array<ChainPolicy>,
+  originalChain: Array<ChainPolicy>,
   policyConfig: ChainPolicy,
   ui: UIState,
   boundActionCreators: IPoliciesActions

--- a/app/javascript/src/Policies/components/PolicyTile.jsx
+++ b/app/javascript/src/Policies/components/PolicyTile.jsx
@@ -2,10 +2,10 @@
 
 import * as React from 'react'
 
-import type { ShallowPolicy } from 'Policies/types'
+import type { RegistryPolicy } from 'Policies/types'
 
 type Props = {
-  policy: ShallowPolicy,
+  policy: RegistryPolicy,
   title?: string,
   onClick: () => void
 }

--- a/app/javascript/src/Policies/index.jsx
+++ b/app/javascript/src/Policies/index.jsx
@@ -14,13 +14,13 @@ import { initialState } from 'Policies/reducers/initialState'
 import { actions } from 'Policies/actions/index'
 import { createReactWrapper } from 'utilities/createReactWrapper'
 
-import type { RawRegistry, StoredChainPolicy } from 'Policies/types'
+import type { RawRegistry, PolicyConfig } from 'Policies/types'
 
 import 'Policies/styles/policies.scss'
 
 type PoliciesProps = {
   registry: RawRegistry,
-  chain: StoredChainPolicy[],
+  chain: PolicyConfig[],
   serviceId: string
 }
 

--- a/app/javascript/src/Policies/middleware/PolicyChain.jsx
+++ b/app/javascript/src/Policies/middleware/PolicyChain.jsx
@@ -4,13 +4,13 @@ import { generateGuid } from 'Policies/util'
 import { loadChainSuccess, loadChainError, updatePolicyChain } from 'Policies/actions/PolicyChain'
 import { setOriginalPolicyChain } from 'Policies/actions/OriginalPolicyChain'
 
-import type { RegistryPolicy, ChainPolicy, StoredChainPolicy, Dispatch, GetState, PolicyChainMiddlewareAction } from 'Policies/types'
+import type { ChainPolicy, RegistryPolicy, PolicyConfig, Dispatch, GetState, PolicyChainMiddlewareAction } from 'Policies/types'
 
-function findRegistryPolicy (registry: Array<RegistryPolicy>, storedPolicy: StoredChainPolicy): RegistryPolicy | typeof undefined {
+function findRegistryPolicy (registry: Array<RegistryPolicy>, storedPolicy: PolicyConfig): RegistryPolicy | void {
   return registry.find(policy => (policy.name === storedPolicy.name && policy.version === storedPolicy.version))
 }
 
-function convertToChainPolicy (registryPolicy: RegistryPolicy, storedPolicy: StoredChainPolicy): ChainPolicy {
+function convertToChainPolicy (registryPolicy: RegistryPolicy, storedPolicy: PolicyConfig): ChainPolicy {
   const removable = !(storedPolicy.name === 'apicast')
   return {
     ...registryPolicy,
@@ -31,10 +31,10 @@ const updatePolicy = (chain: Array<ChainPolicy>, policyConfig: ChainPolicy): Arr
   return chain.map(policy => (policy.uuid === policyConfig.uuid) ? policyConfig : policy)
 }
 
-const loadChain = ({registry, storedChain, dispatch}: {registry: Array<RegistryPolicy>, storedChain: Array<StoredChainPolicy>, dispatch: Dispatch}) => {
+const loadChain = ({registry, policiesConfig, dispatch}: {registry: Array<RegistryPolicy>, policiesConfig: Array<PolicyConfig>, dispatch: Dispatch}) => {
   let errors = 0
   let updatedChain: Array<ChainPolicy> = []
-  storedChain.forEach(storedPolicy => {
+  policiesConfig.forEach(storedPolicy => {
     const foundRegistryPolicy = findRegistryPolicy(registry, storedPolicy)
     foundRegistryPolicy
       ? updatedChain.push(convertToChainPolicy(foundRegistryPolicy, storedPolicy))
@@ -52,7 +52,7 @@ const policyChainMiddleware = ({ dispatch, getState }: { dispatch: Dispatch, get
   const state = getState()
   switch (action.type) {
     case 'LOAD_CHAIN':
-      loadChain({registry: state.registry, storedChain: action.storedChain, dispatch})
+      loadChain({registry: state.registry, policiesConfig: action.policiesConfig, dispatch})
       break
     case 'REMOVE_POLICY_FROM_CHAIN':
       dispatch(updatePolicyChain(removePolicy(state.chain, action.policy)))

--- a/app/javascript/src/Policies/reducers/OriginalPolicyChain.jsx
+++ b/app/javascript/src/Policies/reducers/OriginalPolicyChain.jsx
@@ -3,15 +3,15 @@
 import { initialState } from 'Policies/reducers/initialState'
 import { createReducer, updateArray } from 'Policies/util'
 
-import type { ChainState } from 'Policies/types'
+import type { ChainPolicy } from 'Policies/types'
 import type { SetOriginalPolicyChainAction } from 'Policies/actions/OriginalPolicyChain'
 
-function setOriginalPolicyChain (state: ChainState, action: SetOriginalPolicyChainAction): ChainState {
+function setOriginalPolicyChain (state: Array<ChainPolicy>, action: SetOriginalPolicyChainAction): Array<ChainPolicy> {
   return updateArray(state, action.payload)
 }
 
 // TODO: use combineReducers instead of createReducer
-const OriginalChainReducer = createReducer<ChainState>(initialState.originalChain, {
+const OriginalChainReducer = createReducer<Array<ChainPolicy>>(initialState.originalChain, {
   'SET_ORIGINAL_POLICY_CHAIN': setOriginalPolicyChain
 })
 

--- a/app/javascript/src/Policies/reducers/PolicyChain.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyChain.jsx
@@ -3,7 +3,7 @@
 import { initialState } from 'Policies/reducers/initialState'
 import { createReducer, generateGuid, updateArray } from 'Policies/util'
 
-import type { ChainState, ChainPolicy, RegistryPolicy } from 'Policies/types'
+import type { ChainPolicy, RegistryPolicy } from 'Policies/types'
 import type {
   AddPolicyToChainAction,
   FetchChainSuccessAction,
@@ -17,20 +17,20 @@ function createChainPolicy (policy: RegistryPolicy): ChainPolicy {
   return {...policy, ...{humanName: policy.humanName, enabled: true, removable: true, uuid: generateGuid()}}
 }
 
-function addPolicy (state: ChainState, action: AddPolicyToChainAction): ChainState {
+function addPolicy (state: Array<ChainPolicy>, action: AddPolicyToChainAction): Array<ChainPolicy> {
   return state.concat([createChainPolicy(action.policy)])
 }
 
-function updateChain (_state: ChainState, action: UpdatePolicyChainAction): ChainState {
+function updateChain (_state: Array<ChainPolicy>, action: UpdatePolicyChainAction): Array<ChainPolicy> {
   return action.payload
 }
 
-function updatePolicies (state: ChainState, action: UpdateChainPolicies): ChainState {
+function updatePolicies (state: Array<ChainPolicy>, action: UpdateChainPolicies): Array<ChainPolicy> {
   return updateArray(state, action.payload)
 }
 
 // TODO: use combineReducers instead of createReducer
-const ChainReducer = createReducer<ChainState>(initialState.chain, {
+const ChainReducer = createReducer<Array<ChainPolicy>>(initialState.chain, {
   'ADD_POLICY_TO_CHAIN': addPolicy,
   'SORT_POLICY_CHAIN': updatePolicies,
   'LOAD_CHAIN_SUCCESS': updatePolicies,

--- a/app/javascript/src/Policies/reducers/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyConfig.jsx
@@ -7,7 +7,7 @@ import type { ChainPolicy } from 'Policies/types'
 import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
 
 function updatePolicyConfig (state: ChainPolicy, action: UpdatePolicyConfigAction): ChainPolicy {
-  return action.policyConfig
+  return action.policy
 }
 
 // TODO: use combineReducers instead of createReducer

--- a/app/javascript/src/Policies/reducers/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyRegistry.jsx
@@ -3,15 +3,15 @@
 import { initialState } from 'Policies/reducers/initialState'
 import { createReducer, updateArray, parsePolicies } from 'Policies/util'
 
-import type { RegistryState } from 'Policies/types'
+import type { RegistryPolicy } from 'Policies/types'
 import type { FetchRegistrySuccessAction } from 'Policies/actions/PolicyRegistry'
 
-function updateRegistry (state: RegistryState, action: FetchRegistrySuccessAction): RegistryState {
+function updateRegistry (state: Array<RegistryPolicy>, action: FetchRegistrySuccessAction): Array<RegistryPolicy> {
   return updateArray(state, parsePolicies(action.payload))
 }
 
 // TODO: use combineReducers instead of createReducer
-const RegistryReducer = createReducer<RegistryState>(initialState.registry, {
+const RegistryReducer = createReducer<Array<RegistryPolicy>>(initialState.registry, {
   'LOAD_REGISTRY_SUCCESS': updateRegistry,
   'FETCH_REGISTRY_SUCCESS': updateRegistry
 })

--- a/app/javascript/src/Policies/reducers/initialState.jsx
+++ b/app/javascript/src/Policies/reducers/initialState.jsx
@@ -14,7 +14,7 @@ export const initialState: State = {
     configuration: {},
     id: 0,
     version: '',
-    description: '',
+    description: [''],
     summary: '',
     enabled: true,
     removable: true,

--- a/app/javascript/src/Policies/types/Actions.jsx
+++ b/app/javascript/src/Policies/types/Actions.jsx
@@ -19,7 +19,7 @@ import type {
   LoadRegistrySuccessAction
 } from 'Policies/actions/PolicyRegistry'
 import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
-import type { Dispatch, GetState, RawRegistry, RegistryPolicy, ChainPolicy, StoredChainPolicy } from 'Policies/types'
+import type { Dispatch, GetState, ChainPolicy, PolicyConfig, RegistryPolicy, RawRegistry } from 'Policies/types'
 
 export interface IAction {
   type: string
@@ -42,7 +42,7 @@ export interface IPoliciesActions {
   closePolicyConfig: () => ThunkAction,
   addPolicy: RegistryPolicy => ThunkAction,
   closePolicyRegistry: () => ThunkAction,
-  populatePolicies: (serviceId: string, chain?: Array<StoredChainPolicy>, registry?: RawRegistry) => ThunkAction,
+  populatePolicies: (serviceId: string, chain?: Array<PolicyConfig>, registry?: RawRegistry) => ThunkAction,
   updatePolicyConfig: (ChainPolicy) => UpdatePolicyConfigAction
 }
 

--- a/app/javascript/src/Policies/types/Policies.jsx
+++ b/app/javascript/src/Policies/types/Policies.jsx
@@ -3,53 +3,37 @@
 // eslint-disable-next-line flowtype/no-weak-types
 export type Configuration = Object
 
-export type RawPolicy = {
-  $schema?: string,
-  id: number,
+// Represents the data stored for @proxy.policies_config
+export type PolicyConfig = {
   name: string,
-  version: string,
-  description?: string,
-  summary?: string,
-  configuration: Configuration
-}
-
-export type RawRegistry = {
-  [string]: Array<RawPolicy>
-}
-
-export type RegistryPolicy = & RawPolicy & {
-  humanName: string,
-  data?: Configuration
-}
-
-export type ChainPolicy = & RegistryPolicy & {
-  enabled: boolean,
-  removable?: boolean,
-  uuid?: string
-}
-
-export type StoredChainPolicy = {
-  name: string,
-  version: string,
   configuration: Configuration,
-  enabled: boolean
+  version: string,
+  enabled: boolean,
 }
 
-export type ShallowPolicy = {
-  id: number,
-  version: string,
-  humanName: string,
-  summary?: string
-}
-export type Schema = {
+// Represents each of the items contained in the registry object
+// returned by rails (@registry_policies)
+export type RawRegistryPolicy = {
+  $schema: string,
+  configuration: Configuration,
+  description: [string],
   name: string,
-  version: string,
   summary: string,
-  description: string,
-  configuration: Configuration
+  version: string
 }
-export type Policy = {
-  id: number,
-  schema: Schema,
-  directory: string
+
+// Represents the registry object returned by the server (@registry_policies)
+export type RawRegistry = { [string]: RawRegistryPolicy[] }
+
+// Represents policies of the Registry
+export type RegistryPolicy = RawRegistryPolicy & {
+  data?: Configuration,
+  humanName: string
+}
+
+// Represents policies stored in the Chain, once copied from the Registry
+export type ChainPolicy = RegistryPolicy & {
+  uuid: string,
+  enabled: boolean,
+  removable: boolean
 }

--- a/app/javascript/src/Policies/types/State.jsx
+++ b/app/javascript/src/Policies/types/State.jsx
@@ -11,15 +11,12 @@ export type UIState = {
   +error: {}
 }
 
-export type RegistryState = Array<RegistryPolicy>
-export type ChainState = Array<ChainPolicy>
-
 export type State = {
-  +registry: RegistryState,
-  +chain: ChainState,
-  +originalChain: ChainState,
+  +registry: RegistryPolicy[],
+  +chain: ChainPolicy[],
+  +originalChain: ChainPolicy[],
   +policyConfig: ChainPolicy,
   +ui: UIState
 }
 
-export type StateSlice = RegistryState | ChainPolicy | ChainState | UIState
+export type StateSlice = RegistryPolicy[] | ChainPolicy | ChainPolicy[] | UIState

--- a/app/javascript/src/Policies/util.jsx
+++ b/app/javascript/src/Policies/util.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Reducer, UIState, FetchErrorAction, RawPolicy, RawRegistry, RegistryPolicy, ChainPolicy, IAction } from 'Policies/types'
+import type { Reducer, UIState, FetchErrorAction, RawRegistry, RawRegistryPolicy, RegistryPolicy, ChainPolicy, IAction } from 'Policies/types'
 
 // Needs to be any, since it's a subset of T
 // eslint-disable-next-line flowtype/no-weak-types
@@ -47,7 +47,7 @@ function parsePolicies (registry: RawRegistry): Array<RegistryPolicy> {
   return policies
 }
 
-function parsePolicy (key: string, policy: RawPolicy): RegistryPolicy {
+function parsePolicy (key: string, policy: RawRegistryPolicy): RegistryPolicy {
   return { ...policy, name: key, humanName: policy.name, data: {} }
 }
 

--- a/spec/javascripts/Policies/components/PolicyChainHiddenInput.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyChainHiddenInput.spec.jsx
@@ -8,8 +8,8 @@ import { PolicyChainHiddenInput } from 'Policies/components/PolicyChainHiddenInp
 import type { ChainPolicy } from 'Policies/types'
 
 const policies: ChainPolicy[] = [
-  { id: 1, enabled: true, name: 'cors', humanName: 'CORS', description: 'CORS headers', version: '1.0.0', configuration: {}, $schema: '', data: {} },
-  { id: 2, enabled: true, name: 'echo', humanName: 'Echo', description: 'Echoes the request', version: '1.0.0', configuration: {}, $schema: '', data: {} }
+  { id: 1, enabled: true, name: 'cors', humanName: 'CORS', description: ['CORS headers'], version: '1.0.0', configuration: {}, $schema: '', data: {}, removable: true, summary: '', uuid: '1' },
+  { id: 2, enabled: true, name: 'echo', humanName: 'Echo', description: ['Echoes the request'], version: '1.0.0', configuration: {}, $schema: '', data: {}, removable: true, summary: '', uuid: '2' }
 ]
 
 it('should render itself', () => {

--- a/spec/javascripts/Policies/middleware/PolicyChain.spec.jsx
+++ b/spec/javascripts/Policies/middleware/PolicyChain.spec.jsx
@@ -49,7 +49,7 @@ describe('PolicyChain Middleware', () => {
   it('Dispatches SET_ORIGINAL_POLICY_CHAIN and LOAD_CHAIN_SUCCESS action', () => {
     invoke({
       type: 'LOAD_CHAIN',
-      storedChain: [validPolicy]
+      policiesConfig: [validPolicy]
     })
 
     expect(store.dispatch.mock.calls[0][0].type).toBe('SET_ORIGINAL_POLICY_CHAIN')
@@ -62,7 +62,7 @@ describe('PolicyChain Middleware', () => {
   it('Dispatches LOAD_CHAIN_ERROR action', () => {
     invoke({
       type: 'LOAD_CHAIN',
-      storedChain: [wrongPolicy]
+      policiesConfig: [wrongPolicy]
     })
 
     expect(store.dispatch).toHaveBeenCalledWith(loadChainError({}))
@@ -71,7 +71,7 @@ describe('PolicyChain Middleware', () => {
   it('Dispatches SET_ORIGINAL_POLICY_CHAIN and LOAD_CHAIN_SUCCESS action only with valid policies', () => {
     invoke({
       type: 'LOAD_CHAIN',
-      storedChain: [wrongPolicy, validPolicy]
+      policiesConfig: [wrongPolicy, validPolicy]
     })
 
     expect(store.dispatch).toHaveBeenCalledWith(loadChainError({}))

--- a/spec/javascripts/Policies/reducers/PolicyChain.spec.jsx
+++ b/spec/javascripts/Policies/reducers/PolicyChain.spec.jsx
@@ -1,4 +1,7 @@
+// @flow
+
 import ChainReducer from 'Policies/reducers/PolicyChain'
+import { initialState } from 'Policies/reducers/initialState'
 
 const headersChainPolicy = {humanName: 'Headers', name: 'headers', description: 'Headers', version: '1.0.0', configuration: {}, enabled: true, id: '666'}
 const corsChainPolicy = {humanName: 'CORS', name: 'cors', description: 'CORS', version: '1.0.0', configuration: {}, enabled: true, id: '007'}
@@ -6,10 +9,10 @@ const chain = [headersChainPolicy, corsChainPolicy]
 
 describe('ChainReducer', () => {
   it('should return the initial state', () => {
-    expect(ChainReducer(undefined, {})).toEqual([])
+    expect(ChainReducer(undefined, { type: 'FOO' })).toEqual(initialState.chain)
   })
 
   it('should return the updated state', () => {
-    expect(ChainReducer([], { type: 'FETCH_CHAIN_SUCCESS', payload: chain })).toEqual(Object.assign([], chain))
+    expect(ChainReducer([], { type: 'FETCH_CHAIN_SUCCESS', payload: chain })).toEqual([...[], ...chain])
   })
 })

--- a/spec/javascripts/Policies/reducers/PolicyConfig.spec.jsx
+++ b/spec/javascripts/Policies/reducers/PolicyConfig.spec.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import PolicyConfigReducer from 'Policies/reducers/PolicyConfig'
 import { initialState } from 'Policies/reducers/initialState'
 
@@ -12,7 +14,7 @@ const schema = {
 
 describe('PolicyConfig Reducer', () => {
   it('should return the initial state', () => {
-    expect(PolicyConfigReducer(undefined, {})).toEqual(initialState.policyConfig)
+    expect(PolicyConfigReducer(undefined, { type: 'FOO' })).toEqual(initialState.policyConfig)
   })
 
   it('should return the updated state when updating the config', () => {
@@ -30,7 +32,7 @@ describe('PolicyConfig Reducer', () => {
       removable: true,
       uuid: ''
     }
-    expect(PolicyConfigReducer(initialState.policyConfig, { type: 'UPDATE_POLICY_CONFIG', policyConfig: newConfig }))
+    expect(PolicyConfigReducer(initialState.policyConfig, { type: 'UPDATE_POLICY_CONFIG', policy: newConfig }))
       .toEqual(newConfig)
   })
 })

--- a/spec/javascripts/Policies/reducers/PolicyRegistry.spec.jsx
+++ b/spec/javascripts/Policies/reducers/PolicyRegistry.spec.jsx
@@ -1,4 +1,7 @@
+// @flow
+
 import RegistryReducer from 'Policies/reducers/PolicyRegistry'
+import { initialState } from 'Policies/reducers/initialState'
 
 const rawRegistry = {
   cors: [{
@@ -13,7 +16,7 @@ const rawRegistry = {
 
 describe('RegistryReducer', () => {
   it('should return the initial state', () => {
-    expect(RegistryReducer(undefined, {})).toEqual([])
+    expect(RegistryReducer(undefined, { type: 'FOO' })).toEqual(initialState.registry)
   })
 
   it('should return the updated state', () => {

--- a/spec/javascripts/Policies/reducers/UISettings.spec.jsx
+++ b/spec/javascripts/Policies/reducers/UISettings.spec.jsx
@@ -1,16 +1,11 @@
+// @flow
+
 import UISettingsReducer from 'Policies/reducers/UISettings'
 import { initialState } from 'Policies/reducers/initialState'
 
 describe('UISettingsReducer', () => {
   it('should return the initial state', () => {
-    expect(UISettingsReducer(undefined, {})).toEqual({
-      'chain': true,
-      'error': {},
-      'policyConfig': false,
-      'registry': false,
-      'submitButtonEnabled': false,
-      'requests': 0
-    })
+    expect(UISettingsReducer(undefined, { type: 'FOO' })).toEqual(initialState.ui)
   })
 
   it('should return the updated state', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Big refactor of types, removing duplications and using names as much clear as possible:
* Policies return by rails is an object of `RawRegistryPolicy`. It is parsed and added into the registry component as an array of `IPolicy`
* policies_config is passed as props as an array of `PolicyConfig`. Then they are parsed and added to the chain, copied from the registry -> `ChainPolicy`
* Some variable/prop names also changed for more consistency and clarity

**Verification steps**:
* `npm run update-dependencies`
* Navigate to `apiconfig/services/<id>/policies/edit`
* Policies widget should work as usual

**Note**:
This is part 8 of the refactorization of Policies:
[THREESCALE-2221: Policies: Normalise the use of policies schema and its types](https://issues.jboss.org/browse/THREESCALE-2221)

Previous step #1410.