### PR TITLE
[2.5] Do not recreate OIDCConf object from UI IntegrationsController

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -223,7 +223,7 @@ class Api::IntegrationsController < Api::BaseController
       :error_headers_auth_missing, :error_auth_missing, :error_status_no_match,
       :error_headers_no_match, :error_no_match, :api_test_path, :policies_config,
       proxy_rules_attributes: %i[_destroy id http_method pattern delta metric_id
-                                 redirect_url position last], oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES
+                                 redirect_url position last], oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES + [:id]
     ]
 
     if Rails.application.config.three_scale.apicast_custom_url || @proxy.saas_configuration_driven_apicast_self_managed?

--- a/test/integration/api/integration_test.rb
+++ b/test/integration/api/integration_test.rb
@@ -151,14 +151,29 @@ class IntegrationsTest < ActionDispatch::IntegrationTest
 
 
   test 'update OIDC Authorization flows' do
-    rolling_updates_off
     service = FactoryBot.create(:simple_service, account: @provider)
     ProxyTestService.any_instance.stubs(disabled?: true)
-    patch admin_service_integration_path(service_id: service, proxy: {oidc_configuration_attributes: {standard_flow_enabled: false, direct_access_grants_enabled: true}})
+    service.proxy.oidc_configuration.save!
+    oidc_params = {oidc_configuration_attributes: {standard_flow_enabled: false, direct_access_grants_enabled: true, id: service.proxy.oidc_configuration.id}}
+    assert_no_change of: -> { service.proxy.reload.oidc_configuration.id } do
+      put admin_service_integration_path(service_id: service.id, proxy: oidc_params)
+    end
     assert_response :redirect
 
     service.reload
     refute service.proxy.oidc_configuration.standard_flow_enabled
     assert service.proxy.oidc_configuration.direct_access_grants_enabled
+  end
+
+  test 'cannot update OIDC of another proxy' do
+    service = FactoryBot.create(:simple_service, account: @provider)
+    ProxyTestService.any_instance.stubs(disabled?: true)
+    service.proxy.oidc_configuration.save!
+    another_oidc_config = FactoryBot.create(:oidc_configuration)
+    oidc_params = {oidc_configuration_attributes: {standard_flow_enabled: false, direct_access_grants_enabled: true, id: another_oidc_config.id}}
+    assert_no_change of: -> { service.proxy.reload.oidc_configuration.id } do
+      put admin_service_integration_path(service_id: service.id, proxy: oidc_params)
+    end
+    assert_response :not_found
   end
 end


### PR DESCRIPTION
2.5 part of [THREESCALE-5103](https://issues.redhat.com/browse/THREESCALE-5103)