### PR TITLE
Fix deploy to OCP with PostgreSQL

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -9,6 +9,18 @@ namespace :db do
   end
 
   namespace :deploy do
-    task setup: %w(db:setup countries:import countries:disable_t5)
+    task setup: %i[environment db:load_config] do
+      begin
+        ActiveRecord::Tasks::DatabaseTasks.create_current
+      rescue ActiveRecord::StatementInvalid => exception
+        raise unless exception.message =~ /PG::InsufficientPrivilege/
+      end
+
+      Rake::Task['db:schema:load'].invoke
+      Rake::Task['db:seed'].invoke
+
+      Rake::Task['countries:import'].invoke
+      Rake::Task['countries:disable_t5'].invoke
+    end
   end
 end

--- a/openshift/system/config/database.yml
+++ b/openshift/system/config/database.yml
@@ -9,11 +9,11 @@ base: &default
     timezone: 'UTC'
 <% else %>
   adapter: mysql2
+  collation: utf8_bin
 <% end %>
 
   url: <%= ENV['DATABASE_URL'] %>
   encoding: utf8
-  collation: utf8_bin
   pool: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
 
 production:


### PR DESCRIPTION
Deploying to OCP with PostgreSQL fails with `PG::InsufficientPrivilege: ERROR: permission denied to create database` due to `db:setup` always trying to create the database, even when the database is already there. This PR handles this error.

Closes [THREESCALE-4522](https://issues.redhat.com/browse/THREESCALE-4522)