### PR TITLE
Fix test curl command bad URI

### DIFF
--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -1,132 +1,13 @@
+# frozen_string_literal: true
+
 module Api::IntegrationsHelper
-
-  class CurlCommandBuilder
-    def initialize(proxy)
-      @proxy = proxy
-    end
-
-    attr_reader :proxy
-
-    def command
-      return if base_endpoint.blank?
-
-      credentials = proxy.authentication_params_for_proxy
-      extheaders = ''
-
-      uri = Addressable::URI.parse(base_endpoint)
-      uri.path, uri.query = path_and_query
-
-      case proxy.credentials_location
-      when 'headers'
-        credentials.each { |k, v| extheaders += " -H'#{k}: #{v}'" }
-      when 'query'
-        uri.query_values = (uri.query_values || {}).merge(credentials)
-      when 'authorization'
-        uri.user, uri.password = proxy.authorization_credentials
-      end
-
-      "curl \"#{uri}\" #{extheaders}"
-    end
-
-    def base_endpoint
-      raise NoMethodError, __method__
-    end
-
-    def path_and_query
-      return api_test_path_and_query unless apiap?
-
-      proxy_rules = proxy.proxy_rules
-      proxy_rules.any? ? proxy_rules.first[:pattern] : '/'
-    end
-
-    def api_test_path_and_query
-      uri = Addressable::URI.parse(proxy.api_test_path)
-      [uri.path, uri.query]
-    end
-
-    def apiap?
-      proxy.provider_can_use?(:api_as_product)
-    end
-
-    class Staging < self
-      def base_endpoint
-        proxy.sandbox_endpoint
-      end
-    end
-
-    class Production < self
-      def base_endpoint
-        proxy.default_production_endpoint
-      end
-    end
-
-    # It quacks like a Proxy but it's actually a json proxy config
-    class ProxyFromConfig
-      def initialize(config)
-        @config = config
-      end
-
-      attr_reader :config
-
-      delegate :sandbox_endpoint, :credentials_location, :api_test_path, :proxy_rules, to: :proxy
-
-      def default_production_endpoint
-        proxy.endpoint
-      end
-
-      def authentication_params_for_proxy(opts = {})
-        params = service.plugin_authentication_params
-        keys_to_proxy_args = { app_key: :auth_app_key, app_id: :auth_app_id, user_key: :auth_user_key }
-        params.keys.map do |key|
-          param_name = opts[:original_names] ? key.to_s : proxy.send(keys_to_proxy_args[key])
-          [param_name, params[key]]
-        end.to_h
-      end
-
-      def authorization_credentials
-        params = authentication_params_for_proxy.symbolize_keys
-        params.values_at(:user_key).compact.presence || params.values_at(:app_id, :app_key)
-      end
-
-      delegate :provider_can_use?, to: 'service.account'
-
-      protected
-
-      def proxy
-        @proxy ||= ActiveSupport::OrderedOptions.new.merge(config[:proxy])
-      end
-
-      def service
-        @service ||= Service.find(proxy.service_id)
-      end
-    end
-  end
-
-  def api_test_curl(proxy, production = false, config_based: false)
-    method_sym = config_based ? :config_based_test_curl_command : :test_curl_command
-    command = public_send(method_sym, proxy, environment: production ? :production : :staging)
+  def api_test_curl(proxy, production = false)
+    command = Apicast::CurlCommandBuilder.new(proxy, environment: production ? :production : :staging)
     credentials = proxy.authentication_params_for_proxy(original_names: true)
     tag_id = production ? 'api-production-curl' : 'api-test-curl'
     content_tag :code, id: tag_id, 'data-credentials' => credentials.to_json do
-      command
+      command.to_s
     end
