### PR TITLE
Support OAS3 in Admin Portal (ActiveDocs)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,4 +15,4 @@
 module.system.node.resolve_dirname=node_modules
 module.name_mapper.extension='scss' -> 'empty/object'
 module.system=haste
-module.name_mapper='\(Applications\|Form\|Settings\|Dashboard\|LoginPage\|Navigation\|Onboarding\|Policies\|services\|Stats\|Types\|Users\|utilities\|NewService\)\(.*\)$' -> '<PROJECT_ROOT>/app/javascript/src/\1/\2'
+module.name_mapper='\(ActiveDocs\|Applications\|Form\|Settings\|Dashboard\|LoginPage\|Navigation\|Onboarding\|Policies\|services\|Stats\|Types\|Users\|utilities\|NewService\)\(.*\)$' -> '<PROJECT_ROOT>/app/javascript/src/\1/\2'

--- a/.flowconfig
+++ b/.flowconfig
@@ -13,6 +13,6 @@
 
 [options]
 module.system.node.resolve_dirname=node_modules
-module.name_mapper.extension='scss' -> 'empty/object'
+module.name_mapper='.*\(.s?css\)' -> 'empty/object'
 module.system=haste
 module.name_mapper='\(ActiveDocs\|Applications\|Form\|Settings\|Dashboard\|LoginPage\|Navigation\|Onboarding\|Policies\|services\|Stats\|Types\|Users\|utilities\|NewService\)\(.*\)$' -> '<PROJECT_ROOT>/app/javascript/src/\1/\2'

--- a/app/helpers/admin/api_docs_helper.rb
+++ b/app/helpers/admin/api_docs_helper.rb
@@ -13,4 +13,8 @@ module Admin::ApiDocsHelper
     service = api_doc.service
     service.present? ? admin_service_api_doc_path(service, api_doc) : admin_api_docs_service_path(api_doc)
   end
+
+  def spec_url(api_docs_service)
+    base_url.gsub(%r{/$}, '').concat(admin_api_docs_service_path(api_docs_service, format: :json))
+  end
 end

--- a/app/javascript/packs/service_active_docs.js
+++ b/app/javascript/packs/service_active_docs.js
@@ -1,0 +1,8 @@
+import { ActiveDocsSpecWrapper as ActiveDocsSpec } from 'ActiveDocs/components/ActiveDocsSpec'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const containerId = 'swagger-ui-container'
+  const { url } = document.getElementById(containerId).dataset
+
+  ActiveDocsSpec({ url }, containerId)
+})

--- a/app/javascript/src/ActiveDocs/components/ActiveDocsSpec.jsx
+++ b/app/javascript/src/ActiveDocs/components/ActiveDocsSpec.jsx
@@ -1,0 +1,18 @@
+// @flow
+
+import React from 'react'
+
+import { createReactWrapper } from 'utilities/createReactWrapper'
+import SwaggerUI from 'swagger-ui-react'
+
+import 'swagger-ui-react/swagger-ui.css'
+
+type ActiveDocsSpecProps = {
+  url: string
+}
+
+const ActiveDocsSpec = ({ url }: ActiveDocsSpecProps) => <SwaggerUI url={url} />
+
+const ActiveDocsSpecWrapper = (props: ActiveDocsSpecProps, id: string) => createReactWrapper(<ActiveDocsSpec {...props} />, id)
+
+export { ActiveDocsSpec, ActiveDocsSpecWrapper }

--- a/app/javascript/src/Types/libs/libdefs.js
+++ b/app/javascript/src/Types/libs/libdefs.js
@@ -27,4 +27,8 @@ declare module 'core-js/fn/symbol' {
 
 }
 
+declare module 'swagger-ui-react' {
+  declare module.exports: any;
+}
+
 export type Window = any

--- a/app/views/admin/api_docs/base/swagger.html.erb
+++ b/app/views/admin/api_docs/base/swagger.html.erb
@@ -3,7 +3,7 @@
 
 <div class="swagger-section">
   <div id="message-bar" class="swagger-ui-wrap">&nbsp;</div>
