### PR TITLE
[Bugfix] Fix Provider::SignupsController#create & tests.

### DIFF
--- a/test/integration/provider/signups_controller_test.rb
+++ b/test/integration/provider/signups_controller_test.rb
@@ -11,21 +11,25 @@ class Provider::SignupsControllerTest < ActionDispatch::IntegrationTest
     ThreeScale::Analytics::UserTracking.any_instance.expects(:track).at_least_once.with('Signup', {mkt_cookie: nil, analytics: {}})
 
     assert_difference(master_account.buyer_accounts.method(:count)) do
-      post provider_signup_path, create_params
+      post provider_signup_path, create_params({account: {name: 'theorganization'}})
     end
 
     assert_redirected_to success_provider_signup_path
 
-    provider = master_account.buyer_accounts.last!
+    provider = master_account.buyer_accounts.order(:id).last!
     assert (user = provider.admin_users.but_impersonation_admin.first)
 
     create_params[:account].except(:user).each do |field_name, expected_value|
       assert_equal expected_value, provider.public_send(field_name)
     end
+    assert provider.sample_data
+    assert_match /^theorganization.*$/, provider.subdomain.to_s
 
-    create_params[:account][:user] do |field_name, expected_value|
+    create_params[:account][:user].except(:password).each do |field_name, expected_value|
       assert_equal expected_value, user.public_send(field_name)
     end
+    assert_equal :new_signup, user.signup_type
+    assert_equal 'admin', user.username
   end
 
   test 'POST without params' do
@@ -36,12 +40,41 @@ class Provider::SignupsControllerTest < ActionDispatch::IntegrationTest
     assert_response :bad_request
   end
 
-  def create_params
+  test 'POST in case of invalid params' do
+    assert_no_difference(master_account.buyer_accounts.method(:count)) do
+      post provider_signup_path, create_params({account: {user: {email: 'invalid email'}}})
+    end
+
+    assert_response :success
+  end
+
+  test 'POST in case of spam check not passing' do
+    Provider::SignupsController.any_instance.expects(:spam_check).returns(false)
+
+    assert_no_difference(master_account.buyer_accounts.method(:count)) do
+      post provider_signup_path, create_params
+    end
+
+    assert_response :success
+  end
+
+  test 'POST accepts the subdomain if given' do
+    assert_difference(master_account.buyer_accounts.method(:count)) do
+      post provider_signup_path, create_params({account: {name: 'organization', subdomain: 'mysubdomain'}})
+    end
+
+    provider = master_account.buyer_accounts.order(:id).last!
+
+    assert_equal 'organization', provider.name
+    assert_equal 'mysubdomain', provider.subdomain
+  end
+
+  def create_params(extra_params = {})
     @create_params ||= {
       account: {
         name: 'organization name',
-        user: {username: 'my username', email: 'email@example.com', password: '123456'}
+        user: {email: 'email@example.com', password: '123456'}
       }
-    }
+    }.deep_merge(extra_params)
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-4423](https://issues.redhat.com/browse/THREESCALE-4423)

- Make Provider::SignupsControllerTest runnable by adding the '.each'
- Fields must be built AFTER building user and account. ActionView::Template::Error: undefined method `defined_extra_fields' for nil:NilClass
- Test with invalid email
- Do not test the value of the password
- Ensure variables @Provider and @user even when spam does not pass
- Ensure the correct value of subdomain and singup_mode
- Test signup_type