### PR TITLE
[Bugfix] [APIAP] Deletion of product also delete backend used by another product

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -22,7 +22,6 @@ class Service < ApplicationRecord
     :application_plans,
     :end_user_plans,
     [:api_docs_services, class_name: 'ApiDocs::Service'],
-    :backend_apis,
     :backend_api_configs,
     :metrics,
     [:proxy, { action: :destroy, has_many: false }]

--- a/app/workers/delete_service_hierarchy_worker.rb
+++ b/app/workers/delete_service_hierarchy_worker.rb
@@ -7,11 +7,11 @@ class DeleteServiceHierarchyWorker < DeleteObjectHierarchyWorker
 
   # TODO: when we remove the Rolling Update, we must remove this whole method
   def destroy_and_delete_associations
+    unless service.account.provider_can_use?(:api_as_product)
+      reflection = BackgroundDeletion::Reflection.new(:backend_apis)
+      ReflectionDestroyer.new(service, reflection, caller_worker_hierarchy).destroy_later
+    end
+
     super
-
-    return unless service.account.provider_can_use?(:api_as_product)
-
-    reflection = BackgroundDeletion::Reflection.new(:backend_apis)
-    ReflectionDestroyer.new(object, reflection, caller_worker_hierarchy).destroy_later
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-4534](https://issues.redhat.com/browse/THREESCALE-4534)

### Bugs fixed
1. In the test, the following line was true no matter if it was `.never` at the end or `.once` (really, try it locally with the master branch before this PR and you will see xD) :joy: :woman_shrugging: :crystal_ball: 
https://github.com/3scale/porta/blob/731e2821a2c70311adf5ca14fd5c1f4366ceed27/test/workers/delete_service_hierarcy_worker_test.rb#L54
So as I saw that we could avoid relying on the dangerous "never called" and we could just run it and see if it is deleted for real or not, that is what I did :smile: 
2. In the same test, lacking `::Logic::RollingUpdates.stubs(enabled?: true)` and `::Logic::RollingUpdates.stubs(skipped?: false)` made the 2 following lines completely useless and both tests turned out to have the same value for the rolling update (true) :sweat: 
https://github.com/3scale/porta/blob/731e2821a2c70311adf5ca14fd5c1f4366ceed27/test/workers/delete_service_hierarcy_worker_test.rb#L49
https://github.com/3scale/porta/blob/731e2821a2c70311adf5ca14fd5c1f4366ceed27/test/workers/delete_service_hierarcy_worker_test.rb#L63
Btw, stubbing the rest of rolling updates (the previous line of each of the 2 lines mentioned above) is not necessary anymore because the stubbing of the rolling update now it is done after the creation that is done now in the setup (and that setup also helps for DRY).
3. From the worker, in the case of destroying backend_apis, we were destroying first all the other associations of service, including its backend_api_configs, and later the backend_apis, which is wrong because by then, we do not know which backend_api was associated to that service because its backend_api_config has already been destroyed.
4. From the model, the config of background_deletion must NOT contain backend_apis, which was at first the main goal of this PR and the issue reported by QE in the Jira.

### Requirements after merging this PR
The 3rd bug explained above implies for SaaS (no problem for on-prem, because they all have `api as product` enabled from the very beginning) that after deploying, we will have to run the following task:
https://github.com/3scale/porta/blob/731e2821a2c70311adf5ca14fd5c1f4366ceed27/lib/tasks/backend_api.rake#L3-L11