### PR TITLE
Test Plan not locked if destroyed_by_association

### DIFF
--- a/test/unit/plan_test.rb
+++ b/test/unit/plan_test.rb
@@ -614,6 +614,14 @@ class PlanTest < ActiveSupport::TestCase
     plan.destroy
   end
 
+  def test_plan_not_locked_if_destroyed_by_association
+    plan = FactoryBot.create(:simple_application_plan)
+    plan.class.stubs(:exists?).with(plan.id).returns(true)
+    plan.class.stubs(:destroyed_by_association).with(plan.id).returns(true)
+    plan.expects(:lock!).never
+    plan.destroy
+  end
+
   def test_provided_by
     plan = FactoryBot.create(:application_plan)
     provider = plan.provider_account


### PR DESCRIPTION
I saw the scenario of this test is lacking when I was reviewing the Rails 5 PR.