### PR TITLE
[PortaFly] camelCasing props

### DIFF
--- a/portafly/src/components/pages/accounts/AccountOverviewLink.tsx
+++ b/portafly/src/components/pages/accounts/AccountOverviewLink.tsx
@@ -18,7 +18,7 @@ const AccountOverviewLink: React.FunctionComponent<Props> = ({ account }) => {
       href={`/accounts/${account.id}`}
       isInline
     >
-      {account.org_name}
+      {account.orgName}
     </Button>
   )
 }

--- a/portafly/src/components/pages/accounts/ExportAccountsButton.tsx
+++ b/portafly/src/components/pages/accounts/ExportAccountsButton.tsx
@@ -12,12 +12,12 @@ const ExportAccountsButton: React.FunctionComponent<Props> = ({ data }) => {
 
   const exportHeaders = [
     { label: 'ID', key: 'id' },
-    { label: t('accounts_table.admin_header'), key: 'admin_name' },
-    { label: t('accounts_table.group_header'), key: 'org_name' },
+    { label: t('accounts_table.admin_header'), key: 'adminName' },
+    { label: t('accounts_table.group_header'), key: 'orgName' },
     { label: t('accounts_table.state_header'), key: 'state' },
-    { label: t('accounts_table.applications_header'), key: 'apps_count' },
-    { label: t('accounts_table.created_header'), key: 'created_at' },
-    { label: t('accounts_table.updated_header'), key: 'updated_at' }
+    { label: t('accounts_table.applications_header'), key: 'appsCount' },
+    { label: t('accounts_table.created_header'), key: 'createdAt' },
+    { label: t('accounts_table.updated_header'), key: 'updatedAt' }
   ]
 
   const isDisabled = !(data && data.length)

--- a/portafly/src/components/pages/accounts/utils/accountsTableDataFactory.tsx
+++ b/portafly/src/components/pages/accounts/utils/accountsTableDataFactory.tsx
@@ -8,11 +8,11 @@ const generateRows: DataListRowGenerator = (accounts: IDeveloperAccount[]) => {
   // Rows and Columns must have the same order
   const mapAccountToRowCell = (account: IDeveloperAccount) => [
     {
-      stringValue: account.org_name,
+      stringValue: account.orgName,
       title: <AccountOverviewLink account={account} />
     },
-    account.admin_name,
-    account.created_at,
+    account.adminName,
+    account.createdAt,
     account.state,
     {
       stringValue: '',

--- a/portafly/src/dal/accounts/getDeveloperAccounts.ts
+++ b/portafly/src/dal/accounts/getDeveloperAccounts.ts
@@ -50,11 +50,11 @@ type BuyersAccount = {
 
 const parseAccounts = (accounts: BuyersAccount[]) => accounts.map(({ account }) => ({
   id: account.id,
-  created_at: account.created_at,
-  updated_at: account.updated_at,
-  org_name: account.org_name,
+  createdAt: account.created_at,
+  updatedAt: account.updated_at,
+  orgName: account.org_name,
   // TODO: Porta should return admin_name (username of first user role admin)
-  admin_name: account.billing_address?.company,
+  adminName: account.billing_address?.company,
   state: account.state
 }))
 

--- a/portafly/src/tests/components/pages/accounts/AccountOverviewLink.test.tsx
+++ b/portafly/src/tests/components/pages/accounts/AccountOverviewLink.test.tsx
@@ -7,7 +7,7 @@ const account = factories.DeveloperAccount.build()
 
 const setup = () => {
   const wrapper = render(<AccountOverviewLink account={account} />)
-  const row = wrapper.getByText(account.org_name).closest('a') as HTMLElement
+  const row = wrapper.getByText(account.orgName).closest('a') as HTMLElement
   return { ...wrapper, row }
 }
 

--- a/portafly/src/tests/components/pages/accounts/AccountsIndexPage.test.tsx
+++ b/portafly/src/tests/components/pages/accounts/AccountsIndexPage.test.tsx
@@ -53,7 +53,7 @@ describe('when backend returns a list of accounts', () => {
   it('should render a table with accounts', () => {
     const wrapper = setup({ data: developerAccounts })
     developerAccounts.forEach((account: IDeveloperAccount) => (
-      expect(wrapper.getByText(account.admin_name)).toBeInTheDocument()
+      expect(wrapper.getByText(account.adminName)).toBeInTheDocument()
     ))
   })
 })

--- a/portafly/src/tests/components/pages/accounts/AccountsTable.test.tsx
+++ b/portafly/src/tests/components/pages/accounts/AccountsTable.test.tsx
@@ -12,8 +12,8 @@ const usePaginationMock = useDataListPagination as jest.Mock
 const useFiltersMock = useDataListFilters as jest.Mock
 const developerAccounts: IDeveloperAccount[] = [['Dandelion', 'Rosemary and Thyme'], ['Geralt', 'Wolf School']].map((account) => (
   factories.DeveloperAccount.build({
-    admin_name: account[0],
-    org_name: account[1]
+    adminName: account[0],
+    orgName: account[1]
   })
 ))
 
@@ -41,7 +41,7 @@ afterEach(resetMocks)
 const setup = () => {
   const wrapper = render(<AccountsTable />)
   const table = within(wrapper.queryByRole('grid') as HTMLElement)
-  const getRow = (account: IDeveloperAccount) => table.getByText(account.org_name).closest('tr') as HTMLElement
+  const getRow = (account: IDeveloperAccount) => table.getByText(account.orgName).closest('tr') as HTMLElement
 
   return {
     ...wrapper,

--- a/portafly/src/tests/examples/developerAccounts.ts
+++ b/portafly/src/tests/examples/developerAccounts.ts
@@ -3,7 +3,7 @@ import { IDeveloperAccount } from 'types'
 
 export const developerAccounts: IDeveloperAccount[] = ['Josemi', 'Damian'].map((name) => (
   factories.DeveloperAccount.build({
-    admin_name: name,
-    org_name: `${name}'s Corp.`
+    adminName: name,
+    orgName: `${name}'s Corp.`
   })
 ))

--- a/portafly/src/tests/factories/developer-account.ts
+++ b/portafly/src/tests/factories/developer-account.ts
@@ -2,13 +2,13 @@ import { Factory } from 'fishery'
 import { IDeveloperAccount } from 'types'
 
 const DeveloperAccount = Factory.define<IDeveloperAccount>(({ sequence }) => ({
-  admin_name: 'Oswell E. Spencer',
-  apps_count: 3,
-  created_at: '2019-10-18T05:13:26Z',
+  adminName: 'Oswell E. Spencer',
+  appsCount: 3,
+  createdAt: '2019-10-18T05:13:26Z',
   id: sequence,
-  org_name: 'Umbrella Corp.',
+  orgName: 'Umbrella Corp.',
   state: 'approved',
-  updated_at: '2019-10-18T05:13:27Z'
+  updatedAt: '2019-10-18T05:13:27Z'
 }))
 
 export { DeveloperAccount }

--- a/portafly/src/types/account.d.ts
+++ b/portafly/src/types/account.d.ts
@@ -1,11 +1,11 @@
 export interface IDeveloperAccount extends IAccount {
-  admin_name: string
-  created_at: string // TODO: Find a specific date as string type
+  adminName: string
+  createdAt: string // TODO: Find a specific date as string type
   state: string
-  updated_at: string
+  updatedAt: string
 }
 
 export interface IAccount {
   id: number
-  org_name: string
+  orgName: string
 }

--- a/portafly/src/types/account.d.ts
+++ b/portafly/src/types/account.d.ts
@@ -1,0 +1,11 @@
+export interface IDeveloperAccount extends IAccount {
+  admin_name: string
+  created_at: string // TODO: Find a specific date as string type
+  state: string
+  updated_at: string
+}
+
+export interface IAccount {
+  id: number
+  org_name: string
+}

--- a/portafly/src/types/index.d.ts
+++ b/portafly/src/types/index.d.ts
@@ -1,16 +1,3 @@
 export * from './data-list'
-
-export type ArgumentsType<T extends (...args: any[]) => any> =
-  T extends (...args: infer A) => any ? A : never;
-
-export interface IDeveloperAccount extends IAccount {
-  admin_name: string
-  created_at: string // TODO: Find a specific date as string type
-  state: string
-  updated_at: string
-}
-
-export interface IAccount {
-  id: number
-  org_name: string
-}
+export * from './account'
+export * from './utils'

--- a/portafly/src/types/utils.d.ts
+++ b/portafly/src/types/utils.d.ts
@@ -1,0 +1,2 @@
+export type ArgumentsType<T extends (...args: any[]) => any> =
+  T extends (...args: infer A) => any ? A : never;


### PR DESCRIPTION
**What this PR does / why we need it**:

Our key values (within PortaFly) should be `camelCased` in order to follow convention.

**Which issue(s) this PR fixes** 
Fixes https://issues.redhat.com/browse/THREESCALE-5546
needed for a following PR about storing data coming from API calls in context state