### PR TITLE
Rake task to migrate services to configuration driven

### DIFF
--- a/lib/tasks/proxy.rake
+++ b/lib/tasks/proxy.rake
@@ -58,4 +58,29 @@ namespace :proxy do
       sleep(0.5) unless Rails.env.test?
     end
   end
+
+  desc 'Migrate to services to configuration driven'
+  task :migrate_to_configuration_driven, %i[services_selector deploy_to update_endpoints] => :environment do |_, args|
+    to_arr = ->(arg) { args[arg].to_s.split(',') }
+
+    services_selectors = to_arr.call(:services_selector)   # <id>(,<id>)* | hosted | self_managed | nil
+    deployment_option = services_selectors.delete('hosted') || services_selectors.delete('self_managed') || Service::DeploymentOption.gateways
+    service_ids = services_selectors - %w[hosted self_managed]
+
+    deploy_to = to_arr.call(:deploy_to)                    # staging(,production)? | nil
+
+    update_endpoints = ActiveModel::Type::Boolean.new.deserialize(args[:update_endpoints].presence)
+    update_method = update_endpoints ? :update_attribute : :update_column
+
+    services = Service.accessible.where(deployment_option: deployment_option).where(service_ids.present? ? { id: service_ids } : {})
+    proxies = Proxy.where(apicast_configuration_driven: false, service: services)
+
+    proxies.find_each do |proxy|
+      Proxy.transaction do
+        proxy.public_send(update_method, :apicast_configuration_driven, true)
+        next unless proxy.enabled # proxy.enabled == true means the service was deployed to sandbox proxy before
+        deploy_to.each { |env| ProxyDeploymentService.call(proxy, environment: env) }
+      end
+    end
+  end
 end

--- a/test/unit/tasks/proxy_test.rb
+++ b/test/unit/tasks/proxy_test.rb
@@ -69,5 +69,97 @@ module Tasks
         assert_equal legit_change_date.to_i, proxy_with_legit_change.affecting_change_history.updated_at.to_i
       end
     end
+
+    class MigrateToConfigurationDriven < ActiveSupport::TestCase
+      setup do
+        provider = FactoryBot.create(:simple_provider)
+
+        services = [
+          @hosted_apicast_v1_service_1 = create_service(account: provider, deployment_option: 'hosted', proxy: { apicast_configuration_driven: false }),
+          @hosted_apicast_v1_service_2 = create_service(deployment_option: 'hosted', proxy: { apicast_configuration_driven: false }), # different provider
+          @self_managed_apicast_v1_service = create_service(account: provider, deployment_option: 'self_managed', proxy: { apicast_configuration_driven: false }),
+          @hosted_apicast_v2_service = create_service(account: provider, deployment_option: 'hosted') # configuration driven
+        ]
+
+        @services = Service.where(id: services)
+      end
+
+      attr_reader :services, :hosted_apicast_v1_service_1, :hosted_apicast_v1_service_2, :self_managed_apicast_v1_service, :hosted_apicast_v2_service
+
+      test 'all services' do
+        execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven'
+        assert Proxy.where(service: services).all?(&:apicast_configuration_driven)
+      end
+
+      test 'selected service ids' do
+        execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven', selected_service_ids
+        assert Proxy.where(service: selected_service_ids).all?(&:apicast_configuration_driven)
+        refute hosted_apicast_v1_service_2.reload.proxy.apicast_configuration_driven # not in the list
+      end
+
+      test 'all hosted services' do
+        execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven', 'hosted'
+        assert hosted_apicast_v1_service_1.reload.proxy.apicast_configuration_driven
+        assert hosted_apicast_v1_service_2.reload.proxy.apicast_configuration_driven
+        refute self_managed_apicast_v1_service.reload.proxy.apicast_configuration_driven # not hosted
+      end
+
+      test 'all self_managed services' do
+        execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven', 'self_managed'
+        refute hosted_apicast_v1_proxies.any?(&:apicast_configuration_driven) # not self_managed
+        assert self_managed_apicast_v1_service.reload.proxy.apicast_configuration_driven
+      end
+
+      test 'service selector specifying the deployment option and service ids' do
+        execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven', "self_managed,#{selected_service_ids}"
+        assert self_managed_apicast_v1_service.reload.proxy.apicast_configuration_driven
+        refute hosted_apicast_v1_service_1.reload.proxy.apicast_configuration_driven # not self_managed
+        refute hosted_apicast_v1_service_2.reload.proxy.apicast_configuration_driven # not in the list
+      end
+
+      test 'deploy to staging' do
+        hosted_apicast_v1_proxies.update_all(deployed_at: 1.day.ago)
+        hosted_apicast_v1_proxies.each { |proxy| ProxyDeploymentService.expects(:call).with(proxy, environment: 'staging') }
+        execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven', 'hosted', 'staging'
+      end
+
+      test 'deploy to staging and production' do
+        hosted_apicast_v1_proxies.update_all(deployed_at: 1.day.ago)
+        hosted_apicast_v1_proxies.each do |proxy|
+          ProxyDeploymentService.expects(:call).with(proxy, environment: 'staging')
+          ProxyDeploymentService.expects(:call).with(proxy, environment: 'production')
+        end
+        execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven', 'hosted', 'staging,production'
+      end
+
+      test 'updating the proxy endpoints' do
+        assert hosted_apicast_v1_proxies.all? { |proxy| proxy.endpoint =~ /apicast\.io/ }
+        execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven', 'hosted', nil, true
+        assert hosted_apicast_v1_proxies.all? { |proxy| proxy.endpoint =~ /apicast\.dev/ }
+      end
+
+      test 'without updating the proxy endpoints' do
+        assert hosted_apicast_v1_proxies.all? { |proxy| proxy.endpoint =~ /apicast\.io/ }
+        execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven', 'hosted'
+        assert hosted_apicast_v1_proxies.all? { |proxy| proxy.endpoint =~ /apicast\.io/ }
+      end
+
+      protected
+
+      def create_service(attributes = {})
+        service = FactoryBot.build(:simple_service, attributes.except(:proxy))
+        service.proxy = FactoryBot.build(:simple_proxy, service: service, **attributes.fetch(:proxy, {}))
+        service.save!
+        service
+      end
+
+      def selected_service_ids
+        [hosted_apicast_v1_service_1, self_managed_apicast_v1_service].map(&:id).join(',')
+      end
+
+      def hosted_apicast_v1_proxies
+        Proxy.where(apicast_configuration_driven: false, service: services.where(deployment_option: 'hosted'))
+      end
+    end
   end
 end


