### PR TITLE
[Refactor] Move display methods to the decorator for User and Account

### DIFF
--- a/app/decorators/account_decorator.rb
+++ b/app/decorators/account_decorator.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 class AccountDecorator < ApplicationDecorator
-  def admin_user_display_name
-    admin_user.decorate.display_name
-  end
+  delegate :display_name, to: :admin_user, prefix: true
 
   private
 
   def admin_user
-    @admin_user ||= (super || User.new)
+    @admin_user ||= (super || User.new).decorate
   end
 end

--- a/app/decorators/account_decorator.rb
+++ b/app/decorators/account_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AccountDecorator < ApplicationDecorator
+  def admin_user_display_name
+    admin_user.decorate.display_name
+  end
+
+  private
+
+  def admin_user
+    @admin_user ||= (super || User.new)
+  end
+end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class UserDecorator < ApplicationDecorator
+  def full_name
+    [first_name, last_name].select(&:present?).join(' ')
+  end
+
+  def display_name
+    full_name.presence || username
+  end
+
+  def informal_name
+    first_name.presence || last_name.presence || username
+  end
+end

--- a/app/helpers/buyers/accounts_helper.rb
+++ b/app/helpers/buyers/accounts_helper.rb
@@ -6,7 +6,7 @@ module Buyers::AccountsHelper
   end
 
   def account_title account
-    [ h(account.org_name), h(account.admin_user.try!(:display_name)) ].compact.join(" &mdash; ").html_safe
+    [ h(account.org_name), h(account.decorate.admin_user_display_name) ].compact.join(" &mdash; ").html_safe
   end
 
   def link_to_buyer_or_deleted( buyer, path_method = :admin_buyers_account_path)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -3,7 +3,7 @@ module PostsHelper
     name = if post.user.nil? || post.anonymous_user?
              "Anonymous User"
            else
-             post.user.display_name
+             post.user.decorate.display_name
            end
 
     h(truncate(name, :length => 30))

--- a/app/lib/csv/buyers_exporter.rb
+++ b/app/lib/csv/buyers_exporter.rb
@@ -16,6 +16,7 @@ class Csv::BuyersExporter < ::Csv::Exporter
   end
 
   def values_for_account(account)
+    user = (account.admin_user || User.new).decorate
     [
       account.id,
       account.state,
@@ -24,10 +25,10 @@ class Csv::BuyersExporter < ::Csv::Exporter
       account.bought_account_plan.try!(:name),
       account.created_at.to_s(:db),
       account.bought_cinstances.count,
-      account.first_admin.try!(:display_name),
-      account.first_admin.try!(:email),
+      user.display_name,
+      user.email,
       account.extra_fields.to_json,
-      account.first_admin.try!(:extra_fields).to_json
+      user.extra_fields.to_json
     ]
   end
 

--- a/app/lib/csv/buyers_exporter.rb
+++ b/app/lib/csv/buyers_exporter.rb
@@ -16,7 +16,7 @@ class Csv::BuyersExporter < ::Csv::Exporter
   end
 
   def values_for_account(account)
-    user = (account.admin_user || User.new).decorate
+    user = account.admin_user
     [
       account.id,
       account.state,
@@ -25,10 +25,10 @@ class Csv::BuyersExporter < ::Csv::Exporter
       account.bought_account_plan.try!(:name),
       account.created_at.to_s(:db),
       account.bought_cinstances.count,
-      user.display_name,
-      user.email,
+      account.decorate.admin_user_display_name,
+      user&.email,
       account.extra_fields.to_json,
-      user.extra_fields.to_json
+      user&.extra_fields.to_json
     ]
   end
 

--- a/app/lib/three_scale/analytics/user_tracking.rb
+++ b/app/lib/three_scale/analytics/user_tracking.rb
@@ -77,7 +77,7 @@ module ThreeScale
             firstName: @user.first_name,
             lastName: @user.last_name,
             lastSeen: Time.now,
-            name: @user.full_name,
+            name: @user.decorate.full_name,
             username: @user.username,
             phone: @account.telephone_number,
             organization: @account.org_name,

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -58,8 +58,8 @@ class NotificationMailer < ActionMailer::Base
     @provider_account = event.provider
     @service          = event.service
     @account          = event.account
-    @user             = event.user
-    @receiver         = receiver
+    @user             = event.user.decorate
+    @receiver         = receiver.decorate
     @event            = event
 
     mail to: @receiver.email,
@@ -72,12 +72,12 @@ class NotificationMailer < ActionMailer::Base
   def account_created(event, receiver)
     @provider_account = event.provider
     @account          = event.account
-    @receiver         = receiver
-    @user             = event.user
+    @receiver         = receiver.decorate
+    @user             = event.user.decorate
     @event            = event
 
     mail to: @receiver.email,
