### PR TITLE
Preloads Sphinx indices Rails after initialization

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -271,6 +271,11 @@ module System
       require 'system/redis_pool'
       redis_config = ThreeScale::RedisConfig.new(config.redis)
       System.redis = System::RedisPool.new(redis_config.config)
+
+      # Prevents concurrent threads (e.g. sidekiq, puma) to deadlock while racing to obtain access to the mutex block at https://github.com/pat/thinking-sphinx/blob/v3.4.2/lib/thinking_sphinx/configuration.rb#L78
+      # This is a ThinkingSphinx's known bug, fixed in v4.3.0+ - see: https://github.com/pat/thinking-sphinx/commit/814beb0aa3d9dd1227c0f41d630888a738f7c0d6
+      # See also https://github.com/pat/thinking-sphinx/issues/1051 and https://github.com/pat/thinking-sphinx/issues/1132
+      ThinkingSphinx::Configuration.instance.preload_indices if ActiveRecord::Base.connected?
     end
 
     config.assets.quiet = true

--- a/config/initializers/sphinx.rb
+++ b/config/initializers/sphinx.rb
@@ -1,8 +1,3 @@
 SPHINX_DELTA_INTERVAL = 90.minutes
 
 ThinkingSphinx::Callbacks.suspend!
-
-# Prevents concurrent threads (e.g. sidekiq, puma) to deadlock while racing to obtain access to the mutex block at https://github.com/pat/thinking-sphinx/blob/v3.4.2/lib/thinking_sphinx/configuration.rb#L78
-# This is a ThinkingSphinx's known bug, fixed in v4.3.0+ - see: https://github.com/pat/thinking-sphinx/commit/814beb0aa3d9dd1227c0f41d630888a738f7c0d6
-# See also https://github.com/pat/thinking-sphinx/issues/1051 and https://github.com/pat/thinking-sphinx/issues/1132
-ThinkingSphinx::Configuration.instance.preload_indices if Rails.env.development?


### PR DESCRIPTION
Prevents failing with wrong number of arguments at `Fields::Fields::ActiverecordOverrides#initialize`.

```
ArgumentError: wrong number of arguments (given 2, expected 0..1)...

Failure:
test_find_by_domain!_raises_an_exception_if_domain_is_blank_even_if_there_is_an_account_with_blank_domain(Account::ProviderDomainsTest) [/opt/app-root/src/project/vendor/bundle/ruby/2.5.0/gems/state_machines-activerecord-0.5.2/lib/state_machines/integrations/active_record.rb:461]:
ArgumentError: wrong number of arguments (given 2, expected 0..1)
    app/lib/fields/fields.rb:107:in `initialize'
    test/unit/account/provider_domains_test.rb:73:in `block in <class:ProviderDomainsTest>'
```

This was actually the right fix to https://app.circleci.com/pipelines/github/3scale/porta/12581/workflows/1082990c-d295-4d66-83f9-0fac30692c8b.

Related to https://github.com/3scale/porta/pull/2017