### PR TITLE
Fix member users can manage service resources without permission

### DIFF
--- a/app/controllers/admin/api/api_docs_services_controller.rb
+++ b/app/controllers/admin/api/api_docs_services_controller.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
   before_action :deny_on_premises_for_master
+  before_action :authorize_api_docs
   before_action :find_api_docs_service, only: %i[show update destroy]
-  before_action :find_service, only: %i[create update]
+  before_action :new_service_id_permitted, only: %i[create update]
 
   wrap_parameters ::ApiDocs::Service, name: :api_docs_service, include: ::ApiDocs::Service.attribute_names
 
@@ -141,10 +144,14 @@ class Admin::Api::ApiDocsServicesController < Admin::Api::BaseController
     @api_docs_service = api_docs_services.find(params[:id])
   end
 
-  def find_service
+  def new_service_id_permitted
     service_id = api_docs_params[:service_id]
     service_id.blank? || current_user.blank? || current_user.accessible_services.find(service_id)
   rescue ActiveRecord::RecordNotFound
     render_error('Service not found', status: :unprocessable_entity)
+  end
+
+  def authorize_api_docs
+    authorize! :manage, :plans if current_user
   end
 end

--- a/app/controllers/admin/api_docs/base_controller.rb
+++ b/app/controllers/admin/api_docs/base_controller.rb
@@ -2,6 +2,7 @@
 
 class Admin::ApiDocs::BaseController < FrontendController
   before_action :deny_on_premises_for_master
+  before_action :authorize_api_docs
   before_action :find_api_docs, only: %i[show preview toggle_visible edit update destroy]
   before_action :new_service_id_permitted, only: %i[create update]
 
@@ -125,5 +126,9 @@ class Admin::ApiDocs::BaseController < FrontendController
       ],
       basePath: "#{request.protocol}#{request.host_with_port}"
     }
+  end
+
+  def authorize_api_docs
+    authorize! :manage, :plans
   end
 end

--- a/app/controllers/admin/api_docs/base_controller.rb
+++ b/app/controllers/admin/api_docs/base_controller.rb
@@ -1,10 +1,42 @@
 # frozen_string_literal: true
 
 class Admin::ApiDocs::BaseController < FrontendController
-  before_action :find_api_docs, only: %i[destroy edit update show preview toggle_visible]
   before_action :deny_on_premises_for_master
+  before_action :find_api_docs, only: %i[show preview toggle_visible edit update destroy]
+  before_action :new_service_id_permitted, only: %i[create update]
 
+  def index
+    @api_docs_services = accessible_api_docs_services.page(params[:page]).includes(:service)
+  end
 
+  def new
+    @api_docs_service = api_docs_services.new
+  end
+
+  def create
+    @api_docs_service = api_docs_services.new(api_docs_params(:system_name), without_protection: true)
+    if @api_docs_service.save
+      redirect_to(preview_admin_api_docs_service_path(@api_docs_service), notice: 'ActiveDocs Spec was successfully saved.')
+    else
+      render :new
+    end
+  end
+
+  def show
+    specification = api_docs_service.specification
+    if specification.swagger_2_0?
+      # TODO: this is temporary until we get swagger-ui to load swagger-2.0
+      response.headers['X-Frame-Options'] = 'SAMEORIGIN'
+      json = JSON.pretty_generate specification.as_json
+    else
+      translator = ThreeScale::Swagger::Translator.translate! @api_docs_service.body
+      json = translator.as_json
+    end
+
+    respond_to do | format |
+      format.json { render json: json }
+    end
+  end
 
   def preview
     if api_docs_service.specification.swagger?
@@ -27,26 +59,6 @@ class Admin::ApiDocs::BaseController < FrontendController
     redirect_to preview_admin_api_docs_service_path(api_docs_service), notice: "Spec #{api_docs_service.name} #{message}"
   end
 
-  def show
-    specification = api_docs_service.specification
-    if specification.swagger_2_0?
-      # TODO: this is temporary until we get swagger-ui to load swagger-2.0
-      response.headers['X-Frame-Options'] = 'SAMEORIGIN'
-      json = JSON.pretty_generate specification.as_json
-    else
-      translator = ThreeScale::Swagger::Translator.translate! @api_docs_service.body
-      json = translator.as_json
-    end
-
-    respond_to do | format |
-      format.json { render json: json }
-    end
-  end
-
-  def new
-    @api_docs_service = current_scope.api_docs_services.new
-  end
-
   def edit; end
 
   def update
@@ -59,19 +71,6 @@ class Admin::ApiDocs::BaseController < FrontendController
         format.html { render :edit }
         format.js {}
       end
