### PR TITLE
Uri shortener for long host label endpoints

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -216,11 +216,13 @@ class Proxy < ApplicationRecord
     def generate(name)
       template = config.fetch(name.try(:to_sym)) { return }
 
-      format template, {
+      uri = format template, {
         system_name: service.parameterized_system_name, account_id: service.account_id,
         tenant_name: provider_subdomain,
         env: proxy.proxy_env, port: proxy.proxy_port
       }
+
+      UriShortener.call(uri).to_s
     end
   end
 

--- a/app/services/service_creator.rb
+++ b/app/services/service_creator.rb
@@ -22,10 +22,6 @@ class ServiceCreator
   def call(params = {})
     call!(params)
   rescue ActiveRecord::RecordInvalid
-    return if !proxy || proxy.errors[:endpoint].none? { |message| message =~ /is too long/ }
-
-    @service.errors.add(:system_name, :invalid_for_proxy_endpoints)
-
     false
   end
 

--- a/app/services/uri_shortener.rb
+++ b/app/services/uri_shortener.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class UriShortener
+  def self.call(uri)
+    new(uri).call
+  end
+
+  def initialize(uri)
+    @uri = URI.parse(uri)
+  rescue URI::InvalidURIError
+  end
+
+  attr_reader :uri
+
+  def call
+    return unless uri
+    labels = uri.host.split('.')
+    uri.host = labels.map(&UriLabelShortner.method(:call)).join('.')
+    uri
+  end
+
+  class UriLabelShortner
+    def self.call(label)
+      new(label).call
+    end
+
+    def initialize(label)
+      @label = label
+    end
+
+    attr_reader :label
+    delegate :size, to: :label
+
+    MAX_LABEL_SIZE = UriValidator::UriThreeScaleComplianceChecker::MAX_LABEL_SIZE
+    HASH_SIZE = 7
+    KEEP_SIZE = (MAX_LABEL_SIZE - HASH_SIZE - 1).freeze
+
+    def call
+      return label if size <= MAX_LABEL_SIZE
+      [*label.slice(0, KEEP_SIZE).split('-'), hash].join('-')
+    end
+
+    def hash
+      Digest::SHA1.hexdigest(label).slice(0, HASH_SIZE)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -898,7 +898,6 @@ en:
           attributes:
             system_name:
               invalid: invalid. Only ASCII letters, numbers, dashes and underscores are allowed.
-              invalid_for_proxy_endpoints: must be shorter.
 
         cinstance:
           attributes:

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -236,16 +236,5 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       post admin_services_path, service: { name: 'example-service', system_name: '###' }
       assert_equal 'System name invalid. Only ASCII letters, numbers, dashes and underscores are allowed.', flash[:error]
     end
-
-    test 'chosen system name affects proxy endpoint validation' do
-      @provider.settings.allow_multiple_services!
-
-      post admin_services_path, service: { name: 'My New Product', system_name: 'this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035' }
-      assert_equal 'System name must be shorter.', flash[:error]
-
-      post admin_services_path, service: { name: 'My New Product', system_name: 'short-labels-are-ok' }
-      refute flash[:error].presence
-      assert_response :redirect
-    end
   end
 end

--- a/test/unit/services/service_creator_test.rb
+++ b/test/unit/services/service_creator_test.rb
@@ -46,11 +46,10 @@ class ServiceCreatorTest < ActiveSupport::TestCase
     assert backend_api_config.persisted?
   end
 
-  test 'service with a too long system_name for its proxy' do
+  test 'service with a long system_name used in its proxy endpoint' do
     system_name = 'this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035'
     service = FactoryBot.build(:service, system_name: system_name)
-    creator = ServiceCreator.new(service: service)
-    creator.call
-    assert_includes service.errors[:system_name], 'must be shorter.'
+    ServiceCreator.new(service: service).call
+    assert_match /this-hostname-label-is-longer-than-63-chars-which-is-no-/, service.proxy.endpoint
   end
 end

--- a/test/unit/services/uri_shortener_test.rb
+++ b/test/unit/services/uri_shortener_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UriShortenerTest < ActiveSupport::TestCase
+  test 'uri with long label' do
+    shortener = UriShortener.new('http://this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035.example.com')
+    assert_equal 'http://this-hostname-label-is-longer-than-63-chars-which-is-no-a6ca0fb.example.com', shortener.call.to_s
+  end
+
+  test 'uri with multiple long labels' do
+    shortener = UriShortener.new('http://this-hostname-label-is-longer-than-63-chars-which-is-not-allowed-according-to-rfc-1035.this-other-label-is-as-well-longer-than-63-chars-also-violating-the-rfc-1035.example.com')
+    assert_equal 'http://this-hostname-label-is-longer-than-63-chars-which-is-no-a6ca0fb.this-other-label-is-as-well-longer-than-63-chars-also-v-57fa2c4.example.com', shortener.call.to_s
+  end
+
+  test 'does not duplicate leading dash' do
+    shortener = UriShortener.new('http://long-system-name-that-will-cause-invalid-host-needs-to-be-63-chars-or-shorter.example.com')
+    assert_not_equal 'http://long-system-name-that-will-cause-invalid-host-needs-to--4207987.example.com', shortener.call.to_s
+    assert_equal     'http://long-system-name-that-will-cause-invalid-host-needs-to-4207987.example.com', shortener.call.to_s
+  end
+
+  test 'uri with no long labels' do
+    shortener = UriShortener.new('http://this-label-is-ok.example.com')
+    assert_equal 'http://this-label-is-ok.example.com', shortener.call.to_s
+  end
+
+  test 'invalid uri' do
+    shortener = UriShortener.new('not a uri')
+    refute shortener.call
+  end
+end


### PR DESCRIPTION
It will automatically shorten host labels of system-generated proxy endpoints, that exceed the 63-char limit imposed by RFC-1035.

Closes [THREESCALE-5089](https://issues.redhat.com/browse/THREESCALE-5089)