### PR TITLE
Change Accounts Listing path

### DIFF
--- a/portafly/src/App.tsx
+++ b/portafly/src/App.tsx
@@ -18,7 +18,7 @@ const PagesSwitch = () => (
   <SwitchWith404>
     <LazyRoute path="/" exact getComponent={getOverviewPage} />
     <LazyRoute path="/applications" exact getComponent={getApplicationsPage} />
-    <LazyRoute path="/accounts" exact getComponent={getAccountsIndexPage} />
+    <LazyRoute path="/audience/accounts/listing" exact getComponent={getAccountsIndexPage} />
     <Redirect path="/overview" to="/" exact />
   </SwitchWith404>
 )

--- a/portafly/src/components/Root.tsx
+++ b/portafly/src/components/Root.tsx
@@ -35,9 +35,9 @@ const Root: React.FunctionComponent = ({ children }) => {
     },
     {
       title: t('navigation_items.accounts'),
-      to: '/accounts',
+      to: '/audience/accounts/listing',
       items: [
-        { to: '/accounts', title: t('navigation_items.accounts_listing') }
+        { to: '/audience/accounts/listing', title: t('navigation_items.accounts_listing') }
       ]
     },
     {


### PR DESCRIPTION
[THREESCALE-5333: Use correct path](https://issues.redhat.com/browse/THREESCALE-5333)

Changes the path from `/accounts` to `/audience/accounts/listing`.
