### PR TITLE
Bugfix: autocomplete support for common  parameters in path

### DIFF
--- a/app/javascript/packs/OAS3Autocomplete.js
+++ b/app/javascript/packs/OAS3Autocomplete.js
@@ -35,14 +35,12 @@ const addAutocompleteToParam = (param: Param, accountData: AccountData): Param =
 }
 
 const injectParametersToPathOperation = (pathOperation: PathOperationObject, accountData: AccountData): PathOperationObject => {
-  const operationParameters = pathOperation.parameters || undefined
-  if (!operationParameters) {
-    return pathOperation
-  }
+  const operationParameters = pathOperation.parameters
+  if (!operationParameters) return pathOperation
   const parametersWithAutocompleteData = operationParameters.map(param => X_DATA_ATTRIBUTE in param ? addAutocompleteToParam(param, accountData) : param)
   return {
     ...pathOperation,
-    'parameters': parametersWithAutocompleteData
+    parameters: parametersWithAutocompleteData
   }
 }
 
@@ -52,11 +50,9 @@ const injectAutocompleteToCommonParameters = (parameters: Array<Param>, accountD
 
 const injectParametersToPath = (path: PathItemObject, commonParameters: Array<Param>, accountData: AccountData): PathItemObject => (
   Object.keys(path).reduce((updatedPath, item) => {
-    if (item === 'parameters' && commonParameters) {
-      updatedPath[item] = injectAutocompleteToCommonParameters(commonParameters, accountData)
-    } else {
-      updatedPath[item] = injectParametersToPathOperation(path[item], accountData)
-    }
+    updatedPath[item] = (item === 'parameters' && commonParameters)
+      ? injectAutocompleteToCommonParameters(commonParameters, accountData)
+      : injectParametersToPathOperation(path[item], accountData)
     return updatedPath
   }, {})
 )

--- a/app/javascript/packs/OAS3Autocomplete.js
+++ b/app/javascript/packs/OAS3Autocomplete.js
@@ -4,6 +4,8 @@ import { fetchData } from 'utilities/utils'
 import type {
   AccountData,
   Param,
+  PathItemObject,
+  PathOperationObject,
   ResponseBody,
   SwaggerResponse
 } from 'Types/SwaggerTypes'
@@ -32,7 +34,7 @@ const addAutocompleteToParam = (param: Param, accountData: AccountData): Param =
     : param
 }
 
-const injectParametersToPathOperation = (pathOperation, accountData) => {
+const injectParametersToPathOperation = (pathOperation: PathOperationObject, accountData: AccountData): PathOperationObject => {
   const operationParameters = pathOperation.parameters || undefined
   if (!operationParameters) {
     return pathOperation
@@ -44,11 +46,11 @@ const injectParametersToPathOperation = (pathOperation, accountData) => {
   }
 }
 
-const injectAutocompleteToCommonParameters = (parameters, accountData) => parameters.map(
+const injectAutocompleteToCommonParameters = (parameters: Array<Param>, accountData: AccountData): Array<Param> => parameters.map(
   param => X_DATA_ATTRIBUTE in param ? addAutocompleteToParam(param, accountData) : param
 )
 
-const injectParametersToPath = (path, commonParameters, accountData) => (
+const injectParametersToPath = (path: PathItemObject, commonParameters: Array<Param>, accountData: AccountData): PathItemObject => (
   Object.keys(path).reduce((updatedPath, item) => {
     if (item === 'parameters' && commonParameters) {
       updatedPath[item] = injectAutocompleteToCommonParameters(commonParameters, accountData)

--- a/app/javascript/src/Types/SwaggerTypes.jsx
+++ b/app/javascript/src/Types/SwaggerTypes.jsx
@@ -27,6 +27,21 @@ export type Param = {
  examples?: Examples
 }
 
+export type PathOperationObject = {
+  [string]: ?string,
+  servers?: {},
+  responses?: {},
+  parameters?: Array<Param>,
+  ...
+}
+
+export type PathItemObject = {
+  [string]: ?string,
+  [string]: ?PathOperationObject,
+  parameters?: Array<Param>,
+  ...
+}
+
 export type ResponseBody = {
  paths: {
    [string]: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Autocomplete of 3scale data is failing in some OAS specs because of the following reason:
The `parameters` can be placed in several places:

In the path object, like:
```
"paths": {
  "/": {
    "parameters": [],
    "get": {},
    "post": {}
    ...
  }
}
```
Inside the http verbs, like:
```
"paths": {
  "/": {
    "get": {
      "parameters": []
    },
    "post": {}
    ...
  }
}
```

Or inside both the path and the verb, like:
```
"paths": {
  "parameters": [],
  "/": {
    "get": {
      "parameters": []
    },
    "post": {}
    ...
  }
}
```
This PR adds support for the 3 scenarios

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-6088

**Verification steps** 

Go to API > ActiveDocs
Create a new valid OAS 3 spec (or better use the [default Echo API](https://github.com/3scale/porta/blob/master/public/echo-api-3.0.json), which includes the `x-data-threescale-name` fields)
Test your spec in both Admin and Developer Portal.

![oas](https://user-images.githubusercontent.com/13486237/95203496-208cc880-07e3-11eb-8913-c7c2661d1948.png)
____
![oas2](https://user-images.githubusercontent.com/13486237/95203562-37331f80-07e3-11eb-9b20-e0952ee45e00.png)


**Special notes for your reviewer**:
Related docs:
https://swagger.io/specification/
https://swagger.io/docs/specification/describing-parameters/#path-parameters
Official examples of OAS v3:
https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v3.0