### PR TITLE
Require CSV in Csv::Exporter

### DIFF
--- a/app/lib/csv/exporter.rb
+++ b/app/lib/csv/exporter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 class Csv::Exporter
   BOM = "\uFEFF"
 


### PR DESCRIPTION
This commit forces the require of the csv lib in the Csv::Exporter
class. This will fix the problem that we have when Sidekiq process this
in background and explodes with the `undefined method `generate' for
CSV:Module` error.