### PR TITLE
API Account find without params should not try to find a 'nil' email

### DIFF
--- a/app/controllers/admin/api/accounts_controller.rb
+++ b/app/controllers/admin/api/accounts_controller.rb
@@ -266,7 +266,7 @@ class Admin::Api::AccountsController < Admin::Api::BaseController
       buyer_accounts.first_by_provider_key!(provider_key, error: ActiveRecord::RecordNotFound)
     when current_account.master? && service_token = params[:buyer_service_token]
       buyer_accounts.find_by_service_token!(service_token)
-    when email = params[:email]
+    when email = params[:email].presence
       buyer_users.find_by!(email: email).account
     else
       raise ActiveRecord::RecordNotFound

--- a/app/controllers/admin/api/accounts_controller.rb
+++ b/app/controllers/admin/api/accounts_controller.rb
@@ -266,8 +266,10 @@ class Admin::Api::AccountsController < Admin::Api::BaseController
       buyer_accounts.first_by_provider_key!(provider_key, error: ActiveRecord::RecordNotFound)
     when current_account.master? && service_token = params[:buyer_service_token]
       buyer_accounts.find_by_service_token!(service_token)
+    when email = params[:email]
+      buyer_users.find_by!(email: email).account
     else
-      buyer_users.find_by!(email: params[:email]).account
+      raise ActiveRecord::RecordNotFound
     end
   end
 end

--- a/test/integration/admin/api/accounts_controller_test.rb
+++ b/test/integration/admin/api/accounts_controller_test.rb
@@ -34,6 +34,19 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  class TenantAdminTest < Admin::Api::AccountsControllerTest
+    test '#find without params should not find any account even if there is one with a null email' do
+      rolling_updates_on
+
+      buyer = FactoryBot.create(:simple_buyer, provider_account: provider)
+      buyer_user = FactoryBot.create(:admin, account: buyer)
+      buyer_user.update_column(:email, nil)
+
+      get find_admin_api_accounts_path(format: :json, access_token: token.value)
+      assert_response :not_found
+    end
+  end
+
   class TenantMemberTest < Admin::Api::AccountsControllerTest
     def setup
       super


### PR DESCRIPTION
Fix 1st error reported by QE in [THREESCALE-5390](https://issues.redhat.com/browse/THREESCALE-5390)

Explained in [this comment in Jira](https://issues.redhat.com/browse/THREESCALE-5390?focusedCommentId=14242400&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14242400)

I do not know how the email can be nil according to our validations but anyway it sounds like a good idea to me performance-wise to not do a search in the DB of empty user emails when the param has not been sent.