### PR TITLE
[Rails 5] Refactor Test ExtraFieldsTest

### DIFF
--- a/test/unit/extra_fields_test.rb
+++ b/test/unit/extra_fields_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 
-
 class ExtraFieldsTest < ActiveSupport::TestCase
 
   setup do
@@ -8,10 +7,10 @@ class ExtraFieldsTest < ActiveSupport::TestCase
     @buyer = FactoryBot.create :buyer_account, :provider_account => @provider
 
     FactoryBot.create(:fields_definition, :account => @provider, :target => "Account",
-            :name => "provider_extra_field", :required => true)
+                       :name => "provider_extra_field", :required => true)
     FactoryBot.create(:fields_definition, :account => Account.master,
-            :target => "Account",
-            :name => "master_extra_field", :required => true)
+                       :target => "Account",
+                       :name => "master_extra_field", :required => true)
 
     @provider.reload
     @buyer.reload
@@ -32,10 +31,10 @@ class ExtraFieldsTest < ActiveSupport::TestCase
 
   test 'to_xml renders extra_fields' do
     FactoryBot.create(:fields_definition,
-            account: @provider,
-            target: "Account",
-            name: "stuff",
-            choices: ["Orange", "Apple", "Banana"])
+                       account: @provider,
+                       target: "Account",
+                       name: "stuff",
+                       choices: ["Orange", "Apple", "Banana"])
     @buyer.reload
     @buyer.extra_fields = { "stuff"=> "Apple" }
     doc = Nokogiri::XML.parse(@buyer.to_xml)
@@ -47,10 +46,10 @@ class ExtraFieldsTest < ActiveSupport::TestCase
   # Regression test for https://github.com/3scale/system/issues/2752
   test 'to_xml works with multiple valued extra field' do
     FactoryBot.create(:fields_definition,
-            account: @provider,
-            target: "Account",
-            name: "stuff",
-            choices: ["Orange", "Apple", "Banana"])
+                       account: @provider,
+                       target: "Account",
+                       name: "stuff",
+                       choices: ["Orange", "Apple", "Banana"])
     @buyer.reload
     @buyer.extra_fields = { "stuff"=>["Apple", "Orange"] }
 
@@ -61,91 +60,116 @@ class ExtraFieldsTest < ActiveSupport::TestCase
 
   # TODO: make it independent on Account model
   # TODO: remove the shoulda forest
-  context 'extra fields' do
-    context 'validations' do
-      should 'never be done for provider resource' do
-        @provider.extra_fields = { :provider_extra_field => nil }
-        @provider.validate_fields!
-        User.current = @provider.admins.first
+  class ExtrafieldsValidations < ActiveSupport::TestCase
+    setup do
+      @provider = FactoryGirl.create :provider_account
+      @buyer = FactoryGirl.create :buyer_account, :provider_account => @provider
 
-        assert @provider.valid?
-      end
+      FactoryGirl.create(:fields_definition, :account => @provider, :target => "Account",
+                         :name => "provider_extra_field", :required => true)
+      FactoryGirl.create(:fields_definition, :account => Account.master,
+                         :target => "Account",
+                         :name => "master_extra_field", :required => true)
 
-      should 'never be done for master resource' do
-        master = Account.master
-        master.extra_fields = { :master_extra_field => nil }
-        master.validate_fields!
-        User.current = Account.master.admins.first
+      @provider.reload
+      @buyer.reload
+    end
 
-        assert master.extra_fields[:master_extra_field].nil?
-        assert master.valid?
-      end
-    end # validations
+    test 'never be done for provider resource' do
+      @provider.extra_fields = { :provider_extra_field => nil }
+      @provider.validate_fields!
+      User.current = @provider.admins.first
 
-    context 'setters' do
-      should 'set key value defined in FieldsDefinition' do
-        expected = @buyer.extra_fields = { :provider_extra_field => "is set" }
-        @buyer.save!
-        assert_equal expected, @buyer.extra_fields
-      end
+      assert @provider.valid?
+    end
 
-      should 'not set key value not defined in FieldsDefinition' do
-        @buyer.extra_fields = { :non_existant => "is set" }
-        @buyer.save!
-        assert @buyer.extra_fields.empty?
-      end
+    test 'never be done for master resource' do
+      master = Account.master
+      master.extra_fields = { :master_extra_field => nil }
+      master.validate_fields!
+      User.current = Account.master.admins.first
 
