### PR TITLE
Update package.json and yarn.lock after yarn checks integrity

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "url-polyfill": "^1.1.3",
     "validate.js": "^0.13.1",
     "virtual-dom": "^2.1.1",
-    "whatwg-fetch": "^3.0.0"
+    "whatwg-fetch": "^3.0.0",
+    "yarn": "^1.22.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13796,6 +13796,11 @@ yargs@^7.0.0:
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
 
+yarn@^1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.0.tgz#acf82906e36bcccd1ccab1cfb73b87509667c881"
+  integrity sha512-KMHP/Jq53jZKTY9iTUt3dIVl/be6UPs2INo96+BnZHLKxYNTfwMmlgHTaMWyGZoO74RI4AIFvnWhYrXq2USJkg==
+
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"


### PR DESCRIPTION
When I was using my personal laptop, for every action like going to the rails console or running the server, it appeared a message like this one:
![image](https://user-images.githubusercontent.com/11318903/75811661-1dcd7f00-5d8d-11ea-9f34-732552ab47d2.png)

And I always had to end up updating the package.json and the yarn.lock by it in order to be able to keep working.

I thought it was a problem with my laptop, but now I've done a setup from scratch in the Mac, and I kept having the same problem... so this is what it updates in order to work properly for me.

But I definitely need help from the @3scale/system-ux team because I do not know if this is correct or not and I may be doing something wrong.