### PR TITLE
Deliver invitations async and fix notification message

### DIFF
--- a/app/controllers/buyers/invitations_controller.rb
+++ b/app/controllers/buyers/invitations_controller.rb
@@ -12,7 +12,7 @@ class Buyers::InvitationsController < Buyers::BaseController
   create! do |success, failure|
     success.html do
       redirect_to admin_buyers_account_invitations_path(@account),
-                  notice: 'Invitation was successfully sent.'
+                  notice: 'Invitation will be sent soon.'
     end
   end
 
@@ -26,7 +26,7 @@ class Buyers::InvitationsController < Buyers::BaseController
 
     respond_to do |format|
       format.html do
-        flash[:success] = "Invitation was successfully resent"
+        flash[:success] = 'Invitation will be resent soon.'
         redirect_to(admin_buyers_account_invitations_path(@account))
       end
       format.xml  { head :ok }

--- a/app/controllers/provider/admin/account/invitations_controller.rb
+++ b/app/controllers/provider/admin/account/invitations_controller.rb
@@ -10,7 +10,7 @@ class Provider::Admin::Account::InvitationsController < Provider::Admin::Account
   create! do |success, failure|
     success.html do
       redirect_to provider_admin_account_invitations_path,
-                  notice: 'Invitation was successfully sent.'
+                  notice: 'Invitation will be sent soon.'
     end
   end
 
@@ -24,7 +24,7 @@ class Provider::Admin::Account::InvitationsController < Provider::Admin::Account
 
     respond_to do |format|
       format.html do
-        flash[:success] = "Invitation was successfully resent"
+        flash[:success] = 'Invitation will be resent soon.'
         redirect_to provider_admin_account_invitations_path
       end
       format.xml  { head :ok }

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -1,6 +1,6 @@
 module InvitationsHelper
   def invitation_sent_date(invitation)
-    invitation.sent_at&.to_s(:long) || '-'
+    invitation.sent_at&.to_s(:long) || 'Not sent yet'
   end
 
   def invitation_status(invitation)

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -1,6 +1,6 @@
 module InvitationsHelper
   def invitation_sent_date(invitation)
-    (invitation.sent_at.presence || invitation.created_at).to_s(:long)
+    invitation.sent_at&.to_s(:long) || '-'
   end
 
   def invitation_status(invitation)

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -39,6 +39,7 @@ class Invitation < ApplicationRecord
 
   def resend
     notify_invitee unless accepted?
+    update!(sent_at: nil)
   end
 
   private

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -38,9 +38,7 @@ class Invitation < ApplicationRecord
   end
 
   def resend
-    return if accepted?
-    notify_invitee
-    update!(sent_at: nil)
+    notify_invitee unless accepted?
   end
 
   private

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -58,14 +58,7 @@ class Invitation < ApplicationRecord
   end
 
   def notify_invitee
-    # TODO: maybe subclass to Invitation and ProviderInvitation
-    if account.provider?
-      ProviderInvitationMailer.invitation(self).deliver_now
-    else
-      InvitationMailer.invitation(self).deliver_now
-    end
-
-    update_column(:sent_at, Time.zone.now)
+    SendUserInvitationWorker.perform_later(id)
   end
 
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -30,6 +30,7 @@ class Invitation < ApplicationRecord
   end
 
   def accepted?
+    return true
     accepted_at.present?
   end
 
@@ -38,7 +39,8 @@ class Invitation < ApplicationRecord
   end
 
   def resend
-    notify_invitee unless accepted?
+    return if accepted?
+    notify_invitee
     update!(sent_at: nil)
   end
 
@@ -59,7 +61,7 @@ class Invitation < ApplicationRecord
   end
 
   def notify_invitee
-    SendUserInvitationWorker.perform_later(id)
+    SendUserInvitationWorker.perform_later(self)
   end
 
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -30,7 +30,6 @@ class Invitation < ApplicationRecord
   end
 
   def accepted?
-    return true
     accepted_at.present?
   end
 

