### PR TITLE
[Rails 5] Remove skip_before_action :activate_menu_site_or_settings

### DIFF
--- a/app/controllers/sites/base_controller.rb
+++ b/app/controllers/sites/base_controller.rb
@@ -9,6 +9,4 @@ class Sites::BaseController < FrontendController
     authorize! :manage, :settings
   end
 
-
-
 end

--- a/app/controllers/sites/documentations_controller.rb
+++ b/app/controllers/sites/documentations_controller.rb
@@ -1,6 +1,5 @@
 class Sites::DocumentationsController < Sites::BaseController
   # see ForumsController
-  skip_before_action :activate_menu_site_or_settings
   activate_menu :serviceadmin
 
   before_action :authorize_connect


### PR DESCRIPTION
The name of the commit is not related to what it currently does. Explanation in https://github.com/3scale/porta/pull/1601#discussion_r373514905