### PR TITLE
[sphinx] Fix cron hour for sphinx enqueue

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -45,7 +45,7 @@ every :day, :at => '08:00', roles: [:cron] do
   ThreeScale::Jobs::BILLING.each { |task| instance_exec(task, &job_proc) }
 end
 
-every 1.day, :at => '6:00 am', roles: [:sphinx_server] do
+every :tuesday, :at => '1:00 pm', roles: [:sphinx_server] do
   ThreeScale::Jobs::SPHINX_INDEX_ALL.each { |task| instance_exec(task, &job_proc) }
 end
 

--- a/config/thinking_sphinx.yml
+++ b/config/thinking_sphinx.yml
@@ -7,6 +7,7 @@ common: &sphinx
   min_infix_len: 3
   enable_star: 1
   pid_file: <%= ENV.fetch('THINKING_SPHINX_PID_FILE') { Rails.root.join('log', "searchd.#{Rails.env}.pid") } %>
+  binlog_path: ''
 
   # This is from TS FAQ - makes reindex MUCH faster.
   sql_range_step: 2000000000

--- a/openshift/system/config/sidekiq_schedule.yml
+++ b/openshift/system/config/sidekiq_schedule.yml
@@ -37,7 +37,7 @@ billing_jobs:
   status: enabled
 
 sphinx_index:
-  cron: '0 6 * * *'
+  cron: '0 13 * * 2'
   class: CronJob::Enqueuer
   args: ['SPHINX_INDEX_ALL']
   queue: critical


### PR DESCRIPTION
Put it at 13:00 UTC for safety, monitoring queue growth in SaaS