### PR TITLE
Fix eslint warnings and re-enable CI env var for yarn build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -858,7 +858,7 @@ jobs:
             cd portafly
             yarn --version
             yarn install --frozen-lockfile
-            CI=false yarn build
+            yarn build
 
   check_production_gemfile:
     parameters:

--- a/portafly/.eslintrc.js
+++ b/portafly/.eslintrc.js
@@ -14,9 +14,12 @@ module.exports = {
     'semi': ['error', 'never'],
     'comma-dangle': ['error', 'never'],
     'no-prototype-builtins': 1,
+    'no-console': ['warn', { allow: ['error'] }],
 
     // import
-    'import/no-extraneous-dependencies': 1, // Because of @testing-library
+    'import/no-extraneous-dependencies': ['error', {
+      'peerDependencies': true
+    }],
     'import/no-default-export': 2,
     'import/prefer-default-export': 0,
     'import/no-unresolved': 0, // Need to add a resolver probably https://github.com/benmosher/eslint-plugin-import/blob/master/README.md#resolvers

--- a/portafly/config/webpack.config.js
+++ b/portafly/config/webpack.config.js
@@ -50,6 +50,10 @@ const cssModuleRegex = /\.module\.css$/;
 const sassRegex = /\.(scss|sass)$/;
 const sassModuleRegex = /\.module\.(scss|sass)$/;
 
+// ** CUSTOM-PORTAFLY START **
+const eslintConfig = path.join(paths.appPath, '.eslintrc.js')
+// ** CUSTOM-PORTAFLY END **
+
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 module.exports = function(webpackEnv) {
@@ -336,7 +340,9 @@ module.exports = function(webpackEnv) {
                 formatter: require.resolve('react-dev-utils/eslintFormatter'),
                 eslintPath: require.resolve('eslint'),
                 resolvePluginsRelativeTo: __dirname,
-                
+                // ** CUSTOM-PORTAFLY START **
+                configFile: eslintConfig
+                // ** CUSTOM-PORTAFLY END **
               },
               loader: require.resolve('eslint-loader'),
             },
@@ -369,7 +375,7 @@ module.exports = function(webpackEnv) {
                 customize: require.resolve(
                   'babel-preset-react-app/webpack-overrides'
                 ),
-                
+
                 plugins: [
                   [
                     require.resolve('babel-plugin-named-asset-import'),
@@ -411,7 +417,7 @@ module.exports = function(webpackEnv) {
                 cacheDirectory: true,
                 // See #6846 for context on why cacheCompression is disabled
                 cacheCompression: false,
-                
+
                 // Babel sourcemaps are needed for debugging into node_modules
                 // code.  Without the options below, debuggers like VSCode
                 // show incorrect code and set breakpoints on the wrong lines.

--- a/portafly/package.json
+++ b/portafly/package.json
@@ -25,6 +25,9 @@
     "react-router-last-location": "^2.0.1",
     "resolve": "1.17.0"
   },
+  "peerDependencies": {
+    "@patternfly/react-icons": "^4.4.2"
+  },
   "devDependencies": {
     "@babel/core": "7.9.6",
     "@stoplight/prism-cli": "^3.3.2",

--- a/portafly/src/components/AppLayout.tsx
+++ b/portafly/src/components/AppLayout.tsx
@@ -81,6 +81,7 @@ export const AppLayout: React.FunctionComponent<IAppLayoutProps> = ({
     <Nav id="nav-primary-simple" theme={theme} variant={variant}>
       <NavList id="nav-list-simple">
         {navItems.map((navItem) => {
+          // eslint-disable-next-line no-prototype-builtins
           if (navItem && navItem.hasOwnProperty('items') && isVertical) {
             if (navGroupsStyle === 'expandable') {
               const { title, to, items } = navItem as IAppNavExpandableProps

--- a/portafly/src/components/pages/Overview.tsx
+++ b/portafly/src/components/pages/Overview.tsx
@@ -1,6 +1,6 @@
+/* eslint-disable no-console */
 import React from 'react'
 import { useTranslation } from 'i18n/useTranslation'
-// @ts-ignore
 import {
   useA11yRouteChange,
   useDocumentTitle,

--- a/portafly/src/components/pages/applications/ApplicationsTable.tsx
+++ b/portafly/src/components/pages/applications/ApplicationsTable.tsx
@@ -39,7 +39,6 @@ const ApplicationsTable: React.FunctionComponent<Props> = ({ applications }) => 
   const { startIdx, endIdx, resetPagination } = useDataListPagination()
   const { filters } = useDataListFilters()
 
-  // @ts-ignore
   const planOptions = applications.reduce(
     (plans, { plan }) => (plans.find((p) => p.id === plan.id) ? plans : [...plans, plan]),
     [] as IPlan[]

--- a/portafly/src/components/shared/data-list/SearchWidget.tsx
+++ b/portafly/src/components/shared/data-list/SearchWidget.tsx
@@ -119,6 +119,7 @@ const SearchBar = ({ textInputRef, category, onSearchClick }: ISearchBar) => {
         onKeyUp={(ev) => ev.key === 'Enter' && onClick()}
       />
       <Button
+        aria-label={t('accountsIndex:accounts_filter_button_aria_label')}
         variant={ButtonVariant.control}
         onClick={onClick}
       >

--- a/portafly/src/i18n/locales/en/audience/accounts/listing.yml
+++ b/portafly/src/i18n/locales/en/audience/accounts/listing.yml
@@ -41,6 +41,8 @@ accounts_filter_field: "Filter by {{filter_option}}"
 accounts_filter_field_description: Filter by typeahead a text input. This applies for filters by group/organization and admin
 accounts_filter_field_aria_label: Filter text input
 accounts_filter_field_aria_label_description: Aria label for the filter text input
+accounts_filter_button_aria_label: Add filter
+accounts_filter_button_aria_label_description: Aria label for the filter button
 
 ## Header
 accounts_table:

--- a/portafly/src/tests/components/SwitchWith404.test.tsx
+++ b/portafly/src/tests/components/SwitchWith404.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Link, Route, Switch } from 'react-router-dom'
-import { fireEvent } from '@testing-library/dom'
+import { fireEvent } from '@testing-library/react'
 import { render } from 'tests/custom-render'
 import { SwitchWith404 } from 'components'
 

--- a/portafly/src/tests/components/shared/data-list/SearchWidget.test.tsx
+++ b/portafly/src/tests/components/shared/data-list/SearchWidget.test.tsx
@@ -51,12 +51,12 @@ describe('SearchWidget', () => {
   it.skip('should be able to filter by admin', () => {
     // FIXME: Update test after MOB session
     const { getByPlaceholderText, getByTestId } = setup()
-    const searchInput = getByPlaceholderText('Filter by Admin')
+    const searchInput = getByPlaceholderText('accountsIndex:accounts_filter_field')
     fireEvent.change(searchInput, { target: { value: 'big boss' } })
     expect(getByTestId('data-toolbar')).toMatchSnapshot()
   })
 
+  // TODO: PF React makes it hard to target the button of the select...
   it.skip('should be able to filter by state', () => {
-    // FIXME: PF React makes it hard to target the button of the select...
   })
 })

--- a/portafly/src/tests/components/shared/data-list/__snapshots__/SearchWidget.test.tsx.snap
+++ b/portafly/src/tests/components/shared/data-list/__snapshots__/SearchWidget.test.tsx.snap
@@ -2,143 +2,123 @@
 
 exports[`SearchWidget should be able to filter by admin 1`] = `
 <div
-  class="pf-c-data-toolbar DataToolbar-class"
-  data-testid="data-toolbar"
-  id="data-list"
+  class="pf-c-toolbar__item"
+  data-testid="search-widget"
 >
   <div
-    class="pf-c-data-toolbar__content"
+    class="pf-c-toolbar__group pf-m-filter-group"
   >
     <div
-      class="pf-c-data-toolbar__content-section"
+      class="pf-c-select"
+      data-ouia-component-id="0"
+      data-ouia-component-type="PF4/Select"
+      data-ouia-safe="true"
     >
-      <div
-        class="pf-c-data-toolbar__item"
+      <button
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby=" pf-toggle-id-0"
+        class="pf-c-select__toggle"
+        id="pf-toggle-id-0"
+        type="button"
       >
         <div
-          class="pf-c-data-toolbar__group pf-m-filter-group"
+          class="pf-c-select__toggle-wrapper"
         >
-          <div
-            class="pf-c-select"
+          <span
+            class="pf-c-select__toggle-icon"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-labelledby=" pf-toggle-id-1"
-              class="pf-c-select__toggle"
-              id="pf-toggle-id-1"
-              type="button"
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 512 512"
+              width="1em"
             >
-              <div
-                class="pf-c-select__toggle-wrapper"
-              >
-                <span
-                  class="pf-c-select__toggle-icon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 512 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                      transform=""
-                    />
-                  </svg>
-                </span>
-                <span
-                  class="pf-c-select__toggle-text"
-                >
-                  Admin
-                </span>
-              </div>
-              <svg
-                aria-hidden="true"
-                class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
-              >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pf-c-data-toolbar__item"
+              <path
+                d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                transform=""
+              />
+            </svg>
+          </span>
+          <span
+            class="pf-c-select__toggle-text"
           >
-            <span />
-          </div>
-          <div
-            class="pf-c-data-toolbar__item"
-          >
-            <span />
-          </div>
-          <div
-            class="pf-c-data-toolbar__item"
-          >
-            <span />
-          </div>
-          <div
-            class="pf-c-input-group"
-          >
-            <input
-              aria-invalid="false"
-              aria-label="Aria label of the text input for filtering"
-              class="pf-c-form-control"
-              placeholder="Filter by Admin"
-              type="search"
-              value=""
-            />
-            <button
-              aria-label="Aria label for button"
-              class="pf-c-button pf-m-control"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 512 512"
-                width="1em"
-              >
-                <path
-                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                  transform=""
-                />
-              </svg>
-            </button>
-          </div>
+            Admin
+          </span>
         </div>
-      </div>
+        <span
+          class="pf-c-select__toggle-arrow"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </span>
+      </button>
     </div>
     <div
-      class="pf-c-data-toolbar__expandable-content"
-      id="data-list-expandable-content-3"
+      class="pf-c-toolbar__item"
     >
-      <div
-        class="pf-c-data-toolbar__group"
-      />
+      <span />
     </div>
-  </div>
-  <div
-    class="pf-c-data-toolbar__content pf-m-hidden"
-    hidden=""
-  >
     <div
-      class="pf-c-data-toolbar__group"
-    />
+      class="pf-c-toolbar__item"
+    >
+      <span />
+    </div>
+    <div
+      class="pf-c-toolbar__item"
+    >
+      <span />
+    </div>
+    <div
+      class="pf-c-input-group"
+    >
+      <input
+        aria-invalid="false"
+        aria-label="accountsIndex:accounts_filter_field_aria_label"
+        class="pf-c-form-control"
+        placeholder="accountsIndex:accounts_filter_field"
+        type="search"
+        value=""
+      />
+      <button
+        aria-disabled="false"
+        class="pf-c-button pf-m-control"
+        data-ouia-component-id="1"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+            transform=""
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </div>
 `;
@@ -240,6 +220,7 @@ exports[`SearchWidget should render correctly 1`] = `
       />
       <button
         aria-disabled="false"
+        aria-label="accountsIndex:accounts_filter_button_aria_label"
         class="pf-c-button pf-m-control"
         data-ouia-component-id="1"
         data-ouia-component-type="PF4/Button"

--- a/portafly/src/tests/components/util/AlertContext.test.tsx
+++ b/portafly/src/tests/components/util/AlertContext.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { AlertsProvider, useAlertsContext } from 'components'
 import { render } from 'tests/custom-render'
-import { waitFor } from '@testing-library/dom'
+import { waitFor } from '@testing-library/react'
 
 const AlertComponent = () => {
   const { addAlert } = useAlertsContext()

--- a/portafly/src/tests/custom-render.tsx
+++ b/portafly/src/tests/custom-render.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
 import * as React from 'react'
 import { render, RenderOptions } from '@testing-library/react'
 import { MemoryRouter, MemoryRouterProps } from 'react-router'

--- a/portafly/src/utils/reducers.ts
+++ b/portafly/src/utils/reducers.ts
@@ -7,6 +7,7 @@ export type ActionHandlers<S, A> = Record<string, (state: S, action: Action<A>) 
 
 const createReducer = (handlers: ActionHandlers<any, any>) => (
   (state: any, action: Action<any>): any => (
+    // eslint-disable-next-line no-prototype-builtins
     handlers.hasOwnProperty(action.type) ? handlers[action.type](state, action) : state
   )
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to have `CI=true` when building in CircleCI
We need to remove some eslint warnings for that (and pass our config, not React's, to webpack)

**Warnings in tests are OK!**
They are ignored by `yarn build` and therefore we should worry about them at development time only.

**Verification steps** 

1. This should work locally:
```
CI=true yarn build
```
2. CircleCI should pass as well

**Special notes for your reviewer**:
