### PR TITLE
[Bugfix] Changing the 'OIDC Authorization Flow' does not work when using 'API as a Product'

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -101,7 +101,7 @@ class Api::ServicesController < Api::BaseController
   end
 
   def proxy_params
-    oidc_params = %i[oidc_issuer_type oidc_issuer_endpoint jwt_claim_with_client_id jwt_claim_with_client_id_type] + OIDCConfiguration::Config::FLOWS
+    oidc_params = %i[oidc_issuer_type oidc_issuer_endpoint jwt_claim_with_client_id jwt_claim_with_client_id_type] + [{oidc_configuration_attributes: OIDCConfiguration::Config::FLOWS}]
     permitted_params = oidc_params + %i[
       auth_user_key auth_app_id auth_app_key credentials_location hostname_rewrite secret_token
       error_status_auth_failed error_headers_auth_failed error_auth_failed

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -38,6 +38,7 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
 
       update_service_params = update_params[:service]
       update_proxy_params = update_service_params.delete(:proxy_attributes)
+      oidc_configuration_params = update_proxy_params.delete(:oidc_configuration_attributes)
       expected_notification_settings = update_service_params[:notification_settings].transform_values { |notifications| notifications.map(&:to_i) }
       expected_buyer_plan_change_permission = update_service_params[:buyer_plan_change_permission]
       expected_signup_and_use = update_service_params
@@ -54,6 +55,13 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       update_proxy_params.each do |field_name, expected_value|
         assert_equal expected_value, proxy.public_send(field_name)
       end
+
+      oidc_configuration = proxy.oidc_configuration
+      oidc_configuration_params.each do |field_name, param_value|
+        expected_value = param_value == '1'
+        assert_equal expected_value, oidc_configuration.public_send(field_name)
+      end
+
     end
 
     # This test can be removed once used deprecated attributes have been removed from the schema
@@ -167,7 +175,15 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
           },
           proxy_attributes: {
             endpoint: 'http://api.example.com:8080',
-            sandbox_endpoint: 'http://api.staging.example.com:8080'
+            sandbox_endpoint: 'http://api.staging.example.com:8080',
+            oidc_issuer_type: 'keycloak',
+            oidc_issuer_endpoint: '',
+            oidc_configuration_attributes: {
+              standard_flow_enabled: '1',
+              implicit_flow_enabled: '1',
+              service_accounts_enabled: '0',
+              direct_access_grants_enabled: '0'
+            }
           }
         }
       }


### PR DESCRIPTION
Closes [THREESCALE-4162](https://issues.redhat.com/browse/THREESCALE-4162)

The problem was that the format of the strong params wasn't matching how the values are sent.

![image](https://user-images.githubusercontent.com/11318903/71083125-995a5f80-2192-11ea-97cf-bba624a87202.png)

