### PR TITLE
Prepare removing monkey patch on request.host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,10 +47,11 @@ C:\\nppdf32Log\\debuglog.txt
 /coverage/
 
 /config/amazon_s3.yml
-/config/backend.yml
 /config/application.yml
-/config/database.yml
+/config/backend.yml
 /config/backend_redis.yml
+/config/database.yml
+/config/domain_substitution.yml
 /config/redis.yml
 /config/oauth2.yml
 /config/slave_redis.yml

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -49,7 +49,7 @@ module ErrorHandling
 
       respond_to do |format|
         format.html do
-          if Account.is_admin_domain?(request.host) || site_account.master?
+          if Account.is_admin_domain?(request.internal_host) || site_account.master?
             handle_provider_side(status, exception, title)
           else
             handle_buyer_side(status)

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -149,20 +149,20 @@ class FrontendController < ApplicationController
   end
 
   def ensure_provider_domain
-    return if Account.is_admin_domain?(request.host) || site_account.master?
+    return if Account.is_admin_domain?(internal_host) || site_account.master?
     notify_about_wrong_domain(request.url, :provider, error_request_data)
     render_wrong_domain_error
     false
   end
 
   def ensure_buyer_domain
-    return unless Account.is_admin_domain?(request.host) || site_account.master?
+    return unless Account.is_admin_domain?(internal_host) || site_account.master?
     notify_about_wrong_domain(request.url, :buyer)
     render_wrong_domain_error
   end
 
   def ensure_master_domain
-    return if Account.is_master_domain?(request.host)
+    return if Account.is_master_domain?(internal_host)
     notify_about_wrong_domain(request.url, :master)
     render_wrong_domain_error
     false

--- a/app/controllers/master/base_controller.rb
+++ b/app/controllers/master/base_controller.rb
@@ -8,6 +8,6 @@ class Master::BaseController < ApplicationController
   end
 
   def force_master_domain
-    head(403) unless Account.is_master_domain?(request.host)
+    head(403) unless Account.is_master_domain?(request.internal_host)
   end
 end

--- a/app/controllers/provider/passwords_controller.rb
+++ b/app/controllers/provider/passwords_controller.rb
@@ -60,10 +60,10 @@ class Provider::PasswordsController < FrontendController
   # Can't be used for neither Buyer nor Master
   #
   def find_provider
-    @provider ||= Account.tenants.find_by(self_domain: request.host.to_s)
+    @provider ||= Account.tenants.find_by(self_domain: request.internal_host.to_s)
     return if @provider
 
-    render_error "Wrong domain '#{request.host}' for path '#{request.path}'", status: 404
+    render_error "Wrong domain '#{request.internal_host}' for path '#{request.path}'", status: 404
     false
   end
 

--- a/app/controllers/provider/passwords_controller.rb
+++ b/app/controllers/provider/passwords_controller.rb
@@ -60,10 +60,11 @@ class Provider::PasswordsController < FrontendController
   # Can't be used for neither Buyer nor Master
   #
   def find_provider
-    @provider ||= Account.tenants.find_by(self_domain: request.internal_host.to_s)
+    host = request.internal_host
+    @provider ||= Account.tenants.find_by(self_domain: host)
     return if @provider
 
-    render_error "Wrong domain '#{request.internal_host}' for path '#{request.path}'", status: 404
+    render_error "Wrong domain '#{host}' for path '#{request.path}'", status: 404
     false
   end
 

--- a/app/lib/authenticated_system.rb
+++ b/app/lib/authenticated_system.rb
@@ -124,7 +124,7 @@ module AuthenticatedSystem
     store_location
     flash.keep
 
-    if Account.is_admin_domain?(request.host) || site_account.master?
+    if Account.is_admin_domain?(request.internal_host) || site_account.master?
       redirect_to_login_for_providers
     else
       redirect_to_login_for_buyers

--- a/app/lib/three_scale/api/controller.rb
+++ b/app/lib/three_scale/api/controller.rb
@@ -12,7 +12,7 @@ module ThreeScale::Api::Controller
   end
 
   def api_request?
