### PR TITLE
Log webpacker compile errors

### DIFF
--- a/app/javascript/packs/LoginPage.js
+++ b/app/javascript/packs/LoginPage.js
@@ -4,7 +4,8 @@ import {isBrowserIE11} from 'utilities/ie11Utils'
 
 const isIE11 = isBrowserIE11(window)
 if (isIE11) {
-    import('LoginPage/assets/styles/ie11-pf4BaseStyles.css')
+  // eslint-disable-next-line no-unused-expressions
+  import('LoginPage/assets/styles/ie11-pf4BaseStyles.css')
 }
 
 import {LoginPageWrapper} from 'LoginPage'

--- a/app/javascript/packs/PF4Styles/base.js
+++ b/app/javascript/packs/PF4Styles/base.js
@@ -1,8 +1,9 @@
 import '@babel/polyfill'
-import {isBrowserIE11} from 'utilities/ie11Utils'
 import 'patternflyStyles/pf4Base'
+import {isBrowserIE11} from 'utilities/ie11Utils'
 
 const isIE11 = isBrowserIE11(window)
 if (isIE11) {
+  // eslint-disable-next-line no-unused-expressions
   import('patternflyStyles/pf4BaseIE11.scss')
 }

--- a/app/javascript/packs/SignUpPage.js
+++ b/app/javascript/packs/SignUpPage.js
@@ -7,6 +7,7 @@ import {isBrowserIE11} from 'utilities/ie11Utils'
 
 const isIE11 = isBrowserIE11(window)
 if (isIE11) {
+  // eslint-disable-next-line no-unused-expressions
   import('LoginPage/assets/styles/ie11-pf4BaseStyles.css')
 }
 

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -32,6 +32,7 @@ default: &default
 development:
   <<: *default
   compile: true
+  webpack_compile_output: true
 
   dev_server:
     host: localhost


### PR DESCRIPTION
**What this PR does / why we need it**:

Webpacker assets compilation in dev mode is very slow, it fails silently in loop but doesn't log any useful info:

```
[Webpacker] Compiling…

[Webpacker] Compilation failed:

[Webpacker] Compiling…

[Webpacker] Compilation failed:
```
This PR adds  `webpack_compile_output: true` to webpacker config file, and fix current found errors
