### PR TITLE
[portafly] Patch dev accounts collection

### DIFF
--- a/portafly/portafly_api.yml
+++ b/portafly/portafly_api.yml
@@ -18,6 +18,27 @@ paths:
           $ref: '#/components/responses/developerAccountList'
       operationId: developerAccountList
       summary: Get developer account list
+    patch:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/DeveloperAccount'
+            examples:
+              Patch the state of 2 Dev Accounts:
+                value:
+                - id: 37
+                  state: active
+                - id: 18
+                  state: active
+        required: true
+      responses:
+        "204":
+          description: Resource updated correctly
+      summary: Partially updates developer accounts
+      description: Applies partial modifications to the Developer Accounts collection
     parameters:
     - name: page
       description: Page in the paginated list. Defaults to 1.

--- a/portafly/portafly_api.yml
+++ b/portafly/portafly_api.yml
@@ -89,8 +89,8 @@ components:
           type: integer
       example:
         id: 1
-        created_at: 2019-10-18T05:13:26Z
-        updated_at: 2019-10-18T05:13:27Z
+        created_at: 2019-10-18T05:13:26.000Z
+        updated_at: 2019-10-18T05:13:27.000Z
         state: approved
         org_name: Umbrella Corp.
         admin_name: Oswell E. Spencer


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the PortaFly OAS for the update of a developer accounts collection
The definition can be found in https://issues.redhat.com/browse/THREESCALE-5330

**Which issue(s) this PR fixes** 
Fixes https://issues.redhat.com/browse/THREESCALE-5348

