### PR TITLE
[Test] API Account endpoints fire webhook

### DIFF
--- a/test/integration/admin/api/accounts_controller_test.rb
+++ b/test/integration/admin/api/accounts_controller_test.rb
@@ -4,8 +4,14 @@ require 'test_helper'
 
 class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
 
-  class MasterAccount < ActionDispatch::IntegrationTest
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    host! provider.admin_domain
+  end
 
+  attr_reader :provider
+
+  class MasterAccountTest < ActionDispatch::IntegrationTest
     def setup
       host! master_account.admin_domain
     end
@@ -28,97 +34,113 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  disable_transactional_fixtures!
-
-  def setup
-    @provider = FactoryBot.create(:provider_account)
-    host! @provider.admin_domain
-    @member = FactoryBot.create(:member, account: @provider, member_permission_ids: [:partners])
-    @access_token = FactoryBot.create(:access_token, owner: @member, scopes: 'account_management')
-    @account = FactoryBot.create(:buyer_account, provider_account: @provider)
-    @account.settings.update_column(:monthly_billing_enabled, false)
-    Logic::RollingUpdates.stubs(:enabled?).returns(true)
-  end
-
-  def test_find
-    account = FactoryBot.create(:simple_provider, provider: @provider)
-    service = FactoryBot.create(:simple_service, account: account)
-    service.service_tokens.create!(value: 'token')
-
-    get find_admin_api_accounts_path(format: :xml, provider_key: @provider.api_key, buyer_service_token: 'token')
-    assert_response :not_found
-
-    provider_key = master_account.buyer_accounts.first.provider_key
-    get find_admin_api_accounts_path(format: :xml, provider_key: @provider.api_key, buyer_provider_key: provider_key)
-    assert_response :not_found
-
-    buyer_user = @provider.buyer_users.last
-    get find_admin_api_accounts_path(format: :xml, provider_key: @provider.api_key, username: buyer_user.username)
-    assert_response :success
-
-    get find_admin_api_accounts_path(format: :xml, provider_key: @provider.api_key, user_id: buyer_user.id)
-    assert_response :success
-
-    get find_admin_api_accounts_path(format: :xml, provider_key: @provider.api_key, email: buyer_user.email)
-    assert_response :success
-  end
-
-  def test_show
-    @access_token.permission = 'ro'
-    @access_token.save!
-    @account.update_columns(credit_card_auth_code: 'abcd',
-      credit_card_expires_on: Date.new(2020, 4, 2), credit_card_partial_number: '0989')
-    @account.payment_detail.destroy!
-
-    assert_difference(PaymentDetail.method(:count), 0) do
-      get admin_api_account_path(@account, format: :xml, access_token: @access_token.value)
-      assert_response :success
+  class TenantMemberTest < Admin::Api::AccountsControllerTest
+    def setup
+      super
+      token(user: member)
     end
 
-    @account.settings.destroy!
-    assert_difference(Settings.method(:count), 0) do
-      get admin_api_account_path(@account, format: :xml, access_token: @access_token.value)
-      assert_response :success
+    test '#update from a member with service_permissions is updated correctly' do
+      rolling_updates_on
+      rolling_update(:service_permissions, enabled: true)
+
+      put admin_api_account_path(buyer, format: :xml), update_params
+      assert_response :ok
+      assert_xml '//account/id'
+      assert buyer.reload.settings.monthly_billing_enabled
     end
 
-    assert_difference(PaymentDetail.method(:count), 1) do
-      assert_difference(Settings.method(:count), 1) do
-        get admin_api_account_path(@account, format: :xml, provider_key: @provider.provider_key)
+    test '#update from a member without service_permissions returns error message in xml' do
+      rolling_updates_on
+      rolling_update(:service_permissions, enabled: false)
+
+      put admin_api_account_path(buyer, format: :xml), update_params
+      assert_xml_403
+      refute buyer.reload.settings.monthly_billing_enabled
+    end
+
+    test '#update from a member without service_permissions returns error message in json' do
+      rolling_updates_on
+      rolling_update(:service_permissions, enabled: false)
+
+      put admin_api_account_path(buyer, format: :json), update_params
+      assert_equal 'Forbidden', JSON.parse(response.body).dig('status')
+      assert_response :forbidden
+      refute buyer.reload.settings.monthly_billing_enabled
+    end
+  end
+
+  class TenantProviderKeyTest < Admin::Api::AccountsControllerTest
+    def test_find
+      account = FactoryBot.create(:simple_provider, provider: provider)
+      service = FactoryBot.create(:simple_service, account: account)
+      service.service_tokens.create!(value: 'token')
+
+      get find_admin_api_accounts_path(format: :xml, provider_key: provider.api_key, buyer_service_token: 'token')
+      assert_response :not_found
+
+      buyer_user = buyer.users.last!
+      get find_admin_api_accounts_path(format: :xml, provider_key: provider.api_key, username: buyer_user.username)
+      assert_response :success
+
+      get find_admin_api_accounts_path(format: :xml, provider_key: provider.api_key, user_id: buyer_user.id)
+      assert_response :success
+
+      get find_admin_api_accounts_path(format: :xml, provider_key: provider.api_key, email: buyer_user.email)
+      assert_response :success
+    end
+  end
+
+  class ReadOnlyTokenTest < Admin::Api::AccountsControllerTest
+    disable_transactional_fixtures!
+
+    def test_show
+      token(user: member)
+      token.permission = 'ro'
+      token.save!
+
+      buyer.update_columns(credit_card_auth_code: 'abcd',
+        credit_card_expires_on: Date.new(2020, 4, 2), credit_card_partial_number: '0989')
+      buyer.payment_detail.destroy!
+
+      assert_difference(PaymentDetail.method(:count), 0) do
+        get admin_api_account_path(buyer, format: :xml, access_token: token.value)
         assert_response :success
