### PR TITLE
[Bugfix] [Oracle] Patch Upgrade from 2.5 to 2.6. FixOracleDeletedObjectsPrecision with data

### DIFF
--- a/db/migrate/20190527104222_fix_oracle_deleted_objects_precision.rb
+++ b/db/migrate/20190527104222_fix_oracle_deleted_objects_precision.rb
@@ -1,8 +1,21 @@
 class FixOracleDeletedObjectsPrecision < ActiveRecord::Migration
-  def change
+  def up
     return unless System::Database.oracle?
+
     # Safety assured because this will run only for on-prem using Oracle at booting time
-    safety_assured { change_column :deleted_objects, :owner_id, :bigint, limit: 8 }
+
+    add_column :deleted_objects, :owner_id_tmp,  :bigint, limit: 8
+    add_column :deleted_objects, :object_id_tmp, :bigint, limit: 8
+
+    DeletedObject.update_all('owner_id_tmp = owner_id, object_id_tmp = object_id')
+    DeletedObject.update_all(owner_id: nil, object_id: nil)
+
+    safety_assured { change_column :deleted_objects, :owner_id,  :bigint, limit: 8 }
     safety_assured { change_column :deleted_objects, :object_id, :bigint, limit: 8 }
+
+    DeletedObject.update_all('owner_id = owner_id_tmp, object_id = object_id_tmp')
+
+    safety_assured { remove_column :deleted_objects, :owner_id_tmp }
+    safety_assured { remove_column :deleted_objects, :object_id_tmp }
   end
 end


### PR DESCRIPTION
Cherry-pick of the patch for 2.6 to master 😄 
It is the same code that we merged to 2.6 : https://github.com/3scale/porta/pull/1799
Done for [THREESCALE-4793](https://issues.redhat.com/browse/THREESCALE-4793)
