### PR TITLE
Support OAS3: add proper styling to Dev Portal

### DIFF
--- a/app/javascript/packs/active_docs.js
+++ b/app/javascript/packs/active_docs.js
@@ -2,4 +2,6 @@
 import SwaggerUI from 'swagger-ui'
 import 'swagger-ui/dist/swagger-ui.css'
 
+import 'ActiveDocs/swagger-ui-3-patch.scss'
+
 window.SwaggerUI = SwaggerUI

--- a/app/javascript/src/ActiveDocs/swagger-ui-3-patch.scss
+++ b/app/javascript/src/ActiveDocs/swagger-ui-3-patch.scss
@@ -1,0 +1,106 @@
+.swagger-section {
+  section {
+    background-color: unset;
+  }
+
+  .wrapper {
+    background-color: rgba(255, 255, 255, 0.2);
+    padding-bottom: 4em;
+    padding-top: 2em;
+    padding-left: 30px;
+    padding-right: 30px;
+  }
+
+  .information-container {
+    background-color: unset;
+    padding: 0;
+
+    .info {
+      .title {
+        color: rgba(0, 0, 0, 0.6);
+        font-family: Futura, "Trebuchet MS", Arial, sans-serif;
+        font-size: 25px;
+      }
+      .main {
+        small,
+        pre,
+        a {
+          // Version and base URL
+          display: none;
+        }
+      }
+    }
+  }
+
+  .scheme-container {
+    // display: none;
+    padding: unset;
+    background: unset;
+    box-shadow: unset;
+
+    .wrapper {
+      padding-bottom: 2em;
+    }
+  }
+
+  .opblock {
+    margin: 0 0 10px;
+    border: none;
+
+    .opblock-tag-section {
+      &.is-open {
+        .nostyle {
+          color: black;
+        }
+      }
+      .nostyle {
+        color: #999;
+        font-family: Droid Sans, sans-serif;
+        font-size: 1.6rem;
+        font-weight: 700;
+      }
+    }
+
+    .opblock-summary {
+      background-color: #e7f0f7;
+      border: 1px solid #c3d9ec;
+      padding: 0;
+    }
+
+    .opblock-summary-method {
+      border-radius: 0;
+      color: #fff;
+      display: inline-block;
+      font-size: 0.7em;
+      line-height: 2em;
+      padding: 7px 0 4px;
+      text-transform: uppercase;
+      text-decoration: none;
+      text-align: center;
+      width: 50px;
+    }
+
+    .opblock-summary-path {
+      padding-left: 10px;
+    }
+
+    .opblock-summary-path span {
+      font-size: 1.4rem;
+      font-family: Futura, "Trebuchet MS", Arial, sans-serif;
+      font-weight: normal;
+    }
+
+    .opblock-tag {
+      a,
+      small,
+      div {
+        display: inline-block;
+      }
+
+      button {
+        display: inline-block;
+        margin-left: 1rem;
+      }
+    }
+  }
+}


### PR DESCRIPTION
> Moved from #1544

Adds a CSS "patch" that overrides Swagger-ui styles and makes it look more like dev portal.

![Screen Shot 2020-01-20 at 16 42 38](https://user-images.githubusercontent.com/11672286/72739607-3c443600-3ba4-11ea-8344-0dff6959a7af.png)

![Screen Shot 2020-01-20 at 16 42 46](https://user-images.githubusercontent.com/11672286/72739611-3e0df980-3ba4-11ea-816f-3666fee33e21.png)

![Screen Shot 2020-01-20 at 16 42 57](https://user-images.githubusercontent.com/11672286/72739615-3fd7bd00-3ba4-11ea-96ed-5cc8a24ecec9.png)
