### PR TITLE
Require 'plans' permission for member users to manage API backends

### DIFF
--- a/app/controllers/admin/api/backend_apis/base_controller.rb
+++ b/app/controllers/admin/api/backend_apis/base_controller.rb
@@ -17,6 +17,7 @@ class Admin::Api::BackendApis::BaseController < Admin::Api::BaseController
   end
 
   def authorize
-    authorize! :manage, BackendApi
+    return unless current_user # provider_key access
+    authorize! :edit, BackendApi
   end
 end

--- a/app/controllers/admin/api/backend_apis_controller.rb
+++ b/app/controllers/admin/api/backend_apis_controller.rb
@@ -129,7 +129,8 @@ class Admin::Api::BackendApisController < Admin::Api::BaseController
   private_constant :DEFAULT_PARAMS
 
   def authorize
-    authorize! :manage, BackendApi
+    return unless current_user # provider_key access
+    authorize! action_name.to_sym, BackendApi
   end
 
   def backend_api

--- a/app/controllers/provider/admin/backend_apis/base_controller.rb
+++ b/app/controllers/provider/admin/backend_apis/base_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Provider::Admin::BackendApis::BaseController < Provider::Admin::BaseController
+  before_action :authorize
   before_action :find_backend_api
 
   activate_menu :backend_api
@@ -10,5 +11,9 @@ class Provider::Admin::BackendApis::BaseController < Provider::Admin::BaseContro
 
   def find_backend_api
     @backend_api = current_account.backend_apis.accessible.find(params[:backend_api_id])
+  end
+
+  def authorize
+    authorize! :edit, BackendApi
   end
 end

--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -1,19 +1,16 @@
 # frozen_string_literal: true
 
 class Provider::Admin::BackendApisController < Provider::Admin::BaseController
-  before_action :find_backend_api, except: %i[new create]
-  before_action :authorize
+  load_and_authorize_resource :backend_api, through: :current_user, through_association: :accessible_backend_apis
 
   activate_menu :backend_api, :overview
   layout 'provider'
 
   def new
     activate_menu :dashboard
-    @backend_api = collection.build params[:backend_api]
   end
 
   def create
-    @backend_api = current_account.backend_apis.build(create_params)
     if @backend_api.save
       redirect_to provider_admin_backend_api_path(@backend_api), notice: 'Backend created'
     else
@@ -50,23 +47,13 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   DEFAULT_PARAMS = %i[name description private_endpoint].freeze
   private_constant :DEFAULT_PARAMS
 
-  def find_backend_api
-    @backend_api = current_account.backend_apis.accessible.find(params[:id])
+  def backend_api_params(*extra_params)
+    params.require(:backend_api).permit(DEFAULT_PARAMS | extra_params)
   end
 
   def create_params
-    params.require(:backend_api).permit(DEFAULT_PARAMS | %i[system_name])
+    backend_api_params(:system_name)
   end
 
-  def update_params
-    params.require(:backend_api).permit(DEFAULT_PARAMS)
-  end
-
-  def authorize
-    authorize! :manage, BackendApi
-  end
-
-  def collection
-    current_account.backend_apis
-  end
+  alias update_params backend_api_params
 end

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -50,6 +50,7 @@ module Account::ProviderMethods
     end
 
     has_many :backend_apis, inverse_of: :account, dependent: :destroy
+    has_many :accessible_backend_apis, -> { accessible }, class_name: 'BackendApi'
 
     has_attached_file :proxy_configs, storage: :s3, path: '.sandbox_proxy/sandbox_proxy_:id.lua'
     do_not_validate_attachment_file_type :proxy_configs

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,6 +195,8 @@ class User < ApplicationRecord
     accessible_services.exists?
   end
 
+  delegate :accessible_backend_apis, to: :account
+
   def allowed_access_token_scopes
     AccessToken.scopes.allowed_for(self)
   end

--- a/config/abilities/master_admin.rb
+++ b/config/abilities/master_admin.rb
@@ -3,7 +3,7 @@
 Ability.define do |user|
   if user && user.admin? && user.account.master?
     can [:read, :show, :edit, :update, :create, :destroy], Cinstance
-    
+
     can :manage, :logo
 
     can %i[read delete configure], Account
@@ -48,10 +48,9 @@ Ability.define do |user|
     can :manage, :authentication_providers
     can :manage, :web_hooks
 
-    if user.account.provider_can_use?(:api_as_product)
-      can :manage, BackendApi
-      can :manage, BackendApiConfig
-    end
+    can %i[index show edit update create destroy], BackendApi
+
+    can :manage, BackendApiConfig
 
     #COPY these come from forum.rb
     can :manage, TopicCategory do |category|

--- a/config/abilities/provider_admin.rb
+++ b/config/abilities/provider_admin.rb
@@ -79,10 +79,9 @@ Ability.define do |user|
     service.account_id == user.account_id && can?(:manage, :multiple_services) and not service.default_or_last?
   end
 
-  if account.provider_can_use?(:api_as_product)
-    can :manage, BackendApi
-    can :manage, BackendApiConfig
-  end
+  can %i[index show edit update create destroy], BackendApi
+
+  can :manage, BackendApiConfig
 
   # TODO: there should be user.accessible_cinstances.where_values_hash, but that query is impossible
   # we have to wait until we denormalize Cinstance and add provider_account_id there

--- a/config/abilities/provider_member.rb
+++ b/config/abilities/provider_member.rb
@@ -36,6 +36,8 @@ Ability.define do |user|
     can :admin, :account_plans
     can :admin, :service_plans
     can :admin, :service_contracts
+    can %i[index show edit update], BackendApi
+    can :manage, BackendApiConfig
   end
 
   if user.has_permission?('settings')
@@ -54,8 +56,6 @@ Ability.define do |user|
   if user.has_permission?('legal')
     can :manage, LegalTerm
   end
-
-  can :manage, BackendApiConfig if account.provider_can_use?(:api_as_product)
 
   # Member cannot manage permissions, neither his own, nor other members'
   cannot :update_permissions, User

--- a/config/initializers/cancan_hacks.rb
+++ b/config/initializers/cancan_hacks.rb
@@ -29,7 +29,7 @@ module CanCanHacks
     def authorization_action
       action = @params[:action].to_sym
 
-      if @controller.request.get? && !%i[index edit].include?(action)
+      if @controller.request.get? && !%i[index new edit].include?(action)
         :show
       else
         super

--- a/test/integration/admin/api/backend_apis/mapping_rules_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/mapping_rules_controller_test.rb
@@ -4,111 +4,169 @@ require 'test_helper'
 
 class Admin::Api::BackendApis::MappingRulesControllerTest < ActionDispatch::IntegrationTest
   def setup
-    @tenant = FactoryBot.create(:provider_account)
-    host! @tenant.admin_domain
-    @access_token_value = FactoryBot.create(:access_token, owner: @tenant.admin_users.first!, scopes: %w[account_management], permission: 'rw').value
-    @backend_api = FactoryBot.create(:backend_api, account: @tenant)
+    @provider = FactoryBot.create(:simple_provider)
+    @backend_api = FactoryBot.create(:backend_api, account: provider)
+    @mapping_rule = FactoryBot.create(:proxy_rule, owner: backend_api, proxy: nil)
+    host! provider.admin_domain
   end
 
-  attr_reader :backend_api, :access_token_value, :tenant
+  attr_reader :provider, :backend_api, :mapping_rule
 
-  test 'index' do
-    FactoryBot.create_list(:proxy_rule, 2, owner: backend_api, proxy: nil)
-    FactoryBot.create(:proxy_rule, owner: FactoryBot.create(:backend_api, account: tenant), proxy: nil)
-    FactoryBot.create(:proxy_rule, proxy: tenant.default_service.proxy)
+  class AdminPermission < self
+    def setup
+      super
 
