### PR TITLE
BackendClient::Application::Utilization with the metric's extended system_name

### DIFF
--- a/app/decorators/proxy_rule_decorator.rb
+++ b/app/decorators/proxy_rule_decorator.rb
@@ -10,7 +10,7 @@ class ProxyRuleDecorator < ApplicationDecorator
   end
 
   def metric_system_name
-    object.metric.attributes['system_name']
+    object.metric.extended_system_name
   end
 
   private

--- a/app/lib/backend/model_extensions/metric.rb
+++ b/app/lib/backend/model_extensions/metric.rb
@@ -28,11 +28,11 @@ module Backend
       end
 
       def sync_backend_for_service(service)
-        ::BackendMetricWorker.perform_async(service.backend_id, id, attributes['system_name'])
+        ::BackendMetricWorker.perform_async(service.backend_id, id, extended_system_name)
       end
 
       def sync_backend_for_service!(service)
-        ::BackendMetricWorker.new.perform(service.backend_id, id, attributes['system_name'])
+        ::BackendMetricWorker.new.perform(service.backend_id, id, extended_system_name)
       end
 
       private

--- a/app/lib/backend_api_logic/metric_extension.rb
+++ b/app/lib/backend_api_logic/metric_extension.rb
@@ -10,9 +10,8 @@ module BackendApiLogic
       validate :unique_extended_system_name, if: :backend_api_metric?
       before_save :extend_system_name, if: :backend_api_metric?
 
-      def system_name
-        attributes['system_name'].to_s.gsub(/#{Regexp.escape(SYSTEM_NAME_SUFFIX_SEPARATOR)}\d+\z/, '')
-      end
+      alias_method :system_name, :system_name_without_suffix
+      public :system_name
     end
 
     def backend_api_metric?
@@ -37,14 +36,20 @@ module BackendApiLogic
       end
     end
 
+    def extended_system_name
+      parts = [system_name_without_suffix]
+      parts << owner_id if backend_api_metric?
+      parts.compact.join SYSTEM_NAME_SUFFIX_SEPARATOR
+    end
+
     protected
+
+    def system_name_without_suffix
+      attributes['system_name'].to_s.gsub(/#{Regexp.escape(SYSTEM_NAME_SUFFIX_SEPARATOR)}\d+\z/, '')
+    end
 
     def extend_system_name
       self.system_name = extended_system_name
-    end
-
-    def extended_system_name
-      [system_name, owner_id].join SYSTEM_NAME_SUFFIX_SEPARATOR
     end
 
     def unique_extended_system_name

--- a/app/lib/backend_client/application/utilization.rb
+++ b/app/lib/backend_client/application/utilization.rb
@@ -27,7 +27,7 @@ module BackendClient
       private
 
       def process_utilization(records, metrics_list)
-        metrics_by_name = metrics_list.index_by(&:system_name)
+        metrics_by_name = metrics_list.index_by(&:extended_system_name)
 
         # Cannot call #map! on a ThreeScale::Core::APIClient::Collection instance
         records = records.map do |record|

--- a/app/lib/backend_client/application/utilization.rb
+++ b/app/lib/backend_client/application/utilization.rb
@@ -31,9 +31,11 @@ module BackendClient
 
         # Cannot call #map! on a ThreeScale::Core::APIClient::Collection instance
         records = records.map do |record|
-          attributes = record.attributes.merge(metric: metrics_by_name[record.metric_name])
+          metric = metrics_by_name[record.metric_name]
+          next unless metric
+          attributes = record.attributes.merge(metric: metric)
           UtilizationRecord.new attributes
-        end
+        end.compact
 
         finite, infinite = records.partition(&:finite?)
         finite.sort_by!(&:percentage).reverse!

--- a/app/representers/method_representer.rb
+++ b/app/representers/method_representer.rb
@@ -23,6 +23,6 @@ module MethodRepresenter
   end
 
   def system_name
-    backend_api_metric? ? attributes['system_name'] : super
+    extended_system_name
   end
 end

--- a/app/representers/metric_representer.rb
+++ b/app/representers/metric_representer.rb
@@ -29,6 +29,6 @@ module MetricRepresenter
   end
 
   def system_name
-    backend_api_metric? ? attributes['system_name'] : super
+    extended_system_name
   end
 end

--- a/app/workers/backend_metric_worker.rb
+++ b/app/workers/backend_metric_worker.rb
@@ -45,7 +45,7 @@ class BackendMetricWorker
       new_metric_attributes = {
         service_id: service_backend_id,
         id: metric_id,
-        name: metric.attributes['system_name'],
+        name: metric.extended_system_name,
         parent_id: metric.parent_id_for_service(service)
       }
       ThreeScale::Core::Metric.save(new_metric_attributes)

--- a/test/integration/admin/api/backend_apis/metric_methods_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metric_methods_controller_test.rb
@@ -33,7 +33,7 @@ class Admin::API::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
 
     assert_response :success
     assert_equal metric_method.id, JSON.parse(response.body).dig('method', 'id')
-    assert_equal "#{metric_method.system_name}.#{backend_api.id}", metric_method.attributes['system_name']
+    assert_equal "#{metric_method.system_name}.#{backend_api.id}", metric_method.extended_system_name
   end
 
   test 'create' do
@@ -44,7 +44,7 @@ class Admin::API::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
     assert(@metric_method = hits.children.find_by(id: JSON.parse(response.body).dig('method', 'id')))
     assert_equal 'my friendly name', metric_method.friendly_name
     assert_equal 'hit', metric_method.unit
-    assert_equal "my_friendly_name.#{backend_api.id}", metric_method.attributes['system_name']
+    assert_equal "my_friendly_name.#{backend_api.id}", metric_method.extended_system_name
   end
 
   test 'create with errors in the model' do
@@ -99,10 +99,10 @@ class Admin::API::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
   test 'system_name can be created but not updated' do
     post admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value), { friendly_name: 'my friendly name', unit: 'hit', system_name: 'first-system-name' }
     metric_method = hits.children.last!
-    assert_equal "first-system-name.#{backend_api.id}", metric_method.attributes['system_name']
+    assert_equal "first-system-name.#{backend_api.id}", metric_method.extended_system_name
 
     put admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id), { friendly_name: 'my friendly name', unit: 'hit', system_name: 'edited' }