+      end
+
+      buyer.settings.destroy!
+      assert_difference(Settings.method(:count), 0) do
+        get admin_api_account_path(buyer, format: :xml, access_token: token.value)
+        assert_response :success
+      end
+
+      assert_difference(PaymentDetail.method(:count), 1) do
+        assert_difference(Settings.method(:count), 1) do
+          get admin_api_account_path(buyer, format: :xml, provider_key: provider.provider_key)
+          assert_response :success
+        end
       end
     end
   end
 
-  test '#update from a member with service_permissions is updated correctly' do
-    Logic::RollingUpdates::Features::ServicePermissions.any_instance.stubs(:enabled?).returns(true)
-
-    put admin_api_account_path(@account, format: :xml), update_params
-    assert_response :ok
-    assert_xml '//account/id'
-    assert @account.reload.settings.monthly_billing_enabled
-  end
-
-  test '#update from a member without service_permissions returns error message in xml' do
-    Logic::RollingUpdates::Features::ServicePermissions.any_instance.stubs(:enabled?).returns(false)
-
-    put admin_api_account_path(@account, format: :xml), update_params
-    assert_xml_403
-    refute @account.reload.settings.monthly_billing_enabled
-  end
-
-  test '#update from a member without service_permissions returns error message in json' do
-    Logic::RollingUpdates::Features::ServicePermissions.any_instance.stubs(:enabled?).returns(false)
-
-    put admin_api_account_path(@account, format: :json), update_params
-    assert_equal 'Forbidden', JSON.parse(response.body).dig('status')
-    assert_response :forbidden
-    refute @account.reload.settings.monthly_billing_enabled
-  end
-
   private
 
+  def buyer
+    @buyer ||= FactoryBot.create(:buyer_account, provider_account: provider).tap do |buyer|
+      buyer.settings.update_column(:monthly_billing_enabled, false)
+    end
+  end
+
   def update_params
-    @params ||= { monthly_billing_enabled: true, access_token: @access_token.value }
+    @params ||= { monthly_billing_enabled: true, access_token: token.value }
+  end
+
+  def token(user: provider.admin_user)
+    @token ||= FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw')
+  end
+
+  def member
+    @member ||= FactoryBot.create(:member, account: provider, member_permission_ids: [:partners])
   end
 
 end

--- a/test/integration/admin/api/signups_controller_test.rb
+++ b/test/integration/admin/api/signups_controller_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Admin::Api::SignupsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    host! provider.admin_domain
+  end
+
+  attr_reader :provider
+
+  class WebHooksTest < Admin::Api::SignupsControllerTest
+    disable_transactional_fixtures!
+
+    test 'create by access token fires webhooks' do
+      provider.settings.allow_web_hooks!
+      FactoryBot.create(:webhook, account: provider, account_created_on: true, active: true)
+
+      assert_difference(provider.buyers.method(:count)) do
+        assert_difference(WebHookWorker.jobs.method(:size)) do
+          post(admin_api_signup_path, format: :json, access_token: token.value, org_name: 'company', username: 'person')
+          assert_response :created
+        end
+      end
+    end
+
+    test 'create by provider key does not fire webhooks' do
+      provider.settings.allow_web_hooks!
+      FactoryBot.create(:webhook, account: provider, account_created_on: true, active: true)
+
+      assert_difference(provider.buyers.method(:count)) do
+        assert_no_difference(WebHookWorker.jobs.method(:size)) do
+          post(admin_api_signup_path, format: :json, provider_key: provider.provider_key, org_name: 'company', username: 'person')
+          assert_response :created
+        end
+      end
+    end
+  end
+
+  private
+
+  def token(user: provider.admin_user)
+    @token ||= FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw')
+  end
+end


### PR DESCRIPTION
Closes [THREESCALE-5207](https://issues.redhat.com/browse/THREESCALE-5207)

It was accidentally implemented for 2.8 when we added https://github.com/3scale/porta/pull/1546/commits/e2e44c797f41784565b8b0b424567b6cd6e4b81e
This PR is to add tests.

### Tasks
- [X] Test Create Buyers through API fires webhook
- [X] Test Update/Delete Buyers through API fires webhook