### PR TITLE
[PoliciesController] InvalidPoliciesConfigError

### DIFF
--- a/app/controllers/admin/api/services/proxy/policies_controller.rb
+++ b/app/controllers/admin/api/services/proxy/policies_controller.rb
@@ -56,8 +56,9 @@ class Admin::Api::Services::Proxy::PoliciesController < Admin::Api::Services::Ba
 
   def proxy_params
     proxy_params = params.require(:proxy).dup
+
     proxy_params.permit(:policies_config).tap do |whitelisted|
-      whitelisted[:policies_config] = proxy_params[:policies_config].tap{|h| h.try(:each, &:permit!)}
+      whitelisted[:policies_config] = PoliciesConfigParams.new(proxy_params[:policies_config]).call
     end
   end
 

--- a/app/services/policies_config_params_wrapper.rb
+++ b/app/services/policies_config_params_wrapper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class PoliciesConfigParams
+
+  attr_reader :policies_config_params
+
+  def initialize(policies_config_params)
+    @policies_config_params = policies_config_params
+  end
+
+  def call
+    return policies_config_params if json_param?
+
+    [policies_config_params].flatten.map do |policies_config|
+      policies_config.try(:permit!)
+    end
+  end
+
+  private
+
+  def json_param?
+    params_class_name == 'String'
+  end
+
+  def params_class_name
+    policies_config_params.class.name
+  end
+end

--- a/test/integration/user-management-api/services/proxy/policies_test.rb
+++ b/test/integration/user-management-api/services/proxy/policies_test.rb
@@ -53,6 +53,11 @@ class Admin::Api::Services::Proxy::PoliciesTest < ActionDispatch::IntegrationTes
     assert_equal ['can\'t be blank'], json_response.dig('policies_config', 0, 'errors', 'configuration')
   end
 
+  def test_invalid_policies_config
+    put admin_api_service_proxy_policies_path(valid_params.merge({ proxy: { policies_config: { name: 'echo '} }}))
+    assert_response :unprocessable_entity
+  end
+
   def valid_params
     {
       service_id:   @service.id,


### PR DESCRIPTION
**What this PR does / why we need it**:

A policies_config parameter should be an array. If it's an object, it fails on 500. We should validate this scenario and return 422 if possible.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-1059
