### PR TITLE
'ActionDispatch::ParamsParser::ParseError' is a 400 instead of 422

### DIFF
--- a/lib/three_scale/middleware/handle_parse_error.rb
+++ b/lib/three_scale/middleware/handle_parse_error.rb
@@ -14,7 +14,7 @@ module ThreeScale
       # TODO: In Rails 5.1, replace this error class for ActionDispatch::Http::Parameters::ParseError
       # https://github.com/rails/rails/blob/ce93740a5e4437dfc1cf9b0b13da1bad06a2a598/actionpack/lib/action_dispatch/http/parameters.rb#L125
       rescue ActionDispatch::ParamsParser::ParseError => error
-        status = 422
+        status = 400
         Rails.logger.error("Handling Exception: '#{error.class}' with status #{status}")
         [status, {}, [nil]]
       end

--- a/test/unit/three_scale/middleware/handle_parse_error_test.rb
+++ b/test/unit/three_scale/middleware/handle_parse_error_test.rb
@@ -12,12 +12,12 @@ class ThreeScale::Middleware::HandleParseErrorTest < ActiveSupport::TestCase
   end
 
   test 'invalid request params' do
-    Rails.logger.expects(:error).with('Handling Exception: \'ActionDispatch::ParamsParser::ParseError\' with status 422')
+    Rails.logger.expects(:error).with('Handling Exception: \'ActionDispatch::ParamsParser::ParseError\' with status 400')
 
     app = proc { perform_post_request(raw_post_data: '{ wrong: "invalid", ') }
     middleware = ThreeScale::Middleware::HandleParseError.new(app)
 
-    assert_equal [422, {}, [nil]], middleware.call({})
+    assert_equal [400, {}, [nil]], middleware.call({})
   end
 
   private


### PR DESCRIPTION
My bad 🙈 
Fixes the status of https://github.com/3scale/porta/pull/1914. Part of [THREESCALE-5280](https://issues.redhat.com/browse/THREESCALE-5280)

[This is why](https://www.restapitutorial.com/httpstatuscodes.html):

-  **400 Bad Request**
The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modifications.

- **422 Unprocessable Entity (WebDAV)**
The 422 (Unprocessable Entity) status code means the server understands the content type of the request entity (hence a 415(Unsupported Media Type) status code is inappropriate), and the syntax of the request entity is correct (thus a 400 (Bad Request) status code is inappropriate) but was unable to process the contained instructions. For example, this error condition may occur if an XML request body contains well-formed (i.e., syntactically correct), but semantically erroneous, XML instructions.