### PR TITLE
Fixes wizard's test request

### DIFF
--- a/app/forms/onboarding/request_form.rb
+++ b/app/forms/onboarding/request_form.rb
@@ -39,7 +39,9 @@ class Onboarding::RequestForm < Reform::Form
 
   def uri
     return unless model.api_backend
-    URI.join(api_base_url, path || SLASH).to_s
+    base_url = api_base_url
+    test_path = File.join(base_url.try(:path).to_s, path.to_s)
+    URI.join(base_url, test_path).to_s
   end
 
   def proxy_auth_params

--- a/app/services/proxy_test_service.rb
+++ b/app/services/proxy_test_service.rb
@@ -96,9 +96,15 @@ class ProxyTestService
       uri = URI(override)
     end
 
-    uri.merge!(proxy.api_test_path.to_s)
+    path = File.join(uri.path.to_s, backend_api_config_path.to_s, proxy.api_test_path.to_s)
+    uri.merge!(path)
 
     uri
+  end
+
+  def backend_api_config_path
+    return unless proxy.provider_can_use?(:api_as_product)
+    proxy.backend_api_configs.first&.path
   end
 
   def api_test_host

--- a/test/integration/provider/admin/onboarding/wizard/request_controller_test.rb
+++ b/test/integration/provider/admin/onboarding/wizard/request_controller_test.rb
@@ -24,10 +24,10 @@ class Provider::Admin::Onboarding::Wizard::RequestControllerTest < ActionDispatc
     stub_request(:get, %r{staging\.apicast\.dev}).to_return(status: 200, body: 'some body response')
 
     put provider_admin_onboarding_wizard_request_path(request: { path: nil })
-    assert_redirected_to provider_admin_onboarding_wizard_request_path(response: 'some body response')
+    assert_redirected_to provider_admin_onboarding_wizard_request_path(response: encode('some body response'))
 
     put provider_admin_onboarding_wizard_request_path(request: { path: '/path' })
-    assert_redirected_to provider_admin_onboarding_wizard_request_path(response: 'some body response')
+    assert_redirected_to provider_admin_onboarding_wizard_request_path(response: encode('some body response'))
 
     put provider_admin_onboarding_wizard_request_path(request: { path: 'some invalid !!! path' })
     assert_response :success
@@ -36,5 +36,26 @@ class Provider::Admin::Onboarding::Wizard::RequestControllerTest < ActionDispatc
     put provider_admin_onboarding_wizard_request_path(request: { path: '/path' })
     assert_response :success
     assert_match 'please try again', response.body
+  end
+
+  test '#update truncates large api response before redirect' do
+    very_long_api_response = 'some body response ' * 1000
+    stub_request(:get, %r{staging\.apicast\.dev}).to_return(status: 200, body: very_long_api_response)
+
+    truncated_response = very_long_api_response.slice(0...7669) + '…' # (1024*10-10)/(4/3) - 3 = 7669. Notice that -10 is due to reserved_bytes = provider_admin_onboarding_wizard_request_path(response: '').bytesize
+    put provider_admin_onboarding_wizard_request_path(request: { path: nil })
+    assert_redirected_to provider_admin_onboarding_wizard_request_path(response: encode(truncated_response))
+  end
+
+  test '#show decodes the response' do
+    encoded_response = encode('some body response')
+    get provider_admin_onboarding_wizard_request_path(response: encoded_response)
+    assert_match /some body response/, response.body
+  end
+
+  protected
+
+  def encode(content)
+    Base64.urlsafe_encode64(content, padding: false)
   end
 end

--- a/test/unit/services/proxy_test_service_test.rb
+++ b/test/unit/services/proxy_test_service_test.rb
@@ -1,23 +1,27 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ProxyTestServiceTest < ActiveSupport::TestCase
 
   def setup
     @proxy = FactoryBot.build_stubbed(:proxy)
-    @service = ProxyTestService.new(@proxy)
+    @test_service = ProxyTestService.new(proxy)
   end
 
-  def test_api_test_path
-    @proxy.sandbox_endpoint = 'http://example.com'
-    @proxy.api_test_path = 'api_test_path'
+  attr_reader :proxy, :test_service
 
-    assert_equal 'http://example.com/api_test_path', @service.api_test_path.to_s
+  test '#api_test_path' do
+    proxy.sandbox_endpoint = 'http://example.com'
+    proxy.api_test_path = 'api_test_path'
 
-    @service.config = @service.config.merge(override: 'https://example.net:8090/path/')
-    assert_equal 'https://example.net:8090/path/api_test_path', @service.api_test_path.to_s
+    assert_equal 'http://example.com/api_test_path', test_service.api_test_path.to_s
+
+    test_service.config = test_service.config.merge(override: 'https://example.net:8090/path/')
+    assert_equal 'https://example.net:8090/path/api_test_path', test_service.api_test_path.to_s
   end
 
