### PR TITLE
Fix proxy domains event on background deletion of proxy

### DIFF
--- a/app/events/domains/proxy_domains_changed_event.rb
+++ b/app/events/domains/proxy_domains_changed_event.rb
@@ -33,6 +33,7 @@ class Domains::ProxyDomainsChangedEvent < BaseEventStoreEvent
   end
 
   def self.valid?(proxy)
-    !!proxy # TODO: check if deployment_option or domains actually changed
+    # TODO: check if deployment_option or domains actually changed
+    proxy && proxy.provider&.persisted? # Proxy's service or account may have been deleted
   end
 end

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -513,7 +513,7 @@ class Proxy < ApplicationRecord
   end
 
   def provider
-    @provider ||= self.service.account
+    @provider ||= self.service&.account
   end
 
   PROXY_ENV = {

--- a/test/events/domains/proxy_domains_changed_event_test.rb
+++ b/test/events/domains/proxy_domains_changed_event_test.rb
@@ -3,12 +3,23 @@
 require 'test_helper'
 
 class Domains::ProxyDomainsChangedEventTest < ActiveSupport::TestCase
+  setup do
+    @proxy = FactoryBot.create(:simple_proxy)
+  end
+
+  attr_reader :proxy
+
   test 'deserialises correctly when the Proxy is deleted' do
-    proxy = FactoryBot.create(:simple_proxy)
     event = Domains::ProxyDomainsChangedEvent.create_and_publish!(proxy)
 
     proxy.delete
 
     assert EventStore::Repository.find_event(event.event_id)
+  end
+
+  test 'invalid is missing provider' do
+    assert Domains::ProxyDomainsChangedEvent.create_and_publish!(proxy)
+    proxy.provider.delete
+    refute Domains::ProxyDomainsChangedEvent.create_and_publish!(proxy)
   end
 end


### PR DESCRIPTION
A missing service while a proxy is being deleted in the background is causing a proxy domains changed event to fail to issue. We don't care about the event itself. The idea is preventing the error to be raised at this point.

Closes [THREESCALE-4248](https://issues.redhat.com/browse/THREESCALE-4248)