### PR TITLE
Fixes typo and Yaml

### DIFF
--- a/portafly/src/components/pages/Overview.tsx
+++ b/portafly/src/components/pages/Overview.tsx
@@ -36,6 +36,7 @@ import {
 } from '@patternfly/react-table'
 import { CategoryOption } from 'types'
 import { StateLabel, useDataListData } from 'components/shared'
+import { Trans } from 'react-i18next'
 
 const categories = [
   {
@@ -169,6 +170,8 @@ const Overview: React.FunctionComponent = () => {
           <CardBody>
             <TextContent>
               <p>{t('shared:format.uppercase', { text: 'Ohai' })}</p>
+              <p>{t('test_interpolate', { text: 'Ohai' })}</p>
+              <p><Trans t={t} i18nKey="test_format" /></p>
               {/* This is just for testing, will be removed */}
               <Button
                 icon={<BellIcon />}

--- a/portafly/src/components/pages/applications/utils/applicationsTableDataFactory.tsx
+++ b/portafly/src/components/pages/applications/utils/applicationsTableDataFactory.tsx
@@ -20,7 +20,7 @@ const generateRows: DataListRowGenerator = (applications: IProductApplication[])
       title: <ApplicationPageLink application={application} />
     },
     {
-      stringValue: application.account.org_name,
+      stringValue: application.account.orgName,
       title: <AccountOverviewLink account={application.account} />
     },
     {

--- a/portafly/src/dal/applications/getApplications.ts
+++ b/portafly/src/dal/applications/getApplications.ts
@@ -37,7 +37,7 @@ const parseApplications = (applications: Application[]) => applications.map(({ a
   state: application.state as State,
   account: {
     id: application.account_id,
-    org_name: application.org_name
+    orgName: application.org_name
   },
   plan: {
     id: application.plan_id,

--- a/portafly/src/i18n/locales/en/account_settings/personal/personal_details.yml
+++ b/portafly/src/i18n/locales/en/account_settings/personal/personal_details.yml
@@ -32,13 +32,11 @@ email_validation_description: Input field that holds the valid user's email addr
 
 first_name_label: First name
 first_name_label_description: Label for the field that holds the user's first name.
-first_name_value: {{user_first_name}}
 
 last_name_label: Last name
 last_name_label_description: Label for the field that holds the user's last name.
-last_name_value: {{user_last_name}}
 update_details_button: Update details
-update_details_description: The user clicks this button to procede with updating their **details.**
+update_details_description: The user clicks this button to proceed with updating their **details.**
 
 # Modal: Update details
 
@@ -46,7 +44,6 @@ current_password_title: Provide your current password to update your personal de
 current_password_title_description: Body title of modal dialog which prompts the user to provide their current password to make the update.
 current_password_label: Current password
 current_password_label_description: Label for the field for the user to enter a new password.
-current_password_value: {{user_password}}
 current_password_helper: When you update your personal details, all other active sessions for this user will end. This happens in order to confirm that it is you, and not somebody else trying to lock you out of your account.
 current_password_helper_description: Text to let the user know when they updates their personal details, all other active session are ended for security reasons.
 #-------# Confirm button: available in shared.yml
@@ -55,8 +52,8 @@ current_password_helper_description: Text to let the user know when they updates
 # Change password tab
 
 password_update_options:
- success: You have successfully updated your user details
- error: Your user details were not updated. Please review the password you provided
+  success: You have successfully updated your user details
+  error: Your user details were not updated. Please review the password you provided
 password_update_options_description: Input field for the user to enter the current password.
 new_password_label: New password
 new_password_label_description: Label that prompts the user to enter their new password in the given field.

--- a/portafly/src/i18n/locales/en/account_settings/users/listing-invitations.yml
+++ b/portafly/src/i18n/locales/en/account_settings/users/listing-invitations.yml
@@ -100,8 +100,8 @@ team_member_deletion:
 #-------# Bulk selector: available in shared.yml
 #-------# Delete button: available in shared.yml
 invitations_filter:
- by_recipient: Recipient
- by_acceptance: Acceptance
+  by_recipient: Recipient
+  by_acceptance: Acceptance
 invitations_filter_description: List containing the criteria to filter invitations
 invitations_typeahead:
   filter_by_recipient: Filter by recipient

--- a/portafly/src/i18n/locales/en/applications/listing.yml
+++ b/portafly/src/i18n/locales/en/applications/listing.yml
@@ -19,12 +19,12 @@ create_application_button_aria_label_description: Aria label for the new applica
 
 ## Toolbar
 actions_filter_options:
- by_name: Name
- by_state: State
- by_state_options:
-  live: Live
-  pending: Pending
-  approved: Approved
+  by_name: Name
+  by_state: State
+  by_state_options:
+    live: Live
+    pending: Pending
+    approved: Approved
 applications_filter_field: "Filter by {{filter_option}}"
 applications_filter_field_description: Filter by typeahead a text input. This applies for filter by name
 applications_filter_field_aria_label: Filter text input
@@ -32,21 +32,21 @@ applications_filter_field_aria_label_description: Aria label for the filter text
 
 ## Header
 applications_table:
- aria_label: Applications table
- aria_label_description: Aria label of the table of applications
- empty_state: Currently, there are no applications to show. Add applications.
- empty_state_description: Message to display when there are no applications to show, and prompt the user to add applications
- name_header: Name
- name_header_description: Column listing the application names
- state_header: State
- state_header_description: Column listing the state of the applications
- account_header: Account
- account_header_description: Column listing administrators
- plan_header: Plan
- plan_header_description: Column listing current plans
- created_header: Created on
- created_header_description: Column listing the creation date of the applications
- traffic_header: Traffic on
- traffic_header_description: Column listing the date an application was last used
- application_overview_link_aria_label: Go to application's overview page
- application_overview_link_aria_label_description: Aria label for the link to open each application's overview page
+  aria_label: Applications table
+  aria_label_description: Aria label of the table of applications
+  empty_state: Currently, there are no applications to show. Add applications.
+  empty_state_description: Message to display when there are no applications to show, and prompt the user to add applications
+  name_header: Name
+  name_header_description: Column listing the application names
+  state_header: State
+  state_header_description: Column listing the state of the applications
+  account_header: Account
+  account_header_description: Column listing administrators
+  plan_header: Plan
+  plan_header_description: Column listing current plans
+  created_header: Created on
+  created_header_description: Column listing the creation date of the applications
+  traffic_header: Traffic on
+  traffic_header_description: Column listing the date an application was last used
+  application_overview_link_aria_label: Go to application's overview page
+  application_overview_link_aria_label_description: Aria label for the link to open each application's overview page

--- a/portafly/src/i18n/locales/en/audience/accounts/account.yml
+++ b/portafly/src/i18n/locales/en/audience/accounts/account.yml
@@ -3,55 +3,54 @@
 # Page details
 
 overview:
- page_title: Account
- page_title_description: Page title of the subsection for Accounts Overview
+  page_title: Account
+  page_title_description: Page title of the subsection for Accounts Overview
 
- # Top area
- body_title: {{organization_name}}
- body_title_description: Body title of the page for Accounts Overview
+  # Top area
+  body_title_description: Body title of the page for Accounts Overview
 
- # Tabs
- overview_title: Overview
- overview_description: This is the title of the tab containing the organization or group name, the administrator name/email address, signup date, and state.
- applications_title: Applications
- applications_description: This is the title of the tab containing the list of applications on the account, their names, the associated product, its plan, creation date, and its current state.
+  # Tabs
+  overview_title: Overview
+  overview_description: This is the title of the tab containing the organization or group name, the administrator name/email address, signup date, and state.
+  applications_title: Applications
+  applications_description: This is the title of the tab containing the list of applications on the account, their names, the associated product, its plan, creation date, and its current state.
 
- # Main area
- # Tab overview
- organization_label: Organization/Group Name
- administrator_label: Administrator
- signup_label: Signed up on
- state_label: State
+  # Main area
+  # Tab overview
+  organization_label: Organization/Group Name
+  administrator_label: Administrator
+  signup_label: Signed up on
+  state_label: State
 
 # Tab Applications
 # Top area
 applications:
- create_application_button: Create application
- create_application_button_description: Button to create an application
+  create_application_button: Create application
+  create_application_button_description: Button to create an application
 
- applications_filter_options:
-  by_name: Name
-  by_product: Product
-  by_plan: Plan
-  by_state: State
- applications_filter_field: "Filter by {{filter_option}}"
- applications_filter_field_description: Filter by typeahead a text input.
- applications_filter_field_aria_label: Filter text input
- applications_filter_field_aria_label_description: Aria label for the filter text input
+  applications_filter_options:
+    by_name: Name
+    by_product: Product
+    by_plan: Plan
+    by_state: State
+  applications_filter_field: "Filter by {{filter_option}}"
+  applications_filter_field_description: Filter by typeahead a text input.
+  applications_filter_field_aria_label: Filter text input
+  applications_filter_field_aria_label_description: Aria label for the filter text input
 
- ## Header
- applications_table:
-  aria_label: Applications table
-  aria_label_description: Aria label of the table of applications
-  empty_state: Currently, there are no applications to show. Add applications. # Temporary
-  empty_state_description: Message to display when there are no applications to show, and prompt the user to add applications
-  name_header: Name
-  name_header_description: Column listing names of applications
-  product_header: Product
-  product_header_description: Column listing application products
-  plan_header: Plan
-  plan_header_description: Column listing plans
-  created_header: Created on
-  created_header_description: Column listing the creation date of the applications
-  state_header: State
-  state_header_description: Column listing the state of the applications
+  ## Header
+  applications_table:
+    aria_label: Applications table
+    aria_label_description: Aria label of the table of applications
+    empty_state: Currently, there are no applications to show. Add applications. # Temporary
+    empty_state_description: Message to display when there are no applications to show, and prompt the user to add applications
+    name_header: Name
+    name_header_description: Column listing names of applications
+    product_header: Product
+    product_header_description: Column listing application products
+    plan_header: Plan
+    plan_header_description: Column listing plans
+    created_header: Created on
+    created_header_description: Column listing the creation date of the applications
+    state_header: State
+    state_header_description: Column listing the state of the applications

--- a/portafly/src/i18n/locales/en/audience/accounts/listing.yml
+++ b/portafly/src/i18n/locales/en/audience/accounts/listing.yml
@@ -29,14 +29,14 @@ actions_dropdownlist_options:
 accounts_filter: Group/organization
 accounts_filter_description: Dropdown list to filter accounts by specified option
 actions_filter_options:
- by_group: Group/organization
- by_admin: Admin
- by_state: State
- by_state_options:
-  approved: Approved
-  pending: Pending
-  rejected: Rejected
-  suspended: Suspended
+  by_group: Group/organization
+  by_admin: Admin
+  by_state: State
+  by_state_options:
+    approved: Approved
+    pending: Pending
+    rejected: Rejected
+    suspended: Suspended
 accounts_filter_field: "Filter by {{filter_option}}"
 accounts_filter_field_description: Filter by typeahead a text input. This applies for filters by group/organization and admin
 accounts_filter_field_aria_label: Filter text input
@@ -46,34 +46,34 @@ accounts_filter_button_aria_label_description: Aria label for the filter button
 
 ## Header
 accounts_table:
- aria_label: Accounts table
- aria_label_description: Aria label of the table of accounts
- empty_state: Currently, there are no accounts to show. Add accounts.
- empty_state_description: Message to display when there are no accounts to show, and prompt the user to add accounts
- group_header: Group/Organization
- group_header_description: Column listing groups and organizations
- admin_header: Admin
- admin_header_description: Column listing administrators
- signup_header: Signup date
- signup_header_description: Column listing signup dates
- applications_header: Applications
- applications_header_description: Column listing applications linked to accounts, on a 1:1 relationship
- state_header: State
- state_header_description: Column listing the state of the accounts
- created_header: Created at
- created_header_description: Column listing the creation date of the accounts
- updated_header: Updated at
- updated_header_description: Column listing the date an account was last updated
- #-------# actions_header_plural: available in shared.yml
- account_overview_link_aria_label: Go to account's overview
- account_overview_link_aria_label_description: Aria label for the link to open each account's overview
- actions_column_options:
-  approve: Approve
-  approve_description: Button link to approve an account
-  activate: Activate
-  activate_description: Button link to perform the activation of an account
-  act_as: Act as
-  act_as_description: Button link enabled for administrators to impersonate an account
+  aria_label: Accounts table
+  aria_label_description: Aria label of the table of accounts
+  empty_state: Currently, there are no accounts to show. Add accounts.
+  empty_state_description: Message to display when there are no accounts to show, and prompt the user to add accounts
+  group_header: Group/Organization
+  group_header_description: Column listing groups and organizations
+  admin_header: Admin
+  admin_header_description: Column listing administrators
+  signup_header: Signup date
+  signup_header_description: Column listing signup dates
+  applications_header: Applications
+  applications_header_description: Column listing applications linked to accounts, on a 1:1 relationship
+  state_header: State
+  state_header_description: Column listing the state of the accounts
+  created_header: Created at
+  created_header_description: Column listing the creation date of the accounts
+  updated_header: Updated at
+  updated_header_description: Column listing the date an account was last updated
+  #-------# actions_header_plural: available in shared.yml
+  account_overview_link_aria_label: Go to account's overview
+  account_overview_link_aria_label_description: Aria label for the link to open each account's overview
+  actions_column_options:
+    approve: Approve
+    approve_description: Button link to approve an account
+    activate: Activate
+    activate_description: Button link to perform the activation of an account
+    act_as: Act as
+    act_as_description: Button link enabled for administrators to impersonate an account
 
 # Modal: Send email
 send_email:
@@ -88,12 +88,12 @@ send_email:
   #-------# Send button: available in shared.yml
   #-------# Cancel button: available in shared.yml
   toasts:
-   send_email_start: Sending email
-   send_email_start_description: Alert message when email is being sent
-   send_email_success: Your message was sent.
-   send_email_success_description: Alert message when email is sent
-   send_email_error: Your message was not sent because of a network error.
-   send_email_error_description: Alert message when email could not be sent
+    send_email_start: Sending email
+    send_email_start_description: Alert message when email is being sent
+    send_email_success: Your message was sent.
+    send_email_success_description: Alert message when email is sent
+    send_email_error: Your message was not sent because of a network error.
+    send_email_error_description: Alert message when email could not be sent
 
 # Modal: Change state
 change_state:

--- a/portafly/src/i18n/locales/en/overview.yml
+++ b/portafly/src/i18n/locales/en/overview.yml
@@ -5,3 +5,5 @@ body_title: Overview
 body_title_description: Body title of the Overview page
 subtitle: This is the Overview page
 subtitle_description: Subtitle of the Overview page
+test_interpolate: "{{text}} interpolated"
+test_format: <i>Here's a formatted string</i>

--- a/portafly/src/i18n/locales/en/product.yml
+++ b/portafly/src/i18n/locales/en/product.yml
@@ -26,11 +26,11 @@ create:
   # Validation errors
   required_name: <i>Name</i> is empty. You must specify a name for the product.
   required_name_description: Validation message to prompt the indication of a product name before saving details.
-  duplicated_name: <i>{{product_name}}</i> already exists. Please use a different name for the product.
+  duplicated_name: "<i>{{product_name}}</i> already exists. Please use a different name for the product."
   duplicated_name_description: Validation message to request the change of the product name due to  duplication.
   systemname_characters: System names can only use letters, numbers, hyphens and underscores.
   systemname_characters_description: Validation message to explain the allowed characters for a system name.
-  duplicated_systemname: <i>{{system_name}}</i> already exists. Please use a different system name.
+  duplicated_systemname: "<i>{{system_name}}</i> already exists. Please use a different system name."
   duplicated_systemname_description: Validation message to request the change of the system name due to duplication.
 
 # ------------------ Product > Edit product
@@ -54,7 +54,7 @@ edit:
   #-------# save_button: available in shared.yml
   #-------# cancel_button: available in shared.yml
   # Validation errors
-  required_name: "<i>Name</i> is empty. You must specify a name for the product."
+  required_name: <i>Name</i> is empty. You must specify a name for the product.
   required_name_description: Validation message to prompt the indication of a product name before saving product details.
   duplicated_name: "<i>{{product_name}}/<i> already exists. Please use a different name for the product."
   duplicated_name_description: Validation message to request the change of the product name due to duplication.

--- a/portafly/src/i18n/locales/en/shared.yml
+++ b/portafly/src/i18n/locales/en/shared.yml
@@ -62,13 +62,13 @@ alerts:
 bulk_selector:
   none: Select none (0 items)
   none_description: Bulk Selector option for selecting no items
-  page: Select page ({{count}} item)
+  page: "Select page ({{count}} item)"
   page_description: Bulk Selector option for selecting current page items
-  page_plural: Select page ({{count}} items)
+  page_plural: "Select page ({{count}} items)"
   page_plural_description: Bulk Selector option for selecting current page items (plural version)
-  all: Select all ({{count}} item)
+  all: "Select all ({{count}} item)"
   all_description: Bulk Selector option for selecting all available items
-  all_plural: Select all ({{count}} items)
+  all_plural: "Select all ({{count}} items)"
   all_plural_description: Bulk Selector option for selecting all available items (plural version)
   label: "{{selectedCount}} selected"
   label_description: Label indicating how many items are currently selected

--- a/portafly/src/tests/components/pages/applications/utils/__snapshots__/applicationsTableDataFactory.test.ts.snap
+++ b/portafly/src/tests/components/pages/applications/utils/__snapshots__/applicationsTableDataFactory.test.ts.snap
@@ -56,7 +56,7 @@ Array [
             Object {
               "account": Object {
                 "id": 0,
-                "org_name": "Ramdon Org 0",
+                "orgName": "Ramdon Org 0",
               },
               "created_on": "2020-06-01T00:00:00Z",
               "id": 0,
@@ -77,7 +77,7 @@ Array [
           account={
             Object {
               "id": 0,
-              "org_name": "Ramdon Org 0",
+              "orgName": "Ramdon Org 0",
             }
           }
         />,

--- a/portafly/src/tests/factories/applications.ts
+++ b/portafly/src/tests/factories/applications.ts
@@ -7,7 +7,7 @@ const Application = Factory.define<IApplication>(({ sequence }) => ({
   state: 'live',
   account: {
     id: sequence,
-    org_name: `Ramdon Org ${sequence}`
+    orgName: `Ramdon Org ${sequence}`
   },
   plan: {
     id: sequence,


### PR DESCRIPTION
* Fixes a typo from another PR `org_name -> orgName`
* Fixes a typo in a personal_details.yaml `proced -> proceed`
* Fixes indentation in Yaml
* Remove redundant translations variables that cause warnings when building