### PR TITLE
[Rails 5] ProviderInvitationMailerTest Use assert_difference with block

### DIFF
--- a/test/unit/mailers/provider_invitation_mailer_test.rb
+++ b/test/unit/mailers/provider_invitation_mailer_test.rb
@@ -9,8 +9,9 @@ class ProviderInvitationMailerTest < ActionMailer::TestCase
   end
 
   test 'deliver' do
-    @provider_invitation_email.deliver_now
-    assert_equal 1, ActionMailer::Base.deliveries.count
+    assert_difference ActionMailer::Base.deliveries.method(:count) do
+      @provider_invitation_email.deliver_now
+    end
   end
 
   test 'is sent to the invited provider' do


### PR DESCRIPTION
Extracted from https://github.com/3scale/porta/pull/4/commits/2834e501511638f18de23cdefdd9cdc3cfa6a1f3