### PR TITLE
Use and cache system_url_helpers and cms_url_helpers

### DIFF
--- a/app/lib/authentication/strategy/base.rb
+++ b/app/lib/authentication/strategy/base.rb
@@ -22,7 +22,7 @@ module Authentication
     end
 
     class Base
-      include DeveloperPortal::Engine.routes.url_helpers
+      include System::UrlHelpers.cms_url_helpers
 
       attr_reader :site_account, :admin_domain, :user_for_signup, :new_user_created
 
@@ -66,8 +66,7 @@ module Authentication
 
       def signup_path(params)
         permitted_params = params.respond_to?(:permit!) ? params.dup.permit! : params
-        DeveloperPortal::Engine.routes.url_helpers
-            .signup_path(permitted_params.except(:action, :controller))
+        System::UrlHelpers.cms_url_helpers.signup_path(permitted_params.except(:action, :controller))
       end
 
       # This is the template rendered by sessions controller, usually the login form

--- a/app/lib/cms/sidebar.rb
+++ b/app/lib/cms/sidebar.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CMS::Sidebar
-  include Rails.application.routes.url_helpers
+  include System::UrlHelpers.system_url_helpers
 
   def initialize(provider)
     @provider = provider

--- a/app/lib/messenger/base.rb
+++ b/app/lib/messenger/base.rb
@@ -126,7 +126,7 @@ module Messenger
 
 
   class DeveloperPortalRoutes
-    include DeveloperPortal::Engine.routes.url_helpers
+    include System::UrlHelpers.cms_url_helpers
 
     private
 
@@ -137,7 +137,7 @@ module Messenger
   end
 
   class AppRoutes
-    include Rails.application.routes.url_helpers
+    include System::UrlHelpers.system_url_helpers
 
     private
 

--- a/app/lib/system/url_helpers.rb
+++ b/app/lib/system/url_helpers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module System
+  module UrlHelpers
+    cattr_accessor :cms_url_helpers, :system_url_helpers, instance_writer: false
+    self.cms_url_helpers = DeveloperPortal::Engine.routes.url_helpers
+    self.system_url_helpers =  Rails.application.routes.url_helpers
+  end
+end

--- a/app/lib/three_scale/dev_domain.rb
+++ b/app/lib/three_scale/dev_domain.rb
@@ -6,7 +6,7 @@ module ThreeScale::DevDomain
   end
 
   extend ActiveSupport::Concern
-  include Rails.application.routes.url_helpers
+  include System::UrlHelpers.system_url_helpers
 
   included do
     helper URL

--- a/app/models/sso_token.rb
+++ b/app/models/sso_token.rb
@@ -53,12 +53,6 @@ class SSOToken
     end
   end
 
-  class_attribute :system_url_helpers, instance_writer: false
-  self.system_url_helpers = Rails.application.routes.url_helpers
-
-  class_attribute :cms_url_helpers, instance_writer: false
-  self.cms_url_helpers = DeveloperPortal::Engine.routes.url_helpers
-
   # It will save the object if new and will return the sso_url
   #
   # Default for a provider account is to create an url that works on its buyer side,
@@ -75,7 +69,7 @@ class SSOToken
       expires_at: expires_at.to_i,
       redirect_url: redirect_url
     }.delete_if{|k,v| v.nil?}
-    host.nil? ? cms_url_helpers.create_session_url(params) : system_url_helpers.provider_sso_url(params)
+    host.nil? ?  System::UrlHelpers.cms_url_helpers.create_session_url(params) : System::UrlHelpers.system_url_helpers.provider_sso_url(params)
   end
 
   protected

--- a/app/observers/post_observer.rb
+++ b/app/observers/post_observer.rb
@@ -3,7 +3,7 @@ class PostObserver < ActiveRecord::Observer
 
   include AfterCommitOn
 
-  include Rails.application.routes.url_helpers
+  include System::UrlHelpers.system_url_helpers
 
   def after_commit_on_create(post)
     account = post.forum.account

--- a/app/portlets/latest_forum_posts_portlet.rb
+++ b/app/portlets/latest_forum_posts_portlet.rb
@@ -43,7 +43,7 @@ END
   end
 
   module ToLiquid
-    include DeveloperPortal::Engine.routes.url_helpers
+    include System::UrlHelpers.cms_url_helpers
     include ActionView::Helpers::DateHelper
 
     def self.included(base)

