### PR TITLE
[sphinx] Remove thread in openshift:thinking_sphinx:start

### DIFF
--- a/app/indices/account_index.rb
+++ b/app/indices/account_index.rb
@@ -19,7 +19,7 @@ ThinkingSphinx::Index.define(:account, with: :real_time) do
   has :tenant_id, type: :integer
   has :state, type: :string
 
-  scope { Account.where(master: false).includes(:users, :bought_cinstances) }
+  scope { Account.not_master.includes(:users, :bought_cinstances) }
 end
 
 module AccountIndex

--- a/app/indices/cms_page_index.rb
+++ b/app/indices/cms_page_index.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 ThinkingSphinx::Index.define 'cms/page', with: :real_time do
   indexes :title
   has :tenant_id, type: :integer
 
   indexes :published
+  scope { CMS::Page.where(searchable: true) }
 end
 
 module CMSPageIndex
@@ -16,6 +19,7 @@ module CMSPageIndex
 
   def sphinx_index
     return unless searchable?
+
     SphinxIndexationWorker.perform_later(self)
   end
 end

--- a/app/indices/topic_index.rb
+++ b/app/indices/topic_index.rb
@@ -10,6 +10,8 @@ unless System::Database.oracle?
     has :forum_id, type: :integer
     has :sticky, type: :boolean
     has :last_updated_at, type: :timestamp
+
+    scope { Topic.includes(:posts) }
   end
 end
 
@@ -36,6 +38,7 @@ module TopicIndex
 
     def index_topic
       return if System::Database.oracle?
+
       SphinxIndexationWorker.perform_later(topic)
     end
   end
@@ -44,6 +47,7 @@ module TopicIndex
 
   def sphinx_index
     return if System::Database.oracle?
+
     SphinxIndexationWorker.perform_later(self)
   end
 end

--- a/config/jobs.rb
+++ b/config/jobs.rb
@@ -44,9 +44,6 @@ module ThreeScale
 
     HOUR = %w[Rails.env].freeze # just a fake job to ensure cron works
 
-    SPHINX_INDEX = [{ 'rake' => 'ts:index' }].freeze
-    SPHINX_DELTA = [{ 'rake' => 'ts:in:delta' }].freeze
-
     CUSTOM = {
     }.freeze
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -50,12 +50,3 @@ ThreeScale::Jobs::CUSTOM.each_pair do |interval, task|
     instance_exec(task, &job_proc)
   end
 end
-
-every 1.day, :at => '6:00 am', roles: [:sphinx_server] do
-  ThreeScale::Jobs::SPHINX_INDEX.each { |task| instance_exec(task, &job_proc) }
-end
-
-# every hour would put at minute 0 which is quite busy with tasks already
-every '42 * * * *', roles: [:sphinx_server] do
-  ThreeScale::Jobs::SPHINX_DELTA.each { |task| instance_exec(task, &job_proc) }
-end


### PR DESCRIPTION
It does not create a thread for indexing anymore

All indexing is done real time in background with Sidekiq

To initialize an indexation, run `rake ts:clear ts:rebuild`