### PR TITLE
[2.8] Do not recreate OIDCConf object from UI IntegrationsController

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -240,7 +240,7 @@ class Api::IntegrationsController < Api::BaseController
       :error_headers_auth_missing, :error_auth_missing, :error_status_no_match,
       :error_headers_no_match, :error_no_match, :error_status_limits_exceeded, :error_headers_limits_exceeded, :error_limits_exceeded,
       :api_test_path, :policies_config, proxy_rules_attributes: %i[_destroy id http_method pattern delta metric_id
-                                                                   redirect_url position last], oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES
+                                                                   redirect_url position last], oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES + [:id]
     ]
 
     if Rails.application.config.three_scale.apicast_custom_url || @proxy.saas_configuration_driven_apicast_self_managed?

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -101,7 +101,7 @@ class Api::ServicesController < Api::BaseController
   end
 
   def proxy_params
-    oidc_params = %i[oidc_issuer_type oidc_issuer_endpoint jwt_claim_with_client_id jwt_claim_with_client_id_type] + [{oidc_configuration_attributes: OIDCConfiguration::Config::FLOWS}]
+    oidc_params = %i[oidc_issuer_type oidc_issuer_endpoint jwt_claim_with_client_id jwt_claim_with_client_id_type] + [{oidc_configuration_attributes: OIDCConfiguration::Config::FLOWS + [:id]}]
     permitted_params = oidc_params + %i[
       auth_user_key auth_app_id auth_app_key credentials_location hostname_rewrite secret_token
       error_status_auth_failed error_headers_auth_failed error_auth_failed

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -154,12 +154,28 @@ class IntegrationsTest < ActionDispatch::IntegrationTest
   test 'update OIDC Authorization flows' do
     service = FactoryBot.create(:simple_service, account: @provider)
     ProxyTestService.any_instance.stubs(disabled?: true)
-    put admin_service_integration_path(service_id: service.id, proxy: {oidc_configuration_attributes: {standard_flow_enabled: false, direct_access_grants_enabled: true}})
+    service.proxy.oidc_configuration.save!
+    oidc_params = {oidc_configuration_attributes: {standard_flow_enabled: false, direct_access_grants_enabled: true, id: service.proxy.oidc_configuration.id}}
+    assert_no_change of: -> { service.proxy.reload.oidc_configuration.id } do
+      put admin_service_integration_path(service_id: service.id, proxy: oidc_params)
+    end
     assert_response :redirect
 
     service.reload
     refute service.proxy.oidc_configuration.standard_flow_enabled
     assert service.proxy.oidc_configuration.direct_access_grants_enabled
+  end
+
+  test 'cannot update OIDC of another proxy' do
+    service = FactoryBot.create(:simple_service, account: @provider)
+    ProxyTestService.any_instance.stubs(disabled?: true)
+    service.proxy.oidc_configuration.save!
+    another_oidc_config = FactoryBot.create(:oidc_configuration)
+    oidc_params = {oidc_configuration_attributes: {standard_flow_enabled: false, direct_access_grants_enabled: true, id: another_oidc_config.id}}
+    assert_no_change of: -> { service.proxy.reload.oidc_configuration.id } do
+      put admin_service_integration_path(service_id: service.id, proxy: oidc_params)
+    end
+    assert_response :not_found
   end
 
   test 'edit not found for apiap' do

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -31,9 +31,12 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     test 'update the settings' do
       Account.any_instance.stubs(:provider_can_use?).returns(true)
       rolling_update(:api_as_product, enabled: false)
-
       service.update!(deployment_option: 'self_managed')
-      put admin_service_path(service), update_params
+      service.proxy.oidc_configuration.save!
+      previous_oidc_config_id = service.proxy.reload.oidc_configuration.id
+
+      put admin_service_path(service), update_params(oidc_id: previous_oidc_config_id)
+
       assert_equal 'Service information updated.', flash[:notice]
 
       update_service_params = update_params[:service]
@@ -57,11 +60,21 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       end
 
       oidc_configuration = proxy.oidc_configuration
-      oidc_configuration_params.each do |field_name, param_value|
+      oidc_configuration_params.except(:id).each do |field_name, param_value|
         expected_value = param_value == '1'
         assert_equal expected_value, oidc_configuration.public_send(field_name)
       end
+      assert_equal previous_oidc_config_id, proxy.reload.oidc_configuration.id
+    end
 
+    test 'cannot update OIDC of another proxy' do
+      service.proxy.oidc_configuration.save!
+      another_oidc_config = FactoryBot.create(:oidc_configuration)
+      oidc_params = {oidc_configuration_attributes: {direct_access_grants_enabled: true, id: another_oidc_config.id}}
+      assert_no_change of: -> { service.proxy.reload.oidc_configuration.id } do
+        put admin_service_path(service), {service: {proxy_attributes: oidc_params}}
+      end
+      assert_response :not_found
     end
 
     # This test can be removed once used deprecated attributes have been removed from the schema
@@ -159,7 +172,7 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
 
     private
 
-    def update_params
+    def update_params(oidc_id: nil)
       @update_params ||= { service:
         { intentions_required: '0',
           buyers_manage_apps: '0',
@@ -182,7 +195,8 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
               standard_flow_enabled: '1',
               implicit_flow_enabled: '1',
               service_accounts_enabled: '0',
-              direct_access_grants_enabled: '0'
+              direct_access_grants_enabled: '0',
+              id: oidc_id
             }
           }
         }


