### PR TITLE
[hotfix] Roll back liquid template for the documentation page

### DIFF
--- a/lib/developer_portal/app/views/developer_portal/docs.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/docs.html.liquid
@@ -1,9 +1,21 @@
 <h1>Documentation</h1>
 
-<p>Use our live documentation to learn about the Echo API</p>
+<p>Use our live documentation to learn about the Fixer.io</p>
 
-{% content_for javascripts %}
-    {{ 'active_docs.js' | javascript_include_tag }}
-{% endcontent_for %}
+{% cdn_asset /swagger-ui/2.2.10/swagger-ui.js %}
+{% cdn_asset /swagger-ui/2.2.10/swagger-ui.css %}
 
 {% include 'shared/swagger_ui' %}
+
+<script type="text/javascript">
+  $(function () {
+    {% comment %}
+      // you have access to swaggerUi.options object to customize its behaviour
+      // such as setting a different docExpansion mode
+      window.swaggerUi.options['docExpansion'] = 'none';
+      // or even getting the swagger specification loaded from a different url
+      window.swaggerUi.options['url'] = "http://petstore.swagger.wordnik.com/api/api-docs";
+    {% endcomment %}
+    window.swaggerUi.load();
+  });
+</script>


### PR DESCRIPTION
We should not be creating new accounts with liquid template of the Documentation page expecting a OAS 3-based ActiveDoc.

Closeso [THREESCALE-4578](https://issues.redhat.com/browse/THREESCALE-4578)