### PR TITLE
Support websocket protocol in BackendApi

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -27,7 +27,7 @@ class BackendApi < ApplicationRecord
 
   validates :private_endpoint, length: { maximum: 255 },
     presence: true,
-    uri: { path: proc { provider_can_use?(:proxy_private_base_path) } },
+    uri: { path: proc { provider_can_use?(:proxy_private_base_path) }, scheme: %w[http https ws wss] },
     non_localhost: { message: :protected_domain }
 
   alias_attribute :api_backend, :private_endpoint

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -858,7 +858,7 @@ en:
             base:
               cannot_be_destroyed_with_products: cannot be deleted because it is used by at least one Product
             private_endpoint:
-              invalid: "the accepted format is 'scheme://address(:port)(/path). Accepted schemes are http, https, ws and wss'"
+              invalid: "the accepted format is 'scheme://address(:port)(/path)'. Accepted schemes are http, https, ws and wss"
         proxy:
           attributes:
             api_backend:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -862,7 +862,7 @@ en:
         proxy:
           attributes:
             api_backend:
-              invalid: "the accepted format is 'http(s)://address(:port)(/path)'"
+              invalid: "the accepted format is 'scheme://address(:port)(/path)'. Accepted schemes are http, https, ws and wss"
             api_test_path:
               invalid: "only URI characters allowed"
             endpoint:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -858,7 +858,7 @@ en:
             base:
               cannot_be_destroyed_with_products: cannot be deleted because it is used by at least one Product
             private_endpoint:
-              invalid: "the accepted format is 'protocol://address(:port)(/path). Accepted protocols are http and ws'"
+              invalid: "the accepted format is 'scheme://address(:port)(/path). Accepted schemes are http, https, ws and wss'"
         proxy:
           attributes:
             api_backend:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -858,7 +858,7 @@ en:
             base:
               cannot_be_destroyed_with_products: cannot be deleted because it is used by at least one Product
             private_endpoint:
-              invalid: "the accepted format is 'http(s)://address(:port)(/path)'"
+              invalid: "the accepted format is 'protocol://address(:port)(/path). Accepted protocols are http and ws'"
         proxy:
           attributes:
             api_backend:

--- a/test/models/backend_api_test.rb
+++ b/test/models/backend_api_test.rb
@@ -31,6 +31,18 @@ class BackendApiTest < ActiveSupport::TestCase
     assert @backend_api.valid?
   end
 
+  test 'allows to use http or wss protocol in private_endpoint' do
+    @backend_api.private_endpoint = 'http://example.org:3/path'
+    assert @backend_api.valid?
+    @backend_api.private_endpoint = 'https://example.org:3/path'
+    assert @backend_api.valid?
+
+    @backend_api.private_endpoint = 'ws://example.org:3/path'
+    assert @backend_api.valid?
+    @backend_api.private_endpoint = 'wss://example.org:3/path'
+    assert @backend_api.valid?
+  end
+
   test '.not_used_by returns the backend apis that are not related to that service' do
     account = FactoryBot.create(:simple_provider)
     backend_api_not_used_by_any_service = FactoryBot.create(:backend_api, account: account)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit allows the BackendApi to accept websocket protocol (ws://
and wss://) in the private_endpoint attribute.

**Which issue(s) this PR fixes** 

[THREESCALE-916](https://issues.redhat.com/browse/THREESCALE-916)