### PR TITLE
[Rails 5] ActionController::Parameters will not have #to_a

### DIFF
--- a/app/presenters/dashboard_widget_presenter.rb
+++ b/app/presenters/dashboard_widget_presenter.rb
@@ -41,7 +41,7 @@ class DashboardWidgetPresenter
   end
 
   def id
-    "dashboard-widget-#{params.to_a.join('-')}#{name}"
+    "dashboard-widget-#{params.to_h.to_a.join('-')}#{name}"
   end
 
   def template_name


### PR DESCRIPTION
Extracted from https://github.com/3scale/porta/pull/4/commits/65ebd218ee23d5f887d54dec9cff0d65d6ca30cb