### PR TITLE
Fix connection error on detection of Redis sentinel

### DIFF
--- a/config/initializers/redis_hacks.rb
+++ b/config/initializers/redis_hacks.rb
@@ -4,36 +4,34 @@
 # See https://github.com/redis/redis-rb/pull/856
 # We can remove this once we can upgrade the gem to >= v4.1.2
 
-class Redis
-  class Client
-    class Connector
-      class Sentinel < Connector
-        def sentinel_detect
-          @sentinels.each do |sentinel|
-            client = Client.new(@options.merge({
-              :host => sentinel[:host],
-              :port => sentinel[:port],
-              :password => sentinel[:password], # https://github.com/redis/redis-rb/pull/856
-              :reconnect_attempts => 0,
-            }))
+module RedisHacks
+  def sentinel_detect
+    @sentinels.each do |sentinel|
+      client = Redis::Client.new(@options.merge({
+        :host => sentinel[:host],
+        :port => sentinel[:port],
+        :password => sentinel[:password], # https://github.com/redis/redis-rb/pull/856
+        :reconnect_attempts => 0,
+      }))
 
-            begin
-              if result = yield(client)
-                # This sentinel responded. Make sure we ask it first next time.
-                @sentinels.delete(sentinel)
-                @sentinels.unshift(sentinel)
+      begin
+        if result = yield(client)
+          # This sentinel responded. Make sure we ask it first next time.
+          @sentinels.delete(sentinel)
+          @sentinels.unshift(sentinel)
 
-                return result
-              end
-            rescue BaseConnectionError
-            ensure
-              client.disconnect
-            end
-          end
-
-          raise CannotConnectError, "No sentinels available."
+          return result
         end
+      rescue Redis::BaseConnectionError
+      rescue RuntimeError => exception
+        raise unless exception.message =~ /Name or service not known/
+      ensure
+        client.disconnect
       end
     end
+
+    raise CannotConnectError, "No sentinels available."
   end
 end
+
+Redis::Client::Connector::Sentinel.prepend(RedisHacks)


### PR DESCRIPTION
While trying to detect redis sentinels, DNS failures are raised not with the expected `Redis::BaseConnectionError` class, but as simple `RuntimeError`, making https://github.com/redis/redis-rb to fail on `Redis::Client::Connector::Sentinel#sentinel_detect` without rescue.

This PR makes the hack introduced in https://github.com/3scale/porta/pull/858 to address this issue as well.

Closes System part of [THREESCALE-4495](https://issues.redhat.com/browse/THREESCALE-4495).