### PR TITLE
Allowing all parameters in the Service Discovery request

### DIFF
--- a/app/controllers/master/service_discovery/auth_controller.rb
+++ b/app/controllers/master/service_discovery/auth_controller.rb
@@ -11,7 +11,7 @@ class Master::ServiceDiscovery::AuthController < Master::BaseController
   protected
 
   def self_domain_url(self_domain)
-    options = params.except(:self_domain, :scope).merge(host: self_domain, controller: 'provider/admin/service_discovery/auth')
+    options = params.except(:self_domain, :scope).merge(host: self_domain, controller: 'provider/admin/service_discovery/auth').permit!
     url_for(options)
   end
 end

--- a/app/controllers/master/service_discovery/auth_controller.rb
+++ b/app/controllers/master/service_discovery/auth_controller.rb
@@ -11,7 +11,7 @@ class Master::ServiceDiscovery::AuthController < Master::BaseController
   protected
 
   def self_domain_url(self_domain)
-    options = params.permit(*%i[code referrer state]).merge(host: self_domain, controller: 'provider/admin/service_discovery/auth', action: :show)
+    options = params.permit(:code, :referrer, :state).merge(host: self_domain, controller: 'provider/admin/service_discovery/auth', action: :show)
     url_for(options)
   end
 end

--- a/app/controllers/master/service_discovery/auth_controller.rb
+++ b/app/controllers/master/service_discovery/auth_controller.rb
@@ -11,7 +11,7 @@ class Master::ServiceDiscovery::AuthController < Master::BaseController
   protected
 
   def self_domain_url(self_domain)
-    options = params.permit(*%i[code referrer state]).except(:self_domain, :scope).merge(host: self_domain, controller: 'provider/admin/service_discovery/auth')
+    options = params.permit(*%i[code referrer state]).merge(host: self_domain, controller: 'provider/admin/service_discovery/auth', action: :show)
     url_for(options)
   end
 end

--- a/app/controllers/master/service_discovery/auth_controller.rb
+++ b/app/controllers/master/service_discovery/auth_controller.rb
@@ -11,7 +11,7 @@ class Master::ServiceDiscovery::AuthController < Master::BaseController
   protected
 
   def self_domain_url(self_domain)
-    options = params.except(:self_domain, :scope).merge(host: self_domain, controller: 'provider/admin/service_discovery/auth').permit!
+    options = params.permit(*%i[code referrer state]).except(:self_domain, :scope).merge(host: self_domain, controller: 'provider/admin/service_discovery/auth')
     url_for(options)
   end
 end

--- a/test/integration/master/service_discovery/auth_controller_test.rb
+++ b/test/integration/master/service_discovery/auth_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class Master::ServiceDiscovery::AuthControllerTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @master = master_account
+    @callback_url = "/auth/#{ServiceDiscovery}/callback"
+  end
+
+  test 'master callback redirects to provider callback' do
+    host! @master.admin_domain
+    get "#{@callback_url}?self_domain=example.com"
+    assert_redirected_to "http://example.com/p/admin#{@callback_url}"
+  end
+end

--- a/test/integration/master/service_discovery/auth_controller_test.rb
+++ b/test/integration/master/service_discovery/auth_controller_test.rb
@@ -1,15 +1,21 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Master::ServiceDiscovery::AuthControllerTest < ActionDispatch::IntegrationTest
-
-  def setup
-    @master = master_account
-    @callback_url = "/auth/#{ServiceDiscovery}/callback"
+  setup do
+    @provider = FactoryBot.create(:simple_provider)
+    ThreeScale.config.service_discovery.stubs(enabled: true, authentication_method: 'oauth')
+    Rails.application.reload_routes!
+    host! master_account.internal_admin_domain
   end
 
+  attr_reader :provider
+
   test 'master callback redirects to provider callback' do
-    host! @master.admin_domain
-    get "#{@callback_url}?self_domain=example.com"
-    assert_redirected_to "http://example.com/p/admin#{@callback_url}"
+    provider_self_domain = provider.internal_self_domain
+    params = { code: '123', referrer: '/apiconfig/services/new', state: '' }
+    get auth_service_discovery_callback_path(self_domain: provider_self_domain, **params)
+    assert_redirected_to url_for(host: provider_self_domain, controller: 'provider/admin/service_discovery/auth', action: :show, **params)
   end
 end


### PR DESCRIPTION
Also added the integration test for service_discovery/auth_controller.

Closes [THREESCALE-4851](https://issues.redhat.com/browse/THREESCALE-4851)