-  end
-
-  def test_curl_command(proxy, environment: :staging)
-    builder = case environment
-              when :staging, :sandbox
-                CurlCommandBuilder::Staging
-              when :production
-                CurlCommandBuilder::Production
-              end.new(proxy)
-    builder.command
-  end
-
-  def config_based_test_curl_command(proxy, environment: :staging)
-    proxy_configs = proxy.proxy_configs.by_environment(environment.to_s).current_versions.to_a
-    return if proxy_configs.empty?
-    proxy_from_config = CurlCommandBuilder::ProxyFromConfig.new(proxy_configs.first.send(:parsed_content))
-    test_curl_command(proxy_from_config, environment: :staging)
   end
 
   def is_https?(url)

--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -40,7 +40,7 @@ module Api::IntegrationsHelper
     end
 
     def api_test_path_and_query
-      uri = URI.parse(proxy.api_test_path)
+      uri = Addressable::URI.parse(proxy.api_test_path)
       [uri.path, uri.query]
     end
 

--- a/app/lib/apicast/curl_command_builder.rb
+++ b/app/lib/apicast/curl_command_builder.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+module Apicast
+  class CurlCommandBuilder
+    class Builder
+      def initialize(proxy, test_path: nil)
+        @proxy = proxy
+        @test_path = test_path
+      end
+
+      attr_reader :proxy, :test_path
+
+      def command
+        return unless proxy
+        return if base_endpoint.blank?
+
+        credentials = proxy.authentication_params_for_proxy
+        extheaders = ''
+
+        uri = Addressable::URI.parse(base_endpoint)
+        uri.path, uri.query = path_and_query
+
+        case proxy.credentials_location
+        when 'headers'
+          credentials.each { |k, v| extheaders += " -H'#{k}: #{v}'" }
+        when 'query'
+          uri.query_values = (uri.query_values || {}).merge(credentials)
+        when 'authorization'
+          uri.user, uri.password = proxy.authorization_credentials
+        end
+
+        "curl \"#{uri}\" #{extheaders}"
+      end
+
+      protected
+
+      def base_endpoint
+        raise NoMethodError, __method__
+      end
+
+      def path_and_query
+        path = test_path ? test_path : first_proxy_rule_pattern
+        uri = Addressable::URI.parse(path)
+        [uri.path, uri.query]
+      end
+
+      def first_proxy_rule_pattern
+        proxy_rules = proxy.proxy_rules
+        proxy_rules.any? ? proxy_rules.first[:pattern] : '/'
+      end
+    end
+
+    class StagingBuilder < Builder
+      def base_endpoint
+        proxy.sandbox_endpoint
+      end
+    end
+
+    class ProductionBuilder < Builder
+      def base_endpoint
+        proxy.default_production_endpoint
+      end
+    end
+
+    # It quacks like a Proxy but it's actually a json proxy config
+    class ProxyFromConfig
+      def initialize(config)
+        @config = config
+      end
+
+      attr_reader :config
+
+      delegate :sandbox_endpoint, :credentials_location, :api_test_path, :proxy_rules, to: :proxy
+
+      def default_production_endpoint
+        proxy.endpoint
+      end
+
+      def authentication_params_for_proxy(opts = {})
+        params = service.plugin_authentication_params
+        keys_to_proxy_args = { app_key: :auth_app_key, app_id: :auth_app_id, user_key: :auth_user_key }
+        params.keys.map do |key|
+          param_name = opts[:original_names] ? key.to_s : proxy.send(keys_to_proxy_args[key])
+          [param_name, params[key]]
+        end.to_h
+      end
+
+      def authorization_credentials
+        params = authentication_params_for_proxy.symbolize_keys
+        params.values_at(:user_key).compact.presence || params.values_at(:app_id, :app_key)
+      end
+
+      delegate :provider_can_use?, to: 'service.account'
+
+      protected
+
+      def proxy
+        @proxy ||= ActiveSupport::OrderedOptions.new.merge(config[:proxy])
+      end
+
+      def service
+        @service ||= Service.find(proxy.service_id)
+      end
+    end
+
+    def initialize(proxy, environment: :staging, build_from_config: -> { apiap? }, use_api_test_path: -> { !apiap? })
+      @proxy = proxy
+      @environment = environment
+      call_or_self = ->(param) { param.respond_to?(:call) ? param.call : param }
+      source = call_or_self.call(build_from_config) ? proxy_from_config : proxy
+      options = call_or_self.call(use_api_test_path) ? { test_path: proxy.api_test_path } : {}
+      @builder = builder_class.new(source, options)
+    end
+
+    attr_reader :proxy, :environment, :builder
+
+    delegate :command, to: :builder
+    delegate :to_s, to: :command
+
+    protected
+
+    def builder_class
+      case environment.to_sym
+      when :staging, :sandbox
+        StagingBuilder
+      when :production
+        ProductionBuilder
+      else
+        raise
+      end
+    end
+
+    def apiap?
+      proxy.provider_can_use?(:api_as_product)
+    end
+
+    def proxy_from_config
+      proxy_configs = proxy.proxy_configs.by_environment(environment.to_s).current_versions.to_a
+      return if proxy_configs.empty?
+      ProxyFromConfig.new(proxy_configs.first.send(:parsed_content))
+    end
+  end
+end

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -56,7 +56,7 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
             dd.u-dl-definition = @show_presenter.staging_proxy_endpoint
             dt.u-dl-term Example curl for testing
             dd.u-dl-definition