-    end
-  end
-
-  def index
-    @api_docs_services = current_scope.api_docs_services.page(params[:page]).includes(:service)
-  end
-
-  def create
-    @api_docs_service = current_scope.api_docs_services.new(api_docs_params(:system_name), without_protection: true)
-    if @api_docs_service.save
-      redirect_to(preview_admin_api_docs_service_path(@api_docs_service), notice: 'ActiveDocs Spec was successfully saved.')
-    else
-      render :new
     end
   end
 
@@ -93,8 +92,21 @@ class Admin::ApiDocs::BaseController < FrontendController
     params.require(:api_docs_service).permit(*permit_params)
   end
 
+  def api_docs_services
+    current_scope.api_docs_services
+  end
+
+  def accessible_api_docs_services
+    api_docs_services.permitted_for(current_user)
+  end
+
   def find_api_docs
-    @api_docs_service = current_scope.api_docs_services.find_by_id_or_system_name!(params[:id])
+    @api_docs_service = accessible_api_docs_services.find_by_id_or_system_name!(params[:id])
+  end
+
+  def new_service_id_permitted
+    service_id = api_docs_params[:service_id]
+    service_id.blank? || current_user.accessible_services.find(service_id)
   end
 
   def swagger_spec

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -132,14 +132,13 @@ class FrontendController < ApplicationController
     end
   end
 
-  def find_service(id = params[:service_id])
-    services = if current_account.try!(:provider?)
-      current_account.accessible_services
-               else
-      site_account.accessible_services
-    end
+  def accessible_services
+    return site_account.accessible_services unless current_account.try!(:provider?)
+    current_account.accessible_services.merge(Service.permitted_for(current_user))
+  end
 
-    @service = id.present? ? services.find(id) : services.default
+  def find_service(id = params[:service_id])
+    @service = id.present? ? accessible_services.find(id) : accessible_services.default
   end
 
   def ensure_provider

--- a/app/controllers/provider/admin/dashboards_controller.rb
+++ b/app/controllers/provider/admin/dashboards_controller.rb
@@ -6,8 +6,6 @@ class Provider::Admin::DashboardsController < FrontendController
 
   def show
     @service    = find_service
-    @metrics    = @service.metrics.top_level
-    @cinstances = @service.cinstances.latest
     # Would be cool to
     #
     # .scoped(:include => [ :message => [ :sender ]])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,11 +184,11 @@ class User < ApplicationRecord
   end
 
   def accessible_services
-    account.accessible_services.permitted_for_user(self)
+    account.accessible_services.permitted_for(self)
   end
 
   def multiple_accessible_services?
-    account.multiple_accessible_services?(Service.permitted_for_user(self))
+    account.multiple_accessible_services?(Service.permitted_for(self))
   end
 
   def accessible_services?

--- a/app/views/admin/api_docs/base/_form.html.slim
+++ b/app/views/admin/api_docs/base/_form.html.slim
@@ -10,7 +10,7 @@
   = form.input :published, label: 'Publish?'
   = form.input :description, input_html: {rows: 3}
   - unless @api_docs_service.new_record? && @api_docs_service.service_id.present?
-    = form.input :service_id, as: :select, collection: current_account.accessible_services
+    = form.input :service_id, as: :select, collection: current_user.accessible_services
   = form.input :body, label: 'API JSON Spec', inline_errors: :list
   = form.semantic_errors :base_path
   = form.input :skip_swagger_validations, as: :boolean

--- a/test/integration/admin/api_docs/account_api_docs_controller_test.rb
+++ b/test/integration/admin/api_docs/account_api_docs_controller_test.rb
@@ -92,11 +92,53 @@ class Admin::ApiDocs::AccountApiDocsControllerTest < ActionDispatch::Integration
       assert_equal old_system_name, api_docs_service.reload.system_name
     end
 