-      #beware of this!!!
-      # should 'not set key value not defined in FieldsDefinition using [] notation' do
-      #   @buyer[:extra_fields][:hack] = "attack"
-      #   @buyer.save!
-      #   assert @buyer.extra_fields[:hack].nil?
-      # end
+      assert master.extra_fields[:master_extra_field].nil?
+      assert master.valid?
+    end
+  end
 
-      should 'not remove already set extra_fields' do
-        bar_field = FactoryBot.create(:fields_definition, :account => @provider,
-                            :target => "Account", :name => "deleted_field")
-        @buyer.reload
-        expected = @buyer.extra_fields = { :deleted_field => "exists yet" }
-        @buyer.save!
-        bar_field.destroy
+  class ExtrafieldsSetters < ActiveSupport::TestCase
+    setup do
+      @provider = FactoryGirl.create :provider_account
+      @buyer = FactoryGirl.create :buyer_account, :provider_account => @provider
 
-        @buyer.extra_fields = { :provider_extra_field => "bar" }
-        @buyer.save!
-        assert_equal 'exists yet', @buyer.extra_fields[:deleted_field]
-      end
+      FactoryGirl.create(:fields_definition, :account => @provider, :target => "Account",
+                         :name => "provider_extra_field", :required => true)
+      FactoryGirl.create(:fields_definition, :account => Account.master,
+                         :target => "Account",
+                         :name => "master_extra_field", :required => true)
 
-      should 'override using [] notation' do
-        @buyer.extra_fields = { :provider_extra_field => "[] notation overridable" }
-        @buyer.save!
+      @provider.reload
+      @buyer.reload
+    end
+    test 'set key value defined in FieldsDefinition' do
+      expected = @buyer.extra_fields = { :provider_extra_field => "is set" }
+      @buyer.save!
+      assert_equal expected, @buyer.extra_fields
+    end
 
-        @buyer[:extra_fields] = { }
-        @buyer.save!
-        assert @buyer.extra_fields.empty?
-      end
+    test 'not set key value not defined in FieldsDefinition' do
+      @buyer.extra_fields = { :non_existant => "is set" }
+      @buyer.save!
+      assert @buyer.extra_fields.empty?
+    end
 
-      should 'force encoding on strings' do
-        @buyer.extra_fields = {
-          provider_extra_field: "\xD0\xBF\xD0\xBE\xD0\xBA\xD0\xB0\xD0\xB7\xD1\x8B\xD0\xB2\xD0\xB0\xD1\x82\xD1\x8C \xD0\xBD\xD0\xB0 \xD0\xB1\xD0\xB5\xD1\x81\xD0\xBF\xD0\xBB\xD0\xB0\xD1\x82\xD0\xBD\xD0\xBE\xD0\xBC \xD0\xBF\xD1\x80\xD0\xB8\xD0\xBB\xD0\xBE\xD0\xB6\xD0\xB5\xD0\xBD\xD0\xB8\xD0\xB8 \xD1\x82\xD0\xB0\xD0\xB1\xD0\xBB\xD0\xBE \xD0\xB2\xD1\x8B\xD0\xBB\xD0\xB5\xD1\x82\xD0\xBE\xD0\xB2 \xD1\x81\xD0\xB0\xD0\xBC\xD0\xBE\xD0\xBB\xD0\xB5\xD1\x82\xD0\xBE\xD0\xB2".force_encoding('BINARY')
-        }
+    #beware of this!!!
+    # should 'not set key value not defined in FieldsDefinition using [] notation' do
+    #   @buyer[:extra_fields][:hack] = "attack"
+    #   @buyer.save!
+    #   assert @buyer.extra_fields[:hack].nil?
+    # end
 
-        str = @buyer.extra_fields[:provider_extra_field]
+    test 'not remove already set extra_fields' do
+      bar_field = FactoryBot.create(:fields_definition, :account => @provider,
+                                     :target => "Account", :name => "deleted_field")
+      @buyer.reload
+      expected = @buyer.extra_fields = { :deleted_field => "exists yet" }
+      @buyer.save!
+      bar_field.destroy
 
-        assert_equal Encoding.default_internal, str.encoding
-      end
+      @buyer.extra_fields = { :provider_extra_field => "bar" }
+      @buyer.save!
+      assert_equal 'exists yet', @buyer.extra_fields[:deleted_field]
+    end
 