-  <div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+  <div id="swagger-ui-container" class="swagger-ui-wrap" data-url="<%= spec_url(@api_docs_service) %>"></div>
 </div>
 
 <div class='apidocs-param-tips apidocs-signin-message' style='display:none;'>
@@ -11,7 +11,11 @@
 </div>
 
 <%# TODO: this is here until we get swagger-ui 2.1 to load swagger spec 1.2 and 2.0 %>
-<% if @api_docs_service.specification.swagger_2_0? -%>
+
+<% if @api_docs_service.specification.openapi_3_0? -%>
+ <%= javascript_pack_tag 'service_active_docs'%>
+
+<% elsif @api_docs_service.specification.swagger_2_0? -%>
 
   <% content_for :javascripts do -%>
     <%= javascript_include_tag "/_cdn_assets_/swagger-ui/2.2.10/swagger-ui.js" -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1183,7 +1183,7 @@ en:
       liquid_enabled: "Process Liquid tags and drops?"
 
       api_docs/service:
-        body: 'Specification must comply with Swagger <a href="https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#52-api-declaration">1.2</a> or <a href="https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md">2.0</a>.'
+        body: 'Specification must comply with Swagger <a href="https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#52-api-declaration">1.2</a>, <a href="https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md">2.0</a> or <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md">3.0</a>'
         system_name: "Only ASCII letters, numbers, dashes and underscores are allowed.<br/><span style='font-size:90%;color:red'>Warning: With ActiveDocs 1.2 the API will be described in your developer portal as <i>System name: Description</i></span>"
 
       settings:

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -609,3 +609,29 @@
 - - :approve
   - WHY=MIT License
   - *13
+- - :approve
+  - dompurify
+  - &14
+    :who: 
+    :why: 
+    :versions: []
+    :when: 2020-01-20 15:25:04.043922000 Z
+- - :approve
+  - WHO=Didier Di Cesare
+  - *14
+- - :approve
+  - WHY=MPL-2.0 OR Apache-2.0
+  - *14
+- - :approve
+  - emitter-component
+  - &15
+    :who: 
+    :why: 
+    :versions: []
+    :when: 2020-01-20 15:26:46.368257000 Z
+- - :approve
+  - WHO=Didier Di Cesare
+  - *15
+- - :approve
+  - WHY=MIT
+  - *15

--- a/package-lock.json
+++ b/package-lock.json
@@ -1001,6 +1001,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@braintree/sanitize-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz",
+      "integrity": "sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg=="
+    },
     "@cnakazawa/watch": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -1312,6 +1317,19 @@
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
+      }
+    },
+    "@kyleshockey/object-assign-deep": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@kyleshockey/object-assign-deep/-/object-assign-deep-0.4.2.tgz",
+      "integrity": "sha1-hJAPDu/DcnmPR1G1JigwuCCJIuw="
+    },
+    "@kyleshockey/xml": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@kyleshockey/xml/-/xml-1.0.2.tgz",
+      "integrity": "sha512-iMo32MPLcI9cPxs3YL5kmKxKgDmkSZDCFEqIT5eRk7d/Ll8r4X3SwGYSigzALd6+RHWlFEmjL1QyaQ15xDZFlw==",
+      "requires": {
+        "stream": "^0.0.2"
       }
     },
     "@metahub/karma-jasmine-jquery": {
@@ -1679,6 +1697,15 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
+    },
+    "@types/react": {
+      "version": "16.4.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.6.tgz",
+      "integrity": "sha512-9LDZdhsuKSc+DjY65SjBkA958oBWcTWSVWAd2cD9XqKBjhGw1KzAkRhWRw2eIsXvaIE/TOTjjKMFVC+JA1iU4g==",
+      "optional": true,
+      "requires": {
+        "csstype": "^2.2.0"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -2245,6 +2272,11 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -2319,7 +2351,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -2354,6 +2385,14 @@
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
       "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
       "dev": true
+    },
+    "autolinker": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+      "integrity": "sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=",
+      "requires": {
+        "gulp-header": "^1.7.1"
+      }
     },
     "autoprefixer": {
       "version": "9.7.3",
@@ -3453,6 +3492,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "btoa": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.2.tgz",
+      "integrity": "sha1-PkC4FmP4HS3WWWpMtxSo3BbPq+A="
+    },
     "btoa-lite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
