### PR TITLE
Add Product and Backends index

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::ServicesController < Api::BaseController
   include ServiceDiscovery::ControllerMethods
+  include ThreeScale::Search::Helpers
 
   activate_menu :serviceadmin, :overview
 
@@ -14,6 +15,12 @@ class Api::ServicesController < Api::BaseController
 
   with_options only: %i[edit update settings usage_rules] do |actions|
     actions.sublayout 'api/service'
+  end
+
+  def index
+    activate_menu :dashboard
+    @services = current_user.accessible_services
+                            .paginate(pagination_params)
   end
 
   def show

--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
 class Provider::Admin::BackendApisController < Provider::Admin::BaseController
+  include ThreeScale::Search::Helpers
+
   load_and_authorize_resource :backend_api, through: :current_user, through_association: :accessible_backend_apis
 
   activate_menu :backend_api, :overview
   layout 'provider'
+
+  def index
+    activate_menu :dashboard
+    @backend_apis = current_account.backend_apis
+                                   .paginate(pagination_params)
+  end
 
   def new
     activate_menu :dashboard

--- a/app/views/api/services/index.html.slim
+++ b/app/views/api/services/index.html.slim
@@ -1,0 +1,10 @@
+table#services
+  thead
+    tr
+      th Name
+      th System name
+  tbody
+    - @services.each do |service|
+      tr
+        td = link_to service.name, admin_service_path(service)
+        td = service.system_name

--- a/app/views/provider/admin/backend_apis/index.html.slim
+++ b/app/views/provider/admin/backend_apis/index.html.slim
@@ -1,0 +1,12 @@
+table#backend_apis
+  thead
+    tr
+      th Name
+      th System name
+      th Private Base URL
+  tbody
+    - @backend_apis.each do |backend_api|
+      tr
+        td = link_to backend_api.name, provider_admin_backend_api_path(backend_api)
+        td = backend_api.system_name
+        td = backend_api.private_endpoint

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,7 +199,7 @@ without fake Core server your after commit callbacks will crash and you might ge
     get 'admin', to: 'admin#show'
 
     namespace :admin do
-      resources :backend_apis, :except => [:index] do
+      resources :backend_apis do
         scope module: :backend_apis do
           resources :metrics, :except => [:show] do
             resources :children, :controller => 'metrics', :only => [:new, :create]
@@ -764,7 +764,7 @@ without fake Core server your after commit callbacks will crash and you might ge
           resources :pricing_rules, :only => [:edit, :update, :destroy]
         end
 
-        resources :services, except: :index do
+        resources :services do
           member do
             get :settings
             get :usage_rules

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -12,6 +12,11 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
 
   attr_reader :service
 
+  test 'index' do
+    get admin_services_path
+    assert response
+  end
+
   class SettingsTest < Api::ServicesControllerTest
     test 'settings renders the right template and contains the right sections' do
       Account.any_instance.stubs(:provider_can_use?).returns(true)

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -14,7 +14,7 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
 
   test 'index' do
     get admin_services_path
-    assert response
+    assert_response :success
   end
 
   class SettingsTest < Api::ServicesControllerTest

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -13,6 +13,11 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
 
   attr_reader :provider
 
+  test '#index' do
+    get provider_admin_backend_apis_path
+    assert_response :success
+  end
+
   test '#new' do
     get new_provider_admin_backend_api_path
     assert_response :success


### PR DESCRIPTION
**What this PR does / why we need it**:

Products/Backends lists are being taken out from the Dashboard into their own pages. This is only the Rails part of it.

**Which issue(s) this PR fixes** 

[APPDUX-545: Implement Ruby code for Product / Backend Apis](https://issues.redhat.com/browse/APPDUX-545)
