### PR TITLE
Warning message for the api_backend attr in the API

### DIFF
--- a/app/controllers/admin/api/services/proxies_controller.rb
+++ b/app/controllers/admin/api/services/proxies_controller.rb
@@ -39,7 +39,7 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_service_id_by_id_name
   ##~ op.parameters.add name: "endpoint", description: "Public Base URL for production environment.", dataType: "string", paramType: "query", required: false
-  ##~ op.parameters.add name: "api_backend", description: "Private Base URL.", dataType: "string", paramType: "query", required: false
+  ##~ op.parameters.add name: "api_backend", description: "Private Base URL. Caution! Do not use it if the account has API as a Product enabled. It may cause API backend usages to be removed from the Product.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "credentials_location", description: "Credentials Location. Either headers, query or authorization for the Basic Authorization.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "auth_app_key", description: "Parameter/Header where App Key is expected.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "auth_app_id", description: "Parameter/Header where App ID is expected.", dataType: "string", paramType: "query", required: false

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -3267,7 +3267,7 @@
             },
             {
               "name": "private_endpoint",
-              "description": "Private endpoint of the Backend",
+              "description": "Private Base URL (your API)",
               "dataType": "string",
               "required": true,
               "paramType": "query"
@@ -3346,7 +3346,7 @@
             },
             {
               "name": "private_endpoint",
-              "description": "Private endpoint of the Backend",
+              "description": "Private Base URL (your API)",
               "dataType": "string",
               "required": false,
               "paramType": "query"
@@ -6733,7 +6733,7 @@
             },
             {
               "name": "api_backend",
-              "description": "Private Base URL.",
+              "description": "Private Base URL. Caution! Do not use it if the account has API as a Product enabled. It may cause API backend usages to be removed from the Product.",
               "dataType": "string",
               "paramType": "query",
               "required": false


### PR DESCRIPTION
Adds a warning to the description of the attribute `api_backend` of the Proxy Update endpoint of the Admin API. This attribute should not be used in combination with APIAP as it may result in Backend Usages being removed from the Product. Instead, when APIAP is enabled (Saas and 2.7+), the new Backend Update endpoint should be used instead.

The reason why the attribute was not removed from the API is for compatibility reasons. We still need to support it in Saas for non-APIAP accounts.

<img width="1618" alt="Screenshot 2020-03-05 at 19 02 50" src="https://user-images.githubusercontent.com/1842261/76010987-17b5da80-5f14-11ea-9289-fc981551ef16.png">


Closes [THREESCALE-4117](https://issues.redhat.com/browse/THREESCALE-4117)