### PR TITLE
[Rails 5] Do not assert_equal nil values for ServiceContracts::ServiceContractCreatedEventTest

### DIFF
--- a/test/events/service_contracts/service_contract_created_event_test.rb
+++ b/test/events/service_contracts/service_contract_created_event_test.rb
@@ -4,6 +4,7 @@ class ServiceContracts::ServiceContractCreatedEventTest < ActiveSupport::TestCas
 
   def test_create
     contract = FactoryBot.build_stubbed(:simple_service_contract, id: 1)
+    contract.stubs(provider_account: Account.new)
     user     = FactoryBot.build_stubbed(:simple_user, id: 2)
     event    = ServiceContracts::ServiceContractCreatedEvent.create(contract, user)
 


### PR DESCRIPTION
So the test is meaningful.