### PR TITLE
Fix ActiveDocs 2.0 Liquid Oracle CircleCI failures & Speed it up

### DIFF
--- a/features/step_definitions/active_docs_steps.rb
+++ b/features/step_definitions/active_docs_steps.rb
@@ -37,6 +37,7 @@ end
 
 Then(/^the swagger autocomplete should work for "(.*?)" with "(.*?)"$/) do |input_name, autocomplete|
   click_on 'get'
+  wait_for_requests
   assert_equal 1, evaluate_script("$('input[name=#{input_name}]').focus().length")
   assert_equal 1, evaluate_script("$('.apidocs-param-tips.#{autocomplete}:visible').length")
 end

--- a/features/support/initial_data.rb
+++ b/features/support/initial_data.rb
@@ -1,4 +1,5 @@
-#TODO: join all these into one single Before for speed
+# frozen_string_literal: true
+
 Before do
   countries = {'ES' => 'Spain',
                'US' => 'United States of America'}
@@ -6,11 +7,9 @@ Before do
   countries.each do |code, name|
     FactoryBot.create(:country, :name => name, :code => code) unless Country.exists?(:code => code)
   end
-end
 
-Before do
   ThreeScale.config.stubs(superdomain: 'example.com')
-  FieldsDefinition.create_defaults! FactoryBot.create(:master_account)
+  FieldsDefinition.create_defaults! master_account
   ThreeScale.config.stubs(onpremises: false)
   ThreeScale.config.sandbox_proxy.stubs(apicast_registry_url: 'http://apicast.alaska/policies')
   ThreeScale.config.sandbox_proxy.stubs(self_managed_apicast_registry_url: 'http://self-managed.apicast.alaska/policies')


### PR DESCRIPTION
Part of [THREESCALE-5261](https://issues.redhat.com/browse/THREESCALE-5261)
- [X] Fix ActiveDocs 2.0 Liquid

- [X] InitialData reuses master_account and has one single Before block.
This is faster and it can be reused comfortably when doing ssh to CircleCI 😄 