### PR TITLE
Use domain substitution in mailers

### DIFF
--- a/app/mailers/account_mailer.rb
+++ b/app/mailers/account_mailer.rb
@@ -88,7 +88,7 @@ class AccountMailer < ActionMailer::Base
   def assigns(account)
     {
       :user => Liquid::Drops::User.new(admin_of(account)),
-      :domain => account.provider_account.domain,
+      :domain => account.provider_account.external_domain,
       :account => Liquid::Drops::Account.new(account),
       :provider => Liquid::Drops::Provider.new(account.provider_account),
       :support_email => admin_of(account.provider_account).email

--- a/app/mailers/data_export_mailer.rb
+++ b/app/mailers/data_export_mailer.rb
@@ -7,7 +7,7 @@ class DataExportMailer < ActionMailer::Base
     provider = recipient.account
     stash =  { report_name: report_type,
                name: recipient.first_name,
-               domain_name: provider.domain }
+               domain_name: provider.external_domain }
     assign_drops(stash)
 
 

--- a/app/mailers/post_office.rb
+++ b/app/mailers/post_office.rb
@@ -22,9 +22,9 @@ class PostOffice < ActionMailer::Base
       subject = "[msg] #{message.subject}"
 
       msg_url = if recipient.receiver.buyer?
-        developer_portal.admin_messages_inbox_url(recipient, host: recipient.receiver.provider_account.domain)
+        developer_portal.admin_messages_inbox_url(recipient, host: recipient.receiver.provider_account.external_domain)
                 else # provider or master
-        provider_admin_messages_inbox_url(recipient, host: recipient.receiver.self_domain)
+        provider_admin_messages_inbox_url(recipient, host: recipient.receiver.external_self_domain)
                 end
 
       @sender = message.sender.org_name

--- a/app/mailers/provider_invitation_mailer.rb
+++ b/app/mailers/provider_invitation_mailer.rb
@@ -4,7 +4,7 @@ class ProviderInvitationMailer < ActionMailer::Base
     # TODO: subject and sender should be taken from invitating account.
     @account = invitation.account
     @url = provider_invitee_signup_url(invitation_token: invitation.token,
-                                       host: @account.admin_domain,
+                                       host: @account.external_admin_domain,
                                        protocol: 'https')
 
     headers('Return-Path' => @account.from_email,

--- a/app/mailers/provider_user_mailer.rb
+++ b/app/mailers/provider_user_mailer.rb
@@ -37,7 +37,7 @@ class ProviderUserMailer < ActionMailer::Base
 
   def domain(account)
     raise "Using ProviderUserMailer for buyer account #{account.name}(#{account.id})" unless account.master? || account.provider?
-    account.admin_domain
+    account.external_admin_domain
   end
 
 
@@ -82,7 +82,7 @@ class ProviderUserMailer < ActionMailer::Base
   # private
 
   # def admin_url(user)
-  #   admin_dashboard_url(:host => user.account.provider_account.domain)
+  #   admin_dashboard_url(:host => user.account.provider_account.external_admin_domain)
   # end
 
 

--- a/app/mailers/topic_mailer.rb
+++ b/app/mailers/topic_mailer.rb
@@ -17,7 +17,7 @@ class TopicMailer < ActionMailer::Base
   private
 
   def domain(post)
-    post.forum.account.domain
+    post.forum.account.external_domain
   end
 
   def from_address(sender)

--- a/lib/developer_portal/app/mailers/invitation_mailer.rb
+++ b/lib/developer_portal/app/mailers/invitation_mailer.rb
@@ -15,10 +15,10 @@ class InvitationMailer < ActionMailer::Base
 
     domain = if @invitation.account.provider?
                self.provider_account = @invitation.account
-               provider.admin_domain
+               provider.external_admin_domain
              else
                self.provider_account = @invitation.account.provider_account
-               provider.domain
+               provider.external_domain
              end
 
     @url = invitee_signup_url(:invitation_token => @invitation.token,

--- a/lib/developer_portal/app/mailers/user_mailer.rb
+++ b/lib/developer_portal/app/mailers/user_mailer.rb
@@ -74,18 +74,18 @@ class UserMailer < ActionMailer::Base
   private
 
   def admin_url(user)
-    developer_portal.admin_dashboard_url(:host => user.account.provider_account.domain)
+    developer_portal.admin_dashboard_url(:host => user.account.provider_account.external_domain)
   end
 
   def domain(user)
     account = user.account
 
     if account.master?
-      account.domain
+      account.external_domain
     elsif account.provider?
-      account.admin_domain
+      account.external_admin_domain
     else
-      account.provider_account.domain
+      account.provider_account.external_domain
     end
   end
 

--- a/lib/three_scale/domain_substitution.rb
+++ b/lib/three_scale/domain_substitution.rb
@@ -146,7 +146,9 @@ module ThreeScale::DomainSubstitution
     #   root_url(host: account.external_admin_domain)
     #   # => "https://provider-admin.proxied-domain.com"
     def external_admin_domain
-      ThreeScale::DomainSubstitution::Substitutor.to_external(admin_domain)
+      ThreeScale::Deprecation.silence do
+        ThreeScale::DomainSubstitution::Substitutor.to_external(admin_domain)
+      end
     end
 
     # Matches if the database value of _self_domain_ matches the host.

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -52,7 +52,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match "A new application subscribed to the #{application.plan.name} plan on the #{service.name} service of the #{application.account.name} account.", body.encoded
       assert_match 'Application details:', body.encoded
       cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(service, application,
-                                                                                         host: service.account.admin_domain)
+                                                                                         host: service.account.external_admin_domain)
       assert_match cinstance_url, body.encoded
 
       assert_html_email(mail) do
@@ -117,7 +117,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match "Application #{application.name} of your client #{application.user_account.name}", body.encoded
       assert_match "is above #{alert.level}% limit utilization of #{alert.message}.", body.encoded
       cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(service, application,
-                                                                                         host: service.account.admin_domain)
+                                                                                         host: service.account.external_admin_domain)
       assert_match cinstance_url, body.encoded
     end
   end
