### PR TITLE
Show hint message when protocol is not https

### DIFF
--- a/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
@@ -166,8 +166,12 @@ $(document).on 'initialize', '#proxy', ->
       input = $(this)
       undo_button = input.siblings '.undo'
       undo_button.toggle( input_changed_from_default(input) )
-      protocolWarn = input.siblings('.inline-hints').find('.protocol-warn')
-      protocolWarn.toggle( !inputHasSameProtocols(input) )
+
+  toggle_secure_scheme_hint =  ->
+    input = $(this)
+    protocolWarn = input.siblings('.inline-hints').find('.protocol-warn')
+    protocolWarn.toggle( !inputHasSecureProtocol(input) )
+    input.toggleClass('hint-error', !inputHasSecureProtocol(input))
 
   reset_proxy_input = (event) ->
     input = $(this).siblings('input')
@@ -185,12 +189,10 @@ $(document).on 'initialize', '#proxy', ->
   compareHttpHosts = (input) ->
     extractHost(input.val()) == extractHost(input.data('default'))
 
-  inputHasSameProtocols = (input) ->
-    actualValue = document.createElement('a')
-    actualValue.href = input.val()
-    defaultValue = document.createElement('a')
-    defaultValue.href = input.data('default')
-    actualValue.protocol == defaultValue.protocol
+  inputHasSecureProtocol = (input) ->
+    link = document.createElement('a')
+    link.href = input.val()
+    link.protocol == 'https:' || link.protocol == 'wss:'
 
   toggle_reset_buttons()
   toggle_host_header_warning()
@@ -229,6 +231,7 @@ $(document).on 'initialize', '#proxy', ->
   form = $("form.proxy")
   form.on "change keyup", "input, select", toggle_form_changed_ui
   form.on "click", ".undo", reset_proxy_input
+  form.on "change keyup", "#proxy_api_backend", toggle_secure_scheme_hint
 
   #---------------------------------------------------------------------
 

--- a/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
@@ -159,14 +159,15 @@ $(document).on 'initialize', '#proxy', ->
     host_header_warning.toggle(!valid)
 
   input_changed_from_default = (input) ->
-    !compareHttpHosts( input.val(), input.data('default') )
+    !compareHttpHosts(input)
 
   toggle_reset_buttons = ->
     $('form.proxy input[data-default]').each ->
       input = $(this)
       undo_button = input.siblings '.undo'
       undo_button.toggle( input_changed_from_default(input) )
-      input.siblings('.inline-hints').find('span').toggle( input_changed_from_default(input) )
+      protocolWarn = input.siblings('.inline-hints').find('.protocol-warn')
+      protocolWarn.toggle( !inputHasSameProtocols(input) )
 
   reset_proxy_input = (event) ->
     input = $(this).siblings('input')
@@ -181,16 +182,15 @@ $(document).on 'initialize', '#proxy', ->
     link.href = url
     link.hostname
 
-  compareHttpHosts = (a, b) ->
-    extractHost(a) == extractHost(b)
+  compareHttpHosts = (input) ->
+    extractHost(input.val()) == extractHost(input.data('default'))
 
-  extractHost = (url) ->
-    link = document.createElement('a')
-    link.href = url
-    link.hostname
-
-  compareHttpHosts = (a, b) ->
-    extractHost(a) == extractHost(b)
+  inputHasSameProtocols = (input) ->
+    actualValue = document.createElement('a')
+    actualValue.href = input.val()
+    defaultValue = document.createElement('a')
+    defaultValue.href = input.data('default')
+    actualValue.protocol == defaultValue.protocol
 
   toggle_reset_buttons()
   toggle_host_header_warning()

--- a/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
+++ b/app/assets/javascripts/provider/admin/apiconfig/services/integration.js.coffee
@@ -166,12 +166,12 @@ $(document).on 'initialize', '#proxy', ->
       input = $(this)
       undo_button = input.siblings '.undo'
       undo_button.toggle( input_changed_from_default(input) )
