### PR TITLE
Make more clear that configuration page is about the APIcast configuration

### DIFF
--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -590,15 +590,8 @@ li.hidden {
   form.formtastic.u-inline {
     display: inline-block;
   }
-
-  .SettingsBox form.formtastic {
-    padding: line-height-times(1);
-  }
-
 }
 
 form#liquid-settings > fieldset {
   border-top: 0;
 }
-
-

--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -196,14 +196,14 @@ module Api::IntegrationsHelper
   def promote_to_staging_button_options(proxy)
     return disabled_promote_button_options if proxy.any_sandbox_configs? && !proxy.pending_affecting_changes?
 
-    label = deployment_option_is_service_mesh?(proxy.service) ? 'Update Configuration' : "Promote v. #{proxy.next_sandbox_config_version} to Staging"
+    label = deployment_option_is_service_mesh?(proxy.service) ? 'Update Configuration' : "Promote v. #{proxy.next_sandbox_config_version} to APIcast Staging"
     promote_button_options(label)
   end
 
   def promote_to_production_button_options(proxy)
     return disabled_promote_button_options if proxy.environments_have_same_config?
 
-    label = "Promote v. #{proxy.next_production_config_version} to Production"
+    label = "Promote v. #{proxy.next_production_config_version} to APIcast Production"
     promote_button_options(label)
   end
 

--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -196,14 +196,14 @@ module Api::IntegrationsHelper
   def promote_to_staging_button_options(proxy)
     return disabled_promote_button_options if proxy.any_sandbox_configs? && !proxy.pending_affecting_changes?
 
-    label = deployment_option_is_service_mesh?(proxy.service) ? 'Update Configuration' : "Promote v. #{proxy.next_sandbox_config_version} to APIcast Staging"
+    label = deployment_option_is_service_mesh?(proxy.service) ? 'Update Configuration' : "Promote to Staging APIcast"
     promote_button_options(label)
   end
 
   def promote_to_production_button_options(proxy)
     return disabled_promote_button_options if proxy.environments_have_same_config?
 
-    label = "Promote v. #{proxy.next_production_config_version} to APIcast Production"
+    label = "Promote to Production APIcast"
     promote_button_options(label)
   end
 

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -46,12 +46,11 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
 
 - unless deployment_option_is_service_mesh?(@service)
   section style="margin-top: 48px;"
-    h2 Environments
 
     .SettingsBox.Environment class=('Environment--is-promoted' if @show_presenter.environments_have_same_config?) class="Environment--#{@show_presenter.test_state_modifier}"
       = link_to 'Configuration history', admin_service_proxy_configs_path(@service, environment: 'staging'), class: 'SettingsBox-toggle'
       article.Environment-summary data-state="open" class="Environment--#{@show_presenter.test_state_modifier}"
-        h3.Environment-title Staging Environment
+        h3.Environment-title APIcast Staging
         - if @show_presenter.any_sandbox_configs?
           dl.u-dl
             dt.u-dl-term URL
@@ -76,13 +75,13 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
               = semantic_form_for @proxy, url: promote_to_production_admin_service_integration_path(@service, anchor: 'production') do |f|
                 = f.button *promote_to_production_button_options(@show_presenter)
         - else
-          | no configuration has been saved for the staging environment yet
+          | no configuration has been saved for APIcast staging yet
 
     .SettingsBox.Environment
       - if @show_presenter.any_production_configs?
         = link_to 'Configuration history', admin_service_proxy_configs_path(@service, environment: 'production'), class: 'SettingsBox-toggle'
       article.Environment-summary class=("Environment--#{@show_presenter.test_state_modifier}" if @show_presenter.environments_have_same_config?) data-state="open" style="margin-top: 24px;"
-        h3.Environment-title Production Environment
+        h3.Environment-title APIcast Production
         - if @show_presenter.any_production_configs?
           dl.u-dl
             dt.u-dl-term URL
@@ -92,4 +91,4 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
               ' v.
               = @show_presenter.last_production_config.version
         - else
-          | no configuration has been saved for the production environment yet
+          | no configuration has been saved for APIcast production yet

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -38,6 +38,10 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
               dt.u-dl-term Mapping rules
               dd.u-dl-definition = proxy_rules_preview(backend_api, path: backend_api_config.path)
 
