### PR TITLE
Rails data migrations

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -19,6 +19,7 @@ gem 'protected_attributes', '~> 1.1.4'
 gem 'rails-observers'
 
 gem 'strong_migrations'
+gem 'rails-data-migrations'
 
 group :assets do
   gem 'coffee-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,6 +529,8 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.11.1)
       sprockets-rails
+    rails-data-migrations (1.2.0)
+      rails (>= 4.0.0)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.9)
@@ -896,6 +898,7 @@ DEPENDENCIES
   rack-utf8_sanitizer
   rack-x_served_by (~> 0.1.1)
   rails (= 4.2.11.1)
+  rails-data-migrations
   rails-observers
   rails_event_store (~> 0.9.0)
   ratelimit

--- a/db/data_migrations/20200108105400_create_backend_apis.rb
+++ b/db/data_migrations/20200108105400_create_backend_apis.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'progress_counter'
+
+class CreateBackendApis < ActiveRecord::DataMigration
+  def up
+    services = Service.where.has { not_exists(BackendApiConfig.except(:order).select(:id).by_service(BabySqueel[:services].id)) }
+
+    return puts 'Nothing to do.' if services.empty?
+
+    progress = ProgressCounter.new(services.count)
+
+    services.includes(:backend_api_configs).find_each(batch_size: 100) do |service|
+      progress.call do
+        next if service.backend_api_configs.any?
+
+        service_name = service.name
+        backend_api = service.account.backend_apis.create(
+          system_name: service.system_name,
+          name: "#{service_name} Backend",
+          description: "Backend of #{service_name}",
+          private_endpoint: service.proxy&.[]('api_backend')
+        )
+
+        service.backend_api_configs.create(backend_api: backend_api, path: '/')
+      end
+    end
+  end
+end

--- a/db/data_migrations/20200108171934_update_metric_owners.rb
+++ b/db/data_migrations/20200108171934_update_metric_owners.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'progress_counter'
+
+class UpdateMetricOwners < ActiveRecord::DataMigration
+  def up
+    progress = ProgressCounter.new(Metric.count)
+    Metric.find_each do |metric|
+      metric.update_columns(owner_id: metric.service_id, owner_type: 'Service') unless metric.owner_type?
+      progress.call
+    end
+  end
+end

--- a/db/data_migrations/20200108173336_update_proxy_rule_owners.rb
+++ b/db/data_migrations/20200108173336_update_proxy_rule_owners.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'progress_counter'
+
+class UpdateProxyRuleOwners < ActiveRecord::DataMigration
+  def up
+    progress = ProgressCounter.new(ProxyRule.count)
+    ProxyRule.find_each do |proxy_rule|
+      proxy_rule.update_columns(owner_id: proxy_rule.proxy_id, owner_type: 'Proxy') unless proxy_rule.owner_type?
+      progress.call
+    end
+  end
+end

--- a/db/data_migrations/20200108174841_fix_backend_config_path.rb
+++ b/db/data_migrations/20200108174841_fix_backend_config_path.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-namespace :data_migration do
-  desc 'Backfill Paths for Backend Api Configs'
-  task fix_backend_config_path: :environment do
+require 'progress_counter'
+
+class FixBackendConfigPath < ActiveRecord::DataMigration
+  def up
     query = System::Database.oracle? ? BackendApiConfig.where('path is NULL') : BackendApiConfig.where(path: '')
     progress = ProgressCounter.new(query.count)
     BackendApiConfig.transaction do

--- a/db/migrate/20190805135829_backfill_metric_owners.rb
+++ b/db/migrate/20190805135829_backfill_metric_owners.rb
@@ -1,8 +1,8 @@
-require 'progress_counter'
+require Rails.root.join('db', 'data_migrations', '20200108171934_update_metric_owners')
 
 class BackfillMetricOwners < ActiveRecord::Migration
   def up
     Metric.reset_column_information
-    Rake::Task['services:update_metric_owners'].invoke
+    UpdateMetricOwners.new.up
   end
 end

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -530,6 +530,8 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.11.1)
       sprockets-rails
