### PR TITLE
[Bugfix] LineItem does not raise an error if the cost cannot be converted to BigDecimal

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -44,6 +44,8 @@ class LineItem < ApplicationRecord
 
   def cost=(value)
     self[:cost] = BigDecimal((value || 0).to_s).round(DECIMALS)
+  rescue ArgumentError
+    self[:cost] = 0
   end
 
   def custom?

--- a/test/integration/finance/api/line_items_controller_test.rb
+++ b/test/integration/finance/api/line_items_controller_test.rb
@@ -101,6 +101,15 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response 422
   end
 
+  test 'does not raise an error if the cost cannot be converted to BigDecimal' do
+    assert_difference '@invoice.line_items.count', 1 do
+      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(cost: '$5.50'), accept: Mime[:json]
+    end
+    assert_response :created
+    line_item = @invoice.line_items.order(:id).last!
+    assert_equal ThreeScale::Money.new(0, line_item.currency), line_item.cost 
+  end
+
   test '#destroy' do
     assert_difference( LineItem.method(:count), -1 ) do
       delete api_invoice_line_item_path(invoice_id: @line_item.invoice.id, id: @line_item.id), nil, accept: Mime[:json]

--- a/test/integration/finance/api/line_items_controller_test.rb
+++ b/test/integration/finance/api/line_items_controller_test.rb
@@ -84,16 +84,11 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2222, plan_id
   end
 
-  test '#create' do
-    post api_invoice_line_items_path(@invoice.id), line_item_params, accept: Mime[:json]
-    assert_response :success
-  end
-
   test '#create with attributes saved correctly' do
     assert_difference LineItem.method(:count) do
       post api_invoice_line_items_path(@invoice.id), line_item_params, accept: Mime[:json]
     end
-    new_line_item = LineItem.reorder(:id).last
+    new_line_item = LineItem.reorder(:id).last!
     line_item_params.each do |field_name, field_value|
       assert_equal field_value, new_line_item.send(field_name)
     end


### PR DESCRIPTION
Closes [THREESCALE-4953](https://issues.redhat.com/browse/THREESCALE-4953)

`BigDecimal('something-wrong')` in Ruby 2.3 returns `BigDecimal(0)`
`BigDecimal('something-wrong')` in Ruby 2.4 raises `ArgumentError`

We are using Ruby 2.4 in SaaS since a couple of months ago approx.
This PR makes the easy/quick fix, which is making the code behave like few months ago, since it wasn't failing back then.
A better solution would be returning an invalid error instead, but that is not trivial in our case.