### PR TITLE
Fix `make bundle` for multiple versions of bundler installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,11 +119,13 @@ clean-cache: export CACHE = true
 clean-cache:
 	$(MAKE) clean
 
+BUNDLER_VERSION ?= $(echo $(shell awk '/BUNDLED WITH/{getline;print}' Gemfile.lock))
+
 bundle: ## Installs dependencies using bundler. Run this after you make some changes to Gemfile.
 bundle: gemfiles/prod/Gemfile Gemfile
-	BUNDLE_GEMFILE=Gemfile bundle lock
+	BUNDLE_GEMFILE=Gemfile bundle _$(BUNDLER_VERSION)_ lock
 	cp Gemfile.lock gemfiles/prod/Gemfile.lock
-	BUNDLE_GEMFILE=gemfiles/prod/Gemfile bundle lock
+	BUNDLE_GEMFILE=gemfiles/prod/Gemfile bundle _$(BUNDLER_VERSION)_ lock
 
 oracle-db-setup: ## Creates databases in Oracle
 oracle-db-setup: oracle-database


### PR DESCRIPTION
Bundler 2+ was supposed to [auto-select the right version](https://bundler.io/v2.0/guides/bundler_2_upgrade.html#version-autoswitch) of Bundler based on `Gemfile.lock`. For some reason that's not working in some environments, or maybe it's `bundle lock` that fails to select the version.

In my case, I have Bundler v2.1.4 and v1.17.3 installed, and still on rbenv Ruby 2.4.1. Whenever I `make bundle`, Bundler 2.1.4 is always selected. Exporting `BUNDLER_VERSION` didn't help. The output will still be something like the following:

```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    license_finder (~> 5.5.2) was resolved to 5.5.2, which depends on
      bundler

    rails (= 4.2.11.1) was resolved to 4.2.11.1, which depends on
      bundler (< 2.0, >= 1.3.0)

  Current Bundler version:
    bundler (2.1.4)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (< 2.0, >= 1.3.0)', which is required by gem 'rails (= 4.2.11.1)', in any of the sources.
make: *** [bundle] Error 6

```

This PR makes `make bundle` to get the current version of Bundler locked in `Gemfile.lock` and use that version by default in the `bundle lock` command. You can still do `BUNDLER_VERSION=x make bundle` to force a specific version (like to upgrade).