-      should 'force encoding on the getter' do
-        @buyer.extra_fields[:provider_extra_field] = "\xD0\xBF\xD0\xBE\xD0\xBA\xD0\xB0\xD0\xB7\xD1\x8B\xD0\xB2\xD0\xB0\xD1\x82\xD1\x8C \xD0\xBD\xD0\xB0 \xD0\xB1\xD0\xB5\xD1\x81\xD0\xBF\xD0\xBB\xD0\xB0\xD1\x82\xD0\xBD\xD0\xBE\xD0\xBC \xD0\xBF\xD1\x80\xD0\xB8\xD0\xBB\xD0\xBE\xD0\xB6\xD0\xB5\xD0\xBD\xD0\xB8\xD0\xB8 \xD1\x82\xD0\xB0\xD0\xB1\xD0\xBB\xD0\xBE \xD0\xB2\xD1\x8B\xD0\xBB\xD0\xB5\xD1\x82\xD0\xBE\xD0\xB2 \xD1\x81\xD0\xB0\xD0\xBC\xD0\xBE\xD0\xBB\xD0\xB5\xD1\x82\xD0\xBE\xD0\xB2".force_encoding('BINARY')
+    test 'override using [] notation' do
+      @buyer.extra_fields = { :provider_extra_field => "[] notation overridable" }
+      @buyer.save!
 
-        str = @buyer.extra_fields[:provider_extra_field]
+      @buyer[:extra_fields] = { }
+      @buyer.save!
+      assert @buyer.extra_fields.empty?
+    end
 
-        assert_equal Encoding.default_internal, str.encoding
-      end
-    end # setters
+    test 'force encoding on strings' do
+      @buyer.extra_fields = {
+        provider_extra_field: "\xD0\xBF\xD0\xBE\xD0\xBA\xD0\xB0\xD0\xB7\xD1\x8B\xD0\xB2\xD0\xB0\xD1\x82\xD1\x8C \xD0\xBD\xD0\xB0 \xD0\xB1\xD0\xB5\xD1\x81\xD0\xBF\xD0\xBB\xD0\xB0\xD1\x82\xD0\xBD\xD0\xBE\xD0\xBC \xD0\xBF\xD1\x80\xD0\xB8\xD0\xBB\xD0\xBE\xD0\xB6\xD0\xB5\xD0\xBD\xD0\xB8\xD0\xB8 \xD1\x82\xD0\xB0\xD0\xB1\xD0\xBB\xD0\xBE \xD0\xB2\xD1\x8B\xD0\xBB\xD0\xB5\xD1\x82\xD0\xBE\xD0\xB2 \xD1\x81\xD0\xB0\xD0\xBC\xD0\xBE\xD0\xBB\xD0\xB5\xD1\x82\xD0\xBE\xD0\xB2".force_encoding('BINARY')
+      }
 
-  end # extra fields
+      str = @buyer.extra_fields[:provider_extra_field]
 
-  context 'fields definitions' do
+      assert_equal Encoding.default_internal, str.encoding
+    end
+
+    test 'force encoding on the getter' do
+      @buyer.extra_fields[:provider_extra_field] = "\xD0\xBF\xD0\xBE\xD0\xBA\xD0\xB0\xD0\xB7\xD1\x8B\xD0\xB2\xD0\xB0\xD1\x82\xD1\x8C \xD0\xBD\xD0\xB0 \xD0\xB1\xD0\xB5\xD1\x81\xD0\xBF\xD0\xBB\xD0\xB0\xD1\x82\xD0\xBD\xD0\xBE\xD0\xBC \xD0\xBF\xD1\x80\xD0\xB8\xD0\xBB\xD0\xBE\xD0\xB6\xD0\xB5\xD0\xBD\xD0\xB8\xD0\xB8 \xD1\x82\xD0\xB0\xD0\xB1\xD0\xBB\xD0\xBE \xD0\xB2\xD1\x8B\xD0\xBB\xD0\xB5\xD1\x82\xD0\xBE\xD0\xB2 \xD1\x81\xD0\xB0\xD0\xBC\xD0\xBE\xD0\xBB\xD0\xB5\xD1\x82\xD0\xBE\xD0\xB2".force_encoding('BINARY')
+
+      str = @buyer.extra_fields[:provider_extra_field]
+
+      assert_equal Encoding.default_internal, str.encoding
+    end
+  end # setters
+
+
+  class FieldsDefinitionTest < ActiveSupport::TestCase
     #TODO: do this test in user and cinstance also or find a way of doing
     # shared_examples
     setup do
@@ -155,125 +179,122 @@ class ExtraFieldsTest < ActiveSupport::TestCase
       @master_field = Account.optional_fields.last
 
       @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider,
