### PR TITLE
🐛 Fix HTTP utils

### DIFF
--- a/portafly/src/tests/utils/http.test.ts
+++ b/portafly/src/tests/utils/http.test.ts
@@ -1,0 +1,37 @@
+import { craftRequest } from 'utils/http'
+import { getToken } from 'utils/auth'
+
+jest.mock('utils/auth')
+
+describe('craftRequest', () => {
+  (getToken as jest.Mock).mockReturnValue('token')
+
+  it('should throw when API_HOST is invalid', () => {
+    process.env.REACT_APP_API_HOST = 'localhost'
+    expect(() => craftRequest('planets')).toThrow()
+
+    process.env.REACT_APP_API_HOST = '/wrong'
+    expect(() => craftRequest('planets')).toThrow()
+  })
+
+  it('should craft the correct url provided API_HOST is valid', () => {
+    const targetURL = 'http://starwars.db/planets?access_token=token'
+
+    process.env.REACT_APP_API_HOST = 'http://starwars.db'
+    expect(craftRequest('planets').url).toEqual(targetURL)
+
+    process.env.REACT_APP_API_HOST = 'http://starwars.db/'
+    expect(craftRequest('planets').url).toEqual(targetURL)
+
+    process.env.REACT_APP_API_HOST = 'http://starwars.db'
+    expect(craftRequest('/planets').url).toEqual(targetURL)
+
+    process.env.REACT_APP_API_HOST = 'http://starwars.db/'
+    expect(craftRequest('/planets').url).toEqual(targetURL)
+  })
+
+  it('should craft a valid url when API_HOST is unset', () => {
+    delete process.env.REACT_APP_API_HOST
+    expect(craftRequest('/planets').url).toEqual('/planets?access_token=token')
+  })
+})

--- a/portafly/src/utils/http.ts
+++ b/portafly/src/utils/http.ts
@@ -18,14 +18,19 @@ const fetchData = async <T>(request: Request): Promise<T> => {
   return response.parsedBody as T
 }
 
+const getStringUrl = (path: string, params: URLSearchParams) => {
+  const host = process.env.REACT_APP_API_HOST
+  // REACT_APP_API_HOST will be undefined in Openshift and URL is not compatible with relative paths
+  const url = host ? new URL(path, host) : path
+  return `${url.toString()}?${params.toString()}`
+}
+
 const craftRequest = (path: string, params = new URLSearchParams()) => {
   const authToken = getToken()
   params.append('access_token', authToken as string)
 
-  const url = `${process.env.REACT_APP_API_HOST || '/'}${path}?${params.toString()}`.replace('//', '/')
-
   return new Request(
-    url,
+    getStringUrl(path, params),
     {
       headers: { Accept: 'application/json' }
     }


### PR DESCRIPTION
`craftRequest` should work regardless of API_HOST being defined. For local for instance we need it but for a production environment such as Openshift we don't.

😓 
<img width="565" alt="Screen Shot 2020-07-21 at 09 25 17" src="https://user-images.githubusercontent.com/11672286/88025136-1fc58e00-cb34-11ea-96f0-b4d04e2c555f.png">
