### PR TITLE
Avoid Master account to access routes with ProviderDomain constraint

### DIFF
--- a/lib/routing_constraints.rb
+++ b/lib/routing_constraints.rb
@@ -26,7 +26,7 @@ module ProviderDomainConstraint
     request.extend(ThreeScale::DevDomain::Request) if ThreeScale::DevDomain.enabled?
 
     with_deleted = AuthenticatedSystem::Request.new(request).zync?
-    Account.providers.without_deleted(!with_deleted).exists?(:self_domain => request.host)
+    Account.tenants.without_deleted(!with_deleted).exists?(self_domain: request.host)
   end
 end
 

--- a/lib/routing_constraints.rb
+++ b/lib/routing_constraints.rb
@@ -26,7 +26,7 @@ module ProviderDomainConstraint
     request.extend(ThreeScale::DevDomain::Request) if ThreeScale::DevDomain.enabled?
 
     with_deleted = AuthenticatedSystem::Request.new(request).zync?
-    Account.without_deleted(!with_deleted).exists?(:self_domain => request.host)
+    Account.providers.without_deleted(!with_deleted).exists?(:self_domain => request.host)
   end
 end
 

--- a/test/integration/provider/passwords_test.rb
+++ b/test/integration/provider/passwords_test.rb
@@ -56,7 +56,7 @@ class Provider::PasswordsControllerTest < ActionDispatch::IntegrationTest
 
       delete provider_password_path, email: 'example@test.com'
 
-      assert_response :not_found
+      assert_raise(ActionController::RoutingError) { delete provider_password_path, email: 'example@test.com' }
     end
   end
 end

--- a/test/integration/provider/passwords_test.rb
+++ b/test/integration/provider/passwords_test.rb
@@ -54,8 +54,6 @@ class Provider::PasswordsControllerTest < ActionDispatch::IntegrationTest
     test '#destroy does not work for master account' do
       login_provider master_account
 
-      delete provider_password_path, email: 'example@test.com'
-
       assert_raise(ActionController::RoutingError) { delete provider_password_path, email: 'example@test.com' }
     end
   end

--- a/test/unit/domain_constraints_test.rb
+++ b/test/unit/domain_constraints_test.rb
@@ -83,6 +83,14 @@ class DomainConstraintsTest < ActiveSupport::TestCase
       assert Account.exists?(self_domain: self_domain)
       assert ProviderDomainConstraint.matches?(request)
     end
+
+    test 'master domain' do
+      master = master_account
+      request = mock
+      request.expects(:host).returns(master.domain)
+
+      refute ProviderDomainConstraint.matches?(request)
+    end
   end
 
   class MasterDomainConstraintTest < DomainConstraintsTest


### PR DESCRIPTION
Extracted from: https://github.com/3scale/porta/pull/1765/

Currently ProviderDomainConstraint has a bug that it also allows Master
to access it. We should only allow provider on this constraint because
we have another one called MasterOrProviderDomainConstraint to be used
when both can access a route.

This commit changes this behave forbidding MasterDomain to access routes
only for providers.