### PR TITLE
[Bugfix][Task] Create default metrics for the backend apis that do not have it

### DIFF
--- a/lib/tasks/backend_api.rake
+++ b/lib/tasks/backend_api.rake
@@ -8,4 +8,11 @@ namespace :backend_api do
       DeleteObjectHierarchyWorker.perform_later(backend_api)
     end
   end
+
+  desc 'Create default metrics for the backend apis that do not have it'
+  task :create_default_metrics => :environment do
+    BackendApi.where.has do
+      not_exists Metric.where.has { owner_type == BackendApi.name }.where.has { owner_id == BabySqueel[:backend_apis].id }.select(:id)
+    end.find_each(&:create_default_metrics)
+  end
 end

--- a/test/unit/tasks/backend_api_test.rb
+++ b/test/unit/tasks/backend_api_test.rb
@@ -2,26 +2,28 @@ require 'test_helper'
 
 module Tasks
   class BackendApiTest < ActiveSupport::TestCase
-    setup do
-      @backend_api = FactoryBot.create(:backend_api)
-      FactoryBot.create(:backend_api_config, backend_api: @backend_api)
-      @orphan_backend_api = FactoryBot.create(:backend_api)
-    end
+    class DestroyOrphans < ActiveSupport::TestCase
+      setup do
+        @backend_api = FactoryBot.create(:backend_api)
+        FactoryBot.create(:backend_api_config, backend_api: @backend_api)
+        @orphan_backend_api = FactoryBot.create(:backend_api)
+      end
 
-    test 'destroy orphans when account can not use api as product' do
-      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-      DeleteObjectHierarchyWorker.expects(:perform_later).with(@orphan_backend_api).once
-      DeleteObjectHierarchyWorker.expects(:perform_later).with(@backend_api).never
+      test 'destroy orphans when account can not use api as product' do
+        Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
+        DeleteObjectHierarchyWorker.expects(:perform_later).with(@orphan_backend_api).once
+        DeleteObjectHierarchyWorker.expects(:perform_later).with(@backend_api).never
 
-      execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
-    end
+        execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
+      end
 
-    test 'does not destroy orphans when account can use api as product' do
-      Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
-      DeleteObjectHierarchyWorker.expects(:perform_later).with(@orphan_backend_api).never
-      DeleteObjectHierarchyWorker.expects(:perform_later).with(@backend_api).never
+      test 'does not destroy orphans when account can use api as product' do
+        Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
+        DeleteObjectHierarchyWorker.expects(:perform_later).with(@orphan_backend_api).never
+        DeleteObjectHierarchyWorker.expects(:perform_later).with(@backend_api).never
 
-      execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
+        execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
+      end
     end
   end
 end

--- a/test/unit/tasks/backend_api_test.rb
+++ b/test/unit/tasks/backend_api_test.rb
@@ -29,11 +29,11 @@ module Tasks
     test 'create_default_metrics' do
       backend_apis_without_metrics = FactoryBot.create_list(:backend_api, 2)
       backend_apis_without_metrics.each { |backend_api| backend_api.metrics.delete_all }
-      _backend_apis_with_metrics = FactoryBot.create_list(:backend_api, 2)
+      backend_apis_with_metrics = FactoryBot.create_list(:backend_api, 2)
 
       execute_rake_task 'backend_api.rake', 'backend_api:create_default_metrics'
 
-      BackendApi.all.each do |backend_api|
+      (backend_apis_without_metrics + backend_apis_with_metrics).each do |backend_api|
         assert_equal 1, backend_api.metrics.count
         assert_instance_of Metric, backend_api.metrics.top_level.hits
       end

--- a/test/unit/tasks/backend_api_test.rb
+++ b/test/unit/tasks/backend_api_test.rb
@@ -25,5 +25,18 @@ module Tasks
         execute_rake_task 'backend_api.rake', 'backend_api:destroy_orphans'
       end
     end
+
+    test 'create_default_metrics' do
+      backend_apis_without_metrics = FactoryBot.create_list(:backend_api, 2)
+      backend_apis_without_metrics.each { |backend_api| backend_api.metrics.delete_all }
+      _backend_apis_with_metrics = FactoryBot.create_list(:backend_api, 2)
+
+      execute_rake_task 'backend_api.rake', 'backend_api:create_default_metrics'
+
+      BackendApi.all.each do |backend_api|
+        assert_equal 1, backend_api.metrics.count
+        assert_instance_of Metric, backend_api.metrics.top_level.hits
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-5137](https://issues.redhat.com/browse/THREESCALE-5137)

Problem explained in https://issues.redhat.com/browse/THREESCALE-5137?focusedCommentId=14066849&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14066849

The reason is that this backend api does not have metrics. Since [THREESCALE-3355](https://issues.redhat.com/browse/THREESCALE-3355), we create this metric for all new backend apis. But [this was made the 9th of September](https://github.com/3scale/porta/commit/6be289ac6ce93b1a83aa99fd6d4bc1f3793b9167), but this backend api was created before that... so we should create it for all the older backend apis.