### PR TITLE
"Account Overview" page

### DIFF
--- a/portafly/src/App.tsx
+++ b/portafly/src/App.tsx
@@ -13,12 +13,17 @@ import { LastLocationProvider } from 'react-router-last-location'
 const OverviewPage = React.lazy(() => import('components/pages/Overview'))
 const ApplicationsPage = React.lazy(() => import('components/pages/applications/ApplicationsIndexPage'))
 const AccountsIndexPage = React.lazy(() => import('components/pages/accounts/AccountsIndexPage'))
+const AccountPage = React.lazy(() => import('components/pages/account/AccountPage'))
 
 const PagesSwitch = () => (
   <SwitchWith404>
     <LazyRoute path="/" exact render={() => <OverviewPage />} />
     <LazyRoute path="/applications" exact render={() => <ApplicationsPage />} />
     <LazyRoute path="/accounts" exact render={() => <AccountsIndexPage />} />
+    <LazyRoute
+      path="/accounts/:accountId"
+      render={({ match }) => <AccountPage accountId={match.params.accountId} />}
+    />
     <Redirect path="/overview" to="/" exact />
   </SwitchWith404>
 )

--- a/portafly/src/components/pages/account/AccountPage.tsx
+++ b/portafly/src/components/pages/account/AccountPage.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react'
+import { useDocumentTitle, CreateApplicationButton } from 'components'
+import { OverviewTabContent, ApplicationsTabContent } from 'components/pages/account'
+import { useTranslation } from 'i18n/useTranslation'
+import {
+  PageSection,
+  Text,
+  TextContent,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Flex,
+  FlexItem
+} from '@patternfly/react-core'
+import { useHistory } from 'react-router'
+import { useAsync } from 'react-async'
+import { getAccount } from 'dal/account'
+
+import './accountPage.scss'
+
+type OnSelect = (event: React.MouseEvent, eventKey: React.ReactText) => void
+
+type TabKey = 'overview' | 'applications'
+
+interface Props {
+  accountId: string
+}
+
+const AccountOverviewPage: React.FunctionComponent<Props> = ({
+  accountId
+}) => {
+  const { t } = useTranslation('accountOverview')
+  useDocumentTitle(t('overview.page_title'))
+
+  const { data: account, error, isPending } = useAsync(getAccount, { accountId })
+
+  const tabs = [
+    {
+      key: 'overview',
+      href: `/accounts/${accountId}/overview`,
+      title: t('overview.overview_title'),
+      render: () => <OverviewTabContent account={account} error={error} isPending={isPending} />
+    },
+    {
+      key: 'applications',
+      href: `/accounts/${accountId}/applications`,
+      title: t('overview.applications_title'),
+      render: () => <ApplicationsTabContent accountId={accountId} />
+    }
+  ]
+
+  const history = useHistory()
+  const initialTab = tabs.find((tab) => tab.href === history.location.pathname)
+  const [activeTab, setActiveTab] = useState(initialTab?.key || 'overview')
+
+  const handleTabClick: OnSelect = (_event, tabKey) => {
+    const match = tabs.find((tab) => tab.key === tabKey)
+
+    if (match) {
+      setActiveTab(tabKey as TabKey)
+      history.push(match.href)
+    }
+  }
+
+  return (
+    <div className="account-page">
+      <PageSection variant="light">
+        <Flex>
+          <FlexItem>
+            <TextContent>
+              <Text component="h1">{account?.orgName}</Text>
+            </TextContent>
+          </FlexItem>
+          <FlexItem align={{ default: 'alignRight' }}>
+            { activeTab === 'applications' && <CreateApplicationButton /> }
+          </FlexItem>
+        </Flex>
+      </PageSection>
+
+      <Tabs
+        mountOnEnter
+        activeKey={activeTab}
+        onSelect={handleTabClick}
+      >
+        {tabs.map(({ title, key, render }) => (
+          <Tab
+            aria-label={title}
+            eventKey={key}
+            key={key}
+            title={<TabTitleText>{title}</TabTitleText>}
+          >
+            {render()}
+          </Tab>
+        ))}
+      </Tabs>
+    </div>
+  )
+}
+
+// Default export needed for React.lazy
+// eslint-disable-next-line import/no-default-export
+export default AccountOverviewPage

