### PR TITLE
Remove '.decorate' from Helpers

### DIFF
--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -41,6 +41,7 @@ class Api::ApplicationsController < Api::BaseController
                       .scope_search(@search).order_by(params[:sort], params[:direction])
                       .preload(:service, user_account: [:admin_user], plan: [:pricing_rules])
                       .paginate(pagination_params)
+                      .decorate
   end
 
   def show

--- a/app/controllers/buyers/applications_controller.rb
+++ b/app/controllers/buyers/applications_controller.rb
@@ -46,6 +46,7 @@ class Buyers::ApplicationsController < FrontendController
       .scope_search(@search).order_by(params[:sort], params[:direction])
       .preload(:service, user_account: [:admin_user], plan: [:pricing_rules])
       .paginate(pagination_params)
+      .decorate
 
     display_view_portion!(:service) if current_account.multiservice?
   end

--- a/app/controllers/buyers/service_contracts_controller.rb
+++ b/app/controllers/buyers/service_contracts_controller.rb
@@ -33,11 +33,10 @@ class Buyers::ServiceContractsController < Buyers::BaseController
       activate_menu :audience, :accounts, :listing
     end
 
-    scope = current_account.provided_service_contracts
+    @service_contracts = current_account.provided_service_contracts
               .scope_search(@search).order_by(*sorting_params)
               .paginate(pagination_params)
-
-    @service_contracts = scope
+              .decorate
 
     activate_menu :serviceadmin, :subscriptions if @service
   end

--- a/app/controllers/finance/provider/invoices_controller.rb
+++ b/app/controllers/finance/provider/invoices_controller.rb
@@ -11,7 +11,7 @@ class Finance::Provider::InvoicesController < Finance::Provider::BaseController
 
   def index
     @search = ThreeScale::Search.new(params[:search] || params)
-    @invoices = collection.scope_search(@search).order_by(params[:sort], params[:direction]).paginate(paginate_params)
+    @invoices = collection.scope_search(@search).order_by(params[:sort], params[:direction]).paginate(paginate_params).decorate
   end
 
   def create

--- a/app/controllers/provider/admin/messages/inbox_controller.rb
+++ b/app/controllers/provider/admin/messages/inbox_controller.rb
@@ -3,7 +3,7 @@ class Provider::Admin::Messages::InboxController < FrontendController
   activate_menu :buyers, :messages, :inbox
 
   def index
-    @messages = current_account.received_messages.not_system.latest_first.paginate(page: params[:page])
+    @messages = current_account.received_messages.not_system.latest_first.paginate(page: params[:page]).decorate
   end
 
   def show
@@ -36,6 +36,6 @@ class Provider::Admin::Messages::InboxController < FrontendController
   end
 
   def find_message
-    @message = current_account.received_messages.find(params[:id])
+    @message = current_account.received_messages.find(params[:id]).decorate
   end
 end

--- a/app/controllers/provider/admin/messages/outbox_controller.rb
+++ b/app/controllers/provider/admin/messages/outbox_controller.rb
@@ -32,11 +32,11 @@ class Provider::Admin::Messages::OutboxController < FrontendController
   end
 
   def index
-    @messages = current_account.messages.not_system_for_provider.latest_first.paginate(page: params[:page])
+    @messages = current_account.messages.not_system_for_provider.latest_first.paginate(page: params[:page]).decorate
   end
 
   def show
-    @message = current_account.messages.find(params[:id])
+    @message = current_account.messages.find(params[:id]).decorate
   end
 
   private

--- a/app/controllers/provider/admin/messages/trash_controller.rb
+++ b/app/controllers/provider/admin/messages/trash_controller.rb
@@ -4,7 +4,10 @@ class Provider::Admin::Messages::TrashController < FrontendController
 
   def index
     @messages = current_account.trashed_messages
-                               .not_system.latest_first.paginate(page: params[:page])
+                               .not_system
+                               .latest_first
+                               .paginate(page: params[:page])
+                               .decorate
   end
 
   def show
@@ -29,6 +32,6 @@ class Provider::Admin::Messages::TrashController < FrontendController
   private
 
   def find_message
