### PR TITLE
Strong params for stats data controllers

### DIFF
--- a/app/controllers/stats/data/base_controller.rb
+++ b/app/controllers/stats/data/base_controller.rb
@@ -71,7 +71,7 @@ class Stats::Data::BaseController < ApplicationController
   private
 
   def render_usage(parameter)
-    options = slice_and_use_defaults(params, parameter,
+    options = slice_and_use_defaults(usage_params(parameter), parameter,
                                      :period, :since, :timezone, :granularity, :until, :skip_change)
     @data = @source.usage(options)
 
@@ -84,6 +84,13 @@ class Stats::Data::BaseController < ApplicationController
     end
   rescue Stats::InvalidParameterError => e
     render_error e.to_s, :status => :bad_request
+  end
+
+  def usage_params(required_parameter)
+    params.require(required_parameter)
+    permitted_params = params.permit(*%i[metric_name granularity period since until skip_change timezone application_id backend_api_id service_id response_code])
+    permitted_params.require([:granularity, :since]) if permitted_params[:period].blank?
+    permitted_params
   end
 
   # Slices supplied params to allowed set, using defaults

--- a/app/lib/stats/views/usage.rb
+++ b/app/lib/stats/views/usage.rb
@@ -132,7 +132,7 @@ module Stats
           length = 1.send(period)
 
           timezone = extract_timezone(options)
-          range_since = options[:since] && to_time(options[:since],timezone) || timezone.now - length
+          range_since = to_time(options[:since].presence || timezone.now - length, timezone)
           range_until = (range_since + length - 1.second).end_of_minute # taking a second away means excluding the extra day in case of a month, etc
 
           sanitize_range_and_granularity(range_since..range_until, granularity)
@@ -141,11 +141,11 @@ module Stats
           # due to the unfortunate use of 21600 as a valid granularity  the parameter is required to a symbol or fixnum
           raise InvalidParameterError, "Granularity must be one of #{GRANULARITIES.values.inspect}, not #{options[:granularity]}" unless GRANULARITIES.values.include?(options[:granularity]) || GRANULARITIES.values.include?(options[:granularity].to_sym)
 
-          if options[:since] && options[:until]
+          if options[:since].present? && options[:until].present?
             timezone = extract_timezone(options)
             range = to_time(options[:since], timezone)..to_time(options[:until], timezone)
             sanitize_range_and_granularity(range, options[:granularity])
-          elsif options[:range]
+          elsif options[:range].present?
             sanitize_range_and_granularity(options[:range], options[:granularity])
           else
             raise InvalidParameterError, "You need to specify either 'range' or 'since' and 'until'"

--- a/test/functional/stats/data/applications_controller_test.rb
+++ b/test/functional/stats/data/applications_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Stats::Data::ApplicationsControllerTest < ActionController::TestCase
@@ -16,11 +18,11 @@ class Stats::Data::ApplicationsControllerTest < ActionController::TestCase
     setup_data
 
     get :usage, format: :csv, application_id: @app.id, period: 'troloro'
-    assert_equal 'text/plain', response.header['Content-Type']
+    assert_match /text\/plain/, response.header['Content-Type']
     assert_equal 400, response.status
 
     get :usage_response_code, format: :csv, application_id: @app.id, period: 'troloro'
-    assert_equal 'text/plain', response.header['Content-Type']
+    assert_match /text\/plain/, response.header['Content-Type']
     assert_equal 400, response.status
   end
 

--- a/test/functional/stats/data/services_controller_test.rb
+++ b/test/functional/stats/data/services_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Stats::Data::ServicesControllerTest < ActionController::TestCase
@@ -14,7 +16,7 @@ class Stats::Data::ServicesControllerTest < ActionController::TestCase
     setup_data
 
     get :usage, format: :csv, service_id: @provider.default_service.id, period: 'troloro'
-    assert_equal 'text/plain', response.header['Content-Type']
+    assert_match /text\/plain/, response.header['Content-Type']
     assert_equal 400, response.status
   end
 

--- a/test/integration/stats/authentication_test.rb
+++ b/test/integration/stats/authentication_test.rb
@@ -9,18 +9,19 @@ class Stats::AuthenticationTest < ActionDispatch::IntegrationTest
   end
 
   test 'access allowed with authentication' do
-    get "/stats/services/#{@service.id}/usage.json", period: 'day', metric_name: 'hits', provider_key: @provider_account.api_key
+    params = { period: 'day', metric_name: 'hits' }
+    get "/stats/services/#{@service.id}/usage.json", params.merge(provider_key: @provider_account.api_key)
     assert_response :success
     assert_content_type 'application/json'
 
     token = FactoryBot.create(:access_token, owner: @provider_account.first_admin, scopes: ['stats'])
-    get "/stats/services/#{@service.id}/usage.json", period: 'day', metric_name: 'hits', access_token: token.value
+    get "/stats/services/#{@service.id}/usage.json", params.merge(access_token: token.value)
     assert_response :success
     assert_content_type 'application/json'
   end
 
   test 'access forbidden without authentication' do
-    get "/stats/services/#{@service.id}/usage.json", :period => 'day', :metric_name => "hits"
+    get "/stats/services/#{@service.id}/usage.json", period: 'day', metric_name: "hits"
 
     assert_response :forbidden
     assert_content_type 'application/json'
@@ -32,7 +33,7 @@ class Stats::AuthenticationTest < ActionDispatch::IntegrationTest
   # https://3scale.hoptoadapp.com/errors/9899473
   #
   test 'access forbidden without authentication and invalid format' do
-    get "/stats/services/#{@service.id}/usage.INVALID", :period => 'day', :metric_name => "hits"
+    get "/stats/services/#{@service.id}/usage.INVALID", period: 'day', metric_name: "hits"
 
     assert_response 403
   end

--- a/test/integration/stats/data/applications_test.rb
+++ b/test/integration/stats/data/applications_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Stats::Data::ApplicationsTest < ActionDispatch::IntegrationTest

--- a/test/integration/stats/data/base_controller_test.rb
+++ b/test/integration/stats/data/base_controller_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Stats::Data::BaseControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    @service = @provider.default_service
+    @metric = service.metrics.hits
+    @access_token = FactoryBot.create(:access_token, owner: provider.admin_users.first, scopes: ['stats'])
+
+    host! @provider.self_domain
+  end
+
+  attr_reader :provider, :service, :metric, :access_token
+
+  test 'required params' do
+    url_params = { service_id: service.id, format: :json, access_token: access_token.value }
+    stats_params = { metric_name: metric.system_name, period: 'day', timezone: ActiveSupport::TimeZone['UTC'].name, skip_change: false }
+
+    get usage_stats_data_services_path(url_params), stats_params
+    assert_response :success
+
+    get usage_stats_data_services_path(url_params), stats_params.except(:metric_name)
+    assert_response :bad_request
+    assert_equal 'Required parameter missing: metric_name', response.body
+
+    get usage_stats_data_services_path(url_params), stats_params.except(:period)
+    assert_response :bad_request
+    assert_equal 'Required parameter missing: granularity', response.body
+
+    get usage_stats_data_services_path(url_params), stats_params.except(:period).merge(granularity: 'hour')
+    assert_response :bad_request
+    assert_equal 'Required parameter missing: since', response.body
+
+    get usage_stats_data_services_path(url_params), stats_params.except(:period).merge(granularity: 'hour', since: '')
+    assert_response :bad_request
+    assert_equal 'Required parameter missing: since', response.body
+
+    get usage_stats_data_services_path(url_params), stats_params.except(:period).merge(granularity: 'hour', since: Time.utc(2020, 3, 19).to_date, until: Time.utc(2020, 3, 21).to_date)
+    assert_response :success
+
+    # TODO: add a test for the undocumented use case: stats_params.except(:period).merge(granularity: 'hour', range: ?)
+  end
+end


### PR DESCRIPTION
Adds Rails strong params validation to stats/data usage and usage_response_code actions.
It affects essentially analytics requests for services (API products), API backends and applications, both UI and API.
Makes it consistent with the 3scale api docs where the `since` parameter is a required param.

_Missing:_ support for the use case of the `range` param (undocumented):
https://github.com/3scale/porta/blob/ff0b72315fcd58397aeac04aa254ad6c66376f52/app/lib/stats/views/usage.rb#L148

---

Closes [THREESCALE-5798](https://issues.redhat.com/browse/THREESCALE-5798).