### PR TITLE
[CVE-2020-8165] Patch: Unintended unmarshalling in ActiveSupport

### DIFF
--- a/config/initializers/cve-2020-8165.rb
+++ b/config/initializers/cve-2020-8165.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# [CVE-2020-8165] https://groups.google.com/g/rubyonrails-security/c/bv6fW4S0Y1c
+# Can be removed after upgrade to Rails v5.2.4.3+
+
+ActiveSupport::Cache::MemCacheStore.prepend(Module.new do
+  protected
+
+  # Reimplements from `ActiveSupport::Cache::Strategy::LocalCache#read_entry` instead of `ActiveSupport::Cache::MemCacheStore::LocalCacheWithRaw#read_entry`
+  def read_entry(key, options)
+    if cache = local_cache
+      cache.fetch_entry(key) { super }
+    else
+      super
+    end
+  end
+
+  # Redefines just like https://groups.google.com/group/rubyonrails-security/attach/1c0cea804792a/5-2-cache-storage.patch?part=0.1
+  def deserialize_entry(entry)
+    return unless entry
+    entry.is_a?(Entry) ? entry : Entry.new(entry)
+  end
+end)

--- a/test/cves/cve-2020-8165_test.rb
+++ b/test/cves/cve-2020-8165_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CVE20208165Test < ActiveSupport::TestCase
+  # Can be removed after upgrade to Rails v5.2.4.3+
+  test "MemCacheStore#read_entry does't use LocalCacheWithRaw" do
+    local_cache = Rails.cache
+    local_cache.expects(:fetch_entry).with('foo').returns(ActiveSupport::Cache::Entry.new('bar'))
+
+    mem_cache = ActiveSupport::Cache::MemCacheStore.new('localhost')
+    mem_cache.expects(:local_cache).returns(local_cache).at_least_once
+    mem_cache.expects(:deserialize_entry).with('bar').never
+    mem_cache.send(:read_entry, 'foo', raw: true)
+  end
+end


### PR DESCRIPTION
Monkey patches Rails prior to v5.2.4.3 with the [recommended changes](https://groups.google.com/group/rubyonrails-security/attach/1c0cea804792a/5-2-cache-storage.patch?part=0.1) of [CVE-2020-8165](https://groups.google.com/g/rubyonrails-security/c/bv6fW4S0Y1c).

Closes [THREESCALE-5318](https://issues.redhat.com/browse/THREESCALE-5318)