-    get admin_api_backend_api_mapping_rules_path(backend_api_id: backend_api.id, access_token: access_token_value)
-
-    assert_response :success
-    assert(response_collection_mapping_rules_of_backend_api = JSON.parse(response.body)['mapping_rules'])
-    assert_equal 2, response_collection_mapping_rules_of_backend_api.length
-    response_collection_mapping_rules_of_backend_api.each do |response_mapping_rule|
-      assert backend_api.mapping_rules.find_by(id: response_mapping_rule.dig('mapping_rule', 'id'))
+      admin = FactoryBot.create(:admin, account: provider)
+      @access_token = FactoryBot.create(:access_token, owner: admin, scopes: %w[account_management], permission: 'rw')
     end
-  end
 
-  test 'show' do
-    get admin_api_backend_api_mapping_rule_path(backend_api_id: backend_api.id, access_token: access_token_value, id: mapping_rule.id)
+    attr_reader :access_token
+    delegate :value, to: :access_token, prefix: true
 
-    assert_response :success
-    assert_equal mapping_rule.id, JSON.parse(response.body).dig('mapping_rule', 'id')
-  end
+    test 'index' do
+      FactoryBot.create_list(:proxy_rule, 2, owner: backend_api, proxy: nil) # two more of the same backend api
+      FactoryBot.create(:proxy_rule, owner: FactoryBot.create(:backend_api, account: provider), proxy: nil) # other backend api
+      FactoryBot.create(:proxy_rule, proxy: FactoryBot.create(:simple_service, account: provider).proxy) # owned by a proxy, not a backend api
 
-  test 'create' do
-    assert_difference(ProxyRule.method(:count)) do
-      post admin_api_backend_api_mapping_rules_path(backend_api_id: backend_api.id, access_token: access_token_value), mapping_rule_params
-      assert_response :created
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value }
+
+      assert_response :success
+      assert(response_mapping_rules = JSON.parse(response.body)['mapping_rules'])
+      assert_equal 3, response_mapping_rules.length
+      response_mapping_rule_ids = response_mapping_rules.map { |mapping_rule| mapping_rule.dig('mapping_rule', 'id') }
+      assert_same_elements backend_api.mapping_rules.pluck(:id), response_mapping_rule_ids
     end
-    assert(@mapping_rule = backend_api.mapping_rules.find_by(id: JSON.parse(response.body).dig('mapping_rule', 'id')))
-    mapping_rule_params.each do |field_name, expected_value|
-      assert_equal expected_value, mapping_rule.public_send(field_name)
-    end
-  end
 
-  test 'create without metric_id gives an error' do
-    assert_no_difference(ProxyRule.method(:count)) do
-      post admin_api_backend_api_mapping_rules_path(backend_api_id: backend_api.id, access_token: access_token_value), mapping_rule_params.except(:metric_id)
+    test 'show' do
+      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+
+      assert_response :success
+      assert_equal mapping_rule.id, JSON.parse(response.body).dig('mapping_rule', 'id')
+    end
+
+    test 'create' do
+      assert_difference(ProxyRule.method(:count)) do
+        post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, **mapping_rule_params }
+        assert_response :created
+      end
+
+      mapping_rule = backend_api.mapping_rules.find(JSON.parse(response.body).dig('mapping_rule', 'id'))
+      mapping_rule_params.each do |field_name, expected_value|
+        assert_equal expected_value, mapping_rule.public_send(field_name)
+      end
+    end
+
+    test 'create without metric_id gives an error' do
+      assert_no_difference(ProxyRule.method(:count)) do
+        post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, **mapping_rule_params.except(:metric_id) }
+        assert_response :unprocessable_entity
+        assert_contains JSON.parse(response.body).dig('errors', 'metric_id'), 'can\'t be blank'
+      end
+    end
+
+    test 'update' do
+      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value, **mapping_rule_params }
+      assert_response :success
+      mapping_rule.reload
+      mapping_rule_params.each do |field_name, expected_value|
+        assert_equal expected_value, mapping_rule.public_send(field_name)
+      end
+    end
+
+    test 'update with errors in the model' do
+      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value, http_method: 'invalid' }
       assert_response :unprocessable_entity
-      assert_contains JSON.parse(response.body).dig('errors', 'metric_id'), 'can\'t be blank'
+      assert_contains JSON.parse(response.body).dig('errors', 'http_method'), 'is not included in the list'
+    end
+
+    test 'destroy' do
+      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      assert_response :success
+      assert_raises(ActiveRecord::RecordNotFound) { mapping_rule.reload }
+    end
+
+    test 'index can be paginated' do
+      FactoryBot.create_list(:proxy_rule, 5, owner: backend_api, proxy_id: nil)
+
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, per_page: 3, page: 2 }
+
+      assert_response :success
+      response_ids = JSON.parse(response.body)['mapping_rules'].map { |response| response.dig('mapping_rule', 'id') }
+      assert_equal backend_api.mapping_rules.order(:id).offset(3).limit(3).select(:id).map(&:id), response_ids
+    end
+
+    test 'it cannot operate under a non-accessible backend api' do
+      backend_api = FactoryBot.create(:backend_api, account: provider, state: :deleted)
+      mapping_rule = FactoryBot.create(:proxy_rule, owner: backend_api, proxy: nil)
+
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value }
+      assert_response :not_found
+
+      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      assert_response :not_found
+
+      post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, **mapping_rule_params }
+      assert_response :not_found
+
+      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value, **mapping_rule_params }
+      assert_response :not_found
+
+      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      assert_response :not_found
     end
   end
 
-  test 'update' do
-    put admin_api_backend_api_mapping_rule_path(backend_api_id: backend_api.id, access_token: access_token_value, id: mapping_rule.id), mapping_rule_params
-    assert_response :success
-    mapping_rule.reload
-    mapping_rule_params.each do |field_name, expected_value|
-      assert_equal expected_value, mapping_rule.public_send(field_name)
+  class MemberPermission < self
+    def setup
+      super
+
+      @member = FactoryBot.create(:member, account: provider)
+      @access_token = FactoryBot.create(:access_token, owner: member, scopes: %w[account_management], permission: 'rw')
+      member.activate!
+    end
+
+    attr_reader :member, :access_token
+    delegate :value, to: :access_token, prefix: true
+
+    test 'member with permission' do
+      member.admin_sections = %w[partners plans]
+      member.save!
+
+      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      assert_response :success
+
+      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value, **mapping_rule_params }
+      assert_response :success
+
+      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      assert_response :success
+
+      post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, **mapping_rule_params }
+      assert_response :success
+
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value }
+      assert_response :success
+    end
+
+    test 'member without permission' do
+      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      assert_response :forbidden
+
+      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value, **mapping_rule_params }
+      assert_response :forbidden
+
+      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      assert_response :forbidden
+
+      post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, **mapping_rule_params }
+      assert_response :forbidden
+
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value }
+      assert_response :forbidden
     end
   end
 
