### PR TITLE
Change validation for Host Header to support <host>:<port>

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -35,7 +35,7 @@ class Proxy < ApplicationRecord
   URI_OR_LOCALHOST  = /\A(https?:\/\/([a-zA-Z0-9._:\/?-])+|.*localhost.*)\Z/
   OPTIONAL_QUERY_FORMAT = "(?:\\?(#{uri_pattern.fetch(:QUERY)}))?"
   URI_PATH_PART = Regexp.new('\A' + uri_pattern.fetch(:ABS_PATH) + OPTIONAL_QUERY_FORMAT + '\z')
-  HOSTNAME = Regexp.new('\A' + uri_pattern.fetch(:HOSTNAME) + '\z')
+  HOST = Regexp.new('\A' + uri_pattern.fetch(:HOSTNAME) + '(:\d+)?' + '\z')
 
   OAUTH_PARAMS = /(\?|&)(scope=|state=|tok=)/
 
@@ -59,7 +59,7 @@ class Proxy < ApplicationRecord
   validates :endpoint,         uri: true, allow_nil: true, allow_blank: true
   validates :sandbox_endpoint, uri: true, allow_nil: true, allow_blank: true
 
-  validates :hostname_rewrite, format: { with: HOSTNAME,           allow_nil: true, allow_blank: true }
+  validates :hostname_rewrite, format: { with: HOST, allow_nil: true, allow_blank: true }
 
   validates :oauth_login_url, format: { with: URI_OR_LOCALHOST,    allow_nil: true, allow_blank: true }
 

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -234,6 +234,26 @@ class ProxyTest < ActiveSupport::TestCase
     refute @proxy.errors[:endpoint].any?
   end
 
+  test 'hostname_rewrite validates a host that complies with rfc 2616' do
+    @proxy.hostname_rewrite = 'my-own.api.example.net'
+    assert @proxy.valid?
+
+    @proxy.hostname_rewrite = 'my-own.api.example.net:8080'
+    assert @proxy.valid?
+
+    @proxy.hostname_rewrite = 'my-own.api.example.net:80'
+    assert @proxy.valid?
+
+    @proxy.hostname_rewrite = 'my-own.api.example.net:'
+    refute @proxy.valid?
+
+    @proxy.hostname_rewrite = 'my-own.api.example.net:hello'
+    refute @proxy.valid?
+
+    @proxy.hostname_rewrite = 'my-own.api.example.net::80'
+    refute @proxy.valid?
+  end
+
   test 'backend' do
     proxy_config = System::Application.config.three_scale.sandbox_proxy
     proxy_config.stubs(backend_scheme: 'https', backend_host: 'example.net:4400')


### PR DESCRIPTION
Closes [THREESCALE-1408](https://issues.redhat.com/browse/THREESCALE-1408)
It should comply with [RFC 2616 Section 14](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23)

### Verification steps
Thanks to Gui for letting me know how to find it in the UI 😄 
It is in `http://provider-admin.example.com.lvh.me:3000/apiconfig/services/2/integration/edit` (without APIAP), in `AUTHENTICATION SETTINGS` -> `SECURITY` -> `Host Header`
You can write there for example `my-own.api.example.net:8080` and click on `Update & test Staging Environment`. Reload the page and see that the `Host Header` has been updated correctly.