### PR TITLE
[Bugfix][ORA-00907] Rake backend_api:test_create_default_metrics

### DIFF
--- a/lib/tasks/backend_api.rake
+++ b/lib/tasks/backend_api.rake
@@ -11,8 +11,8 @@ namespace :backend_api do
 
   desc 'Create default metrics for the backend apis that do not have it'
   task :create_default_metrics => :environment do
-    BackendApi.where.has do
-      not_exists Metric.where.has { owner_type == BackendApi.name }.where.has { owner_id == BabySqueel[:backend_apis].id }.select(:id)
+    BackendApi.order(:id).where.has do
+      not_exists Metric.except(:order).where.has { owner_type == BackendApi.name }.where.has { owner_id == BabySqueel[:backend_apis].id }.select(:id)
     end.find_each(&:create_default_metrics)
   end
 end


### PR DESCRIPTION
Fix Oracle for https://github.com/3scale/porta/pull/1841

```
Error:
 
Tasks::BackendApiTest#test_create_default_metrics:
 
ActiveRecord::StatementInvalid: OCIError: ORA-00907: missing right parenthesis: SELECT * FROM (SELECT  "BACKEND_APIS".* FROM "BACKEND_APIS" WHERE (NOT EXISTS(SELECT "METRICS"."ID" FROM "METRICS" WHERE "METRICS"."OWNER_TYPE" = 'BackendApi' AND "METRICS"."OWNER_ID" = "BACKEND_APIS"."ID" ORDER BY "METRICS"."ID" ASC)) ORDER BY "BACKEND_APIS"."ID" ASC ) WHERE ROWNUM <= :a1
 
    lib/tasks/backend_api.rake:16:in `block (2 levels) in <top (required)>'
    test/test_helpers/rake.rb:12:in `execute_rake_task'
    test/unit/tasks/backend_api_test.rb:34:in `block in <class:BackendApiTest>'
```