### PR TITLE
[Bugfix & Refactor] Improve validation of URIs.

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -31,7 +31,7 @@ class BackendApi < ApplicationRecord
 
   validates :private_endpoint, length: { maximum: 255 },
     presence: true,
-    uri: { path: proc { provider_can_use?(:proxy_private_base_path) }, scheme: %w[http https ws wss] },
+    uri: { path: ->(backend_api_object) { backend_api_object.provider_can_use?(:proxy_private_base_path) }, scheme: %w[http https ws wss] },
     non_localhost: { message: :protected_domain }
 
   alias_attribute :api_backend, :private_endpoint

--- a/app/services/service_creator.rb
+++ b/app/services/service_creator.rb
@@ -22,9 +22,9 @@ class ServiceCreator
   def call(params = {})
     call!(params)
   rescue ActiveRecord::RecordInvalid
-    if proxy && proxy.errors[:endpoint].any? { |message| message =~ /the accepted format is/ }
-      @service.errors.add(:system_name, :invalid_for_proxy_endpoints)
-    end
+    return if !proxy || proxy.errors[:endpoint].none? { |message| message =~ /is too long/ }
+
+    @service.errors.add(:system_name, :invalid_for_proxy_endpoints)
 
     false
   end

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -1,53 +1,102 @@
 # frozen_string_literal: true
 
 class UriValidator < ActiveModel::EachValidator
-  DEFAULT_ACCEPTED_SCHEMES = /^https?$/
-  DEFAULT_OPTIONAL_PARTS = %i[port].freeze
-  DEFAULT_FORBIDDEN_PARTS = %i[userinfo registry path opaque query fragment].freeze
+  DEFAULT_ACCEPTED_SCHEME = /^https?$/
+  DEFAULT_PERMISSIONS_OF_PARTS = {
+    port:     true,
+    userinfo: false,
+    registry: false,
+    path:     false,
+    opaque:   false,
+    query:    false,
+    fragment: false
+  }.freeze
 
-  def validate_each(record, attribute, value)
-    valid = begin
-              uri = URI.parse(value)
-              valid_scheme?(uri.scheme) && valid_host?(uri.host) && !forbidden_part?(record, uri)
-            rescue URI::InvalidURIError
-              false
-            end
-    record.errors.add(attribute, options[:message] || :invalid) unless valid
-    valid
+  def validate_each(record, attribute_name, attribute_value)
+    uri_3scale_compliance_checker = UriThreeScaleComplianceChecker.new(
+      uri: self.class.safe_parse_uri(attribute_value),
+      permissions_parts: permissions_for_record(record),
+      accepted_scheme: options.fetch(:scheme, DEFAULT_ACCEPTED_SCHEME)
+    )
+
+    errors = uri_3scale_compliance_checker.errors
+    errors.each do |error|
+      record.errors.add(attribute_name, error)
+    end
+    errors.empty?
   end
 
-  def valid_scheme?(scheme)
-    accepted_scheme = options.fetch(:scheme, DEFAULT_ACCEPTED_SCHEMES)
-    case accepted_scheme
-    when Regexp
-      scheme =~ accepted_scheme
-    else
-      [*accepted_scheme].include? scheme
+  # This smells :reek:ManualDispatch
+  def permissions_for_record(record)
+    permissions = options.slice(*DEFAULT_PERMISSIONS_OF_PARTS.keys).reverse_merge(DEFAULT_PERMISSIONS_OF_PARTS)
+    permissions.transform_values do |option_value|
+      option_value.respond_to?(:call) ? option_value.call(record) : option_value.presence
     end
   end
 
-  def valid_host?(host)
-    return false if host.blank?
-    (host.size <= 255) && valid_host_labels?(host)
+  def self.safe_parse_uri(value)
+    URI.parse(value)
+  rescue URI::InvalidURIError
+    nil
   end
 
