### PR TITLE
Remove Account#display_name

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -359,11 +359,6 @@ class Account < ApplicationRecord
   # def self.to_csv
   # end
 
-  # Display name for account. Handy for situations where org_name is empty.
-  def display_name
-    org_name.empty? ? admins.first.username : org_name
-  end
-
   def emails
     admins.map(&:email).compact
   end

--- a/app/views/notification_mailer/account_created.html.slim
+++ b/app/views/notification_mailer/account_created.html.slim
@@ -2,7 +2,7 @@ p
   | Dear #{@receiver.informal_name},
 
 p
-  | #{@user.informal_name} from #{@account.display_name} has signed-up for:
+  | #{@user.informal_name} from #{@account.name} has signed-up for:
   |  #{@account.bought_service_contracts.accessible_services.pluck(:name).to_sentence.presence || 'does not have service'}.
 
 p

--- a/app/views/notification_mailer/account_created.text.erb
+++ b/app/views/notification_mailer/account_created.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @receiver.informal_name %>,
 
-<%= @user.informal_name %> from <%= @account.display_name %> has signed-up for: <%= @account.bought_service_contracts.accessible_services.pluck(:name).to_sentence.presence || 'does not have service' %>.
+<%= @user.informal_name %> from <%= @account.name %> has signed-up for: <%= @account.bought_service_contracts.accessible_services.pluck(:name).to_sentence.presence || 'does not have service' %>.
 
 New user details:
 

--- a/app/views/notification_mailer/account_deleted.html.slim
+++ b/app/views/notification_mailer/account_deleted.html.slim
@@ -5,4 +5,3 @@ p
   | The account #{@account_name} has been deleted.
 
 p= link_to 'Go to developer accounts', admin_buyers_accounts_url
-

--- a/app/views/notification_mailer/cinstance_cancellation.html.slim
+++ b/app/views/notification_mailer/cinstance_cancellation.html.slim
@@ -1,6 +1,6 @@
 p
   | Dear #{@receiver.informal_name},
 
-p 
+p
   | The application #{@cinstance_name} on application plan #{@plan_name}
     of your service #{@service_name} for developer account #{@account_name} has been deleted.

--- a/app/views/notification_mailer/cinstance_expired_trial.html.slim
+++ b/app/views/notification_mailer/cinstance_expired_trial.html.slim
@@ -1,7 +1,7 @@
 p
   | Dear #{@receiver.informal_name},
 
-p 
+p
   | #{@account.name}'s trial of the #{application_friendly_name(@application)} on the #{@plan.name} has expired.
 
 p

--- a/app/views/notification_mailer/cinstance_plan_changed.text.erb
+++ b/app/views/notification_mailer/cinstance_plan_changed.text.erb
@@ -8,4 +8,3 @@ Service: <%= @service.name %>
 Previous plan: <%= @old_plan.name %>
 Current plan: <%= @new_plan.name %>
 To view application, follow this link: <%= admin_service_application_url(@cinstance.service, @cinstance) %>
-

--- a/app/views/notification_mailer/plan_downgraded.html.slim
+++ b/app/views/notification_mailer/plan_downgraded.html.slim
@@ -1,7 +1,7 @@
 p
   | Dear #{@receiver.informal_name},
 
-p 
+p
   | #{@account.name} has downgraded to #{@new_plan.name} plan (from #{@old_plan.name}).
 
 p

--- a/app/views/provider_user_mailer/activation.text.erb
+++ b/app/views/provider_user_mailer/activation.text.erb
@@ -6,7 +6,7 @@ To activate your account, please visit:
 
 <%= @activate_url %>
 
-You will then be able to login with your email and password. 
+You will then be able to login with your email and password.
 
 Cheers,
 The <%= master_mailer_name %> Team

--- a/lib/developer_portal/lib/liquid/drops/account.rb
+++ b/lib/developer_portal/lib/liquid/drops/account.rb
@@ -45,9 +45,10 @@ A developer account. See `User` drop if you are looking for the email addresses 
         @model.name
       end
 
-      desc "Returns account's display name"
+      # TODO: Remove this eventually. It is redundant.
+      desc "Returns the organization name of the developer's account."
       def display_name
-        @model.display_name
+        @model.name
       end
 
       desc "Returns a text about a VAT zero."

--- a/test/unit/liquid/drops/account_drop_test.rb
+++ b/test/unit/liquid/drops/account_drop_test.rb
@@ -125,6 +125,10 @@ class Liquid::Drops::AccountDropTest < ActiveSupport::TestCase
     test 'not return fields' do
       assert_nil @drop.extra_fields["org_name"]
     end
+
+    test '#display_name' do
+      assert_equal @buyer.name, @drop.display_name
+    end
   end
   # End fields tests
 end


### PR DESCRIPTION
Removed completely from the model because it does not belong there and because it responds with the org_name, and if it is empty (which never happens!), would return the username of the admin_user.
The Account drop with display_name method stays because someone might be already using it, but with a comment.
All the rest of the references to display_name everywhere else become references to the organization name.

![image](https://user-images.githubusercontent.com/11318903/86483314-15457f00-bd54-11ea-99ee-7769f7d2fcf3.png)

1st PR of [THREESCALE-5541](https://issues.redhat.com/browse/THREESCALE-5541)