@@ -4362,6 +4406,14 @@
         }
       }
     },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "requires": {
+        "source-map": "^0.6.1"
+      }
+    },
     "connect": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
@@ -4427,8 +4479,7 @@
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -4560,6 +4611,41 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "create-react-class": {
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+      "requires": {
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "cross-fetch": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-0.0.8.tgz",
+      "integrity": "sha1-Ae2U3EB98sAPGAf95wCnz6SKIFw=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+          "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        }
       }
     },
     "cross-spawn": {
@@ -4756,6 +4842,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
       "integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw=="
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
     },
     "cssdb": {
       "version": "4.4.0",
@@ -4994,7 +5085,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -5007,16 +5097,14 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         }
       }
     },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -5356,6 +5444,11 @@
         "domelementtype": "1"
       }
     },
+    "dompurify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.7.tgz",
+      "integrity": "sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A=="
+    },
     "domutils": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
@@ -5490,6 +5583,11 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -5526,11 +5624,24 @@
         "envify": "^3.4.0"
       }
     },
+    "encode-3986": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/encode-3986/-/encode-3986-1.0.0.tgz",
+      "integrity": "sha1-lA1RSY+HQa3hhLda0UObMXwMemA="
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -5878,6 +5989,17 @@
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -6432,6 +6554,15 @@
         "individual": "^3.0.0"
       }
     },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "eventemitter3": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
@@ -6748,6 +6879,14 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-json-patch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.1.0.tgz",
+      "integrity": "sha512-PipOsAKamRw7+CXtKiieehyjUeDVPJ5J7b2kdJYerEf6TSUQoD2ijpVyZ88KQm5YXziff4h762bz3+vzf56khg==",
+      "requires": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -6774,6 +6913,27 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        }
       }
     },
     "fbjs-scripts": {
@@ -8149,6 +8309,59 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
+    "gulp-header": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
+      "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
+      "requires": {
+        "concat-with-sourcemaps": "*",
+        "lodash.template": "^4.4.0",
+        "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        }
+      }
+    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -8615,6 +8828,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -8880,8 +9098,7 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -8978,6 +9195,15 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+    },
+    "is-dom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.1.0.tgz",
+      "integrity": "sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==",
+      "requires": {
+        "is-object": "^1.0.1",
+        "is-window": "^1.0.2"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -9100,8 +9326,7 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -9165,6 +9390,11 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
+    "is-window": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
+      "integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -9206,6 +9436,46 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
+    },
+    "isomorphic-form-data": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-0.0.1.tgz",
+      "integrity": "sha1-Am9ifgMrDNhBPsyHVZKLlKRosGI=",
+      "requires": {
+        "form-data": "^1.0.0-rc3"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+          "requires": {
+            "async": "^2.0.1",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
+          }
         }
       }
     },
@@ -10136,6 +10406,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
+    "js-file-download": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.9.tgz",
+      "integrity": "sha512-/qFei3bAo/BmV05ScKp3KDUMf57qD6UVkMa1gfOnwpLHuuHXRNXW42QbcQPi8+1Kn5LSrTEM28V2cooeHsU66w=="
+    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -10797,6 +11072,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+    },
     "lodash._arraypool": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
@@ -10975,6 +11255,11 @@
         "lodash._baseclone": "~2.4.1",
         "lodash._basecreatecallback": "~2.4.1"
       }
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.escape": {
       "version": "4.0.1",
@@ -11192,6 +11477,14 @@
         "yallist": "^2.1.2"
       }
     },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "macos-release": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
@@ -11287,6 +11580,21 @@
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
+      }
+    },
+    "memoizee": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.45",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.5"
       }
     },
     "memory-fs": {
@@ -12393,8 +12701,7 @@
     "object-is": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
-      "dev": true
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
     },
     "object-keys": {
       "version": "0.4.0",
@@ -14160,6 +14467,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "promise-each": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/promise-each/-/promise-each-2.2.0.tgz",
@@ -14308,6 +14623,11 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
+    "querystring-browser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/querystring-browser/-/querystring-browser-1.0.4.tgz",
+      "integrity": "sha1-8uNYgYQKgZvHsb9Zf68JeeZiLcY="
+    },
     "querystring-es3": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
