### PR TITLE
Updates Portafly http utils

### DIFF
--- a/portafly/src/utils/http.ts
+++ b/portafly/src/utils/http.ts
@@ -18,10 +18,10 @@ const fetchData = async <T>(request: Request): Promise<T> => {
   return response.parsedBody as T
 }
 
-const craftRequest = (path: string, params: URLSearchParams) => {
+const craftRequest = (path: string, params?: URLSearchParams) => {
   const authToken = getToken()
 
-  const url = new URL(`${process.env.REACT_APP_API_HOST || '/'}${path}?${params.toString()}`)
+  const url = new URL(`${process.env.REACT_APP_API_HOST || '/'}${path}?${params?.toString()}`)
   url.searchParams.append('access_token', authToken as string)
 
   return new Request(


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes `URLSearchParams` optional for API calls that don't have any.