### PR TITLE
[WIP] [Rails 5] I18n.t('date.formats.long') output has changed

### DIFF
--- a/test/integration/finance/charging_invoice_states_test.rb
+++ b/test/integration/finance/charging_invoice_states_test.rb
@@ -47,8 +47,8 @@ class Finance::ChargingInvoiceStatesTest < ActionDispatch::IntegrationTest
 
       @invoice.buyer_account.bought_plan.update_attributes!(name: 'Paid', cost_per_month: 100)
 
-      ThreeScale::Analytics.expects(:track).with(instance_of(User), 'Charged Invoice',
-                                                 {:plan => 'Paid', :period => 'January  1, 1984 - January 31, 1984', :revenue => 100.0})
+      ThreeScale::Analytics.expects(:track).with(@provider.first_admin, 'Charged Invoice',
+                                                 {:plan => 'Paid', :period => 'January 01, 1984 - January 31, 1984', :revenue => 100.0})
 
       @invoice.charge!
       assert @invoice.paid?, 'Should be paid after successful charge'


### PR DESCRIPTION
Extracted from https://github.com/3scale/porta/pull/4/commits/66bc5ef3a1a1208c67ab53f0ce16e718d4c72730
