### PR TITLE
Fix Warning: Pass String instead of Class as value in AR query.

### DIFF
--- a/app/models/deleted_object.rb
+++ b/app/models/deleted_object.rb
@@ -7,7 +7,8 @@ class DeletedObject < ApplicationRecord
   serialize :metadata, Hash
 
   [Metric, Contract, User, ApplicationKey, ReferrerFilter].each do |scoped_class|
-    scope scoped_class.to_s.underscore.pluralize.to_sym, -> { where(object_type: scoped_class) }
+    scoped_class_string = scoped_class.to_s
+    scope scoped_class_string.underscore.pluralize.to_sym, -> { where(object_type: scoped_class_string) }
   end
 
   scope :deleted_owner, -> do


### PR DESCRIPTION
Fixes deprecation warning:
![image](https://user-images.githubusercontent.com/11318903/80957400-588e7a80-8e03-11ea-80a0-d39c0835d046.png)
