### PR TITLE
Refactor LazyRoute to support passing props better

### DIFF
--- a/portafly/src/App.tsx
+++ b/portafly/src/App.tsx
@@ -10,15 +10,15 @@ import {
 } from 'components'
 import { LastLocationProvider } from 'react-router-last-location'
 
-const getOverviewPage = () => import('components/pages/Overview')
-const getApplicationsPage = () => import('components/pages/Applications')
-const getAccountsIndexPage = () => import('components/pages/accounts/AccountsIndexPage')
+const OverviewPage = React.lazy(() => import('components/pages/Overview'))
+const ApplicationsPage = React.lazy(() => import('components/pages/Applications'))
+const AccountsIndexPage = React.lazy(() => import('components/pages/accounts/AccountsIndexPage'))
 
 const PagesSwitch = () => (
   <SwitchWith404>
-    <LazyRoute path="/" exact getComponent={getOverviewPage} />
-    <LazyRoute path="/applications" exact getComponent={getApplicationsPage} />
-    <LazyRoute path="/accounts" exact getComponent={getAccountsIndexPage} />
+    <LazyRoute path="/" exact render={() => <OverviewPage />} />
+    <LazyRoute path="/applications" exact render={() => <ApplicationsPage />} />
+    <LazyRoute path="/accounts" exact render={() => <AccountsIndexPage />} />
     <Redirect path="/overview" to="/" exact />
   </SwitchWith404>
 )

--- a/portafly/src/components/LazyRoute.tsx
+++ b/portafly/src/components/LazyRoute.tsx
@@ -2,19 +2,10 @@ import * as React from 'react'
 import { RouteProps, Route } from 'react-router-dom'
 import { Loading } from 'components'
 
-export interface IDynamicImportProps extends RouteProps {
-  getComponent: () => Promise<{ default: React.ComponentType }>
-}
-
-export function LazyRoute({ path, exact, getComponent }: IDynamicImportProps) {
-  const LazyComponent = React.useMemo(() => React.lazy(getComponent), [
-    getComponent
-  ])
+export function LazyRoute({ path, exact, render }: RouteProps) {
   return (
-    <Route path={path} exact={exact}>
-      <React.Suspense fallback={<Loading />}>
-        <LazyComponent />
-      </React.Suspense>
-    </Route>
+    <React.Suspense fallback={<Loading />}>
+      <Route path={path} exact={exact} render={render} />
+    </React.Suspense>
   )
 }

--- a/portafly/src/tests/components/LazyRoute.test.tsx
+++ b/portafly/src/tests/components/LazyRoute.test.tsx
@@ -6,15 +6,16 @@ import { waitFor } from '@testing-library/react'
 const getComponent = () => Promise.resolve({
   default: () => <div data-testid="async-component">Hello!</div>
 })
+const TestComponent = React.lazy(getComponent)
 
-test('should render a spinner while waiting for a component module to be loaded', () => {
-  const { queryByTestId, getByText } = render(<LazyRoute getComponent={getComponent} />)
-  expect(getByText('loading.title')).toBeInTheDocument()
+test('should render a spinner while waiting for a component module to be loaded', async () => {
+  const { queryByTestId, getByText } = render(<LazyRoute component={TestComponent} />)
+  waitFor(() => expect(getByText('loading.title')).toBeInTheDocument())
   expect(queryByTestId('async-component')).not.toBeInTheDocument()
 })
 
 test('should render the async component', async () => {
-  const { queryByTestId, getByTestId } = render(<LazyRoute getComponent={getComponent} />)
+  const { queryByTestId, getByTestId } = render(<LazyRoute component={TestComponent} />)
 
   expect(queryByTestId('async-component')).not.toBeInTheDocument()
   waitFor(() => expect(getByTestId('async-component')).toBeInTheDocument())


### PR DESCRIPTION
**What this PR does / why we need it**:

Some pages such as Account Overview need being passed props (la the account's own id). The current implementation of `LazyRoute` is too obscured and also its types not well defined.

Here's the aforementioned example implemented https://github.com/3scale/porta/pull/1998/files#diff-e4adad5bca8019703fcc2feecd1730c6R23-R30.

`useMemo` is also not really necessary and finally `React.Suspense` could be moved outside.

The component `LazyRoute` is therefore not really needed, but I preferred doing one step at a time. If the team agrees this PR can do the whole refactorization.

**Verification steps** 

`yarn start` and navigate around, everything should work.
Looking at browser's react tools, only **one** route should be rendered at any time.
<img width="1440" alt="Screen Shot 2020-06-29 at 17 14 53" src="https://user-images.githubusercontent.com/11672286/86023490-08f7b400-ba2c-11ea-8cb0-af41edf8a2eb.png">

