### PR TITLE
private define_method in ruby 2.4

### DIFF
--- a/lib/three_scale/lazy_initialization.rb
+++ b/lib/three_scale/lazy_initialization.rb
@@ -37,9 +37,10 @@ module ThreeScale
         mod = Module.new
         names.each do |name|
           options_for_lazy_initialization[name] = options
-
-          mod.define_method(name.to_s) do
-            super() || lazily_initialize(name)
+          mod.instance_eval do
+            define_method(name.to_s) do
+              super() || lazily_initialize(name)
+            end
           end
         end
 


### PR DESCRIPTION
We want to switch to ruby 2.5 at least but for now we need to be compatible with 2.4
See https://bugs.ruby-lang.org/issues/14133
Closes [THREESCALE-4409](https://issues.redhat.com/browse/THREESCALE-4409
)