### PR TITLE
Upgrade to ruby2 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,6 +267,10 @@ commands: # reusable commands with parameters
       - steps: << parameters.extra-deps >>
       - prepare-db-for-tests
       - run:
+        name: "Ruby Version"
+        command: |
+          ruby -v
+      - run:
           name: Run Rails tests
           command: |
             taskname=$(echo $CIRCLE_JOB | sed -e 's/-\(postgres\|oracle\|[0-9]\)//g')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,12 +267,10 @@ commands: # reusable commands with parameters
       - steps: << parameters.extra-deps >>
       - prepare-db-for-tests
       - run:
-        name: "Ruby Version"
-        command: |
-          ruby -v
-      - run:
           name: Run Rails tests
           command: |
+            echo "Ruby version ==="
+            ruby -v
             taskname=$(echo $CIRCLE_JOB | sed -e 's/-\(postgres\|oracle\|[0-9]\)//g')
             TESTS=$(bundle exec rake "test:files:${taskname}" | circleci tests split --split-by=timings)
             bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ attach-to-workspace: &attach-to-workspace
     at: .
 
 system-builder-ruby25: &system-builder-ruby25
-  image: quay.io/3scale/system-builder:ruby25
+  image: quay.io/duduribeiro/3scale-system-builder:ruby25
   environment:
     BUNDLE_FROZEN: true
     BUNDLE_PATH: 'vendor/bundle'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,8 +269,6 @@ commands: # reusable commands with parameters
       - run:
           name: Run Rails tests
           command: |
-            echo "Ruby version ==="
-            ruby -v
             taskname=$(echo $CIRCLE_JOB | sed -e 's/-\(postgres\|oracle\|[0-9]\)//g')
             TESTS=$(bundle exec rake "test:files:${taskname}" | circleci tests split --split-by=timings)
             bundle exec rake test:run TESTS="$TESTS" TESTOPTS=--verbose --verbose --trace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ attach-to-workspace: &attach-to-workspace
     at: .
 
 system-builder-ruby25: &system-builder-ruby25
-  image: quay.io/duduribeiro/3scale-system-builder:ruby25
+  image: quay.io/3scale/system-builder:ruby25
   environment:
     BUNDLE_FROZEN: true
     BUNDLE_PATH: 'vendor/bundle'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ attach-to-workspace: &attach-to-workspace
   attach_workspace:
     at: .
 
-system-builder-ruby24: &system-builder-ruby24
-  image: quay.io/3scale/system-builder:ruby24
+system-builder-ruby25: &system-builder-ruby25
+  image: quay.io/3scale/system-builder:ruby25
   environment:
     BUNDLE_FROZEN: true
     BUNDLE_PATH: 'vendor/bundle'
@@ -298,69 +298,69 @@ commands: # reusable commands with parameters
 ##################################### CIRCLECI EXECUTORS ############################################
 
 executors:
-  builder-ruby24: &builder-ruby24
+  builder-ruby25: &builder-ruby25
     parameters:
       database:
         type: string
         default: mysql
     docker:
-      - *system-builder-ruby24
+      - *system-builder-ruby25
     environment:
       DB: << parameters.database >>
     working_directory: /opt/app-root/src/project
 
-  builder-with-mysql-ruby24: &builder-with-mysql-ruby24
+  builder-with-mysql-ruby25: &builder-with-mysql-ruby25
     resource_class: small
     docker:
-      - *system-builder-ruby24
+      - *system-builder-ruby25
       - *mysql-container
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
     <<: *build-envs-mysql
 
-  builder-with-postgres-ruby24: &builder-with-postgres-ruby24
+  builder-with-postgres-ruby25: &builder-with-postgres-ruby25
     resource_class: small
     docker:
-      - *system-builder-ruby24
+      - *system-builder-ruby25
       - *postgres-container
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
     <<: *build-envs-postgresql
 
-  builder-with-oracle-ruby24: &builder-with-oracle-ruby24
+  builder-with-oracle-ruby25: &builder-with-oracle-ruby25
     resource_class: large
     docker:
-      - *system-builder-ruby24
+      - *system-builder-ruby25
       - *oracle-db-container
       - *memcached-container
       - *redis-container
     working_directory: /opt/app-root/src/project
     <<: *build-envs-oracle
 
-  cucumber-with-mysql-ruby24: &cucumber-with-mysql-ruby24
+  cucumber-with-mysql-ruby25: &cucumber-with-mysql-ruby25
     resource_class: small
     docker:
