### PR TITLE
[Sphinx] Do not index Topic for Oracle

### DIFF
--- a/app/indices/topic_index.rb
+++ b/app/indices/topic_index.rb
@@ -1,16 +1,21 @@
-ThinkingSphinx::Index.define(:topic,
-                             with: :active_record,
-                             delta: ThinkingSphinx::Deltas::DatetimeDelta,
-                             delta_options: {
-                               threshold: SPHINX_DELTA_INTERVAL,
-                               column: :last_updated_at
-                             }) do
-  indexes :title
-  indexes posts.body, as: 'post'
+# frozen_string_literal: true
 
-  has :tenant_id
+unless System::Database.oracle?
+  ThinkingSphinx::Index.define(:topic,
+                               with: :active_record,
+                               delta: ThinkingSphinx::Deltas::DatetimeDelta,
+                               delta_options: {
+                                 threshold: SPHINX_DELTA_INTERVAL,
+                                 column: :last_updated_at
+                               }
+                              ) do
+    indexes :title
+    indexes posts.body, as: 'post'
 
-  has :forum_id
-  has :sticky
-  has :last_updated_at
+    has :tenant_id
+
+    has :forum_id
+    has :sticky
+    has :last_updated_at
+  end
 end


### PR DESCRIPTION
Closes [THREESCALE-4652](https://issues.redhat.com/browse/THREESCALE-4652)

Topic has been deprecated for 3 years and it is SaaS-only.
We do not even run tests of Topic for Oracle:
https://github.com/3scale/porta/blob/670411d5bdcba562da6d413446c521bf7e9c598b/test/unit/topic_test.rb#L4-L6

So this PR does not index the topic.

![image](https://user-images.githubusercontent.com/11318903/76033871-98d59780-5f3d-11ea-9c8d-14c101759170.png)

![image](https://user-images.githubusercontent.com/11318903/76033801-72aff780-5f3d-11ea-9a80-60734e7fdc73.png)