-  test 'update with errors in the model' do
-    put admin_api_backend_api_mapping_rule_path(backend_api_id: backend_api.id, access_token: access_token_value, id: mapping_rule.id), { http_method: 'invalid' }
-    assert_response :unprocessable_entity
-    assert_contains JSON.parse(response.body).dig('errors', 'http_method'), 'is not included in the list'
-  end
-
-  test 'destroy' do
-    delete admin_api_backend_api_mapping_rule_path(backend_api_id: backend_api.id, access_token: access_token_value, id: mapping_rule.id)
-    assert_response :success
-    assert_raises(ActiveRecord::RecordNotFound) { mapping_rule.reload }
-  end
-
-  test 'index can be paginated' do
-    FactoryBot.create_list(:proxy_rule, 5, owner: backend_api, proxy_id: nil)
-
-    get admin_api_backend_api_mapping_rules_path(backend_api_id: backend_api.id, access_token: access_token_value, per_page: 3, page: 2)
-
-    assert_response :success
-    response_ids = JSON.parse(response.body)['mapping_rules'].map { |response| response.dig('mapping_rule', 'id') }
-    assert_equal backend_api.mapping_rules.order(:id).offset(3).limit(3).select(:id).map(&:id), response_ids
-  end
-
-  test 'it cannot operate under a non-accessible backend api' do
-    backend_api = FactoryBot.create(:backend_api, account: tenant, state: :deleted)
-    mapping_rule = FactoryBot.create(:proxy_rule, owner: backend_api, proxy: nil)
-
-    get admin_api_backend_api_mapping_rules_path(backend_api_id: backend_api.id, access_token: access_token_value)
-    assert_response :not_found
-
-    get admin_api_backend_api_mapping_rule_path(backend_api_id: backend_api.id, access_token: access_token_value, id: mapping_rule.id)
-    assert_response :not_found
-
-    post admin_api_backend_api_mapping_rules_path(backend_api_id: backend_api.id, access_token: access_token_value), mapping_rule_params
-    assert_response :not_found
-
-    put admin_api_backend_api_mapping_rule_path(backend_api_id: backend_api.id, access_token: access_token_value, id: mapping_rule.id), mapping_rule_params
-    assert_response :not_found
-
-    delete admin_api_backend_api_mapping_rule_path(backend_api_id: backend_api.id, access_token: access_token_value, id: mapping_rule.id)
-    assert_response :not_found
-  end
-
-  private
-
-  def mapping_rule
-    @mapping_rule ||= FactoryBot.create(:proxy_rule, owner: backend_api, proxy: nil)
-  end
+  protected
 
   def mapping_rule_params
     @mapping_rule_params ||= { http_method: 'POST', pattern: '/mypattern', delta: 3, last: true, position: 2, metric_id: backend_api.metrics.hits.id }

--- a/test/integration/admin/api/backend_apis/metric_methods_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metric_methods_controller_test.rb
@@ -4,154 +4,184 @@ require 'test_helper'
 
 class Admin::Api::BackendApis::MetricMethodsControllerTest < ActionDispatch::IntegrationTest
   def setup
-    @tenant = FactoryBot.create(:provider_account)
-    host! @tenant.admin_domain
-    @access_token_value = FactoryBot.create(:access_token, owner: @tenant.admin_users.first!, scopes: %w[account_management], permission: 'rw').value
-    @backend_api = FactoryBot.create(:backend_api, account: @tenant)
+    @provider = FactoryBot.create(:simple_provider)
+    @backend_api = FactoryBot.create(:backend_api, account: provider)
+    @hits = backend_api.metrics.hits
+    @method_metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil, parent: hits)
+    host! provider.admin_domain
   end
 
-  attr_reader :backend_api, :access_token_value, :tenant
+  attr_reader :provider, :backend_api, :hits, :method_metric
 
-  test 'index' do
-    FactoryBot.create_list(:metric, 2, owner: backend_api, service_id: nil, parent: hits)
+  class AdminPermission < self
+    def setup
+      super
 
-    FactoryBot.create(:metric, owner: FactoryBot.create(:backend_api, account: tenant), service_id: nil)
-    FactoryBot.create(:metric, service: FactoryBot.create(:service, account: tenant))
-
-    get admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value)
-
-    assert_response :success
-    assert(response_collection_methods_of_hits = JSON.parse(response.body)['methods'])
-    assert_equal 2, response_collection_methods_of_hits.length
-    response_collection_methods_of_hits.each do |response_method|
-      assert hits.children.find_by(id: response_method.dig('method', 'id'))
+      admin = FactoryBot.create(:admin, account: provider)
+      @access_token = FactoryBot.create(:access_token, owner: admin, scopes: %w[account_management], permission: 'rw')
     end
-  end
 
-  test 'show' do
-    get admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id)
+    attr_reader :access_token
+    delegate :value, to: :access_token, prefix: true
 
-    assert_response :success
-    assert_equal metric_method.id, JSON.parse(response.body).dig('method', 'id')
-  end
+    test 'index' do
+      FactoryBot.create_list(:metric, 2, owner: backend_api, service_id: nil, parent: hits) # two more method metrics of the backend api
+      FactoryBot.create(:metric, owner: FactoryBot.create(:backend_api, account: provider), service_id: nil) # other backend api
+      FactoryBot.create(:metric, service: FactoryBot.create(:service, account: provider)) # owned by service, not a backend api
 
-  test 'create' do
-    assert_difference(Metric.method(:count)) do
-      post admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value), { friendly_name: 'my friendly name', unit: 'hit' }
-      assert_response :created
+      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
+
+      assert_response :success
+      assert(response_metrics = JSON.parse(response.body)['methods'])
+      assert_equal 3, response_metrics.length
+      response_metric_ids = response_metrics.map { |metric| metric.dig('method', 'id') }
+      assert_same_elements hits.children.pluck(:id), response_metric_ids
     end
-    assert(@metric_method = hits.children.find_by(id: JSON.parse(response.body).dig('method', 'id')))
-    assert_equal 'my friendly name', metric_method.friendly_name
-    assert_equal 'hit', metric_method.unit
-    assert_equal "my_friendly_name.#{backend_api.id}", metric_method.attributes['system_name']
-  end
 
-  test 'create with errors in the model' do
-    post admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value), { friendly_name: '' }
-    assert_response :unprocessable_entity
-    assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
-  end
+    test 'show' do
+      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
 
-  test 'update' do
-    put admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id), { friendly_name: 'my friendly name', unit: 'hit' }
-    assert_response :success
-    metric_method.reload
-    assert_equal 'my friendly name', metric_method.friendly_name
-    assert_equal 'hit', metric_method.unit
-  end
+      assert_response :success
+      assert_equal method_metric.id, JSON.parse(response.body).dig('method', 'id')
+    end
 
-  test 'update with errors in the model' do
-    put admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id), { friendly_name: '' }
-    assert_response :unprocessable_entity
-    assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
-  end
+    test 'create' do
+      assert_difference(Metric.method(:count)) do
+        post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+        assert_response :created
+      end
+      method_metric = hits.children.find(JSON.parse(response.body).dig('method', 'id'))
+      assert_equal 'my friendly name', method_metric.friendly_name
+      assert_equal 'hit', method_metric.unit
+      assert_equal "my_friendly_name.#{backend_api.id}", method_metric.attributes['system_name']
+    end
 
