### PR TITLE
Update some i18n strings

### DIFF
--- a/portafly/src/components/shared/data-list/SearchWidget.tsx
+++ b/portafly/src/components/shared/data-list/SearchWidget.tsx
@@ -41,8 +41,7 @@ const CategorySelect: React.FunctionComponent<ICategorySelect> = ({
     <Select
       toggleIcon={<FilterIcon />}
       variant={SelectVariant.single}
-      // FIXME: missing translation string
-      aria-label={t('category_select_aria_label')}
+      aria-label={t('data_list_filter.category_select_aria_label')}
       onSelect={onSelect}
       selections={selections}
       isOpen={isOpen}
@@ -72,6 +71,7 @@ const OptionsSelect: React.FunctionComponent<ICollectionSelect> = ({
   selections,
   categoryName
 }) => {
+  const { t } = useTranslation('shared')
   const [isOpen, setIsOpen] = useState(false)
   const onSelect = (ev: React.SyntheticEvent, selection: string | SelectOptionObject) => {
     const { checked } = ev.currentTarget as HTMLInputElement
@@ -79,12 +79,13 @@ const OptionsSelect: React.FunctionComponent<ICollectionSelect> = ({
   }
   return (
     <Select
+      aria-label={t('data_list_filter.state_select_aria_label')}
       variant={SelectVariant.checkbox}
       onSelect={onSelect}
       selections={selections}
       isOpen={isOpen}
       onToggle={setIsOpen}
-      placeholderText={`Filter by ${categoryName}`}
+      placeholderText={t('audienceAccountsListing:accounts_filter_field', { filter_option: categoryName })}
     >
       { options.map(({ name, humanName }) => (
         <SelectOption key={name} value={humanName} />
@@ -100,7 +101,7 @@ interface ISearchBar {
 }
 
 const SearchBar = ({ textInputRef, category, onSearchClick }: ISearchBar) => {
-  const { t } = useTranslation('audienceAccountsListing')
+  const { t } = useTranslation('shared')
   const onClick = () => {
     if (textInputRef.current?.value) {
       onSearchClick(textInputRef.current.value)
@@ -113,10 +114,8 @@ const SearchBar = ({ textInputRef, category, onSearchClick }: ISearchBar) => {
       <TextInput
         ref={textInputRef}
         type="search"
-        // FIXME: missing translation string
-        aria-label={t('filter_aria_label')}
-        // FIXME: this should be moved to shared
-        placeholder={t('accounts_filter_typeahead', { filter_option: category.humanName })}
+        aria-label={t('audienceAccountsListing:accounts_filter_field_aria_label')}
+        placeholder={t('audienceAccountsListing:accounts_filter_field', { filter_option: category.humanName })}
         onKeyUp={(ev) => ev.key === 'Enter' && onClick()}
       />
       <Button

--- a/portafly/src/components/shared/data-list/modals/ChangeStateModal.tsx
+++ b/portafly/src/components/shared/data-list/modals/ChangeStateModal.tsx
@@ -41,7 +41,7 @@ const ChangeStateModal: React.FunctionComponent<Props> = ({
     changeState()
       .then(() => {
         actionSuccess()
-        addAlert({ id: 'success', variant: 'success', title: t('toasts.change_state_start') })
+        addAlert({ id: 'success', variant: 'success', title: t('toasts.change_state_success') })
       })
       .catch(() => {
         const error = t('toasts.change_state_error')

--- a/portafly/src/components/shared/data-list/modals/SendEmailModal.tsx
+++ b/portafly/src/components/shared/data-list/modals/SendEmailModal.tsx
@@ -40,7 +40,7 @@ const SendEmailModal: React.FunctionComponent<Props> = ({
     sendEmail()
       .then(() => {
         actionSuccess()
-        addAlert({ id: 'success', variant: 'success', title: t('toasts.send_email_start') })
+        addAlert({ id: 'success', variant: 'success', title: t('toasts.send_email_success') })
       })
       .catch(() => {
         const error = t('toasts.send_email_error')

--- a/portafly/src/i18n/locales/en/audience/accounts/listing.yml
+++ b/portafly/src/i18n/locales/en/audience/accounts/listing.yml
@@ -33,8 +33,10 @@ actions_filter_options:
   pending: Pending
   rejected: Rejected
   suspended: Suspended
-accounts_filter_typeahead: "Filter by {{filter_option}}"
-accounts_filter_typeahead_description: Filter by typeahead a text input. This applies for filters by group/organization and admin
+accounts_filter_field: "Filter by {{filter_option}}"
+accounts_filter_field_description: Filter by typeahead a text input. This applies for filters by group/organization and admin
+accounts_filter_field_aria_label: Filter text input
+accounts_filter_field_aria_label_description: Aria label for the filter text input
 
 ## Header
 accounts_table:

--- a/portafly/src/i18n/locales/en/shared.yml
+++ b/portafly/src/i18n/locales/en/shared.yml
@@ -128,3 +128,9 @@ loading:
   title_description: Title displayed as part of the loading state
   aria_label: Loading spinner  #-----TODO: revise this aria label
   aria_label_description: Aria label for the Loading component
+
+data_list_filter:
+  category_select_aria_label: Select a filter category
+  category_select_aria_label_description: Aria label for the filter category select
+  state_select_aria_label: Select a state
+  state_select_aria_label_description: Aria label for the state select

--- a/portafly/src/tests/components/shared/data-list/__snapshots__/SearchWidget.test.tsx.snap
+++ b/portafly/src/tests/components/shared/data-list/__snapshots__/SearchWidget.test.tsx.snap
@@ -232,9 +232,9 @@ exports[`SearchWidget should render correctly 1`] = `
     >
       <input
         aria-invalid="false"
-        aria-label="filter_aria_label"
+        aria-label="audienceAccountsListing:accounts_filter_field_aria_label"
         class="pf-c-form-control"
-        placeholder="accounts_filter_typeahead"
+        placeholder="audienceAccountsListing:accounts_filter_field"
         type="search"
         value=""
       />


### PR DESCRIPTION
* Moves strings from `accounts/listing` to `shared`
* Rename some strings (`typeahead` for instance is misleading)
* Apply `i18n` to some left hardcoded strings
* Create some aria-labels (accessibility is still to be reviewed more thoroughly)