### PR TITLE
[wip] Fix a couple more random test failures

### DIFF
--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -218,6 +218,8 @@ FactoryBot.define do
       account.admins.each { |user| user.activate! if user.can_activate? }
       account.approve! if account.can_approve?
 
+      next account.reload if account.default_service
+
       #[multiservice] First service is the default
       service = FactoryBot.create(:service, :account => account)
 
@@ -233,10 +235,10 @@ FactoryBot.define do
 
       # TODO: add more master features here, if needed
       %w[prepaid_billing postpaid_billing anonymous_clients liquid].each do |feature|
-        account.default_service.features.create!(:system_name => feature, :name => feature.humanize)
+        service.features.create!(:system_name => feature, :name => feature.humanize)
       end
 
-      FactoryBot.create(:cinstance, :plan => account.default_service.application_plans.published.first,
+      FactoryBot.create(:cinstance, :plan => service.application_plans.published.first,
                         :user_account => account)
 
       account.reload

--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -190,7 +190,7 @@ FactoryBot.define do
 
   factory(:provider_with_billing, :parent => :provider_account) do
     after(:create) do |a|
-      a.billing_strategy= FactoryBot.create(:postpaid_billing, :numbering_period => 'monthly');
+      a.billing_strategy = FactoryBot.create(:postpaid_billing, account: a, numbering_period: 'monthly');
       a.save
     end
   end

--- a/test/unit/finance/billing_strategy_test.rb
+++ b/test/unit/finance/billing_strategy_test.rb
@@ -21,7 +21,8 @@ class Finance::BillingStrategyTest < ActiveSupport::TestCase
     # TODO: calling a private method is not nice.
     @bs.send(:add_cost, contract, 'foo', 'bar', 10)
 
-    assert line_item = LineItem::PlanCost.last, 'missing plan cost'
+    line_item = @provider.invoices.last.line_items.where(type: LineItem::PlanCost).last
+    assert line_item, 'missing plan cost'
 
     assert_equal 'foo', line_item.name
     assert_equal 'bar', line_item.description

--- a/test/unit/finance/variable_cost_test.rb
+++ b/test/unit/finance/variable_cost_test.rb
@@ -1,18 +1,17 @@
 require 'test_helper'
 
 class Finance::VariableCostTest < ActiveSupport::TestCase
-
   test 'bill_variable_fee_for' do
     cinstance = FactoryBot.create(:cinstance)
-    fake_model = FactoryBot.create(:provider_with_billing)
+    provider = FactoryBot.create(:provider_with_billing)
     period = Month.new(Time.now)
-    invoice_proxy = Finance::InvoiceProxy.new(fake_model, period)
+    invoice_proxy = Finance::InvoiceProxy.new(provider, period)
 
     metric = FactoryBot.create(:metric)
     cinstance.stubs(:calculate_variable_cost).returns([{metric => 1},{metric => 10}])
     cinstance.send(:bill_variable_fee_for, period, invoice_proxy, cinstance.plan)
 
-    line_item = LineItem.last
+    line_item = invoice_proxy.line_items.last
     assert_equal 'LineItem::VariableCost', line_item.type
     assert_equal metric, line_item.metric
     assert_equal metric.friendly_name, line_item.name

--- a/test/unit/mailers/post_office_test.rb
+++ b/test/unit/mailers/post_office_test.rb
@@ -41,9 +41,9 @@ class PostOfficeTest < ActionMailer::TestCase
   test 'message_notification from master to provider test send only to admins' do
     FactoryBot.create(:simple_user, account: @provider)
     @provider.reload
-    Account.master.update_column(:email_all_users, false)
+    master_account.update_column(:email_all_users, false)
     subject = generate_message_subject
-    message   = Message.create!(:sender => Account.master, :to => [@provider], :subject => subject, :body => "message")
+    message   = Message.create!(:sender => master_account, :to => [@provider], :subject => subject, :body => "message")
     recipient = message.recipients.first
 
     PostOffice.message_notification(message, recipient).deliver_now
@@ -55,9 +55,9 @@ class PostOfficeTest < ActionMailer::TestCase
   test 'message_notification from master to provider should send to all users' do
     FactoryBot.create(:simple_user, account: @provider)
     @provider.reload
-    Account.master.update_column(:email_all_users, true)
+    master_account.update_column(:email_all_users, true)
     subject = generate_message_subject
-    message   = Message.create!(:sender => Account.master, :to => [@provider], :subject => subject, :body => "message")
+    message   = Message.create!(:sender => master_account, :to => [@provider], :subject => subject, :body => "message")
     recipient = message.recipients.first
 
     PostOffice.message_notification(message, recipient).deliver_now
@@ -67,17 +67,17 @@ class PostOfficeTest < ActionMailer::TestCase
   end
 
   test 'message_notification from provider to master should send only to admin' do
-    FactoryBot.create(:simple_user, account: Account.master)
-    Account.master.update_column(:email_all_users, true)
+    FactoryBot.create(:simple_user, account: master_account)
+    master_account.update_column(:email_all_users, true)
     @provider.reload
     subject = generate_message_subject
-    message   = Message.create!(:sender => @provider, :to => [Account.master], :subject => subject, :body => "message")
+    message   = Message.create!(:sender => @provider, :to => [master_account], :subject => subject, :body => "message")
     recipient = message.recipients.first
 
     PostOffice.message_notification(message, recipient).deliver_now
 
     assert email = find_message_by_subject(subject)
-    assert_equal Account.master.admins.map(&:email), email.bcc
+    assert_equal master_account.admins.map(&:email), email.bcc
   end
 
   test 'message_notification from provider to buyer should send only to admin' do


### PR DESCRIPTION
Fixes some random test failures such as the following recurrent ones:

https://app.circleci.com/jobs/github/3scale/porta/159064
```
Error:
Finance::VariableCostTest#test_bill_variable_fee_for:
NoMethodError: undefined method `create_invoice!' for nil:NilClass
    app/models/finance/buyer_invoice_finder.rb:26:in `create_invoice'
    app/models/finance/buyer_invoice_finder.rb:14:in `find'
    app/models/finance/buyer_invoice_finder.rb:18:in `find'
    app/models/finance/invoice_proxy.rb:35:in `invoice'
    app/models/finance/invoice_proxy.rb:11:in `check_editable_line_items'
    app/lib/finance/background_billing.rb:10:in `bill'
    app/lib/finance/billing.rb:20:in `create_line_item!'
    app/lib/finance/variable_cost.rb:94:in `block in bill_variable_fee_for'
    app/lib/finance/variable_cost.rb:93:in `each'
    app/lib/finance/variable_cost.rb:93:in `bill_variable_fee_for'
    test/unit/finance/variable_cost_test.rb:13:in `block in <class:VariableCostTest>'

Error:
Finance::BillingStrategyTest#test_add_cost:
NoMethodError: undefined method `create_invoice!' for nil:NilClass
    app/models/finance/buyer_invoice_finder.rb:26:in `create_invoice'
    app/models/finance/buyer_invoice_finder.rb:14:in `find'
    app/models/finance/buyer_invoice_finder.rb:18:in `find'
    app/models/finance/invoice_proxy.rb:35:in `invoice'
    app/models/finance/invoice_proxy.rb:11:in `check_editable_line_items'
    app/lib/finance/background_billing.rb:10:in `bill'
    app/lib/finance/billing.rb:20:in `create_line_item!'
    app/models/finance/billing_strategy.rb:400:in `add_cost'
    test/unit/finance/billing_strategy_test.rb:22:in `block in <class:BillingStrategyTest>'
```

https://app.circleci.com/jobs/github/3scale/porta/159176
```
Error:
SiteAccountSupportTest#test_master_on_premises:
ActiveRecord::RecordNotFound: Couldn't find Cinstance with [WHERE `cinstances`.`type` IN ('Cinstance') AND `cinstances`.`user_account_id` = ?]
    app/models/account/provider_methods.rb:192:in `provider_key'
    test/unit/site_account_support_test.rb:49:in `block in <class:SiteAccountSupportTest>'
```

https://app.circleci.com/jobs/github/3scale/porta/158766
```
Failure:
PostOfficeTest#test_message_notification_from_provider_to_master_should_send_only_to_admin [/opt/app-root/src/project/test/unit/mailers/post_office_test.rb:75]
Minitest::Assertion: Expected: []
  Actual: nil
```