-    request.path =~ /\A\/api/ &&  Account.is_admin_domain?(request.host)
+    request.path =~ /\A\/api/ &&  Account.is_admin_domain?(request.internal_host)
     # &&  [ :xml, :json ].include?(request.format.to_sym)
   end
 

--- a/app/models/account/provider_domains.rb
+++ b/app/models/account/provider_domains.rb
@@ -4,6 +4,7 @@ module Account::ProviderDomains
   extend ActiveSupport::Concern
 
   included do
+    include ThreeScale::DomainSubstitution::Account
 
     with_options :if => :validate_domains? do |provider|
       provider.validate :domain_uniqueness, :self_domain_uniqueness, :domain_not_self_domain
@@ -157,7 +158,6 @@ module Account::ProviderDomains
 
     !scope.exists?
   end
-
   private
 
   def validate_domains?

--- a/app/presenters/redhat_customer_oauth_flow_presenter.rb
+++ b/app/presenters/redhat_customer_oauth_flow_presenter.rb
@@ -21,8 +21,7 @@ class RedhatCustomerOAuthFlowPresenter < OauthFlowPresenter
   attr_reader :redirect_uri
 
   def domain_parameters
-    host = request.try(:real_host).presence || request.host
-    { self_domain: host }
+    { self_domain: request.host }
   end
 
   def build_redirect_uri

--- a/app/presenters/service_discovery_oauth_flow_presenter.rb
+++ b/app/presenters/service_discovery_oauth_flow_presenter.rb
@@ -15,7 +15,10 @@ class ServiceDiscoveryOAuthFlowPresenter < OauthFlowPresenter
   end
 
   def authorize_url
-    client.authorize_url(redirect_uri.base_url, redirect_uri.query_options.merge(referrer: request.fullpath))
+    client.authorize_url(
+      redirect_uri.base_url,
+      redirect_uri.query_options.merge(referrer: request.fullpath)
+    )
   end
 
   private
@@ -23,8 +26,7 @@ class ServiceDiscoveryOAuthFlowPresenter < OauthFlowPresenter
   attr_reader :redirect_uri
 
   def domain_parameters
-    host = request.try(:real_host).presence || request.host
-    { self_domain: host }
+    { self_domain: request.host }
   end
 
   def build_redirect_uri

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title><%= yield(:title).try(:strip).try(:presence) || 'We are sorry, but something went wrong' %></title>
-    <%- admin_domain = Account.is_admin_domain?(request.host) -%>
-    <%- master_domain = Account.is_master_domain?(request.host) -%>
+    <%- admin_domain = Account.is_admin_domain?(request.internal_host) -%>
+    <%- master_domain = Account.is_master_domain?(request.internal_host) -%>
     <%- site_account ||= Account.master -%>
     <%= stylesheet_link_tag 'error' -%>
     <%= render 'provider/analytics' if admin_domain %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -198,6 +198,9 @@ module System
     config.three_scale.message_bus = ActiveSupport::OrderedOptions.new
     config.three_scale.message_bus.merge!(try_config_for(:message_bus) || {})
 
+    config.domain_substitution = ActiveSupport::OrderedOptions.new
+    config.domain_substitution.merge!(try_config_for(:domain_substitution) || {})
+
     three_scale = config_for(:settings).symbolize_keys
     three_scale[:error_reporting_stages] = three_scale[:error_reporting_stages].to_s.split(/\W+/)
 
@@ -217,6 +220,7 @@ module System
     config.cms_files_path = ':url_root/:date_partition/:basename-:random_secret.:extension'
 
     require 'three_scale/deprecation'
+    require 'three_scale/domain_substitution'
     require 'three_scale/middleware/multitenant'
     require 'three_scale/middleware/dev_domain'
 

--- a/config/examples/domain_substitution.yml
+++ b/config/examples/domain_substitution.yml
@@ -1,0 +1,19 @@
+default: &default
+  enabled: false
+  request_pattern: "\\.stg-saas\\.localhost"
+  request_replacement: ".example.com"
+  response_pattern: "\\.example\\.com"
+  response_replacement: ".stg-saas.localhost"
+
+development:
+  <<: *default
+  enabled: true
+
+test:
+  <<: *default
+
+production:
+  <<: *default
+
+preview:
+  <<: *default

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
@@ -67,7 +67,7 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
     @provider = site_account
 
     unless @provider.provider?
