### PR TITLE
Fix proxy config affecting change on create

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -536,11 +536,9 @@ class Proxy < ApplicationRecord
     super
   end
 
-  def find_or_create_proxy_config_affecting_change
+  def affecting_change_history
     proxy_config_affecting_change || create_proxy_config_affecting_change
   end
-  alias affecting_change_history find_or_create_proxy_config_affecting_change
-  private :find_or_create_proxy_config_affecting_change
 
   def pending_affecting_changes?
     return unless apicast_configuration_driven?

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -27,6 +27,7 @@ class Proxy < ApplicationRecord
 
   has_one :proxy_config_affecting_change, dependent: :delete
   private :proxy_config_affecting_change
+  after_commit :create_proxy_config_affecting_change, on: :create
 
   validates :error_status_no_match, :error_status_auth_missing, :error_status_auth_failed, :error_status_limits_exceeded, presence: true
 
@@ -649,6 +650,7 @@ class Proxy < ApplicationRecord
   end
 
   def create_proxy_config_affecting_change(*)
+    return unless persisted?
     super
   rescue ActiveRecord::RecordNotUnique
     reload.send(:proxy_config_affecting_change)

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -10,7 +10,7 @@ class Proxy < ApplicationRecord
   include GatewaySettings::ProxyExtension
   include ProxyConfigAffectingChanges::ModelExtension
 
-  define_proxy_config_affecting_attributes except: %i[updated_at lock_version]
+  define_proxy_config_affecting_attributes except: %i[api_test_path api_test_success lock_version]
 
   self.background_deletion = [:proxy_rules, [:proxy_configs, { action: :delete }], [:oidc_configuration, { action: :delete, has_many: false }]]
 

--- a/test/unit/backend/model_extensions/service_test.rb
+++ b/test/unit/backend/model_extensions/service_test.rb
@@ -6,7 +6,7 @@ class Backend::ModelExtensions::ServiceTest < ActiveSupport::TestCase
     service = FactoryBot.build(:service,
       account: FactoryBot.create(:provider_account), referrer_filters_required: true)
 
-    ThreeScale::Core::Service.expects(:save!).with do |params|
+    ThreeScale::Core::Service.expects(:save!).at_least_once.with do |params|
       params[:id] == service.backend_id &&
         params[:referrer_filters_required] == true
     end

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -648,9 +648,12 @@ class ProxyTest < ActiveSupport::TestCase
   end
 
   test 'affecting change' do
-    refute ProxyConfigAffectingChange.find_by(proxy_id: @proxy.id)
-    @proxy.affecting_change_history
-    assert ProxyConfigAffectingChange.find_by(proxy_id: @proxy.id)
+    proxy = FactoryBot.create(:simple_proxy)
+    assert ProxyConfigAffectingChange.find_by(proxy_id: proxy.id)
+
+    assert_no_change(of: -> { ProxyConfigAffectingChange.where(proxy_id: proxy.id).count }) do
+      proxy.affecting_change_history
+    end
   end
 
   test '#pending_affecting_changes?' do
@@ -682,7 +685,9 @@ class ProxyTest < ActiveSupport::TestCase
     end
 
     service = FactoryBot.create(:simple_service)
-    proxy = ProxyWithFiber.find(service.proxy.id)
+    proxy_id = service.proxy.id
+    proxy = ProxyWithFiber.find(proxy_id)
+    ProxyConfigAffectingChange.where(proxy_id: proxy_id).delete_all
 
     f1 = Fiber.new { proxy.affecting_change_history }
     f2 = Fiber.new { proxy.affecting_change_history }

--- a/test/unit/tasks/proxy_test.rb
+++ b/test/unit/tasks/proxy_test.rb
@@ -7,7 +7,6 @@ module Tasks
     class ResetProxyConfigChangeHistoryTest < ActiveSupport::TestCase
       setup do
         @providers = FactoryBot.create_list(:provider_account, 3)
-        proxies.each(&:affecting_change_history) # so change history exists for the proxies associated with all these accounts
 
         @proxy_with_legit_change = proxies.last
         @legit_change_date = 2.minutes.from_now.freeze
@@ -15,6 +14,7 @@ module Tasks
 
         @providers << FactoryBot.create(:provider_account) # change history for the proxy associated with this account does not exist
         @proxy_without_change_history = proxies.last
+        ProxyConfigAffectingChange.where(proxy: proxy_without_change_history).delete_all
         @reset_date = Time.utc(1900, 1, 1).freeze
       end
 

--- a/test/workers/proxy_config_affecting_change_worker_test.rb
+++ b/test/workers/proxy_config_affecting_change_worker_test.rb
@@ -15,7 +15,7 @@ class ProxyConfigAffectingChangeWorkerTest < ActiveSupport::TestCase
     event = ProxyConfigs::AffectingObjectChangedEvent.create_and_publish!(proxy, mock(id: 123))
 
     affecting_change_history = mock
-    Proxy.any_instance.expects(:create_proxy_config_affecting_change).returns(affecting_change_history)
+    Proxy.any_instance.expects(:affecting_change_history).returns(affecting_change_history)
     affecting_change_history.expects(:touch)
 
     worker.perform(event.event_id)


### PR DESCRIPTION
The exclamation sign, close to “Integration” in the sidebar menu of the Admin Porta and also in the Dashboard, is showing up for API products just created, right after finishing the provider wizard. This should not happen and neither it was when ProxyConfigAffectingChanges were first introduced. I guess some change later on caused the creation of the proxy’s affecting change history to be postponed to _after_ the creation of the first proxy config itself – likely #1658.

This PR ensure the proxy’s affecting change history exists since creation of the proxy object.