### PR TITLE
Do not run callback to destroy customized plan if it is about to be destroyed anyway

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -331,7 +331,8 @@ class Contract < ApplicationRecord
   end
 
   def destroy_customized_plan
-    plan.destroy if plan.try!(:customized?)
+    return if !plan || !plan.customized? || plan.scheduled_for_deletion?
+    plan.destroy
   end
 
   def accept_on_create

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -446,6 +446,10 @@ class Plan < ApplicationRecord
     plan_rule ? plan_rule.switches : []
   end
 
+  def scheduled_for_deletion?
+    !issuer || issuer.deleted? || provider_account&.scheduled_for_deletion?
+  end
+
   protected
 
   def xml_builder(options, attrs = {}, extra_nodes = {})
@@ -481,10 +485,6 @@ class Plan < ApplicationRecord
   end
 
   private
-
-  def scheduled_for_deletion?
-    !issuer || issuer.deleted? || provider_account&.scheduled_for_deletion?
-  end
 
   # act_as_list updates the position every time that a plan is destroyed.
   # But we do not want to do that when its issuer is going to be deleted anyway.


### PR DESCRIPTION
Attempt to fix [THREESCALE-3876](https://issues.redhat.com/browse/THREESCALE-3876)

I am not sure if it fixes it or not because I could not reproduce it and I do not have access to those Bugsnag logs anymore. And I couldn't reproduce it.

But either way, this will help to avoid duplication... when a plan is about to be destroyed, let's do not try to destroyed it again.