### PR TITLE
Add Captcha to password reset form in Dev Portal

### DIFF
--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
@@ -10,9 +10,7 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
   before_action :find_user, :only => [:show, :update]
 
   def create
-    unless spam_check(@buyer)
-      return redirect_to new_admin_account_password_url
-    end
+    return redirect_to new_admin_account_password_url unless spam_check(buyer)
 
     if user = @provider.buyer_users.find_by_email(params[:email])
       user.generate_lost_password_token!
@@ -24,10 +22,7 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
     end
   end
 
-  def new
-    @buyer = @provider.buyers.build
-    assign_drops(account: Liquid::Drops::Account.new(@buyer))
-  end
+  def new; end
 
   def show
     assign_drops password_reset_token: @token
@@ -46,6 +41,10 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
   end
 
   private
+
+  def buyer
+    @buyer ||= @provider.buyers.build
+  end
 
   def password_params
     params.require(:user).permit(:password, :password_confirmation)

--- a/lib/developer_portal/app/views/developer_portal/password/new.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/password/new.html.liquid
@@ -6,7 +6,7 @@
         Forgot password
       </div>
       <div class="panel-body">
-        {% form 'password_reset', account, class: 'form-horizontal' %}
+        {% form 'password_reset', { class: 'form-horizontal' } %}
           <fieldset>
             <div class="form-group">
               <label for="email" class="control-label col-md-4">Email address</label>

--- a/lib/developer_portal/app/views/developer_portal/password/new.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/password/new.html.liquid
@@ -6,7 +6,7 @@
         Forgot password
       </div>
       <div class="panel-body">
-        {% form 'password_reset', { class: 'form-horizontal' } %}
+        {% form 'password_reset', account, class: 'form-horizontal' %}
           <fieldset>
             <div class="form-group">
               <label for="email" class="control-label col-md-4">Email address</label>

--- a/lib/developer_portal/lib/liquid/forms/base.rb
+++ b/lib/developer_portal/lib/liquid/forms/base.rb
@@ -54,6 +54,7 @@ module Liquid
       end
 
       def render(content)
+        # TODO: append captcha before button, not after
         content_tag(:form, metadata + content, form_options.stringify_keys.update(@html_attributes.except("class")))
       end
 

--- a/lib/developer_portal/lib/liquid/forms/password_reset.rb
+++ b/lib/developer_portal/lib/liquid/forms/password_reset.rb
@@ -2,7 +2,7 @@
 
 module Liquid
   module Forms
-    class PasswordReset < Forms::Create
+    class PasswordReset < Forms::SpamProtected
 
       def html_class_name
         'formtastic'
@@ -10,42 +10,6 @@ module Liquid
 
       def path
         admin_account_password_path
-      end
-
-      def render(content)
-        super(content + spam_protection)
-      end
-
-      delegate :input, :semantic_errors, to: :form_builder
-
-      def template
-        @context.registers[:view]
-      end
-
-      protected
-
-      def model
-        @model ||= object.instance_variable_get(:@model)
-      end
-
-      def spam_protection
-        protector = model.spam_protection.form(self).to_s
-
-        if protector.present?
-          form_builder.inputs do
-            template.concat(protector)
-          end
-        else
-          ''
-        end
-      end
-
-      def form_builder
-        @form_builder ||= begin
-                            object_name = ActiveModel::Naming.param_key(model)
-                            Formtastic::SemanticFormBuilder.new(object_name, model, template, {})
-                          end
-
       end
     end
   end

--- a/lib/developer_portal/lib/liquid/forms/password_reset.rb
+++ b/lib/developer_portal/lib/liquid/forms/password_reset.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Liquid
   module Forms
     class PasswordReset < Forms::Create
@@ -8,6 +10,42 @@ module Liquid
 
       def path
         admin_account_password_path
+      end
+
+      def render(content)
+        super(content + spam_protection)
+      end
+
+      delegate :input, :semantic_errors, to: :form_builder
+
+      def template
+        @context.registers[:view]
+      end
+
+      protected
+
+      def model
+        @model ||= object.instance_variable_get(:@model)
+      end
+
+      def spam_protection
+        protector = model.spam_protection.form(self).to_s
+
+        if protector.present?
+          form_builder.inputs do
+            template.concat(protector)
+          end
+        else
+          ''
+        end
+      end
+
+      def form_builder
+        @form_builder ||= begin
+                            object_name = ActiveModel::Naming.param_key(model)
+                            Formtastic::SemanticFormBuilder.new(object_name, model, template, {})
+                          end
+
       end
     end
   end

--- a/lib/developer_portal/lib/liquid/forms/signup.rb
+++ b/lib/developer_portal/lib/liquid/forms/signup.rb
@@ -1,6 +1,6 @@
 module Liquid
   module Forms
-    class Signup < Forms::Create
+    class Signup < Forms::SpamProtected
 
       def html_class_name
         'account formtastic'
@@ -23,7 +23,7 @@ module Liquid
       end
 
       def render(content)
-        super(content + spam_protection + selected_plans)
+        super(content + selected_plans)
       end
 
       def form_options
@@ -32,14 +32,6 @@ module Liquid
 
       def path
         signup_path
-      end
-
-      # methods needed for spam protection
-
-      delegate :input, :semantic_errors, to: :form_builder
-
-      def template
-        @context.registers[:view]
       end
 
       protected
@@ -54,30 +46,6 @@ module Liquid
         else
           ''
         end
-      end
-
-      def model
-        @model ||= object.instance_variable_get(:@model)
-      end
-
-      def spam_protection
-        protector = model.spam_protection.form(self).to_s
-
-        if protector.present?
-          form_builder.inputs do
-            template.concat(protector)
-          end
-        else
-          ''
-        end
-      end
-
-      def form_builder
-        @form_builder ||= begin
-                            object_name = ActiveModel::Naming.param_key(model)
-                            Formtastic::SemanticFormBuilder.new(object_name, model, template, {})
-                          end
-
       end
     end
   end