--- a/app/views/buyers/invitations/index.html.erb
+++ b/app/views/buyers/invitations/index.html.erb
@@ -25,7 +25,8 @@
         <td>
           <% if can? :manage, invitation %>
             <% unless invitation.accepted? -%>
-               <%= fancy_link_to('Resend', resend_admin_buyers_account_invitation_path(invitation.account,invitation), { :class => "refresh", :id => "resend-invitation-#{invitation.id}", :method => :put }) %>
+               <%= fancy_link_to('Resend', resend_admin_buyers_account_invitation_path(invitation.account,invitation),
+                                           { :class => "refresh", :id => "resend-invitation-#{invitation.id}", :method => :put, :disabled => "#{invitation.accepted?}" }) %>
             <% end -%>
           <% end %>
         <td>

--- a/app/views/buyers/invitations/index.html.erb
+++ b/app/views/buyers/invitations/index.html.erb
@@ -25,8 +25,7 @@
         <td>
           <% if can? :manage, invitation %>
             <% unless invitation.accepted? -%>
-               <%= fancy_link_to('Resend', resend_admin_buyers_account_invitation_path(invitation.account,invitation),
-                                           { :class => "refresh", :id => "resend-invitation-#{invitation.id}", :method => :put, :disabled => "#{invitation.accepted?}" }) %>
+               <%= fancy_link_to('Resend', resend_admin_buyers_account_invitation_path(invitation.account,invitation), { :class => "refresh", :id => "resend-invitation-#{invitation.id}", :method => :put }) %>
             <% end -%>
           <% end %>
         <td>

--- a/app/workers/send_user_invitation_worker.rb
+++ b/app/workers/send_user_invitation_worker.rb
@@ -11,12 +11,10 @@ class SendUserInvitationWorker < ApplicationJob
     Net::SMTPSyntaxError,
     Net::SMTPUnknownError,
     Net::SMTPUnsupportedCommand,
-    SocketError,
+    SocketError
   ].freeze
 
-  def perform(invitation_id)
-    invitation = Invitation.find(invitation_id)
-
+  def perform(invitation)
     mailer = invitation.account.provider? ? ProviderInvitationMailer : InvitationMailer
     mailer.invitation(invitation).deliver_now!
 

--- a/app/workers/send_user_invitation_worker.rb
+++ b/app/workers/send_user_invitation_worker.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SendUserInvitationWorker < ApplicationJob
+  queue_as :default
+  include Net
+
+  def perform(invitation_id)
+    invitation = Invitation.find(invitation_id)
+
+    mailer = invitation.account.provider? ? ProviderInvitationMailer : InvitationMailer
+    mailer.invitation(invitation).deliver_now!
+
+    invitation.update!(sent_at: Time.zone.now)
+  rescue OpenSSL::SSL::SSLError, Net::SMTPError, SocketError, ActiveRecord::RecordNotFound => err
+    logger.error(err.message)
+  end
+end

--- a/app/workers/send_user_invitation_worker.rb
+++ b/app/workers/send_user_invitation_worker.rb
@@ -2,7 +2,21 @@
 
 class SendUserInvitationWorker < ApplicationJob
   queue_as :default
-  include Net
+
+  RETRY_ERRORS = [
+    OpenSSL::SSL::SSLError,
+    Net::SMTPAuthenticationError,
+    Net::SMTPFatalError,
+    Net::SMTPServerBusy,
+    Net::SMTPSyntaxError,
+    Net::SMTPUnknownError,
+    Net::SMTPUnsupportedCommand,
+    SocketError,
+  ].freeze
+
+  DISCARD_ERRORS = [
+    ActiveRecord::RecordNotFound
+  ].freeze
 
   def perform(invitation_id)
     invitation = Invitation.find(invitation_id)
@@ -11,7 +25,10 @@ class SendUserInvitationWorker < ApplicationJob
     mailer.invitation(invitation).deliver_now!
 
     invitation.update!(sent_at: Time.zone.now)
