### PR TITLE
[Rails 5] Fix protected_attributes_continued's evil monkey patch

### DIFF
--- a/config/initializers/protected_attributes_hacks.rb
+++ b/config/initializers/protected_attributes_hacks.rb
@@ -1,0 +1,25 @@
+# OMG!!!! Such bad citizen!!!
+# https://github.com/westonganger/protected_attributes_continued/blob/master/lib/active_record/mass_assignment_security/relation.rb
+# They just reopened Rails module instead of using their proper module ...
+# Thus they totally short circuit all the other modules, not really good with integration with other gems like BabySqueel
+
+ActiveRecord::QueryMethods.module_eval do
+  remove_method :sanitize_forbidden_attributes
+end
+
+module ProtectedAttributesHacks
+  module QueryMethods
+    def sanitize_forbidden_attributes(attributes)
+      if model._uses_mass_assignment_security
+        # We just permit everything
+        super(attributes.respond_to?(:permit!) ? attributes.dup.permit! : attributes)
+      else
+        super
+      end
+    end
+  end
+end
+
+ActiveRecord::Relation.class_eval do
+  include ProtectedAttributesHacks::QueryMethods
+end


### PR DESCRIPTION
Protected attributes gem is a bad citizen. They monkey patch `ActiveRecord::QueryMethods` instead of adding their own module. It doesn't play well with BabySqueel, for example.

This PR reverts the patch and make it right.