### PR TITLE
[portafly] Refactor: filterRows fn

### DIFF
--- a/portafly/src/components/data-list/utils/filterRows.ts
+++ b/portafly/src/components/data-list/utils/filterRows.ts
@@ -1,22 +1,35 @@
 import { DataListRow, DataListCol, Filters } from 'types/data-list'
 
-const filterByTerm = (colIdx: number, terms: string[]) => (row: DataListRow): boolean => (
+/**
+ * Filters a DataListRow given a colIdx and filtering terms.
+ * @param colIdx number - The index of a categoryName column.
+ * @param terms string[] - An array of filtering terms.
+ * @returns {(row: DataListRow) => boolean} - fn that takes a DataListRow and returns boolean
+ */
+const filterRowByTerm = (colIdx: number, terms: string[]) => (row: DataListRow): boolean => (
   terms.length
     ? terms.some((f) => (row.cells)[colIdx].toLowerCase().indexOf(f.toLowerCase()) > -1)
     : true
 )
 
+/**
+ * Finds the index of a DataListCol.
+ * @param columns DataListCol[] - An array of DataListCol.
+ * @returns {(categoryName: string) => number} - fn that takes a categoryName and returns its index.
+ */
 const findColIdx = (columns: DataListCol[]) => (categoryName: string): number => {
   const index = columns.findIndex((c) => c.categoryName === categoryName)
   // TODO: In the future we could show the error in a toast. Event driven approach maybe.
   if (index === -1) throw new Error('You are trying to filter a category that doesn\'t correspond to any column in your DataList')
   return index
 }
+
 /**
  * Returns a new array with the provided rows filtered.
  * @param rows DataListRow[] - The rows to be filtered
  * @param filters Filters - An object containing different categories and filtering terms
  * @param columns DataListCol[] - The columns of the Table being filtered
+ * @returns DataListRow[] - The given rows filtered.
  */
 
 const filterRows = (
@@ -24,8 +37,13 @@ const filterRows = (
   filters: Filters,
   columns: DataListCol[]
 ): DataListRow[] => (
-  Object.keys(filters).reduce((acc, categoryName) => (
-    acc.filter(filterByTerm(findColIdx(columns)(categoryName), filters[categoryName]))
+  Object.keys(filters).reduce((filteredRows, categoryName) => (
+    filteredRows.filter(
+      filterRowByTerm(
+        findColIdx(columns)(categoryName),
+        filters[categoryName]
+      )
+    )
   ), rows)
 )
 

--- a/portafly/src/tests/components/data-list/utils/filterRows.test.ts
+++ b/portafly/src/tests/components/data-list/utils/filterRows.test.ts
@@ -55,10 +55,10 @@ it('filters from same category should be inclusive, but exclusive from different
   expect(filterRows(rows, filterExclusive, columns)).toEqual([])
 })
 
-it('should skip invalid categories', () => {
+it('should throw error when invalid categories', () => {
   const wrongFilterLast: Filters = { explorer: ['Indiana', 'Lara'], origin: ['movie'] }
-  expect(filterRows(rows, wrongFilterLast, columns)).toEqual([Lara, Indi])
+  expect(() => filterRows(rows, wrongFilterLast, columns)).toThrow(new Error('You are trying to filter a category that doesn\'t correspond to any column in your DataList'))
 
   const wrongFilterFirst: Filters = { items: ['whip'], explorer: ['Indiana', 'Lara'] }
-  expect(filterRows(rows, wrongFilterFirst, columns)).toEqual([Lara, Indi])
+  expect(() => filterRows(rows, wrongFilterFirst, columns)).toThrow(new Error('You are trying to filter a category that doesn\'t correspond to any column in your DataList'))
 })


### PR DESCRIPTION
* A more declarative approach
* If a wrong/invalid filter category is passed, it means the context
state was tampered or no longer valid