### PR TITLE
APIAP small ux improvements

### DIFF
--- a/app/assets/stylesheets/provider/_commons.scss
+++ b/app/assets/stylesheets/provider/_commons.scss
@@ -95,7 +95,7 @@ main > p:not(:first-child) {
 main > h1:first-child + p,
 main > h2:first-child + p {
   box-shadow: none;
-  margin: line-height-times(-1) line-height-times(-1) line-height-times(1);
+  margin: line-height-times(-2) line-height-times(-1) line-height-times(1);
 }
 
 dd p {

--- a/app/controllers/admin/api/backend_apis_controller.rb
+++ b/app/controllers/admin/api/backend_apis_controller.rb
@@ -60,7 +60,7 @@ class Admin::Api::BackendApisController < Admin::Api::BaseController
   ##~ op.parameters.add :name => "name", :description => "Name of the Backend", :dataType => "string", :required => true, :paramType => "query"
   ##~ op.parameters.add @parameter_system_name_by_name
   ##~ op.parameters.add @parameter_backend_api_description
-  ##~ op.parameters.add :name => "private_endpoint", :description => "Private endpoint of the Backend", :dataType => "string", :required => true, :paramType => "query"
+  ##~ op.parameters.add :name => "private_endpoint", :description => "Private Base URL (your API)", :dataType => "string", :required => true, :paramType => "query"
   #
   def create
     backend_api = current_account.backend_apis.create(create_params)
@@ -98,7 +98,7 @@ class Admin::Api::BackendApisController < Admin::Api::BaseController
   ##~ op.parameters.add @parameter_backend_api_id_by_id
   ##~ op.parameters.add :name => "name", :description => "Name of the Backend", :dataType => "string", :required => false, :paramType => "query"
   ##~ op.parameters.add @parameter_backend_api_description
-  ##~ op.parameters.add :name => "private_endpoint", :description => "Private endpoint of the Backend", :dataType => "string", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "private_endpoint", :description => "Private Base URL (your API)", :dataType => "string", :required => false, :paramType => "query"
   #
   def update
     backend_api.update(update_params)

--- a/app/views/api/backend_usages/edit.html.slim
+++ b/app/views/api/backend_usages/edit.html.slim
@@ -1,12 +1,11 @@
-= content_for :sublayout_title, 'Edit Backend usage'
+= content_for :sublayout_title, 'Edit Backend Usage'
 
 = semantic_form_for @backend_api_config, url: admin_service_backend_usage_path(@service, @backend_api_config) do |form|
   = form.inputs do
     li
       = form.label :backend_api_id, 'Backend'
       = form.text_field :backend_api_id, class: 'text', value: @backend_api_config.backend_api.name, disabled: true
-    = form.input :path, hint: 'Changing this path will only affect the behaviour of this Backend within the context of this Product'
+    = form.input :path, hint: 'Changing the public path will only affect this product', label: 'Public Path'
 
   = form.buttons do
     = form.commit_button 'Update'
-

--- a/app/views/api/backend_usages/edit.html.slim
+++ b/app/views/api/backend_usages/edit.html.slim
@@ -5,7 +5,7 @@
     li
       = form.label :backend_api_id, 'Backend'
       = form.text_field :backend_api_id, class: 'text', value: @backend_api_config.backend_api.name, disabled: true
-    = form.input :path, hint: 'Changing the public path will only affect this product', label: 'Public Path'
+    = form.input :path, hint: 'Changing the Public Path will only affect this Product.', label: 'Public Path'
 
   = form.buttons do
     = form.commit_button 'Update'

--- a/app/views/api/backend_usages/index.html.slim
+++ b/app/views/api/backend_usages/index.html.slim
@@ -1,11 +1,15 @@
-h2 Backends
+h1 Backends
+p.intro For a product to work, it needs to have at least one backend with a Private Base URL (your API). If multiple backends are added to a product, each backend will have a unique public path.
+
 
 table#backend_api_configs.data
   thead
     tr
-      th = sortable('backend_apis.name', 'Backend')
-      th = sortable('backend_apis.private_endpoint', 'Private URL')
-      th = sortable('backend_api_configs.path', 'Path')
+      th = sortable('backend_apis.name', 'Name')
+      th = sortable('backend_apis.private_endpoint', 'Private Base URL')
+      th
+        = sortable('backend_api_configs.path', 'Public Path')
+        = help_bubble( 'api_endpoint_bubble', t('api.backend_apis.public_path_help_html'))
       th.actions
         = action_link_to :add, new_admin_service_backend_usage_path(@service), label: 'Add Backend'
   tbody

--- a/app/views/api/backend_usages/index.html.slim
+++ b/app/views/api/backend_usages/index.html.slim
@@ -1,5 +1,5 @@
 h1 Backends
-p.intro For a product to work, it needs to have at least one backend with a Private Base URL (your API). If multiple backends are added to a product, each backend will have a unique public path.
+p.intro For a Product to work, it needs to have at least one Backend with a Private Base URL (your API). If multiple Backends are added to a Product, each Backend should have a unique Public Path.
 
 
 table#backend_api_configs.data

--- a/app/views/provider/admin/backend_apis/forms/_naming.html.slim
+++ b/app/views/provider/admin/backend_apis/forms/_naming.html.slim
@@ -4,4 +4,4 @@
   = form.input :description, input_html: { rows: 3 }
 
 = form.inputs 'API' do
-  = form.input :private_endpoint, hint: t("formtastic.hints.proxy.api_backend_https")
+  = form.input :private_endpoint, hint: t("formtastic.hints.proxy.api_backend_https"), label: "Private Base URL"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -459,6 +459,7 @@ en:
     backend_apis:
       edit:
         delete_confirmation: "Are you sure you want to delete the backend '%{name}'?"
+      public_path_help_html: "The path where this backend and its methods are available within the context of this product."
     services:
       forms:
         definition_settings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -459,7 +459,7 @@ en:
     backend_apis:
       edit:
         delete_confirmation: "Are you sure you want to delete the backend '%{name}'?"
-      public_path_help_html: "The path where this backend and its methods are available within the context of this product."
+      public_path_help_html: "The path where this Backend API and its methods are available within the context of this Product."
     services:
       forms:
         definition_settings:


### PR DESCRIPTION
Fixes nothing, just tries to:
- make backends in a product and the path they have a bit easier to understand
- be consistent with naming of Private Base URL

(triggered by docs review)

<img width="1680" alt="Screenshot 2020-02-18 16 43 38" src="https://user-images.githubusercontent.com/54224/74751750-04491500-526e-11ea-9a35-129f7128cdd5.png">
<img width="575" alt="Screenshot 2020-02-18 16 43 43" src="https://user-images.githubusercontent.com/54224/74751748-03b07e80-526e-11ea-95c1-474e1cefe23a.png">
<img width="828" alt="Screenshot 2020-02-18 16 44 50" src="https://user-images.githubusercontent.com/54224/74751746-0317e800-526e-11ea-8d2f-ce94e34afc92.png">


<img width="629" alt="Screenshot 2020-02-18 at 16 46 24" src="https://user-images.githubusercontent.com/54224/74751899-35294a00-526e-11ea-9ab9-39f5c22d3b29.png">



