### PR TITLE
Remove EndUser and EndUserPlans [triggers]

### DIFF
--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -63,12 +63,6 @@ System::Database::MySQL.define do
     SQL
   end
 
-  trigger 'end_user_plans' do
-    <<~SQL
-      SET NEW.tenant_id = (SELECT tenant_id FROM services WHERE id = NEW.service_id AND tenant_id <> master_id);
-    SQL
-  end
-
   trigger 'features' do
     <<~SQL
       IF NEW.featurable_type = 'Account' AND NEW.featurable_id <> master_id THEN

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -63,12 +63,6 @@ System::Database::Oracle.define do
     SQL
   end
 
-  trigger 'end_user_plans' do
-    <<~SQL
-      SELECT tenant_id INTO :new.tenant_id FROM services WHERE id = :new.service_id AND tenant_id <> master_id;
-    SQL
-  end
-
   trigger 'features' do
     <<~SQL
       IF :new.featurable_type = 'Account' AND :new.featurable_id <> master_id THEN

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -63,12 +63,6 @@ System::Database::Postgres.define do
     SQL
   end
 
-  trigger 'end_user_plans' do
-    <<~SQL
-      SELECT tenant_id INTO NEW.tenant_id FROM services WHERE id = NEW.service_id AND tenant_id <> master_id;
-    SQL
-  end
-
   trigger 'features' do
     <<~SQL
       IF NEW.featurable_type = 'Account' AND NEW.featurable_id <> master_id THEN


### PR DESCRIPTION
Removes the triggers for End User Plans in the 3 DBs. Merge before https://github.com/3scale/porta/pull/1648

**Which issue(s) this PR fixes**

[THREESCALE-2490: Remove “End-user plans” feature (SaaS) - Phase 2](https://issues.redhat.com/browse/THREESCALE-2490)
