### PR TITLE
Fix proxy affecting changes event not issued on Settings update

### DIFF
--- a/app/lib/proxy_config_affecting_changes.rb
+++ b/app/lib/proxy_config_affecting_changes.rb
@@ -62,6 +62,21 @@ module ProxyConfigAffectingChanges
     end
   end
 
+  module ServiceExtension
+    extend ActiveSupport::Concern
+
+    included do
+      include ProxyConfigAffectingChanges
+
+      after_commit :issue_proxy_affecting_change_events, on: :update
+
+      def issue_proxy_affecting_change_events
+        return unless previously_changed?(:backend_version)
+        issue_proxy_affecting_change_event(proxy)
+      end
+    end
+  end
+
   module BackendApiConfigExtension
     extend ActiveSupport::Concern
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -11,6 +11,7 @@ class Service < ApplicationRecord
   include SystemName
   extend System::Database::Scopes::IdOrSystemName
   include ServiceDiscovery::ModelExtensions::Service
+  include ProxyConfigAffectingChanges::ServiceExtension
 
   self.background_deletion = [
     :service_plans,


### PR DESCRIPTION
This PR ensures that proxy config affecting changes events are issued when the `Service`'s `backend_version` attribute changes. In theory, this should not be needed, because changing `backend_version` also causes the `Proxy`'s `authentication_method` to change, and this one is tracked already as a so called "proxy config affecting change". The problem is that sometimes we change both the service and the proxy together, the service "autosaves" the proxy, but yet the callback fails to catch `authentication_method` among the `previous_changes` and the event is never issued.

With this PR, we will issue redundant events, which is not great resources-wise, but acceptable for now. Important to recall that the event for proxy config affecting changes is idempotent.

In the future, we should replace those `after_commit` callbacks with a more intelligent mechanism to track the changes in the models.