### PR TITLE
Fix pdf report file name

### DIFF
--- a/app/lib/pdf/report.rb
+++ b/app/lib/pdf/report.rb
@@ -53,7 +53,7 @@ module Pdf
       metrics
       move_down 3
 
-      @report = @pdf.render_file(Rails.root.join('tmp', "#{@account.domain} #{@service.name}.pdf"))
+      @report = @pdf.render_file(pdf_file_path)
 
       self
     end
@@ -86,7 +86,11 @@ module Pdf
     end
 
     def pdf_file_name
-      [@account.id, @service.id, 'report.pdf'].join '_'
+      ['report', @account.id, @service.id].join('-') + '.pdf'
+    end
+
+    def pdf_file_path
+      Rails.root.join('tmp', pdf_file_name)
     end
 
     def print_period

--- a/app/lib/pdf/report.rb
+++ b/app/lib/pdf/report.rb
@@ -86,7 +86,7 @@ module Pdf
     end
 
     def pdf_file_name
-      ['report', @account.id, @service.id].join('-') + '.pdf'
+      ['report', @account.domain, @service.id].join('-') + '.pdf'
     end
 
     def pdf_file_path

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -385,7 +385,7 @@ class NotificationMailer < ActionMailer::Base
     @provider_account = report.account
     @receiver         = receiver
     report_file       = File.read(report.report.path)
-    report_name       = "report-#{report.service.name}.pdf"
+    report_name       = report.pdf_file_name
 
     attachments[report_name] = report_file
 

--- a/app/mailers/post_office.rb
+++ b/app/mailers/post_office.rb
@@ -44,27 +44,24 @@ class PostOffice < ActionMailer::Base
 
   def report(report, period)
     account = report.account
+    service_name = report.service.name
 
     headers(
       'Return-Path' => from_address(account),
       'X-SMTPAPI' => '{"category": "Report"}'
     )
 
-    attachments["report-#{service_name(report)}.pdf"] = File.read(report.report.path)
+    attachments[report.pdf_file_name] = File.read(report.report.path)
 
     mail(
-      :subject => "3scale: #{service_name(report)} - #{period}",
-      :body => "Service: #{service_name(report)}\n\nPlease find attached your API Usage Report from 3scale.\n",
+      :subject => "3scale: #{service_name} - #{period}",
+      :body => "Service: #{service_name}\n\nPlease find attached your API Usage Report from 3scale.\n",
       :bcc => account.admins.map(&:email),
       :from => from_address(account)
     )
   end
 
   private
-
-  def service_name(report)
-    report.service.name
-  end
 
   def emails_for_message(message, recipient)
     sender = message.sender

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -476,7 +476,7 @@ class NotificationMailerTest < ActionMailer::TestCase
 
     assert mail.attachments
     assert_equal mail.attachments.count, 1
-    assert_match "report-#{provider.id}-#{service.id}.pdf", mail.attachments.first.filename
+    assert_match "report-#{provider.domain}-#{service.id}.pdf", mail.attachments.first.filename
 
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match 'Please find attached your API Usage Report', body.encoded
@@ -492,7 +492,7 @@ class NotificationMailerTest < ActionMailer::TestCase
 
     assert mail.attachments
     assert_equal mail.attachments.count, 1
-    assert_match "report-#{provider.id}-#{service.id}.pdf", mail.attachments.first.filename
+    assert_match "report-#{provider.domain}-#{service.id}.pdf", mail.attachments.first.filename
 
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match 'Please find attached your API Usage Report', body.encoded

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -476,7 +476,7 @@ class NotificationMailerTest < ActionMailer::TestCase
 
     assert mail.attachments
     assert_equal mail.attachments.count, 1
-    assert_match "report-#{service.name}.pdf", mail.attachments.first.filename
+    assert_match "report-#{provider.id}-#{service.id}.pdf", mail.attachments.first.filename
 
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match 'Please find attached your API Usage Report', body.encoded
@@ -492,7 +492,7 @@ class NotificationMailerTest < ActionMailer::TestCase
 
     assert mail.attachments
     assert_equal mail.attachments.count, 1
-    assert_match "report-#{service.name}.pdf", mail.attachments.first.filename
+    assert_match "report-#{provider.id}-#{service.id}.pdf", mail.attachments.first.filename
 
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match 'Please find attached your API Usage Report', body.encoded

--- a/test/unit/mailers/post_office_test.rb
+++ b/test/unit/mailers/post_office_test.rb
@@ -169,8 +169,9 @@ class PostOfficeTest < ActionMailer::TestCase
   test 'report should verify email' do
     account = @provider
     service = account.first_service!
