### PR TITLE
Create a loader to deserialize both Hashes and

### DIFF
--- a/app/models/cms/email_template.rb
+++ b/app/models/cms/email_template.rb
@@ -50,7 +50,7 @@ class CMS::EmailTemplate < CMS::Template
   EMAIL_FORMAT = /(?:(#{EMAIL_ADDRESS_FORMAT})|#{EMAIL_WITH_NAME_FORMAT})\s*/i
   EMAILS_FORMAT = /\A#{EMAIL_FORMAT}(,\s*#{EMAIL_FORMAT})*\Z/i
 
-  serialize :options, Hash
+  serialize :options, HashOrActionParameter
 
   attr_accessor :file
 

--- a/app/models/hash_or_action_parameter.rb
+++ b/app/models/hash_or_action_parameter.rb
@@ -1,0 +1,18 @@
+class HashOrActionParameter
+  class << self
+    # Load our serialized data, that can be: ActionController::Parameters or a Hash
+    def load(value)
+      return unless value
+      if value.match(/!ruby\/object:ActionController::Parameters/) || value.starts_with?('---')
+        object = YAML.load(value)
+        object.try(:to_unsafe_hash) || object.to_h
+      else
+        JSON.parse(value.gsub(/:([a-zA-z]+)/,'"\\1"').gsub('=>', ': '))
+      end.symbolize_keys
+    end
+
+    def dump(data)
+      data.to_s
+    end
+  end
+end

--- a/test/unit/cms/email_template_test.rb
+++ b/test/unit/cms/email_template_test.rb
@@ -39,6 +39,30 @@ class EmailTemplateTest < ActiveSupport::TestCase
     assert template.valid?
   end
 
+  test 'it deserialize correctly an ActionController::Parameter' do
+    class CMS::EmailTemplate < CMS::Template
+      serialize :options, ActionController::Parameters
+    end
+    template = FactoryBot.create(:cms_email_template, options: ActionController::Parameters.new({"subject"=>"Test", "bcc"=>"", "cc"=>"", "reply_to"=>"", "from"=>"AYLIEN"}))
+    class CMS::EmailTemplate < CMS::Template
+      serialize :options, HashOrActionParameter
+    end
+
+    assert template.valid?
+  end
+
+  test 'it deserialize correctly an Hash' do
+    class CMS::EmailTemplate < CMS::Template
+      serialize :options, Hash
+    end
+    template = FactoryBot.create(:cms_email_template, options: {"subject"=>"Test", "bcc"=>"", "cc"=>"", "reply_to"=>"", "from"=>"AYLIEN"})
+    class CMS::EmailTemplate < CMS::Template
+      serialize :options, HashOrActionParameter
+    end
+
+    assert template.valid?
+  end
+
   test 'validates email format' do
     template = FactoryBot.build(:cms_email_template)
     template.headers = {


### PR DESCRIPTION
ActionController::Parameter

In Rails5 ActionController::Parameter does not inherits from Hash
anymore, this is causing errors in our application since we have a lot
of stored ActionController::Parameters serialized in our cms_template
table. This commit creates a custom loader that can serialize /
deserialize both hashes and ActionController::Parameters

