### PR TITLE
Revert "ThreeScale::Core::AlertLimit.load_all mocked"

### DIFF
--- a/test/test_helpers/backend.rb
+++ b/test/test_helpers/backend.rb
@@ -45,14 +45,6 @@ module TestHelpers
           :save!, :delete
         clear_method ThreeScale::Core::UsageLimit.singleton_class,
           :save, :load_value, :delete
-
-        clear_method ThreeScale::Core::AlertLimit.singleton_class,
-                     :save, :delete
-
-        clear_method ThreeScale::Core::AlertLimit.singleton_class, :load_all do |service_id|
-          []
-        end
-
         clear_method ThreeScale::Core::User.singleton_class,
           :load, :delete_all_for_service
         clear_method ThreeScale::Core::ApplicationKey.singleton_class,


### PR DESCRIPTION
This reverts commit 440cc4c332b12f49a0ef7c3aebd1272749341781.