-    @message = current_account.trashed_messages.not_system.find(params[:id])
+    @message = current_account.trashed_messages.not_system.find(params[:id]).decorate
   end
 end

--- a/app/decorators/contract_decorator.rb
+++ b/app/decorators/contract_decorator.rb
@@ -3,8 +3,6 @@
 class ContractDecorator < ApplicationDecorator
   delegate :admin_user_display_name, to: :account, prefix: :account
 
-  private
-
   def account
     @account ||= super.decorate
   end

--- a/app/decorators/invoice_decorator.rb
+++ b/app/decorators/invoice_decorator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class InvoiceDecorator < ApplicationDecorator
+  # This smells of :reek:NilCheck
+  def buyer
+    @buyer ||= super&.decorate
+  end
+end

--- a/app/decorators/message_decorator.rb
+++ b/app/decorators/message_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class MessageDecorator < ApplicationDecorator
+  def sender
+    @sender ||= super.decorate
+  end
+
+  def recipients
+    @recipients ||= super.decorate
+  end
+end

--- a/app/decorators/message_recipient_decorator.rb
+++ b/app/decorators/message_recipient_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class MessageRecipientDecorator < ApplicationDecorator
+  def receiver
+    @receiver ||= super.decorate
+  end
+
+  def sender
+    @sender ||= super.decorate
+  end
+end

--- a/app/helpers/buyers/accounts_helper.rb
+++ b/app/helpers/buyers/accounts_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Buyers::AccountsHelper
 
   def public_domain(account)
@@ -5,8 +7,8 @@ module Buyers::AccountsHelper
     "http://#{account.domain}#{access_code}".html_safe
   end
 
-  def account_title account
-    [ h(account.org_name), h(account.decorate.admin_user_display_name) ].compact.join(" &mdash; ").html_safe
+  def account_title(account)
+    [h(account.org_name), h(account.admin_user_display_name)].compact.join(" &mdash; ").html_safe
   end
 
   def link_to_buyer_or_deleted( buyer, path_method = :admin_buyers_account_path)

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,15 +1,14 @@
 module MessagesHelper
-  # Format name of message receiver(s). Do not display each recipient's name, if there
-  # are multiple
+  # Format name of message receiver(s). Do not display each recipient's name, if there are multiple
+  # This smells of :reek:NilCheck
   def message_receiver(message)
-    if message.recipients.count > 1
-      "Multiple Recipients"
-    else
-      receiver = message.recipients.first.try!(:receiver)
-      (receiver.nil? || receiver.buyer?) ? link_to_buyer_or_deleted(receiver) : receiver.org_name
-    end
+    return 'Multiple Recipients' if message.recipients.count > 1
+
+    receiver = message.recipients.first&.receiver
+    (receiver.nil? || receiver.buyer?) ? link_to_buyer_or_deleted(receiver) : receiver.org_name
   end
 
+  # This smells of :reek:NilCheck
   def message_sender(message)
     sender = message.sender
     (sender.nil? || sender.buyer?) ? link_to_buyer_or_deleted(sender) : sender.org_name

--- a/app/views/buyers/applications/_listing.html.slim
+++ b/app/views/buyers/applications/_listing.html.slim
@@ -99,7 +99,7 @@ table class="data"
           - if cinstance.trial?
             = remaining_trial_days(cinstance)
         - unless @account
-          td = link_to_buyer_or_deleted cinstance.user_account, :admin_buyers_account_path
+          td = link_to_buyer_or_deleted cinstance.account, :admin_buyers_account_path
         - if display_view_portion?(:service)
           td = link_to_service cinstance.service
         - if show_application_plans

--- a/test/decorators/invoice_decorator_test.rb
+++ b/test/decorators/invoice_decorator_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class InvoiceDecoratorTest < Draper::TestCase
+  test '#buyer' do
+    invoice = FactoryBot.build_stubbed(:invoice)
+
+    assert_equal invoice.buyer.id, invoice.decorate.buyer.id
+    assert_instance_of AccountDecorator, invoice.decorate.buyer
+  end
+end

