### PR TITLE
[Oracle][Docker] Setup Docker Instructions + Use AppArmor default docker profile to run Oracle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ oracle-database: ORACLE_DATA_DIR ?= $(HOME)
 oracle-database:
 	[ "$(shell docker inspect -f '{{.State.Running}}' oracle-database 2>/dev/null)" = "true" ] || docker start oracle-database || docker run \
 		--shm-size=6gb \
+		--security-opt apparmor=docker-default \
 		-p 1521:1521 -p 5500:5500 \
 		--name oracle-database \
 		-e ORACLE_PDB=systempdb \

--- a/SETUP_ORACLE.md
+++ b/SETUP_ORACLE.md
@@ -1,0 +1,39 @@
+# Setup Oracle
+
+## Install Oracle Instant Client
+
+1. Go to [the official Oracle Instant Client Downloads site](https://www.oracle.com/database/technologies/instant-client/downloads.html) and download the following **.rpm** packages for your operative system:
+
+  - Basic
+  - SQL Plus
+  - SDK
+
+2. Create a folder in `/opt/oracle` if it does not exist yet (with `mkdir -p /opt/oracle`) and save these packages there.
+
+3. Install the dependency `libaio1` and the package `alien`.
+In Ubuntu that is done with `sudo apt-get install libaio1 alien`.
+
+4. Go to `/opt/oracle` through the terminal (with `cd /opt/oracle`) and use **alien** to convert all those **.rpm** packages to **.deb** (with `sudo alien --to-deb --scripts *.rpm`).
+
+5. Execute all those `.deb` packages with `sudo dpkg -i *.deb`.
+
+6. Execute the following lines and also add them at the end of `~/.profile`. Replace 'X' for the version of the package that you have just installed.
+
+```
+export ORACLE_HOME=/usr/lib/oracle/X/client64
+export PATH=$PATH:$ORACLE_HOME/bin
+export OCI_LIB_DIR=$ORACLE_HOME/lib
+export OCI_INC_DIR=/usr/include/oracle/X/client64
+```
+
+## Run Oracle Server from Docker
+
+### Prerequisites
+
+You need to have Docker installed and running. You also need to be able to [run containers as a non-root user](https://docs.docker.com/install/linux/linux-postinstall/).
+
+### Steps
+
+1. From this repository, do `make oracle-database` and wait to see *DATABASE IS READY TO USE!*.
+
+2. Finally initialize the database with some seed data by running: `DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG=AMERICAN_AMERICA.UTF8 USER_PASSWORD=123456 MASTER_PASSWORD=123456 MASTER_ACCESS_TOKEN=token bundle exec rake db:drop db:create db:setup`


### PR DESCRIPTION
This is needed in order to work in Ubuntu (and some other Linux distributions).
It works for Mac because although it does not have 'AppArmor', it just ignores the option and works anyway.
In Fedora, @srijitamukherjee has tested it and we have the same problem. So I have created [THREESCALE-4171](https://issues.redhat.com/browse/THREESCALE-4171) for that.