### PR TITLE
Custom ThreeScale::Deprecation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -216,7 +216,7 @@ module System
 
     config.cms_files_path = ':url_root/:date_partition/:basename-:random_secret.:extension'
 
-
+    require 'three_scale/deprecation'
     require 'three_scale/middleware/multitenant'
     require 'three_scale/middleware/dev_domain'
 

--- a/config/initializers/deprecation.rb
+++ b/config/initializers/deprecation.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Silence our custom deprecator in test, production and preview
+# Stop to spam
+ThreeScale::Deprecation.silenced = %w[test production preview].include?(Rails.env)

--- a/lib/three_scale/deprecation.rb
+++ b/lib/three_scale/deprecation.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ThreeScale
+
+  class Deprecation < ActiveSupport::Deprecation # :nodoc:
+
+    def initialize(deprecation_horizon = 'future version', gem_name = '3scale')
+      super
+    end
+
+    # # WARNING: This is a private method in ActiveSupport::Deprecation
+    # # Uncomment this to have custom default deprecation message
+    # def deprecation_message(callstack, message = nil)
+    #   message ||= 'You are using a deprecated method.'
+    #   "DEPRECATION WARNING: #{message} #{deprecation_caller_message(callstack)}"
+    # end
+
+    # Deprecator class
+    # Custom deprecator to display message warning for deprecation
+    class Deprecator
+      def deprecation_warning(
+        deprecated_method_name, message = nil, caller_backtrace = nil
+      )
+        caller_backtrace ||= caller_locations(2)
+        message ||= "`#{deprecated_method_name}' is not fully implemented."
+        ThreeScale::Deprecation.warn(message, caller_backtrace)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Just a subclass of `ActiveSupport::Deprecation`
But it has its own `#behavior` and `#silenced` methods

To modify its configurations, edit ./config/initializers/deprecation.rb


## Usage

See `ActiveSupport::Deprecation` for full usage

```ruby
deprecate :some_method,
  another_method: "use #replacement_method instead",
  deprecator: ThreeScale::Deprecation.new
```