### PR TITLE
[Refactor] Service objects for destroy_backend_value in associations of Application

### DIFF
--- a/app/events/applications/application_deleted_event.rb
+++ b/app/events/applications/application_deleted_event.rb
@@ -3,17 +3,18 @@
 class Applications::ApplicationDeletedEvent < ApplicationRelatedEvent
 
   # @param [Cinstance] application
+  # :reek:NilCheck but proxy can be nil at this point
   def self.create(application)
-    service_id = application.service_id
+    service = application.service || Service.new({id: application.service_id}, without_protection: true)
     new(
       application: MissingModel::MissingApplication.new(id: application.id),
-      service_id: service_id,
+      service_backend_id: service.backend_id,
       application_id: application.application_id,
       metadata: {
         provider_id: application.provider_account_id || application.tenant_id,
         zync: {
-          service_id: service_id,
-          proxy_id: application.service.try(:proxy).try(:id)
+          service_id: service.id,
+          proxy_id: service.proxy&.id
         }
       }
     )

--- a/app/lib/backend/model_extensions/cinstance.rb
+++ b/app/lib/backend/model_extensions/cinstance.rb
@@ -18,13 +18,6 @@ module Backend
         end
       end
 
-      def delete_backend_cinstance
-        application_keys.each(&:destroy_backend_value)
-        referrer_filters.each(&:destroy_backend_value)
-        delete_backend_user_key_to_application_id_mapping
-        delete_backend_application
-      end
-
       def update_backend_application
         if plan && service
           state = self.state

--- a/app/models/application_key.rb
+++ b/app/models/application_key.rb
@@ -126,15 +126,15 @@ class ApplicationKey < ApplicationRecord
                                           value)
   end
 
-  def destroy_backend_value
-    ThreeScale::Core::ApplicationKey.delete(application.service.backend_id,
-                                            application.application_id,
-                                            value)
-  end
-
   delegate :provider_id_for_audits, to: :account, allow_nil: true
 
   protected
+
+  def destroy_backend_value
+    ApplicationKeyBackendService.delete(service_backend_id: application.service.backend_id,
+                                        application_backend_id: application.application_id,
+                                        value: value)
+  end
 
   def publish_application_event
     Applications::ApplicationUpdatedEvent.create_and_publish!(application)

--- a/app/models/deleted_object.rb
+++ b/app/models/deleted_object.rb
@@ -26,12 +26,4 @@ class DeletedObject < ApplicationRecord
       & (created_at <= 1.week.ago)
     end
   end
-
-  def object_instance
-    obj_attrs = {id: object_id}.merge(metadata)
-    object = object_type.constantize.new(obj_attrs, without_protection: true)
-    yield(object) if block_given?
-    object.readonly!
-    object.freeze
-  end
 end

--- a/app/models/referrer_filter.rb
+++ b/app/models/referrer_filter.rb
@@ -84,14 +84,14 @@ class ReferrerFilter < ApplicationRecord
                                                      value)
   end
 
+  protected
+
   def destroy_backend_value
-    ThreeScale::Core::ApplicationReferrerFilter.delete(application.service.backend_id,
-                                                       application.application_id,
-                                                       value)
+    ReferrerFilterBackendService.delete(service_backend_id: application.service.backend_id,
+                                        application_backend_id: application.application_id,
+                                        value: value)
 
   end
-
-  protected
 
   def cache_needed_associations
     self.application

--- a/app/services/application_association_backend_service.rb
+++ b/app/services/application_association_backend_service.rb
@@ -2,7 +2,7 @@
 
 module ApplicationAssociationBackendService
   def delete_all(application_id:, service_backend_id:, application_backend_id:)
-    DeletedObject.public_send(reflection_name).where(owner_type: Contract, owner_id: application_id).order(:id).find_each do |deleted_object|
+    DeletedObject.public_send(reflection_name).where(owner_type: Contract.name, owner_id: application_id).order(id: :asc).find_each do |deleted_object|
       delete(service_backend_id: service_backend_id, application_backend_id: application_backend_id, value: deleted_object.metadata[:value])
     end
   end

