### PR TITLE
ConnectionPool prepend 'stat' method

### DIFF
--- a/lib/system/database.rb
+++ b/lib/system/database.rb
@@ -187,6 +187,23 @@ module System
   end
 end
 
+# TODO: Remove for Rails 5.1 because it is already implemented there
+ActiveRecord::ConnectionAdapters::ConnectionPool.prepend(Module.new do
+  def stat
+    synchronize do
+      {
+        size: size,
+        connections: @connections.size,
+        busy: @connections.count { |c| c.in_use? && c.owner.alive? },
+        dead: @connections.count { |c| c.in_use? && !c.owner.alive? },
+        idle: @connections.count { |c| !c.in_use? },
+        waiting: num_waiting_in_queue,
+        checkout_timeout: checkout_timeout
+      }
+    end
+  end
+end)
+
 if System::Database.oracle? && defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::DatabaseTasks)
   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::DatabaseTasks.class_eval do
     prepend(Module.new do


### PR DESCRIPTION
[Add 'stat' to the connection pool abstract adapter.](https://issues.redhat.com/browse/THREESCALE-5698?focusedCommentId=15309911&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15309911)
[Copy-paste from the original method](https://github.com/rails/rails/commit/35b6898f7cb5223e1de4edc1b4539e05dfd83d41#diff-642b90553b888bd2c724c093a1a685a5408a7d8293f3751366c25dc548936eb7R588) (Rails 5.1).

MySQL
![image](https://user-images.githubusercontent.com/11318903/96014925-3afc1d00-0e47-11eb-80d8-4857971dda21.png)


Postgres
![image](https://user-images.githubusercontent.com/11318903/96015496-e907c700-0e47-11eb-8481-11a700d58ea9.png)


Oracle
![image](https://user-images.githubusercontent.com/11318903/96015768-3be17e80-0e48-11eb-8650-428b20bf50a1.png)
