### PR TITLE
[PortaFly] Removing unused features from Account > Index

### DIFF
--- a/portafly/src/components/pages/accounts/AccountsTable.tsx
+++ b/portafly/src/components/pages/accounts/AccountsTable.tsx
@@ -16,7 +16,6 @@ import {
   PaginationWidget,
   SendEmailModal,
   ChangeStateModal,
-  BulkActionsWidget,
   filterRows
 } from 'components'
 import { useTranslation } from 'i18n/useTranslation'
@@ -56,11 +55,6 @@ const AccountsTable: React.FunctionComponent = () => {
 
   useEffect(() => resetPagination, [filters])
 
-  const actions = {
-    sendEmail: t('shared:bulk_actions.send_email'),
-    changeState: t('shared:bulk_actions.change_state')
-  }
-
   const filteredRows = filterRows(rows, filters, columns)
 
   const visibleRows = filteredRows.slice(startIdx, endIdx)
@@ -74,9 +68,6 @@ const AccountsTable: React.FunctionComponent = () => {
   const Header = (
     <Toolbar>
       <ToolbarContent>
-        <ToolbarItem>
-          <BulkActionsWidget actions={actions} />
-        </ToolbarItem>
         <ToolbarItem>
           <SearchWidget categories={categories} />
         </ToolbarItem>

--- a/portafly/src/components/pages/accounts/AccountsTable.tsx
+++ b/portafly/src/components/pages/accounts/AccountsTable.tsx
@@ -10,17 +10,13 @@ import {
   useDataListFilters,
   useDataListPagination,
   useDataListTable,
-  useDataListBulkActions,
   Toolbar,
   SearchWidget,
   PaginationWidget,
-  SendEmailModal,
-  ChangeStateModal,
   filterRows
 } from 'components'
 import { useTranslation } from 'i18n/useTranslation'
 import { ToolbarContent, ToolbarItem } from '@patternfly/react-core'
-import { DataListRow } from 'types'
 
 const AccountsTable: React.FunctionComponent = () => {
   const { t } = useTranslation('accountsIndex')
@@ -28,8 +24,7 @@ const AccountsTable: React.FunctionComponent = () => {
     columns,
     rows,
     sortBy,
-    setSortBy,
-    selectedRows
+    setSortBy
   } = useDataListTable()
 
   if (rows.length === 0) {
@@ -38,7 +33,6 @@ const AccountsTable: React.FunctionComponent = () => {
 
   const { startIdx, endIdx, resetPagination } = useDataListPagination()
   const { filters } = useDataListFilters()
-  const { modal } = useDataListBulkActions()
 
   const options = [
     { name: 'approved', humanName: t('actions_filter_options.by_state_options.approved') },
@@ -78,9 +72,6 @@ const AccountsTable: React.FunctionComponent = () => {
     </Toolbar>
   )
 
-  const extractSendEmailItemTitle = ({ cells }: DataListRow) => `${cells[1]} (${cells[0]})`
-  const extractChangeStateItemTitle = ({ cells } :DataListRow) => `${cells[0]} (${cells[4]})`
-
   return (
     <>
       <Table
@@ -102,14 +93,6 @@ const AccountsTable: React.FunctionComponent = () => {
           </ToolbarItem>
         </ToolbarContent>
       </Toolbar>
-
-      {modal === 'sendEmail' && (
-        <SendEmailModal items={selectedRows.map(extractSendEmailItemTitle)} />
-      )}
-
-      {modal === 'changeState' && (
-        <ChangeStateModal items={selectedRows.map(extractChangeStateItemTitle)} states={options} />
-      )}
     </>
   )
 }

--- a/portafly/src/components/pages/accounts/AccountsTable.tsx
+++ b/portafly/src/components/pages/accounts/AccountsTable.tsx
@@ -3,7 +3,6 @@ import {
   Table,
   TableHeader,
   TableBody,
-  OnSelect,
   OnSort
 } from '@patternfly/react-table'
 import {
@@ -15,7 +14,6 @@ import {
   Toolbar,
   SearchWidget,
   PaginationWidget,
-  BulkSelectorWidget,
   SendEmailModal,
   ChangeStateModal,
   BulkActionsWidget,
@@ -32,8 +30,7 @@ const AccountsTable: React.FunctionComponent = () => {
     rows,
     sortBy,
     setSortBy,
-    selectedRows,
-    selectOne
+    selectedRows
   } = useDataListTable()
 
   if (rows.length === 0) {
@@ -72,18 +69,11 @@ const AccountsTable: React.FunctionComponent = () => {
     setSortBy(index, direction, true)
   }
 
-  const onSelectOne: OnSelect = (_ev, selected, _rowIndex, rowData) => {
-    selectOne(rowData.id, selected)
-  }
-
   const pagination = <PaginationWidget itemCount={filteredRows.length} />
 
   const Header = (
     <Toolbar>
       <ToolbarContent>
-        <ToolbarItem>
-          <BulkSelectorWidget />
-        </ToolbarItem>
         <ToolbarItem>
           <BulkActionsWidget actions={actions} />
         </ToolbarItem>
@@ -107,7 +97,6 @@ const AccountsTable: React.FunctionComponent = () => {
         header={Header}
         cells={columns}
         rows={visibleRows}
-        onSelect={visibleRows.length ? onSelectOne : undefined}
         canSelectAll={false}
         sortBy={sortBy}
         onSort={onSort}

--- a/portafly/src/components/pages/accounts/AccountsTable.tsx
+++ b/portafly/src/components/pages/accounts/AccountsTable.tsx
@@ -54,7 +54,7 @@ const AccountsTable: React.FunctionComponent = () => {
   const visibleRows = filteredRows.slice(startIdx, endIdx)
 
   const onSort: OnSort = (_event, index, direction) => {
-    setSortBy(index, direction, true)
+    setSortBy(index, direction)
   }
 
   const pagination = <PaginationWidget itemCount={filteredRows.length} />

--- a/portafly/src/components/pages/accounts/utils/accountsTableDataFactory.tsx
+++ b/portafly/src/components/pages/accounts/utils/accountsTableDataFactory.tsx
@@ -11,7 +11,6 @@ const generateRows = (accounts: IDeveloperAccount[]) => {
     account.org_name,
     account.admin_name,
     account.created_at,
-    account.apps_count.toString(),
     account.state,
     {
       title: isMultitenant ? <ActionButtonImpersonate /> : ''
@@ -40,11 +39,6 @@ const generateColumns = (t: TFunction) => [
   {
     categoryName: 'signup',
     title: t('accountsIndex:accounts_table.signup_header'),
-    transforms: [sortable]
-  },
-  {
-    categoryName: 'apps',
-    title: t('accountsIndex:accounts_table.applications_header'),
     transforms: [sortable]
   },
   {

--- a/portafly/src/dal/accounts/getDeveloperAccounts.ts
+++ b/portafly/src/dal/accounts/getDeveloperAccounts.ts
@@ -55,7 +55,6 @@ const parseAccounts = (accounts: BuyersAccount[]) => accounts.map(({ account }) 
   org_name: account.org_name,
   // TODO: Porta should return admin_name (username of first user role admin)
   admin_name: account.billing_address?.company,
-  apps_count: 0, // TODO: this is not included in /admin/api/accounts
   state: account.state
 }))
 

--- a/portafly/src/tests/components/pages/accounts/AccountsTable.test.tsx
+++ b/portafly/src/tests/components/pages/accounts/AccountsTable.test.tsx
@@ -1,12 +1,6 @@
 import React from 'react'
-
 import { render } from 'tests/custom-render'
-import {
-  useDataListTable,
-  useDataListPagination,
-  useDataListFilters,
-  useDataListBulkActions
-} from 'components'
+import { useDataListTable, useDataListPagination, useDataListFilters } from 'components'
 import { AccountsTable, generateColumns, generateRows } from 'components/pages/accounts'
 import { within } from '@testing-library/react'
 import { IDeveloperAccount } from 'types'
@@ -16,7 +10,6 @@ jest.mock('components/shared/data-list/DataListContext')
 const useTableMock = useDataListTable as jest.Mock
 const usePaginationMock = useDataListPagination as jest.Mock
 const useFiltersMock = useDataListFilters as jest.Mock
-const useBulkActionsMock = useDataListBulkActions as jest.Mock
 const developerAccounts: IDeveloperAccount[] = [['Dandelion', 'Rosemary and Thyme'], ['Geralt', 'Wolf School']].map((account) => (
   factories.DeveloperAccount.build({
     admin_name: account[0],
@@ -30,23 +23,17 @@ const columns = generateColumns((s: string) => s)
 const defaultTable = {
   rows,
   columns,
-  selectedRows: [],
   sortBy: {},
-  setSortBy: jest.fn(),
-  selectOne: jest.fn(),
-  selectPage: jest.fn(),
-  selectAll: jest.fn()
+  setSortBy: jest.fn()
 }
 const resetPagination = jest.fn()
 const defaultPagination = { startIdx: 0, endIdx: 5, resetPagination }
 const defaultFilters = { filters: {} }
-const defaultBulkActions = {}
 
 const resetMocks = () => {
   useTableMock.mockReturnValue(defaultTable)
   usePaginationMock.mockReturnValue(defaultPagination)
   useFiltersMock.mockReturnValue(defaultFilters)
-  useBulkActionsMock.mockReturnValue(defaultBulkActions)
 }
 beforeAll(resetMocks)
 afterEach(resetMocks)

--- a/portafly/src/tests/components/pages/accounts/utils/__snapshots__/accountsTableDataFactory.test.tsx.snap
+++ b/portafly/src/tests/components/pages/accounts/utils/__snapshots__/accountsTableDataFactory.test.tsx.snap
@@ -24,13 +24,6 @@ Array [
     ],
   },
   Object {
-    "categoryName": "apps",
-    "title": undefined,
-    "transforms": Array [
-      [Function],
-    ],
-  },
-  Object {
     "categoryName": "state",
     "title": undefined,
     "transforms": Array [

--- a/portafly/src/types/index.d.ts
+++ b/portafly/src/types/index.d.ts
@@ -5,7 +5,6 @@ export type ArgumentsType<T extends (...args: any[]) => any> =
 
 export interface IDeveloperAccount {
   admin_name: string,
-  apps_count: number
   created_at: string, // TODO: Find a specific date as string type
   id: number,
   org_name: string,


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes features not needed in our first version of the account index.
https://github.com/3scale/porta/pull/1985 covers the missing tests.

**Which issue(s) this PR fixes** 

Fixes: https://issues.redhat.com/browse/THREESCALE-5430

<img width="1680" alt="Screenshot 2020-06-22 at 11 51 52" src="https://user-images.githubusercontent.com/4183971/85274114-ce67a780-b47e-11ea-83bc-2b0da2bc81e9.png">
