### PR TITLE
Fix HttpBasicAuth security scope check in api calls

### DIFF
--- a/app/lib/api_authentication/by_access_token.rb
+++ b/app/lib/api_authentication/by_access_token.rb
@@ -112,7 +112,7 @@ module ApiAuthentication
     end
 
     def verify_access_token_scopes
-      return true unless params[:access_token]
+      return true unless access_token
 
       raise PermissionError if !authenticated_token || allowed_scopes.blank?
       raise ScopeError if (allowed_scopes & authenticated_token.scopes).blank?
@@ -121,7 +121,7 @@ module ApiAuthentication
     end
 
     def verify_write_permission
-      return true unless params[:access_token]
+      return true unless access_token
       raise PermissionError unless authenticated_token.try(:permission) == PermissionEnforcer::READ_WRITE
     end
 

--- a/test/integration/by_access_token_test.rb
+++ b/test/integration/by_access_token_test.rb
@@ -8,13 +8,14 @@ class ApiAuthentication::ByAccessTokenTest < ActionDispatch::IntegrationTest
     login_provider @provider
 
     host! @provider.admin_domain
+
+    @user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners', 'finance'])
+    @token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management')
   end
 
   def test_index_with_access_token
-    user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners', 'finance'])
-    token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
-    provider_2 = FactoryBot.create(:simple_provider)
 
+    provider_2 = FactoryBot.create(:simple_provider)
     # none token
     get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key)
     assert_response :success
@@ -24,12 +25,12 @@ class ApiAuthentication::ByAccessTokenTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
 
     # valid token
-    get(admin_api_accounts_path(format: :xml), access_token: token.value)
+    get(admin_api_accounts_path(format: :xml), access_token: @token.value)
     assert_response :success
 
     # token belongs to a different admin domain
     host! provider_2.admin_domain
-    get(admin_api_accounts_path(format: :xml), access_token: token.value)
+    get(admin_api_accounts_path(format: :xml), access_token: @token.value)
     assert_response :forbidden
 
     host! @provider.admin_domain
@@ -37,20 +38,26 @@ class ApiAuthentication::ByAccessTokenTest < ActionDispatch::IntegrationTest
     get(admin_api_accounts_path(format: :xml), access_token: 'alaska')
     assert_response :forbidden
 
-    token.scopes = ['finance']
-    token.save!
+    @token.scopes = ['finance']
+    @token.save!
 
     # invalid scope
-    get(admin_api_accounts_path(format: :xml), access_token: token.value)
+    get(admin_api_accounts_path(format: :xml), access_token: @token.value)
     assert_response :forbidden
 
-    token.scopes = ['account_management']
-    token.save!
-    user.admin_sections = []
-    user.save!
+    @token.scopes = ['account_management']
+    @token.save!
+    @user.admin_sections = []
+    @user.save!
 
     # user does not have a permission
-    get(admin_api_accounts_path(format: :xml), access_token: token.value)
+    get(admin_api_accounts_path(format: :xml), access_token: @token.value)
+    assert_response :forbidden
+  end
+
+  test 'validates the scope using HttpBasicAuth' do
+    auth_headers = {'Authorization' => "Basic #{Base64.encode64(":#{@token.value}")}"}
+    get(admin_api_registry_policies_path(format: :json), headers: auth_headers)
     assert_response :forbidden
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

In System API requests it is possible to bypass access token security by
using HTTPBasicAuth. This is a security issue.

A member access token that does not have access to a given scope should
also be denied when used in HTTPBasicAuth requests targeting API
endpoints secured under that same scope.

Example:
```
$ curl
"https://<host>/admin/api/registry/policies.json?access_token=<my-secret-access-token>"
{"error":"Your access token does not have the correct permissions"}

$ curl -u :<my-secret-access-token>
"https://<host>.3scale.net/admin/api/registry/policies.json"
{"policies":[]}
```

The problem was a problem in the token checking. We were only checking
the if the token was being sent in params. This commit also considers
the HttpBasicAuth token to make the scope check.

**Which issue(s) this PR fixes** 

[THREESCALE-2711](https://issues.redhat.com/browse/THREESCALE-2711)


**Verification steps** 

$ curl -u :<my-secret-access-token>
"https://<host>.3scale.net/admin/api/registry/policies.json"

should return 403 status
