### PR TITLE
Access yabeda metrics in unicorn

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -57,9 +57,10 @@ gem 'sidekiq-throttled'
 gem 'sidekiq-prometheus-exporter'
 
 # Yabeda metrics
-gem 'yabeda-sidekiq'
-gem 'prometheus-client-mmap'
+
 gem 'yabeda-prometheus'
+gem 'yabeda-prometheus-mmap'
+gem 'yabeda-sidekiq'
 
 gem 'activemerchant', '~> 1.77.0'
 gem 'active_merchant-adyen12', github: '3scale/active_merchant-adyen12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -486,6 +486,7 @@ GEM
     prawn-format (0.2.1)
       prawn-core
     prawn-layout (0.2.1)
+    prometheus-client (2.1.0)
     prometheus-client-mmap (0.11.0)
     protected_attributes_continued (1.3.0)
       activemodel (~> 5.0)
@@ -784,14 +785,16 @@ GEM
     yabeda (0.8.0)
       concurrent-ruby
       dry-initializer
-    yabeda-prometheus (0.1.4)
-      yabeda
+    yabeda-prometheus (0.6.1)
+      prometheus-client (>= 0.10, < 3.0)
+      rack
+      yabeda (~> 0.5)
     yabeda-prometheus-mmap (0.1.1)
       prometheus-client-mmap
       yabeda (~> 0.5)
-    yabeda-sidekiq (0.6.0)
+    yabeda-sidekiq (0.7.0)
       sidekiq
