### PR TITLE
OAS autocomplete: Supporting all methods, not just get

### DIFF
--- a/app/javascript/packs/OAS3Autocomplete.js
+++ b/app/javascript/packs/OAS3Autocomplete.js
@@ -33,22 +33,36 @@ const addAutocompleteToParam = (param: Param, accountData: AccountData): Param =
 }
 
 const getPathParameters = (path) => (
-  Object.keys(path).reduce((params, item) => {
-    params[item] = path[item].parameters
-    return params
-  }, {})
+  Object.keys(path).reduce((params, item) => (
+    {
+      ...params,
+      [item]: item === 'parameters'
+        ? path.parameters
+        : path[item].parameters
+    }
+  ), {})
 )
 
-const injectParametersToPath = (path, pathParameters, accountData) => (
-  Object.keys(pathParameters).reduce((parameters, item) => {
-    parameters[item] = {
-      ...path[item],
-      parameters: pathParameters[item]
-        ? pathParameters[item].map(param => X_DATA_ATTRIBUTE in param ? addAutocompleteToParam(param, accountData) : param)
-        : []
+const injectParametersField = (key, value, accountData) => {
+  const parametersArray = value.map(param => X_DATA_ATTRIBUTE in param ? addAutocompleteToParam(param, accountData) : param)
+  if (key === 'parameters') {
+    return parametersArray
+  } else {
+    return {
+      ...value,
+      parameters: parametersArray
     }
-    return parameters
-  }, {})
+  }
+}
+
+const injectParametersToPath = (path, pathParameters, accountData) => (
+  Object.keys(pathParameters).reduce((parameters, item) => (
+    {
+      ...parameters,
+      [item]: pathParameters[item]
+        ? injectParametersField(item, pathParameters[item], accountData)
+        : path[item]
+    }), {})
 )
 
 const injectAutocompleteToResponseBody = (responseBody: ResponseBody, accountData: AccountData): ResponseBody => (

--- a/app/javascript/packs/OAS3Autocomplete.js
+++ b/app/javascript/packs/OAS3Autocomplete.js
@@ -45,14 +45,7 @@ const getPathParameters = (path) => (
 
 const injectParametersField = (key, value, accountData) => {
   const parametersArray = value.map(param => X_DATA_ATTRIBUTE in param ? addAutocompleteToParam(param, accountData) : param)
-  if (key === 'parameters') {
-    return parametersArray
-  } else {
-    return {
-      ...value,
-      parameters: parametersArray
-    }
-  }
+  return (key === 'parameters') ? parametersArray : { ...value, parameters: parametersArray }
 }
 
 const injectParametersToPath = (path, pathParameters, accountData) => (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

In a previous PR (https://github.com/3scale/porta/pull/2022) we added support for `get` methods in paths, but other methods as `post`, `put`, or `delete` are missing.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-5516

**Verification steps** 

Go to ActiveDocs and create a new OAS 3 spec, you can use this example: https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/petstore-expanded.json
All paths should work fine
Also tests with our Echo Api default example, autocomplete should still work

**Special notes for your reviewer**:
