### PR TITLE
[Rails5] Eager load test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,6 +10,8 @@ System::Application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
+  config.eager_load = true
+
   # Show full error reports and disable caching
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false


### PR DESCRIPTION
Extracted: 6c8fd304

A copy of Provider::Admin::Dashboard::Service has been removed from the
module tree but is still active