@@ -138,7 +138,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match "Application #{application.name} of your client #{application.user_account.name}", body.encoded
       assert_match "is above #{alert.level}% limit utilization of #{alert.message}.", body.encoded
       cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(service, application,
-                                                                                         host: service.account.admin_domain)
+                                                                                         host: service.account.external_admin_domain)
       assert_match cinstance_url, body.encoded
     end
   end
@@ -197,7 +197,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match 'Dear Foobar Admin', body.encoded
       assert_match "#{user.informal_name} from SimpleCompany has requested to change their Foo Service", body.encoded
       assert_match 'service subscription from Plan 1 to Plan 2.', body.encoded
-      assert_match url_helpers.admin_buyers_account_service_contracts_url(account, host: provider.admin_domain), body.encoded
+      assert_match url_helpers.admin_buyers_account_service_contracts_url(account, host: provider.external_admin_domain), body.encoded
     end
   end
 
@@ -301,7 +301,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match 'Dear Foobar Admin', body.encoded
       assert_match "Alex's trial of the LALA application on the planLALA has expired.", body.encoded
-      assert_match url_helpers.admin_service_application_url(service, cinstance, host: service.provider.admin_domain), body.encoded
+      assert_match url_helpers.admin_service_application_url(service, cinstance, host: service.provider.external_admin_domain), body.encoded
     end
   end
 
@@ -395,7 +395,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match "Current plan: #{cinstance.plan.name}", body.encoded
       assert_match "Application #{cinstance.name} has changed to plan #{cinstance.plan.name}.", body.encoded
       cinstance_url = System::UrlHelpers.system_url_helpers.admin_service_application_url(cinstance.service, cinstance,
-                                                                                         host: cinstance.service.account.admin_domain)
+                                                                                         host: cinstance.service.account.external_admin_domain)
       assert_match cinstance_url, body.encoded
     end
   end
@@ -410,7 +410,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal "New message from #{message.sender.name}", mail.subject
     assert_equal [receiver.email], mail.to
 
