### PR TITLE
[WIP] Remove EndUser and EndUserPlans [DB migration]

### DIFF
--- a/db/migrate/20200211154433_remove_end_user_plans.rb
+++ b/db/migrate/20200211154433_remove_end_user_plans.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RemoveEndUserPlans < ActiveRecord::Migration
+  def change
+    safety_assured { remove_column :settings, :end_users_switch }
+    safety_assured { remove_column :settings, :end_user_plans_ui_visible }
+
+    safety_assured { remove_column :cinstances, :end_user_required }
+
+    safety_assured { remove_column :plans, :end_user_required }
+
+    safety_assured { remove_column :services, :end_user_registration_required }
+    safety_assured { remove_column :services, :default_end_user_plan_id }
+
+    drop_table :end_user_plans
+  end
+end

--- a/db/migrate/20200302173620_drop_end_user_trigger_procedure.rb
+++ b/db/migrate/20200302173620_drop_end_user_trigger_procedure.rb
@@ -1,0 +1,9 @@
+require 'system/database/postgres'
+
+class DropEndUserTriggerProcedure < ActiveRecord::Migration[5.0]
+  def change
+    return unless System::Database.postgres?
+    System::Database::Postgres::TriggerProcedure.new('tp_end_user_plans_tenant_id', nil).drop
+  end
+end
+

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200211154433) do
+ActiveRecord::Schema.define(version: 20200302173620) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer  "owner_id",   precision: 38,                  null: false

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200224095152) do
+ActiveRecord::Schema.define(version: 20200211154433) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer  "owner_id",   precision: 38,                  null: false
@@ -318,7 +318,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.text     "redirect_url"
     t.datetime "variable_cost_paid_until",             precision: 6
     t.text     "extra_fields"
-    t.boolean  "end_user_required"
     t.integer  "tenant_id",                            precision: 38
     t.string   "create_origin"
     t.datetime "first_traffic_at",                     precision: 6
@@ -503,14 +502,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
 
   add_index "deleted_objects", ["object_type", "object_id"], name: "index_deleted_objects_on_object_type_and_object_id"
   add_index "deleted_objects", ["owner_type", "owner_id"], name: "index_deleted_objects_on_owner_type_and_owner_id"
-
-  create_table "end_user_plans", force: :cascade do |t|
-    t.integer  "service_id", precision: 38, null: false
-    t.string   "name",                      null: false
-    t.datetime "created_at", precision: 6
-    t.datetime "updated_at", precision: 6
-    t.integer  "tenant_id",  precision: 38
-  end
 
   create_table "event_store_events", force: :cascade do |t|
     t.string   "stream",                     null: false
@@ -989,7 +980,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.string   "issuer_type",                                                    null: false
     t.text     "description"
     t.boolean  "approval_required",                              default: false, null: false
-    t.boolean  "end_user_required",                              default: false
     t.integer  "tenant_id",             precision: 38
     t.string   "system_name",                                                    null: false
     t.integer  "partner_id",            precision: 38
@@ -1217,47 +1207,45 @@ ActiveRecord::Schema.define(version: 20200224095152) do
   add_index "service_tokens", ["service_id"], name: "index_service_tokens_on_service_id"
 
   create_table "services", force: :cascade do |t|
-    t.integer  "account_id",                     precision: 38,                     null: false
-    t.string   "name",                                          default: ""
+    t.integer  "account_id",                   precision: 38,                     null: false
+    t.string   "name",                                        default: ""
     t.text     "oneline_description"
     t.text     "description"
     t.text     "txt_api"
     t.text     "txt_support"
     t.text     "txt_features"
-    t.datetime "created_at",                     precision: 6
-    t.datetime "updated_at",                     precision: 6
+    t.datetime "created_at",                   precision: 6
+    t.datetime "updated_at",                   precision: 6
     t.string   "logo_file_name"
     t.string   "logo_content_type"
-    t.integer  "logo_file_size",                 precision: 38
-    t.string   "state",                                                             null: false
-    t.boolean  "intentions_required",                           default: false
-    t.string   "draft_name",                                    default: ""
+    t.integer  "logo_file_size",               precision: 38
+    t.string   "state",                                                           null: false
+    t.boolean  "intentions_required",                         default: false
+    t.string   "draft_name",                                  default: ""
     t.text     "infobar"
     t.text     "terms"
