### PR TITLE
[Bugfix] InvalidForeignKey deleting an account while persisting its payment detail

### DIFF
--- a/app/models/account/payment_details.rb
+++ b/app/models/account/payment_details.rb
@@ -37,7 +37,7 @@ module Account::PaymentDetails
       read_only_transaction = ActiveRecord::Base.connection.read_only_transaction?
       any_payment_attributes = payment_detail_attributes.any? { |_, value| value.present? }
 
-      if persisted? && any_payment_attributes && !read_only_transaction
+      if persisted? && !will_be_deleted? && any_payment_attributes && !read_only_transaction
         create_payment_detail(payment_detail_attributes, &:do_not_notify)
       else
         build_payment_detail

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -127,11 +127,15 @@ module Account::States
     end
 
     def should_be_deleted?
-      scheduled_for_deletion? || suspended? || (buyer? && provider_account.try(:should_be_deleted?))
+      suspended? || will_be_deleted?
     end
 
     def should_not_be_deleted?
       !should_be_deleted?
+    end
+
+    def will_be_deleted?
+      scheduled_for_deletion? || (buyer? && provider_account.try(:should_be_deleted?))
     end
 
     def can_be_suspended?


### PR DESCRIPTION
Bugfix for `ActiveRecord::InvalidForeignKey` when destroying an account.
The error info from the logs is the following:
```ruby
{
  class: ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper,
  wrapped: DeletePlainObjectWorker,
  queue: 'default',
  args: [{
    job_class: DeletePlainObjectWorker,
    job_id: '85eff265-d651-4c89-a018-4c72208623d7',
    provider_job_id: nil,
    queue_name: 'default',
    priority: nil,
    arguments: [{ _aj_globalid: 'gid://system/Account/ObfuscatedID' }, ['Hierarchy-Account-ObfuscatedID'], 'destroy'],
    locale: 'en'
  }],
  retry: true,
  jid: '835a14c11d288e7aa9f458f4',
  created_at: 1_582_278_967.298682,
  enqueued_at: 1_582_279_062.923246,
  error_message: "Mysql2::Error: Cannot add or update a child row: a foreign key constraint fails
                  (`preview01`.`payment_details`, CONSTRAINT `_fk_rails_ffc9ce649e` FOREIGN KEY (`account_id`)
                  REFERENCES `accounts` (`id`) ON DELETE CASCADE):
                    INSERT INTO `payment_details` (`account_id`, `credit_card_expires_on`, `created_at`, `updated_at`)
                    VALUES (ObfuscatedID, '2021-02-01', '2020-02-21 09:58:06', '2020-02-21 09:58:06')
                  ",
  error_class: ActiveRecord::InvalidForeignKey
}
```

Encountered when testing [THREESCALE-4483](https://issues.redhat.com/browse/THREESCALE-4483) and necessary to be able to do it.

Every time that we destroy an account, if it didn't have a payment detail persisted, it creates and persists one, and then it destroys it... and that happens regardless of being a buyer or a tenant, and regardless of being done in background or just by `account.destroy!`.

This error is only raised when this process is done in the background and parallelizing these tasks. 

In my opinion, either way, we should not create a payment detail for accounts when the account is about to be destroyed anyway and cannot be used at all in the meantime.