@@ -14316,14 +14636,12 @@
     "querystringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-      "dev": true
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -14409,6 +14727,15 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-debounce-input": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-debounce-input/-/react-debounce-input-3.2.2.tgz",
+      "integrity": "sha512-RIBu68Cq/gImKz/2h1cE042REDqyqj3D+7SJ3lnnIpJX0ht9D9PfH7KAnL+SgDz6hvKa9pZS2CnAxlkrLmnQlg==",
+      "requires": {
+        "lodash.debounce": "^4",
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-dom": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
@@ -14418,6 +14745,29 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.18.0"
+      }
+    },
+    "react-immutable-proptypes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz",
+      "integrity": "sha1-Aj1vObsVyXwHHp5g0A0TbqxfoLQ="
+    },
+    "react-immutable-pure-component": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/react-immutable-pure-component/-/react-immutable-pure-component-1.2.3.tgz",
+      "integrity": "sha512-kNy2A/fDrSuR8TKwB+4ynmItmp1vgF87tWxxfmadwDYo2J3ANipHqTjDIBvJvJ7libvuh76jIbvmK0krjtKH1g==",
+      "requires": {
+        "@types/react": "16.4.6"
+      }
+    },
+    "react-inspector": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.3.1.tgz",
+      "integrity": "sha512-tUUK7t3KWgZEIUktOYko5Ic/oYwvjEvQUFAGC1UeMeDaQ5za2yZFtItJa2RTwBJB//NxPr000WQK6sEbqC6y0Q==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "is-dom": "^1.0.9",
+        "prop-types": "^15.6.1"
       }
     },
     "react-is": {
@@ -14444,6 +14794,23 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-motion": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
+      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
+      "requires": {
+        "performance-now": "^0.2.0",
+        "prop-types": "^15.5.8",
+        "raf": "^3.1.0"
+      },
+      "dependencies": {
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+        }
+      }
     },
     "react-redux": {
       "version": "5.1.2",
@@ -14672,6 +15039,14 @@
       "resolved": "https://registry.npmjs.org/redux-api-middleware/-/redux-api-middleware-3.0.1.tgz",
       "integrity": "sha512-orktovWGaLoKZU88hWcQ+LswSyMmfxyrR4zEpAa/Ccc3BW2ugZoRqA9ZBFaa8+VbxfZGzz6DsTTxjxsShY9Zqg=="
     },
+    "redux-immutable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-immutable/-/redux-immutable-3.1.0.tgz",
+      "integrity": "sha1-yvvWhuBxEmERm5wolgk13EeknQo=",
+      "requires": {
+        "immutable": "^3.8.1"
+      }
+    },
     "redux-immutable-state-invariant": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/redux-immutable-state-invariant/-/redux-immutable-state-invariant-2.1.0.tgz",
@@ -14751,7 +15126,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
       "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2"
       }
@@ -14801,6 +15175,15 @@
       "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
       "requires": {
         "isobject": "^2.0.0"
+      }
+    },
+    "remarkable": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+      "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
+      "requires": {
+        "argparse": "^1.0.10",
+        "autolinker": "~0.28.0"
       }
     },
     "remove-trailing-separator": {
@@ -14911,8 +15294,12 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-2.5.4.tgz",
+      "integrity": "sha1-t9I/3wC4P6etAnlUb427vXZccEc="
     },
     "resolve": {
       "version": "1.13.1",
@@ -15255,6 +15642,11 @@
           "dev": true
         }
       }