-    t.boolean  "display_provider_keys",                         default: false
+    t.boolean  "display_provider_keys",                       default: false
     t.string   "tech_support_email"
     t.string   "admin_support_email"
     t.string   "credit_card_support_email"
-    t.boolean  "buyers_manage_apps",                            default: true
-    t.boolean  "buyers_manage_keys",                            default: true
-    t.boolean  "custom_keys_enabled",                           default: true
-    t.string   "buyer_plan_change_permission",                  default: "request"
-    t.boolean  "buyer_can_select_plan",                         default: false
+    t.boolean  "buyers_manage_apps",                          default: true
+    t.boolean  "buyers_manage_keys",                          default: true
+    t.boolean  "custom_keys_enabled",                         default: true
+    t.string   "buyer_plan_change_permission",                default: "request"
+    t.boolean  "buyer_can_select_plan",                       default: false
     t.text     "notification_settings"
-    t.integer  "default_application_plan_id",    precision: 38
-    t.integer  "default_service_plan_id",        precision: 38
-    t.integer  "default_end_user_plan_id",       precision: 38
-    t.boolean  "end_user_registration_required",                default: true
-    t.integer  "tenant_id",                      precision: 38
-    t.string   "system_name",                                                       null: false
-    t.string   "backend_version",                               default: "1",       null: false
-    t.boolean  "mandatory_app_key",                             default: true
-    t.boolean  "buyer_key_regenerate_enabled",                  default: true
+    t.integer  "default_application_plan_id",  precision: 38
+    t.integer  "default_service_plan_id",      precision: 38
+    t.integer  "tenant_id",                    precision: 38
+    t.string   "system_name",                                                     null: false
+    t.string   "backend_version",                             default: "1",       null: false
+    t.boolean  "mandatory_app_key",                           default: true
+    t.boolean  "buyer_key_regenerate_enabled",                default: true
     t.string   "support_email"
-    t.boolean  "referrer_filters_required",                     default: false
-    t.string   "deployment_option",                             default: "hosted"
+    t.boolean  "referrer_filters_required",                   default: false
+    t.string   "deployment_option",                           default: "hosted"
     t.string   "kubernetes_service_link"
-    t.boolean  "act_as_product",                                default: false
+    t.boolean  "act_as_product",                              default: false
   end
 
   add_index "services", ["account_id"], name: "idx_account_id"
@@ -1303,7 +1291,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.boolean  "can_create_service",                                             default: false,             null: false
     t.string   "spam_protection_level",                                          default: "none",            null: false
     t.integer  "tenant_id",                                       precision: 38
-    t.string   "end_users_switch"
     t.string   "multiple_applications_switch",                                                               null: false
     t.string   "multiple_users_switch",                                                                      null: false
     t.string   "finance_switch",                                                                             null: false
@@ -1330,7 +1317,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.boolean  "account_plans_ui_visible",                                       default: false
     t.boolean  "service_plans_ui_visible",                                       default: false
     t.string   "skip_email_engagement_footer_switch",                            default: "denied",          null: false
