### PR TITLE
Add validation to trial period, setup fee and cost per month

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -61,8 +61,8 @@ class Plan < ApplicationRecord
 
   validates :name, presence: true
 
-  validates :setup_fee, :cost_per_month, numericality: { allow_nil: false, allow_blank: false }
-
+  validates :setup_fee, :cost_per_month, numericality: { allow_nil: false, allow_blank: false, greater_than_or_equal_to: 0.00 }
+  validates :trial_period_days, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }
   validates :system_name, length: { maximum: 255 }
   validates :name, :rights, :state, :cost_aggregation_rule, :type, :issuer_type,
             length: { maximum: 255 }

--- a/test/unit/plan_test.rb
+++ b/test/unit/plan_test.rb
@@ -589,6 +589,33 @@ class PlanTest < ActiveSupport::TestCase
     end
   end
 
+  test 'setup_fee cannot be negative' do
+    plan = FactoryBot.build_stubbed(:application_plan)
+    plan.setup_fee = -10.00
+    refute plan.valid?
+    assert_equal ['must be greater than or equal to 0.0'], plan.errors[:setup_fee]
+    plan.setup_fee = 15.00
+    assert plan.valid?
+  end
+  
+  test 'cost_per_month cannot be negative' do
+    plan = FactoryBot.build_stubbed(:application_plan)
+    plan.cost_per_month = -10.00
+    refute plan.valid?
+    assert_equal ['must be greater than or equal to 0.0'], plan.errors[:cost_per_month]
+    plan.cost_per_month = 15.00
+    assert plan.valid?
+  end
+    
+   test 'trial_period_days cannot be negative' do
+    plan = FactoryBot.build_stubbed(:application_plan)
+    plan.trial_period_days = -1
+    refute plan.valid?
+    assert_equal ['must be greater than or equal to 0'], plan.errors[:trial_period_days]
+    plan.trial_period_days = 10
+    assert plan.valid?
+  end
+
   should 'let global finance setting prevail' do
     @plan = FactoryBot.create(:simple_application_plan)
     @plan.provider_account.billing_strategy = Finance::BillingStrategy.new


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a validation for parameters which cannot be negative. 

**Which issue(s) this PR fixes** 

[THREESCALE-1758: Negative value can be set for trial period](https://issues.redhat.com/browse/THREESCALE-1758)

While creating a new application, User(previously) could give negative inputs in the fields like: trial period, setup fee and cost per month. Now these fields ask for a positive value.

**Verification steps** 

- Go to the 'Context Selector'
- Click on the 'API'
- On the left hand side, under the functionality panel, click on 'Applications' and choose 'Application Plans'
- Click on 'Create Application Plan' and these parameters are available on the new page that shows up. 
