### PR TITLE
[ThreeScale::SpamProtection::Integration::Controller] mark_possible_spam

### DIFF
--- a/app/lib/three_scale/spam_protection/integration/controller.rb
+++ b/app/lib/three_scale/spam_protection/integration/controller.rb
@@ -12,7 +12,7 @@ module ThreeScale::SpamProtection
         verify_recaptcha(model: object, attribute: :recaptcha)
       end
 
-      def spam_check(object)
+      def spam_check(object, session_store: ThreeScale::SpamProtection::SessionStore)
         return true if logged_in?
 
         case level = site_account.settings.spam_protection_level
@@ -21,6 +21,7 @@ module ThreeScale::SpamProtection
           true
         when :auto
           if object.spam?
+            session_store.new(request.session).mark_possible_spam
             Rails.logger.debug "[SpamProtection][Integration] Captcha filled and object is spam - verifying captcha"
             verify_captcha(object)
           else

--- a/test/integration/developer_portal/passwords_controller_test.rb
+++ b/test/integration/developer_portal/passwords_controller_test.rb
@@ -57,13 +57,17 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
     ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: true)
     Recaptcha::Verify.stubs(skip?: false)
 
+    get developer_portal.new_admin_account_password_path
+    assert_response :success
+    assert_not body.include? 'g-recaptcha'
+
     post developer_portal.admin_account_password_path(email: 'user@example.com')
     assert_equal 'Spam protection failed.', flash[:error]
     assert_redirected_to developer_portal.new_admin_account_password_path(request_password_reset: true)
 
     get developer_portal.new_admin_account_password_path
     assert_response :success
-    assert_not body.include? 'g-recaptcha'
+    assert body.include? 'g-recaptcha'
   end
 
   test 'captcha is not present when spam security disabled' do


### PR DESCRIPTION
**What this PR does / why we need it**:

The controller request should mark in a session that the request was considered as spam for the next GET request. 

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-4531