### PR TITLE
4836-Account_Users-cleanup removed PROPOSED tags

### DIFF
--- a/portafly/src/i18n/locales/en/accounts.yml
+++ b/portafly/src/i18n/locales/en/accounts.yml
@@ -23,7 +23,7 @@ invitations_tab_description: Label for the tab that contains the list of all inv
 ## Toolbar
 #-------# Bulk selector: available in shared.yml
 #-------# Delete button: available in shared.yml
-team_members_filter: #----PROPOSED
+team_members_filter:
   by_name: Name
   by_email: Email
   by_sso_authentication: SSO authentication
@@ -41,13 +41,13 @@ team_members_filter: #----PROPOSED
    configuration_application_plans: Configuration and application plans
    policy_registry: Policy registry
 team_members_filter_description: List containing the name criterion to filter team members
-team_members_typeahead: Filter by name #----PROPOSED
+team_members_typeahead: Filter by name
 team_members_typeahead_description: Default text to show when the user wants to filter by typing the text
 
 team_members_table:
   aria_label: Team members table
   aria_label_description: Aria label of the table of team members
-  empty_state: Currently, there are no team members. Add team members. #----PROPOSED
+  empty_state: Currently, there are no team members. Add team members.
   empty_state_description: Message to show when there are no team members to show, and prompt the user to add members
   name_header: Name
   name_header_description: Column listing names of team members
@@ -61,7 +61,7 @@ team_members_table:
   sso_authentication_value_description: Container of possible values about users having SSO configured
   role_header: Role
   role_header_description: Column listing the roles associated to each team member
-  role_header_value: #----PROPOSED: Approved
+  role_header_value:
     admin_you: Admin (you)
     admin: Admin
     member: Member
@@ -74,9 +74,9 @@ team_members_table:
 
 # Modal: Team member deletion
 team_member_deletion:
-  page: Delete selected team members #----PROPOSED: Approved
+  page: Delete selected team members
   page_description: Body title of modal dialog to delete the selected team members from the table
-  admonition: This action will irreversibly delete the selected team members. Please confirm below to proceed with deleting them. #----PROPOSED
+  admonition: This action will irreversibly delete the selected team members. Please confirm below to proceed with deleting them.
   admonition_description: Admonition text to explain that the removal of the selected team members cannot be undone.
   #-------# Delete button: available in shared.yml
   #-------# Cancel button: available in shared.yml
@@ -86,7 +86,7 @@ team_member_deletion:
 ## Toolbar
 #-------# Bulk selector: available in shared.yml
 #-------# Delete button: available in shared.yml
-invitations_filter:  #----PROPOSED: Approved
+invitations_filter:
  by_recipient: Recipient
  by_acceptance: Acceptance
 invitations_filter_description: List containing the criteria to filter invitations
@@ -98,15 +98,15 @@ invitations_typeahead_description: Default text to show when the user filters by
 invitations_table:
   aria_label: Invitations table
   aria_label_description: Aria label of the table of invitations
-  empty_state: Currently, there are no invitations sent. Start sending invitations to your team members. #----PROPOSED: placeholder
+  empty_state: Currently, there are no invitations sent. Start sending invitations to your team members.
   empty_state_description: Message to show when there are no invitations to show, and prompt the user to send some invites
   recipient_header: Recipient
   recipient_header_description: Column listing the email addresses of invitation recipients
-  sent_header: Sent on UTC time #----PROPOSED
+  sent_header: Sent on UTC time
   sent_header_description: Column listing the date when invitations were sent
-  acceptance_header: Accepted on UTC time #----PROPOSED
+  acceptance_header: Accepted on UTC time
   acceptance_header_description: Column listing the date when the invitations were accepted
-  acceptance_values: #----PROPOSED
+  acceptance_values:
     yes_with_time: Yes – {{utc_time}}
     not_yet: Not yet
   acceptance_values_description: Container with the possible responses to whether the invitation has been accepted or not.
@@ -117,9 +117,9 @@ invitations_table:
 
 # Modal: Invitation deletion
 invitation_deletion:
-  page: Delete selected invitations #----PROPOSED: Approved
+  page: Delete selected invitations
   page_description: Body title of modal dialog to delete the selected invitations from the table
-  admonition: This action will irreversibly delete the selected invitations. Please confirm below to proceed with deleting them. #----PROPOSED
+  admonition: This action will irreversibly delete the selected invitations. Please confirm below to proceed with deleting them.
   admonition_description: Admonition text to explain that the removal of the selected invitations cannot be undone.
   #-------# Delete button: available in shared.yml
   #-------# Cancel button: available in shared.yml
@@ -130,9 +130,9 @@ invitation_sending:
   page_description: Body title of modal dialog to send invitation to a new team member
   label: Send invitation to *
   label_description: Label prompting the user to specify the email address of the invitation recipient
-  validation: Please indicate a valid email address of the colleague or friend you want to invite to your team. #----PROPOSED
+  validation: Please indicate a valid email address of the colleague or friend you want to invite to your team.
   validation_description: Validation message to prompt user to specify a valid email address; to prevent an empty value, or bad format email address.
-  helper: Email address of a colleague or friend you want to invite to your team #----PROPOSED
+  helper: Email address of a colleague or friend you want to invite to your team 
   helper_description: Text to prompt the user to specify an email address.
   #-------# Send button: available in shared.yml
   #-------# Cancel button: available in shared.yml


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes `PROPOSED` tags to have a clean file.

**Which issue(s) this PR fixes** 
[THREESCALE-4836](https://issues.redhat.com/browse/THREESCALE-4836)

**Special notes for your reviewer**:
* The strings marked as _Proposed_ have been approved in this MR: https://github.com/3scale/porta/pull/1861