-    url = url_helpers.provider_admin_messages_inbox_url(recipient, host: provider.admin_domain)
+    url = url_helpers.provider_admin_messages_inbox_url(recipient, host: provider.external_admin_domain)
 
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match "You have a new message from #{message.sender.name}.", body.encoded
@@ -476,7 +476,7 @@ class NotificationMailerTest < ActionMailer::TestCase
 
     assert mail.attachments
     assert_equal mail.attachments.count, 1
-    assert_match "report-#{provider.domain}-#{service.id}.pdf", mail.attachments.first.filename
+    assert_match "report-#{provider.external_domain}-#{service.id}.pdf", mail.attachments.first.filename
 
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match 'Please find attached your API Usage Report', body.encoded
@@ -492,7 +492,7 @@ class NotificationMailerTest < ActionMailer::TestCase
 
     assert mail.attachments
     assert_equal mail.attachments.count, 1
-    assert_match "report-#{provider.domain}-#{service.id}.pdf", mail.attachments.first.filename
+    assert_match "report-#{provider.external_domain}-#{service.id}.pdf", mail.attachments.first.filename
 
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match 'Please find attached your API Usage Report', body.encoded
@@ -509,7 +509,7 @@ class NotificationMailerTest < ActionMailer::TestCase
 
     [mail.html_part.body, mail.text_part.body].each do |body|
       assert_match "The service #{service.name} has been deleted.", body.encoded
-      assert_match url_helpers.provider_admin_dashboard_url(host: persisted_provider.admin_domain), body.encoded
+      assert_match url_helpers.provider_admin_dashboard_url(host: persisted_provider.external_admin_domain), body.encoded
     end
   end
 
@@ -535,7 +535,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       assert_match "Application: Boo App", body.encoded
       assert_match "Current plan: #{plan.name}", body.encoded
       assert_match "Requested plan: #{plan_2.name}", body.encoded
-      assert_match url_helpers.admin_service_application_url(application.service, application, host: application.service.provider.admin_domain), body.encoded
+      assert_match url_helpers.admin_service_application_url(application.service, application, host: application.service.provider.external_admin_domain), body.encoded
     end
   end
 

--- a/test/unit/mailers/invitation_mailer_test.rb
+++ b/test/unit/mailers/invitation_mailer_test.rb
@@ -18,7 +18,7 @@ class InvitationMailerTest < ActionMailer::TestCase
     should 'body contains signup link to admin domain of the inviting provider' do
       account = @invitation.account
 
-      assert_match("https://#{account.admin_domain}/signup/#{@invitation.token}", @email.body.to_s)
+      assert_match("https://#{account.external_admin_domain}/signup/#{@invitation.token}", @email.body.to_s)
       assert_match(@invitation.account.org_name, @email.body.to_s)
     end
   end
@@ -28,7 +28,7 @@ class InvitationMailerTest < ActionMailer::TestCase
     buyer_invitation = FactoryBot.create(:invitation, :account => buyer)
     buyer_email      = InvitationMailer.invitation(buyer_invitation)
 
-    assert_match("https://#{buyer.provider_account.domain}/signup/#{buyer_invitation.token}", buyer_email.body.to_s)
+    assert_match("https://#{buyer.provider_account.external_domain}/signup/#{buyer_invitation.token}", buyer_email.body.to_s)
   end
 
   # TODO: is sent from ...

--- a/test/unit/mailers/post_office_test.rb
+++ b/test/unit/mailers/post_office_test.rb
@@ -145,7 +145,7 @@ class PostOfficeTest < ActionMailer::TestCase
     assert email = find_message_by_subject("[msg] #{subject}")
     assert_equal @buyer.admins.map(&:email), email.bcc
     assert_equal [Rails.configuration.three_scale.noreply_email], email.from
-    assert_match "http://#{@provider.domain}/admin/messages/received", email.body.to_s
+    assert_match "http://#{@provider.external_domain}/admin/messages/received", email.body.to_s
   end
 
   test 'messages sent via web have link to provider dashboard if sent to provider' do
@@ -158,14 +158,14 @@ class PostOfficeTest < ActionMailer::TestCase
     assert email = find_message_by_subject("[msg] #{subject}")
     assert_equal @provider.admins.map(&:email), email.bcc
     assert_equal [Rails.configuration.three_scale.noreply_email], email.from