-  test 'api_test_path with backend api config path' do
+  test '#api_test_path with backend api config path' do
     proxy = FactoryBot.create(:proxy)
     proxy.service.backend_api_configs.first.update(path: '/echo')
     proxy.sandbox_endpoint = 'http://example.com'
@@ -27,96 +31,96 @@ class ProxyTestServiceTest < ActiveSupport::TestCase
     assert_equal 'http://example.com/echo/hello', test_service.api_test_path.to_s
   end
 
-  def test_api_test_host
-    @proxy.sandbox_endpoint = 'http://example.com:8080'
+  test '#api_test_host' do
+    proxy.sandbox_endpoint = 'http://example.com:8080'
 
-    assert_equal 'example.com', @service.api_test_host
+    assert_equal 'example.com', test_service.api_test_host
   end
 
-  def test_credentials
-    @proxy.stubs(:authentication_params_for_proxy).returns({user_key: 'abcd'})
+  test '#credentials' do
+    proxy.stubs(:authentication_params_for_proxy).returns({user_key: 'abcd'})
 
-    assert_equal({query: {user_key: 'abcd'}}, @service.credentials)
+    assert_equal({query: {user_key: 'abcd'}}, test_service.credentials)
 
-    @proxy.credentials_location = 'headers'
-    assert_equal({header: {user_key: 'abcd'}}, @service.credentials)
+    proxy.credentials_location = 'headers'
+    assert_equal({header: {user_key: 'abcd'}}, test_service.credentials)
 
-    @proxy.credentials_location = 'authorization'
+    proxy.credentials_location = 'authorization'
 
     encoded_string = Base64.encode64("abcd:").strip
-    assert_equal({header: {'Authorization' => "Basic #{encoded_string}"}}, @service.credentials)
+    assert_equal({header: {'Authorization' => "Basic #{encoded_string}"}}, test_service.credentials)
 
-    @proxy.stubs(:authentication_params_for_proxy).returns({app_id: 'abcd', app_key: 'efgh'})
+    proxy.stubs(:authentication_params_for_proxy).returns({app_id: 'abcd', app_key: 'efgh'})
     encoded_string = Base64.encode64("abcd:efgh").strip
-    assert_equal({header: {'Authorization' => "Basic #{encoded_string}"}}, @service.credentials)
+    assert_equal({header: {'Authorization' => "Basic #{encoded_string}"}}, test_service.credentials)
   end
 
-  def test_client
-    client = @service.http_client
+  test 'http client options' do
+    client = test_service.http_client
 
     assert_equal 10, client.connect_timeout
     assert_equal 10, client.send_timeout
     assert_equal 10, client.receive_timeout
   end
 
-  def test_perform
-    @proxy.service.expects(:plugin_authentication_params).returns(user_key: 'SOME_KEY').at_least_once
+  test '#perform' do
+    proxy.service.expects(:plugin_authentication_params).returns(user_key: 'SOME_KEY').at_least_once
 
-    @proxy.sandbox_endpoint = nil
-    @proxy.api_test_path = nil
+    proxy.sandbox_endpoint = nil
+    proxy.api_test_path = nil
 
-    refute @service.perform.success?, 'invalid url should fail'
+    refute test_service.perform.success?, 'invalid url should fail'
 
-    @proxy.api_backend = 'http://api-sentiment.3scale.net'
-    @proxy.sandbox_endpoint = 'http://proxy:80'
-    @proxy.api_test_path = '/v1/word/stuff.json'
-    @proxy.secret_token = '123'
+    proxy.api_backend = 'http://api-sentiment.3scale.net'
+    proxy.sandbox_endpoint = 'http://proxy:80'
+    proxy.api_test_path = '/v1/word/stuff.json'
+    proxy.secret_token = '123'
 
-    assert_equal 'http://proxy/v1/word/stuff.json', @service.api_test_path.to_s
+    assert_equal 'http://proxy/v1/word/stuff.json', test_service.api_test_path.to_s
     successful_request = stub_request(:get, 'http://proxy/v1/word/stuff.json?user_key=SOME_KEY')
         .to_return(status: 200)
 
-    result = @service.perform
+    result = test_service.perform
     assert result.success?, 'result should be successful'
     assert_empty Array(result.error)
     assert_requested successful_request
 
-    @proxy.api_test_path = '/v2/word/stuff.json'
-    assert_equal 'http://proxy/v2/word/stuff.json', @service.api_test_path.to_s
+    proxy.api_test_path = '/v2/word/stuff.json'
+    assert_equal 'http://proxy/v2/word/stuff.json', test_service.api_test_path.to_s
     failed_request = stub_request(:get, 'http://proxy/v2/word/stuff.json?user_key=SOME_KEY')
                          .to_return(status: 500, body: 'some body')
 
