### PR TITLE
Update i18n strings

### DIFF
--- a/portafly/src/components/Loading.tsx
+++ b/portafly/src/components/Loading.tsx
@@ -7,12 +7,16 @@ import {
   Title,
   Spinner
 } from '@patternfly/react-core'
+import { useTranslation } from 'i18n/useTranslation'
 
-export const Loading: React.FunctionComponent = () => (
-  <PageSection aria-label="Loading Content Container">
-    <EmptyState variant={EmptyStateVariant.full}>
-      <EmptyStateIcon variant="container" component={Spinner} />
-      <Title headingLevel="h2" size="lg">Loading</Title>
-    </EmptyState>
-  </PageSection>
-)
+export const Loading: React.FunctionComponent = () => {
+  const { t } = useTranslation('shared')
+  return (
+    <PageSection aria-label={t('loading.aria_label')}>
+      <EmptyState variant={EmptyStateVariant.full}>
+        <EmptyStateIcon variant="container" component={Spinner} />
+        <Title headingLevel="h2" size="lg">{t('loading.title')}</Title>
+      </EmptyState>
+    </PageSection>
+  )
+}

--- a/portafly/src/components/data-list/SearchWidget.tsx
+++ b/portafly/src/components/data-list/SearchWidget.tsx
@@ -15,6 +15,7 @@ import {
 } from '@patternfly/react-core'
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons'
 import { useDataListFilters } from 'components/data-list/'
+import { useTranslation } from 'i18n/useTranslation'
 import { Category, CategoryOption } from 'types'
 
 import './searchWidget.scss'
