### PR TITLE
Sphinx indexation rake task accepts param for specific classes to index

### DIFF
--- a/lib/tasks/sphinx.rake
+++ b/lib/tasks/sphinx.rake
@@ -7,7 +7,7 @@ namespace :sphinx do
   task enqueue: :environment do |_task, args|
     klasses_index = args.to_a
     indices = ThinkingSphinx::RakeInterface.new.rt.send(:indices)
-    indices = indices.select { |ind| klasses_index.include?(ind.model.name) } if klasses_index.any?
+    indices.select! { |ind| klasses_index.include?(ind.model.name) } if klasses_index.any?
 
     indices.each do |index|
       scope = index.scope

--- a/lib/tasks/sphinx.rake
+++ b/lib/tasks/sphinx.rake
@@ -4,8 +4,10 @@ require 'progress_counter'
 
 namespace :sphinx do
   desc "Enqueue indexation of tables"
-  task enqueue: :environment do
+  task enqueue: :environment do |_task, args|
+    klasses_index = args.to_a
     indices = ThinkingSphinx::RakeInterface.new.rt.send(:indices)
+    indices = indices.select { |ind| klasses_index.include?(ind.model.name) } if klasses_index.any?
 
     indices.each do |index|
       scope = index.scope


### PR DESCRIPTION
Part of [THREESCALE-6214](https://issues.redhat.com/browse/THREESCALE-6214)
The purpose of this PR is not having to index all models when we only want to index a specific model.