### PR TITLE
Use uri instead of original_request.path in the apiap routing policy

### DIFF
--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -73,7 +73,7 @@ module BackendApiLogic
         def replace_path
           return {} if config_path.blank?
 
-          { replace_path: "{{original_request.path | remove_first: '#{config_path.path}'}}" }
+          { replace_path: "{{uri | remove_first: '#{config_path.path}'}}" }
         end
       end
       private_constant :Rule

--- a/test/unit/backend_api_logic/routing_policy_test.rb
+++ b/test/unit/backend_api_logic/routing_policy_test.rb
@@ -25,7 +25,7 @@ module BackendApiLogic
       backend_api1 = backend_apis.first
       backend_api2 = backend_apis.last
       injected_rules = [
-        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '/foo/.*|/foo/?'] }, replace_path: "{{original_request.path | remove_first: '/foo'}}" },
+        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '/foo/.*|/foo/?'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
         { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '/.*'] } }
       ]
       apicast_policy = { name: 'apicast', 'version': 'builtin', 'configuration': {} }
@@ -52,7 +52,7 @@ module BackendApiLogic
       backend_api1 = backend_apis.first
       backend_api2 = backend_apis.last
       injected_rules = [
-        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '/foo/.*|/foo/?'] }, replace_path: "{{original_request.path | remove_first: '/foo'}}" },
+        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '/foo/.*|/foo/?'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
         { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '/.*'] } },
         routing_rule
       ]
@@ -78,9 +78,9 @@ module BackendApiLogic
           [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: '/' }, nil],
           [{ private_endpoint: 'https://safe-second-api.io', path: '/' }, nil],
           [{ private_endpoint: 'https://safe-second-api.io/v2', path: '/' }, nil],
-          [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: '/hey' }, "{{original_request.path | remove_first: '/hey'}}"],
-          [{ private_endpoint: 'https://safe-second-api.io', path: '/ho' }, "{{original_request.path | remove_first: '/ho'}}"],
-          [{ private_endpoint: 'https://safe-second-api.io/v2', path: '/lets-go' }, "{{original_request.path | remove_first: '/lets-go'}}"]
+          [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: '/hey' }, "{{uri | remove_first: '/hey'}}"],
+          [{ private_endpoint: 'https://safe-second-api.io', path: '/ho' }, "{{uri | remove_first: '/ho'}}"],
+          [{ private_endpoint: 'https://safe-second-api.io/v2', path: '/lets-go' }, "{{uri | remove_first: '/lets-go'}}"]
         ].each do |config, replace_path_value|
           expected_replace_path = replace_path_value ? { replace_path: replace_path_value } : {}
           assert_equal expected_replace_path, rule_class.new(stub(config)).replace_path

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -92,8 +92,8 @@ class ProxyTest < ActiveSupport::TestCase
         {"name"=>"routing", "version"=>"builtin", "enabled"=>true,
           "configuration"=>{
             "rules"=>[
-              {"url"=>"https://private-2.example.com:443", "owner_id"=>backend_api2.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/bar/.*|/foo/bar/?"}]}, 'replace_path'=>"{{original_request.path | remove_first: '/foo/bar'}}"},
-              {"url"=>"https://private-1.example.com:443", "owner_id"=>backend_api1.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/.*|/foo/?"}]}, 'replace_path'=>"{{original_request.path | remove_first: '/foo'}}"},
+              {"url"=>"https://private-2.example.com:443", "owner_id"=>backend_api2.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/bar/.*|/foo/bar/?"}]}, 'replace_path'=>"{{uri | remove_first: '/foo/bar'}}"},
+              {"url"=>"https://private-1.example.com:443", "owner_id"=>backend_api1.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/.*|/foo/?"}]}, 'replace_path'=>"{{uri | remove_first: '/foo'}}"},
               {"url"=>"https://echo-api.3scale.net:443", "owner_id"=>backend_api0.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/.*"}]}}
             ]
           }


### PR DESCRIPTION
We currently use `original_request.path` in the config for the APIAP routing policy. This causes the URL Rewriting policy to be a no-op when used in combination with APIAP. This PR replaces `original_request.path` with `uri`, which should have no side-effect for APIAP and re-enable the URL Rewriting policy in combination.

Customers may need to regenerate their proxy configs (i.e. promote) for this change to take effect, but this is OK, because that would be needed anyway in order to append an eventual URL Rewriting policy config.

Closes [THREESCALE-4301](https://issues.redhat.com/browse/THREESCALE-4301)