### PR TITLE
Disable generate client secret button in Dev portal

### DIFF
--- a/lib/developer_portal/lib/liquid/filters/rails_helpers.rb
+++ b/lib/developer_portal/lib/liquid/filters/rails_helpers.rb
@@ -192,7 +192,7 @@ module Liquid
       end
 
       def regenerate_oauth_secret_button(title, url)
-        button title, url, :put, class: 'delete', remote: true
+        update_button_ajax title, url, { 'class' => 'btn btn-danger', 'disable_with' => 'Generating...' }
       end
 
       desc "Create link from given text"


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses argument `disable_with` for the button to be disabled after submission.

Also adds proper styling, similar to other "Regenerate" buttons.

![disable_with](https://user-images.githubusercontent.com/11672286/72141022-4b500a80-3392-11ea-9d98-7042bc130dd8.gif)


**Which issue(s) this PR fixes** 

[THREESCALE-942: Application show view is overlaid by the Error Layout when a 404 Not Found is returned](https://issues.redhat.com/browse/THREESCALE-942)

**Verification steps** 

- Sign in to the dev portal
- Go to an application, it must make use of a client secret
- Click multiple times on "Regenerate"
- (More detailed steps to reproduce in the [JIRA](https://issues.redhat.com/browse/THREESCALE-942))
