### PR TITLE
[Portafly] Porta-wiring refactor

### DIFF
--- a/portafly/src/auth/AuthContext.tsx
+++ b/portafly/src/auth/AuthContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useState } from 'react'
-
-type AuthToken = string | null
+import { getToken, setToken, AuthToken } from 'utils'
 
 interface IAuthContext {
   authToken: AuthToken,
@@ -13,15 +12,15 @@ const AuthContext = createContext<IAuthContext>({
 })
 
 const AuthProvider: React.FunctionComponent = ({ children }) => {
-  const existingToken = localStorage.getItem('token')
-  const [authToken, setAuthToken] = useState(existingToken && JSON.parse(existingToken))
+  const existingToken = getToken()
+  const [authToken, setAuthToken] = useState(existingToken)
 
-  const setToken = (token: AuthToken) => {
-    localStorage.setItem('token', JSON.stringify(token))
+  const saveToken = (token: AuthToken) => {
+    setToken(token)
     setAuthToken(token)
   }
   return (
-    <AuthContext.Provider value={{ authToken, setAuthToken: setToken }}>
+    <AuthContext.Provider value={{ authToken, setAuthToken: saveToken }}>
       {children}
     </AuthContext.Provider>
   )

--- a/portafly/src/components/data-list/reducers/PaginationReducer.ts
+++ b/portafly/src/components/data-list/reducers/PaginationReducer.ts
@@ -40,7 +40,9 @@ const usePagination = ({ state, dispatch }: IUsePagination) => ({
   startIdx: state.pagination.startIdx,
   endIdx: state.pagination.endIdx,
   resetPagination: () => dispatch({ type: SET_PAGINATION, payload: defaultPagination }),
-  setPagination: (pagination: PaginationState) => dispatch({ type: SET_PAGINATION, payload: pagination })
+  setPagination: (pagination: PaginationState) => (
+    dispatch({ type: SET_PAGINATION, payload: pagination })
+  )
 })
 
 export { paginationReducer, usePagination, defaultPagination }

--- a/portafly/src/dal/accounts/getDeveloperAccounts.ts
+++ b/portafly/src/dal/accounts/getDeveloperAccounts.ts
@@ -1,6 +1,5 @@
-import { useFetch } from 'react-async'
+import { craftRequest, http } from 'utils'
 import { IDeveloperAccount } from 'types'
-import { useAuth } from 'auth'
 
 type User = {
   id: string
@@ -60,37 +59,13 @@ const parseAccounts = (accounts: BuyersAccount[]) => accounts.map(({ account }) 
   state: account.state
 }))
 
-interface Response<T> {
-  payload?: T,
-  error?: Error
-  isPending: boolean
-}
-
-const craftRequest = (path: string, params: URLSearchParams) => {
-  const { authToken } = useAuth()
-
-  params.append('access_token', authToken as string)
-
-  return {
-    resource: `${process.env.REACT_APP_API_HOST}${path}?${params.toString()}`,
-    init: { headers: { Accept: 'application/json' } }
-  }
-}
-
-/**
- * Get all Applications asynchronously
- * @returns An object containing: { accounts, error, isPending }
- */
-function useGetDeveloperAccounts(): Response<IDeveloperAccount[]> {
-  const { resource, init } = craftRequest('/admin/api/accounts.json', new URLSearchParams({
+const getDeveloperAccounts = async (): Promise<IDeveloperAccount[]> => {
+  const request = craftRequest('/admin/api/accounts.json', new URLSearchParams({
     page: '1',
     perPage: '500'
   }))
-  const { data, error, isPending } = useFetch<{ accounts: BuyersAccount[] }>(resource, init)
-
-  const payload = data && parseAccounts(data.accounts)
-
-  return { payload, error, isPending }
+  const data = await http<{ accounts: BuyersAccount[] }>(request)
+  return parseAccounts(data.accounts)
 }
 
-export { useGetDeveloperAccounts }
+export { getDeveloperAccounts }

--- a/portafly/src/dal/accounts/getDeveloperAccounts.ts
+++ b/portafly/src/dal/accounts/getDeveloperAccounts.ts
@@ -1,4 +1,4 @@
-import { craftRequest, http } from 'utils'
+import { craftRequest, fetchData } from 'utils'
 import { IDeveloperAccount } from 'types'
 
 type User = {
@@ -64,7 +64,7 @@ const getDeveloperAccounts = async (): Promise<IDeveloperAccount[]> => {
     page: '1',
     perPage: '500'
   }))
-  const data = await http<{ accounts: BuyersAccount[] }>(request)
+  const data = await fetchData<{ accounts: BuyersAccount[] }>(request)
   return parseAccounts(data.accounts)
 }
 

--- a/portafly/src/pages/DeveloperAccounts.tsx
+++ b/portafly/src/pages/DeveloperAccounts.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useAsync } from 'react-async'
 import { useDocumentTitle, Loading, DeveloperAccountsTable } from 'components'
 import {
   Alert,
@@ -7,14 +8,14 @@ import {
   TextContent,
   Text
 } from '@patternfly/react-core'
-import { useGetDeveloperAccounts } from 'dal/accounts'
+import { getDeveloperAccounts } from 'dal/accounts'
 import { useTranslation } from 'i18n/useTranslation'
 
 const DeveloperAccounts: React.FunctionComponent = () => {
+  const { data: accounts, error, isPending } = useAsync(getDeveloperAccounts)
   const { t } = useTranslation('accounts')
-  useDocumentTitle(t('page_title'))
 
-  const { payload: accounts, error, isPending } = useGetDeveloperAccounts()
+  useDocumentTitle(t('page_title'))
 
   return (
     <>

--- a/portafly/src/tests/pages/DeveloperAccounts.test.tsx
+++ b/portafly/src/tests/pages/DeveloperAccounts.test.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 
 import { render } from 'tests/custom-render'
 import { DeveloperAccounts } from 'pages'
-import { useGetDeveloperAccounts } from 'dal/accounts'
 import { developerAccounts } from 'tests/examples'
+import { useAsync } from 'react-async'
 
-jest.mock('dal/accounts')
+jest.mock('react-async')
 
 describe('when the request is pending', () => {
-  (useGetDeveloperAccounts as jest.Mock).mockReturnValueOnce({ isPending: true })
+  (useAsync as jest.Mock).mockReturnValueOnce({ isPending: true })
 
   it('should render spinner', () => {
     const wrapper = render(<DeveloperAccounts />)
@@ -17,7 +17,7 @@ describe('when the request is pending', () => {
 })
 
 describe('when backend returns an error', () => {
-  (useGetDeveloperAccounts as jest.Mock).mockReturnValueOnce({ error: { message: 'ERROR' } })
+  (useAsync as jest.Mock).mockReturnValueOnce({ error: { message: 'ERROR' } })
 
   it('should render an alert', () => {
     const wrapper = render(<DeveloperAccounts />)
@@ -26,7 +26,7 @@ describe('when backend returns an error', () => {
 })
 
 describe('when backend returns a list of accounts', () => {
-  (useGetDeveloperAccounts as jest.Mock).mockReturnValueOnce({ payload: developerAccounts })
+  (useAsync as jest.Mock).mockReturnValueOnce({ data: developerAccounts })
 
   it('should render a table with accounts', () => {
     const wrapper = render(<DeveloperAccounts />)

--- a/portafly/src/utils/auth.ts
+++ b/portafly/src/utils/auth.ts
@@ -1,0 +1,10 @@
+// Token is stored in JSON and not string since in the future we will be working with JWT
+export type AuthToken = Object | null
+const getToken = () => JSON.parse(String(localStorage.getItem('token'))) as AuthToken
+const setToken = (token: AuthToken) => (
+  token
+    ? localStorage.setItem('token', JSON.stringify(token))
+    : localStorage.removeItem('token')
+)
+
+export { getToken, setToken }

--- a/portafly/src/utils/http.ts
+++ b/portafly/src/utils/http.ts
@@ -1,0 +1,35 @@
+import { getToken } from 'utils'
+
+interface HttpResponse<T> extends Response {
+  parsedBody?: T
+}
+
+const fetchData = async <T>(request: Request): Promise<T> => {
+  const response: HttpResponse<T> = await fetch(request)
+  try {
+    response.parsedBody = await response.json()
+  } catch (ex) {
+    throw new Error(`The request ${request} didn't return a valid body`)
+  }
+
+  if (!response.ok) {
+    throw new Error(response.statusText)
+  }
+  return response.parsedBody as T
+}
+
+const craftRequest = (path: string, params: URLSearchParams) => {
+  const authToken = getToken()
+
+  const url = new URL(`${process.env.REACT_APP_API_HOST || '/'}${path}?${params.toString()}`)
+  url.searchParams.append('access_token', authToken as string)
+
+  return new Request(
+    url.toString(),
+    {
+      headers: { Accept: 'application/json' }
+    }
+  )
+}
+
+export { fetchData, craftRequest }

--- a/portafly/src/utils/index.ts
+++ b/portafly/src/utils/index.ts
@@ -1,22 +1,3 @@
-export type Action<P> = {
-  type: string,
-  payload?: P
-}
-
-export type ActionHandlers<S, A> = Record<string, (state: S, action: Action<A>) => S>
-
-const createReducer = (handlers: ActionHandlers<any, any>) => (
-  (state: any, action: Action<any>): any => (
-    handlers.hasOwnProperty(action.type) ? handlers[action.type](state, action) : state
-  )
-)
-const combineReducers = (reducerSlices: Record<string, any>) => (
-  (prevState: any, action: Action<any>) => Object.keys(reducerSlices).reduce(
-    (nextState, nextProp) => ({
-      ...nextState,
-      [nextProp]: reducerSlices[nextProp](prevState[nextProp], action)
-    }),
-    prevState
-  ))
-
-export { createReducer, combineReducers }
+export * from './auth'
+export * from './http'
+export * from './reducers'

--- a/portafly/src/utils/reducers.ts
+++ b/portafly/src/utils/reducers.ts
@@ -1,0 +1,22 @@
+export type Action<P> = {
+  type: string,
+  payload?: P
+}
+
+export type ActionHandlers<S, A> = Record<string, (state: S, action: Action<A>) => S>
+
+const createReducer = (handlers: ActionHandlers<any, any>) => (
+  (state: any, action: Action<any>): any => (
+    handlers.hasOwnProperty(action.type) ? handlers[action.type](state, action) : state
+  )
+)
+const combineReducers = (reducerSlices: Record<string, any>) => (
+  (prevState: any, action: Action<any>) => Object.keys(reducerSlices).reduce(
+    (nextState, nextProp) => ({
+      ...nextState,
+      [nextProp]: reducerSlices[nextProp](prevState[nextProp], action)
+    }),
+    prevState
+  ))
+
+export { createReducer, combineReducers }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is refactor that will ease the use of http async requests and managing responses from Porta API

We were using hooks inside the data layer functions that was an anti pattern. Also redefining `Response` type and using async hooks inside components. 

**Which issue(s) this PR fixes** 

**Verification steps** 
Launch the app with `yarn start` and porta Rails server,  login with a valid token and navigate to dev accounts, it should render a list of dev accounts. It varies depending on the data in your local porta

**Special notes for your reviewer**:
