### PR TITLE
Fix APIAP routing policy rule

### DIFF
--- a/app/models/config_path.rb
+++ b/app/models/config_path.rb
@@ -10,9 +10,9 @@ class ConfigPath
   end
 
   def to_regex
-    return '/.*' if empty?
+    return '^(/.*)' if empty?
 
-    "#{path}/.*|#{path}/?"
+    "^(#{path}/.*|#{path}/?)"
   end
 
   def empty?

--- a/test/unit/backend_api_logic/routing_policy_test.rb
+++ b/test/unit/backend_api_logic/routing_policy_test.rb
@@ -25,8 +25,8 @@ module BackendApiLogic
       backend_api1 = backend_apis.first
       backend_api2 = backend_apis.last
       injected_rules = [
-        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '/foo/.*|/foo/?'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
-        { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '/.*'] } }
+        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/foo/.*|/foo/?)'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
+        { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/.*)'] } }
       ]
       apicast_policy = { name: 'apicast', 'version': 'builtin', 'configuration': {} }
       injected_policy = {
@@ -52,8 +52,8 @@ module BackendApiLogic
       backend_api1 = backend_apis.first
       backend_api2 = backend_apis.last
       injected_rules = [
-        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '/foo/.*|/foo/?'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
-        { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '/.*'] } },
+        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/foo/.*|/foo/?)'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
+        { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/.*)'] } },
         routing_rule
       ]
       injected_routing_policy = {

--- a/test/unit/config_path_test.rb
+++ b/test/unit/config_path_test.rb
@@ -17,11 +17,11 @@ class ConfigPathTest < ActiveSupport::TestCase
     refute ConfigPath.new('/somepath').empty?
   end
 
-  test '#to_regex returns "/.*" if path is not informed' do
-    assert_equal '/.*', ConfigPath.new('/').to_regex
+  test '#to_regex returns "^(/.*)" if path is not informed' do
+    assert_equal '^(/.*)', ConfigPath.new('/').to_regex
   end
 
   test '#to_regex returns the regex for the path if it is informed' do
-    assert_equal '/some/path/.*|/some/path/?', ConfigPath.new('/some/path').to_regex
+    assert_equal '^(/some/path/.*|/some/path/?)', ConfigPath.new('/some/path').to_regex
   end
 end

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -100,9 +100,9 @@ class ProxyTest < ActiveSupport::TestCase
         {"name"=>"routing", "version"=>"builtin", "enabled"=>true,
           "configuration"=>{
             "rules"=>[
-              {"url"=>"https://private-2.example.com:443", "owner_id"=>backend_api2.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/bar/.*|/foo/bar/?"}]}, 'replace_path'=>"{{uri | remove_first: '/foo/bar'}}"},
-              {"url"=>"https://private-1.example.com:443", "owner_id"=>backend_api1.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/foo/.*|/foo/?"}]}, 'replace_path'=>"{{uri | remove_first: '/foo'}}"},
-              {"url"=>"https://echo-api.3scale.net:443", "owner_id"=>backend_api0.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"/.*"}]}}
+              {"url"=>"https://private-2.example.com:443", "owner_id"=>backend_api2.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"^(/foo/bar/.*|/foo/bar/?)"}]}, 'replace_path'=>"{{uri | remove_first: '/foo/bar'}}"},
+              {"url"=>"https://private-1.example.com:443", "owner_id"=>backend_api1.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"^(/foo/.*|/foo/?)"}]}, 'replace_path'=>"{{uri | remove_first: '/foo'}}"},
+              {"url"=>"https://echo-api.3scale.net:443", "owner_id"=>backend_api0.id, "owner_type" => "BackendApi", "condition"=>{"operations"=>[{"match"=>"path", "op"=>"matches", "value"=>"^(/.*)"}]}}
             ]
           }
         },


### PR DESCRIPTION
The regex used to match the path of the backend in the APIAP routing policy configuration should only allow paths that _start with_ the chosen value for the path. Currently it matches all paths that _contains_ the value.

This PR fixes it by wrapping the current regex pattern within a `^()` group.

Closes [THREESCALE-4736](https://issues.redhat.com/browse/THREESCALE-4736)