-  test 'destroy' do
-    @metric_method = FactoryBot.create(:metric, owner: backend_api, service_id: nil, parent: hits)
-    assert_difference(Metric.method(:count), -1) do
-      delete admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id)
+    test 'create with errors in the model' do
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: '' }
+      assert_response :unprocessable_entity
+      assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
+    end
+
+    test 'update' do
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      assert_response :success
+      method_metric.reload
+      assert_equal 'my friendly name', method_metric.friendly_name
+      assert_equal 'hit', method_metric.unit
+    end
+
+    test 'update with errors in the model' do
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: '' }
+      assert_response :unprocessable_entity
+      assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
+    end
+
+    test 'system_name can be created but not updated' do
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit', system_name: 'first-system-name' }
+      method_metric = hits.children.find(JSON.parse(response.body).dig('method', 'id'))
+      assert_equal "first-system-name.#{backend_api.id}", method_metric.system_name
+
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit', system_name: 'edited' }
+      assert_equal "first-system-name.#{backend_api.id}", method_metric.reload.system_name
+    end
+
+    test 'destroy' do
+      method_metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil, parent: hits)
+      assert_difference(Metric.method(:count), -1) do
+        delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+        assert_response :success
+      end
+      assert_raises(ActiveRecord::RecordNotFound) { method_metric.reload }
+    end
+
+    test 'index can be paginated' do
+      FactoryBot.create_list(:metric, 5, owner: backend_api, parent: hits, service_id: nil)
+
+      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, per_page: 3, page: 2 }
+
+      assert_response :success
+      response_ids = JSON.parse(response.body)['methods'].map { |response| response.dig('method', 'id') }
+      assert_equal hits.children.order(:id).offset(3).limit(3).select(:id).map(&:id), response_ids
+    end
+
+    test 'it cannot operate for metrics under a non-accessible backend api' do
+      backend_api = FactoryBot.create(:backend_api, account: provider, state: :deleted)
+      hits = backend_api.metrics.hits
+      method_metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil, parent: hits)
+
+      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      assert_response :not_found
+
+      delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      assert_response :not_found
+
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      assert_response :not_found
+
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      assert_response :not_found
+
+      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
+      assert_response :not_found
+    end
+
+    test 'when no params are sent, the error message is the same as in the other metrics endpoint' do
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
+      assert_response :unprocessable_entity
+      assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
+
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
       assert_response :success
     end
-    assert_raises(ActiveRecord::RecordNotFound) { metric_method.reload }
   end
 
-  test 'without permission' do
-    member = FactoryBot.create(:member, account: tenant)
-    access_token_value = FactoryBot.create(:access_token, owner: member, scopes: %w[account_management], permission: 'rw').value
+  class MemberPermission < self
+    def setup
+      super
 
-    get admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id)
-    assert_response :forbidden
+      @member = FactoryBot.create(:member, account: provider)
+      @access_token = FactoryBot.create(:access_token, owner: member, scopes: %w[account_management], permission: 'rw')
+      member.activate!
+    end
 
-    delete admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id)
-    assert_response :forbidden
+    attr_reader :member, :access_token
+    delegate :value, to: :access_token, prefix: true
 
-    put admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id), { friendly_name: 'my friendly name', unit: 'hit' }
-    assert_response :forbidden
+    test 'member with permission' do
+      member.admin_sections = %w[partners plans]
+      member.save!
 
-    post admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value), { friendly_name: 'my friendly name', unit: 'hit' }
-    assert_response :forbidden
+      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      assert_response :success
 
-    get admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value)
-    assert_response :forbidden
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      assert_response :success
+
+      delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      assert_response :success
+
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      assert_response :success
+
+      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
+      assert_response :success
+    end
+
+    test 'member without permission' do
+      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      assert_response :forbidden
+
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      assert_response :forbidden
+
+      delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      assert_response :forbidden
+
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      assert_response :forbidden
+
+      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
+      assert_response :forbidden
+    end
   end
-
-  test 'system_name can be created but not updated' do
-    post admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value), { friendly_name: 'my friendly name', unit: 'hit', system_name: 'first-system-name' }
-    metric_method = hits.children.last!
-    assert_equal "first-system-name.#{backend_api.id}", metric_method.system_name
-
-    put admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id), { friendly_name: 'my friendly name', unit: 'hit', system_name: 'edited' }
-    assert_equal "first-system-name.#{backend_api.id}", metric_method.reload.system_name
-  end
-
-  test 'index can be paginated' do
-    FactoryBot.create_list(:metric, 5, owner: backend_api, parent: hits, service_id: nil)
-
-    get admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, per_page: 3, page: 2)
-
-    assert_response :success
-    response_ids = JSON.parse(response.body)['methods'].map { |response| response.dig('method', 'id') }
-    assert_equal hits.children.order(:id).offset(3).limit(3).select(:id).map(&:id), response_ids
-  end
-
-  test 'it cannot operate for metrics under a non-accessible backend api' do
-    backend_api = FactoryBot.create(:backend_api, account: tenant, state: :deleted)
-    hits = backend_api.metrics.hits
-    metric_method = FactoryBot.create(:metric, owner: backend_api, service_id: nil, parent: hits)
-
-    get admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id)
-    assert_response :not_found
-
-    delete admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id)
-    assert_response :not_found
-
-    put admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id), { friendly_name: 'my friendly name', unit: 'hit' }
-    assert_response :not_found
-
-    post admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value), { friendly_name: 'my friendly name', unit: 'hit' }
-    assert_response :not_found
-
-    get admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value)
-    assert_response :not_found
-  end
-
-  test 'when no params are sent, the error message is the same as in the other metrics endpoint' do
-    post admin_api_backend_api_metric_methods_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value), {}
-    assert_response :unprocessable_entity
-    assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
-
-    put admin_api_backend_api_metric_method_path(backend_api_id: backend_api.id, metric_id: hits.id, access_token: access_token_value, id: metric_method.id), {}
-    assert_response :success
-  end
-
-  private
-
-  def metric_method
-    @metric_method ||= FactoryBot.create(:metric, owner: backend_api, service_id: nil, parent: hits)
-  end
-
-  def hits
-    @hits ||= backend_api.metrics.hits
-  end
-
 end

--- a/test/integration/admin/api/backend_apis/metrics_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metrics_controller_test.rb
@@ -4,156 +4,190 @@ require 'test_helper'
 
 class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::IntegrationTest
   def setup
-    @tenant = FactoryBot.create(:provider_account)
-    host! @tenant.admin_domain
-    @access_token_value = FactoryBot.create(:access_token, owner: @tenant.admin_users.first!, scopes: %w[account_management], permission: 'rw').value
-    @backend_api = FactoryBot.create(:backend_api, account: @tenant)
+    @provider = FactoryBot.create(:simple_provider)
+    @backend_api = FactoryBot.create(:backend_api, account: provider)
+    @metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil) # the 2nd metric of the backend
+    host! provider.admin_domain
   end
 
-  attr_reader :backend_api, :access_token_value, :tenant
+  attr_reader :provider, :backend_api, :metric
 
-  test 'index' do
-    FactoryBot.create(:metric, owner: backend_api, parent: backend_api.metrics.hits, service_id: nil)
+  class AdminPermission < self
+    def setup
+      super
 
-    FactoryBot.create(:metric, owner: FactoryBot.create(:backend_api, account: tenant), service_id: nil)
-    FactoryBot.create(:metric, service: FactoryBot.create(:service, account: tenant))
-
-    get admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value)
-
-    assert_response :success
-    assert(response_collection_metrics_of_backend_api = JSON.parse(response.body)['metrics'])
-    assert_equal 2, response_collection_metrics_of_backend_api.length
-    response_collection_metrics_of_backend_api.each do |response_metric|
-      assert backend_api.metrics.find_by(id: response_metric.dig('metric', 'id'))
+      admin = FactoryBot.create(:admin, account: provider)
+      @access_token = FactoryBot.create(:access_token, owner: admin, scopes: %w[account_management], permission: 'rw')
     end
-  end
 
-  test 'show' do
-    get admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id)
+    attr_reader :access_token
+    delegate :value, to: :access_token, prefix: true
 
-    assert_response :success
-    assert_equal metric.id, JSON.parse(response.body).dig('metric', 'id')
-  end
+    test 'index' do
+      FactoryBot.create(:metric, owner: backend_api, parent: backend_api.metrics.hits, service_id: nil) # a method metric
+      FactoryBot.create(:metric, owner: FactoryBot.create(:backend_api, account: provider), service_id: nil) # other backend api
+      FactoryBot.create(:metric, service: FactoryBot.create(:service, account: provider)) # owned by a service, not a backend api
 
