### PR TITLE
Save AppKey/RefFilter as DeletedObject for destroyed_by_association

### DIFF
--- a/app/models/application_key.rb
+++ b/app/models/application_key.rb
@@ -1,4 +1,5 @@
 class ApplicationKey < ApplicationRecord
+  include SaveDestroyForApplicationAssociation
 
   KEYS_LIMIT = 5
 

--- a/app/models/concerns/save_destroy_for_application_association.rb
+++ b/app/models/concerns/save_destroy_for_application_association.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module SaveDestroyForApplicationAssociation
+  extend ActiveSupport::Concern
+  included do
+    after_destroy :archive_as_deleted, if: :destroyed_by_association
+  end
+
+  private
+
+  def archive_as_deleted
+    ::DeletedObject.create!(object: self, owner: application, metadata: {value: value})
+  end
+end

--- a/app/models/deleted_object.rb
+++ b/app/models/deleted_object.rb
@@ -4,6 +4,8 @@ class DeletedObject < ApplicationRecord
   belongs_to :owner, polymorphic: true
   belongs_to :object, polymorphic: true
 
+  serialize :metadata, Hash
+
   [Metric, Contract, User].each do |scoped_class|
     scope scoped_class.to_s.underscore.pluralize.to_sym, -> { where(object_type: scoped_class) }
   end

--- a/app/models/deleted_object.rb
+++ b/app/models/deleted_object.rb
@@ -6,7 +6,7 @@ class DeletedObject < ApplicationRecord
 
   serialize :metadata, Hash
 
-  [Metric, Contract, User].each do |scoped_class|
+  [Metric, Contract, User, ApplicationKey, ReferrerFilter].each do |scoped_class|
     scope scoped_class.to_s.underscore.pluralize.to_sym, -> { where(object_type: scoped_class) }
   end
 

--- a/app/models/referrer_filter.rb
+++ b/app/models/referrer_filter.rb
@@ -1,4 +1,6 @@
 class ReferrerFilter < ApplicationRecord
+  include SaveDestroyForApplicationAssociation
+
   REFERRER_FILTERS_LIMIT = 5
 
   belongs_to :application, :class_name => 'Cinstance', :inverse_of => :referrer_filters

--- a/db/migrate/20200420104331_add_metadata_text_column_to_deleted_objects.rb
+++ b/db/migrate/20200420104331_add_metadata_text_column_to_deleted_objects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMetadataTextColumnToDeletedObjects < ActiveRecord::Migration[5.0]
+  def change
+    add_column :deleted_objects, :metadata, :text
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200324130825) do
+ActiveRecord::Schema.define(version: 20200420104331) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer  "owner_id",   precision: 38,                  null: false
@@ -499,6 +499,7 @@ ActiveRecord::Schema.define(version: 20200324130825) do
     t.integer  "object_id",   precision: 38
     t.string   "object_type"
     t.datetime "created_at",  precision: 6,  null: false
+    t.text     "metadata"
   end
 
   add_index "deleted_objects", ["object_type", "object_id"], name: "index_deleted_objects_on_object_type_and_object_id"

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200324130825) do
+ActiveRecord::Schema.define(version: 20200420104331) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -474,6 +474,7 @@ ActiveRecord::Schema.define(version: 20200324130825) do
     t.bigint   "object_id"
     t.string   "object_type"
     t.datetime "created_at",  null: false
+    t.text     "metadata"
     t.index ["object_type", "object_id"], name: "index_deleted_objects_on_object_type_and_object_id", using: :btree
     t.index ["owner_type", "owner_id"], name: "index_deleted_objects_on_owner_type_and_owner_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200324130825) do
+ActiveRecord::Schema.define(version: 20200420104331) do
 
   create_table "access_tokens", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.bigint   "owner_id",                                  null: false
@@ -474,7 +474,8 @@ ActiveRecord::Schema.define(version: 20200324130825) do
     t.string   "owner_type"
     t.bigint   "object_id"
     t.string   "object_type"
