### PR TITLE
Do not report error to Bugsnag if Authentication Token is empty

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -28,7 +28,7 @@ module ErrorHandling
     end
 
     def handle_forgery_protection(exception)
-      System::ErrorReporting.report_error(exception)
+      System::ErrorReporting.report_error(exception) if params[:authenticity_token].present?
       handle_error(exception, :forbidden)
     end
 

--- a/test/integration/developer_portal/login_test.rb
+++ b/test/integration/developer_portal/login_test.rb
@@ -134,13 +134,14 @@ class DeveloperPortal::LoginTest < ActionDispatch::IntegrationTest
     assert_nil waiting_list_confirmation_email('foo2@example.com')
   end
 
-  test 'create with invalid CSRF token' do
+  test 'create with invalid or empty CSRF token' do
+    with_forgery_protection { post session_path(system_name: @auth.system_name, code: 'example') }
+    assert_response :forbidden
+
     System::ErrorReporting.expects(:report_error).once.with do |exception|
       exception.is_a?(ActionController::InvalidAuthenticityToken)
     end
-
-    with_forgery_protection { post session_path(system_name: @auth.system_name, code: 'example') }
-
+    with_forgery_protection { post session_path(system_name: @auth.system_name, code: 'example', authenticity_token: 'invalid') }
     assert_response :forbidden
   end
 


### PR DESCRIPTION
If someone tries to do `POST /session` to login to the dev portal without the `authentication token` it will fail the request as `forbidden` for https://github.com/3scale/porta/pull/1873
It will also log the error in Rails (because `handle_error` does it 😄 ), but we should additionally notify to Bugsnag when it might be a bug on our side, which is not when the authentication token is sent empty.
Related to what I explained [in this comment in JIRA](https://issues.redhat.com/browse/THREESCALE-5240?focusedCommentId=14109051&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14109051).