### PR TITLE
Adding a simple first version of an ongoing shaping OAS3 spec

### DIFF
--- a/portafly/portafly_api.yml
+++ b/portafly/portafly_api.yml
@@ -8,3 +8,95 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /developer/accounts:
+    summary: A list of developer accounts
+    description: A list of developer accounts.
+    get:
+      responses:
+        "200":
+          $ref: '#/components/responses/developerAccountList'
+      operationId: developerAccountList
+      summary: Get developer account list
+    parameters:
+    - name: page
+      description: Page in the paginated list. Defaults to 1.
+      schema:
+        type: integer
+      in: query
+      required: false
+    - name: per_page
+      description: Number of results per page. Default and max is 500.
+      schema:
+        type: integer
+      in: query
+      required: false
+    - name: state
+      description: Account state.
+      schema:
+        type: string
+      in: query
+components:
+  schemas:
+    DeveloperAccount:
+      title: Root Type for developerAccountData
+      description: A simplified format for a developer account data.
+      type: object
+      properties:
+        id:
+          description: The account ID number
+          type: integer
+        created_at:
+          format: date-time
+          description: When it was created
+          type: string
+        updated_at:
+          format: date-time
+          description: When it was last updated
+          type: string
+        state:
+          description: The current state of the account
+          type: string
+        org_name:
+          description: The organization name
+          type: string
+        admin_name:
+          description: The name of the admin user
+          type: string
+        apps_count:
+          description: The total amount of applications
+          type: integer
+      example:
+        id: 1
+        created_at: 2019-10-18T05:13:26Z
+        updated_at: 2019-10-18T05:13:27Z
+        state: approved
+        org_name: Umbrella Corp.
+        admin_name: Oswell E. Spencer
+        apps_count: 3
+  responses:
+    developerAccountList:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/DeveloperAccount'
+          examples:
+            developerAccountListExample:
+              value:
+              - id: 22
+                created_at: 2018-02-10T09:30Z
+                updated_at: 2018-02-10T09:30Z
+                state: approved
+                org_name: Capsule Corp
+                admin_name: Dr. Brief
+                apps_count: 4
+              - id: 72
+                created_at: 2018-02-10T09:30Z
+                updated_at: 2018-02-10T09:30Z
+                state: approved
+                org_name: FOXHOUND
+                admin_name: Big Boss
+                apps_count: 5
+      description: Developer accountlist

--- a/portafly/portafly_api.yml
+++ b/portafly/portafly_api.yml
@@ -1,0 +1,10 @@
+---
+openapi: 3.0.2
+info:
+  title: PortaFly
+  version: 1.0.0
+  description: |
+    A tuned API for PortaFly, a Patternfly SPA consuming 3scale Porta API MGMT solution.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
In order to not only shaping but documenting the API endpoints we need to hydrate PortaFly, we need to use as base an OAS. This will also serve as a testing tool and development used as mocked data.
This PR also solves the first specification needed for Account > List

This spec is created with Apicurio and it's meant to be edited with it. More info in https://www.apicur.io/

**What this PR does / why we need it**:

Introduces an Open API Specification and address the specification needs described in https://issues.redhat.com/browse/THREESCALE-4731

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-4711
https://issues.redhat.com/browse/THREESCALE-4731

BASED ON https://marvelapp.com/55343de/screen/67190787

**How it looks**
<img width="1656" alt="Screenshot 2020-03-19 at 14 41 57" src="https://user-images.githubusercontent.com/4183971/77043310-d9c6b500-69ef-11ea-8e20-15ac50907f3b.png">


**Special notes for your reviewer**:
**PLEASE, READ THE ISSUES ATTACH TO UNDERSTAND THIS PR, THERE'S DEFINITION OF WHAT'S NEEDED** First @hallelujah comment is obsolete, those issues are meant to cover what he expressed there.

And if you want to see the responses, etc... you might want to check it in online spec docs like redoc or locally with said tool