--- a/app/presenters/provider_oauth_flow_presenter.rb
+++ b/app/presenters/provider_oauth_flow_presenter.rb
@@ -1,7 +1,7 @@
 class ProviderOauthFlowPresenter < OauthFlowPresenter
   delegate :human_kind, to: :authentication_provider
 
-  include Rails.application.routes.url_helpers
+  include System::UrlHelpers.system_url_helpers
 
   # @param [AuthenticationProvider] authentication_provider
   # @param [ActionDispatch::Request] request

--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -5,8 +5,6 @@ require 'httpclient/include_client'
 class ZyncWorker
   include Sidekiq::Worker
   include ThreeScale::SidekiqRetrySupport::Worker
-  class_attribute :main_app, instance_writer: false
-  self.main_app = Rails.application.routes.url_helpers
 
   extend ::HTTPClient::IncludeClient
 
@@ -333,7 +331,7 @@ class ZyncWorker
               when 'development' then { host: "#{host}.#{ThreeScale.config.dev_gtld}", port: 3000 }
               else { host: host }.reverse_merge(ActionMailer::Base.default_url_options)
               end
-    main_app.root_url(options)
+    System::UrlHelpers.system_url_helpers.root_url(options)
   end
 
   delegate :provider_access_token, to: :class

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -386,8 +386,8 @@ without fake Core server your after commit callbacks will crash and you might ge
         end
 
         resource :personal_details, only: [] do
