### PR TITLE
Not displaying suspend button when tenant is deleted

### DIFF
--- a/app/models/account/buyer_methods.rb
+++ b/app/models/account/buyer_methods.rb
@@ -161,8 +161,4 @@ module Account::BuyerMethods
   def not_paying_monthly!
     settings.update_attribute(:monthly_charging_enabled, false)
   end
-
-  def account_suspended_or_scheduled_for_deletion?(account)
-    account.suspended? || account.scheduled_for_deletion?
-  end
 end

--- a/app/models/account/buyer_methods.rb
+++ b/app/models/account/buyer_methods.rb
@@ -161,4 +161,8 @@ module Account::BuyerMethods
   def not_paying_monthly!
     settings.update_attribute(:monthly_charging_enabled, false)
   end
+
+  def account_suspended_or_scheduled_for_deletion?(account)
+    account.suspended? || account.scheduled_for_deletion?
+  end
 end

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -79,7 +79,7 @@ module Account::States
       end
 
       event :suspend do
-        transition all => :suspended, if: :can_be_suspended?
+        transition all => :suspended, if: :ready_to_be_suspended?
       end
 
       event :resume do
@@ -138,11 +138,15 @@ module Account::States
       scheduled_for_deletion? || (buyer? && provider_account.try(:should_be_deleted?))
     end
 
-    def can_be_suspended?
+    def ready_to_be_suspended?
       tenant? || marked_for_suspension
     end
 
     attr_accessor :marked_for_suspension
+
+    def suspended_or_scheduled_for_deletion?
+      suspended? || scheduled_for_deletion?
+    end
   end
 
   module ClassMethods

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -62,13 +62,13 @@ h1 data-hook="account-show"
                                  reject_admin_buyers_account_path(@account),
                                  method: :post,
                                  class: 'reject action'
-            - if can? :suspend, @account
+            - if can?(:suspend, @account) && @account.can_suspend?
               = action_link_to 'Suspend',
-                               suspend_admin_buyers_account_path(@account),
-                               method: :post,
-                               data: { confirm: 'Are you sure?', disable_with: 'suspending…' },
-                               class: 'action suspend'
-            - if can? :resume, @account
+                                suspend_admin_buyers_account_path(@account),
+                                method: :post,
+                                data: { confirm: 'Are you sure?', disable_with: 'suspending…' },
+                                class: 'action suspend'
+            - if can?(:resume, @account) && @account.can_resume?
               = action_link_to 'Resume',
                                resume_admin_buyers_account_path(@account),
                                method: :post,

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -62,7 +62,7 @@ h1 data-hook="account-show"
                                  reject_admin_buyers_account_path(@account),
                                  method: :post,
                                  class: 'reject action'
-            - if !@account.suspended? && !@account.scheduled_for_deletion?
+            - unless @account.account_suspended_or_scheduled_for_deletion?(@account)
               = action_link_to 'Suspend',
                                 suspend_admin_buyers_account_path(@account),
                                 method: :post,

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -62,7 +62,7 @@ h1 data-hook="account-show"
                                  reject_admin_buyers_account_path(@account),
                                  method: :post,
                                  class: 'reject action'
-            - if can?(:suspend, @account) && @account.can_suspend?
+            - if !@account.suspended? && !@account.scheduled_for_deletion?
               = action_link_to 'Suspend',
                                 suspend_admin_buyers_account_path(@account),
                                 method: :post,

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -62,7 +62,7 @@ h1 data-hook="account-show"
                                  reject_admin_buyers_account_path(@account),
                                  method: :post,
                                  class: 'reject action'
-            - unless @account.account_suspended_or_scheduled_for_deletion?(@account)
+            - unless @account.suspended_or_scheduled_for_deletion?
               = action_link_to 'Suspend',
                                 suspend_admin_buyers_account_path(@account),
                                 method: :post,

--- a/app/workers/process_notification_event_worker.rb
+++ b/app/workers/process_notification_event_worker.rb
@@ -37,7 +37,7 @@ class ProcessNotificationEventWorker
   def create_notifications(event)
     provider = Provider.find(event.provider_id)
 
-    if provider.suspended? || provider.scheduled_for_deletion?
+    if provider.suspended_or_scheduled_for_deletion?
       Rails.logger.info "[Notification] skipping notifications for event #{event.event_id} of #{provider.state} account #{event.provider_id}"
       return
     end

--- a/test/integration/buyers/accounts_controller_test.rb
+++ b/test/integration/buyers/accounts_controller_test.rb
@@ -316,6 +316,13 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
       assert_xpath( './/div[@id="applications_widget"]//table[@class="list"]//tr', 2)
       refute_xpath( './/div[@id="applications_widget"]//table[@class="list"]//tr', /plan/i )
     end
+
+    test 'suspend button is not displayed when account is deleted or marked for deletion' do
+      ThreeScale.config.stubs(onpremises: false)
+      delete admin_buyers_account_path(@provider)
+      assert_select %(td a.button-to.action.suspend), false
+    end
+
   end
 
   class NotLoggedInTest < ActionDispatch::IntegrationTest

--- a/test/integration/buyers/accounts_controller_test.rb
+++ b/test/integration/buyers/accounts_controller_test.rb
@@ -317,10 +317,18 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
       refute_xpath( './/div[@id="applications_widget"]//table[@class="list"]//tr', /plan/i )
     end
 
-    test 'suspend button is not displayed when account is deleted or marked for deletion' do
+    test 'suspend button is displayed only when account is not deleted or marked for deletion' do
       ThreeScale.config.stubs(onpremises: false)
+      get admin_buyers_account_path(@provider)
+      assert_select %(td a.button-to.action.suspend), true
+
+      @provider.suspend
+      get admin_buyers_account_path(@provider)
+      assert_select %(td a.button-to.action.suspend), false
+
       delete admin_buyers_account_path(@provider)
       assert_select %(td a.button-to.action.suspend), false
+
     end
 
   end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

When you first delete tenant and after want you try to suspend it 404 page is displayed and tenant cannot be suspended.
Note: Login as master

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-5738

**Verification steps** 

1. Login as master
2. Create new tenant
3. Go to /buyers/accounts/{tenant_id}/edit and delete tenant
4. Go to /buyers/accounts/{tenant_id} and try to suspend tenant

**Before:**
![before](https://user-images.githubusercontent.com/13486237/90521564-f87dd300-e16a-11ea-8d6a-6093af5b422a.png)

**After:**
![after](https://user-images.githubusercontent.com/13486237/90521579-fd428700-e16a-11ea-9024-a16f0a3c4228.png)
