### PR TITLE
[WRONG - EXPLAINED IN THE JIRA] [Bugfix] The supplied SphinxQL statement is 8978262 characters long. The maximum allowed length is 8388603

### DIFF
--- a/config/thinking_sphinx.yml
+++ b/config/thinking_sphinx.yml
@@ -1,4 +1,5 @@
 common: &sphinx
+  batch_size: 500
   configuration_file: <%= ENV['THINKING_SPHINX_CONFIGURATION_FILE'] %>
   big_document_ids: true
   html_strip: 1


### PR DESCRIPTION
Closes [THREESCALE-5939](https://issues.redhat.com/browse/THREESCALE-5939)

> gems/thinking-sphinx-3.4.2/lib/thinking_sphinx/connection/client.rb:24:in `check': The supplied SphinxQL statement is 8978262 characters long. The maximum allowed length is 8388603.
> 
> If this error has been raised during real-time index population, it's probably due to overly large batches of records being processed at once. The default is 1000, but you can lower it on a per-environment basis in config/thinking_sphinx.yml:
> 
>   development:
>     batch_size: 500
>  (ThinkingSphinx::QueryLengthError)
>     from gems/thinking-sphinx-3.4.2/lib/thinking_sphinx/connection/client.rb:29:in `check_and_perform'
>     from gems/thinking-sphinx-3.4.2/lib/thinking_sphinx/connection/client.rb:11:in `execute'
>     from gems/thinking-sphinx-3.4.2/lib/thinking_sphinx/real_time/transcriber.rb:21:in `block (2 levels) in copy'
>     from gems/thinking-sphinx-3.4.2/lib/thinking_sphinx/connection.rb:39:in `block in take'
>     from gems/innertube-1.1.0/lib/innertube.rb:138:in `take'
>     from gems/thinking-sphinx-3.4.2/lib/thinking_sphinx/connection.rb:37:in `take'
