### PR TITLE
[Bugfix] [Oracle] Patch Upgrade from 2.5 to 2.6. FixOracleDeletedObjectsPrecision with data

### DIFF
--- a/db/migrate/20190527104222_fix_oracle_deleted_objects_precision.rb
+++ b/db/migrate/20190527104222_fix_oracle_deleted_objects_precision.rb
@@ -1,8 +1,21 @@
 class FixOracleDeletedObjectsPrecision < ActiveRecord::Migration
-  def change
+  def up
     return unless System::Database.oracle?
+
     # Safety assured because this will run only for on-prem using Oracle at booting time
-    safety_assured { change_column :deleted_objects, :owner_id, :bigint, limit: 8 }
+
+    add_column :deleted_objects, :owner_id_tmp,  :bigint, limit: 8
+    add_column :deleted_objects, :object_id_tmp, :bigint, limit: 8
+
+    DeletedObject.update_all('owner_id_tmp = owner_id, object_id_tmp = object_id')
+    DeletedObject.update_all(owner_id: nil, object_id: nil)
+
+    safety_assured { change_column :deleted_objects, :owner_id,  :bigint, limit: 8 }
     safety_assured { change_column :deleted_objects, :object_id, :bigint, limit: 8 }
+
+    DeletedObject.update_all('owner_id = owner_id_tmp, object_id = object_id_tmp')
+
+    safety_assured { remove_column :deleted_objects, :owner_id_tmp }
+    safety_assured { remove_column :deleted_objects, :object_id_tmp }
   end
 end


### PR DESCRIPTION
**DONE AND WORKING... NOW IT MUST BE DECIDED IF WE ARE GOING TO MERGE THIS PR BEING A PATCH FOR 2.6 OR JUST CLOSE IT** 😄 

Closes [THREESCALE-4793](https://issues.redhat.com/browse/THREESCALE-4793)

### Verification steps
1. Go to the code of 2.6. `git checkout 3scale-2.6.0-CR1`. _Ideally, we should do the test from 2.5, but that is more time consuming because it implies [installing an older version of Ruby and may give errors trying to install it all now](https://stackoverflow.com/questions/59350892/installing-ruby-2-1-2-cannot-load-such-file-openssl-loaderror)._
2. Set the config files of that moment in time. `yes | cp config/examples/* config/` and `git checkout . && git clean -f -d`
3. Install the gems of that code. `DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" ORACLE_SYSTEM_PASSWORD=... NLS_LANG=AMERICAN_AMERICA.UTF8 bundle install`. If you want to know the password, ask me in private 😄 
4. Recreate the schema. `DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" ORACLE_SYSTEM_PASSWORD=... NLS_LANG=AMERICAN_AMERICA.UTF8 bundle exec rake db:drop db:create db:schema:load`
5. Open the Rails Console with _safety assured_. DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" `ORACLE_SYSTEM_PASSWORD=... NLS_LANG=AMERICAN_AMERICA.UTF8 SAFETY_ASSURED=1 bundle exec rails console`
6. Add data to DeletedObject.
```ruby
20.times do |n|
  DeletedObject.create!(object_id: n, object_type: Metric, owner_id: n, owner_type: Service)
end
```
![image](https://user-images.githubusercontent.com/11318903/77764822-90a0e180-703d-11ea-9b79-d0dfa0fed0ec.png)

6. Ensure that the previous migration would fail.
```ruby
ActiveRecord::Migration.change_column :deleted_objects, :owner_id, :bigint, limit: 8
```
![image](https://user-images.githubusercontent.com/11318903/77764858-a2828480-703d-11ea-9361-e01400de4470.png)

7. Run the code of the new migration 😄 
```ruby
ActiveRecord::Migration.add_column :deleted_objects, :owner_id_tmp, :bigint, limit: 8
ActiveRecord::Migration.add_column :deleted_objects, :object_id_tmp, :bigint, limit: 8
DeletedObject.update_all('owner_id_tmp = owner_id, object_id_tmp = object_id')
DeletedObject.update_all(owner_id: nil, object_id: nil)
ActiveRecord::Migration.change_column :deleted_objects, :owner_id, :bigint, limit: 8
ActiveRecord::Migration.change_column :deleted_objects, :object_id, :bigint, limit: 8
DeletedObject.update_all('owner_id = owner_id_tmp, object_id = object_id_tmp')
ActiveRecord::Migration.remove_column :deleted_objects, :owner_id_tmp
ActiveRecord::Migration.remove_column :deleted_objects, :object_id_tmp
```
![image](https://user-images.githubusercontent.com/11318903/77765002-e5dcf300-703d-11ea-891b-dc5961954dff.png)

![image](https://user-images.githubusercontent.com/11318903/77765045-f55c3c00-703d-11ea-8699-66cfd49677b9.png)

8. Ensure that it has the proper data. `pp DeletedObject.columns_hash['owner_id']` and `pp DeletedObject.columns_hash['object_id']`
![image](https://user-images.githubusercontent.com/11318903/77767546-85e84b80-7041-11ea-8bb6-d428ebc8d599.png)
![image](https://user-images.githubusercontent.com/11318903/77767561-8ed91d00-7041-11ea-89d6-fd9e0083d474.png)
