### PR TITLE
OAS3 for 3scale API Docs

### DIFF
--- a/app/controllers/provider/admin/api_docs_controller.rb
+++ b/app/controllers/provider/admin/api_docs_controller.rb
@@ -4,7 +4,7 @@ class Provider::Admin::ApiDocsController < Provider::Admin::BaseController
   layout 'provider'
 
   def show
-    render current_account.provider_can_use?(:new_provider_documentation) ? 'show-v2' : action_name
+    render current_account.provider_can_use?(:new_provider_documentation) ? 'show-oas3' : action_name
   end
 
 end

--- a/app/javascript/packs/3scale_api_docs.js
+++ b/app/javascript/packs/3scale_api_docs.js
@@ -1,0 +1,10 @@
+import { ActiveDocsSpecWrapper as ActiveDocsSpec } from 'ActiveDocs/components/ActiveDocsSpec'
+
+document.addEventListener('DOMContentLoaded', () => {
+  ['accounts', 'analytics', 'finance'].forEach(name => {
+    ActiveDocsSpec({
+      url: `/p/admin/api_docs/specs/${name}`,
+      docExpansion: 'none'
+    }, `swagger-ui-${name}`)
+  })
+})

--- a/app/views/provider/admin/api_docs/show-oas3.html.slim
+++ b/app/views/provider/admin/api_docs/show-oas3.html.slim
@@ -1,0 +1,12 @@
+= javascript_pack_tag '3scale_api_docs'
+
+- content_for :title, '3scale API Documentation'
+
+- if current_user.access_tokens.empty?
+  p class='InfoBox InfoBox--notice'
+    = link_to 'Create an access token', provider_admin_user_access_tokens_path
+    ' to authenticate against the Account Management API, the Analytics API and the Billing API.
+
+div id='swagger-ui-accounts' class='swagger-ui-wrap'
+div id='swagger-ui-analytics' class='swagger-ui-wrap'
+div id='swagger-ui-finance' class='swagger-ui-wrap'


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrades the UI to use Swagger-UI 3

**Which issue(s) this PR fixes** 

[THREESCALE-3927: Update our own docs to OAS 2.0 or 3.0](https://issues.redhat.com/browse/THREESCALE-3927)