### PR DESCRIPTION
Introduces a rake task to migrate services to configuration-driven gateway. it can be used for hosted and/self-managed services.

Usage:

```
rake proxy:migrate_to_configuration_driven[<services_selector>,<deploy_to>,<update_endpoints>]

<services_selector> ::= <selector> | <selector>","<services_selector> | nil (default: all services)
<selector> ::= service_id | "hosted" | "self_managed"

<deploy_to> ::= "staging" | "production" | "staging,production" | nil (default: no deploy)

<update_endpoints> ::= <truthy> | <falsey> | nil (default: falsey)
<truthy> and <falsey> resolved by ActiveModel::Type::Boolean#deserialize
```

Examples:

| Command                                                                    | Services                                            | Deploy(*)              | Update endpoints? |
|----------------------------------------------------------------------------|-----------------------------------------------------|------------------------|:-----------------:|
| `rake proxy:migrate_to_configuration_driven`                               | All services                                        | None                   | No                |
| `rake proxy:migrate_to_configuration_driven[hosted]`                       | All cloud-hosted services                           | None                   | No                |
| `rake proxy:migrate_to_configuration_driven[self_managed]`                 | All self-managed services                           | None                   | No                |
| `rake proxy:migrate_to_configuration_driven["123\,456"]`                   | Services 123 and 456                                | None                   | No                |
| `rake proxy:migrate_to_configuration_driven["123\,456\,hosted"]`           | Services 123 and 456, only the ones that are hosted | None                   | No                |
| `rake proxy:migrate_to_configuration_driven[hosted,staging]`               | All cloud-hosted services                           | staging                | No                |
| `rake proxy:migrate_to_configuration_driven[hosted,"staging\,production"]` | All cloud-hosted services                           | staging and production | No                |
| `rake proxy:migrate_to_configuration_driven[hosted,staging,true]`          | All cloud-hosted services                           | staging                | Yes               |

(*) Proxies that have never been deployed while on APIcast v1 will ignore any `<deploy_to>` parameter and will NOT be deployed by the rake task.

----

Closes [THREESCALE-2071](https://issues.redhat.com/browse/THREESCALE-2071)