+    },
+    "serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serialize-javascript": {
       "version": "2.1.2",
@@ -16052,6 +16444,14 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
+    "stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "requires": {
+        "emitter-component": "^1.1.1"
+      }
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -16489,6 +16889,52 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "swagger-client": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.10.0.tgz",
+      "integrity": "sha512-XUvqO/jeF+P5gYklN+ThEFq1++XnXV9RTdOpS65B5Y0dHnamxO8v0wG8geVEwIIqKjCYbKQ2Vd67DZMZMeaNvg==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.0.0",
+        "@kyleshockey/object-assign-deep": "^0.4.0",
+        "btoa": "1.1.2",
+        "buffer": "^5.1.0",
+        "cookie": "^0.3.1",
+        "cross-fetch": "0.0.8",
+        "deep-extend": "^0.5.1",
+        "encode-3986": "^1.0.0",
+        "fast-json-patch": "~2.1.0",
+        "isomorphic-form-data": "0.0.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.14",
+        "qs": "^6.3.0",
+        "querystring-browser": "^1.0.4",
+        "traverse": "^0.6.6",
+        "url": "^0.11.0",
+        "utf8-bytes": "0.0.1",
+        "utfstring": "^2.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
+        },
+        "traverse": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+          "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+        }
+      }
+    },
     "swagger-converter": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/swagger-converter/-/swagger-converter-0.1.7.tgz",
@@ -16660,6 +17106,73 @@
           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
           "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
           "dev": true
+        }
+      }
+    },
+    "swagger-ui-react": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-3.25.0.tgz",
+      "integrity": "sha512-2MMk3p42Q3x/E91vIqitvXJLAvDsBwxW8DLt3FfI0H6YPnWGqafsU4kP6unVriQqJqafcQII5suDwmycdmqSdw==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.5.5",
+        "@braintree/sanitize-url": "^3.0.0",
+        "@kyleshockey/object-assign-deep": "^0.4.2",
+        "@kyleshockey/xml": "^1.0.2",
+        "base64-js": "^1.2.0",
+        "classnames": "^2.2.6",
+        "core-js": "^2.5.1",
+        "css.escape": "1.5.1",
+        "deep-extend": "0.6.0",
+        "dompurify": "^2.0.7",
+        "ieee754": "^1.1.13",
+        "immutable": "^3.x.x",
+        "js-file-download": "^0.4.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.15",
+        "memoizee": "^0.4.12",
+        "prop-types": "^15.7.2",
+        "randombytes": "^2.1.0",
+        "react-debounce-input": "^3.2.0",
+        "react-immutable-proptypes": "2.1.0",
+        "react-immutable-pure-component": "^1.1.1",
+        "react-inspector": "^2.3.0",
+        "react-motion": "^0.5.2",
+        "react-redux": "^4.x.x",
+        "redux": "^3.x.x",
+        "redux-immutable": "3.1.0",
+        "remarkable": "^1.7.4",
+        "reselect": "^2.5.4",
+        "serialize-error": "^2.1.0",
+        "sha.js": "^2.4.11",
+        "swagger-client": "^3.10.0",
+        "url-parse": "^1.4.7",
+        "xml-but-prettier": "^1.0.1",
+        "zenscroll": "^4.0.2"
+      },
+      "dependencies": {
+        "react-redux": {
+          "version": "4.4.10",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.10.tgz",
+          "integrity": "sha512-tjL0Bmpkj75Td0k+lXlF8Fc8a9GuXFv/3ahUOCXExWs/jhsKiQeTffdH0j5byejCGCRL4tvGFYlrwBF1X/Aujg==",
+          "requires": {
+            "create-react-class": "^15.5.1",
+            "hoist-non-react-statics": "^3.3.0",
+            "invariant": "^2.0.0",
+            "lodash": "^4.17.11",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "redux": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+          "requires": {
+            "lodash": "^4.2.1",
+            "lodash-es": "^4.2.1",
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.0.3"
+          }
         }
       }
     },
@@ -16978,6 +17491,15 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
+    },
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
@@ -17208,6 +17730,11 @@
       "resolved": "https://registry.npmjs.org/typescript-compiler/-/typescript-compiler-1.4.1-2.tgz",
       "integrity": "sha1-uk99si2RU0oZKdkACdzhYety/T8=",
       "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "uglify-js": {
       "version": "3.7.2",
@@ -17463,7 +17990,6 @@
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -17511,6 +18037,16 @@
         "lru-cache": "4.1.x",
         "tmp": "0.0.x"
       }