-  test 'create' do
-    assert_difference(Metric.method(:count)) do
-      post admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value), { friendly_name: 'metric friendly name', unit: 'hit' }
-			assert_response :created
+      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
+
+      assert_response :success
+      assert(response_metrics = JSON.parse(response.body)['metrics'])
+      assert_equal 3, response_metrics.length
+      response_metric_ids = response_metrics.map { |metric| metric.dig('metric', 'id') }
+      assert_same_elements backend_api.metrics.pluck(:id), response_metric_ids
     end
-    assert(@metric = backend_api.metrics.find_by(id: JSON.parse(response.body).dig('metric', 'id')))
-    assert_equal 'metric friendly name', metric.friendly_name
-    assert_equal 'hit', metric.unit
-    assert_equal "metric_friendly_name.#{backend_api.id}", metric.attributes['system_name']
-  end
 
-  test 'create with errors in the model' do
-    post admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value), { friendly_name: '', unit: 'hit' }
-    assert_response :unprocessable_entity
-    assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
-  end
+    test 'show' do
+      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
 
-  test 'update' do
-    put admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id), { friendly_name: 'metric friendly name', unit: 'hit' }
-    assert_response :success
-    metric.reload
-    assert_equal 'metric friendly name', metric.friendly_name
-    assert_equal 'hit', metric.unit
-  end
+      assert_response :success
+      assert_equal metric.id, JSON.parse(response.body).dig('metric', 'id')
+    end
 
-  test 'cannot update system_name' do
-    old_system_name = metric.system_name
-    put admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id), { system_name: 'new_system_name' }
-    assert_response :success
-    assert_equal old_system_name, metric.reload.system_name
-  end
+    test 'create' do
+      assert_difference(Metric.method(:count)) do
+        post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+        assert_response :created
+      end
+      metric = backend_api.metrics.find(JSON.parse(response.body).dig('metric', 'id'))
+      assert_equal 'metric friendly name', metric.friendly_name
+      assert_equal 'hit', metric.unit
+      assert_equal "metric_friendly_name.#{backend_api.id}", metric.attributes['system_name']
+    end
 
-  test 'update with errors in the model' do
-    put admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id), { friendly_name: '' }
-    assert_response :unprocessable_entity
-    assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
-  end
+    test 'create with errors in the model' do
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: '', unit: 'hit' }
+      assert_response :unprocessable_entity
+      assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
+    end
 
-  test 'destroy' do
-    @metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil)
-    assert_difference(Metric.method(:count), -1) do
-      delete admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id)
+    test 'update' do
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      assert_response :success
+      metric.reload
+      assert_equal 'metric friendly name', metric.friendly_name
+      assert_equal 'hit', metric.unit
+    end
+
+    test 'cannot update system_name' do
+      old_system_name = metric.system_name
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, system_name: 'new_system_name' }
+      assert_response :success
+      assert_equal old_system_name, metric.reload.system_name
+    end
+
+    test 'system_name can be created but not updated' do
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit', system_name: 'edited', system_name: 'first-system-name' }
+      metric = backend_api.metrics.find(JSON.parse(response.body).dig('metric', 'id'))
+      assert_equal "first-system-name.#{backend_api.id}", metric.attributes['system_name']
+
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit', system_name: 'edited' }
+      assert_equal "first-system-name.#{backend_api.id}", metric.reload.attributes['system_name']
+    end
+
+    test 'update with errors in the model' do
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: '' }
+      assert_response :unprocessable_entity
+      assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
+    end
+
+    test 'destroy' do
+      metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil)
+      assert_difference(Metric.method(:count), -1) do
+        delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+        assert_response :success
+      end
+      assert_raises(ActiveRecord::RecordNotFound) { metric.reload }
+    end
+
+    test 'index can be paginated' do
+      FactoryBot.create_list(:metric, 5, owner: backend_api, service_id: nil)
+
+      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, per_page: 3, page: 2 }
+
+      assert_response :success
+      response_ids = JSON.parse(response.body)['metrics'].map { |response| response.dig('metric', 'id') }
+      assert_equal backend_api.metrics.order(:id).offset(3).limit(3).select(:id).map(&:id), response_ids
+    end
+
+    test 'it cannot operate for metrics under a non-accessible backend api' do
+      backend_api = FactoryBot.create(:backend_api, account: provider, state: :deleted)
+      metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil)
+
+      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      assert_response :not_found
+
+      delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      assert_response :not_found
+
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      assert_response :not_found
+
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      assert_response :not_found
+
+      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
+      assert_response :not_found
+    end
+
+    test 'when no params are sent, the error message is the same as in the other metrics endpoint' do
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
+      assert_response :unprocessable_entity
+      assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
+      assert_contains JSON.parse(response.body).dig('errors', 'unit'), 'can\'t be blank'
+
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
       assert_response :success
     end
-    assert_raises(ActiveRecord::RecordNotFound) { metric.reload }
   end
 
-  test 'without permission' do
-    member = FactoryBot.create(:member, account: tenant)
-    access_token_value = FactoryBot.create(:access_token, owner: member, scopes: %w[account_management], permission: 'rw').value
+  class MemberPermission < self
+    def setup
+      super
 
-    get admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id)
-    assert_response :forbidden
+      @member = FactoryBot.create(:member, account: provider)
+      @access_token = FactoryBot.create(:access_token, owner: member, scopes: %w[account_management], permission: 'rw')
+      member.activate!
+    end
 
-    delete admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id)
-    assert_response :forbidden
+    attr_reader :member, :access_token
+    delegate :value, to: :access_token, prefix: true
 
-    put admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id), { friendly_name: 'metric friendly name', unit: 'hit' }
-    assert_response :forbidden
+    test 'member with permission' do
+      member.admin_sections = %w[partners plans]
+      member.save!
 
-    post admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value), { friendly_name: 'metric friendly name', unit: 'hit' }
-    assert_response :forbidden
+      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      assert_response :success
 
-    get admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value)
-    assert_response :forbidden
-  end
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      assert_response :success
 
-  test 'system_name can be created but not updated' do
-    post admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value), { friendly_name: 'metric friendly name', unit: 'hit', system_name: 'edited', system_name: 'first-system-name' }
-    metric = backend_api.metrics.last!
-    assert_equal "first-system-name.#{backend_api.id}", metric.attributes['system_name']
+      delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      assert_response :success
 
-    put admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id), { friendly_name: 'metric friendly name', unit: 'hit', system_name: 'edited' }
-    assert_equal "first-system-name.#{backend_api.id}", metric.reload.attributes['system_name']
-  end
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      assert_response :success
 
-  test 'index can be paginated' do
-    FactoryBot.create_list(:metric, 5, owner: backend_api, service_id: nil)
+      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
+      assert_response :success
+    end
 
-    get admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value, per_page: 3, page: 2)
+    test 'member without permission' do
+      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      assert_response :forbidden
 
-    assert_response :success
-    response_ids = JSON.parse(response.body)['metrics'].map { |response| response.dig('metric', 'id') }
-    assert_equal backend_api.metrics.order(:id).offset(3).limit(3).select(:id).map(&:id), response_ids
-  end
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      assert_response :forbidden
 
-  test 'it cannot operate for metrics under a non-accessible backend api' do
-    backend_api = FactoryBot.create(:backend_api, account: tenant, state: :deleted)
-    metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil)
+      delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      assert_response :forbidden
 