+    test 'member permission' do
+      forbidden_service = FactoryBot.create(:simple_service, account: provider)
+      forbidden_api_docs_service = FactoryBot.create(:api_docs_service, account: provider, service: forbidden_service)
+
+      member = FactoryBot.create(:member, account: provider, admin_sections: ['plans'])
+      member.member_permission_service_ids = [service.id]
+      member.activate!
+
+      logout! && login!(provider, user: member)
+
+      get admin_api_docs_services_path
+      api_docs_service_ids = assigns(:api_docs_services).map(&:id)
+      assert_includes api_docs_service_ids, api_docs_service.id
+      assert_not_includes api_docs_service_ids, forbidden_api_docs_service.id
+
+      get new_admin_api_docs_service_path
+      page = Nokogiri::HTML::Document.parse(response.body)
+      service_ids = page.xpath(".//select[@id='api_docs_service_service_id']/option").map { |option| option.attributes['value'].value.presence }.compact.map(&:to_i)
+      assert_includes service_ids, service.id
+      assert_not_includes service_ids, forbidden_service.id
+
+      put toggle_visible_admin_api_docs_service_path(api_docs_service)
+      assert_response :redirect
+
+      delete admin_api_docs_service_path(api_docs_service)
+      assert_response :redirect
+
+      post admin_api_docs_services_path(api_docs_params(service_id: service.id, system_name: 'permitted_service_spec'))
+      assert_response :redirect
+
+      put toggle_visible_admin_api_docs_service_path(forbidden_api_docs_service)
+      assert_response :not_found
+
+      put admin_api_docs_service_path(forbidden_api_docs_service), api_docs_service: { service_id: forbidden_api_docs_service.id }
+      assert_response :not_found
+
+      delete admin_api_docs_service_path(forbidden_api_docs_service)
+      assert_response :not_found
+
+      post admin_api_docs_services_path(api_docs_params(service_id: forbidden_api_docs_service.id, system_name: 'forbidden_service_spec'))
+      assert_response :not_found
+    end
+
     private
 
     attr_reader :provider, :service, :api_docs_service
     alias current_account provider
-
   end
 
   class MasterLoggedInTest < Admin::ApiDocs::AccountApiDocsControllerTest

--- a/test/integration/admin/api_docs/account_api_docs_controller_test.rb
+++ b/test/integration/admin/api_docs/account_api_docs_controller_test.rb
@@ -135,6 +135,23 @@ class Admin::ApiDocs::AccountApiDocsControllerTest < ActionDispatch::Integration
       assert_response :not_found
     end
 
+    test 'member missing right admin section' do
+      member = FactoryBot.create(:member, account: provider, admin_sections: ['partners'])
+      member.member_permission_service_ids = [service.id]
+      member.activate!
+
+      logout! && login!(provider, user: member)
+
+      put toggle_visible_admin_api_docs_service_path(api_docs_service)
+      assert_response :forbidden
+
+      delete admin_api_docs_service_path(api_docs_service)
+      assert_response :forbidden
+
+      post admin_api_docs_services_path(api_docs_params(service_id: service.id, system_name: 'permitted_service_spec'))
+      assert_response :forbidden
+    end
+
     private
 
     attr_reader :provider, :service, :api_docs_service

--- a/test/integration/admin/api_docs/service_api_docs_controller_test.rb
+++ b/test/integration/admin/api_docs/service_api_docs_controller_test.rb
@@ -75,6 +75,26 @@ class Admin::ApiDocs::ServiceApiDocsControllerTest < ActionDispatch::Integration
     assert_response :not_found
   end
 
+  test 'member missing right admin section' do
+    member = FactoryBot.create(:member, account: provider, admin_sections: ['partners'])
+    member.member_permission_service_ids = [service.id]
+    member.activate!
+
+    logout! && login!(provider, user: member)
+
+    get admin_service_api_docs_path(service)
+    assert_response :forbidden
+
+    get new_admin_service_api_doc_path(service)
+    assert_response :forbidden
+
+    get preview_admin_service_api_doc_path(service, api_docs_service)
+    assert_response :forbidden
+
+    get edit_admin_service_api_doc_path(service, api_docs_service)
+    assert_response :forbidden
+  end
+
   protected
 
   def assert_service_active_docs_menus

--- a/test/integration/admin/api_docs/service_api_docs_controller_test.rb
+++ b/test/integration/admin/api_docs/service_api_docs_controller_test.rb
@@ -13,8 +13,16 @@ class Admin::ApiDocs::ServiceApiDocsControllerTest < ActionDispatch::Integration
   attr_reader :provider, :service, :api_docs_service
 
   test 'index works under the service scope' do
+    other_service = FactoryBot.create(:simple_service, account: provider)
+    other_api_docs_service = FactoryBot.create(:api_docs_service, account: provider, service: other_service, name: 'Other spec')
+
     get admin_service_api_docs_path(service)
     assert_service_active_docs_menus
+
+    page = Nokogiri::HTML::Document.parse(response.body)
+    assert_equal 1, page.xpath(".//table[@class='data']/tbody//tr").count
+    assert_match api_docs_service.name, page.xpath(".//table[@class='data']/tbody").text
+    assert_not_match other_api_docs_service.name, page.xpath(".//table[@class='data']/tbody").text
   end
 
   test 'new works under the service scope' do
