### PR TITLE
Disable update of proxy rule position when account is gone

### DIFF
--- a/app/events/proxy_configs/affecting_object_changed_event.rb
+++ b/app/events/proxy_configs/affecting_object_changed_event.rb
@@ -12,4 +12,8 @@ class ProxyConfigs::AffectingObjectChangedEvent < ServiceRelatedEvent
       }
     )
   end
+
+  def self.valid?(proxy, *_args)
+    proxy && proxy.account&.persisted? # Proxy's service or account may have been deleted
+  end
 end

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -93,6 +93,10 @@ class BackendApi < ApplicationRecord
     metrics.create_default!(:hits)
   end
 
+  def scheduled_for_deletion?
+    deleted? || !account || account.scheduled_for_deletion?
+  end
+
   private
 
   def schedule_deletion

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -109,6 +109,7 @@ class Proxy < ApplicationRecord
   delegate :account, to: :service
   delegate :provider_can_use?, to: :account
   delegate :backend_apis, :backend_api_configs, to: :service
+  delegate :scheduled_for_deletion?, to: :account, allow_nil: true
 
   def self.user_attribute_names
     super + %w[api_backend] + GatewayConfiguration::ATTRIBUTES

--- a/app/models/proxy_rule.rb
+++ b/app/models/proxy_rule.rb
@@ -124,6 +124,18 @@ class ProxyRule < ApplicationRecord
     owner_type == 'BackendApi'
   end
 
+  delegate :account, to: :owner, allow_nil: true
+
+  def destroy
+    if !owner || !account || owner.scheduled_for_deletion?
+      self.class.acts_as_list_no_update do
+        super
+      end
+    else
+      super
+    end
+  end
+
   protected
 
   def querystring_parameter_keys

--- a/app/models/proxy_rule.rb
+++ b/app/models/proxy_rule.rb
@@ -126,14 +126,12 @@ class ProxyRule < ApplicationRecord
 
   delegate :account, to: :owner, allow_nil: true
 
-  def destroy
-    if !owner || !account || owner.scheduled_for_deletion?
-      self.class.acts_as_list_no_update do
-        super
-      end
-    else
-      super
-    end
+  def scheduled_for_deletion?
+    !owner || !account || owner.scheduled_for_deletion?
+  end
+
+  def act_as_list_no_update?
+    super || scheduled_for_deletion?
   end
 
   protected

--- a/test/unit/proxy_rule_test.rb
+++ b/test/unit/proxy_rule_test.rb
@@ -157,6 +157,39 @@ class ProxyRuleTest < ActiveSupport::TestCase
     assert backend_proxy_rule.valid?
   end
 
+  test 'position is not updated when account has been deleted' do
+    provider = FactoryBot.create(:simple_provider)
+    proxy = FactoryBot.create(:service, account: provider).proxy
+    proxy_rule = FactoryBot.create(:proxy_rule, proxy: proxy)
+
+    provider.delete
+
+    ProxyRule.expects(:acts_as_list_no_update)
+    proxy_rule.reload.destroy
+  end
+
+  test 'position is not updated when owner proxy has been deleted' do
+    provider = FactoryBot.create(:simple_provider)
+    proxy = FactoryBot.create(:service, account: provider).proxy
+    proxy_rule = FactoryBot.create(:proxy_rule, proxy: proxy)
+
+    proxy.delete
+
+    ProxyRule.expects(:acts_as_list_no_update)
+    proxy_rule.reload.destroy
+  end
+
+  test 'position is not updated when owner backend has been deleted' do
+    provider = FactoryBot.create(:simple_provider)
+    backend_api = FactoryBot.create(:backend_api, account: provider)
+    proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, proxy: nil)
+
+    backend_api.mark_as_deleted
+
+    ProxyRule.expects(:acts_as_list_no_update)
+    proxy_rule.reload.destroy
+  end
+
   class ProxyConfigAffectingChangesTest < ActiveSupport::TestCase
     disable_transactional_fixtures!
 

--- a/test/unit/proxy_rule_test.rb
+++ b/test/unit/proxy_rule_test.rb
@@ -157,37 +157,44 @@ class ProxyRuleTest < ActiveSupport::TestCase
     assert backend_proxy_rule.valid?
   end
 
-  test 'position is not updated when account has been deleted' do
-    provider = FactoryBot.create(:simple_provider)
-    proxy = FactoryBot.create(:service, account: provider).proxy
-    proxy_rule = FactoryBot.create(:proxy_rule, proxy: proxy)
+  class PositionUpdateOnConcurrentDeletion < ActiveSupport::TestCase
+    disable_transactional_fixtures!
 
-    provider.delete
+    setup do
+      @provider = FactoryBot.create(:simple_provider)
+    end
 
-    ProxyRule.expects(:acts_as_list_no_update)
-    proxy_rule.reload.destroy
-  end
+    attr_reader :provider
 
-  test 'position is not updated when owner proxy has been deleted' do
-    provider = FactoryBot.create(:simple_provider)
-    proxy = FactoryBot.create(:service, account: provider).proxy
-    proxy_rule = FactoryBot.create(:proxy_rule, proxy: proxy)
+    test 'position is not updated when account has been deleted' do
+      proxy = FactoryBot.create(:service, account: provider).proxy
+      proxy_rule = FactoryBot.create(:proxy_rule, proxy: proxy)
 
-    proxy.delete
+      provider.delete
 
-    ProxyRule.expects(:acts_as_list_no_update)
-    proxy_rule.reload.destroy
-  end
+      proxy_rule.expects(:decrement_positions_on_lower_items).never
+      proxy_rule.reload.destroy
+    end
 
-  test 'position is not updated when owner backend has been deleted' do
-    provider = FactoryBot.create(:simple_provider)
-    backend_api = FactoryBot.create(:backend_api, account: provider)
-    proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, proxy: nil)
+    test 'position is not updated when owner proxy has been deleted' do
+      proxy = FactoryBot.create(:service, account: provider).proxy
+      proxy_rule = FactoryBot.create(:proxy_rule, proxy: proxy)
 
-    backend_api.mark_as_deleted
+      proxy.delete
 
-    ProxyRule.expects(:acts_as_list_no_update)
-    proxy_rule.reload.destroy
+      proxy_rule.expects(:decrement_positions_on_lower_items).never
+      proxy_rule.reload.destroy
+    end
+
+    test 'position is not updated when owner backend has been deleted' do
+      backend_api = FactoryBot.create(:backend_api, account: provider)
+      proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, proxy: nil)
+
+      backend_api.mark_as_deleted
+
+      proxy_rule.expects(:decrement_positions_on_lower_items).never
+      proxy_rule.reload.destroy
+    end
   end
 
   class ProxyConfigAffectingChangesTest < ActiveSupport::TestCase


### PR DESCRIPTION
Deletion of multiple proxy rule objects in parallel, which may happen when an Account or a Backend is being deleted in the background, can deadlock on the update of the "position" of the proxy rules. This PR disables `acts_as_list` position update when a proxy rule is destroyed if (and only if) the proxy rule's owner or the account top of it has been deleted (scheduled for deletion).

Closes [THREESCALE-3845](https://issues.jboss.org/browse/THREESCALE-3845)