### PR TITLE
Validation of labels of domain names according to RFC 1035

### DIFF
--- a/app/services/service_creator.rb
+++ b/app/services/service_creator.rb
@@ -2,7 +2,7 @@
 
 class ServiceCreator
 
-  delegate :backend_api_configs, :backend_api_proxy, :account, to: :@service
+  delegate :backend_api_configs, :backend_api_proxy, :account, :proxy, to: :@service
   delegate :provider_can_use?, to: :account
 
   def initialize(service:, backend_api: nil)
@@ -22,6 +22,10 @@ class ServiceCreator
   def call(params = {})
     call!(params)
   rescue ActiveRecord::RecordInvalid
+    if proxy && proxy.errors[:endpoint].any? { |message| message =~ /the accepted format is/ }
+      @service.errors.add(:system_name, :invalid_for_proxy_endpoints)
+    end
+
     false
   end
 

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -8,7 +8,7 @@ class UriValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     valid = begin
               uri = URI.parse(value)
-              valid_scheme?(uri.scheme) && uri.host.present? && !forbidden_part?(record, uri)
+              valid_scheme?(uri.scheme) && valid_host?(uri.host) && !forbidden_part?(record, uri)
             rescue URI::InvalidURIError
               false
             end
@@ -24,6 +24,15 @@ class UriValidator < ActiveModel::EachValidator
     else
       [*accepted_scheme].include? scheme
     end
+  end
+
+  def valid_host?(host)
+    return false if host.blank?
+    (host.size <= 255) && valid_host_labels?(host)
+  end
+
+  def valid_host_labels?(host)
+    host.split('.').map(&:size).none?(&63.method(:'<'))
   end
 
   def forbidden_part?(record, uri)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -888,6 +888,7 @@ en:
           attributes:
             system_name:
               invalid: invalid. Only ASCII letters, numbers, dashes and underscores are allowed.
+              invalid_for_proxy_endpoints: must be shorter.
 
         cinstance:
           attributes:

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -245,7 +245,7 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       @provider.settings.allow_multiple_services!
 
       post admin_services_path, service: { name: 'My New Product', system_name: 'this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035' }
-      assert_equal 'Couldn\'t create Product. Check your Plan limits', flash[:error]
+      assert_equal 'System name must be shorter.', flash[:error]
 
       post admin_services_path, service: { name: 'My New Product', system_name: 'short-labels-are-ok' }
       refute flash[:error].presence

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -240,5 +240,16 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       post admin_services_path, service: { name: 'example-service', system_name: '###' }
       assert_equal 'System name invalid. Only ASCII letters, numbers, dashes and underscores are allowed.', flash[:error]
     end
+
+    test 'chosen system name affects proxy endpoint validation' do
+      @provider.settings.allow_multiple_services!
+
+      post admin_services_path, service: { name: 'My New Product', system_name: 'this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035' }
+      assert_equal 'Couldn\'t create Product. Check your Plan limits', flash[:error]
+
+      post admin_services_path, service: { name: 'My New Product', system_name: 'short-labels-are-ok' }
+      refute flash[:error].presence
+      assert_response :redirect
+    end
   end
 end

--- a/test/unit/models_test.rb
+++ b/test/unit/models_test.rb
@@ -10,7 +10,7 @@ class ModelsTest < ActiveSupport::TestCase
       'System::Database::ConnectionProbe' => :all, 'ActsAsTaggableOn::Tag' => :all, 'ActsAsTaggableOn::Tagging' => :all, 'ApplicationRecord' => :all,
       'FieldsDefinition' => %w[target], 'AuthenticationProvider' => %w[account_type], 'Feature' => %w[featurable_type scope], 'Message' => %w[state],
       'UsageLimit' => %w[period plan_type], 'Policy' => %w[identifier], 'ProxyRule' => %w[metric_system_name], 'ProxyConfig' => %w[hosts],
