### PR TITLE
Fix HTTP BasicAuth when using ProviderKey

### DIFF
--- a/app/lib/api_authentication/by_access_token.rb
+++ b/app/lib/api_authentication/by_access_token.rb
@@ -104,6 +104,7 @@ module ApiAuthentication
 
     def authenticated_token
       return @authenticated_token if instance_variable_defined?(:@authenticated_token)
+
       @authenticated_token = domain_account.access_tokens.find_from_value(access_token) if access_token
     end
 
@@ -112,7 +113,7 @@ module ApiAuthentication
     end
 
     def verify_access_token_scopes
-      return true unless access_token
+      return true unless authenticated_token
 
       raise PermissionError if !authenticated_token || allowed_scopes.blank?
       raise ScopeError if (allowed_scopes & authenticated_token.scopes).blank?
@@ -121,7 +122,7 @@ module ApiAuthentication
     end
 
     def verify_write_permission
-      return true unless access_token
+      return true unless authenticated_token
       raise PermissionError unless authenticated_token.try(:permission) == PermissionEnforcer::READ_WRITE
     end
 

--- a/test/integration/admin/api/services_controller_test.rb
+++ b/test/integration/admin/api/services_controller_test.rb
@@ -165,6 +165,14 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'published', service.reload.state
     end
 
+    test 'index works using the provider key via http authorization' do
+      auth_headers = {'Authorization' => "Basic #{Base64.encode64("#{@provider.provider_key}:")}"}
+
+      get admin_api_services_path(format: :json), headers: auth_headers
+
+      assert_response :ok
+    end
+
     private
 
     def assert_correct_params

--- a/test/integration/admin/api/services_controller_test.rb
+++ b/test/integration/admin/api/services_controller_test.rb
@@ -165,14 +165,6 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'published', service.reload.state
     end
 
-    test 'index works using the provider key via http authorization' do
-      auth_headers = {'Authorization' => "Basic #{Base64.encode64("#{@provider.provider_key}:")}"}
-
-      get admin_api_services_path(format: :json), headers: auth_headers
-
-      assert_response :ok
-    end
-
     private
 
     def assert_correct_params

--- a/test/integration/by_access_token_test.rb
+++ b/test/integration/by_access_token_test.rb
@@ -5,8 +5,6 @@ class ApiAuthentication::ByAccessTokenTest < ActionDispatch::IntegrationTest
   def setup
     @provider = FactoryBot.create(:provider_account)
 
-    login_provider @provider
-
     host! @provider.admin_domain
 
     @user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners', 'finance'])

--- a/test/integration/by_provider_key_test.rb
+++ b/test/integration/by_provider_key_test.rb
@@ -5,8 +5,6 @@ class ApiAuthentication::ByProviderKeyTest < ActionDispatch::IntegrationTest
   def setup
     @provider = FactoryBot.create(:provider_account)
 
-    login_provider @provider
-
     host! @provider.admin_domain
   end
 

--- a/test/integration/by_provider_key_test.rb
+++ b/test/integration/by_provider_key_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class ApiAuthentication::ByProviderKeyTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+
+    login_provider @provider
+
+    host! @provider.admin_domain
+  end
+
+  test 'authenticates using HttpBasicAuth' do
+    auth_headers = {'Authorization' => "Basic #{Base64.encode64("#{@provider.provider_key}:")}"}
+
+    get admin_api_services_path(format: :json), headers: auth_headers
+
+    assert_response :ok
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

We currently have a bug when apicast tries to fetch the proxy configs
for a service using ProviderKey via BasicAuth. It returns a forbidden
status.

This happened because we changed in #1736 to consider the access_token
when sent in HttpBasicAuth but we only considered if the token was
present.

This commit changes this behave to also consider if the AccessToken is
present, otherwise, it will tries to make the authentication using the
provider key.

**Which issue(s) this PR fixes** 
[THREESCALE-4625](https://issues.redhat.com/browse/THREESCALE-4625)
