### PR TITLE
THREESCALE-5817

### DIFF
--- a/app/indices/proxy_rules_index.rb
+++ b/app/indices/proxy_rules_index.rb
@@ -7,4 +7,5 @@ ThinkingSphinx::Index.define(:proxy_rule, with: :real_time) do
   has owner_type, as: :owner_type, type: :string
 
   set_property min_infix_len: 1
+  set_property charset_table: "0..9, A..Z->a..z, a..z, U+21, U+27, U+28..U+2F, U+5F"
 end

--- a/test/unit/indices/proxy_rules_indices_test.rb
+++ b/test/unit/indices/proxy_rules_indices_test.rb
@@ -1,0 +1,138 @@
+require 'test_helper'
+
+class ProxyRulesIndicesTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test 'alphanumeric characters are indexed' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/abc/123')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('/abc/123')
+      end
+    end
+  end
+
+  test 'character `/` is indexed' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('/')
+      end
+    end
+  end
+
+  test 'character `!` is indexed' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/!/')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('/!/')
+      end
+    end
+  end
+
+  test "character `'` is indexed" do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: "/'/")
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for("/'/")
+      end
+    end
+  end
+
+  test 'characters `()` are indexed' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/()/')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('/()/')
+      end
+    end
+  end
+
+  test 'character `*` is indexed' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/*/')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('/*/')
+      end
+    end
+  end
+
+  test 'character `+` is indexed' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/+/')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('/+/')
+      end
+    end
+  end
+
+  test 'character `,` is indexed' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/,/')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('/,/')
+      end
+    end
+  end
+
+  test 'character `-` is indexed' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/-/')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('/-/')
+      end
+    end
+  end
+
+  test 'character `.` is indexed' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/./')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('/./')
+      end
+    end
+  end
+
+  test 'character `_` is indexed' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: IndexProxyRuleWorker) do
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/_/')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+
+        assert_equal [proxy_rule], query.search_for('/_/')
+      end
+    end
+  end
+
+end

--- a/test/unit/queries/proxy_rule_query_test.rb
+++ b/test/unit/queries/proxy_rule_query_test.rb
@@ -1,3 +1,4 @@
+require 'test_helper'
 # frozen_string_literal: true
 
 class ProxyRuleTest < ActiveSupport::TestCase


### PR DESCRIPTION
**What this PR does**:

> fix for THREESCALE-5817: adds some special characters to the indexing charset in order to allow searching proxy rules like `/v1.0.0/test` with perfect match queries (e.g. search query = `/v1.0.0/test`)