@@ -31,6 +39,43 @@ class Admin::ApiDocs::ServiceApiDocsControllerTest < ActionDispatch::Integration
     get edit_admin_service_api_doc_path(service, api_docs_service)
     assert_service_active_docs_menus
   end
+
+  test 'member permission' do
+    forbidden_service = FactoryBot.create(:simple_service, account: provider)
+    forbidden_api_docs_service = FactoryBot.create(:api_docs_service, account: provider, service: forbidden_service)
+
+    member = FactoryBot.create(:member, account: provider, admin_sections: ['plans'])
+    member.member_permission_service_ids = [service.id]
+    member.activate!
+
+    logout! && login!(provider, user: member)
+
+    get admin_service_api_docs_path(service)
+    assert_response :success
+
+    get new_admin_service_api_doc_path(service)
+    assert_response :success
+
+    get preview_admin_service_api_doc_path(service, api_docs_service)
+    assert_response :success
+
+    get edit_admin_service_api_doc_path(service, api_docs_service)
+    assert_response :success
+
+    get admin_service_api_docs_path(forbidden_service)
+    assert_response :not_found
+
+    get new_admin_service_api_doc_path(forbidden_service)
+    assert_response :not_found
+
+    get preview_admin_service_api_doc_path(forbidden_service, forbidden_api_docs_service)
+    assert_response :not_found
+
+    get edit_admin_service_api_doc_path(forbidden_service, forbidden_api_docs_service)
+    assert_response :not_found
+  end
+
+  protected
 
   def assert_service_active_docs_menus
     expected_active_menus = {main_menu: :serviceadmin, submenu: :ActiveDocs}

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -585,17 +585,19 @@ class ServiceTest < ActiveSupport::TestCase
     assert service.persisted?
   end
 
-  test '.permitted_for_user' do
-    FactoryBot.create_list(:simple_service, 2)
-    user = User.new
+  test '.permitted_for' do
+    account = FactoryBot.create(:simple_provider)
+    FactoryBot.create_list(:simple_service, 2, account: account)
+    user = FactoryBot.create(:member, account: account)
     member_permission_service_ids = [Service.last.id]
     user.stubs(member_permission_service_ids: member_permission_service_ids)
 
     user.stubs(forbidden_some_services?: false)
-    assert_same_elements Service.pluck(:id), Service.permitted_for_user(user).pluck(:id)
+    assert_same_elements account.services.pluck(:id), Service.permitted_for(user).pluck(:id)
 
     user.stubs(forbidden_some_services?: true)
-    assert_same_elements member_permission_service_ids, Service.permitted_for_user(user).pluck(:id)
+    assert_same_elements member_permission_service_ids, Service.permitted_for(user).pluck(:id)
+    assert_same_elements Service.pluck(:id), Service.permitted_for.pluck(:id)
   end
 
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -146,10 +146,10 @@ class UserTest < ActiveSupport::TestCase
     user = FactoryBot.create(:user, account: provider)
     FactoryBot.create_list(:simple_service, 2, account: provider)
 
-    Service.stubs(permitted_for_user: [provider.services.last!.id])
+    Service.stubs(permitted_for: [provider.services.last!.id])
     refute user.multiple_accessible_services?
 
-    Service.stubs(permitted_for_user: Service.all)
+    Service.stubs(permitted_for: Service.all)
     assert user.multiple_accessible_services?
 
     provider.services.first!.mark_as_deleted!


### PR DESCRIPTION
**What this PR do**
- [x] Ensure members cannot navigate to any service page if user does not have permission over the service (service-level access control)
- [x] Ensure members cannot navigate to ApiDocs::Service pages when the user does not have the “Integration & Application Plans” permission (permission-level access control)
- [x] Ensure members cannot use ApiDocs::Service endpoints of the Admin API unless they have the “Integration & Application Plans” permission (permission-level access control)
- [x] Filter account index of ApiDocs::Service (Audience > Developer Portal > ActiveDocs) to consider services the user has access to
- [x] Ensure only permitted services are listed in the select box to choose the service of an ApiDocs::Service
- [x] Ensure user cannot toggle visibility, update, nor delete ApiDocs::Services whose service the user does not have access to
- [x] Rename `Service.permitted_for_user` -> `Service.permitted_for`
- [x] Refactoring of `Service.permitted_for` to only include services of the provider the user belongs to
- [x] Fix crash of Dashboard when the user does not have permission over any service

**What this PR does NOT do**
- Permission-level access control other than the ones mentioned above

Closes [THREESCALE-952](https://issues.redhat.com/browse/THREESCALE-952) and a small part of [THREESCALE-5867](https://issues.redhat.com/browse/THREESCALE-5867)