### PR TITLE
[api] attributes base_url and admin_url to account

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -499,6 +499,8 @@ class Account < ApplicationRecord
       if provider?
         xml.admin_domain admin_domain
         xml.domain domain
+        xml.admin_base_url admin_base_url
+        xml.base_url base_url
         xml.from_email from_email
         xml.support_email support_email
         xml.finance_support_email finance_support_email

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -253,6 +253,14 @@ module Account::ProviderMethods
     end
   end
 
+  def admin_base_url
+    build_base_url(admin_domain)
+  end
+
+  def base_url
+    build_base_url(domain)
+  end
+
   def require_billing_information!
     @require_billing_information = true
   end
@@ -345,6 +353,14 @@ module Account::ProviderMethods
     # we don't do this for master to avoid slow things more
     # reason of the unless : Account.master.provider? => true
     FieldsDefinition.create_defaults!(self) unless master?
+  end
+
+  def base_url_protocol
+    Rails.application.config.force_ssl ? 'https' : 'http'
+  end
+
+  def build_base_url(host)
+    [base_url_protocol, host.to_s.split('://').last].compact.join('://').presence
   end
 
   private

--- a/app/representers/account_representer.rb
+++ b/app/representers/account_representer.rb
@@ -20,6 +20,8 @@ module AccountRepresenter
   with_options(if: ->(*) { provider? }) do
     property :admin_domain
     property :domain
+    property :admin_base_url
+    property :base_url
     property :from_email
     property :support_email
     property :finance_support_email

--- a/spec/acceptance/api/account_spec.rb
+++ b/spec/acceptance/api/account_spec.rb
@@ -14,7 +14,7 @@ resource "Account" do
     account
   end
 
-  let(:expected_provider_fields) { %w[admin_domain domain from_email support_email finance_support_email site_access_code] }
+  let(:expected_provider_fields) { %w[admin_domain domain admin_base_url base_url from_email support_email finance_support_email site_access_code] }
 
   shared_context "with billing address set up" do
     before do

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -770,16 +770,23 @@ class AccountTest < ActiveSupport::TestCase
     # just to make the serialization work
     def account.fields_definitions_source_root!; self; end
 
-    account.domain = 'some.example.com'
-    account.self_domain = 'admin.#{ThreeScale.config.superdomain}'
+    domain = 'some.example.com'
+    admin_domain = 'admin.#{ThreeScale.config.superdomain}'
 
-    domain_xml = '<domain>some.example.com</domain>'
-    admin_domain_xml = '<admin_domain>admin.#{ThreeScale.config.superdomain}</admin_domain>'
+    account.domain = domain
+    account.self_domain = admin_domain
+
+    domain_xml = "<domain>#{domain}</domain>"
+    admin_domain_xml = "<admin_domain>#{admin_domain}</admin_domain>"
+    base_url_xml = "<base_url>http://#{domain}</base_url>"
+    admin_base_url_xml = "<admin_base_url>http://#{admin_domain}</admin_base_url>"
 
     xml = account.to_xml
 
     refute_match domain_xml, xml
     refute_match admin_domain_xml, xml
+    refute_match base_url_xml, xml
+    refute_match admin_base_url_xml, xml
 
     account.provider = true
 
@@ -787,6 +794,8 @@ class AccountTest < ActiveSupport::TestCase
 
     assert_match domain_xml, xml
     assert_match admin_domain_xml, xml
+    assert_match base_url_xml, xml
+    assert_match admin_base_url_xml, xml
   end
 
   test 'settings' do


### PR DESCRIPTION
Introduces two new attributes in the representation of account objects in the admin API responses: `base_url` and `admin_base_url`. These correspond to the existing `domain` and `admin_domain` attributes prepended with the current HTTP scheme of the system (http or https) to make them full URLs, instead of just domain names.

In particular, this change will allow Zync to resolve which TLS configuration to apply to the Kubernetes/OpenShift routes it manages for the accounts, without having to rely on a default.

Related to [THREESCALE-4832](https://issues.redhat.com/browse/THREESCALE-4832).