### PR TITLE
adds yarn install steps to MacOS setup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -183,12 +183,18 @@ bundle config --local build.mysql2 "--with-ldflags=-L/usr/local/opt/openssl/lib 
 
 and run `bundle install` again.
 
-#### NPM
+#### Yarn
 
-Run [NPM](https://www.npmjs.com/) to install all the required Node modules:
+Install [Yarn](https://yarnpkg.com/):
 
 ```bash
-npm install
+npm install -g yarn
+```
+
+Run [Yarn](https://yarnpkg.com/) to install all the required packages:
+
+```bash
+yarn install
 ```
 
 ## Manual setup on Fedora (29)


### PR DESCRIPTION
Seems we are using Yarn instead of NPM now? I had to run the commands added in this commit but it also raises the question whether NPM is needed at all here? How to migrate from NPM to Yarn for contributors, are my steps sufficient and correct?