-                       @provider_field => "") # <= this won't be needed when accounts.org_legaladdress can be null in db
+                                  @provider_field => "") # <= this won't be needed when accounts.org_legaladdress can be null in db
 
       FactoryBot.create(:fields_definition, :account => Account.master,
-              :target => "Account", :name => @master_field, :required => true)
+                         :target => "Account", :name => @master_field, :required => true)
       FactoryBot.create(:fields_definition, :account => @provider, :target => "Account",
-              :name => @provider_field, :required => true)
+                         :name => @provider_field, :required => true)
 
       @provider.reload
       @buyer.reload
     end
+  end
 
-    context 'fields methods' do
-      setup do
-        FactoryBot.create(:fields_definition, :account => @provider,
-                :target => "Account", :name => "extra_field", :required => true)
-      end
-
-      should '#defined_builtin_fields not include extra fields' do
-        assert @buyer.defined_builtin_fields.map(&:name).exclude?("extra_field")
-      end
-
-      should '#fields_to_xml not include extra fields' do
-        @buyer.send "#{@provider_field}=", "builtin"
-        @buyer.extra_fields = { "extra_field" => "extra_field" }
-        @buyer.save!
-        xml = Builder::XmlMarkup.new
-
-        @buyer.fields_to_xml(xml)
-        assert xml.to_s !~ /extra_field/
-      end
+  class FieldsMethods < FieldsDefinitionTest
+    setup do
+      FactoryGirl.create(:fields_definition, :account => @provider,
+                         :target => "Account", :name => "extra_field", :required => true)
     end
 
-    context 'validations' do
+    test '#defined_builtin_fields not include extra fields' do
+      assert @buyer.defined_builtin_fields.map(&:name).exclude?("extra_field")
+    end
 
-      context 'buyer resource' do
+    test '#fields_to_xml not include extra fields' do
+      @buyer.send "#{@provider_field}=", "builtin"
+      @buyer.extra_fields = { "extra_field" => "extra_field" }
+      @buyer.save!
+      xml = Builder::XmlMarkup.new
 
-        should 'not be done by default' do
-          assert @buyer.valid?
-          assert @buyer.errors[@provider_field].empty?
+      @buyer.fields_to_xml(xml)
+      assert xml.to_s !~ /extra_field/
+    end
+  end
+
+  class Validations < FieldsDefinitionTest
+    class BuyerResource < FieldsDefinitionTest
+      test 'resource not be done by default' do
+        assert @buyer.valid?
+        assert @buyer.errors[@provider_field].empty?
+      end
+
+      test 'resource be done if said so' do
+        @buyer.validate_fields!
+
+        assert false == @buyer.valid?
+        assert @buyer.errors[@provider_field].present?
+      end
+
+      class ChoicesFields < FieldsDefinitionTest
+        setup do
+          #OPTIMIZE: better would be not to have this here by rewriting the tests
+          @buyer.reload
+          FactoryGirl.create(:fields_definition,
+                             :account => @provider,
+                             :target => "Account",
+                             :name => "city",
+                             :required => true,
+                             :choices => ["Vic", "Avia"])
+          @buyer.attributes = { @provider_field => "avoiding errors on other field" }
         end
 
-        should 'be done if said so' do
+        test 'be invalid if value is not allowed' do
+          @buyer.city = "Solsona"
           @buyer.validate_fields!
-
-          assert false == @buyer.valid?
-          assert @buyer.errors[@provider_field].present?
+          refute @buyer.valid?
+          assert_not_empty @buyer.errors["city"]
         end
 
-        context 'choices fields' do
-          setup do
-            #OPTIMIZE: better would be not to have this here by rewriting the tests
-            @buyer.reload
-            FactoryBot.create(:fields_definition,
-                    :account => @provider,
-                    :target => "Account",
-                    :name => "city",
-                    :required => true,
-                    :choices => ["Vic", "Avia"])
-            @buyer.attributes = { @provider_field => "avoiding errors on other field" }
-          end
+        test 'be valid if value is allowed' do
+          @buyer.city = "Vic"
+          @buyer.validate_fields!
+          assert @buyer.valid?
+        end
+      end # choices fields
+    end # buyer resource
 
-          should 'be invalid if value is not allowed' do
-            @buyer.city = "Solsona"
-            @buyer.validate_fields!
-            refute @buyer.valid?
-            assert_not_empty @buyer.errors["city"]
-          end
+    test 'never be done for provider resource' do
+      @provider.send "#{@provider_field}=", nil
+      @provider.validate_fields!
 
