### PR TITLE
Prevent creating application with forbidden plan in UI

### DIFF
--- a/app/views/buyers/applications/_listing.html.slim
+++ b/app/views/buyers/applications/_listing.html.slim
@@ -18,7 +18,7 @@ div id="bulk-operations" style="display: none;"
     = javascript_include_tag 'bulk_operations.js'
     = javascript_include_tag 'vendor/jquery.tipsy.js'
 
-- show_application_plans = @stock_and_custom_application_plans > 1 && !master_on_premises?
+- show_application_plans = @application_plans.size > 1 && !master_on_premises?
 
 table class="data"
   thead
@@ -66,13 +66,13 @@ table class="data"
 
           - if display_view_portion?(:service)
             th
-              = s.collection_select :service_id, @services, :id, :name,
+              = s.collection_select :service_id, accessible_services, :id, :name,
                                       { include_blank: true },
                                       { disabled: @service }
 
           - if show_application_plans
-            - if @services
-              th = s.grouped_collection_select :plan_id, @services,
+            - if display_view_portion?(:service)
+              th = s.grouped_collection_select :plan_id, accessible_services,
                                               :application_plans, :name, :id, :name,
                                               { include_blank: true },
                                               { disabled: @plan }

--- a/test/integration/buyers/applications_controller_test.rb
+++ b/test/integration/buyers/applications_controller_test.rb
@@ -22,8 +22,7 @@ class Buyers::ApplicationsTest < ActionDispatch::IntegrationTest
     def setup
       @provider = FactoryBot.create(:provider_account)
 
-      host! @provider.admin_domain
-      provider_login_with @provider.admins.first.username, "supersecret"
+      login! provider
 
       #TODO: dry with @ignore-backend tag on cucumber
       stub_backend_get_keys
@@ -31,19 +30,93 @@ class Buyers::ApplicationsTest < ActionDispatch::IntegrationTest
       stub_backend_utilization
     end
 
+    attr_reader :provider
+
     test 'index shows the services column when the provider is multiservice' do
-      @provider.services.create!(name: '2nd-service')
-      assert @provider.reload.multiservice?
+      provider.services.create!(name: '2nd-service')
+      assert provider.reload.multiservice?
       get admin_buyers_applications_path
       page = Nokogiri::HTML::Document.parse(response.body)
       assert page.xpath("//tr").text.match /Service/
     end
 
     test 'index does not show the services column when the provider is not multiservice' do
-      refute @provider.reload.multiservice?
+      refute provider.reload.multiservice?
       get admin_buyers_applications_path
       page = Nokogiri::HTML::Document.parse(response.body)
       refute page.xpath("//tr").text.match /Service/
+    end
+
+    test 'index shows an application of a custom plan' do
+      service = provider.default_service
+      buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+      app_plan = FactoryBot.create(:application_plan, issuer: service)
+      custom_plan = app_plan.customize
+      cinstance = FactoryBot.create(:cinstance, user_account: buyer, plan: custom_plan, name: 'my custom cinstance')
+
+      get admin_buyers_applications_path
+      assert_response :success
+      page = Nokogiri::HTML::Document.parse(response.body)
+      assert page.xpath("//td").text.match /my custom cinstance/
+    end
+
+    test 'member cannot create an application when lacking access to a service' do
+      forbidden_service = FactoryBot.create(:service, account: provider)
+      forbidden_plan = FactoryBot.create(:application_plan, issuer: forbidden_service)
+      forbidden_service_plan = FactoryBot.create(:service_plan, issuer: forbidden_service)
+
+      authorized_service = FactoryBot.create(:service, account: provider)
+      authorized_plan = FactoryBot.create(:application_plan, issuer: authorized_service)
+      authorized_service_plan = FactoryBot.create(:service_plan, issuer: authorized_service)
+
+      buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+
+      member = FactoryBot.create(:member, account: provider,
+                                          member_permission_ids: [:partners])
+      member.activate!
+      FactoryBot.create(:member_permission, user: member,
+                                            admin_section: :services,
+                                            service_ids: [authorized_service.id])
+
+      login_provider provider, user: member
+
+      post admin_buyers_account_applications_path(account_id: buyer.id), cinstance: {
+        plan_id: forbidden_plan.id,
+        name: 'Not Allowed!',
+        service_plan_id: forbidden_service_plan.id
+      }
+
+      assert_response :not_found
+
+      post admin_buyers_account_applications_path(account_id: buyer.id), cinstance: {
+        plan_id: authorized_plan.id,
+        name: 'Allowed',
+        service_plan_id: authorized_service_plan.id
+      }
+
+      assert_response :found
+    end
+
+    test 'buying a stock plan is allowed but buying a custom plan is not' do
+      service = provider.default_service
+      initial_plan = FactoryBot.create(:application_plan, issuer: service)
+      buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+      cinstance = FactoryBot.create(:cinstance, user_account: buyer, plan: initial_plan)
+
+      app_plan = FactoryBot.create(:application_plan, issuer: service)
+      custom_plan = app_plan.customize
+
+
+      put change_plan_admin_buyers_application_path(account_id: buyer.id, id: cinstance.id), cinstance: {plan_id: custom_plan.id}
+
+      assert_response :not_found
+      assert_equal initial_plan.id, cinstance.reload.plan_id
+
+
+      put change_plan_admin_buyers_application_path(account_id: buyer.id, id: cinstance.id), cinstance: {plan_id: app_plan.id}
+
+      assert_redirected_to admin_service_application_path(service, cinstance)
+      assert_equal app_plan.id, cinstance.reload.plan_id
     end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Restrain the list of plans returned to a user, depending on his permissions. [This line](https://github.com/3scale/porta/blob/031493986866f026054a06c7b575c325cf8d446f/app/controllers/buyers/applications_controller.rb#L61) probably.

**Which issue(s) this PR fixes** 

[THREESCALE-3268: Admin Portal member user with the access "Developer Accounts -- Applications" is able to create new Applications using the UI for Services they don't have permissions
](https://issues.redhat.com/browse/THREESCALE-3268)

**Verification steps**
See JIRA ticket.
