### PR TITLE
[apiap] Fix routing policy's replace_path rule with Lua magic characters

### DIFF
--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -73,7 +73,7 @@ module BackendApiLogic
         def replace_path
           return {} if config_path.blank?
 
-          { replace_path: "{{uri | remove_first: '#{config_path.path}'}}" }
+          { replace_path: "{{uri | remove_first: '#{LuaUtility.escape(config_path.path)}'}}" }
         end
       end
       private_constant :Rule

--- a/app/lib/lua_utility.rb
+++ b/app/lib/lua_utility.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module LuaUtility
+  MAGIC_CHARACTERS = %w@( ) . % + - * ? [ ^ $@.freeze
+  ESCAPE_CHARACTER = '%'
+
+  module_function
+
+  def escape(string)
+    string.gsub(/./) do |char|
+      MAGIC_CHARACTERS.include?(char) ? [ESCAPE_CHARACTER, char].join : char
+    end
+  end
+end

--- a/test/unit/backend_api_logic/routing_policy_test.rb
+++ b/test/unit/backend_api_logic/routing_policy_test.rb
@@ -80,7 +80,10 @@ module BackendApiLogic
           [{ private_endpoint: 'https://safe-second-api.io/v2', path: '/' }, nil],
           [{ private_endpoint: 'http://actual-api.behind.com/ns/', path: '/hey' }, "{{uri | remove_first: '/hey'}}"],
           [{ private_endpoint: 'https://safe-second-api.io', path: '/ho' }, "{{uri | remove_first: '/ho'}}"],
-          [{ private_endpoint: 'https://safe-second-api.io/v2', path: '/lets-go' }, "{{uri | remove_first: '/lets-go'}}"]
+          [{ private_endpoint: 'https://safe-second-api.io', path: '/foo/bar' }, "{{uri | remove_first: '/foo/bar'}}"],
+          [{ private_endpoint: 'https://safe-second-api.io/v2', path: '/lets-go' }, "{{uri | remove_first: '/lets%-go'}}"],
+          [{ private_endpoint: 'https://safe-second-api.io/v2', path: '/let/us+go' }, "{{uri | remove_first: '/let/us%+go'}}"],
+          [{ private_endpoint: 'https://safe-api-api.io/', path: '/path%20with%20percent' }, "{{uri | remove_first: '/path%%20with%%20percent'}}"],
         ].each do |config, replace_path_value|
           expected_replace_path = replace_path_value ? { replace_path: replace_path_value } : {}
           assert_equal expected_replace_path, rule_class.new(stub(config)).replace_path

--- a/test/unit/lua_utility_test.rb
+++ b/test/unit/lua_utility_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LuaUtilityTest < ActiveSupport::TestCase
+  test '#escape' do
+    assert_equal 'mystring', LuaUtility.escape('mystring')
+    assert_equal 'my%%string', LuaUtility.escape('my%string')
+    assert_equal 'my%-string', LuaUtility.escape('my-string')
+    assert_equal 'my%+string', LuaUtility.escape('my+string')
+    assert_equal 'my%(string', LuaUtility.escape('my(string')
+    assert_equal 'my%(string%)', LuaUtility.escape('my(string)')
+    assert_equal 'my%*string', LuaUtility.escape('my*string')
+    assert_equal 'my%[string]', LuaUtility.escape('my[string]')
+    assert_equal 'my%^string', LuaUtility.escape('my^string')
+    assert_equal 'my%$string', LuaUtility.escape('my$string')
+    assert_equal 'my@string', LuaUtility.escape('my@string')
+    assert_equal 'my%-c/o/o/l%-string', LuaUtility.escape('my-c/o/o/l-string')
+  end
+end


### PR DESCRIPTION
Routing paths that include [Lua magic characters](https://www.lua.org/pil/20.2.html) will cause apicast to fail removing the pattern from the backend request before redirect, essentially making the `remove_first` directive injected by porta in the APIAP routing policy rules a no-op in such cases. So the magic characters such as the dash sign (`-`), the plus sign (`+`) and others need to be escaped with a `%` character.

Closes https://issues.redhat.com/browse/THREESCALE-4937