### PR TITLE
Add empty state generic components

### DIFF
--- a/portafly/src/components/pages/audience/accounts/listing/DeveloperAccountsTable.tsx
+++ b/portafly/src/components/pages/audience/accounts/listing/DeveloperAccountsTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Table, TableHeader, TableBody } from '@patternfly/react-table'
-import { SimpleEmptyState } from 'components'
+import { PageEmptyState } from 'components'
 import { IDeveloperAccount } from 'types'
 import { useTranslation } from 'i18n/useTranslation'
 
@@ -12,7 +12,7 @@ const DeveloperAccountsTable: React.FunctionComponent<IDeveloperAccountsTable> =
   const { t } = useTranslation('audienceAccountsListing')
 
   if (accounts.length === 0) {
-    return <SimpleEmptyState msg={t('accounts_table.empty_state')} />
+    return <PageEmptyState msg={t('accounts_table.empty_state')} />
   }
 
   const COLUMNS = [

--- a/portafly/src/components/shared/empty-states/PageEmptyState.tsx
+++ b/portafly/src/components/shared/empty-states/PageEmptyState.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 import {
-  Title,
   EmptyState,
-  EmptyStateVariant,
-  EmptyStateIcon
+  EmptyStateIcon,
+  Title,
+  EmptyStateVariant
 } from '@patternfly/react-core'
 import { CubesIcon } from '@patternfly/react-icons'
 
-export interface ISimpleEmptyStateProps {
+interface Props {
   msg: string
 }
 
-const SimpleEmptyState: React.FunctionComponent<ISimpleEmptyStateProps> = ({ msg }) => (
+const PageEmptyState: React.FunctionComponent<Props> = ({ msg }) => (
   <EmptyState variant={EmptyStateVariant.full}>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h5" size="lg">
@@ -20,4 +20,4 @@ const SimpleEmptyState: React.FunctionComponent<ISimpleEmptyStateProps> = ({ msg
   </EmptyState>
 )
 
-export { SimpleEmptyState }
+export { PageEmptyState }

--- a/portafly/src/components/shared/empty-states/TableEmptyState.tsx
+++ b/portafly/src/components/shared/empty-states/TableEmptyState.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  EmptyStateVariant
+} from '@patternfly/react-core'
+import { SearchIcon } from '@patternfly/react-icons'
+
+interface Props {
+  title: string
+  body: string
+  button?: JSX.Element
+}
+
+const TableEmptyState: React.FunctionComponent<Props> = ({
+  title,
+  body,
+  button
+}) => (
+  <Bullseye>
+    <EmptyState variant={EmptyStateVariant.small}>
+      <EmptyStateIcon icon={SearchIcon} />
+      <Title headingLevel="h2" size="lg">
+        {title}
+      </Title>
+      <EmptyStateBody>
+        {body}
+      </EmptyStateBody>
+      {button}
+    </EmptyState>
+  </Bullseye>
+)
+
+export { TableEmptyState }

--- a/portafly/src/components/shared/empty-states/index.tsx
+++ b/portafly/src/components/shared/empty-states/index.tsx
@@ -1,0 +1,2 @@
+export * from './PageEmptyState'
+export * from './TableEmptyState'

--- a/portafly/src/components/shared/index.tsx
+++ b/portafly/src/components/shared/index.tsx
@@ -1,3 +1,3 @@
 export * from './data-list'
-export * from './EmptyState'
+export * from './empty-states'
 export * from './Loading'

--- a/portafly/src/tests/components/shared/empty-states/PageEmptyState.test.tsx
+++ b/portafly/src/tests/components/shared/empty-states/PageEmptyState.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+import { render } from 'tests/custom-render'
+import { PageEmptyState } from 'components'
+
+it('should render', () => {
+  const msg = 'No results'
+  const { getByText } = render(<PageEmptyState msg={msg} />)
+  expect(getByText(msg)).toBeInTheDocument()
+})

--- a/portafly/src/tests/components/shared/empty-states/TableEmptyState.test.tsx
+++ b/portafly/src/tests/components/shared/empty-states/TableEmptyState.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import { render } from 'tests/custom-render'
+import { TableEmptyState } from 'components'
+import { Button } from '@patternfly/react-core'
+import { fireEvent } from '@testing-library/react'
+
+it('should render', () => {
+  const title = 'Title'
+  const body = 'Body'
+  const buttonTitle = 'Button'
+  const onClick = jest.fn()
+  const { getByText } = render(
+    <TableEmptyState
+      title={title}
+      body={body}
+      button={<Button onClick={onClick}>{buttonTitle}</Button>}
+    />
+  )
+
+  expect(getByText(title)).toBeInTheDocument()
+  expect(getByText(body)).toBeInTheDocument()
+
+  const button = getByText(buttonTitle)
+  fireEvent.click(button)
+  expect(onClick).toHaveBeenCalled()
+})


### PR DESCRIPTION
Adding the EmptyState components that will be used first by Accounts Listing but then for any page/data-list page.

The Page version is meant to occupy the whole page.
The Table version is meant to be inside a table after loading/filtersing and to have a button like "Try again", "Refresh", "Clear all filters", etc.