### PR TITLE
[rake] Task to reset password of a User of Master tenant

### DIFF
--- a/lib/tasks/password_reset.rake
+++ b/lib/tasks/password_reset.rake
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'io/console'
+
+namespace :password do
+  namespace :master do
+    desc 'Reset password for a master user'
+    task(:reset, %i[email_or_username password] => [:environment]) do |_task, args|
+      def say(message, icon = :info)
+        puts "[#{emoji(icon)}] " + message.to_s
+      end
+
+      def emoji(icon)
+        case icon
+        when :question
+          "\e[34m?\e[0m"
+        when :info
+          "\e[36m\xE2\x84\xB9\e[0m"
+        when :ok
+          "\e[32m\xE2\x9C\x94\e[0m"
+        when :fail
+          "\e[32m\xE2\x9C\x96	\e[0m"
+        else
+          "....."
+        end
+      end
+
+      say "You are about to change the password of a user of Master tenant"
+      email = args.email_or_username
+      password = args.password
+      password_confirmation = args.password
+
+      if email.blank?
+        say "Please give the email or username of the user", :question
+        email = STDIN.gets
+        email.chomp!
+      end
+      user = Account.master.users.where.has { |t| (t.email == email) | (t.username == email) }.first
+      unless user
+        say "Can't find User `#{email}`", :fail
+        exit 1
+      end
+      if password.blank?
+        loop do
+          say "Please enter the NEW password", :question
+          password = STDIN.noecho(&:gets).chomp
+          break if password.present?
+        end
+        loop do
+          say "Please confirm the password", :question
+          password_confirmation = STDIN.noecho(&:gets).chomp
+          break if password_confirmation.present?
+        end
+
+        if password != password_confirmation
+          say "Password and confirmation does not match", :fail
+          exit 1
+        end
+      end
+
+      user.password = user.password_confirmation = password
+
+      if user.save
+        say "`#{email}` password has been changed successfully", :ok
+      else
+        say "Error in saving #{email} password"
+        say user.errors.full_messages.join("\n"), :info
+        exit 1
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Relates to https://issues.redhat.com/browse/THREESCALE-303

Usage, in a shell console where the application is running

#### Resetting password

```shell
bundle exec rails 'password:reset:master'
```

You will be prompted for the email or username
Then you will be prompted for the password and confirm it

#### Resetting password providing the username/email

```shell
bundle exec rails 'password:reset:master[john]'
```

Then you will be prompted for the password and confirm it

#### Resetting password providing username/email and password

```shell
bundle exec rails 'password:reset:master[john,123456]'
```

It will set the password of User `john` to `123456`