-         subject: "#{@user.informal_name} from #{@account.name} signed up"
+         subject: "#{@user.decorate.informal_name} from #{@account.name} signed up"
   end
 
   # @param [Alerts::LimitAlertReachedProviderEvent] event
@@ -99,9 +99,10 @@ class NotificationMailer < ActionMailer::Base
   delivers Accounts::AccountPlanChangeRequestedEvent, hidden_onprem_multitenancy: true
   def account_plan_change_requested(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
-    @user             = event.user
-    @account          = @user.account
+    @receiver         = receiver.decorate
+    user              = event.user
+    @user             = user.decorate
+    @account          = user.account
     @current_plan     = event.current_plan
     @requested_plan   = event.requested_plan
     @event            = event
@@ -115,7 +116,7 @@ class NotificationMailer < ActionMailer::Base
   def account_deleted(event, receiver)
     @provider_account = event.provider
     @account_name     = event.account_name
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @event            = event
 
     mail to: @receiver.email, subject: "Account #{@account_name} deleted"
@@ -126,7 +127,7 @@ class NotificationMailer < ActionMailer::Base
   delivers Cinstances::CinstanceCancellationEvent, hidden_onprem_multitenancy: true
   def cinstance_cancellation(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @cinstance_name   = event.cinstance_name
     @plan_name        = event.plan_name
     @service_name     = event.service_name
@@ -144,8 +145,8 @@ class NotificationMailer < ActionMailer::Base
   delivers Cinstances::CinstancePlanChangedEvent, hidden_onprem_multitenancy: true
   def cinstance_plan_changed(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
-    @user             = event.user
+    @receiver         = receiver.decorate
+    @user             = event.user.decorate
     @account          = event.account
     @cinstance        = event.cinstance
     @service          = @cinstance.service
@@ -159,13 +160,13 @@ class NotificationMailer < ActionMailer::Base
   delivers Applications::ApplicationPlanChangeRequestedEvent, hidden_onprem_multitenancy: true
   def application_plan_change_requested(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @account          = event.account
     @current_plan     = event.current_plan
     @requested_plan   = event.requested_plan
     @application      = event.application
     @service          = @application.service
-    @user             = event.user
+    @user             = event.user.decorate
     @event            = event
 
     mail to: @receiver.email, subject: "Action required: #{@user.username} from #{@account.org_name} requested an app plan change"
@@ -176,9 +177,9 @@ class NotificationMailer < ActionMailer::Base
   delivers ServiceContracts::ServiceContractCreatedEvent
   def service_contract_created(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @service          = event.service
-    @user             = event.user
+    @user             = event.user.decorate
     @plan             = event.plan
     @account          = Liquid::Drops::Account.new(event.account)
     @event            = event
@@ -190,8 +191,8 @@ class NotificationMailer < ActionMailer::Base
   delivers Services::ServicePlanChangeRequestedEvent, hidden_onprem_multitenancy: true
   def service_plan_change_requested(event, receiver)
     @provider_account = event.provider
-    @user             = event.user
-    @receiver         = receiver
+    @user             = event.user.decorate
+    @receiver         = receiver.decorate
     @account          = event.account
     @current_plan     = event.current_plan
     @requested_plan   = event.requested_plan
@@ -206,10 +207,10 @@ class NotificationMailer < ActionMailer::Base
   delivers ServiceContracts::ServiceContractPlanChangedEvent, hidden_onprem_multitenancy: true
   def service_contract_plan_changed(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @service_contract = event.service_contract
     @service          = @service_contract.service
-    @user             = event.user
+    @user             = event.user.decorate
     @account          = event.account
     @new_plan         = event.new_plan
     @old_plan         = event.old_plan
@@ -223,7 +224,7 @@ class NotificationMailer < ActionMailer::Base
   delivers ServiceContracts::ServiceContractCancellationEvent
   def service_contract_cancellation(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @account_name     = event.account_name
     @plan_name        = event.plan_name
     @service_name     = event.service_name
@@ -239,7 +240,7 @@ class NotificationMailer < ActionMailer::Base
     @service          = event.service
     @plan             = event.plan
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @account          = event.account
     @event            = event
     @application      = event.cinstance
@@ -252,7 +253,7 @@ class NotificationMailer < ActionMailer::Base
   delivers Invoices::InvoicesToReviewEvent
   def invoices_to_review(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @event            = event
 
     mail to: @receiver.email, subject: 'Action needed: review invoices'
@@ -263,7 +264,7 @@ class NotificationMailer < ActionMailer::Base
   delivers Plans::PlanDowngradedEvent, hidden_onprem_multitenancy: true
   def plan_downgraded(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @account          = event.account
     @old_plan         = event.old_plan
     @new_plan         = event.new_plan
@@ -277,7 +278,7 @@ class NotificationMailer < ActionMailer::Base
   delivers Accounts::ExpiredCreditCardProviderEvent
   def expired_credit_card_provider(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @account          = event.account
     @event            = event
 
@@ -290,7 +291,7 @@ class NotificationMailer < ActionMailer::Base
   def unsuccessfully_charged_invoice_provider(event, receiver)
     @provider_account = event.provider
     @account          = event.invoice.buyer_account
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @event            = event
 
     mail to: @receiver.email, subject: "#{@account.name}'s payment has failed"
@@ -302,7 +303,7 @@ class NotificationMailer < ActionMailer::Base
   def unsuccessfully_charged_invoice_final_provider(event, receiver)
     @provider_account = event.provider
     @account          = event.invoice.buyer_account
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @event            = event
 
     mail to: @receiver.email, subject: "#{@account.name}'s payment has failed without retry"
@@ -315,7 +316,7 @@ class NotificationMailer < ActionMailer::Base
     @provider_account = event.provider
     @sender           = event.sender
     @recipient        = event.recipient
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @message          = event.message
     @event            = event
 
@@ -327,11 +328,11 @@ class NotificationMailer < ActionMailer::Base
   delivers Posts::PostCreatedEvent, abilities: { manage: :forum }, hidden_onprem_multitenancy: true
   def post_created(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @post             = event.post
-    @user             = event.try(:user)
     @account          = event.try(:account)
-    @user_name        = @user.present? ? @user.informal_name : 'anonymous user'
+    @user             = (event.try(:user) || User.new(username: 'anonymous user')).decorate
+    @user_name        = @user.informal_name
     @event            = event
 
     mail to: @receiver.email, subject: "New forum post by #{@user_name}"
@@ -342,7 +343,7 @@ class NotificationMailer < ActionMailer::Base
   delivers Reports::CsvDataExportEvent, hidden: true
   def csv_data_export(event, receiver)
     @provider_account = event.provider
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     export_service    = Reports::DataExportService.new(event.provider, event.type, event.period)
     @event            = event
 
@@ -372,7 +373,7 @@ class NotificationMailer < ActionMailer::Base
   delivers Services::ServiceDeletedEvent
   def service_deleted(event, receiver)
     @provider_account = Account.find(event.metadata[:provider_id])
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @service_name     = event.service_name
     @event            = event
 
@@ -383,7 +384,7 @@ class NotificationMailer < ActionMailer::Base
 
   def pdf_report_mail(report, receiver, mail_name)
     @provider_account = report.account
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     report_file       = File.read(report.report.path)
     report_name       = report.pdf_file_name
 
@@ -397,7 +398,7 @@ class NotificationMailer < ActionMailer::Base
     @alert            = event.alert
     @account          = @alert.account
     @cinstance        = @alert.cinstance
-    @receiver         = receiver
+    @receiver         = receiver.decorate
     @event            = event
 
     subject = t_subject(mail_name, name: @cinstance.name, message: @alert.message, level: @alert.level)

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -77,7 +77,7 @@ class NotificationMailer < ActionMailer::Base
     @event            = event
 
     mail to: @receiver.email,
-         subject: "#{@user.decorate.informal_name} from #{@account.name} signed up"
+         subject: "#{@user.informal_name} from #{@account.name} signed up"
   end
 
   # @param [Alerts::LimitAlertReachedProviderEvent] event

--- a/app/mailers/provider_user_mailer.rb
+++ b/app/mailers/provider_user_mailer.rb
@@ -16,7 +16,7 @@ class ProviderUserMailer < ActionMailer::Base
   end
 
   def lost_password(user)
-    @user = user
+    @user = user.decorate
     @url = provider_password_url(password_reset_token: user.lost_password_token, host: domain(user.account))
 
     prepare_email(subject: 'Password Recovery', headers: {'X-SMTPAPI' => '{"category": "Lost password"}'}, to: user.email, template: 'provider_lost_password')
@@ -30,7 +30,7 @@ class ProviderUserMailer < ActionMailer::Base
   private
 
   def activation_email(user:, subject:)
-    @user = user
+    @user = user.decorate
     @activate_url = provider_activate_url(activation_code: user.activation_code, host: domain(user.account))
     prepare_email(subject: subject, to: user.email, headers: {'X-SMTPAPI' => '{"category": "Signup Notification"}'})
   end

--- a/app/mailers/topic_mailer.rb
+++ b/app/mailers/topic_mailer.rb
@@ -3,7 +3,7 @@ class TopicMailer < ActionMailer::Base
   def new_post(subscriber, post)
     @post = post
     @sender = @post.user
-    @subscriber = subscriber
+    @subscriber = subscriber.decorate
     @domain = domain(@post)
 
     headers({'Return-Path' => from_address(@sender), 'X-SMTPAPI' => '{"category": "New Post"}'})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -314,19 +314,6 @@ class User < ApplicationRecord
     !minimal_signup? && super
   end
 
-  def informal_name
-    first_name.present? ? first_name : display_name
-  end
-
-  def display_name
-    name = full_name
-    name.present? ? name : username
-  end
-
-  def full_name
-    [first_name, last_name].select(&:present?).join(' ')
-  end
-
   # CMS Methods patched below - to be moved to module, or gem to be adjusted directly
 
   def self.current

--- a/app/views/api/proxy_configs/index.html.slim
+++ b/app/views/api/proxy_configs/index.html.slim
@@ -3,7 +3,7 @@
 table class="data"
   thead
     tr
-      th Configuration file    
+      th Configuration file
       th Version
       th Date
       th Configured by
@@ -14,7 +14,8 @@ table class="data"
         td = link_to proxy_config.filename, admin_service_proxy_config_path(@service, proxy_config.id)
         td = proxy_config.version
         td = proxy_config.created_at
-        td = proxy_config.user.display_name if proxy_config.user
+        - user = proxy_config.user
+        td = user.decorate.display_name if user
 
 
 = will_paginate(@proxy_configs)

--- a/app/views/buyers/accounts/_search_results.html.slim
+++ b/app/views/buyers/accounts/_search_results.html.slim
@@ -44,7 +44,7 @@ table class="data" id="buyer_accounts"
       tr id=dom_id(account)
         td class="select" =  bulk_select_one account
         td = link_to (account.org_name), admin_buyers_account_path(account)
-        td = account.admins.first.try(:display_name)
+        td = account.decorate.admin_user_display_name
         td = account.created_at.strftime("%e %b, %Y")
         - if @account_plans.size > 1
           td class="plan" = h account.bought_account_plan.try(:name)

--- a/app/views/buyers/accounts/bulk/_selected_accounts.html.erb
+++ b/app/views/buyers/accounts/bulk/_selected_accounts.html.erb
@@ -2,9 +2,9 @@
   <label>Selected Accounts</label>
   <ul class="bulk_operation_items">
     <% @accounts.each do |account| %>
-      <%= content_tag :li, :title => "#{account.org_name} - #{account.admins.first.try(:display_name)}" do %>
+      <%= content_tag :li, :title => "#{account.org_name} - #{account.decorate.admin_user_display_name}" do %>
         <span class="name"><%= account.org_name %></span>
-        (<%= h account.admins.first.try(:display_name) %>)
+        (<%= h account.decorate.admin_user_display_name %>)
         <%= hidden_field_tag 'selected[]', account.id %>
       <%end%>
     <%-end-%>

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -33,10 +33,10 @@ h1 data-hook="account-show"
           tr
             th Administrator
             td
-              - @account.admins.first.tap do |admin|
-                => admin.decorate.display_name
-                - if admin.email.present?
-                  | (#{mail_to admin.email})
+              => @account.decorate.admin_user_display_name
+              - admin_user_email = @account.admin_user.email
+              - if admin_user_email.present?
+                | (#{mail_to admin_user_email})
         tr
           th Signed up on
           td = @account.created_at.to_s(:long)

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -34,7 +34,7 @@ h1 data-hook="account-show"
             th Administrator
             td
               - @account.admins.first.tap do |admin|
-                => admin.display_name
+                => admin.decorate.display_name
                 - if admin.email.present?
                   | (#{mail_to admin.email})
         tr

--- a/app/views/buyers/applications/bulk/_selected_applications.html.erb
+++ b/app/views/buyers/applications/bulk/_selected_applications.html.erb
@@ -3,7 +3,7 @@
   <ul class="bulk_operation_items">
     <% @applications.each do |cinstance| %>
       <%= content_tag :li,
-          :title => "#{cinstance.user_account.org_name} - #{cinstance.user_account.admins.first.try(:display_name)}" do %>
+          :title => "#{cinstance.user_account.org_name} - #{cinstance.user_account.decorate.admin_user_display_name}" do %>
         <span class="name"><%= h cinstance.name %></span>
         (<span class="account"><%= h cinstance.user_account.org_name %></span>)
         <%= hidden_field_tag 'selected[]', cinstance.id %>

--- a/app/views/buyers/service_contracts/bulk/_selected_contracts.html.erb
+++ b/app/views/buyers/service_contracts/bulk/_selected_contracts.html.erb
@@ -3,7 +3,7 @@
   <ul class="bulk_operation_items">
     <% @service_contracts.each do |contract| %>
       <%= content_tag :li,
-          :title => "#{contract.account.org_name} - #{contract.account.admins.first.try(:display_name)}" do %>
+          :title => "#{contract.account.org_name} - #{contract.account.decorate.admin_user_display_name}" do %>
         <span class="account"><%= contract.account.org_name %></span>
         <span class="plan"><%= contract.plan.name %></span>
         <%= hidden_field_tag 'selected[]', contract.id %>

--- a/app/views/buyers/users/edit.html.erb
+++ b/app/views/buyers/users/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render 'buyers/accounts/menu' %>
 
 <h2>
-  Edit User <%= h @user.display_name %> of the account <%= h @user.account.org_name %>
+  Edit User <%= h @user.decorate.display_name %> of the account <%= h @user.account.org_name %>
 </h2>
 <%= semantic_form_for @user, :url => resource_path(@user), :builder => Fields::FormBuilder do |form| %>
 

--- a/app/views/buyers/users/index.html.erb
+++ b/app/views/buyers/users/index.html.erb
@@ -17,7 +17,7 @@
     <% @users.each do |user| %>
       <tr id="<%= dom_id(user) %>">
         <td class="<%= user.state %>">
-          <%= link_to h(user.display_name), resource_path(user) %>
+          <%= link_to h(user.decorate.display_name), resource_path(user) %>
         </td>
         <td><%= h user.email %></td>
         <td><%= user.created_at.to_date.to_s(:long) %></td>

--- a/app/views/buyers/users/show.html.erb
+++ b/app/views/buyers/users/show.html.erb
@@ -1,7 +1,7 @@
 <%= render 'buyers/accounts/menu' %>
 
 <h2>
-  User <%= h @user.display_name %> of the account <%= h @user.account.org_name %>
+  User <%= h @user.decorate.display_name %> of the account <%= h @user.account.org_name %>
   <%= link_to 'Edit', edit_resource_path(@user), :class => 'action edit' %>
 </h2>
 
@@ -9,7 +9,7 @@
 
   <tr>
     <th>Name</th>
-    <td><%= h @user.display_name %></td>
+    <td><%= h @user.decorate.display_name %></td>
   </tr>
 
   <tr>

--- a/app/views/provider/admin/account/users/index.html.slim
+++ b/app/views/provider/admin/account/users/index.html.slim
@@ -23,11 +23,11 @@ table class="data" id="users"
         td
           - if can? :manage, user
             - if current_user == user
-              = link_to user.display_name,
+              = link_to user.decorate.display_name,
                 edit_provider_admin_user_personal_details_path(origin: 'users'),
                 title: 'Personal Details'
             - else
-              = link_to user.display_name,
+              = link_to user.decorate.display_name,
                 edit_provider_admin_account_user_path(user),
                 title: 'Edit'
           - else

--- a/app/views/provider/admin/accounts/suspended.html.slim
+++ b/app/views/provider/admin/accounts/suspended.html.slim
@@ -1,4 +1,4 @@
-h1 Hello #{current_user.display_name},
+h1 Hello #{current_user.decorate.display_name},
 p
   | Your 3scale trial has expired and the account is de-activated.
     To continue using the service, you’ll need to move onto a paid plan.
@@ -20,4 +20,3 @@ javascript:
     step: 'click upgrade suspended account',
     path: window.location.pathname
   })
-

--- a/app/views/provider/admin/onboarding/wizard/info/intro.html.slim
+++ b/app/views/provider/admin/onboarding/wizard/info/intro.html.slim
@@ -1,5 +1,5 @@
 - content_for :title do
-  = "Hello #{current_user.informal_name},"
+  = "Hello #{current_user.decorate.informal_name},"
 
 p The best way to start discovering 3scale is through the APIcast staging gateway. You'll be up and running in minutes – ready to try all the different features of the platform.
 

--- a/app/views/shared/_service_access.slim
+++ b/app/views/shared/_service_access.slim
@@ -1,7 +1,7 @@
-- admin = current_account.admin_user
 p
   ' You don't have access to any API on the
   => current_account.org_name
   ' account. Please
-  => mail_to admin.email, "contact #{admin.decorate.display_name}"
+  - admin = current_account.admin_user
+  => mail_to admin.email, "contact #{current_account.decorate.admin_user_display_name}"
   | to request access.

--- a/app/views/shared/_service_access.slim
+++ b/app/views/shared/_service_access.slim
@@ -1,7 +1,7 @@
-- admin = current_account.first_admin
+- admin = current_account.admin_user
 p
   ' You don't have access to any API on the
   => current_account.org_name
   ' account. Please
-  => mail_to admin.email, "contact #{admin.display_name}"
+  => mail_to admin.email, "contact #{admin.decorate.display_name}"
   | to request access.

--- a/app/views/shared/provider/_header.html.slim
+++ b/app/views/shared/provider/_header.html.slim
@@ -47,9 +47,9 @@ header.pf-c-page__header id="user_widget" class='Header' class=('Header--master'
               ' Impersonating a virtual admin user from
             - else
               ' Signed in to
-            => current_user.account.name
+            => current_account.name
             ' as
-            = current_user.display_name
+            = current_user.decorate.display_name
             | .
 
           = fixed_width_icon_link_to 'Sign Out', 'times', provider_logout_path, class: 'PopNavigation-link', title: "Sign Out #{current_user.username}"

--- a/features/step_definitions/mailers/notification_mailer_steps.rb
+++ b/features/step_definitions/mailers/notification_mailer_steps.rb
@@ -26,7 +26,7 @@ end
 And(/^the users should receive the account created notification email$/) do
   registered_buyer = @provider.buyers.last
   registered_user  = registered_buyer.users.last
-  subject          = "#{registered_user.informal_name} from #{registered_buyer.name} signed up"
+  subject          = "#{registered_user.decorate.informal_name} from #{registered_buyer.name} signed up"
 
   @provider.users.each do |user|
     step %("#{user.email}" should receive an email with subject "#{subject}")

--- a/lib/developer_portal/lib/liquid/drops/user.rb
+++ b/lib/developer_portal/lib/liquid/drops/user.rb
@@ -50,18 +50,18 @@ module Liquid
 
       desc "Returns the first and last name of the user."
       def name
-        h(@user.full_name)
+        h(@user.decorate.full_name)
       end
 
       # TODO: display name, really? reconsider
       hidden
       def display_name
-        h(@user.display_name)
+        h(@user.decorate.display_name)
       end
 
       hidden
       def informal_name
-        h(@user.informal_name)
+        h(@user.decorate.informal_name)
       end
 
       hidden

--- a/test/decorators/account_decorator_test.rb
+++ b/test/decorators/account_decorator_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AccountDecoratorTest < Draper::TestCase
+  test '#admin_user_display_name' do
+    account = FactoryBot.create(:simple_account)
+    user = FactoryBot.create(:admin, account: account)
+    account.reload
+
+    decorator = account.decorate
+    assert_equal user.decorate.display_name, decorator.admin_user_display_name
+    assert_not_nil decorator.admin_user_display_name
+
+    account_without_admin_user = Account.new
+    assert_nil account_without_admin_user.decorate.admin_user_display_name
+  end
+end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UserDecoratorTest < Draper::TestCase
+  def setup
+    @user = FactoryBot.build(:admin)
+    @decorator = user.decorate
+  end
+
+  attr_reader :user, :decorator
+
+  test 'full_name' do
+    user.first_name = 'Foo'
+    user.last_name = 'Bar'
+    assert_equal 'Foo Bar', decorator.full_name
+
+    user.first_name = ' '
+    user.last_name = 'Bar'
+    assert_equal 'Bar', decorator.full_name
+
+    user.first_name = 'Foo'
+    user.last_name = ' '
+    assert_equal 'Foo', decorator.full_name
+  end
+
+  test 'display_name' do
+    user.first_name = 'Foo'
+    user.last_name = 'Bar'
+    user.username = 'Baz'
+    assert_equal 'Foo Bar', decorator.display_name
+
+    user.first_name = ' '
+    user.last_name = ' '
+    user.username = 'Baz'
+    assert_equal 'Baz', decorator.display_name
+  end
+
+  test 'informal_name' do
+    user.first_name = 'Foo'
+    user.last_name = 'Bar'
+    user.username = 'Baz'
+    assert_equal 'Foo', decorator.informal_name
+
+    user.first_name = ' '
+    user.last_name = 'Bar'
+    user.username = 'Baz'
+    assert_equal 'Bar', decorator.informal_name
+
+    user.first_name = ' '
+    user.last_name = ' '
+    user.username = 'Baz'
+    assert_equal 'Baz', decorator.informal_name
+  end
+end

--- a/test/helpers/posts_helper_test.rb
+++ b/test/helpers/posts_helper_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class PostsHelperTest < ActionView::TestCase
+  test '#display_author_name' do
+    post_with_known_author = FactoryBot.create(:post)
+    assert_equal post_with_known_author.user.decorate.display_name.truncate(30), display_author_name(post_with_known_author)
+
+    post_without_author = Post.new
+    assert_equal 'Anonymous User', display_author_name(post_without_author)
+
+    post_with_anonymous_author = FactoryBot.create(:post, anonymous_user: true)
+    assert_equal 'Anonymous User', display_author_name(post_with_anonymous_author)
+  end
+end

--- a/test/unit/liquid/drops/user_drop_test.rb
+++ b/test/unit/liquid/drops/user_drop_test.rb
@@ -10,6 +10,18 @@ class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
     @drop = Drops::User.new(@user)
   end
 
+  test '#display_name' do
+    assert_equal @user.decorate.display_name, @drop.display_name
+  end
+
+  test '#informal_name' do
+    assert_equal @user.decorate.informal_name, @drop.informal_name
+  end
+
+  test '#name' do
+    assert_equal @user.decorate.full_name, @drop.name
+  end
+
   def test_oauth2
     @user.signup.expects(:oauth2?).returns(true)
     assert @drop.oauth2?

--- a/test/unit/mailers/provider_user_mailer_test.rb
+++ b/test/unit/mailers/provider_user_mailer_test.rb
@@ -23,7 +23,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal [@support_email_address], email.from
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
-        assert_match %r{Dear #{user.informal_name}}, email_body
+        assert_match %r{Dear #{user_decorator.informal_name}}, email_body
         assert_match %r{Thank you for signing up to Red Hat 3scale}, email_body
         assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, email_body
         assert_match %r{The Red Hat 3scale Team}, email_body
@@ -38,7 +38,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal [@support_email_address], email.from
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
-        assert_match %r{#{user.informal_name}}, email_body
+        assert_match %r{#{user_decorator.informal_name}}, email_body
         assert_match %r{A couple of days ago you signed up for Red Hat 3scale to manage your API}, email_body
         assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, email_body
         assert_match %r{The Red Hat 3scale Team}, email_body
@@ -68,7 +68,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal [@support_email_address], email.from
         assert_equal '{"category": "Lost password"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
-        assert_match %r{Dear #{user.display_name}}, email_body
+        assert_match %r{Dear #{user_decorator.display_name}}, email_body
         assert_match %r{You can reset your password by visiting the following link}, email_body
         assert_match %r{#{account.external_admin_domain}/p/password}, email_body
         assert_match %r{The Red Hat 3scale Team}, email_body
@@ -90,7 +90,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal [@support_email_address], email.from
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
-        assert_match %r{Dear #{user.informal_name}}, email_body
+        assert_match %r{Dear #{user_decorator.informal_name}}, email_body
         assert_match %r{Thank you for signing up to #{master_account.org_name}}, email_body
         assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, email_body
         assert_match %r{The #{master_account.org_name} Team}, email_body
@@ -106,7 +106,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal [@support_email_address], email.from
         assert_equal '{"category": "Signup Notification"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
-        assert_match %r{#{user.informal_name}}, email_body
+        assert_match %r{#{user_decorator.informal_name}}, email_body
         assert_match %r{A couple of days ago you signed up for #{master_account.org_name} to manage your API}, email_body
         assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, email_body
         assert_match %r{The #{master_account.org_name} Team}, email_body
@@ -138,7 +138,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
         assert_equal [@support_email_address], email.from
         assert_equal '{"category": "Lost password"}', email.header_fields.find{ |header| header.name.eql? 'X-SMTPAPI' }.value
 
-        assert_match %r{Dear #{user.display_name}}, email_body
+        assert_match %r{Dear #{user_decorator.display_name}}, email_body
         assert_match %r{You can reset your password by visiting the following link}, email_body
         assert_match %r{#{account.external_admin_domain}/p/password}, email_body
         assert_match %r{The #{master_account.org_name} Team}, email_body
@@ -163,20 +163,16 @@ class ProviderUserMailerTest < ActionMailer::TestCase
       ActionMailer::Base.unstub :default_url_options
     end
 
+    def user_decorator
+      @user_decorator ||= user.decorate
+    end
+
     def user
-      @user ||= create_user
+      @user ||= FactoryBot.create(:admin, account: account, first_name: 'Jolly Good', last_name: 'Fellow')
     end
 
     def account
-      @account ||= create_account
-    end
-
-    def create_user
-      FactoryBot.create(:admin, account: account, first_name: 'Jolly Good', last_name: 'Fellow')
-    end
-
-    def create_account
-      FactoryBot.create(:provider_account, provider_account: master_account, domain: 'api.monkey.com', org_name: 'Monkey', self_domain: 'monkey-admin.com', from_email: 'api@monkey.com', subdomain: 'monkey')
+      @account ||= FactoryBot.create(:provider_account, provider_account: master_account, domain: 'api.monkey.com', org_name: 'Monkey', self_domain: 'monkey-admin.com', from_email: 'api@monkey.com', subdomain: 'monkey')
     end
   end
 
@@ -196,7 +192,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
     private
 
     def user
-      @user ||= master_account.admin_users.first
+      @user ||= master_account.admin_user
     end
 
     def account

--- a/test/unit/mailers/user_mailer_test.rb
+++ b/test/unit/mailers/user_mailer_test.rb
@@ -66,7 +66,7 @@ class UserMailerTest < ActionMailer::TestCase
         email = deliver_lost_password
         # assert_match "CUSTOM SUBJECT", email.subject
         assert_match "Lost password recovery", email.subject
-        assert_match "Dear #{@user.display_name},", email.body.to_s
+        assert_match "Dear #{user_decorator.display_name},", email.body.to_s
         assert_match "CUSTOM MESSAGE", email.body.to_s
         assert_match "http://#{@provider_account.external_admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
         assert_match "The API Team", email.body.to_s
@@ -107,7 +107,7 @@ class UserMailerTest < ActionMailer::TestCase
         with_default_url_options protocol: 'https' do
           email = deliver_signup_notification
 
-          assert_match "Dear #{@user.display_name},", email.body.to_s
+          assert_match "Dear #{user_decorator.display_name},", email.body.to_s
           assert_match "Thank you for signing up for access to the Monkey API", email.body.to_s
           assert_match "Your username is: #{@user.username}", email.body.to_s
           assert_match "https://api.monkey.com/activate/#{@user.activation_code}", email.body.to_s
@@ -129,7 +129,7 @@ Customized Template
         email = deliver_signup_notification
 
         assert_match "Customized Template", email.body.to_s
-        assert_match @user.display_name, email.body.to_s
+        assert_match user_decorator.display_name, email.body.to_s
         assert_match "Monkey", email.body.to_s
         assert_match "http://api.monkey.com/activate/#{@user.activation_code}", email.body.to_s
       end
@@ -191,7 +191,7 @@ Customized Template
             email = deliver_lost_password
             # assert_match "CUSTOM SUBJECT", email.subject
             assert_match "Lost password recovery", email.subject
-            assert_match "Dear #{@user.display_name},", email.body.to_s
+            assert_match "Dear #{user_decorator.display_name},", email.body.to_s
             assert_match "CUSTOM MESSAGE", email.body.to_s
             assert_match "http://#{@provider_account.external_domain}/admin/account/password?password_reset_token=abc123", email.body.to_s
             assert_match "The API Team", email.body.to_s
@@ -203,6 +203,10 @@ Customized Template
 
       end
     end
+  end
+
+  def user_decorator
+    @user_decorator ||= @user.decorate
   end
 
   def with_default_url_options(options)

--- a/test/unit/messengers/cinstance_messenger_test.rb
+++ b/test/unit/messengers/cinstance_messenger_test.rb
@@ -80,7 +80,7 @@ class CinstanceMessengerTest < ActiveSupport::TestCase
     message = Message.last.body
     user = @app.user_account.admins.first
     user_account = @app.user_account
-    assert_match "Name: #{user.full_name}", message
+    assert_match "Name: #{user.decorate.full_name}", message
     assert_match "Email: #{user.email}", message
     assert_match "Organization: #{user_account.org_name}", message
     assert_match "Telephone: #{user_account.telephone_number}", message

--- a/test/unit/three_scale/analytics/user_tracking_test.rb
+++ b/test/unit/three_scale/analytics/user_tracking_test.rb
@@ -5,7 +5,7 @@ class ThreeScale::Analytics::UserTrackingTest < ActiveSupport::TestCase
 
   def setup
     account = FactoryBot.build_stubbed(:simple_account, provider: true)
-    @user = FactoryBot.build_stubbed(:user, account: account, email: 'foo@example.net')
+    @user = FactoryBot.build_stubbed(:user, account: account, email: 'foo@example.net', first_name: 'John', last_name: 'Doe')
   end
 
   def teardown
@@ -73,7 +73,8 @@ class ThreeScale::Analytics::UserTrackingTest < ActiveSupport::TestCase
 
       traits = UserTracking.new(@user).basic_traits
 
-      assert_equal traits.slice(:email), email: @user.email
+      assert_equal @user.email, traits[:email]
+      assert_equal @user.decorate.full_name, traits[:name]
     end
 
     test 'identify' do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -613,36 +613,6 @@ class UserTest < ActiveSupport::TestCase
     assert user.can_login?
   end
 
-  test '#full_name returns full name' do
-    user = User.new
-    assert user.full_name.blank?
-
-    user.first_name = 'Eric'
-    assert_equal 'Eric', user.full_name
-
-    user.first_name = nil
-    user.last_name = 'Cartman'
-    assert_equal 'Cartman', user.full_name
-
-    user.first_name = ''
-    user.last_name = 'Cartman'
-    assert_equal 'Cartman', user.full_name
-
-    user.first_name = 'Eric'
-    user.last_name = 'Cartman'
-    assert_equal 'Eric Cartman', user.full_name
-  end
-
-  test '#display_name returns full_name if it is present' do
-    user = User.new(:first_name => 'Kyle', :last_name => 'Broflowsky')
-    assert_equal 'Kyle Broflowsky', user.display_name
-  end
-
-  test '#display_name returns username if full_name is not present' do
-    user = User.new(:username => 'ninjaassassin')
-    assert_equal 'ninjaassassin', user.display_name
-  end
-
   context 'deletion of users' do
     setup do
       @account = FactoryBot.create(:account, :org_name => "Alice's web empire")


### PR DESCRIPTION
Part of [THREESCALE-5541](https://issues.redhat.com/browse/THREESCALE-5541)

### TODO in the following PR

The views should receive the user/account already decorated by the controller.
Too risky to do it in this same PR.
It will be in https://github.com/3scale/porta/pull/2043