### PR TITLE
Pass Options as a Prop in Change State Modal

### DIFF
--- a/portafly/src/components/pages/Overview.tsx
+++ b/portafly/src/components/pages/Overview.tsx
@@ -34,6 +34,7 @@ import { BellIcon } from '@patternfly/react-icons'
 import {
   TableHeader, TableBody, Table, OnSort, sortable
 } from '@patternfly/react-table'
+import { CategoryOption } from 'types'
 
 const categories = [
   {
@@ -96,6 +97,7 @@ const DataListTable = () => {
 
   const filteredRows = filterRows(rows, filters, columns)
   const pageRows = filteredRows.slice(startIdx, endIdx)
+  const states = categories[2].options as CategoryOption[]
 
   return (
     <>
@@ -115,7 +117,7 @@ const DataListTable = () => {
         <TableBody />
       </Table>
       {modal === 'sendEmail' && <SendEmailModal items={['1', '2', '3', '4', '5', '6']} />}
-      {modal === 'changeState' && <ChangeStateModal items={['1', '2', '3', '4', '5', '6']} />}
+      {modal === 'changeState' && <ChangeStateModal items={['1', '2', '3', '4', '5', '6']} states={states} />}
     </>
   )
 }

--- a/portafly/src/components/shared/data-list/modals/ChangeStateModal.tsx
+++ b/portafly/src/components/shared/data-list/modals/ChangeStateModal.tsx
@@ -13,12 +13,15 @@ import {
   useAlertsContext
 } from 'components'
 import { changeState } from 'dal/accounts/bulkActions'
+import { CategoryOption } from 'types'
 
 interface Props {
+  states: CategoryOption[],
   items: string[]
 }
 
 const ChangeStateModal: React.FunctionComponent<Props> = ({
+  states,
   items
 }) => {
   const { t } = useTranslation('shared')
@@ -57,13 +60,7 @@ const ChangeStateModal: React.FunctionComponent<Props> = ({
     </SubmitButton>
   )
 
-  const options = [
-    { value: '', label: '' },
-    { value: 'approved', label: t('states.approved') },
-    { value: 'pending', label: t('states.pending') },
-    { value: 'rejected', label: t('states.rejected') },
-    { value: 'suspended', label: t('states.suspended') }
-  ]
+  const options = [{ name: '', humanName: '' }, ...states]
 
   return (
     <DataListModal
@@ -89,7 +86,7 @@ const ChangeStateModal: React.FunctionComponent<Props> = ({
             aria-label={t('modals.change_state.aria_label')}
           >
             {options.map((option) => (
-              <FormSelectOption key={option.value} value={option.value} label={option.label} />
+              <FormSelectOption key={option.name} value={option.name} label={option.humanName} />
             ))}
           </FormSelect>
         </FormGroup>

--- a/portafly/src/tests/components/shared/data-list/modals/ChangeStateModal.test.tsx
+++ b/portafly/src/tests/components/shared/data-list/modals/ChangeStateModal.test.tsx
@@ -3,14 +3,33 @@ import React from 'react'
 import { render } from 'tests/custom-render'
 import { fireEvent } from '@testing-library/react'
 import { ChangeStateModal } from 'components'
+import { CategoryOption } from 'types'
+
+const states: CategoryOption[] = [
+  { name: 'approved', humanName: 'Approved' },
+  { name: 'pending', humanName: 'Pending' }
+]
+
+const setup = () => {
+  const wrapper = render(<ChangeStateModal items={['test']} states={states} />)
+  const select = wrapper.baseElement.querySelector('[id="state"]') as HTMLElement
+
+  return { ...wrapper, select }
+}
 
 it('should disable its submit button when any field is empty', () => {
-  const { baseElement, getByText } = render(<ChangeStateModal items={['test']} />)
-  const select = baseElement.querySelector('[id="state"]') as HTMLElement
+  const { getByText, select } = setup()
   const submitButton = getByText('modals.change_state.send')
 
   expect(submitButton).toBeDisabled()
 
-  fireEvent.change(select, { target: { value: 'approved' } })
+  fireEvent.change(select, { target: { value: states[0].name } })
   expect(submitButton).not.toBeDisabled()
+})
+
+it('should be able to select a state', () => {
+  const { getByText } = setup()
+  states.forEach(({ humanName }) => (
+    expect(getByText(humanName)).toBeInTheDocument()
+  ))
 })


### PR DESCRIPTION
Since `ChangeStateModal` is a generic component, we have to pass its options as a prop.

Also we weren't using the proper type `CategoryOption`.