### PR TITLE
[Bugfix] NameError in DeleteServiceHierarchyWorker@deletion. uninitialized constant ApiDocsService

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -61,7 +61,7 @@ class Account < ApplicationRecord
   self.background_deletion = [
     :users,
     :mail_dispatch_rules,
-    :api_docs_services,
+    [:api_docs_services, class_name: 'ApiDocs::Service'],
     :services,
     :contracts,
     :account_plans,
@@ -77,7 +77,7 @@ class Account < ApplicationRecord
     [:files, { action: :delete }],
     [:builtin_pages, { action: :delete }],
     [:provided_groups, { action: :delete }]
-  ]
+  ].freeze
 
   #TODO: this needs testing?
   scope :providers, -> { where(provider: true) }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -12,8 +12,16 @@ class Service < ApplicationRecord
   extend System::Database::Scopes::IdOrSystemName
   include ServiceDiscovery::ModelExtensions::Service
 
-  self.background_deletion = [:service_plans, :application_plans, :end_user_plans, :api_docs_services,
-                              :backend_apis, :backend_api_configs, :metrics, [:proxy, { action: :destroy, has_many: false }]]
+  self.background_deletion = [
+    :service_plans,
+    :application_plans,
+    :end_user_plans,
+    [:api_docs_services, class_name: 'ApiDocs::Service'],
+    :backend_apis,
+    :backend_api_configs,
+    :metrics,
+    [:proxy, { action: :destroy, has_many: false }]
+  ].freeze
 
   DELETE_STATE = 'deleted'.freeze
 

--- a/test/workers/delete_account_hierarchy_worker_test.rb
+++ b/test/workers/delete_account_hierarchy_worker_test.rb
@@ -28,6 +28,8 @@ class DeleteAccountHierarchyWorkerTest < ActiveSupport::TestCase
     users = provider.users
     cms_sections = provider.sections
 
+    api_docs_service = FactoryBot.create(:api_docs_service, account: provider)
+
     DeleteObjectHierarchyWorker.stubs(:perform_later)
     users.each { |user| DeleteObjectHierarchyWorker.expects(:perform_later).with(user, anything, 'destroy') }
     services.each { |service| DeleteServiceHierarchyWorker.expects(:perform_later).with(service, anything, 'destroy') }
@@ -39,6 +41,7 @@ class DeleteAccountHierarchyWorkerTest < ActiveSupport::TestCase
       DeleteObjectHierarchyWorker.expects(:perform_later).with(CMS::Section.new({ id: cms_section.id }, without_protection: true), anything, 'delete')
     end
     DeletePaymentSettingHierarchyWorker.expects(:perform_later).with(provider.payment_gateway_setting, anything, 'destroy')
+    DeleteObjectHierarchyWorker.expects(:perform_later).with(api_docs_service, anything, 'destroy')
 
     perform_enqueued_jobs { DeleteAccountHierarchyWorker.perform_now(provider) }
   end

--- a/test/workers/delete_service_hierarcy_worker_test.rb
+++ b/test/workers/delete_service_hierarcy_worker_test.rb
@@ -26,17 +26,19 @@ class DeleteServiceHierarchyWorkerTest < ActiveSupport::TestCase
 
   test 'perform destroys the associations in background' do
     service_plan = service.service_plans.first
-    application_plan = FactoryBot.create(:application_plan, :issuer => service)
+    application_plan = FactoryBot.create(:application_plan, issuer: service)
     end_user_plan = FactoryBot.create(:end_user_plan, service: service)
     metrics = service.metrics
     service.update_attribute :default_service_plan, service_plan
     service.update_attribute :default_application_plan, application_plan
+    api_docs_service = FactoryBot.create(:api_docs_service, service: service, account: service.account)
 
     perform_enqueued_jobs do
       [service_plan, application_plan, end_user_plan].each do |association|
         DeleteObjectHierarchyWorker.expects(:perform_later).with(association, anything, 'destroy')
       end
       metrics.each { |metric| DeleteObjectHierarchyWorker.expects(:perform_later).with(metric, anything, 'destroy') }
+      DeleteObjectHierarchyWorker.expects(:perform_later).with(api_docs_service, anything, 'destroy')
 
       DeleteServiceHierarchyWorker.perform_now(service)
     end


### PR DESCRIPTION
Easy fix for [this bugsnag error](https://app.bugsnag.com/3scale-networks-sl/system/errors/5e29562a4b57c80019134019?event_id=5e29ba7a0055efac186c0000&i=sk&m=fq).
Closes [THREESCALE-4318 - NameError in DeleteServiceHierarchyWorker@deletion](https://issues.redhat.com/browse/THREESCALE-4318)