-      render_error "Wrong domain '#{request.host}' for path '#{request.path}'"
+      render_error "Wrong domain '#{request.internal_host}' for path '#{request.path}'"
       false
     end
   end

--- a/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
@@ -66,7 +66,7 @@ class DeveloperPortal::CMS::NewContentController < DeveloperPortal::BaseControll
 
   def redirect_to_dashboard
     # ignore buyer domains
-    return if Account.providers.find_by_domain(request.host)
+    return if Account.providers.find_by_domain(request.internal_host)
 
     if not current_account
       redirect_to(provider_login_path)

--- a/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
@@ -66,7 +66,7 @@ class DeveloperPortal::CMS::NewContentController < DeveloperPortal::BaseControll
 
   def redirect_to_dashboard
     # ignore buyer domains
-    return if Account.providers.find_by_domain(request.internal_host)
+    return if Account.providers.find_by(domain: request.internal_host)
 
     if not current_account
       redirect_to(provider_login_path)

--- a/lib/developer_portal/lib/site_account_support.rb
+++ b/lib/developer_portal/lib/site_account_support.rb
@@ -22,6 +22,7 @@ module SiteAccountSupport
   end
 
   delegate :site_account, :site_account_by_provider_key, to: :site_account_request
+  delegate :internal_host, to: :request
 
   def site_account_request
     @_site_account_request ||= SiteAccountSupport::Request.new(request)
@@ -41,17 +42,17 @@ module SiteAccountSupport
   end
 
   def force_provider_or_master_domain
-    unless ThreeScale.tenant_mode.master? || Account.is_admin_domain?(request.internal_host) || Account.is_master_domain?(request.internal_host)
+    unless ThreeScale.tenant_mode.master? || Account.is_admin_domain?(internal_host) || Account.is_master_domain?(internal_host)
       render_error 'Access denied', :status => :forbidden
     end
   end
 
   def buyer_domain?
-    @_buyer_domain ||= !Account.is_admin_domain?(request.internal_host)
+    @_buyer_domain ||= !Account.is_admin_domain?(internal_host)
   end
 
   def admin_domain?
-    current_account.self_domain == request.internal_host
+    current_account.internal_self_domain == internal_host
   end
 
   class Request

--- a/lib/developer_portal/lib/site_account_support.rb
+++ b/lib/developer_portal/lib/site_account_support.rb
@@ -59,7 +59,7 @@ module SiteAccountSupport
     private :request
 
     delegate :tenant_mode, to: ThreeScale
-    delegate :host, to: :request, allow_nil: true
+    delegate :host, :internal_host, to: :request, allow_nil: true
 
     module MasterDomainWildcard
       def find_provider
@@ -92,11 +92,11 @@ module SiteAccountSupport
     end
 
     def find_provider
-      Account.providers_with_master.find_by!(self_domain: host)
+      Account.providers_with_master.find_by!(self_domain: internal_host)
     end
 
     def domain_account
-      Account.find_by(self_domain: host)
+      Account.find_by(self_domain: internal_host)
     end
 
     def site_account
@@ -105,15 +105,15 @@ module SiteAccountSupport
 
     def site_account_by_provider_key
       return unless (key = provider_key.presence)
-      Account.providers_with_master.by_self_domain(host).first_by_provider_key!(key)
+      Account.providers_with_master.by_self_domain(internal_host).first_by_provider_key!(key)
     end
 
     def site_account_by_domain
-      site = Account.find_by(self_domain: host)
+      site = Account.find_by(self_domain: internal_host)
       if site
         site.provider_account
       else
-        Account.find_by(domain: host)
+        Account.find_by(domain: internal_host)
       end
     end
 

--- a/lib/developer_portal/lib/site_account_support.rb
+++ b/lib/developer_portal/lib/site_account_support.rb
@@ -41,17 +41,17 @@ module SiteAccountSupport
   end
 
   def force_provider_or_master_domain
