### PR TITLE
Fix AWS S3 options

### DIFF
--- a/app/lib/cms/s3.rb
+++ b/app/lib/cms/s3.rb
@@ -11,7 +11,7 @@ module CMS
     end
 
     def enable!
-      @enabled = true if options
+      @enabled = true if config
     end
 
     def disable!
@@ -19,35 +19,42 @@ module CMS
     end
 
     def bucket
-      options.fetch(:bucket) if enabled?
+      config.fetch(:bucket) if enabled?
     end
 
     def region
-      options.fetch(:region) if enabled?
+      config.fetch(:region) if enabled?
     end
 
     def credentials
-      options.slice(:access_key_id, :secret_access_key) if enabled?
+      config.slice(:access_key_id, :secret_access_key) if enabled?
     end
 
     def hostname
-      options[:hostname].presence if enabled?
+      config[:hostname].presence if enabled?
     end
 
     def protocol
-      options[:protocol].presence || 'https' if enabled?
+      config[:protocol].presence || 'https' if enabled?
+    end
+
+    def options
+      return unless enabled?
+      opts = config.slice(:force_path_style)
+      opts[:endpoint] = [protocol, hostname].join('://') if protocol && hostname
+      opts
     end
 
     def stub!
-      @options ||= { bucket: 'test', access_key_id: 'key', secret_access_key: 'secret', region: 'us-east-1' }
+      @config ||= { bucket: 'test', access_key_id: 'key', secret_access_key: 'secret', region: 'us-east-1' }
       Aws.config[:s3] = { stub_responses: true }
       enable!
     end
 
     private
 
-    def options
-      @options ||= Rails.application.config.s3.try(:symbolize_keys)
+    def config
+      @config ||= Rails.application.config.s3.try(:symbolize_keys)
     rescue IndexError, KeyError
       raise NoConfigError, "No S3 config for #{Rails.env} environment"
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -252,16 +252,20 @@ module System
     end
 
     config.paperclip_defaults = {
-        storage: :s3,
-        s3_credentials: ->(*) { CMS::S3.credentials },
-        bucket: ->(*) { CMS::S3.bucket },
-        s3_protocol: ->(*) { CMS::S3.protocol },
-        s3_permissions: 'private'.freeze,
-        s3_region: ->(*) { CMS::S3.region },
-        s3_host_name: ->(*) { CMS::S3.hostname },
-        url: ':storage_root/:class/:id/:attachment/:style/:basename.:extension'.freeze,
-        path: ':rails_root/public/system/:url'.freeze
+      storage: :s3,
+      s3_credentials: ->(*) { CMS::S3.credentials },
+      bucket: ->(*) { CMS::S3.bucket },
+      s3_protocol: ->(*) { CMS::S3.protocol },
+      s3_permissions: 'private'.freeze,
+      s3_region: ->(*) { CMS::S3.region },
+      s3_host_name: ->(*) { CMS::S3.hostname },
+      url: ':storage_root/:class/:id/:attachment/:style/:basename.:extension'.freeze,
+      path: ':rails_root/public/system/:url'.freeze
     }.merge(try_config_for(:paperclip) || {})
+
+    initializer :paperclip_defaults, after: :load_config_initializers do
+      Paperclip::Attachment.default_options.merge!(s3_options: CMS::S3.options) # Paperclip does not accept s3_options set as a Proc
+    end
 
     config.after_initialize do
       require_or_load 'three_scale'

--- a/config/docker/amazon_s3.yml
+++ b/config/docker/amazon_s3.yml
@@ -5,6 +5,7 @@ default: &DEFAULT
   region:            "<%= ENV['AWS_REGION'] %>"
   hostname:          "<%= ENV['AWS_HOSTNAME'] %>"
   protocol:          "<%= ENV['AWS_PROTOCOL'] %>"
+  force_path_style:  <%= ENV['AWS_PATH_STYLE'].presence || false %>
 
 production:
  <<: *DEFAULT

--- a/config/examples/amazon_s3.yml
+++ b/config/examples/amazon_s3.yml
@@ -3,6 +3,7 @@ development:
   secret_access_key: secret_access_key
   bucket:            dev.my-s3-bucket.example.com
   region:            "us-east-1"
+  force_path_style:  true
 
 test: &test
   access_key_id: invalid

--- a/openshift/system/config/amazon_s3.yml
+++ b/openshift/system/config/amazon_s3.yml
@@ -8,6 +8,7 @@ s3: &s3
   region:            "<%= ENV['AWS_REGION'] %>"
   hostname:          "<%= ENV['AWS_HOSTNAME'] %>"
   protocol:          "<%= ENV['AWS_PROTOCOL'] %>"
+  force_path_style:  <%= ENV['AWS_PATH_STYLE'].presence || false %>
 
 preview:
   <<: *<%= ENV['FILE_UPLOAD_STORAGE'].presence || 'default' %>


### PR DESCRIPTION
Related to [THREESCALE-4052](https://issues.redhat.com/browse/THREESCALE-4052)

----

This PR ensures Paperclip will consider the new configuration options introduced by https://github.com/3scale/porta/pull/1522 while uploading attachments to S3, passing them along to the `Aws::S3::Resource` instance.

- Sets `s3_options` with the `endpoint` value (matching `s3_protocol` and `s3_host_name`) if configured by the user
- Sets `force_path_style: true` by default

----

AWS S3
<img width="943" alt="Screenshot 2020-01-17 at 19 32 35" src="https://user-images.githubusercontent.com/1842261/72637055-b5534b80-3960-11ea-8679-9ae182de2387.png">

Minio.io
<img width="882" alt="Screenshot 2020-01-17 at 19 32 10" src="https://user-images.githubusercontent.com/1842261/72637081-c0a67700-3960-11ea-9938-2fa8cc6db76f.png">
