### PR TITLE
Fix Invitation send message with Observer

### DIFF
--- a/app/controllers/buyers/invitations_controller.rb
+++ b/app/controllers/buyers/invitations_controller.rb
@@ -12,7 +12,7 @@ class Buyers::InvitationsController < Buyers::BaseController
   create! do |success, failure|
     success.html do
       redirect_to admin_buyers_account_invitations_path(@account),
-                  notice: 'Invitation was successfully sent.'
+                  notice: 'Invitation will be sent soon.'
     end
   end
 
@@ -26,7 +26,7 @@ class Buyers::InvitationsController < Buyers::BaseController
 
     respond_to do |format|
       format.html do
-        flash[:success] = "Invitation was successfully resent"
+        flash[:success] = 'Invitation will be sent soon.'
         redirect_to(admin_buyers_account_invitations_path(@account))
       end
       format.xml  { head :ok }

--- a/app/controllers/provider/admin/account/invitations_controller.rb
+++ b/app/controllers/provider/admin/account/invitations_controller.rb
@@ -10,7 +10,7 @@ class Provider::Admin::Account::InvitationsController < Provider::Admin::Account
   create! do |success, failure|
     success.html do
       redirect_to provider_admin_account_invitations_path,
-                  notice: 'Invitation was successfully sent.'
+                  notice: 'Invitation will be sent soon.'
     end
   end
 
@@ -24,7 +24,7 @@ class Provider::Admin::Account::InvitationsController < Provider::Admin::Account
 
     respond_to do |format|
       format.html do
-        flash[:success] = "Invitation was successfully resent"
+        flash[:success] = 'Invitation will be sent soon.'
         redirect_to provider_admin_account_invitations_path
       end
       format.xml  { head :ok }

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -1,6 +1,6 @@
 module InvitationsHelper
   def invitation_sent_date(invitation)
-    (invitation.sent_at.presence || invitation.created_at).to_s(:long)
+    invitation.sent_at || '-'
   end
 
   def invitation_status(invitation)

--- a/app/lib/three_scale/invitation_email_delivery_observer.rb
+++ b/app/lib/three_scale/invitation_email_delivery_observer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ThreeScale::InvitationEmailDeliveryObserver
+  def self.delivered_email(message)
+    binding.pry
+    user = User.find_by(email: message.from)
+
+    invitations = user ? user.account.invitations : Invitation
+    invitations.find_by!(email: message.to)
+               .update!(sent_at: Time.zone.now)
+  end
+end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -64,8 +64,6 @@ class Invitation < ApplicationRecord
     else
       InvitationMailer.invitation(self).deliver_now
     end
-
-    update_column(:sent_at, Time.zone.now)
   end
 
 end

--- a/config/initializers/email_delivery_observer.rb
+++ b/config/initializers/email_delivery_observer.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+ProviderInvitationMailer.register_observer ThreeScale::InvitationEmailDeliveryObserver
+InvitationMailer.register_observer ThreeScale::InvitationEmailDeliveryObserver

--- a/test/unit/three_scale/invitation_email_delivery_observer_test.rb
+++ b/test/unit/three_scale/invitation_email_delivery_observer_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ThreeScale::InvitationEmailDeliveryObserverTest < ActiveSupport::TestCase
+  # include ActionMailer::TestHelper
+
+  def setup
+    # InvitationMailer.register_observer ThreeScale::InvitationEmailDeliveryObserver
+  end
+
+  def test_update_date_after_sent_only
+    # assert_no_emails do
+      invitation = FactoryBot.create(:invitation)
+      mailer = nil
+
+      date = Date.parse('2019-09-01')
+      Timecop.freeze(date) do
+      #   perform_enqueued_jobs do
+      #     mailer     = InvitationMailer.invitation(@invitation)
+          assert_nil invitation.sent_at
+      #   end
+      end
+    # end
+
+    # assert_emails 0 do
+    #   invitation.expects(:update_column).once
+
+    #   Invitation.expects(find_by).once.return(invitation)
+
+    #   assert_nil invitation.sent_at
+    # end
+
+    # assert_emails 1 do
+    #   @mailer.deliver_now
+    # end
+  end
+
+end


### PR DESCRIPTION
### Alternative for #2092

**What this PR does / why we need it**:

Invitation delivery is notified as "successfully sent" when it really isn't.
1. Change the message to "it will be sent"
2. Update the column `sent_at` only after the email has been sent by the Mailer

**Which issue(s) this PR fixes** 

[THREESCALE-4360: Using "Invite New User" button, no verification that email is sent](https://issues.redhat.com/browse/THREESCALE-4360)

**Verification steps** 

1. Go to `p/admin/account/invitations` and create a new invitation.
2. The notification should say it _will_ be sent
3. Refresh and check the column `Sent` shows the correct value (perhaps blanks at first, email should be sent not inmediately)
4. Hitting _Resend_ also should update the _Sent at_ column values.