-    unless ThreeScale.tenant_mode.master? || Account.is_admin_domain?(request.host) || Account.is_master_domain?(request.host)
+    unless ThreeScale.tenant_mode.master? || Account.is_admin_domain?(request.internal_host) || Account.is_master_domain?(request.internal_host)
       render_error 'Access denied', :status => :forbidden
     end
   end
 
   def buyer_domain?
-    @_buyer_domain ||= !Account.is_admin_domain?(request.host)
+    @_buyer_domain ||= !Account.is_admin_domain?(request.internal_host)
   end
 
   def admin_domain?
-    current_account.self_domain == request.host
+    current_account.self_domain == request.internal_host
   end
 
   class Request

--- a/lib/routing_constraints.rb
+++ b/lib/routing_constraints.rb
@@ -4,8 +4,7 @@ module BuyerDomainConstraint
   module_function
 
   def matches?(request)
-    request.extend(ThreeScale::DevDomain::Request) if ThreeScale::DevDomain.enabled?
-    Account.without_deleted.exists?(:domain => request.host) && !MasterDomainConstraint.matches?(request)
+    Account.without_deleted.exists?(:domain => request.internal_host) && !MasterDomainConstraint.matches?(request)
   end
 end
 
@@ -15,7 +14,7 @@ class DomainConstraint
   end
 
   def matches?(request)
-    request.host == @domain
+    request.internal_host == @domain
   end
 end
 
@@ -26,7 +25,7 @@ module ProviderDomainConstraint
     request.extend(ThreeScale::DevDomain::Request) if ThreeScale::DevDomain.enabled?
 
     with_deleted = AuthenticatedSystem::Request.new(request).zync?
-    Account.tenants.without_deleted(!with_deleted).exists?(self_domain: request.host)
+    Account.tenants.without_deleted(!with_deleted).exists?(self_domain: request.internal_host)
   end
 end
 
@@ -38,7 +37,7 @@ module MasterDomainConstraint
     return true if ThreeScale.master_on_premises?
 
     master = Account.master
-    master.admin_domain == request.host or master.domain == request.host
+    master.admin_domain == request.internal_host or master.domain == request.internal_host
   end
 end
 

--- a/lib/routing_constraints.rb
+++ b/lib/routing_constraints.rb
@@ -37,7 +37,8 @@ module MasterDomainConstraint
     return true if ThreeScale.master_on_premises?
 
     master = Account.master
-    master.admin_domain == request.internal_host or master.domain == request.internal_host
+    host = request.internal_host
+    master.match_internal_admin_domain?(host) or master.match_internal_domain?(host)
   end
 end
 

--- a/lib/three_scale/domain_substitution.rb
+++ b/lib/three_scale/domain_substitution.rb
@@ -7,6 +7,76 @@ module ThreeScale::DomainSubstitution
     end
   end
 
+  # Transforms a admin domain from the database to proxied domain.
+  #   Example:
+  #
+  #     An external proxied domain provider-admin.proxied-domain.com
+  #     maps to an Account with provider-admin.example.com in the Database
+  #
+  #     account.provider?
+  #     # => true
+  #
+  #     account['domain']
+  #     # => "provider.example.com"
+  #
+  #     account['self_domain']
+  #     # => "provider-admin.example.com"
+  #
+  #     account.external_domain
+  #     # => "provider.proxied-domain.com"
+  #
+  #     account.external_admin_domain
+  #     # => "provider-admin.proxied-domain.com"
+  #
+  #
+  module Account
+    extend ActiveSupport::Concern
+
+    # included do
+    #   deprecated_methods :domain, :self_domain, :admin_domain
+    # end
+
+    def internal_domain
+      self['domain']
+    end
+
+    def internal_admin_domain
+      admin_domain
+    end
+
+    def internal_self_domain
+      self['self_domain']
+    end
+
+    def external_self_domain
+      ThreeScale::DomainSubstitution.to_external(self['self_domain'])
+    end
+
+    def external_domain
+      ThreeScale::DomainSubstitution.to_external(self['domain'])
+    end
+
+    def external_admin_domain
+      ThreeScale::DomainSubstitution.to_external(admin_domain)
+    end
+
+    def match_internal_admin_domain?(host)
+      internal_admin_domain == host
+    end
+
+    # This methods should not be used
+    # Use match_internal_admin_domain? instead
+    def match_internal_self_domain?(host)
+      internal_self_domain == host
+    end
+    deprecate :match_internal_self_domain?,
+      match_internal_self_domain?: "use match_internal_admin_domain?"
+
+    def match_internal_domain?(host)
+      internal_domain == host
+    end
+  end
+
   class Substitutor
     def self.config
       Rails.application.config.domain_substitution