-      - *system-builder-ruby24
+      - *system-builder-ruby25
       - *dnsmasq-container
       - *mysql-container
       - *memcached-container
       - *redis-container
 
-  cucumber-with-postgres-ruby24: &cucumber-with-postgres-ruby24
+  cucumber-with-postgres-ruby25: &cucumber-with-postgres-ruby25
     resource_class: small
     docker:
-      - *system-builder-ruby24
+      - *system-builder-ruby25
       - *dnsmasq-container
       - *postgres-container
       - *memcached-container
       - *redis-container
 
-  cucumber-with-oracle-ruby24: &cucumber-with-oracle-ruby24
+  cucumber-with-oracle-ruby25: &cucumber-with-oracle-ruby25
     resource_class: large
     docker:
-      - *system-builder-ruby24
+      - *system-builder-ruby25
       - *dnsmasq-container
       - *oracle-db-container
       - *memcached-container
@@ -373,7 +373,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-ruby24
+        default: builder-ruby25
     executor:
       name: << parameters.executor >>
       database: mysql
@@ -384,7 +384,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-ruby24
+        default: builder-ruby25
     executor:
       name: << parameters.executor >>
       database: postgresql
@@ -395,7 +395,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-ruby24
+        default: builder-ruby25
     executor:
       name: << parameters.executor >>
       database: oracle
@@ -408,7 +408,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-ruby24
+        default: builder-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -429,7 +429,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-ruby24
+        default: builder-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -456,7 +456,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-ruby24
+        default: builder-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -493,7 +493,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-ruby24
+        default: builder-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -512,7 +512,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-ruby24
+        default: builder-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -529,7 +529,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-mysql-ruby24
+        default: builder-with-mysql-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -540,7 +540,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-postgres-ruby24
+        default: builder-with-postgres-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -551,7 +551,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-oracle-ruby24
+        default: builder-with-oracle-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -564,7 +564,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-mysql-ruby24
+        default: builder-with-mysql-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -575,7 +575,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-postgres-ruby24
+        default: builder-with-postgres-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -586,7 +586,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-oracle-ruby24
+        default: builder-with-oracle-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -599,7 +599,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-mysql-ruby24
+        default: builder-with-mysql-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -610,7 +610,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-postgres-ruby24
+        default: builder-with-postgres-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -621,7 +621,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-oracle-ruby24
+        default: builder-with-oracle-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -634,7 +634,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-mysql-ruby24
+        default: builder-with-mysql-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -645,7 +645,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-postgres-ruby24
+        default: builder-with-postgres-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -656,7 +656,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: builder-with-oracle-ruby24
+        default: builder-with-oracle-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -670,7 +670,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: cucumber-with-mysql-ruby24
+        default: cucumber-with-mysql-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -682,7 +682,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: cucumber-with-postgres-ruby24
+        default: cucumber-with-postgres-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -694,7 +694,7 @@ jobs:
     parameters:
       executor:
         type: string
-        default: cucumber-with-oracle-ruby24
+        default: cucumber-with-oracle-ruby25
     executor:
       name: << parameters.executor >>
     steps:
@@ -825,7 +825,7 @@ jobs:
     parallelism: 1
     resource_class: small
     docker:
-      - *system-builder-ruby24
+      - *system-builder-ruby25
       - image: quay.io/mikz/dnsmasq
         command:
           - --no-poll
@@ -1084,39 +1084,39 @@ workflows:
   ######## Nightly workflows
 
 
-  mysql_nightly_build_ruby24:
+  mysql_nightly_build_ruby25:
     jobs:
       - notify_start:
           <<: *only-master-filter
       - dependencies_bundler:
-          executor: builder-ruby24
+          executor: builder-ruby25
       - dependencies_npm:
-          executor: builder-ruby24
+          executor: builder-ruby25
       - docker-build:
           context: org-global
       - assets_precompile:
-          executor: builder-ruby24
+          executor: builder-ruby25
           requires:
             - dependencies_bundler
             - dependencies_npm
       - unit:
-          executor: builder-with-mysql-ruby24
+          executor: builder-with-mysql-ruby25
           requires:
             - dependencies_bundler
       - functional:
-          executor: builder-with-mysql-ruby24
+          executor: builder-with-mysql-ruby25
           requires:
             - assets_precompile
       - integration:
-          executor: builder-with-mysql-ruby24
+          executor: builder-with-mysql-ruby25
           requires:
             - assets_precompile
       - rspec:
