### PR TITLE
Use distinct in relation instead of uniq

### DIFF
--- a/app/lib/logic/contracting.rb
+++ b/app/lib/logic/contracting.rb
@@ -12,7 +12,7 @@ module Logic
         # Has to have default or published application plan
         # so this method should be called only in this scope
         scope :can_create_application_contract, -> {
-          query = joining { application_plans.outer }.uniq
+          query = joining { application_plans.outer }.distinct
           .where.has {
             default_application_plan_id.not_eq(nil) |
             ((application_plans.state.eq('published') & application_plans.id.not_eq(nil)))

--- a/app/models/account/buyer_methods.rb
+++ b/app/models/account/buyer_methods.rb
@@ -44,7 +44,7 @@ module Account::BuyerMethods
 
       class << self
         def to_proc
-          -> { System::Database.oracle? ? extending(UniqueAssociation) : uniq }
+          -> { System::Database.oracle? ? extending(UniqueAssociation) : distinct }
         end
 
         delegate :arity, to: :to_proc

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -96,7 +96,7 @@ class Contract < ApplicationRecord
 
   def self.by_plan_type(type)
 
-    plans = Plan.unscoped.uniq.joins { pricing_rules.outer }
+    plans = Plan.unscoped.distinct.joins { pricing_rules.outer }
 
     plan_type = case type.to_s
                 when 'free'

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -30,7 +30,7 @@ class Topic < ApplicationRecord
   has_many :posts, -> { oldest_first }, :dependent => :delete_all
   has_one  :recent_post, -> { latest_first }, :class_name => 'Post'
 
-  has_many :voices, -> { uniq }, :through => :posts, :source => :user
+  has_many :voices, -> { distinct }, :through => :posts, :source => :user
 
   has_many :user_topics, :dependent => :destroy
   has_many :subscribers, :through => :user_topics, :source => :user


### PR DESCRIPTION
Rails 5.0 has deprecated it https://github.com/rails/rails/commit/adfab2dcf4003ca564d78d4425566dd2d9cd8b4f
It is removed in rails 5.1

Cherry-picked from https://github.com/3scale/porta/pull/1669
To clean up the following warning:
![image](https://user-images.githubusercontent.com/11318903/85020137-2b5a1980-b170-11ea-8606-cbdab070230f.png)
