### PR TITLE
Improve performance in API Services List

### DIFF
--- a/app/controllers/admin/api/services_controller.rb
+++ b/app/controllers/admin/api/services_controller.rb
@@ -7,6 +7,7 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   before_action :deny_on_premises_for_master
   before_action :can_create, only: :create
 
+  paginate only: :index
 
   # swagger
   ##~ sapi = source2swagger.namespace("Account Management API")
@@ -23,7 +24,8 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add @parameter_access_token
   #
   def index
-    respond_with(accessible_services.includes(:proxy, :account))
+    services = accessible_services.includes(:proxy, :account).order(:id).paginate(pagination_params)
+    respond_with(services)
   end
 
   # swagger

--- a/app/controllers/admin/api/services_controller.rb
+++ b/app/controllers/admin/api/services_controller.rb
@@ -23,7 +23,7 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add @parameter_access_token
   #
   def index
-    respond_with(accessible_services)
+    respond_with(accessible_services.includes(:proxy, :account))
   end
 
   # swagger

--- a/db/migrate/20200921135637_add_index_to_services_account_id_and_state.rb
+++ b/db/migrate/20200921135637_add_index_to_services_account_id_and_state.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddIndexToServicesAccountIdAndState < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def change
+    index_options = {}
+    index_options[:algorithm] = :concurrently if System::Database.postgres?
+    add_index :services, %i[account_id state], index_options
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200629110740) do
+ActiveRecord::Schema.define(version: 20200921135637) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer  "owner_id",   precision: 38, null: false
@@ -1223,6 +1223,7 @@ ActiveRecord::Schema.define(version: 20200629110740) do
     t.string   "kubernetes_service_link"
   end
 
+  add_index "services", ["account_id", "state"], name: "index_services_on_account_id_and_state"
   add_index "services", ["account_id"], name: "idx_account_id"
   add_index "services", ["system_name", "account_id"], name: "index_services_on_system_name_and_account_id_and_deleted_at", unique: true
 

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200629110740) do
+ActiveRecord::Schema.define(version: 20200921135637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1166,6 +1166,7 @@ ActiveRecord::Schema.define(version: 20200629110740) do
     t.boolean  "referrer_filters_required",                default: false
     t.string   "deployment_option",            limit: 255, default: "hosted"
     t.string   "kubernetes_service_link",      limit: 255
+    t.index ["account_id", "state"], name: "index_services_on_account_id_and_state", using: :btree
     t.index ["account_id"], name: "idx_account_id", using: :btree
     t.index ["system_name", "account_id"], name: "index_services_on_system_name_and_account_id_and_deleted_at", unique: true, using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200629110740) do
+ActiveRecord::Schema.define(version: 20200921135637) do
 
   create_table "access_tokens", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.bigint   "owner_id",                 null: false
@@ -1166,6 +1166,7 @@ ActiveRecord::Schema.define(version: 20200629110740) do
     t.boolean  "referrer_filters_required",                  default: false
     t.string   "deployment_option",                          default: "hosted"
     t.string   "kubernetes_service_link"
+    t.index ["account_id", "state"], name: "index_services_on_account_id_and_state", using: :btree
     t.index ["account_id"], name: "idx_account_id", using: :btree
     t.index ["system_name", "account_id"], name: "index_services_on_system_name_and_account_id_and_deleted_at", unique: true, using: :btree
   end

--- a/test/factories/simple.rb
+++ b/test/factories/simple.rb
@@ -73,7 +73,7 @@ FactoryBot.define do
 
   factory(:simple_service, :class => Service) do
     mandatory_app_key { false }
-    sequence(:name) { |n| "service#{n}" }
+    sequence(:name) { |n| "simpleservice#{n}" }
     association(:account, :factory => :simple_provider)
     after(:create) do |record|
       record.service_tokens.first_or_create!(value: 'token')

--- a/test/integration/admin/api/services_controller_test.rb
+++ b/test/integration/admin/api/services_controller_test.rb
@@ -72,7 +72,7 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       get admin_api_services_path(access_token: access_token_value, format: :json, per_page: 3, page: 2)
       assert_response :success
       response_service_ids = JSON.parse(response.body)['services'].map { |response_service| response_service.dig('service', 'id') }
-      assert_equal provider.accessible_services.order(:id).offset(3).limit(3).select(:id).map(&:id), response_service_ids
+      assert_equal provider.accessible_services.order(:id).offset(3).limit(3).pluck(:id), response_service_ids
     end
 
     test 'delete with api_key' do

