### PR TITLE
Destroy a default service through a rake task

### DIFF
--- a/app/lib/backend/model_extensions/service.rb
+++ b/app/lib/backend/model_extensions/service.rb
@@ -45,6 +45,7 @@ module Backend
 
       def make_default_backend_service
         ThreeScale::Core::Service.make_default(backend_id)
+        account.update!({default_service_id: id}, without_protection: true)
       end
     end
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -276,12 +276,6 @@ class Service < ApplicationRecord
     application_plans.published
   end
 
-  # use this method to destroy the default service with all callbacks firing
-  def destroy_default
-    @destroy_default_allowed = true
-    destroy
-  end
-
   def stop_destroy_if_last_or_default
     return if destroyable?
     errors.add :base, 'This service cannot be removed'
@@ -553,8 +547,7 @@ class Service < ApplicationRecord
   end
 
   def destroyable?
-    return true if destroyed_by_association
-    !default_or_last? || @destroy_default_allowed
+    destroyed_by_association || !default_or_last?
   end
 
   def create_default_proxy

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -12,4 +12,16 @@ namespace :services do
   task :destroy_marked_as_deleted => :environment do
     DestroyAllDeletedObjectsWorker.perform_later(Service.to_s)
   end
+
+  desc 'Destroy a service in the Background as long as the provider has at least 1 more service. Whether it is a default one or not'
+  task :destroy_service, %i[account_id service_id] => [:environment] do |_task, args|
+    account = Account.providers.find(args[:account_id])
+    service_id = args[:service_id]
+    service = account.services.find(service_id) # So it will raise an error if this service does not belong to this account :)
+    if service.default?
+      new_default_service = account.services.where.not(id: service_id).first! # It will raise an error if it does not have another service
+      new_default_service.send(:make_default_backend_service)
+    end
+    service.reload.mark_as_deleted!
+  end
 end

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -99,21 +99,6 @@ class AccountTest < ActiveSupport::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { metric.reload }
   end
 
-  def test_default_service_id
-    service = FactoryBot.create(:simple_service)
-    account = FactoryBot.create(:simple_account, services: [service], default_service_id: service.id)
-
-    assert service.default?
-    assert_equal service.id, account.default_service_id
-
-    service.destroy_default
-
-    account.reload
-
-    assert_raises(ActiveRecord::RecordNotFound) { service.reload }
-    assert_nil account.default_service_id
-  end
-
   test '#trashed_messages' do
     account  = FactoryBot.build_stubbed(:simple_account)
     other    = FactoryBot.build_stubbed(:simple_account)

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -4,10 +4,82 @@ require 'test_helper'
 
 module Tasks
   class ServicesTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
     test 'destroy_marked_as_deleted' do
       DestroyAllDeletedObjectsWorker.expects(:perform_later).once.with('Service')
 
       execute_rake_task 'services.rake', 'services:destroy_marked_as_deleted'
+    end
+
+    test 'destroy_service removes the default service in Porta and Apisonator' do
+      default_service = FactoryBot.create(:simple_service)
+      account = default_service.account
+      another_service = FactoryBot.create(:simple_service, account: account)
+      account.update!({default_service_id: default_service.id}, without_protection: true)
+      default_service.reload
+
+      ThreeScale::Core::Service.expects(:make_default).with(another_service.backend_id)
+
+      assert_difference(EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent).method(:count)) do
+        perform_enqueued_jobs do
+          execute_rake_task 'services.rake', 'services:destroy_service', account.id, default_service.id
+        end
+      end
+
+      refute Service.where(id: default_service.id).exists?
+      assert_equal another_service.id, account.reload.default_service_id
+
+      event = EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent).last!
+      assert_equal event.data[:service_id], default_service.id
+    end
+
+    test 'destroy_service raises ActiveRecord::RecordNotFound or StateMachines::InvalidTransition when the Account does not have another active Service' do
+      default_service = FactoryBot.create(:simple_service)
+      default_service.account.update!({default_service_id: default_service.id}, without_protection: true)
+      non_default_service = FactoryBot.create(:simple_service)
+      non_default_service.account.update!({default_service_id: nil}, without_protection: true)
+
+      assert_raise(ActiveRecord::RecordNotFound) do
+        execute_rake_task 'services.rake', 'services:destroy_service', default_service.account.id, default_service.id
+      end
+
+      assert_raise(StateMachines::InvalidTransition) do
+        execute_rake_task 'services.rake', 'services:destroy_service', non_default_service.account.id, non_default_service.id
+      end
+    end
+
+    test 'destroy_service raises ActiveRecord::RecordNotFound when the Service does not belong to the Account' do
+      service = FactoryBot.create(:simple_service)
+      FactoryBot.create(:simple_service, account: service.account)
+      another_account = FactoryBot.create(:simple_account)
+
+      assert_raise(ActiveRecord::RecordNotFound) do
+        execute_rake_task 'services.rake', 'services:destroy_service', another_account.id, service.id
+      end
+    end
+
+    test 'destroy_service removes the non-default Service in Porta and Apisonator' do
+      default_service = FactoryBot.create(:simple_service)
+      account = default_service.account
+      non_default_service = FactoryBot.create(:simple_service, account: account)
+      account.update!({default_service_id: default_service.id}, without_protection: true)
+      default_service.reload
+
+      ThreeScale::Core::Service.expects(:make_default).never
+      ThreeScale::Core::Service.expects(:save!).never
+
+      assert_difference(EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent).method(:count)) do
+        perform_enqueued_jobs do
+          execute_rake_task 'services.rake', 'services:destroy_service', account.id, non_default_service.id
+        end
+      end
+
+      refute Service.where(id: non_default_service.id).exists?
+      assert_equal default_service.id, account.reload.default_service_id
+
+      event = EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent).last!
+      assert_equal event.data[:service_id], non_default_service.id
     end
   end
 end


### PR DESCRIPTION
Tested in Preview 
`RAILS_ENV=preview bundle exec rake "services:destroy_default_service[account_id_here service_id_here]"`

We were requested to destroy a default service in [THREESCALE-5238](https://issues.redhat.com/browse/THREESCALE-5238)
That is a very old and deprecated flag. We do not add it anymore in Porta, but in Apisonator it is mandatory and they usually add it for the first service of the provider.
We did all this in the rails console for it is dangerous and we should have a rake task instead.