+    rails-data-migrations (1.2.0)
+      rails (>= 4.0.0)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.9)
@@ -897,6 +899,7 @@ DEPENDENCIES
   rack-utf8_sanitizer
   rack-x_served_by (~> 0.1.1)
   rails (= 4.2.11.1)
+  rails-data-migrations
   rails-observers
   rails_event_store (~> 0.9.0)
   ratelimit

--- a/lib/tasks/proxy.rake
+++ b/lib/tasks/proxy.rake
@@ -37,17 +37,4 @@ namespace :proxy do
   task :set_correct_endpoint_hosted => :environment do
     Service.includes(:proxy).where(proxies: {endpoint: nil}, deployment_option: 'hosted').find_each(&:deployment_option_changed)
   end
-
-  desc 'Update proxy rules owners'
-  task update_proxy_rule_owners: :environment do
-    puts 'Updating proxy rules owners...'
-    duration = Benchmark.measure do
-      progress = ProgressCounter.new(ProxyRule.count)
-      ProxyRule.find_each do |proxy_rule|
-        proxy_rule.update_columns(owner_id: proxy_rule.proxy_id, owner_type: 'Proxy') unless proxy_rule.owner_type?
-        progress.call
-      end
-    end
-    puts "Finished in #{format('%.1fs', duration.real)}\n\t"
-  end
 end

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -12,17 +12,4 @@ namespace :services do
   task :destroy_marked_as_deleted => :environment do
     DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
   end
-
-  desc 'Update metric owners'
-  task update_metric_owners: :environment do
-    puts 'Updating metric owners...'
-    duration = Benchmark.measure do
-      progress = ProgressCounter.new(Metric.count)
-      Metric.find_each do |metric|
-        metric.update_columns(owner_id: metric.service_id, owner_type: 'Service') unless metric.owner_type?
-        progress.call
-      end
-    end
-    puts "Finished in #{format('%.1fs', duration.real)}\n\t"
-  end
 end

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -13,32 +13,6 @@ namespace :services do
     DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
   end
 
-  desc 'Migrate proxies api_backend to backend api configs.'
-  task create_backend_apis: :environment do
-    puts 'Migrating proxies api_backend to backend api configs...'
-    duration = Benchmark.measure do
-      Service.transaction do
-        progress = ProgressCounter.new(Service.count)
-        Service.includes(:backend_api_configs).find_each(batch_size: 100) do |service|
-          progress.call do
-            next if service.backend_api_configs.any?
-
-            service_name = service.name
-            backend_api = service.account.backend_apis.create(
-              system_name: service.system_name,
-              name: "#{service_name} Backend",
-              description: "Backend of #{service_name}",
-              private_endpoint: service.proxy&.[]('api_backend')
-            )
-
-            service.backend_api_configs.create(backend_api: backend_api, path: '/')
-          end
-        end
-      end
-    end
-    puts "Finished in #{format('%.1fs', duration.real)}\n\t"
-  end
-
   desc 'Update metric owners'
   task update_metric_owners: :environment do
     puts 'Updating metric owners...'

--- a/test/data_migrations/create_backend_apis_test.rb
+++ b/test/data_migrations/create_backend_apis_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DataMigrations
+  class CreateBackendApisTest < DataMigrationTest
+    setup do
+      @migration = CreateBackendApis.new
+    end
+
+    attr_reader :migration
+
+    test "creates backend api for services that don't have one" do
+      provider = FactoryBot.create(:simple_provider)
+      services = FactoryBot.create_list(:simple_service, 7, account: provider)
+      services.each { |service| service.proxy.update_column(:api_backend, 'https://api.example.com') }
+
+      # 1st service already has backend api
+      services.first.backend_api_configs.create(backend_api: FactoryBot.create(:backend_api, account: provider), path: '/')
+
+      # 2nd and 3rd services don't have backend_api but neither their proxy have a private_endpoint
+      services[1..2].each { |service| service.proxy.update_column(:api_backend, nil) }
+
+      assert_change of: ->{ provider.backend_apis.count }, by: 4 do
+        migration.up
+      end
+    end
+
+    test 'it does nothing when all services already have backend api config' do
+      $stdout.expects(:puts).with('Nothing to do.')
+      refute migration.up
+    end
+  end
+end