-          match '/', via: :any, to: redirect { Rails.application.routes.url_helpers.edit_provider_admin_user_personal_details_path }
-          get 'edit', action: 'edit', on: :member, to: redirect { Rails.application.routes.url_helpers.edit_provider_admin_user_personal_details_path }
+          match '/', via: :any, to: redirect { System::UrlHelpers.system_url_helpers.edit_provider_admin_user_personal_details_path }
+          get 'edit', action: 'edit', on: :member, to: redirect { System::UrlHelpers.system_url_helpers.edit_provider_admin_user_personal_details_path }
         end
 
         resource :change_plan, :only => [:show, :update] do

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -3,7 +3,7 @@
 World(Module.new do
   break unless defined?(DeveloperPortal)
 
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def provider_first_service!
     @provider.first_service!

--- a/lib/developer_portal/app/helpers/developer_portal/cms/toolbar_helper.rb
+++ b/lib/developer_portal/app/helpers/developer_portal/cms/toolbar_helper.rb
@@ -43,7 +43,7 @@ module DeveloperPortal::CMS::ToolbarHelper
 
       # main_app is not available in the engine
       routes = Rails.application.routes
-      main_app = ActionDispatch::Routing::RoutesProxy.new(routes, self, routes.url_helpers)
+      main_app = ActionDispatch::Routing::RoutesProxy.new(routes, self, System::UrlHelpers.system_url_helpers)
 
       polymorphic_url([ main_app, :edit, :provider, :admin, template ], opts)
     end

--- a/lib/developer_portal/app/mailers/invitation_mailer.rb
+++ b/lib/developer_portal/app/mailers/invitation_mailer.rb
@@ -1,7 +1,7 @@
 class InvitationMailer < ActionMailer::Base
 
   include Liquid::Assigns
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
   include CMS::EmailTemplate::MailerExtension
 
   def invitation(invitation)

--- a/lib/developer_portal/lib/cms/toolbar.rb
+++ b/lib/developer_portal/lib/cms/toolbar.rb
@@ -113,7 +113,7 @@ module CMS::Toolbar
   end
 
   class View < ActionView::Base
-    include ::Rails.application.routes.url_helpers
+    include System::UrlHelpers.system_url_helpers
     include ::DeveloperPortal::CMS::ToolbarHelper
   end
 end

--- a/lib/developer_portal/lib/liquid/drops/api_spec.rb
+++ b/lib/developer_portal/lib/liquid/drops/api_spec.rb
@@ -8,7 +8,7 @@ module Liquid
 
       desc 'Returns the url of the API spec.'
       def url
-        cms_url_helpers.swagger_spec_path(system_name, format: :json)
+        System::UrlHelpers.cms_url_helpers.swagger_spec_path(system_name, format: :json)
       end
 
       desc 'Returns the name of the spec.'

--- a/lib/developer_portal/lib/liquid/drops/application.rb
+++ b/lib/developer_portal/lib/liquid/drops/application.rb
@@ -17,7 +17,7 @@ module Liquid
       # Filter might be better, as in Shopify: http://cheat.markdunkley.com/
       desc "Returns the admin_url of the application."
       def admin_url
-        system_url_helpers.admin_service_application_url(@contract.service, @contract, host: @contract.provider_account.self_domain)
+        System::UrlHelpers.system_url_helpers.admin_service_application_url(@contract.service, @contract, host: @contract.provider_account.self_domain)
       end
 
       def path
@@ -287,7 +287,7 @@ module Liquid
         end
 
         def regenerate_secret_url
-          cms_url_helpers.regenerate_admin_application_key_path(application_id: @application.id,
+          System::UrlHelpers.cms_url_helpers.regenerate_admin_application_key_path(application_id: @application.id,
                                                                 id: @application.keys.first)
         end
       end

--- a/lib/developer_portal/lib/liquid/drops/base.rb
+++ b/lib/developer_portal/lib/liquid/drops/base.rb
@@ -5,13 +5,6 @@ module Liquid
     class Base < Liquid::Drop
       class_attribute :_deprecated_names, :_allowed_names, :instance_writer => false, :instance_reader => false
 
-      class_attribute :system_url_helpers, instance_writer: false
-      self.system_url_helpers = Rails.application.routes.url_helpers
-
-      class_attribute :cms_url_helpers, instance_writer: false
-      self.cms_url_helpers = DeveloperPortal::Engine.routes.url_helpers
-
-
       extend Liquid::Docs::DSL::Drops
 
       private
@@ -99,7 +92,7 @@ module Liquid
       end
 
       privately_include  do
-        include DeveloperPortal::Engine.routes.url_helpers
+        include System::UrlHelpers.cms_url_helpers
       end
 
       def url_options

--- a/lib/developer_portal/lib/liquid/drops/plan_change.rb
+++ b/lib/developer_portal/lib/liquid/drops/plan_change.rb
@@ -76,7 +76,7 @@ module Liquid
 
       desc 'Returns the url to confirm the change. The request method must be POST'
       def confirm_path
-        cms_url_helpers.admin_contract_path(@contract.id, plan_id: @plan.id)
+        System::UrlHelpers.cms_url_helpers.admin_contract_path(@contract.id, plan_id: @plan.id)
       end
 
       desc 'Returns the url to cancel the change. The request method must be DELETE'

--- a/lib/developer_portal/lib/liquid/drops/post.rb
+++ b/lib/developer_portal/lib/liquid/drops/post.rb
@@ -24,7 +24,7 @@ module Liquid
 
       desc "The URL of this post within its topic."
       def url
-        system_url_helpers.forum_topic_path(@model.topic, anchor: "post_#{@model.id}")
+        System::UrlHelpers.system_url_helpers.forum_topic_path(@model.topic, anchor: "post_#{@model.id}")
       end
     end
   end

--- a/lib/developer_portal/lib/liquid/drops/service.rb
+++ b/lib/developer_portal/lib/liquid/drops/service.rb
@@ -83,7 +83,7 @@ module Liquid
       end
 
       def subscribe_url
-        cms_url_helpers.new_admin_service_contract_path(service_id: @service)
+        System::UrlHelpers.cms_url_helpers.new_admin_service_contract_path(service_id: @service)
       end
 
       desc "Returns the **published** application plans of the service."

--- a/lib/developer_portal/lib/liquid/drops/topic.rb
+++ b/lib/developer_portal/lib/liquid/drops/topic.rb
@@ -10,7 +10,7 @@ module Liquid
       end
 
       def url
-        system_url_helpers.forum_topic_path(@model)
+        System::UrlHelpers.system_url_helpers.forum_topic_path(@model)
       end
     end
   end

--- a/lib/developer_portal/lib/liquid/filters/url_helpers.rb
+++ b/lib/developer_portal/lib/liquid/filters/url_helpers.rb
@@ -3,7 +3,7 @@ module Liquid
     # DEPRECATED
     module UrlHelpers
       include Liquid::Filters::Base
-      include Rails.application.routes.url_helpers
+      include System::UrlHelpers.system_url_helpers
 
       # TODO: consider allowing more parameters
       desc """

--- a/lib/developer_portal/lib/liquid/forms/base.rb
+++ b/lib/developer_portal/lib/liquid/forms/base.rb
@@ -3,7 +3,7 @@ module Liquid
     class Base
       attr_reader :context
 
-      include DeveloperPortal::Engine.routes.url_helpers
+      include System::UrlHelpers.cms_url_helpers
 
       delegate :tag, :content_tag, to: 'Liquid::Filters::RailsHelpers'
 

--- a/lib/developer_portal/lib/liquid/tags/form.rb
+++ b/lib/developer_portal/lib/liquid/tags/form.rb
@@ -4,7 +4,7 @@ module Liquid
 
       extend Liquid::Docs::DSL::Tags
 
-      include Rails.application.routes.url_helpers
+      include System::UrlHelpers.system_url_helpers
 
       # list of allowed html attributes
       HTML_FORM_ATTRIBUTES = ["class", "id"]

--- a/test/decorators/plan_decorator_test.rb
+++ b/test/decorators/plan_decorator_test.rb
@@ -10,12 +10,12 @@ class PlanDecoratorTest < Draper::TestCase
     plan.id = 42
 
     decorator = PlanDecorator.new(plan)
-    assert_equal "#{Rails.application.routes.url_helpers.admin_service_applications_path(service)}?search%5Bplan_id%5D=42", decorator.plan_path
+    assert_equal "#{System::UrlHelpers.system_url_helpers.admin_service_applications_path(service)}?search%5Bplan_id%5D=42", decorator.plan_path
 
     decorator = PlanDecorator.new(plan, context: { service: other = Service.new })
     other.id = 2
 
-    assert_equal "#{Rails.application.routes.url_helpers.admin_service_applications_path(other)}?search%5Bplan_id%5D=42", decorator.plan_path
+    assert_equal "#{System::UrlHelpers.system_url_helpers.admin_service_applications_path(other)}?search%5Bplan_id%5D=42", decorator.plan_path
   end
 
   def test_link_to_edit
@@ -39,7 +39,7 @@ class PlanDecoratorTest < Draper::TestCase
     assert_equal '0 applications', decorator.link_to_applications
 
     helpers.expects(:can?).with(:show, Cinstance).returns(true)
-    assert_equal "<a href=\"#{Rails.application.routes.url_helpers.admin_service_applications_path(service)}?search%5Bplan_id%5D=\">0 applications</a>",
+    assert_equal "<a href=\"#{System::UrlHelpers.system_url_helpers.admin_service_applications_path(service)}?search%5Bplan_id%5D=\">0 applications</a>",
                  decorator.link_to_applications
   end
 end

--- a/test/decorators/service_decorator_test.rb
+++ b/test/decorators/service_decorator_test.rb
@@ -11,7 +11,7 @@ class ServiceDecoratorTest < Draper::TestCase
     assert_equal '0 live applications', decorator.link_to_live_applications
 
     helpers.expects(:can?).with(:show, Cinstance).returns(true)
-    assert_equal "<a href=\"#{Rails.application.routes.url_helpers.admin_service_applications_path(service)}?search%5Bstate%5D=live\">0 live applications</a>",
+    assert_equal "<a href=\"#{System::UrlHelpers.system_url_helpers.admin_service_applications_path(service)}?search%5Bstate%5D=live\">0 live applications</a>",
                  decorator.link_to_live_applications
   end
 

--- a/test/integration/developer_portal/accounts/invitee_signups_controller_test.rb
+++ b/test/integration/developer_portal/accounts/invitee_signups_controller_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class DeveloperPortal::Accounts::InviteeSignupsControllerTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @buyer = FactoryBot.create(:buyer_account)

--- a/test/integration/developer_portal/admin/account/payment_details_base_controller_test.rb
+++ b/test/integration/developer_portal/admin/account/payment_details_base_controller_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DeveloperPortal::Admin::Account::PaymentDetailsBaseTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   setup do
     @provider = FactoryBot.create(:provider_with_billing)

--- a/test/integration/developer_portal/admin/applications_controller_test.rb
+++ b/test/integration/developer_portal/admin/applications_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::Admin::ApplicationsControllerTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @provider  = FactoryBot.create(:provider_account)

--- a/test/integration/developer_portal/admin/messages/outbox_controller_test.rb
+++ b/test/integration/developer_portal/admin/messages/outbox_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::Admin::Messages::OutboxControllerTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @provider = FactoryBot.create(:simple_provider)

--- a/test/integration/developer_portal/api_docs/account_data_controller_test.rb
+++ b/test/integration/developer_portal/api_docs/account_data_controller_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class DeveloperPortal::ApiDocs::AccountDataControllerTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @provider = FactoryBot.create(:provider_account)

--- a/test/integration/developer_portal/edit_account_test.rb
+++ b/test/integration/developer_portal/edit_account_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::EditAccountTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @provider = FactoryBot.create(:simple_provider)

--- a/test/integration/developer_portal/forums/admin/categories_controller_test.rb
+++ b/test/integration/developer_portal/forums/admin/categories_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 module DeveloperPortal
   class Forums::Admin::CategoriesControllerTest < ActionDispatch::IntegrationTest
-    include DeveloperPortal::Engine.routes.url_helpers
+    include System::UrlHelpers.cms_url_helpers
 
     def setup
       @provider = FactoryBot.create(:provider_account)

--- a/test/integration/developer_portal/invitation_signup_test.rb
+++ b/test/integration/developer_portal/invitation_signup_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::InvitationSignupTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   Oauth2 = Authentication::Strategy::Oauth2
 

--- a/test/integration/developer_portal/login_test.rb
+++ b/test/integration/developer_portal/login_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::LoginTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
   include UserDataHelpers
 
   def setup

--- a/test/integration/developer_portal/signup_test.rb
+++ b/test/integration/developer_portal/signup_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::SignupTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
   include UserDataHelpers
 
   def setup

--- a/test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
+++ b/test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Admin::Api::ApplicationPlanMetricPricingRulesTest < ActionDispatch::IntegrationTest
 
-  include ThreeScale::PrivateModule(Rails.application.routes.url_helpers)
+  include ThreeScale::PrivateModule(System::UrlHelpers.system_url_helpers)
 
   def setup
     @provider = FactoryBot.create :provider_account, :domain => 'provider.example.com'

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -51,7 +51,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match 'Dear Foobar Admin', body.encoded
       assert_match "A new application subscribed to the #{application.plan.name} plan on the #{service.name} service of the #{application.account.name} account.", body.encoded
       assert_match 'Application details:', body.encoded
-      cinstance_url = Rails.application.routes.url_helpers.admin_service_application_url(service, application,
+      cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(service, application,
                                                                                          host: service.account.admin_domain)
       assert_match cinstance_url, body.encoded
 
@@ -116,7 +116,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match 'Dear Foobar Admin', body.encoded
       assert_match "Application #{application.name} of your client #{application.user_account.name}", body.encoded
       assert_match "is above #{alert.level}% limit utilization of #{alert.message}.", body.encoded
-      cinstance_url = Rails.application.routes.url_helpers.admin_service_application_url(service, application,
+      cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(service, application,
                                                                                          host: service.account.admin_domain)
       assert_match cinstance_url, body.encoded
     end
@@ -137,7 +137,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match 'Dear Foobar Admin', body.encoded
       assert_match "Application #{application.name} of your client #{application.user_account.name}", body.encoded
       assert_match "is above #{alert.level}% limit utilization of #{alert.message}.", body.encoded
-      cinstance_url = Rails.application.routes.url_helpers.admin_service_application_url(service, application,
+      cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(service, application,
                                                                                          host: service.account.admin_domain)
       assert_match cinstance_url, body.encoded
     end
@@ -394,7 +394,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match "Previous plan: #{old_plan.name}", body.encoded
       assert_match "Current plan: #{cinstance.plan.name}", body.encoded
       assert_match "Application #{cinstance.name} has changed to plan #{cinstance.plan.name}.", body.encoded
-      cinstance_url = Rails.application.routes.url_helpers.admin_service_application_url(cinstance.service, cinstance,
+      cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(cinstance.service, cinstance,
                                                                                          host: cinstance.service.account.admin_domain)
       assert_match cinstance_url, body.encoded
     end
@@ -558,7 +558,7 @@ class NotificationMailerTest < ActionMailer::TestCase
   end
 
   def url_helpers
-    Rails.application.routes.url_helpers
+    System::UrlHelpers.system_url_helpers
   end
 
   def assert_html_email(delivery, &block)

--- a/test/unit/liquid/drops/account_drop_test.rb
+++ b/test/unit/liquid/drops/account_drop_test.rb
@@ -10,7 +10,7 @@ class Liquid::Drops::AccountDropTest < ActiveSupport::TestCase
   end
 
   def test_url_helpers
-    routes      = Rails.application.routes.url_helpers
+    routes      = System::UrlHelpers.system_url_helpers
     account_url = routes.admin_buyers_account_url(@drop, host: 'foo.example.com')
 
     assert account_url

--- a/test/unit/liquid/drops/application_drop_test.rb
+++ b/test/unit/liquid/drops/application_drop_test.rb
@@ -18,7 +18,7 @@ class Liquid::Drops::ApplicationDropTest < ActiveSupport::TestCase
   end
 
   test 'admin_url' do
-    assert_match Rails.application.routes.url_helpers.admin_service_application_path(@app.service, @app), @drop.admin_url
+    assert_match System::UrlHelpers.system_url_helpers.admin_service_application_path(@app.service, @app), @drop.admin_url
   end
 
   test 'alerts' do

--- a/test/unit/liquid/drops/invitation_drop_test.rb
+++ b/test/unit/liquid/drops/invitation_drop_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Liquid::Drops::InvitationDropTest < ActiveSupport::TestCase
   include Liquid
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @invitation = FactoryBot.build_stubbed(:invitation)

--- a/test/unit/liquid/forms_test.rb
+++ b/test/unit/liquid/forms_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Liquid::FormsTest < ActiveSupport::TestCase
-  include ThreeScale::PrivateModule(Rails.application.routes.url_helpers)
+  include ThreeScale::PrivateModule(System::UrlHelpers.system_url_helpers)
 
   test 'unknown form name' do
     assert_raises(Liquid::Forms::NotFoundError) do

--- a/test/unit/mailers/post_office_test.rb
+++ b/test/unit/mailers/post_office_test.rb
@@ -197,7 +197,7 @@ class PostOfficeTest < ActionMailer::TestCase
   end
 
   def url_helpers
-    Rails.application.routes.url_helpers
+    System::UrlHelpers.system_url_helpers
   end
 
   def generate_message_subject

--- a/test/unit/messengers/account_messenger_test.rb
+++ b/test/unit/messengers/account_messenger_test.rb
@@ -56,6 +56,6 @@ class AccountMessengerTest < ActiveSupport::TestCase
   end
 
   def url_helpers
-    Rails.application.routes.url_helpers
+    System::UrlHelpers.system_url_helpers
   end
 end

--- a/test/unit/messengers/cinstance_messenger_test.rb
+++ b/test/unit/messengers/cinstance_messenger_test.rb
@@ -58,7 +58,7 @@ class CinstanceMessengerTest < ActiveSupport::TestCase
     CinstanceMessenger.new_application(@app).deliver
 
     assert_match "This application requires your approval", Message.last.body
-    expected_url = Rails.application.routes.url_helpers.admin_service_application_url(@app.service, @app, host: @provider_account.admin_domain)
+    expected_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(@app.service, @app, host: @provider_account.admin_domain)
     assert_match expected_url, Message.last.body
   end
 

--- a/test/unit/messengers/plans_messenger_test.rb
+++ b/test/unit/messengers/plans_messenger_test.rb
@@ -12,7 +12,7 @@ class PlansMessengerTest < ActiveSupport::TestCase
     PlansMessenger.plan_change_request(cinstance, plan).deliver
 
     email = ActionMailer::Base.deliveries.last
-    expected_url = Rails.application.routes.url_helpers.admin_service_application_url(cinstance.service, cinstance, host: cinstance.account.provider_account.admin_domain)
+    expected_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(cinstance.service, cinstance, host: cinstance.account.provider_account.admin_domain)
     assert_includes email.body.to_s, expected_url
   end
 end

--- a/test/unit/presenters/redhat_customer_oauth_flow_presenter_test.rb
+++ b/test/unit/presenters/redhat_customer_oauth_flow_presenter_test.rb
@@ -24,6 +24,6 @@ class RedhatCustomerOAuthFlowPresenterTest < ActiveSupport::TestCase
   end
 
   def url_helpers
-    Rails.application.routes.url_helpers
+    System::UrlHelpers.system_url_helpers
   end
 end


### PR DESCRIPTION
They are initialized just once and reused later

We could use System::DeveloperRoutes and System::MainRoutes

But I think it is not intended to be constantized even though they are
modules

Related to #1693 

How to verify there is no more use of generated/non-cached routes?

```shell
$ rg '^((?!System::UrlHelpers).)*url_helpers' --pcre2 --type ruby
```