### PR TITLE
[DEPRECATED - WE WILL TAKE A DIFFERENT APPROACH] [Bugfix][ActiveJob::DeserializationError] Couldn't find Account in BackendDeleteServiceWorker

### DIFF
--- a/app/events/services/service_deleted_event.rb
+++ b/app/events/services/service_deleted_event.rb
@@ -12,7 +12,7 @@ class Services::ServiceDeletedEvent < ServiceRelatedEvent
         provider_id: provider.id
       }
     }
-    data[:provider] = provider if provider.persisted?
+    data[:provider] = provider if provider.persisted? && !provider.scheduled_for_deletion?
 
     new(data)
   end


### PR DESCRIPTION
The 1st idea for [THREESCALE-4620](https://issues.redhat.com/browse/THREESCALE-4620)

What was happening before this PR is:
1. The DeleteAccountHierarchyWorker performs for its associations, including its services
2. The services of the account get destroyed and a `ServiceDeletedEvent` is created for each one of them.
3. As the associations of the account are already deleted, the account gets deleted.
4. The subscriber of `ServiceDeletedEvent` calls `BackendDeleteServiceWorker` sending the event. It tries to deserialize it but it cannot do it because the account has already been deleted.