### PR TITLE
Remove empty methods related to a test helper to unstub spam_protection

### DIFF
--- a/test/test_helpers/spam_protection_stubs.rb
+++ b/test/test_helpers/spam_protection_stubs.rb
@@ -1,29 +1,14 @@
+# frozen_string_literal: true
+
 module TestHelpers
   module SpamProtectionStubs
-
-    def self.included(base)
-      base.teardown(:clear_spam_protection_stubs)
-    end
-
     def stub_spam_protection_needed
       ThreeScale::SpamProtection::Protector::FormProtector.any_instance.stubs(:captcha_needed?)
     end
 
-
     def stub_spam_protection_timestamp_probability(value)
       ThreeScale::SpamProtection::Checks::Timestamp.any_instance.stubs(:probability).returns(value)
     end
-
-    # unstubs
-
-    def unstub_spam_protection_needed
-
-    end
-
-    def clear_spam_protection_stubs
-      unstub_spam_protection_needed
-    end
-
   end
 end
 


### PR DESCRIPTION
Because they seem to do nothing at all 😂 