### PR TITLE
Fix Slack Webhook URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -741,7 +741,7 @@ jobs:
                 ] \
               } \
               ] \
-            }" $SLACK_WEBHOOK_URL
+            }" $SLACK_WEBHOOK_SYSTEM
 
   notify_failure:
     docker:
@@ -771,7 +771,7 @@ jobs:
                 ] \
               } \
               ] \
-            }" $SLACK_WEBHOOK_URL
+            }" $SLACK_WEBHOOK_SYSTEM
           when: on_fail
 
   notify_success:
@@ -802,7 +802,7 @@ jobs:
                 ] \
               } \
               ] \
-            }" $SLACK_WEBHOOK_URL
+            }" $SLACK_WEBHOOK_SYSTEM
           when: on_success
 
   visual:


### PR DESCRIPTION
Our Slack isn't receiving any notifications from CI. When you run the
curl command manually, it returns `no_system` error. We added a new
environment variable with the right endpoint.