--- a/test/data_migrations/fix_backend_config_path_test.rb
+++ b/test/data_migrations/fix_backend_config_path_test.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
-module Tasks
-  class FixBackendConfigPathTest < ActiveSupport::TestCase
+module DataMigrations
+  class FixBackendConfigPathTest < DataMigrationTest
     fixtures :backend_api_configs
 
     setup do
@@ -13,7 +15,7 @@ module Tasks
       assert @config_without_path.path.blank?
       assert_equal '/some/path', @config_with_path.path
 
-      execute_rake_task 'data_migration/fix_backend_config_path.rake', 'data_migration:fix_backend_config_path'
+      FixBackendConfigPath.new.up
 
       assert_equal '/', @config_without_path.reload.path
       assert_equal '/some/path', @config_with_path.reload.path

--- a/test/data_migrations/update_metric_owners_test.rb
+++ b/test/data_migrations/update_metric_owners_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DataMigrations
+  class UpdateMetricOwnersTest < DataMigrationTest
+    test 'updates metrics owned by services' do
+      metrics = FactoryBot.create_list(:metric, 3)
+      Metric.where(id: metrics.map(&:id)).update_all(owner_id: nil, owner_type: nil)
+      FactoryBot.create(:metric, service_id: nil, owner: FactoryBot.create(:backend_api))
+      assert_change of: ->{ Metric.where(owner_type: 'Service').count }, by: 3 do
+        UpdateMetricOwners.new.up
+      end
+    end
+  end
+end

--- a/test/data_migrations/update_proxy_rule_owners_test.rb
+++ b/test/data_migrations/update_proxy_rule_owners_test.rb
@@ -2,14 +2,14 @@
 
 require 'test_helper'
 
-module Tasks
-  class ProxyTest < ActiveSupport::TestCase
-    test 'update_proxy_rule_owners' do
+module DataMigrations
+  class UpdateProxyRuleOwnersTest < DataMigrationTest
+    test 'updates metrics owned by services' do
       proxy_rules = FactoryBot.create_list(:proxy_rule, 3)
       ProxyRule.where(id: proxy_rules.map(&:id)).update_all(owner_id: nil, owner_type: nil)
       FactoryBot.create(:proxy_rule, proxy_id: nil, owner: FactoryBot.create(:backend_api))
       assert_change of: ->{ ProxyRule.where(owner_type: 'Proxy').count }, by: 3 do
-        execute_rake_task 'proxy.rake', 'proxy:update_proxy_rule_owners'
+        UpdateProxyRuleOwners.new.up
       end
     end
   end

--- a/test/test_helpers/data_migrations.rb
+++ b/test/test_helpers/data_migrations.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Test your data migrations as follows.
+#
+# require 'test_helper'
+#
+# module DataMigrations
+#   class MyDataMigrationTest < DataMigrationTest
+#     test 'does something' do
+#       migration = MyDataMigration.new
+#       assert_something do
+#         migration.up
+#       end
+#     end
+#   end
+# end
+
+module DataMigrations
+  class DataMigrationTest < ActiveSupport::TestCase ; end
+end
+
+RailsDataMigrations::LogEntry.create_table unless ActiveRecord::Base.connection.table_exists? RailsDataMigrations::LogEntry.table_name
+
+Dir[Rails.root.join *%w[db data_migrations *.rb]].each { |file| require file }