-          should 'be valid if value is allowed' do
-            @buyer.city = "Vic"
-            @buyer.validate_fields!
-            assert @buyer.valid?
-          end
-        end # choices fields
+      assert @provider.field_value(@provider_field).nil?
+      assert @provider.valid?
+    end
 
-      end # buyer resource
+    test 'never be done for master resource' do
+      master = Account.master
+      master.send "#{@master_field}=", nil
+      master.validate_fields!
 
-      should 'never be done for provider resource' do
-        @provider.send "#{@provider_field}=", nil
-        @provider.validate_fields!
+      assert master.field_value(@master_field).nil?
+      assert master.valid?
+    end
 
-        assert @provider.field_value(@provider_field).nil?
-        assert @provider.valid?
-      end
+  end
 
-      should 'never be done for master resource' do
-        master = Account.master
-        master.send "#{@master_field}=", nil
-        master.validate_fields!
+  class Source < FieldsDefinitionTest
+    test 'be provider fields for existing providers' do
+      @provider.send "#{@master_field}=", nil
+      @provider.validate_fields!
+      assert @provider.valid?
 
-        assert master.field_value(@master_field).nil?
-        assert master.valid?
-      end
+    end
 
-    end # validations
+    test 'be master fields for new providers' do
+      new_provider = Factory.build :provider_account
+      assert new_provider.defined_fields.map(&:name).include?(@master_field)
+    end
+  end # source
 
-    context 'source' do
-      should 'be provider fields for existing providers' do
-        @provider.send "#{@master_field}=", nil
-        @provider.validate_fields!
+  class RequiredFields < FieldsDefinitionTest
+    test 'be created automatically for provider' do
+      provider = Factory.build :provider_account
+      provider.save
 
-        assert @provider.valid?
-      end
+      assert provider.fields_definitions.present?
+      assert provider.fields_definitions.all? { |f| f.required? }
+    end
+  end # required fields
 
-      should 'be master fields for new providers' do
-        new_provider = FactoryBot.build :provider_account
-        assert new_provider.defined_fields.map(&:name).include?(@master_field)
-      end
-    end # source
-
-    context 'required fields' do
-      should 'be created automatically for provider' do
-        provider = FactoryBot.build :provider_account
-        provider.save
-
-        assert provider.fields_definitions.present?
-        assert provider.fields_definitions.all? { |f| f.required? }
-      end
-    end # required fields
-
-  end # fields definitions
 end

--- a/test/unit/extra_fields_test.rb
+++ b/test/unit/extra_fields_test.rb
@@ -2,81 +2,77 @@ require 'test_helper'
 
 class ExtraFieldsTest < ActiveSupport::TestCase
 
-  setup do
-    @provider = FactoryBot.create :provider_account
-    @buyer = FactoryBot.create :buyer_account, :provider_account => @provider
-
-    FactoryBot.create(:fields_definition, :account => @provider, :target => "Account",
-                       :name => "provider_extra_field", :required => true)
-    FactoryBot.create(:fields_definition, :account => Account.master,
-                       :target => "Account",
-                       :name => "master_extra_field", :required => true)
+  def setup
+    @provider = FactoryBot.create(:provider_account, provider_account: master_account)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
 
     @provider.reload
     @buyer.reload
   end
 
-  test 'extra_fields not validated by default' do
-    assert @buyer.valid?
-  end
+  class FieldsDefinitionTest < ExtraFieldsTest
 
-  test '#validate_fields!' do
-    # extra fields are validated on demand only
-    @buyer.validate_fields!
-    User.current = @buyer.admins.first
+    def setup
+      super
 
-    refute @buyer.valid?
-    assert_not_empty @buyer.errors["provider_extra_field"]
-  end
+      @provider_field = Account.optional_fields.first
+      @master_field = Account.optional_fields.last
 
-  test 'to_xml renders extra_fields' do
-    FactoryBot.create(:fields_definition,
-                       account: @provider,
-                       target: "Account",
-                       name: "stuff",
-                       choices: ["Orange", "Apple", "Banana"])
-    @buyer.reload
-    @buyer.extra_fields = { "stuff"=> "Apple" }
-    doc = Nokogiri::XML.parse(@buyer.to_xml)
+      @buyer.update!({@provider_field => ''}) # this won't be needed when accounts.org_legaladdress can be null in db
 
