### PR TITLE
Update branding_state to custom _brand on runtime

### DIFF
--- a/app/controllers/provider/admin/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/authentication_providers_controller.rb
@@ -98,7 +98,8 @@ class Provider::Admin::AuthenticationProvidersController < FrontendController
                      username_key trust_email].freeze
 
   def update_params
-    params.require(:authentication_provider).permit(UPDATE_PARAMS)
+    defaults = { branding_state_event: 'custom_brand' }
+    params.require(:authentication_provider).permit(UPDATE_PARAMS).reverse_merge(defaults)
   end
 
   def create_params

--- a/app/controllers/provider/admin/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/authentication_providers_controller.rb
@@ -97,10 +97,11 @@ class Provider::Admin::AuthenticationProvidersController < FrontendController
                      token_url authorize_url user_info_url identifier_key
                      username_key trust_email].freeze
 
-  def update_params
-    defaults = { branding_state_event: 'custom_brand' }
-    params.require(:authentication_provider).permit(UPDATE_PARAMS).reverse_merge(defaults)
-  end
+UPDATE_PARAM_DEFAULTS = { branding_state_event: 'custom_brand' }.freeze
+
+def update_params
+  params.require(:authentication_provider).permit(UPDATE_PARAMS).reverse_merge(UPDATE_PARAM_DEFAULTS)
+end
 
   def create_params
     permitted_params = UPDATE_PARAMS + %i[name system_name kind published]


### PR DESCRIPTION
Signed-off-by: Srijita Mukherjee <srijita92mukherjee@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

>While authenticating using GitHub Client-Id and Client-Secret on Developer Portal, the branding_state parameter will change to custom_brand.
Previously, the "Test authentication flow" URL – included 3scale's Client ID for GitHub app.
Now, it redirects to the external Application link provided in the GitHub Developer settings. 


**Which issue(s) this PR fixes** 

>Partial fix for https://issues.redhat.com/browse/THREESCALE-4144

**Verification steps** 

>Add Client-Id and Client-Secret in Developer Portal -> SSO Integration -> GitHub.
> 
**Special notes for your reviewer**:
This PR is part of https://github.com/3scale/porta/pull/2050. 
Keeping 2050 for resolving the branding visibility fix, which, as of now, is under discussion. 