### PR TITLE
Set i18n debug mode

### DIFF
--- a/portafly/src/i18n/i18n.tsx
+++ b/portafly/src/i18n/i18n.tsx
@@ -12,7 +12,7 @@ const formatFn: FormatFunction = (value, format) => {
 const options = {
   lng: EN,
   fallbackLng: [EN],
-  debug: false,
+  debug: process.env.NODE_ENV === 'development',
   interpolation: {
     format: formatFn,
     escapeValue: false


### PR DESCRIPTION
Only for development. It's super convenient to keep track of missing strings (and other errors like typos).

<img width="569" alt="Screen Shot 2020-07-21 at 09 27 37" src="https://user-images.githubusercontent.com/11672286/88025342-6c10ce00-cb34-11ea-9881-79544ea3312e.png">
