### PR TITLE
Remove "Admin" from getAccounts

### DIFF
--- a/portafly/src/dal/accounts/getDeveloperAccounts.ts
+++ b/portafly/src/dal/accounts/getDeveloperAccounts.ts
@@ -53,8 +53,7 @@ const parseAccounts = (accounts: BuyersAccount[]) => accounts.map(({ account }) 
   createdAt: account.created_at,
   updatedAt: account.updated_at,
   orgName: account.org_name,
-  // TODO: Porta should return admin_name (username of first user role admin)
-  adminName: account.billing_address?.company,
+  adminName: 'TODO', // TODO: include admin_display_name in the response body
   state: account.state as State
 }))
 


### PR DESCRIPTION
~**What this PR does / why we need it**:~

~Once `admin_user_display_name` is returned by porta, it has to be included in Accounts > Index table.~
~**Which issue(s) this PR fixes**~


### EDIT:
The admin's name will be included in the future due to implementation complexities. It's a TODO for now.