### PR TITLE
[CVE-2020-8161] Patch Rack directory traversal vulnerability

### DIFF
--- a/config/initializers/cve-2020-8161.rb
+++ b/config/initializers/cve-2020-8161.rb
@@ -1,0 +1,30 @@
+# https://groups.google.com/forum/#!topic/rubyonrails-security/IOO1vNZTzPA
+
+Rack::Directory.prepend(Module.new do
+  def list_directory(path_info, path, script_name)
+    files = [['../','Parent Directory','','','']]
+
+    url_head = (script_name.split('/') + path_info.split('/')).map do |part|
+      Rack::Utils.escape_path part
+    end
+
+    Dir.entries(path).reject { |e| e.start_with?('.') }.sort.each do |node|
+      stat = stat(node)
+      next unless stat
+      basename = ::File.basename(node)
+      ext = ::File.extname(node)
+
+      url = ::File.join(*url_head + [Rack::Utils.escape_path(basename)])
+      size = stat.size
+      type = stat.directory? ? 'directory' : Mime.mime_type(ext)
+      size = stat.directory? ? '-' : filesize_format(size)
+      mtime = stat.mtime.httpdate
+      url << '/'  if stat.directory?
+      basename << '/'  if stat.directory?
+
+      files << [ url, basename, size, type, mtime ]
+    end
+
+    return [ 200, { CONTENT_TYPE =>'text/html; charset=utf-8'}, DirectoryBody.new(@root, path, files) ]
+  end
+end)


### PR DESCRIPTION
Since we cannot yet upgrade rack to 2.1.3 or 2.2+ due to restrictions related to the Sidekiq version.

Ref.: https://groups.google.com/forum/#!topic/rubyonrails-security/IOO1vNZTzPA