### PR TITLE
Fix Portafly source for the Openshift ImageStream

### DIFF
--- a/portafly/openshift/imagestream.yml
+++ b/portafly/openshift/imagestream.yml
@@ -16,7 +16,7 @@ spec:
       openshift.io/display-name: amp-portafly master
     from:
       kind: DockerImage
-      name: ${PORTAFLY_IMAGE}
+      name: quay.io/3scale/portafly:latest
     generation: null
     importPolicy:
       insecure: false


### PR DESCRIPTION
It fixes for Portafly's Openshift ImageStream the source to quay.io/3scale/portafly:latest, now that the repo was created.