### PR TITLE
Remove lib/color.rb

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -171,7 +171,6 @@ gem 'draper', '~> 2.0'
 # TODO: gem 'draper', '~> 3.0'
 
 group :development do
-  gem 'colorize'
   gem 'bullet', '~> 4.2'
 
   gem 'letter_opener', require: false if ENV.fetch('LETTER_OPENER', '1') == '0'
@@ -244,6 +243,7 @@ group :test do
 end
 
 group :development, :test do
+  gem 'colorize'
   gem 'factory_bot_rails', '~> 4.11.1'
   gem 'unicorn-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    colorize (0.7.7)
+    colorize (0.8.1)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,4 +1,5 @@
-require 'color'
+BOLD  = "\033[1m"
+CLEAR = "\033[0m"
 
 Before '@ignore-backend' do
   stub_backend_get_keys
@@ -192,7 +193,7 @@ print_banner = -> (title, step) do
   step_name = (step.try(:actual_keyword) || step.keyword) + step.name
   Rails.logger.info <<-NEXT
 
-| #{title}: #{Color::BOLD}#{step_name}#{Color::CLEAR} |
+| #{title}: #{BOLD}#{step_name}#{CLEAR} |
 | #{'=' * (step_name.length + title.length + 2)} |
 #{step.multiline_arg}
 NEXT

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,5 +1,4 @@
-BOLD  = "\033[1m"
-CLEAR = "\033[0m"
+# frozen_string_literal: true
 
 Before '@ignore-backend' do
   stub_backend_get_keys
@@ -189,13 +188,13 @@ current_step = ->(scenario) do
   [ steps[index], steps[index+1] ]
 end
 
-print_banner = -> (title, step) do
+print_banner = ->(title, step) do
   step_name = (step.try(:actual_keyword) || step.keyword) + step.name
-  Rails.logger.info <<-NEXT
+  Rails.logger.info <<~NEXT
 
-| #{title}: #{BOLD}#{step_name}#{CLEAR} |
-| #{'=' * (step_name.length + title.length + 2)} |
-#{step.multiline_arg}
+    | #{title}: #{step_name.bold} |
+    | #{'=' * (step_name.length + title.length + 2)} |
+    #{step.multiline_arg}
 NEXT
 end
 

--- a/lib/color.rb
+++ b/lib/color.rb
@@ -1,7 +1,0 @@
-module Color
-  GREEN = "\033[92m".freeze
-  RED = "\033[91m".freeze
-  BOLD = "\033[1m".freeze
-  CLEAR = "\033[0m".freeze
-  CLEAR_COLOR = "\x1b[39;49m".freeze
-end


### PR DESCRIPTION
Extracted from #1396

 In order to remove the lib folder from autoload, this commit removes the
 lib/color file, since it was not being used in any place. Only one test
 was using some of its constant.