### PR TITLE
Remove unused exception class PlanRulesNotLoaded

### DIFF
--- a/app/lib/plan_rules_collection.rb
+++ b/app/lib/plan_rules_collection.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module PlanRulesCollection
-  class PlanRulesNotLoaded < StandardError; end
-
   module_function
 
   PLAN_RULES_BY_NAME = PlanRuleLoader.load_config


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11318903/82077825-5a4c1e00-96e0-11ea-858d-38dc7cfc41be.png)
This was initially introduced in https://github.com/3scale/system/pull/9326, and since the very beginning, this has not being used. This happened because that PR required some refactoring and after doing it, I forgot to remove this line 😄 