-  rescue OpenSSL::SSL::SSLError, Net::SMTPError, SocketError, ActiveRecord::RecordNotFound => err
-    logger.error(err.message)
+  rescue *RETRY_ERRORS => error
+    logger.error(error.message)
+  rescue *DISCARD_ERRORS => error
+    logger.error(error.message)
+    false
   end
 end

--- a/app/workers/send_user_invitation_worker.rb
+++ b/app/workers/send_user_invitation_worker.rb
@@ -3,7 +3,7 @@
 class SendUserInvitationWorker < ApplicationJob
   queue_as :default
 
-  ERRORS = [
+  RETRY_ERRORS = [
     OpenSSL::SSL::SSLError,
     Net::SMTPAuthenticationError,
     Net::SMTPFatalError,
@@ -14,12 +14,18 @@ class SendUserInvitationWorker < ApplicationJob
     SocketError
   ].freeze
 
+  DISCARD_ERRORS = [
+    ActiveJob::DeserializationError
+  ].freeze
+
   def perform(invitation)
     mailer = invitation.account.provider? ? ProviderInvitationMailer : InvitationMailer
     mailer.invitation(invitation).deliver_now!
 
     invitation.update(sent_at: Time.zone.now)
-  rescue *ERRORS => e
+  rescue *DISCARD_ERRORS => ex
+    Rails.logger.info "SphinxIndexationWorker#perform raised" #{ex.class} with message #{ex.message}"
+  rescue *RETRY_ERRORS => e
     logger.error(e.message)
     retry_job
   end

--- a/features/step_definitions/providers/invitations_steps.rb
+++ b/features/step_definitions/providers/invitations_steps.rb
@@ -9,7 +9,7 @@ Then /^I should see the invite user link$/ do
 end
 
 Then /^I should see a new buyer user was invited$/ do
-  step %{I should see "Partner user invitation was successfully sent."}
+  step %{I should see "Partner user invitation will be sent soon."}
   Invitation.find_by_email(@user_attrs[:email]).should_not be_nil
 end
 

--- a/test/unit/invitation_test.rb
+++ b/test/unit/invitation_test.rb
@@ -44,7 +44,7 @@ class InvitationTest < ActiveSupport::TestCase
     assert_not_nil invitation.token
   end
 
-  test 'creates a worker when created' do
+  test 'enqueues a worker when created' do
     SendUserInvitationWorker.expects(:perform_later)
     @provider.invitations.create!(:email => 'buddy@example.net')
   end

--- a/test/unit/invitation_test.rb
+++ b/test/unit/invitation_test.rb
@@ -44,39 +44,20 @@ class InvitationTest < ActiveSupport::TestCase
     assert_not_nil invitation.token
   end
 
-  test 'sends invitation email when created' do
-    ProviderInvitationMailer.any_instance.expects(:invitation)
+  test 'creates a worker when created' do
+    SendUserInvitationWorker.expects(:perform_later)
     @provider.invitations.create!(:email => 'buddy@example.net')
   end
 
-  test 'sets sent_at field when created' do
-    # This is needed, database will not save fractions of seconds
-    # so something like:
-    # Time.now.to_f #=> 1512012308.293877
-    # will be saved in DB as 1512012308
-    Timecop.freeze(Time.zone.parse('2017-11-23 03:25:08 UTC +00:00')) do
-      invitation = @provider.invitations.create!(:email => 'buddy@example.net')
-      assert_equal Time.zone.now, invitation.sent_at
-    end
+  test 'sent_at field is nil when created' do
+    invitation = @provider.invitations.create!(email: 'buddy@example.net')
+    assert_nil invitation.sent_at
   end
 
   test 'resend unaccepted invitation email' do
+    SendUserInvitationWorker.expects(:perform_later).twice
     @unaccepted_invitation = @provider.invitations.create!(:email => 'buddy@example.net')
-
-    # REVIEW: ProviderInvitationMailer.any_instance.expects(:invitation)
-    # Before mails in background only call one time
-    ProviderInvitationMailer.any_instance.expects(:invitation)
     @unaccepted_invitation.resend
-  end
-
-  test '#resend unaccepted invitationset sent_at field' do
-    @unaccepted_invitation = @provider.invitations.create!(:email => 'buddy@example.net')
-    last_sent_at = @unaccepted_invitation.sent_at
-
-    Timecop.travel(2.days.from_now) do
-      @unaccepted_invitation.resend
-      assert_not_equal last_sent_at, @unaccepted_invitation.sent_at
-    end
   end
 
   test '#resend accepted should not send invitation email' do
@@ -145,15 +126,4 @@ class InvitationTest < ActiveSupport::TestCase
     assert Invitation.pending.include?(@pending)
     refute Invitation.pending.include?(@accepted)
   end
-
-  # regression test for: https://github.com/3scale/system/pull/3316
-  test 'send invitation with helper tag' do
-    buyer = FactoryBot.create(:simple_buyer, provider_account: @provider)
-    FactoryBot.create(:cms_email_template, system_name: 'invitation', provider: @provider, published: '{% debug:help %}', rails_view_path: 'emails/invitation')
-
-    assert_difference('ActionMailer::Base.deliveries.count') do
-      FactoryBot.create(:invitation, account: buyer)
-    end
-  end
-
 end

--- a/test/workers/send_user_invitation_worker_test.rb
+++ b/test/workers/send_user_invitation_worker_test.rb
@@ -25,7 +25,7 @@ class SendUserInvitationWorkerTest < ActiveJob::TestCase
     assert invitation.reload.sent_at
   end
 
-  def test_perform_ssl_error
+  def test_handles_ssl_error
     ProviderInvitationMailer.any_instance.expects(:invitation).raises(OpenSSL::SSL::SSLError)
 
     invitation = FactoryBot.create(:invitation)

--- a/test/workers/send_user_invitation_worker_test.rb
+++ b/test/workers/send_user_invitation_worker_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SendUserInvitationWorkerTest < ActiveJob::TestCase
+  def test_provider_mailer_perform
+    ProviderInvitationMailer.any_instance.expects(:invitation).once
+
+    provider_account = FactoryBot.create(:provider_account)
+    invitation = FactoryBot.create(:invitation, account: provider_account)
+
+    assert_nil invitation.sent_at
+    SendUserInvitationWorker.new.perform(invitation.id)
+    assert invitation.reload.sent_at
+  end
+
+  def test_buyer_mailer_perform
+    InvitationMailer.any_instance.expects(:invitation).once
+
+    buyer_account = FactoryBot.create(:buyer_account)
+    invitation = FactoryBot.create(:invitation, account: buyer_account)
+
+    assert_nil invitation.sent_at
+    SendUserInvitationWorker.new.perform(invitation.id)
+    assert invitation.reload.sent_at
+  end
+
+  def test_perform_ssl_error
+    ProviderInvitationMailer.any_instance.expects(:invitation).raises(OpenSSL::SSL::SSLError)
+
+    invitation = FactoryBot.create(:invitation)
+
+    assert_nil invitation.sent_at
+    SendUserInvitationWorker.new.perform(invitation.id)
+    assert_nil invitation.reload.sent_at
+  end
+
+  def test_handles_smpt_error
+    ProviderInvitationMailer.any_instance.expects(:invitation).raises(Net::SMTPAuthenticationError)
+
+    invitation = FactoryBot.create(:invitation)
+
+    assert_nil invitation.sent_at
+    SendUserInvitationWorker.new.perform(invitation.id)
+    assert_nil invitation.reload.sent_at
+  end
+
+  def test_handles_socket_error
+    ProviderInvitationMailer.any_instance.expects(:invitation).raises(SocketError)
+
+    invitation = FactoryBot.create(:invitation)
+
+    assert_nil invitation.sent_at
+    SendUserInvitationWorker.new.perform(invitation.id)
+    assert_nil invitation.reload.sent_at
+  end
+
+  def test_handles_not_found_error
+    ProviderInvitationMailer.any_instance.expects(:invitation).raises(ActiveRecord::RecordNotFound)
+
+    invitation = FactoryBot.create(:invitation)
+
+    assert_nil invitation.sent_at
+    SendUserInvitationWorker.new.perform(invitation.id)
+    assert_nil invitation.reload.sent_at
+  end
+end

--- a/test/workers/send_user_invitation_worker_test.rb
+++ b/test/workers/send_user_invitation_worker_test.rb
@@ -30,7 +30,11 @@ class SendUserInvitationWorkerTest < ActiveJob::TestCase
   end
 
   def test_handles_errors
-    SendUserInvitationWorker::ERRORS.each do |error_class|
+    errors = [
+      *SendUserInvitationWorker::RETRY_ERRORS,
+      *SendUserInvitationWorker::DISCARD_ERRORS,
+    ]
+    errors.each do |error_class|
       ProviderInvitationMailer.any_instance.expects(:invitation).raises(error_class)
 
       invitation = FactoryBot.create(:invitation)

--- a/test/workers/send_user_invitation_worker_test.rb
+++ b/test/workers/send_user_invitation_worker_test.rb
@@ -4,64 +4,53 @@ require 'test_helper'
 
 class SendUserInvitationWorkerTest < ActiveJob::TestCase
   def test_provider_mailer_perform
-    ProviderInvitationMailer.any_instance.expects(:invitation).once
+    Timecop.freeze(Time.zone.parse('2017-11-23 03:25:08 UTC +00:00')) do
+      ProviderInvitationMailer.any_instance.expects(:invitation).once
 
-    provider_account = FactoryBot.create(:provider_account)
-    invitation = FactoryBot.create(:invitation, account: provider_account)
+      provider_account = FactoryBot.create(:provider_account)
+      invitation = FactoryBot.create(:invitation, account: provider_account)
 
-    assert_nil invitation.sent_at
-    SendUserInvitationWorker.new.perform(invitation.id)
-    assert invitation.reload.sent_at
+      assert_not invitation.sent_at
+      SendUserInvitationWorker.new.perform(invitation.id)
+      assert_in_delta Time.zone.now, invitation.reload.sent_at, 1.second
+    end
   end
 
   def test_buyer_mailer_perform
-    InvitationMailer.any_instance.expects(:invitation).once
+    Timecop.freeze(Time.zone.parse('2017-11-23 03:25:08 UTC +00:00')) do
+      InvitationMailer.any_instance.expects(:invitation).once
 
-    buyer_account = FactoryBot.create(:buyer_account)
-    invitation = FactoryBot.create(:invitation, account: buyer_account)
+      buyer_account = FactoryBot.create(:buyer_account)
+      invitation = FactoryBot.create(:invitation, account: buyer_account)
 
-    assert_nil invitation.sent_at
-    SendUserInvitationWorker.new.perform(invitation.id)
-    assert invitation.reload.sent_at
+      assert_not invitation.sent_at
+      SendUserInvitationWorker.new.perform(invitation.id)
+      assert_in_delta Time.zone.now, invitation.reload.sent_at, 1.second
+    end
   end
 
-  def test_handles_ssl_error
-    ProviderInvitationMailer.any_instance.expects(:invitation).raises(OpenSSL::SSL::SSLError)
+  def test_handles_errors
+    errors = SendUserInvitationWorker::RETRY_ERRORS + SendUserInvitationWorker::DISCARD_ERRORS
+    errors.each do |error_class|
+      ProviderInvitationMailer.any_instance.expects(:invitation).raises(error_class)
 
-    invitation = FactoryBot.create(:invitation)
+      invitation = FactoryBot.create(:invitation)
 
-    assert_nil invitation.sent_at
-    SendUserInvitationWorker.new.perform(invitation.id)
-    assert_nil invitation.reload.sent_at
+      assert_not invitation.sent_at
+      SendUserInvitationWorker.new.perform(invitation.id)
+      assert_not invitation.reload.sent_at, error_class.to_s
+    end
   end
 
-  def test_handles_smpt_error
-    ProviderInvitationMailer.any_instance.expects(:invitation).raises(Net::SMTPAuthenticationError)
-
+  # regression test for: https://github.com/3scale/system/pull/3316
+  def test_send_invitation_with_helper_tag
+    provider = FactoryBot.create(:simple_provider)
+    buyer = FactoryBot.create(:simple_buyer, provider_account: provider)
+    FactoryBot.create(:cms_email_template, system_name: 'invitation', provider: provider, published: '{% debug:help %}', rails_view_path: 'emails/invitation')
     invitation = FactoryBot.create(:invitation)
 
-    assert_nil invitation.sent_at
-    SendUserInvitationWorker.new.perform(invitation.id)
-    assert_nil invitation.reload.sent_at
-  end
-
-  def test_handles_socket_error
-    ProviderInvitationMailer.any_instance.expects(:invitation).raises(SocketError)
-
-    invitation = FactoryBot.create(:invitation)
-
-    assert_nil invitation.sent_at
-    SendUserInvitationWorker.new.perform(invitation.id)
-    assert_nil invitation.reload.sent_at
-  end
-
-  def test_handles_not_found_error
-    ProviderInvitationMailer.any_instance.expects(:invitation).raises(ActiveRecord::RecordNotFound)
-
-    invitation = FactoryBot.create(:invitation)
-
-    assert_nil invitation.sent_at
-    SendUserInvitationWorker.new.perform(invitation.id)
-    assert_nil invitation.reload.sent_at
+    assert_difference('ActionMailer::Base.deliveries.count') do
+      SendUserInvitationWorker.new.perform(invitation.id)
+    end
   end
 end

--- a/test/workers/send_user_invitation_worker_test.rb
+++ b/test/workers/send_user_invitation_worker_test.rb
@@ -11,7 +11,7 @@ class SendUserInvitationWorkerTest < ActiveJob::TestCase
       invitation = FactoryBot.create(:invitation, account: provider_account)
 
       assert_not invitation.sent_at
-      SendUserInvitationWorker.new.perform(invitation.id)
+      SendUserInvitationWorker.new.perform(invitation)
       assert_in_delta Time.zone.now, invitation.reload.sent_at, 1.second
     end
   end
@@ -24,7 +24,7 @@ class SendUserInvitationWorkerTest < ActiveJob::TestCase
       invitation = FactoryBot.create(:invitation, account: buyer_account)
 
       assert_not invitation.sent_at
-      SendUserInvitationWorker.new.perform(invitation.id)
+      SendUserInvitationWorker.new.perform(invitation)
       assert_in_delta Time.zone.now, invitation.reload.sent_at, 1.second
     end
   end
@@ -38,7 +38,7 @@ class SendUserInvitationWorkerTest < ActiveJob::TestCase
       assert_not invitation.sent_at
       worker = SendUserInvitationWorker.new
       worker.expects(:retry_job)
-      worker.perform(invitation.id)
+      worker.perform(invitation)
       assert_not invitation.reload.sent_at
     end
   end
@@ -51,7 +51,7 @@ class SendUserInvitationWorkerTest < ActiveJob::TestCase
     invitation = FactoryBot.create(:invitation)
 
     assert_difference('ActionMailer::Base.deliveries.count') do
-      SendUserInvitationWorker.new.perform(invitation.id)
+      SendUserInvitationWorker.new.perform(invitation)
     end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Invitation delivery is notified as "successfully sent" when it really isn't.
1. Change the message to "it will be sent"
2. Update the colum `sent_at` only after the email has been sent by the Mailer

<img width="900" alt="Screen Shot 2020-08-13 at 12 10 15" src="https://user-images.githubusercontent.com/11672286/90122658-e6acc200-dd5d-11ea-9a38-e5f171cc5537.png">

**Which issue(s) this PR fixes** 

[THREESCALE-4360: Using "Invite New User" button, no verification that email is sent](https://issues.redhat.com/browse/THREESCALE-4360)

**Verification steps** 

1. Go to `p/admin/account/invitations` and create a new invitation.
2. The notification should say it will be sent
3. Refresh and check the column `Sent` shows the correct value (perhaps blanks at first, email should be sent not inmediately)
