### PR TITLE
[Bugfix][UI] Apisonator Utilization nil => Show message 'This is an unmetered app'

### DIFF
--- a/app/lib/backend_client/application/utilization.rb
+++ b/app/lib/backend_client/application/utilization.rb
@@ -3,7 +3,7 @@ module BackendClient
     module Utilization
 
       def utilization(metrics_list)
-        utilization_records = ThreeScale::Core::Utilization.load(service_id, id)
+        utilization_records = ThreeScale::Core::Utilization.load(service_id, id) || []
         process_utilization(utilization_records, metrics_list)
       rescue
         System::ErrorReporting.report_error($!)

--- a/test/integration/api/applications_controller_test.rb
+++ b/test/integration/api/applications_controller_test.rb
@@ -123,6 +123,15 @@ class Api::ApplicationsControllerTest < ActionDispatch::IntegrationTest
         assert_match 'was a problem getting utilization', response.body
       end
 
+      test 'shows renders app and a message for utilization when backend result is nil' do
+        ThreeScale::Core::Utilization.expects(:load).with(application.service.backend_id, application.application_id).returns(nil)
+
+        get admin_service_application_path(application.service, application)
+
+        assert_response :success
+        assert_match 'This is an unmetered application, there are no limits defined', response.body
+      end
+
       test 'show renders application for the permitted services ids when there is no access to all services' do
         second_service = FactoryBot.create(:simple_service, account: provider)
         second_plan = FactoryBot.create(:application_plan, issuer: second_service)

--- a/test/unit/backend_client/application/utilization_test.rb
+++ b/test/unit/backend_client/application/utilization_test.rb
@@ -104,4 +104,10 @@ class BackendClient::Application::UtilizationTest < ActiveSupport::TestCase
     assert_equal 2, utilization.size
     assert_same_elements requested_metrics, utilization.map(&:metric)
   end
+
+  test 'nil result returns empty utilizations' do
+    ThreeScale::Core::Utilization.expects(:load).with(@service_id, @application_id).returns(nil)
+
+    assert_equal [], @application.utilization([])
+  end
 end


### PR DESCRIPTION
Closes [THREESCALE-3351 - NoMethodError in api/applications#show](https://issues.redhat.com/browse/THREESCALE-3351)

Bugsnag log:
```
app/lib/backend_client/application/utilization.rb:33:in `process_utilization': undefined method `map' for nil:NilClass (NoMethodError)
    from app/lib/backend_client/application/utilization.rb:7:in `utilization'
    from app/controllers/api/applications_controller.rb:47:in `show'
```

The problem is just that Pisoni can return nil but we weren't contemplating this option here (however, we were covering it in the view already):
https://github.com/3scale/porta/blob/62f27e830b521413b56c984f0f586aec542b3093/app/controllers/api/applications_controller.rb#L46-L48
https://github.com/3scale/porta/blob/62f27e830b521413b56c984f0f586aec542b3093/app/lib/backend_client/application/utilization.rb#L6
https://github.com/3scale/pisoni/blob/9904bce5dfb482a49a49fb5684f6262af7591ada/lib/3scale/core/utilization.rb#L21
https://github.com/3scale/porta/blob/62f27e830b521413b56c984f0f586aec542b3093/app/lib/backend_client/application/utilization.rb#L7
https://github.com/3scale/porta/blob/62f27e830b521413b56c984f0f586aec542b3093/app/lib/backend_client/application/utilization.rb#L33
https://github.com/3scale/porta/blob/62f27e830b521413b56c984f0f586aec542b3093/app/views/buyers/applications/_utilization.html.erb#L5-L6

