### PR TITLE
2.8 CR1

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -94,7 +94,7 @@ end
 
 gem 'nokogiri', '>= 1.6.8'
 gem 'dalli', '~> 2.7'
-gem 'secure_headers', '~> 2.2'
+gem 'secure_headers', '~> 3.9'
 gem 'faraday', '~> 0.15.3'
 gem 'faraday_middleware', '~> 0.13.1'
 

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -94,7 +94,7 @@ end
 
 gem 'nokogiri', '>= 1.6.8'
 gem 'dalli', '~> 2.7'
-gem 'secure_headers', '~> 3.9'
+gem 'secure_headers', '~> 6.3.0'
 gem 'faraday', '~> 0.15.3'
 gem 'faraday_middleware', '~> 0.13.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -657,8 +657,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    secure_headers (2.5.3)
-      user_agent_parser
+    secure_headers (3.9.0)
+      useragent
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -766,7 +766,7 @@ GEM
       unicorn
     uniform_notifier (1.10.0)
     url (0.3.2)
-    user_agent_parser (2.5.0)
+    useragent (0.16.10)
     webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -928,7 +928,7 @@ DEPENDENCIES
   ruby-prof
   rubyzip (~> 1.3.0)
   sass-rails (~> 5.0)
-  secure_headers (~> 2.2)
+  secure_headers (~> 3.9)
   selenium-webdriver (~> 3.142)
   shoulda (~> 3.5.0)
   shoulda-context (~> 1.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -657,8 +657,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    secure_headers (3.9.0)
-      useragent
+    secure_headers (6.3.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -766,7 +765,6 @@ GEM
       unicorn
     uniform_notifier (1.10.0)
     url (0.3.2)
-    useragent (0.16.10)
     webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -928,7 +926,7 @@ DEPENDENCIES
   ruby-prof
   rubyzip (~> 1.3.0)
   sass-rails (~> 5.0)
-  secure_headers (~> 3.9)
+  secure_headers (~> 6.3.0)
   selenium-webdriver (~> 3.142)
   shoulda (~> 3.5.0)
   shoulda-context (~> 1.2.2)

--- a/app/assets/stylesheets/provider/_commons.scss
+++ b/app/assets/stylesheets/provider/_commons.scss
@@ -164,6 +164,10 @@ p + ul {
   }
 }
 
+.u-dl-definition {
+  word-break: break-word;
+}
+
 .u-dl-definition,
 .u-dl-description {
   @extend %dd;

--- a/app/assets/stylesheets/provider/_tables.scss
+++ b/app/assets/stylesheets/provider/_tables.scss
@@ -299,7 +299,9 @@ table.data {
   }
 }
 
-td.metric {
+td.metric,
+td.pattern,
+td.StatsMethodsTable-name {
   word-break: break-word;
 }
 

--- a/app/controllers/admin/api/services/proxies_controller.rb
+++ b/app/controllers/admin/api/services/proxies_controller.rb
@@ -39,7 +39,7 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_service_id_by_id_name
   ##~ op.parameters.add name: "endpoint", description: "Public Base URL for production environment.", dataType: "string", paramType: "query", required: false
-  ##~ op.parameters.add name: "api_backend", description: "Private Base URL.", dataType: "string", paramType: "query", required: false
+  ##~ op.parameters.add name: "api_backend", description: "Private Base URL. Caution! Do not use it if the account has API as a Product enabled. It may cause API backend usages to be removed from the Product.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "credentials_location", description: "Credentials Location. Either headers, query or authorization for the Basic Authorization.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "auth_app_key", description: "Parameter/Header where App Key is expected.", dataType: "string", paramType: "query", required: false
   ##~ op.parameters.add name: "auth_app_id", description: "Parameter/Header where App ID is expected.", dataType: "string", paramType: "query", required: false

--- a/app/controllers/api_docs/tracking_controller.rb
+++ b/app/controllers/api_docs/tracking_controller.rb
@@ -1,5 +1,4 @@
 class ApiDocs::TrackingController < FrontendController
-  skip_before_action :set_x_content_type_options_header
   skip_before_action :login_required
 
   skip_before_action :verify_authenticity_token

--- a/app/controllers/api_docs/tracking_controller.rb
+++ b/app/controllers/api_docs/tracking_controller.rb
@@ -1,6 +1,6 @@
 class ApiDocs::TrackingController < FrontendController
+  before_action :disable_x_content_type
   skip_before_action :login_required
-
   skip_before_action :verify_authenticity_token
 
   def update

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,6 @@ class ApplicationController < ActionController::Base
   before_action :set_newrelic_custom_params
 
   protect_from_forgery with: :reset_session # See ActionController::RequestForgeryProtection for details
-  ensure_security_headers
 
   # Disable CSRF protection for non xml requests.
   skip_before_action :verify_authenticity_token, if: -> do

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class FrontendController < ApplicationController
+  SecureHeaders::Configuration.override(:disable_x_content_type) do |config|
+    config.x_content_type_options = SecureHeaders::OPT_OUT
+  end
+
   include SiteAccountSupport
   include AccessCodeProtection
 
@@ -36,6 +40,10 @@ class FrontendController < ApplicationController
   end
 
   helper_method :apiap?
+
+  def disable_x_content_type
+    SecureHeaders.use_secure_headers_override(request, :disable_x_content_type)
+  end
 
   def disable_x_frame
     override_x_frame_options(SecureHeaders::OPT_OUT)

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -37,6 +37,10 @@ class FrontendController < ApplicationController
 
   helper_method :apiap?
 
+  def disable_x_frame
+    override_x_frame_options(SecureHeaders::OPT_OUT)
+  end
+
   def do_nothing_if_head
     render head: :success, nothing: true if request.head?
   end

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class FrontendController < ApplicationController
+  SecureHeaders::Configuration.override(:disable_x_frame) do |config|
+    config.x_frame_options = SecureHeaders::OPT_OUT
+  end
+
   SecureHeaders::Configuration.override(:disable_x_content_type) do |config|
     config.x_content_type_options = SecureHeaders::OPT_OUT
   end
@@ -42,11 +46,11 @@ class FrontendController < ApplicationController
   helper_method :apiap?
 
   def disable_x_content_type
-    SecureHeaders.use_secure_headers_override(request, :disable_x_content_type)
+    use_secure_headers_override(:disable_x_content_type)
   end
 
   def disable_x_frame
-    override_x_frame_options(SecureHeaders::OPT_OUT)
+    use_secure_headers_override(:disable_x_frame)
   end
 
   def do_nothing_if_head

--- a/app/controllers/provider/admin/dashboards_controller.rb
+++ b/app/controllers/provider/admin/dashboards_controller.rb
@@ -1,5 +1,6 @@
 class Provider::Admin::DashboardsController < FrontendController
   before_action :ensure_provider_domain
+  before_action :disable_x_frame
 
   activate_menu :dashboard
   layout 'provider'

--- a/app/controllers/provider/admin/dashboards_controller.rb
+++ b/app/controllers/provider/admin/dashboards_controller.rb
@@ -1,6 +1,5 @@
 class Provider::Admin::DashboardsController < FrontendController
   before_action :ensure_provider_domain
-  before_action :disable_x_frame
 
   activate_menu :dashboard
   layout 'provider'

--- a/app/controllers/provider/domains_controller.rb
+++ b/app/controllers/provider/domains_controller.rb
@@ -1,6 +1,5 @@
 class Provider::DomainsController < Provider::BaseController
 
-  skip_before_action :set_x_frame_options_header
   skip_before_action :login_required
 
   layout 'provider/iframe'

--- a/app/controllers/provider/domains_controller.rb
+++ b/app/controllers/provider/domains_controller.rb
@@ -1,5 +1,6 @@
 class Provider::DomainsController < Provider::BaseController
 
+  before_action :disable_x_frame
   skip_before_action :login_required
 
   layout 'provider/iframe'

--- a/app/controllers/provider/signups_controller.rb
+++ b/app/controllers/provider/signups_controller.rb
@@ -1,7 +1,6 @@
 class Provider::SignupsController < Provider::BaseController
   include ThreeScale::SpamProtection::Integration::Controller
 
-  skip_before_action :set_x_frame_options_header
   before_action :ensure_signup_possible
 
   skip_before_action :login_required

--- a/app/controllers/provider/signups_controller.rb
+++ b/app/controllers/provider/signups_controller.rb
@@ -1,6 +1,7 @@
 class Provider::SignupsController < Provider::BaseController
   include ThreeScale::SpamProtection::Integration::Controller
 
+  before_action :disable_x_frame
   before_action :ensure_signup_possible
 
   skip_before_action :login_required

--- a/app/events/proxy_configs/affecting_object_changed_event.rb
+++ b/app/events/proxy_configs/affecting_object_changed_event.rb
@@ -14,6 +14,8 @@ class ProxyConfigs::AffectingObjectChangedEvent < ServiceRelatedEvent
   end
 
   def self.valid?(proxy, *_args)
-    proxy && proxy.account&.persisted? # Proxy's service or account may have been deleted
+    return unless proxy
+    account = proxy.account
+    account && !account.scheduled_for_deletion?
   end
 end

--- a/app/indices/topic_index.rb
+++ b/app/indices/topic_index.rb
@@ -1,16 +1,21 @@
-ThinkingSphinx::Index.define(:topic,
-                             with: :active_record,
-                             delta: ThinkingSphinx::Deltas::DatetimeDelta,
-                             delta_options: {
-                               threshold: SPHINX_DELTA_INTERVAL,
-                               column: :last_updated_at
-                             }) do
-  indexes :title
-  indexes posts.body, as: 'post'
+# frozen_string_literal: true
 
-  has :tenant_id
+unless System::Database.oracle?
+  ThinkingSphinx::Index.define(:topic,
+                               with: :active_record,
+                               delta: ThinkingSphinx::Deltas::DatetimeDelta,
+                               delta_options: {
+                                 threshold: SPHINX_DELTA_INTERVAL,
+                                 column: :last_updated_at
+                               }
+                              ) do
+    indexes :title
+    indexes posts.body, as: 'post'
 
-  has :forum_id
-  has :sticky
-  has :last_updated_at
+    has :tenant_id
+
+    has :forum_id
+    has :sticky
+    has :last_updated_at
+  end
 end

--- a/app/lib/api_authentication/by_access_token.rb
+++ b/app/lib/api_authentication/by_access_token.rb
@@ -104,6 +104,7 @@ module ApiAuthentication
 
     def authenticated_token
       return @authenticated_token if instance_variable_defined?(:@authenticated_token)
+
       @authenticated_token = domain_account.access_tokens.find_from_value(access_token) if access_token
     end
 
@@ -112,7 +113,7 @@ module ApiAuthentication
     end
 
     def verify_access_token_scopes
-      return true unless access_token
+      return true unless authenticated_token
 
       raise PermissionError if !authenticated_token || allowed_scopes.blank?
       raise ScopeError if (allowed_scopes & authenticated_token.scopes).blank?
@@ -121,7 +122,7 @@ module ApiAuthentication
     end
 
     def verify_write_permission
-      return true unless access_token
+      return true unless authenticated_token
       raise PermissionError unless authenticated_token.try(:permission) == PermissionEnforcer::READ_WRITE
     end
 

--- a/app/lib/authentication/strategy/base.rb
+++ b/app/lib/authentication/strategy/base.rb
@@ -22,7 +22,7 @@ module Authentication
     end
 
     class Base
-      include DeveloperPortal::Engine.routes.url_helpers
+      include System::UrlHelpers.cms_url_helpers
 
       attr_reader :site_account, :admin_domain, :user_for_signup, :new_user_created
 
@@ -66,8 +66,7 @@ module Authentication
 
       def signup_path(params)
         permitted_params = params.respond_to?(:permit!) ? params.dup.permit! : params
-        DeveloperPortal::Engine.routes.url_helpers
-            .signup_path(permitted_params.except(:action, :controller))
+        System::UrlHelpers.cms_url_helpers.signup_path(permitted_params.except(:action, :controller))
       end
 
       # This is the template rendered by sessions controller, usually the login form

--- a/app/lib/cms/sidebar.rb
+++ b/app/lib/cms/sidebar.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CMS::Sidebar
-  include Rails.application.routes.url_helpers
+  include System::UrlHelpers.system_url_helpers
 
   def initialize(provider)
     @provider = provider

--- a/app/lib/messenger/base.rb
+++ b/app/lib/messenger/base.rb
@@ -126,7 +126,7 @@ module Messenger
 
 
   class DeveloperPortalRoutes
-    include DeveloperPortal::Engine.routes.url_helpers
+    include System::UrlHelpers.cms_url_helpers
 
     private
 
@@ -137,7 +137,7 @@ module Messenger
   end
 
   class AppRoutes
-    include Rails.application.routes.url_helpers
+    include System::UrlHelpers.system_url_helpers
 
     private
 

--- a/app/lib/system/url_helpers.rb
+++ b/app/lib/system/url_helpers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module System
+  module UrlHelpers
+    cattr_accessor :cms_url_helpers, :system_url_helpers, instance_writer: false
+    self.cms_url_helpers = DeveloperPortal::Engine.routes.url_helpers
+    self.system_url_helpers =  Rails.application.routes.url_helpers
+  end
+end

--- a/app/lib/three_scale/dev_domain.rb
+++ b/app/lib/three_scale/dev_domain.rb
@@ -6,7 +6,7 @@ module ThreeScale::DevDomain
   end
 
   extend ActiveSupport::Concern
-  include Rails.application.routes.url_helpers
+  include System::UrlHelpers.system_url_helpers
 
   included do
     helper URL

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -242,7 +242,7 @@ class Cinstance < Contract
 
   # Shortcut for plan.service.metrics
   def metrics
-    service && service.metrics
+    service && service.all_metrics
   end
 
   # Is this cinstance bought by an account?

--- a/app/models/sso_token.rb
+++ b/app/models/sso_token.rb
@@ -53,12 +53,6 @@ class SSOToken
     end
   end
 
-  class_attribute :system_url_helpers, instance_writer: false
-  self.system_url_helpers = Rails.application.routes.url_helpers
-
-  class_attribute :cms_url_helpers, instance_writer: false
-  self.cms_url_helpers = DeveloperPortal::Engine.routes.url_helpers
-
   # It will save the object if new and will return the sso_url
   #
   # Default for a provider account is to create an url that works on its buyer side,
@@ -75,7 +69,7 @@ class SSOToken
       expires_at: expires_at.to_i,
       redirect_url: redirect_url
     }.delete_if{|k,v| v.nil?}
-    host.nil? ? cms_url_helpers.create_session_url(params) : system_url_helpers.provider_sso_url(params)
+    host.nil? ?  System::UrlHelpers.cms_url_helpers.create_session_url(params) : System::UrlHelpers.system_url_helpers.provider_sso_url(params)
   end
 
   protected

--- a/app/observers/post_observer.rb
+++ b/app/observers/post_observer.rb
@@ -3,7 +3,7 @@ class PostObserver < ActiveRecord::Observer
 
   include AfterCommitOn
 
-  include Rails.application.routes.url_helpers
+  include System::UrlHelpers.system_url_helpers
 
   def after_commit_on_create(post)
     account = post.forum.account

--- a/app/portlets/latest_forum_posts_portlet.rb
+++ b/app/portlets/latest_forum_posts_portlet.rb
@@ -43,7 +43,7 @@ END
   end
 
   module ToLiquid
-    include DeveloperPortal::Engine.routes.url_helpers
+    include System::UrlHelpers.cms_url_helpers
     include ActionView::Helpers::DateHelper
 
     def self.included(base)

--- a/app/presenters/provider_oauth_flow_presenter.rb
+++ b/app/presenters/provider_oauth_flow_presenter.rb
@@ -1,7 +1,7 @@
 class ProviderOauthFlowPresenter < OauthFlowPresenter
   delegate :human_kind, to: :authentication_provider
 
-  include Rails.application.routes.url_helpers
+  include System::UrlHelpers.system_url_helpers
 
   # @param [AuthenticationProvider] authentication_provider
   # @param [ActionDispatch::Request] request

--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -5,8 +5,6 @@ require 'httpclient/include_client'
 class ZyncWorker
   include Sidekiq::Worker
   include ThreeScale::SidekiqRetrySupport::Worker
-  class_attribute :main_app, instance_writer: false
-  self.main_app = Rails.application.routes.url_helpers
 
   extend ::HTTPClient::IncludeClient
 
@@ -333,7 +331,7 @@ class ZyncWorker
               when 'development' then { host: "#{host}.#{ThreeScale.config.dev_gtld}", port: 3000 }
               else { host: host }.reverse_merge(ActionMailer::Base.default_url_options)
               end
-    main_app.root_url(options)
+    System::UrlHelpers.system_url_helpers.root_url(options)
   end
 
   delegate :provider_access_token, to: :class

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,12 +1,15 @@
 ::SecureHeaders::Configuration.default do |config|
-  config.hsts = false
+  config.hsts = "max-age=#{20.years.to_i}; includeSubdomains"
   config.x_frame_options = 'DENY'
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'
 
-  config.csp = false
+  config.csp = {
+    report_only:  true,
+    default_src: %w(https: 'self')
+  }
 
   # not sure what they do, so rather disabling them
-  config.x_download_options = false
-  config.x_permitted_cross_domain_policies = false
+  config.x_download_options = nil
+  config.x_permitted_cross_domain_policies = 'none'
 end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,5 +1,5 @@
 ::SecureHeaders::Configuration.default do |config|
-  config.hsts = "max-age=#{20.years.to_i}; includeSubdomains"
+  config.hsts = "max-age=#{20.years.to_i}"
   config.x_frame_options = 'DENY'
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,5 +1,5 @@
 ::SecureHeaders::Configuration.default do |config|
-  config.hsts = "max-age=#{20.years.to_i}"
+  config.hsts = SecureHeaders::OPT_OUT
   config.x_frame_options = 'DENY'
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'
@@ -7,5 +7,5 @@
   config.csp = SecureHeaders::OPT_OUT
   # not sure what they do, so rather disabling them
   config.x_download_options = SecureHeaders::OPT_OUT
-  config.x_permitted_cross_domain_policies = 'none'
+  config.x_permitted_cross_domain_policies = SecureHeaders::OPT_OUT
 end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -4,11 +4,7 @@
   config.x_content_type_options = 'nosniff'
   config.x_xss_protection = '1; mode=block'
 
-  config.csp = {
-    report_only:  true,
-    default_src: %w(https: 'self')
-  }
-
+  config.csp = SecureHeaders::OPT_OUT
   # not sure what they do, so rather disabling them
   config.x_download_options = SecureHeaders::OPT_OUT
   config.x_permitted_cross_domain_policies = 'none'

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,6 +10,6 @@
   }
 
   # not sure what they do, so rather disabling them