-    assert_equal "first-system-name.#{backend_api.id}", metric_method.reload.attributes['system_name']
+    assert_equal "first-system-name.#{backend_api.id}", metric_method.reload.extended_system_name
   end
 
   test 'index can be paginated' do

--- a/test/integration/admin/api/backend_apis/metrics_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metrics_controller_test.rb
@@ -33,7 +33,7 @@ class Admin::API::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
 
     assert_response :success
     assert_equal metric.id, JSON.parse(response.body).dig('metric', 'id')
-    assert_equal "#{metric.system_name}.#{backend_api.id}", metric.attributes['system_name']
+    assert_equal "#{metric.system_name}.#{backend_api.id}", metric.extended_system_name
   end
 
   test 'create' do
@@ -44,7 +44,7 @@ class Admin::API::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
     assert(@metric = backend_api.metrics.find_by(id: JSON.parse(response.body).dig('metric', 'id')))
     assert_equal 'metric friendly name', metric.friendly_name
     assert_equal 'hit', metric.unit
-    assert_equal "metric_friendly_name.#{backend_api.id}", metric.attributes['system_name']
+    assert_equal "metric_friendly_name.#{backend_api.id}", metric.extended_system_name
   end
 
   test 'create with errors in the model' do
@@ -99,10 +99,10 @@ class Admin::API::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
   test 'system_name can be created but not updated' do
     post admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value), { friendly_name: 'metric friendly name', unit: 'hit', system_name: 'edited', system_name: 'first-system-name' }
     metric = backend_api.metrics.last!
-    assert_equal "first-system-name.#{backend_api.id}", metric.attributes['system_name']
+    assert_equal "first-system-name.#{backend_api.id}", metric.extended_system_name
 
     put admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id), { friendly_name: 'metric friendly name', unit: 'hit', system_name: 'edited' }
