### PR TITLE
[gem] Remove deadlock_retry gem and fix random failures

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -127,7 +127,6 @@ gem 'will_paginate', '~> 3.1.6'
 gem 'browser'
 
 gem 'rack-x_served_by', '~> 0.1.1'
-gem 'deadlock_retry'
 gem 'addressable', require: false
 gem 'roar-rails'
 gem 'acts_as_tree'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,6 @@ GEM
     daemons (1.3.1)
     dalli (2.7.10)
     database_cleaner (1.7.0)
-    deadlock_retry (1.2.0)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     diffy (3.2.1)
@@ -839,7 +838,6 @@ DEPENDENCIES
   cucumber-rails
   dalli (~> 2.7)
   database_cleaner (~> 1.7)
-  deadlock_retry
   developer_portal!
   diff-lcs (~> 1.2)
   dotenv-rails (~> 2.7)

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -280,7 +280,6 @@ GEM
     daemons (1.3.1)
     dalli (2.7.10)
     database_cleaner (1.7.0)
-    deadlock_retry (1.2.0)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     diffy (3.2.1)
@@ -840,7 +839,6 @@ DEPENDENCIES
   cucumber-rails
   dalli (~> 2.7)
   database_cleaner (~> 1.7)
-  deadlock_retry
   developer_portal!
   diff-lcs (~> 1.2)
   dotenv-rails (~> 2.7)

--- a/config/initializers/active_record.rb
+++ b/config/initializers/active_record.rb
@@ -1,4 +1,5 @@
 # TODO: remove this hack?
