### PR TITLE
Fix random failure in impersonation_admin_user:update rake task test

### DIFF
--- a/test/unit/tasks/impersonation_admin_user_test.rb
+++ b/test/unit/tasks/impersonation_admin_user_test.rb
@@ -5,23 +5,36 @@ require 'test_helper'
 module Tasks
   class ImpersonationAdminUserTest < ActiveSupport::TestCase
     setup do
-      3.times do
-        FactoryBot.create(:active_admin,
-                              username: '3scaleadmin',
-                              account: FactoryBot.create(:simple_provider, provider_account: master_account)
-                            )
+      @impersonation_other_admin_users = FactoryBot.build_list(:active_admin, 3, username: '3scaleadmin') do |user|
+        user.account = FactoryBot.create(:simple_provider, provider_account: master_account)
+        user.save!
       end
-      FactoryBot.create_list(:active_admin, 2)
+
+      @other_admin_users = FactoryBot.create_list(:active_admin, 2)
     end
 
+    attr_reader :impersonation_other_admin_users, :other_admin_users
+
     test 'update' do
+      other_admin_users_attributes_before = other_admin_users_attributes
+
       execute_rake_task 'impersonation_admin_user.rake', 'impersonation_admin_user:update', 'example-username', 'domain.example.com'
 
-      users = User.where(username: 'example-username')
-      assert_equal 0, User.where(username: '3scaleadmin').count
-      assert_equal 3, users.count
-      assert_equal 3, User.where('username <> \'3scaleadmin\'').where('username <> \'example-username\'').count
-      users.each { |user| assert_match /\Aexample\-username\+#{user.account.self_domain}@domain\.example\.com\z/, user.email }
+      # It doesn't test that ALL '3scaleadmin' users have been updated because this would be error-prone under concurrency
+      impersonation_other_admin_users.each do |user|
+        user.reload
+        assert_equal 'example-username', user.username
+        assert_equal "example-username+#{user.account.self_domain}@domain.example.com", user.email
+      end
+
+      # After upgrading to Rails v5.2, we can use `assert_no_changes` around `execute_rake_task` instead of this
+      assert_equal other_admin_users_attributes_before, other_admin_users_attributes
+    end
+
+    protected
+
+    def other_admin_users_attributes
+      other_admin_users.map { |user| user.reload.attributes.slice('username', 'email') }
     end
   end
 end


### PR DESCRIPTION
The fix drops the assertion that used to check if ALL impersonation admin users were updated (as expected according to implementation), but this is OK because:
1. It still asserts that users expected to be affected are indeed affected, with chance of missing correspondence with ALL only in case of creation of another 3scaleadmin user by a concurrent test.
2. It still asserts that users NOT expected to be affected remain untouched.

The previous assertion was based on a fixed number of expected user records in the database, which was causing random failures.

---

**Alternative**

We could remove this rake task as it's not used anymore https://github.com/3scale/porta/blob/master/lib/tasks/impersonation_admin_user.rake

In case we do, make sure to ping @3scale/documentation, though I think this rake task is only mentioned in the docs in the instructions to upgrade from 2.3 to 2.4.