-    assert_equal 1, doc.xpath('//extra_fields/stuff').size
-    assert_equal 'Apple', doc.xpath('//extra_fields/stuff').first.text
-  end
+      FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'provider_extra_field', required: true)
+      FactoryBot.create(:fields_definition, account: master_account, target: 'Account', name: 'master_extra_field', required: true)
 
-  # Regression test for https://github.com/3scale/system/issues/2752
-  test 'to_xml works with multiple valued extra field' do
-    FactoryBot.create(:fields_definition,
-                       account: @provider,
-                       target: "Account",
-                       name: "stuff",
-                       choices: ["Orange", "Apple", "Banana"])
-    @buyer.reload
-    @buyer.extra_fields = { "stuff"=>["Apple", "Orange"] }
-
-    doc = Nokogiri::XML.parse(@buyer.to_xml)
-    assert_equal ['Apple', 'Orange'], doc.xpath('//extra_fields/stuff').map(&:text)
-  end
-
-
-  # TODO: make it independent on Account model
-  # TODO: remove the shoulda forest
-  class ExtrafieldsValidations < ActiveSupport::TestCase
-    setup do
-      @provider = FactoryGirl.create :provider_account
-      @buyer = FactoryGirl.create :buyer_account, :provider_account => @provider
-
-      FactoryGirl.create(:fields_definition, :account => @provider, :target => "Account",
-                         :name => "provider_extra_field", :required => true)
-      FactoryGirl.create(:fields_definition, :account => Account.master,
-                         :target => "Account",
-                         :name => "master_extra_field", :required => true)
+      FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: @provider_field, required: true)
+      FactoryBot.create(:fields_definition, account: master_account, target: 'Account', name: @master_field, required: true)
 
       @provider.reload
       @buyer.reload
     end
 
+    test 'extra_fields not validated by default' do
+      assert @buyer.valid?
+    end
+
+    test '#validate_fields!' do
+      # extra fields are validated on demand only
+      @buyer.validate_fields!
+      User.current = @buyer.admins.first
+
+      assert_not @buyer.valid?
+      assert_not_empty @buyer.errors['provider_extra_field']
+    end
+
+    test 'to_xml renders extra_fields' do
+      FactoryBot.create(:fields_definition,
+                         account: @provider,
+                         target: 'Account',
+                         name: 'stuff',
+                         choices: %w[Orange Apple Banana])
+      @buyer.reload
+      @buyer.extra_fields = { 'stuff' => 'Apple' }
+      doc = Nokogiri::XML.parse(@buyer.to_xml)
+
+      assert_equal 1, doc.xpath('//extra_fields/stuff').size
+      assert_equal 'Apple', doc.xpath('//extra_fields/stuff').first.text
+    end
+
+    # Regression test for https://github.com/3scale/system/issues/2752
+    test 'to_xml works with multiple valued extra field' do
+      FactoryBot.create(:fields_definition,
+                         account: @provider,
+                         target: 'Account',
+                         name: 'stuff',
+                         choices: %w[Orange Apple Banana])
+      @buyer.reload
+      @buyer.extra_fields = { 'stuff' => %w[Apple Orange] }
+
+      doc = Nokogiri::XML.parse(@buyer.to_xml)
+      assert_equal %w[Apple Orange], doc.xpath('//extra_fields/stuff').map(&:text)
+    end
+
     test 'never be done for provider resource' do
-      @provider.extra_fields = { :provider_extra_field => nil }
+      @provider.extra_fields = { provider_extra_field: nil }
       @provider.validate_fields!
       User.current = @provider.admins.first
 
@@ -84,64 +80,40 @@ class ExtraFieldsTest < ActiveSupport::TestCase
     end
 
     test 'never be done for master resource' do
-      master = Account.master
-      master.extra_fields = { :master_extra_field => nil }
-      master.validate_fields!
-      User.current = Account.master.admins.first
+      master_account.extra_fields = { master_extra_field: nil }
+      master_account.validate_fields!
+      User.current = master_account.admins.first!
 
-      assert master.extra_fields[:master_extra_field].nil?
-      assert master.valid?
+      assert master_account.extra_fields[:master_extra_field].nil?
+      assert master_account.valid?
     end
-  end
 
-  class ExtrafieldsSetters < ActiveSupport::TestCase
-    setup do
-      @provider = FactoryGirl.create :provider_account
-      @buyer = FactoryGirl.create :buyer_account, :provider_account => @provider
-
-      FactoryGirl.create(:fields_definition, :account => @provider, :target => "Account",
-                         :name => "provider_extra_field", :required => true)
-      FactoryGirl.create(:fields_definition, :account => Account.master,
-                         :target => "Account",
-                         :name => "master_extra_field", :required => true)
-
-      @provider.reload
-      @buyer.reload
-    end
     test 'set key value defined in FieldsDefinition' do
