### PR TITLE
[CVE] Rails SQLi also check for ActionController::Parameters

### DIFF
--- a/test/unit/rails_sqli_test.rb
+++ b/test/unit/rails_sqli_test.rb
@@ -7,7 +7,6 @@ class RailsSqliTest < ActiveSupport::TestCase
     # This should fix # https://groups.google.com/forum/#!topic/rubyonrails-security/8CVoclw-Xkk
     # No error should be raised on that and the SQL
 
-    db_quote = System::Database.mysql? ? '`' : '"'
     CMS::Section.find_by(params)
     sanitized = ActiveRecord::Base.sanitize params['system_name'].to_s
     assert_match sanitized, CMS::Section.where(params).to_sql

--- a/test/unit/rails_sqli_test.rb
+++ b/test/unit/rails_sqli_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class RailsSqliTest < ActiveSupport::TestCase
+  def test_action_controller_params_are_escaped
+    params = ActionController::Parameters.new('system_name' => {'0' => 'foo'})
+    # This should fix # https://groups.google.com/forum/#!topic/rubyonrails-security/8CVoclw-Xkk
+    # No error should be raised on that and the SQL
+
+    db_quote = System::Database.mysql? ? '`' : '"'
+    CMS::Section.find_by(params)
+    sanitized = ActiveRecord::Base.sanitize params['system_name'].to_s
+    assert_match sanitized, CMS::Section.where(params).to_sql
+  end
+
+  def test_quoting_acton_controller_parameters
+    params = ActionController::Parameters.new('system_name' => {'0' => 'foo'})
+    master_account.sections.find_by_system_name(params[:system_name])
+  end
+end


### PR DESCRIPTION
We forbid all nested subquery like: Model.where({models: {column: true}}) in the code on purpose.
To prepare for Rails 5.x we need to take into account ActionController::Parameters as well

The fix is a bit reworked on for it to be more robust