### PR TITLE
Find user with an invalid value returns 'nil' instead of crashing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -157,6 +157,8 @@ class User < ApplicationRecord
 
   def self.find_by_username_or_email(value)
     find_by(['users.username = ? OR users.email = ?', value, value])
+  rescue TypeError
+    nil
   end
 
   def self.find_with_valid_password_token(token)

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -137,6 +137,10 @@ class UserTest < ActiveSupport::TestCase
     assert_equal [service.id], member.accessible_services.map(&:id)
   end
 
+  test '#find_by_username_or_email returns nil for TypeError' do
+    assert_nil User.find_by_username_or_email({"＄foo" => "bar1"})
+  end
+
   test '#multiple_accessible_services?' do
     provider = FactoryBot.create(:simple_provider)
     user = FactoryBot.create(:user, account: provider)


### PR DESCRIPTION
Closes [THREESCALE-5686](https://issues.redhat.com/browse/THREESCALE-5686)