### PR TITLE
Hiding test curl command when the integration in OpenID Connect

### DIFF
--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -54,17 +54,18 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
           dl.u-dl
             dt.u-dl-term URL
             dd.u-dl-definition = @show_presenter.staging_proxy_endpoint
-            dt.u-dl-term Example curl for testing
-            dd.u-dl-definition
-              = api_test_curl(@proxy)
-              - unless @service.cinstances.any?
-                br
-                br
-                hr
-                em
-                  => t('api.integrations.proxy.curl.no_application')
-                  - unless @service.application_plans.any?
-                    = link_to t('api.integrations.proxy.curl.no_application_plan'), admin_service_application_plans_path(@service)
+            - unless @service.oauth?
+              dt.u-dl-term Example curl for testing
+              dd.u-dl-definition
+                = api_test_curl(@proxy)
+                - unless @service.cinstances.any?
+                  br
+                  br
+                  hr
+                  em
+                    => t('api.integrations.proxy.curl.no_application')
+                    - unless @service.application_plans.any?
+                      = link_to t('api.integrations.proxy.curl.no_application_plan'), admin_service_application_plans_path(@service)
             dt.u-dl-term Version
             dd.u-dl-definition
               ' v.

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -172,7 +172,8 @@ class IntegrationsTest < ActionDispatch::IntegrationTest
   end
 
   def test_example_curl
-    service = FactoryBot.create(:simple_service, account: @provider)
+    service = @provider.default_service
+    FactoryBot.create(:service_token, service: service)
     FactoryBot.create(:proxy_config, proxy: service.proxy, environment: 'sandbox')
     Api::IntegrationsShowPresenter.any_instance.expects(:apicast_config_ready?).returns(true).at_least_once
     Api::IntegrationsShowPresenter.any_instance.expects(:any_sandbox_configs?).returns(true).at_least_once

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -170,4 +170,21 @@ class IntegrationsTest < ActionDispatch::IntegrationTest
     get edit_admin_service_integration_path(service_id: service.id)
     assert_response :not_found
   end
+
+  def test_example_curl
+    service = FactoryBot.create(:simple_service, account: @provider)
+    FactoryBot.create(:proxy_config, proxy: service.proxy, environment: 'sandbox')
+    Api::IntegrationsShowPresenter.any_instance.expects(:apicast_config_ready?).returns(true).at_least_once
+    Api::IntegrationsShowPresenter.any_instance.expects(:any_sandbox_configs?).returns(true).at_least_once
+
+    Service.any_instance.expects(:oauth?).returns(true).at_least_once
+    get admin_service_integration_path(service_id: service.id)
+    assert_response :success
+    assert_not_match 'Example curl for testing', response.body
+
+    Service.any_instance.expects(:oauth?).returns(false).at_least_once
+    get admin_service_integration_path(service_id: service.id)
+    assert_response :success
+    assert_match 'Example curl for testing', response.body
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it:**
Hiding test curl command when the integration in OpenID Connect

Which issue(s) this PR fixes
https://issues.redhat.com/browse/THREESCALE-4384

Verification steps
Go to **Integration > Configuration** change **Integration settings** to OpenID Connect

![Screenshot from 2020-03-30 12-06-46](https://user-images.githubusercontent.com/53568062/77885321-74db4c80-7284-11ea-92b6-1f3ef44560da.png)
