### PR TITLE
[oracle] Fix creation of unique index on metrics(owner_type, owner_id, system_name)

### DIFF
--- a/db/migrate/20190716110000_add_owner_to_metrics.rb
+++ b/db/migrate/20190716110000_add_owner_to_metrics.rb
@@ -9,6 +9,5 @@ class AddOwnerToMetrics < ActiveRecord::Migration
 
     index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
     add_index :metrics, [:owner_type, :owner_id], index_options
-    add_index :metrics, [:owner_type, :owner_id, :system_name], index_options.merge(unique: true)
   end
 end

--- a/db/migrate/20190716110000_add_owner_to_metrics.rb
+++ b/db/migrate/20190716110000_add_owner_to_metrics.rb
@@ -2,7 +2,7 @@ class AddOwnerToMetrics < ActiveRecord::Migration
   disable_ddl_transaction!
 
    def change
-    return if ActiveRecord::SchemaMigration.find_by(version: 20190805135730) # this migration was repositioned back
+    return if ActiveRecord::Base.connection.index_exists?(:metrics, [:owner_type, :owner_id])
 
     add_column :metrics, :owner_id, :integer, limit: 8
     add_column :metrics, :owner_type, :string

--- a/db/migrate/20190805135829_backfill_metric_owners.rb
+++ b/db/migrate/20190805135829_backfill_metric_owners.rb
@@ -2,15 +2,7 @@ require 'progress_counter'
 
 class BackfillMetricOwners < ActiveRecord::Migration
   def up
-    return puts "Nothing to do, this migration should not be executed" # Moved to lib/tasks/service.rake:update_metric_owners
-
-    say_with_time 'Updating metric owners...' do
-      Metric.reset_column_information
-      progress = ProgressCounter.new(Metric.count)
-      Metric.find_each do |metric|
-        metric.update_columns(owner_id: metric.service_id, owner_type: 'Service') unless metric.owner_type?
-        progress.call
-      end
-    end
+    Metric.reset_column_information
+    Rake::Task['services:update_metric_owners'].invoke
   end
 end

--- a/db/migrate/20190805135839_add_index_to_metrics_owner_and_system_name.rb
+++ b/db/migrate/20190805135839_add_index_to_metrics_owner_and_system_name.rb
@@ -2,7 +2,7 @@ class AddIndexToMetricsOwnerAndSystemName < ActiveRecord::Migration
   disable_ddl_transaction!
 
    def change
-    return if ActiveRecord::SchemaMigration.find_by(version: 20190805135730) # this migration was repositioned back
+    return if ActiveRecord::Base.connection.index_exists?(:metrics, [:owner_type, :owner_id, :system_name])
 
     index_options = { unique: true }
     index_options[:algorithm] = :concurrently if System::Database.postgres?

--- a/db/migrate/20190805135839_add_index_to_metrics_owner_and_system_name.rb
+++ b/db/migrate/20190805135839_add_index_to_metrics_owner_and_system_name.rb
@@ -1,0 +1,11 @@
+class AddIndexToMetricsOwnerAndSystemName < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+   def change
+    return if ActiveRecord::SchemaMigration.find_by(version: 20190805135730) # this migration was repositioned back
+
+    index_options = { unique: true }
+    index_options[:algorithm] = :concurrently if System::Database.postgres?
+    add_index :metrics, [:owner_type, :owner_id, :system_name], index_options
+  end
+end


### PR DESCRIPTION
The index uses columns recently added combined with existing system_name. This makes Oracle to activate the uniqueness constraint and fail if the owner_id and owner_type haven't yet been backfilled.

Closes [THREESCALE-3944](https://issues.jboss.org/browse/THREESCALE-3944)

Alternative to https://github.com/3scale/porta/pull/1444.