### PR TITLE
Fix toggle metric enabled/disabled

### DIFF
--- a/test/integration/api/metrics_controller_test.rb
+++ b/test/integration/api/metrics_controller_test.rb
@@ -78,4 +78,19 @@ class Api::MetricsControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'The Hits metric cannot be deleted', flash[:error]
     end
   end
+
+  test 'toggle enabled' do
+    plan = FactoryBot.create(:application_plan, issuer: @service)
+    FactoryBot.create(:usage_limit, plan: plan, metric: @metric)
+    assert @metric.enabled_for_plan?(plan)
+
+    params = { application_plan_id: plan.id, id: @metric.id, format: :js }
+    put toggle_enabled_admin_application_plan_metric_path(params)
+    assert_response :success
+    refute @metric.enabled_for_plan?(plan)
+
+    put toggle_enabled_admin_application_plan_metric_path(params)
+    assert_response :success
+    assert @metric.enabled_for_plan?(plan)
+  end
 end


### PR DESCRIPTION
https://github.com/3scale/porta/commit/91cac4d1101b43cfae3b85239af82f8e6e9126ae broke finding the metric for methods `toggle_(enabled|visible|limits_only_text)`. This PR fixes it.

BTW, those methods should not even be part of that controller!

Closes [THREESCALE-4936](https://issues.redhat.com/browse/THREESCALE-4936)