@@ -30,6 +31,7 @@ const CategorySelect: React.FunctionComponent<ICategorySelect> = ({
   selections,
   onCategorySelect
 }) => {
+  const { t } = useTranslation('shared')
   const [isOpen, setIsOpen] = useState(false)
   const onSelect = (_: any, value: SelectOptionObject) => {
     onCategorySelect((value as { name: string }).name)
@@ -39,7 +41,8 @@ const CategorySelect: React.FunctionComponent<ICategorySelect> = ({
     <Select
       toggleIcon={<FilterIcon />}
       variant={SelectVariant.single}
-      aria-label="category-select"
+      // FIXME: missing translation string
+      aria-label={t('category_select_aria_label')}
       onSelect={onSelect}
       selections={selections}
       isOpen={isOpen}
@@ -97,6 +100,7 @@ interface ISearchBar {
 }
 
 const SearchBar = ({ textInputRef, category, onSearchClick }: ISearchBar) => {
+  const { t } = useTranslation('audienceAccountsListing')
   const onClick = () => {
     if (textInputRef.current?.value) {
       onSearchClick(textInputRef.current.value)
@@ -109,13 +113,14 @@ const SearchBar = ({ textInputRef, category, onSearchClick }: ISearchBar) => {
       <TextInput
         ref={textInputRef}
         type="search"
-        aria-label="Aria label of the text input for filtering"
-        placeholder={`Filter by ${category.humanName}`}
+        // FIXME: missing translation string
+        aria-label={t('filter_aria_label')}
+        // FIXME: this should be moved to shared
+        placeholder={t('accounts_filter_typeahead', { filter_option: category.humanName })}
         onKeyUp={(ev) => ev.key === 'Enter' && onClick()}
       />
       <Button
         variant={ButtonVariant.control}
-        aria-label="Aria label for button"
         onClick={onClick}
       >
         <SearchIcon />

--- a/portafly/src/components/data-list/modals/ChangeStateModal.tsx
+++ b/portafly/src/components/data-list/modals/ChangeStateModal.tsx
@@ -81,7 +81,8 @@ const ChangeStateModal: React.FunctionComponent<Props> = ({
             id="state"
             value={value}
             onChange={setValue}
-            aria-label={t('aria-label-select')}
+            // FIXME: missing translation string
+            aria-label={t('modals.change_state.aria_label')}
           >
             {options.map((option) => (
               <FormSelectOption key={option.value} value={option.value} label={option.label} />

--- a/portafly/src/components/data-list/modals/DataListModal.tsx
+++ b/portafly/src/components/data-list/modals/DataListModal.tsx
@@ -72,7 +72,7 @@ const DataListModal: React.FunctionComponent<Props> = ({
       variant="link"
       onClick={onClose}
     >
-      {t('modals.cancel')}
+      {t('buttons.cancel')}
     </Button>
   ]
 

--- a/portafly/src/components/data-list/modals/SendEmailModal.tsx
+++ b/portafly/src/components/data-list/modals/SendEmailModal.tsx
@@ -76,7 +76,8 @@ const SendEmailModal: React.FunctionComponent<Props> = ({
             type="text"
             id="subject"
             name="subject"
-            aria-describedby="subject-helper"
+            // FIXME: missing translation string
+            aria-describedby={t('modas.send_email.subject_input_aria_label')}
             value={subject}
             onChange={setSubject}
           />
@@ -91,7 +92,8 @@ const SendEmailModal: React.FunctionComponent<Props> = ({
             isRequired
             id="body"
             name="body"
-            aria-label="aria label"
+            // FIXME: missing translation string
+            aria-label={t('modals.send_email.body_textarea_aria_label')}
             value={body}
             onChange={setBody}
           />

--- a/portafly/src/components/developer-accounts/DeveloperAccountsTable.tsx
+++ b/portafly/src/components/developer-accounts/DeveloperAccountsTable.tsx
@@ -9,18 +9,18 @@ export interface IDeveloperAccountsTable {
 }
 
 const DeveloperAccountsTable: React.FunctionComponent<IDeveloperAccountsTable> = ({ accounts }) => {
-  const { t } = useTranslation('accounts')
+  const { t } = useTranslation('audienceAccountsListing')
 
   if (accounts.length === 0) {
     return <SimpleEmptyState msg={t('accounts_table.empty_state')} />
   }
 
   const COLUMNS = [
-    t('accounts_table.col_group'),
-    t('accounts_table.col_admin'),
-    t('accounts_table.col_signup'),
-    t('accounts_table.col_apps'),
-    t('accounts_table.col_state')
+    t('accounts_table.group_header'),
+    t('accounts_table.admin_header'),
+    t('accounts_table.signup_header'),
+    t('accounts_table.applications_header'),
+    t('accounts_table.state_header')
   ]
 
   const rows: string[][] = accounts.map((a) => [

--- a/portafly/src/i18n/i18n.tsx
+++ b/portafly/src/i18n/i18n.tsx
@@ -1,15 +1,13 @@
 import i18n, { FormatFunction } from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import { initReactI18next } from 'react-i18next'
-import { ITranslationsPages, Translations, EN } from 'i18n'
+import { namespaces, Translations, EN } from 'i18n'
 
 const formatFn: FormatFunction = (value, format) => {
   if (format === 'uppercase') return value.toUpperCase()
   if (format === 'lowercase') return value.toLowerCase()
   return value
 }
-
-const sections: Array<ITranslationsPages> = ['shared', 'overview', 'analytics', 'applications', 'accounts', 'integration']
 
 const options = {
   lng: EN,
@@ -19,7 +17,7 @@ const options = {
     format: formatFn,
     escapeValue: false
   },
-  ns: sections,
+  ns: namespaces,
   defaultNS: 'shared',
   react: {
     transKeepBasicHtmlNodesFor: ['br', 'strong', 'i']

--- a/portafly/src/i18n/locales/en/index.ts
+++ b/portafly/src/i18n/locales/en/index.ts
@@ -4,6 +4,8 @@
 import shared from 'i18n/locales/en/shared.yml'
 import overview from 'i18n/locales/en/overview.yml'
 import login from 'i18n/locales/en/login.yml'
+// Audience
+import audienceAccountsListing from 'i18n/locales/en/audience/accounts/listing.yml'
 // Applications
 import applicationsListing from 'i18n/locales/en/applications/listing.yml'
 import applicationsPlans from 'i18n/locales/en/applications/applications_plans.yml'
@@ -43,6 +45,7 @@ const integration = {
 
 
 export {
+  audienceAccountsListing,
   shared,
   overview,
   analytics,

--- a/portafly/src/i18n/locales/en/shared.yml
+++ b/portafly/src/i18n/locales/en/shared.yml
@@ -123,3 +123,8 @@ toasts:
   change_state_error: Account state could not be changed
   change_state_error_description: Alert message when state could not be changed
 # ------------- End of Duplicated block: already included in Audience > Accounts > listing.yml -----·#
+loading:
+  title: Loading
+  title_description: Title displayed as part of the loading state
+  aria_label: Loading spinner  #-----TODO: revise this aria label
+  aria_label_description: Aria label for the Loading component

--- a/portafly/src/i18n/locales/index.ts
+++ b/portafly/src/i18n/locales/index.ts
@@ -8,4 +8,6 @@ const Translations: Record<ISupportedLanguages, ITranslations> = {
   en
 }
 
-export { Translations }
+const namespaces = Object.keys(en) as Array<ITranslationsPages>
+
+export { Translations, namespaces }

--- a/portafly/src/pages/DeveloperAccounts.tsx
+++ b/portafly/src/pages/DeveloperAccounts.tsx
@@ -13,14 +13,14 @@ import { useTranslation } from 'i18n/useTranslation'
 
 const DeveloperAccounts: React.FunctionComponent = () => {
   const { data: accounts, error, isPending } = useAsync(getDeveloperAccounts)
-  const { t } = useTranslation('accounts')
-  useDocumentTitle(t('users.page_title'))
+  const { t } = useTranslation('audienceAccountsListing')
+  useDocumentTitle(t('title_page'))
 
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
         <TextContent>
-          <Text component="h1">{t('users.body_title')}</Text>
+          <Text component="h1">{t('title_page')}</Text>
         </TextContent>
       </PageSection>
 

--- a/portafly/src/tests/components/LazyRoute.test.tsx
+++ b/portafly/src/tests/components/LazyRoute.test.tsx
@@ -9,7 +9,7 @@ const getComponent = () => Promise.resolve({
 
 test('should render a spinner while waiting for a component module to be loaded', () => {
   const { queryByTestId, getByText } = render(<LazyRoute getComponent={getComponent} />)
-  expect(getByText('Loading')).toBeInTheDocument()
+  expect(getByText('loading.title')).toBeInTheDocument()
   expect(queryByTestId('async-component')).not.toBeInTheDocument()
 })
 

--- a/portafly/src/tests/components/data-list/__snapshots__/SearchWidget.test.tsx.snap
+++ b/portafly/src/tests/components/data-list/__snapshots__/SearchWidget.test.tsx.snap
@@ -232,14 +232,13 @@ exports[`SearchWidget should render correctly 1`] = `
     >
       <input
         aria-invalid="false"
-        aria-label="Aria label of the text input for filtering"
+        aria-label="filter_aria_label"
         class="pf-c-form-control"
-        placeholder="Filter by Admin"
+        placeholder="accounts_filter_typeahead"
         type="search"
         value=""
       />
       <button
-        aria-label="Aria label for button"
         class="pf-c-button pf-m-control"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"

--- a/portafly/src/tests/components/developer-accounts/__snapshots__/DeveloperAccountsTable.test.tsx.snap
+++ b/portafly/src/tests/components/developer-accounts/__snapshots__/DeveloperAccountsTable.test.tsx.snap
@@ -139,42 +139,42 @@ Object {
             <th
               class=""
               data-key="0"
-              data-label="accounts_table.col_group"
+              data-label="accounts_table.group_header"
               scope="col"
             >
-              accounts_table.col_group
+              accounts_table.group_header
             </th>
             <th
               class=""
               data-key="1"
-              data-label="accounts_table.col_admin"
+              data-label="accounts_table.admin_header"
               scope="col"
             >
-              accounts_table.col_admin
+              accounts_table.admin_header
             </th>
             <th
               class=""
               data-key="2"
-              data-label="accounts_table.col_signup"
+              data-label="accounts_table.signup_header"
               scope="col"
             >
-              accounts_table.col_signup
+              accounts_table.signup_header
             </th>
             <th
               class=""
               data-key="3"
-              data-label="accounts_table.col_apps"
+              data-label="accounts_table.applications_header"
               scope="col"
             >
-              accounts_table.col_apps
+              accounts_table.applications_header
             </th>
             <th
               class=""
               data-key="4"
-              data-label="accounts_table.col_state"
+              data-label="accounts_table.state_header"
               scope="col"
             >
-              accounts_table.col_state
+              accounts_table.state_header
             </th>
           </tr>
         </thead>
@@ -190,35 +190,35 @@ Object {
             <td
               class=""
               data-key="0"
-              data-label="accounts_table.col_group"
+              data-label="accounts_table.group_header"
             >
               Josemi's Corp.
             </td>
             <td
               class=""
               data-key="1"
-              data-label="accounts_table.col_admin"
+              data-label="accounts_table.admin_header"
             >
               Josemi
             </td>
             <td
               class=""
               data-key="2"
-              data-label="accounts_table.col_signup"
+              data-label="accounts_table.signup_header"
             >
               2019-10-18T05:13:26Z
             </td>
             <td
               class=""
               data-key="3"
-              data-label="accounts_table.col_apps"
+              data-label="accounts_table.applications_header"
             >
               3
             </td>
             <td
               class=""
               data-key="4"
-              data-label="accounts_table.col_state"
+              data-label="accounts_table.state_header"
             >
               approved
             </td>
@@ -232,35 +232,35 @@ Object {
             <td
               class=""
               data-key="0"
-              data-label="accounts_table.col_group"
+              data-label="accounts_table.group_header"
             >
               Damian's Corp.
             </td>
             <td
               class=""
               data-key="1"
-              data-label="accounts_table.col_admin"
+              data-label="accounts_table.admin_header"
             >
               Damian
             </td>
             <td
               class=""
               data-key="2"
-              data-label="accounts_table.col_signup"
+              data-label="accounts_table.signup_header"
             >
               2019-10-18T05:13:26Z
             </td>
             <td
               class=""
               data-key="3"
-              data-label="accounts_table.col_apps"
+              data-label="accounts_table.applications_header"
             >
               3
             </td>
             <td
               class=""
               data-key="4"
-              data-label="accounts_table.col_state"
+              data-label="accounts_table.state_header"
             >
               approved
             </td>
@@ -285,42 +285,42 @@ Object {
           <th
             class=""
             data-key="0"
-            data-label="accounts_table.col_group"
+            data-label="accounts_table.group_header"
             scope="col"
           >
-            accounts_table.col_group
+            accounts_table.group_header
           </th>
           <th
             class=""
             data-key="1"
-            data-label="accounts_table.col_admin"
+            data-label="accounts_table.admin_header"
             scope="col"
           >
-            accounts_table.col_admin
+            accounts_table.admin_header
           </th>
           <th
             class=""
             data-key="2"
-            data-label="accounts_table.col_signup"
+            data-label="accounts_table.signup_header"
             scope="col"
           >
-            accounts_table.col_signup
+            accounts_table.signup_header
           </th>
           <th
             class=""
             data-key="3"
-            data-label="accounts_table.col_apps"
+            data-label="accounts_table.applications_header"
             scope="col"
           >
-            accounts_table.col_apps
+            accounts_table.applications_header
           </th>
           <th
             class=""
             data-key="4"
-            data-label="accounts_table.col_state"
+            data-label="accounts_table.state_header"
             scope="col"
           >
-            accounts_table.col_state
+            accounts_table.state_header
           </th>
         </tr>
       </thead>
@@ -336,35 +336,35 @@ Object {
           <td
             class=""
             data-key="0"
-            data-label="accounts_table.col_group"
+            data-label="accounts_table.group_header"
           >
             Josemi's Corp.
           </td>
           <td
             class=""
             data-key="1"
-            data-label="accounts_table.col_admin"
+            data-label="accounts_table.admin_header"
           >
             Josemi
           </td>
           <td
             class=""
             data-key="2"
-            data-label="accounts_table.col_signup"
+            data-label="accounts_table.signup_header"
           >
             2019-10-18T05:13:26Z
           </td>
           <td
             class=""
             data-key="3"
-            data-label="accounts_table.col_apps"
+            data-label="accounts_table.applications_header"
           >
             3
           </td>
           <td
             class=""
             data-key="4"
-            data-label="accounts_table.col_state"
+            data-label="accounts_table.state_header"
           >
             approved
           </td>
@@ -378,35 +378,35 @@ Object {
           <td
             class=""
             data-key="0"
-            data-label="accounts_table.col_group"
+            data-label="accounts_table.group_header"
           >
             Damian's Corp.
           </td>
           <td
             class=""
             data-key="1"
-            data-label="accounts_table.col_admin"
+            data-label="accounts_table.admin_header"
           >
             Damian
           </td>
           <td
             class=""
             data-key="2"
-            data-label="accounts_table.col_signup"
+            data-label="accounts_table.signup_header"
           >
             2019-10-18T05:13:26Z
           </td>
           <td
             class=""
             data-key="3"
-            data-label="accounts_table.col_apps"
+            data-label="accounts_table.applications_header"
           >
             3
           </td>
           <td
             class=""
             data-key="4"
-            data-label="accounts_table.col_state"
+            data-label="accounts_table.state_header"
           >
             approved
           </td>

--- a/portafly/src/tests/pages/__snapshots__/DeveloperAccounts.test.tsx.snap
+++ b/portafly/src/tests/pages/__snapshots__/DeveloperAccounts.test.tsx.snap
@@ -15,7 +15,7 @@ Object {
             class=""
             data-pf-content="true"
           >
-            users.body_title
+            title_page
           </h1>
         </div>
       </section>
@@ -37,42 +37,42 @@ Object {
               <th
                 class=""
                 data-key="0"
-                data-label="accounts_table.col_group"
+                data-label="accounts_table.group_header"
                 scope="col"
               >
-                accounts_table.col_group
+                accounts_table.group_header
               </th>
               <th
                 class=""
                 data-key="1"
-                data-label="accounts_table.col_admin"
+                data-label="accounts_table.admin_header"
                 scope="col"
               >
-                accounts_table.col_admin
+                accounts_table.admin_header
               </th>
               <th
                 class=""
                 data-key="2"
-                data-label="accounts_table.col_signup"
+                data-label="accounts_table.signup_header"
                 scope="col"
               >
-                accounts_table.col_signup
+                accounts_table.signup_header
               </th>
               <th
                 class=""
                 data-key="3"
-                data-label="accounts_table.col_apps"
+                data-label="accounts_table.applications_header"
                 scope="col"
               >
-                accounts_table.col_apps
+                accounts_table.applications_header
               </th>
               <th
                 class=""
                 data-key="4"
-                data-label="accounts_table.col_state"
+                data-label="accounts_table.state_header"
                 scope="col"
               >
-                accounts_table.col_state
+                accounts_table.state_header
               </th>
             </tr>
           </thead>
@@ -88,35 +88,35 @@ Object {
               <td
                 class=""
                 data-key="0"
-                data-label="accounts_table.col_group"
+                data-label="accounts_table.group_header"
               >
                 Josemi's Corp.
               </td>
               <td
                 class=""
                 data-key="1"
-                data-label="accounts_table.col_admin"
+                data-label="accounts_table.admin_header"
               >
                 Josemi
               </td>
               <td
                 class=""
                 data-key="2"
-                data-label="accounts_table.col_signup"
+                data-label="accounts_table.signup_header"
               >
                 2019-10-18T05:13:26Z
               </td>
               <td
                 class=""
                 data-key="3"
-                data-label="accounts_table.col_apps"
+                data-label="accounts_table.applications_header"
               >
                 3
               </td>
               <td
                 class=""
                 data-key="4"
-                data-label="accounts_table.col_state"
+                data-label="accounts_table.state_header"
               >
                 approved
               </td>
@@ -130,35 +130,35 @@ Object {
               <td
                 class=""
                 data-key="0"
-                data-label="accounts_table.col_group"
+                data-label="accounts_table.group_header"
               >
                 Damian's Corp.
               </td>
               <td
                 class=""
                 data-key="1"
-                data-label="accounts_table.col_admin"
+                data-label="accounts_table.admin_header"
               >
                 Damian
               </td>
               <td
                 class=""
                 data-key="2"
-                data-label="accounts_table.col_signup"
+                data-label="accounts_table.signup_header"
               >
                 2019-10-18T05:13:26Z
               </td>
               <td
                 class=""
                 data-key="3"
-                data-label="accounts_table.col_apps"
+                data-label="accounts_table.applications_header"
               >
                 3
               </td>
               <td
                 class=""
                 data-key="4"
-                data-label="accounts_table.col_state"
+                data-label="accounts_table.state_header"
               >
                 approved
               </td>
@@ -179,7 +179,7 @@ Object {
           class=""
           data-pf-content="true"
         >
-          users.body_title
+          title_page
         </h1>
       </div>
     </section>
@@ -201,42 +201,42 @@ Object {
             <th
               class=""
               data-key="0"
-              data-label="accounts_table.col_group"
+              data-label="accounts_table.group_header"
               scope="col"
             >
-              accounts_table.col_group
+              accounts_table.group_header
             </th>
             <th
               class=""
               data-key="1"
-              data-label="accounts_table.col_admin"
+              data-label="accounts_table.admin_header"
               scope="col"
             >
-              accounts_table.col_admin
+              accounts_table.admin_header
             </th>
             <th
               class=""
               data-key="2"
-              data-label="accounts_table.col_signup"
+              data-label="accounts_table.signup_header"
               scope="col"
             >
-              accounts_table.col_signup
+              accounts_table.signup_header
             </th>
             <th
               class=""
               data-key="3"
-              data-label="accounts_table.col_apps"
+              data-label="accounts_table.applications_header"
               scope="col"
             >
-              accounts_table.col_apps
+              accounts_table.applications_header
             </th>
             <th
               class=""
               data-key="4"
-              data-label="accounts_table.col_state"
+              data-label="accounts_table.state_header"
               scope="col"
             >
-              accounts_table.col_state
+              accounts_table.state_header
             </th>
           </tr>
         </thead>
@@ -252,35 +252,35 @@ Object {
             <td
               class=""
               data-key="0"
-              data-label="accounts_table.col_group"
+              data-label="accounts_table.group_header"
             >
               Josemi's Corp.
             </td>
             <td
               class=""
               data-key="1"
-              data-label="accounts_table.col_admin"
+              data-label="accounts_table.admin_header"
             >
               Josemi
             </td>
             <td
               class=""
               data-key="2"
-              data-label="accounts_table.col_signup"
+              data-label="accounts_table.signup_header"
             >
               2019-10-18T05:13:26Z
             </td>
             <td
               class=""
               data-key="3"
-              data-label="accounts_table.col_apps"
+              data-label="accounts_table.applications_header"
             >
               3
             </td>
             <td
               class=""
               data-key="4"
-              data-label="accounts_table.col_state"
+              data-label="accounts_table.state_header"
             >
               approved
             </td>
@@ -294,35 +294,35 @@ Object {
             <td
               class=""
               data-key="0"
-              data-label="accounts_table.col_group"
+              data-label="accounts_table.group_header"
             >
               Damian's Corp.
             </td>
             <td
               class=""
               data-key="1"
-              data-label="accounts_table.col_admin"
+              data-label="accounts_table.admin_header"
             >
               Damian
             </td>
             <td
               class=""
               data-key="2"
-              data-label="accounts_table.col_signup"
+              data-label="accounts_table.signup_header"
             >
               2019-10-18T05:13:26Z
             </td>
             <td
               class=""
               data-key="3"
-              data-label="accounts_table.col_apps"
+              data-label="accounts_table.applications_header"
             >
               3
             </td>
             <td
               class=""
               data-key="4"
-              data-label="accounts_table.col_state"
+              data-label="accounts_table.state_header"
             >
               approved
             </td>
@@ -400,7 +400,7 @@ Object {
             class=""
             data-pf-content="true"
           >
-            users.body_title
+            title_page
           </h1>
         </div>
       </section>
@@ -458,7 +458,7 @@ Object {
           class=""
           data-pf-content="true"
         >
-          users.body_title
+          title_page
         </h1>
       </div>
     </section>
@@ -573,7 +573,7 @@ Object {
             class=""
             data-pf-content="true"
           >
-            users.body_title
+            title_page
           </h1>
         </div>
       </section>
@@ -581,7 +581,7 @@ Object {
         class="pf-c-page__main-section"
       >
         <section
-          aria-label="Loading Content Container"
+          aria-label="loading.aria_label"
           class="pf-c-page__main-section"
         >
           <div
@@ -612,7 +612,7 @@ Object {
               <h2
                 class="pf-c-title pf-m-lg"
               >
-                Loading
+                loading.title
               </h2>
             </div>
           </div>
@@ -631,7 +631,7 @@ Object {
           class=""
           data-pf-content="true"
         >
-          users.body_title
+          title_page
         </h1>
       </div>
     </section>
@@ -639,7 +639,7 @@ Object {
       class="pf-c-page__main-section"
     >
       <section
-        aria-label="Loading Content Container"
+        aria-label="loading.aria_label"
         class="pf-c-page__main-section"
       >
         <div
@@ -670,7 +670,7 @@ Object {
             <h2
               class="pf-c-title pf-m-lg"
             >
-              Loading
+              loading.title
             </h2>
           </div>
         </div>


### PR DESCRIPTION
### What / Why
* Removal of all aria-labels that are not being tracked in our translations. They will be added properly when we figure out what we need.
* Proposal for namespaces: since we have so many files inside our translations folder, I came up with the idea of defining a namespace for each page so usage of `t` is less verbose. We no longer have to define `sections` (renamed to `namespaces`) manually because it uses the keys of the exports directly.