### PR TITLE
[WIP] [Bugfix] THREESCALE-4531 - Dev portal - password reset email does not get sent

### DIFF
--- a/app/lib/three_scale/spam_protection/protector.rb
+++ b/app/lib/three_scale/spam_protection/protector.rb
@@ -55,16 +55,20 @@ module ThreeScale::SpamProtection
         end
       end
 
+      def level_captcha?
+        level == :captcha || (level == :auto && spam?)
+      end
+
       def captcha_required?
-        (captcha_configured? && level == :captcha) && !logged_in?
+        captcha_configured? && enabled?
       end
 
       def captcha_needed?
-        captcha_required? || (!http_method.get? && spam?)
+        captcha_required? && (http_method.get? || spam?)
       end
 
       def enabled?
-        not logged_in? and level != :none
+        level_captcha? && !logged_in?
       end
 
       def to_str

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
@@ -10,17 +10,15 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
   before_action :find_user, :only => [:show, :update]
 
   def create
-    if !spam_check(buyer)
-      flash[:error] = 'Spam protection failed.'
-      redirect_to_password_reset_url
-    elsif (user = @provider.buyer_users.find_by_email(params[:email]))
-      user.generate_lost_password_token!
-      flash[:notice] = 'A password reset link has been emailed to you.'
-      redirect_to login_url
-    else
-      flash[:error] = 'Email not found.'
-      redirect_to_password_reset_url
-    end
+    return password_reset_error('Spam protection failed.') unless spam_check(buyer)
+
+    user = @provider.buyer_users.find_by_email(params[:email])
+    return password_reset_error('Email not found.') unless user
+
+    user.generate_lost_password_token!
+
+    flash[:notice] = 'A password reset link has been emailed to you.'
+    redirect_to login_url
   end
 
   def new; end
@@ -43,7 +41,8 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
 
   private
 
-  def redirect_to_password_reset_url
+  def password_reset_error(message)
+    flash[:error] = message
     redirect_to new_admin_account_password_url(request_password_reset: true) # keep hash for retrocompatibility
   end
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
@@ -10,15 +10,16 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
   before_action :find_user, :only => [:show, :update]
 
   def create
-    return redirect_to new_admin_account_password_url unless spam_check(buyer)
-
-    if user = @provider.buyer_users.find_by_email(params[:email])
+    if !spam_check(buyer)
+      flash[:error] = 'Spam protection failed.'
+      redirect_to new_admin_account_password_url(request_password_reset: true)
+    elsif (user = @provider.buyer_users.find_by_email(params[:email]))
       user.generate_lost_password_token!
-      flash[:notice] = "A password reset link has been emailed to you."
+      flash[:notice] = 'A password reset link has been emailed to you.'
       redirect_to login_url
     else
       flash[:error] = 'Email not found.'
-      redirect_to new_admin_account_password_url(:request_password_reset => true) # keep hash for retrocompatibility
+      redirect_to new_admin_account_password_url(request_password_reset: true) # keep hash for retrocompatibility
     end
   end
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
@@ -12,14 +12,14 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
   def create
     if !spam_check(buyer)
       flash[:error] = 'Spam protection failed.'
-      redirect_to new_admin_account_password_url(request_password_reset: true)
+      redirect_to_password_reset_url
     elsif (user = @provider.buyer_users.find_by_email(params[:email]))
       user.generate_lost_password_token!
       flash[:notice] = 'A password reset link has been emailed to you.'
       redirect_to login_url
     else
       flash[:error] = 'Email not found.'
-      redirect_to new_admin_account_password_url(request_password_reset: true) # keep hash for retrocompatibility
+      redirect_to_password_reset_url
     end
   end
 
@@ -42,6 +42,10 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
   end
 
   private
+
+  def redirect_to_password_reset_url
+    redirect_to new_admin_account_password_url(request_password_reset: true) # keep hash for retrocompatibility
+  end
 
   def buyer
     @buyer ||= @provider.buyers.build

