### PR TITLE
Fix Analytics for API Backends when not used by any API Product

### DIFF
--- a/app/lib/stats/backend_api.rb
+++ b/app/lib/stats/backend_api.rb
@@ -13,6 +13,8 @@ module Stats
     attr_reader :services
 
     def usage(options)
+      return empty_result(options) if services.empty?
+
       results = services.map { |service| service.usage(options) }
       results_values = ->(attr) { results.map { |result| result[attr] } }
 
@@ -29,6 +31,19 @@ module Stats
       result[:change] = total.percentage_change_from(previous_total)
 
       result
+    end
+
+    protected
+
+    def empty_result(options)
+      metric = extract_metric(options.symbolize_keys)
+
+      {
+        metric.class.name.underscore.to_sym => detail(metric),
+        period: period_detail(options),
+        total: 0,
+        values: []
+      }
     end
   end
 end

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -15,6 +15,7 @@ class BackendApi < ApplicationRecord
 
   has_many :proxy_rules, as: :owner, dependent: :destroy, inverse_of: :owner
   has_many :metrics, as: :owner, dependent: :destroy, inverse_of: :owner
+  alias_method :all_metrics, :metrics
 
   has_many :backend_api_configs, inverse_of: :backend_api, dependent: :destroy
   has_many :services, through: :backend_api_configs

--- a/test/unit/stats/backend_api_test.rb
+++ b/test/unit/stats/backend_api_test.rb
@@ -36,6 +36,17 @@ class Stats::BackendApiTest < ActiveSupport::TestCase
     assert_equal 150.0, stats[:change]
   end
 
+  test 'backend api without products' do
+    backend_api.backend_api_configs.delete_all
+    client = Stats::BackendApi.new(backend_api.reload)
+
+    today = Time.utc(2020, 3, 19).to_date
+    range = (today - 1.day)..today
+    stats = client.usage(metric_name: backend_api.metrics.hits.system_name, since: range.begin, until: range.end, granularity: :day, timezone: ActiveSupport::TimeZone['UTC'].name)
+    assert_equal 0, stats[:total]
+    assert stats[:values].empty?
+  end
+
   protected
 
   def fake_storage_stats


### PR DESCRIPTION
The analytics page of API Backends crashes with a 500 in the ajax request to the usage data when the Backend is not used by any Product. This PR fixes the bug.

Closes [THREESCALE-3159](https://issues.redhat.com/browse/THREESCALE-3159)