### PR TITLE
[test] Allow the use of Spring

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = true 
+  config.eager_load = Kernel.const_defined?(:Spring) ? false : true
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = Kernel.const_defined?(:Spring) ? false : true
+  config.eager_load = !Kernel.const_defined?(:Spring)
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {


### PR DESCRIPTION
Do not eager_load if Spring is defined in Kernel.
Meaning it is run inside of a Spring server fork