### PR TITLE
Policies/parse registry in rails

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -137,10 +137,7 @@ class Api::IntegrationsController < Api::BaseController
 
   def find_registry_policies
     policies_list = Policies::PoliciesListService.call!(current_account, proxy: @proxy)
-    @registry_policies = policies_list.map do |key, value|
-      policy = value.first
-      policy.merge :name => key, :humanName => policy['name'], :data => {}
-    end
+    @registry_policies = PoliciesListPresenter.new(policies_list).registry
   rescue StandardError => error
     @error = error
   end

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -136,7 +136,11 @@ class Api::IntegrationsController < Api::BaseController
   protected
 
   def find_registry_policies
-    @registry_policies ||= Policies::PoliciesListService.call!(current_account, proxy: @proxy)
+    policies_list = Policies::PoliciesListService.call!(current_account, proxy: @proxy)
+    @registry_policies = policies_list.map do |key, value|
+      policy = value.first
+      policy.merge :name => key, :humanName => policy['name'], :data => {}
+    end
   rescue StandardError => error
     @error = error
   end

--- a/app/controllers/api/policies_controller.rb
+++ b/app/controllers/api/policies_controller.rb
@@ -42,7 +42,11 @@ class Api::PoliciesController < Api::BaseController
   end
 
   def find_resources
-    @registry_policies = Policies::PoliciesListService.call!(current_account, proxy: proxy)
+    policies_list = Policies::PoliciesListService.call!(current_account, proxy: proxy)
+    @registry_policies = policies_list.map do |key, value|
+      policy = value.first
+      policy.merge :name => key, :humanName => policy['name'], :data => {}
+    end
   rescue StandardError => error
     @error = error
   end

--- a/app/controllers/api/policies_controller.rb
+++ b/app/controllers/api/policies_controller.rb
@@ -43,10 +43,7 @@ class Api::PoliciesController < Api::BaseController
 
   def find_resources
     policies_list = Policies::PoliciesListService.call!(current_account, proxy: proxy)
-    @registry_policies = policies_list.map do |key, value|
-      policy = value.first
-      policy.merge :name => key, :humanName => policy['name'], :data => {}
-    end
+    @registry_policies = PoliciesListPresenter.new(policies_list).registry
   rescue StandardError => error
     @error = error
   end

--- a/app/javascript/src/Policies/actions/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/actions/PolicyRegistry.jsx
@@ -2,17 +2,17 @@
 
 import { RSAA } from 'redux-api-middleware'
 
-import type { RSSAAction, RawRegistry } from 'Policies/types'
+import type { RSSAAction, RegistryPolicy } from 'Policies/types'
 
-export type FetchRegistrySuccessAction = { type: 'FETCH_REGISTRY_SUCCESS', payload: RawRegistry, meta: ?{} }
+export type FetchRegistrySuccessAction = { type: 'FETCH_REGISTRY_SUCCESS', payload: Array<RegistryPolicy>, meta: ?{} }
 export type FetchRegistryErrorAction = { type: 'FETCH_REGISTRY_ERROR', payload: {}, error: boolean, meta: ?{} }
 
 const REQUEST = { type: 'FETCH_REGISTRY_REQUEST' }
 const SUCCESS = { type: 'FETCH_REGISTRY_SUCCESS' }
 const FAILURE = { type: 'FETCH_REGISTRY_ERROR' }
 
