### PR TITLE
When a Cinstance is destroyed => We delete in Apisonator the Cinstance and its associations saved in DeletedObject

### DIFF
--- a/app/events/applications/application_deleted_event.rb
+++ b/app/events/applications/application_deleted_event.rb
@@ -4,12 +4,16 @@ class Applications::ApplicationDeletedEvent < ApplicationRelatedEvent
 
   # @param [Cinstance] application
   def self.create(application)
+    service_id = application.service_id
     new(
       application: MissingModel::MissingApplication.new(id: application.id),
+      service_id: service_id,
+      user_key: application.user_key,
+      application_id: application.application_id,
       metadata: {
         provider_id: application.provider_account_id || application.tenant_id,
         zync: {
-          service_id: application.service_id,
+          service_id: service_id,
           proxy_id: application.service.try(:proxy).try(:id)
         }
       }

--- a/app/events/applications/application_deleted_event.rb
+++ b/app/events/applications/application_deleted_event.rb
@@ -8,7 +8,6 @@ class Applications::ApplicationDeletedEvent < ApplicationRelatedEvent
     new(
       application: MissingModel::MissingApplication.new(id: application.id),
       service_id: service_id,
-      user_key: application.user_key,
       application_id: application.application_id,
       metadata: {
         provider_id: application.provider_account_id || application.tenant_id,

--- a/app/lib/event_store/repository.rb
+++ b/app/lib/event_store/repository.rb
@@ -163,6 +163,7 @@ module EventStore
       subscribe_event(ServiceTokenEventSubscriber.new, ServiceTokenDeletedEvent)
       subscribe_event(ServiceDeletionSubscriber.new, Services::ServiceScheduledForDeletionEvent)
       subscribe_event(ServiceDeletedSubscriber.new, Services::ServiceDeletedEvent)
+      subscribe_event(ApplicationDeletedSubscriber.new, Applications::ApplicationDeletedEvent)
       subscribe_event(ProxyConfigEventSubscriber.new, ProxyConfigs::AffectingObjectChangedEvent)
       subscribe_event(ZyncSubscriber.new, ZyncEvent)
     end

--- a/app/models/deleted_object.rb
+++ b/app/models/deleted_object.rb
@@ -25,4 +25,12 @@ class DeletedObject < ApplicationRecord
       & (created_at <= 1.week.ago)
     end
   end
+
+  def object_instance
+    obj_attrs = {id: object_id}.merge(metadata)
+    object = object_type.constantize.new(obj_attrs, without_protection: true)
+    yield(object) if block_given?
+    object.readonly!
+    object.freeze
+  end
 end

--- a/app/subscribers/application_deleted_subscriber.rb
+++ b/app/subscribers/application_deleted_subscriber.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ApplicationDeletedSubscriber < AfterCommitSubscriber
+  def after_commit(event)
+    case event
+    when Applications::ApplicationDeletedEvent then BackendDeleteApplicationWorker.perform_later(event.event_id)
+    else raise "Unknown event type #{event.class}"
+    end
+  end
+end

--- a/app/workers/backend_delete_application_worker.rb
+++ b/app/workers/backend_delete_application_worker.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class BackendDeleteApplicationWorker < ApplicationJob
+  queue_as :low
+
+  def perform(event_id)
+    event = EventStore::Repository.find_event!(event_id)
+
+    @application = build_application(event)
+
+    [ApplicationKey, ReferrerFilter].each(&method(:delete_backend_associations))
+
+    delete_backend_application
+  rescue ActiveRecord::RecordNotFound => exception
+    System::ErrorReporting.report_error(exception, parameters: {event_id: event_id})
+  end
+
+  private
+
+  attr_reader :application
+
+  def build_application(event)
+    app_attrs = {id: event.application.id, user_key: event.user_key, application_id: event.application_id}
+    Cinstance.new(app_attrs, without_protection: true).tap do |app|
+      app.service = Service.new({id: event.service_id}, without_protection: true)
+    end
+  end
+
+  def build_association_object(deleted_object)
+    deleted_object.object_instance { |object| object.application = application }
+  end
+
+  def delete_backend_associations(klass)
+    DeletedObject.public_send(klass.to_s.underscore.pluralize).where(owner: application).order(:id).find_each do |deleted_object|
+      build_association_object(deleted_object).destroy_backend_value
+    end
+  end
+
+  def delete_backend_application
+    application.delete_backend_user_key_to_application_id_mapping
+    application.delete_backend_application
+  end
+end

--- a/test/events/applications/application_deleted_event_test.rb
+++ b/test/events/applications/application_deleted_event_test.rb
@@ -20,7 +20,6 @@ class Applications::ApplicationDeletedEventTest < ActiveSupport::TestCase
     event_stored = EventStore::Repository.find_event!(event.event_id)
     assert_equal application.id, event_stored.application.id
     assert_equal application.service_id, event_stored.service_id
-    assert_equal application.user_key, event_stored.user_key
     assert_equal application.application_id, event_stored.application_id
     assert_equal provider_id, event_stored.metadata[:provider_id]
     assert_equal application.service_id, event_stored.metadata.dig(:zync, :service_id)

--- a/test/events/applications/application_deleted_event_test.rb
+++ b/test/events/applications/application_deleted_event_test.rb
@@ -18,8 +18,12 @@ class Applications::ApplicationDeletedEventTest < ActiveSupport::TestCase
     event = Applications::ApplicationDeletedEvent.create_and_publish!(application.reload)
 
     event_stored = EventStore::Repository.find_event!(event.event_id)
+    assert_equal application.id, event_stored.application.id
+    assert_equal application.service_id, event_stored.service_id
+    assert_equal application.user_key, event_stored.user_key
+    assert_equal application.application_id, event_stored.application_id
     assert_equal provider_id, event_stored.metadata[:provider_id]
-    assert event_stored.metadata.dig(:zync, :service_id)
+    assert_equal application.service_id, event_stored.metadata.dig(:zync, :service_id)
     assert event_stored.metadata[:zync].has_key?(:proxy_id)
     assert_nil event_stored.metadata.dig(:zync, :proxy_id)
   end

--- a/test/subscribers/application_deleted_subscriber_test.rb
+++ b/test/subscribers/application_deleted_subscriber_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationDeletedSubscriberTest < ActiveSupport::TestCase
+  def test_create
+    application = FactoryBot.build_stubbed(:simple_cinstance)
+    event = Applications::ApplicationDeletedEvent.create_and_publish!(application)
+
+    BackendDeleteApplicationWorker.expects(:perform_later).with(event.event_id)
+
+    ApplicationDeletedSubscriber.new.after_commit(event)
+  end
+end

--- a/test/unit/deleted_object_test.rb
+++ b/test/unit/deleted_object_test.rb
@@ -86,4 +86,17 @@ class DeletedObjectTest < ActiveSupport::TestCase
     assert_not_includes stale, deleted_object_service_but_owner_persisted_recent
     assert_not_includes stale, deleted_object_account_but_owner_persisted_recent
   end
+
+  test 'object_instance' do
+    app_key = FactoryBot.build_stubbed(:application_key)
+    deleted_object = DeletedObject.create(owner: app_key.application, object: app_key, metadata: {value: app_key.value})
+
+    object = deleted_object.object_instance { |obj| obj.application = app_key.application }
+
+    assert object.readonly?
+    assert_equal ApplicationKey, object.class
+    assert_equal app_key.id, object.id
+    assert_equal app_key.value, object.value
+    assert_equal app_key.application, object.application
+  end
 end

--- a/test/workers/backend_delete_application_worker_test.rb
+++ b/test/workers/backend_delete_application_worker_test.rb
@@ -18,7 +18,6 @@ class BackendDeleteApplicationWorkerTest < ActiveSupport::TestCase
     seq = sequence('destroy sequence')
     app_keys.each { |app_key| ThreeScale::Core::ApplicationKey.expects(:delete).with(service.id.to_s, application.application_id, app_key.value).in_sequence(seq) }
     ref_filters.each { |ref_filter| ThreeScale::Core::ApplicationReferrerFilter.expects(:delete).with(service.id.to_s, application.application_id, ref_filter.value).in_sequence(seq) }
-    ThreeScale::Core::Application.expects(:delete_id_by_key).with(service.id.to_s, application.user_key).in_sequence(seq)
     ThreeScale::Core::Application.expects(:delete).with(service.id.to_s, application.application_id).in_sequence(seq)
 
     event = Applications::ApplicationDeletedEvent.create_and_publish!(application)

--- a/test/workers/backend_delete_application_worker_test.rb
+++ b/test/workers/backend_delete_application_worker_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class BackendDeleteApplicationWorkerTest < ActiveSupport::TestCase
+  test 'perform' do
+    application = FactoryBot.create(:simple_cinstance)
+    service = application.plan.service
+
+    app_keys = FactoryBot.build_stubbed_list(:application_key, 2, application: application)
+    app_keys.each { |app_key| DeletedObject.create(owner: application, object: app_key, metadata: {value: app_key.value}) }
+    ref_filters = FactoryBot.build_stubbed_list(:referrer_filter, 2, application: application)
+    ref_filters.each { |ref_filter| DeletedObject.create(owner: application, object: ref_filter, metadata: {value: ref_filter.value}) }
+
+    app_key_of_another_application = FactoryBot.build_stubbed(:application_key)
+    DeletedObject.create(object: app_key_of_another_application, owner: app_key_of_another_application.application)
+
+    seq = sequence('destroy sequence')
+    app_keys.each { |app_key| ThreeScale::Core::ApplicationKey.expects(:delete).with(service.id.to_s, application.application_id, app_key.value).in_sequence(seq) }
+    ref_filters.each { |ref_filter| ThreeScale::Core::ApplicationReferrerFilter.expects(:delete).with(service.id.to_s, application.application_id, ref_filter.value).in_sequence(seq) }
+    ThreeScale::Core::Application.expects(:delete_id_by_key).with(service.id.to_s, application.user_key).in_sequence(seq)
+    ThreeScale::Core::Application.expects(:delete).with(service.id.to_s, application.application_id).in_sequence(seq)
+
+    event = Applications::ApplicationDeletedEvent.create_and_publish!(application)
+    Sidekiq::Testing.inline! { BackendDeleteApplicationWorker.perform_later(event.event_id) }
+  end
+
+  test 'perform reports error when the event does not exist' do
+    System::ErrorReporting.expects(:report_error).once.with do |exception, options|
+      exception.is_a?(ActiveRecord::RecordNotFound) && (parameters = options[:parameters]) && parameters[:event_id] == 'fake-id'
+    end
+    Sidekiq::Testing.inline! { BackendDeleteApplicationWorker.perform_later('fake-id') }
+  end
+end


### PR DESCRIPTION
Extracted from #1815 as part of [THREESCALE-4806](https://issues.redhat.com/browse/THREESCALE-4806
)

Depends on #1829 (already merged 💃 )