--- a/app/services/application_association_backend_service.rb
+++ b/app/services/application_association_backend_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ApplicationAssociationBackendService
+  def delete_all(application_id:, service_backend_id:, application_backend_id:)
+    DeletedObject.public_send(reflection_name).where(owner_type: Contract, owner_id: application_id).order(:id).find_each do |deleted_object|
+      delete(service_backend_id: service_backend_id, application_backend_id: application_backend_id, value: deleted_object.metadata[:value])
+    end
+  end
+
+  def delete(service_backend_id:, application_backend_id:, value:)
+    pisoni_class.delete(service_backend_id, application_backend_id, value)
+  end
+
+  def reflection_name
+    raise NoMethodError, __method__
+  end
+
+  def pisoni_class
+    raise NoMethodError, __method__
+  end
+end

--- a/app/services/application_key_backend_service.rb
+++ b/app/services/application_key_backend_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ApplicationKeyBackendService
+  module_function
+  extend ApplicationAssociationBackendService
+
+  def reflection_name
+    :application_keys
+  end
+
+  def pisoni_class
+    ThreeScale::Core::ApplicationKey
+  end
+end

--- a/app/services/referrer_filter_backend_service.rb
+++ b/app/services/referrer_filter_backend_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ReferrerFilterBackendService
+  module_function
+  extend ApplicationAssociationBackendService
+
+  def reflection_name
+    :referrer_filters
+  end
+
+  def pisoni_class
+    ThreeScale::Core::ApplicationReferrerFilter
+  end
+end

--- a/app/workers/backend_delete_application_worker.rb
+++ b/app/workers/backend_delete_application_worker.rb
@@ -4,18 +4,22 @@ class BackendDeleteApplicationWorker < ApplicationJob
   queue_as :low
 
   def perform(event_id)
-    event = EventStore::Repository.find_event!(event_id)
+    @event = EventStore::Repository.find_event!(event_id)
 
-    DeletedObject.application_keys.where(owner_type: Contract, owner_id: event.application.id).order(:id).find_each do |deleted_object|
-      ThreeScale::Core::ApplicationKey.delete(event.service_id.to_s, event.application_id, deleted_object.metadata[:value])
-    end
+    delete_associations
 
-    DeletedObject.referrer_filters.where(owner_type: Contract, owner_id: event.application.id).order(:id).find_each do |deleted_object|
-      ThreeScale::Core::ApplicationReferrerFilter.delete(event.service_id.to_s, event.application_id, deleted_object.metadata[:value])
-    end
-
-    ThreeScale::Core::Application.delete(event.service_id.to_s, event.application_id)
+    ThreeScale::Core::Application.delete(event.service_backend_id, event.application_id)
   rescue ActiveRecord::RecordNotFound => exception
     System::ErrorReporting.report_error(exception, parameters: {event_id: event_id})
   end
+
+  private
+
+  attr_reader :event
+
+  def delete_associations
+    delete_params = { application_id: event.application.id, service_backend_id: event.service_backend_id, application_backend_id: event.application_id }
+    [ApplicationKeyBackendService, ReferrerFilterBackendService].each { |klass| klass.delete_all(delete_params) }
+  end
+
 end

--- a/app/workers/backend_delete_application_worker.rb
+++ b/app/workers/backend_delete_application_worker.rb
@@ -6,33 +6,16 @@ class BackendDeleteApplicationWorker < ApplicationJob
   def perform(event_id)
     event = EventStore::Repository.find_event!(event_id)
 
-    @application = build_application(event)
+    DeletedObject.application_keys.where(owner_type: Contract, owner_id: event.application.id).order(:id).find_each do |deleted_object|
+      ThreeScale::Core::ApplicationKey.delete(event.service_id.to_s, event.application_id, deleted_object.metadata[:value])
+    end
 
-    [ApplicationKey, ReferrerFilter].each(&method(:delete_backend_associations))
+    DeletedObject.referrer_filters.where(owner_type: Contract, owner_id: event.application.id).order(:id).find_each do |deleted_object|
+      ThreeScale::Core::ApplicationReferrerFilter.delete(event.service_id.to_s, event.application_id, deleted_object.metadata[:value])
+    end
 
