### PR TITLE
Downgrades rack from 2.2.2 back to 2.0.9

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -6,6 +6,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # on servers we don't have proper LANG
 Encoding.default_external = Encoding::UTF_8
 
+gem 'rack', '~> 2.0.9'
+
 gem 'aws-sdk', '~> 2'
 gem 'aws-sdk-rails', '~> 1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,7 +507,7 @@ GEM
       pry (>= 0.9.11)
     public_suffix (3.1.1)
     raabro (1.1.6)
-    rack (2.2.2)
+    rack (2.0.9)
     rack-no_animations (1.0.3)
     rack-openid (1.4.2)
       rack (>= 1.1.0)
@@ -900,6 +900,7 @@ DEPENDENCIES
   pry-doc (>= 0.8)
   pry-rails
   pry-stack_explorer
+  rack (~> 2.0.9)
   rack-no_animations (~> 1.0.3)
   rack-utf8_sanitizer
   rack-x_served_by (~> 0.1.1)

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
       pry (>= 0.9.11)
     public_suffix (3.1.1)
     raabro (1.1.6)
-    rack (2.2.2)
+    rack (2.0.9)
     rack-no_animations (1.0.3)
     rack-openid (1.4.2)
       rack (>= 1.1.0)
@@ -901,6 +901,7 @@ DEPENDENCIES
   pry-doc (>= 0.8)
   pry-rails
   pry-stack_explorer
+  rack (~> 2.0.9)
   rack-no_animations (~> 1.0.3)
   rack-utf8_sanitizer
   rack-x_served_by (~> 0.1.1)


### PR DESCRIPTION
Closes [THREESCALE-4527](https://issues.redhat.com/browse/THREESCALE-4527)