### PR TITLE
Add Account settings Users path to Portafly OAS

### DIFF
--- a/portafly/portafly_api.yml
+++ b/portafly/portafly_api.yml
@@ -56,61 +56,6 @@ paths:
         schema:
           type: integer
         in: query
-  /accounts/invitations:
-    summary: A list of sent invitations
-    description: List of invitations sent by an account
-    get:
-      responses:
-        '200':
-          $ref: '#/components/responses/invitationList'
-      operationId: invitationList
-      summary: Get sent invitations list
-    parameters:
-      - name: page
-        description: Page in the paginated list. Defaults to 1.
-        schema:
-          type: integer
-        in: query
-      - name: per_page
-        description: Number of results per page. Default and max is 500.
-        schema:
-          type: integer
-        in: query
-      - name: account_id
-        description: Id of current account.
-        schema:
-          type: integer
-        in: query
-  /accounts/invitations/new:
-    summary: A new invitation request
-    description: A new invitation request
-    post:
-      responses:
-        '201':
-          $ref: '#/components/responses/invitationNew'
-      operationId: invitationNew
-      summary: Post a new invitation
-    parameters:
-      - name: email
-        description: Email the invitation will be sent to
-        schema:
-          type: string
-        in: query
-  /accounts/invitations/delete/:id:
-    summary: Deletes an invitation
-    description: Deletes an invitation based on id
-    delete:
-      responses:
-        '204':
-          description: Invitation deleted
-      operationId: invitationDelete
-      summary: Deletes an invitation
-    parameters:
-      - name: id
-        description: ID of invitation to delete.
-        schema:
-          type: integer
-        in: query
 components:
   schemas:
     DeveloperAccount:
@@ -186,46 +131,6 @@ components:
           type: array
           items:
             type: string
-    Invitation:
-      title: Root Type for InvitationData
-      description: A simplified format for an invitation data.
-      type: object
-      properties:
-        id:
-          description: The invitation ID number
-          type: integer
-        email:
-          description: The email of the user invited
-          type: string
-        sent_at:
-          format: date-time
-          description: Date when the invitation was sent
-          type: string
-        is_accepted:
-          description: Is the invitation accepted?
-          type: boolean
-        accepted_at:
-          format: date-time
-          description: Date when the invitation was accepted
-          type: string
-      example:
-        id: 2
-        email: stan@southpark.com
-        sent_at: 2019-10-18T05:13:26Z
-        accepted: true
-        accepted_at: 2019-10-19T05:13:26Z
-    InvitationNew:
-      title: Root Type for InvitationNewData
-      description: A simplified format for a new invitation data.
-      type: object
-      properties:
-        email:
-          description: The email of the user invited
-          type: string
-      example:
-        id: 1
-        email: stan@southpark.com
-        sent_at: 2019-10-18T05:13:26Z
   responses:
     developerAccountList:
       content:
@@ -313,38 +218,3 @@ components:
                   can_delete_user: false
                   can_invite_user: false
       description: Account Users List
-    invitationList:
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/Invitation'
-          examples:
-            accountInvitationListExample:
-              value:
-                - id: 1
-                  email: kenny@southpark.com
-                  sent_at: 2019-10-18T05:13:26Z
-                  accepted: false
-                  accepted_at: null
-                - id: 2
-                  email: stan@southpark.com
-                  sent_at: 2019-10-18T05:13:26Z
-                  accepted: true
-                  accepted_at: 2019-10-19T05:13:26Z
-      description: Account Invitations List
-    invitationNew:
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/InvitationNew'
-          examples:
-            invitationNewExample:
-              value:
-                - id: 1
-                  email: kenny@southpark.com
-                  sent_at: 2019-10-18T05:13:26Z
-      description: New Account Invitation

--- a/portafly/portafly_api.yml
+++ b/portafly/portafly_api.yml
@@ -96,22 +96,20 @@ paths:
         schema:
           type: string
         in: query
-  /accounts/invitations/delete:
-    summary: A list of invitations to delete
-    description: Request the deletion of a list of invitations
-    post:
+  /accounts/invitations/delete/:id:
+    summary: Deletes an invitation
+    description: Deletes an invitation based on id
+    delete:
       responses:
-        '202':
-          $ref: '#/components/responses/invitationDeleteList'
-      operationId: invitationDeleteList
-      summary: Post invitations to delete list
+        '204':
+          description: Invitation deleted
+      operationId: invitationDelete
+      summary: Deletes an invitation
     parameters:
-      - name: invitation_ids
-        description: List of ids of invitations to delete.
+      - name: id
+        description: ID of invitation to delete.
         schema:
-          type: array
-          items:
-            type: integer
+          type: integer
         in: query
 components:
   schemas:
