### PR TITLE
Disable Reset Password for Master account

### DIFF
--- a/app/controllers/provider/passwords_controller.rb
+++ b/app/controllers/provider/passwords_controller.rb
@@ -56,10 +56,11 @@ class Provider::PasswordsController < FrontendController
   # Can't be used for neither Buyer nor Master
   #
   def find_provider
-    unless @provider ||= Account.providers_with_master.find_by_self_domain(request.host.to_s)
-      render_error "Wrong domain '#{request.host}' for path '#{request.path}'", status: 404
-      false
-    end
+    @provider ||= Account.tenants.find_by_self_domain(request.host.to_s)
+    return if @provider
+
+    render_error "Wrong domain '#{request.host}' for path '#{request.path}'", status: 404
+    false
   end
 
   def find_user

--- a/app/controllers/provider/passwords_controller.rb
+++ b/app/controllers/provider/passwords_controller.rb
@@ -56,7 +56,7 @@ class Provider::PasswordsController < FrontendController
   # Can't be used for neither Buyer nor Master
   #
   def find_provider
-    @provider ||= Account.tenants.find_by_self_domain(request.host.to_s)
+    @provider ||= Account.tenants.find_by(self_domain: request.host.to_s)
     return if @provider
 
     render_error "Wrong domain '#{request.host}' for path '#{request.path}'", status: 404