--- a/lib/three_scale/domain_substitution.rb
+++ b/lib/three_scale/domain_substitution.rb
@@ -66,15 +66,18 @@ module ThreeScale::DomainSubstitution
 
     # This methods should not be used
     # Use match_internal_admin_domain? instead
+    # It will work for provider and developer
     def match_internal_self_domain?(host)
       internal_self_domain == host
     end
-    deprecate :match_internal_self_domain?,
-      match_internal_self_domain?: "use match_internal_admin_domain?"
+    deprecate match_internal_self_domain?: "use #match_internal_admin_domain?"
 
     def match_internal_domain?(host)
       internal_domain == host
     end
+
+    deprecate domain: "use #internal_domain",
+      self_domain: "use #internal_admin_domain"
   end
 
   class Substitutor

--- a/lib/three_scale/domain_substitution.rb
+++ b/lib/three_scale/domain_substitution.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require 'three_scale/deprecation'
+
 module ThreeScale::DomainSubstitution
+
+
   module Request
     def internal_host
       Substitutor.to_internal(host)
@@ -31,10 +35,6 @@ module ThreeScale::DomainSubstitution
   #
   module Account
     extend ActiveSupport::Concern
-
-    # included do
-    #   deprecated_methods :domain, :self_domain, :admin_domain
-    # end
 
     def internal_domain
       self['domain']
@@ -70,14 +70,15 @@ module ThreeScale::DomainSubstitution
     def match_internal_self_domain?(host)
       internal_self_domain == host
     end
-    deprecate match_internal_self_domain?: "use #match_internal_admin_domain?"
 
     def match_internal_domain?(host)
       internal_domain == host
     end
 
     deprecate domain: "use #internal_domain",
-      self_domain: "use #internal_admin_domain"
+      self_domain: "use #internal_admin_domain",
+      match_internal_self_domain?: "use #match_internal_admin_domain?",
+      deprecator: ThreeScale::Deprecation::Deprecator.new
   end
 
   class Substitutor

--- a/lib/three_scale/domain_substitution.rb
+++ b/lib/three_scale/domain_substitution.rb
@@ -128,7 +128,7 @@ module ThreeScale::DomainSubstitution
     #   root_url(host: account.external_self_domain)
     #   # => "https://provider-admin.proxied-domain.com"
     def external_self_domain
-      ThreeScale::DomainSubstitution.to_external(self['self_domain'])
+      ThreeScale::DomainSubstitution::Substitutor.to_external(self['self_domain'])
     end
 
     # Use this method if you want to expose the domain to the view.
@@ -137,21 +137,19 @@ module ThreeScale::DomainSubstitution
     #   root_url(host: account.external_domain)
     #   # => "https://provider.proxied-domain.com"
     def external_domain
-      ThreeScale::DomainSubstitution.to_external(self['domain'])
+      ThreeScale::DomainSubstitution::Substitutor.to_external(self['domain'])
     end
 
     # Use this method if you want to expose the domain to the view.
-    # Works for provider and developer accounts
     # @return [String] the mapped external admin domain to be used in views
     # @example
     #   root_url(host: account.external_admin_domain)
     #   # => "https://provider-admin.proxied-domain.com"
     def external_admin_domain
-      ThreeScale::DomainSubstitution.to_external(admin_domain)
+      ThreeScale::DomainSubstitution::Substitutor.to_external(admin_domain)
     end
 
     # Matches if the database value of _self_domain_ matches the host.
-    # Works for provider and developer accounts
     # @param host [String] the host to compare
     #   with the database value of _self_domain_
     # @return [Boolean]

