### PR TITLE
Test for the RedisHacks

### DIFF
--- a/config/initializers/redis_hacks.rb
+++ b/config/initializers/redis_hacks.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
+# [Patch #1]
 # Monkey patches redis-db so sentinel passwords are supported
 # See https://github.com/redis/redis-rb/pull/856
-# We can remove this once we can upgrade the gem to >= v4.1.2
+# We can remove this specific part of the hack once we can upgrade the gem to >= v4.1.2
+
+# [Patch #2]
+# Monkey patches redis-db so connections errors with exception class `RuntimeError` and
+# message "Name or service not known" (i.e. name solving problems) are properly handled
+# This is because hiredis does not issue a `SocketError` in such cases, but an ugly
+# `RuntimeError` instead
 
 module RedisHacks
   def sentinel_detect
@@ -10,7 +17,7 @@ module RedisHacks
       client = Redis::Client.new(@options.merge({
         :host => sentinel[:host],
         :port => sentinel[:port],
-        :password => sentinel[:password], # https://github.com/redis/redis-rb/pull/856
+        :password => sentinel[:password], # [Patch #1]
         :reconnect_attempts => 0,
       }))
 
@@ -23,7 +30,7 @@ module RedisHacks
           return result
         end
       rescue Redis::BaseConnectionError
-      rescue RuntimeError => exception
+      rescue RuntimeError => exception # [Patch #2]
         raise unless exception.message =~ /Name or service not known/
       ensure
         client.disconnect

--- a/test/unit/redis_hacks_test.rb
+++ b/test/unit/redis_hacks_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RedisHacksTest < ActiveSupport::TestCase
+  test 'Name or service not known' do
+    redis_config = ThreeScale::RedisConfig.new(
+      url: 'redis://mymaster',
+      pool_size: 5,
+      pool_timeout: 5,
+      sentinels: '127.0.0.1:26380,localhost:26381',
+      role: :master
+    ).config
+
+    redis = Redis.new(redis_config)
+    redis_client = redis.client
+
+    sentinel_1_options = build_sentinel_options(redis_client, redis_config[:sentinels].first)
+    sentinel_2_options = build_sentinel_options(redis_client, redis_config[:sentinels].second)
+
+    Redis::Client.expects(:new).with(sentinel_1_options).returns(sentinel_1 = mock)
+    Redis::Client.expects(:new).with(sentinel_2_options).returns(sentinel_2 = mock)
+
+    sentinel_1.expects(:call).raises(RuntimeError.new('Name or service not known'))
+    sentinel_1.expects(:disconnect)
+    sentinel_2.expects(:call).returns(sentinel_2_options.values_at(:host, :port))
+    sentinel_2.expects(:disconnect)
+
+    exception = assert_raises(Redis::CannotConnectError) { redis_client.send(:establish_connection) }
+    assert_equal 'Error connecting to Redis on localhost:26381 (Errno::ECONNREFUSED)', exception.message
+  end
+
+  protected
+
+  def build_sentinel_options(redis_client, sentinel)
+    options = redis_client.instance_variable_get(:@options).dup
+    options.delete(:sentinels)
+    options.merge!(
+      db: 0,
+      host: sentinel[:host],
+      port: sentinel[:port],
+      password: sentinel[:password],
+      reconnect_attempts: 0
+    )
+  end
+end


### PR DESCRIPTION
Introduces a test for the `RedisHacks` module, ensuring that the `RuntimeError` exceptions with message "Name or service not known" are handled when trying attempting to connect to Redis sentinels.

The test assumes too much about the implementation of `Redis::Client`, but I found no other way since it's testing a hack on that class. Maybe we could mock the connection with the sentinel instead.