### PR TITLE
[PortaFly] DataList component test

### DIFF
--- a/portafly/src/tests/components/pages/accounts/AccountsTable.test.tsx
+++ b/portafly/src/tests/components/pages/accounts/AccountsTable.test.tsx
@@ -8,20 +8,24 @@ import {
   useDataListBulkActions
 } from 'components'
 import { AccountsTable, generateColumns, generateRows } from 'components/pages/accounts'
-import { developerAccounts } from 'tests/examples'
-import { fireEvent, within } from '@testing-library/react'
+import { within } from '@testing-library/react'
 import { IDeveloperAccount } from 'types'
+import { factories } from 'tests/factories'
 
 jest.mock('components/shared/data-list/DataListContext')
 const useTableMock = useDataListTable as jest.Mock
 const usePaginationMock = useDataListPagination as jest.Mock
 const useFiltersMock = useDataListFilters as jest.Mock
 const useBulkActionsMock = useDataListBulkActions as jest.Mock
+const developerAccounts: IDeveloperAccount[] = [['Dandelion', 'Rosemary and Thyme'], ['Geralt', 'Wolf School']].map((account) => (
+  factories.DeveloperAccount.build({
+    admin_name: account[0],
+    org_name: account[1]
+  })
+))
 
-const rows = generateRows(developerAccounts, false)
+const rows = generateRows(developerAccounts)
 const columns = generateColumns((s: string) => s)
