### PR TITLE
[hotfix] Remove dev_gtld refs left behind

### DIFF
--- a/app/helpers/cms/url_helper.rb
+++ b/app/helpers/cms/url_helper.rb
@@ -26,12 +26,7 @@ module CMS
       uri.query = { return_to: page.path ? page.path : HARD_WIRED_PATHS[page.system_name],
                     access_code: current_account.site_access_code,
                     cms_token: page.provider.settings.cms_token! }.to_query
-
-      if Rails.env.development?
-        uri.port = request.port
-        uri.host += ".#{ThreeScale.config.dev_gtld}"
-      end
-
+      uri.port = request.port if Rails.env.development?
       uri
     end
 

--- a/app/views/admin/api_docs/base/active_docs.html.erb
+++ b/app/views/admin/api_docs/base/active_docs.html.erb
@@ -7,8 +7,7 @@
 <div class='api-docs-wrap'></div>
 <script>
 
-  <% domain = current_account.domain
-     domain += ".#{ThreeScale.config.dev_gtld}:3000" if Rails.env.development? -%>
+  <% domain = current_account.domain + (Rails.env.development? ? ':3000' : '') -%>
   $(function(){
     ThreeScale.APIDocs.preview = true;
     ThreeScale.APIDocs.account_type = 'provider';

--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -325,12 +325,9 @@ class ZyncWorker
     root_url = config.root_url
     return root_url if root_url
 
-    host = provider.admin_domain
     # This is far for perfect, but there is no request in workers to infer the domain from.
-    options = case Rails.env
-              when 'development' then { host: "#{host}.#{ThreeScale.config.dev_gtld}", port: 3000 }
-              else { host: host }.reverse_merge(ActionMailer::Base.default_url_options)
-              end
+    options = { host: provider.admin_domain }
+    options.reverse_merge!(Rails.env.development? ? { port: 3000 } : ActionMailer::Base.default_url_options)
     System::UrlHelpers.system_url_helpers.root_url(options)
   end
 


### PR DESCRIPTION
Having these references to `ThreeScale.config.dev_gtld` that we left behind in the code will cause the following problems in dev env:
1. Provider endpoint passed in the Zync update tenant payload has a wrong trailing `.{dev_gtld}` termination, making Zync to fail to fetch data fro Porta
2. The link to non-OAS ActiveDocs preview page will be wrong in the UI
3. Links to draft and published pages of the CMS from the Admin Portal will be broken

The solution here proposed is far from ideal because we still have the Rails server port (3000) hard-coded, but it's a quick and easy fix for the dev_gtld part of the issue, so we don't get blocked in dev.