-    get admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id)
-    assert_response :not_found
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      assert_response :forbidden
 
-    delete admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id)
-    assert_response :not_found
-
-    put admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id), { friendly_name: 'metric friendly name', unit: 'hit' }
-    assert_response :not_found
-
-    post admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value), { friendly_name: 'metric friendly name', unit: 'hit' }
-    assert_response :not_found
-
-    get admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value)
-    assert_response :not_found
-  end
-
-  test 'when no params are sent, the error message is the same as in the other metrics endpoint' do
-    post admin_api_backend_api_metrics_path(backend_api_id: backend_api.id, access_token: access_token_value), {}
-    assert_response :unprocessable_entity
-    assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
-    assert_contains JSON.parse(response.body).dig('errors', 'unit'), 'can\'t be blank'
-
-    put admin_api_backend_api_metric_path(backend_api_id: backend_api.id, access_token: access_token_value, id: metric.id), {}
-    assert_response :success
-  end
-
-  private
-
-  def metric
-    @metric ||= FactoryBot.create(:metric, owner: backend_api, service_id: nil)
+      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
+      assert_response :forbidden
+    end
   end
 end

--- a/test/integration/admin/api/backend_apis_controller_test.rb
+++ b/test/integration/admin/api/backend_apis_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   def setup
     @provider = FactoryBot.create(:provider_account)
-    host! @provider.admin_domain
+    host! provider.admin_domain
   end
 
   attr_reader :provider
@@ -13,7 +13,7 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   test 'show' do
     backend_api_configs = FactoryBot.create_list(:backend_api_config, 2, backend_api: backend_api)
 
-    get admin_api_backend_api_path(backend_api, access_token: access_token_value)
+    get admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
 
     assert_response :success
     backend_api_response = JSON.parse(response.body)
@@ -21,7 +21,7 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'destroy' do
-    delete admin_api_backend_api_path(backend_api, access_token: access_token_value)
+    delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
     assert_response :success
     assert backend_api.reload.deleted?
   end
@@ -29,27 +29,27 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   test 'destroy with errors' do
     provider.default_service.backend_api_configs.create!(backend_api: backend_api, path: 'whatever')
 
-    delete admin_api_backend_api_path(backend_api, access_token: access_token_value)
+    delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
     refute backend_api.reload.deleted?
     assert_contains JSON.parse(response.body).dig('errors', 'base'), 'cannot be deleted because it is used by at least one Product'
   end
 
   test 'update' do
-    put admin_api_backend_api_path(backend_api, access_token: access_token_value), permitted_params.merge(forbidden_params)
+    put admin_api_backend_api_path(backend_api), params: { access_token: access_token_value, **permitted_params.merge(forbidden_params) }
     assert_response :success
     backend_api.reload
     assert_persists_right_params
   end
 
   test 'update with errors in the model' do
-    put admin_api_backend_api_path(backend_api, access_token: access_token_value), { private_endpoint: '' }
+    put admin_api_backend_api_path(backend_api), params: { access_token: access_token_value, private_endpoint: '' }
     assert_response :unprocessable_entity
     assert_contains JSON.parse(response.body).dig('errors', 'private_endpoint'), 'can\'t be blank'
   end
 
   test 'create' do
     assert_difference(BackendApi.method(:count)) do
-      post admin_api_backend_apis_path(access_token: access_token_value), permitted_params.merge(forbidden_params)
+      post admin_api_backend_apis_path, params: { access_token: access_token_value, **permitted_params.merge(forbidden_params) }
       assert_response :created
     end
     assert(@backend_api = provider.backend_apis.find_by(id: JSON.parse(response.body).dig('backend_api', 'id')))
@@ -57,7 +57,7 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'create with errors in the model' do
-    post admin_api_backend_apis_path(access_token: access_token_value), { private_endpoint: '' }
+    post admin_api_backend_apis_path, params: { access_token: access_token_value,  private_endpoint: '' }
     assert_response :unprocessable_entity
     assert_contains JSON.parse(response.body).dig('errors', 'private_endpoint'), 'can\'t be blank'
   end
@@ -65,7 +65,7 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   test 'index' do
     FactoryBot.create_list(:backend_api, 2, account: provider)
     FactoryBot.create(:backend_api) # belonging to another provider
-    get admin_api_backend_apis_path(access_token: access_token_value)
+    get admin_api_backend_apis_path, params: { access_token: access_token_value }
     assert_response :success
     assert(response_collection_backend_apis = JSON.parse(response.body)['backend_apis'])
     assert_equal provider.backend_apis.count, response_collection_backend_apis.length
@@ -77,57 +77,98 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   test 'index can be paginated' do
     FactoryBot.create_list(:backend_api, 5, account: provider)
     provider.backend_apis.each_with_index { |backend_api, index| backend_api.update_column(:created_at, Date.today - index.days) }
-    get admin_api_backend_apis_path(access_token: access_token_value, per_page: 3, page: 2)
+    get admin_api_backend_apis_path, params: { access_token: access_token_value, per_page: 3, page: 2 }
     assert_response :success
     response_backend_api_ids = JSON.parse(response.body)['backend_apis'].map { |response_backend_api| response_backend_api.dig('backend_api', 'id') }
     assert_equal provider.backend_apis.oldest_first.offset(3).limit(3).select(:id).map(&:id), response_backend_api_ids
   end
 
-  test 'without permission' do
-    member = FactoryBot.create(:member, account: provider)
-    @access_token_value = create_access_token_value(member)
-
-    get admin_api_backend_api_path(backend_api, access_token: access_token_value)
-    assert_response :forbidden
-
-    delete admin_api_backend_api_path(backend_api, access_token: access_token_value)
-    assert_response :forbidden
-
-    put admin_api_backend_api_path(backend_api, access_token: access_token_value), permitted_params
-    assert_response :forbidden
-
-    post admin_api_backend_apis_path(access_token: access_token_value), permitted_params
-    assert_response :forbidden
-
-    get admin_api_backend_apis_path(access_token: access_token_value)
-    assert_response :forbidden
-  end
-
   test 'system_name can be created but not updated' do
-    post admin_api_backend_apis_path(access_token: access_token_value), permitted_params.merge({system_name: 'first-system-name'})
+    post admin_api_backend_apis_path, params: permitted_params.merge(system_name: 'first-system-name', access_token: access_token_value)
     backend_api = provider.backend_apis.last!
     assert_equal 'first-system-name', backend_api.system_name
 
-    put admin_api_backend_api_path(backend_api, access_token: access_token_value), permitted_params.merge(forbidden_params).merge({system_name: 'updated-system-name'})
+    put admin_api_backend_api_path(backend_api), params: permitted_params.merge(forbidden_params).merge(system_name: 'updated-system-name', access_token: access_token_value)
     assert_equal 'first-system-name', backend_api.reload.system_name
   end
 
   test 'backend api marked as deleted cannot be found' do
     backend_api.mark_as_deleted!
 
-    get admin_api_backend_api_path(backend_api, access_token: access_token_value)
+    get admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
     assert_response :not_found
 
-    delete admin_api_backend_api_path(backend_api, access_token: access_token_value)
+    delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
     assert_response :not_found
 
-    put admin_api_backend_api_path(backend_api, access_token: access_token_value), permitted_params
+    put admin_api_backend_api_path(backend_api), params: { access_token: access_token_value, **permitted_params }
     assert_response :not_found
 
-    get admin_api_backend_apis_path(access_token: access_token_value)
+    get admin_api_backend_apis_path, params: { access_token: access_token_value }
     assert_response :success
     response_backend_api_ids = JSON.parse(response.body)['backend_apis'].map { |response_backend_api| response_backend_api.dig('backend_api', 'id') }
     assert_not_includes response_backend_api_ids, backend_api.id
