### PR TITLE
Fix invisible policy when re-ordering Policy Chain

### DIFF
--- a/app/javascript/src/Policies/components/PolicyChain.jsx
+++ b/app/javascript/src/Policies/components/PolicyChain.jsx
@@ -68,6 +68,7 @@ const PolicyChain = ({chain, actions}: Props) => {
         onSortEnd={onSortEnd}
         useDragHandle={true}
         editPolicy={actions.editPolicy}
+        helperClass="Policy--sortable"
       />
     </section>
   )

--- a/app/javascript/src/Policies/styles/policies.scss
+++ b/app/javascript/src/Policies/styles/policies.scss
@@ -3,6 +3,7 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
   @import "~bootstrap-sass/assets/stylesheets/_bootstrap.scss";
 }
 
+$body-background: #fff;
 $color: #464646;
 $disabledColor: #8b8d8f;
 $goColor: #4a90e2;
@@ -253,6 +254,11 @@ $error-color: #c00;
     border-bottom: 1px solid $subtleColor;
     border-top: 1px solid $subtleColor;
   }
+}
+
+.Policy--sortable {
+  background-color: $body-background;
+  z-index: 100;
 }
 
 .u-link {


### PR DESCRIPTION
**What this PR does / why we need it**:

When dragging a policy from the policy chain, it disappears.

This PR adds a css class to the item being dragged (via `helperClass` prop) which sets a high enough `z-index` and a background.

Before:
![sortable-before](https://user-images.githubusercontent.com/11672286/69714892-94f8d480-1107-11ea-9f26-4f06f40aad0e.gif)

After:
![sortable-after](https://user-images.githubusercontent.com/11672286/69714898-975b2e80-1107-11ea-934a-bbf8d5254f4c.gif)


**Which issue(s) this PR fixes** 

No JIRA

**Verification steps** 

1. Go to a Product > Integration > Policies (apiap) or Service > Integration settings (non apiap)
2. Sort policy chain: the policy being moved should be visible