### PR TITLE
Fix console error in Overview

### DIFF
--- a/portafly/src/components/data-list/BulkActionsWidget.tsx
+++ b/portafly/src/components/data-list/BulkActionsWidget.tsx
@@ -8,7 +8,7 @@ import {
   TextContent,
   TextVariants
 } from '@patternfly/react-core'
-import { CaretDownIcon, WarningTriangleIcon } from '@patternfly/react-icons'
+import { WarningTriangleIcon } from '@patternfly/react-icons'
 import { useTranslation } from 'i18n/useTranslation'
 import { BulkAction } from 'components/data-list/reducers'
 import { useDataListTable, useDataListBulkActions } from 'components/data-list'
@@ -29,7 +29,7 @@ const BulkActionsWidget: React.FunctionComponent<Props> = ({
   const [isOpen, setIsOpen] = useState(false)
 
   const toggle = (
-    <DropdownToggle onToggle={setIsOpen} icon={CaretDownIcon} isPrimary>
+    <DropdownToggle onToggle={setIsOpen} isPrimary>
       {t('bulk_actions.title')}
     </DropdownToggle>
   )


### PR DESCRIPTION
Fixes this console error:
<img width="1440" alt="Screen Shot 2020-05-22 at 19 20 55" src="https://user-images.githubusercontent.com/11672286/82693239-75c7a380-9c61-11ea-9e58-9807fadd3f86.png">

It's caused by wrong use of a prop.