-              = api_test_curl(@proxy, config_based: apiap?)
+              = api_test_curl(@proxy)
               - unless @service.cinstances.any?
                 br
                 br

--- a/test/test_helpers/curl_command_test_helpers.rb
+++ b/test/test_helpers/curl_command_test_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ConfigBasedCommandTestHelpers
+  protected
+
+  SIMPLE_PROXY_CONFIG_PROXY_ATTRS = %w[service_id endpoint sandbox_endpoint auth_app_key auth_app_id auth_user_key credentials_location api_test_path].freeze
+
+  def simple_proxy_config_content
+    proxy_attributes = proxy.attributes.slice(*SIMPLE_PROXY_CONFIG_PROXY_ATTRS)
+    proxy_attributes[:proxy_rules] = [{ pattern: '/foo' }, { pattern: '/bar' }]
+    { proxy: proxy_attributes }
+  end
+
+  def create_proxy_config(patch = {})
+    proxy_config_content = simple_proxy_config_content.deep_merge(patch)
+    FactoryBot.create(:proxy_config, proxy: proxy, content: proxy_config_content.to_json)
+  end
+end

--- a/test/unit/apicast/curl_command_builder_test.rb
+++ b/test/unit/apicast/curl_command_builder_test.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Apicast
+  class CurlCommandBuilderTest < ActiveSupport::TestCase
+    def setup
+      @proxy = FactoryBot.create(:proxy,
+        auth_app_key: 'app_key',
+        auth_app_id: 'app_id',
+        auth_user_key: 'user_key',
+        credentials_location: 'query',
+        api_test_path: '/test'
+      )
+    end
+
+    attr_reader :proxy
+
+    class BasedOnValuesOfModel < self
+      test 'auth in query' do
+        proxy.update_attributes(credentials_location: 'query')
+        assert_match(/user_key=USER_KEY/, command.to_s)
+      end
+
+      test 'auth in headers' do
+        proxy.update_attributes(credentials_location: 'headers')
+        assert_match(/-H'user_key: USER_KEY/, command.to_s)
+      end
+
+      test 'auth basic (without password)' do
+        proxy.update_attributes(credentials_location: 'authorization')
+        assert_match %r(http://USER_KEY@), command.to_s
+      end
+
+      test 'auth basic (with password)' do
+        proxy.update_attributes(credentials_location: 'authorization')
+        proxy.service.update_attributes(backend_version: '2')
+        proxy.reload
+        assert_match %r(http://APP_ID:APP_KEY@), command.to_s
+      end
+
+      test 'auth mode app_id and app_key' do
+        proxy.service.update_attributes(backend_version: '2')
+        proxy.update_attributes(credentials_location: 'query')
+        assert_match(/&?app_key=APP_KEY/, command.to_s)
+        assert_match(/&?app_id=APP_ID/, command.to_s)
+      end
+
+      test 'app_id and app_key with customized params name' do
+        proxy.service.update_attributes(backend_version: '2')
+        proxy.update_attributes(auth_app_id: 'id')
+        proxy.update_attributes(auth_app_key: 'p-a-s-s')
+        assert_match(/id=APP_ID/, command.to_s)
+        assert_match(/p-a-s-s=APP_KEY/, command.to_s)
+      end
+
+      test 'root path' do
+        FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/', position: 1)
+        assert_match(/\?user/, command.to_s)
+      end
+
+      test 'path with wildcards' do
+        FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/{param}/path', position: 1)
+        assert_match(%r(/{param}/path), command.to_s)
+      end
+
+      test 'path with query string' do
+        FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/path?test=true', position: 1)
+        assert_match(%r(/path\?test=true), command.to_s)
+      end
+
+      test 'no double ?' do
+        FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/a?b=c', position: 1)
+        assert_match(/a\?b=c&/, command.to_s)
+      end
+
+      test 'blank endpoint' do
+        proxy.update_attributes(endpoint: '', sandbox_endpoint: '')
+        refute command.command
+      end
+
+      protected
+
+      def command
+        @command ||= CurlCommandBuilder.new(proxy, build_from_config: false, use_api_test_path: false)
+      end
+    end
+
+    class BasedOnLatestProxyConfig < self
+      include ConfigBasedCommandTestHelpers
+
+      test 'auth in query' do
+        create_proxy_config
+        assert_match(/user_key=USER_KEY/, command.to_s)
+      end
+
+      test 'auth in headers' do
+        create_proxy_config(proxy: { credentials_location: 'headers' })
+        assert_match(/-H'user_key: USER_KEY/, command.to_s)
+      end
+
+      test 'auth basic (without password)' do
+        create_proxy_config(proxy: { credentials_location: 'authorization' })
+        assert_match %r(http://USER_KEY@), command.to_s
+      end
+
+      test 'auth based (with password)' do
+        create_proxy_config(proxy: { credentials_location: 'authorization' })
+        proxy.service.update_attributes(backend_version: '2')
+        proxy.reload
+        assert_match %r(http://APP_ID:APP_KEY@), command.to_s
+      end
+
+      test 'auth mode app_id and app_key' do
+        create_proxy_config
+        proxy.service.update_attributes(backend_version: '2')
+        assert_match(/&?app_key=APP_KEY/, command.to_s)
+        assert_match(/&?app_id=APP_ID/, command.to_s)
+      end
+
+      test 'app_id and app_key with customized params name' do
+        create_proxy_config(proxy: { auth_app_id: 'id', auth_app_key: 'p-a-s-s' })
+        proxy.service.update_attributes(backend_version: '2')
+        assert_match(/id=APP_ID/, command.to_s)
+        assert_match(/p-a-s-s=APP_KEY/, command.to_s)
+      end
+
+      test 'root path' do
+        create_proxy_config(proxy: { proxy_rules: [{ pattern: '/' }] })
+        assert_match(/\?user/, command.to_s)
+      end
+
+      test 'path with wildcards' do
+        create_proxy_config(proxy: { proxy_rules: [{ pattern: '/{param}/path' }] })
+        assert_match(%r(/{param}/path), command.to_s)
+      end
+
+      test 'path with query string' do
+        create_proxy_config(proxy: { proxy_rules: [{ pattern: 'path?test=true' }] })
+        assert_match(%r(/path\?test=true), command.to_s)
+      end
+
+      test 'no double ?' do
+        create_proxy_config(proxy: { proxy_rules: [{ pattern: '/a?b=c' }] })
+        assert_match(/a\?b=c&/, command.to_s)
+      end
+
+      test 'blank endpoint' do
+        create_proxy_config(proxy: { endpoint: '', sandbox_endpoint: '' })
+        refute command.command
+      end
+
+      protected
+
+      def command
+        @command ||= CurlCommandBuilder.new(proxy, build_from_config: true, use_api_test_path: false)
+      end
+    end
+
+    class UseApiTestPathOrProxyRules < self
+      include ConfigBasedCommandTestHelpers
+
+      def setup
+        super
+
+        proxy.update_attributes(api_test_path: '/test')
+        FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/foo', position: 1)
+        create_proxy_config(proxy: { api_test_path: '/test', proxy_rules: [{ pattern: '/foo' }] })
+      end
+
+      test 'use api_test_path based on the values of the model' do
+        command = CurlCommandBuilder.new(proxy, build_from_config: false, use_api_test_path: true)
+        assert_match(/\/test\?/, command.to_s)
+      end
+
+      test 'use proxy rules based on the values of the model' do
+        command = CurlCommandBuilder.new(proxy, build_from_config: false, use_api_test_path: false)
+        assert_match(/\/foo\?/, command.to_s)
+      end
+
+      test 'use api_test_path based on the latest proxy config' do
+        command = CurlCommandBuilder.new(proxy, build_from_config: true, use_api_test_path: true)
+        assert_match(/\/test\?/, command.to_s)
+      end
+
+      test 'use proxy rules based on the latest proxy config' do
+        command = CurlCommandBuilder.new(proxy, build_from_config: true, use_api_test_path: false)
+        assert_match(/\/foo\?/, command.to_s)
+      end
+    end
+
+    class ApiapEnabledOrDisabled < self
+      include ConfigBasedCommandTestHelpers
+
+      def setup
+        super
+        create_proxy_config
+      end
+
+      test 'api as product enabled' do
+        CurlCommandBuilder::StagingBuilder.expects(:new).with(instance_of(CurlCommandBuilder::ProxyFromConfig), {})
+        CurlCommandBuilder.new(proxy)
+      end
+
+      test 'api as product disabled' do
+        disable_apiap!
+        CurlCommandBuilder::StagingBuilder.expects(:new).with(proxy, { test_path: '/test' })
+        CurlCommandBuilder.new(proxy)
+      end
+
+      protected
+
+      def disable_apiap!
+        account = proxy.service.account
+        account.stubs(:provider_can_use?).returns(true)
+        account.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+      end
+    end
+
+    class StagingOrProductionEnvironment < self
+      test 'staging environment' do
+        proxy.update_column(:sandbox_endpoint, 'http://public-staging.fake')
+        command = CurlCommandBuilder.new(proxy, environment: :staging, build_from_config: false, use_api_test_path: false)
+        assert_match %r(http://public-staging.fake/\?user_key=), command.to_s
+      end
+
+      test 'production environment' do
+        proxy.stubs(default_production_endpoint: 'http://public-production.fake')
+        command = CurlCommandBuilder.new(proxy, environment: :production, build_from_config: false, use_api_test_path: false)
+        assert_match %r(http://public-production.fake/\?user_key=), command.to_s
+      end
+    end
+  end
+end

--- a/test/unit/helpers/api/integrations_helper_test.rb
+++ b/test/unit/helpers/api/integrations_helper_test.rb
@@ -75,6 +75,26 @@ class Api::IntegrationsHelperTest < ActionView::TestCase
       assert_match(/\/bar\?/, res)
     end
 
+    test 'build path with parameters when api as product is disabled' do
+      account = @proxy.service.account
+      account.stubs(:provider_can_use?).returns(true)
+      account.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+
+      @proxy.update_attributes(api_test_path: '/{param}/path')
+      res = api_test_curl(@proxy)
+      assert_match(/\/{param}\/path/, res)
+    end
+
+    test 'build path with query string when api as product is disabled' do
+      account = @proxy.service.account
+      account.stubs(:provider_can_use?).returns(true)
+      account.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+
+      @proxy.update_attributes(api_test_path: '/path?test=true')
+      res = api_test_curl(@proxy)
+      assert_match(/\/path\?test=true/, res)
+    end
+
     test 'auth mode app_id and app_key' do
       @proxy.service.update_attributes(backend_version: '2')
       @proxy.update_attributes(credentials_location:  'query')

--- a/test/unit/helpers/api/integrations_helper_test.rb
+++ b/test/unit/helpers/api/integrations_helper_test.rb
@@ -1,265 +1,52 @@
 require 'test_helper'
 
 class Api::IntegrationsHelperTest < ActionView::TestCase
-
-  def setup
-    @proxy = FactoryBot.create(:proxy, :service => FactoryBot.create(:service))
+  test 'is_https? returns false for invalid urls, without throwing errors' do
+    refute(is_https?('foo'))
+    refute(is_https?(1))
+    refute(is_https?(nil))
   end
 
-  class ModelBasedCurlCommandTest < self
-    test 'auth in query' do
-      @proxy.update_attributes(credentials_location:  'query')
-      res = api_test_curl(@proxy)
-      assert_match(/user_key=USER_KEY/, res)
-    end
+  test 'print the proper proxy rule preview' do
+    pattern = '/foo'
+    backend_api = FactoryBot.create(:backend_api)
+    FactoryBot.create(:proxy_rule, owner: backend_api, proxy: nil, pattern: pattern)
+    backend_api_config = FactoryBot.create(:backend_api_config)
+    backend_api_config.stubs(:path).returns('/')
 
-    test 'user_key mode with customized param name' do
-      @proxy.update_attributes(auth_user_key:  'my_cool_name_for_user_key')
-      res = api_test_curl(@proxy)
-      assert_match(/my_cool_name_for_user_key=USER_KEY/, res)
-      assert_match(%{data-credentials="{&quot;user_key&quot;:&quot;USER_KEY&quot;}"}, res)
-    end
-
-    test 'auth in headers' do
-      @proxy.update_attributes(credentials_location:  'headers')
-      res = api_test_curl(@proxy)
-      assert_match(/-H&#39;user_key: USER_KEY/, res) # 39 is ', 27 is escape
-    end
-
-    test 'auth basic' do
-      @proxy.update_attributes(credentials_location: 'authorization')
-
-      res = api_test_curl(@proxy)
-      assert_match %r(http://USER_KEY@), res
-
-      @proxy.service.update_attributes(backend_version: '2')
-      @proxy.reload
-      res = api_test_curl(@proxy)
-      assert_match %r(http://APP_ID:APP_KEY@), res
-    end
-
-    test 'no double ?' do
-      account = @proxy.service.account
-      account.stubs(:provider_can_use?).returns(true)
-      account.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-      @proxy.update_attributes(api_test_path: '/a?b=c')
-      res = api_test_curl(@proxy)
-      assert_match(/a\?b=c&/, res)
-    end
-
-    test 'empty api_test_path' do
-      @proxy.update_attributes(api_test_path: nil)
-      res = api_test_curl(@proxy)
-      assert_match(/\?user/, res)
-    end
-
-    test 'build path from proxy_rules when api as product is enabled' do
-      account = @proxy.service.account
-      account.stubs(:provider_can_use?).returns(true)
-      account.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
-
-      @proxy.update_attributes(api_test_path: '/bar')
-      FactoryBot.create(:proxy_rule, proxy: @proxy, pattern: '/foo', position: 1)
-      res = api_test_curl(@proxy)
-      assert_match(/\/foo\?/, res)
-    end
-
-    test 'build path from api_test_path when api as product is disabled' do
-      account = @proxy.service.account
-      account.stubs(:provider_can_use?).returns(true)
-      account.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-
-      @proxy.update_attributes(api_test_path: '/bar')
-      FactoryBot.create(:proxy_rule, proxy: @proxy, pattern: '/foo', position: 1)
-      res = api_test_curl(@proxy)
-      assert_match(/\/bar\?/, res)
-    end
-
-    test 'build path with parameters when api as product is disabled' do
-      account = @proxy.service.account
-      account.stubs(:provider_can_use?).returns(true)
-      account.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-
-      @proxy.update_attributes(api_test_path: '/{param}/path')
-      res = api_test_curl(@proxy)
-      assert_match(/\/{param}\/path/, res)
-    end
-
-    test 'build path with query string when api as product is disabled' do
-      account = @proxy.service.account
-      account.stubs(:provider_can_use?).returns(true)
-      account.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-
-      @proxy.update_attributes(api_test_path: '/path?test=true')
-      res = api_test_curl(@proxy)
-      assert_match(/\/path\?test=true/, res)
-    end
-
-    test 'auth mode app_id and app_key' do
-      @proxy.service.update_attributes(backend_version: '2')
-      @proxy.update_attributes(credentials_location:  'query')
-      res = api_test_curl(@proxy)
-      assert_match(/&?app_key=APP_KEY/, res)
-      assert_match(/&?app_id=APP_ID/, res)
-    end
-
-    test 'app_id and app_key mode with customized params name' do
-      @proxy.service.update_attributes(backend_version: '2')
-      @proxy.update_attributes(auth_app_id:  'id')
-      @proxy.update_attributes(auth_app_key:  'p-a-s-s')
-      res = api_test_curl(@proxy)
-      assert_match(/id=APP_ID/, res)
-      assert_match(/p-a-s-s=APP_KEY/, res)
-    end
+    assert_equal pattern, proxy_rule_uri(backend_api_config.path, backend_api.proxy_rules.last)
   end
 
-  class ConfigBasedCurlCommandTest < self
-    def setup
-      super
+  class CurlCommand < ActionView::TestCase
+    setup do
+      @proxy = FactoryBot.create(:proxy)
     end
 
     attr_reader :proxy
 
-    test 'auth in query' do
+    include ConfigBasedCommandTestHelpers
+
+    test 'code with curl command' do
       create_proxy_config
-      res = api_test_curl(proxy, config_based: true)
-      assert_match(/user_key=USER_KEY/, res)
+      res = api_test_curl(proxy)
+      assert_match %r(<code.+>curl &quot;.+user_key=USER_KEY&quot; </code>), res
     end
 
-    test 'auth in headers' do
-      create_proxy_config(proxy: { credentials_location: 'headers' })
-      res = api_test_curl(proxy, config_based: true)
-      assert_match(/-H&#39;user_key: USER_KEY/, res) # 39 is ', 27 is escape
+    test 'curl command when api as product is disabled' do
+      account = proxy.service.account
+      account.stubs(:provider_can_use?).returns(true)
+      account.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+      proxy.update_attributes(api_test_path: '/api?test=true')
+      res = api_test_curl(proxy)
+      assert_match %r(<code.+>curl &quot;.+/api\?test=true&amp;user_key=USER_KEY&quot; </code>), res
     end
 
-    test 'auth basic' do
-      create_proxy_config(proxy: { credentials_location: 'authorization' })
-
-      res = api_test_curl(proxy, config_based: true)
-      assert_match %r(https://USER_KEY@), res
-
-      proxy.service.update_attributes(backend_version: '2')
-      proxy.reload
-      res = api_test_curl(proxy, config_based: true)
-      assert_match %r(https://APP_ID:APP_KEY@), res
-    end
-
-    test 'user_key mode with customized param name' do
-      create_proxy_config(proxy: { auth_user_key: 'my_cool_name_for_user_key' })
-      res = api_test_curl(proxy, config_based: true)
+    test 'data-credentials' do
+      @proxy = FactoryBot.create(:proxy, auth_user_key: 'my_cool_name_for_user_key')
+      create_proxy_config
+      res = api_test_curl(proxy)
       assert_match(/my_cool_name_for_user_key=USER_KEY/, res)
       assert_match(%{data-credentials="{&quot;user_key&quot;:&quot;USER_KEY&quot;}"}, res)
-    end
-
-    test 'no double ?' do
-      Account.any_instance.stubs(:provider_can_use?).returns(true)
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-      create_proxy_config(proxy: { api_test_path: '/a?b=c' })
-      res = api_test_curl(proxy, config_based: true)
-      assert_match(/a\?b=c&/, res)
-    end
-
-    test 'empty api_test_path' do
-      create_proxy_config(proxy: { api_test_path: nil })
-      res = api_test_curl(proxy, config_based: true)
-      assert_match(/\?user/, res)
-    end
-
-    test 'build path from proxy_rules when api as product is enabled' do
-      Account.any_instance.stubs(:provider_can_use?).returns(true)
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
-      create_proxy_config
-      res = api_test_curl(proxy, config_based: true)
-      assert_match(/\/foo\?/, res)
-    end
-
-    test 'build path from api_test_path when api as product is disabled' do
-      Account.any_instance.stubs(:provider_can_use?).returns(true)
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-      create_proxy_config
-      res = api_test_curl(proxy, config_based: true)
-      assert_match(/\/test\?/, res)
-    end
-
-    test 'auth mode app_id and app_key' do
-      proxy.service.update_attributes(backend_version: '2')
-      create_proxy_config
-      res = api_test_curl(proxy, config_based: true)
-      assert_match(/&?app_key=APP_KEY/, res)
-      assert_match(/&?app_id=APP_ID/, res)
-    end
-
-    test 'app_id and app_key mode with customized params name' do
-      proxy.service.update_attributes(backend_version: '2')
-      create_proxy_config(proxy: { auth_app_id: 'id', auth_app_key: 'p-a-s-s' })
-      res = api_test_curl(proxy, config_based: true)
-      assert_match(/id=APP_ID/, res)
-      assert_match(/p-a-s-s=APP_KEY/, res)
-    end
-
-    test 'should not create the run command if endpoint is blank' do
-      proxy = FactoryBot.create(:proxy)
-      content = {
-        proxy: {
-          service_id: proxy.service_id,
-          endpoint: '',
-          sandbox_endpoint: '',
-          auth_app_key: 'app_key',
-          auth_app_id: 'app_id',
-          auth_user_key: 'user_key',
-          credentials_location: 'authorization',
-          api_test_path: '/test',
-          proxy_rules: [{ pattern: "/foo" }, { pattern: "/bar" }]
-        }
-      }
-      FactoryBot.create(:proxy_config, proxy: proxy, content: content.to_json)
-
-      assert_nothing_raised do
-        res = api_test_curl(proxy, config_based: true)
-        refute_match /curl http/, res
-      end
-    end
-
-    protected
-
-    def proxy_config_content
-      {
-        proxy: {
-          service_id: @proxy.service_id,
-          endpoint: 'https://public-production.fake',
-          sandbox_endpoint: 'https://public-staging.fake',
-          auth_app_key: 'app_key',
-          auth_app_id: 'app_id',
-          auth_user_key: 'user_key',
-          credentials_location: 'query',
-          api_test_path: '/test',
-          proxy_rules: [{ pattern: "/foo" }, { pattern: "/bar" }]
-        }
-      }
-    end
-
-    def create_proxy_config(patch = {})
-      FactoryBot.create(:proxy_config, proxy: proxy, content: proxy_config_content.deep_merge(patch).to_json)
-    end
-  end
-
-  class IsHttpTest < self
-    test 'is_https? returns false for invalid urls, without throwing errors' do
-      refute(is_https?('foo'))
-      refute(is_https?(1))
-      refute(is_https?(nil))
-    end
-  end
-
-  class ProxyRuleUri < self
-    test 'print the proper preview' do
-      pattern = '/foo'
-      backend_api = FactoryBot.create(:backend_api)
-      FactoryBot.create(:proxy_rule, owner: backend_api, proxy: nil, pattern: pattern)
-      backend_api_config = FactoryBot.create(:backend_api_config)
-      backend_api_config.stubs(:path).returns('/')
-
-      assert_equal pattern, proxy_rule_uri(backend_api_config.path, backend_api.proxy_rules.last)
     end
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-3797](https://issues.redhat.com/browse/THREESCALE-3797) + Refactoring of the `CurlCommandBuilder` class used by the `IntegrationsHelper`.

It also fixes a bug with the test curl command showed for accounts with api as product enabled, when apicast's target environment is `production`. I don't think we really show the example curl command in such case, in a way that the bug was probably never activated. Still, just in case we ever decide to use that option, the `environment` argument was supposed to be passed along and it is not in https://github.com/3scale/porta/blob/3ef93f4c68835705e134cd81c9cb9f7f2c888cbd/app/helpers/api/integrations_helper.rb#L129 It was hard-coded always `:staging`.