### PR TITLE
Remove unused method Api::ServicesController#integration_method_changed?

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -124,10 +124,6 @@ class Api::ServicesController < Api::BaseController
     apiap? ? 'Product' : 'Service'
   end
 
-  def integration_method_changed?
-    @service.previous_changes['deployment_option']
-  end
-
   def collection
     current_user.accessible_services
   end


### PR DESCRIPTION
Unused since https://github.com/3scale/porta/pull/2178/files#diff-01277c9f472ebf2c339e13f600d053b4L61