-      expected = @buyer.extra_fields = { :provider_extra_field => "is set" }
+      expected = @buyer.extra_fields = { provider_extra_field: 'is set' }
       @buyer.save!
       assert_equal expected, @buyer.extra_fields
     end
 
     test 'not set key value not defined in FieldsDefinition' do
-      @buyer.extra_fields = { :non_existant => "is set" }
+      @buyer.extra_fields = { non_existant: 'is set' }
       @buyer.save!
       assert @buyer.extra_fields.empty?
     end
 
-    #beware of this!!!
-    # should 'not set key value not defined in FieldsDefinition using [] notation' do
-    #   @buyer[:extra_fields][:hack] = "attack"
-    #   @buyer.save!
-    #   assert @buyer.extra_fields[:hack].nil?
-    # end
-
     test 'not remove already set extra_fields' do
-      bar_field = FactoryBot.create(:fields_definition, :account => @provider,
-                                     :target => "Account", :name => "deleted_field")
+      bar_field = FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'deleted_field')
       @buyer.reload
-      expected = @buyer.extra_fields = { :deleted_field => "exists yet" }
+      @buyer.extra_fields = { deleted_field: 'exists yet' }
       @buyer.save!
       bar_field.destroy
 
-      @buyer.extra_fields = { :provider_extra_field => "bar" }
+      @buyer.extra_fields = { provider_extra_field: 'bar' }
       @buyer.save!
       assert_equal 'exists yet', @buyer.extra_fields[:deleted_field]
     end
 
     test 'override using [] notation' do
-      @buyer.extra_fields = { :provider_extra_field => "[] notation overridable" }
+      @buyer.extra_fields = { provider_extra_field: '[] notation overridable' }
       @buyer.save!
 
       @buyer[:extra_fields] = { }
@@ -166,95 +138,45 @@ class ExtraFieldsTest < ActiveSupport::TestCase
 
       assert_equal Encoding.default_internal, str.encoding
     end
-  end # setters
 
+    test 'FieldsMethods #defined_builtin_fields not include extra fields' do
+      FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'extra_field', required: true)
 
-  class FieldsDefinitionTest < ActiveSupport::TestCase
-    #TODO: do this test in user and cinstance also or find a way of doing
-    # shared_examples
-    setup do
-      @provider = FactoryBot.create :provider_account
-
-      @provider_field = Account.optional_fields.first
-      @master_field = Account.optional_fields.last
-
-      @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider,
-                                  @provider_field => "") # <= this won't be needed when accounts.org_legaladdress can be null in db
-
-      FactoryBot.create(:fields_definition, :account => Account.master,
-                         :target => "Account", :name => @master_field, :required => true)
-      FactoryBot.create(:fields_definition, :account => @provider, :target => "Account",
-                         :name => @provider_field, :required => true)
-
-      @provider.reload
-      @buyer.reload
-    end
-  end
-
-  class FieldsMethods < FieldsDefinitionTest
-    setup do
-      FactoryGirl.create(:fields_definition, :account => @provider,
-                         :target => "Account", :name => "extra_field", :required => true)
+      assert @buyer.defined_builtin_fields.map(&:name).exclude?('extra_field')
     end
 
-    test '#defined_builtin_fields not include extra fields' do
-      assert @buyer.defined_builtin_fields.map(&:name).exclude?("extra_field")
-    end
+    test 'FieldsMethods #fields_to_xml not include extra fields' do
+      FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'extra_field', required: true)
 
-    test '#fields_to_xml not include extra fields' do
-      @buyer.send "#{@provider_field}=", "builtin"
-      @buyer.extra_fields = { "extra_field" => "extra_field" }
+      @buyer.send "#{@provider_field}=", 'builtin'
+      @buyer.extra_fields = { 'extra_field' => 'extra_field' }
       @buyer.save!
       xml = Builder::XmlMarkup.new
 
       @buyer.fields_to_xml(xml)
       assert xml.to_s !~ /extra_field/
     end
-  end
 
-  class Validations < FieldsDefinitionTest
-    class BuyerResource < FieldsDefinitionTest
-      test 'resource not be done by default' do
-        assert @buyer.valid?
-        assert @buyer.errors[@provider_field].empty?
-      end
+    test 'Source be provider fields for existing providers' do
+      @provider.send "#{@master_field}=", nil
+      @provider.validate_fields!
+      assert @provider.valid?
 
