### PR TITLE
Skip multiple services upgrade message cuke

### DIFF
--- a/features/old/services/switch.feature
+++ b/features/old/services/switch.feature
@@ -16,6 +16,7 @@ Feature: Services switch
       And I follow "New Product"
     Then I should be on the upgrade notice page for "multiple_services"
 
+  @wip
   Scenario: In allowed state (hidden and visible), I should have the functionality enabled
     Given provider "foo.example.com" has "multiple_services" switch allowed
       And I am on the provider dashboard


### PR DESCRIPTION
Known bug for 2.10 ER1

The bug is that we are redirecting to the services' new page always whether the customer has the switch multiple_services or not, and if it does not have it, the response is 'access denied' page.
The right workflow if the mutliple_services is not allowed, is showing the message to upgrade plan as we used to.