### PR TITLE
Apply member permissions to Admin API's ActiveDoc Specs endpoints

### DIFF
--- a/app/controllers/admin/api/api_docs_services_controller.rb
+++ b/app/controllers/admin/api/api_docs_services_controller.rb
@@ -134,9 +134,7 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   end
 
   def api_docs_services
-    collection = current_account.api_docs_services.accessible
-    return collection unless current_user
-    collection.permitted_for(current_user)
+    current_account.api_docs_services.accessible.permitted_for(current_user)
   end
 
   def find_api_docs_service

--- a/app/controllers/admin/api/api_docs_services_controller.rb
+++ b/app/controllers/admin/api/api_docs_services_controller.rb
@@ -1,6 +1,7 @@
 class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   before_action :deny_on_premises_for_master
   before_action :find_api_docs_service, only: %i[show update destroy]
+  before_action :find_service, only: %i[create update]
 
   wrap_parameters ::ApiDocs::Service, name: :api_docs_service, include: ::ApiDocs::Service.attribute_names
 
@@ -28,7 +29,7 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   ##~ op.parameters.add @parameter_access_token
   #
   def index
-    @api_docs_services = current_account.api_docs_services.all
+    @api_docs_services = api_docs_services.all
     respond_with(@api_docs_services)
   end
 
@@ -132,8 +133,20 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
     params.require(:api_docs_service).permit(*permit_params)
   end
 
-  def find_api_docs_service
-    @api_docs_service = current_account.api_docs_services.find(params[:id])
+  def api_docs_services
+    collection = current_account.api_docs_services.accessible
+    return collection unless current_user
+    collection.permitted_for(current_user)
   end
 
+  def find_api_docs_service
+    @api_docs_service = api_docs_services.find(params[:id])
+  end
+
+  def find_service
+    service_id = api_docs_params[:service_id]
+    service_id.blank? || current_user.blank? || current_user.accessible_services.find(service_id)
+  rescue ActiveRecord::RecordNotFound
+    render_error('Service not found', status: :unprocessable_entity)
+  end
 end

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -27,6 +27,7 @@ class ApiDocs::Service < ApplicationRecord
   scope :published, -> { where(published: true) }
   scope :accessible, -> { joining { service.outer }.where.has { (service_id == nil) | (service.state != ::Service::DELETE_STATE) } }
   scope :without_service, -> { where(service_id: nil) }
+  scope :permitted_for, ->(user) { where.has { (service_id == nil) | service_id.in(user.accessible_services.select(:id)) } }
 
   before_save :set_default_values
   before_save :prepare_base_path_notify

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -27,7 +27,7 @@ class ApiDocs::Service < ApplicationRecord
   scope :published, -> { where(published: true) }
   scope :accessible, -> { joining { service.outer }.where.has { (service_id == nil) | (service.state != ::Service::DELETE_STATE) } }
   scope :without_service, -> { where(service_id: nil) }
-  scope :permitted_for, ->(user) { where.has { (service_id == nil) | service_id.in(user.accessible_services.select(:id)) } }
+  scope :permitted_for, ->(user = nil) { user ? where.has { (service_id == nil) | service_id.in(user.accessible_services.select(:id)) } : self }
 
   before_save :set_default_values
   before_save :prepare_base_path_notify

--- a/test/unit/api_docs/service_test.rb
+++ b/test/unit/api_docs/service_test.rb
@@ -559,6 +559,23 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     assert_equal [api_docs_services.last.id], ApiDocs::Service.without_service.pluck(:id)
   end
 
+  test 'scope permitted_for' do
+    permitted_service, forbidden_service = FactoryBot.create_list(:simple_service, 2, account: account)
+
+    account_level_api_docs_service = FactoryBot.create(:api_docs_service, account: account, service: nil)
+    permitted_api_docs_service = FactoryBot.create(:api_docs_service, account: account, service: permitted_service)
+    forbidden_api_docs_service = FactoryBot.create(:api_docs_service, account: account, service: forbidden_service)
+
+    member = FactoryBot.create(:member, account: account, admin_sections: ['partners'])
+    member.member_permission_service_ids = [permitted_service.id]
+    member.save!
+
+    permitted_api_docs_service_ids = ApiDocs::Service.permitted_for(member).pluck(:id)
+    assert_includes permitted_api_docs_service_ids, account_level_api_docs_service.id
+    assert_includes permitted_api_docs_service_ids, permitted_api_docs_service.id
+    assert_not_includes permitted_api_docs_service_ids, forbidden_api_docs_service.id
+  end
+
   private
 
   def valid_attributes

--- a/test/unit/api_docs/service_test.rb
+++ b/test/unit/api_docs/service_test.rb
@@ -574,6 +574,9 @@ class ApiDocs::ServiceTest < ActiveSupport::TestCase
     assert_includes permitted_api_docs_service_ids, account_level_api_docs_service.id
     assert_includes permitted_api_docs_service_ids, permitted_api_docs_service.id
     assert_not_includes permitted_api_docs_service_ids, forbidden_api_docs_service.id
+
+    all_api_docs_service_ids = ApiDocs::Service.permitted_for.pluck(:id)
+    assert_same_elements [account_level_api_docs_service.id, permitted_api_docs_service.id, forbidden_api_docs_service.id], all_api_docs_service_ids
   end
 
   private


### PR DESCRIPTION
- index only includes accessible api docs specs
- show, update and delete will throw `404 Not Found` if api docs spec is not accessible
- create and update will return `422 Unprocessable Entity` if `service_id` param is not of an accessible service
- account-level api docs specs remain accessible

Close [THREESCALE-5884](https://issues.redhat.com/browse/THREESCALE-5884)