--- a/app/javascript/src/LoginPage/LoginPageWrapper.jsx
+++ b/app/javascript/src/LoginPage/LoginPageWrapper.jsx
@@ -37,6 +37,7 @@ type Props = {
   providerSessionsPath: string,
   redirectUrl: string,
   show3scaleLoginForm: boolean,
+  masterAccount: boolean,
   session: {
     username: ?string
   }
@@ -74,7 +75,7 @@ class SimpleLoginPage extends React.Component<Props, State> {
   }
 
   showForgotCredentials () {
-    const showForgotCredentials = this.state.formMode === formModeTuple[0]
+    const showForgotCredentials = this.state.formMode === formModeTuple[0] && !this.props.masterAccount
     return showForgotCredentials && <ForgotCredentials providerLoginPath={this.props.providerLoginPath}/>
   }
 

--- a/app/javascript/src/LoginPage/LoginPageWrapper.jsx
+++ b/app/javascript/src/LoginPage/LoginPageWrapper.jsx
@@ -37,7 +37,7 @@ type Props = {
   providerSessionsPath: string,
   redirectUrl: string,
   show3scaleLoginForm: boolean,
-  masterAccount: boolean,
+  disablePasswordReset: boolean,
   session: {
     username: ?string
   }
@@ -75,7 +75,7 @@ class SimpleLoginPage extends React.Component<Props, State> {
   }
 
   showForgotCredentials () {
-    const showForgotCredentials = this.state.formMode === formModeTuple[0] && !this.props.masterAccount
+    const showForgotCredentials = this.state.formMode === formModeTuple[0] && !this.props.disablePasswordReset
     return showForgotCredentials && <ForgotCredentials providerLoginPath={this.props.providerLoginPath}/>
   }
 

--- a/app/views/provider/sessions/new.html.slim
+++ b/app/views/provider/sessions/new.html.slim
@@ -1,6 +1,7 @@
 = javascript_pack_tag 'LoginPage'
 - authentication_providers = (@authentication_providers || []).map { |ap| {authorizeURL: ap.authorize_url, humanKind: ap.human_kind} }
 - flash_messages = (flash || []).map { |f| {type: f[0], message: f[1]}}
+- is_master_account = domain_account.master?
 div#pf-login-page-container data-login-props={redirectUrl: (session[:return_to].nil? ? "null" : (request.protocol + request.host_with_port + session[:return_to])),
   enforceSSO: false,
   authenticationProviders: authentication_providers,
@@ -10,6 +11,7 @@ div#pf-login-page-container data-login-props={redirectUrl: (session[:return_to].
   providerLoginPath: provider_login_path,
   providerPasswordPath: provider_password_path,
   providerAdminDashboardPath: provider_admin_dashboard_path,
+  disablePasswordReset: is_master_account,
   session: {username: params[:username]} }.to_json
 
 #old-login-page-wrapper
@@ -35,7 +37,7 @@ div#pf-login-page-container data-login-props={redirectUrl: (session[:return_to].
             = f.input :password, input_html: { name: 'password', tabindex: 2, autofocus: (params[:username] ? true : false) }
             = f.hidden_field :remember_me, value: 'true'
           = f.buttons do
-            - unless domain_account.master?
+            - unless is_master_account
               li.forgot
                 = link_to 'Forgot password?', provider_login_path(request_password_reset: true), class: 'toggle-panel', data: { panel:  'request_password_reset_panel' }
 

--- a/app/views/provider/sessions/new.html.slim
+++ b/app/views/provider/sessions/new.html.slim
@@ -35,8 +35,9 @@ div#pf-login-page-container data-login-props={redirectUrl: (session[:return_to].
             = f.input :password, input_html: { name: 'password', tabindex: 2, autofocus: (params[:username] ? true : false) }
             = f.hidden_field :remember_me, value: 'true'
           = f.buttons do
-            li.forgot
-              = link_to 'Forgot password?', provider_login_path(request_password_reset: true), class: 'toggle-panel', data: { panel:  'request_password_reset_panel' }
+            - unless domain_account.master?
+              li.forgot
+                = link_to 'Forgot password?', provider_login_path(request_password_reset: true), class: 'toggle-panel', data: { panel:  'request_password_reset_panel' }
 
             li.commit
               = submit_tag 'Sign in', class: 'important-button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,10 +163,13 @@ without fake Core server your after commit callbacks will crash and you might ge
   get '/auth/:system_name/callback' => 'provider/sessions#create', constraints: MasterOrProviderDomainConstraint
   get '/auth/:system_name/bounce' => 'provider/sessions#bounce', constraints: ProviderDomainConstraint, as: :authorization_provider_bounce
 
+  namespace :provider, path: 'p', constraints: ProviderDomainConstraint do
+    resource :password, :only => %i(new show update destroy)
+  end
+
   namespace :provider, :path => 'p', constraints: MasterOrProviderDomainConstraint do
     get 'activate/:activation_code' => 'activations#create', :as => :activate
 
-    resource :password, :only => %i(new show update destroy)
     resource :domains, :only => [:show] do
       collection do
         post :recover

--- a/features/old/accounts/password_reset.feature
+++ b/features/old/accounts/password_reset.feature
@@ -28,6 +28,14 @@ Feature: Provider password reset
     And I press "Sign in"
     Then I should be logged in as "zed"
 
+  Scenario: Reset password not available for master domain
+    When current domain is the master domain of provider "foo.example.com"
+    And I go to the provider login page
+
+    Then I should see "Email"
+    Then I should see "Password"
+    Then I should not see "Forgot Password?"
+
   Scenario: Invalid email
     Given no user exists with an email of "bob@example.com"
     And I follow "Forgot password?"

--- a/features/step_definitions/url_steps.rb
+++ b/features/step_definitions/url_steps.rb
@@ -17,9 +17,9 @@ When /^I hit "([^"]*)" on ([^\s]+)$/ do |path,domain|
   visit path
 end
 
-When /^current domain is the admin domain of (provider "[^"]*")$/ do |provider|
+When /^current domain is the (admin|master) domain of (provider "[^"]*")$/ do |level, provider|
   raise "Missing admin domain of #{provider.name}" if provider.admin_domain.blank?
