### PR TITLE
[oracle] Missing a semi-colon in trigger declaration

### DIFF
--- a/lib/system/database/oracle/trigger.rb
+++ b/lib/system/database/oracle/trigger.rb
@@ -36,7 +36,7 @@ module System
         protected
 
         def set_master_id
-          "master_id := #{master_id}"
+          "master_id := #{master_id};"
         rescue ActiveRecord::RecordNotFound
           <<~SQL
             BEGIN


### PR DESCRIPTION
Generating an error with

SELECT * FROM user_errors where type = 'TRIGGER' and NAME = 'BACKEND_APIS_TENANT_ID'

PLS-00103: Encountered the symbol "IF" when expecting one of the following:
   * & = - + ; < / > at in is mod remainder not rem
   <an exponent (**)> <> or != or ~= >= <= <> and or like like2
   like4 likec between || multiset member submultiset