### PR TITLE
Fix BackendApiConfig issuing ProxyConfigs::AffectingObjectChangedEvent on proxy update

### DIFF
--- a/app/lib/proxy_config_affecting_changes.rb
+++ b/app/lib/proxy_config_affecting_changes.rb
@@ -71,7 +71,7 @@ module ProxyConfigAffectingChanges
       after_commit :issue_proxy_affecting_change_events
 
       def issue_proxy_affecting_change_events
-        return unless service
+        return unless service && previous_changes.present?
 
         issue_proxy_affecting_change_event(service.proxy)
       end


### PR DESCRIPTION
Closes [THREESCALE-3989](https://issues.jboss.org/browse/THREESCALE-3989)