### PR TITLE
Removes ignored columns of Service from JSON serialization with Apicast::ProviderSource

### DIFF
--- a/app/lib/apicast/provider_source.rb
+++ b/app/lib/apicast/provider_source.rb
@@ -16,6 +16,7 @@ module Apicast
     delegate :services, :provider_key, :id, to: :mash
 
     SERVICE_SERIALIZE_OPTIONS = {
+      except: Service.ignored_columns,
       methods: [:proxiable?, :backend_authentication_type, :backend_authentication_value, :updated_at],
       include: [
         proxy: {

--- a/test/unit/apicast/proxy_source_test.rb
+++ b/test/unit/apicast/proxy_source_test.rb
@@ -1,17 +1,26 @@
 require 'test_helper'
 
 class Apicast::ProxySourceTest < ActiveSupport::TestCase
+  setup do
+    @proxy = FactoryBot.create(:proxy)
+    @source = Apicast::ProxySource.new(@proxy)
+  end
 
-  def test_proxy_rules
-    proxy = FactoryBot.create(:proxy)
+  attr_reader :proxy, :source
+
+  test 'proxy rules' do
     rule_1 = FactoryBot.create(:proxy_rule, proxy: proxy, last: true)
     rule_2 = FactoryBot.create(:proxy_rule, proxy: proxy)
 
-    source = Apicast::ProxySource.new(proxy).to_hash
-    proxy_rules_source = source['proxy']['proxy_rules']
+    proxy_rules_source = source.to_hash.dig('proxy', 'proxy_rules')
     assert proxy_rules_source
     assert find_by_id_in_hash(rule_1.id, proxy_rules_source)['last']
     refute find_by_id_in_hash(rule_2.id, proxy_rules_source)['last']
+  end
+
+  test 'does not include ignored columns of Service' do
+    source_hash = source.to_hash.with_indifferent_access
+    Service.ignored_columns.each { |column| source_hash[column] }
   end
 
   private


### PR DESCRIPTION
`ActiveModel::Serializer::JSON` includes attributes whose corresponding columns are ignored in the model [1][2]. See, for example, in the Rails console,

```ruby
Service.find(2).attributes.keys - Service.column_names
=> ["tech_support_email", "admin_support_email", "act_as_product", "default_end_user_plan_id", "end_user_registration_required"]
```

[1] https://github.com/rails/rails/blob/4642d68d8021893c69bfd16ed6e926ae03a6d777/activemodel/lib/active_model/serializers/json.rb#L88-L101
[2] https://github.com/rails/rails/blob/1fdb98c033f49254394d16ea154c76596d70885b/activemodel/lib/active_model/serialization.rb#L127


This PR makes sure ignored columns of the `Service` model are NOT included in the JSON serialization of the service for the proxy config.

Closes [THREESCALE-5199](https://issues.redhat.com/browse/THREESCALE-5199)