-    application.delete_backend_application
+    ThreeScale::Core::Application.delete(event.service_id.to_s, event.application_id)
   rescue ActiveRecord::RecordNotFound => exception
     System::ErrorReporting.report_error(exception, parameters: {event_id: event_id})
-  end
-
-  private
-
-  attr_reader :application
-
-  def build_application(event)
-    app_attrs = {id: event.application.id, application_id: event.application_id}
-    Cinstance.new(app_attrs, without_protection: true).tap do |app|
-      app.service = Service.new({id: event.service_id}, without_protection: true)
-    end
-  end
-
-  def build_association_object(deleted_object)
-    deleted_object.object_instance { |object| object.application = application }
-  end
-
-  def delete_backend_associations(klass)
-    DeletedObject.public_send(klass.to_s.underscore.pluralize).where(owner: application).order(:id).find_each do |deleted_object|
-      build_association_object(deleted_object).destroy_backend_value
-    end
   end
 end

--- a/test/events/applications/application_deleted_event_test.rb
+++ b/test/events/applications/application_deleted_event_test.rb
@@ -4,22 +4,23 @@ require 'test_helper'
 
 class Applications::ApplicationDeletedEventTest < ActiveSupport::TestCase
   def setup
-    @application = FactoryBot.create(:cinstance)
+    @application = FactoryBot.create(:simple_cinstance)
+    @service = application.service
   end
 
-  attr_reader :application
+  attr_reader :application, :service
 
   def test_create_and_publish_when_the_application_associations_do_not_exist_anymore
     assert provider_id = application.provider_account.id
-    application.service.proxy.destroy!
-    application.service.delete
+    service.proxy.destroy!
+    service.delete
     application.provider_account.delete
 
     event = Applications::ApplicationDeletedEvent.create_and_publish!(application.reload)
 
     event_stored = EventStore::Repository.find_event!(event.event_id)
     assert_equal application.id, event_stored.application.id
-    assert_equal application.service_id, event_stored.service_id
+    assert_equal service.backend_id, event_stored.service_backend_id
     assert_equal application.application_id, event_stored.application_id
     assert_equal provider_id, event_stored.metadata[:provider_id]
     assert_equal application.service_id, event_stored.metadata.dig(:zync, :service_id)

--- a/test/unit/backend/model_extensions/cinstance_test.rb
+++ b/test/unit/backend/model_extensions/cinstance_test.rb
@@ -170,25 +170,4 @@ class Backend::ModelExtensions::CinstanceTest < ActiveSupport::TestCase
 
     cinstance.update_attribute(:user_key, '')
   end
-
-  test '#delete_backend_cinstance deletes application_keys, referrer_filters, user_key and application' do
-    plan      = FactoryBot.create(:application_plan)
-    service   = plan.service
-    buyer     = FactoryBot.create(:buyer_account)
-    cinstance = Cinstance.create!(plan: plan, user_account: buyer, service: service)
-    FactoryBot.create_list(:application_key, 2, application: cinstance)
-    FactoryBot.create_list(:referrer_filter, 2, application: cinstance)
-
-    backend_id = service.backend_id
-    app_id     = cinstance.application_id
-    user_key   = cinstance.user_key
-
-    cinstance.reload
-    cinstance.application_keys.each { |app_key| ThreeScale::Core::ApplicationKey.expects(:delete).with(backend_id, app_id, app_key.value) }
-    cinstance.referrer_filters.each { |referrer_filter| ThreeScale::Core::ApplicationReferrerFilter.expects(:delete).with(backend_id, app_id, referrer_filter.value) }
-    ThreeScale::Core::Application.expects(:delete_id_by_key).with(backend_id, user_key)
-    ThreeScale::Core::Application.expects(:delete).with(backend_id, app_id)
-
-    cinstance.delete_backend_cinstance
-  end
 end

--- a/test/unit/deleted_object_test.rb
+++ b/test/unit/deleted_object_test.rb
@@ -86,17 +86,4 @@ class DeletedObjectTest < ActiveSupport::TestCase
     assert_not_includes stale, deleted_object_service_but_owner_persisted_recent
     assert_not_includes stale, deleted_object_account_but_owner_persisted_recent
   end