--- a/portafly/src/components/pages/account/ApplicationsTabContent.tsx
+++ b/portafly/src/components/pages/account/ApplicationsTabContent.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import { PageSection, Alert } from '@patternfly/react-core'
+import { useAsync } from 'react-async'
+import { Loading, ApplicationsTabDataListTable } from 'components'
+import { getAccountApplications } from 'dal/account'
+
+interface Props {
+  accountId: string
+}
+
+const ApplicationsTabContent: React.FunctionComponent<Props> = ({ accountId }) => {
+  const { data: applications, error, isPending } = useAsync(getAccountApplications, { accountId })
+
+  return (
+    <PageSection>
+      {isPending && <Loading />}
+      {error && <Alert variant="danger" title={error.message} />}
+      {applications && <ApplicationsTabDataListTable applications={applications} />}
+    </PageSection>
+  )
+}
+
+export { ApplicationsTabContent }

--- a/portafly/src/components/pages/account/ApplicationsTabDataListTable.tsx
+++ b/portafly/src/components/pages/account/ApplicationsTabDataListTable.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { DataListProvider, ApplicationsTable } from 'components'
+import { generateColumns, generateRows } from 'components/pages/account/utils'
+import { useTranslation } from 'i18n/useTranslation'
+import { IApplication } from 'types'
+
+interface Props {
+  applications: IApplication[]
+}
+
+const ApplicationsTabDataListTable: React.FunctionComponent<Props> = ({ applications }) => {
+  const { t } = useTranslation('accountOverview')
+  const columns = generateColumns(t)
+  const rows = generateRows(applications)
+
+  const initialState = {
+    table: { columns, rows }
+  }
+
+  return (
+    <DataListProvider initialState={initialState}>
+      <ApplicationsTable applications={applications} />
+    </DataListProvider>
+  )
+}
+
+export { ApplicationsTabDataListTable }

--- a/portafly/src/components/pages/account/OverviewTabContent.tsx
+++ b/portafly/src/components/pages/account/OverviewTabContent.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+
+import {
+  Card,
+  PageSection,
+  Alert,
+  GridItem,
+  Grid,
+  CardBody
+} from '@patternfly/react-core'
+import { Loading, StateLabel } from 'components'
+import { useTranslation } from 'i18n/useTranslation'
+import { IAccountOverview } from 'types'
+
+interface Props {
+  isPending: boolean
+  account?: IAccountOverview
+  error?: Error
+}
+
+const OverviewTabContent: React.FunctionComponent<Props> = ({ isPending, account, error }) => {
+  const { t } = useTranslation('accountOverview')
+
+  return (
+    <PageSection>
+      {isPending && <Loading />}
+      {error && <Alert variant="danger" title={error.message} />}
+      {account && (
+      <Card>
+        <CardBody>
+          <Grid hasGutter>
+            <GridItem rowSpan={2} span={3}>{t('overview.organization_label')}</GridItem>
+            <GridItem rowSpan={2} span={9}>{account.orgName}</GridItem>
+
+            <GridItem rowSpan={4} span={3}>{t('overview.administrator_label')}</GridItem>
+            <GridItem rowSpan={2} span={9}>{account.adminName}</GridItem>
+            <GridItem rowSpan={2} span={9}>
+              <a href={`mailto:${account.adminEmail}`}>{account.adminEmail}</a>
+            </GridItem>
+
+            <GridItem rowSpan={2} span={3}>{t('overview.signup_label')}</GridItem>
+            <GridItem rowSpan={2} span={9}>{account.createdAt}</GridItem>
+
+            <GridItem rowSpan={2} span={3}>{t('overview.state_label')}</GridItem>
+            <GridItem rowSpan={2} span={9}><StateLabel state={account.state} /></GridItem>
+          </Grid>
+        </CardBody>
+      </Card>
+      )}
+    </PageSection>
+  )
+}
+
+export { OverviewTabContent }

