### PR TITLE
[Bugfix] Custom Admin Portal address from 3scale signup form not being created

### DIFF
--- a/app/controllers/provider/signups_controller.rb
+++ b/app/controllers/provider/signups_controller.rb
@@ -32,6 +32,7 @@ class Provider::SignupsController < Provider::BaseController
       @user = result.user
       @provider.signup_mode!
       @provider.subdomain = account_params[:subdomain]
+      @provider.self_subdomain = account_params[:self_subdomain]
       result.add_error(message: 'spam check failed') unless spam_check(@provider)
     end
     @fields = Fields::SignupForm.new(@provider, @user, params[:fields])

--- a/app/controllers/provider/signups_controller.rb
+++ b/app/controllers/provider/signups_controller.rb
@@ -27,14 +27,8 @@ class Provider::SignupsController < Provider::BaseController
 
   def create
     @plan = plan
-    signup_result = Signup::ProviderAccountManager.new(master).create(signup_params) do |result|
-      @provider = result.account
-      @user = result.user
-      @provider.signup_mode!
-      @provider.subdomain = account_params[:subdomain]
-      @provider.self_subdomain = account_params[:self_subdomain]
-      result.add_error(message: 'spam check failed') unless spam_check(@provider)
-    end
+    provider_account_manager = Signup::ProviderAccountManager.new(master)
+    signup_result = provider_account_manager.create(signup_params, &method(:build_signup_result_custom_fields))
     @fields = Fields::SignupForm.new(@provider, @user, params[:fields])
 
     return render :show unless signup_result.persisted?
@@ -93,6 +87,15 @@ class Provider::SignupsController < Provider::BaseController
 
     System::ErrorReporting.report_error('Provider signup not enabled. Check all master\'s plans are in place.')
     render_error 'Provider signup not enabled.', status: :not_found
+  end
+
+  def build_signup_result_custom_fields(result)
+    @provider = result.account
+    @user = result.user
+    @provider.signup_mode!
+    @provider.subdomain = account_params[:subdomain]
+    @provider.self_subdomain = account_params[:self_subdomain]
+    result.add_error(message: 'spam check failed') unless spam_check(@provider)
   end
 
   def plan

--- a/app/controllers/provider/signups_controller.rb
+++ b/app/controllers/provider/signups_controller.rb
@@ -89,10 +89,10 @@ class Provider::SignupsController < Provider::BaseController
   end
 
   def ensure_signup_possible
-    unless master.signup_provider_possible?
-      System::ErrorReporting.report_error("Provider signup not enabled. Check all master's plans are in place.")
-      render_error 'Provider signup not enabled.', :status => :not_found
-    end
+    return if master.signup_provider_possible?
+
+    System::ErrorReporting.report_error('Provider signup not enabled. Check all master\'s plans are in place.')
+    render_error 'Provider signup not enabled.', status: :not_found
   end
 
   def plan

--- a/test/integration/provider/signups_controller_test.rb
+++ b/test/integration/provider/signups_controller_test.rb
@@ -23,7 +23,8 @@ class Provider::SignupsControllerTest < ActionDispatch::IntegrationTest
       assert_equal expected_value, provider.public_send(field_name)
     end
     assert provider.sample_data
-    assert_match /^theorganization.*$/, provider.subdomain.to_s
+    assert_match /^theorganization(-\d+)?$/, provider.subdomain.to_s
+    assert_match /^theorganization(-\d+)?-admin$/, provider.self_subdomain.to_s
 
     create_params[:account][:user].except(:password).each do |field_name, expected_value|
       assert_equal expected_value, user.public_send(field_name)
@@ -60,13 +61,14 @@ class Provider::SignupsControllerTest < ActionDispatch::IntegrationTest
 
   test 'POST accepts the subdomain if given' do
     assert_difference(master_account.buyer_accounts.method(:count)) do
-      post provider_signup_path, create_params({account: {name: 'organization', subdomain: 'mysubdomain'}})
+      post provider_signup_path, create_params({account: {org_name: 'organization', subdomain: 'mysubdomain', self_subdomain: 'selfsubdomain-admin'}})
     end
 
     provider = master_account.buyer_accounts.order(:id).last!
 
     assert_equal 'organization', provider.name
     assert_equal 'mysubdomain', provider.subdomain
+    assert_equal 'selfsubdomain-admin', provider.self_subdomain
   end
 
   def create_params(extra_params = {})


### PR DESCRIPTION
Closes [THREESCALE-4476](https://issues.redhat.com/browse/THREESCALE-4476)

### Verification Steps
1. Go to master-domain.example.com/p/signup
2. Fill different values for **organization name**, **subdomain**, and **admin domain**.
3. Create and confirm that the new account has been created with those values.