### PR TITLE
Fix email validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,9 +83,8 @@ class User < ApplicationRecord
                                  :message => MSG_LOGIN_BAD }
 
   #OPTIMIZE: use the same format validations in user, account and invitation, add TESTS!
-  validates :email, length: { :within => 6..255, :allow_blank => true } #r@a.wk
-  validates :email, format: { :with => RE_EMAIL_OK, :allow_blank => false,
-                              :message => MSG_EMAIL_BAD, :unless => :minimal_signup? }
+  validates :email, length: { :within => 6..255, :allow_blank => false } #r@a.wk
+  validates :email, format: { :with => RE_EMAIL_OK, :allow_blank => false, :message => MSG_EMAIL_BAD }
 
   #TODO: this needs tests
   validates :password, length: { :minimum => 6, :allow_blank => true,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,6 +14,7 @@ ActiveRecord::Base.transaction do
   master_plan = ENV.fetch('MASTER_PLAN', 'Master Plan')
   master_domain = ENV['MASTER_DOMAIN'].presence
   master_access_code = ENV.fetch('MASTER_ACCESS_CODE', '')
+  master_email = ENV.fetch('MASTER_EMAIL', 'master@example.com')
 
   master_login = ENV.fetch('MASTER_USER', 'master')
   master_password = ENV.fetch('MASTER_PASSWORD') { SecureRandom.base64(32) }
@@ -65,6 +66,7 @@ ActiveRecord::Base.transaction do
   master_user = master.users.create!(username: master_login, password: master_password, password_confirmation: master_password) do |user|
     user.signup_type = 'minimal'
     user.role = :admin
+    user.email = master_email
   end
   master_user.activate!
 

--- a/test/integration/admin/api/signups_controller_test.rb
+++ b/test/integration/admin/api/signups_controller_test.rb
@@ -19,7 +19,7 @@ class Admin::Api::SignupsControllerTest < ActionDispatch::IntegrationTest
 
       assert_difference(provider.buyers.method(:count)) do
         assert_difference(WebHookWorker.jobs.method(:size)) do
-          post(admin_api_signup_path, format: :json, access_token: token.value, org_name: 'company', username: 'person')
+          post(admin_api_signup_path, format: :json, access_token: token.value, org_name: 'company', username: 'person', email: 'person@example.com')
           assert_response :created
         end
       end
@@ -31,7 +31,7 @@ class Admin::Api::SignupsControllerTest < ActionDispatch::IntegrationTest
 
       assert_difference(provider.buyers.method(:count)) do
         assert_no_difference(WebHookWorker.jobs.method(:size)) do
-          post(admin_api_signup_path, format: :json, provider_key: provider.provider_key, org_name: 'company', username: 'person')
+          post(admin_api_signup_path, format: :json, provider_key: provider.provider_key, org_name: 'company', username: 'person', email: 'person@example.com')
           assert_response :created
         end
       end

--- a/test/unit/db/seeds_test.rb
+++ b/test/unit/db/seeds_test.rb
@@ -12,6 +12,7 @@ class SeedsTest < ActiveSupport::TestCase
     'MASTER_USER' => 'my-username',
     'MASTER_SERVICE' => 'the master service',
     'MASTER_PLAN' => 'the master plan',
+    'MASTER_EMAIL' => 'master@example.com',
 
     'PROVIDER_NAME' => 'tenant account name',
     'TENANT_NAME' => 'provider-subdomain',
@@ -61,6 +62,7 @@ class SeedsTest < ActiveSupport::TestCase
     assert_equal 1, master_account.users.count
     master_user = master_account.users.first!
     assert_equal 'master', master_user.username
+    assert_equal 'master@example.com', master_user.email
     assert master_user.minimal_signup?
     assert master_user.admin?
     assert master_user.active?


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the validation to not allow blank.

**Which issue(s) this PR fixes** 

[THREESCALE-5653: /admin/api/signup.json doesn't require email and creates user without it](https://issues.redhat.com/browse/THREESCALE-5653)

**Verification steps** 
This should return an error `Email can't be blank`:
```
HOST="..." \
TOKEN="..." \
curl -v "$HOST/admin/api/signup.json" -d 'access_token=$TOKEN&name=Peter&username=Griffin&org_name=Petoria'
```

**Special notes for your reviewer**:
