### PR TITLE
[Rails 5] Use assert_in_delta because of DateTime in DB rounding usec to 0

### DIFF
--- a/test/unit/invoice_test.rb
+++ b/test/unit/invoice_test.rb
@@ -69,7 +69,10 @@ class InvoiceTest < ActiveSupport::TestCase
     time = Time.zone.now
     Timecop.freeze(time) { @invoice.finalize! }
 
-    assert_equal time.round, @invoice.finalized_at.round
+    # assert_in_delta because the time stored in database do not have usec
+    # But end of day has .999999
+    # Solution is to move from Mysql or migrate to 5.6.24+ and use precision (limit: 6) on datetime
+    assert_in_delta time, @invoice.finalized_at, 1.second
     assert @invoice.finalized?
   end
 


### PR DESCRIPTION
Cherry picked from https://github.com/3scale/porta/pull/4/commits/09ac1f11e14ea0b07869aa50c1d7ec848211f2bb