### PR TITLE
Fix CircleCI Oracle random failure: press inside dropdown is AJAX and must wait for requests

### DIFF
--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -298,6 +298,7 @@ And(/^I press "([^"]*)" inside the dropdown$/) do |name|
 
   toggle.click
   find(:xpath, link).click
+  wait_for_requests
 end
 
 toggled_input_selector = '[data-behavior="toggle-inputs"] legend'


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/3scale/porta/11868/workflows/200fae06-aa98-41a6-9b69-0f62c8d81f03/jobs/173141/steps

The problem is just that we make an AJAX request by pressing something in the dropdown, and our Oracle CircleCI is a bit slow... so it reaches the 'then blah blah' before the request has been finished.