### PR TITLE
[Rails 5] CMS::Portlet does not have attribute #description

### DIFF
--- a/app/representers/cms/portlet_representer.rb
+++ b/app/representers/cms/portlet_representer.rb
@@ -8,7 +8,6 @@ module CMS::PortletRepresenter
   property :title
   property :portlet_type
   property :name
-  property :description
 
   with_options(if: ->(options) { options[:short] == false }) do |p|
     p.property :draft


### PR DESCRIPTION
Extracted from the Rails 5 PR :smile: 