### PR TITLE
Allow reset password in master provider

### DIFF
--- a/app/controllers/provider/passwords_controller.rb
+++ b/app/controllers/provider/passwords_controller.rb
@@ -51,7 +51,7 @@ class Provider::PasswordsController < FrontendController
   # Can't be used for neither Buyer nor Master
   #
   def find_provider
-    unless @provider ||= Account.providers.find_by_self_domain(request.host.to_s)
+    unless @provider ||= Account.providers_with_master.find_by_self_domain(request.host.to_s)
       render_error "Wrong domain '#{request.host}' for path '#{request.path}'", status: 404
       false
     end

--- a/test/functional/provider/passwords_controller_test.rb
+++ b/test/functional/provider/passwords_controller_test.rb
@@ -40,5 +40,4 @@ class Provider::PasswordsControllerTest < ActionController::TestCase
 
     assert_redirected_to back
   end
-
 end

--- a/test/integration/provider/passwords_test.rb
+++ b/test/integration/provider/passwords_test.rb
@@ -2,49 +2,61 @@ require 'test_helper'
 
 class Provider::PasswordsControllerTest < ActionDispatch::IntegrationTest
 
-  def setup
-    @user = FactoryBot.create(:simple_user)
+  class WithProviderUserTest < Provider::PasswordsControllerTest
+    def setup
+      @user = FactoryBot.create(:simple_user)
 
-    host! @user.account.self_domain
+      host! @user.account.self_domain
+    end
+
+    def test_user_reset_his_password
+      # user requests for a forgotten password email
+      delete provider_password_path(email: @user.email)
+      assert_response :redirect
+      assert_match 'password reset link has been emailed', flash[:notice]
+
+      # user opens forgotten password page with a password reset token parameter
+      email_token = @user.reload.lost_password_token
+      assert_nil session[:password_reset_token]
+      get provider_password_path(password_reset_token: email_token)
+      # new token is being generated and stored in a session
+      assert_response :redirect
+      regenerated_token = @user.reload.lost_password_token
+      assert_not_equal email_token, regenerated_token
+      assert_equal session[:password_reset_token], regenerated_token
+
+      # new token is not being generated, it just renders :show
+      get provider_password_path(password_reset_token: '12345')
+      assert_response :success
+      assert_equal session[:password_reset_token], regenerated_token
+
+      # user updates his password
+      put provider_password_path(user: { password: 'alaska123',password_confirmation: 'alaska123' })
+      assert_response :redirect
+      assert_match 'password has been changed', flash[:notice]
+      assert_nil session[:password_reset_token]
+
+      # user is unable to open forgotten password page again (missing parameter)
+      get provider_password_path
+      assert_response 400
+      # user is unable to open forgotten password page again (invalid token)
+      assert_nil @user.reload.lost_password_token
+      get provider_password_path(password_reset_token: email_token)
+      assert_response :redirect
+      assert_match 'password reset token is invalid', flash[:error]
+      get provider_password_path(password_reset_token: regenerated_token)
+      assert_response :redirect
+      assert_match 'password reset token is invalid', flash[:error]
+    end
   end
 
-  def test_user_reset_his_password
-    # user requests for a forgotten password email
-    delete provider_password_path(email: @user.email)
-    assert_response :redirect
-    assert_match 'password reset link has been emailed', flash[:notice]
+  class WithMasterUserTest < Provider::PasswordsControllerTest
+    test '#destroy also works for master account' do
+      login_provider master_account
 
-    # user opens forgotten password page with a password reset token parameter
-    email_token = @user.reload.lost_password_token
-    assert_nil session[:password_reset_token]
-    get provider_password_path(password_reset_token: email_token)
-    # new token is being generated and stored in a session
-    assert_response :redirect
-    regenerated_token = @user.reload.lost_password_token
-    assert_not_equal email_token, regenerated_token
-    assert_equal session[:password_reset_token], regenerated_token
+      delete provider_password_path, email: 'example@test.com'
 
-    # new token is not being generated, it just renders :show
-    get provider_password_path(password_reset_token: '12345')
-    assert_response :success
-    assert_equal session[:password_reset_token], regenerated_token
-
-    # user updates his password
-    put provider_password_path(user: { password: 'alaska123',password_confirmation: 'alaska123' })
-    assert_response :redirect
-    assert_match 'password has been changed', flash[:notice]
-    assert_nil session[:password_reset_token]
-
-    # user is unable to open forgotten password page again (missing parameter)
-    get provider_password_path
-    assert_response 400
-    # user is unable to open forgotten password page again (invalid token)
-    assert_nil @user.reload.lost_password_token
-    get provider_password_path(password_reset_token: email_token)
-    assert_response :redirect
-    assert_match 'password reset token is invalid', flash[:error]
-    get provider_password_path(password_reset_token: regenerated_token)
-    assert_response :redirect
-    assert_match 'password reset token is invalid', flash[:error]
+      assert_response :found
+    end
   end
 end


### PR DESCRIPTION
We currently have a bug in production that does not allow the user to
reset its password in the master provider. It returns a `Wrong domain
for pat /p/password` error.