### PR TITLE
Bugfix: autocomplete params

### DIFF
--- a/app/javascript/packs/OAS3Autocomplete.js
+++ b/app/javascript/packs/OAS3Autocomplete.js
@@ -32,12 +32,17 @@ const addAutocompleteToParam = (param: Param, accountData: AccountData): Param =
     : param
 }
 
+const getPathParameters = (path) => {
+  const hasParamsInGet = path.get && path.get.parameters
+  return hasParamsInGet ? path.get.parameters : path.parameters
+}
+
 const injectAutocompleteToResponseBody = (responseBody: ResponseBody, accountData: AccountData): ResponseBody => (
   {
     ...responseBody,
     paths: Object.keys(responseBody.paths).reduce(
       (paths, key) => {
-        const pathParameters = responseBody.paths[key].get.parameters
+        const pathParameters = getPathParameters(responseBody.paths[key])
         if (pathParameters) {
           paths[key] = {
             get: {

--- a/app/javascript/src/Types/SwaggerTypes.jsx
+++ b/app/javascript/src/Types/SwaggerTypes.jsx
@@ -30,7 +30,11 @@ export type Param = {
 export type ResponseBody = {
  paths: {
    [string]: {
-     parameters: Array<Param>,
+     parameters?: Array<Param>,
+     get?: {
+      parameters?: Array<Param>,
+      [string]: string | {}
+     },
      [string]: string | {}
    }
  },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:
Autocomplete of OAS 3 parameters fails, depending on the format of spec
`parameters` can be placed inside or outside the `get` object, but we are handling only the second scenario
```
{
  "openapi": "3.0.2",
  "info": {},
  "paths": {
      "/example/path": {
          "parameters": []
      }
  }
}
```

```
{
  "openapi": "3.0.2",
  "info": {},
  "paths": {
      "/example/path": {
          "get": {
              "parameters": []
          }
      }
  }
}
```
**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-5516
