### PR TITLE
UserSessionSweeperWorker uses delete instead of destroy for the UserSession

### DIFF
--- a/app/workers/user_session_sweeper_worker.rb
+++ b/app/workers/user_session_sweeper_worker.rb
@@ -5,6 +5,6 @@ class UserSessionSweeperWorker
   sidekiq_options queue: :low
 
   def perform(id)
-    UserSession.destroy(id)
+    UserSession.delete(id)
   end
 end


### PR DESCRIPTION
Requested by Hery in this comment: https://github.com/3scale/porta/pull/1415#issuecomment-554879081
Sorry, I saw it after merging 🙈 