--- a/test/unit/models_test.rb
+++ b/test/unit/models_test.rb
@@ -6,7 +6,7 @@ class ModelsTest < ActiveSupport::TestCase
 
   test 'validate length of strings for all models to do not raise an error reaching DB' do
     exceptions = {
-      'ActiveRecord::SchemaMigration' => :all, 'Audited::Audit' => :all, 'RailsEventStoreActiveRecord::Event' => :all,
+      'ActiveRecord::SchemaMigration' => :all, 'RailsDataMigrations::LogEntry' => :all, 'Audited::Audit' => :all, 'RailsEventStoreActiveRecord::Event' => :all,
       'System::Database::ConnectionProbe' => :all, 'ActsAsTaggableOn::Tag' => :all, 'ActsAsTaggableOn::Tagging' => :all, 'ApplicationRecord' => :all,
       'FieldsDefinition' => %w[target], 'AuthenticationProvider' => %w[account_type], 'Feature' => %w[featurable_type scope], 'Message' => %w[state],
       'UsageLimit' => %w[period plan_type], 'Policy' => %w[identifier], 'ProxyRule' => %w[metric_system_name], 'ProxyConfig' => %w[hosts],

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -10,22 +10,6 @@ module Tasks
       execute_rake_task 'services.rake', 'services:destroy_marked_as_deleted'
     end
 
-    test 'create_backend_apis' do
-      provider = FactoryBot.create(:simple_provider)
-      services = FactoryBot.create_list(:simple_service, 7, account: provider)
-      services.each { |service| service.proxy.update_column(:api_backend, 'https://api.example.com') }
-
-      # 1st service already has backend api
-      services.first.backend_api_configs.create(backend_api: FactoryBot.create(:backend_api, account: provider), path: '/')
-
-      # 2nd and 3rd services don't have backend_api but neither their proxy have a private_endpoint
-      services[1..2].each { |service| service.proxy.update_column(:api_backend, nil) }
-
-      assert_change of: ->{ provider.backend_apis.count }, by: 4 do
-        execute_rake_task 'services.rake', 'services:create_backend_apis'
-      end
-    end
-
     test 'update_metric_owners' do
       metrics = FactoryBot.create_list(:metric, 3)
       Metric.where(id: metrics.map(&:id)).update_all(owner_id: nil, owner_type: nil)

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -9,14 +9,5 @@ module Tasks
 
       execute_rake_task 'services.rake', 'services:destroy_marked_as_deleted'
     end
-
-    test 'update_metric_owners' do
-      metrics = FactoryBot.create_list(:metric, 3)
-      Metric.where(id: metrics.map(&:id)).update_all(owner_id: nil, owner_type: nil)
-      FactoryBot.create(:metric, service_id: nil, owner: FactoryBot.create(:backend_api))
-      assert_change of: ->{ Metric.where(owner_type: 'Service').count }, by: 3 do
-        execute_rake_task 'services.rake', 'services:update_metric_owners'
-      end
-    end
   end
 end


### PR DESCRIPTION
This PR adds https://github.com/OffgridElectric/rails-data-migrations to manage data migrations in porta separately from any DDL code and yet without having to define them as rake tasks.

It also cleans up 4 rake tasks introduced in 2.7, meant to be executed only once, to handle legacy data of Saas and on-prem customers migrating from 2.6. The tasks were at first rewritten as data migration files, but since we won't need any of that to run again in 2.8, then so those files (and corresponding tests) will most likely be removed before we merge this PR. The 4 rake tasks are:
- `services:create_backend_apis`
- `service:update_metric_owners`
- `proxy:update_proxy_rule_owners`
- `data_migration:fix_backend_config_path`

Closes [THREESCALE-3630](https://issues.redhat.com/browse/THREESCALE-3630)

----

We reviewed 3 options of gems to handle DML code. This is the summary of our findings about them:

https://github.com/ilyakatz/data-migrate
- 22 contributors 👍
- Recently updated 👍
- Rails 5+ 😕
- It sorts data migrations mixed to DDL migrations 👎 https://github.com/ilyakatz/data-migrate/blob/4db2dba7d53e73cac06aa9bfab136c10aa38367b/tasks/databases.rake#L357

https://github.com/ka8725/migration_data
- 6 contributors 👎
- ~3 years outdated 👎
- Rails 4 and 5 👎
- DML code goes inside normal `ActiveRecord::Migration`s 👎

https://github.com/OffgridElectric/rails-data-migrations
- 5 contributors 👎
- ~2 years-old 👎
- Rails 4+ 👍
- Data migrations triggered through an independent rake task 👍

----

Useful rake tasks of https://github.com/OffgridElectric/rails-data-migrations:

```
# List data migrations pending to run
rake data:migrate:pending

# Run pending data migrations
rake data:migrate

# Rollback data migrations to a `VERSION`
VERSION=<...> rake data:migrate:down

# Mark all pending migrations as 'complete' (as opposed to 'pending')
rake data:reset
```

To generate a new data migration file:

```
rails generate data_migration my_data_migration
```