-    t.datetime "created_at",  null: false
+    t.datetime "created_at",                null: false
+    t.text     "metadata",        limit: 65535
     t.index ["object_type", "object_id"], name: "index_deleted_objects_on_object_type_and_object_id", using: :btree
     t.index ["owner_type", "owner_id"], name: "index_deleted_objects_on_owner_type_and_owner_id", using: :btree
   end

--- a/test/unit/application_keys_test.rb
+++ b/test/unit/application_keys_test.rb
@@ -14,6 +14,18 @@ class ApplicationKeysTest < ActiveSupport::TestCase
     ApplicationKey.enable_backend!
   end
 
+  test 'archive_as_deleted' do
+    application = FactoryBot.create(:simple_cinstance)
+
+    application_key = FactoryBot.create(:application_key, application: application)
+    assert_no_difference(DeletedObject.application_keys.method(:count)) { application_key.destroy! }
+
+    application_key = FactoryBot.create(:application_key, application: application)
+    application_key.stubs(destroyed_by_association: true)
+    assert_difference(DeletedObject.application_keys.method(:count)) { application_key.destroy! }
+    assert_equal application_key.id, DeletedObject.application_keys.last!.object_id
+  end
+
   test 'have immutable value' do
     assert_raise(ActiveRecord::ActiveRecordError) do
       subject.update_attribute :value, 'another'

--- a/test/unit/deleted_object_test.rb
+++ b/test/unit/deleted_object_test.rb
@@ -18,6 +18,17 @@ class DeletedObjectTest < ActiveSupport::TestCase
     assert_same_elements users.map(&:id),     DeletedObject.users.pluck(:object_id)
   end
 
+  test 'scopes application_keys and referrer_filters' do
+    application = FactoryBot.build_stubbed(:simple_cinstance)
+    app_keys = FactoryBot.build_stubbed_list(:application_key, 2, application: application)
+    app_keys.each { |app_key| DeletedObject.create(owner: application, object: app_key) }
+    ref_filters = FactoryBot.build_stubbed_list(:referrer_filter, 2, application: application)
+    ref_filters.each { |ref_filter| DeletedObject.create(owner: application, object: ref_filter) }
+
+    assert_same_elements app_keys.map(&:id),    DeletedObject.application_keys.pluck(:object_id)
+    assert_same_elements ref_filters.map(&:id), DeletedObject.referrer_filters.pluck(:object_id)
+  end
+
   test 'deleted_owner' do
     service = FactoryBot.create(:simple_service)
     metric = FactoryBot.create(:metric, service: service)

--- a/test/unit/referrer_filters_test.rb
+++ b/test/unit/referrer_filters_test.rb
@@ -14,6 +14,18 @@ class ReferrerFiltersTest < ActiveSupport::TestCase
     end
   end
 
+  test 'archive_as_deleted' do
+    application = FactoryBot.create(:simple_cinstance)
+
+    referrer_filter = FactoryBot.create(:referrer_filter, application: application)
+    assert_no_difference(DeletedObject.referrer_filters.method(:count)) { referrer_filter.destroy! }
+
+    referrer_filter = FactoryBot.create(:referrer_filter, application: application)
+    referrer_filter.stubs(destroyed_by_association: true)
+    assert_difference(DeletedObject.referrer_filters.method(:count)) { referrer_filter.destroy! }
+    assert_equal referrer_filter.id, DeletedObject.referrer_filters.last!.object_id
+  end
+
   context 'referrer_filters' do
 
     setup do


### PR DESCRIPTION
Extracted from #1815 as part of [THREESCALE-4806](https://issues.redhat.com/browse/THREESCALE-4806
)

There are corrections and comments from https://github.com/3scale/porta/pull/1815#discussion_r412776325 😄 

It has the same naming as #1827 

We also clean DeletedObject orphans 1 week after their parents have been deleted, so even if at 1st we will save things that we won't need, it will be only for 1 week.