-
-  test 'object_instance' do
-    app_key = FactoryBot.build_stubbed(:application_key)
-    deleted_object = DeletedObject.create(owner: app_key.application, object: app_key, metadata: {value: app_key.value})
-
-    object = deleted_object.object_instance { |obj| obj.application = app_key.application }
-
-    assert object.readonly?
-    assert_equal ApplicationKey, object.class
-    assert_equal app_key.id, object.id
-    assert_equal app_key.value, object.value
-    assert_equal app_key.application, object.application
-  end
 end

--- a/test/unit/services/application_key_backend_service_test.rb
+++ b/test/unit/services/application_key_backend_service_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationKeyBackendServiceTest < ActiveSupport::TestCase
+  def setup
+    @application = FactoryBot.create(:simple_cinstance, application_id: 'backend-app-id')
+    @service = application.service
+  end
+
+  attr_reader :application, :service
+
+  test 'delete_all' do
+    app_keys = FactoryBot.build_stubbed_list(:application_key, 2, application: application)
+    app_keys.each { |app_key| DeletedObject.create(owner: application, object: app_key, metadata: {value: app_key.value}) }
+
+    app_key_of_another_application = FactoryBot.build_stubbed(:application_key)
+    DeletedObject.create(object: app_key_of_another_application, owner: app_key_of_another_application.application)
+
+    seq = sequence('app keys destroy sequence')
+    app_keys.each { |app_key| ThreeScale::Core::ApplicationKey.expects(:delete).with(service.backend_id, application.application_id, app_key.value).in_sequence(seq) }
+
+    ApplicationKeyBackendService.delete_all(application_id: application.id, service_backend_id: application.service.backend_id, application_backend_id: application.application_id)
+  end
+
+  test 'delete' do
+    app_key = FactoryBot.build_stubbed(:application_key, application: application)
+    DeletedObject.create(owner: application, object: app_key, metadata: {value: app_key.value})
+
+    app_key_of_another_application = FactoryBot.build_stubbed(:application_key)
+    DeletedObject.create(object: app_key_of_another_application, owner: app_key_of_another_application.application)
+
+    ThreeScale::Core::ApplicationKey.expects(:delete).with(service.backend_id, application.application_id, app_key.value)
+
+    ApplicationKeyBackendService.delete(service_backend_id: application.service.backend_id, application_backend_id: application.application_id, value: app_key.value)
+  end
+end

--- a/test/unit/services/referrer_filter_backend_service_test.rb
+++ b/test/unit/services/referrer_filter_backend_service_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ReferrerFilterBackendServiceTest < ActiveSupport::TestCase
+  def setup
+    @application = FactoryBot.create(:simple_cinstance, application_id: 'backend-app-id')
+    @service = application.service
+  end
+
+  attr_reader :application, :service
+
+  test 'delete_all' do
+    ref_filters = FactoryBot.build_stubbed_list(:referrer_filter, 2, application: application)
+    ref_filters.each { |ref_filter| DeletedObject.create(owner: application, object: ref_filter, metadata: {value: ref_filter.value}) }
+
+    ref_fil_of_another_application = FactoryBot.build_stubbed(:referrer_filter)
+    DeletedObject.create(object: ref_fil_of_another_application, owner: ref_fil_of_another_application.application)
+
+    seq = sequence('ref filters destroy sequence')
+    ref_filters.each { |ref_filter| ThreeScale::Core::ApplicationReferrerFilter.expects(:delete).with(service.backend_id, application.application_id, ref_filter.value).in_sequence(seq) }
+
+    ReferrerFilterBackendService.delete_all(application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id)
+  end
+
+  test 'delete' do
+    ref_filter = FactoryBot.build_stubbed(:referrer_filter, application: application)
+    DeletedObject.create(owner: application, object: ref_filter, metadata: {value: ref_filter.value})
+
+    ref_filter_of_another_application = FactoryBot.build_stubbed(:referrer_filter)
+    DeletedObject.create(object: ref_filter_of_another_application, owner: ref_filter_of_another_application.application)
+
+    ThreeScale::Core::ApplicationReferrerFilter.expects(:delete).with(service.backend_id, application.application_id, ref_filter.value)
+
+    ReferrerFilterBackendService.delete(service_backend_id: service.backend_id, application_backend_id: application.application_id, value: ref_filter.value)
+  end
+end

