### PR TITLE
Fixes sorting index

### DIFF
--- a/portafly/src/pages/Overview.tsx
+++ b/portafly/src/pages/Overview.tsx
@@ -83,8 +83,7 @@ const DataListTable = () => {
   const { modal, setModal } = useDataListBulkActions()
 
   const onSort: OnSort = (event, index, direction) => {
-    // When table is selectable, index must be corrected because of the first row of checkboxes
-    setSortBy(index - 1, direction)
+    setSortBy(index, direction, true)
   }
 
   return (


### PR DESCRIPTION
Turned out the index correction has to be handled inside the reducer. It depends on the sorted table being "selectable" or not. That means, it has a `onSelect` callback defined.