### PR TITLE
Fix HTTP utils and add PUBLIC_URL

### DIFF
--- a/portafly/src/App.tsx
+++ b/portafly/src/App.tsx
@@ -25,7 +25,7 @@ const PagesSwitch = () => (
 
 const App = () => (
   <AuthProvider>
-    <Router>
+    <Router basename={process.env.PUBLIC_URL}>
       <LastLocationProvider>
         <AlertsProvider>
           <Root>

--- a/portafly/src/utils/http.ts
+++ b/portafly/src/utils/http.ts
@@ -18,14 +18,14 @@ const fetchData = async <T>(request: Request): Promise<T> => {
   return response.parsedBody as T
 }
 
-const craftRequest = (path: string, params?: URLSearchParams) => {
+const craftRequest = (path: string, params = new URLSearchParams()) => {
   const authToken = getToken()
+  params.append('access_token', authToken as string)
 
-  const url = new URL(`${process.env.REACT_APP_API_HOST || '/'}${path}?${params?.toString()}`)
-  url.searchParams.append('access_token', authToken as string)
+  const url = `${process.env.REACT_APP_API_HOST || '/'}${path}?${params.toString()}`.replace('//', '/')
 
   return new Request(
-    url.toString(),
+    url,
     {
       headers: { Accept: 'application/json' }
     }


### PR DESCRIPTION
⚠️ This is blocking #2058 

**What this PR does / why we need it**:

Adds PUBLIC_URL to the router
Fixes error in `craftRequest` when API_HOST is undefined