--- a/test/integration/developer_portal/passwords_controller_test.rb
+++ b/test/integration/developer_portal/passwords_controller_test.rb
@@ -43,12 +43,22 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
     assert body.include? 'g-recaptcha'
   end
 
-  test 'captcha is not present when spam security set to auto' do
+  test 'captcha is not present when spam security set to auto and it is not a spam object' do
     provider.settings.update_attributes(spam_protection_level: :auto)
+    ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: false)
 
     get developer_portal.new_admin_account_password_path
     assert_response :success
     assert_not body.include? 'g-recaptcha'
+  end
+
+  test 'captcha is present when spam security set to auto it is a spam object' do
+    provider.settings.update_attributes(spam_protection_level: :auto)
+    ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: true)
+
+    get developer_portal.new_admin_account_password_path
+    assert_response :success
+    assert body.include? 'g-recaptcha'
   end
 
   test 'captcha is not present when spam security disabled' do
@@ -57,6 +67,37 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
     get developer_portal.new_admin_account_password_path
     assert_response :success
     assert_not body.include? 'g-recaptcha'
+  end
+
+  test 'create responds with error message when detects spam' do
+    provider.settings.update_attributes(spam_protection_level: :auto)
+    ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: true)
+    Recaptcha::Verify.stubs(skip?: false)
+
+    post developer_portal.admin_account_password_path(email: 'user@example.com')
+    assert_equal 'Spam protection failed.', flash[:error]
+    assert_redirected_to developer_portal.new_admin_account_password_path(request_password_reset: true)
+  end
+
+  test 'create sends the email when captcha passes and finds the email' do
+    provider.settings.update_attributes(spam_protection_level: :auto)
+    ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: true)
+    Recaptcha::Verify.stubs(skip?: true)
+
+    post developer_portal.admin_account_password_path(email: user.email)
+    assert_equal 'A password reset link has been emailed to you.', flash[:notice]
+    assert_redirected_to developer_portal.login_path
+    assert user.reload.lost_password_token
+    assert user.reload.lost_password_token_generated_at
+  end
+
+  test 'create renders the right error message when the email is not found' do
+    provider.settings.update_attributes(spam_protection_level: :none)
+    Recaptcha::Verify.stubs(skip?: false)
+
+    post developer_portal.admin_account_password_path(email: 'fake@example.com')
+    assert_equal 'Email not found.', flash[:error]
+    assert_redirected_to developer_portal.new_admin_account_password_path(request_password_reset: true)
   end
 
   private


### PR DESCRIPTION
Closes [THREESCALE-4531 - Dev portal - password reset email does not get sent](https://issues.redhat.com/browse/THREESCALE-4531)
Related to [ [THREESCALE-1135 - Add Captcha element in the password reset form](https://issues.redhat.com/browse/THREESCALE-1135) | https://github.com/3scale/porta/pull/1466 ]

The captcha loads when is configured in the settings.yml and the tenant settings spam_protection_level is either :captcha or :auto but the object is considered spam?
If the captcha is not configured but the object is still considered spam, then we display an error message informing of that.

### Verification steps
For :auto in the settings spam_protection_level. With recaptcha configured.

The captcha loads
![image](https://user-images.githubusercontent.com/11318903/78016136-afa7b800-734a-11ea-986d-7a926af7d2ad.png)

#### If I don't fill it
![image](https://user-images.githubusercontent.com/11318903/78016339-f5fd1700-734a-11ea-817e-71aedf2187f1.png)
![image](https://user-images.githubusercontent.com/11318903/78016460-204ed480-734b-11ea-876d-b4bf30078792.png)

#### If I fill it
![image](https://user-images.githubusercontent.com/11318903/78016507-32307780-734b-11ea-9fea-5ae8d314f563.png)

![image](https://user-images.githubusercontent.com/11318903/78016526-3a88b280-734b-11ea-94b5-0d5749d3d21c.png)
