### PR TITLE
Fix & Refactor BackendAPI scopes: orphans & not_used_by

### DIFF
--- a/app/lib/fields/fields.rb
+++ b/app/lib/fields/fields.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-#this is tested in unit/account_test
 module Fields::Fields
   extend ActiveSupport::Concern
 

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -37,25 +37,20 @@ class BackendApi < ApplicationRecord
 
   has_system_name(uniqueness_scope: [:account_id])
 
-  scope :orphans, -> { where.has { id.not_in(BackendApiConfig.selecting { :backend_api_id }) } }
+  scope :orphans, -> {
+    where.has do
+      not_exists(BackendApiConfig.except(:order).by_backend_api(BabySqueel[:backend_apis].id).select(:id))
+    end
+  }
 
   scope :not_used_by, ->(service_id) {
-    # TODO: Baby Squeel
-    # It should be:
-    # where.has do
-    #   not_exists BackendApiConfig.by_service(service_id).by_backend_api(BabySqueel[:backend_apis].id).select(:id)
-    # end
-    # And that works for MySQL and Postgres but not Oracle
-    sql_query = <<~SQL
-      (
-        NOT EXISTS (
-          SELECT id
-          FROM backend_api_configs
-          WHERE service_id = ? AND backend_api_configs.backend_api_id = backend_apis.id
-        )
+    where.has do
+      not_exists(
+        BackendApiConfig.except(:order).select(:id)
+          .by_service(service_id)
+          .by_backend_api(BabySqueel[:backend_apis].id)
       )
-    SQL
-    where(sql_query, service_id)
+    end
   }
 
   scope :oldest_first, -> { order(created_at: :asc) }

--- a/lib/tasks/backend_api.rake
+++ b/lib/tasks/backend_api.rake
@@ -3,6 +3,9 @@
 namespace :backend_api do
   desc 'Destroy all orphan backend apis that does not belongs to any service when api_as_product is disabled'
   task :destroy_orphans => :environment do
-    BackendApi.orphans.find_each { |backend_api| DeleteObjectHierarchyWorker.perform_later(backend_api) unless backend_api.account.provider_can_use?(:api_as_product) }
+    BackendApi.orphans.joins(:account).select(:id, :account_id).find_each do |backend_api|
+      next if backend_api.account.provider_can_use?(:api_as_product)
+      DeleteObjectHierarchyWorker.perform_later(backend_api)
+    end
   end
 end


### PR DESCRIPTION
### 1st commit

This comment is not true anymore. Now it is tested in the place where one would expect:
1. `test/unit/fields/fields_test.rb`
2. `test/unit/account/fields_test.rb`
3. `test/unit/extra_fields_test.rb`
Each testing individually what it should.

It is unrelated to the rest of the PR but it is just removing an outdated pretty irrelevant comment and  removing it was committed originally just to check if circleci was working properly back then :smile: 
__________________________________________________________

### The rest

Makes `lib/tasks/backend_api.rake` more efficient by fetching the account in the same query and selecting only the necessary fields.

Closes [THREESCALE-3966](https://issues.jboss.org/browse/THREESCALE-3966)
Closes [THREESCALE-3554
](https://issues.jboss.org/browse/THREESCALE-3554)

Fixes [this random failure](https://app.circleci.com/jobs/github/3scale/porta/133424).

The reason is in `BackendApiConfigs` at that moment it fails there is stored something like this:

```
backend_api_configs
--------------------------------------------------------
ID ; backend_api_id ; service_id
1  ; NULL           ; NULL
2  ; NULL           ; NULL
```

What [this line](https://github.com/3scale/porta/blob/e588416f06ac36c46d2c7d7e12edf59fcd733d7e/app/models/backend_api.rb#L40) is actually doing in that case is:
```sql
SELECT `backend_apis`.* FROM `backend_apis` WHERE (`backend_apis`.`id` NOT IN (NULL, NULL))
```

I don't know what provokes the table to have records with null values occasionally in the CircleCI tests, but that shouldn't be possible.
I hope the reason is just that the test is missing `disable_transactional_fixtures!`

anyway, [using NOT IN operator with null values is asking for problems](http://www.sqlbadpractices.com/using-not-in-operator-with-null-values/).
And doing `not exists` instead fixes it, [except for Oracle without doing anything else](https://app.circleci.com/jobs/github/3scale/porta/134261) because [BabySqueel does not convert well the not_exists to SQL for Oracle](https://issues.jboss.org/browse/THREESCALE-3554). It can be done using bare SQL for the not_exists [as we are doing for BackendApi.not_used_by](https://github.com/3scale/porta/pull/1241/files#diff-fa56de9974347a6267b1a1940abc1eb5R37-R54), but we did that because it was urgent back then but it is a bad idea and we should fix the BabySqueel conversion to SQL of not_exists.
Now I discovered that the problem is just that it attempts to add an 'order by' in the subquery by default but in a weird format that it makes it crash (the error is `ORA-00907 missing right parenthesis: SELECT * FROM (SELECT  "BACKEND_APIS".* FROM "BACKEND_APIS" WHERE (NOT EXISTS(SELECT "BACKEND_API_CONFIGS".* FROM "BACKEND_API_CONFIGS" WHERE "BACKEND_API_CONFIGS"."BACKEND_API_ID" = "BACKEND_APIS"."ID"  ORDER BY "BACKEND_API_CONFIGS"."ID" ASC))  ORDER BY "BACKEND_APIS"."ID" ASC ) WHERE ROWNUM <= 1000`), and we do not even need the 'order' at all, so I unscoped the order for the subquery and it works this way.