### PR TITLE
With cucumber 2+ the line is in scenario.location

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -109,8 +109,8 @@ After do |scenario|
   end
 
   folder = folder.expand_path(root)
-  next
-  line_number = scenario.line.to_s
+
+  line_number = scenario.location.line.to_s
 
   if (ex = scenario.try(:exception)) # `try` so it does not raise on undefined method
     file = folder.join("#{line_number}.txt")


### PR DESCRIPTION
So we can re-enable taking screenshot and getting more browser info on our tests

It was disabled when migrating to rails 5