+        dt.u-dl-term Version
+        dd.u-dl-definition
+          ' v.
+          = @show_presenter.next_sandbox_config_version
         dt.u-dl-term Promote
         dd.u-dl-definition.Configuration-promote-button
           = semantic_form_for @proxy, url: admin_service_integration_path(@service) do |f|
@@ -50,15 +54,11 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
     .SettingsBox.Environment class=('Environment--is-promoted' if @show_presenter.environments_have_same_config?) class="Environment--#{@show_presenter.test_state_modifier}"
       = link_to 'Configuration history', admin_service_proxy_configs_path(@service, environment: 'staging'), class: 'SettingsBox-toggle'
       article.Environment-summary data-state="open" class="Environment--#{@show_presenter.test_state_modifier}"
-        h3.Environment-title APIcast Staging
+        h3.Environment-title Staging APIcast
         - if @show_presenter.any_sandbox_configs?
           dl.u-dl
             dt.u-dl-term URL
             dd.u-dl-definition = @show_presenter.staging_proxy_endpoint
-            dt.u-dl-term Version
-            dd.u-dl-definition
-              ' v.
-              = @show_presenter.last_sandbox_config.version
             dt.u-dl-term Example curl for testing
             dd.u-dl-definition
               = api_test_curl(@proxy, config_based: apiap?)
@@ -70,8 +70,12 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
                   => t('api.integrations.proxy.curl.no_application')
                   - unless @service.application_plans.any?
                     = link_to t('api.integrations.proxy.curl.no_application_plan'), admin_service_application_plans_path(@service)
-            dt.u-dl-term Promote
+            dt.u-dl-term Version
             dd.u-dl-definition
+              ' v.
+              = @show_presenter.last_sandbox_config.version
+            dt.u-dl-term Promote
+            dd.u-dl-definition.Configuration-promote-button
               = semantic_form_for @proxy, url: promote_to_production_admin_service_integration_path(@service, anchor: 'production') do |f|
                 = f.button *promote_to_production_button_options(@show_presenter)
         - else
@@ -81,7 +85,7 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
       - if @show_presenter.any_production_configs?
         = link_to 'Configuration history', admin_service_proxy_configs_path(@service, environment: 'production'), class: 'SettingsBox-toggle'
       article.Environment-summary class=("Environment--#{@show_presenter.test_state_modifier}" if @show_presenter.environments_have_same_config?) data-state="open" style="margin-top: 24px;"
-        h3.Environment-title APIcast Production
+        h3.Environment-title Production APIcast
         - if @show_presenter.any_production_configs?
           dl.u-dl
             dt.u-dl-term URL

--- a/app/views/api/integrations/show.html.slim
+++ b/app/views/api/integrations/show.html.slim
@@ -1,5 +1,3 @@
-= stylesheet_link_tag 'highlight/styles/rainbow.css'
-
 - content_for :sublayout_title, 'Configuration'
 
 #integration-tabs

--- a/test/functional/api/integrations_controller_test.rb
+++ b/test/functional/api/integrations_controller_test.rb
@@ -257,7 +257,7 @@ class Api::IntegrationsControllerTest < ActionController::TestCase
     get :show, service_id: service.id
 
     assert_response :success
-    assert_match "Promote v. #{config.version} to Production", response.body
+    assert_match "Promote v. #{config.version} to APIcast Production", response.body
   end
 
   test 'promote to production' do

--- a/test/functional/api/integrations_controller_test.rb
+++ b/test/functional/api/integrations_controller_test.rb
@@ -257,7 +257,7 @@ class Api::IntegrationsControllerTest < ActionController::TestCase
     get :show, service_id: service.id
 
     assert_response :success
-    assert_match "Promote v. #{config.version} to APIcast Production", response.body
+    assert_match "Promote to Production APIcast", response.body
   end
 
   test 'promote to production' do


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/THREESCALE-4242

- make more clear that this about staging apicast configs and not staging their API
- show version above promote button so button text doesn't get too long

before:
<img width="1341" alt="Screenshot 2020-01-30 15 40 05" src="https://user-images.githubusercontent.com/54224/73459271-db241b80-4376-11ea-8a64-6e577afeb2f6.png">

after:
<img width="1375" alt="Screenshot 2020-01-29 18 23 49" src="https://user-images.githubusercontent.com/54224/73380568-93dd5280-42c4-11ea-86b9-229495103a23.png">