--- a/lib/three_scale/domain_substitution.rb
+++ b/lib/three_scale/domain_substitution.rb
@@ -11,11 +11,72 @@ module ThreeScale::DomainSubstitution
     end
   end
 
-  # Transforms a admin domain from the database to proxied domain.
-  #   Example:
+  # == Context
+  # In any debugging environment _development_ or _preview_,
+  # - database has account super domain set to *example.com*
+  # - you access the UI or with another super domain like *proxied-domain.com*
   #
-  #     An external proxied domain provider-admin.proxied-domain.com
-  #     maps to an Account with provider-admin.example.com in the Database
+  # You still want to point your browser to *http://provider-admin.proxied-domain.com*
+  # and expect it to work.
+  #
+  # In a "_proxied_" request, we used to monkey patch +request.host+ with
+  # +ThreeScale::Middleware::DevDomain+ and +ThreeScale::DevDomain+, leading to:
+  # - weird behavior
+  # - feature needing to know the environment.
+  #   Is it preview or development or production?
+  # - monkey patching feature to make it testable locally or in preview
+  # - library failures in preview (sidekiq-web not working well)
+  #
+  # === Using a prroxy as a solution?
+  #
+  # Why not using a proxy (e.g. nginx) to replace the URL?
+  #
+  # Well, it would not work for server responses.
+  # When the code is using +account.domain+ or the likes, it will then use
+  # *provider-admin.3scale.net* instead of *provider-admin.example.com*
+  #
+  # == Features that do not work well
+  #
+  # - sidekiq web and any middleware that relies on request.host
+  # - email views will render link with the incorrect domain:
+  #   url are rendered with +host: account.domain+
+  # - service discovery Authentication needs to craft some the url
+  #   with +:host+ option
+  # - SSO login will not work for the same reason
+  # - whenever you use +url_for(host: account.domain)+ there is an issue
+  #
+  #
+  # == So what solution?
+  #
+  # This module adds some convenient methods to be used in the correct context
+  # i.e. the writer will have the responsibility to use the correct method
+  #
+  # - {Account#external_domain} or {Account#internal_domain}
+  # - {Account#external_admin_domain} or {Account#internal_admin_domain}
+  #
+  # Most of the use cases:
+  # - in the context of a request, use +Account#internal_\*+ methods
+  # - in the context of a response, use +Account#external_\*+ methods
+  #
+  #
+  # Examples:
+  #
+  #   Config file: config/domain_substitution.yml
+  #
+  #     development:
+  #       enabled: true
+  #       request_pattern: "\\.proxied-domain\\.com"
+  #       request_replacement: ".example.com"
+  #       response_pattern: "\\.example\\.com"
+  #       response_replacement: ".proxied-domain.com"
+  #
+  #   In Ruby:
+  #
+  #     request.host
+  #     # => provider-admin.proxied-domain.com
+  #
+  #     request.internal_host
+  #     # => provider-admin.example.com
   #
   #     account.provider?
   #     # => true
@@ -36,47 +97,87 @@ module ThreeScale::DomainSubstitution
   module Account
     extend ActiveSupport::Concern
 
+    # Just an alias to _#domain_ as _#domain_ will be private.
+    # Use this method when checking against the database
+    # or some internal checks (See lib/routing_constraints.rb)
+    # @return [String] the domain of the Account
     def internal_domain
       self['domain']
     end
 
+    # This is an alias to _#admin_domain_ as _#admin_domain_ will be private.
+    # Use this method when checking against the database
+    # @return [String] the admin domain of the Account
     def internal_admin_domain
-      admin_domain
+      ThreeScale::Deprecation.silence do
+        admin_domain
+      end
     end
 
+    # This is just an alias to _#self_domain_
+    # @deprecated Use {#internal_admin_domain}
+    # @return [String] the database _self_domain_ value
     def internal_self_domain
       self['self_domain']
     end
 
+    # Use this method if you want to expose the self domain to the view
+    # @deprecated Use {#external_admin_domain}
+    # @return [String] the mapped external self domain to be used in views
+    # @example
+    #   root_url(host: account.external_self_domain)
+    #   # => "https://provider-admin.proxied-domain.com"
     def external_self_domain
       ThreeScale::DomainSubstitution.to_external(self['self_domain'])
     end
 
