### PR TITLE
[WIP][Rails 5] Add activemodel-serializers-xml as it was removed from Rails 5

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -10,6 +10,11 @@ gem 'aws-sdk', '~> 2'
 gem 'aws-sdk-rails', '~> 1.0'
 
 gem 'dotenv-rails', '~> 2.7'
+
+# Needed for XML serialization of ActiveRecord::Base
+gem 'activemodel-serializers-xml'
+
+gem 'protected_attributes_continued', '~> 1.3.0'
 gem 'rails', '4.2.11.1'
 #gem 'rails', '5.0.6'
 #gem 'activesupport', '4.2.9' # somehow paperclip needs to explicitly lock the version to not use 5.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -803,6 +803,7 @@ DEPENDENCIES
   active-docs!
   active_merchant-adyen12!
   activemerchant (~> 1.77.0)
+  activemodel-serializers-xml
   activerecord-oracle_enhanced-adapter (~> 1.6.0)
   acts-as-taggable-on (~> 4.0)
   acts_as_list (~> 0.9.17)

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -804,6 +804,7 @@ DEPENDENCIES
   active-docs!
   active_merchant-adyen12!
   activemerchant (~> 1.77.0)
+  activemodel-serializers-xml
   activerecord-oracle_enhanced-adapter (~> 1.6.0)
   acts-as-taggable-on (~> 4.0)
   acts_as_list (~> 0.9.17)


### PR DESCRIPTION
Extracted from https://github.com/3scale/porta/pull/4/commits/def3c88adfcd7f32df915e07b02d2eabd94a639c

I dunno if this should work without Rails 5 so we'll see :woman_shrugging: 