-    t.boolean  "end_user_plans_ui_visible",                                      default: false
     t.string   "web_hooks_switch",                                               default: "denied",          null: false
     t.string   "iam_tools_switch",                                               default: "denied",          null: false
     t.string   "require_cc_on_signup_switch",                                    default: "denied",          null: false

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200211154433) do
+ActiveRecord::Schema.define(version: 20200302173620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200224095152) do
+ActiveRecord::Schema.define(version: 20200211154433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -304,7 +304,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.text     "redirect_url"
     t.datetime "variable_cost_paid_until"
     t.text     "extra_fields"
-    t.boolean  "end_user_required"
     t.bigint   "tenant_id"
     t.string   "create_origin",            limit: 255
     t.datetime "first_traffic_at"
@@ -476,14 +475,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.datetime "created_at",  null: false
     t.index ["object_type", "object_id"], name: "index_deleted_objects_on_object_type_and_object_id", using: :btree
     t.index ["owner_type", "owner_id"], name: "index_deleted_objects_on_owner_type_and_owner_id", using: :btree
-  end
-
-  create_table "end_user_plans", force: :cascade do |t|
-    t.bigint   "service_id",             null: false
-    t.string   "name",       limit: 255, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.bigint   "tenant_id"
   end
 
   create_table "event_store_events", force: :cascade do |t|
@@ -939,7 +930,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.string   "issuer_type",           limit: 255,                                          null: false
     t.text     "description"
     t.boolean  "approval_required",                                          default: false, null: false
-    t.boolean  "end_user_required",                                          default: false
     t.bigint   "tenant_id"
     t.string   "system_name",           limit: 255,                                          null: false
     t.bigint   "partner_id"
@@ -1156,8 +1146,8 @@ ActiveRecord::Schema.define(version: 20200224095152) do
   end
 
   create_table "services", force: :cascade do |t|
-    t.bigint   "account_id",                                                     null: false
-    t.string   "name",                           limit: 255, default: ""
+    t.bigint   "account_id",                                                   null: false
+    t.string   "name",                         limit: 255, default: ""
     t.text     "oneline_description"
     t.text     "description"
     t.text     "txt_api"
@@ -1165,38 +1155,36 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.text     "txt_features"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "logo_file_name",                 limit: 255
-    t.string   "logo_content_type",              limit: 255
+    t.string   "logo_file_name",               limit: 255
+    t.string   "logo_content_type",            limit: 255
     t.integer  "logo_file_size"
-    t.string   "state",                          limit: 255,                     null: false
-    t.boolean  "intentions_required",                        default: false
-    t.string   "draft_name",                     limit: 255, default: ""
+    t.string   "state",                        limit: 255,                     null: false
+    t.boolean  "intentions_required",                      default: false
+    t.string   "draft_name",                   limit: 255, default: ""
     t.text     "infobar"
     t.text     "terms"
-    t.boolean  "display_provider_keys",                      default: false
-    t.string   "tech_support_email",             limit: 255
-    t.string   "admin_support_email",            limit: 255
-    t.string   "credit_card_support_email",      limit: 255
-    t.boolean  "buyers_manage_apps",                         default: true
-    t.boolean  "buyers_manage_keys",                         default: true
-    t.boolean  "custom_keys_enabled",                        default: true
-    t.string   "buyer_plan_change_permission",   limit: 255, default: "request"
-    t.boolean  "buyer_can_select_plan",                      default: false
+    t.boolean  "display_provider_keys",                    default: false
+    t.string   "tech_support_email",           limit: 255
+    t.string   "admin_support_email",          limit: 255
+    t.string   "credit_card_support_email",    limit: 255
+    t.boolean  "buyers_manage_apps",                       default: true
+    t.boolean  "buyers_manage_keys",                       default: true
+    t.boolean  "custom_keys_enabled",                      default: true
+    t.string   "buyer_plan_change_permission", limit: 255, default: "request"
+    t.boolean  "buyer_can_select_plan",                    default: false
     t.text     "notification_settings"
     t.bigint   "default_application_plan_id"
     t.bigint   "default_service_plan_id"
-    t.bigint   "default_end_user_plan_id"
-    t.boolean  "end_user_registration_required",             default: true
     t.bigint   "tenant_id"
-    t.string   "system_name",                    limit: 255,                     null: false
-    t.string   "backend_version",                limit: 255, default: "1",       null: false
-    t.boolean  "mandatory_app_key",                          default: true
-    t.boolean  "buyer_key_regenerate_enabled",               default: true
-    t.string   "support_email",                  limit: 255
-    t.boolean  "referrer_filters_required",                  default: false
-    t.string   "deployment_option",              limit: 255, default: "hosted"
-    t.string   "kubernetes_service_link",        limit: 255
-    t.boolean  "act_as_product",                             default: false
+    t.string   "system_name",                  limit: 255,                     null: false
+    t.string   "backend_version",              limit: 255, default: "1",       null: false
+    t.boolean  "mandatory_app_key",                        default: true
+    t.boolean  "buyer_key_regenerate_enabled",             default: true
+    t.string   "support_email",                limit: 255
+    t.boolean  "referrer_filters_required",                default: false
+    t.string   "deployment_option",            limit: 255, default: "hosted"
+    t.string   "kubernetes_service_link",      limit: 255
+    t.boolean  "act_as_product",                           default: false
     t.index ["account_id"], name: "idx_account_id", using: :btree
     t.index ["system_name", "account_id"], name: "index_services_on_system_name_and_account_id_and_deleted_at", unique: true, using: :btree
   end
@@ -1241,7 +1229,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.boolean  "can_create_service",                              default: false,             null: false
     t.string   "spam_protection_level",               limit: 255, default: "none",            null: false
     t.bigint   "tenant_id"
-    t.string   "end_users_switch",                    limit: 255
     t.string   "multiple_applications_switch",        limit: 255,                             null: false
     t.string   "multiple_users_switch",               limit: 255,                             null: false
     t.string   "finance_switch",                      limit: 255,                             null: false
@@ -1268,7 +1255,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.boolean  "account_plans_ui_visible",                        default: false
     t.boolean  "service_plans_ui_visible",                        default: false
     t.string   "skip_email_engagement_footer_switch", limit: 255, default: "denied",          null: false
-    t.boolean  "end_user_plans_ui_visible",                       default: false
     t.string   "web_hooks_switch",                    limit: 255, default: "denied",          null: false
     t.string   "iam_tools_switch",                    limit: 255, default: "denied",          null: false
     t.string   "require_cc_on_signup_switch",         limit: 255, default: "denied",          null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200211154433) do
