### PR TITLE
Moving icon to submenu when expanded

### DIFF
--- a/app/assets/stylesheets/provider/_vertical_nav.scss
+++ b/app/assets/stylesheets/provider/_vertical_nav.scss
@@ -1,3 +1,12 @@
+@mixin outdatedIcon {
+  content: '\f071';
+  font-family: FontAwesome;
+  font-weight: normal;
+  position: absolute;
+  right: line-height-times(3);
+  top: line-height-times(1 / 3);
+}
+
 .pf-c-page__sidebar {
   text-align: left;
 
@@ -7,12 +16,19 @@
   }
 
   // scss-lint:disable SelectorFormat
-  .pf-c-nav__item.outdated-config::before {
-    content: '\f071';
-    font-family: FontAwesome;
-    font-weight: normal;
-    position: absolute;
-    right: line-height-times(3);
-    top: line-height-times(1 / 3);
+  .pf-c-nav__item {
+    &.outdated-config {
+      &:not(.pf-m-expanded)::before {
+        @include outdatedIcon;
+      }
+
+      .pf-c-nav__subnav {
+        // scss-lint:disable SelectorDepth
+        .pf-c-nav__item:first-child::before {
+          @include outdatedIcon;
+          top: line-height-times(2);
+        }
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/provider/_vertical_nav.scss
+++ b/app/assets/stylesheets/provider/_vertical_nav.scss
@@ -1,12 +1,3 @@
-@mixin outdatedIcon {
-  content: '\f071';
-  font-family: FontAwesome;
-  font-weight: normal;
-  position: absolute;
-  right: line-height-times(3);
-  top: line-height-times(1 / 3);
-}
-
 .pf-c-page__sidebar {
   text-align: left;
 
@@ -17,18 +8,13 @@
 
   // scss-lint:disable SelectorFormat
   .pf-c-nav__item {
-    &.outdated-config {
-      &:not(.pf-m-expanded)::before {
-        @include outdatedIcon;
-      }
-
-      .pf-c-nav__subnav {
-        // scss-lint:disable SelectorDepth
-        .pf-c-nav__item:first-child::before {
-          @include outdatedIcon;
-          top: line-height-times(2);
-        }
-      }
+    &.outdated-config:not(.pf-m-expanded) > a::before {
+      content: '\f071';
+      float: right;
+      font-family: FontAwesome;
+      font-weight: normal;
+      left: line-height-times(9);
+      position: absolute;
     }
   }
 }

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -242,7 +242,7 @@ module VerticalNavHelper
 
   def service_integration_items
     items = []
-    items << {id: :configuration,       title: 'Configuration',     path: path_to_service(@service)}
+    items << {id: :configuration,       title: 'Configuration',     path: path_to_service(@service), itemOutOfDateConfig: has_out_of_date_configuration?(@service)}
     items << {id: :methods_metrics,     title: 'Methods & Metrics', path: admin_service_metrics_path(@service)}
     items << {id: :mapping_rules,       title: 'Mapping Rules',     path: admin_service_proxy_rules_path(@service)} if current_account.independent_mapping_rules_enabled?
     if current_account.provider_can_use?(:api_as_product)

--- a/app/javascript/src/Navigation/components/VerticalNav.jsx
+++ b/app/javascript/src/Navigation/components/VerticalNav.jsx
@@ -8,7 +8,8 @@ type Item = {
   id: string,
   title: string,
   path: ?string,
-  target: ?string
+  target: ?string,
+  itemOutOfDateConfig: ?boolean
 }
 
 type Section = Item & {
@@ -39,9 +40,9 @@ const VerticalNav = ({ sections, activeSection, activeItem }: Props) => (
 const NavSection = ({title, isSectionActive, activeItem, items, outOfDateConfig}) => {
   return (
     <NavExpandable title={title} isActive={isSectionActive} isExpanded={isSectionActive} className={outOfDateConfig ? 'outdated-config' : ''}>
-      {items.map(({id, title, path, target}) => (
+      {items.map(({id, title, path, target, itemOutOfDateConfig}) => (
         path
-          ? <NavItem to={path} isActive={isSectionActive && activeItem === id} target={target} key={title} >{title}</NavItem>
+          ? <NavItem to={path} isActive={isSectionActive && activeItem === id} target={target} key={title} className={itemOutOfDateConfig ? 'outdated-config' : ''}>{title}</NavItem>
           : <NavGroup title={title} className='vertical-nav-label' key={title}></NavGroup>
       ))}
     </NavExpandable>


### PR DESCRIPTION
**What this PR does / why we need it**:

Outdated icon in vertical nav bar should be displayed in **Integration** when menu collapsed, then move to **Configuration** when menu expanded

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-4392

![move-icon2](https://user-images.githubusercontent.com/13486237/73653327-3e6cc100-4689-11ea-9ac4-6105fbddf906.gif)


