### PR TITLE
Automatically redirect users to SSO if it is enforced

### DIFF
--- a/app/controllers/provider/sessions_controller.rb
+++ b/app/controllers/provider/sessions_controller.rb
@@ -7,8 +7,8 @@ class Provider::SessionsController < FrontendController
   before_action :ensure_provider_domain
   before_action :find_provider
   before_action :instantiate_sessions_presenter, only: [:new, :create]
-  before_action :redirect_if_logged_in, :only => [:new]
-  before_action :redirect_to_sso_params, :only => [:new]
+  before_action :redirect_if_logged_in, only: %i[new]
+  before_action :redirect_to_enforced_sso, only: %i[new]
 
   def new
     @session = Session.new
@@ -65,9 +65,7 @@ class Provider::SessionsController < FrontendController
   end
 
   def redirect_if_logged_in
-    if logged_in? && current_account.provider?
-      redirect_to provider_admin_dashboard_path
-    end
+    redirect_to provider_admin_dashboard_path if logged_in?
   end
 
   def authenticate_user
@@ -103,7 +101,8 @@ class Provider::SessionsController < FrontendController
     @presenter = Provider::SessionsPresenter.new(domain_account)
   end
 
-  def redirect_to_sso_params
-    redirect_to authorization_provider_bounce_path(published_authentication_providers.first.system_name) if domain_account.settings.enforce_sso? && published_authentication_providers.count == 1
+  def redirect_to_enforced_sso
+    return if !domain_account.settings.enforce_sso? || published_authentication_providers.count != 1
+    redirect_to authorization_provider_bounce_path(published_authentication_providers.first.system_name)
   end
 end

--- a/app/controllers/provider/sessions_controller.rb
+++ b/app/controllers/provider/sessions_controller.rb
@@ -7,9 +7,10 @@ class Provider::SessionsController < FrontendController
   before_action :ensure_provider_domain
   before_action :find_provider
   before_action :instantiate_sessions_presenter, only: [:new, :create]
+  before_action :redirect_if_logged_in, :only => [:new]
+  before_action :redirect_to_sso_params, :only => [:new]
 
   def new
-    redirect_to provider_admin_dashboard_url if logged_in?
     @session = Session.new
     @authentication_providers = published_authentication_providers
   end
@@ -100,5 +101,9 @@ class Provider::SessionsController < FrontendController
 
   def instantiate_sessions_presenter
     @presenter = Provider::SessionsPresenter.new(domain_account)
+  end
+
+  def redirect_to_sso_params
+    redirect_to authorization_provider_bounce_path(published_authentication_providers.first.system_name) if domain_account.settings.enforce_sso? && published_authentication_providers.count == 1
   end
 end

--- a/test/integration/provider/sessions_controller_test.rb
+++ b/test/integration/provider/sessions_controller_test.rb
@@ -39,19 +39,25 @@ class Provider::SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "redirect users to SSO when there's only one authentication provider and enforce_sso is on" do
-  @provider.settings.update_column(:enforce_sso, true)
-  get new_provider_sessions_path
-  request = ActionDispatch::TestRequest.create
-  assert_redirected_to authorization_provider_bounce_path(authentication_provider.system_name)
+    @provider.settings.update_column(:enforce_sso, true)
+    get new_provider_sessions_path
+    assert_redirected_to authorization_provider_bounce_path(authentication_provider.system_name)
+  end
+
+  test "redirect users to SSO when there's more than one authentication provider but only one is published " do
+    @provider.settings.update_column(:enforce_sso, true)
+    FactoryBot.create(:self_authentication_provider, account: @provider)
+    get new_provider_sessions_path
+    assert_redirected_to authorization_provider_bounce_path(authentication_provider.system_name)
   end
 
   test "does not redirect when there's more than one authentication provider" do
-  @provider.settings.update_column(:enforce_sso, true)
-  FactoryBot.create(:self_authentication_provider, account: @provider, published: true)
-  get new_provider_sessions_path
-  assert_response :success
+    @provider.settings.update_column(:enforce_sso, true)
+    FactoryBot.create(:self_authentication_provider, account: @provider, published: true)
+    get new_provider_sessions_path
+    assert_response :success
 
-  # password login is disabled, there's no passoword login form
-  refute_match 'Email or Username', response.body
+    # password login is disabled, there's no passoword login form
+    refute_match 'Email or Username', response.body
   end
 end

--- a/test/integration/provider/sessions_controller_test.rb
+++ b/test/integration/provider/sessions_controller_test.rb
@@ -6,7 +6,7 @@ class Provider::SessionsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @provider = FactoryBot.create(:provider_account)
     host! @provider.admin_domain
-    @authentication_provider = FactoryBot.create(:self_authentication_provider, account: @provider)
+    @authentication_provider = FactoryBot.create(:self_authentication_provider, account: @provider, published: true)
   end
 
   attr_reader :authentication_provider
@@ -36,5 +36,22 @@ class Provider::SessionsControllerTest < ActionDispatch::IntegrationTest
     delete provider_sessions_path
 
     assert_redirected_to "http://example.net/?provider_id=#{account.id}&user_id=#{account.admin_user.id}"
+  end
+
+  test "redirect users to SSO when there's only one authentication provider and enforce_sso is on" do
+  @provider.settings.update_column(:enforce_sso, true)
+  get new_provider_sessions_path
+  request = ActionDispatch::TestRequest.create
+  assert_redirected_to authorization_provider_bounce_path(authentication_provider.system_name)
+  end
+
+  test "does not redirect when there's more than one authentication provider" do
+  @provider.settings.update_column(:enforce_sso, true)
+  FactoryBot.create(:self_authentication_provider, account: @provider, published: true)
+  get new_provider_sessions_path
+  assert_response :success
+
+  # password login is disabled, there's no passoword login form
+  refute_match 'Email or Username', response.body
   end
 end

--- a/test/integration/sso_enforce_flow_test.rb
+++ b/test/integration/sso_enforce_flow_test.rb
@@ -106,11 +106,6 @@ class SsoEnforceFlowTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_match 'You have been logged out.', flash[:notice]
 
-    # password login is disabled, there's no passoword login form
-    get new_provider_sessions_path
-    assert_response :success
-    refute_match 'Email or Username', response.body
-
     # password login is disabled
     post provider_sessions_path(username: @user.username, password: 'alaska1233')
     refute_match 'Signed in successfully', flash[:notice]


### PR DESCRIPTION
**What this PR does / why we need it**:

Automatically redirect users to SSO if it is enforced

**Which issue(s) this PR fixes** 

  closes https://issues.redhat.com/browse/THREESCALE-2795

output
1. **When SSO is configured but not enforced**
![sso_not_enforced](https://user-images.githubusercontent.com/53568062/93755575-2c905c00-fc21-11ea-887c-7e397452cd4d.gif)

2. **when only one SSO integration is configured and enforced**
![only_one_sso](https://user-images.githubusercontent.com/53568062/93756562-ecca7400-fc22-11ea-9ffb-f634603b93d5.gif)

3. **when more than one SSO integration is configured but not enforced**
![two](https://user-images.githubusercontent.com/53568062/93757365-43847d80-fc24-11ea-8e9d-626044d2321e.gif)

4.**when more than one SSO integration is configured and enforced**
![more_than_one_published](https://user-images.githubusercontent.com/53568062/93757486-7a5a9380-fc24-11ea-9fc7-806b7f8b7a02.gif)







