### PR TITLE
Adds HTTP timeout errors to fallback conditions of ImportCountriesService

### DIFF
--- a/app/services/import_countries_service.rb
+++ b/app/services/import_countries_service.rb
@@ -81,7 +81,7 @@ class ImportCountriesService
   def load_countries
     info 'Downloading countries from geonames.org...'
     GeonamesLoader.load_countries
-  rescue OpenURI::HTTPError
+  rescue OpenURI::HTTPError, Timeout::Error
     error 'Download countries failed. Using local static source...'
     load_static_countries
   end


### PR DESCRIPTION
Right now `ImportCountriesService#call!` only rescues from `OpenURI::HTTPError` exceptions, which include 404 but not time out errors, for example. Without including time out errors, the step to import the list of countries using the Geonames API will fail to fallback to the static list of countries shipped with the code in some scenarios of disconnected deployment. This PR addresses this issue by including HTTP timeout errors to the fallback conditions of `ImportCountriesService`.

Closes [THREESCALE-4373](https://issues.redhat.com/browse/THREESCALE-4373)