### PR TITLE
Remove requests about an Application to Apisonator through its user_key as the identifier param

### DIFF
--- a/app/lib/backend/model_extensions/cinstance.rb
+++ b/app/lib/backend/model_extensions/cinstance.rb
@@ -8,9 +8,7 @@ module Backend
           before_destroy :preload_used_associations
           before_validation :set_application_id, :on => :create
 
-          after_commit :update_provider_backend_service_if_user_key_changed, :on => :update
-
-          after_commit :update_backend_user_key_to_application_id_mapping, unless: :destroyed?
+          after_commit :update_provider_backend_service_if_user_key_changed, on: :update
 
           after_commit :update_backend_application, unless: :destroyed?
 
@@ -21,7 +19,6 @@ module Backend
       def delete_backend_cinstance
         application_keys.each(&:destroy_backend_value)
         referrer_filters.each(&:destroy_backend_value)
-        delete_backend_user_key_to_application_id_mapping
         delete_backend_application
       end
 
@@ -47,28 +44,6 @@ module Backend
         else
           Rails.logger.warn("Cinstance id: #{id}, application_id: #{application_id} cannot be deleted from backend")
         end
-        true
-      end
-
-      def update_backend_user_key_to_application_id_mapping
-        user_key_was, current_user_key = previous_changes[:user_key]
-
-        if previously_changed?(:user_key) && service.id.present? && user_key_was.present?
-          ThreeScale::Core::Application.delete_id_by_key(service.backend_id, user_key_was)
-        end
-
-        ## save no matter what, even if not changed, it's safe. Required for backend rake task that are
-        ## unaware of previous changes
-        if !service.nil? && user_key.present?
-          ThreeScale::Core::Application.save_id_by_key(service.backend_id, user_key, application_id)
-        end
-
-        true
-      end
-
-      def delete_backend_user_key_to_application_id_mapping
-        return true if !service || !service.id || user_key.blank?
-        ThreeScale::Core::Application.delete_id_by_key(service.backend_id, user_key)
         true
       end
 

--- a/app/lib/backend/model_extensions/cinstance.rb
+++ b/app/lib/backend/model_extensions/cinstance.rb
@@ -32,6 +32,7 @@ module Backend
                                               :state      => state,
                                               :plan_id    => plan.id,
                                               :plan_name  => plan.name,
+                                              :user_key   => user_key,
                                               :redirect_url => redirect_url )
         end
 

--- a/app/lib/backend/storage_rewrite.rb
+++ b/app/lib/backend/storage_rewrite.rb
@@ -25,7 +25,7 @@ module Backend
 
       Cinstance.find_each do |cinstance|
         cinstance.send(:update_backend_application)
-        cinstance.send(:update_backend_user_key_to_application_id_mapping)
+        cinstance.send(:update_provider_backend_service_if_user_key_changed)
 
         # to ensure that there is a 'backend_object' - there are
         # invalid data floating around
@@ -91,7 +91,7 @@ module Backend
 
       update_cinstance = ->(cinstance) do
         cinstance.send(:update_backend_application)
-        cinstance.send(:update_backend_user_key_to_application_id_mapping)
+        cinstance.send(:update_provider_backend_service_if_user_key_changed)
         if cinstance.provider_account
           cinstance.application_keys.each { |k| k.send(:update_backend_value) }
           cinstance.referrer_filters.each { |f| f.send(:update_backend_value) }

--- a/test/unit/backend/model_extensions/cinstance_test.rb
+++ b/test/unit/backend/model_extensions/cinstance_test.rb
@@ -59,13 +59,14 @@ class Backend::ModelExtensions::CinstanceTest < ActiveSupport::TestCase
     plan = FactoryBot.create(:application_plan, :issuer => service)
     buyer_account = FactoryBot.create(:buyer_account, :provider_account => provider_account)
 
-    cinstance = Cinstance.new(:plan => plan, :user_account => buyer_account)
+    cinstance = Cinstance.new(plan: plan, user_account: buyer_account, user_key: 'my-user-key')
 
     app_id = nil
     ThreeScale::Core::Application.expects(:save)
         .with(has_entries(service_id: service.backend_id,
                          plan_id: plan.id,
                          plan_name: plan.name,
+                         user_key: cinstance.user_key,
                          state: :active)) do |params|
       app_id = params[:id]
     end


### PR DESCRIPTION
Closes [THREESCALE-5151](https://issues.redhat.com/browse/THREESCALE-5151)

Please review each person from @3scale/system-ruby **very carefully**.

### Motivation
I encountered last week a bunch of "repeated" call to Apisonator/Pisoni. We were saving/deleting/updating Cinstances both identifying them by its `ID` and identifying them by its `user_key`. It turns our that this is not only unnecessary, but also those endpoints identifying them through `user_key` have been deprecated for many years, and they only introduced them again 6 years ago with the message "this is deprecated" because in System/Porta side we had not deleted that code yet and it was raising errors in multitenant for them deleting it before us.

### Solution
Let's remove all calls identifying the application by `user_key` and let's keep the already existing calls identifying them by ID. Thus, we only use ID as the identifier, but we keep updating the user_key in the Service when it changes.
The calls we already use and will keep using instead of the old ones are the following.
https://github.com/3scale/porta/blob/356bc620ffaaf0557006ec6347a7aa413f930f84/app/lib/backend/model_extensions/cinstance.rb#L44-L51
https://github.com/3scale/porta/blob/356bc620ffaaf0557006ec6347a7aa413f930f84/app/lib/backend/model_extensions/cinstance.rb#L28-L42
https://github.com/3scale/porta/blob/356bc620ffaaf0557006ec6347a7aa413f930f84/app/lib/backend/model_extensions/cinstance.rb#L87-L97
