### PR TITLE
Automatically fetch model error message when fails to create service

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -48,7 +48,7 @@ class Api::ServicesController < Api::BaseController
       onboarding.bubble_update('api')
       redirect_to admin_service_path(@service)
     else
-      flash.now[:error] = flash_message(@service.errors.keys.first, {scope: %i[flash services create errors]})
+      flash.now[:error] = @service.errors.full_messages.to_sentence.presence || I18n.t!('flash.services.create.errors.default', {resource_type: product_or_service_type})
       activate_menu :dashboard
       render :new
     end
@@ -153,12 +153,5 @@ class Api::ServicesController < Api::BaseController
 
   def authorize_admin_plans
     authorize! :admin, :plans
-  end
-
-  def flash_message(key, opts = {})
-    options = opts.reverse_merge(resource_type: product_or_service_type)
-    I18n.t!(key, options)
-  rescue I18n::MissingTranslationData
-    t(:default, options)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -886,6 +886,11 @@ en:
         service_plan:
           has_contracts: 'This service plan cannot be deleted! At least one contract depends on it.'
 
+        service:
+          attributes:
+            system_name:
+              invalid: invalid. Only ASCII letters, numbers, dashes and underscores are allowed.
+
         cinstance:
           attributes:
             plan:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1138,8 +1138,6 @@ en:
       create:
         notice: "%{resource_type} created."
         errors:
-          name: "Name can't be blank."
-          system_name: "System name invalid. Only ASCII letters, numbers, dashes and underscores are allowed."
           default: "Couldn't create %{resource_type}. Check your Plan limits"
       update:
         notice: "%{resource_type} information updated."

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -217,8 +217,12 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'Couldn\'t create Product. Check your Plan limits', flash[:error]
 
       @provider.settings.allow_multiple_services!
+
       post admin_services_path, service: { name: '' }
       assert_equal 'Name can\'t be blank', flash[:error]
+
+      post admin_services_path, service: { name: 'example-service', system_name: '###' }
+      assert_equal 'System name invalid. Only ASCII letters, numbers, dashes and underscores are allowed.', flash[:error]
     end
   end
 end

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -174,7 +174,7 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  class BackendApiCreation < Api::ServicesControllerTest
+  class BackendApiCreationTest < Api::ServicesControllerTest
     def setup
       super
       Logic::RollingUpdates.stubs(enabled?: true)
@@ -208,6 +208,17 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       end
 
       assert_equal 1, Service.last.backend_api_configs.count
+    end
+  end
+
+  class ServiceCreateTest < Api::ServicesControllerTest
+    test 'create error shows the right flash message' do
+      post admin_services_path, service: { name: '' }
+      assert_equal 'Couldn\'t create Product. Check your Plan limits', flash[:error]
+
+      @provider.settings.allow_multiple_services!
+      post admin_services_path, service: { name: '' }
+      assert_equal 'Name can\'t be blank', flash[:error]
     end
   end
 end


### PR DESCRIPTION
This is my proposal for https://github.com/3scale/porta/pull/1398/files#r347518158
This way the result is exactly the same, but we don't have to manually add/edit/remove every validation from the model also in the locale, because many are already done by ActiveRecord and the less repetition, the less changes to mess up from us while maintaining the code 😄 