### PR TITLE
Fix Random CircleCI Failure in Test for Segment Rake Task

### DIFF
--- a/test/unit/tasks/segment/segment_test.rb
+++ b/test/unit/tasks/segment/segment_test.rb
@@ -4,6 +4,8 @@ require 'test_helper'
 
 module Tasks
   class Segment::SegmentTest < ActiveSupport::TestCase
+    disable_transactional_fixtures!
+
     def given_segment_users_config(user_id_saved_locally)
       FakeFS do
         config = Rails.root.join('config', 'segment_users.csv')
@@ -19,16 +21,16 @@ module Tasks
         execute_rake_task 'segment/segment.rake', 'segment:save_deleted_users', 'config/segment_users.csv'
       end
       deleted_object_ids = DeletedObject.users.pluck(:object_id)
-      assert_includes deleted_object_ids, 1
-      assert_includes deleted_object_ids, 2
+      assert_includes deleted_object_ids, 100
+      assert_includes deleted_object_ids, 200
       assert_not_includes deleted_object_ids, user_id
     end
 
     def segment_users_csv(user_id_saved)
       <<-CSV
       First name,Last name,Name,User ID,account_id
-      ExampleName1,ExampleSurname1,Display Name 1,1,-11
-      ExampleName2,ExampleSurname2,Display Name 2,2,
+      ExampleName1,ExampleSurname1,Display Name 1,100,-11
+      ExampleName2,ExampleSurname2,Display Name 2,200,
       ExampleName3,ExampleSurname3,Display Name 3,#{user_id_saved},
       CSV
     end


### PR DESCRIPTION
Fixes https://app.circleci.com/jobs/github/3scale/porta/129583

#### Problem
It creates the user with ID 1 at that moment, so it exists and it detects that it is not deleted, which is correct. So the CSV must contain different user ids that the ones in DB for the test.

#### What this PR does to solve it
1. 'disable transactional fixtures' to don't have other user ids in the DB from other tests
2. change the ids of the csv for higher so the user we create in the test is the 1 always