### PR TITLE
[Rails 5] Use of unsafe parameters in URL generation

### DIFF
--- a/app/controllers/provider/admin/cms/email_templates_controller.rb
+++ b/app/controllers/provider/admin/cms/email_templates_controller.rb
@@ -18,7 +18,7 @@ class Provider::Admin::CMS::EmailTemplatesController < Sites::BaseController
   def update
     @page = templates.find(params[:id])
 
-    if @page.update_attributes(params[:cms_template])
+    if @page.update_attributes(cms_templates_params)
       flash[:info] = 'Email Template updated.'
       redirect_to action: :index
     else
@@ -27,7 +27,7 @@ class Provider::Admin::CMS::EmailTemplatesController < Sites::BaseController
   end
 
   def create
-    @page ||= templates.build(params[:cms_template])
+    @page ||= templates.build(cms_templates_params)
 
     if @page.save
       flash[:info] = 'Email Template overrided.'
@@ -41,6 +41,10 @@ class Provider::Admin::CMS::EmailTemplatesController < Sites::BaseController
 
   def templates
     current_account.email_templates
+  end
+
+  def cms_templates_params
+    params[:cms_template].permit!
   end
 
 end

--- a/app/lib/authentication/strategy/base.rb
+++ b/app/lib/authentication/strategy/base.rb
@@ -65,8 +65,9 @@ module Authentication
       end
 
       def signup_path(params)
+        permitted_params = params.respond_to?(:permit!) ? params.dup.permit! : params
         DeveloperPortal::Engine.routes.url_helpers
-            .signup_path(params.except(:action, :controller))
+            .signup_path(permitted_params.except(:action, :controller))
       end
 
       # This is the template rendered by sessions controller, usually the login form

--- a/app/lib/three_scale/api/responder.rb
+++ b/app/lib/three_scale/api/responder.rb
@@ -30,6 +30,8 @@ class ThreeScale::Api::Responder < ActionController::Responder
       params.merge!(controller.request.query_parameters)
       params[:id] = resource.id
       params[:action] = :show
+      # Permitting all parameters here but it is not really secure
+      params.permit! if params.respond_to?(:permit!)
       controller.url_for(params)
     end
   end

--- a/app/models/web_hook/event.rb
+++ b/app/models/web_hook/event.rb
@@ -76,7 +76,7 @@ class WebHook
 
     # this could be activemodel validation
     def valid?
-       enabled? && push_event?  && push_user? && provider.web_hooks_allowed?
+      enabled? && push_event?  && push_user? && provider.web_hooks_allowed?
     end
 
     # use i18n to figure this out

--- a/app/presenters/dashboard_widget_presenter.rb
+++ b/app/presenters/dashboard_widget_presenter.rb
@@ -8,7 +8,7 @@ class DashboardWidgetPresenter
 
   def initialize(name, params = {})
     @name = name
-    @params = params.freeze
+    @params = params.respond_to?(:permit!) ? params.dup.permit!.freeze : params.freeze
     @data = nil
     @value = spinner
     @previous_value = nil

--- a/lib/developer_portal/app/controllers/developer_portal/access_codes_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/access_codes_controller.rb
@@ -32,7 +32,7 @@ class DeveloperPortal::AccessCodesController < ApplicationController
   private
 
   def cms_params
-    params.slice(:cms_token, :cms)
+    params.permit(:cms_token, :cms)
   end
 
   def return_url

--- a/lib/developer_portal/lib/liquid/drops/pagination.rb
+++ b/lib/developer_portal/lib/liquid/drops/pagination.rb
@@ -134,7 +134,10 @@ module Liquid
         protected
 
         def make_url(options = {})
-          @url_builder.url_for(@url_builder.params.merge(options))
+          params = @url_builder.params
+          unsafe_params = params.respond_to?(:to_unsafe_h) ? params.to_unsafe_h : params.to_h
+
+          @url_builder.url_for(unsafe_params.merge(options))
         end
 
         def make_part(title, link = nil, rel = nil)

--- a/test/functional/provider/admin/dashboard/service/hits_controller_test.rb
+++ b/test/functional/provider/admin/dashboard/service/hits_controller_test.rb
@@ -1,13 +1,14 @@
 require 'test_helper'
 
-class Provider::Admin::Dashboard::Service::HitsControllerTest < ActionController::TestCase
+class Provider::Admin::Dashboard::Service::HitsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @provider = FactoryBot.create(:provider_account)
-    login_provider(@provider)
+    login! @provider
   end
 
   test "should get show" do
-    xhr :get, :show, service_id: FactoryBot.create(:simple_service, account: @provider)
+    service = FactoryGirl.create(:simple_service, account: @provider)
+    get provider_admin_dashboard_service_hits_path(service_id: service.id), xhr: true
     assert_response :success
   end
 end

--- a/test/integration/provider/admin/dashboard/service/hits_controller_test.rb
+++ b/test/integration/provider/admin/dashboard/service/hits_controller_test.rb
@@ -7,7 +7,7 @@ class Provider::Admin::Dashboard::Service::HitsControllerTest < ActionDispatch::
   end
 
   test "should get show" do
-    service = FactoryGirl.create(:simple_service, account: @provider)
+    service = FactoryBot.create(:simple_service, account: @provider)
     get provider_admin_dashboard_service_hits_path(service_id: service.id), xhr: true
     assert_response :success
   end


### PR DESCRIPTION
Causing this error:

Attempting to generate a URL from non-sanitized request parameters! An attacker can inject malicious data into the generated URL, such as changing the host. Whitelist and sanitize passed parameters to be secure. (ActionView::Template::Error)