### PR TITLE
[Refactor] Make some workers inherit from ApplicationJob

### DIFF
--- a/app/services/messages/destroy_all_service.rb
+++ b/app/services/messages/destroy_all_service.rb
@@ -1,5 +1,6 @@
-class Messages::DestroyAllService
+# frozen_string_literal: true
 
+class Messages::DestroyAllService
   def self.run!(account:, association_class:, scope:)
     association_class
       .of_account(account)
@@ -7,6 +8,6 @@ class Messages::DestroyAllService
       .update_all(deleted_at: DateTime.now)
 
     # hard destroy as background job
-    DestroyAllDeletedObjectsWorker.perform_async(association_class.to_s)
+    DestroyAllDeletedObjectsWorker.perform_later(association_class.to_s)
   end
 end

--- a/app/workers/delete_plain_object_worker.rb
+++ b/app/workers/delete_plain_object_worker.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# TODO: Rails 5 --> class DeletePlainObjectWorker < ApplicationJob
-class DeletePlainObjectWorker < ActiveJob::Base
+class DeletePlainObjectWorker < ApplicationJob
 
   # TODO: Rails 5 --> discard_on ActiveJob::DeserializationError, ActiveRecord::RecordNotFound
   rescue_from(ActiveJob::DeserializationError, ActiveRecord::RecordNotFound) do |exception|

--- a/app/workers/destroy_all_deleted_objects_worker.rb
+++ b/app/workers/destroy_all_deleted_objects_worker.rb
@@ -1,6 +1,6 @@
-class DestroyAllDeletedObjectsWorker
-  include Sidekiq::Worker
+# frozen_string_literal: true
 
+class DestroyAllDeletedObjectsWorker < ApplicationJob
   def perform(class_name)
     class_name.constantize.deleted.find_each(&DeleteObjectHierarchyWorker.method(:perform_later))
   end

--- a/app/workers/proxy_config_affecting_change_worker.rb
+++ b/app/workers/proxy_config_affecting_change_worker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProxyConfigAffectingChangeWorker < ActiveJob::Base # rubocop:disable Rails/ApplicationJob
+class ProxyConfigAffectingChangeWorker < ApplicationJob
   def perform(event_id)
     event = EventStore::Repository.find_event!(event_id)
     proxy = Proxy.find(event.proxy_id)

--- a/app/workers/publish_enabled_changed_event_for_provider_applications_worker.rb
+++ b/app/workers/publish_enabled_changed_event_for_provider_applications_worker.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# TODO: Rails 5 --> class PublishEnabledChangedEventForProviderApplicationsWorker < ApplicationJob
-class PublishEnabledChangedEventForProviderApplicationsWorker < ActiveJob::Base
+class PublishEnabledChangedEventForProviderApplicationsWorker < ApplicationJob
   rescue_from(ActiveJob::DeserializationError) do |exception|
     Rails.logger.info "PublishEnabledChangedEventForProviderApplicationsWorker#perform raised #{exception.class} with message #{exception.message}"
   end

--- a/app/workers/purge_stale_objects_worker.rb
+++ b/app/workers/purge_stale_objects_worker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PurgeStaleObjectsWorker < ActiveJob::Base
+class PurgeStaleObjectsWorker < ApplicationJob
 
   def perform(*classes_names)
     classes_names.each do |class_name|

--- a/config/jobs.rb
+++ b/config/jobs.rb
@@ -34,7 +34,7 @@ module ThreeScale
       Cinstance.notify_about_expired_trial_periods
       Pdf::Dispatch.daily
       DeleteProvidedAccessTokensWorker.perform_async
