### PR TITLE
[Hotfix] Sphinx search Service & BackendAPI

### DIFF
--- a/app/indices/backend_api_index.rb
+++ b/app/indices/backend_api_index.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+ThinkingSphinx::Index.define(:backend_api, with: :real_time) do
+  indexes :name, as: :name
+end

--- a/app/indices/service_index.rb
+++ b/app/indices/service_index.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+ThinkingSphinx::Index.define(:service, with: :real_time) do
+  indexes :name, as: :name
+end

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -5,6 +5,13 @@ class BackendApi < ApplicationRecord
   include SystemName
   include ProxyConfigAffectingChanges::ModelExtension
 
+  self.allowed_search_scopes = %i[query]
+
+  scope :by_query, ->(query) do
+    options = {ids_only: true, per_page: 1_000_000, star: true, ignore_scopes: true, with: { }}
+    where(id: search(ThinkingSphinx::Query.escape(query), options))
+  end
+
   define_proxy_config_affecting_attributes :private_endpoint
 
   self.background_deletion = %i[proxy_rules metrics backend_api_configs]

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -15,6 +15,13 @@ class Service < ApplicationRecord
   include ServiceDiscovery::ModelExtensions::Service
   include ProxyConfigAffectingChanges::ModelExtension
 
+  self.allowed_search_scopes = %i[query]
+
+  scope :by_query, ->(query) do
+    options = {ids_only: true, per_page: 1_000_000, star: true, ignore_scopes: true, with: { }}
+    where(id: search(ThinkingSphinx::Query.escape(query), options))
+  end
+
   define_proxy_config_affecting_attributes :backend_version
 
   self.background_deletion = [


### PR DESCRIPTION
It works. It needs to be polished and add a test. I'll do it in the next PR.

### Validation Steps
1. Clear config, configure and run Sphinx. `rake ts:clear ts:configure && bundle exec rake openshift:thinking_sphinx:start`
2. Run rails server. `RAILS_LOG_TO_STDOUT=1 UNICORN_WORKERS=8 bundle exec rails server -b 0.0.0.0`
3. Run Sidekiq. Consider cleaning pending stuff that you don't care about first (with `redis-cli flushall`). `bundle exec sidekiq -q default -q low -q critical -L log/sidekiq.log`. We are interested in the default queue for this.
4. Enqueue indexations.  `bundle exec rake sphinx:enqueue`

When the indexations are done, feel free to test the search.