### PR TITLE
Do not issue ProxyConfigs::AffectingObjectChangedEvent when account is scheduled_for_deletion

### DIFF
--- a/app/events/proxy_configs/affecting_object_changed_event.rb
+++ b/app/events/proxy_configs/affecting_object_changed_event.rb
@@ -14,6 +14,8 @@ class ProxyConfigs::AffectingObjectChangedEvent < ServiceRelatedEvent
   end
 
   def self.valid?(proxy, *_args)
-    proxy && proxy.account&.persisted? # Proxy's service or account may have been deleted
+    return unless proxy
+    account = proxy.account
+    account && !account.scheduled_for_deletion?
   end
 end

--- a/test/events/proxy_configs/affecting_object_changed_event_test.rb
+++ b/test/events/proxy_configs/affecting_object_changed_event_test.rb
@@ -3,47 +3,40 @@
 require 'test_helper'
 
 class ProxyConfigs::AffectingObjectChangedEventTest < ActiveSupport::TestCase
-  test 'create' do
-    proxy = FactoryBot.create(:proxy)
-    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
-    event = ProxyConfigs::AffectingObjectChangedEvent.create(proxy, proxy_rule)
+  test 'create_and_publish! persists with the right data when the proxy and the account are persisted and not scheduled_for_deletion' do
+    stored_event = EventStore::Repository.find_event!(event_published.event_id)
 
-    assert_equal proxy.id, event.proxy_id
-    assert_equal proxy_rule.id, event.object_id
-    assert_equal 'ProxyRule', event.object_type
-  end
-
-  test 'create_and_publish! persists when the proxy and the account are persisted and not scheduled_for_deletion' do
-    proxy = FactoryBot.create(:proxy)
-    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
-
-    event = ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy, proxy_rule)
-
-    assert EventStore::Repository.find_event(event.event_id)
+    assert_equal proxy.id, stored_event.proxy_id
+    assert_equal proxy_rule.id, stored_event.object_id
+    assert_equal 'ProxyRule', stored_event.object_type
   end
 
   test 'create_and_publish! does not persist when the proxy is not present' do
-    proxy_rule = FactoryBot.build_stubbed(:proxy_rule)
-
-    refute ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(nil, proxy_rule)
+    refute event_published(proxy: nil)
   end
 
   test 'create_and_publish! does not persist when the account is not persisted' do
-    proxy = FactoryBot.create(:proxy)
-    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
-
     proxy.account.delete
 
-    refute ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy.reload, proxy_rule)
+    refute event_published
   end
   test 'create_and_publish! does not persist when the account is scheduled_for_deletion' do
-    proxy = FactoryBot.create(:proxy)
-    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
-
     proxy.account.schedule_for_deletion!
 
-    refute ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy, proxy_rule)
+    refute event_published
   end
 
+  private
 
+  def proxy_rule
+    @proxy_rule ||= FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
+  end
+
+  def proxy
+    @proxy ||= FactoryBot.create(:proxy)
+  end
+
+  def event_published(proxy: proxy_rule.proxy)
+    @event_published ||= ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy&.reload, proxy_rule)
+  end
 end

--- a/test/events/proxy_configs/affecting_object_changed_event_test.rb
+++ b/test/events/proxy_configs/affecting_object_changed_event_test.rb
@@ -12,4 +12,38 @@ class ProxyConfigs::AffectingObjectChangedEventTest < ActiveSupport::TestCase
     assert_equal proxy_rule.id, event.object_id
     assert_equal 'ProxyRule', event.object_type
   end
+
+  test 'create_and_publish! persists when the proxy and the account are persisted and not scheduled_for_deletion' do
+    proxy = FactoryBot.create(:proxy)
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
+
+    event = ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy, proxy_rule)
+
+    assert EventStore::Repository.find_event(event.event_id)
+  end
+
+  test 'create_and_publish! does not persist when the proxy is not present' do
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule)
+
+    refute ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(nil, proxy_rule)
+  end
+
+  test 'create_and_publish! does not persist when the account is not persisted' do
+    proxy = FactoryBot.create(:proxy)
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
+
+    proxy.account.delete
+
+    refute ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy.reload, proxy_rule)
+  end
+  test 'create_and_publish! does not persist when the account is scheduled_for_deletion' do
+    proxy = FactoryBot.create(:proxy)
+    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
+
+    proxy.account.schedule_for_deletion!
+
+    refute ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy, proxy_rule)
+  end
+
+
 end


### PR DESCRIPTION
Closes [THREESCALE-4322](https://issues.redhat.com/browse/THREESCALE-4322)
It will help a lot for [THREESCALE-4483](https://issues.redhat.com/browse/THREESCALE-4483)