### PR TITLE
Fix word-break for long words

### DIFF
--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -26,7 +26,6 @@ table {
     height: line-height-times(2);
     padding: line-height-times(1/2, true) line-height-times(1/2) line-height-times(1/2) 0;
     vertical-align: top;
-    word-break: break-word;
 
     &.u-underline {
       border-bottom: $border-width solid $border-color;
@@ -298,6 +297,10 @@ table.data {
   &.StatsMethodsTable {
     box-shadow: none;
   }
+}
+
+td.metric {
+  word-break: break-word;
 }
 
 // IE 11 hack


### PR DESCRIPTION
**What this PR does / why we need it**:

In a[ previous PR](https://github.com/3scale/porta/commit/2aa16f13084ddf75ac3c89d8e53664d800ee92b2#diff-a0b0a5af615f99925dc446629346f40bR29) word-break was added to handle long metric names, but now it's affecting also other places.

**BEFORE:**
![before](https://user-images.githubusercontent.com/13486237/75334004-682f9700-5887-11ea-9de3-1c9f1e422a4c.png)

**AFTER:**
![large-04](https://user-images.githubusercontent.com/13486237/75334160-a6c55180-5887-11ea-9dc4-5a9455571680.png)
![large-03](https://user-images.githubusercontent.com/13486237/75334177-ac229c00-5887-11ea-936e-127b23f8f023.png)
![large-02](https://user-images.githubusercontent.com/13486237/75334191-b04eb980-5887-11ea-8a69-66882607965e.png)