-      DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
+      DestroyAllDeletedObjectsWorker.perform_later(Service.to_s)
     ].freeze
 
     BILLING = %w[

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -10,6 +10,6 @@ namespace :services do
   end
 
   task :destroy_marked_as_deleted => :environment do
-    DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
+    DestroyAllDeletedObjectsWorker.perform_later(Service.to_s)
   end
 end

--- a/test/unit/services/messages/destroy_all_service_test.rb
+++ b/test/unit/services/messages/destroy_all_service_test.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Messages::DestroyAllServiceTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
 
   def setup
     @message  = FactoryBot.create(:received_message, hidden_at: DateTime.yesterday)
@@ -9,35 +12,28 @@ class Messages::DestroyAllServiceTest < ActiveSupport::TestCase
   end
 
   def test_run!
-    Sidekiq::Testing.fake! do
-      assert_nil @message.deleted_at
+    assert_nil @message.deleted_at
 
-      ::Messages::DestroyAllService.run!({
-        account:           @account,
-        association_class: MessageRecipient,
-        scope:             :hidden
-      })
+    Messages::DestroyAllService.run!({
+      account: @account,
+      association_class: MessageRecipient,
+      scope: :hidden
+    })
 
-      @message.reload
-
-      assert_not_equal nil, @message.deleted_at
-    end
+    assert_not_equal nil, @message.reload.deleted_at
   end
 
   def test_run_with_sidekiq_job
-    Sidekiq::Testing.inline! do
-      assert @message.present?
+    assert @message.present?
 
-      ::Messages::DestroyAllService.run!({
-        account:           @account,
+    perform_enqueued_jobs do
+      Messages::DestroyAllService.run!({
+        account: @account,
         association_class: MessageRecipient,
-        scope:             :hidden
+        scope: :hidden
       })
-
-      assert_raise(ActiveRecord::RecordNotFound) do
-        @message.reload
-      end
     end
+
+    assert_raise(ActiveRecord::RecordNotFound) { @message.reload }
   end
 end
-

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 module Tasks
   class ServicesTest < ActiveSupport::TestCase
     test 'destroy_marked_as_deleted' do
-      DestroyAllDeletedObjectsWorker.expects(:perform_async).once.with('Service')
+      DestroyAllDeletedObjectsWorker.expects(:perform_later).once.with('Service')
 
       execute_rake_task 'services.rake', 'services:destroy_marked_as_deleted'
     end

--- a/test/workers/destroy_all_deleted_objects_worker_test.rb
+++ b/test/workers/destroy_all_deleted_objects_worker_test.rb
@@ -7,13 +7,11 @@ class DestroyAllDeletedObjectsWorkerTest < ActiveSupport::TestCase
 
   def test_perform_destroys_message_recipient
     message = FactoryBot.create(:received_message, deleted_at: DateTime.yesterday)
-    Sidekiq::Testing.inline! do
-      perform_enqueued_jobs do
-        assert_difference(MessageRecipient.method(:count), -1) do
-          DestroyAllDeletedObjectsWorker.perform_async('MessageRecipient')
-        end
-        assert_raise(ActiveRecord::RecordNotFound) { message.reload }
+    perform_enqueued_jobs do
+      assert_difference(MessageRecipient.method(:count), -1) do
+        DestroyAllDeletedObjectsWorker.perform_later('MessageRecipient')
       end
+      assert_raise(ActiveRecord::RecordNotFound) { message.reload }
     end
   end
 
@@ -26,8 +24,8 @@ class DestroyAllDeletedObjectsWorkerTest < ActiveSupport::TestCase
       object.id == services.first.id
     end
 
-    Sidekiq::Testing.inline! do
-      DestroyAllDeletedObjectsWorker.perform_async(Service.to_s)
+    perform_enqueued_jobs do
+      DestroyAllDeletedObjectsWorker.perform_later(Service.to_s)
     end
   end
 end


### PR DESCRIPTION
- Inherit from ApplicationJob instead of ActionJob::Base
- [RuboCop] DestroyAllDeletedObjectsWorker with frozen_string_literal
- DestroyAllDeletedObjectsWorker inherits from ApplicationJob instead of including
- [Refactor] Simplify Messages::DestroyAllServiceTest

A small part of this is extracted from https://github.com/3scale/porta/pull/4/commits/d3f4aa7e58a5a30c26b6cfc83f029d42209c603d, but the vast majority of this PR is just refactoring :smile: 