--- a/test/integration/admin/api/services_controller_test.rb
+++ b/test/integration/admin/api/services_controller_test.rb
@@ -67,6 +67,14 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
 
     attr_reader :provider, :service
 
+    test 'index can be paginated' do
+      FactoryBot.create_list(:simple_service, 5, account: provider)
+      get admin_api_services_path(access_token: access_token_value, format: :json, per_page: 3, page: 2)
+      assert_response :success
+      response_service_ids = JSON.parse(response.body)['services'].map { |response_service| response_service.dig('service', 'id') }
+      assert_equal provider.accessible_services.order(:id).offset(3).limit(3).select(:id).map(&:id), response_service_ids
+    end
+
     test 'delete with api_key' do
       assert_change(of: -> { service.reload.deleted? }, from: false, to: true) do
         delete admin_api_service_path(service, provider_key: provider.api_key)


### PR DESCRIPTION
1st part of [THREESCALE-4528](https://issues.redhat.com/browse/THREESCALE-4528)

### Problems/Solutions

#### N + 1 for Proxy and Account

![image](https://user-images.githubusercontent.com/11318903/92380170-f45d2980-f108-11ea-9f30-e01ce97a1606.png)

![image](https://user-images.githubusercontent.com/11318903/92380191-fd4dfb00-f108-11ea-92e0-e77e05f3f080.png)

#### Explain for Queries

##### Query by account_id and state

![image](https://user-images.githubusercontent.com/11318903/93782216-94977000-fc2a-11ea-83f8-2c2c8ad05c7c.png)

##### Query by account_id and state and permitted_for(user)

![image](https://user-images.githubusercontent.com/11318903/95734877-5965eb00-0c84-11eb-8cb2-d2e03c205bee.png)

#### Paginate
Not sure if it is a good idea because there are people already using this API and this is a breaking change, but to some extend it is necessary because no matter how much we optimize, there is always a limit of what we are able to load and respond at once.

### Verification steps

1. Create many services, for different accounts, and keeping in mind that a few services must have state 'deleted'.
Still not keeping in mind the **permitted_for**.

`bundle exec rails console` and run:
```ruby
tenant_1st = Account.tenants.first!

# 1. create a new tenant
def create_tenant(signup_params)
  begin
    Signup::ProviderAccountManager.new(Account.master).create(signup_params)  
  rescue ThreeScale::Core::APIClient::ConnectionError  , ThreeScale::Core::APIClient::JSONError
  end  
end

signup_params = Signup::SignupParams.new(user_attributes: {email: 'testtenant@example.com', username: 'testtenant', role: :admin, password: '123456'}, account_attributes: {name: 'testtenant'})

create_tenant(signup_params)


# 2. create a bunch of services for those tenants

def create_service(tenant, name)
  begin
    tenant.services.create!(name: name)
  rescue ThreeScale::Core::APIClient::ConnectionError, ThreeScale::Core::APIClient::JSONError
  end
end

def mark_service_as_deleted(service)
  begin
    service.mark_as_deleted
  rescue ThreeScale::Core::APIClient::ConnectionError, ThreeScale::Core::APIClient::JSONError
  end
end

1000.times do |i|
  tenant = Account.tenants.last(2).to_a.sample
  create_service(tenant, "myy service #{i}")
  service = Service.last!
  mark_service_as_deleted(service) if service.id % 5 == 0
end

# create a member user for the 1st tenant
tenant_1st.users.create!(username: 'member', password: '123456', role: :member, email: 'member@example.com')
user = tenant_1st.users.where(role: :member).first!

# allow only some services for this user
user.admin_sections = [:services, :partners]
user.member_permission_service_ids = tenant_1st.services.pluck(:id).shuffle.first(tenant_1st.services.count / 3)
user.save!

# Create an access token to access the API
admin_token_value, member_token_value = [tenant_1st.admin_user, user].map { |u| AccessToken.create!(owner: u, permission: 'ro', scopes: ['account_management'], name: 'token').value }
```

2. Run the rails server. `UNICORN_WORKERS=8 bundle exec rails server -b 0.0.0.0`

3. Check the logs in another tab. `tail -f log/development.log`

4. In another tab, do the request: `curl -v  -X GET "http://provider-admin.3scale.localhost:3000/admin/api/services.json?access_token=889bfa550a2f2a3a07d112a4bdbbc9b2c686145e434ef48be7aaecc234b8fbc3"` . This is a local access token, no secrets exposed 😉 
