### PR TITLE
Remove lib from autoload

### DIFF
--- a/app/workers/backend_metric_worker.rb
+++ b/app/workers/backend_metric_worker.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'three_scale/sidekiq_lock_worker' # Temporary added until https://github.com/3scale/porta/pull/1498 is not merged
 
 class BackendMetricWorker < ApplicationJob
   include Sidekiq::Throttled::Worker

--- a/app/workers/backend_metric_worker.rb
+++ b/app/workers/backend_metric_worker.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'three_scale/sidekiq_lock_worker' # Temporary added until https://github.com/3scale/porta/pull/1498 is not merged
 
 class BackendMetricWorker < ApplicationJob
   include Sidekiq::Throttled::Worker

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,6 +73,13 @@ module System
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # Include developer_portal into the autoload and eager load path
+    config.autoload_paths += [Rails.root.join('lib', 'developer_portal', 'app'), Rails.root.join('lib', 'developer_portal', 'lib')]
+    config.eager_load_paths += [Rails.root.join('lib', 'developer_portal', 'app'), Rails.root.join('lib', 'developer_portal', 'lib')]
+
+    config.eager_load = true
+    config.enable_dependency_loading = false
+
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,9 +73,6 @@ module System
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(#{config.root.join('lib')})
-
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,6 @@
 # Load the rails application
 require File.expand_path('../application', __FILE__)
+require 'system/database'
 
 # Initialize the rails application
 System::Application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,7 @@ System::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
   config.eager_load = false
+  config.enable_dependency_loading = true
 
   # In the development environment your application's code is reloaded on
   # every request.  This slows down response time but is perfect for development

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,7 +4,6 @@ System::Application.configure do
   # Disable css/jquery animations in tests, makes percy much happier
   config.middleware.use Rack::NoAnimations
 
-  config.eager_load = false # true if you use a tool to preload your test environment
   config.allow_concurrency = false
 
   # The test environment is used exclusively to run your application's

--- a/lib/system/database.rb
+++ b/lib/system/database.rb
@@ -176,6 +176,7 @@ module System
         require 'system/database/mysql'
         MySQL
       else
+        require "system/database/#{adapter}"
         "System::Database::#{adapter.camelize}".constantize
       end
     end

--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'system/database/mysql'
 
 System::Database::MySQL.define do

--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'system/database/mysql'
 
 System::Database::MySQL.define do
   trigger 'accounts' do

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'system/database/oracle'
 
 System::Database::Oracle.define do
   trigger 'accounts' do

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'system/database/oracle'
 
 System::Database::Oracle.define do

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'system/database/procedure'
 
 System::Database::Postgres.define do
   trigger 'accounts' do

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'system/database/procedure'
 
 System::Database::Postgres.define do

--- a/lib/system/database/mysql/procedure.rb
+++ b/lib/system/database/mysql/procedure.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'system/database/procedure'
 
 module System
   module Database

--- a/lib/system/database/mysql/procedure.rb
+++ b/lib/system/database/mysql/procedure.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'system/database/procedure'
 
 module System

--- a/lib/system/database/mysql/trigger.rb
+++ b/lib/system/database/mysql/trigger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'system/database/trigger'
 
 module System
   module Database

--- a/lib/system/database/mysql/trigger.rb
+++ b/lib/system/database/mysql/trigger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'system/database/trigger'
 
 module System

--- a/lib/system/database/oracle/procedure.rb
+++ b/lib/system/database/oracle/procedure.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'system/database/procedure'
 
 module System
   module Database

--- a/lib/system/database/oracle/procedure.rb
+++ b/lib/system/database/oracle/procedure.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'system/database/procedure'
 
 module System

--- a/lib/system/database/oracle/trigger.rb
+++ b/lib/system/database/oracle/trigger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'system/database/trigger'
 
 module System
   module Database

--- a/lib/system/database/oracle/trigger.rb
+++ b/lib/system/database/oracle/trigger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'system/database/trigger'
 
 module System

--- a/lib/system/database/postgres/procedure.rb
+++ b/lib/system/database/postgres/procedure.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'system/database/procedure'
 
 module System
   module Database

--- a/lib/system/database/postgres/procedure.rb
+++ b/lib/system/database/postgres/procedure.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'system/database/procedure'
 
 module System

--- a/lib/system/database/postgres/trigger.rb
+++ b/lib/system/database/postgres/trigger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'system/database/trigger'
 
 module System
   module Database

--- a/lib/system/database/postgres/trigger.rb
+++ b/lib/system/database/postgres/trigger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'system/database/trigger'
 
 module System

--- a/test/integration/developer_portal/forums/admin/categories_controller_test.rb
+++ b/test/integration/developer_portal/forums/admin/categories_controller_test.rb
@@ -2,30 +2,32 @@
 
 require 'test_helper'
 
-class DeveloperPortal::Forums::Admin::CategoriesControllerTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+module DeveloperPortal
+  class Forums::Admin::CategoriesControllerTest < ActionDispatch::IntegrationTest
+    include DeveloperPortal::Engine.routes.url_helpers
 
-  def setup
-    @provider = FactoryBot.create(:provider_account)
-    provider.settings.allow_multiple_applications!
-    provider.settings.show_multiple_applications!
-    provider.settings.update_column(:forum_enabled, true)
-    @buyer = FactoryBot.create(:buyer_account, provider_account: provider)
-    @category = provider.forum.categories.create!(name: 'Security')
-    login_buyer buyer
-  end
+    def setup
+      @provider = FactoryBot.create(:provider_account)
+      provider.settings.allow_multiple_applications!
+      provider.settings.show_multiple_applications!
+      provider.settings.update_column(:forum_enabled, true)
+      @buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+      @category = provider.forum.categories.create!(name: 'Security')
+      login_buyer buyer
+    end
 
-  attr_reader :provider, :buyer, :category
+    attr_reader :provider, :buyer, :category
 
-  test '#create' do
-    assert_raises(ActionController::RoutingError) { post admin_forum_categories_path({topic_category: {name: 'fake'}}) }
-  end
+    test '#create' do
+      assert_raises(::ActionController::RoutingError) { post admin_forum_categories_path({topic_category: {name: 'fake'}}) }
+    end
 
-  test '#update' do
-    assert_raises(ActionController::RoutingError) { put admin_forum_category_path(category) }
-  end
+    test '#update' do
+      assert_raises(::ActionController::RoutingError) { put admin_forum_category_path(category) }
+    end
 
-  test '#delete' do
-    assert_raises(ActionController::RoutingError) { delete admin_forum_category_path(category) }
+    test '#delete' do
+      assert_raises(::ActionController::RoutingError) { delete admin_forum_category_path(category) }
+    end
   end
 end

--- a/test/unit/apicast/abstract_generator_test.rb
+++ b/test/unit/apicast/abstract_generator_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Apicast::AbstractGeneratorTest < ActiveSupport::TestCase
 
-  class SomeGenerator < AbstractGenerator
+  class SomeGenerator < Apicast::AbstractGenerator
 
   end
 


### PR DESCRIPTION
This commit removes the lib directory from the autoload path. It also
forces the inclusion of the database files that are still present in the
folder.