### PR TITLE
Added service_hosts to json account data (active doc autocompletion)

### DIFF
--- a/app/lib/api_docs/account_data.rb
+++ b/app/lib/api_docs/account_data.rb
@@ -15,6 +15,15 @@ module ApiDocs
       Hash[data_items.map { |item| [item.to_sym, send(item)] }]
     end
 
+    protected
+
+    def service_hosts
+      accessible_services.map do |service|
+        { :name => service.proxy.sandbox_endpoint,
+          :value => service.id }
+      end
+    end
+
     private
 
     def return_account_data
@@ -69,6 +78,5 @@ module ApiDocs
     def apps_with_backend_version(*versions)
       apps.joins(:service).where.has { service.backend_version.in [*versions] }
     end
-
   end
 end

--- a/app/lib/api_docs/buyer_data.rb
+++ b/app/lib/api_docs/buyer_data.rb
@@ -4,12 +4,21 @@ module ApiDocs
   class BuyerData < AccountData
 
     def apps
-      @apps ||= @account.bought_cinstances.latest.live
+      @apps ||= bought_applications.latest.live
     end
 
     def data_items
-      %w[app_keys app_ids user_keys client_ids client_secrets]
+      %w[app_keys app_ids user_keys client_ids client_secrets service_hosts]
     end
 
+    protected
+
+    def bought_applications
+      @account.bought_cinstances
+    end
+
+    def accessible_services
+      @account.provider_account.services.accessible.where(id: bought_applications.select(:service_id))
+    end
   end
 end

--- a/app/lib/api_docs/provider_data.rb
+++ b/app/lib/api_docs/provider_data.rb
@@ -102,7 +102,13 @@ module ApiDocs
     end
 
     def data_items
-      %w[app_keys app_ids application_ids user_keys user_ids account_ids metric_names metric_ids backend_api_metric_names service_ids admin_ids service_plan_ids application_plan_ids account_plan_ids client_ids client_secrets]
+      %w[app_keys app_ids application_ids user_keys user_ids account_ids metric_names metric_ids backend_api_metric_names service_ids service_hosts admin_ids service_plan_ids application_plan_ids account_plan_ids client_ids client_secrets]
+    end
+
+    protected
+
+    def accessible_services
+      @account.services
     end
   end
 end

--- a/test/unit/api_docs/account_data_test.rb
+++ b/test/unit/api_docs/account_data_test.rb
@@ -105,4 +105,18 @@ class ApiDocs::AccountDataTest < ActiveSupport::TestCase
     end
   end
 
+  test 'service_hosts for provider' do
+    data = ApiDocs::ProviderData.new(@provider).as_json[:results]
+    assert_equal @services.map { |service| { name: service.proxy.sandbox_endpoint, value: service.id } }.sort_by(&SORT_PROC), data[:service_hosts].sort_by(&SORT_PROC)
+  end
+
+  test 'service_hosts for buyer' do
+    service4 = FactoryBot.create(:simple_service, name: 'service-4', account_id: @provider.id)
+    plan4 = FactoryBot.create(:simple_application_plan, issuer: service4)
+    unrelated_buyer = FactoryBot.create(:simple_buyer, provider_account: @provider)
+    unrelated_app = FactoryBot.create(:simple_cinstance, service: service4, application_id: 'UNRELATED_APP', name: 'Unrelated App', plan: plan4, user_account: unrelated_buyer)
+
+    data = ApiDocs::BuyerData.new(@buyer).as_json[:results]
+    assert_equal @services.map { |service| { name: service.proxy.sandbox_endpoint, value: service.id } }.sort_by(&SORT_PROC), data[:service_hosts].sort_by(&SORT_PROC)
+  end
 end


### PR DESCRIPTION
This is an alternative for how to pass service hosts to the JavaScript layer.

Instead of just one host, it provides with an array of all public URLs (sandbox endpoints), available both at Admin Portal and Developer Portal.

Format: `[{ name: <endpoint>, value: <service_id> }]`

**Admin Portal**
<img width="1729" alt="Screenshot 2020-06-25 at 17 21 31" src="https://user-images.githubusercontent.com/1842261/85748472-61ffd900-b708-11ea-92e7-adda511f23f6.png">

Developer **Portal**
<img width="1729" alt="Screenshot 2020-06-25 at 17 21 42" src="https://user-images.githubusercontent.com/1842261/85748492-65936000-b708-11ea-9bf3-72e76e57f0bd.png">

The UI will have to find the service id in the list (`value` property) and fetch the corresponding endpoint (`name`) to replace the OAS host/servers with.

In cases where the ActiveDoc is not associated to any service, maybe one solution could be displaying all the options (if any) for the user to pick one. Alternatively, do nothing and use the original host. TBD.