### PR TITLE
[WIP] Add possibility to set admin section access from SSO

### DIFF
--- a/app/lib/authentication/strategy/provider_oauth2.rb
+++ b/app/lib/authentication/strategy/provider_oauth2.rb
@@ -8,7 +8,10 @@ module Authentication
 
         def call
           (active_user(find_user) || create_user(session)).tap do |user|
-            strategy.user_used_sso_authorization(user, ThreeScale::OAuth2::UserData.new(uid: uid)) if user
+            if user
+              assign_updatable_sso_attributes(user)
+              strategy.user_used_sso_authorization(user, ThreeScale::OAuth2::UserData.new(uid: uid))
+            end
           end
         end
 
@@ -50,6 +53,10 @@ module Authentication
 
         def site_account
           @site_account ||= users.proxy_association.owner
+        end
+
+        def assign_updatable_sso_attributes(user)
+          user.admin_sections = user_data.admin_access
         end
       end
 

--- a/app/lib/three_scale/oauth2/client_base.rb
+++ b/app/lib/three_scale/oauth2/client_base.rb
@@ -154,6 +154,10 @@ module ThreeScale
         access_token.params['id_token']
       end
 
+      def admin_access
+        (raw_info['admin_sections'] || []).map { |str| str.parameterize.underscore.to_sym }
+      end
+
       private
 
       def scopes

--- a/app/lib/three_scale/oauth2/keycloak_client.rb
+++ b/app/lib/three_scale/oauth2/keycloak_client.rb
@@ -33,6 +33,10 @@ module ThreeScale
         raw_info['sub']
       end
 
+      def user_role
+        raw_info['user_role']
+      end
+
       def realm
         authentication.options.site || raise(MissingRealmError, authentication.options)
       end

--- a/app/lib/three_scale/oauth2/user_data.rb
+++ b/app/lib/three_scale/oauth2/user_data.rb
@@ -2,7 +2,7 @@ module ThreeScale
   module OAuth2
     class UserData
 
-      ATTRIBUTES = %i[email email_verified username uid org_name kind authentication_id id_token].freeze
+      ATTRIBUTES = %i[email email_verified username admin_access uid org_name kind authentication_id id_token].freeze
 
       # @param [ThreeScale::OAuth2::ClientBase] client
       def self.build(client)
@@ -10,6 +10,7 @@ module ThreeScale
           email: client.email,
           email_verified: client.email_verified?,
           username: client.username,
+          admin_access: client.admin_access,
           uid: client.uid,
           org_name: client.org_name,
           kind: client.kind,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ x-system_environment:
     - mailhog
     - memcached
     - mysql
+    - mysqlk
     - redis
+    - keycloak
   environment:
     - DATABASE_URL=mysql2://root@mysql/3scale_system_development
     - REDIS_URL=redis://redis/1
@@ -96,5 +98,35 @@ services:
       - "1025:1025"
       - "8025:8025"
 
+  keycloak:
+    image: quay.io/keycloak/keycloak:latest
+    container_name: keycloak_compose
+    ports:
+      - "8080:8080"
+    environment:
+      JDBC_PARAMS: "useSSL=false"
+      DB_VENDOR: MYSQL
+      DB_ADDR: mysqlk
+      DB_DATABASE: keycloak
+      DB_USER: keycloak
+      DB_PASSWORD: password
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+    depends_on:
+      - mysqlk
+
+  mysqlk:
+    image: mysql:5.7
+    container_name: mysqlk_compose  
+    volumes:
+      - mysql-data-k:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: keycloak
+      MYSQL_USER: keycloak
+      MYSQL_PASSWORD: password
+
 volumes:
   mysql-data:
+  mysql-data-k:
+    driver: local


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Several customers have requested a possibility to set Member access permissions to different sections upon logging in to 3Scale admin portal using SSO.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-1634
https://issues.redhat.com/browse/THREESCALE-1341
https://issues.redhat.com/browse/THREESCALE-1286
https://issues.redhat.com/browse/THREESCALE-400

**Verification steps** 

1. in SSO add user attribute "admin_sections" containing any of:
   portal, finance, settings, partners, monitoring, plans
   eg. admin_sections: portal##finance##plans
2. add mapper in 3scale-provider-admin client:
   add mapper -> user_attribute -> admin_sections
   enable Multivalued, Add to userinfo
3. login using SSO to admin portal as the user to verify available
   sections match