-
-const isChecked = (c: HTMLElement) => (c as HTMLInputElement).checked
 
 const defaultTable = {
   rows,
@@ -37,6 +41,7 @@ const resetPagination = jest.fn()
 const defaultPagination = { startIdx: 0, endIdx: 5, resetPagination }
 const defaultFilters = { filters: {} }
 const defaultBulkActions = {}
+
 const resetMocks = () => {
   useTableMock.mockReturnValue(defaultTable)
   usePaginationMock.mockReturnValue(defaultPagination)
@@ -48,202 +53,22 @@ afterEach(resetMocks)
 
 const setup = () => {
   const wrapper = render(<AccountsTable />)
-  const getRow = (account: IDeveloperAccount) => wrapper.getByText(account.org_name).closest('tr') as HTMLElement
-  const bulkSelectorDropdown = within(wrapper.container.querySelector('#data-list-bulk-selector-dropdown') as HTMLElement)
-  const bulkActionsDropdown = within(wrapper.container.querySelector('#data-list-bulk-actions-dropdown') as HTMLElement)
+  const table = within(wrapper.queryByRole('grid') as HTMLElement)
+  const getRow = (account: IDeveloperAccount) => table.getByText(account.org_name).closest('tr') as HTMLElement
 
   return {
     ...wrapper,
-    getRow,
-    bulkSelectorDropdown,
-    bulkActionsDropdown
+    getRow
   }
 }
-
-it('should be able to sort columns', () => {
-  const { container } = setup()
-  const table = within(container.querySelector('table') as HTMLElement)
-  fireEvent.click(table.getByText(/accounts_table.group_header/))
-
-  expect(defaultTable.setSortBy).toHaveBeenLastCalledWith(1, 'asc', true)
+it('should render the data list table with the accounts provided', () => {
+  const { queryByText, getRow } = setup()
+  developerAccounts.map((account) => expect(getRow(account)).toBeInTheDocument())
+  expect(queryByText(/accounts_table.empty_state/)).not.toBeInTheDocument()
 })
 
-describe('when there are any accounts, but none selected', () => {
-  beforeEach(() => {
-    useTableMock.mockReturnValue({ ...defaultTable, selectedRows: [] })
-  })
-
-  it('should be able to select one account', () => {
-    const wrapper = setup()
-    const checkboxes = wrapper.getAllByRole('checkbox')
-    expect(checkboxes).toHaveLength(developerAccounts.length + 1)
-    expect(checkboxes.some(isChecked)).toBe(false)
-    // TODO: assert text '0 Selected' in BulkSelectorWidget test
-
-    const account = developerAccounts[0]
-    const row = wrapper.getRow(account)
-    fireEvent.click(within(row).getByRole('checkbox'))
-
-    expect(defaultTable.selectOne).toHaveBeenLastCalledWith(account.id, true)
-  })
-
-  it('should be able to select all accounts in a page', () => {
-    const { bulkSelectorDropdown: dropdown } = setup()
-
-    fireEvent.click(dropdown.getByRole('button'))
-    fireEvent.click(dropdown.getByText('bulk_selector.page'))
-
-    expect(defaultTable.selectPage).toHaveBeenLastCalledWith(expect.any(Array))
-  })
-
-  it('should be able to select all accounts', () => {
-    const { bulkSelectorDropdown: dropdown } = setup()
-
-    fireEvent.click(dropdown.getByRole('button'))
-    fireEvent.click(dropdown.getByText('bulk_selector.all'))
-
-    expect(defaultTable.selectAll).toHaveBeenNthCalledWith(1, true, expect.any(Array))
-  })
-
-  it('should select all when clicking the checkbox', () => {
-    const { bulkSelectorDropdown: dropdown } = setup()
-
-    fireEvent.click(dropdown.getByRole('checkbox'))
-
-    expect(defaultTable.selectAll).toHaveBeenLastCalledWith(true, expect.any(Array))
-  })
-
-  it('should display bulk actions disabled and a warning', () => {
-    const { bulkActionsDropdown: dropdown } = setup()
-
-    fireEvent.click(dropdown.getByRole('button'))
-
-    expect(dropdown.getByText('bulk_actions.warning')).toBeInTheDocument()
-    expect(dropdown.getByText('shared:bulk_actions.send_email')).toBeDisabled()
-    expect(dropdown.getByText('shared:bulk_actions.change_state')).toBeDisabled()
-  })
-})
-
-describe('when there are any accounts, and some are selected', () => {
-  const selectedAccount = developerAccounts[0]
-
-  beforeEach(() => {
-    useTableMock.mockReturnValue({
-      ...defaultTable,
-      rows: rows.map((r) => ({ ...r, selected: r.id === selectedAccount.id })),
-      selectedRows: rows.slice(0, 1)
-    })
-  })
-
-  it('should render selected accounts and be able to deselect them', () => {
-    const wrapper = setup()
-    const checkboxes = wrapper.getAllByRole('checkbox')
-    expect(checkboxes).toHaveLength(developerAccounts.length + 1)
-    expect(checkboxes.filter(isChecked)).toHaveLength(1)
-    // TODO: assert text '1 Selected' in BulkSelectorWidget test
-
-    const row = wrapper.getRow(selectedAccount)
-    fireEvent.click(within(row).getByRole('checkbox'))
-
-    expect(defaultTable.selectOne).toHaveBeenLastCalledWith(selectedAccount.id, false)
-  })
-
-  it('should remove all selections when clicking the checkbox', () => {
-    const { bulkSelectorDropdown: dropdown } = setup()
-
-    fireEvent.click(dropdown.getByRole('checkbox'))
-
-    expect(defaultTable.selectAll).toHaveBeenLastCalledWith(false, expect.any(Array))
-  })
-
-  it('should be able to deselect all', () => {
-    const { bulkSelectorDropdown: dropdown } = setup()
-
-    fireEvent.click(dropdown.getByRole('button'))
-    fireEvent.click(dropdown.getByText('bulk_selector.none'))
-
-    expect(defaultTable.selectAll).toHaveBeenLastCalledWith(false)
-  })
-
-  it('should display bulk actions enabled and no warning', () => {
-    const { bulkActionsDropdown: dropdown } = setup()
-
-    fireEvent.click(dropdown.getByRole('button'))
-
-    expect(dropdown.queryByText('bulk_actions.warning')).not.toBeInTheDocument()
-    expect(dropdown.getByText('shared:bulk_actions.send_email')).toBeEnabled()
-    expect(dropdown.getByText('shared:bulk_actions.send_email')).toBeEnabled()
-  })
-})
-
-describe('when there are any accounts, and all are selected', () => {
-  beforeEach(() => {
-    useTableMock.mockReturnValue({
-      ...defaultTable,
-      rows: rows.map((r) => ({ ...r, selected: true })),
-      selectedRows: rows
-    })
-  })
-
-  it('should render selected accounts and be able to deselect them', () => {
-    const wrapper = setup()
-    const checkboxes = wrapper.getAllByRole('checkbox')
-    expect(checkboxes).toHaveLength(developerAccounts.length + 1)
-    expect(checkboxes.every(isChecked)).toBe(true)
-    // TODO: assert text '2 Selected' in BulkSelectorWidget test
-
-    const account = developerAccounts[0]
-    const row = wrapper.getRow(account)
-    fireEvent.click(within(row).getByRole('checkbox'))
-
-    expect(defaultTable.selectOne).toHaveBeenLastCalledWith(account.id, false)
-  })
-
-  it('should remove all selections when clicking the checkbox', () => {
-    const { bulkSelectorDropdown: dropdown } = setup()
-
-    fireEvent.click(dropdown.getByRole('checkbox'))
-
-    expect(defaultTable.selectAll).toHaveBeenLastCalledWith(false, expect.any(Array))
-  })
-
-  it('should be able to deselect all', () => {
-    const { bulkSelectorDropdown: dropdown } = setup()
-
-    fireEvent.click(dropdown.getByRole('button'))
-    fireEvent.click(dropdown.getByText('bulk_selector.none'))
-
-    expect(defaultTable.selectAll).toHaveBeenLastCalledWith(false)
-  })
-})
-
-describe('when there are any filters', () => {
-  const filteredAccount = developerAccounts[0]
-  const hiddenAccount = developerAccounts[1]
-
-  beforeEach(() => {
-    useFiltersMock.mockReturnValue({
-      filters: {
-        admin: [filteredAccount.admin_name]
-      }
-    })
-  })
-
-  it('should render only filtered rows', () => {
-    const { getRow } = setup()
-
-    expect(getRow(filteredAccount)).toBeInTheDocument()
-    expect(() => getRow(hiddenAccount)).toThrowError()
-  })
-})
-
-describe('when there are NO accounts', () => {
-  beforeEach(() => {
-    useTableMock.mockReturnValue({ ...defaultTable, rows: [] })
-  })
-
-  it('should render an empty view', () => {
-    const { getByText } = setup()
-    expect(getByText(/accounts_table.empty_state/)).toBeInTheDocument()
-  })
+it('should render an empty view when there are NO accounts', () => {
+  useTableMock.mockReturnValue({ ...defaultTable, rows: [] })
+  const { getByText } = setup()
+  expect(getByText(/accounts_table.empty_state/)).toBeInTheDocument()
 })

--- a/portafly/src/tests/components/shared/data-list/DataListTable.test.tsx
+++ b/portafly/src/tests/components/shared/data-list/DataListTable.test.tsx
@@ -45,7 +45,7 @@ const characters = [
     name: 'Calanthe',
     species: 'Human',
     nationality: 'Cintra',
-    state: 'Dead'
+    state: 'Deceased'
   },
   {
     id: 2,
@@ -103,7 +103,8 @@ afterEach(resetMocks)
 
 const setup = () => {
   const wrapper = render(<DataListTable />)
-  const getRow = (character) => wrapper.getByText(character.name).closest('tr') as HTMLElement
+  const table = within(wrapper.queryByRole('grid') as HTMLElement)
+  const getRow = (character) => table.getByText(character.name).closest('tr') as HTMLElement
   const bulkSelectorDropdown = within(wrapper.container.querySelector('#data-list-bulk-selector-dropdown') as HTMLElement)
   const bulkActionsDropdown = within(wrapper.container.querySelector('#data-list-bulk-actions-dropdown') as HTMLElement)
 
@@ -118,9 +119,11 @@ const setup = () => {
 it('should be able to sort columns', () => {
   const { container } = setup()
   const table = within(container.querySelector('table') as HTMLElement)
-  fireEvent.click(table.getByText(/Name/))
 
-  expect(defaultTable.setSortBy).toHaveBeenLastCalledWith(1, 'asc', true)
+  expect(defaultTable.setSortBy).not.toHaveBeenCalled()
+
+  fireEvent.click(table.getByText(/Name/))
+  expect(defaultTable.setSortBy).toHaveBeenCalled()
 })
 
 describe('when there are any records, but none selected', () => {
@@ -279,7 +282,7 @@ describe('when there are any filters', () => {
   beforeEach(() => {
     useFiltersMock.mockReturnValue({
       filters: {
-        state: ['dead']
+        state: ['deceased']
       }
     })
   })

--- a/portafly/src/tests/components/shared/data-list/DataListTable.test.tsx
+++ b/portafly/src/tests/components/shared/data-list/DataListTable.test.tsx
@@ -1,0 +1,304 @@
+import React from 'react'
+import { render } from 'tests/custom-render'
+import {
+  useDataListTable,
+  useDataListPagination,
+  useDataListFilters,
+  useDataListBulkActions
+} from 'components'
+import { DataListTable } from 'tests/components/shared/data-list/examples/DataListTable'
+import { fireEvent, within } from '@testing-library/react'
+import { sortable } from '@patternfly/react-table'
+
+jest.mock('components/shared/data-list/DataListContext')
+const useTableMock = useDataListTable as jest.Mock
+const usePaginationMock = useDataListPagination as jest.Mock
+const useFiltersMock = useDataListFilters as jest.Mock
+const useBulkActionsMock = useDataListBulkActions as jest.Mock
+
+const columns = [
+  {
+    categoryName: 'name',
+    title: 'Name',
+    transforms: [sortable]
+  },
+  {
+    categoryName: 'species',
+    title: 'Species / Race',
+    transforms: [sortable]
+  },
+  {
+    categoryName: 'nationality',
+    title: 'Nationality',
+    transforms: [sortable]
+  },
+  {
+    categoryName: 'state',
+    title: 'State',
+    transforms: [sortable]
+  }
+]
+
+const characters = [
+  {
+    id: 1,
+    name: 'Calanthe',
+    species: 'Human',
+    nationality: 'Cintra',
+    state: 'Dead'
+  },
+  {
+    id: 2,
+    name: 'Geralt',
+    species: 'Witcher',
+    nationality: '',
+    state: 'Alive'
+  },
+  {
+    id: 3,
+    name: 'Cirilla',
+    species: 'Human',
+    nationality: 'Cintra',
+    state: 'Alive'
+  },
+  {
+    id: 4,
+    name: 'Zoltan',
+    species: 'Dwarf',
+    nationality: 'Mahakam',
+    state: 'Alive'
+  }
+]
+
+const rows = characters.map((c) => ({
+  id: c.id,
+  cells: Object.keys(c).filter((k) => k !== 'id').map((k) => c[k]),
+  selected: false
+}))
+
+const isChecked = (c: HTMLElement) => (c as HTMLInputElement).checked
+
+const defaultTable = {
+  rows,
+  columns,
+  selectedRows: [],
+  sortBy: {},
+  setSortBy: jest.fn(),
+  selectOne: jest.fn(),
+  selectPage: jest.fn(),
+  selectAll: jest.fn()
+}
+const resetPagination = jest.fn()
+const defaultPagination = { startIdx: 0, endIdx: 5, resetPagination }
+const defaultFilters = { filters: {} }
+const defaultBulkActions = {}
+const resetMocks = () => {
+  useTableMock.mockReturnValue(defaultTable)
+  usePaginationMock.mockReturnValue(defaultPagination)
+  useFiltersMock.mockReturnValue(defaultFilters)
+  useBulkActionsMock.mockReturnValue(defaultBulkActions)
+}
+beforeAll(resetMocks)
+afterEach(resetMocks)
+
+const setup = () => {
+  const wrapper = render(<DataListTable />)
+  const getRow = (character) => wrapper.getByText(character.name).closest('tr') as HTMLElement
+  const bulkSelectorDropdown = within(wrapper.container.querySelector('#data-list-bulk-selector-dropdown') as HTMLElement)
+  const bulkActionsDropdown = within(wrapper.container.querySelector('#data-list-bulk-actions-dropdown') as HTMLElement)
+
+  return {
+    ...wrapper,
+    getRow,
+    bulkSelectorDropdown,
+    bulkActionsDropdown
+  }
+}
+
+it('should be able to sort columns', () => {
+  const { container } = setup()
+  const table = within(container.querySelector('table') as HTMLElement)
+  fireEvent.click(table.getByText(/Name/))
+
+  expect(defaultTable.setSortBy).toHaveBeenLastCalledWith(1, 'asc', true)
+})
+
+describe('when there are any records, but none selected', () => {
+  beforeEach(() => {
+    useTableMock.mockReturnValue({ ...defaultTable, selectedRows: [] })
+  })
+
+  it('should be able to select one record', () => {
+    const wrapper = setup()
+    const checkboxes = wrapper.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(characters.length + 1)
+    expect(checkboxes.some(isChecked)).toBe(false)
+    // TODO: assert text '0 Selected' in BulkSelectorWidget test
+
+    const character = characters[0]
+    const row = wrapper.getRow(character)
+    fireEvent.click(within(row).getByRole('checkbox'))
+
+    expect(defaultTable.selectOne).toHaveBeenLastCalledWith(character.id, true)
+  })
+
+  it('should be able to select all records in a page', () => {
+    const { bulkSelectorDropdown: dropdown } = setup()
+
+    fireEvent.click(dropdown.getByRole('button'))
+    fireEvent.click(dropdown.getByText('bulk_selector.page'))
+
+    expect(defaultTable.selectPage).toHaveBeenLastCalledWith(expect.any(Array))
+  })
+
+  it('should be able to select all records', () => {
+    const { bulkSelectorDropdown: dropdown } = setup()
+
+    fireEvent.click(dropdown.getByRole('button'))
+    fireEvent.click(dropdown.getByText('bulk_selector.all'))
+
+    expect(defaultTable.selectAll).toHaveBeenNthCalledWith(1, true, expect.any(Array))
+  })
+
+  it('should select all when clicking the checkbox', () => {
+    const { bulkSelectorDropdown: dropdown } = setup()
+
+    fireEvent.click(dropdown.getByRole('checkbox'))
+
+    expect(defaultTable.selectAll).toHaveBeenLastCalledWith(true, expect.any(Array))
+  })
+
+  it('should display bulk actions disabled and a warning', () => {
+    const { bulkActionsDropdown: dropdown } = setup()
+
+    fireEvent.click(dropdown.getByRole('button'))
+
+    expect(dropdown.getByText('bulk_actions.warning')).toBeInTheDocument()
+    expect(dropdown.getByText('Send Raven')).toBeDisabled()
+    expect(dropdown.getByText('Change State')).toBeDisabled()
+  })
+})
+
+describe('when there are any records, and some are selected', () => {
+  const selectedCharacter = characters[0]
+
+  beforeEach(() => {
+    useTableMock.mockReturnValue({
+      ...defaultTable,
+      rows: rows.map((r) => ({ ...r, selected: r.id === selectedCharacter.id })),
+      selectedRows: rows.slice(0, 1)
+    })
+  })
+
+  it('should render selected records and be able to deselect them', () => {
+    const wrapper = setup()
+    const checkboxes = wrapper.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(characters.length + 1)
+    expect(checkboxes.filter(isChecked)).toHaveLength(1)
+    // TODO: assert text '1 Selected' in BulkSelectorWidget test
+
+    const row = wrapper.getRow(selectedCharacter)
+    fireEvent.click(within(row).getByRole('checkbox'))
+
+    expect(defaultTable.selectOne).toHaveBeenLastCalledWith(selectedCharacter.id, false)
+  })
+
+  it('should remove all selections when clicking the checkbox', () => {
+    const { bulkSelectorDropdown: dropdown } = setup()
+
+    fireEvent.click(dropdown.getByRole('checkbox'))
+
+    expect(defaultTable.selectAll).toHaveBeenLastCalledWith(false, expect.any(Array))
+  })
+
+  it('should be able to deselect all', () => {
+    const { bulkSelectorDropdown: dropdown } = setup()
+
+    fireEvent.click(dropdown.getByRole('button'))
+    fireEvent.click(dropdown.getByText('bulk_selector.none'))
+
+    expect(defaultTable.selectAll).toHaveBeenLastCalledWith(false)
+  })
+
+  it('should display bulk actions enabled and no warning', () => {
+    const { bulkActionsDropdown: dropdown } = setup()
+
+    fireEvent.click(dropdown.getByRole('button'))
+
+    expect(dropdown.queryByText('bulk_actions.warning')).not.toBeInTheDocument()
+    expect(dropdown.getByText('Send Raven')).toBeEnabled()
+    expect(dropdown.getByText('Change State')).toBeEnabled()
+  })
+})
+
+describe('when there are any records, and all are selected', () => {
+  beforeEach(() => {
+    useTableMock.mockReturnValue({
+      ...defaultTable,
+      rows: rows.map((r) => ({ ...r, selected: true })),
+      selectedRows: rows
+    })
+  })
+
+  it('should render selected records and be able to deselect them', () => {
+    const wrapper = setup()
+    const checkboxes = wrapper.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(characters.length + 1)
+    expect(checkboxes.every(isChecked)).toBe(true)
+    // TODO: assert text '2 Selected' in BulkSelectorWidget test
+
+    const character = characters[0]
+    const row = wrapper.getRow(character)
+    fireEvent.click(within(row).getByRole('checkbox'))
+
+    expect(defaultTable.selectOne).toHaveBeenLastCalledWith(character.id, false)
+  })
+
+  it('should remove all selections when clicking the checkbox', () => {
+    const { bulkSelectorDropdown: dropdown } = setup()
+
+    fireEvent.click(dropdown.getByRole('checkbox'))
+
+    expect(defaultTable.selectAll).toHaveBeenLastCalledWith(false, expect.any(Array))
+  })
+
+  it('should be able to deselect all', () => {
+    const { bulkSelectorDropdown: dropdown } = setup()
+
+    fireEvent.click(dropdown.getByRole('button'))
+    fireEvent.click(dropdown.getByText('bulk_selector.none'))
+
+    expect(defaultTable.selectAll).toHaveBeenLastCalledWith(false)
+  })
+})
+
+describe('when there are any filters', () => {
+  const filteredCharacter = characters[0]
+  const hiddenCharacter = characters[1]
+
+  beforeEach(() => {
+    useFiltersMock.mockReturnValue({
+      filters: {
+        state: ['dead']
+      }
+    })
+  })
+
+  it('should render only filtered rows', () => {
+    const { getRow } = setup()
+
+    expect(getRow(filteredCharacter)).toBeInTheDocument()
+    expect(() => getRow(hiddenCharacter)).toThrowError()
+  })
+})
+
+describe('when there are NO accounts', () => {
+  beforeEach(() => {
+    useTableMock.mockReturnValue({ ...defaultTable, rows: [] })
+  })
+
+  it('should render an empty view', () => {
+    const { getByText } = setup()
+    expect(getByText('No characters found')).toBeInTheDocument()
+  })
+})

--- a/portafly/src/tests/components/shared/data-list/examples/DataListTable.tsx
+++ b/portafly/src/tests/components/shared/data-list/examples/DataListTable.tsx
@@ -44,7 +44,7 @@ const DataListTable: React.FunctionComponent = () => {
 
   const options = [
     { name: 'alive', humanName: 'Alive' },
-    { name: 'dead', humanName: 'Dead' }
+    { name: 'deceased', humanName: 'Deceased' }
   ]
 
   const categories = [

--- a/portafly/src/tests/components/shared/data-list/examples/DataListTable.tsx
+++ b/portafly/src/tests/components/shared/data-list/examples/DataListTable.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect } from 'react'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  OnSelect,
+  OnSort
+} from '@patternfly/react-table'
+import {
+  PageEmptyState,
+  useDataListFilters,
+  useDataListPagination,
+  useDataListTable,
+  useDataListBulkActions,
+  Toolbar,
+  SearchWidget,
+  PaginationWidget,
+  BulkSelectorWidget,
+  ChangeStateModal,
+  BulkActionsWidget,
+  filterRows,
+  SendEmailModal
+} from 'components'
+import { ToolbarContent, ToolbarItem } from '@patternfly/react-core'
+import { DataListRow } from 'types'
+
+const DataListTable: React.FunctionComponent = () => {
+  const {
+    columns,
+    rows,
+    sortBy,
+    setSortBy,
+    selectedRows,
+    selectOne
+  } = useDataListTable()
+
+  if (rows.length === 0) {
+    return <PageEmptyState msg="No characters found" />
+  }
+
+  const { startIdx, endIdx, resetPagination } = useDataListPagination()
+  const { filters } = useDataListFilters()
+  const { modal } = useDataListBulkActions()
+
+  const options = [
+    { name: 'alive', humanName: 'Alive' },
+    { name: 'dead', humanName: 'Dead' }
+  ]
+
+  const categories = [
+    { name: 'name', humanName: 'Name' },
+    { name: 'species', humanName: 'Species' },
+    { name: 'state', humanName: 'State', options }
+  ]
+
+  useEffect(() => resetPagination, [filters])
+
+  const actions = {
+    sendEmail: 'Send Raven',
+    changeState: 'Change State'
+  }
+
+  const filteredRows = filterRows(rows, filters, columns)
+
+  const visibleRows = filteredRows.slice(startIdx, endIdx)
+
+  const onSort: OnSort = (_event, index, direction) => {
+    setSortBy(index, direction, true)
+  }
+
+  const onSelectOne: OnSelect = (_ev, selected, _rowIndex, rowData) => {
+    selectOne(rowData.id, selected)
+  }
+
+  const pagination = <PaginationWidget itemCount={filteredRows.length} />
+
+  const Header = (
+    <Toolbar>
+      <ToolbarContent>
+        <ToolbarItem>
+          <BulkSelectorWidget />
+        </ToolbarItem>
+        <ToolbarItem>
+          <BulkActionsWidget actions={actions} />
+        </ToolbarItem>
+        <ToolbarItem>
+          <SearchWidget categories={categories} />
+        </ToolbarItem>
+        <ToolbarItem variant="pagination" breakpointMods={[{ modifier: 'align-right', breakpoint: 'md' }]}>
+          {pagination}
+        </ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  )
+
+  const extractSendEmailItemTitle = ({ cells }: DataListRow) => `${cells[1]} (${cells[0]})`
+  const extractChangeStateItemTitle = ({ cells } :DataListRow) => `${cells[0]} (${cells[4]})`
+
+  return (
+    <>
+      <Table
+        aria-label="Harry Potter characters"
+        header={Header}
+        cells={columns}
+        rows={visibleRows}
+        onSelect={visibleRows.length ? onSelectOne : undefined}
+        canSelectAll={false}
+        sortBy={sortBy}
+        onSort={onSort}
+      >
+        <TableHeader />
+        <TableBody />
+      </Table>
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarItem variant="pagination" breakpointMods={[{ modifier: 'align-right', breakpoint: 'md' }]}>
+            {pagination}
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+
+      {modal === 'sendEmail' && (
+        <SendEmailModal items={selectedRows.map(extractSendEmailItemTitle)} />
+      )}
+
+      {modal === 'changeState' && (
+        <ChangeStateModal items={selectedRows.map(extractChangeStateItemTitle)} states={options} />
+      )}
+    </>
+  )
+}
+
+export { DataListTable }


### PR DESCRIPTION
**What this PR does / why we need it**:

We were testing the Data List composed component within the Accounts index page and not by itself.

Related to https://github.com/3scale/porta/pull/1977

**Which issue(s) this PR fixes** 
Complementary to fix https://issues.redhat.com/browse/THREESCALE-5430

**Verification steps** 

**Special notes for your reviewer**:
