### PR TITLE
Fix ensure_provider callback returning false

### DIFF
--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -143,42 +143,29 @@ class FrontendController < ApplicationController
   end
 
   def ensure_provider
-    unless current_account.provider?
-      render_error 'Not authorized', :status => :not_authorized
-      false
-    else
-      true
-    end
+    return if current_account.provider?
+    render_error 'Not authorized', :status => :not_authorized
+    false
   end
 
   def ensure_provider_domain
-    unless Account.is_admin_domain?(request.host) || site_account.master?
-      notify_about_wrong_domain(request.url, :provider, error_request_data)
-      render_wrong_domain_error
-      false
-    else
-      true
-    end
+    return if Account.is_admin_domain?(request.host) || site_account.master?
+    notify_about_wrong_domain(request.url, :provider, error_request_data)
+    render_wrong_domain_error
+    false
   end
 
   def ensure_buyer_domain
-    if Account.is_admin_domain?(request.host) || site_account.master?
-      notify_about_wrong_domain(request.url, :buyer)
-      render_wrong_domain_error
-      false
-    else
-      true
-    end
+    return unless Account.is_admin_domain?(request.host) || site_account.master?
+    notify_about_wrong_domain(request.url, :buyer)
+    render_wrong_domain_error
   end
 
   def ensure_master_domain
-    unless Account.is_master_domain?(request.host)
-      notify_about_wrong_domain(request.url, :master)
-      render_wrong_domain_error
-      false
-    else
-      true
-    end
+    return if Account.is_master_domain?(request.host)
+    notify_about_wrong_domain(request.url, :master)
+    render_wrong_domain_error
+    false
   end
 
   def render_wrong_domain_error

--- a/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
@@ -3,6 +3,7 @@ class DeveloperPortal::CMS::NewContentController < DeveloperPortal::BaseControll
   skip_before_action :login_required
 
   before_action :ensure_can_view_content, :if => :check_permissions?
+  append_before_action :ensure_buyer_domain, only: [:show]
 
   # Redirect to credit card details only for '/' and '/docs' path
   # Other pages will be normally accessible
@@ -22,9 +23,8 @@ class DeveloperPortal::CMS::NewContentController < DeveloperPortal::BaseControll
   activate_menu :portal
 
   PROTECTED_CONTENT_FROM_PAID_SIGNUP = Set.new(['/', '/docs']).freeze
-  def show
-    return unless ensure_buyer_domain
 
+  def show
     case
     when redirect # redirect
       head(:moved_permanently, :location => redirect.target)


### PR DESCRIPTION
Fixes rubocop warnnig

Notes: `throw(:abort)` only works for ActiveRecord and ActiveModel