### PR TITLE
[Rails 5] Race condition non requiring Stats::Service

### DIFF
--- a/app/controllers/provider/admin/dashboard/service/hits_controller.rb
+++ b/app/controllers/provider/admin/dashboard/service/hits_controller.rb
@@ -31,3 +31,4 @@ class Provider::Admin::Dashboard::Service::HitsController < Provider::Admin::Das
     TrafficService.new(stats_client)
   end
 end
+require_dependency 'stats/service'

--- a/app/controllers/provider/admin/dashboard/service/top_traffic_controller.rb
+++ b/app/controllers/provider/admin/dashboard/service/top_traffic_controller.rb
@@ -11,3 +11,4 @@ class Provider::Admin::Dashboard::Service::TopTrafficController < Provider::Admi
     ::Stats::Service.new(service)
   end
 end
+require_dependency 'stats/service'


### PR DESCRIPTION
Stats::Service is autoloaded and Rails dependency loader is trying to acquire lock in two different thread but failed