@@ -216,37 +214,9 @@ components:
         sent_at: 2019-10-18T05:13:26Z
         accepted: true
         accepted_at: 2019-10-19T05:13:26Z
-    InvitationDelete:
-      title: Root Type for InvitationDeleteData
-      description: A simplified format for an invitation delete data.
-      type: object
-      properties:
-        id:
-          description: The invitation ID number
-          type: integer
-        email:
-          description: The email of the user invited
-          type: string
-        sent_at:
-          format: date-time
-          description: Date of invitation sent
-          type: string
-        accepted:
-          description: Is the invitation accepted ?
-          type: boolean
-        accepted_at:
-          format: date-time
-          description: Date of acceptation of invitation
-          type: string
-      example:
-        id: 2
-        email: stan@southpark.com
-        sent_at: 2019-10-18T05:13:26Z
-        accepted: true
-        accepted_at: 2019-10-19T05:13:26Z
     InvitationNew:
       title: Root Type for InvitationNewData
-      description: A simplified format for a new invitation Z data.
+      description: A simplified format for a new invitation data.
       type: object
       properties:
         email:
@@ -378,24 +348,3 @@ components:
                   email: kenny@southpark.com
                   sent_at: 2019-10-18T05:13:26Z
       description: New Account Invitation
-    invitationDeleteList:
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/InvitationDelete'
-          examples:
-            invitationDeleteListExample:
-              value:
-                - id: 1
-                  email: kenny@southpark.com
-                  sent_at: 2019-10-18T05:13:26Z
-                  accepted: false
-                  accepted_at: null
-                - id: 2
-                  email: stan@southpark.com
-                  sent_at: 2019-10-18T05:13:26Z
-                  accepted: true
-                  accepted_at: 2019-10-19T05:13:26Z
-      description: Account Invitations to Delete List

--- a/portafly/portafly_api.yml
+++ b/portafly/portafly_api.yml
@@ -14,28 +14,48 @@ paths:
     description: A list of developer accounts.
     get:
       responses:
-        "200":
+        '200':
           $ref: '#/components/responses/developerAccountList'
       operationId: developerAccountList
       summary: Get developer account list
     parameters:
-    - name: page
-      description: Page in the paginated list. Defaults to 1.
-      schema:
-        type: integer
-      in: query
-      required: false
-    - name: per_page
-      description: Number of results per page. Default and max is 500.
-      schema:
-        type: integer
-      in: query
-      required: false
-    - name: state
-      description: Account state.
-      schema:
-        type: string
-      in: query
+      - name: page
+        description: Page in the paginated list. Defaults to 1.
+        schema:
+          type: integer
+        in: query
+        required: false
+      - name: per_page
+        description: Number of results per page. Default and max is 500.
+        schema:
+          type: integer
+        in: query
+        required: false
+      - name: state
+        description: Account state.
+        schema:
+          type: string
+        in: query
+  /users:
+    summary: A list of user
+    description: A list of users
+    get:
+      responses:
+        '200':
+          $ref: '#/components/responses/userList'
+      operationId: userList
+      summary: Get account users list
+    parameters:
+      - name: page
+        description: Page in the paginated list. Defaults to 1.
+        schema:
+          type: integer
+        in: query
+      - name: per_page
+        description: Number of results per page. Default and max is 500.
+        schema:
+          type: integer
+        in: query
 components:
   schemas:
     DeveloperAccount:
@@ -74,6 +94,57 @@ components:
         org_name: Umbrella Corp.
         admin_name: Oswell E. Spencer
         apps_count: 3
+    User:
+      title: Root Type for UserData
+      description: A simplified format for a user data.
+      type: object
+      properties:
+        id:
+          description: The user ID number
+          type: integer
+        name:
+          description: The name of the user
+          type: string
+        email:
+          description: The email of the user
+          type: string
+        role:
+          description: The role of the user
+          type: string
+        is_current_user:
+          description: Is current user logged in?
+          type: boolean
+        can_see_users:
+          description: Can the user see other users?
+          type: boolean
+        authenticated_through_sso:
+          description: Is the user authenticated through SSO?
+          type: boolean
+        can_delete_user:
+          description: Can current user delete other users?
+          type: boolean
+        can_invite_user:
+          description: Can the current user invite users?
+          type: boolean
+        permissions:
+          description: List of user permissions
+          type: array
+          items:
+            type: string
+      example:
+        id: 1
+        name: Eric Cartman
+        email: eric@southpark.com
+        role: admin
+        permissions:
+          - Developer Portal
+          - Billing
+          - Settings
+        is_current_user: true
+        can_see_users: true
+        authenticated_through_sso: false
+        can_delete_user: true
+        can_invite_user: true
   responses:
     developerAccountList:
       content:
@@ -85,46 +156,79 @@ components:
           examples:
             developerAccountListExample:
               value:
