### PR TITLE
Fixed Branding issues in Dev Portal and SaaS Auth Provider Create and Update APIs

### DIFF
--- a/app/controllers/admin/api/authentication_providers_controller.rb
+++ b/app/controllers/admin/api/authentication_providers_controller.rb
@@ -155,14 +155,14 @@ class Admin::Api::AuthenticationProvidersController < Admin::Api::BaseController
       :name, :system_name, :client_id, :client_secret,
       :token_url, :user_info_url, :authorize_url, :site,
       :identifier_key, :username_key, :trust_email, :kind,
-      :published, :branding_state_event, :skip_ssl_certificate_verification,
+      :published, :branding_state, :skip_ssl_certificate_verification,
       :automatically_approve_accounts
     )
   end
 
   def authentication_provider_update_params
     params.require(:authentication_provider).permit(
-      :client_id, :client_secret, :published, :site,
+      :client_id, :client_secret, :published, :branding_state, :site,
       :skip_ssl_certificate_verification, :automatically_approve_accounts
     )
   end

--- a/app/controllers/provider/admin/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/authentication_providers_controller.rb
@@ -93,12 +93,13 @@ class Provider::Admin::AuthenticationProvidersController < FrontendController
   end
 
   UPDATE_PARAMS = %i[client_id client_secret automatically_approve_accounts site
-                     realm skip_ssl_certificate_verification branding_state_event
+                     realm skip_ssl_certificate_verification branding_state
                      token_url authorize_url user_info_url identifier_key
                      username_key trust_email].freeze
 
   def update_params
-    params.require(:authentication_provider).permit(UPDATE_PARAMS)
+    defaults = { branding_state: 'custom_branded' }
+    params.require(:authentication_provider).permit(UPDATE_PARAMS).reverse_merge(defaults)
   end
 
   def create_params

--- a/app/models/authentication_provider.rb
+++ b/app/models/authentication_provider.rb
@@ -130,7 +130,7 @@ class AuthenticationProvider < ApplicationRecord
   def self.branded_available?
     config = ThreeScale::OAuth2.config.fetch(kind, {})
 
-    return unless config[:enabled]
+    return true unless config[:enabled]
 
     credentials = config.slice(:client_id, :client_secret)
     credentials.values.any?(&:present?)

--- a/app/views/provider/admin/authentication_providers/_branding_select.html.slim
+++ b/app/views/provider/admin/authentication_providers/_branding_select.html.slim
@@ -2,6 +2,6 @@
         url: provider_admin_authentication_provider_path(@authentication_provider),
         as: :authentication_provider,
         :html => { :class => 'autosubmit' } do |f|
-  = f.select :branding_state_event,
+  = f.select :branding_state,
           @authentication_provider.allowed_state_transitions,
           include_blank: @authentication_provider.human_state_name

--- a/app/views/provider/admin/authentication_providers/show.html.slim
+++ b/app/views/provider/admin/authentication_providers/show.html.slim
@@ -21,10 +21,7 @@ h1.title
       dt.u-dl-term
         | Branding
       dd.u-dl-definition
-        - if @authentication_provider.can_switch_at_will?
-          = render 'branding_select'
-        - else
-          = @authentication_provider.human_state_name
+        = @authentication_provider.human_state_name
 
     - if @authentication_provider.callback_account == current_account
       dt.u-dl-term

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -2320,8 +2320,8 @@
               "paramType": "query"
             },
             {
-              "name": "branding_state_event",
-              "description": "Branding state event of the authentication provider. Only available for Github. It can be either 'brand_as_threescale' (the default one) or 'custom_brand'",
+              "name": "branding_state",
+              "description": "Branding state event of the authentication provider. Only available for Github. It can be either 'threescale_branded' (the default one) or 'custom_branded'",
               "dataType": "string",
               "required": false,
               "paramType": "query"
@@ -2394,6 +2394,13 @@
               "name": "published",
               "description": "Published authentication provider. False by default",
               "dataType": "boolean",
+              "required": false,
+              "paramType": "query"
+            },
+            {
+              "name": "branding_state",
+              "description": "Branding state event of the authentication provider. Only available for Github. It can be either 'threescale_branded' (the default one) or 'custom_branded'",
+              "dataType": "string",
               "required": false,
               "paramType": "query"
             },

