### PR TITLE
[Fix Oracle Tests] Test oidc_issuer_endpoint with an actual value

### DIFF
--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -177,7 +177,7 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
             endpoint: 'http://api.example.com:8080',
             sandbox_endpoint: 'http://api.staging.example.com:8080',
             oidc_issuer_type: 'keycloak',
-            oidc_issuer_endpoint: '',
+            oidc_issuer_endpoint: 'http://u:p@localhost:8080/auth/realms/my-realm',
             oidc_configuration_attributes: {
               standard_flow_enabled: '1',
               implicit_flow_enabled: '1',


### PR DESCRIPTION
Fixes Oracle tests because it was being saved as `''` which in Oracle is 'nil' so [it failed](https://app.circleci.com/jobs/github/3scale/porta/138852) in `assert_equal '', nil`. Besides, it is better to test and actual value to ensure that it works :smile: 