### PR TITLE
[Bugfix] Broken link to Documentation of Openshift#creating-routes

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1243,7 +1243,7 @@ en:
         endpoint: "Public address of your API gateway in the production environment. This field customizes the server_name directive in the NGINX Config file and defaults to $hostname if left blank."
         endpoint_apicast_2_openshift_html:
           Public address of your API gateway in the %{environment_name} environment.
-          <span>Make sure to <a href="https://docs.openshift.com/container-platform/latest/dev_guide/routes.html#creating-routes">add the correct route</a></span>
+          <span>Make sure to <a href="https://docs.openshift.com/container-platform/3.11/dev_guide/routes.html#creating-routes">add the correct route</a></span>
         endpoint_apicast_2_html: >
           Public address of your API gateway in the %{environment_name} environment.
         api_backend_https: |


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/11318903/88409947-f6c42800-cdd5-11ea-9a01-edeec1cf671c.png)

This fix is not pointing to the latest version.
An alternative approach would be not linking anywhere.