### PR TITLE
Apicast::CurlCommandBuilder renders the page with an invalid uri as well

### DIFF
--- a/app/lib/apicast/curl_command_builder.rb
+++ b/app/lib/apicast/curl_command_builder.rb
@@ -17,7 +17,9 @@ module Apicast
         credentials = proxy.authentication_params_for_proxy
         extheaders = ''
 
-        uri = Addressable::URI.parse(base_endpoint)
+        uri = uri_base_endpoint
+        return unless uri
+
         uri.path, uri.query = path_and_query
 
         case proxy.credentials_location
@@ -33,6 +35,12 @@ module Apicast
       end
 
       protected
+
+      def uri_base_endpoint
+        Addressable::URI.parse(base_endpoint)
+      rescue Addressable::URI::InvalidURIError
+        nil
+      end
 
       def base_endpoint
         raise NoMethodError, __method__

--- a/test/unit/apicast/curl_command_builder_test.rb
+++ b/test/unit/apicast/curl_command_builder_test.rb
@@ -230,5 +230,15 @@ module Apicast
         assert_match %r(http://public-production.fake/\?user_key=), command.to_s
       end
     end
+
+    class InvalidEndpointTest < ActiveSupport::TestCase
+      test 'the command does not raise an error when the base_endpoint is invalid' do
+        proxy = FactoryBot.create(:proxy)
+        proxy.attributes = {sandbox_endpoint: ' https://invalid example.com'}
+        refute proxy.valid?
+
+        assert_nil Apicast::CurlCommandBuilder::StagingBuilder.new(proxy).command
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-4786](https://issues.redhat.com/browse/THREESCALE-4786)

It tries to update the proxy with an invalid URI, it detects it as invalid in the model when it rescues the error and adds an error message. Then, it tries to render the edit page with the error message, but it also tries again to use the URI as such without rescues the error that it rescued before so it gets raised. 

With this PR, the page renders anyway.

https://github.com/3scale/porta/blob/3970c8a478ebcb6e033cd4255d09df5136fe3c90/app/controllers/api/integrations_controller.rb#L30

https://github.com/3scale/porta/blob/3970c8a478ebcb6e033cd4255d09df5136fe3c90/app/models/proxy.rb#L698-L704

https://github.com/3scale/porta/blob/3970c8a478ebcb6e033cd4255d09df5136fe3c90/app/controllers/api/integrations_controller.rb#L46-L57

https://github.com/3scale/porta/blob/3970c8a478ebcb6e033cd4255d09df5136fe3c90/app/views/api/integrations/apicast/shared/_curl.html.slim#L10

https://github.com/3scale/porta/blob/3970c8a478ebcb6e033cd4255d09df5136fe3c90/app/helpers/api/integrations_helper.rb#L4-L11

https://github.com/3scale/porta/blob/3970c8a478ebcb6e033cd4255d09df5136fe3c90/app/lib/apicast/curl_command_builder.rb#L20

### Verification Steps
1. Go to `http://provider-admin.example.com.lvh.me:3000/apiconfig/services/2/integration` and try to edit the proxy with an invalid endpoint value (as you are doing it locally and with the default values, then it is the `staging_endpoint`).
2. See this automatically rendered:
![image](https://user-images.githubusercontent.com/11318903/79462805-49808d80-7ff8-11ea-9db0-b7aadd44fc07.png)
![image](https://user-images.githubusercontent.com/11318903/79480788-de8e8100-800e-11ea-89a9-f9b1c74e743d.png)