--- a/lib/developer_portal/lib/liquid/forms/spam_protected.rb
+++ b/lib/developer_portal/lib/liquid/forms/spam_protected.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Liquid
+  module Forms
+    class SpamProtected < Forms::Create
+      def initialize(context, _object_name, html_attributes = {})
+        # FIXME: object_name should be removed and the template password/new fixed. We're
+        # accidentally passing a bracket '{'
+        super(context, 'site_account', html_attributes)
+      end
+
+      def render(content)
+        super(content + spam_protection)
+      end
+
+      delegate :input, :semantic_errors, to: :form_builder
+
+      def template
+        context.registers[:view]
+      end
+
+      protected
+
+      def model
+        @model ||= object.instance_variable_get(:@model)
+      end
+
+      def spam_protection
+        protector = model.spam_protection.form(self).to_s
+
+        return '' if protector.blank?
+
+        form_builder.inputs { template.concat(protector) }
+      end
+
+      def form_builder
+        @form_builder ||= begin
+                            object_name = ActiveModel::Naming.param_key(model)
+                            Formtastic::SemanticFormBuilder.new(object_name, model, template, {})
+                          end
+
+      end
+    end
+  end
+end

--- a/test/integration/developer_portal/password_reset_test.rb
+++ b/test/integration/developer_portal/password_reset_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DeveloperPortal::PasswordTokenTest < ActionDispatch::IntegrationTest
+
+  def setup
+    Recaptcha.stubs(:captcha_configured?).returns(true)
+    @provider = FactoryBot.create(:simple_provider)
+
+    host! @provider.domain
+  end
+
+  test 'captcha is present when spam security enabled' do
+    @provider.settings.update_attributes(spam_protection_level: :captcha)
+
+    get developer_portal.new_admin_account_password_path
+    assert_response :success
+    assert body.include? 'g-recaptcha'
+  end
+
+  test 'captcha is not present when spam security set to auto' do
+    @provider.settings.update_attributes(spam_protection_level: :auto)
+
+    get developer_portal.new_admin_account_password_path
+    assert_response :success
+    assert_not body.include? 'g-recaptcha'
+  end
+
+  test 'captcha is not present when spam security disabled' do
+    @provider.settings.update_attributes(spam_protection_level: :none)
+
+    get developer_portal.new_admin_account_password_path
+    assert_response :success
+    assert_not body.include? 'g-recaptcha'
+  end
+end

--- a/test/unit/liquid/forms_test.rb
+++ b/test/unit/liquid/forms_test.rb
@@ -27,7 +27,9 @@ class Liquid::FormsTest < ActiveSupport::TestCase
   end
 
   test 'password_reset form' do
-    form = get('password_reset', "  ")
+    form = get('password_reset', 'site_account')
+    account = FactoryBot.create(:account)
+    form.context['site_account'] = Liquid::Drops::Message.new(account)
     content = form.render('content')
     assert_match %r{<form.*action="/admin/account/password".*</form>}, content
   end

--- a/test/unit/liquid/forms_test.rb
+++ b/test/unit/liquid/forms_test.rb
@@ -29,7 +29,7 @@ class Liquid::FormsTest < ActiveSupport::TestCase
   test 'password_reset form' do
     form = get('password_reset', 'site_account')
     account = FactoryBot.create(:account)
-    form.context['site_account'] = Liquid::Drops::Message.new(account)
+    form.context['site_account'] = Liquid::Drops::Account.new(account)
     content = form.render('content')
     assert_match %r{<form.*action="/admin/account/password".*</form>}, content
   end

--- a/test/unit/liquid/tags/form_test.rb
+++ b/test/unit/liquid/tags/form_test.rb
@@ -29,14 +29,18 @@ class Liquid::Tags::FormTest < ActiveSupport::TestCase
   end
 
   test "signup form basics" do
-    @context['my_account'] = Liquid::Drops::Account.new(FactoryBot.create(:simple_buyer))
+    account = Liquid::Drops::Account.new(FactoryBot.create(:simple_buyer))
+    @context['my_account'] = account
+    @context['site_account'] = account
     @tag = Liquid::Tags::Form.parse('form', "'signup', my_account", ["CONTENT", '{% endform %}'], {})
     assert_match %r{<form.*id="signup_form".*>.*</form>}, @tag.render(@context)
   end
 
 
   test "signup form with plan_ids param" do
-    @context['my_account'] = Liquid::Drops::Account.new(FactoryBot.create(:simple_buyer))
+    account = Liquid::Drops::Account.new(FactoryBot.create(:simple_buyer))
+    @context['my_account'] = account
+    @context['site_account'] = account
     @context.registers[:request] = stub(params: { plan_ids: [ 1,2,42 ]})
 
     @tag = Liquid::Tags::Form.parse('form', "'signup', my_account", ["CONTENT", '{% endform %}'], {})


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adds recaptcha to the reset password form in Dev portal (provided **Spam Protection** is enabled)
* refactor and extract `spam_protection` logic from `sign_up` and `password_reset` into a new form class `SpamProtected`.

![Screen Shot 2019-12-03 at 11 12 10](https://user-images.githubusercontent.com/11672286/70041639-d1bc4400-15bd-11ea-9705-18f1b56c91b1.png)


**Which issue(s) this PR fixes** 

[THREESCALE-1135: Add Captcha element in the password reset form](https://issues.jboss.org/browse/THREESCALE-1135)

**Verification steps** 
1. Go to admin/account/password/new in the Developer Portal
2. There should be a captcha
3. Form can't be submitted without completing the captcha

