### PR TITLE
EventStore::Event does not include BackgroundDeletion

### DIFF
--- a/app/lib/event_store/event.rb
+++ b/app/lib/event_store/event.rb
@@ -4,6 +4,8 @@ require 'active_job/arguments'
 
 module EventStore
   class Event < RailsEventStoreActiveRecord::Event
+    include BackgroundDeletion
+
     module WithGlobalId
       module_function
 


### PR DESCRIPTION
Because it inherits from another class than ApplicationRecord
Closes: THREESCALE-4339