--- a/portafly/src/components/pages/account/ProductLink.tsx
+++ b/portafly/src/components/pages/account/ProductLink.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { IProduct } from 'types'
+import { Button } from '@patternfly/react-core'
+
+interface Props {
+  product: IProduct
+}
+
+const ProductLink: React.FunctionComponent<Props> = ({ product }) => (
+  <Button
+    aria-label={product.name}
+    component="a"
+    variant="link"
+    href={`/products/${product.id}`} // TODO: probably wrong path
+    isInline
+  >
+    {product.name}
+  </Button>
+)
+
+export { ProductLink }

--- a/portafly/src/components/pages/account/accountPage.scss
+++ b/portafly/src/components/pages/account/accountPage.scss
@@ -1,0 +1,25 @@
+// This rules modify PF-React Tabs so they match the ones in our Mockup
+.account-page {
+  .pf-l-flex {
+    // The Create Application button is slightly bigger than its Flex container and the UI glitches
+    // every time the tab is changed.
+    min-height: 35.4px;
+  }
+
+  .pf-c-tabs {
+    background-color: #fff;
+  }
+
+  .pf-c-tabs__list {
+    padding-left: var(--pf-c-page__main-section--PaddingLeft);
+  }
+
+  .pf-c-tabs__item {
+    padding-right: var(--pf-c-tabs__link--PaddingRight);
+  }
+
+  .pf-c-tabs__link {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}

--- a/portafly/src/components/pages/account/index.ts
+++ b/portafly/src/components/pages/account/index.ts
@@ -1,0 +1,5 @@
+export { default as AccountPage } from './AccountPage'
+export * from './ApplicationsTabContent'
+export * from './ApplicationsTabDataListTable'
+export * from './OverviewTabContent'
+export * from './ProductLink'

--- a/portafly/src/components/pages/account/utils/applicationsTabTableDataFactory.tsx
+++ b/portafly/src/components/pages/account/utils/applicationsTabTableDataFactory.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { sortable } from '@patternfly/react-table'
+import { DataListRowGenerator, DataListColumnGenerator, IAccountApplication } from 'types'
+import { TFunction } from 'i18next'
+import {
+  ApplicationPageLink,
+  PlanOverviewLink,
+  StateLabel,
+  ProductLink
+} from 'components'
+
+const generateRows: DataListRowGenerator = (applications: IAccountApplication[]) => {
+  // Rows and Columns must have the same order
+  const mapAccountToRowCell = (application: IAccountApplication) => [
+    {
+      stringValue: application.name,
+      title: <ApplicationPageLink application={application} />
+    },
+    {
+      stringValue: application.product.name,
+      title: <ProductLink product={application.product} />
+    },
+    {
+      stringValue: application.plan.name,
+      title: <PlanOverviewLink plan={application.plan} />
+    },
+    application.createdOn,
+    {
+      stringValue: application.state,
+      title: <StateLabel state={application.state} />
+    }
+  ]
+
+  return applications.map((a) => ({
+    id: a.id,
+    cells: mapAccountToRowCell(a),
+    selected: false
+  }))
+}
+
+// Filterable columns must have an id equal to its category name
+const generateColumns: DataListColumnGenerator = (t: TFunction) => [
+  {
+    categoryName: 'name',
+    title: t('applications.applications_table.name_header'),
+    transforms: [sortable]
+  },
+  {
+    categoryName: 'product',
+    title: t('applications.applications_table.product_header'),
+    transforms: [sortable]
+  },
+  {
+    categoryName: 'plan',
+    title: t('applications.applications_table.plan_header'),
+    transforms: [sortable]
+  },
+  {
+    categoryName: 'createdOn',
+    title: t('applications.applications_table.created_header'),
+    transforms: [sortable]
+  },
+  {
+    categoryName: 'state',
+    title: t('applications.applications_table.state_header'),
+    transforms: [sortable]
+  }
+]
+
+export { generateColumns, generateRows }

--- a/portafly/src/components/pages/account/utils/index.ts
+++ b/portafly/src/components/pages/account/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './applicationsTabTableDataFactory'

--- a/portafly/src/components/pages/index.tsx
+++ b/portafly/src/components/pages/index.tsx
@@ -1,4 +1,5 @@
 export * from './accounts'
+export * from './account'
 export { default as Overview } from './Overview'
 export * from './applications'
 export { default as Login } from './Login'

--- a/portafly/src/dal/account/getAccount.tsx
+++ b/portafly/src/dal/account/getAccount.tsx
@@ -1,0 +1,48 @@
+import { craftRequest, fetchData } from 'utils'
+import { IAccountOverview, State } from 'types'
+import { PromiseFn } from 'react-async'
+
+type Account = {
+  id: number
+  created_at: string
+  updated_at: string
+  credit_card_stored: boolean
+  monthly_billing_enabled: boolean
+  monthly_charging_enabled: boolean
+  public_domain: string // FIXME: add this to the endpoint response
+  admin_domain: string // FIXME: add this to the endpoint response
+  plan_name: string // FIXME: add this to the endpoint response
+  admin_name: string // FIXME: add this to the endpoint response
+  admin_email: string // FIXME: add this to the endpoint response
+  state: string
+  links: Array<{
+    rel: string,
+    href: string
+  }>
+  org_name: string
+}
+
+const parseAccount = (account: Account) => ({
+  publicDomain: account.public_domain,
+  adminDomain: account.admin_domain,
+  planName: account.plan_name,
+  id: account.id,
+  adminName: account.admin_name,
+  adminEmail: account.admin_email,
+  createdAt: account.created_at,
+  state: account.state as State,
+  updatedAt: account.updated_at,
+  orgName: account.org_name,
+  applications: []
+})
+
+const getAccount: PromiseFn<IAccountOverview> = async ({ accountId }) => {
+  const request = craftRequest(`/admin/api/accounts/${accountId}.json`, new URLSearchParams({
+    page: '1',
+    perPage: '500'
+  }))
+  const data = await fetchData<{ account: Account }>(request)
+  return parseAccount(data.account)
+}
+
+export { getAccount }

--- a/portafly/src/dal/account/getAccountApplications.ts
+++ b/portafly/src/dal/account/getAccountApplications.ts
@@ -1,0 +1,52 @@
+import { craftRequest, fetchData } from 'utils'
+import { IAccountApplication, State } from 'types'
+import { PromiseFn } from 'react-async'
+
+type Application = {
+  application: {
+    id: number
+    state: string
+    enabled: boolean
+    created_at: string
+    updated_at: string
+    service_id: number
+    service_name: string // FIXME: add this to the endpoint response
+    plan_id: number
+    plan_name: string
+    account_id: number
+    first_traffic_at: string
+    first_daily_traffic_at: string
+    user_key: string
+    provider_verification_key: string
+    links: Array<{
+      rel: string,
+      href: string
+    }>,
+    name: string,
+    description: string
+  }
+}
+
+const parseApplications = (applications: Application[]) => applications.map(({ application }) => ({
+  id: application.id,
+  name: application.name,
+  state: application.state as State,
+  product: {
+    id: application.service_id,
+    name: application.service_name
+  },
+  plan: {
+    id: application.plan_id,
+    name: application.plan_name
+  },
+  createdOn: application.created_at,
+  trafficOn: application.first_daily_traffic_at
+}))
+
+const getAccountApplications: PromiseFn<IAccountApplication[]> = async ({ accountId }) => {
+  const request = craftRequest(`/admin/api/accounts/${accountId}/applications.json`)
+  const data = await fetchData<{ applications: Application[] }>(request)
+  return parseApplications(data.applications)
+}
+
+export { getAccountApplications }

--- a/portafly/src/dal/account/index.tsx
+++ b/portafly/src/dal/account/index.tsx
@@ -1,0 +1,2 @@
+export * from './getAccount'
+export * from './getAccountApplications'

--- a/portafly/src/i18n/locales/en/index.ts
+++ b/portafly/src/i18n/locales/en/index.ts
@@ -5,6 +5,7 @@ import shared from 'i18n/locales/en/shared.yml'
 import overview from 'i18n/locales/en/overview.yml'
 import login from 'i18n/locales/en/login.yml'
 // Audience
+import accountOverview from 'i18n/locales/en/audience/accounts/account.yml'
 import accountsIndex from 'i18n/locales/en/audience/accounts/listing.yml'
 // Applications
 import applicationsIndex from 'i18n/locales/en/applications/listing.yml'
@@ -42,6 +43,7 @@ const integration = {
 export {
   applicationsPlans,
   applicationsIndex,
+  accountOverview,
   accountsIndex,
   shared,
   overview,

--- a/portafly/src/tests/components/pages/applications/utils/__snapshots__/applicationsTableDataFactory.test.ts.snap
+++ b/portafly/src/tests/components/pages/applications/utils/__snapshots__/applicationsTableDataFactory.test.ts.snap
@@ -72,7 +72,7 @@ Array [
         />,
       },
       Object {
-        "stringValue": undefined,
+        "stringValue": "Ramdon Org 0",
         "title": <AccountOverviewLink
           account={
             Object {

--- a/portafly/src/tests/components/pages/applications/utils/__snapshots__/applicationsTableDataFactory.test.ts.snap
+++ b/portafly/src/tests/components/pages/applications/utils/__snapshots__/applicationsTableDataFactory.test.ts.snap
@@ -72,7 +72,7 @@ Array [
         />,
       },
       Object {
-        "stringValue": "Ramdon Org 0",
+        "stringValue": undefined,
         "title": <AccountOverviewLink
           account={
             Object {

--- a/portafly/src/types/account.d.ts
+++ b/portafly/src/types/account.d.ts
@@ -5,6 +5,15 @@ export interface IDeveloperAccount extends IAccount {
   updatedAt: string
 }
 
+export interface IAccountOverview extends IDeveloperAccount {
+  publicDomain: string
+  adminDomain: string
+  applications: any[]
+  planName: string
+  adminEmail: string
+  state: State
+}
+
 export interface IAccount {
   id: number
   orgName: string

--- a/portafly/src/types/application.d.ts
+++ b/portafly/src/types/application.d.ts
@@ -10,3 +10,10 @@ export interface IProductApplication extends IApplication {
   created_on: string
   traffic_on: string
 }
+
+export interface IAccountApplication extends IApplication {
+  state: State
+  product: IProduct
+  createdOn: string
+  trafficOn: string
+}

--- a/portafly/src/types/index.d.ts
+++ b/portafly/src/types/index.d.ts
@@ -1,7 +1,6 @@
 export * from './data-list'
 export * from './utils'
 export * from './account'
-export * from './utils'
 export * from './application'
 export * from './plan'
 export * from './product'

--- a/portafly/src/types/product.d.ts
+++ b/portafly/src/types/product.d.ts
@@ -1,0 +1,4 @@
+export interface IProduct {
+  id: number
+  name: string
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements Account Overview page for Portafly.

**Which issue(s) this PR fixes** 

[THREESCALE-5461: Component for "Account Overview" page](https://issues.redhat.com/browse/THREESCALE-5461)

![account-detail](https://user-images.githubusercontent.com/11672286/86385762-13ff4e00-bc91-11ea-9dc9-3a613fee1c19.gif)

⚠️ Screenshot is a bit old, strings are working.