### PR TITLE
Skip ModelsTest for all ActiveRecord classes declared inside the Tests

### DIFF
--- a/test/unit/models_test.rb
+++ b/test/unit/models_test.rb
@@ -18,18 +18,18 @@ class ModelsTest < ActiveSupport::TestCase
       'Profile' => %w[logo_file_name logo_content_type state], 'UserSession' => %w[key user_agent], 'CMS::Partial' => %w[content_type],
       'CMS::EmailTemplate' => %w[content_type], 'CMS::Builtin' => %w[title], 'CMS::Builtin::StaticPage' => %w[title], 'CMS::Builtin::Page' => %w[title content_type],
       'CMS::Builtin::Partial' => %w[title content_type], 'CMS::Portlet' => %w[content_type], 'CMS::Builtin::LegalTerm' => %w[title content_type],
-      'CMS::PortletTest::CustomPortlet' => :all, 'CMS::Portlet::Base' => %w[content_type], 'ExternalRssFeedPortlet' => %w[content_type],
+      'CMS::Portlet::Base' => %w[content_type], 'ExternalRssFeedPortlet' => %w[content_type],
       'LatestForumPostsPortlet' => %w[content_type], 'TableOfContentsPortlet' => %w[content_type], 'AuthenticationProvider::GitHub' => %w[branding_state account_type],
       'AuthenticationProvider::Keycloak' => %w[account_type], 'AuthenticationProvider::Auth0' => %w[account_type], 'AuthenticationProvider::Custom' => %w[account_type],
       'AuthenticationProvider::ServiceDiscoveryProvider' => %w[account_type], 'AuthenticationProvider::RedhatCustomerPortal' => %w[account_type],
-      'Account' => %w[credit_card_auth_code credit_card_authorize_net_payment_profile_token credit_card_partial_number],
-      'DeadlockTest::Model' => :all, 'ThreeScale::SearchTest::Model' => :all
+      'Account' => %w[credit_card_auth_code credit_card_authorize_net_payment_profile_token credit_card_partial_number]
     }
 
     Rails.application.eager_load!
     models = ActiveRecord::Base.descendants - [BackendApi, Service, Proxy]
 
     validate_columns_for = ->(model, options = {}) do
+      next if model.name.match(/^.+Test::.+$/)
       exception_attributes = exceptions.fetch(model.name, [])
       next if exception_attributes == :all
       model.columns.each do |column|


### PR DESCRIPTION
Fixes this random bug:
![image](https://user-images.githubusercontent.com/11318903/69532848-f6d60480-0f76-11ea-9ad2-c1c8835d5ec6.png)

In [this case](https://app.circleci.com/jobs/github/3scale/porta/131905), it is because it was trying to test this class:
https://github.com/3scale/porta/blob/00f267bb5cf8dbdbe05e36a2071e8345c31e5516/test/unit/provider_constraints_test.rb#L5-L11

But the purpose of this test is not for classes inside the tests, which is only problematic, so I am skipping them all here :smile: 
