### PR TITLE
Better error messages for creating a Buyer Account from the admin portal UI

### DIFF
--- a/app/controllers/buyers/accounts_controller.rb
+++ b/app/controllers/buyers/accounts_controller.rb
@@ -52,6 +52,7 @@ class Buyers::AccountsController < Buyers::BaseController
       redirect_to admin_buyers_account_path(@buyer)
     else
       @user = signup_result.user
+      flash.now[:error] = signup_result.errors.messages.without(:account, :user).values.join('. ')
       render action: :new
     end
   end

--- a/app/lib/logic/signup.rb
+++ b/app/lib/logic/signup.rb
@@ -4,7 +4,7 @@ module Logic
   module Signup
     module Provider
       def create_buyer_possible?
-        account_plans.stock.present?
+        account_plans.default_or_nil.present?
       end
 
       def signup_enabled?

--- a/app/lib/signup/result.rb
+++ b/app/lib/signup/result.rb
@@ -33,7 +33,7 @@ module Signup
     end
 
     def save!
-      raise ActiveRecord::RecordInvalid, self if @errors.present?
+      raise ActiveRecord::RecordInvalid, self if errors.present?
       ActiveRecord::Base.transaction do
         account.save! && user.save!
       end


### PR DESCRIPTION
Fixes issues 1 & 2 of [THREESCALE-5678](https://issues.redhat.com/browse/THREESCALE-5678)