### PR TITLE
[Rails 5] Remove config.allow_concurrency = false. It causes the session to be reset

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,8 +4,6 @@ System::Application.configure do
   # Disable css/jquery animations in tests, makes percy much happier
   config.middleware.use Rack::NoAnimations
 
-  config.allow_concurrency = false
-
   # The test environment is used exclusively to run your application's
   # test suite.  You never need to work with it otherwise.  Remember that
   # your test database is "scratch space" for the test suite and is wiped


### PR DESCRIPTION
Extracted from https://github.com/3scale/porta/pull/4/commits/2c3deee3cfb5a83768151e451bcfb34c92ce7578