### PR TITLE
Revert "[portafly] Fix tsconfig baseUrl path"

### DIFF
--- a/portafly/tsconfig.json
+++ b/portafly/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "src",
     "target": "es5",
     "lib": [
       "dom",


### PR DESCRIPTION
Reverts 3scale/porta#1747

https://github.com/3scale/porta/pull/1747 introduced the following error:

> Failed to compile.
> 
> ./src/index.tsx
> Module not found: Can't resolve 'root' in '/Users/damian/Documents/3scale/porta/portafly/src'