### PR TITLE
Get rid of deprecation warning about :text format in render

### DIFF
--- a/app/controllers/provider/admin/webhooks_controller.rb
+++ b/app/controllers/provider/admin/webhooks_controller.rb
@@ -24,7 +24,7 @@ class Provider::Admin::WebhooksController < Sites::BaseController
         if @webhook
           @ping_response = @webhook.ping
         else
-          render :status => :forbidden, :text => 'Nowhere to ping'
+          render :status => :forbidden, :plain => 'Nowhere to ping'
         end
       end
     end

--- a/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
@@ -54,7 +54,7 @@ class DeveloperPortal::CMS::NewContentController < DeveloperPortal::BaseControll
 
       # CMS::Page#mime_type is parsed and valid Mime::Type
       # in case it can't be parsed (nil, something invalid) returns 'text/html'
-      render :layout => false, :content_type => page.mime_type, :text => renderer.content
+      render layout: false, content_type: page.mime_type, body: renderer.content
     end
   end
 


### PR DESCRIPTION
Remove deprecation of render text: 'Something'
Uses render plain: 'Something' instead