-  def valid_host_labels?(host)
-    host.split('.').map(&:size).none?(&63.method(:'<'))
-  end
+  class UriThreeScaleComplianceChecker
+    MAX_HOST_SIZE = 255
+    MAX_LABEL_SIZE = 63
 
-  def forbidden_part?(record, uri)
-    forbidden_parts = DEFAULT_FORBIDDEN_PARTS.reject { |part| truthy?(record, options[part]) }
-    forbidden_parts += DEFAULT_OPTIONAL_PARTS.select { |part| options.key?(part) && falsy?(record, options[part]) }
-    forbidden_parts.any? { |forbidden_attr| uri.public_send(forbidden_attr).present? }
-  end
+    def initialize(uri:, permissions_parts:, accepted_scheme:)
+      @uri = uri
+      @permissions_parts = permissions_parts
+      @accepted_scheme = accepted_scheme
+    end
 
-  protected
+    attr_reader :uri, :permissions_parts, :accepted_scheme, :generic_error_message
+    delegate :host, :scheme, to: :uri
 
-  def truthy?(record, part)
-    !!(part.respond_to?(:call) ? record.instance_eval(&part) : part.present?)
-  end
+    def errors
+      return [generic_error_message] if uri.blank?
 
-  def falsy?(record, part)
-    !truthy?(record, part)
+      errors_scheme | errors_host | errors_forbidden_parts
+    end
+
+    private
+
+    def errors_scheme
+      valid = case accepted_scheme
+              when Regexp
+                scheme =~ accepted_scheme
+              else
+                [*accepted_scheme].include?(scheme)
+      end
+
+      valid ? [] : [:invalid]
+    end
+
+    def errors_host
+      return [:invalid] if host.blank?
+
+      errors = []
+      errors << I18n.t('errors.messages.too_long', count: MAX_HOST_SIZE) unless valid_host_size?
+      errors << I18n.t('errors.messages.host_label_too_long', count: MAX_LABEL_SIZE) unless valid_host_labels?
+      errors
+    end
+
+    def valid_host_size?
+      host.size <= MAX_HOST_SIZE
+    end
+
+    def valid_host_labels?
+      host.split('.').map(&:size).none?(&MAX_LABEL_SIZE.method(:'<'))
+    end
+
+    def errors_forbidden_parts
+      contains_forbidden_parts? ? [:invalid] : []
+    end
+
+    def contains_forbidden_parts?
+      permissions_parts.find do |part_name, permitted|
+        uri.public_send(part_name).present? unless permitted
+      end
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -766,6 +766,7 @@ en:
 
   errors:
     messages:
+      host_label_too_long: is too long for one or more labels of the host (maximum is %{count} characters)
       duplicated_user_provider_side: "Duplicate user registration. Delete one of the duplicates in order to continue."
       duplicated_user_buyer_side: "For activating your account please contact support."
       activation_complete: "Signup complete. You can now sign in."

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -209,11 +209,21 @@ class ProxyTest < ActiveSupport::TestCase
   end
 
   test 'hosts comply with rfc 1035' do
-    @proxy.endpoint = 'http://this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035.com:3000/'
+    @proxy.endpoint = 'http://this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035.com:3000'
     @proxy.sandbox_endpoint = 'http://short-labels-are-ok.com:8080'
     refute @proxy.valid?
     assert @proxy.errors[:endpoint].any?
+    assert_match /is too long for one or more labels of the host \(maximum is 63 characters\)/, @proxy.errors[:endpoint].to_sentence
+    assert_not_match /the accepted format is/, @proxy.errors[:endpoint].to_sentence
     refute @proxy.errors[:sandbox_endpoint].any?
+
+    @proxy.endpoint = 'http://short-labels-are-ok.com:8080'
+    @proxy.sandbox_endpoint = 'http://this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035.com:3000'
+    refute @proxy.valid?
+    assert @proxy.errors[:sandbox_endpoint].any?
+    assert_match /is too long for one or more labels of the host \(maximum is 63 characters\)/, @proxy.errors[:sandbox_endpoint].to_sentence
+    assert_not_match /the accepted format is/, @proxy.errors[:endpoint].to_sentence
+    refute @proxy.errors[:endpoint].any?
   end
 
   test 'backend' do

