### PR TITLE
Remove EndUserPlans table (and Postgres' procedure)

### DIFF
--- a/db/migrate/20200629105416_remove_end_user_plans_table.rb
+++ b/db/migrate/20200629105416_remove_end_user_plans_table.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveEndUserPlansTable < ActiveRecord::Migration[5.0]
+  def up
+    drop_table :end_user_plans
+  end
+end

--- a/db/migrate/20200629110740_remove_postgres_procedure_end_user_plans_tenant_id.rb
+++ b/db/migrate/20200629110740_remove_postgres_procedure_end_user_plans_tenant_id.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "system/database/#{System::Database.adapter}"
+
+class RemovePostgresProcedureEndUserPlansTenantId < ActiveRecord::Migration[5.0]
+  def up
+    return unless System::Database.postgres?
+    System::Database::Postgres::TriggerProcedure.new('tp_end_user_plans_tenant_id', nil).drop
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200629110238) do
+ActiveRecord::Schema.define(version: 20200629110740) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer  "owner_id",   precision: 38, null: false
@@ -491,14 +491,6 @@ ActiveRecord::Schema.define(version: 20200629110238) do
 
   add_index "deleted_objects", ["object_type", "object_id"], name: "index_deleted_objects_on_object_type_and_object_id"
   add_index "deleted_objects", ["owner_type", "owner_id"], name: "index_deleted_objects_on_owner_type_and_owner_id"
-
-  create_table "end_user_plans", force: :cascade do |t|
-    t.integer  "service_id", precision: 38, null: false
-    t.string   "name",                      null: false
-    t.datetime "created_at", precision: 6
-    t.datetime "updated_at", precision: 6
-    t.integer  "tenant_id",  precision: 38
-  end
 
   create_table "event_store_events", force: :cascade do |t|
     t.string   "stream",                     null: false

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200629110238) do
+ActiveRecord::Schema.define(version: 20200629110740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -469,14 +469,6 @@ ActiveRecord::Schema.define(version: 20200629110238) do
     t.text     "metadata"
     t.index ["object_type", "object_id"], name: "index_deleted_objects_on_object_type_and_object_id", using: :btree
     t.index ["owner_type", "owner_id"], name: "index_deleted_objects_on_owner_type_and_owner_id", using: :btree
-  end
-
-  create_table "end_user_plans", force: :cascade do |t|
-    t.bigint   "service_id",             null: false
-    t.string   "name",       limit: 255, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.bigint   "tenant_id"
   end
 
   create_table "event_store_events", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200629110238) do
+ActiveRecord::Schema.define(version: 20200629110740) do
 
   create_table "access_tokens", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.bigint   "owner_id",                 null: false
@@ -468,14 +468,6 @@ ActiveRecord::Schema.define(version: 20200629110238) do
     t.text     "metadata",    limit: 65535
     t.index ["object_type", "object_id"], name: "index_deleted_objects_on_object_type_and_object_id", using: :btree
     t.index ["owner_type", "owner_id"], name: "index_deleted_objects_on_owner_type_and_owner_id", using: :btree
-  end
-
-  create_table "end_user_plans", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
-    t.bigint   "service_id", null: false
-    t.string   "name",       null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.bigint   "tenant_id"
   end
 
   create_table "event_store_events", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|


### PR DESCRIPTION
I've noticed by running https://github.com/3scale/porta/pull/1979 in Preview that this can be done outside the maintenance window. It is non-blocking and quick 😄 