+    # Use this method if you want to expose the domain to the view.
+    # @return [String] the mapped external domain to be used in views
+    # @example
+    #   root_url(host: account.external_domain)
+    #   # => "https://provider.proxied-domain.com"
     def external_domain
       ThreeScale::DomainSubstitution.to_external(self['domain'])
     end
 
+    # Use this method if you want to expose the domain to the view.
+    # Works for provider and developer accounts
+    # @return [String] the mapped external admin domain to be used in views
+    # @example
+    #   root_url(host: account.external_admin_domain)
+    #   # => "https://provider-admin.proxied-domain.com"
     def external_admin_domain
       ThreeScale::DomainSubstitution.to_external(admin_domain)
     end
 
+    # Matches if the database value of _self_domain_ matches the host.
+    # Works for provider and developer accounts
+    # @param host [String] the host to compare
+    #   with the database value of _self_domain_
+    # @return [Boolean]
     def match_internal_admin_domain?(host)
       internal_admin_domain == host
     end
 
-    # This methods should not be used
-    # Use match_internal_admin_domain? instead
-    # It will work for provider and developer
+    # @deprecated Use {#match_internal_admin_domain?}
+    # @param host [String] the host to compare
+    # @return [Boolean]
+    # @see #match_internal_admin_domain?
     def match_internal_self_domain?(host)
       internal_self_domain == host
     end
 
+    # Matches if the database value of _domain_ matches the host
+    # @param host [String] the host to compare
+    #   with the database value of _domain_
+    # @return [Boolean]
     def match_internal_domain?(host)
       internal_domain == host
     end
 
-    deprecate domain: "use #internal_domain",
-      self_domain: "use #internal_admin_domain",
+    deprecate domain: "use #internal_domain or #external_domain",
+      self_domain: "use #internal_admin_domain or #external_admin_domain",
+      external_self_domain: "use #external_admin_domain",
       match_internal_self_domain?: "use #match_internal_admin_domain?",
       deprecator: ThreeScale::Deprecation::Deprecator.new
   end

--- a/lib/three_scale/domain_substitution.rb
+++ b/lib/three_scale/domain_substitution.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module ThreeScale::DomainSubstitution
+  module Request
+    def internal_host
+      Substitutor.to_internal(host)
+    end
+  end
+
+  class Substitutor
+    def self.config
+      Rails.application.config.domain_substitution
+    end
+
+    def self.request_pattern
+      @request_pattern ||= Regexp.compile config.request_pattern.to_s
+    end
+
+    def self.request_replacement
+      @request_replacement ||= config.request_replacement.to_s
+    end
+
+    def self.response_pattern
+      @response_pattern ||= Regexp.compile config.response_pattern.to_s
+    end
+
+    def self.response_replacement
+      @response_replacement ||= config.response_replacement.to_s
+    end
+
+    def self.enabled?
+      config.enabled
+    end
+
+    # to_internal a request host to system host
+    def self.to_internal(host)
+      return host unless enabled?
+
+      host.to_s.sub(request_pattern, request_replacement)
+    end
+
+    # to_internal a system host to a request host
+    def self.to_external(host)
+      return host unless enabled?
+
+      host.to_s.sub(response_pattern, response_replacement)
+    end
+  end
+end
+
+[Rack::Request, ActionDispatch::Request].each do |klass|
+  klass.prepend(ThreeScale::DomainSubstitution::Request)
+end

--- a/test/unit/domain_constraints_test.rb
+++ b/test/unit/domain_constraints_test.rb
@@ -11,8 +11,8 @@ class DomainConstraintsTest < ActiveSupport::TestCase
       ThreeScale.config.stubs(tenant_mode: 'multitenant')
       @domain = 'domain.example.com'
 
-      @request = mock
-      @request.stubs(:host).returns(@domain)
+      @request = ActionDispatch::TestRequest.create
+      @request.host = @domain
     end
 
     attr_reader :domain, :request
