### PR TITLE
[Bugfix] ServiceDeletedEvent never saves the entire provider object

### DIFF
--- a/app/events/services/service_deleted_event.rb
+++ b/app/events/services/service_deleted_event.rb
@@ -2,18 +2,13 @@
 
 class Services::ServiceDeletedEvent < ServiceRelatedEvent
   def self.create(service)
-    provider = service.account || Account.new({id: service.tenant_id}, without_protection: true)
-
-    data = {
-      service_id:   service.id,
+    new(
+      service_id: service.id,
       service_name: service.name,
       service_created_at: service.created_at.to_s,
       metadata: {
-        provider_id: provider.id
+        provider_id: service.account_id || service.tenant_id
       }
-    }
-    data[:provider] = provider if provider.persisted?
-
-    new(data)
+    )
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-4620](https://issues.redhat.com/browse/THREESCALE-4620)

We are using this event from the following places only (except for the tests 😄 ):

https://github.com/3scale/porta/blob/d30107bb05143712c5ef9545a822f3db93555b52/app/mailers/notification_mailer.rb#L370-L380

https://github.com/3scale/porta/blob/d30107bb05143712c5ef9545a822f3db93555b52/app/models/service.rb#L587-L589

https://github.com/3scale/porta/blob/d30107bb05143712c5ef9545a822f3db93555b52/app/lib/event_store/repository.rb#L150

https://github.com/3scale/porta/blob/d30107bb05143712c5ef9545a822f3db93555b52/app/lib/event_store/repository.rb#L165

https://github.com/3scale/porta/blob/d30107bb05143712c5ef9545a822f3db93555b52/app/subscribers/service_deleted_subscriber.rb#L6

This means that it is used only for mailing and for deleting in Apisonator after it has been deleted in Porta. And none of them uses the `provider` object stored in the event.

For Zync we do not use this event, but this other one:
https://github.com/3scale/porta/blob/d30107bb05143712c5ef9545a822f3db93555b52/app/subscribers/publish_zync_event_subscriber.rb#L27

Read the description of the Jira issue for more information 😄 
