### PR TITLE
Removes services from the ApiSelector (aka ContextSwitcher)

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -12,26 +12,4 @@ class ApplicationDecorator < Draper::Decorator
   def self.collection_decorator_class
     PaginatingDecorator
   end
-
-  private
-
-  API_KEYS = %w[id name system_name].freeze
-
-  def parse_api(api_hash)
-    add_link(add_api_type(api_hash.slice(*API_KEYS)))
-  end
-
-  def add_link(api_hash)
-    api_hash[:link] = api_selector_api_link if object.id
-    api_hash
-  end
-
-  def add_api_type(api_hash)
-    api_hash[:type] = backend_api? ? 'backend' : 'product'
-    api_hash
-  end
-
-  def backend_api?
-    raise NoMethodError, __method__
-  end
 end

--- a/app/decorators/backend_api_decorator.rb
+++ b/app/decorators/backend_api_decorator.rb
@@ -8,11 +8,6 @@ class BackendApiDecorator < ApplicationDecorator
     h.provider_admin_backend_api_path(object)
   end
 
-  def as_json(options = {})
-    hash = super(options)
-    parse_api hash
-  end
-
   private
 
   def backend_api?

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -46,11 +46,6 @@ class ServiceDecorator < ApplicationDecorator
     end
   end
 
-  def as_json(options = {})
-    hash = super(options)
-    parse_api hash
-  end
-
   private
 
   def backend_api?

--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -84,12 +84,6 @@ module MenuHelper
     account.settings.public_send(switch).is_a?(Settings::SwitchDenied)
   end
 
-  def api_selector_services
-    @api_selector_services ||= (site_account.provider? && logged_in? ? current_user.accessible_services : Service.none).decorate
-    @api_selector_services.concat(current_user.account.backend_apis.decorate) if current_account.provider_can_use?(:api_as_product)
-    @api_selector_services
-  end
-
   def audience_link
     if can?(:manage, :partners)
       admin_buyers_accounts_path

--- a/app/javascript/packs/api_selector.js
+++ b/app/javascript/packs/api_selector.js
@@ -1,0 +1,15 @@
+import { ContaoIcon } from '@patternfly/react-icons'
+import { ContextSelectorWrapper } from 'Navigation/components/ContextSelector'
+
+const containerId = 'api_selector'
+
+document.addEventListener('DOMContentLoaded', function () {
+  const apiSelector = document.getElementById(containerId)
+
+  const { currentApi } = apiSelector.dataset
+
+  ContextSelectorWrapper({
+    ...apiSelector.dataset,
+    currentApi: JSON.parse(currentApi)
+  }, containerId)
+})

--- a/app/javascript/packs/api_selector.js
+++ b/app/javascript/packs/api_selector.js
@@ -1,4 +1,3 @@
-import { ContaoIcon } from '@patternfly/react-icons'
 import { ContextSelectorWrapper } from 'Navigation/components/ContextSelector'
 
 const containerId = 'api_selector'

--- a/app/javascript/packs/navigation.js
+++ b/app/javascript/packs/navigation.js
@@ -1,15 +1,8 @@
 import '@babel/polyfill'
 
 import { toggleNavigation, hideAllToggleable } from 'Navigation/utils/toggle_navigation'
