### PR TITLE
Fix Deadlock destroying plans by association without updating the position within the service

### DIFF
--- a/test/workers/delete_plain_object_worker_test.rb
+++ b/test/workers/delete_plain_object_worker_test.rb
@@ -139,4 +139,70 @@ class DeletePlainObjectWorkerTest < ActiveSupport::TestCase
     end
 
   end
+
+  class DeletePlanUpdatePosition < DeletePlainObjectWorkerTest
+    test 'destroy plan updates position when the plan is destroyed individually' do
+      service = FactoryBot.create(:simple_service)
+      FactoryBot.create_list(:simple_application_plan, 2, issuer: service)
+      plans = service.plans.order(position: :asc)
+      assert_change of: -> { plans.last.reload.position }, by: -1 do
+        DeletePlainObjectWorker.perform_now(plans.first, %w[HTestClass123])
+      end
+    end
+
+    test 'destroy plan does not update position when it is destroyed by association for the issuer service with state deleted' do
+      service = FactoryBot.create(:simple_service)
+      service.update_column(:state, :deleted)
+      FactoryBot.create_list(:simple_application_plan, 2, issuer: service)
+      plans = service.plans.order(position: :asc)
+
+      assert_no_change of: -> { plans.last.reload.position } do
+        DeletePlainObjectWorker.perform_now(plans.first, %w[HTestClass123 HTestClass123 HTestClass1123])
+      end
+    end
+
+    test 'destroy plan does not update position when it is destroyed by association for the issuer service of an account scheduled for deletion' do
+      service = FactoryBot.create(:simple_service)
+      service.account.update_column(:state, :scheduled_for_deletion)
+      FactoryBot.create_list(:simple_application_plan, 2, issuer: service)
+      plans = service.plans.order(position: :asc)
+
+      assert_no_change of: -> { plans.last.reload.position } do
+        DeletePlainObjectWorker.perform_now(plans.first, %w[HTestClass123 HTestClass123 HTestClass1123])
+      end
+    end
+
+    test 'destroy plan does not update position when it is destroyed by association for the issuer service already deleted' do
+      service = FactoryBot.create(:simple_service)
+      FactoryBot.create_list(:simple_application_plan, 2, issuer: service)
+      plans = service.plans.order(position: :asc)
+      Service.where(id: service.id).delete_all # To don't delete in the same instance :)
+
+      assert_no_change of: -> { plans.last.reload.position } do
+        DeletePlainObjectWorker.perform_now(plans.first, %w[HTestClass123 HTestClass123 HTestClass1123])
+      end
+    end
+
+    test 'destroy plan does not update position when it is destroyed by association for the issuer account scheduled for deletion' do
+      account = FactoryBot.create(:simple_account)
+      FactoryBot.create_list(:simple_account_plan, 2, issuer: account)
+      plans = account.account_plans.order(position: :asc)
+      account.update_column(:state, :scheduled_for_deletion)
+
+      assert_no_change of: -> { plans.last.reload.position } do
+        DeletePlainObjectWorker.perform_now(plans.first, %w[HTestClass123 HTestClass123 HTestClass1123])
+      end
+    end
+
+    test 'destroy plan does not update position when it is destroyed by association for the issuer account already deleted' do
+      account = FactoryBot.create(:simple_account)
+      FactoryBot.create_list(:simple_account_plan, 2, issuer: account)
+      plans = account.account_plans.order(position: :asc)
+      Account.where(id: account.id).delete_all # To don't delete in the same instance :)
+
+      assert_no_change of: -> { plans.last.reload.position } do
+        DeletePlainObjectWorker.perform_now(plans.first, %w[HTestClass123 HTestClass123 HTestClass1123])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is necessary to do [THREESCALE-4483](https://issues.redhat.com/browse/THREESCALE-4483)
It fixes the deadlock described in [this comment](https://issues.redhat.com/browse/THREESCALE-4483?focusedCommentId=13971719&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13971719).

We need to update the position of the plans within an issuer when we remove a plan, however, when we are gonna remove the issuer anyway (which means when the plan is destroyed_by_association), we do not need to do that update.
