### PR TITLE
Bump Liquid to 3.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ PATH
   remote: lib/developer_portal
   specs:
     developer_portal (1.0.0)
-      liquid (~> 3.0.5)
+      liquid (~> 3.0.6)
       railties (>= 3.2)
 
 PATH

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -90,7 +90,7 @@ PATH
   remote: lib/developer_portal
   specs:
     developer_portal (1.0.0)
-      liquid (~> 3.0.5)
+      liquid (~> 3.0.6)
       railties (>= 3.2)
 
 PATH

--- a/lib/developer_portal/developer_portal.gemspec
+++ b/lib/developer_portal/developer_portal.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "railties", ">= 3.2"
-  s.add_dependency 'liquid', '~>3.0.5'
+  s.add_dependency 'liquid', '~>3.0.6'
 
 
   # s.add_dependency "jquery-rails"


### PR DESCRIPTION
Part of [THREESCALE-401](https://issues.redhat.com/browse/THREESCALE-401) & [THREESCALE-4053](https://issues.redhat.com/browse/THREESCALE-4053)
Updating Liquid step by step, version by version.
This one is an easy one.

These are the only [differences](https://github.com/Shopify/liquid/compare/v3.0.5...v3.0.6) between the current version and the one of this PR:
![image](https://user-images.githubusercontent.com/11318903/96469448-82aaec00-122d-11eb-8648-8769da87144d.png)
![image](https://user-images.githubusercontent.com/11318903/96469469-89d1fa00-122d-11eb-9677-d52a824ba131.png)
