### PR TITLE
Bump cancancan from 1.7.1 to 2.3.0

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -67,7 +67,7 @@ gem 'audited'
 
 gem 'acts_as_list', '~> 0.9.17'
 gem 'braintree', '~> 2.89'
-gem 'cancancan', '~> 1.7.1'
+gem 'cancancan', '~> 2.3.0'
 gem 'formtastic', '~> 1.2.4'
 gem 'rmagick', '~> 2.15.3', require: false
 gem 'gruff', '~>0.3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
     byebug (11.0.1)
-    cancancan (1.7.1)
+    cancancan (2.3.0)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -831,7 +831,7 @@ DEPENDENCIES
   browser
   bugsnag (~> 6.11)
   bullet (~> 5.6)
-  cancancan (~> 1.7.1)
+  cancancan (~> 2.3.0)
   capybara (~> 2.18)!
   childprocess
   chronic

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -150,30 +150,6 @@ class ApplicationController < ActionController::Base
     ReportTrafficWorker.enqueue(current_account, metric_to_report, request, response)
   end
 
-  class CustomCanCanControllerResource < CanCan::ControllerResource
-
-    def authorization_action
-      action = @params[:action].to_sym
-
-      if @controller.request.get? && !%i(index edit).include?(action)
-        :show
-      else
-        super
-      end
-    end
-  end
-
-  # CanCanCan
-  # [default] custom controller [GET] methods are being authorized separately
-  # [custom] custom controller [GET] methods are being authorized as show method
-  def self.cancan_resource_class
-    if ancestors.map(&:to_s).include? 'InheritedResources::Actions'
-      CanCan::InheritedResource
-    else
-      CustomCanCanControllerResource
-    end
-  end
-
   private
 
   delegate :notify_about, :silent_about, :to => :NotificationCenter

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,6 +18,7 @@ class Ability
   def reload!
     @user.try!(:reload)
     @rules = []
+    @rules_index = nil
     load_rules!
     self
   end

--- a/config/initializers/cancan_hacks.rb
+++ b/config/initializers/cancan_hacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This makes CanCan work with Inherited resources.
 #
 # Inspiration comes from hexors's comment over here:
@@ -5,23 +7,65 @@
 #
 # TODO: Maybe this is no longer needed, as there is a new version of canca. Check it.
 module CanCanHacks
+  class InheritedResource < CanCan::ControllerResource
+    def load_resource_instance
+      if parent?
+        @controller.send :association_chain
+        @controller.instance_variable_get("@#{instance_name}")
+      elsif new_actions.include? @params[:action].to_sym
+        resource = @controller.send :build_resource
+        assign_attributes(resource)
+      else
+        @controller.send :resource
+      end
+    end
+
+    def resource_base
+      @controller.send :end_of_association_chain
+    end
+  end
+
+  class CustomControllerResource < CanCan::ControllerResource
+    def authorization_action
+      action = @params[:action].to_sym
+
+      if @controller.request.get? && !%i[index edit].include?(action)
+        :show
+      else
+        super
+      end
+    end
+  end
+
+  module ControllerAdditions
+    # [default] custom controller [GET] methods are being authorized separately
+    # [custom] custom controller [GET] methods are being authorized as show method
+    def cancan_resource_class
+      if ancestors.map(&:to_s).include? 'InheritedResources::Actions'
+        InheritedResource
+      else
+        CustomControllerResource
+      end
+    end
+
+    def authorize_resource(options = {})
+      if inherits_resources?
+        before_action :authorize_inherited_resource
+      else
+        super(options)
+      end
+    end
+
+    private
+
+    def inherits_resources?
+      included_modules.include?(InheritedResources::BaseHelpers)
+    end
+  end
+
   def self.included(base)
     class << base
-      prepend(Module.new do
-        def authorize_resource(options = {})
-          if inherits_resources?
-            before_action :authorize_inherited_resource
-          else
-            super(options)
-          end
-        end
-
-        private
-
-        def inherits_resources?
-          included_modules.include?(InheritedResources::BaseHelpers)
-        end
-      end)
+      prepend ControllerAdditions
     end
   end
 

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
     byebug (11.0.1)
-    cancancan (1.7.1)
+    cancancan (2.3.0)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -832,7 +832,7 @@ DEPENDENCIES
   browser
   bugsnag (~> 6.11)
   bullet (~> 5.6)
-  cancancan (~> 1.7.1)
+  cancancan (~> 2.3.0)
   capybara (~> 2.18)!
   childprocess
   chronic

--- a/lib/developer_portal/app/controllers/developer_portal/admin/accounts_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/accounts_controller.rb
@@ -2,7 +2,7 @@ class DeveloperPortal::Admin::AccountsController < DeveloperPortal::BaseControll
 
   liquify prefix: 'account'
 
-  authorize_resource
+  authorize_resource class: Account
   activate_menu :account, :overview
 
   layout 'main_layout'


### PR DESCRIPTION
Fixes Rails 5 deprecation warning messages to use before_action instead of before_filter.

Allows to close https://github.com/3scale/porta/pull/452 (together with https://github.com/3scale/porta/pull/1670) and https://github.com/3scale/porta/pull/1668
Contains a commit extracted from https://github.com/3scale/porta/pull/1669.