-    assert_match url_helpers.provider_admin_messages_inbox_url(recipient, host: @provider.self_domain), email.body.to_s
+    assert_match url_helpers.provider_admin_messages_inbox_url(recipient, host: @provider.external_self_domain), email.body.to_s
   end
 
   test 'messages sent via web throw better error when :host is missing' do
     message   = Message.create!(sender: @buyer, to: [@provider], subject: 'provider', body: "provider", origin: "web")
     recipient = message.recipients.first
 
-    recipient.receiver.stubs(:self_domain).returns(nil)
+    recipient.receiver.self_domain = nil
 
     begin
       PostOffice.message_notification(message, recipient).deliver_now
@@ -193,7 +193,7 @@ class PostOfficeTest < ActionMailer::TestCase
     assert_equal [account.admins.first.email], email.bcc
     assert_equal [Rails.configuration.three_scale.noreply_email], email.from
     assert_match "Please find attached your API Usage Report from 3scale.", email.parts.first.body.to_s
-    assert_equal "report-#{account.domain}-#{service_id}.pdf", email.attachments.first.filename
+    assert_equal "report-#{account.external_domain}-#{service_id}.pdf", email.attachments.first.filename
   end
 
   def url_helpers

--- a/test/unit/mailers/provider_user_mailer_test.rb
+++ b/test/unit/mailers/provider_user_mailer_test.rb
@@ -25,7 +25,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
 
         assert_match %r{Dear #{user.informal_name}}, email_body
         assert_match %r{Thank you for signing up to Red Hat 3scale}, email_body
-        assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
+        assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, email_body
         assert_match %r{The Red Hat 3scale Team}, email_body
       end
 
@@ -40,12 +40,12 @@ class ProviderUserMailerTest < ActionMailer::TestCase
 
         assert_match %r{#{user.informal_name}}, email_body
         assert_match %r{A couple of days ago you signed up for Red Hat 3scale to manage your API}, email_body
-        assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
+        assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, email_body
         assert_match %r{The Red Hat 3scale Team}, email_body
       end
 
       test 'lost_domain' do
-        ProviderUserMailer.lost_domain('the.one.who.forgets@example.com', [account.domain]).deliver_now
+        ProviderUserMailer.lost_domain('the.one.who.forgets@example.com', [account.external_domain]).deliver_now
         email = ActionMailer::Base.deliveries.last
         email_body = email.body.to_s
 
@@ -55,7 +55,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal '{"category": "Domain Recovery"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
         assert_match %r{Dear User}, email_body
-        assert_match %r{https://#{account.domain}/p/login}, email_body
+        assert_match %r{https://#{account.external_domain}/p/login}, email_body
         assert_match %r{The Red Hat 3scale Team}, email_body
       end
 
@@ -70,7 +70,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
 
         assert_match %r{Dear #{user.display_name}}, email_body
         assert_match %r{You can reset your password by visiting the following link}, email_body
-        assert_match %r{#{account.admin_domain}/p/password}, email_body
+        assert_match %r{#{account.external_admin_domain}/p/password}, email_body
         assert_match %r{The Red Hat 3scale Team}, email_body
       end
     end
@@ -92,7 +92,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
 
         assert_match %r{Dear #{user.informal_name}}, email_body
         assert_match %r{Thank you for signing up to #{master_account.org_name}}, email_body
-        assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
+        assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, email_body
         assert_match %r{The #{master_account.org_name} Team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
@@ -108,13 +108,13 @@ class ProviderUserMailerTest < ActionMailer::TestCase
 
         assert_match %r{#{user.informal_name}}, email_body
         assert_match %r{A couple of days ago you signed up for #{master_account.org_name} to manage your API}, email_body
-        assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, email_body
+        assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, email_body
         assert_match %r{The #{master_account.org_name} Team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
 
       test 'lost_domain' do
-        ProviderUserMailer.lost_domain('the.one.who.forgets@example.com', [account.domain]).deliver_now
+        ProviderUserMailer.lost_domain('the.one.who.forgets@example.com', [account.external_domain]).deliver_now
         email = ActionMailer::Base.deliveries.last
         email_body = email.body.to_s
 
@@ -124,7 +124,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal '{"category": "Domain Recovery"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
         assert_match %r{Dear User}, email_body
-        assert_match %r{https://#{account.domain}/p/login}, email_body
+        assert_match %r{https://#{account.external_domain}/p/login}, email_body
         assert_match %r{The #{master_account.org_name} Team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
@@ -140,7 +140,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
 
         assert_match %r{Dear #{user.display_name}}, email_body
         assert_match %r{You can reset your password by visiting the following link}, email_body
-        assert_match %r{#{account.admin_domain}/p/password}, email_body
+        assert_match %r{#{account.external_admin_domain}/p/password}, email_body
         assert_match %r{The #{master_account.org_name} Team}, email_body
         refute_match %r{/3scale|redhat/i}, email_body
       end
@@ -150,7 +150,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
           user.stubs lost_password_token: 'abc123'
           ProviderUserMailer.lost_password(user).deliver_now
           email = ActionMailer::Base.deliveries.last
-          assert_match "https://#{account.admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
+          assert_match "https://#{account.external_admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
         end
       end
     end
@@ -184,13 +184,13 @@ class ProviderUserMailerTest < ActionMailer::TestCase
 
     test 'master user activation on saas' do
       ProviderUserMailer.activation(user).deliver_now
-      assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, ActionMailer::Base.deliveries.last.body.to_s
+      assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, ActionMailer::Base.deliveries.last.body.to_s
     end
 
     test 'master user activation on-prem' do
       ThreeScale.config.stubs(onpremises: true)
       ProviderUserMailer.activation(user).deliver_now
-      assert_match %r{#{account.admin_domain}/p/activate/[a-z0-9]+}, ActionMailer::Base.deliveries.last.body.to_s
+      assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, ActionMailer::Base.deliveries.last.body.to_s
     end
 
     private

--- a/test/unit/mailers/user_mailer_test.rb
+++ b/test/unit/mailers/user_mailer_test.rb
@@ -40,7 +40,7 @@ class UserMailerTest < ActionMailer::TestCase
       with_default_url_options protocol: 'https' do
         email = deliver_lost_password
         assert_match "You can reset your password by visiting the following link", email.body.to_s
-        assert_match "https://#{@provider_account.admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
+        assert_match "https://#{@provider_account.external_admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
       end
     end
 
@@ -68,7 +68,7 @@ class UserMailerTest < ActionMailer::TestCase
         assert_match "Lost password recovery", email.subject
         assert_match "Dear #{@user.display_name},", email.body.to_s
         assert_match "CUSTOM MESSAGE", email.body.to_s
-        assert_match "http://#{@provider_account.admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
+        assert_match "http://#{@provider_account.external_admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
         assert_match "The API Team", email.body.to_s
 
       end
@@ -165,7 +165,7 @@ Customized Template
           with_default_url_options protocol: 'https' do
             email = deliver_lost_password
             assert_match "You can reset your password by visiting the following link", email.body.to_s
-            assert_match "https://#{@provider_account.domain}/admin/account/password?password_reset_token=abc123", email.body.to_s
+            assert_match "https://#{@provider_account.external_domain}/admin/account/password?password_reset_token=abc123", email.body.to_s
           end
         end
 
@@ -193,7 +193,7 @@ Customized Template
             assert_match "Lost password recovery", email.subject
             assert_match "Dear #{@user.display_name},", email.body.to_s
             assert_match "CUSTOM MESSAGE", email.body.to_s
-            assert_match "http://#{@provider_account.domain}/admin/account/password?password_reset_token=abc123", email.body.to_s
+            assert_match "http://#{@provider_account.external_domain}/admin/account/password?password_reset_token=abc123", email.body.to_s
             assert_match "The API Team", email.body.to_s
 
           end


### PR DESCRIPTION
Do not use account.domain or account.admin_domain anymore in mailers
Other url in drops will have to be fixed

Relates to https://issues.redhat.com/browse/THREESCALE-5265