+ActiveRecord::Schema.define(version: 20200302173620) do
 
   create_table "access_tokens", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.bigint   "owner_id",                                  null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200224095152) do
+ActiveRecord::Schema.define(version: 20200211154433) do
 
   create_table "access_tokens", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.bigint   "owner_id",                                  null: false
@@ -305,7 +305,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.text     "redirect_url",             limit: 65535
     t.datetime "variable_cost_paid_until"
     t.text     "extra_fields",             limit: 65535
-    t.boolean  "end_user_required"
     t.bigint   "tenant_id"
     t.string   "create_origin"
     t.datetime "first_traffic_at"
@@ -477,14 +476,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.datetime "created_at",  null: false
     t.index ["object_type", "object_id"], name: "index_deleted_objects_on_object_type_and_object_id", using: :btree
     t.index ["owner_type", "owner_id"], name: "index_deleted_objects_on_owner_type_and_owner_id", using: :btree
-  end
-
-  create_table "end_user_plans", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
-    t.bigint   "service_id", null: false
-    t.string   "name",       null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.bigint   "tenant_id"
   end
 
   create_table "event_store_events", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
@@ -940,7 +931,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.string   "issuer_type",                                                                       null: false
     t.text     "description",           limit: 65535
     t.boolean  "approval_required",                                                 default: false, null: false
-    t.boolean  "end_user_required",                                                 default: false
     t.bigint   "tenant_id"
     t.string   "system_name",                                                                       null: false
     t.bigint   "partner_id"
@@ -1157,47 +1147,45 @@ ActiveRecord::Schema.define(version: 20200224095152) do
   end
 
   create_table "services", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
-    t.bigint   "account_id",                                                       null: false
-    t.string   "name",                                         default: ""
-    t.text     "oneline_description",            limit: 65535
-    t.text     "description",                    limit: 65535
-    t.text     "txt_api",                        limit: 65535
-    t.text     "txt_support",                    limit: 65535
-    t.text     "txt_features",                   limit: 65535
+    t.bigint   "account_id",                                                     null: false
+    t.string   "name",                                       default: ""
+    t.text     "oneline_description",          limit: 65535
+    t.text     "description",                  limit: 65535
+    t.text     "txt_api",                      limit: 65535
+    t.text     "txt_support",                  limit: 65535
+    t.text     "txt_features",                 limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "logo_file_name"
     t.string   "logo_content_type"
     t.integer  "logo_file_size"
