### PR TITLE
Revert "[2.8] Do not recreate OIDCConf object from UI IntegrationsController"

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -240,7 +240,7 @@ class Api::IntegrationsController < Api::BaseController
       :error_headers_auth_missing, :error_auth_missing, :error_status_no_match,
       :error_headers_no_match, :error_no_match, :error_status_limits_exceeded, :error_headers_limits_exceeded, :error_limits_exceeded,
       :api_test_path, :policies_config, proxy_rules_attributes: %i[_destroy id http_method pattern delta metric_id
-                                                                   redirect_url position last], oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES + [:id]
+                                                                   redirect_url position last], oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES
     ]
 
     if Rails.application.config.three_scale.apicast_custom_url || @proxy.saas_configuration_driven_apicast_self_managed?

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -101,7 +101,7 @@ class Api::ServicesController < Api::BaseController
   end
 
   def proxy_params
-    oidc_params = %i[oidc_issuer_type oidc_issuer_endpoint jwt_claim_with_client_id jwt_claim_with_client_id_type] + [{oidc_configuration_attributes: OIDCConfiguration::Config::FLOWS + [:id]}]
+    oidc_params = %i[oidc_issuer_type oidc_issuer_endpoint jwt_claim_with_client_id jwt_claim_with_client_id_type] + [{oidc_configuration_attributes: OIDCConfiguration::Config::FLOWS}]
     permitted_params = oidc_params + %i[
       auth_user_key auth_app_id auth_app_key credentials_location hostname_rewrite secret_token
       error_status_auth_failed error_headers_auth_failed error_auth_failed

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -154,28 +154,12 @@ class IntegrationsTest < ActionDispatch::IntegrationTest
   test 'update OIDC Authorization flows' do
     service = FactoryBot.create(:simple_service, account: @provider)
     ProxyTestService.any_instance.stubs(disabled?: true)
-    service.proxy.oidc_configuration.save!
-    oidc_params = {oidc_configuration_attributes: {standard_flow_enabled: false, direct_access_grants_enabled: true, id: service.proxy.oidc_configuration.id}}
-    assert_no_change of: -> { service.proxy.reload.oidc_configuration.id } do
-      put admin_service_integration_path(service_id: service.id, proxy: oidc_params)
-    end
+    put admin_service_integration_path(service_id: service.id, proxy: {oidc_configuration_attributes: {standard_flow_enabled: false, direct_access_grants_enabled: true}})
     assert_response :redirect
 
     service.reload
     refute service.proxy.oidc_configuration.standard_flow_enabled
     assert service.proxy.oidc_configuration.direct_access_grants_enabled
-  end
-
-  test 'cannot update OIDC of another proxy' do
-    service = FactoryBot.create(:simple_service, account: @provider)
-    ProxyTestService.any_instance.stubs(disabled?: true)
-    service.proxy.oidc_configuration.save!
-    another_oidc_config = FactoryBot.create(:oidc_configuration)
-    oidc_params = {oidc_configuration_attributes: {standard_flow_enabled: false, direct_access_grants_enabled: true, id: another_oidc_config.id}}
-    assert_no_change of: -> { service.proxy.reload.oidc_configuration.id } do
-      put admin_service_integration_path(service_id: service.id, proxy: oidc_params)
-    end
-    assert_response :not_found
   end
 
   test 'edit not found for apiap' do


### PR DESCRIPTION
Reverts 3scale/porta#1838

Just reverting. It won't be a 2.8 patch and will be for 2.9 only 😉 