### PR TITLE
Extract isMultitenant as an Env variable

### DIFF
--- a/portafly/src/components/pages/accounts/AccountsDataListTable.tsx
+++ b/portafly/src/components/pages/accounts/AccountsDataListTable.tsx
@@ -5,8 +5,6 @@ import { DataListProvider, AccountsTable } from 'components'
 import { generateColumns, generateRows } from 'components/pages/accounts'
 import { useTranslation } from 'i18n/useTranslation'
 
-const isMultitenant = false // TODO: get this somehow
-
 interface Props {
   accounts: IDeveloperAccount[]
 }
@@ -14,7 +12,7 @@ interface Props {
 const AccountsDataListTable: React.FunctionComponent<Props> = ({ accounts }) => {
   const { t } = useTranslation('accountsIndex')
   const columns = generateColumns(t)
-  const rows = generateRows(accounts, isMultitenant)
+  const rows = generateRows(accounts)
 
   const initialState = {
     table: { columns, rows }

--- a/portafly/src/components/pages/accounts/utils/accountsTableDataFactory.tsx
+++ b/portafly/src/components/pages/accounts/utils/accountsTableDataFactory.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 import { sortable } from '@patternfly/react-table'
 import { IDeveloperAccount } from 'types'
 import { TFunction } from 'i18next'
-import { ActionButtonImpersonate } from 'components'
+import { ActionButtonImpersonate } from 'components/pages/accounts'
 
-const generateRows = (accounts: IDeveloperAccount[], isMultitenant = false) => {
+const generateRows = (accounts: IDeveloperAccount[]) => {
+  const isMultitenant = process.env.REACT_APP_MULTITENANT === 'true'
   // Rows and Columns must have the same order
   const mapAccountToRowCell = (account: IDeveloperAccount) => [
     account.org_name,

--- a/portafly/src/components/pages/accounts/utils/accountsTableDataFactory.tsx
+++ b/portafly/src/components/pages/accounts/utils/accountsTableDataFactory.tsx
@@ -5,7 +5,7 @@ import { TFunction } from 'i18next'
 import { ActionButtonImpersonate } from 'components/pages/accounts'
 
 const generateRows = (accounts: IDeveloperAccount[]) => {
-  const isMultitenant = process.env.REACT_APP_MULTITENANT === 'true'
+  const isMultitenant = process.env.REACT_APP_MULTITENANT
   // Rows and Columns must have the same order
   const mapAccountToRowCell = (account: IDeveloperAccount) => [
     account.org_name,

--- a/portafly/src/tests/components/pages/accounts/utils/__snapshots__/accountsTableDataFactory.test.tsx.snap
+++ b/portafly/src/tests/components/pages/accounts/utils/__snapshots__/accountsTableDataFactory.test.tsx.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should generate columns 1`] = `
+Array [
+  Object {
+    "categoryName": "group",
+    "title": undefined,
+    "transforms": Array [
+      [Function],
+    ],
+  },
+  Object {
+    "categoryName": "admin",
+    "title": undefined,
+    "transforms": Array [
+      [Function],
+    ],
+  },
+  Object {
+    "categoryName": "signup",
+    "title": undefined,
+    "transforms": Array [
+      [Function],
+    ],
+  },
+  Object {
+    "categoryName": "apps",
+    "title": undefined,
+    "transforms": Array [
+      [Function],
+    ],
+  },
+  Object {
+    "categoryName": "state",
+    "title": undefined,
+    "transforms": Array [
+      [Function],
+    ],
+  },
+  Object {
+    "categoryName": "actions",
+    "title": undefined,
+  },
+]
+`;

--- a/portafly/src/tests/components/pages/accounts/utils/accountsTableDataFactory.test.ts
+++ b/portafly/src/tests/components/pages/accounts/utils/accountsTableDataFactory.test.ts
@@ -2,7 +2,7 @@ import { generateColumns, generateRows } from 'components/pages/accounts'
 import { developerAccounts } from 'tests/examples'
 
 it('should work', () => {
-  const isMultitenant = false
+  process.env.REACT_APP_MULTITENANT = 'false'
   expect(generateColumns(jest.fn())).not.toBeUndefined()
-  expect(generateRows(developerAccounts, isMultitenant)).not.toBeUndefined()
+  expect(generateRows(developerAccounts)).not.toBeUndefined()
 })

--- a/portafly/src/tests/components/pages/accounts/utils/accountsTableDataFactory.test.ts
+++ b/portafly/src/tests/components/pages/accounts/utils/accountsTableDataFactory.test.ts
@@ -1,8 +1,0 @@
-import { generateColumns, generateRows } from 'components/pages/accounts'
-import { developerAccounts } from 'tests/examples'
-
-it('should work', () => {
-  process.env.REACT_APP_MULTITENANT = 'false'
-  expect(generateColumns(jest.fn())).not.toBeUndefined()
-  expect(generateRows(developerAccounts)).not.toBeUndefined()
-})

--- a/portafly/src/tests/components/pages/accounts/utils/accountsTableDataFactory.test.tsx
+++ b/portafly/src/tests/components/pages/accounts/utils/accountsTableDataFactory.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import { generateColumns, generateRows, ActionButtonImpersonate } from 'components/pages/accounts'
+import { developerAccounts } from 'tests/examples'
+
+it('should generate columns', () => {
+  const columns = generateColumns(jest.fn())
+  expect(columns).toMatchSnapshot()
+})
+
+describe.skip('when it is provider', () => {
+  beforeAll(() => {
+    process.env.REACT_APP_MULTITENANT = null
+  })
+})
+
+describe('when it is multitenant', () => {
+  beforeAll(() => {
+    process.env.REACT_APP_MULTITENANT = 'true'
+  })
+
+  it('should render an impersonate button as action', () => {
+    expect(generateRows(developerAccounts.slice(0, 1)))
+      .toMatchObject([{ cells: expect.arrayContaining([{ title: <ActionButtonImpersonate /> }]) }])
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now `isMultitenant` is a hardcoded value.

**Which issue(s) this PR fixes** 

[THREESCALE-5326: Distinguish multitenant accounts](https://issues.redhat.com/browse/THREESCALE-5326)