### PR TITLE
[memory-leak] Do not regenerate routes every requests

### DIFF
--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -58,7 +58,7 @@ module AccountHelper
       host = current_account.admin_domain + request.port_string
       edit_provider_admin_user_personal_details_url(host: host, protocol: 'https')
     else
-      DeveloperPortal::Engine.routes.url_helpers.admin_account_personal_details_url(host: current_account.domain)
+      developer_portal.admin_account_personal_details_url(host: current_account.domain)
     end
   end
 

--- a/app/models/sso_token.rb
+++ b/app/models/sso_token.rb
@@ -2,7 +2,6 @@ class SSOToken
   include ActiveModel::Validations
   include ActiveModel::MassAssignmentSecurity
   include ActiveModel::Serializers::Xml
-  include Rails.application.routes.url_helpers
 
   attr_accessor   :user_id, :username, :expires_in, :redirect_url, :protocol, :account
   attr_accessible :user_id, :username, :expires_in, :redirect_url, :protocol
@@ -54,6 +53,12 @@ class SSOToken
     end
   end
 
+  class_attribute :system_url_helpers, instance_writer: false
+  self.system_url_helpers = Rails.application.routes.url_helpers
+
+  class_attribute :cms_url_helpers, instance_writer: false
+  self.cms_url_helpers = DeveloperPortal::Engine.routes.url_helpers
+
   # It will save the object if new and will return the sso_url
   #
   # Default for a provider account is to create an url that works on its buyer side,
@@ -70,7 +75,7 @@ class SSOToken
       expires_at: expires_at.to_i,
       redirect_url: redirect_url
     }.delete_if{|k,v| v.nil?}
-    host.nil? ? developer_portal.create_session_url(params) : provider_sso_url(params)
+    host.nil? ? cms_url_helpers.create_session_url(params) : system_url_helpers.provider_sso_url(params)
   end
 
   protected

--- a/app/models/sso_token.rb
+++ b/app/models/sso_token.rb
@@ -70,7 +70,7 @@ class SSOToken
       expires_at: expires_at.to_i,
       redirect_url: redirect_url
     }.delete_if{|k,v| v.nil?}
-    host.nil? ? DeveloperPortal::Engine.routes.url_helpers.create_session_url(params) : provider_sso_url(params)
+    host.nil? ? developer_portal.create_session_url(params) : provider_sso_url(params)
   end
 
   protected

--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -5,6 +5,8 @@ require 'httpclient/include_client'
 class ZyncWorker
   include Sidekiq::Worker
   include ThreeScale::SidekiqRetrySupport::Worker
+  class_attribute :main_app, instance_writer: false
+  self.main_app = Rails.application.routes.url_helpers
 
   extend ::HTTPClient::IncludeClient
 
@@ -331,7 +333,7 @@ class ZyncWorker
               when 'development' then { host: "#{host}.#{ThreeScale.config.dev_gtld}", port: 3000 }
               else { host: host }.reverse_merge(ActionMailer::Base.default_url_options)
               end
-    Rails.application.routes.url_helpers.root_url(options)
+    main_app.root_url(options)
   end
 
   delegate :provider_access_token, to: :class

--- a/lib/developer_portal/app/views/developer_portal/dashboards/components/_latest_forum_posts.html.erb
+++ b/lib/developer_portal/app/views/developer_portal/dashboards/components/_latest_forum_posts.html.erb
@@ -7,8 +7,8 @@
         <li>
           New
           <%= link_to 'post',
-            Rails.application.routes.url_helpers.forum_topic_path(post.topic, :anchor => "post_#{post.id}") %>
-          on topic <%= link_to post.topic.title, Rails.application.routes.url_helpers.forum_topic_path(post.topic) %>
+              main_app.forum_topic_path(post.topic, :anchor => "post_#{post.id}") %>
+          on topic <%= link_to post.topic.title, main_app.forum_topic_path(post.topic) %>
         </li>
       <%- end -%>
     </ul>

--- a/lib/developer_portal/lib/liquid/drops/application.rb
+++ b/lib/developer_portal/lib/liquid/drops/application.rb
@@ -17,7 +17,7 @@ module Liquid
       # Filter might be better, as in Shopify: http://cheat.markdunkley.com/
       desc "Returns the admin_url of the application."
       def admin_url
-        Rails.application.routes.url_helpers.admin_service_application_url(@contract.service, @contract, host: @contract.provider_account.self_domain)
+        system_url_helpers.admin_service_application_url(@contract.service, @contract, host: @contract.provider_account.self_domain)
       end
 
       def path

--- a/lib/developer_portal/lib/liquid/drops/base.rb
+++ b/lib/developer_portal/lib/liquid/drops/base.rb
@@ -5,6 +5,13 @@ module Liquid
     class Base < Liquid::Drop
       class_attribute :_deprecated_names, :_allowed_names, :instance_writer => false, :instance_reader => false
 
+      class_attribute :system_url_helpers, instance_writer: false
+      self.system_url_helpers = Rails.application.routes.url_helpers
+
+      class_attribute :cms_url_helpers, instance_writer: false
+      self.cms_url_helpers = DeveloperPortal::Engine.routes.url_helpers
+
+
       extend Liquid::Docs::DSL::Drops
 
       private
@@ -102,14 +109,6 @@ module Liquid
 
       def optimize_routes_generation?
         true
-      end
-
-      def system_url_helpers
-        Rails.application.routes.url_helpers
-      end
-
-      def cms_url_helpers
-        DeveloperPortal::Engine.routes.url_helpers
       end
     end
   end

--- a/lib/developer_portal/lib/liquid/drops/topic.rb
+++ b/lib/developer_portal/lib/liquid/drops/topic.rb
@@ -10,7 +10,7 @@ module Liquid
       end
 
       def url
-        Rails.application.routes.url_helpers.forum_topic_path(@model)
+        system_url_helpers.forum_topic_path(@model)
       end
     end
   end

--- a/lib/developer_portal/lib/liquid/forms/base.rb
+++ b/lib/developer_portal/lib/liquid/forms/base.rb
@@ -3,7 +3,6 @@ module Liquid
     class Base
       attr_reader :context
 
-      #include Rails.application.routes.url_helpers
       include DeveloperPortal::Engine.routes.url_helpers
 
       delegate :tag, :content_tag, to: 'Liquid::Filters::RailsHelpers'


### PR DESCRIPTION
Fixes THREESCALE-3397

Big thanks to @guicassolato  who made a deep search on this memory leak
He found out that the routes helpers were increasing every requests

Also read rails/rails#32304 (comment)