### PR TITLE
OAS Autocomplete: Fixing missing description and responses in path

### DIFF
--- a/app/javascript/packs/OAS3Autocomplete.js
+++ b/app/javascript/packs/OAS3Autocomplete.js
@@ -35,7 +35,7 @@ const addAutocompleteToParam = (param: Param, accountData: AccountData): Param =
 const getPathParameters = (path) => (
   Object.keys(path).reduce((params, item) => (
     {
-      ...params,
+      ...path[item],
       [item]: item === 'parameters'
         ? path.parameters
         : path[item].parameters


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

When doing autocompletion of OAS3 specs, the description and responses of the paths were missing

**BEFORE:**
<img width="723" alt="Screenshot 2020-09-01 at 15 57 22" src="https://user-images.githubusercontent.com/13486237/91860764-5da5ee00-ec6c-11ea-97e2-ac5b308eec39.png">

**AFTER:**
<img width="741" alt="Screenshot 2020-09-01 at 15 56 52" src="https://user-images.githubusercontent.com/13486237/91860828-6c8ca080-ec6c-11ea-8299-547eae95e96c.png">

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/THREESCALE-5516

**Verification steps** 

Go to ActiveDocs and create a new OAS 3 spec, you can use this example: https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/petstore-expanded.json


