### PR TITLE
Set compile to true in test environent

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -42,7 +42,7 @@ development:
 
 test:
   <<: *default
-  compile: false
+  compile: true
   webpack_compile_output: true
 
   # Compile test packs to a separate directory


### PR DESCRIPTION
**What this PR does / why we need it**:

When running test (features) locally, webpacker doesn't compile, resulting in errors like:

> Webpacker can't find XXXXX in /your-path-to-file.
> Possible causes:
>       1. You want to set webpacker.yml value of compile to true for your environment
>          unless you are using the `webpack -w` or the webpack-dev-server.
>       2. webpack has not yet re-run to reflect updates.
>       3. You have misconfigured Webpacker's config/webpacker.yml file.
>       4. Your webpack configuration is not creating a manifest.

