### PR TITLE
Fix 'Abilities::ProviderMemberTest' - ActiveRecord::RecordNotUnique: Duplicate entry '{id_value}'

### DIFF
--- a/test/unit/abilities/provider_member_test.rb
+++ b/test/unit/abilities/provider_member_test.rb
@@ -29,7 +29,7 @@ module Abilities
 
     def test_events_according_the_service
       # service has to be stored in database, because ability depends on scope user.accessible_services
-      service  = FactoryBot.create(:simple_service, id: 1, account: @account)
+      service  = FactoryBot.create(:simple_service, account: @account)
       plan     = FactoryBot.build_stubbed(:simple_service_plan, issuer: service)
       contract = FactoryBot.build_stubbed(:simple_service_contract, plan: plan)
       event    = ServiceContracts::ServiceContractCreatedEvent.create(contract, @member)
@@ -78,9 +78,9 @@ module Abilities
     end
 
     def test_services
-      service_1 = FactoryBot.create(:simple_service, id: 1)
-      service_2 = FactoryBot.create(:simple_service, id: 2, account: @account)
-      service_3 = FactoryBot.create(:simple_service, id: 3, account: @account)
+      service_1 = FactoryBot.create(:simple_service)
+      service_2 = FactoryBot.create(:simple_service, account: @account)
+      service_3 = FactoryBot.create(:simple_service, account: @account)
 
       assert_cannot ability, :show, service_1, 'foreign service'
       assert_can ability, :show, service_2, 'all services allowed by default'
@@ -92,7 +92,7 @@ module Abilities
       assert_cannot ability, :show, service_2, 'none services allowed'
       assert_cannot ability, :show, service_3, 'none services allowed'
 
-      @member.member_permission_service_ids = [1, 2]
+      @member.member_permission_service_ids = [service_1.id, service_2.id]
       @member.save
 
       assert_cannot ability, :show, service_1, 'foreign service'


### PR DESCRIPTION
Fixes https://app.circleci.com/jobs/github/3scale/porta/131396

```
Error:
Abilities::ProviderMemberTest#test_events_according_the_service:
ActiveRecord::RecordNotUnique: Mysql2::Error: Duplicate entry '1' for key 'PRIMARY': INSERT INTO `services` (`state`, `mandatory_app_key`, `name`, `account_id`, `id`, `system_name`, `created_at`, `updated_at`) VALUES ('incomplete', 0, 'service88', 68, 1, 'service88', '2019-11-22 00:05:47', '2019-11-22 00:05:47')
    test/unit/abilities/provider_member_test.rb:32:in `test_events_according_the_service'

Error:
Abilities::ProviderMemberTest#test_services:
ActiveRecord::RecordNotUnique: Mysql2::Error: Duplicate entry '1' for key 'PRIMARY': INSERT INTO `services` (`state`, `mandatory_app_key`, `name`, `account_id`, `id`, `system_name`, `created_at`, `updated_at`) VALUES ('incomplete', 0, 'service89', 74, 1, 'service89', '2019-11-22 00:05:47', '2019-11-22 00:05:47')
    test/unit/abilities/provider_member_test.rb:81:in `test_services'
```