### PR TITLE
[oracle] Fix sphinx delta not using correct datatypes

### DIFF
--- a/config/initializers/oracle.rb
+++ b/config/initializers/oracle.rb
@@ -125,7 +125,7 @@ if System::Database.oracle?
 
       if is_delta
         if adapter.class.name.downcase[/oracle/]
-          "((#{table_name}.#{column_name} - SYSDATE) * 60 * 60 * 24) + #{@threshold} > 0"
+          "EXTRACT( day from ((#{table_name}.#{column_name} - SYSDATE) * 60 * 60 * 24)) + #{@threshold} > 0"
         else
           super
         end


### PR DESCRIPTION
INTERVAL DAY TO SECOND cannot be cast to integer thus the delta indices fail

[Oracle][ODBC][Ora]ORA-30081: invalid data type for datetime/interval arithmetic


Closes THREESCALE-4652


- [X] No tests: 🤠 

Helped from https://stackoverflow.com/questions/10092032/extracting-the-total-number-of-seconds-from-an-interval-data-type

```sql
SELECT DUMP("ACCOUNTS"."UPDATED_AT" - SYSDATE) FROM "ACCOUNTS"
WHERE ROWNUM = 1
```

```
Typ=190 Len=24: 0,0,0,0,0,0,0,0,244,255,255,255,220,255,255,255,56,12,106,247,10,0,0,0
```



```
rake openshift:thinking_sphinx:start                                                                                                                               [2.5]
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <top (required)> at /Users/hery/Devel/3scale/porta/config/application.rb:7)
Warning: NLS_LANG is not set. fallback to US7ASCII.
[config/routes.rb] You need more than 1 unicorn worker to run fake Core server
without fake Core server your after commit callbacks will crash and you might get unexpected failures
searchd is not currently running.
Generating configuration to /Users/hery/Devel/3scale/porta/config/development.sphinx.conf
Index starting
Sphinx 2.2.11-id64-release (95ae9a6)
Copyright (c) 2001-2016, Andrew Aksyonoff
Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)

using config file '/Users/hery/Devel/3scale/porta/config/development.sphinx.conf'...
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
indexing index 'account_core'...
collected 2 docs, 0.0 MB
sorted 0.0 Mhits, 100.0% done
total 2 docs, 387 bytes
total 0.147 sec, 2617 bytes/sec, 13.52 docs/sec
indexing index 'account_delta'...
collected 0 docs, 0.0 MB
total 0 docs, 0 bytes
total 0.077 sec, 0 bytes/sec, 0.00 docs/sec
indexing index 'cms_page_core'...
collected 0 docs, 0.0 MB
total 0 docs, 0 bytes
total 0.057 sec, 0 bytes/sec, 0.00 docs/sec
skipping non-plain index 'proxy_rule_core'...
skipping non-plain index 'account'...
skipping non-plain index 'cms_page'...
skipping non-plain index 'proxy_rule'...
total 10 reads, 0.000 sec, 0.1 kb/call avg, 0.0 msec/call avg
total 26 writes, 0.000 sec, 0.2 kb/call avg, 0.0 msec/call avg
Index finished
Delta index starting
Sphinx 2.2.11-id64-release (95ae9a6)
Copyright (c) 2001-2016, Andrew Aksyonoff
Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)

using config file '/Users/hery/Devel/3scale/porta/config/development.sphinx.conf'...
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
merging index 'account_delta' into index 'account_core'...
read 0.0 of 0.0 MB, 100.0% done
merged 0.0 Kwords
merged in 0.022 sec
total 40 reads, 0.000 sec, 5.6 kb/call avg, 0.0 msec/call avg
total 8 writes, 0.000 sec, 0.4 kb/call avg, 0.0 msec/call avg
Delta index finished
Sphinx 2.2.11-id64-release (95ae9a6)
Copyright (c) 2001-2016, Andrew Aksyonoff
Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)

using config file '/Users/hery/Devel/3scale/porta/config/development.sphinx.conf'...
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
listening on 127.0.0.1:9306
precaching index 'account_core'
precaching index 'account_delta'
precaching index 'cms_page_core'
precaching index 'proxy_rule_core'
precached 4 indexes in 0.004 sec
Started searchd successfully (pid: 80807).

^CSphinx 2.2.11-id64-release (95ae9a6)
Copyright (c) 2001-2016, Andrew Aksyonoff
Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)

using config file '/Users/hery/Devel/3scale/porta/config/development.sphinx.conf'...
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
WARNING: key 'enable_star' was permanently removed from Sphinx configuration. Refer to documentation for details.
stop: successfully sent SIGTERM to pid 80807
Stopped searchd daemon (pid: 80807).
```