-              - id: 22
-                created_at: 2018-02-10T09:30Z
-                updated_at: 2018-02-10T09:30Z
-                state: approved
-                org_name: Capsule Corp
-                admin_name: Dr. Brief
-                apps_count: 4
-              - id: 72
-                created_at: 2018-02-10T09:30Z
-                updated_at: 2018-02-10T09:30Z
-                state: approved
-                org_name: FOXHOUND
-                admin_name: Big Boss
-                apps_count: 5
-              - id: 40
-                created_at: 2018-02-11T09:30Z
-                updated_at: 2018-02-11T09:30Z
-                state: pending
-                org_name: B.P.R.D
-                admin_name: Dr. Thomas Manning
-                apps_count: 10
-              - id: 41
-                created_at: 2018-02-12T09:30Z
-                updated_at: 2018-02-12T09:30Z
-                state: approved
-                org_name: MomCorp
-                admin_name: Mom
-                apps_count: 2
-              - id: 42
-                created_at: 2018-02-12T09:30Z
-                updated_at: 2018-02-12T09:30Z
-                state: approved
-                org_name: Sirius Cybernetics
-                admin_name: Admin
-                apps_count: 3
-              - id: 43
-                created_at: 2018-03-10T09:30Z
-                updated_at: 2018-03-10T09:30Z
-                state: approved
-                org_name: Los Pollos Hermanos
-                admin_name: Gustavo Fring
-                apps_count: 4
+                - id: 22
+                  created_at: 2018-02-10T09:30Z
+                  updated_at: 2018-02-10T09:30Z
+                  state: approved
+                  org_name: Capsule Corp
+                  admin_name: Dr. Brief
+                  apps_count: 4
+                - id: 72
+                  created_at: 2018-02-10T09:30Z
+                  updated_at: 2018-02-10T09:30Z
+                  state: approved
+                  org_name: FOXHOUND
+                  admin_name: Big Boss
+                  apps_count: 5
+                - id: 40
+                  created_at: 2018-02-11T09:30Z
+                  updated_at: 2018-02-11T09:30Z
+                  state: pending
+                  org_name: B.P.R.D
+                  admin_name: Dr. Thomas Manning
+                  apps_count: 10
+                - id: 41
+                  created_at: 2018-02-12T09:30Z
+                  updated_at: 2018-02-12T09:30Z
+                  state: approved
+                  org_name: MomCorp
+                  admin_name: Mom
+                  apps_count: 2
+                - id: 42
+                  created_at: 2018-02-12T09:30Z
+                  updated_at: 2018-02-12T09:30Z
+                  state: approved
+                  org_name: Sirius Cybernetics
+                  admin_name: Admin
+                  apps_count: 3
+                - id: 43
+                  created_at: 2018-03-10T09:30Z
+                  updated_at: 2018-03-10T09:30Z
+                  state: approved
+                  org_name: Los Pollos Hermanos
+                  admin_name: Gustavo Fring
+                  apps_count: 4
       description: Developer accountlist
+    userList:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+          examples:
+            accountUserListExample:
+              value:
+                - id: 1
+                  name: Eric Cartman
+                  email: eric@southpark.com
+                  role: admin
+                  is_current_user: true
+                  can_see_users: true
+                  authenticated_through_sso: false
+                  can_delete_user: true
+                  can_invite_user: true
+                - id: 2
+                  name: Kyle Broflovski
+                  email: kyle@southpark.com
+                  role: member
+                  permissions:
+                    - Developer Portal
+                    - Billing
+                    - Settings
+                  is_current_user: false
+                  can_see_users: true
+                  authenticated_through_sso: false
+                  can_delete_user: false
+                  can_invite_user: false
+      description: Account Users List

--- a/portafly/portafly_api.yml
+++ b/portafly/portafly_api.yml
@@ -47,6 +47,26 @@ paths:
       summary: Get account users list
     parameters:
       - name: page
+        description: Current page for pagination
+        schema:
+          type: integer
+        in: query
+      - name: per_page
+        description: Number of results per page. Default and max is 500.
+        schema:
+          type: integer
+        in: query
+  /accounts/invitations:
+    summary: A list of sent invitations
+    description: List of invitations sent by an account
+    get:
+      responses:
+        '200':
+          $ref: '#/components/responses/invitationList'
+      operationId: invitationList
+      summary: Get sent invitations list
+    parameters:
+      - name: page
         description: Page in the paginated list. Defaults to 1.
         schema:
           type: integer
@@ -55,6 +75,43 @@ paths:
         description: Number of results per page. Default and max is 500.
         schema:
           type: integer
