### PR TITLE
Remove Trait in Account to create BackendApi associated to its default Service

### DIFF
--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -176,13 +176,6 @@ FactoryBot.define do
         account.users << FactoryBot.create(:admin, :account_id => account.id, :username => username, :tenant_id => account.id)
       end
     end
-
-    trait(:with_default_backend_api) do
-      after(:create) do |account|
-        backend_api = FactoryBot.create(:backend_api, account: account)
-        FactoryBot.create(:backend_api_config, service: account.default_service, backend_api: backend_api)
-      end
-    end
   end
 
   factory(:provider_with_billing, :parent => :provider_account) do

--- a/test/functional/api/integrations_controller_test.rb
+++ b/test/functional/api/integrations_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Api::IntegrationsControllerTest < ActionController::TestCase
 
   def setup
-    @provider = FactoryBot.create(:provider_account, :with_default_backend_api)
+    @provider = FactoryBot.create(:provider_account)
     @provider.default_service.service_tokens.create!(value: 'token')
 
     stub_apicast_registry

--- a/test/integration/provider/admin/backend_apis/mapping_rules_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/mapping_rules_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class Provider::Admin::BackendApis::MappingRulesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @provider = FactoryBot.create(:provider_account, :with_default_backend_api)
+    @provider = FactoryBot.create(:provider_account)
     @backend_api = @provider.first_service.backend_api
 
     FactoryBot.create(:proxy_rule, proxy: nil, owner: @backend_api)

--- a/test/integration/provider/admin/backend_apis/metrics_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/metrics_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class Provider::Admin::BackendApis::MetricsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @provider = FactoryBot.create(:provider_account, :with_default_backend_api)
+    @provider = FactoryBot.create(:provider_account)
     @service = @provider.first_service
     @backend_api = @service.backend_api
 

--- a/test/integration/provider/admin/backend_apis/stats/usage_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/stats/usage_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class Provider::Admin::BackendApis::Stats::UsageControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @provider = FactoryBot.create(:provider_account, :with_default_backend_api)
+    @provider = FactoryBot.create(:provider_account)
     @backend_api = @provider.first_service.backend_api
   end
 


### PR DESCRIPTION
Related to https://github.com/3scale/porta/pull/1805

As explained in that issue, we do not need this anymore.

I have removed the trait only from provider_account and not from the simple_service factory because that explanation only applies to the default service and not all services.

Not generating or saving these extra objects anymore may also make the tests a little bit faster.