### PR DESCRIPTION
2.8 patch for [THREESCALE-5103](https://issues.redhat.com/browse/THREESCALE-5103)

### Verification steps
Follow these steps to test it locally.
1. Add this to `config/rolling_updates.yml` (I think that only the 2nd one is necessary for this, but just in case):
```
apicast_v2: true
apicast_oidc: true
```
2. Make webpack work properly for development `bundle exec rake webpack:dev`
3. Run the rails server `UNICORN_WORKERS=8 bundle exec rails server -b 0.0.0.0`
4. You need to ensure that your service has a service token. If you are not sure of that, open sidekiq with the default queue `bundle exec sidekiq -q default -L log/sidekiq.log` and run `bundle exec rake fixes:create_missing_service_tokens`. Then you won't need sidekiq anymore for this so feel free to close it after this 😄 
5. Go to `http://provider-admin.example.com.lvh.me:3000/apiconfig/services/2/integration`,  `Edit authentication settings` and select the _Authentication_ `OpenID Connect`
![image](https://user-images.githubusercontent.com/11318903/80590554-62d40180-8a1c-11ea-930e-bdfc40fc6ce9.png)
![image](https://user-images.githubusercontent.com/11318903/80590479-37e9ad80-8a1c-11ea-8c3b-6f827dc1b32b.png)
6. In `http://provider-admin.example.com.lvh.me:3000/apiconfig/services/2/integration`, `add the base URL of your API and save the configuration`, scroll down to `Authentication Settings`, change the OIDC config, and click to `Update`.
![image](https://user-images.githubusercontent.com/11318903/80590674-9c0c7180-8a1c-11ea-8d81-f4dda909f14d.png)
![image](https://user-images.githubusercontent.com/11318903/80590691-a4fd4300-8a1c-11ea-8a6c-86fe69770729.png)
7. Go to the rails console with `bundle exec rails console` and check the OIDCConfig with `Proxy.find(2).oidc_configuration`. Ensure that it has the configuration that you saved and that it contains an ID.
8. Repeat _step 6_ with a different configuration. Then repeat _step 7_ and see that the new configuration is saved with the data you sent and that the ID is the same one as before.
As a bonus, do `OIDCConfiguration.all` and see that there is only one.

It is recommended to do these steps with this branch and also in a branch without these changes so you can see the difference.