-      yabeda
+      yabeda (~> 0.6)
     yard (0.9.25)
     zip-zip (0.3)
       rubyzip (>= 1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,7 @@ GEM
       sass-rails (< 5.1)
       sprockets (< 4.0)
     concurrent-ruby (1.1.7)
-    connection_pool (2.2.2)
+    connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -297,7 +297,7 @@ GEM
       activemodel-serializers-xml (~> 1.0)
       activesupport (~> 5.0)
       request_store (~> 1.0)
-    dry-initializer (3.0.1)
+    dry-initializer (3.0.3)
     dynamic_form (1.1.4)
     email_spec (2.2.0)
       htmlentities (~> 4.3.3)
@@ -486,7 +486,7 @@ GEM
     prawn-format (0.2.1)
       prawn-core
     prawn-layout (0.2.1)
-    prometheus-client-mmap (0.10.0)
+    prometheus-client-mmap (0.11.0)
     protected_attributes_continued (1.3.0)
       activemodel (~> 5.0)
     pry (0.13.1)
@@ -573,7 +573,7 @@ GEM
       actionview (>= 5)
     recursive-open-struct (1.0.5)
     redcarpet (3.4.0)
-    redis (4.1.3)
+    redis (4.1.4)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
     redis-prescription (1.0.0)
@@ -665,11 +665,11 @@ GEM
     shoulda-context (1.2.2)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    sidekiq (5.2.8)
+    sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
+      rack (~> 2.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+      redis (>= 3.3.5, < 4.2)
     sidekiq-batch (0.1.6)
       sidekiq (>= 3)
     sidekiq-cron (1.0.4)
@@ -678,7 +678,7 @@ GEM
     sidekiq-lock (0.4.0)
       redis (>= 3.0.5)
       sidekiq (>= 2.14.0)
-    sidekiq-prometheus-exporter (0.1.11)
+    sidekiq-prometheus-exporter (0.1.13)
       sidekiq (>= 3.3.1)
     sidekiq-throttled (0.11.0)
       concurrent-ruby
@@ -781,12 +781,15 @@ GEM
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    yabeda (0.1.3)
+    yabeda (0.7.0)
       concurrent-ruby
       dry-initializer
     yabeda-prometheus (0.1.4)
       yabeda
-    yabeda-sidekiq (0.1.3)
+    yabeda-prometheus-mmap (0.1.1)
+      prometheus-client-mmap
+      yabeda (~> 0.5)
+    yabeda-sidekiq (0.6.0)
       sidekiq
       yabeda
     yard (0.9.25)
@@ -888,7 +891,6 @@ DEPENDENCIES
   prawn-core!
   prawn-format (= 0.2.1)
   prawn-layout (= 0.2.1)
-  prometheus-client-mmap
   protected_attributes_continued (~> 1.3.0)
   pry-byebug (>= 3.7.0)
   pry-doc (>= 0.8)
@@ -959,6 +961,7 @@ DEPENDENCIES
   will_paginate (~> 3.1.6)
   xpath (~> 2.1)
   yabeda-prometheus
+  yabeda-prometheus-mmap
   yabeda-sidekiq
   yard
   zip-zip

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -781,7 +781,7 @@ GEM
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    yabeda (0.7.0)
+    yabeda (0.8.0)
       concurrent-ruby
       dry-initializer
     yabeda-prometheus (0.1.4)

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -255,7 +255,7 @@ GEM
       sass-rails (< 5.1)
       sprockets (< 4.0)
     concurrent-ruby (1.1.7)
-    connection_pool (2.2.2)
+    connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -298,7 +298,7 @@ GEM
       activemodel-serializers-xml (~> 1.0)
       activesupport (~> 5.0)
       request_store (~> 1.0)
-    dry-initializer (3.0.1)
+    dry-initializer (3.0.3)
     dynamic_form (1.1.4)
     email_spec (2.2.0)
       htmlentities (~> 4.3.3)
@@ -487,7 +487,7 @@ GEM
     prawn-format (0.2.1)
       prawn-core
     prawn-layout (0.2.1)
-    prometheus-client-mmap (0.10.0)
+    prometheus-client-mmap (0.11.0)
     protected_attributes_continued (1.3.0)
       activemodel (~> 5.0)
     pry (0.13.1)
@@ -574,7 +574,7 @@ GEM
       actionview (>= 5)
     recursive-open-struct (1.0.5)
     redcarpet (3.4.0)
-    redis (4.1.3)
+    redis (4.1.4)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
     redis-prescription (1.0.0)
@@ -666,11 +666,11 @@ GEM
     shoulda-context (1.2.2)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    sidekiq (5.2.8)
+    sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
+      rack (~> 2.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+      redis (>= 3.3.5, < 4.2)
     sidekiq-cron (1.0.4)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
@@ -679,7 +679,7 @@ GEM
       sidekiq (>= 2.14.0)
     sidekiq-pro (3.7.1)
       sidekiq (>= 4.1.5)
-    sidekiq-prometheus-exporter (0.1.11)
+    sidekiq-prometheus-exporter (0.1.13)
       sidekiq (>= 3.3.1)
     sidekiq-throttled (0.11.0)
       concurrent-ruby
@@ -782,12 +782,15 @@ GEM
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    yabeda (0.1.3)
+    yabeda (0.7.0)
       concurrent-ruby
       dry-initializer
     yabeda-prometheus (0.1.4)
       yabeda
-    yabeda-sidekiq (0.1.3)
+    yabeda-prometheus-mmap (0.1.1)
+      prometheus-client-mmap
+      yabeda (~> 0.5)
+    yabeda-sidekiq (0.6.0)
       sidekiq
       yabeda
     yard (0.9.25)
@@ -889,7 +892,6 @@ DEPENDENCIES
   prawn-core!
   prawn-format (= 0.2.1)
   prawn-layout (= 0.2.1)
-  prometheus-client-mmap
   protected_attributes_continued (~> 1.3.0)
   pry-byebug (>= 3.7.0)
   pry-doc (>= 0.8)
@@ -960,6 +962,7 @@ DEPENDENCIES
   will_paginate (~> 3.1.6)
   xpath (~> 2.1)
   yabeda-prometheus
+  yabeda-prometheus-mmap
   yabeda-sidekiq
   yard
   zip-zip

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -487,6 +487,7 @@ GEM
     prawn-format (0.2.1)
       prawn-core
     prawn-layout (0.2.1)
+    prometheus-client (2.1.0)
     prometheus-client-mmap (0.11.0)
     protected_attributes_continued (1.3.0)
       activemodel (~> 5.0)
@@ -785,14 +786,16 @@ GEM
     yabeda (0.8.0)
       concurrent-ruby
       dry-initializer
-    yabeda-prometheus (0.1.4)
-      yabeda
+    yabeda-prometheus (0.6.1)
+      prometheus-client (>= 0.10, < 3.0)
+      rack
+      yabeda (~> 0.5)
     yabeda-prometheus-mmap (0.1.1)
       prometheus-client-mmap
       yabeda (~> 0.5)
-    yabeda-sidekiq (0.6.0)
+    yabeda-sidekiq (0.7.0)
       sidekiq
-      yabeda
+      yabeda (~> 0.6)
     yard (0.9.25)
     zip-zip (0.3)
       rubyzip (>= 1.0.0)

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -782,7 +782,7 @@ GEM
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    yabeda (0.7.0)
+    yabeda (0.8.0)
       concurrent-ruby
       dry-initializer
     yabeda-prometheus (0.1.4)

--- a/config/docker/unicorn.rb
+++ b/config/docker/unicorn.rb
@@ -1,10 +1,9 @@
 # config/unicorn.rb
 require 'pathname'
 require 'etc'
-require_relative '../../lib/prometheus_exporter_port'
 
 app_path = Pathname.pwd
-
+require app_path.join('lib/prometheus_exporter_port').to_s
 
 Unicorn::HttpServer::START_CTX[0] = '/usr/local/bin/unicorn'
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -36,6 +36,9 @@ Sidekiq.configure_server do |config|
   port = ENV.fetch('PROMETHEUS_EXPORTER_PORT', 9394).to_i
   port += Sidekiq.options[:index].to_i
   ENV['PROMETHEUS_EXPORTER_PORT'] ||= port.to_s
+
+  require 'yabeda/prometheus/mmap'
+
   Yabeda::Prometheus::Exporter.start_metrics_server!
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,10 +15,11 @@ end
 Rails.application.routes.draw do
 
   constraints PortConstraint.new(PrometheusExporterPort.call) do
-    prometheus = Rack::Builder.app do
-      run Sidekiq::Prometheus::Exporter
-    end
-    mount prometheus, at: '/metrics'
+    require 'sidekiq/prometheus/exporter'
+    require 'yabeda/prometheus/mmap'
+
+    mount Sidekiq::Prometheus::Exporter, at: '/metrics'
+    mount Yabeda::Prometheus::Exporter, at: '/yabeda-metrics'
   end
 
   mount CdnAssets.new => '/_cdn_assets_' unless Rails.configuration.three_scale.assets_cdn_host

--- a/config/unicorn/development.rb
+++ b/config/unicorn/development.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+app_dir = Pathname.new(File.dirname(__FILE__) + "/../..").realpath
+
+require app_dir.join('lib/prometheus_exporter_port').to_s
+
+ENV['RAILS_ENV'] ||= 'development'
+
+worker_processes((ENV["UNICORN_WORKERS"] || "1").to_i)
+
+# Do not preload app to save the memory
+preload_app false
+
+# Restart any workers that haven't responded in 300 seconds
+timeout 300
+
+# Listen on a Unix data socket
+listen ENV.fetch('PORT', 3000).to_i
+
+prometheus_port = PrometheusExporterPort.call
+$stdout.puts "=> Unicorn Prometheus endpoint http://localhost:#{prometheus_port}/metrics"
+$stdout.puts "=> Unicorn Prometheus endpoint http://localhost:#{prometheus_port}/yabeda-metrics"
+listen prometheus_port
+
+pid app_dir.join('tmp/pids/unicorn.pid').to_s
+
+stderr_path app_dir.join("log/unicorn.stderr.log").to_s
+stdout_path app_dir .join("log/unicorn.stdout.log").to_s
+
+# http://www.rubyenterpriseedition.com/faq.html#adapt_apps_for_cow
+GC.copy_on_write_friendly = true if GC.respond_to?(:copy_on_write_friendly=)
+
+before_fork do |server, worker|
+  # The following is only recommended for memory/DB-constrained
+  # installations.  It is not needed if your system can house
+  # twice as many worker_processes as you have configured.
+  #
+  # This allows a new master process to incrementally
+  # phase out the old master process with SIGTTOU to avoid a
+  # thundering herd (especially in the "preload_app false" case)
+  # when doing a transparent upgrade.  The last worker spawned
+  # will then kill off the old master process with a SIGQUIT.
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if File.exist?(old_pid) && server.pid != old_pid
+    begin
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
+      Process.kill(sig, File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH
+      # someone else did our job for us
+      $stdout.puts "Process already killed..."
+    end
+  end
+end
+
+
+after_fork do |server, worker|
+  ##
+  # Unicorn master loads the app then forks off workers - because of the way
+  # Unix forking works, we need to make sure we aren't using any of the parent's
+  # sockets, e.g. db connection
+
+  # ActiveRecord::Base.establish_connection
+  # Redis and Memcached would go here but their connections are established
+  # on demand, so the master never opens a socket
+
+
+  ##
+  # Unicorn master is started as root, which is fine, but let's
+  # drop the workers to git:git
+
+  # begin
+  #   uid, gid = Process.euid, Process.egid
+  #   user, group = 'www-seslost', 'seslost'
+  #   target_uid = Etc.getpwnam(user).uid
+  #   target_gid = Etc.getgrnam(group).gid
+  #   worker.tmp.chown(target_uid, target_gid)
+  #   if uid != target_uid || gid != target_gid
+  #     Process.initgroups(user, target_gid)
+  #     Process::GID.change_privilege(target_gid)
+  #     Process::UID.change_privilege(target_uid)
+  #   end
+  # rescue => e
+  #   if ENV['RAILS_ENV'] == 'development'
+  #     STDERR.puts "couldn't change user, oh well"
+  #   else
+  #     raise e
+  #   end
+  # end
+end

--- a/lib/prometheus_exporter_port.rb
+++ b/lib/prometheus_exporter_port.rb
@@ -4,9 +4,9 @@ class PrometheusExporterPort
 
   PROMETHEUS_EXPORTER_DEFAULT_PORTS = {
     'multitenant' => 9394,
-    'master' => 9394,
-    'provider' => 9395,
-    'developer' => 9396
+    'master' => 9395,
+    'provider' => 9396,
+    'developer' => 9394
   }.freeze
 
   class InvalidTenantModeError < StandardError
@@ -27,6 +27,7 @@ class PrometheusExporterPort
   end
 
   def self.tenant_mode
-    ENV['TENANT_MODE'].to_s.empty? ? 'multitenant' : ENV['TENANT_MODE']
+    mode = ENV['TENANT_MODE'].to_s
+    mode.empty? ? 'multitenant' : mode
   end
 end

--- a/lib/prometheus_exporter_port.rb
+++ b/lib/prometheus_exporter_port.rb
@@ -10,10 +10,13 @@ class PrometheusExporterPort
   }.freeze
 
   class InvalidTenantModeError < StandardError
+    def initialize(tenant_mode)
+      @message = "TENANT_MODE #{tenant_mode.inspect} is not allowed"
+    end
   end
 
   TENANT_MODE_CHECK = ->(mode) do
-    PROMETHEUS_EXPORTER_DEFAULT_PORTS.key?(mode.to_s) ? mode.to_s : raise(InvalidTenantModeError)
+    PROMETHEUS_EXPORTER_DEFAULT_PORTS.key?(mode.to_s) ? mode.to_s : raise(InvalidTenantModeError, mode)
   end
 
   def self.call
@@ -24,6 +27,6 @@ class PrometheusExporterPort
   end
 
   def self.tenant_mode
-    ENV.fetch('TENANT_MODE', 'multitenant')
+    ENV['TENANT_MODE'].to_s.empty? ? 'multitenant' : ENV['TENANT_MODE']
   end
 end


### PR DESCRIPTION
Have another endpoint for yabeda-sidekiq /yabeda-metrics

Also use prometheus mmap client to share metrics between processes

Use environment variable `prometheus_multiproc_dir` 

Requires https://github.com/3scale/deploy/pull/679