### PR TITLE
Enables Janitor cleanup worker by default on Openshift

### DIFF
--- a/config/docker/settings.yml
+++ b/config/docker/settings.yml
@@ -39,6 +39,7 @@ base: &default
   onpremises: true
   dev_gtld: <%= ENV.fetch('DEV_GTLD', 'localhost') %>
   active_merchant_logging: <%= ENV.fetch('ACTIVE_MERCHANT_LOGGING', false) %>
+  janitor_worker_enabled: true
   billing_canaries:
   apicast_staging_url: <%= ENV.fetch('APICAST_STAGING_URL', 'apicast-staging:8090') %>
   zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATON_TOKEN', '') %>

--- a/openshift/system/config/settings.yml
+++ b/openshift/system/config/settings.yml
@@ -39,6 +39,8 @@ base: &default
     enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %>
     to: <%= ENV.fetch('EMAIL_SANITIZER_TO', 'sanitizer@example.com') %>
 
+  janitor_worker_enabled: true
+
   active_merchant_logging: false
   billing_canaries:
 


### PR DESCRIPTION
So old user sessions ans stale objects (event store events and deleted objects) are removed automatically once a week on OpenShift.

Explains [THREESCALE-5464](https://issues.redhat.com/browse/THREESCALE-5464)