-import { ContextSelectorWrapper } from 'Navigation/components/ContextSelector'
 
 document.addEventListener('DOMContentLoaded', () => {
-  const apiSelector = 'api_selector'
-  const apiSelectorNode = document.getElementById(apiSelector)
-  const apiSelectorData = JSON.parse(apiSelectorNode.dataset.api)
-
-  ContextSelectorWrapper({...apiSelectorData}, apiSelector)
-
   let store = window.localStorage
   const togglers = document.getElementsByClassName('u-toggler')
   const vertNavTogglers = document.getElementsByClassName('vert-nav-toggle')

--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -1,64 +1,31 @@
 // @flow
 
-import 'raf/polyfill'
-import 'core-js/es6/map'
-import 'core-js/es6/set'
-import 'core-js/es6/array'
+import React, { useState, useRef } from 'react'
 
-import React from 'react'
 import { ActiveMenuTitle } from 'Navigation/components/ActiveMenuTitle'
 import { createReactWrapper } from 'utilities/createReactWrapper'
+import { useClickOutside } from 'utilities/useClickOutside'
 
 import 'Navigation/styles/ContextSelector.scss'
 
 import type { Api, Menu } from 'Types'
 
 type Props = {
-  apis: Api[],
   currentApi: Api,
   activeMenu: Menu,
   audienceLink: string,
-  apiap?: boolean
-}
-
-type State = {
-  filterQuery: string
+  productsLink: string,
+  backendsLink: string
 }
 
 const DASHBOARD_PATH = '/p/admin/dashboard'
 
-class ContextSelector extends React.Component<Props, State> {
-  state = {
-    filterQuery: ''
-  }
+const ContextSelector = ({ currentApi, activeMenu, audienceLink, productsLink, backendsLink }: Props) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const ref = useRef(null)
+  useClickOutside(ref, () => setIsOpen(false))
 
-  onFilterChange (event: SyntheticInputEvent<HTMLInputElement>) {
-    const filterQuery = event.target.value.toLowerCase()
-    this.setState({ filterQuery })
-  }
-
-  renderInput () {
-    const { apis = [] } = this.props
-
-    if (apis.length < 2) {
-      return null
-    }
-
-    return (
-      <li className="PopNavigation-listItem nav-search-widget docs-search" id="context-widget">
-        <input
-          onChange={(e: SyntheticInputEvent<HTMLInputElement>) => this.onFilterChange(e)}
-          type="search"
-          className="docs-search-input"
-          placeholder="Type the API name"
-        />
-      </li>
-    )
-  }
-
-  getClassNamesForMenu (menu: Menu): string {
-    const { activeMenu } = this.props
-
+  function getClassNamesForMenu (menu: Menu): string {
     const isDashboardSelected = menu === 'dashboard' && activeMenu === 'dashboard'
     const isAudienceSelected = menu === 'audience' && (['buyers', 'finance', 'cms', 'site'].indexOf(activeMenu) !== -1)
 
@@ -69,84 +36,38 @@ class ContextSelector extends React.Component<Props, State> {
     return 'PopNavigation-link'
   }
 
-  getClassNamesForService (api: Api): string {
-    const { activeMenu, currentApi } = this.props
-    let classNames = 'PopNavigation-link'
-
-    if (['serviceadmin', 'monitoring', 'backend_api'].indexOf(activeMenu) !== -1 &&
-      `${api.type}${api.id}` === `${currentApi.type}${currentApi.id}`) {
-      classNames += ' current-context'
-    }
-
-    if (!api.link) {
-      classNames += ' unauthorized'
-    }
-
-    return classNames
-  }
-
-  renderOptions () {
-    const { apis, apiap } = this.props
-    const { filterQuery } = this.state
-    const filteredApis = apis.filter(api => api.name.toLowerCase().indexOf(filterQuery) !== -1)
-
-    if (filteredApis.length === 0) {
-      return null
-    }
-
-    const displayedApis = filteredApis.map(api => (
-      <li key={`${api.type}-${api.id}`} className="PopNavigation-listItem">
-        <a className={this.getClassNamesForService(api)} href={api.link}>
-          <Icon apiap={apiap} apiType={api.type} />{api.name}
-        </a>
-      </li>
-    ))
-
-    return (
-      <li className="PopNavigation-listItem">
-        <ul className="PopNavigation-results">
-          {displayedApis}
-        </ul>
-      </li>
-    )
-  }
-
-  render () {
-    const { currentApi, activeMenu, audienceLink, apiap } = this.props
-
-    return (
-      <div className="PopNavigation PopNavigation--context">
-        <a className="PopNavigation-trigger u-toggler" href="#context-menu" title="Context Selector">
-          <ActiveMenuTitle currentApi={currentApi} activeMenu={activeMenu} apiap={apiap}/>
-        </a>
-        <ul id="context-menu" className="PopNavigation-list u-toggleable">
+  return (
+    <div className="PopNavigation PopNavigation--context" ref={ref}>
+      <a className="PopNavigation-trigger" href="#context-menu" title="Context Selector" onClick={() => setIsOpen(!isOpen)}>
+        <ActiveMenuTitle currentApi={currentApi} activeMenu={activeMenu} apiap={true}/>
+      </a>
+      {isOpen && (
+        <ul id="context-menu" className="PopNavigation-list">
           <li className="PopNavigation-listItem">
-            <a className={this.getClassNamesForMenu('dashboard')} href={DASHBOARD_PATH}>
+            <a className={getClassNamesForMenu('dashboard')} href={DASHBOARD_PATH}>
               <i className='fa fa-home' />Dashboard
             </a>
           </li>
-          {audienceLink ? (
+          {audienceLink && (
             <li className="PopNavigation-listItem">
-              <a className={this.getClassNamesForMenu('audience')} href={audienceLink}>
+              <a className={getClassNamesForMenu('audience')} href={audienceLink}>
                 <i className='fa fa-bullseye' />Audience
               </a>
             </li>
-          ) : null}
-          {this.renderInput()}
-          {this.renderOptions()}
+          )}
+          <li className="PopNavigation-listItem">
+            <a className={getClassNamesForMenu('products')} href={productsLink}>
+              <i className='fa fa-cubes' />Products
+            </a>
+          </li>
+          <li className="PopNavigation-listItem">
+            <a className={getClassNamesForMenu('backends')} href={backendsLink}>
+              <i className='fa fa-cube' />Backends
+            </a>
+          </li>
         </ul>
-      </div >
-    )
-  }
-}
-
-const Icon = ({ apiType, apiap }: {apiType: string, apiap: ?boolean}) => {
-  const iconClassName = apiap
-    ? (apiType === 'product' ? 'fa-cubes' : 'fa-cube')
-    : 'fa-puzzle-piece'
-
-  return (
-    <i className={`fa ${iconClassName}`} />
+      )}
+    </div >
   )
 }
 

--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -56,12 +56,12 @@ const ContextSelector = ({ currentApi, activeMenu, audienceLink, productsLink, b
             </li>
           )}
           <li className="PopNavigation-listItem">
-            <a className={getClassNamesForMenu('products')} href={productsLink}>
+            <a className="PopNavigation-link" href={productsLink}>
               <i className='fa fa-cubes' />Products
             </a>
           </li>
           <li className="PopNavigation-listItem">
-            <a className={getClassNamesForMenu('backends')} href={backendsLink}>
+            <a className="PopNavigation-link" href={backendsLink}>
               <i className='fa fa-cube' />Backends
             </a>
           </li>

--- a/app/javascript/src/Navigation/styles/ContextSelector.scss
+++ b/app/javascript/src/Navigation/styles/ContextSelector.scss
@@ -11,6 +11,9 @@ $font-color: #393f44; // pf-black-800
 .current-context {
   color: $lochMaraBlue;
 }
+.PopNavigation-list {
+  animation: none;
+}
 
 .PopNavigation-link > i {
   padding-right: 0.5rem;

--- a/app/javascript/src/utilities/useClickOutside.js
+++ b/app/javascript/src/utilities/useClickOutside.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+
+const useClickOutside = (ref, cb) => {
+  useEffect(() => {
+    /**
+    * Alert if clicked on outside of element
+    */
+    function handleClickOutside (event) {
+      if (ref.current && !ref.current.contains(event.target)) {
+        cb()
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [ref])
+}
+
+export { useClickOutside }

--- a/app/views/shared/_api_selector.html.slim
+++ b/app/views/shared/_api_selector.html.slim
@@ -1,1 +1,7 @@
-#api_selector data-api={currentApi: current_api, apis: api_selector_services, activeMenu: active_menu, audienceLink: audience_link, apiap: current_account.provider_can_use?(:api_as_product)}.to_json
+= javascript_pack_tag 'api_selector'
+
+#api_selector data={ 'current-api': current_api.to_json,
+                     'active-menu': active_menu,
+                     'audience-link': audience_link,
+                     'products-link': admin_services_path,
+                     'backends-link': provider_admin_backend_apis_path }

--- a/spec/javascripts/Navigation/ContextSelector.spec.jsx
+++ b/spec/javascripts/Navigation/ContextSelector.spec.jsx
@@ -2,165 +2,77 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { ContextSelector } from 'Navigation/components/ContextSelector'
 
-function getWrapper (apis = [], audienceLink, apiap = true) {
-  return mount(<ContextSelector apis={apis} audienceLink={audienceLink} apiap={apiap} />)
+const audienceLink = '/audience'
+const productsLink = '/products'
+const backendsLink = '/backends'
+
+const currentApi = { name: 'api 0', id: 0, link: 'foo.bar' }
+
+function getWrapper (customProps) {
+  const props = {
+    currentApi: null,
+    activeMenu: '',
+    audienceLink: audienceLink,
+    productsLink: productsLink,
+    backendsLink: backendsLink,
+    ...customProps
+  }
+  return mount(<ContextSelector {...props} />)
 }
 
-let contextSelector
-
-const apis = [
-  { name: 'api 0', id: 0, link: 'foo.bar', type: 'product' },
-  { name: 'api 1', id: 1, link: 'baz.bar', type: 'product' },
-  { name: 'api 2', id: 2, type: 'backend' }
-]
-const audienceLink = 'foo.bar'
-
-beforeEach(() => {
-  contextSelector = getWrapper(apis, audienceLink)
-})
-
-afterEach(() => {
-  contextSelector.unmount()
-})
-
 it('should render itself', () => {
-  expect(contextSelector.find(ContextSelector).exists()).toEqual(true)
+  expect(getWrapper().find(ContextSelector).exists()).toEqual(true)
 })
 
-it('should have a Dashboard option on top', () => {
-  const dashboard = contextSelector.find('#context-menu').childAt(0)
-  expect(dashboard.exists()).toEqual(true)
-  expect(dashboard.text()).toEqual('Dashboard')
-  expect(dashboard.find('a').props().href).not.toBeUndefined()
+it('should have Dashboard, Audience, Products and Backends', () => {
+  const wrapper = getWrapper()
+  wrapper.find('.PopNavigation-trigger').simulate('click')
+  expect(wrapper).toMatchSnapshot()
 })
 
-it('should have a Audience option after Dashboard, only if audience link is defined', () => {
-  const audience = contextSelector.find('#context-menu').childAt(1)
-  expect(audience.exists()).toEqual(true)
-  expect(audience.text()).toEqual('Audience')
-  expect(audience.find('a').props().href).toEqual(audienceLink)
-})
-
-it('should not have a Audience option when audience link is undefined', () => {
-  contextSelector = getWrapper(apis, undefined)
-  let audience = contextSelector.find('a').filterWhere(a => a.text() === 'Audience')
-  expect(audience.exists()).toEqual(false)
+it('should not have Audience if not provided', () => {
+  const wrapper = getWrapper()
+  wrapper.setProps({ audienceLink: undefined })
+  wrapper.find('.PopNavigation-trigger').simulate('click')
+  expect(wrapper).toMatchSnapshot()
 })
 
 it('should highlight the selected context', () => {
-  contextSelector.setProps({ activeMenu: 'buyers', currentApi: null })
-  expect(contextSelector.find('.current-context')).toHaveLength(1)
-  expect(contextSelector.find('.current-context').text()).toEqual('Audience')
+  const wrapper = getWrapper()
+  wrapper.find('.PopNavigation-trigger').simulate('click')
 
-  contextSelector.setProps({ activeMenu: 'finance', currentApi: null })
-  expect(contextSelector.find('.current-context')).toHaveLength(1)
-  expect(contextSelector.find('.current-context').text()).toEqual('Audience')
+  wrapper.setProps({ activeMenu: 'buyers', currentApi: null })
+  expect(wrapper.find('.current-context')).toHaveLength(1)
+  expect(wrapper.find('.current-context').text()).toEqual('Audience')
 
-  contextSelector.setProps({ activeMenu: 'cms', currentApi: null })
-  expect(contextSelector.find('.current-context')).toHaveLength(1)
-  expect(contextSelector.find('.current-context').text()).toEqual('Audience')
+  wrapper.setProps({ activeMenu: 'finance', currentApi: null })
+  expect(wrapper.find('.current-context')).toHaveLength(1)
+  expect(wrapper.find('.current-context').text()).toEqual('Audience')
 
-  contextSelector.setProps({ activeMenu: 'site', currentApi: null })
-  expect(contextSelector.find('.current-context')).toHaveLength(1)
+  wrapper.setProps({ activeMenu: 'cms', currentApi: null })
+  expect(wrapper.find('.current-context')).toHaveLength(1)
+  expect(wrapper.find('.current-context').text()).toEqual('Audience')
 
-  contextSelector.setProps({ activeMenu: 'dashboard', currentApi: apis[0] })
-  expect(contextSelector.find('.current-context')).toHaveLength(1)
-  expect(contextSelector.find('.current-context').text()).toEqual('Dashboard')
+  wrapper.setProps({ activeMenu: 'site', currentApi: null })
+  expect(wrapper.find('.current-context')).toHaveLength(1)
+  expect(wrapper.find('.current-context').text()).toEqual('Audience')
 
-  // For the particular APIs
-  contextSelector.setProps({ activeMenu: 'serviceadmin', currentApi: apis[1] })
-  expect(contextSelector.find('.current-context')).toHaveLength(1)
-  expect(contextSelector.find('.current-context').text()).toEqual('api 1')
-
-  contextSelector.setProps({ activeMenu: 'monitoring', currentApi: apis[2] })
-  expect(contextSelector.find('.current-context')).toHaveLength(1)
-  expect(contextSelector.find('.current-context').text()).toEqual('api 2')
+  wrapper.setProps({ activeMenu: 'dashboard', currentApi })
+  expect(wrapper.find('.current-context')).toHaveLength(1)
+  expect(wrapper.find('.current-context').text()).toEqual('Dashboard')
 })
 
-describe('When there is only 1 service', () => {
-  beforeEach(() => {
-    contextSelector = getWrapper(apis.slice(0, 1), audienceLink)
-    expect(contextSelector.props().apis.length).toEqual(1)
-  })
+it('should display the current api', () => {
+  const wrapper = getWrapper({ activeMenu: 'serviceadmin', currentApi })
 
-  it('should not have a search field', () => {
-    expect(contextSelector.props().apis).toHaveLength(1)
-    expect(contextSelector.find('input').exists()).toEqual(false)
-  })
+  expect(wrapper.find('.fa-cubes').exists()).toBe(true)
+  expect(wrapper.find('.PopNavigation-trigger').text()).toContain(currentApi.name)
 
-  it('should have the only api after Audience', () => {
-    const api = contextSelector.find('#context-menu').childAt(2)
-    expect(api.exists()).toEqual(true)
-    expect(api.text()).toEqual('api 0')
-  })
+  wrapper.setProps({ activeMenu: 'monitoring' })
+  expect(wrapper.find('.fa-cubes').exists()).toBe(true)
+  expect(wrapper.find('.PopNavigation-trigger').text()).toContain(currentApi.name)
 
-  it('should mark the api as unauthorized when link is undefined', () => {
-    contextSelector = getWrapper(apis.slice(0, 1), audienceLink)
-    expect(contextSelector.find('.unauthorized')).toHaveLength(0)
-
-    contextSelector = getWrapper(apis.slice(2, 3), audienceLink)
-    expect(contextSelector.find('.unauthorized')).toHaveLength(1)
-  })
-})
-
-describe('When there are many services', () => {
-  beforeEach(() => {
-    expect(contextSelector.props().apis.length).toBeGreaterThan(0)
-  })
-
-  it('should have a search field after audience', () => {
-    const searchField = contextSelector.find('#context-menu').childAt(2)
-
-    expect(searchField.exists()).toEqual(true)
-    expect(searchField.find('input').exists()).toEqual(true)
-    expect(searchField.find('input').props().placeholder).toEqual('Type the API name')
-  })
-
-  it('should have a list of apis after the search field', () => {
-    expect(contextSelector.find('#context-menu').childAt(3).find('.PopNavigation-results').exists())
-      .toEqual(true)
-  })
-
-  it('should render all APIs when input is empty', () => {
-    const input = contextSelector.find('input')
-    expect(input.props().value).toBeUndefined()
-
-    const apiList = contextSelector.find('.PopNavigation-results').children()
-    expect(apiList).toHaveLength(apis.length)
-  })
-
-  it('should filter APIs by name', () => {
-    const input = contextSelector.find('input')
-
-    input.simulate('change', { target: { value: 'api' } })
-    expect(contextSelector.find('.PopNavigation-results').children()).toHaveLength(3)
-
-    input.simulate('change', { target: { value: 'api 1' } })
-    expect(contextSelector.find('.PopNavigation-results').children()).toHaveLength(1)
-
-    input.simulate('change', { target: { value: 'wubba lubba dub dub' } })
-    expect(contextSelector.find('.PopNavigation-results').children()).toHaveLength(0)
-  })
-
-  it('should mark apis as unauthorized when link is undefined', () => {
-    const apiList = contextSelector.find('.PopNavigation-results').children()
-    expect(apiList.find('.unauthorized')).toHaveLength(1)
-  })
-
-  it('should render the correct icons for backend and product APIs', () => {
-    const apiIconsClassNames = contextSelector.find('.PopNavigation-results .PopNavigation-link')
-      .map(link => [link.text(), link.find('i').prop('className')])
-    expect(apiIconsClassNames)
-      .toEqual([ ['api 0', 'fa fa-cubes'], ['api 1', 'fa fa-cubes'], ['api 2', 'fa fa-cube'] ])
-  })
-
-  it('should render the correct icons when apiap is disabled', () => {
-    contextSelector.unmount()
-    contextSelector = getWrapper(apis, audienceLink, false)
-    const puzzleApiIcons = contextSelector.find('.PopNavigation-results .PopNavigation-link .fa-puzzle-piece')
-    expect(puzzleApiIcons.length).toEqual(3)
-
-    const giftApiIcons = contextSelector.find('.PopNavigation-results .PopNavigation-link .fa-gift')
-    expect(giftApiIcons.length).toEqual(0)
-  })
+  wrapper.setProps({ activeMenu: 'backend_api' })
+  expect(wrapper.find('.fa-cube').exists()).toBe(true)
+  expect(wrapper.find('.PopNavigation-trigger').text()).toContain(currentApi.name)
 })

--- a/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.jsx.snap
+++ b/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.jsx.snap
@@ -1,0 +1,179 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should have Dashboard, Audience, Products and Backends 1`] = `
+<ContextSelector
+  activeMenu=""
+  audienceLink="/audience"
+  backendsLink="/backends"
+  currentApi={null}
+  productsLink="/products"
+>
+  <div
+    className="PopNavigation PopNavigation--context"
+  >
+    <a
+      className="PopNavigation-trigger"
+      href="#context-menu"
+      onClick={[Function]}
+      title="Context Selector"
+    >
+      <ActiveMenuTitle
+        activeMenu=""
+        apiap={true}
+        currentApi={null}
+      >
+        <span
+          className="ActiveMenuTitle"
+        >
+          <i
+            className="fa fa-puzzle-piece"
+          />
+          Choose an API
+          <i
+            className="fa fa-chevron-down"
+          />
+        </span>
+      </ActiveMenuTitle>
+    </a>
+    <ul
+      className="PopNavigation-list"
+      id="context-menu"
+    >
+      <li
+        className="PopNavigation-listItem"
+      >
+        <a
+          className="PopNavigation-link"
+          href="/p/admin/dashboard"
+        >
+          <i
+            className="fa fa-home"
+          />
+          Dashboard
+        </a>
+      </li>
+      <li
+        className="PopNavigation-listItem"
+      >
+        <a
+          className="PopNavigation-link"
+          href="/audience"
+        >
+          <i
+            className="fa fa-bullseye"
+          />
+          Audience
+        </a>
+      </li>
+      <li
+        className="PopNavigation-listItem"
+      >
+        <a
+          className="PopNavigation-link"
+          href="/products"
+        >
+          <i
+            className="fa fa-cubes"
+          />
+          Products
+        </a>
+      </li>
+      <li
+        className="PopNavigation-listItem"
+      >
+        <a
+          className="PopNavigation-link"
+          href="/backends"
+        >
+          <i
+            className="fa fa-cube"
+          />
+          Backends
+        </a>
+      </li>
+    </ul>
+  </div>
+</ContextSelector>
+`;
+
+exports[`should not have Audience if not provided 1`] = `
+<ContextSelector
+  activeMenu=""
+  backendsLink="/backends"
+  currentApi={null}
+  productsLink="/products"
+>
+  <div
+    className="PopNavigation PopNavigation--context"
+  >
+    <a
+      className="PopNavigation-trigger"
+      href="#context-menu"
+      onClick={[Function]}
+      title="Context Selector"
+    >
+      <ActiveMenuTitle
+        activeMenu=""
+        apiap={true}
+        currentApi={null}
+      >
+        <span
+          className="ActiveMenuTitle"
+        >
+          <i
+            className="fa fa-puzzle-piece"
+          />
+          Choose an API
+          <i
+            className="fa fa-chevron-down"
+          />
+        </span>
+      </ActiveMenuTitle>
+    </a>
+    <ul
+      className="PopNavigation-list"
+      id="context-menu"
+    >
+      <li
+        className="PopNavigation-listItem"
+      >
+        <a
+          className="PopNavigation-link"
+          href="/p/admin/dashboard"
+        >
+          <i
+            className="fa fa-home"
+          />
+          Dashboard
+        </a>
+      </li>
+      <li
+        className="PopNavigation-listItem"
+      >
+        <a
+          className="PopNavigation-link"
+          href="/products"
+        >
+          <i
+            className="fa fa-cubes"
+          />
+          Products
+        </a>
+      </li>
+      <li
+        className="PopNavigation-listItem"
+      >
+        <a
+          className="PopNavigation-link"
+          href="/backends"
+        >
+          <i
+            className="fa fa-cube"
+          />
+          Backends
+        </a>
+      </li>
+    </ul>
+  </div>
+</ContextSelector>
+`;


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of the improvements in the Dashboard, we're removing the list of services and searchbar inside the ContextSwitcher.

<img width="600" alt="Screenshot 2020-10-08 at 16 57 51" src="https://user-images.githubusercontent.com/11672286/95476504-9893f380-0987-11eb-98f5-fd1ed046d8c0.png">

<img width="600" alt="Screenshot 2020-10-08 at 16 58 03" src="https://user-images.githubusercontent.com/11672286/95476518-9b8ee400-0987-11eb-96c8-fff571b362bd.png">


**Which issue(s) this PR fixes** 

[Address UI scalability issues in API Management Service](https://issues.redhat.com/browse/APPDUX-462)
