### PR TITLE
Ensures `proxy_id` on create proxy config affecting change

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -637,8 +637,8 @@ class Proxy < ApplicationRecord
     end
   end
 
-  def create_proxy_config_affecting_change(*)
-    super
+  def create_proxy_config_affecting_change(attributes = {}, options = {}, &block)
+    super(attributes.merge(proxy_id: id), options, &block)
   rescue ActiveRecord::RecordNotUnique
     reload.send(:proxy_config_affecting_change)
   end


### PR DESCRIPTION
Tries to fix ~[THREESCALE-4470](https://issues.redhat.com/browse/THREESCALE-4470)~ [THREESCALE-4565](https://issues.redhat.com/browse/THREESCALE-4565).

I don't really know why some times the `ProxyConfigAffectingChange` object is tried to be saved without a `proxy_id` if it's created using the (has_one) association of the `Proxy` object. I think it has to do with the hacks of https://github.com/westonganger/protected_attributes_continued, which BTW would be great if we could remove for good.

What this PR does is making `Proxy#create_proxy_config_affecting_change` to comply with the method signature of gem's override for `ActiveRecord::Associations::SingularAssociation#create`, and ensures `proxy_id` is always passed among the attributes.

A test would probably be stupid at this point, like checking if we pass something that wasn't even supposed to be passed in the first place :/