### PR TITLE
[portafly] Dockerfile and openshift definitions

### DIFF
--- a/portafly/.dockerignore
+++ b/portafly/.dockerignore
@@ -1,0 +1,5 @@
+build
+node_modules
+.env
+.dockerignore
+Dockerfile*

--- a/portafly/Dockerfile
+++ b/portafly/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:10-alpine as builder
+WORKDIR /tmp/portafly
+COPY . ./
+ENV PUBLIC_URL="/portafly"
+RUN yarn install \
+    && yarn build --production --frozen-lockfile
+
+FROM node:10-alpine
+RUN npm install -g local-web-server
+WORKDIR /opt/portafly
+COPY --from=builder /tmp/portafly/build ./
+EXPOSE 5000
+CMD ws -p 5000 --rewrite '/portafly/(.*)->$1' -d /opt/portafly --spa index.html

--- a/portafly/openshift/deploymentconfig.yml
+++ b/portafly/openshift/deploymentconfig.yml
@@ -1,0 +1,66 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    app: 3scale-api-management
+    threescale_component: portafly
+  name: portafly
+spec:
+  replicas: 1
+  selector:
+    deploymentConfig: portafly
+  strategy:
+    resources: {}
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 1200
+      updatePeriodSeconds: 1
+    type: Rolling
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: 3scale-api-management
+        deploymentConfig: portafly
+        threescale_component: system
+        threescale_component_element: portafly
+    spec:
+      containers:
+      - env:
+        - name: PORT
+          value: "5000"
+        image: amp-portafly:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5000
+          name: serve
+          protocol: TCP
+        livenessProbe:
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          tcpSocket:
+            port: serve
+        name: portafly
+        resources: {}
+      serviceAccountName: amp
+  test: false
+  triggers:
+  - type: ConfigChange
+  - type: ImageChange
+    imageChangeParams:
+      automatic: true
+      containerNames:
+      - portafly
+      from:
+        kind: ImageStreamTag
+        name: amp-portafly:master
+status:
+  availableReplicas: 0
+  latestVersion: 0
+  observedGeneration: 0
+  replicas: 0
+  unavailableReplicas: 0
+  updatedReplicas: 0

--- a/portafly/openshift/imagestream.yml
+++ b/portafly/openshift/imagestream.yml
@@ -1,0 +1,25 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/display-name: AMP portafly
+  creationTimestamp: null
+  labels:
+    app: 3scale-api-management
+    threescale_component: portafly
+  name: amp-portafly
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations:
+      openshift.io/display-name: amp-portafly master
+    from:
+      kind: DockerImage
+      name: ${PORTAFLY_IMAGE}
+    generation: null
+    importPolicy:
+      insecure: false
+    name: master
+    referencePolicy:
+      type: ""

--- a/portafly/openshift/route.yml
+++ b/portafly/openshift/route.yml
@@ -1,0 +1,22 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  creationTimestamp: null
+  labels:
+    app: 3scale-api-management
+    threescale_component: portafly
+  name: portafly-3scale-provider
+spec:
+  host: ${PROVIDER_ADMIN_DOMAIN}
+  path: /portafly
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: Allow
+    termination: edge
+  to:
+    kind: Service
+    name: portafly
+    weight: null
+status:
+  ingress: null

--- a/portafly/openshift/service.yml
+++ b/portafly/openshift/service.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: 3scale-api-management
+    threescale_component: portafly
+  name: portafly
+spec:
+  ports:
+  - name: http
+    port: 5000
+    protocol: TCP
+    targetPort: serve
+  selector:
+    deploymentConfig: portafly
+status:
+  loadBalancer: {}


### PR DESCRIPTION
- Adds a Dockerfile to build Portafly independently from Porta
- Adds examples of Openshift ImageStream, DeploymentConfig, Service and (provider) Route to deploy Portafly

Depends on https://github.com/3scale/porta/tree/portafly/fix_http_url

----

Deployed to Openshift:
<img width="1729" alt="Screenshot 2020-07-16 at 17 57 42" src="https://user-images.githubusercontent.com/1842261/87696747-8abc4100-c791-11ea-8244-19f0144b78d0.png">
