### PR TITLE
[Bugfix] Ensure that all associations of the BackgroundDeletion config can be constantized

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -60,22 +60,22 @@ class Account < ApplicationRecord
   self.background_deletion = [
     :users,
     :mail_dispatch_rules,
-    [:api_docs_services, class_name: 'ApiDocs::Service'],
+    [:api_docs_services, { class_name: 'ApiDocs::Service' }],
     :services,
     :contracts,
     :account_plans,
-    [:settings, { action: :destroy, has_many: false }],
+    [:settings, { action: :destroy, class_name: 'Settings', has_many: false }],
     [:payment_detail, { action: :destroy, has_many: false }],
     [:buyer_accounts, { action: :destroy, class_name: 'Account' }],
     [:payment_gateway_setting, { action: :destroy, has_many: false }],
     [:profile, { action: :delete, has_many: false }],
-    [:templates, { action: :delete }],
+    [:templates, { action: :delete, class_name: 'CMS::Template' }],
     [:sections, { action: :delete, class_name: 'CMS::Section' }],
     [:provided_sections, { action: :delete, class_name: 'CMS::Section' }],
-    [:redirects, { action: :delete }],
-    [:files, { action: :delete }],
-    [:builtin_pages, { action: :delete }],
-    [:provided_groups, { action: :delete }]
+    [:redirects, { action: :delete, class_name: 'CMS::Redirect' }],
+    [:files, { action: :delete, class_name: 'CMS::File' }],
+    [:builtin_pages, { action: :delete, class_name: 'CMS::BuiltinPage' }],
+    [:provided_groups, { action: :delete, class_name: 'CMS::Group' }]
   ].freeze
 
   #TODO: this needs testing?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,9 +23,15 @@ class User < ApplicationRecord
   include Permissions
   include ProvidedAccessTokens
 
-  self.background_deletion = [:user_sessions, :access_tokens, [:sso_authorizations, { action: :delete }],
-                              [:moderatorships, { action: :delete }], [:notifications, { action: :delete }],
-                              [:notification_preferences, { action: :delete, has_many: false }]]
+  self.background_deletion = [
+    :user_sessions,
+    :access_tokens,
+    [:sso_authorizations, { action: :delete }],
+    [:moderatorships, { action: :delete }],
+    [:notifications, { action: :delete }],
+    [:notification_preferences, { action: :delete, class_name: 'NotificationPreferences', has_many: false }]
+  ].freeze
+
   audited
 
   before_validation :trim_white_space_from_username

--- a/test/unit/concerns/background_deletion_test.rb
+++ b/test/unit/concerns/background_deletion_test.rb
@@ -40,10 +40,9 @@ module Concerns
     test 'all associations of the config can be constantized' do
       Rails.application.eager_load!
 
-      models = ActiveRecord::Base.descendants - [DoubleObject, DoubleActiveRecordObject, SecondDoubleActiveRecordObject]
+      ActiveRecord::Base.descendants.each do |klass|
+        next if [DoubleObject, DoubleActiveRecordObject, SecondDoubleActiveRecordObject].include?(klass) || !klass.respond_to?(:background_deletion)
 
-      models.each do |klass|
-        next unless klass.included_modules.include? BackgroundDeletion
         Array(klass.background_deletion).each do |config|
           reflection = BackgroundDeletion::Reflection.new(config)
           class_name = reflection.class_name

--- a/test/unit/concerns/background_deletion_test.rb
+++ b/test/unit/concerns/background_deletion_test.rb
@@ -40,8 +40,8 @@ module Concerns
     test 'all associations of the config can be constantized' do
       Rails.application.eager_load!
 
-      ActiveRecord::Base.descendants.each do |klass|
-        next if [DoubleObject, DoubleActiveRecordObject, SecondDoubleActiveRecordObject].include?(klass) || !klass.respond_to?(:background_deletion)
+      ApplicationRecord.descendants.each do |klass|
+        next if [DoubleObject, DoubleActiveRecordObject, SecondDoubleActiveRecordObject].include?(klass) || klass.background_deletion.blank?
 
         Array(klass.background_deletion).each do |config|
           reflection = BackgroundDeletion::Reflection.new(config)

--- a/test/unit/concerns/background_deletion_test.rb
+++ b/test/unit/concerns/background_deletion_test.rb
@@ -36,5 +36,20 @@ module Concerns
       DeleteObjectHierarchyWorker.expects(:perform_later).with(user, anything, 'destroy').never
       DeleteObjectHierarchyWorker.perform_now(double_object)
     end
+
+    test 'all associations of the config can be constantized' do
+      Rails.application.eager_load!
+
+      models = ActiveRecord::Base.descendants - [DoubleObject, DoubleActiveRecordObject, SecondDoubleActiveRecordObject]
+
+      models.each do |klass|
+        next unless klass.included_modules.include? BackgroundDeletion
+        Array(klass.background_deletion).each do |config|
+          reflection = BackgroundDeletion::Reflection.new(config)
+          class_name = reflection.class_name
+          assert reflection.try(:class_name).safe_constantize, "expected #{class_name.inspect} of the model #{klass} to be instantiated"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This is necessary to be able to do [THREESCALE-4483](https://issues.redhat.com/browse/THREESCALE-4483)
I encountered when testing that Jira issue in preview and seeing:
> DeleteAccountHierarchyWorker Account->associations NameError: uninitialized constant 'class_name'