### PR TITLE
Fix CMS/Content sidebar

### DIFF
--- a/app/assets/javascripts/provider/cms/sidebar.js.coffee
+++ b/app/assets/javascripts/provider/cms/sidebar.js.coffee
@@ -175,14 +175,11 @@ class Sidebar
     @items('[title]').tipsy(gravity: $.fn.tipsy.autoWE);
 
   group: (json) ->
-    section_id = (p) -> p.section_id
-    parent_id = (s) -> s.parent_id
-
     {
-      sections: _(json.sections).groupBy(parent_id),
-      pages: _(json.pages).groupBy(section_id),
-      files: _(json.files).groupBy(section_id),
-      builtins: _(json.builtins).groupBy(section_id)
+      sections: _.groupBy(json.sections, 'parent_id'),
+      pages: _.groupBy(json.pages, 'section_id'),
+      files: _.groupBy(json.files, 'section_id'),
+      builtins: _.groupBy(json.builtins, 'section_id')
     }
 
   render_layouts: (layouts) =>


### PR DESCRIPTION
**Jira Issue:**
https://issues.redhat.com/browse/THREESCALE-5382

Fix usage of Underscore's collection groupBy function in the sidebar for the CMS Content page of the Admin Portal.

Before:
<img width="1055" alt="Screenshot 2020-06-22 at 19 39 21" src="https://user-images.githubusercontent.com/1842261/85371760-17783400-b531-11ea-9b73-895726220cb7.png">

After:
<img width="1055" alt="Screenshot 2020-06-22 at 19 38 48" src="https://user-images.githubusercontent.com/1842261/85371776-1e06ab80-b531-11ea-9d73-e22fe5678b10.png">
