### PR TITLE
Include 'service_name' in /admin/api/accounts/:id/applications

### DIFF
--- a/app/representers/cinstance_representer.rb
+++ b/app/representers/cinstance_representer.rb
@@ -15,6 +15,7 @@ module CinstanceRepresenter
   property :created_at
   property :updated_at
   property :service_id
+  property :service_name
   property :plan_id
   property :plan_name
   property :user_account_id, as: :account_id
@@ -79,6 +80,7 @@ module CinstanceRepresenter
   end
 
   delegate :id, to: :service, prefix: true
+  delegate :name, to: :service, prefix: true
   delegate :org_name, to: :user_account
   delegate :name, to: :plan, prefix: true
   delegate :oidc_configuration, to: :service

--- a/spec/acceptance/api/application_spec.rb
+++ b/spec/acceptance/api/application_spec.rb
@@ -197,7 +197,7 @@ resource "Cinstance" do
 
     it { should have_properties('id', 'state', 'name', 'plan_id', 'description',
                       'service_id', 'first_traffic_at', 'first_daily_traffic_at',
-                      'plan_name', 'org_name').from(resource) }
+                      'plan_name', 'org_name', 'service_name').from(resource) }
     it { should have_links('self', 'account', 'plan', 'keys', 'referrer_filters', 'service') }
 
     it { should include('account_id' => resource.buyer.id )}


### PR DESCRIPTION
**What this PR does / why we need it**:

We need `service_name` to show it in column _Product_. (see [mockups linked in the JIRA](https://issues.redhat.com/browse/THREESCALE-5421))

**What issue** 

[THREESCALE-5545: Update Applications endpoint (to include missing data for Portafly)](https://issues.redhat.com/browse/THREESCALE-5545)

**Verification steps** 

```
curl -v  -X GET "<URL>/admin/api/accounts/<ACCOUNT_ID>/applications.json?access_token=<TOKEN>"
```
Should include `service_name`.
