### PR TITLE
Showing exclamation mark when outdated config

### DIFF
--- a/app/assets/stylesheets/provider/_vertical_nav.scss
+++ b/app/assets/stylesheets/provider/_vertical_nav.scss
@@ -1,10 +1,18 @@
 .pf-c-page__sidebar {
-  color: $white;
   text-align: left;
-  text-decoration: none;
 
   .pf-c-nav__section-title {
     // Give artificial margin-top of pf-c-nav__section
     margin-top: 2rem;
+  }
+
+  // scss-lint:disable SelectorFormat
+  .pf-c-nav__item.outdated-config::before {
+    content: '\f071';
+    font-family: FontAwesome;
+    font-weight: normal;
+    position: absolute;
+    right: line-height-times(3);
+    top: line-height-times(1 / 3);
   }
 }

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -242,7 +242,7 @@ module VerticalNavHelper
 
   def service_integration_items
     items = []
-    items << {id: :configuration,       title: 'Configuration',     path: path_to_service(@service),    outOfDateConfig: has_out_of_date_configuration?(@service)}
+    items << {id: :configuration,       title: 'Configuration',     path: path_to_service(@service)}
     items << {id: :methods_metrics,     title: 'Methods & Metrics', path: admin_service_metrics_path(@service)}
     items << {id: :mapping_rules,       title: 'Mapping Rules',     path: admin_service_proxy_rules_path(@service)} if current_account.independent_mapping_rules_enabled?
     if current_account.provider_can_use?(:api_as_product)

--- a/app/javascript/src/Navigation/components/VerticalNav.jsx
+++ b/app/javascript/src/Navigation/components/VerticalNav.jsx
@@ -8,8 +8,7 @@ type Item = {
   id: string,
   title: string,
   path: ?string,
-  target: ?string,
-  outOfDateConfig: ?boolean
+  target: ?string
 }
 
 type Section = Item & {
@@ -39,10 +38,10 @@ const VerticalNav = ({ sections, activeSection, activeItem }: Props) => (
 
 const NavSection = ({title, isSectionActive, activeItem, items, outOfDateConfig}) => {
   return (
-    <NavExpandable title={title} isActive={isSectionActive} isExpanded={isSectionActive} outOfDateConfig={outOfDateConfig}>
-      {items.map(({id, title, path, target, outOfDateConfig}) => (
+    <NavExpandable title={title} isActive={isSectionActive} isExpanded={isSectionActive} className={outOfDateConfig ? 'outdated-config' : ''}>
+      {items.map(({id, title, path, target}) => (
         path
-          ? <NavItem to={path} isActive={isSectionActive && activeItem === id} target={target} key={title} outOfDateConfig={outOfDateConfig} >{title}</NavItem>
+          ? <NavItem to={path} isActive={isSectionActive && activeItem === id} target={target} key={title} >{title}</NavItem>
           : <NavGroup title={title} className='vertical-nav-label' key={title}></NavGroup>
       ))}
     </NavExpandable>


### PR DESCRIPTION
**What this PR does / why we need it**:

We switched to PF4 dark mode in https://github.com/3scale/porta/pull/1525
Now the exclamation mark icon for outdated configuration is missing

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-4353

![outdated](https://user-images.githubusercontent.com/13486237/73343067-32939000-4280-11ea-8500-e1d57d4b074c.png)

