### PR TITLE
THREESCALE-5952 Multiple Memcache servers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -134,7 +134,11 @@ module System
     # We don't want Rack::Cache to be used
     config.action_dispatch.rack_cache = false
 
-    config.cache_store = config_for(:cache_store)
+    args = config_for(:cache_store)
+    store_type = args.shift
+    options = args.extract_options!
+    servers = args.flat_map { |arg| arg.split(',') }
+    config.cache_store = [store_type, servers, options]
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"


### PR DESCRIPTION
Closes THREESCALE-5952

Making the plural in MEMCACHE_SERVERS actually effective ...

Basically you can add multiple servers for Dalli following https://github.com/petergoldstein/dalli#configuration


```
ActiveSupport::Cache.lookup_store :dalli_store, ['localhost:332211', 'localhost:112233'], compress: true                                                                            
# => #<ActiveSupport::Cache::DalliStore:0x00000000093b2208
 @data=#<Dalli::Client:0x00000000093b20f0 @options={:compress=>true}, @ring=nil, @servers=["localhost:332211", "localhost:112233"]>,
 @options={:compress=>true}>
```

## Proof

With:

```
MEMCACHE_SERVERS="localhost:11211,localhost:11311" rails c
Rails.cache.dalli
```

### Before
![image](https://user-images.githubusercontent.com/64276/125527850-f85c4d1a-8159-4a71-982f-22b549094ea8.png)

### After
![image](https://user-images.githubusercontent.com/64276/125528047-3b0844a3-bad8-4a93-b4e3-503a87c754d1.png)

