### PR TITLE
[hotfix] Rake task to migrate services to configuration driven

### DIFF
--- a/lib/tasks/proxy.rake
+++ b/lib/tasks/proxy.rake
@@ -68,7 +68,7 @@ namespace :proxy do
     update_endpoints = ActiveModel::Type::Boolean.new.deserialize(args[:update_endpoints].presence)
     update_method = update_endpoints ? :update_attribute : :update_column
 
-    services = Service.accessible.where(deployment_option: deployment_option).where(service_ids.present? ? { id: service_ids } : {})
+    services = Service.accessible.where(deployment_option: deployment_option, account: Account.providers.without_deleted).where(service_ids.present? ? { id: service_ids } : {})
     proxies = Proxy.where(apicast_configuration_driven: false, service: services)
 
     progress = ProgressCounter.new(proxies.count)

--- a/lib/tasks/proxy.rake
+++ b/lib/tasks/proxy.rake
@@ -79,7 +79,7 @@ namespace :proxy do
       Proxy.transaction do
         proxy.public_send(update_method, :apicast_configuration_driven, true)
         next unless proxy.enabled # proxy.enabled == true means the service was deployed to sandbox proxy before
-        deploy_to.each { |env| ProxyDeploymentService.call(proxy, environment: env) }
+        deploy_to.each { |env| ProxyDeploymentService.call(proxy, environment: env.to_sym) }
       end
     end
   end

--- a/test/unit/tasks/proxy_test.rb
+++ b/test/unit/tasks/proxy_test.rb
@@ -119,15 +119,15 @@ module Tasks
 
       test 'deploy to staging' do
         hosted_apicast_v1_proxies.update_all(deployed_at: 1.day.ago)
-        hosted_apicast_v1_proxies.each { |proxy| ProxyDeploymentService.expects(:call).with(proxy, environment: 'staging') }
+        hosted_apicast_v1_proxies.each { |proxy| ProxyDeploymentService.expects(:call).with(proxy, environment: :staging) }
         execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven', 'hosted', 'staging'
       end
 
       test 'deploy to staging and production' do
         hosted_apicast_v1_proxies.update_all(deployed_at: 1.day.ago)
         hosted_apicast_v1_proxies.each do |proxy|
-          ProxyDeploymentService.expects(:call).with(proxy, environment: 'staging')
-          ProxyDeploymentService.expects(:call).with(proxy, environment: 'production')
+          ProxyDeploymentService.expects(:call).with(proxy, environment: :staging)
+          ProxyDeploymentService.expects(:call).with(proxy, environment: :production)
         end
         execute_rake_task 'proxy.rake', 'proxy:migrate_to_configuration_driven', 'hosted', 'staging,production'
       end


### PR DESCRIPTION
- [x] Fix bug with the name of the APIcast environment to deploy to (`String` → `Symbol`)
- [x] Remove parameter to control whether to deploy the config or not (*)
- [x] Add progress report
- [x] Add sleep between batches
- [x] Exclude accounts scheduled for deletion (some of them will break on deploy due to empty `bought_cinstances` and backend authentication type set to `provider_key`)

(*) Whether the config will be deployed or not is controlled by the values of `Proxy.deployed_at` and `Account.hosted_proxy_deployed_at`.
- If `Proxy.deployed_at` if present, then the config will be deployed to apicast staging
- If `Account.hosted_proxy_deployed_at >= Proxy.created_at`, then the config will be deployed to apicast production

----

Updated instructions:

Introduces a rake task to migrate services to configuration-driven gateway. it can be used for hosted and/self-managed services.

Usage:

```
rake proxy:migrate_to_configuration_driven[<services_selector>,<update_endpoints>]

<services_selector> ::= <selector> | <selector>","<services_selector> | nil (default: all services)
<selector> ::= service_id | "hosted" | "self_managed"

<update_endpoints> ::= <truthy> | <falsey> | nil (default: falsey)
<truthy> and <falsey> resolved by ActiveModel::Type::Boolean#deserialize
```

Examples:

| Command                                                            | Services                                            | Update endpoints? |
|--------------------------------------------------------------------|-----------------------------------------------------|:-----------------:|
| `rake proxy:migrate_to_configuration_driven`                       | All services                                        | No                |
| `rake proxy:migrate_to_configuration_driven[hosted]`               | All cloud-hosted services                           | No                |
| `rake proxy:migrate_to_configuration_driven[self_managed]`         | All self-managed services                           | No                |
| `rake proxy:migrate_to_configuration_driven["123\,456"]`           | Services 123 and 456                                | No                |
| `rake proxy:migrate_to_configuration_driven["123\,456\,hosted"]`   | Services 123 and 456, only the ones that are hosted | No                |
| `rake proxy:migrate_to_configuration_driven[hosted]`               | All cloud-hosted services                           | No                |
| `rake proxy:migrate_to_configuration_driven[hosted]`               | All cloud-hosted services                           | No                |
| `rake proxy:migrate_to_configuration_driven[hosted,true]`          | All cloud-hosted services                           | Yes               |

----

Closes [THREESCALE-2071](https://issues.redhat.com/browse/THREESCALE-2071)