### PR TITLE
Remove Proxy#api_backend column from tests

### DIFF
--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -327,9 +327,10 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
   test 'update production should change deployment bubble state to done' do
     provider.create_onboarding
     FactoryBot.create(:service_token, service: service)
+    backend_api = service.backend_apis.first!
 
     rolling_updates_on
-    proxy.update_column :api_backend, 'http://some-api.example.com'
+    backend_api.update_column(:private_endpoint, 'http://some-api.example.com')
 
     patch update_production_admin_service_integration_path(proxy: { api_backend: 'http://some-api.example.com:443'}, service_id: service.id)
     assert_response :redirect

--- a/test/unit/proxy_config_test.rb
+++ b/test/unit/proxy_config_test.rb
@@ -103,12 +103,7 @@ class ProxyConfigTest < ActiveSupport::TestCase
     proxy = FactoryBot.create(:proxy, service: service)
     proxy_config = FactoryBot.build(:proxy_config, environment: 'sandbox', proxy: proxy)
 
-    proxy.update_columns(api_backend: 'http://my-api.test')
     proxy.backend_api_configs.delete_all
-    proxy.reload
-    assert proxy_config.valid?
-
-    proxy.update_columns(api_backend: nil)
     proxy.reload
     refute proxy_config.valid?
     assert_equal :missing, proxy_config.errors.details[:api_backend].first[:error]


### PR DESCRIPTION
We ignored the column, now it is in its BackendApi, which they all are supposed to have. According to this new reality, the tests should not rely on this column anymore. Especially now that it will be removed for real soon.
Needed for https://github.com/3scale/porta/pull/1979