### PR TITLE
[Refactor] Use require for CSV instead of require_dependency

### DIFF
--- a/app/lib/stats/views/csv/top_applications.rb
+++ b/app/lib/stats/views/csv/top_applications.rb
@@ -1,4 +1,4 @@
-require_dependency 'csv/exporter'
+require 'csv/exporter'
 
 module Stats
   module Views

--- a/app/lib/stats/views/csv/usage.rb
+++ b/app/lib/stats/views/csv/usage.rb
@@ -1,4 +1,4 @@
-require_dependency 'csv/exporter'
+require 'csv/exporter'
 
 module Stats
   module Views

--- a/app/workers/data_exports_worker.rb
+++ b/app/workers/data_exports_worker.rb
@@ -1,5 +1,5 @@
 require 'zip'
-require_dependency 'csv'
+require 'csv'
 
 class DataExportsWorker
   include Sidekiq::Worker

--- a/lib/tasks/provider_stats.rb
+++ b/lib/tasks/provider_stats.rb
@@ -1,4 +1,4 @@
-require_dependency 'csv'
+require 'csv'
 
 def days_since(time)
   return -1 if time.nil?

--- a/lib/tasks/segment/segment.rake
+++ b/lib/tasks/segment/segment.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_dependency 'csv'
+require 'csv'
 
 namespace :segment do
   desc 'Save as deleted objects the users from the imported segment csv'


### PR DESCRIPTION
Get rid of the following obnoxious warnings:

```
jgallaso (feature/THREESCALE-1135_captcha_password_reset *) ~/Projects/3scale/porta $ rake routes
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:211: warning: already initialized constant CSV::VERSION
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:211: warning: previous definition of VERSION was here
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:929: warning: already initialized constant CSV::FieldInfo
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:929: warning: previous definition of FieldInfo was here
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:932: warning: already initialized constant CSV::DateMatcher
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:932: warning: previous definition of DateMatcher was here
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:935: warning: already initialized constant CSV::DateTimeMatcher
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:935: warning: previous definition of DateTimeMatcher was here
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:940: warning: already initialized constant CSV::ConverterEncoding
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:940: warning: previous definition of ConverterEncoding was here
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:966: warning: already initialized constant CSV::Converters
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:966: warning: previous definition of Converters was here
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:1014: warning: already initialized constant CSV::HeaderConverters
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:1014: warning: previous definition of HeaderConverters was here
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:1039: warning: already initialized constant CSV::DEFAULT_OPTIONS
/usr/local/Cellar/ruby@2.4/2.4.6_1/lib/ruby/2.4.0/csv.rb:1039: warning: previous definition of DEFAULT_OPTIONS was here
```