-    assert_equal "first-system-name.#{backend_api.id}", metric.reload.attributes['system_name']
+    assert_equal "first-system-name.#{backend_api.id}", metric.reload.extended_system_name
   end
 
   test 'index can be paginated' do

--- a/test/unit/backend/model_extensions/metric_test.rb
+++ b/test/unit/backend/model_extensions/metric_test.rb
@@ -89,10 +89,10 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
     services.last.backend_api_configs.create(backend_api: backend_api, path: 'other') # other service using the same BackendApi
     metric = FactoryBot.build(:metric, service: nil, owner: backend_api)
 
-    services.each { |service| BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.attributes['system_name']) }
+    services.each { |service| BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.extended_system_name) }
     metric.sync_backend
 
-    services.each { |service| BackendMetricWorker.any_instance.expects(:perform).with(service.backend_id, metric.id, metric.attributes['system_name']) }
+    services.each { |service| BackendMetricWorker.any_instance.expects(:perform).with(service.backend_id, metric.id, metric.extended_system_name) }
     metric.sync_backend!
   end
 
@@ -101,10 +101,10 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
     backend_api = FactoryBot.create(:backend_api, account: service.account)
     metric = backend_api.metrics.hits
 
-    BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.attributes['system_name'])
+    BackendMetricWorker.expects(:perform_async).with(service.backend_id, metric.id, metric.extended_system_name)
     metric.sync_backend_for_service(service)
 
-    BackendMetricWorker.any_instance.expects(:perform).with(service.backend_id, metric.id, metric.attributes['system_name'])
+    BackendMetricWorker.any_instance.expects(:perform).with(service.backend_id, metric.id, metric.extended_system_name)
     metric.sync_backend_for_service!(service)
   end
 end

--- a/test/unit/backend_api_logic/metric_extension_test.rb
+++ b/test/unit/backend_api_logic/metric_extension_test.rb
@@ -11,8 +11,10 @@ class MetricExtensionTest < ActiveSupport::TestCase
   attr_reader :backend_api, :metric
 
   test 'extends metric system_name with backend api id' do
+    extended_system_name = metric.extended_system_name
     assert metric.save
-    assert_equal "whatever.#{backend_api.id}", metric.reload.attributes['system_name']
+    assert_equal "whatever.#{backend_api.id}", extended_system_name
+    assert_equal extended_system_name, metric.reload.attributes['system_name']
   end
 
   test 'keeps showing system name without the suffix' do

--- a/test/workers/backend_metric_worker_test.rb
+++ b/test/workers/backend_metric_worker_test.rb
@@ -64,10 +64,10 @@ class BackendMetricWorkerTest < ActiveSupport::TestCase
     worker = BackendMetricWorker.new
 
     metric_attributes = [
-      { id: service_hits.id, name: service_hits.attributes['system_name'], parent_id: nil },
-      { id: service_other.id, name: service_other.attributes['system_name'], parent_id: nil },
-      { id: backend_hits.id, name: backend_hits.attributes['system_name'], parent_id: service_hits.id },
-      { id: backend_other.id, name: backend_other.attributes['system_name'], parent_id: nil }
+      { id: service_hits.id, name: service_hits.extended_system_name, parent_id: nil },
+      { id: service_other.id, name: service_other.extended_system_name, parent_id: nil },
+      { id: backend_hits.id, name: backend_hits.extended_system_name, parent_id: service_hits.id },
+      { id: backend_other.id, name: backend_other.extended_system_name, parent_id: nil }
     ]
     metric_attributes.each do |attrs|
       ThreeScale::Core::Metric.expects(:save).with(attrs.merge(service_id: service_backend_id))


### PR DESCRIPTION
This PR fixes a bug in the `BackendClient::Application::Utilization` module that, despite receiving usage data from apisonator properly separated by each metric's true/extended system_name, was ignoring the extension and grouping the records by `system_name` without the suffix. This was causing a 500 error while at `/apiconfig/services/<service_id>/applications/<application_id>`.

Closes [THREESCALE-4013](https://issues.jboss.org/browse/THREESCALE-4013)