### PR TITLE
[Bugfix] DB timeout deleting many records at once

### DIFF
--- a/app/workers/delete_plain_object_worker.rb
+++ b/app/workers/delete_plain_object_worker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class DeletePlainObjectWorker < ApplicationJob
+  include Sidekiq::Throttled::Worker
 
   # TODO: Rails 5 --> discard_on ActiveJob::DeserializationError, ActiveRecord::RecordNotFound
   rescue_from(ActiveJob::DeserializationError, ActiveRecord::RecordNotFound) do |exception|
@@ -21,6 +22,8 @@ class DeletePlainObjectWorker < ApplicationJob
   end
 
   queue_as :default
+
+  sidekiq_throttle({ concurrency: { limit: 10 } })
 
   before_perform do |job|
     @object, workers_hierarchy, @destroy_method = job.arguments


### PR DESCRIPTION
Closes [THREESCALE-4445](https://issues.redhat.com/browse/THREESCALE-4445)

Mysql raises timeouts when it tries to delete many records at once.

Error:
```
{:exception=>{:class=>ActiveRecord::StatementInvalid, :message=>"Mysql2::Error: Lock wait timeout exceeded; try restarting transaction: DELETE FROM `application_keys` WHERE `application_keys`.`id` = 20391", :backtrace=>[...]}, :parameters=>{:context=>"Job raised exception", :job=>{"class"=>"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper", "wrapped"=>"DeletePlainObjectWorker", "queue"=>"default", "args"=>[{"job_class"=>"DeletePlainObjectWorker", "job_id"=>"aa6dfb9a-c59e-4141-b80c-302bfdd73eb5", "queue_name"=>"default", "arguments"=>[{"_aj_globalid"=>"gid://system/Account/ObfuscatedID"}, ["Hierarchy-Account-ObfuscatedID", "Hierarchy-Account-ObfuscatedID"], "destroy"], "locale"=>"en"}], "retry"=>true, "jid"=>"b67c4177265cf14645e244d1", "created_at"=>1576856326.722353, "enqueued_at"=>1576856505.170878, "error_message"=>"Mysql2::Error: Lock wait timeout exceeded; try restarting transaction: DELETE FROM `application_keys` WHERE `application_keys`.`id` = ObfuscatedID", "error_class"=>"ActiveRecord::StatementInvalid", "failed_at"=>1576856373.8736906, "retry_count"=>2, "retried_at"=>1576856570.0086374}, :jobstr=>"
```

It is suggested [in StackOverflow to perform fewer deletions at once](https://stackoverflow.com/questions/64653/mysql-lock-wait-timeout-exceeded).