### PR TITLE
[Rails5] Fix Baby Squeel usage

### DIFF
--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -33,7 +33,7 @@ class Api::ApplicationsController < Api::BaseController
 
     if params[:account_id]
       @account = current_account.buyers.find params[:account_id]
-      @search.account = @account
+      @search.account = @account.id
       activate_menu :buyers, :accounts
     end
 

--- a/app/controllers/buyers/applications_controller.rb
+++ b/app/controllers/buyers/applications_controller.rb
@@ -43,7 +43,7 @@ class Buyers::ApplicationsController < FrontendController
 
     if params[:account_id]
       @account = current_account.buyers.find params[:account_id]
-      @search.account = @account
+      @search.account = @account.id
       activate_menu :buyers, :accounts, :listing
     end
 

--- a/app/controllers/buyers/service_contracts_controller.rb
+++ b/app/controllers/buyers/service_contracts_controller.rb
@@ -29,7 +29,7 @@ class Buyers::ServiceContractsController < Buyers::BaseController
 
     if params[:account_id]
       @account = current_account.buyers.find params[:account_id]
-      @search.account = @account
+      @search.account = @account.id
       activate_menu :audience, :accounts, :listing
     end
 

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -86,7 +86,7 @@ class Contract < ApplicationRecord
     where.has { name.op('COLLATE', sql(collate)).matches(pattern)}
   }
 
-  scope :by_account, ->(account) { where.has { user_account_id == account } }
+  scope :by_account, ->(account_id) { where.has { user_account_id == account_id } }
   scope :by_account_query, ->(query) { where( { :user_account_id => Account.buyers.search_ids(query) } ) }
 
   scope :have_paid_on, ->(paid_date) { where.has { (paid_until >= paid_date) | (variable_cost_paid_until >= paid_date) } }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -62,7 +62,7 @@ class Service < ApplicationRecord
     super.reject { |column| %w[act_as_product tech_support_email admin_support_email].include?(column.name) }
   end
 
-  scope :of_account, ->(account) { where.has { account_id == account } }
+  scope :of_account, ->(account) { where.has { account_id == account.id } }
 
   has_one :proxy, dependent: :destroy, inverse_of: :service, autosave: true
 

--- a/features/step_definitions/messages_steps.rb
+++ b/features/step_definitions/messages_steps.rb
@@ -74,8 +74,9 @@ Then('a message should be sent from buyer to provider with plan change details f
 end
 
 Then('a message should be sent from buyer to provider requesting to change plan to paid') do
-  messages = @provider.received_messages.where{ |t| t.message.sender_id == @buyer }
+  messages = @provider.received_messages.where.has { |t| t.message.sender_id == @buyer.id }
   assert msg = messages.to_a.select{|m| m.subject == 'API System: Plan change request' }.last
+
   assert_match %(#{@buyer.org_name} are requesting to have their plan changed to #{@paid_application_plan.name} for application #{@application.name}. You can do this from the application page), msg.body
 end
 

--- a/test/models/backend_api_config_test.rb
+++ b/test/models/backend_api_config_test.rb
@@ -98,9 +98,9 @@ class BackendApiConfigTest < ActiveSupport::TestCase
     end
     configs << FactoryBot.create(:backend_api_config, service: services[0])
 
-    assert_same_elements configs.values_at(0, -1).map(&:id), BackendApiConfig.by_service(services[0]).pluck(:id)
-    assert_equal [configs[1].id], BackendApiConfig.by_service(services[1]).pluck(:id)
-    assert_empty BackendApiConfig.by_service(services[2]).pluck(:id)
+    assert_same_elements configs.values_at(0, -1).map(&:id), BackendApiConfig.by_service(services[0].id).pluck(:id)
+    assert_equal [configs[1].id], BackendApiConfig.by_service(services[1].id).pluck(:id)
+    assert_empty BackendApiConfig.by_service(services[2].id).pluck(:id)
   end
 
   test '.by_backend_api returns the configs related to that backend_api' do
@@ -113,9 +113,9 @@ class BackendApiConfigTest < ActiveSupport::TestCase
     end
     configs << FactoryBot.create(:backend_api_config, backend_api: backend_apis[0])
 
-    assert_same_elements configs.values_at(0, -1).map(&:id), BackendApiConfig.by_backend_api(backend_apis[0]).pluck(:id)
-    assert_equal [configs[1].id], BackendApiConfig.by_backend_api(backend_apis[1]).pluck(:id)
-    assert_empty BackendApiConfig.by_backend_api(backend_apis[2]).pluck(:id)
+    assert_same_elements configs.values_at(0, -1).map(&:id), BackendApiConfig.by_backend_api(backend_apis[0].id).pluck(:id)
+    assert_equal [configs[1].id], BackendApiConfig.by_backend_api(backend_apis[1].id).pluck(:id)
+    assert_empty BackendApiConfig.by_backend_api(backend_apis[2].id).pluck(:id)
   end
 
   test 'accessible' do

--- a/test/unit/contract_test.rb
+++ b/test/unit/contract_test.rb
@@ -9,7 +9,7 @@ class ContractTest < ActiveSupport::TestCase
     accounts.each { |account| FactoryBot.create_list(:application, 2, user_account: account) }
 
     assert_same_elements Contract.where(user_account: accounts[0].id).pluck(:id), Contract.by_account(accounts[0].id).pluck(:id)
-    assert_same_elements Contract.where(user_account: accounts[1].id).pluck(:id), Contract.by_account(accounts[1]).pluck(:id)
+    assert_same_elements Contract.where(user_account: accounts[1].id).pluck(:id), Contract.by_account(accounts[1].id).pluck(:id)
   end
 
   def test_have_paid_on

--- a/test/unit/three_scale/search_test.rb
+++ b/test/unit/three_scale/search_test.rb
@@ -103,7 +103,7 @@ class ThreeScale::SearchTest < ActiveSupport::TestCase
       bcd = FactoryBot.create(:cinstance, :name => "bcd", :user_account => account)
       cde = FactoryBot.create(:cinstance, :name => "cde", :user_account => account)
 
-      options = {:account => account}
+      options = {:account => account.id}
       array = [abc, bcd, cde]
 
       assert_equal array, Cinstance.order_by(:name, :asc).scope_search(options).to_a
@@ -116,7 +116,7 @@ class ThreeScale::SearchTest < ActiveSupport::TestCase
       app = FactoryBot.create(:cinstance, :name => "test")
       plan = app.plan
 
-      options = {:account => app.user_account, :deleted_accounts => true, :plan_type => "free", :plan_id => plan.id, :type => "Cinstance"}
+      options = {:account => app.user_account_id, :deleted_accounts => true, :plan_type => "free", :plan_id => plan.id, :type => "Cinstance"}
 
       assert_equal [app], Cinstance.order_by(:name).scope_search(options)
     end


### PR DESCRIPTION
Baby Squeel does not work with records in Rails 5, it needs the id
instead of the record.