@@ -48,8 +48,8 @@ class DomainConstraintsTest < ActiveSupport::TestCase
       ThreeScale.config.stubs(tenant_mode: 'multitenant')
       @self_domain = 'admin.example.com'
 
-      @request = mock
-      @request.stubs(:host).returns(@self_domain)
+      @request = ActionDispatch::TestRequest.create
+      @request.host = @self_domain
       AuthenticatedSystem::Request.any_instance.stubs(:zync?).returns(false)
     end
 
@@ -86,8 +86,8 @@ class DomainConstraintsTest < ActiveSupport::TestCase
 
     test 'master domain' do
       master = master_account
-      request = mock
-      request.expects(:host).returns(master.domain)
+      request = ActionDispatch::TestRequest.create
+      request.host = master.domain
 
       refute ProviderDomainConstraint.matches?(request)
     end
@@ -96,18 +96,19 @@ class DomainConstraintsTest < ActiveSupport::TestCase
   class MasterDomainConstraintTest < DomainConstraintsTest
     test 'master domain' do
       master = master_account
-      request = mock
-      request.expects(:host).returns(master.domain)
+      request = ActionDispatch::TestRequest.create
+      request.host = master.domain
       assert MasterDomainConstraint.matches?(request)
     end
 
     test 'accepts any domain on premises' do
       ThreeScale.config.stubs(onpremises: true)
       ThreeScale.config.stubs(tenant_mode: 'master')
-      master = master_account
-      request = mock
 
-      request.stubs(:host).returns(master.domain)
+      master = master_account
+      request = ActionDispatch::TestRequest.create
+      request.host = master.domain
+
       assert MasterDomainConstraint.matches?(request)
 
       request.stubs(:host).returns('different' + master.domain)

--- a/test/unit/domain_substitution_test.rb
+++ b/test/unit/domain_substitution_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DomainSubstitutionTest < ActiveSupport::TestCase
+
+  def setup
+    Rails.application.config.stubs(:domain_substitution).returns(config)
+  end
+
+  protected
+
+  def config
+    @config ||= ActiveSupport::OrderedOptions.new.merge({
+      enabled: true,
+      request_pattern: '\.preview\.example.com',
+      request_replacement: '.localhost',
+      response_pattern: '\.localhost',
+      response_replacement: '.foo.bar'
+    })
+  end
+
+  class RequestTest < DomainSubstitutionTest
+
+    def test_internal_host_if_disabled
+      config.enabled = false
+      request = ActionDispatch::TestRequest.create
+      request.host = 'foo.preview.example.com'
+      assert_equal 'foo.preview.example.com', request.internal_host
+    end
+
+    def test_internal_host_when_matched
+      request = ActionDispatch::TestRequest.create
+      request.host = 'foo.preview.example.com'
+      assert_equal 'foo.localhost', request.internal_host
+    end
+
+    def test_internal_host_when_unmatched
+      request = ActionDispatch::TestRequest.create
+      request.host = 'foo.preview.3scale.net'
+      assert_equal 'foo.preview.3scale.net', request.internal_host
+    end
+  end
+
+  class SubstitutorTest < DomainSubstitutionTest
+    include ThreeScale::DomainSubstitution
+
+    def test_disabled
+      config.enabled = false
+      assert_equal 'foo.preview.example.com', Substitutor.to_internal('foo.preview.example.com')
+      assert_equal 'foo.localhost', Substitutor.to_external('foo.localhost')
+    end
+
+    def test_enabled
+      assert_equal 'foo.localhost', Substitutor.to_internal('foo.preview.example.com')
+      assert_equal 'foo.foo.bar', Substitutor.to_external('foo.localhost')
+    end
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not make features worry about if we are in production or in preview.
We need to prepare of the removal of ThreeScale::Middleware::DevDomain and remove all monkey patching of `request.host`

This first step is to use `request.internal_host` when it is possible
It will deprecate the use of `Account#domain` and `Account#self_domain`
They will be private later

**Which issue(s) this PR fixes**

Relates to https://issues.redhat.com/browse/THREESCALE-5265
Partially closes it.


Example:

When enabled you can point your browser to `http://provider-admin.stg-saas.localhost` and it will use the `Account` which `self_domain` is `provider-admin.example.com`