-  config.x_download_options = nil
+  config.x_download_options = SecureHeaders::OPT_OUT
   config.x_permitted_cross_domain_policies = 'none'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -386,8 +386,8 @@ without fake Core server your after commit callbacks will crash and you might ge
         end
 
         resource :personal_details, only: [] do
-          match '/', via: :any, to: redirect { Rails.application.routes.url_helpers.edit_provider_admin_user_personal_details_path }
-          get 'edit', action: 'edit', on: :member, to: redirect { Rails.application.routes.url_helpers.edit_provider_admin_user_personal_details_path }
+          match '/', via: :any, to: redirect { System::UrlHelpers.system_url_helpers.edit_provider_admin_user_personal_details_path }
+          get 'edit', action: 'edit', on: :member, to: redirect { System::UrlHelpers.system_url_helpers.edit_provider_admin_user_personal_details_path }
         end
 
         resource :change_plan, :only => [:show, :update] do

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -3281,7 +3281,7 @@
             },
             {
               "name": "private_endpoint",
-              "description": "Private endpoint of the Backend",
+              "description": "Private Base URL (your API)",
               "dataType": "string",
               "required": true,
               "paramType": "query"
@@ -3360,7 +3360,7 @@
             },
             {
               "name": "private_endpoint",
-              "description": "Private endpoint of the Backend",
+              "description": "Private Base URL (your API)",
               "dataType": "string",
               "required": false,
               "paramType": "query"
@@ -7356,7 +7356,7 @@
             },
             {
               "name": "api_backend",
-              "description": "Private Base URL.",
+              "description": "Private Base URL. Caution! Do not use it if the account has API as a Product enabled. It may cause API backend usages to be removed from the Product.",
               "dataType": "string",
               "paramType": "query",
               "required": false

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -3,7 +3,7 @@
 World(Module.new do
   break unless defined?(DeveloperPortal)
 
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def provider_first_service!
     @provider.first_service!

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -658,8 +658,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    secure_headers (3.9.0)
-      useragent
+    secure_headers (6.3.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -767,7 +766,6 @@ GEM
       unicorn
     uniform_notifier (1.10.0)
     url (0.3.2)
-    useragent (0.16.10)
     webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -929,7 +927,7 @@ DEPENDENCIES
   ruby-prof
   rubyzip (~> 1.3.0)
   sass-rails (~> 5.0)
-  secure_headers (~> 3.9)
+  secure_headers (~> 6.3.0)
   selenium-webdriver (~> 3.142)
   shoulda (~> 3.5.0)
   shoulda-context (~> 1.2.2)

--- a/gemfiles/prod/Gemfile.lock
+++ b/gemfiles/prod/Gemfile.lock
@@ -658,8 +658,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    secure_headers (2.5.3)
-      user_agent_parser
+    secure_headers (3.9.0)
+      useragent
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -767,7 +767,7 @@ GEM
       unicorn
     uniform_notifier (1.10.0)
     url (0.3.2)
-    user_agent_parser (2.5.0)
+    useragent (0.16.10)
     webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -929,7 +929,7 @@ DEPENDENCIES
   ruby-prof
   rubyzip (~> 1.3.0)
   sass-rails (~> 5.0)
-  secure_headers (~> 2.2)
+  secure_headers (~> 3.9)
   selenium-webdriver (~> 3.142)
   shoulda (~> 3.5.0)
   shoulda-context (~> 1.2.2)

--- a/lib/developer_portal/app/controllers/developer_portal/api_docs/services_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/api_docs/services_controller.rb
@@ -1,6 +1,6 @@
 class DeveloperPortal::ApiDocs::ServicesController < DeveloperPortal::BaseController
+  before_action :disable_x_content_type
   skip_before_action :login_required
-
   skip_before_action :verify_authenticity_token, if: -> { request.format.json? }
 
   def index

--- a/lib/developer_portal/app/controllers/developer_portal/api_docs/services_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/api_docs/services_controller.rb
@@ -1,5 +1,4 @@
 class DeveloperPortal::ApiDocs::ServicesController < DeveloperPortal::BaseController
-  skip_before_action :set_x_content_type_options_header
   skip_before_action :login_required
 
   skip_before_action :verify_authenticity_token, if: -> { request.format.json? }

--- a/lib/developer_portal/app/helpers/developer_portal/cms/toolbar_helper.rb
+++ b/lib/developer_portal/app/helpers/developer_portal/cms/toolbar_helper.rb
@@ -43,7 +43,7 @@ module DeveloperPortal::CMS::ToolbarHelper
 
       # main_app is not available in the engine
       routes = Rails.application.routes
-      main_app = ActionDispatch::Routing::RoutesProxy.new(routes, self, routes.url_helpers)
+      main_app = ActionDispatch::Routing::RoutesProxy.new(routes, self, System::UrlHelpers.system_url_helpers)
 
       polymorphic_url([ main_app, :edit, :provider, :admin, template ], opts)
     end

--- a/lib/developer_portal/app/mailers/invitation_mailer.rb
+++ b/lib/developer_portal/app/mailers/invitation_mailer.rb
@@ -1,7 +1,7 @@
 class InvitationMailer < ActionMailer::Base
 
   include Liquid::Assigns
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
   include CMS::EmailTemplate::MailerExtension
 
   def invitation(invitation)

--- a/lib/developer_portal/lib/cms/toolbar.rb
+++ b/lib/developer_portal/lib/cms/toolbar.rb
@@ -113,7 +113,7 @@ module CMS::Toolbar
   end
 
   class View < ActionView::Base
-    include ::Rails.application.routes.url_helpers
+    include System::UrlHelpers.system_url_helpers
     include ::DeveloperPortal::CMS::ToolbarHelper
   end
 end

--- a/lib/developer_portal/lib/liquid/drops/api_spec.rb
+++ b/lib/developer_portal/lib/liquid/drops/api_spec.rb
@@ -8,7 +8,7 @@ module Liquid
 
       desc 'Returns the url of the API spec.'
       def url
-        cms_url_helpers.swagger_spec_path(system_name, format: :json)
+        System::UrlHelpers.cms_url_helpers.swagger_spec_path(system_name, format: :json)
       end
 
       desc 'Returns the name of the spec.'

--- a/lib/developer_portal/lib/liquid/drops/application.rb
+++ b/lib/developer_portal/lib/liquid/drops/application.rb
@@ -17,7 +17,7 @@ module Liquid
       # Filter might be better, as in Shopify: http://cheat.markdunkley.com/
       desc "Returns the admin_url of the application."
       def admin_url
-        system_url_helpers.admin_service_application_url(@contract.service, @contract, host: @contract.provider_account.self_domain)
+        System::UrlHelpers.system_url_helpers.admin_service_application_url(@contract.service, @contract, host: @contract.provider_account.self_domain)
       end
 
       def path
@@ -287,7 +287,7 @@ module Liquid
         end
 
         def regenerate_secret_url
-          cms_url_helpers.regenerate_admin_application_key_path(application_id: @application.id,
+          System::UrlHelpers.cms_url_helpers.regenerate_admin_application_key_path(application_id: @application.id,
                                                                 id: @application.keys.first)
         end
       end

--- a/lib/developer_portal/lib/liquid/drops/base.rb
+++ b/lib/developer_portal/lib/liquid/drops/base.rb
@@ -5,13 +5,6 @@ module Liquid
     class Base < Liquid::Drop
       class_attribute :_deprecated_names, :_allowed_names, :instance_writer => false, :instance_reader => false
 
-      class_attribute :system_url_helpers, instance_writer: false
-      self.system_url_helpers = Rails.application.routes.url_helpers
-
-      class_attribute :cms_url_helpers, instance_writer: false
-      self.cms_url_helpers = DeveloperPortal::Engine.routes.url_helpers
-
-
       extend Liquid::Docs::DSL::Drops
 
       private
@@ -99,7 +92,7 @@ module Liquid
       end
 
       privately_include  do
-        include DeveloperPortal::Engine.routes.url_helpers
+        include System::UrlHelpers.cms_url_helpers
       end
 
       def url_options

--- a/lib/developer_portal/lib/liquid/drops/plan_change.rb
+++ b/lib/developer_portal/lib/liquid/drops/plan_change.rb
@@ -76,7 +76,7 @@ module Liquid
 
       desc 'Returns the url to confirm the change. The request method must be POST'
       def confirm_path
-        cms_url_helpers.admin_contract_path(@contract.id, plan_id: @plan.id)
+        System::UrlHelpers.cms_url_helpers.admin_contract_path(@contract.id, plan_id: @plan.id)
       end
 
       desc 'Returns the url to cancel the change. The request method must be DELETE'

--- a/lib/developer_portal/lib/liquid/drops/post.rb
+++ b/lib/developer_portal/lib/liquid/drops/post.rb
@@ -24,7 +24,7 @@ module Liquid
 
       desc "The URL of this post within its topic."
       def url
-        system_url_helpers.forum_topic_path(@model.topic, anchor: "post_#{@model.id}")
+        System::UrlHelpers.system_url_helpers.forum_topic_path(@model.topic, anchor: "post_#{@model.id}")
       end
     end
   end

--- a/lib/developer_portal/lib/liquid/drops/service.rb
+++ b/lib/developer_portal/lib/liquid/drops/service.rb
@@ -83,7 +83,7 @@ module Liquid
       end
 
       def subscribe_url
-        cms_url_helpers.new_admin_service_contract_path(service_id: @service)
+        System::UrlHelpers.cms_url_helpers.new_admin_service_contract_path(service_id: @service)
       end
 
       desc "Returns the **published** application plans of the service."

--- a/lib/developer_portal/lib/liquid/drops/topic.rb
+++ b/lib/developer_portal/lib/liquid/drops/topic.rb
@@ -10,7 +10,7 @@ module Liquid
       end
 
       def url
-        system_url_helpers.forum_topic_path(@model)
+        System::UrlHelpers.system_url_helpers.forum_topic_path(@model)
       end
     end
   end

--- a/lib/developer_portal/lib/liquid/filters/url_helpers.rb
+++ b/lib/developer_portal/lib/liquid/filters/url_helpers.rb
@@ -3,7 +3,7 @@ module Liquid
     # DEPRECATED
     module UrlHelpers
       include Liquid::Filters::Base
-      include Rails.application.routes.url_helpers
+      include System::UrlHelpers.system_url_helpers
 
       # TODO: consider allowing more parameters
       desc """

--- a/lib/developer_portal/lib/liquid/forms/base.rb
+++ b/lib/developer_portal/lib/liquid/forms/base.rb
@@ -3,7 +3,7 @@ module Liquid
     class Base
       attr_reader :context
 
-      include DeveloperPortal::Engine.routes.url_helpers
+      include System::UrlHelpers.cms_url_helpers
 
       delegate :tag, :content_tag, to: 'Liquid::Filters::RailsHelpers'
 

--- a/lib/developer_portal/lib/liquid/tags/form.rb
+++ b/lib/developer_portal/lib/liquid/tags/form.rb
@@ -4,7 +4,7 @@ module Liquid
 
       extend Liquid::Docs::DSL::Tags
 
-      include Rails.application.routes.url_helpers
+      include System::UrlHelpers.system_url_helpers
 
       # list of allowed html attributes
       HTML_FORM_ATTRIBUTES = ["class", "id"]

--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -63,12 +63,6 @@ System::Database::MySQL.define do
     SQL
   end
 
-  trigger 'end_user_plans' do
-    <<~SQL
-      SET NEW.tenant_id = (SELECT tenant_id FROM services WHERE id = NEW.service_id AND tenant_id <> master_id);
-    SQL
-  end
-
   trigger 'features' do
     <<~SQL
       IF NEW.featurable_type = 'Account' AND NEW.featurable_id <> master_id THEN

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -63,12 +63,6 @@ System::Database::Oracle.define do
     SQL
   end
 
-  trigger 'end_user_plans' do
-    <<~SQL
-      SELECT tenant_id INTO :new.tenant_id FROM services WHERE id = :new.service_id AND tenant_id <> master_id;
-    SQL
-  end
-
   trigger 'features' do
     <<~SQL
       IF :new.featurable_type = 'Account' AND :new.featurable_id <> master_id THEN

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -63,12 +63,6 @@ System::Database::Postgres.define do
     SQL
   end
 
-  trigger 'end_user_plans' do
-    <<~SQL
-      SELECT tenant_id INTO NEW.tenant_id FROM services WHERE id = NEW.service_id AND tenant_id <> master_id;
-    SQL
-  end
-
   trigger 'features' do
     <<~SQL
       IF NEW.featurable_type = 'Account' AND NEW.featurable_id <> master_id THEN

--- a/test/decorators/plan_decorator_test.rb
+++ b/test/decorators/plan_decorator_test.rb
@@ -10,12 +10,12 @@ class PlanDecoratorTest < Draper::TestCase
     plan.id = 42
 
     decorator = PlanDecorator.new(plan)
-    assert_equal "#{Rails.application.routes.url_helpers.admin_service_applications_path(service)}?search%5Bplan_id%5D=42", decorator.plan_path
+    assert_equal "#{System::UrlHelpers.system_url_helpers.admin_service_applications_path(service)}?search%5Bplan_id%5D=42", decorator.plan_path
 
     decorator = PlanDecorator.new(plan, context: { service: other = Service.new })
     other.id = 2
 
-    assert_equal "#{Rails.application.routes.url_helpers.admin_service_applications_path(other)}?search%5Bplan_id%5D=42", decorator.plan_path
+    assert_equal "#{System::UrlHelpers.system_url_helpers.admin_service_applications_path(other)}?search%5Bplan_id%5D=42", decorator.plan_path
   end
 
   def test_link_to_edit
@@ -39,7 +39,7 @@ class PlanDecoratorTest < Draper::TestCase
     assert_equal '0 applications', decorator.link_to_applications
 
     helpers.expects(:can?).with(:show, Cinstance).returns(true)
-    assert_equal "<a href=\"#{Rails.application.routes.url_helpers.admin_service_applications_path(service)}?search%5Bplan_id%5D=\">0 applications</a>",
+    assert_equal "<a href=\"#{System::UrlHelpers.system_url_helpers.admin_service_applications_path(service)}?search%5Bplan_id%5D=\">0 applications</a>",
                  decorator.link_to_applications
   end
 end

--- a/test/decorators/service_decorator_test.rb
+++ b/test/decorators/service_decorator_test.rb
@@ -11,7 +11,7 @@ class ServiceDecoratorTest < Draper::TestCase
     assert_equal '0 live applications', decorator.link_to_live_applications
 
     helpers.expects(:can?).with(:show, Cinstance).returns(true)
-    assert_equal "<a href=\"#{Rails.application.routes.url_helpers.admin_service_applications_path(service)}?search%5Bstate%5D=live\">0 live applications</a>",
+    assert_equal "<a href=\"#{System::UrlHelpers.system_url_helpers.admin_service_applications_path(service)}?search%5Bstate%5D=live\">0 live applications</a>",
                  decorator.link_to_live_applications
   end
 

--- a/test/events/proxy_configs/affecting_object_changed_event_test.rb
+++ b/test/events/proxy_configs/affecting_object_changed_event_test.rb
@@ -3,13 +3,40 @@
 require 'test_helper'
 
 class ProxyConfigs::AffectingObjectChangedEventTest < ActiveSupport::TestCase
-  test 'create' do
-    proxy = FactoryBot.create(:proxy)
-    proxy_rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
-    event = ProxyConfigs::AffectingObjectChangedEvent.create(proxy, proxy_rule)
+  test 'create_and_publish! persists with the right data when the proxy and the account are persisted and not scheduled_for_deletion' do
+    stored_event = EventStore::Repository.find_event!(event_published.event_id)
 
-    assert_equal proxy.id, event.proxy_id
-    assert_equal proxy_rule.id, event.object_id
-    assert_equal 'ProxyRule', event.object_type
+    assert_equal proxy.id, stored_event.proxy_id
+    assert_equal proxy_rule.id, stored_event.object_id
+    assert_equal 'ProxyRule', stored_event.object_type
+  end
+
+  test 'create_and_publish! does not persist when the proxy is not present' do
+    refute event_published(proxy: nil)
+  end
+
+  test 'create_and_publish! does not persist when the account is not persisted' do
+    proxy.account.delete
+
+    refute event_published
+  end
+  test 'create_and_publish! does not persist when the account is scheduled_for_deletion' do
+    proxy.account.schedule_for_deletion!
+
+    refute event_published
+  end
+
+  private
+
+  def proxy_rule
+    @proxy_rule ||= FactoryBot.build_stubbed(:proxy_rule, proxy: proxy)
+  end
+
+  def proxy
+    @proxy ||= FactoryBot.create(:proxy)
+  end
+
+  def event_published(proxy: proxy_rule.proxy)
+    @event_published ||= ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy&.reload, proxy_rule)
   end
 end

--- a/test/integration/api_docs/tracking_controller_test.rb
+++ b/test/integration/api_docs/tracking_controller_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApiDocs::TrackingControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    provider = FactoryBot.create(:provider_account)
+    login_provider provider
+  end
+
+  test 'disables x_content_type_options header' do
+    get api_docs_check_path(format: :json)
+    refute_includes response.headers, 'X-Content-Type-Options'
+  end
+end

--- a/test/integration/by_access_token_test.rb
+++ b/test/integration/by_access_token_test.rb
@@ -5,8 +5,6 @@ class ApiAuthentication::ByAccessTokenTest < ActionDispatch::IntegrationTest
   def setup
     @provider = FactoryBot.create(:provider_account)
 
-    login_provider @provider
-
     host! @provider.admin_domain
 
     @user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners', 'finance'])

--- a/test/integration/by_provider_key_test.rb
+++ b/test/integration/by_provider_key_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ApiAuthentication::ByProviderKeyTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+
+    host! @provider.admin_domain
+  end
+
+  test 'authenticates using HttpBasicAuth' do
+    auth_headers = {'Authorization' => "Basic #{Base64.encode64("#{@provider.provider_key}:")}"}
+
+    get admin_api_services_path(format: :json), headers: auth_headers
+
+    assert_response :ok
+  end
+end

--- a/test/integration/developer_portal/accounts/invitee_signups_controller_test.rb
+++ b/test/integration/developer_portal/accounts/invitee_signups_controller_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class DeveloperPortal::Accounts::InviteeSignupsControllerTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @buyer = FactoryBot.create(:buyer_account)

--- a/test/integration/developer_portal/admin/account/payment_details_base_controller_test.rb
+++ b/test/integration/developer_portal/admin/account/payment_details_base_controller_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DeveloperPortal::Admin::Account::PaymentDetailsBaseTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   setup do
     @provider = FactoryBot.create(:provider_with_billing)

--- a/test/integration/developer_portal/admin/applications_controller_test.rb
+++ b/test/integration/developer_portal/admin/applications_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::Admin::ApplicationsControllerTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @provider  = FactoryBot.create(:provider_account)

--- a/test/integration/developer_portal/admin/messages/outbox_controller_test.rb
+++ b/test/integration/developer_portal/admin/messages/outbox_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::Admin::Messages::OutboxControllerTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @provider = FactoryBot.create(:simple_provider)

--- a/test/integration/developer_portal/api_docs/account_data_controller_test.rb
+++ b/test/integration/developer_portal/api_docs/account_data_controller_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class DeveloperPortal::ApiDocs::AccountDataControllerTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @provider = FactoryBot.create(:provider_account)

--- a/test/integration/developer_portal/api_docs/services_controller_test.rb
+++ b/test/integration/developer_portal/api_docs/services_controller_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DeveloperPortal::ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
+  include DeveloperPortal::Engine.routes.url_helpers
+
+  def setup
+    buyer = FactoryBot.create(:buyer_account)
+    login_buyer(buyer)
+  end
+
+  test 'disables x_content_type_options header' do
+    get api_docs_services_path(format: :json)
+    refute_includes response.headers, 'X-Content-Type-Options'
+  end
+end

--- a/test/integration/developer_portal/edit_account_test.rb
+++ b/test/integration/developer_portal/edit_account_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::EditAccountTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @provider = FactoryBot.create(:simple_provider)

--- a/test/integration/developer_portal/forums/admin/categories_controller_test.rb
+++ b/test/integration/developer_portal/forums/admin/categories_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 module DeveloperPortal
   class Forums::Admin::CategoriesControllerTest < ActionDispatch::IntegrationTest
-    include DeveloperPortal::Engine.routes.url_helpers
+    include System::UrlHelpers.cms_url_helpers
 
     def setup
       @provider = FactoryBot.create(:provider_account)

--- a/test/integration/developer_portal/invitation_signup_test.rb
+++ b/test/integration/developer_portal/invitation_signup_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::InvitationSignupTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   Oauth2 = Authentication::Strategy::Oauth2
 

--- a/test/integration/developer_portal/login_test.rb
+++ b/test/integration/developer_portal/login_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::LoginTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
   include UserDataHelpers
 
   def setup

--- a/test/integration/developer_portal/signup_test.rb
+++ b/test/integration/developer_portal/signup_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeveloperPortal::SignupTest < ActionDispatch::IntegrationTest
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
   include UserDataHelpers
 
   def setup

--- a/test/integration/provider/domains_controller_test.rb
+++ b/test/integration/provider/domains_controller_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Provider::DomainsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    login! master_account
+  end
+
+  test 'disables x_frame_options header' do
+    post recover_provider_domains_path
+    refute_includes response.headers, 'X-Frame-Options'
+  end
+end

--- a/test/integration/provider/signups_controller_test.rb
+++ b/test/integration/provider/signups_controller_test.rb
@@ -7,6 +7,11 @@ class Provider::SignupsControllerTest < ActionDispatch::IntegrationTest
     login! master_account
   end
 
+  test 'disables x_frame_options header' do
+    get provider_signup_path
+    refute_includes response.headers, 'X-Frame-Options'
+  end
+
   test 'POST creates a provider' do
     ThreeScale::Analytics::UserTracking.any_instance.expects(:track).at_least_once.with('Signup', {mkt_cookie: nil, analytics: {}})
 

--- a/test/integration/secure_headers_test.rb
+++ b/test/integration/secure_headers_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class SecureHeadersTest < ActionDispatch::IntegrationTest
+  def setup
+    provider = FactoryBot.create(:provider_account)
+    login! provider
+  end
+
+  test 'adds secure headers in the response' do
+    https!
+
+    get provider_admin_dashboard_path
+
+    assert_includes response.headers, 'X-Request-Id'
+    assert_equal 'DENY', response.headers['X-Frame-Options']
+    assert_equal 'nosniff', response.headers['X-Content-Type-Options']
+    assert_equal '1; mode=block', response.headers['X-XSS-Protection']
+  end
+
+  test 'do not add non used secure headers in the response' do
+    https!
+
+    get provider_admin_dashboard_path
+
+    refute_includes response.headers, 'Content-Security-Policy'
+    refute_includes response.headers, 'X-Download-Options'
+    refute_includes response.headers, 'Strict-Transport-Security'
+    refute_includes response.headers, 'X-Permitted-Cross-Domain-Policies'
+  end
+
+end

--- a/test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
+++ b/test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Admin::Api::ApplicationPlanMetricPricingRulesTest < ActionDispatch::IntegrationTest
 
-  include ThreeScale::PrivateModule(Rails.application.routes.url_helpers)
+  include ThreeScale::PrivateModule(System::UrlHelpers.system_url_helpers)
 
   def setup
     @provider = FactoryBot.create :provider_account, :domain => 'provider.example.com'

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -51,7 +51,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match 'Dear Foobar Admin', body.encoded
       assert_match "A new application subscribed to the #{application.plan.name} plan on the #{service.name} service of the #{application.account.name} account.", body.encoded
       assert_match 'Application details:', body.encoded
-      cinstance_url = Rails.application.routes.url_helpers.admin_service_application_url(service, application,
+      cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(service, application,
                                                                                          host: service.account.admin_domain)
       assert_match cinstance_url, body.encoded
 
@@ -116,7 +116,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match 'Dear Foobar Admin', body.encoded
       assert_match "Application #{application.name} of your client #{application.user_account.name}", body.encoded
       assert_match "is above #{alert.level}% limit utilization of #{alert.message}.", body.encoded
-      cinstance_url = Rails.application.routes.url_helpers.admin_service_application_url(service, application,
+      cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(service, application,
                                                                                          host: service.account.admin_domain)
       assert_match cinstance_url, body.encoded
     end
@@ -137,7 +137,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match 'Dear Foobar Admin', body.encoded
       assert_match "Application #{application.name} of your client #{application.user_account.name}", body.encoded
       assert_match "is above #{alert.level}% limit utilization of #{alert.message}.", body.encoded
-      cinstance_url = Rails.application.routes.url_helpers.admin_service_application_url(service, application,
+      cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(service, application,
                                                                                          host: service.account.admin_domain)
       assert_match cinstance_url, body.encoded
     end
@@ -394,7 +394,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match "Previous plan: #{old_plan.name}", body.encoded
       assert_match "Current plan: #{cinstance.plan.name}", body.encoded
       assert_match "Application #{cinstance.name} has changed to plan #{cinstance.plan.name}.", body.encoded
-      cinstance_url = Rails.application.routes.url_helpers.admin_service_application_url(cinstance.service, cinstance,
+      cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(cinstance.service, cinstance,
                                                                                          host: cinstance.service.account.admin_domain)
       assert_match cinstance_url, body.encoded
     end
@@ -558,7 +558,7 @@ class NotificationMailerTest < ActionMailer::TestCase
   end
 
   def url_helpers
-    Rails.application.routes.url_helpers
+    System::UrlHelpers.system_url_helpers
   end
 
   def assert_html_email(delivery, &block)

--- a/test/unit/alert/alert_methods_test.rb
+++ b/test/unit/alert/alert_methods_test.rb
@@ -4,7 +4,6 @@ class AlertMethodsTest < ActiveSupport::TestCase
   def setup
     provider    = FactoryBot.create(:provider_account)
     service    = provider.first_service!
-    service_id = service.backend_id
     buyer       = FactoryBot.create(:buyer_account, :provider_account => provider)
     plan              = FactoryBot.create(:application_plan, :issuer => service)
     cinstance         = FactoryBot.create(:cinstance, :plan => plan, :user_account => buyer)
@@ -21,4 +20,13 @@ class AlertMethodsTest < ActiveSupport::TestCase
     assert_equal @alert.friendly_message, "Hits per month: 115 of 100"
   end
 
+  should 'find metric of backend' do
+    service = @alert.cinstance.service
+    backend_api = FactoryBot.create(:backend_api, name: 'Other API', system_name: 'other_api', account: service.provider)
+    backend_metric = FactoryBot.create(:metric, owner: backend_api, system_name: 'backend_metric')
+    service.backend_api_configs.create!(backend_api: backend_api, path: '/other-api')
+
+    @alert.message = "#{backend_metric['system_name']} per day: 115 of 100"
+    assert_equal backend_metric, @alert.metric
+  end
 end

--- a/test/unit/liquid/drops/account_drop_test.rb
+++ b/test/unit/liquid/drops/account_drop_test.rb
@@ -10,7 +10,7 @@ class Liquid::Drops::AccountDropTest < ActiveSupport::TestCase
   end
 
   def test_url_helpers
-    routes      = Rails.application.routes.url_helpers
+    routes      = System::UrlHelpers.system_url_helpers
     account_url = routes.admin_buyers_account_url(@drop, host: 'foo.example.com')
 
     assert account_url

--- a/test/unit/liquid/drops/application_drop_test.rb
+++ b/test/unit/liquid/drops/application_drop_test.rb
@@ -18,7 +18,7 @@ class Liquid::Drops::ApplicationDropTest < ActiveSupport::TestCase
   end
 
   test 'admin_url' do
-    assert_match Rails.application.routes.url_helpers.admin_service_application_path(@app.service, @app), @drop.admin_url
+    assert_match System::UrlHelpers.system_url_helpers.admin_service_application_path(@app.service, @app), @drop.admin_url
   end
 
   test 'alerts' do

--- a/test/unit/liquid/drops/invitation_drop_test.rb
+++ b/test/unit/liquid/drops/invitation_drop_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Liquid::Drops::InvitationDropTest < ActiveSupport::TestCase
   include Liquid
-  include DeveloperPortal::Engine.routes.url_helpers
+  include System::UrlHelpers.cms_url_helpers
 
   def setup
     @invitation = FactoryBot.build_stubbed(:invitation)

--- a/test/unit/liquid/forms_test.rb
+++ b/test/unit/liquid/forms_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Liquid::FormsTest < ActiveSupport::TestCase
-  include ThreeScale::PrivateModule(Rails.application.routes.url_helpers)
+  include ThreeScale::PrivateModule(System::UrlHelpers.system_url_helpers)
 
   test 'unknown form name' do
     assert_raises(Liquid::Forms::NotFoundError) do

--- a/test/unit/mailers/post_office_test.rb
+++ b/test/unit/mailers/post_office_test.rb
@@ -197,7 +197,7 @@ class PostOfficeTest < ActionMailer::TestCase
   end
 
   def url_helpers
-    Rails.application.routes.url_helpers
+    System::UrlHelpers.system_url_helpers
   end
 
   def generate_message_subject

--- a/test/unit/messengers/account_messenger_test.rb
+++ b/test/unit/messengers/account_messenger_test.rb
@@ -56,6 +56,6 @@ class AccountMessengerTest < ActiveSupport::TestCase
   end
 
   def url_helpers
-    Rails.application.routes.url_helpers
+    System::UrlHelpers.system_url_helpers
   end
 end

--- a/test/unit/messengers/cinstance_messenger_test.rb
+++ b/test/unit/messengers/cinstance_messenger_test.rb
@@ -58,7 +58,7 @@ class CinstanceMessengerTest < ActiveSupport::TestCase
     CinstanceMessenger.new_application(@app).deliver
 
     assert_match "This application requires your approval", Message.last.body
-    expected_url = Rails.application.routes.url_helpers.admin_service_application_url(@app.service, @app, host: @provider_account.admin_domain)
+    expected_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(@app.service, @app, host: @provider_account.admin_domain)
     assert_match expected_url, Message.last.body
   end
 

--- a/test/unit/messengers/plans_messenger_test.rb
+++ b/test/unit/messengers/plans_messenger_test.rb
@@ -12,7 +12,7 @@ class PlansMessengerTest < ActiveSupport::TestCase
     PlansMessenger.plan_change_request(cinstance, plan).deliver
 
     email = ActionMailer::Base.deliveries.last
-    expected_url = Rails.application.routes.url_helpers.admin_service_application_url(cinstance.service, cinstance, host: cinstance.account.provider_account.admin_domain)
+    expected_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(cinstance.service, cinstance, host: cinstance.account.provider_account.admin_domain)
     assert_includes email.body.to_s, expected_url
   end
 end

--- a/test/unit/presenters/redhat_customer_oauth_flow_presenter_test.rb
+++ b/test/unit/presenters/redhat_customer_oauth_flow_presenter_test.rb
@@ -24,6 +24,6 @@ class RedhatCustomerOAuthFlowPresenterTest < ActiveSupport::TestCase
   end
 
   def url_helpers
-    Rails.application.routes.url_helpers
+    System::UrlHelpers.system_url_helpers
   end
 end


### PR DESCRIPTION
It contains the latest deployment to SaaS  (https://github.com/3scale/porta/compare/6dd9108ae44df975f9a5c11ed67094248e57f1bc...3a3b387ee682208a31e2e4636638fe1586dcb4f2, which contains also #1738, #1413 and #1551) + the following PRs:
https://github.com/3scale/porta/pull/1739
https://github.com/3scale/porta/pull/1754
https://github.com/3scale/porta/pull/1759
https://github.com/3scale/porta/pull/1758
https://github.com/3scale/porta/pull/1760
https://github.com/3scale/porta/pull/1741

PRs that are in master but NOT here:
https://github.com/3scale/porta/pull/1743
https://github.com/3scale/porta/pull/1742
https://github.com/3scale/porta/pull/1626
https://github.com/3scale/porta/pull/1747
https://github.com/3scale/porta/pull/1751
https://github.com/3scale/porta/pull/1757
https://github.com/3scale/porta/pull/1648
https://github.com/3scale/porta/pull/1746
https://github.com/3scale/porta/pull/1753
https://github.com/3scale/porta/pull/1752
https://github.com/3scale/porta/pull/1756
https://github.com/3scale/porta/pull/1718