+  end
+
+  class MemberPermission < ActionDispatch::IntegrationTest
+    def setup
+      @provider = FactoryBot.create(:simple_provider)
+      @backend_api = FactoryBot.create(:backend_api, account: provider)
+      @member = FactoryBot.create(:member, account: provider)
+      @access_token = FactoryBot.create(:access_token, owner: member, scopes: %w[account_management], permission: 'rw')
+      member.activate!
+      host! @provider.admin_domain
+    end
+
+    attr_reader :provider, :backend_api, :member, :access_token
+    delegate :value, to: :access_token, prefix: true
+
+    test 'member with permission' do
+      member.admin_sections = %w[partners plans]
+      member.save!
+
+      get admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+      assert_response :success
+
+      delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+      assert_response :forbidden
+
+      put admin_api_backend_api_path(backend_api), params: { access_token: access_token_value, **backend_api_params }
+      assert_response :success
+
+      post admin_api_backend_apis_path, params: {access_token: access_token_value, **backend_api_params }
+      assert_response :forbidden
+
+      get admin_api_backend_apis_path, params: { access_token: access_token_value }
+      assert_response :success
+    end
+
+    test 'member without permission' do
+      get admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+      assert_response :forbidden
+
+      delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+      assert_response :forbidden
+
+      put admin_api_backend_api_path(backend_api), params: { access_token: access_token_value, **backend_api_params }
+      assert_response :forbidden
+
+      post admin_api_backend_apis_path, params: { access_token: access_token_value, **backend_api_params }
+      assert_response :forbidden
+
+      get admin_api_backend_apis_path, params: { access_token: access_token_value }
+      assert_response :forbidden
+    end
+
+    protected
+
+    def backend_api_params
+      @backend_api_params ||= {
+        name: 'the-name',
+        description: 'New description.',
+        private_endpoint: 'http://custom-api.example.org:80'
+      }
+    end
   end
 
   private

--- a/test/integration/admin/api/services/backend_usages_controller_test.rb
+++ b/test/integration/admin/api/services/backend_usages_controller_test.rb
@@ -22,7 +22,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
 
     test 'create' do
       assert_difference(service.backend_api_configs.method(:count)) do
-        post admin_api_service_backend_usages_path(collection_params), { path: 'foo/bar', backend_api_id: backend_api.id }
+        post admin_api_service_backend_usages_path(collection_params), params: { path: 'foo/bar', backend_api_id: backend_api.id }
         assert_response :created
       end
 
@@ -36,7 +36,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
       backend_api_of_another_tenant = FactoryBot.create(:backend_api)
 
       assert_no_difference(service.backend_api_configs.method(:count)) do
-        post admin_api_service_backend_usages_path(collection_params), { path: 'foo/bar', backend_api_id: backend_api_of_another_tenant.id }
+        post admin_api_service_backend_usages_path(collection_params), params: { path: 'foo/bar', backend_api_id: backend_api_of_another_tenant.id }
         assert_response :not_found
       end
     end
@@ -53,7 +53,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
     test 'update' do
       another_backend_api = FactoryBot.create(:backend_api, account: tenant)
 
-      put admin_api_service_backend_usage_path(resource_params), { path: 'foo/bar/updated', backend_api_id: another_backend_api.id }
+      put admin_api_service_backend_usage_path(resource_params), params: { path: 'foo/bar/updated', backend_api_id: another_backend_api.id }
 
       assert_response :success
       backend_api_config.reload
@@ -63,12 +63,12 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
 
     test 'create or update with errors in the model' do
       assert_no_difference(service.backend_api_configs.method(:count)) do
-        post admin_api_service_backend_usages_path(collection_params), { path: ':)', backend_api_id: backend_api.id }
+        post admin_api_service_backend_usages_path(collection_params), params: { path: ':)', backend_api_id: backend_api.id }
         assert_response :unprocessable_entity
       end
       assert_match /must be a path separated by/, (JSON.parse(response.body).dig('errors', 'path') || []).join
 
-      put admin_api_service_backend_usage_path(resource_params), { path: ':)' }
+      put admin_api_service_backend_usage_path(resource_params), params: { path: ':)' }
       assert_response :unprocessable_entity
       assert_match /must be a path separated by/, (JSON.parse(response.body).dig('errors', 'path') || []).join
     end
@@ -129,12 +129,12 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
       get admin_api_service_backend_usages_path(collection_params(per_page: 3, page: 2))
       assert_response :not_found
 
-      post admin_api_service_backend_usages_path(collection_params), {path: 'foo/bar', backend_api_id: backend_api.id}
+      post admin_api_service_backend_usages_path(collection_params), params: { path: 'foo/bar', backend_api_id: backend_api.id }
       assert_response :not_found
 
       resource_params = resource_params(id: backend_api_config.id)
 
-      put admin_api_service_backend_usage_path(resource_params), {path: 'foo/bar/updated'}
+      put admin_api_service_backend_usage_path(resource_params), params: { path: 'foo/bar/updated' }
       assert_response :not_found
 
       delete admin_api_service_backend_usage_path(resource_params)
@@ -144,7 +144,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
     test 'it cannot create for a deleted backend_api' do
       backend_api.mark_as_deleted!
 
-      post admin_api_service_backend_usages_path(collection_params), {path: 'foo/bar', backend_api_id: backend_api.id}
+      post admin_api_service_backend_usages_path(collection_params), params: { path: 'foo/bar', backend_api_id: backend_api.id }
       assert_response :not_found
     end
   end
@@ -152,7 +152,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
   class WithMemberAccessToken < self
     def setup
       super
-      @member = FactoryBot.create(:member, account: tenant, admin_sections: %w[partners])
+      @member = FactoryBot.create(:member, account: tenant, admin_sections: %w[partners plans]) # FIXME: it should not require 'partners' permission
       @member.activate!
 
       @access_token = FactoryBot.create(:access_token, owner: member, scopes: %w[account_management], permission: 'rw')
@@ -165,7 +165,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
       get admin_api_service_backend_usages_path(collection_params)
       assert_response :success
 
-      post admin_api_service_backend_usages_path(collection_params), { path: 'foo', backend_api_id: backend_api.id }
+      post admin_api_service_backend_usages_path(collection_params), params: { path: 'foo', backend_api_id: backend_api.id }
       assert_response :success
 
       @backend_api_config = service.backend_api_configs.find(JSON.parse(response.body).dig('backend_usage', 'id'))
@@ -173,7 +173,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
       get admin_api_service_backend_usage_path(resource_params)
       assert_response :success
 
-      put admin_api_service_backend_usage_path(resource_params), { path: 'bar' }
+      put admin_api_service_backend_usage_path(resource_params), params: { path: 'bar' }
       assert_response :success
 
       delete admin_api_service_backend_usage_path(resource_params)
@@ -187,7 +187,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
       get admin_api_service_backend_usages_path(collection_params)
       assert_response :success
 
-      post admin_api_service_backend_usages_path(collection_params), { path: 'foo', backend_api_id: backend_api.id }
+      post admin_api_service_backend_usages_path(collection_params), params: { path: 'foo', backend_api_id: backend_api.id }
       assert_response :success
 
       @backend_api_config = service.backend_api_configs.find(JSON.parse(response.body).dig('backend_usage', 'id'))
@@ -195,7 +195,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
       get admin_api_service_backend_usage_path(resource_params)
       assert_response :success
 
-      put admin_api_service_backend_usage_path(resource_params), { path: 'bar' }
+      put admin_api_service_backend_usage_path(resource_params), params: { path: 'bar' }
       assert_response :success
 
       delete admin_api_service_backend_usage_path(resource_params)
