### PR TITLE
Fix static text in the documentation liquid template

### DIFF
--- a/lib/developer_portal/app/views/developer_portal/docs.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/docs.html.liquid
@@ -1,6 +1,6 @@
 <h1>Documentation</h1>
 
-<p>Use our live documentation to learn about the Fixer.io</p>
+<p>Use our live documentation to learn about the Echo API</p>
 
 {% cdn_asset /swagger-ui/2.2.10/swagger-ui.js %}
 {% cdn_asset /swagger-ui/2.2.10/swagger-ui.css %}


### PR DESCRIPTION
Because a [while ago](https://github.com/3scale/porta/pull/1728) I did something very stupid.