--- a/test/decorators/message_decorator_test.rb
+++ b/test/decorators/message_decorator_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MessageDecoratorTest < Draper::TestCase
+  test '#sender is decorated' do
+    message = FactoryBot.build_stubbed(:message)
+    decorated_message_sender = message.decorate.sender
+
+    assert_equal AccountDecorator, decorated_message_sender.class
+    assert_equal message.sender.id, decorated_message_sender.id
+  end
+
+  test '#recipients are decorated' do
+    receivers = FactoryBot.create_list(:simple_buyer, 2)
+    message = FactoryBot.create(:message, to: receivers)
+
+    decorated_message_recipients = message.decorate.recipients
+
+    assert_same_elements message.recipients.map(&:id), decorated_message_recipients.map(&:id)
+    assert decorated_message_recipients.all? { |recipient| recipient.is_a?(MessageRecipientDecorator) }
+  end
+end

--- a/test/decorators/message_recipient_decorator_test.rb
+++ b/test/decorators/message_recipient_decorator_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MessageRecipientDecoratorTest < Draper::TestCase
+  test '#sender is decorated' do
+    message = FactoryBot.create(:message, to: FactoryBot.create(:simple_buyer))
+    decorated_message_recipient = message.recipients.first.decorate
+
+    assert_equal AccountDecorator, decorated_message_recipient.sender.class
+    assert_equal message.sender.id, decorated_message_recipient.sender.id
+  end
+
+  test '#receiver is decorated' do
+    message = FactoryBot.create(:message, to: FactoryBot.create(:simple_buyer))
+    decorated_message_recipient = message.recipients.first.decorate
+
+    assert_equal message.recipients.first.receiver.id, decorated_message_recipient.receiver.id
+    assert_instance_of AccountDecorator, decorated_message_recipient.receiver
+  end
+end

--- a/test/unit/helpers/messages_helper_test.rb
+++ b/test/unit/helpers/messages_helper_test.rb
@@ -15,9 +15,11 @@ class MessagesHelperTest < ActionView::TestCase
     end
 
     should 'return link to buyer for buyer recipient' do
-      message = FactoryBot.create(:message, :to => [@buyer_receiver])
-      assert_equal link_to(@buyer_receiver.org_name, admin_buyers_account_path(@buyer_receiver), :title => account_title(@buyer_receiver)),
-                   message_receiver(message)
+      message = FactoryBot.create(:message, to: [@buyer_receiver]).decorate
+      expected_link = link_to(@buyer_receiver.org_name,
+                        admin_buyers_account_path(@buyer_receiver),
+                        title: account_title(@buyer_receiver.decorate))
+      assert_equal expected_link, message_receiver(message)
     end
 
     should 'return org name for provider recipient' do
@@ -47,8 +49,8 @@ class MessagesHelperTest < ActionView::TestCase
     end
 
     should 'return link to buyer account' do
-      message_from_buyer = FactoryBot.create(:message, :sender => @buyer_sender)
-      assert_equal link_to(@buyer_sender.org_name, admin_buyers_account_path(@buyer_sender), :title => account_title(@buyer_sender)),
+      message_from_buyer = FactoryBot.create(:message, sender: @buyer_sender).decorate
+      assert_equal link_to(@buyer_sender.org_name, admin_buyers_account_path(@buyer_sender), title: account_title(@buyer_sender.decorate)),
                    message_sender(message_from_buyer)
     end
 


### PR DESCRIPTION
Closes [THREESCALE-5813](https://issues.redhat.com/browse/THREESCALE-5813)
It is a bit risky because I do not know if I didn't realize about any Controller using this Helper.
After removing the `.decorate` from the helper, I've changed only the minimum necessary to make it work.


#### Why changing this code in particular
https://github.com/3scale/porta/pull/2106#issuecomment-694251124

#### Ensure that invoices keep working well
Since it is a sensitive issue. We tested in preview to confirm that it keeps working, by checking these scenarios:

1. make sure invoices have no problem to be rendered in the UI
2. the generation of the invoice PDF