-    t.string   "state",                                                            null: false
-    t.boolean  "intentions_required",                          default: false
-    t.string   "draft_name",                                   default: ""
-    t.text     "infobar",                        limit: 65535
-    t.text     "terms",                          limit: 65535
-    t.boolean  "display_provider_keys",                        default: false
+    t.string   "state",                                                          null: false
+    t.boolean  "intentions_required",                        default: false
+    t.string   "draft_name",                                 default: ""
+    t.text     "infobar",                      limit: 65535
+    t.text     "terms",                        limit: 65535
+    t.boolean  "display_provider_keys",                      default: false
     t.string   "tech_support_email"
     t.string   "admin_support_email"
     t.string   "credit_card_support_email"
-    t.boolean  "buyers_manage_apps",                           default: true
-    t.boolean  "buyers_manage_keys",                           default: true
-    t.boolean  "custom_keys_enabled",                          default: true
-    t.string   "buyer_plan_change_permission",                 default: "request"
-    t.boolean  "buyer_can_select_plan",                        default: false
-    t.text     "notification_settings",          limit: 65535
+    t.boolean  "buyers_manage_apps",                         default: true
+    t.boolean  "buyers_manage_keys",                         default: true
+    t.boolean  "custom_keys_enabled",                        default: true
+    t.string   "buyer_plan_change_permission",               default: "request"
+    t.boolean  "buyer_can_select_plan",                      default: false
+    t.text     "notification_settings",        limit: 65535
     t.bigint   "default_application_plan_id"
     t.bigint   "default_service_plan_id"
-    t.bigint   "default_end_user_plan_id"
-    t.boolean  "end_user_registration_required",               default: true
     t.bigint   "tenant_id"
-    t.string   "system_name",                                                      null: false
-    t.string   "backend_version",                              default: "1",       null: false
-    t.boolean  "mandatory_app_key",                            default: true
-    t.boolean  "buyer_key_regenerate_enabled",                 default: true
+    t.string   "system_name",                                                    null: false
+    t.string   "backend_version",                            default: "1",       null: false
+    t.boolean  "mandatory_app_key",                          default: true
+    t.boolean  "buyer_key_regenerate_enabled",               default: true
     t.string   "support_email"
-    t.boolean  "referrer_filters_required",                    default: false
-    t.string   "deployment_option",                            default: "hosted"
+    t.boolean  "referrer_filters_required",                  default: false
+    t.string   "deployment_option",                          default: "hosted"
     t.string   "kubernetes_service_link"
-    t.boolean  "act_as_product",                               default: false
+    t.boolean  "act_as_product",                             default: false
     t.index ["account_id"], name: "idx_account_id", using: :btree
     t.index ["system_name", "account_id"], name: "index_services_on_system_name_and_account_id_and_deleted_at", unique: true, using: :btree
   end
@@ -1242,7 +1230,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.boolean  "can_create_service",                                default: false,             null: false
     t.string   "spam_protection_level",                             default: "none",            null: false
     t.bigint   "tenant_id"
-    t.string   "end_users_switch"
     t.string   "multiple_applications_switch",                                                  null: false
     t.string   "multiple_users_switch",                                                         null: false
     t.string   "finance_switch",                                                                null: false
@@ -1269,7 +1256,6 @@ ActiveRecord::Schema.define(version: 20200224095152) do
     t.boolean  "account_plans_ui_visible",                          default: false
     t.boolean  "service_plans_ui_visible",                          default: false
     t.string   "skip_email_engagement_footer_switch",               default: "denied",          null: false
-    t.boolean  "end_user_plans_ui_visible",                         default: false
     t.string   "web_hooks_switch",                                  default: "denied",          null: false
     t.string   "iam_tools_switch",                                  default: "denied",          null: false
     t.string   "require_cc_on_signup_switch",                       default: "denied",          null: false


### PR DESCRIPTION
Migration to remove all EndUser code from the BDs.

**Which issue(s) this PR fixes**

[THREESCALE-2490: Remove “End-user plans” feature (SaaS) - Phase 2](https://issues.redhat.com/browse/THREESCALE-2490)

Removal from the code base in #1648.