### PR TITLE
Do not push webhook when application key is destroyed by association

### DIFF
--- a/app/models/application_key.rb
+++ b/app/models/application_key.rb
@@ -161,7 +161,8 @@ class ApplicationKey < ApplicationRecord
   end
 
   def push_webhook_key_destroyed
-    application.push_web_hooks_later(:event => "key_deleted")
+    return if destroyed_by_association
+    application.push_web_hooks_later(event: 'key_deleted')
   end
 
   # same as in backend

--- a/test/unit/application_keys_test.rb
+++ b/test/unit/application_keys_test.rb
@@ -113,6 +113,13 @@ class ApplicationKeysTest < ActiveSupport::TestCase
     @application_keys.remove('some-key')
   end
 
+  test 'does not push webhook when it is destroyed by association' do
+    app_key = FactoryBot.create(:application_key)
+    app_key.application.expects(:push_web_hooks_later).with(event: 'key_deleted').never
+    app_key.destroyed_by_association = true
+    app_key.destroy!
+  end
+
   test 'update backend' do
     ApplicationKey.enable_backend!
 


### PR DESCRIPTION
It fixes this:
```
{ 
  exception: {
    class: NoMethodError,
    message: "undefined method `push_web_hooks_later' for nil:NilClass",
    backtrace: [
      "/home/bender/system_preview/releases/20200630090324/app/models/application_key.rb:164:in `push_webhook_key_destroyed'",
      "/home/bender/system_preview/shared/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:382:in `block in make_lambda'",
      "/home/bender/system_preview/shared/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:232:in `block in conditional'",
      "/home/bender/system_preview/shared/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:456:in `block in call'"
    ]
  },
  parameters: {
    context: 'Job raised exception',
    job: {
      'class' => 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
      'wrapped' => 'DeletePlainObjectWorker',
      'queue' => 'default',
      'args' => [
        {
          'job_class' => 'DeletePlainObjectWorker',
          'job_id' => '2c98ce68-9b0f-4bf6-a0c5-e40ed67b2cc0',
          'provider_job_id' => nil,
          'queue_name' => 'default',
          'priority' => nil,
          'arguments' => [
            { '_aj_globalid' => 'gid://system/ApplicationKey/OBFUSCATED' },
            %w[Hierarchy-Account-OBFUSCATED Hierarchy-Account-OBFUSCATED Hierarchy-Cinstance-OBFUSCATED Hierarchy-ApplicationKey-OBFUSCATED],
            'destroy'
          ],
          'locale' => 'en'
        }
      ]
      # ...
  }
}
```

Plus, even when the application has not been destroyed yet but it is about to be destroyed (by the same process), this makes it more efficient by not pushing a webhook unnecessarily 😉 