### PR TITLE
Enable Policies update button after rearranging chain

### DIFF
--- a/app/javascript/src/Policies/util.jsx
+++ b/app/javascript/src/Policies/util.jsx
@@ -52,12 +52,14 @@ function parsePolicy (key: string, policy: RawPolicy): RegistryPolicy {
 }
 
 function isPolicyChainChanged (chain: ChainPolicy[], originalChain: ChainPolicy[]) {
-  if (originalChain.length !== chain.length) {
+  const chainLength = chain.length
+  if (originalChain.length !== chainLength) {
     return true
   }
 
-  for (const policy of chain) {
-    const originalPolicy = originalChain.find(p => p.uuid === policy.uuid)
+  for (let i = 0; i < chainLength; i++) {
+    const policy = chain[i]
+    const originalPolicy = originalChain[i]
     if (JSON.stringify(policy) !== JSON.stringify(originalPolicy)) {
       return true
     }

--- a/spec/javascripts/Policies/util.spec.jsx
+++ b/spec/javascripts/Policies/util.spec.jsx
@@ -1,13 +1,18 @@
 import { isPolicyChainChanged } from 'Policies/util'
 
-const originalChain = [
-  {
-    uuid: '64f09fc1-d35a-0e1b-018c-409312861a7d',
-    data: {
-      allow_origin: '123'
-    }
+const policy1 = {
+  uuid: '64f09fc1-d35a-0e1b-018c-409312861a7d',
+  data: {
+    allow_origin: '123'
   }
-]
+}
+const policy2 = {
+  uuid: '64f09fc1-018c-d35a-0e1b-40931286asdf',
+  data: {
+    allow_origin: '456'
+  }
+}
+const originalChain = [policy1, policy2]
 
 it('should detect when chain did not changed', () => {
   const changed = isPolicyChainChanged(originalChain, originalChain)
@@ -31,6 +36,13 @@ it('should detect a change when a policy is updated', () => {
       }
     }
   ]
+  const changed = isPolicyChainChanged(newChain, originalChain)
+
+  expect(changed).toBe(true)
+})
+
+it('should detect a change when policies are rearranged', () => {
+  const newChain = [policy2, policy1]
   const changed = isPolicyChainChanged(newChain, originalChain)
 
   expect(changed).toBe(true)


### PR DESCRIPTION
**What this PR does / why we need it**:

When polices change their place within the chain, the update button is enabled.

**Which issue(s) this PR fixes** 

[THREESCALE-3941: Policies cannot be updated after reordering them](https://issues.jboss.org/browse/THREESCALE-3941)

**Verification steps** 

1. In Product-> Integration-> Policies-> add multiple policies and update
2. Reload policies page and try to reorder policies
3. Try to click on "Update Policy Chain"
