### PR TITLE
[openshift] Cleanup files When sphinx is not cleanly shutdown

### DIFF
--- a/lib/tasks/openshift.rake
+++ b/lib/tasks/openshift.rake
@@ -46,6 +46,13 @@ ERROR_MESSAGE
 
       daemon.start
     end
+
+    desc 'Cleanup pid and lock files from unclean shutdown'
+    task cleanup: %i[environment] do
+      indices_location = ThinkingSphinx::Configuration.instance.indices_location
+      files = Dir.glob(File.join(indices_location, '*.{lock,pid}'))
+      files.each(&FileUtils.method(:rm_f))
+    end
   end
 
 end


### PR DESCRIPTION
Remove .pid and .lock files in indices location
The pod could be stopped by openshift, leaving dirty artifacts
On new pod creation, indices cannot be used anymore as they are virtually locked