### PR TITLE
[WIP]Updating snapshots when running jest

### DIFF
--- a/spec/javascripts/Settings/components/Common/__snapshots__/SelectGroup.spec.jsx.snap
+++ b/spec/javascripts/Settings/components/Common/__snapshots__/SelectGroup.spec.jsx.snap
@@ -145,6 +145,7 @@ exports[`should render correctly 1`] = `
             ariaLabelledBy=""
             className=""
             createText="Create"
+            customContent={null}
             direction="down"
             id="service_proxy_attributes_jukebox_select"
             isCreatable={false}

--- a/spec/javascripts/Settings/components/Common/__snapshots__/TextInputGroup.spec.jsx.snap
+++ b/spec/javascripts/Settings/components/Common/__snapshots__/TextInputGroup.spec.jsx.snap
@@ -17,6 +17,7 @@ exports[`should render correctly 1`] = `
     onChange={[Function]}
     placeholder="You Favourite Dooz Kawa"
     type="text"
+    validated="default"
     value="Me Faire La Belle"
   />
 </FormGroup>


### PR DESCRIPTION
**What this PR does / why we need it**:

Recently we started using jest snapshots to test React components, but snapshots are not being updated automatically and jest is failing in ci.

Adding `--updateSnapshot` to our `jest` npm script.

**Verification steps** 

`npm run jest`

Expected result: All jest test must be green, and snapshots updated when needed