-      'OIDCConfiguration' => %w[oidc_configurable_type], 'Invitation' => %w[token],
+      'Proxy' => %w[endpoint sandbox_endpoint], 'OIDCConfiguration' => %w[oidc_configurable_type], 'Invitation' => %w[token],
       'Settings' => Switches::SWITCHES.map { |switch| "#{switch}_switch" },
       'Invoice' => %w[pdf_file_name pdf_content_type state friendly_id fiscal_code vat_code currency creation_type], 'DeletedObject' => %w[owner_type object_type],
       'Onboarding' => %w[wizard_state bubble_api_state bubble_metric_state bubble_deployment_state bubble_mapping_state bubble_limit_state],

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -229,6 +229,14 @@ class ProxyTest < ActiveSupport::TestCase
     assert_equal %w(localhost example.com), @proxy.hosts
   end
 
+  test 'hosts comply with rfc 1035' do
+    @proxy.endpoint = 'http://this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035.com:3000/'
+    @proxy.sandbox_endpoint = 'http://short-labels-are-ok.com:8080'
+    refute @proxy.valid?
+    assert @proxy.errors[:endpoint].any?
+    refute @proxy.errors[:sandbox_endpoint].any?
+  end
+
   test 'backend' do
     proxy_config = System::Application.config.three_scale.sandbox_proxy
     proxy_config.stubs(backend_scheme: 'https', backend_host: 'example.net:4400')

--- a/test/unit/validators/uri_validator_test.rb
+++ b/test/unit/validators/uri_validator_test.rb
@@ -78,6 +78,26 @@ class UriValidatorTest < ActiveSupport::TestCase
     end
   end
 
+  test 'hostname with label longer than 63 chars' do
+    record = ModelWithURIValidation.new
+    record.uri = "http://#{long_hostname_label}.#{short_hostname_label}.test"
+    refute record.valid?
+  end
+
+  test 'hostname with labels up to 63 chars' do
+    record = ModelWithURIValidation.new
+    short_labels = (1..2).map { |count| "#{short_hostname_label}-#{count}" }
+    record.uri = "http://#{short_labels.join('.')}.test"
+    assert record.valid?
+  end
+
+  test 'hostname longer than 255 with labels up to 63 chars' do
+    record = ModelWithURIValidation.new
+    short_labels = (1..13).map { |count| "#{short_hostname_label}-#{count}" }
+    record.uri = "http://#{short_labels.join('.')}.test" # hostname with 268 chars
+    refute record.valid?
+  end
+
   test 'forbid optional parts' do
     record = ModelWithURIValidation.new
     record.uri = "http://domain.test:123"
@@ -98,5 +118,13 @@ class UriValidatorTest < ActiveSupport::TestCase
     klass.clear_validators!
     yield
     klass._validate_callbacks = validate_callbacks
+  end
+
+  def long_hostname_label
+    'this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035' # 86 chars
+  end
+
+  def short_hostname_label
+    'short-label-is-ok' # 17 chars
   end
 end


### PR DESCRIPTION
According to RFC 1035, domain host names must be 255 characters-long or less, and its labels must be 63 characters-long or less. Currently we do not validate domain names against this constraint which is causing OpenShift to reject non-compliant routes created by Zync.

One not-so-obvious case where this issue can cause us trouble is when creating a new product. The `system_name` of the product, chosen by the user, will end up being used to generate the proxy endpoints (depending on the sandbox proxy config). A sufficiently long `system_name` may produce a domain name containing a lable that is longer than 63 characters. The route will then fail to be created or updated by Zync, requiring a manual intervention by the user to fix it. The creation of the product succeeds in this case though; yet, the endpoints cannot be used.

This PR fixes this behavior by enforcing every domain name validated with https://github.com/3scale/porta/blob/bdc91b894eac16fbd81afd4f05198eb5cb8beee9/app/validators/uri_validator.rb to comply with the limits of characters specified by the RFC. Moreover, it makes proxy endpoints to be validated using this validator instead of using the old simple regex https://github.com/3scale/porta/blob/bdc91b894eac16fbd81afd4f05198eb5cb8beee9/app/models/proxy.rb#L26.

The PR also makes sure that validation errors on the proxy endpoints due to this new requirement are propagated to the service, specifically marking the `system_name` attribute. This is done with the support of https://github.com/3scale/porta/blob/bdc91b894eac16fbd81afd4f05198eb5cb8beee9/app/services/service_creator.rb.

Closes [THREESCALE-2932](https://issues.redhat.com/browse/THREESCALE-2932).