### PR TITLE
[Rails5] Fix change in ActionController::Parameters#slice!

### DIFF
--- a/app/services/service_creator.rb
+++ b/app/services/service_creator.rb
@@ -12,8 +12,8 @@ class ServiceCreator
 
   def call!(params = {})
     @service.transaction do
-      backend_api_proxy_params = params.dup
-      service_params = backend_api_proxy_params.slice!(:path, :private_endpoint)
+      service_params = params.dup
+      backend_api_proxy_params = service_params.extract!(:path, :private_endpoint)
       @service.attributes = service_params
       save!(backend_api_proxy_params)
     end


### PR DESCRIPTION
Extracted: cb55fdb2

Reason

* Rails 4.2.11

Hash#slice!(*keys)
Replaces the hash with only the given keys. Returns a hash containing the removed key/value pairs.
{ a: 1, b: 2, c: 3, d: 4 }.slice!(:a, :b) #=> {:c=>3, :d=>4}

* Rails 5.x

ActionController::Parameters#slice!(*keys)
Returns current ActionController::Parameters instance which contains only the given keys.

params = ActionController::Parameters.new(a: 1, b: 2, c: 3)
params.slice(:a, :b) # => <ActionController::Parameters {"a"=>1, "b"=>2} permitted: false>
params.slice(:d)     # => <ActionController::Parameters {} permitted: false>

