### PR TITLE
[hotfix] Require threescale.rb before any app initializers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -265,8 +265,11 @@ module System
       Paperclip::Attachment.default_options.merge!(s3_options: CMS::S3.options) # Paperclip does not accept s3_options set as a Proc
     end
 
-    config.after_initialize do
+    config.before_initialize do
       require 'three_scale'
+    end
+
+    config.after_initialize do
       ThreeScale.validate_settings!
       require 'system/redis_pool'
       redis_config = ThreeScale::RedisConfig.new(config.redis)


### PR DESCRIPTION
⚠️ This is a hotfix

Adding as reference https://issues.redhat.com/browse/THREESCALE-4418

### Issues:

* If this file is needed before anything, it should not live app/lib
* Sidekiq config/initializers/sidekiq.rb require some files that live in app/lib

All files that are required before eager_load should live in lib and required manually
Otherwise production dependency require failures might happen: wrong order of dependencies loaded
because it will rely on ActiveSupport::Dependencies loading mechanism ...


### How to reproduce

Just try to launch sidekiq in `test` environment

```shell
RAILS_ENV=test bundle exec sidekiq
```