-  step %(the current domain is #{provider.admin_domain})
+  step %(the current domain is #{level == 'admin' ? provider.admin_domain : 'the master domain'})
   @provider = provider
 end
 

--- a/spec/javascripts/LoginPage/LoginPageWrapper.spec.jsx
+++ b/spec/javascripts/LoginPage/LoginPageWrapper.spec.jsx
@@ -12,7 +12,7 @@ const props = {
   providerSessionsPath: 'sessions-path',
   redirectUrl: 'redirect-url',
   show3scaleLoginForm: true,
-  masterAccount: false,
+  disablePasswordReset: false,
   session: {username: ''}
 }
 
@@ -40,17 +40,13 @@ it('should render <RequestPasswordForm/> component when formMode state is set to
   expect(wrapper.find(RequestPasswordForm).exists()).toEqual(true)
 })
 
-it('should render <ForgotCredentials/> component when masterAccount is false', () => {
+it('should render a reset password button', () => {
   const wrapper = mount(<SimpleLoginPage {...props}/>)
   expect(wrapper.find(ForgotCredentials).exists()).toEqual(true)
 })
 
-it('should not render <ForgotCredentials/> component when masterAccount is true', () => {
-  const propsWithoutMasterAccount = {
-    ...props,
-    masterAccount: true
-  }
-  const wrapper = mount(<SimpleLoginPage {...propsWithoutMasterAccount}/>)
+it('should not render a reset password button when disabled', () => {
+  const wrapper = mount(<SimpleLoginPage {...props} disablePasswordReset />)
   expect(wrapper.find(ForgotCredentials).exists()).toEqual(false)
 })
 

--- a/spec/javascripts/LoginPage/LoginPageWrapper.spec.jsx
+++ b/spec/javascripts/LoginPage/LoginPageWrapper.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {mount} from 'enzyme'
 
-import {SimpleLoginPage, Login3scaleForm, RequestPasswordForm} from 'LoginPage'
+import {SimpleLoginPage, Login3scaleForm, RequestPasswordForm, ForgotCredentials} from 'LoginPage'
 
 const props = {
   enforceSSO: false,
@@ -12,6 +12,7 @@ const props = {
   providerSessionsPath: 'sessions-path',
   redirectUrl: 'redirect-url',
   show3scaleLoginForm: true,
+  masterAccount: false,
   session: {username: ''}
 }
 
@@ -37,6 +38,20 @@ it('should render <RequestPasswordForm/> component when formMode state is set to
   const wrapper = mount(<SimpleLoginPage {...props}/>)
   wrapper.setState({formMode: 'password-reset'})
   expect(wrapper.find(RequestPasswordForm).exists()).toEqual(true)
+})
+
+it('should render <ForgotCredentials/> component when masterAccount is false', () => {
+  const wrapper = mount(<SimpleLoginPage {...props}/>)
+  expect(wrapper.find(ForgotCredentials).exists()).toEqual(true)
+})
+
+it('should not render <ForgotCredentials/> component when masterAccount is true', () => {
+  const propsWithoutMasterAccount = {
+    ...props,
+    masterAccount: true
+  }
+  const wrapper = mount(<SimpleLoginPage {...propsWithoutMasterAccount}/>)
+  expect(wrapper.find(ForgotCredentials).exists()).toEqual(false)
 })
 
 it('should render Login form and Authentication providers when available', () => {

--- a/test/integration/provider/passwords_test.rb
+++ b/test/integration/provider/passwords_test.rb
@@ -51,12 +51,12 @@ class Provider::PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   class WithMasterUserTest < Provider::PasswordsControllerTest
-    test '#destroy also works for master account' do
+    test '#destroy does not work for master account' do
       login_provider master_account
 
       delete provider_password_path, email: 'example@test.com'
 
-      assert_response :found
+      assert_response :not_found
     end
   end
 end


### PR DESCRIPTION
[THREESCALE-303](https://issues.redhat.com/browse/THREESCALE-303)
We currently enabled reseting password for master account but we
shouldn't have done this. This commit disables the reset password link
for master account.