### PR TITLE
[WIP] Fix the endless select of api docs services of a tenant when removing the whole tenant

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -60,7 +60,7 @@ class Account < ApplicationRecord
   self.background_deletion = [
     :users,
     :mail_dispatch_rules,
-    [:api_docs_services, { class_name: 'ApiDocs::Service' }],
+    # [:api_docs_services, { class_name: 'ApiDocs::Service' }],
     :services,
     :contracts,
     :account_plans,

--- a/app/workers/delete_account_hierarchy_worker.rb
+++ b/app/workers/delete_account_hierarchy_worker.rb
@@ -3,6 +3,11 @@
 class DeleteAccountHierarchyWorker < DeleteObjectHierarchyWorker
   def perform(*)
     return unless account.should_be_deleted?
+
+    ApiDocs::Service.where(tenant_id: account.id).select(:id, :tenant_id).find_each do |api_docs_service|
+      DeleteObjectHierarchyWorker.perform_now(api_docs_service)
+    end
+
     super
   end
 


### PR DESCRIPTION
Still testing.
Part of [THREESCALE-4483](https://issues.redhat.com/browse/THREESCALE-4483)