### PR TITLE
OAS3: Cleaning up tests

### DIFF
--- a/features/old/liquid/active_docs_v3.feature
+++ b/features/old/liquid/active_docs_v3.feature
@@ -7,8 +7,6 @@ Feature: ActiveDocs
     Given a provider "foo.example.com"
     And the current provider is foo.example.com
 
-  # FIXME packs are not loaded
-  @wip
   Scenario: Loading new Swagger template with javascript packs
     Given provider "foo.example.com" has the swagger example of signup
     And the provider has cms page "/swagger-ui-3" with:
@@ -18,6 +16,8 @@ Feature: ActiveDocs
     {% endcontent_for %}
 
     <h3>ActiveDocs version 3</h3>
+
+    <div id="swagger-ui-container">
 
     <script type="text/javascript">
       (function () {

--- a/features/old/providers/active_docs_v3.feature
+++ b/features/old/providers/active_docs_v3.feature
@@ -98,7 +98,7 @@ Feature: ActiveDocs
     When I delete the API Spec
     Then I should see "ActiveDocs Spec was successfully deleted."
 
-  # TODO: not sure if supported
+  # TODO: feature not supported. Wait for plugins.
   @wip
   Scenario: OAS 3 and autocomplete
     When I go to the new active docs page
@@ -144,7 +144,7 @@ Feature: ActiveDocs
     Then should see "ActiveDocs Spec was successfully saved."
     And the swagger v3 autocomplete should work for "user_key" with "user_keys"
 
-  # TODO: not sure what to assert
+  # TODO: feature not supported. Wait for plugins.
   @wip
   Scenario: OAS 3 and slashes generated curl command for header values
     When I go to the new active docs page
@@ -168,7 +168,7 @@ Feature: ActiveDocs
               {
                 "name": "user_key",
                 "x-data-threescale-name": "user_keys",
-                "in": "query",
+                "in": "header",
                 "description": "Your API access key",
                 "required": true,
                 "schema": {

--- a/features/provider/active_docs.feature
+++ b/features/provider/active_docs.feature
@@ -23,5 +23,3 @@ Feature: ActiveDocs pages
     When I select a service from the service selector
      And I try to create the active docs with valid data
     Then the api doc spec is saved with this service linked
-
-  # TODO: add here scenarios for OAS3 specs (instead of features/old?)

--- a/features/services/active_docs.feature
+++ b/features/services/active_docs.feature
@@ -22,5 +22,3 @@ Feature: ActiveDocs pages
     When I try to create the active docs of the service with invalid data
     Then I should see the active docs errors in the page
      And the service selector is not in the form
-
-  # TODO: add here scenarios for OAS3 specs (instead of features/old?)

--- a/features/step_definitions/active_docs_steps.rb
+++ b/features/step_definitions/active_docs_steps.rb
@@ -41,28 +41,6 @@ Then(/^the swagger autocomplete should work for "(.*?)" with "(.*?)"$/) do |inpu
   assert_equal 1, evaluate_script("$('.apidocs-param-tips.#{autocomplete}:visible').length")
 end
 
-Then(/^the swagger v3 autocomplete should work for "(.*?)" with "(.*?)"$/) do |input_name, autocomplete|
-  id = 'default' # Could be passed as arg
-  section_id = "#operations-tag-#{id}"
-
-  closed_section = find("#{section_id}[data-is-open='false']")
-  closed_section&.click
-
-  within section_id do
-    method_id = "operations-#{id}-get_"
-    closed_method = find(method_id)
-    closed_method&.click
-
-    within method_id do
-      input = find("[data-param-name='#{input_name}'] input")
-      click_on 'Try it out'
-      # TODO: do the actual assertion
-      assert_equal 1, evaluate_script("$('[data-param-name='#{input_name}'] input').focus().length")
-      assert_equal 1, evaluate_script("$('.apidocs-param-tips.#{autocomplete}:visible').length")
-    end
-  end
-end
-
 Then 'I fill in the API JSON Spec with:' do |spec|
   selector = 'textarea#api_docs_service_body ~ .CodeMirror'
 

--- a/features/step_definitions/api_docs_step.rb
+++ b/features/step_definitions/api_docs_step.rb
@@ -73,28 +73,21 @@ Then(/^swagger v3 should escape properly the curl string$/) do
   section_id = "#operations-tag-#{id}"
 
   closed_section = find("#{section_id}[data-is-open='false']")
-  closed_section&.click
+  closed_section.click
 
-  within section_id do
-    method_id = "#operations-#{id}-get_"
-    closed_method = find(method_id)
-    closed_method&.click
+  method_id = "#operations-#{id}-get_"
+  closed_method = find(method_id)
+  closed_method.click
 
-    within method_id do
-      click_on 'Try it out'
-      input_name = 'user_key'
-      input = find("[data-param-name='#{input_name}'] input")
-      input.set 'Authorization: Oauth:"test"'
+  within method_id do
+    click_on 'Try it out'
+    input_name = 'user_key'
+    input = find("[data-param-name='#{input_name}'] input")
+    input.set 'Authorization: Oauth:"test"'
 
-      click_on 'Execute'
-      # TODO: inputs dont have id in swagger 3???
-      within '.block.curl' do
-        within 'pre' do
-          find('.curl').should have_content('Authorization: Oauth:"test"')
-          page.should have_content('Authorization: Oauth:"test"')
-        end
-      end
-    end
+    click_on 'Execute'
+
+    find('textarea.curl').should have_content('-H Authorization: Oauth:\"test\"')
   end
 end
 


### PR DESCRIPTION
Tests were left half done due to time constraints. This PR is to make sure all necessary tests are present and the ones that are not yet supported (due to lack of plugins) are properly marked as `@wip`.