-          executor: builder-with-mysql-ruby24
+          executor: builder-with-mysql-ruby25
           requires:
             - dependencies_bundler
       - cucumber:
-          executor: cucumber-with-mysql-ruby24
+          executor: cucumber-with-mysql-ruby25
           requires:
             - assets_precompile
       - notify_success:
@@ -1137,39 +1137,39 @@ workflows:
           <<: *only-master-filter
     <<: *nightly-trigger
 
-  postgres_nightly_build_ruby24:
+  postgres_nightly_build_ruby25:
     jobs:
       - notify_start:
           <<: *only-master-filter
       - deps_bundler_postgres:
-          executor: builder-ruby24
+          executor: builder-ruby25
       - dependencies_npm:
-          executor: builder-ruby24
+          executor: builder-ruby25
       - docker-build:
           context: org-global
       - assets_precompile:
-          executor: builder-ruby24
+          executor: builder-ruby25
           requires:
             - deps_bundler_postgres
             - dependencies_npm
       - unit-postgres:
-          executor: builder-with-postgres-ruby24
+          executor: builder-with-postgres-ruby25
           requires:
             - deps_bundler_postgres
       - functional-postgres:
-          executor: builder-with-postgres-ruby24
+          executor: builder-with-postgres-ruby25
           requires:
             - assets_precompile
       - integration-postgres:
-          executor: builder-with-postgres-ruby24
+          executor: builder-with-postgres-ruby25
           requires:
             - assets_precompile
       - rspec-postgres:
-          executor: builder-with-postgres-ruby24
+          executor: builder-with-postgres-ruby25
           requires:
             - deps_bundler_postgres
       - cucumber-postgres:
-          executor: cucumber-with-postgres-ruby24
+          executor: cucumber-with-postgres-ruby25
           requires:
             - assets_precompile
       - notify_success:
@@ -1190,40 +1190,40 @@ workflows:
           <<: *only-master-filter
     <<: *nightly-trigger
 
-  oracle_nightly_build_ruby24:
+  oracle_nightly_build_ruby25:
     jobs:
       - notify_start:
           <<: *only-master-filter
       - deps_bundler_oracle:
-          executor: builder-ruby24
+          executor: builder-ruby25
       - dependencies_npm:
-          executor: builder-ruby24
+          executor: builder-ruby25
       - docker-build:
           context: org-global
       - assets_precompile:
-          executor: builder-ruby24
+          executor: builder-ruby25
           requires:
             - deps_bundler_oracle
             - dependencies_npm
 
       - unit-oracle:
-          executor: builder-with-oracle-ruby24
+          executor: builder-with-oracle-ruby25
           requires:
             - deps_bundler_oracle
       - functional-oracle:
-          executor: builder-with-oracle-ruby24
+          executor: builder-with-oracle-ruby25
           requires:
             - assets_precompile
       - integration-oracle:
-          executor: builder-with-oracle-ruby24
+          executor: builder-with-oracle-ruby25
           requires:
             - assets_precompile
       - rspec-oracle:
-          executor: builder-with-oracle-ruby24
+          executor: builder-with-oracle-ruby25
           requires:
             - deps_bundler_oracle
       - cucumber-oracle:
-          executor: cucumber-with-oracle-ruby24
+          executor: cucumber-with-oracle-ruby25
           requires:
             - assets_precompile
       - notify_success:
@@ -1245,29 +1245,29 @@ workflows:
           <<: *only-master-filter
     <<: *nightly-trigger
 
-  javascript_nightly_build_ruby24:
+  javascript_nightly_build_ruby25:
     jobs:
       - notify_start:
           <<: *only-master-filter
       - dependencies_bundler:
-          executor: builder-ruby24
+          executor: builder-ruby25
       - dependencies_npm:
-          executor: builder-ruby24
+          executor: builder-ruby25
       - assets_precompile:
-          executor: builder-ruby24
+          executor: builder-ruby25
           requires:
             - dependencies_bundler
             - dependencies_npm
       - lint:
-          executor: builder-ruby24
+          executor: builder-ruby25
           requires:
             - assets_precompile
       - karma:
-          executor: builder-ruby24
+          executor: builder-ruby25
           requires:
             - dependencies_npm
       - jest:
-          executor: builder-ruby24
+          executor: builder-ruby25
           requires:
             - dependencies_npm
       - notify_success:
@@ -1284,7 +1284,7 @@ workflows:
           <<: *only-master-filter
     <<: *nightly-trigger
 
