### PR TITLE
Adds a Provider to handle Toast Alerts in all Portafly

### DIFF
--- a/portafly/src/App.tsx
+++ b/portafly/src/App.tsx
@@ -5,7 +5,8 @@ import { AuthProvider } from 'auth'
 import {
   SwitchWith404,
   LazyRoute,
-  Root
+  Root,
+  AlertsProvider
 } from 'components'
 import { LastLocationProvider } from 'react-router-last-location'
 
@@ -26,9 +27,11 @@ const App = () => (
   <AuthProvider>
     <Router>
       <LastLocationProvider>
-        <Root>
-          <PagesSwitch />
-        </Root>
+        <AlertsProvider>
+          <Root>
+            <PagesSwitch />
+          </Root>
+        </AlertsProvider>
       </LastLocationProvider>
     </Router>
   </AuthProvider>

--- a/portafly/src/components/util/AlertsContext.tsx
+++ b/portafly/src/components/util/AlertsContext.tsx
@@ -1,0 +1,68 @@
+import React, { useContext } from 'react'
+import {
+  AlertGroup,
+  AlertActionCloseButton,
+  Alert,
+  AlertVariant
+} from '@patternfly/react-core'
+import { useTranslation } from 'i18n/useTranslation'
+
+interface IAlert {
+  id: string
+  variant: keyof typeof AlertVariant
+  title: string
+}
+
+type IAlertsContext = { addAlert: (alert: IAlert) => void }
+const AlertsContext = React.createContext<IAlertsContext>({ addAlert: () => {} })
+
+const TIMEOUT = 8000
+
+const AlertsProvider: React.FunctionComponent = ({ children }) => {
+  const { t } = useTranslation('shared')
+
+  type AlertsState = Array<IAlert & { timeout: NodeJS.Timeout }>
+  const [alerts, setAlerts] = React.useState<AlertsState>([])
+
+  const removeAlert = (id: string) => (
+    setAlerts((prevAlerts) => prevAlerts.filter((a) => a.id !== id))
+  )
+
+  const addAlert = (alert: IAlert) => {
+    const timeout = setTimeout(() => removeAlert(alert.id), TIMEOUT)
+    setAlerts((prevAlerts) => [...prevAlerts, { ...alert, timeout }])
+  }
+
+  const CloseButton = ({ id, timeout }: { id: string, timeout: NodeJS.Timeout}) => (
+    <AlertActionCloseButton
+      title={t('alerts.close_button')}
+      onClose={() => {
+        removeAlert(id)
+        clearTimeout(timeout)
+      }}
+    />
+  )
+
+  return (
+    <AlertsContext.Provider value={{ addAlert }}>
+      <AlertGroup isToast>
+        {alerts.map(({
+          id, variant, title, timeout
+        }) => (
+          <Alert
+            key={id}
+            isLiveRegion
+            variant={variant}
+            title={title}
+            action={<CloseButton id={id} timeout={timeout} />}
+          />
+        ))}
+      </AlertGroup>
+      {children}
+    </AlertsContext.Provider>
+  )
+}
+
+const useAlertsContext = () => useContext(AlertsContext)
+
+export { AlertsProvider, useAlertsContext }

--- a/portafly/src/components/util/index.tsx
+++ b/portafly/src/components/util/index.tsx
@@ -1,3 +1,4 @@
 export * from './useA11yRoute'
 export * from './useBreadcrumb'
 export * from './useDocumentTitle'
+export * from './AlertsContext'

--- a/portafly/src/i18n/locales/en/shared.yml
+++ b/portafly/src/i18n/locales/en/shared.yml
@@ -33,4 +33,6 @@ format:
   lowercase: "{{text, lowercase}}"
   lowercase_description: Formats a text as lowercase
   format_description: Utilities to format text
-
+alerts:
+  close_button: 'Close alert'
+  close_button_description: 'Button for closing an alert'

--- a/portafly/src/pages/Overview.tsx
+++ b/portafly/src/pages/Overview.tsx
@@ -1,19 +1,22 @@
 import React from 'react'
 import { useTranslation } from 'i18n/useTranslation'
-import { useA11yRouteChange, useDocumentTitle } from 'components'
+import { useA11yRouteChange, useDocumentTitle, useAlertsContext } from 'components'
 import {
   PageSection,
   TextContent,
   Title,
   Text,
   Card,
-  CardBody
+  CardBody,
+  Button
 } from '@patternfly/react-core'
+import { BellIcon } from '@patternfly/react-icons'
 
 const Overview: React.FunctionComponent = () => {
   const { t } = useTranslation('overview')
   useA11yRouteChange()
   useDocumentTitle(t('page_title'))
+  const { addAlert } = useAlertsContext()
   return (
     <>
       <PageSection variant="light">
@@ -29,6 +32,16 @@ const Overview: React.FunctionComponent = () => {
           <CardBody>
             <TextContent>
               <p>{t('shared:format.uppercase', { text: 'Ohai' })}</p>
+              {/* This is just for testing, will be removed */}
+              <Button
+                icon={<BellIcon />}
+                onClick={() => {
+                  const id = Date.now().toString()
+                  addAlert({ id, variant: 'info', title: `Test Alert ${id}` })
+                }}
+              >
+                Add an Alert
+              </Button>
             </TextContent>
           </CardBody>
         </Card>

--- a/portafly/src/tests/components/util/AlertContext.test.tsx
+++ b/portafly/src/tests/components/util/AlertContext.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { AlertsProvider, useAlertsContext } from 'components'
+import { render } from 'tests/custom-render'
+import { waitFor } from '@testing-library/dom'
+
+const AlertComponent = () => {
+  const { addAlert } = useAlertsContext()
+  React.useEffect(() => addAlert({ id: 'id', title: 'title', variant: 'danger' }), [])
+  return <></>
+}
+
+it('shows an alert that disappears after 8 seconds', async () => {
+  jest.setTimeout(8001)
+  const { getByText, queryByText } = render(
+    <AlertsProvider>
+      <AlertComponent />
+    </AlertsProvider>
+  )
+
+  await waitFor(() => expect(getByText('title')).toBeInTheDocument(), { timeout: 7999 })
+  waitFor(() => expect(queryByText('title')).not.toBeInTheDocument(), { timeout: 8001 })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces a Provider that handles toast-like Alerts. By means of a `useAlertsContext` hook, it is possible to pop an alert up from anywhere in the app, using the same AlertGroup. Each Alert has a lifespan of 8 seconds and can be closed manually.

TODO?: theoretically it should be possible to maintain an alert alive as long as the mouse is on top of it.


**Verification steps** 

A test button has been added to `http://localhost:3000/applications` in order to verify/demo this functionality.
