### PR TITLE
Fixes binding.pry in dev env

### DIFF
--- a/config/unicorn/development.rb
+++ b/config/unicorn/development.rb
@@ -26,8 +26,10 @@ listen prometheus_port
 
 pid app_dir.join('tmp/pids/unicorn.pid').to_s
 
-stderr_path app_dir.join("log/unicorn.stderr.log").to_s
-stdout_path app_dir .join("log/unicorn.stdout.log").to_s
+if ENV['RAILS_LOG_TO_STDOUT'].blank?
+  stderr_path app_dir.join("log/unicorn.stderr.log").to_s
+  stdout_path app_dir .join("log/unicorn.stdout.log").to_s
+end
 
 # http://www.rubyenterpriseedition.com/faq.html#adapt_apps_for_cow
 GC.copy_on_write_friendly = true if GC.respond_to?(:copy_on_write_friendly=)


### PR DESCRIPTION
Start the Rails server in dev env with `RAILS_LOG_TO_STDOUT=1`.