### PR TITLE
Add types and encapsulates translations

### DIFF
--- a/portafly/src/components/Root.tsx
+++ b/portafly/src/components/Root.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Brand } from '@patternfly/react-core'
-import { useTranslation } from 'react-i18next'
+import { useTranslation } from 'i18n'
 import { useHistory } from 'react-router-dom'
 import { AppLayout } from 'components'
 import logo from 'assets/logo.svg'

--- a/portafly/src/components/Root.tsx
+++ b/portafly/src/components/Root.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Brand } from '@patternfly/react-core'
-import { useTranslation } from 'i18n'
+import { useTranslation } from 'i18n/useTranslation'
 import { useHistory } from 'react-router-dom'
 import { AppLayout } from 'components'
 import logo from 'assets/logo.svg'

--- a/portafly/src/i18n/i18n.tsx
+++ b/portafly/src/i18n/i18n.tsx
@@ -1,7 +1,7 @@
 import i18n, { FormatFunction } from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import { initReactI18next } from 'react-i18next'
-import { EN } from 'i18n/locales'
+import { ITranslationsPages, Translations, EN } from 'i18n'
 
 const formatFn: FormatFunction = (value, format) => {
   if (format === 'uppercase') return value.toUpperCase()
@@ -9,28 +9,22 @@ const formatFn: FormatFunction = (value, format) => {
   return value
 }
 
+const sections: Array<ITranslationsPages> = ['shared', 'overview', 'analytics', 'applications', 'integration']
+
 const options = {
-  lng: 'en',
-  fallbackLng: ['en'],
+  lng: EN,
+  fallbackLng: [EN],
   debug: false,
   interpolation: {
     format: formatFn,
     escapeValue: false
   },
-  ns: ['shared', 'overview', 'analytics', 'applications', 'integration'],
+  ns: sections,
   defaultNS: 'shared',
   react: {
     transKeepBasicHtmlNodesFor: ['br', 'strong', 'i']
   },
-  resources: {
-    en: {
-      shared: EN.SHARED,
-      overview: EN.OVERVIEW,
-      analytics: EN.ANALYTICS,
-      applications: EN.APPLICATIONS,
-      integration: EN.INTEGRATION
-    }
-  }
+  resources: Translations
 }
 
 i18n.use(LanguageDetector)

--- a/portafly/src/i18n/index.ts
+++ b/portafly/src/i18n/index.ts
@@ -1,0 +1,4 @@
+export * from './i18n'
+export * from './locales'
+export * from './supported-languages'
+export * from './useTranslation'

--- a/portafly/src/i18n/locales/en/index.ts
+++ b/portafly/src/i18n/locales/en/index.ts
@@ -1,0 +1,13 @@
+import shared from 'i18n/locales/en/shared.json'
+import overview from 'i18n/locales/en/overview.json'
+import analytics from 'i18n/locales/en/analytics.json'
+import applications from 'i18n/locales/en/applications.json'
+import integration from 'i18n/locales/en/integration.json'
+
+export {
+  shared,
+  overview,
+  analytics,
+  applications,
+  integration
+}

--- a/portafly/src/i18n/locales/index.ts
+++ b/portafly/src/i18n/locales/index.ts
@@ -2,7 +2,7 @@ import { ISupportedLanguages } from 'i18n'
 import * as en from 'i18n/locales/en'
 
 export type ITranslationsPages = keyof typeof en
-export type ITranslations = { [P in ITranslationsPages]: any}
+export type ITranslations = { [P in ITranslationsPages]: any }
 
 const Translations: Record<ISupportedLanguages, ITranslations> = {
   en

--- a/portafly/src/i18n/locales/index.ts
+++ b/portafly/src/i18n/locales/index.ts
@@ -1,15 +1,11 @@
-import shared from 'i18n/locales/en/shared.json'
-import overview from 'i18n/locales/en/overview.json'
-import analytics from 'i18n/locales/en/analytics.json'
-import applications from 'i18n/locales/en/applications.json'
-import integration from 'i18n/locales/en/integration.json'
+import { ISupportedLanguages } from 'i18n'
+import * as en from 'i18n/locales/en'
 
-const EN = {
-  SHARED: shared,
-  OVERVIEW: overview,
-  ANALYTICS: analytics,
-  APPLICATIONS: applications,
-  INTEGRATION: integration
+export type ITranslationsPages = keyof typeof en
+export type ITranslations = { [P in ITranslationsPages]: any}
+
+const Translations: Record<ISupportedLanguages, ITranslations> = {
+  en
 }
 
-export { EN }
+export { Translations }

--- a/portafly/src/i18n/supported-languages.ts
+++ b/portafly/src/i18n/supported-languages.ts
@@ -1,0 +1,3 @@
+export const EN = 'en'
+
+export type ISupportedLanguages = typeof EN // | typeof ...

--- a/portafly/src/i18n/useTranslation.ts
+++ b/portafly/src/i18n/useTranslation.ts
@@ -1,0 +1,14 @@
+import { useTranslation, UseTranslationOptions } from 'react-i18next'
+import { ITranslationsPages } from 'i18n'
+
+/**
+ * This wrapper mostly allow us to control what strings we pass
+ * into useTranslation and provides the IDE with intellisense for
+ * that matter.
+ */
+const useTranslationWrapper = (
+  ns?: ITranslationsPages | Array<ITranslationsPages>,
+  options?: UseTranslationOptions
+) => useTranslation(ns, options)
+
+export { useTranslationWrapper as useTranslation }

--- a/portafly/src/pages/Applications.tsx
+++ b/portafly/src/pages/Applications.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useTranslation } from 'react-i18next'
+import { useTranslation } from 'i18n/useTranslation'
 import { useFetch } from 'react-async'
 import { useDocumentTitle } from 'components'
 import {

--- a/portafly/src/pages/Overview.tsx
+++ b/portafly/src/pages/Overview.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useTranslation } from 'react-i18next'
+import { useTranslation } from 'i18n/useTranslation'
 import { useA11yRouteChange, useDocumentTitle } from 'components'
 import {
   PageSection,

--- a/portafly/src/tests/__mocks__/reacti18nextMock.js
+++ b/portafly/src/tests/__mocks__/reacti18nextMock.js
@@ -1,3 +1,3 @@
 module.exports = {
-  useTranslation: () => ({ t: key => key })
+  useTranslation: () => ({ t: (key) => key })
 }


### PR DESCRIPTION
Proposal for some improvements in the base PR:
* Creates types for the translations: it's very important to be able to check what "pages" we are requesting.
* Encapsulates translations (JSON) inside their modules (folders). This way no matter if we use one or multiple jsons for each language, the code stays consistent.
* Creates types for the locales (languages really): i18next handles simple strings.

One thing to keep in mind: I think we're starting to mix up _locales_ with _languages_. A locale takes localization into account whereas language does not. That is basically why I defined a `ISupportedLanguages` instead of `ILocales`, because we're using `en` instead of `en-US`.
