### PR TITLE
Remove EndUser and EndUserPlans [default fields to null]

### DIFF
--- a/db/migrate/20200224095152_default_nil_fields_end_user_removal.rb
+++ b/db/migrate/20200224095152_default_nil_fields_end_user_removal.rb
@@ -1,0 +1,13 @@
+class DefaultNilFieldsEndUserRemoval < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :settings, :end_users_switch, true
+    change_column_null :settings, :end_user_plans_ui_visible, true
+
+    change_column_null :cinstances, :end_user_required, true
+
+    change_column_null :plans, :end_user_required, true
+
+    change_column_null :services, :end_user_registration_required, true
+    change_column_null :services, :default_end_user_plan_id, true
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200211080911) do
+ActiveRecord::Schema.define(version: 20200224095152) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer  "owner_id",   precision: 38,                  null: false
@@ -989,7 +989,7 @@ ActiveRecord::Schema.define(version: 20200211080911) do
     t.string   "issuer_type",                                                    null: false
     t.text     "description"
     t.boolean  "approval_required",                              default: false, null: false
-    t.boolean  "end_user_required",                              default: false, null: false
+    t.boolean  "end_user_required",                              default: false
     t.integer  "tenant_id",             precision: 38
     t.string   "system_name",                                                    null: false
     t.integer  "partner_id",            precision: 38
@@ -1247,7 +1247,7 @@ ActiveRecord::Schema.define(version: 20200211080911) do
     t.integer  "default_application_plan_id",    precision: 38
     t.integer  "default_service_plan_id",        precision: 38
     t.integer  "default_end_user_plan_id",       precision: 38
-    t.boolean  "end_user_registration_required",                default: true,      null: false
+    t.boolean  "end_user_registration_required",                default: true
     t.integer  "tenant_id",                      precision: 38
     t.string   "system_name",                                                       null: false
     t.string   "backend_version",                               default: "1",       null: false
@@ -1303,7 +1303,7 @@ ActiveRecord::Schema.define(version: 20200211080911) do
     t.boolean  "can_create_service",                                             default: false,             null: false
     t.string   "spam_protection_level",                                          default: "none",            null: false
     t.integer  "tenant_id",                                       precision: 38
-    t.string   "end_users_switch",                                                                           null: false
+    t.string   "end_users_switch"
     t.string   "multiple_applications_switch",                                                               null: false
     t.string   "multiple_users_switch",                                                                      null: false
     t.string   "finance_switch",                                                                             null: false

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200211080911) do
+ActiveRecord::Schema.define(version: 20200224095152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -939,7 +939,7 @@ ActiveRecord::Schema.define(version: 20200211080911) do
     t.string   "issuer_type",           limit: 255,                                          null: false
     t.text     "description"
     t.boolean  "approval_required",                                          default: false, null: false
-    t.boolean  "end_user_required",                                          default: false, null: false
+    t.boolean  "end_user_required",                                          default: false
     t.bigint   "tenant_id"
     t.string   "system_name",           limit: 255,                                          null: false
     t.bigint   "partner_id"
@@ -1186,7 +1186,7 @@ ActiveRecord::Schema.define(version: 20200211080911) do
     t.bigint   "default_application_plan_id"
     t.bigint   "default_service_plan_id"
     t.bigint   "default_end_user_plan_id"
-    t.boolean  "end_user_registration_required",             default: true,      null: false
+    t.boolean  "end_user_registration_required",             default: true
     t.bigint   "tenant_id"
     t.string   "system_name",                    limit: 255,                     null: false
     t.string   "backend_version",                limit: 255, default: "1",       null: false
@@ -1241,7 +1241,7 @@ ActiveRecord::Schema.define(version: 20200211080911) do
     t.boolean  "can_create_service",                              default: false,             null: false
     t.string   "spam_protection_level",               limit: 255, default: "none",            null: false
     t.bigint   "tenant_id"
-    t.string   "end_users_switch",                    limit: 255,                             null: false
+    t.string   "end_users_switch",                    limit: 255
     t.string   "multiple_applications_switch",        limit: 255,                             null: false
     t.string   "multiple_users_switch",               limit: 255,                             null: false
     t.string   "finance_switch",                      limit: 255,                             null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200211080911) do
+ActiveRecord::Schema.define(version: 20200224095152) do
 
   create_table "access_tokens", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.bigint   "owner_id",                                  null: false
@@ -940,7 +940,7 @@ ActiveRecord::Schema.define(version: 20200211080911) do
     t.string   "issuer_type",                                                                       null: false
     t.text     "description",           limit: 65535
     t.boolean  "approval_required",                                                 default: false, null: false
-    t.boolean  "end_user_required",                                                 default: false, null: false
+    t.boolean  "end_user_required",                                                 default: false
     t.bigint   "tenant_id"
     t.string   "system_name",                                                                       null: false
     t.bigint   "partner_id"
@@ -1187,7 +1187,7 @@ ActiveRecord::Schema.define(version: 20200211080911) do
     t.bigint   "default_application_plan_id"
     t.bigint   "default_service_plan_id"
     t.bigint   "default_end_user_plan_id"
-    t.boolean  "end_user_registration_required",               default: true,      null: false
+    t.boolean  "end_user_registration_required",               default: true
     t.bigint   "tenant_id"
     t.string   "system_name",                                                      null: false
     t.string   "backend_version",                              default: "1",       null: false
@@ -1242,7 +1242,7 @@ ActiveRecord::Schema.define(version: 20200211080911) do
     t.boolean  "can_create_service",                                default: false,             null: false
     t.string   "spam_protection_level",                             default: "none",            null: false
     t.bigint   "tenant_id"
-    t.string   "end_users_switch",                                                              null: false
+    t.string   "end_users_switch"
     t.string   "multiple_applications_switch",                                                  null: false
     t.string   "multiple_users_switch",                                                         null: false
     t.string   "finance_switch",                                                                null: false


### PR DESCRIPTION
Following @Martouta 's [suggestion](https://github.com/3scale/porta/pull/1648#issuecomment-587091982) let's try to default all columns (that will be removed) to `null` before ignoring them. 

**Which issue(s) this PR fixes**

[THREESCALE-2490: Remove “End-user plans” feature (SaaS) - Phase 2](https://issues.redhat.com/browse/THREESCALE-2490)

**Notes:**
Merge before #1677.
The migration consists of:
```ruby
# frozen_string_literal: true

class RemoveEndUserPlans < ActiveRecord::Migration
  def change
    safety_assured { remove_column :settings, :end_users_switch }
    safety_assured { remove_column :settings, :end_user_plans_ui_visible }

    safety_assured { remove_column :cinstances, :end_user_required }

    safety_assured { remove_column :plans, :end_user_required }

    safety_assured { remove_column :services, :end_user_registration_required }
    safety_assured { remove_column :services, :default_end_user_plan_id }

    drop_table :end_user_plans
  end
end
```
