### PR TITLE
[Tests] The Factory provider_account now has only 1 BackendApi and 1 BackendApiConfig

### DIFF
--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -144,8 +144,6 @@ FactoryBot.define do
         account_plans_ui_visible: true,
         service_plans_ui_visible: true
       )
-      backend_api = FactoryBot.create(:backend_api, account: account, name: 'API Backend')
-      FactoryBot.create(:backend_api_config, service: account.services.first, backend_api: backend_api)
     end
   end
 


### PR DESCRIPTION
@guicassolato discovered in https://github.com/3scale/porta/pull/1793#discussion_r402315785 that the tests were creating 2 backend_apis with 2 backend_api_configs for the default service using the factory provider_account.

![image](https://user-images.githubusercontent.com/11318903/78276507-6b1b4880-7513-11ea-9e48-6cae87afd46e.png)

![image](https://user-images.githubusercontent.com/11318903/78276538-75d5dd80-7513-11ea-827e-e90aaec7e10b.png)

This was happening because Rails 5 runs callbacks for the tests and this didn't happen for Rails 4, so in Rails 4, we created the BackendApi and BackendApiConfig of the factory ourselves instead of relying on the callbacks of the regular workflow, and now, it will just follow the regular workflow only instead.

https://github.com/3scale/porta/blob/c67d5d8227a1f64c0ff2c0d91f5ea39a00cb9fb9/app/models/service.rb#L45

https://github.com/3scale/porta/blob/c67d5d8227a1f64c0ff2c0d91f5ea39a00cb9fb9/app/models/service.rb#L560-L562

https://github.com/3scale/porta/blob/c67d5d8227a1f64c0ff2c0d91f5ea39a00cb9fb9/app/lib/backend_api_logic/proxy_extension.rb#L12

https://github.com/3scale/porta/blob/c67d5d8227a1f64c0ff2c0d91f5ea39a00cb9fb9/app/lib/backend_api_logic/proxy_extension.rb#L26-L28

https://github.com/3scale/porta/blob/c67d5d8227a1f64c0ff2c0d91f5ea39a00cb9fb9/app/lib/backend_api_logic/proxy_extension.rb#L9

https://github.com/3scale/porta/blob/c67d5d8227a1f64c0ff2c0d91f5ea39a00cb9fb9/app/lib/backend_api_logic/proxy_extension.rb#L8

https://github.com/3scale/porta/blob/c67d5d8227a1f64c0ff2c0d91f5ea39a00cb9fb9/app/lib/backend_api_logic/service_extension.rb#L11

https://github.com/3scale/porta/blob/c67d5d8227a1f64c0ff2c0d91f5ea39a00cb9fb9/app/lib/backend_api_logic/service_extension.rb#L35-L37
