### PR TITLE
Bump cancancan from 1.7.1 to 1.15.0

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -67,7 +67,7 @@ gem 'audited'
 
 gem 'acts_as_list', '~> 0.9.17'
 gem 'braintree', '~> 2.89'
-gem 'cancancan', '~> 1.7.1'
+gem 'cancancan', '~> 1.15'
 gem 'formtastic', '~> 1.2.4'
 gem 'rmagick', '~> 2.15.3', require: false
 gem 'gruff', '~>0.3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
     byebug (11.0.1)
-    cancancan (1.7.1)
+    cancancan (1.17.0)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -831,7 +831,7 @@ DEPENDENCIES
   browser
   bugsnag (~> 6.11)
   bullet (~> 5.6)
-  cancancan (~> 1.7.1)
+  cancancan (~> 1.15)
   capybara (~> 2.18)!
   childprocess
   chronic

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
     byebug (11.0.1)
-    cancancan (1.7.1)
+    cancancan (1.17.0)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -832,7 +832,7 @@ DEPENDENCIES
   browser
   bugsnag (~> 6.11)
   bullet (~> 5.6)
-  cancancan (~> 1.7.1)
+  cancancan (~> 1.15)
   capybara (~> 2.18)!
   childprocess
   chronic


### PR DESCRIPTION
Fixes Rails 5 deprecation warning messages to use `before_action` instead of `before_filter`.

Previous step before we can move on with
https://github.com/3scale/porta/pull/452.