### PR TITLE
Highlight SSO Integrations in vertical navigation

### DIFF
--- a/app/controllers/provider/admin/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/authentication_providers_controller.rb
@@ -3,7 +3,7 @@
 class Provider::Admin::AuthenticationProvidersController < FrontendController
   before_action :authorize_settings
 
-  activate_menu :audience, :cms, :oauth2
+  activate_menu :audience, :cms, :sso_integrations
   sublayout 'sites/developer_portals'
 
   before_action :find_authentication_provider, only: %i[show edit update publish_or_hide destroy]


### PR DESCRIPTION
Closes [THREESCALE-3548](https://issues.redhat.com/browse/THREESCALE-3548)

**Verification steps** 

The title: SSO Integration, in the vertical navigation, under Developer Portal -> Setting-> SSO Integrations, should be highlight when checked. 