### PR TITLE
Action for Resetting Pagination

### DIFF
--- a/portafly/src/components/data-list/DataListContext.tsx
+++ b/portafly/src/components/data-list/DataListContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useReducer } from 'react'
 import { combineReducers, Action } from 'utils'
 import {
+  defaultPagination,
   filtersReducer,
   paginationReducer,
   useFilters,
@@ -15,12 +16,7 @@ type State = {
 }
 const initialState: State = {
   filters: {},
-  pagination: {
-    page: 1,
-    perPage: 10,
-    startIdx: 0,
-    endIdx: 10
-  }
+  pagination: defaultPagination
 }
 
 export interface IDataListContext {

--- a/portafly/src/components/data-list/reducers/PaginationReducer.ts
+++ b/portafly/src/components/data-list/reducers/PaginationReducer.ts
@@ -12,6 +12,13 @@ export type PaginationState = {
   endIdx?: number
 }
 
+const defaultPagination: PaginationState = {
+  page: 1,
+  perPage: 10,
+  startIdx: 0,
+  endIdx: 10
+}
+
 // Action Handlers
 const paginationActionHandlers: ActionHandlers<PaginationState, PaginationState> = {
   SET_PAGINATION: (state, action) => ({ ...state, ...action.payload })
@@ -31,7 +38,8 @@ const usePagination = ({ state, dispatch }: IUsePagination) => ({
   perPage: state.pagination.perPage,
   startIdx: state.pagination.startIdx,
   endIdx: state.pagination.endIdx,
+  resetPagination: () => dispatch({ type: 'SET_PAGINATION', payload: defaultPagination }),
   setPagination: (pagination: PaginationState) => dispatch({ type: 'SET_PAGINATION', payload: pagination })
 })
 
-export { paginationReducer, usePagination }
+export { paginationReducer, usePagination, defaultPagination }

--- a/portafly/src/components/data-list/reducers/PaginationReducer.ts
+++ b/portafly/src/components/data-list/reducers/PaginationReducer.ts
@@ -20,8 +20,9 @@ const defaultPagination: PaginationState = {
 }
 
 // Action Handlers
+const SET_PAGINATION = 'SET_PAGINATION'
 const paginationActionHandlers: ActionHandlers<PaginationState, PaginationState> = {
-  SET_PAGINATION: (state, action) => ({ ...state, ...action.payload })
+  [SET_PAGINATION]: (state, action) => ({ ...state, ...action.payload })
 }
 
 // Reducer
@@ -38,8 +39,8 @@ const usePagination = ({ state, dispatch }: IUsePagination) => ({
   perPage: state.pagination.perPage,
   startIdx: state.pagination.startIdx,
   endIdx: state.pagination.endIdx,
-  resetPagination: () => dispatch({ type: 'SET_PAGINATION', payload: defaultPagination }),
-  setPagination: (pagination: PaginationState) => dispatch({ type: 'SET_PAGINATION', payload: pagination })
+  resetPagination: () => dispatch({ type: SET_PAGINATION, payload: defaultPagination }),
+  setPagination: (pagination: PaginationState) => dispatch({ type: SET_PAGINATION, payload: pagination })
 })
 
 export { paginationReducer, usePagination, defaultPagination }


### PR DESCRIPTION
**What this PR does / why we need it**:

When being in a distant page (say the last one) and adding filters, the collection is updated but not the Pagination state. It is necessary to reset back to the initial state in order to show the filtered results, for example:
```ts
useEffect(resetPagination, [filters])
```

**Verification steps**:
It can be teste and verified in #1820 