-    result = @service.perform
+    result = test_service.perform
     refute result.success?, 'api_test_request did not fail'
     assert_equal ['Test request failed with HTTP code 500', 'some body'], result.error
     assert_requested failed_request
 
-    @proxy.credentials_location = 'headers'
-    headers_credentials = stub_request(:get, 'http://proxy' + @proxy.api_test_path).with(headers: {'User-Key' => 'SOME_KEY'})
-    assert @service.perform.success?
+    proxy.credentials_location = 'headers'
+    headers_credentials = stub_request(:get, 'http://proxy' + proxy.api_test_path).with(headers: {'User-Key' => 'SOME_KEY'})
+    assert test_service.perform.success?
     assert_requested headers_credentials
 
     overriden_host = stub_request(:get, 'https://example.com/v2/word/stuff.json')
                        .with(headers: { 'Host' => 'proxy' })
                        .to_return(status: 200)
 
-    @service.config = @service.config.merge(override: 'https://example.com')
+    test_service.config = test_service.config.merge(override: 'https://example.com')
 
-    assert @service.perform.success?
+    assert test_service.perform.success?
     assert_requested overriden_host
 
-    @proxy.api_test_path = '/v2/net/error.json'
-    assert_equal 'https://example.com/v2/net/error.json', @service.api_test_path.to_s
+    proxy.api_test_path = '/v2/net/error.json'
+    assert_equal 'https://example.com/v2/net/error.json', test_service.api_test_path.to_s
     failed_request = stub_request(:get, 'https://example.com/v2/net/error.json')
                          .to_raise(Errno::EHOSTUNREACH.new('proxy'))
-    result = @service.perform
+    result = test_service.perform
     assert_requested failed_request
     assert result.error
 
   end
 
-  def test_disabled?
-    @proxy.stubs(deployment_option: 'service_mesh_istio')
-    assert @service.disabled?
+  test '#disabled?' do
+    proxy.stubs(deployment_option: 'service_mesh_istio')
+    assert test_service.disabled?
   end
 end

--- a/test/unit/services/proxy_test_service_test.rb
+++ b/test/unit/services/proxy_test_service_test.rb
@@ -17,6 +17,16 @@ class ProxyTestServiceTest < ActiveSupport::TestCase
     assert_equal 'https://example.net:8090/path/api_test_path', @service.api_test_path.to_s
   end
 
+  test 'api_test_path with backend api config path' do
+    proxy = FactoryBot.create(:proxy)
+    proxy.service.backend_api_configs.first.update(path: '/echo')
+    proxy.sandbox_endpoint = 'http://example.com'
+    proxy.api_test_path = 'hello'
+    test_service = ProxyTestService.new(proxy)
+
+    assert_equal 'http://example.com/echo/hello', test_service.api_test_path.to_s
+  end
+
   def test_api_test_host
     @proxy.sandbox_endpoint = 'http://example.com:8080'
 


### PR DESCRIPTION
Tests requests in the Admin Portal onboarding wizard are currently broken for 2 reasons:

1. It does not take into account the API backend usage routing paths and keeps sending the request to `<sandbox_endpoint>/<api_test_path>`.
2. Even when the test request works, if the response contains characters that are not ideally escaped by `CGI.escape`, or if it's too long, the next screen of the wizard breaks with a 502 or 414 error message (respectively).

This PR addresses these two issues. It ensures a proper APIAP-compatible URL is built for the test request, including the chosen routing path and API test path (1st issue). It also encodes and truncates the test API response before carrying it along to the next step of the wizard, thus preventing from a long or poorly encoded response body breaks the redirect (2nd issue).

<img width="1729" alt="Screenshot 2020-08-06 at 12 38 13" src="https://user-images.githubusercontent.com/1842261/89523917-f2d7d300-d7e3-11ea-847c-dc81cb7f3253.png">



**References about the limit of characters to carry on in the query string of an HTTP request (1024*10 bytes), as imposed by Unicorn and Thin:**
- Unicorn: https://yhbt.net/unicorn.git/tree/ext/unicorn_http/global_variables.h?h=v5.4.1#n68
- Thin: https://github.com/macournoyer/thin/blob/f83ab677f008afcfabcdfa8930225f6cea88f461/ext/thin_parser/thin.c#L71

Web browsers and server may support more than that: https://stackoverflow.com/questions/812925/what-is-the-maximum-possible-length-of-a-query-string. However, the request will break once it hits the Rails server anyway.

----

Closes [THREESCALE-5353](https://issues.redhat.com/browse/THREESCALE-5353)