### PR TITLE
Adding space to exclamation icon in navbar

### DIFF
--- a/app/assets/stylesheets/provider/layouts/_main.scss
+++ b/app/assets/stylesheets/provider/layouts/_main.scss
@@ -31,6 +31,12 @@ body {
   background-color: $gallery;
 }
 
+.pf-c-nav__link {
+  .fa-exclamation-triangle {
+    margin-left: line-height-times(1 / 4);
+  }
+}
+
 @mixin white-box-shadow {
   background-color: $white;
   box-shadow: $whiteBoxShadow;


### PR DESCRIPTION
**What this PR does / why we need it**:

Exclamation mark icon for outdated configuration is missing spacing

**Before:**
![before](https://user-images.githubusercontent.com/13486237/69620285-69a9b300-103d-11ea-894a-77c1c2b7098b.png)

**After:**
![after](https://user-images.githubusercontent.com/13486237/69620303-762e0b80-103d-11ea-9b4f-32cbcf017a45.png)