-      test 'resource be done if said so' do
-        @buyer.validate_fields!
+    end
 
-        assert false == @buyer.valid?
-        assert @buyer.errors[@provider_field].present?
-      end
+    test 'Source be master fields for new providers' do
+      new_provider = FactoryBot.build(:provider_account)
+      assert new_provider.defined_fields.map(&:name).include?(@master_field)
+    end
 
-      class ChoicesFields < FieldsDefinitionTest
-        setup do
-          #OPTIMIZE: better would be not to have this here by rewriting the tests
-          @buyer.reload
-          FactoryGirl.create(:fields_definition,
-                             :account => @provider,
-                             :target => "Account",
-                             :name => "city",
-                             :required => true,
-                             :choices => ["Vic", "Avia"])
-          @buyer.attributes = { @provider_field => "avoiding errors on other field" }
-        end
+    test 'RequiredFields be created automatically for provider' do
+      provider = FactoryBot.create(:provider_account)
 
-        test 'be invalid if value is not allowed' do
-          @buyer.city = "Solsona"
-          @buyer.validate_fields!
-          refute @buyer.valid?
-          assert_not_empty @buyer.errors["city"]
-        end
+      assert provider.fields_definitions.present?
+      assert provider.fields_definitions.all?(&:required?)
+    end
 
-        test 'be valid if value is allowed' do
-          @buyer.city = "Vic"
-          @buyer.validate_fields!
-          assert @buyer.valid?
-        end
-      end # choices fields
-    end # buyer resource
-
-    test 'never be done for provider resource' do
+    test 'Validations never be done for provider resource' do
       @provider.send "#{@provider_field}=", nil
       @provider.validate_fields!
 
@@ -262,39 +184,47 @@ class ExtraFieldsTest < ActiveSupport::TestCase
       assert @provider.valid?
     end
 
-    test 'never be done for master resource' do
-      master = Account.master
-      master.send "#{@master_field}=", nil
-      master.validate_fields!
+    test 'Validations never be done for master resource' do
+      master_account.send "#{@master_field}=", nil
+      master_account.validate_fields!
 
-      assert master.field_value(@master_field).nil?
-      assert master.valid?
+      assert master_account.field_value(@master_field).nil?
+      assert master_account.valid?
+    end
+
+    test 'Validations BuyerResource resource not be done by default' do
+      assert @buyer.valid?
+      assert @buyer.errors[@provider_field].empty?
+    end
+
+    test 'Validations BuyerResource resource be done if said so' do
+      @buyer.validate_fields!
+
+      assert_not @buyer.valid?
+      assert @buyer.errors[@provider_field].present?
     end
 
   end
 
-  class Source < FieldsDefinitionTest
-    test 'be provider fields for existing providers' do
-      @provider.send "#{@master_field}=", nil
-      @provider.validate_fields!
-      assert @provider.valid?
+  class ChoicesFieldsTest < ExtraFieldsTest
 
+    def setup
+      super
+      FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'city', required: true, choices: %w[Vic Avia])
     end
 
-    test 'be master fields for new providers' do
-      new_provider = Factory.build :provider_account
-      assert new_provider.defined_fields.map(&:name).include?(@master_field)
+    test 'be invalid if value is not allowed' do
+      @buyer.city = 'Solsona'
+      @buyer.validate_fields!
+      assert_not @buyer.valid?
+      assert_not_empty @buyer.errors['city']
     end
-  end # source
 
-  class RequiredFields < FieldsDefinitionTest
-    test 'be created automatically for provider' do
-      provider = Factory.build :provider_account
-      provider.save
-
-      assert provider.fields_definitions.present?
-      assert provider.fields_definitions.all? { |f| f.required? }
+    test 'be valid if value is allowed' do
+      @buyer.city = 'Vic'
+      @buyer.validate_fields!
+      assert @buyer.valid?
     end
-  end # required fields
+  end
 
 end

--- a/test/unit/extra_fields_test.rb
+++ b/test/unit/extra_fields_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ExtraFieldsTest < ActiveSupport::TestCase
 
   def setup
-    @provider = FactoryBot.create(:provider_account, provider_account: master_account)
+    @provider = FactoryBot.create(:provider_account)
     @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
 
     @provider.reload


### PR DESCRIPTION
The main goal is to remove the shoulda syntax to be able to run any test in isolation :smile: but the PR also improves the test in other ways :smile: 