### PR TITLE
[Rails 5] Fix Tests: Pdf::Finance::InvoiceReportDataTest & NotificationMailerTest

### DIFF
--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -435,7 +435,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     end
 
     # anonymous user
-    post.user = nil
+    post.stubs(user: nil)
 
     no_user_event = Posts::PostCreatedEvent.create(post)
     not_user_mail = NotificationMailer.post_created(no_user_event, receiver)

--- a/test/unit/pdf/finance/invoice_report_data_test.rb
+++ b/test/unit/pdf/finance/invoice_report_data_test.rb
@@ -83,7 +83,7 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
   # Regression test for https://3scale.hoptoadapp.com/errors/7206313
   #
   test 'not be vulnerable to XSS attack' do
-    @provider.org_name = '<ScRipT>alert("address1")</ScRipT>'
+    @provider.update_attribute(:org_name, '<ScRipT>alert("address1")</ScRipT>')
     assert_equal @data.provider[0][1], '&lt;ScRipT&gt;alert(&quot;address1&quot;)&lt;/ScRipT&gt;'
   end
 end


### PR DESCRIPTION
I've extracted here a small part of this commit https://github.com/3scale/porta/pull/4/commits/d3f4aa7e58a5a30c26b6cfc83f029d42209c603d
Part will be extracted to another PR with more changes, and there is part that cannot be extracted.