--- a/test/unit/services/service_creator_test.rb
+++ b/test/unit/services/service_creator_test.rb
@@ -45,4 +45,12 @@ class ServiceCreatorTest < ActiveSupport::TestCase
     assert backend_api.persisted?
     assert backend_api_config.persisted?
   end
+
+  test 'service with a too long system_name for its proxy' do
+    system_name = 'this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035'
+    service = FactoryBot.build(:service, system_name: system_name)
+    creator = ServiceCreator.new(service: service)
+    creator.call
+    assert_includes service.errors[:system_name], 'must be shorter.'
+  end
 end

--- a/test/unit/validators/uri_validator_test.rb
+++ b/test/unit/validators/uri_validator_test.rb
@@ -40,12 +40,15 @@ class UriValidatorTest < ActiveSupport::TestCase
     record = ModelWithURIValidation.new
     record.uri = "http://domain.test/path"
     refute record.valid?
+    assert_equal 'is invalid', record.errors[:uri].to_sentence
 
     with_clean_validators ModelWithURIValidation do
-      klass = Class.new(ModelWithURIValidation) { validates :uri, uri: { path: true } }
-      record = klass.new
-      record.uri = "http://domain.test/path"
-      assert record.valid?
+      [true, false].each do |valid_path|
+        klass = Class.new(ModelWithURIValidation) { validates :uri, uri: { path: valid_path } }
+        record = klass.new
+        record.uri = "http://domain.test/path"
+        assert_equal valid_path, record.valid?
+      end
     end
   end
 
@@ -82,6 +85,9 @@ class UriValidatorTest < ActiveSupport::TestCase
     record = ModelWithURIValidation.new
     record.uri = "http://#{long_hostname_label}.#{short_hostname_label}.test"
     refute record.valid?
+    error_message = record.errors[:uri].to_sentence
+    assert_match /is too long for one or more labels of the host \(maximum is 63 characters\)/, error_message
+    assert_not_match /invalid/, error_message
   end
 
   test 'hostname with labels up to 63 chars' do
@@ -94,8 +100,18 @@ class UriValidatorTest < ActiveSupport::TestCase
   test 'hostname longer than 255 with labels up to 63 chars' do
     record = ModelWithURIValidation.new
     short_labels = (1..13).map { |count| "#{short_hostname_label}-#{count}" }
-    record.uri = "http://#{short_labels.join('.')}.test" # hostname with 268 chars
+    record.uri = "http://#{short_labels.join('.')}.test" # hostname with 275 chars
     refute record.valid?
+    error_message = record.errors[:uri].to_sentence
+    assert_match /is too long \(maximum is 255 characters\)/, error_message
+    assert_not_match /invalid/, error_message
+  end
+
+  test 'hostname up to 255 with labels up to 63 chars' do
+    record = ModelWithURIValidation.new
+    short_labels = (1..12).map { |count| "#{short_hostname_label}-#{count}" }
+    record.uri = "http://#{short_labels.join('.')}.test" # hostname with 254 chars
+    assert record.valid?
   end
 
   test 'forbid optional parts' do


### PR DESCRIPTION
Closes [THREESCALE-4658](https://issues.redhat.com/browse/THREESCALE-4658)
Fix requested from [ [#1515](https://github.com/3scale/porta/pull/1515) | [THREESCALE-2932](https://issues.redhat.com/browse/THREESCALE-2932) ]

- Add tests for scenarios that were not tested and fix/improve existing tests.
- Respond with 'too_long' message when the label or the host is too long.
- Refactor UriValidator.

TODO in another PR: https://github.com/3scale/porta/pull/1761#discussion_r390632248