-  visual_test_nightly_ruby24:
+  visual_test_nightly_ruby25:
     jobs:
       - dependencies_bundler:
           <<: *only-master-filter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/3scale/system-builder:ruby24
+FROM quay.io/3scale/system-builder:ruby25
 
 ARG SPHINX_VERSION=2.2.11
 ARG BUNDLER_VERSION=1.17.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/3scale/system-builder:ruby25
+FROM quay.io/duduribeiro/3scale-system-builder:ruby25
 
 ARG SPHINX_VERSION=2.2.11
 ARG BUNDLER_VERSION=1.17.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/duduribeiro/3scale-system-builder:ruby25
+FROM quay.io/3scale/system-builder:ruby25
 
 ARG SPHINX_VERSION=2.2.11
 ARG BUNDLER_VERSION=1.17.3

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,9 @@ make help
 ```
 
 ### Entering a Running Container
+
 Download and build all the images and start a shell session inside the container:
+
 ```bash
 make bash
 ```
@@ -43,6 +45,7 @@ make dev-start
 ```
 
 or, you can run the setup and run with
+
 ```
 make default
 ```
@@ -53,16 +56,16 @@ to stop the application, run:
 make dev-stop
 ```
 
-
 ## Manual setup on Mac OS X (10.13)
 
 ### Prerequisites
 
 #### Ruby version
 
-The project supports **Ruby 2.5.x**.
+The project supports **2.5.x**.
 
 Verify you have a proper version by running on your terminal:
+
 ```bash
 ruby -v
 ```
@@ -194,9 +197,10 @@ npm install
 
 #### Ruby version
 
-The project supports **Ruby 2.5.x**.
+The project supports **2.5.x**.
 
 Verify you have a proper version by running on your terminal:
+
 ```bash
 ruby -v
 ```
@@ -294,8 +298,11 @@ bundle exec rake db:reset # This will drop and setup the database
 **NOTE:** This will seed the application and creates the Master, Provider & Developer accounts which are accessible through: `http://master-account.example.com.lvh.me:3000`, `http://provider-admin.example.com.lvh.me:3000`, `http://provider.example.com.lvh.me:3000` respectively. Please take note of the credentials generated at this moment also so that you can log into each of these portals.
 
 ## Run Porta
+
 Start up the rails server by running the following command:
+
 ```bash
 $ env UNICORN_WORKERS=2 rails server -b 0.0.0.0 # Runs the server, available at localhost:3000
 ```
+
 > The number of unicorn workers is variable and sometimes it will need more than 2. In case the server is slow or start suffering from timeouts, try restarting porta with a higher number like 8.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,7 +60,7 @@ make dev-stop
 
 #### Ruby version
 
-The project supports **Ruby 2.4.x**.
+The project supports **Ruby 2.5.x**.
 
 Verify you have a proper version by running on your terminal:
 ```bash
@@ -194,7 +194,7 @@ npm install
 
 #### Ruby version
 
-The project supports **Ruby 2.4.x**.
+The project supports **Ruby 2.5.x**.
 
 Verify you have a proper version by running on your terminal:
 ```bash

--- a/app/lib/pdf/data.rb
+++ b/app/lib/pdf/data.rb
@@ -72,7 +72,7 @@ module Pdf
     def metrics
       data = @source.usage_progress_for_all_metrics(@options)[:metrics]
       data.inject([]) do |row, (metric, stats)|
-        percentage = '%0.2f %' % metric[:data][:change]
+        percentage = '%0.2f %%' % metric[:data][:change]
         row << Format.prep_td_with_negation([metric[:name], metric[:data][:total], percentage])
       end
     end

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/ruby-24-centos7
+FROM centos/ruby-25-centos7
 
 USER root
 

--- a/openshift/system/Dockerfile.on_prem
+++ b/openshift/system/Dockerfile.on_prem
@@ -1,4 +1,4 @@
-FROM centos/ruby-24-centos7
+FROM centos/ruby-25-centos7
 
 USER root
 

--- a/openshift/system/contrib/scl_enable
+++ b/openshift/system/contrib/scl_enable
@@ -1,4 +1,4 @@
 # This file contains automatic SCL enablement.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-ruby24
+source scl_source enable rh-ruby25
 source scl_source enable $NODEJS_SCL


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade ruby to version 2.5.
The current version that we use (2.4) EOL is March 31, 2020.

**Which issue(s) this PR fixes** 

[https://issues.redhat.com/browse/THREESCALE-3900](https://issues.redhat.com/browse/THREESCALE-3900)