+      toggle_secure_scheme_hint()
 
   toggle_secure_scheme_hint =  ->
-    input = $(this)
-    protocolWarn = input.siblings('.inline-hints').find('.protocol-warn')
-    protocolWarn.toggle( !inputHasSecureProtocol(input) )
-    input.toggleClass('hint-error', !inputHasSecureProtocol(input))
+    input = $('#proxy_api_backend')[0]
+    protocolWarn = $(input).siblings('.inline-hints').find('.protocol-warn')[0]
+    $(protocolWarn).toggle(!inputHasSecureProtocol(input))
 
   reset_proxy_input = (event) ->
     input = $(this).siblings('input')
@@ -191,10 +191,11 @@ $(document).on 'initialize', '#proxy', ->
 
   inputHasSecureProtocol = (input) ->
     link = document.createElement('a')
-    link.href = input.val()
+    link.href = $(input).val()
     link.protocol == 'https:' || link.protocol == 'wss:'
 
   toggle_reset_buttons()
+  toggle_secure_scheme_hint()
   toggle_host_header_warning()
 
   #---------------------------------------------------------------------

--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -584,6 +584,10 @@ li.hidden {
     &.staging-settings {
       @include white-box-shadow;
       padding: line-height-times(1);
+
+      .hint-error {
+        border: 1px solid $error-color;
+      }
     }
   }
 

--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -584,10 +584,6 @@ li.hidden {
     &.staging-settings {
       @include white-box-shadow;
       padding: line-height-times(1);
-
-      .hint-error {
-        border: 1px solid $error-color;
-      }
     }
   }
 

--- a/app/views/provider/admin/backend_apis/forms/_naming.html.slim
+++ b/app/views/provider/admin/backend_apis/forms/_naming.html.slim
@@ -4,4 +4,4 @@
   = form.input :description, input_html: { rows: 3 }
 
 = form.inputs 'API' do
-  = form.input :private_endpoint
+  = form.input :private_endpoint, hint: t("formtastic.hints.proxy.api_backend_https")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1244,7 +1244,7 @@ en:
           Public address of your API gateway in the %{environment_name} environment.
         api_backend_https: |
           Private address of your API that will be called by the API gateway.
-          <span class="protocol-warn">For end-to-end encryption your private base URL scheme should use a secure protocol.</span>
+          <span class="protocol-warn">For end-to-end encryption your private base URL scheme should use a secure protocol (https or wss).</span>
         api_backend_http: |
           Private address of your API that will be called by the API gateway.
         oauth_login_url: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1242,10 +1242,11 @@ en:
           <span>Make sure to <a href="https://docs.openshift.com/container-platform/latest/dev_guide/routes.html#creating-routes">add the correct route</a></span>
         endpoint_apicast_2_html: >
           Public address of your API gateway in the %{environment_name} environment.
-        api_backend_https: "Private address of your API that will be called by the API gateway."
+        api_backend_https: |
+          Private address of your API that will be called by the API gateway.
+          <span class="protocol-warn">For end-to-end encryption your private base URL scheme should use a secure protocol.</span>
         api_backend_http: |
           Private address of your API that will be called by the API gateway.
-          <span class="warn">For end-to-end encryption your private base URL scheme should be https</span>.
         oauth_login_url: |
            Since the service has OAuth authentication enabled you have
            to provide a URL where the <em>consumers</em> login and


### PR DESCRIPTION
**What this PR does / why we need it**:

Hint message for Private Base URL is not shown when protocol is 'http'.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-3269

**Verification steps** 

- Go to **API  > Integration > Configuration** (http://provider-admin.example.com.lvh.me:3000/apiconfig/services/2/integration/edit)
- Fill input using 'http://echo-api.3scale.net:443', then 'https://echo-api.3scale.net:443'


![bad](https://user-images.githubusercontent.com/13486237/73467293-6acfc700-4383-11ea-98d6-d2ca3e6631d3.png)

![edit-ok](https://user-images.githubusercontent.com/13486237/73467256-5ee40500-4383-11ea-9d50-19581ad81c40.png)
