### PR TITLE
Replace the forked version of HtmlPipeline gem with the released one

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -161,7 +161,9 @@ gem 'state_machines-activerecord', '~> 0.5.0'
 gem 'after_commit_queue', '~> 1.1.0'
 
 # for liquid docs on-fly generation
-gem 'html-pipeline', github: 'ceritium/html-pipeline', branch: 'master'
+gem 'commonmarker'
+gem 'escape_utils'
+gem 'html-pipeline'
 gem 'github-markdown'
 
 # templating

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,20 +80,6 @@ GIT
     sour (0.1.3)
 
 GIT
-  remote: https://github.com/ceritium/html-pipeline.git
-  revision: e404ae290fe75ba86230b7b27d2c28906dfc9c93
-  branch: master
-  specs:
-    html-pipeline (0.0.12)
-      activesupport (>= 2)
-      escape_utils (= 1.0.1)
-      gemoji (~> 1.0)
-      github-markdown (~> 0.5)
-      nokogiri (~> 1.4)
-      rinku (~> 1.7)
-      sanitize (~> 2.0)
-
-GIT
   remote: https://github.com/mikz/httpclient.git
   revision: fec23fb32fb899b87a8b2c94e2d2069b6b4c633c
   branch: ssl-env-cert
@@ -246,6 +232,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorize (0.8.1)
+    commonmarker (0.21.0)
+      ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -315,7 +303,7 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
-    escape_utils (1.0.1)
+    escape_utils (1.2.1)
     eventmachine (1.2.7)
     excon (0.71.0)
     execjs (2.6.0)
@@ -336,7 +324,6 @@ GEM
       actionpack (>= 2.3.7)
       activesupport (>= 2.3.7)
       i18n (~> 0.4)
-    gemoji (1.5.0)
     gherkin (4.1.3)
     github-markdown (0.6.3)
     globalid (0.4.2)
@@ -349,6 +336,9 @@ GEM
     hashdiff (0.3.9)
     hashie (3.4.4)
     hiredis (0.6.0)
+    html-pipeline (2.12.3)
+      activesupport (>= 2)
+      nokogiri (>= 1.4)
     htmlentities (4.3.4)
     http (2.2.2)
       addressable (~> 2.3)
@@ -586,7 +576,6 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     riddle (2.4.0)
-    rinku (1.7.3)
     rmagick (2.15.3)
     roar (1.0.4)
       representable (>= 2.0.1, < 2.4.0)
@@ -632,6 +621,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-enum (0.7.2)
+      i18n
     ruby-oci8 (2.2.5.1)
     ruby-openid (2.9.1)
     ruby-prof (0.15.8)
@@ -641,8 +632,6 @@ GEM
     rufus-scheduler (3.0.9)
       tzinfo
     safe_yaml (1.0.5)
-    sanitize (2.1.1)
-      nokogiri (>= 1.4.4)
     sass (3.4.25)
     sass-rails (5.0.7)
       railties (>= 4.0.0, < 6)
@@ -829,6 +818,7 @@ DEPENDENCIES
   codemirror-rails (~> 5.6)
   coffee-rails (~> 4.2)
   colorize
+  commonmarker
   compass-rails (~> 3.0.2)
   cucumber (~> 2.0)
   cucumber-rails
@@ -842,6 +832,7 @@ DEPENDENCIES
   dynamic_form
   email_spec
   equivalent-xml
+  escape_utils
   factory_bot_rails (~> 4.11.1)
   fakefs (~> 0.18.0)
   faraday (~> 0.12.0)
@@ -853,7 +844,7 @@ DEPENDENCIES
   gruff (~> 0.3)
   hashie
   hiredis (~> 0.6.0)
-  html-pipeline!
+  html-pipeline
   htmlentities (~> 4.3, >= 4.3.4)
   httpclient!
   i18n

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -80,20 +80,6 @@ GIT
     sour (0.1.3)
 
 GIT
-  remote: https://github.com/ceritium/html-pipeline.git
-  revision: e404ae290fe75ba86230b7b27d2c28906dfc9c93
-  branch: master
-  specs:
-    html-pipeline (0.0.12)
-      activesupport (>= 2)
-      escape_utils (= 1.0.1)
-      gemoji (~> 1.0)
-      github-markdown (~> 0.5)
-      nokogiri (~> 1.4)
-      rinku (~> 1.7)
-      sanitize (~> 2.0)
-
-GIT
   remote: https://github.com/mikz/httpclient.git
   revision: fec23fb32fb899b87a8b2c94e2d2069b6b4c633c
   branch: ssl-env-cert
@@ -247,6 +233,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorize (0.8.1)
+    commonmarker (0.21.0)
+      ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -316,7 +304,7 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
-    escape_utils (1.0.1)
+    escape_utils (1.2.1)
     eventmachine (1.2.7)
     excon (0.71.0)
     execjs (2.6.0)
@@ -337,7 +325,6 @@ GEM
       actionpack (>= 2.3.7)
       activesupport (>= 2.3.7)
       i18n (~> 0.4)
-    gemoji (1.5.0)
     gherkin (4.1.3)
     github-markdown (0.6.3)
     globalid (0.4.2)
@@ -350,6 +337,9 @@ GEM
     hashdiff (0.3.9)
     hashie (3.4.4)
     hiredis (0.6.0)
+    html-pipeline (2.12.3)
+      activesupport (>= 2)
+      nokogiri (>= 1.4)
     htmlentities (4.3.4)
     http (2.2.2)
       addressable (~> 2.3)
@@ -587,7 +577,6 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     riddle (2.4.0)
-    rinku (1.7.3)
     rmagick (2.15.3)
     roar (1.0.4)
       representable (>= 2.0.1, < 2.4.0)
@@ -633,6 +622,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-enum (0.7.2)
+      i18n
     ruby-oci8 (2.2.5.1)
     ruby-openid (2.9.1)
     ruby-prof (0.15.8)
@@ -642,8 +633,6 @@ GEM
     rufus-scheduler (3.0.9)
       tzinfo
     safe_yaml (1.0.5)
-    sanitize (2.1.1)
-      nokogiri (>= 1.4.4)
     sass (3.4.25)
     sass-rails (5.0.7)
       railties (>= 4.0.0, < 6)
@@ -830,6 +819,7 @@ DEPENDENCIES
   codemirror-rails (~> 5.6)
   coffee-rails (~> 4.2)
   colorize
+  commonmarker
   compass-rails (~> 3.0.2)
   cucumber (~> 2.0)
   cucumber-rails
@@ -843,6 +833,7 @@ DEPENDENCIES
   dynamic_form
   email_spec
   equivalent-xml
+  escape_utils
   factory_bot_rails (~> 4.11.1)
   fakefs (~> 0.18.0)
   faraday (~> 0.12.0)
@@ -854,7 +845,7 @@ DEPENDENCIES
   gruff (~> 0.3)
   hashie
   hiredis (~> 0.6.0)
-  html-pipeline!
+  html-pipeline
   htmlentities (~> 4.3, >= 4.3.4)
   httpclient!
   i18n


### PR DESCRIPTION
**What this PR does / why we need it**:

We are using a forked version of HtmlPipeline and looks like it isn't
needed, since the fork was only to be able to run with ruby 2.1.

Using this old forked gem is causing us to have a CVE-2018-3740 because
it uses the sanitize library (in an old version). This new version of
HtmlPipeline doesn't even use sanitize.

**Which issue(s) this PR fixes** 

[THREESCALE-3437](https://issues.redhat.com/browse/THREESCALE-3437)