+        in: query
+      - name: account_id
+        description: Id of current account.
+        schema:
+          type: integer
+        in: query
+  /accounts/invitations/new:
+    summary: A new invitation request
+    description: A new invitation request
+    post:
+      responses:
+        '201':
+          $ref: '#/components/responses/invitationNew'
+      operationId: invitationNew
+      summary: Post a new invitation
+    parameters:
+      - name: email
+        description: Email the invitation will be sent to
+        schema:
+          type: string
+        in: query
+  /accounts/invitations/delete:
+    summary: A list of invitations to delete
+    description: Request the deletion of a list of invitations
+    post:
+      responses:
+        '202':
+          $ref: '#/components/responses/invitationDeleteList'
+      operationId: invitationDeleteList
+      summary: Post invitations to delete list
+    parameters:
+      - name: invitation_ids
+        description: List of ids of invitations to delete.
+        schema:
+          type: array
+          items:
+            type: integer
         in: query
 components:
   schemas:
@@ -117,7 +174,7 @@ components:
         can_see_users:
           description: Can the user see other users?
           type: boolean
-        authenticated_through_sso:
+        is_authenticated_through_sso:
           description: Is the user authenticated through SSO?
           type: boolean
         can_delete_user:
@@ -131,20 +188,74 @@ components:
           type: array
           items:
             type: string
+    Invitation:
+      title: Root Type for InvitationData
+      description: A simplified format for an invitation data.
+      type: object
+      properties:
+        id:
+          description: The invitation ID number
+          type: integer
+        email:
+          description: The email of the user invited
+          type: string
+        sent_at:
+          format: date-time
+          description: Date when the invitation was sent
+          type: string
+        is_accepted:
+          description: Is the invitation accepted?
+          type: boolean
+        accepted_at:
+          format: date-time
+          description: Date when the invitation was accepted
+          type: string
+      example:
+        id: 2
+        email: stan@southpark.com
+        sent_at: 2019-10-18T05:13:26Z
+        accepted: true
+        accepted_at: 2019-10-19T05:13:26Z
+    InvitationDelete:
+      title: Root Type for InvitationDeleteData
+      description: A simplified format for an invitation delete data.
+      type: object
+      properties:
+        id:
+          description: The invitation ID number
+          type: integer
+        email:
+          description: The email of the user invited
+          type: string
+        sent_at:
+          format: date-time
+          description: Date of invitation sent
+          type: string
+        accepted:
+          description: Is the invitation accepted ?
+          type: boolean
+        accepted_at:
+          format: date-time
+          description: Date of acceptation of invitation
+          type: string
+      example:
+        id: 2
+        email: stan@southpark.com
+        sent_at: 2019-10-18T05:13:26Z
+        accepted: true
+        accepted_at: 2019-10-19T05:13:26Z
+    InvitationNew:
+      title: Root Type for InvitationNewData
+      description: A simplified format for a new invitation Z data.
+      type: object
+      properties:
+        email:
+          description: The email of the user invited
+          type: string
       example:
         id: 1
-        name: Eric Cartman
-        email: eric@southpark.com
-        role: admin
-        permissions:
-          - Developer Portal
-          - Billing
-          - Settings
-        is_current_user: true
-        can_see_users: true
-        authenticated_through_sso: false
-        can_delete_user: true
-        can_invite_user: true
+        email: stan@southpark.com
+        sent_at: 2019-10-18T05:13:26Z
   responses:
     developerAccountList:
       content:
@@ -232,3 +343,59 @@ components:
                   can_delete_user: false
                   can_invite_user: false
       description: Account Users List
+    invitationList:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Invitation'
+          examples:
+            accountInvitationListExample:
+              value:
+                - id: 1
+                  email: kenny@southpark.com
+                  sent_at: 2019-10-18T05:13:26Z
+                  accepted: false
+                  accepted_at: null
+                - id: 2
+                  email: stan@southpark.com
+                  sent_at: 2019-10-18T05:13:26Z
+                  accepted: true
+                  accepted_at: 2019-10-19T05:13:26Z
+      description: Account Invitations List
+    invitationNew:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/InvitationNew'
+          examples:
+            invitationNewExample:
+              value:
+                - id: 1
+                  email: kenny@southpark.com
+                  sent_at: 2019-10-18T05:13:26Z
+      description: New Account Invitation
+    invitationDeleteList:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/InvitationDelete'
+          examples:
+            invitationDeleteListExample:
+              value:
+                - id: 1
+                  email: kenny@southpark.com
+                  sent_at: 2019-10-18T05:13:26Z
+                  accepted: false
+                  accepted_at: null
+                - id: 2
+                  email: stan@southpark.com
+                  sent_at: 2019-10-18T05:13:26Z
+                  accepted: true
+                  accepted_at: 2019-10-19T05:13:26Z
+      description: Account Invitations to Delete List


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends our Open API Specification adding Account Settings > Users path

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/THREESCALE-4765 (mockups and analysis)
https://issues.redhat.com/browse/THREESCALE-4944 (OAS