+    },
+    "utf8-bytes": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+      "integrity": "sha1-EWsCVEjJtQAIHN+/H01sbDfYg30="
+    },
+    "utfstring": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/utfstring/-/utfstring-2.0.1.tgz",
+      "integrity": "sha512-x8lx0NGB2OUxOOvFE3z4feOpJWrVrllGRzJq4h6H70bh3sincW+LAlexHBFD5jzV9sZ5qcabZcCwA7ZD6MdUkg=="
     },
     "util": {
       "version": "0.11.1",
@@ -18389,6 +18925,14 @@
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
+    "xml-but-prettier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml-but-prettier/-/xml-but-prettier-1.0.1.tgz",
+      "integrity": "sha1-9aMyZ+1CzNTjVcYlV6XjmwH7QPM=",
+      "requires": {
+        "repeat-string": "^1.5.2"
+      }
+    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -18497,6 +19041,11 @@
         "lodash.isequal": "^4.0.0",
         "validator": "^10.0.0"
       }
+    },
+    "zenscroll": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zenscroll/-/zenscroll-4.0.2.tgz",
+      "integrity": "sha1-6NV3TRwHOKR7z6hynzcS4t7d6yU="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "redux-api-middleware": "^3.0.1",
     "redux-thunk": "^2.3.0",
     "select2": "^4.0.6-rc.1",
+    "swagger-ui-react": "^3.25.0",
     "url-polyfill": "^1.1.3",
     "validate.js": "^0.13.1",
     "virtual-dom": "^2.1.1",

--- a/spec/javascripts/ActiveDocs/ActiveDocsSpec.jsx
+++ b/spec/javascripts/ActiveDocs/ActiveDocsSpec.jsx
@@ -1,0 +1,22 @@
+// @flow
+
+import React from 'react'
+import { mount } from 'enzyme'
+
+import { ActiveDocsSpec } from 'ActiveDocs/components/ActiveDocsSpec'
+
+jest.mock('swagger-ui-react')
+
+const url = 'foo.example.com'
+
+it('should render itself', () => {
+  const wrapper = mount(<ActiveDocsSpec url={url} />)
+  expect(wrapper.find(ActiveDocsSpec).exists()).toBe(true)
+})
+
+it('should render swagger-ui', () => {
+  const wrapper = mount(<ActiveDocsSpec url={url} />)
+  console.log(wrapper.debug())
+
+  expect(wrapper).toMatchSnapshot()
+})

--- a/spec/javascripts/ActiveDocs/__snapshots__/Spec.spec.jsx.snap
+++ b/spec/javascripts/ActiveDocs/__snapshots__/Spec.spec.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render swagger-ui 1`] = `
+<ActiveDocsSpec
+  url="foo.example.com"
+>
+  <SwaggerUI
+    url="foo.example.com"
+  />
+</ActiveDocsSpec>
+`;


### PR DESCRIPTION
> ⚠️ Merge only after #1596

**What this PR does / why we need it**:

Introduces `swagger-ui-react` in ActiveDocs in order to support OAS3 / Swagger 3:

![Screen Shot 2020-01-16 at 12 40 52](https://user-images.githubusercontent.com/11672286/72712704-db007080-3b6b-11ea-8093-aac258711868.png)

![Screen Shot 2020-01-28 at 10 48 05](https://user-images.githubusercontent.com/11672286/73253529-fea36680-41bc-11ea-94ff-d288b642f4d8.png)


**Which issue(s) this PR fixes** 

[THREESCALE-2725: Start using SwaggerUI 3.18.3 or higher for OAS3 specs](https://issues.redhat.com/browse/THREESCALE-2725)

**Verification steps** 
1. Go to any Product's active docs section: apiconfig/services/2/api_docs/<id>/preview#/
2. Create a new spec (v3) i.e. [Swagger petstore](http://petstore.swagger.io:8080/api/v3/openapi.json)
3. It should display the new UI
4. Opening a spec (v2) should still display the old UI:
    ![Screen Shot 2020-01-28 at 10 57 47](https://user-images.githubusercontent.com/11672286/73253559-08c56500-41bd-11ea-8337-b0b4fe95f282.png)


**Special notes for your reviewer**:
Dev portal support and proper styling will be handled in a following PR (#1595).
