### PR TITLE
Oracle unique index for null columns

### DIFF
--- a/db/migrate/20190716110000_add_owner_to_metrics.rb
+++ b/db/migrate/20190716110000_add_owner_to_metrics.rb
@@ -7,8 +7,11 @@ class AddOwnerToMetrics < ActiveRecord::Migration
     add_column :metrics, :owner_id, :integer, limit: 8
     add_column :metrics, :owner_type, :string
 
-    index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+    index_options = {}
+    index_options[:algorithm] = :concurrently if System::Database.postgres?
     add_index :metrics, [:owner_type, :owner_id], index_options
+
+    index_options[:ignore_nulls] = true if System::Database.oracle?
     add_index :metrics, [:owner_type, :owner_id, :system_name], index_options.merge(unique: true)
   end
 end


### PR DESCRIPTION
This PR makes database indexes with uniqueness constraint added to Oracle to include a safe `CASE..WHEN` condition that prevents the constraint to apply for records where any of the involved columns is NULL.

This is useful when some of the columns associated with the index are also new columns and hence with NULL values for existing records. It also reconciles the uniqueness index behaviour of Oracle with other the supported DBMSs (MySQL and Postgres).

Example of SQL command for https://github.com/3scale/porta/blob/d96e4b1e1c2b382d039d790a58ce37afda82f1e6/db/migrate/20190716110000_add_owner_to_metrics.rb

```sql
-- add_index(:metrics, [:owner_type, :owner_id], {})
CREATE  INDEX "INDEX_METRICS_ON_OWNER_TYPE_AND_OWNER_ID" ON "METRICS" ("OWNER_TYPE", "OWNER_ID")
   -> SUCCESS
-- add_index(:metrics, [:owner_type, :owner_id, :system_name], {:ignore_nulls=>true, :unique=>true})
CREATE UNIQUE INDEX "INDEX_METRICS_ON_OWNER_TYPE_AND_OWNER_ID_AND_SYSTEM_NAME" ON "METRICS" (CASE WHEN "OWNER_TYPE" IS NOT NULL AND "OWNER_ID" IS NOT NULL AND "SYSTEM_NAME" IS NOT NULL THEN "OWNER_TYPE" || ',' || "OWNER_ID" || ',' || "SYSTEM_NAME" END)
   -> SUCCESS
ALTER TABLE "METRICS" ADD CONSTRAINT "INDEX_METRICS_ON_OWNER_TYPE_AND_OWNER_ID_AND_SYSTEM_NAME" UNIQUE ("OWNER_TYPE", "OWNER_ID", "SYSTEM_NAME") USING INDEX "INDEX_METRICS_ON_OWNER_TYPE_AND_OWNER_ID_AND_SYSTEM_NAME"
   -> ORA-14196: Specified index cannot be used to enforce the constraint.
```

Closes [THREESCALE-3944](https://issues.jboss.org/browse/THREESCALE-3944)

----

**TODOs**

- [ ] Consider about using the fix for https://github.com/3scale/porta/blob/21337e93d20f5788ca88ea2f2808c768197fb682/db/migrate/20190304094026_add_identifier_to_policies.rb#L4
- [ ] Merge the `ignore_nulls` option into the `unique` option (?)