### PR TITLE
Include 'plan_name' and 'org_name' in /admin/api/applications

### DIFF
--- a/app/representers/cinstance_representer.rb
+++ b/app/representers/cinstance_representer.rb
@@ -16,7 +16,9 @@ module CinstanceRepresenter
   property :updated_at
   property :service_id
   property :plan_id
+  property :plan_name
   property :user_account_id, as: :account_id
+  property :org_name
   property :first_traffic_at, render_nil: true
   property :first_daily_traffic_at, render_nil: true
 
@@ -77,5 +79,7 @@ module CinstanceRepresenter
   end
 
   delegate :id, to: :service, prefix: true
+  delegate :org_name, to: :user_account
+  delegate :name, to: :plan, prefix: true
   delegate :oidc_configuration, to: :service
 end

--- a/spec/acceptance/api/application_spec.rb
+++ b/spec/acceptance/api/application_spec.rb
@@ -196,7 +196,8 @@ resource "Cinstance" do
     end
 
     it { should have_properties('id', 'state', 'name', 'plan_id', 'description',
-                      'service_id', 'first_traffic_at', 'first_daily_traffic_at').from(resource) }
+                      'service_id', 'first_traffic_at', 'first_daily_traffic_at',
+                      'plan_name', 'org_name').from(resource) }
     it { should have_links('self', 'account', 'plan', 'keys', 'referrer_filters', 'service') }
 
     it { should include('account_id' => resource.buyer.id )}


### PR DESCRIPTION
**What this PR does / why we need it**:

We need these 2 fields for Patternfly Applications Index page.

**Which issue(s) this PR fixes** 

[THREESCALE-5456: Update Applications endpoint to include missing data for Portafly](https://issues.redhat.com/browse/THREESCALE-5456)

**Verification steps** 

Verify the response locally or from preview:
```
$ curl -v  -X GET "<URL>/admin/api/accounts.json?access_token=<TOKEN>"
```