+    service_id = service.id
 
-    file = Rails.root.join("tmp", "report-#{account.id}-#{service.id}-internal.pdf")
+    file = Rails.root.join("tmp", "report-#{account.id}-#{service_id}-internal.pdf")
     report = Pdf::Report.new account, service
     file.stubs(:path).returns(file)
     report.stubs(:report).returns(file)
@@ -184,7 +185,7 @@ class PostOfficeTest < ActionMailer::TestCase
     assert_equal [account.admins.first.email], email.bcc
     assert_equal [Rails.configuration.three_scale.noreply_email], email.from
     assert_match "Please find attached your API Usage Report from 3scale.", email.parts.first.body.to_s
-    assert_equal "report-#{account.id}-#{service.id}.pdf", email.attachments.first.filename
+    assert_equal "report-#{account.domain}-#{service_id}.pdf", email.attachments.first.filename
   end
 
   def url_helpers

--- a/test/unit/mailers/post_office_test.rb
+++ b/test/unit/mailers/post_office_test.rb
@@ -167,22 +167,24 @@ class PostOfficeTest < ActionMailer::TestCase
   end
 
   test 'report should verify email' do
-    @account = @provider
-    file = Rails.root.join("tmp", "#{@account.domain}.pdf")
+    account = @provider
+    service = account.first_service!
 
-    report = Pdf::Report.new @account, @account.first_service!
+    file = Rails.root.join("tmp", "report-#{account.id}-#{service.id}-internal.pdf")
+    report = Pdf::Report.new account, service
     file.stubs(:path).returns(file)
     report.stubs(:report).returns(file)
 
     `touch #{file}`
 
     PostOffice.report(report, "December 2010").deliver_now
-    @email = ActionMailer::Base.deliveries.last
+    email = ActionMailer::Base.deliveries.last
 
-    assert_equal "3scale: #{@account.first_service!.name} - December 2010", @email.subject
-    assert_equal [@account.admins.first.email], @email.bcc
-    assert_equal [Rails.configuration.three_scale.noreply_email], @email.from
-    assert_match "Please find attached your API Usage Report from 3scale.", @email.parts.first.body.to_s
+    assert_equal "3scale: #{service.name} - December 2010", email.subject
+    assert_equal [account.admins.first.email], email.bcc
+    assert_equal [Rails.configuration.three_scale.noreply_email], email.from
+    assert_match "Please find attached your API Usage Report from 3scale.", email.parts.first.body.to_s
+    assert_equal "report-#{account.id}-#{service.id}.pdf", email.attachments.first.filename
   end
 
   def url_helpers

--- a/test/unit/pdf/report_test.rb
+++ b/test/unit/pdf/report_test.rb
@@ -45,7 +45,7 @@ class Pdf::ReportTest < ActiveSupport::TestCase
   end
 
   test 'pdf file name' do
-    filename = "report-#{@account.id}-#{@service.id}.pdf"
+    filename = "report-#{@account.domain}-#{@service.id}.pdf"
     assert_equal filename, @report.pdf_file_name
 
     @report.pdf.expects(:render_file).with(Rails.root.join('tmp', filename))

--- a/test/unit/pdf/report_test.rb
+++ b/test/unit/pdf/report_test.rb
@@ -43,4 +43,12 @@ class Pdf::ReportTest < ActiveSupport::TestCase
 
     assert report.generate
   end
+
+  test 'pdf file name' do
+    filename = "report-#{@account.id}-#{@service.id}.pdf"
+    assert_equal filename, @report.pdf_file_name
+
+    @report.pdf.expects(:render_file).with(Rails.root.join('tmp', filename))
+    assert @report.generate
+  end
 end


### PR DESCRIPTION
Makes PDF reports to be named using the account ID and service ID, instead of account domain and service name.

![Screenshot 2020-01-15 at 14 57 00](https://user-images.githubusercontent.com/1842261/72439676-a7a69600-37a7-11ea-9d5f-01b6d569595a.png)


Closes [THREESCALE-4147](https://issues.redhat.com/browse/THREESCALE-4147)

----

- [x] ~Use service ID or sanitize the name~ _Update:_ use https://github.com/3scale/porta/blob/46f6bdb1963498e8a4e4b49a15ec110f2e01e048/app/lib/pdf/report.rb#L88
- [ ] ~Include the name of the service in the header of the PDF file~ _Update:_ already there: https://github.com/3scale/porta/blob/46f6bdb1963498e8a4e4b49a15ec110f2e01e048/app/lib/pdf/report.rb#L98
- [x] Add tests