### PR TITLE
Adding word-break to long names in metrics, patterns and urls

### DIFF
--- a/app/assets/stylesheets/provider/_commons.scss
+++ b/app/assets/stylesheets/provider/_commons.scss
@@ -164,6 +164,10 @@ p + ul {
   }
 }
 
+.u-dl-definition {
+  word-break: break-word;
+}
+
 .u-dl-definition,
 .u-dl-description {
   @extend %dd;

--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -299,7 +299,9 @@ table.data {
   }
 }
 
-td.metric {
+td.metric,
+td.pattern,
+td.StatsMethodsTable-name {
   word-break: break-word;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Very long names of metrics, patterns and url's are not wrapping

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-4659

**Verification steps** 

Fill your Products/Backends with absurd large names in metrics, mapping rules or url's

_______
**Before:**
![before](https://user-images.githubusercontent.com/13486237/76081572-b5a7b480-5fa9-11ea-89aa-b6f9b7aea786.png)
![before02](https://user-images.githubusercontent.com/13486237/76081603-c35d3a00-5fa9-11ea-9cca-2d37d02aeb27.png)
![before03](https://user-images.githubusercontent.com/13486237/76081608-c6f0c100-5fa9-11ea-8cba-e1ed11862d58.png)
![before04](https://user-images.githubusercontent.com/13486237/76081614-c9ebb180-5fa9-11ea-9938-cd6babfb2698.png)

_______
**After:**
![after](https://user-images.githubusercontent.com/13486237/76081665-e687e980-5fa9-11ea-8836-f180b4b9faed.png)
![after02](https://user-images.githubusercontent.com/13486237/76081680-ec7dca80-5fa9-11ea-91ac-dec12e35f4f9.png)
![after03](https://user-images.githubusercontent.com/13486237/76081694-f1db1500-5fa9-11ea-9b14-a11d6d06319d.png)
![after04](https://user-images.githubusercontent.com/13486237/76081701-f6073280-5fa9-11ea-941a-eb62ca38d536.png)
