### PR TITLE
Fix XSS in the API backend Overview page

### DIFF
--- a/app/views/provider/admin/backend_apis/show.html.slim
+++ b/app/views/provider/admin/backend_apis/show.html.slim
@@ -5,14 +5,14 @@ section.Section
     = link_to 'edit', edit_provider_admin_backend_api_path(@backend_api), class: 'SettingsBox-toggle'
     dl.SettingsBox-summary.u-dl data-state="open"
       dt.u-dl-term Name
-      dd.u-dl-definition == @backend_api.name
+      dd.u-dl-definition = @backend_api.name
       dt.u-dl-term System Name
-      dd.u-dl-definition == @backend_api.system_name
+      dd.u-dl-definition = @backend_api.system_name
       - if (description = @backend_api.description.presence)
         dt.u-dl-term Description
-        dd.u-dl-definition == description
+        dd.u-dl-definition = description
       dt.u-dl-term Private Base URL
-      dd.u-dl-definition == @backend_api.private_endpoint
+      dd.u-dl-definition = @backend_api.private_endpoint
 
 section class="overview-widget"
   div

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -99,6 +99,14 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
     end
   end
 
+  test 'xss' do
+    backend_api = @provider.backend_apis.last
+    backend_api.update_column(:description, "<script>alert('XSS')</script>")
+    get provider_admin_backend_api_path(backend_api)
+    page = Nokogiri::HTML::Document.parse(response.body)
+    assert_equal "<script>alert('XSS')</script>", page.xpath("//dt[text() = 'Description']/following-sibling::dd").first.text
+  end
+
   test 'member permissions' do
     backend_api = FactoryBot.create(:backend_api, account: provider)
     member = FactoryBot.create(:member, account: provider)


### PR DESCRIPTION
Start by editing an API backend like this:
<img width="1615" alt="Screenshot 2020-10-21 at 12 45 31" src="https://user-images.githubusercontent.com/1842261/96709783-747ade00-139b-11eb-85c8-ebed306f1b92.png">

Without the fix:
<img width="1615" alt="Screenshot 2020-10-21 at 12 45 39" src="https://user-images.githubusercontent.com/1842261/96709785-7644a180-139b-11eb-934b-224b08fce93a.png">
<img width="1615" alt="Screenshot 2020-10-21 at 12 45 47" src="https://user-images.githubusercontent.com/1842261/96709789-76dd3800-139b-11eb-81c2-79b1d9a5e3a9.png">

With the fix:
<img width="1615" alt="Screenshot 2020-10-21 at 12 46 05" src="https://user-images.githubusercontent.com/1842261/96709791-76dd3800-139b-11eb-997c-a6d63a5c6673.png">


Closes [THREESCALE-5623](https://issues.redhat.com/browse/THREESCALE-5623)