### PR TITLE
[memory-bloat] Do not use batch on pdf worker

### DIFF
--- a/app/lib/pdf/dispatch.rb
+++ b/app/lib/pdf/dispatch.rb
@@ -19,15 +19,9 @@ module Pdf
     def self.enqueue_reports(reference, period)
       return unless (operation = SystemOperation.for(reference))
 
-      batch = Sidekiq::Batch.new
-      batch.description = "PDF Report (period: #{period})"
-
-      batch.jobs do
-        Service.accessible.of_approved_accounts.select(%i[id account_id]).find_each do |service|
-          PdfReportWorker.enqueue(service, period, operation)
-        end
+      Service.accessible.of_approved_accounts.select(%i[id account_id]).find_each do |service|
+        PdfReportWorker.enqueue(service, period, operation)
       end
     end
-
   end
 end


### PR DESCRIPTION
Batch will keep in memory all jobs until it finishes executing the block
Then serializes them ...
Meaning that if the number of Service is high it will make memory bloat

I do not think we need batch jobs for that
If we do we should make groups of batches

For history it was introduced here: https://github.com/3scale/system/pull/7146/files#diff-11a34b15fb80c7e8722c003106db3066