-export type LoadRegistrySuccessAction = { type: string, payload: RawRegistry}
-export function loadRegistrySuccess (payload: RawRegistry): LoadRegistrySuccessAction {
+export type LoadRegistrySuccessAction = { type: string, payload: Array<RegistryPolicy>}
+export function loadRegistrySuccess (payload: Array<RegistryPolicy>): LoadRegistrySuccessAction {
   return { type: 'LOAD_REGISTRY_SUCCESS', payload }
 }
 

--- a/app/javascript/src/Policies/actions/index.jsx
+++ b/app/javascript/src/Policies/actions/index.jsx
@@ -15,21 +15,21 @@ import {
 import { updatePolicyConfig } from 'Policies/actions/PolicyConfig'
 
 import type { UIComponent } from 'Policies/actions/UISettings'
-import type { Dispatch, RawRegistry, RegistryPolicy, ChainPolicy, PolicyConfig, IPoliciesActions, ThunkAction } from 'Policies/types'
+import type { Dispatch, RegistryPolicy, ChainPolicy, PolicyConfig, IPoliciesActions, ThunkAction } from 'Policies/types'
 
 const chainComponent: UIComponent = 'chain'
 const registryComponent: UIComponent = 'registry'
 const policyConfigComponent: UIComponent = 'policyConfig'
 
 // Policies action creators
-function loadSavedPolicies (chain: Array<PolicyConfig>, registry: RawRegistry): ThunkAction {
+function loadSavedPolicies (chain: Array<PolicyConfig>, registry: Array<RegistryPolicy>): ThunkAction {
   return function (dispatch: Dispatch) {
     dispatch(loadRegistrySuccess(registry))
     dispatch(loadChain(chain))
   }
 }
 
-function populatePolicies (serviceId: string, chain?: Array<PolicyConfig>, registry?: RawRegistry): ThunkAction {
+function populatePolicies (serviceId: string, chain?: Array<PolicyConfig>, registry?: Array<RegistryPolicy>): ThunkAction {
   return function (dispatch: Dispatch) {
     if (registry && chain) {
       dispatch(loadSavedPolicies(chain, registry))

--- a/app/javascript/src/Policies/index.jsx
+++ b/app/javascript/src/Policies/index.jsx
@@ -14,12 +14,12 @@ import { initialState } from 'Policies/reducers/initialState'
 import { actions } from 'Policies/actions/index'
 import { createReactWrapper } from 'utilities/createReactWrapper'
 
-import type { RawRegistry, PolicyConfig } from 'Policies/types'
+import type { RegistryPolicy, PolicyConfig } from 'Policies/types'
 
 import 'Policies/styles/policies.scss'
 
 type PoliciesProps = {
-  registry: RawRegistry,
+  registry: RegistryPolicy[],
   chain: PolicyConfig[],
   serviceId: string
 }

--- a/app/javascript/src/Policies/reducers/PolicyRegistry.jsx
+++ b/app/javascript/src/Policies/reducers/PolicyRegistry.jsx
@@ -1,13 +1,13 @@
 // @flow
 
 import { initialState } from 'Policies/reducers/initialState'
-import { createReducer, updateArray, parsePolicies } from 'Policies/util'
+import { createReducer, updateArray } from 'Policies/util'
 
 import type { RegistryPolicy } from 'Policies/types'
 import type { FetchRegistrySuccessAction } from 'Policies/actions/PolicyRegistry'
 
 function updateRegistry (state: Array<RegistryPolicy>, action: FetchRegistrySuccessAction): Array<RegistryPolicy> {
-  return updateArray(state, parsePolicies(action.payload))
+  return updateArray(state, action.payload)
 }
 
 // TODO: use combineReducers instead of createReducer

--- a/app/javascript/src/Policies/types/Actions.jsx
+++ b/app/javascript/src/Policies/types/Actions.jsx
@@ -19,7 +19,7 @@ import type {
   LoadRegistrySuccessAction
 } from 'Policies/actions/PolicyRegistry'
 import type { UpdatePolicyConfigAction } from 'Policies/actions/PolicyConfig'
-import type { Dispatch, GetState, ChainPolicy, PolicyConfig, RegistryPolicy, RawRegistry } from 'Policies/types'
+import type { Dispatch, GetState, ChainPolicy, PolicyConfig, RegistryPolicy } from 'Policies/types'
 
 export interface IAction {
   type: string
@@ -42,7 +42,7 @@ export interface IPoliciesActions {
   closePolicyConfig: () => ThunkAction,
   addPolicy: RegistryPolicy => ThunkAction,
   closePolicyRegistry: () => ThunkAction,
-  populatePolicies: (serviceId: string, chain?: Array<PolicyConfig>, registry?: RawRegistry) => ThunkAction,
+  populatePolicies: (serviceId: string, chain?: Array<PolicyConfig>, registry?: Array<RegistryPolicy>) => ThunkAction,
   updatePolicyConfig: (ChainPolicy) => UpdatePolicyConfigAction
 }
 

--- a/app/javascript/src/Policies/types/Policies.jsx
+++ b/app/javascript/src/Policies/types/Policies.jsx
@@ -11,22 +11,14 @@ export type PolicyConfig = {
   enabled: boolean,
 }
 
-// Represents each of the items contained in the registry object
-// returned by rails (@registry_policies)
-export type RawRegistryPolicy = {
+// Represents policies of the Registry
+export type RegistryPolicy = {
   $schema: string,
   configuration: Configuration,
   description: [string],
   name: string,
   summary: string,
-  version: string
-}
-
-// Represents the registry object returned by the server (@registry_policies)
-export type RawRegistry = { [string]: RawRegistryPolicy[] }
-
-// Represents policies of the Registry
-export type RegistryPolicy = RawRegistryPolicy & {
+  version: string,
   data?: Configuration,
   humanName: string
 }

--- a/app/javascript/src/Policies/util.jsx
+++ b/app/javascript/src/Policies/util.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Reducer, UIState, FetchErrorAction, RawRegistry, RawRegistryPolicy, RegistryPolicy, ChainPolicy, IAction } from 'Policies/types'
+import type { Reducer, UIState, FetchErrorAction, ChainPolicy, IAction } from 'Policies/types'
 
 // Needs to be any, since it's a subset of T
 // eslint-disable-next-line flowtype/no-weak-types
@@ -39,18 +39,6 @@ function generateGuid (): string {
   return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4()
 }
 
-function parsePolicies (registry: RawRegistry): Array<RegistryPolicy> {
-  let policies: Array<RegistryPolicy> = []
-  for (let key in registry) {
-    registry[key].forEach(policy => policies.push(parsePolicy(key, policy)))
-  }
-  return policies
-}
-
-function parsePolicy (key: string, policy: RawRegistryPolicy): RegistryPolicy {
-  return { ...policy, name: key, humanName: policy.name, data: {} }
-}
-
 function isPolicyChainChanged (chain: ChainPolicy[], originalChain: ChainPolicy[]) {
   const chainLength = chain.length
   if (originalChain.length !== chainLength) {
@@ -74,7 +62,5 @@ export {
   createReducer,
   updateError,
   generateGuid,
-  parsePolicies,
-  parsePolicy,
   isPolicyChainChanged
 }

--- a/app/presenters/policies_list_presenter.rb
+++ b/app/presenters/policies_list_presenter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class PoliciesListPresenter
+  def initialize(policies)
+    @policies = policies
+  end
+
+  def registry
+    @policies.map do |key, value|
+      policy = value.first
+      policy.merge :name => key, :humanName => policy['name'], :data => {}
+    end
+  end
+end

--- a/spec/javascripts/Policies/reducers/PolicyRegistry.spec.jsx
+++ b/spec/javascripts/Policies/reducers/PolicyRegistry.spec.jsx
@@ -3,16 +3,15 @@
 import RegistryReducer from 'Policies/reducers/PolicyRegistry'
 import { initialState } from 'Policies/reducers/initialState'
 
-const rawRegistry = {
-  cors: [{
-    $schema: 'http://apicast.io/policy-v1/schema#manifest',
-    name: 'CORS',
-    summary: 'CORS Summary',
-    description: 'CORS Description',
-    version: 'builtin',
-    configuration: {}
-  }]
-}
+const registry = [{
+  $schema: 'http://apicast.io/policy-v1/schema#manifest',
+  name: 'cors',
+  humanName: 'CORS',
+  summary: 'CORS Summary',
+  description: 'CORS Description',
+  version: 'builtin',
+  configuration: {}
+}]
 
 describe('RegistryReducer', () => {
   it('should return the initial state', () => {
@@ -20,19 +19,7 @@ describe('RegistryReducer', () => {
   })
 
   it('should return the updated state', () => {
-    const action = {
-      type: 'FETCH_REGISTRY_SUCCESS',
-      payload: rawRegistry
-    }
-    expect(RegistryReducer([], action)).toEqual([{
-      $schema: 'http://apicast.io/policy-v1/schema#manifest',
-      name: 'cors',
-      configuration: {},
-      description: 'CORS Description',
-      summary: 'CORS Summary',
-      humanName: 'CORS',
-      version: 'builtin',
-      data: {}
-    }])
+    const action = { type: 'FETCH_REGISTRY_SUCCESS', payload: registry }
+    expect(RegistryReducer([], action)).toEqual([...registry, ...[]])
   })
 })

--- a/test/integration/api/policies_controller_test.rb
+++ b/test/integration/api/policies_controller_test.rb
@@ -7,7 +7,7 @@ class Api::PoliciesControllerTest < ActionDispatch::IntegrationTest
     @provider = FactoryBot.create(:provider_account)
     @service = @provider.default_service
     login! @provider
-    Policies::PoliciesListService.expects(:call!)
+    Policies::PoliciesListService.expects(:call!).returns({})
   end
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The registry is being returned in a weird format. The frontend is expecting an array but it is insteaf a dictionary. This PR moves the "parsing" logic to the controller (perhaps a decorator would be better) in order to simplify the frontend logic.

**Verification steps**:
* `npm run update-dependencies`
* Navigate to `apiconfig/services/<id>/policies/edit`
* Policies widget should work as usual

**Note**:
This is part 9 of the refactorization of Policies:
[THREESCALE-2221: Policies: Normalise the use of policies schema and its types](https://issues.jboss.org/browse/THREESCALE-2221)

Previous step #1419.