### PR TITLE
Ignoring Developer portal assets in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -84,6 +84,7 @@ exclude_paths:
   - 'lib/action_dispatch/rails5_ssl.rb'
   - "lib/developer_portal/app/views/developer_portal/javascripts/*"
   - "lib/developer_portal/app/views/developer_portal/css/*"
+  - "lib/developer_portal/app/assets/stylesheets/**/*"
   - "assets/bundles/*.js"
   - "spec/**/*"
   - "spec/**/**/*"


### PR DESCRIPTION
**What this PR does / why we need it**:

Codeclimate should ignore developer portal assets, but some directories were missing from exclusion in codeclimate.yml
(e.g. https://github.com/3scale/porta/pull/1468 was failing because of https://codeclimate.com/github/3scale/porta/pull/1468)

