### PR TITLE
Sparse BackendMetricWorker retries by 5 minutes from each other

### DIFF
--- a/app/workers/backend_metric_worker.rb
+++ b/app/workers/backend_metric_worker.rb
@@ -13,6 +13,10 @@ class BackendMetricWorker < ApplicationJob
                      }
                    })
 
+  rescue_from StandardError do |_exception|
+    retry_job wait: 5.minutes
+  end
+
   def perform(service_backend_id, metric_id)
     metric = Metric.find_by(id: metric_id)
     service = Service.find_by(id: service_backend_id)

--- a/test/workers/backend_metric_worker_test.rb
+++ b/test/workers/backend_metric_worker_test.rb
@@ -41,9 +41,7 @@ class BackendMetricWorkerTest < ActiveSupport::TestCase
     backend_hits = backend_api.metrics.hits
     backend_other = FactoryBot.create(:metric, owner: backend_hits, system_name: 'other-metric-of-backend')
 
-
     worker = BackendMetricWorker.new
-
 
     metric_attributes = [
       { id: service_hits.id, name: service_hits.extended_system_name, parent_id: nil },
@@ -54,6 +52,18 @@ class BackendMetricWorkerTest < ActiveSupport::TestCase
     metric_attributes.each do |attrs|
       ThreeScale::Core::Metric.expects(:save).with(attrs.merge(service_id: service_backend_id))
       worker.perform(service_backend_id, attrs[:id])
+    end
+  end
+
+  test 'retry after 5 minutes' do
+    metric_attributes = { id: metric.id, service_id: service.backend_id, name: metric.system_name, parent_id: nil }
+    exception = ThreeScale::Core::APIClient::ConnectionError.new(mock(message: 'error'))
+    ThreeScale::Core::Metric.expects(:save).with(metric_attributes).raises(exception)
+
+    BackendMetricWorker.any_instance.expects(:retry_job).with(wait: 5.minutes)
+
+    perform_enqueued_jobs(only: BackendMetricWorker) do
+      BackendMetricWorker.perform_later(service.backend_id, metric.id)
     end
   end
 end


### PR DESCRIPTION
`BackendMetricWorker` was [recently refactored](https://github.com/3scale/porta/pull/1498) as an `ApplicationJob`, removing the 5-minute wait between job retries. See https://github.com/3scale/porta/pull/1498/files#r362426938.

This PR reinstantes the wait between job retries.