### PR TITLE
Improve the Admin Portal User search - THREESCALE-632

### DIFF
--- a/app/indices/account_index.rb
+++ b/app/indices/account_index.rb
@@ -12,7 +12,8 @@ ThinkingSphinx::Index.define(:account, with: :real_time) do
   indexes sphinx_user_ids, as: :user_id
 
   set_property field_weights: { name: 2 }
-
+  set_property charset_table: "0..9, A..Z->a..z, a..z, U+23, U+25, U+27, U+2A..U+2C, U+2E, U+3A, U+3B, U+3F, U+5F, U+60, U+7B, U+7D"
+  
   has :provider_account_id, type: :integer
   has :tenant_id, type: :integer
   has :state, type: :string


### PR DESCRIPTION
[Reopening from right branch, previous PR: [here](https://github.com/3scale/porta/pull/1847)]

**What this PR does / why we need it**
Improve the Admin Portal User search feature in order to find users by email address even in case the address contains two-character strings separated by dots (e.g. test@mail.co.uk)
This isn't currently possible due to min_infix_len being set to 3 in thinking_sphinx.yml

**Which issue(s) this PR fixes**
[THREESCALE-632](https://issues.redhat.com/browse/THREESCALE-632) 

**Verification steps**
Go to the Admin Portal and create a user with email test@mail.co.uk
Force a reindex (or wait for it to happen automatically)
Make sure the user can be found via the seach feature by inserting test@mail.co.uk in the search bar