@@ -212,7 +212,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
       get admin_api_service_backend_usage_path(resource_params)
       assert_response :not_found
 
-      put admin_api_service_backend_usage_path(resource_params), { path: 'bar' }
+      put admin_api_service_backend_usage_path(resource_params), params: { path: 'bar' }
       assert_response :not_found
 
       delete admin_api_service_backend_usage_path(resource_params)
@@ -221,7 +221,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
       get admin_api_service_backend_usages_path(collection_params)
       assert_response :not_found
 
-      post admin_api_service_backend_usages_path(collection_params), { path: 'foo', backend_api_id: FactoryBot.create(:backend_api, account: tenant).id }
+      post admin_api_service_backend_usages_path(collection_params), params: { path: 'foo', backend_api_id: FactoryBot.create(:backend_api, account: tenant).id }
       assert_response :not_found
     end
   end

--- a/test/integration/provider/admin/backend_apis/mapping_rules_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/mapping_rules_controller_test.rb
@@ -28,7 +28,7 @@ class Provider::Admin::BackendApis::MappingRulesControllerTest < ActionDispatch:
     get provider_admin_backend_api_mapping_rules_path(backend_api)
     assert_response :not_found
 
-    post provider_admin_backend_api_mapping_rules_path(backend_api), {}
+    post provider_admin_backend_api_mapping_rules_path(backend_api), params: {}
     assert_response :not_found
 
     get new_provider_admin_backend_api_mapping_rule_path(backend_api)
@@ -37,7 +37,7 @@ class Provider::Admin::BackendApis::MappingRulesControllerTest < ActionDispatch:
     get edit_provider_admin_backend_api_mapping_rule_path(backend_api, @backend_api.mapping_rules.first)
     assert_response :not_found
 
-    put provider_admin_backend_api_mapping_rule_path(backend_api, @backend_api.mapping_rules.first), {}
+    put provider_admin_backend_api_mapping_rule_path(backend_api, @backend_api.mapping_rules.first), params: {}
     assert_response :not_found
   end
 
@@ -52,5 +52,54 @@ class Provider::Admin::BackendApis::MappingRulesControllerTest < ActionDispatch:
     get new_provider_admin_backend_api_mapping_rule_path(backend_api)
 
     assert_select '#proxy_rule_redirect_url', false
+  end
+
+  test 'member permissions' do
+    member = FactoryBot.create(:member, account: provider)
+    member.activate!
+
+    logout! && login!(provider, user: member)
+
+    get provider_admin_backend_api_mapping_rules_path(backend_api)
+    assert_response :forbidden
+
+    get new_provider_admin_backend_api_mapping_rule_path(backend_api)
+    assert_response :forbidden
+
+    mapping_rule = backend_api.mapping_rules.first
+    mapping_rule_params = {
+      http_method: 'GET',
+      pattern: '/foo',
+      delta: '1',
+      metric_id: mapping_rule.metric_id.to_s,
+      position: '2',
+      last: '0'
+    }
+    post provider_admin_backend_api_mapping_rules_path(backend_api), params: { proxy_rule: mapping_rule_params }
+    assert_response :forbidden
+
+    get edit_provider_admin_backend_api_mapping_rule_path(backend_api, mapping_rule)
+    assert_response :forbidden
+
+    put provider_admin_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { proxy_rule: mapping_rule_params }
+    assert_response :forbidden
+
+    member.admin_sections = %w[plans]
+    member.save!
+
+    get provider_admin_backend_api_mapping_rules_path(backend_api)
+    assert_response :success
+
+    get new_provider_admin_backend_api_mapping_rule_path(backend_api)
+    assert_response :success
+
+    post provider_admin_backend_api_mapping_rules_path(backend_api), params: { proxy_rule: mapping_rule_params }
+    assert_response :redirect
+
+    get edit_provider_admin_backend_api_mapping_rule_path(backend_api, mapping_rule)
+    assert_response :success
+
+    put provider_admin_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { proxy_rule: mapping_rule_params }
+    assert_response :redirect
   end
 end

--- a/test/unit/abilities/master_admin_test.rb
+++ b/test/unit/abilities/master_admin_test.rb
@@ -96,24 +96,14 @@ module Abilities
       end
     end
 
-    test 'backend apis' do
-      Account.any_instance.stubs(:provider_can_use?).returns(true)
-
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
-      assert_can ability, :manage, BackendApi
-
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-      assert_cannot ability, :manage, BackendApi
+    test 'backend apis and backend api components' do
+      %i[show edit update create destroy].each do |action|
+        assert_can ability, action, BackendApi, "Expected user to be able to #{action} BackendApi, but it's not"
+      end
     end
 
     test 'backend api configs' do
-      Account.any_instance.stubs(:provider_can_use?).returns(true)
-
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
       assert_can ability, :manage, BackendApiConfig
-
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-      assert_cannot ability, :manage, BackendApiConfig
     end
 
     private

--- a/test/unit/abilities/provider_admin_test.rb
+++ b/test/unit/abilities/provider_admin_test.rb
@@ -82,24 +82,14 @@ module Abilities
       assert_can ability, :show, service_3
     end
 
-    test 'backend apis' do
-      Account.any_instance.stubs(:provider_can_use?).returns(true)
-
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
-      assert_can ability, :manage, BackendApi
-
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-      assert_cannot ability, :manage, BackendApi
+    test 'backend apis and backend api components' do
+      %i[show edit update create destroy].each do |action|
+        assert_can ability, action, BackendApi, "Expected user to be able to #{action} BackendApi, but it's not"
+      end
     end
 
     test 'backend api configs' do
-      Account.any_instance.stubs(:provider_can_use?).returns(true)
-
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(true).at_least_once
       assert_can ability, :manage, BackendApiConfig
-
-      Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-      assert_cannot ability, :manage, BackendApiConfig
     end
 
     def test_destroy_services


### PR DESCRIPTION
Permission-level control over the API backend section endpoints of the Admin Portal and Admin API.

API backends are not scoped by service (API product) and it is not possible to do member access control at the API backend level the way we do for services at the service-level. Therefore, here we are simply enforcing that only member users with the “Integration & Application Plans” permission can access the API backend section.

Creating and deleting API backends remain admin users-exclusive.

| Resource                                | Action                                         | Required permission |
|-----------------------------------------|------------------------------------------------|-----------------|
| ☑︎ backend api                           | new backend api                                | \<admin-only\>  |
|                                         | create backend api                             | \<admin-only\>  |
|                                         | show backend api (overview)                    | plans           |
|                                         | edit backend api                               | plans           |
|                                         | update backend api                             | plans           |
|                                         | delete backend api                             | \<admin-only\>  |
| ☐ backend api stats                     | backend api stats                              | monitoring      |
| ☑︎ backend api metrics                   | index backend api metrics                      | plans           |
|                                         | new backend api top-level metric               | plans           |
|                                         | create backend api top-level metric            | plans           |
|                                         | new backend api method metric                  | plans           |
|                                         | create backend api method metric               | plans           |
|                                         | edit backend api metric                        | plans           |
|                                         | update backend api metric                      | plans           |
|                                         | delete backend api metric                      | plans           |
| ☑︎ backend api mapping rules             | index backend api mapping rules                | plans           |
|                                         | new backend api mapping rule                   | plans           |
|                                         | create backend api mapping rule                | plans           |
|                                         | edit backend api mapping rule                  | plans           |
|                                         | update backend api mapping rule                | plans           |
|                                         | delete backend api mapping rule                | plans           |

Closes [THREESCALE-5915](https://issues.redhat.com/browse/THREESCALE-5915).