--- a/test/unit/authentication_provider_test.rb
+++ b/test/unit/authentication_provider_test.rb
@@ -90,7 +90,7 @@ class AuthenticationProviderTest < ActiveSupport::TestCase
     config = { client_id: 'id', client_secret: 'secret' }
     ThreeScale::OAuth2.stubs(config: { 'authentication_provider' => config })
 
-    refute_predicate AuthenticationProvider, :branded_available?
+    assert_predicate AuthenticationProvider, :branded_available?
 
     config[:enabled] = true
     assert_predicate AuthenticationProvider, :branded_available?


### PR DESCRIPTION
**What this PR does / why we need it**:
Problems: 

1. UI : When a user sets the credential for the GitHub SSO Integrations, the credential gets set in the system but the branding field does not get updated to 'custom_branding'. The branding information was not available in the interface either.

Before Adding Client-Id and Client-Secret:
![Screenshot from 2020-07-22 14-00-52](https://user-images.githubusercontent.com/19213040/88154057-e2402e00-cc23-11ea-9a4d-a92342e855de.png)
![Screenshot from 2020-07-22 14-01-01](https://user-images.githubusercontent.com/19213040/88154079-e8cea580-cc23-11ea-9a18-0689ec01e966.png)
After fixing visibility of the branding state:
![Before](https://user-images.githubusercontent.com/19213040/88150455-0a795e00-cc1f-11ea-95f1-5415093e0c8f.png)
![Before1](https://user-images.githubusercontent.com/19213040/88150449-09483100-cc1f-11ea-848b-ae3179fce11e.png)
After adding **Client-Id** and **Client-Secret:**
![github](https://user-images.githubusercontent.com/19213040/88151401-46f98980-cc20-11ea-9505-73245a0bf0b6.png)
![After1](https://user-images.githubusercontent.com/19213040/88150542-28df5980-cc1f-11ea-9abb-1cc76f686d18.png)
![After](https://user-images.githubusercontent.com/19213040/88151215-0ac62900-cc20-11ea-8a60-dd0a8dd30855.png)

2. SaaS API: The _branding_state_event_ parameter is missing in the **Authentication Provider Developer Portal Update** API. And there is no Delete API available. Thus, user is stuck with the default and cannot update it.


**Look for the Branding Key in all the images below:**
The branding parameter was **branding_state_event**. Now it's, **branding_state**
**Authentication Provider Developer Portal Create**

Previously:
![beforeCreateAPI](https://user-images.githubusercontent.com/19213040/88152941-62659400-cc22-11ea-90cf-dfa24f009d73.png)
Now:
![AfterCreateAPI](https://user-images.githubusercontent.com/19213040/88152978-727d7380-cc22-11ea-81a9-5f6a7b1a33ac.png)

**Authentication Provider Developer Portal Update**
Previously:
![BeforeUpdateAPI](https://user-images.githubusercontent.com/19213040/88152935-609bd080-cc22-11ea-982c-36edaac094da.png)
Now:
![After-API](https://user-images.githubusercontent.com/19213040/88152984-74473700-cc22-11ea-82e1-3fb66056c4dd.png)



3. Saas API: Even after setting the right value for the _branding_state_event_ (It can be either 'brand_as_threescale' (the default one) or 'custom_brand') parameter in the **Authentication Provider Developer Portal Create** API, it always is set as threescale_branded.

The Screenshots from Point-1 justifies the solution to this problem.

 
**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-4144


**Verification steps** 
