### PR TITLE
LOG ProxyConfigAffectingChangeWorker to understand the proxy_id as NULL

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -650,8 +650,8 @@ class Proxy < ApplicationRecord
     end
   end
 
-  def create_proxy_config_affecting_change(attributes = {}, options = {}, &block)
-    super(attributes.merge(proxy_id: id), options, &block)
+  def create_proxy_config_affecting_change(*)
+    super
   rescue ActiveRecord::RecordNotUnique
     reload.send(:proxy_config_affecting_change)
   end

--- a/app/workers/proxy_config_affecting_change_worker.rb
+++ b/app/workers/proxy_config_affecting_change_worker.rb
@@ -7,8 +7,7 @@ class ProxyConfigAffectingChangeWorker < ApplicationJob
     proxy.affecting_change_history.touch
   rescue ActiveRecord::StatementInvalid => exception
     # logging to help us understand the problem
-    proxy.reload
-    proxy_config_affecting_change = proxy.send(:proxy_config_affecting_change)
+    proxy_config_affecting_change = proxy.reload.send(:proxy_config_affecting_change)
     parameters = {
       proxy_created_at: proxy.created_at,
       proxy_updated_at: proxy.updated_at,

--- a/app/workers/proxy_config_affecting_change_worker.rb
+++ b/app/workers/proxy_config_affecting_change_worker.rb
@@ -5,6 +5,18 @@ class ProxyConfigAffectingChangeWorker < ApplicationJob
     event = EventStore::Repository.find_event!(event_id)
     proxy = Proxy.find(event.proxy_id)
     proxy.affecting_change_history.touch
+  rescue ActiveRecord::StatementInvalid => exception
+    # logging to help us understand the problem
+    proxy.reload
+    proxy_config_affecting_change = proxy.send(:proxy_config_affecting_change)
+    parameters = {
+      proxy_created_at: proxy.created_at,
+      proxy_updated_at: proxy.updated_at,
+      proxy_affecting_change_created_at: proxy_config_affecting_change&.created_at,
+      proxy_affecting_change_updated_at: proxy_config_affecting_change&.updated_at
+    }
+    System::ErrorReporting.report_error(exception, parameters: parameters)
+    raise
   rescue ActiveRecord::RecordNotFound
   end
 end


### PR DESCRIPTION
The 1st commit reverts https://github.com/3scale/porta/pull/1721 because unfortunately, it does not work 😞 
The 2nd commit adds some logs to help us understand [THREESCALE-4778 - Mysql2::Error: Field 'proxy_id' doesn't have a default value: INSERT INTO `proxy_config_affecting_changes` VALUES ()](https://issues.redhat.com/browse/THREESCALE-4778)