### PR TITLE
[backend_client] Allow setting port from :host configuration

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -80,7 +80,7 @@ gem 'json', '~> 1.8.1'
 
 gem 'mysql2', '~> 0.5.3'
 
-gem '3scale_client', '~> 2.6.1', require: false
+gem '3scale_client', '~> 2.11  ', require: false
 gem 'analytics-ruby', require: false
 
 group :development, :test do

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -80,7 +80,7 @@ gem 'json', '~> 1.8.1'
 
 gem 'mysql2', '~> 0.5.3'
 
-gem '3scale_client', '~> 2.11  ', require: false
+gem '3scale_client', '~> 2.11', require: false
 gem 'analytics-ruby', require: false
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    3scale_client (2.6.1)
+    3scale_client (2.11.0)
       nokogiri
     3scale_time_range (0.0.6)
       activesupport (>= 3.2.19)
@@ -443,7 +443,7 @@ GEM
       connection_pool (~> 2.2)
     netrc (0.11.0)
     nio4r (2.5.2)
-    nokogiri (1.10.8)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     non-stupid-digest-assets (1.0.9)
       sprockets (>= 2.0)
@@ -797,7 +797,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  3scale_client (~> 2.6.1)
+  3scale_client (~> 2.11)
   3scale_time_range (= 0.0.6)
   RedCloth (~> 4.3)
   active-docs!

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -103,7 +103,7 @@ GEM
   remote: https://rubygems.org/
   remote: https://gems.contribsys.com/
   specs:
-    3scale_client (2.6.1)
+    3scale_client (2.11.0)
       nokogiri
     3scale_time_range (0.0.6)
       activesupport (>= 3.2.19)
@@ -445,7 +445,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (5.7.0.350)
     nio4r (2.5.2)
-    nokogiri (1.10.8)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     non-stupid-digest-assets (1.0.9)
       sprockets (>= 2.0)
@@ -798,7 +798,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  3scale_client (~> 2.6.1)
+  3scale_client (~> 2.11)
   3scale_time_range (= 0.0.6)
   RedCloth (~> 4.3)
   active-docs!

--- a/app/lib/backend/random_data_generator.rb
+++ b/app/lib/backend/random_data_generator.rb
@@ -41,7 +41,7 @@ module Backend
         }
 
         invalid = invalid_transactions(cinstance, time, metric, value)
-        client = ThreeScale::Client.new(System::Application.config.backend_client.merge(
+        client = ThreeScale::Client.new(BackendClient.threescale_client_config.merge(
                                          provider_key: service.account.api_key))
         client.report(transactions)
         client.report(invalid)

--- a/app/lib/backend_client.rb
+++ b/app/lib/backend_client.rb
@@ -1,9 +1,30 @@
+# frozen_string_literal: true
+
 module BackendClient
   class BackendError < RuntimeError; end
   class TooManyItems < BackendError; end
   class InvalidItem  < BackendError; end
 
-  def self.config
-    System::Application.config.backend_client
+  class << self
+    def threescale_client_config
+      config.merge(
+        port: uri.port,
+        host: uri.host
+      )
+    end
+
+    def config
+      System::Application.config.backend_client
+    end
+
+    protected
+
+    def uri
+      URI(config[:url].presence || "#{scheme}://#{config[:host]}")
+    end
+
+    def scheme
+      config[:secure] ? 'https' : 'http'
+    end
   end
 end

--- a/app/workers/report_traffic_worker.rb
+++ b/app/workers/report_traffic_worker.rb
@@ -88,7 +88,7 @@ class ReportTrafficWorker
   private
 
   def client
-    @client ||= ThreeScale::Client.new(System::Application.config.backend_client.merge(
+    @client ||= ThreeScale::Client.new(BackendClient.threescale_client_config.merge(
                                         provider_key: master_service.account.api_key))
   end
 

--- a/test/unit/backend_client_test.rb
+++ b/test/unit/backend_client_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class BackendClientTest < ActiveSupport::TestCase
+  test 'normalize host and port' do
+    Rails.application.config.stubs(backend_client: {
+      host: 'backend-host:8443',
+      secure: true
+    })
+    assert_equal({host: 'backend-host', port: 8443, secure: true}, BackendClient.threescale_client_config)
+  end
+
+  test 'set default port for https' do
+    Rails.application.config.stubs(backend_client: {
+      host: 'backend-host',
+      secure: true
+    })
+    assert_equal({host: 'backend-host', port: 443, secure: true}, BackendClient.threescale_client_config)
+  end
+
+  test 'set default port for http' do
+    Rails.application.config.stubs(backend_client: {
+      host: 'backend-host',
+      secure: false
+    })
+    assert_equal({host: 'backend-host', port: 80, secure: false}, BackendClient.threescale_client_config)
+  end
+end


### PR DESCRIPTION
So we can use a different port than 80 or 443 in backend

Fixes:

```
  Failed to open TCP connection to http://backend-listener-internal:80:80
(getaddrinfo: Name or service not known
```

* Update 3scale_client to 2.11 to set backend port