### PR TITLE
👷 bump codeclimate version

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,18 +1,11 @@
-# This is a sample .codeclimate.yml configured for Engine analysis on Code
-# Climate Platform. For an overview of the Code Climate Platform, see here:
-# http://docs.codeclimate.com/article/300-the-codeclimate-platform
-
-# Under the engines key, you can configure which engines will analyze your repo.
-# Each key is an engine name. For each value, you need to specify enabled: true
-# to enable the engine as well as any other engines-specific configuration.
-
-# For more details, see here:
-# http://docs.codeclimate.com/article/289-configuring-your-repository-via-codeclimate-yml#platform
-
-# For a list of all available engines, see here:
-# http://docs.codeclimate.com/article/296-engines-available-engines
-
-engines:
+version: 2
+# All maintainability checks are enabled by default, but can be disabled or tuned individually under the checks node. Example:
+# checks:
+#   argument-count:
+#     enabled: true
+#     config:
+#       threshold: 4
+plugins:
   shellcheck:
     enabled: true
   brakeman:
@@ -47,28 +40,7 @@ engines:
       languages:
         - ruby
         - javascript
-
-# Engines can analyze files and report issues on them, but you can separately
-# decide which files will receive ratings based on those issues. This is
-# specified by path patterns under the ratings key.
-
-# For more details see here:
-# http://docs.codeclimate.com/article/289-configuring-your-repository-via-codeclimate-yml#platform
-
-# Note: If the ratings key is not specified, this will result in a 0.0 GPA on your dashboard.
-
-ratings:
-  paths:
-    - "Gemfile.lock"
-    - "app/javascript/**/*.jsx"
-    - "app/**/*.{rb,js,es6,coffee,scss,css}"
-    - "lib/**/*.{rb,js,es6,coffee}"
-    - "test/**/*.rb"
-
-# You can globally exclude files from being analyzed by any engine using the
-# exclude_paths key.
-
-exclude_paths:
+exclude_patterns:
   - "app/assets/javascripts/plans_widget.js"
   - "app/assets/javascripts/provider/plans_widget.js"
   - "app/javascript/src/patternflyStyles/pf4BaseIE11.scss"


### PR DESCRIPTION
Apparently our codeclimate config file is outdated. Changes:

> In the Fall of 2017, we launched our newest analysis model, which introduced our 10 maintainability checks. With the new model, we've launched a new configuration version which requires updated syntax. A few things to note when updating an older configuration file:
> 
> - version: "2" is required at the top of the .codeclimate.yml.
> - engines has been changed to plugins.
> - checks has been introduced. All maintainability checks are enabled by default, but can be disabled or tuned individually under the checks node.
> - exclude_paths has been changed to exclude_patterns.
> - ratings has been deprecated. All files in our supported languages for maintainability will receive maintainability ratings by default.


(Full article can be found at [Codeclimate](https://docs.codeclimate.com/docs/advanced-configuration#analysis-configuration-versions)).