--- a/test/workers/backend_delete_application_worker_test.rb
+++ b/test/workers/backend_delete_application_worker_test.rb
@@ -4,23 +4,13 @@ require 'test_helper'
 
 class BackendDeleteApplicationWorkerTest < ActiveSupport::TestCase
   test 'perform' do
-    application = FactoryBot.create(:simple_cinstance)
-    service = application.plan.service
-
-    app_keys = FactoryBot.build_stubbed_list(:application_key, 2, application: application)
-    app_keys.each { |app_key| DeletedObject.create(owner: application, object: app_key, metadata: {value: app_key.value}) }
-    ref_filters = FactoryBot.build_stubbed_list(:referrer_filter, 2, application: application)
-    ref_filters.each { |ref_filter| DeletedObject.create(owner: application, object: ref_filter, metadata: {value: ref_filter.value}) }
-
-    app_key_of_another_application = FactoryBot.build_stubbed(:application_key)
-    ref_fil_of_another_application = FactoryBot.build_stubbed(:referrer_filter)
-    DeletedObject.create(object: app_key_of_another_application, owner: app_key_of_another_application.application)
-    DeletedObject.create(object: ref_fil_of_another_application, owner: ref_fil_of_another_application.application)
+    application = FactoryBot.create(:simple_cinstance, application_id: 'backend-app-id')
+    service = application.service
 
     seq = sequence('destroy sequence')
-    app_keys.each { |app_key| ThreeScale::Core::ApplicationKey.expects(:delete).with(service.id.to_s, application.application_id, app_key.value).in_sequence(seq) }
-    ref_filters.each { |ref_filter| ThreeScale::Core::ApplicationReferrerFilter.expects(:delete).with(service.id.to_s, application.application_id, ref_filter.value).in_sequence(seq) }
-    ThreeScale::Core::Application.expects(:delete).with(service.id.to_s, application.application_id).in_sequence(seq)
+    ApplicationKeyBackendService.expects(:delete_all).with(application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id).in_sequence(seq)
+    ReferrerFilterBackendService.expects(:delete_all).with(application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id).in_sequence(seq)
+    ThreeScale::Core::Application.expects(:delete).with(service.backend_id, application.application_id).in_sequence(seq)
 
     event = Applications::ApplicationDeletedEvent.create_and_publish!(application)
     Sidekiq::Testing.inline! { BackendDeleteApplicationWorker.perform_later(event.event_id) }

--- a/test/workers/backend_delete_application_worker_test.rb
+++ b/test/workers/backend_delete_application_worker_test.rb
@@ -13,7 +13,9 @@ class BackendDeleteApplicationWorkerTest < ActiveSupport::TestCase
     ref_filters.each { |ref_filter| DeletedObject.create(owner: application, object: ref_filter, metadata: {value: ref_filter.value}) }
 
     app_key_of_another_application = FactoryBot.build_stubbed(:application_key)
+    ref_fil_of_another_application = FactoryBot.build_stubbed(:referrer_filter)
     DeletedObject.create(object: app_key_of_another_application, owner: app_key_of_another_application.application)
+    DeletedObject.create(object: ref_fil_of_another_application, owner: ref_fil_of_another_application.application)
 
     seq = sequence('destroy sequence')
     app_keys.each { |app_key| ThreeScale::Core::ApplicationKey.expects(:delete).with(service.id.to_s, application.application_id, app_key.value).in_sequence(seq) }


### PR DESCRIPTION
I'm not sure if the way I've done it is a good idea. I definitely need some reviews with suggestions 😄 

This PR intends to improve the code from the reviews I've received in the other PRs of [THREESCALE-4806](https://issues.redhat.com/browse/THREESCALE-4806)

In particular, this is what it does:
1. Add a test to ensure that the ref filters are also removed only belonging to that Application
2. Remove unused method 'delete_backend_cinstance'
3. Use Service Objects instead of rebuilding the model only to call to Pisoni
4. Use service.backend_id instead of service.id.to_s