### PR TITLE
Audit access tokens + Requests through access tokens contain the user_id in their audits

### DIFF
--- a/app/lib/api_authentication/by_access_token.rb
+++ b/app/lib/api_authentication/by_access_token.rb
@@ -5,7 +5,7 @@ module ApiAuthentication
     extend ActiveSupport::Concern
 
     def current_user
-      @current_user ||= authenticated_token&.owner or defined?(super) && super
+      @current_user ||= User.current = authenticated_token&.owner or defined?(super) && super
     end
 
     included do

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -5,6 +5,10 @@ class AccessToken < ApplicationRecord
 
   serialize :scopes, Array
 
+  audited only: %i[owner_id scopes name permission created_at updated_at]
+
+  delegate :provider_id_for_audits, to: :owner
+
   def self.options_to_hash(options)
     options.map do |key|
       [I18n.t(key, scope: :access_token_options), key]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -416,6 +416,10 @@ class User < ApplicationRecord
     not scope.without_ids(self.id).exists?(condition)
   end
 
+  def provider_id_for_audits
+    account.try!(:provider_id_for_audits) || provider_account.try!(:provider_id_for_audits)
+  end
+
   private
 
   def archive_as_deleted
@@ -477,12 +481,6 @@ class User < ApplicationRecord
       sql = construct_finder_sql(options)
       self.connection.select_values(sql)
     end
-  end
-
-  protected
-
-  def provider_id_for_audits
-    account.try!(:provider_id_for_audits) || provider_account.try!(:provider_id_for_audits)
   end
 
   class SignupType

--- a/db/migrate/20200121142649_add_timestamps_to_access_token.rb
+++ b/db/migrate/20200121142649_add_timestamps_to_access_token.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToAccessToken < ActiveRecord::Migration
+  def change
+    add_timestamps(:access_tokens)
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -11,16 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191007101321) do
+ActiveRecord::Schema.define(version: 20200121142649) do
 
   create_table "access_tokens", force: :cascade do |t|
-    t.integer "owner_id",   precision: 38,                  null: false
-    t.string  "owner_type",                default: "User", null: false
-    t.text    "scopes"
-    t.string  "value",                                      null: false
-    t.string  "name",                                       null: false
-    t.string  "permission",                                 null: false
-    t.integer "tenant_id",  precision: 38
+    t.integer  "owner_id",   precision: 38,                  null: false
+    t.string   "owner_type",                default: "User", null: false
+    t.text     "scopes"
+    t.string   "value",                                      null: false
+    t.string   "name",                                       null: false
+    t.string   "permission",                                 null: false
+    t.integer  "tenant_id",  precision: 38
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "access_tokens", ["owner_id", "owner_type"], name: "idx_auth_tokens_of_user"

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -11,19 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191007101321) do
+ActiveRecord::Schema.define(version: 20200121142649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "access_tokens", force: :cascade do |t|
-    t.integer "owner_id",   limit: 8,                    null: false
-    t.string  "owner_type", limit: 255, default: "User", null: false
-    t.text    "scopes"
-    t.string  "value",      limit: 255,                  null: false
-    t.string  "name",       limit: 255,                  null: false
-    t.string  "permission", limit: 255,                  null: false
-    t.integer "tenant_id",  limit: 8
+    t.integer  "owner_id",   limit: 8,                    null: false
+    t.string   "owner_type", limit: 255, default: "User", null: false
+    t.text     "scopes"
+    t.string   "value",      limit: 255,                  null: false
+    t.string   "name",       limit: 255,                  null: false
+    t.string   "permission", limit: 255,                  null: false
+    t.integer  "tenant_id",  limit: 8
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "access_tokens", ["owner_id", "owner_type"], name: "idx_auth_tokens_of_user", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,16 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191007101321) do
+ActiveRecord::Schema.define(version: 20200121142649) do
 
   create_table "access_tokens", force: :cascade do |t|
-    t.integer "owner_id",   limit: 8,                      null: false
-    t.string  "owner_type", limit: 255,   default: "User", null: false
-    t.text    "scopes",     limit: 65535
-    t.string  "value",      limit: 255,                    null: false
-    t.string  "name",       limit: 255,                    null: false
-    t.string  "permission", limit: 255,                    null: false
-    t.integer "tenant_id",  limit: 8
+    t.integer  "owner_id",   limit: 8,                      null: false
+    t.string   "owner_type", limit: 255,   default: "User", null: false
+    t.text     "scopes",     limit: 65535
+    t.string   "value",      limit: 255,                    null: false
+    t.string   "name",       limit: 255,                    null: false
+    t.string   "permission", limit: 255,                    null: false
+    t.integer  "tenant_id",  limit: 8
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "access_tokens", ["owner_id", "owner_type"], name: "idx_auth_tokens_of_user", using: :btree

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -108,6 +108,25 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { AccessToken.find_from_id_or_value!('fake') }
   end
 
+  test 'timestamps filled' do
+    access_token = FactoryBot.build(:access_token)
+    expected_created_at = -1
+    expected_updated_at = -1
+
+    Timecop.freeze(5.months.ago) do
+      expected_created_at = Time.now.utc
+      access_token.save!
+    end
+
+    Timecop.freeze(5.hours.ago) do
+      expected_updated_at = Time.now.utc
+      access_token.update!(name: 'updated name')
+    end
+
+    assert_equal expected_created_at, access_token.created_at
+    assert_equal expected_updated_at, access_token.updated_at
+  end
+
   private
 
   def member

--- a/test/unit/api_authentication/by_authentication_token_test.rb
+++ b/test/unit/api_authentication/by_authentication_token_test.rb
@@ -27,6 +27,7 @@ class ApiAuthentication::ByAuthenticationTokenTest < MiniTest::Unit::TestCase
   def test_current_user
     _token = mock_token(owner: @user = mock('user'))
     assert_equal @user, current_user
+    assert_equal @user, User.current
   end
 
   def test_authenticated_token_correct_scope


### PR DESCRIPTION
Closes [THREESCALE-421](https://issues.redhat.com/browse/THREESCALE-421)

- [X] Add timestamps to access tokens to make it easier for support to debug.
- [X] Add audits for creating/updating/destroying access tokens.
- [X] When a request that contains audits is done by the API through an access token. That audit also contains the user_id as we do for the requests by the UI.