+require 'deadlock_retry'
 class ActiveRecord::Base
 
   # returns a human readable name of the class.

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2005 Jamis Buck
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# Extracted from https://github.com/mperham/deadlock_retry/blob/874c80de92d9eb30405536916aff86f616649b01/lib/deadlock_retry.rb
+require 'active_support/core_ext/module/attribute_accessors'
+
+module DeadlockRetry
+  def self.included(base)
+    class << base
+      prepend(ClassMethods)
+    end
+  end
+
+  mattr_accessor :innodb_status_cmd
+
+  module ClassMethods
+    DEADLOCK_ERROR_MESSAGES = [
+      "Deadlock found when trying to get lock",
+      "Lock wait timeout exceeded",
+      "deadlock detected"
+    ]
+
+    MAXIMUM_RETRIES_ON_DEADLOCK = 3
+
+
+    def transaction(*objects, &block)
+      retry_count = 0
+
+      check_innodb_status_available
+
+      begin
+        super(*objects, &block)
+      rescue ActiveRecord::StatementInvalid => error
+        raise if in_nested_transaction?
+        if DEADLOCK_ERROR_MESSAGES.any? { |msg| error.message =~ /#{Regexp.escape(msg)}/ }
+          raise if retry_count >= MAXIMUM_RETRIES_ON_DEADLOCK
+          retry_count += 1
+          logger.info "Deadlock detected on retry #{retry_count}, restarting transaction"
+          log_innodb_status if DeadlockRetry.innodb_status_cmd
+          exponential_pause(retry_count)
+          retry
+        else
+          raise
+        end
+      end
+    end
+
+    private
+
+    WAIT_TIMES = [0, 1, 2, 4, 8, 16, 32]
+
+    def exponential_pause(count)
+      sec = WAIT_TIMES[count-1] || 32
+      # sleep 0, 1, 2, 4, ... seconds up to the MAXIMUM_RETRIES.
+      # Cap the pause time at 32 seconds.
+      sleep(sec) if sec != 0
+    end
+
+    def in_nested_transaction?
+      # open_transactions was added in 2.2's connection pooling changes.
+      connection.open_transactions != 0
+    end
+
+    def show_innodb_status
+      self.connection.select_value(DeadlockRetry.innodb_status_cmd)
+    end
+
+    # Should we try to log innodb status -- if we don't have permission to,
+    # we actually break in-flight transactions, silently (!)
+    def check_innodb_status_available
+      return unless DeadlockRetry.innodb_status_cmd == nil
+
+      if self.connection.adapter_name == "MySQL"
+        begin
+          mysql_version = self.connection.select_rows('show variables like \'version\'')[0][1]
+          cmd = if mysql_version < '5.5'
+            'show innodb status'
+          else
+            'show engine innodb status'
+          end
+          self.connection.select_value(cmd)
+          DeadlockRetry.innodb_status_cmd = cmd
+        rescue
+          logger.info "Cannot log innodb status: #{$!.message}"
+          DeadlockRetry.innodb_status_cmd = false
+        end
+      else
+        DeadlockRetry.innodb_status_cmd = false
+      end
+    end
+
+    def log_innodb_status
+      # show innodb status is the only way to get visiblity into why
+      # the transaction deadlocked.  log it.
+      lines = show_innodb_status
+      logger.warn "INNODB Status follows:"
+      lines.each_line do |line|
+        logger.warn line
+      end
+    rescue => e
+      # Access denied, ignore
+      logger.info "Cannot log innodb status: #{e.message}"
+    end
+
+  end
+end
+
+ActiveRecord::Base.send(:include, DeadlockRetry) if defined?(ActiveRecord)

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -24,7 +24,7 @@ end
 
 require 'active_support/core_ext'
 
-require 'config/initializers/ruby1.9.rb'
+require 'test_helpers/simple_mini_test'
 
 unless defined?(Rails)
   module Rails extend self

--- a/test/test_helpers/proxy_config_affecting_changes.rb
+++ b/test/test_helpers/proxy_config_affecting_changes.rb
@@ -1,11 +1,11 @@
 module TestHelpers
   module ProxyConfigAffectingChangesHelpers
     def with_proxy_config_affecting_changes_tracker
-      Thread.new do
+      within_thread do
         tracker = ProxyConfigAffectingChanges::Tracker.new
         Thread.current[ProxyConfigAffectingChanges::TRACKER_NAME] = tracker
         yield(tracker)
-      end.join
+      end
     end
   end
 end

--- a/test/test_helpers/simple_mini_test.rb
+++ b/test/test_helpers/simple_mini_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SimpleMiniTest < Minitest::Test
+  def teardown
+    super
+    User.current = nil
+    Timecop.return
+  end
+end

--- a/test/test_helpers/thread_helper.rb
+++ b/test/test_helpers/thread_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ThreadHelper
+  # This allows some part of the code to run in another Thread
+  # The issue is that Rails allocate a new connection on the new Thread
+  # So the global wrapping transaction is obviously not seen by this new Thread
+  # When Rails rolls back the global transaction, this thread has already
+  # committed changes to the DB.
+  def within_thread(*args)
+    Thread.new(*args) do |*arguments|
+      ActiveRecord::Base.transaction(requires_new: true) do
+        yield *arguments
+        raise ActiveRecord::Rollback
+      end
+    end.join
+  end
+end
+
+ActiveSupport::TestCase.class_eval do
+  include ThreadHelper
+end

--- a/test/unit/api_authentication/by_authentication_token_test.rb
+++ b/test/unit/api_authentication/by_authentication_token_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ApiAuthentication::ByAuthenticationTokenTest < MiniTest::Unit::TestCase
+class ApiAuthentication::ByAuthenticationTokenTest < SimpleMiniTest
   include ActiveSupport::Callbacks
   define_callbacks :action
   include ActiveSupport::Rescuable

--- a/test/unit/api_authentication/http_authentication_test.rb
+++ b/test/unit/api_authentication/http_authentication_test.rb
@@ -1,6 +1,6 @@
 require 'base64'
 
-class ApiAuthentication::HttpAuthenticationTest < MiniTest::Unit::TestCase
+class ApiAuthentication::HttpAuthenticationTest < SimpleMiniTest
 
   include ApiAuthentication::HttpAuthentication
   include Base64

--- a/test/unit/api_authentication/suspended_account_test.rb
+++ b/test/unit/api_authentication/suspended_account_test.rb
@@ -1,4 +1,4 @@
-class ApiAuthentication::SuspendedAccountTest < MiniTest::Unit::TestCase
+class ApiAuthentication::SuspendedAccountTest < SimpleMiniTest
   include ActiveSupport::Callbacks
   define_callbacks :action
 

--- a/test/unit/events/event_test.rb
+++ b/test/unit/events/event_test.rb
@@ -2,7 +2,7 @@ require 'minitest_helper'
 
 require 'events/event'
 
-class Events::EventTest < MiniTest::Unit::TestCase
+class Events::EventTest < SimpleMiniTest
   def test_event_type
     event = Events::Event.new(type: 'alert')
     assert_equal 'alert', event.type

--- a/test/unit/events/importer_test.rb
+++ b/test/unit/events/importer_test.rb
@@ -2,7 +2,7 @@ require 'minitest_helper'
 
 require 'events/importer'
 
-class Events::ImporterTest < MiniTest::Unit::TestCase
+class Events::ImporterTest < SimpleMiniTest
 
   def test_async_import_event
     Events::Importer.async_import_event!(object: {}, type: 'alert')

--- a/test/unit/notification_center_test.rb
+++ b/test/unit/notification_center_test.rb
@@ -1,7 +1,7 @@
 require 'minitest_helper'
 require 'notification_center'
 
-class NotificationCenterTest < MiniTest::Unit::TestCase
+class NotificationCenterTest < SimpleMiniTest
 
   MyClass = Class.new
 

--- a/test/unit/proxy_config_affecting_changes_test.rb
+++ b/test/unit/proxy_config_affecting_changes_test.rb
@@ -40,24 +40,24 @@ class ProxyConfigAffectingChangesTest < ActiveSupport::TestCase
   end
 
   test 'tracks proxy config affecting changes on attribute write' do
-    Thread.new do
+    within_thread do
       tracker = ProxyConfigAffectingChanges::Tracker.new
       Thread.current[ProxyConfigAffectingChanges::TRACKER_NAME] = tracker
       CheapTrick = Class.new(Model)
       tracker.expects(:track).with(instance_of(CheapTrick)).at_least_once
       CheapTrick.new(name: 'foo', system_name: 'bar', description: 'this is my proxy config affecting model', created_at: Time.now, updated_at: Time.now)
-    end.join
+    end
   end
 
   test 'tracks proxy config affecting changes on destroy' do
-    Thread.new do
+    within_thread do
       tracker = ProxyConfigAffectingChanges::Tracker.new
       Thread.current[ProxyConfigAffectingChanges::TRACKER_NAME] = tracker
       CheapTrick = Class.new(Model)
       model = CheapTrick.new(name: 'foo', system_name: 'bar', description: 'this is my proxy config affecting model', created_at: Time.now, updated_at: Time.now)
       tracker.expects(:track).with(instance_of(CheapTrick))
       model.destroy
-    end.join
+    end
   end
 
   class TrackerTest < ActiveSupport::TestCase

--- a/test/unit/search_presenters_test.rb
+++ b/test/unit/search_presenters_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'database_cleaner'
 
 class SearchPresentersTest < ActiveSupport::TestCase
   disable_transactional_fixtures!

--- a/test/unit/three_scale/analytics/account_classifier_test.rb
+++ b/test/unit/three_scale/analytics/account_classifier_test.rb
@@ -1,6 +1,6 @@
 require 'minitest_helper'
 
-class ThreeScale::Analytics::AccountClassifierTest < MiniTest::Unit::TestCase
+class ThreeScale::Analytics::AccountClassifierTest < SimpleMiniTest
 
 
   def classifier(user_attributes = {})

--- a/test/unit/three_scale/analytics/user_classifier_test.rb
+++ b/test/unit/three_scale/analytics/user_classifier_test.rb
@@ -1,6 +1,6 @@
 require 'minitest_helper'
 
-class ThreeScaleAnalyticsUserClassifierTest < MiniTest::Unit::TestCase
+class ThreeScaleAnalyticsUserClassifierTest < SimpleMiniTest
 
   def classifier(attributes)
     user_classifier = ThreeScale::Analytics::UserClassifier.new(User.new(attributes))

--- a/test/workers/event_import_worker_test.rb
+++ b/test/workers/event_import_worker_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class EventImportWorkerTest < MiniTest::Unit::TestCase
+class EventImportWorkerTest < SimpleMiniTest
 
   def test_perform
     attributes = {foo: 'foo', bar: 'bar'}

--- a/test/workers/last_traffic_worker_test.rb
+++ b/test/workers/last_traffic_worker_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class LastTrafficWorkerTest < MiniTest::Unit::TestCase
+class LastTrafficWorkerTest < SimpleMiniTest
   def test_perform
     Timecop.freeze do
       last_traffic = LastTraffic.new(provider)

--- a/test/workers/user_session_sweeper_worker_test.rb
+++ b/test/workers/user_session_sweeper_worker_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-class UserSessionSweeperWorkerTest < MiniTest::Unit::TestCase
+class UserSessionSweeperWorkerTest < SimpleMiniTest
   def setup
     @session = UserSession.create!(user_id: 1, key: 'secret', revoked_at: 1.month.ago)
   end


### PR DESCRIPTION
Just use a simple file in lib as it is not maintained anymore
Remove deprecation warning

Also fixes some random failures (commits out of scope of this PR but I am lazy to put them in another PR while those failures happen in this one)

https://app.circleci.com/pipelines/github/3scale/porta/10565/workflows/5a2e408d-4a40-4fd8-bda2-0eeaf294f6e0/jobs/165960/tests

| test_add_cost - Finance::BillingStrategyTest |
| --------------------------------------------|
````
NoMethodError: undefined method `create_invoice!' for nil:NilClass...

Failure:
test_add_cost(Finance::BillingStrategyTest) [/opt/app-root/src/project/app/models/finance/buyer_invoice_finder.rb:26]:
NoMethodError: undefined method `create_invoice!' for nil:NilClass
    app/models/finance/buyer_invoice_finder.rb:26:in `create_invoice'
    app/models/finance/buyer_invoice_finder.rb:14:in `find'
    app/models/finance/buyer_invoice_finder.rb:18:in `find'
    app/models/finance/invoice_proxy.rb:35:in `invoice'
    app/models/finance/invoice_proxy.rb:11:in `check_editable_line_items'
    app/lib/finance/background_billing.rb:10:in `bill'
    app/lib/finance/billing.rb:20:in `create_line_item!'
    app/models/finance/billing_strategy.rb:400:in `add_cost'
    test/unit/finance/billing_strategy_test.rb:22:in `block in <class:BillingStrategyTest>'  
````


| test_bill_variable_fee_for - Finance::VariableCostTest |
| ---- |
```
NoMethodError: undefined method `create_invoice!' for nil:NilClass...

Failure:
test_bill_variable_fee_for(Finance::VariableCostTest) [/opt/app-root/src/project/app/models/finance/buyer_invoice_finder.rb:26]:
NoMethodError: undefined method `create_invoice!' for nil:NilClass
    app/models/finance/buyer_invoice_finder.rb:26:in `create_invoice'
    app/models/finance/buyer_invoice_finder.rb:14:in `find'
    app/models/finance/buyer_invoice_finder.rb:18:in `find'
    app/models/finance/invoice_proxy.rb:35:in `invoice'
    app/models/finance/invoice_proxy.rb:11:in `check_editable_line_items'
    app/lib/finance/background_billing.rb:10:in `bill'
    app/lib/finance/billing.rb:20:in `create_line_item!'
    app/lib/finance/variable_cost.rb:94:in `block in bill_variable_fee_for'
    app/lib/finance/variable_cost.rb:93:in `each'
    app/lib/finance/variable_cost.rb:93:in `bill_variable_fee_for'
    test/unit/finance/variable_cost_test.rb:13:in `block in <class:VariableCostTest>'
```
    
| test_perform_when_never_scheduled_for_deletion - PublishEnabledChangedEventForProviderApplicationsWorkerTest |
| ---------------------------------------------------------------- |
```
NoMethodError: undefined method `email' for nil:NilClass...

Failure:
test_perform_when_never_scheduled_for_deletion(PublishEnabledChangedEventForProviderApplicationsWorkerTest) [/opt/app-root/src/project/app/mailers/account_mailer.rb:94]:
NoMethodError: undefined method `email' for nil:NilClass
    app/mailers/account_mailer.rb:94:in `assigns'
    app/mailers/account_mailer.rb:17:in `confirmed'
    app/models/account/states.rb:169:in `block in deliver_confirmed_notification'
    lib/deadlock_retry.rb:52:in `transaction'
    test/workers/publish_enabled_changed_event_for_provider_applications_worker_test.rb:27:in `test_perform_when_never_scheduled_for_deletion'
```
    
| test_fix_pagination_href - Tasks::CmsTest |
| ----------------------------------------- |
```
unexpected invocation: #<Mock:user>.username()...

Failure:
test_fix_pagination_href(Tasks::CmsTest) [/opt/app-root/src/project/vendor/bundle/ruby/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/core_ext/object/try.rb:17]:
unexpected invocation: #<Mock:user>.username()
```