### PR TITLE
[lib] Move lib/active_merchant_hacks to app/lib

### DIFF
--- a/app/lib/active_merchant_hacks.rb
+++ b/app/lib/active_merchant_hacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # ActiveMerchant monkey patches
 
 class ActiveMerchant::Billing::Gateway


### PR DESCRIPTION
Extracted from #1396

In order to remove the lib folder from autoload, this commit moves the
lib/active_merchant_hacks into app/lib