### PR TITLE
Remove Rails deprecation warning find_by_provider_key

### DIFF
--- a/app/controllers/admin/api/accounts_controller.rb
+++ b/app/controllers/admin/api/accounts_controller.rb
@@ -263,7 +263,7 @@ class Admin::Api::AccountsController < Admin::Api::BaseController
     when user_id = params[:user_id]
       buyer_users.find(user_id).account
     when current_account.master? && provider_key = params[:buyer_provider_key]
-      buyer_accounts.find_by_provider_key!(provider_key, error: ActiveRecord::RecordNotFound)
+      buyer_accounts.first_by_provider_key!(provider_key, error: ActiveRecord::RecordNotFound)
     when current_account.master? && service_token = params[:buyer_service_token]
       buyer_accounts.find_by_service_token!(service_token)
     else

--- a/app/lib/api_authentication/by_provider_key.rb
+++ b/app/lib/api_authentication/by_provider_key.rb
@@ -18,7 +18,7 @@ module ApiAuthentication::ByProviderKey
                            Account
                                .providers_with_master
                                .by_self_domain(request.host)
-                               .find_by_provider_key(provider_key)
+                               .first_by_provider_key(provider_key)
                          end
   end
   # rubocop:enable Rails/DynamicFindBy

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -337,7 +337,7 @@ class Account < ApplicationRecord
   # database lookup if possible (uses cache), so it is super fast.
   def self.id_from_api_key(api_key)
     Rails.cache.fetch("account_ids/#{api_key}") do
-      Account.find_by_provider_key!(api_key).id # rubocop:disable Rails/DynamicFindBy
+      Account.first_by_provider_key!(api_key).id # rubocop:disable Rails/DynamicFindBy
     end
   end
 

--- a/app/models/account/master_methods.rb
+++ b/app/models/account/master_methods.rb
@@ -32,12 +32,12 @@ module Account::MasterMethods
       by_service_token(service_token).first || raise(error)
     end
 
-    def find_by_provider_key(provider_key)
+    def first_by_provider_key(provider_key)
       by_provider_key(provider_key).first
     end
 
-    def find_by_provider_key!(provider_key, error: Backend::ProviderKeyInvalid)
-      find_by_provider_key(provider_key) || raise(error)
+    def first_by_provider_key!(provider_key, error: Backend::ProviderKeyInvalid)
+      first_by_provider_key(provider_key) || raise(error)
     end
   end
 end

--- a/lib/developer_portal/lib/site_account_support.rb
+++ b/lib/developer_portal/lib/site_account_support.rb
@@ -73,7 +73,7 @@ module SiteAccountSupport
       def site_account_by_provider_key
         return unless (key = provider_key.presence)
         if ThreeScale.master_on_premises?
-          Account.where(master: true).find_by_provider_key!(key) || super
+          Account.where(master: true).first_by_provider_key!(key) || super
         else
           super
         end
@@ -105,7 +105,7 @@ module SiteAccountSupport
 
     def site_account_by_provider_key
       return unless (key = provider_key.presence)
-      Account.providers_with_master.by_self_domain(host).find_by_provider_key!(key)
+      Account.providers_with_master.by_self_domain(host).first_by_provider_key!(key)
     end
 
     def site_account_by_domain

--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -163,7 +163,7 @@ FactoryBot.define do
 
       account.stubs(:bought_cinstance).returns(bought_cinstance)
       account.stubs(:provider_account).returns(master_account)
-      Account.stubs(:find_by_provider_key).with(bought_cinstance.user_key).returns(account)
+      Account.stubs(:first_by_provider_key).with(bought_cinstance.user_key).returns(account)
     end
   end
 

--- a/test/functional/developer_portal/admin/account/account_plans_controller_test.rb
+++ b/test/functional/developer_portal/admin/account/account_plans_controller_test.rb
@@ -57,7 +57,7 @@ class DeveloperPortal::Admin::Account::AccountPlansControllerTest < DeveloperPor
   end
 
   test 'change via api with invalid provider_key' do
-    Account.expects(:find_by_provider_key!).with('fake')
+    Account.expects(:first_by_provider_key!).with('fake')
       .raises(Backend::ProviderKeyInvalid)
 
     @request.host = @provider.admin_domain
@@ -71,7 +71,7 @@ class DeveloperPortal::Admin::Account::AccountPlansControllerTest < DeveloperPor
   end
 
   test 'change via api with invalid username' do
-    Account.expects(:find_by_provider_key!).with(@provider.api_key)
+    Account.expects(:first_by_provider_key!).with(@provider.api_key)
       .returns(@provider)
 
     @provider.buyer_users.expects(:find_by)

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -429,17 +429,17 @@ class AccountTest < ActiveSupport::TestCase
     assert_nil account.site_access_code
   end
 
-  test 'Account.find_by_provider_key! raises an exception if the key is invalid' do
+  test 'Account.first_by_provider_key! raises an exception if the key is invalid' do
     assert_raise Backend::ProviderKeyInvalid do
-      Account.find_by_provider_key!('boo')
+      Account.first_by_provider_key!('boo')
     end
   end
 
-  test "Account.find_by_provider_key! finds account by bought cinstance's user_key" do
+  test "Account.first_by_provider_key! finds account by bought cinstance's user_key" do
     account = FactoryBot.create(:simple_account, provider_account: master_account)
     cinstance = account.buy!(master_account.default_service.published_plans.first)
 
-    assert_equal account, Account.find_by_provider_key!(cinstance.user_key)
+    assert_equal account, Account.first_by_provider_key!(cinstance.user_key)
   end
 
   test 'Account.master raises and exception if there is no master account' do


### PR DESCRIPTION
Just renamed `find_by_provider_key` to `first_by_provider_key`

Because it becomes annoying to have them when looking at the logs for debugging.
