### PR TITLE
[circleci] Do not trigger CircleCI build automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -851,10 +851,18 @@ workflows:
 
   mysql_build:
     jobs:
+      - manual_approval: # <<< A job that will require manual approval in the CircleCI web application.
+          type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
       - notify_start:
           <<: *only-master-filter
-      - dependencies_bundler
-      - dependencies_npm
+          requires:
+            - manual_approval
+      - dependencies_bundler:
+          requires:
+            - manual_approval
+      - dependencies_npm:
+          requires:
+            - manual_approval
       - assets_precompile:
           requires:
             - dependencies_bundler
@@ -1018,10 +1026,18 @@ workflows:
 
   javascript_tests:
     jobs:
+      - manual_approval: # <<< A job that will require manual approval in the CircleCI web application.
+          type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
       - notify_start:
           <<: *only-master-filter
-      - dependencies_bundler
-      - dependencies_npm
+          requires:
+            - manual_approval
+      - dependencies_bundler:
+          requires:
+            - manual_approval
+      - dependencies_npm:
+          requires:
+            - manual_approval
       - assets_precompile:
           requires:
             - dependencies_bundler


### PR DESCRIPTION
Now every push will need manual approval
Incovenient but will maybe lower the bill

Press the button if you want your PR to go through the builds

![image](https://user-images.githubusercontent.com/64276/75847790-37081700-5df1-11ea-98fc-06638727dab2.png)

![image](https://user-images.githubusercontent.com/64276/75848447-5142f480-5df3-11ea-901c-6f81146bc7cc.png)
