### PR TITLE
Move Settings out of Masthead into Context Switcher

### DIFF
--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -96,6 +96,12 @@ module MenuHelper
     end
   end
 
+  def settings_link
+    can?(:manage, current_account)
+      ? provider_admin_account_path
+      : edit_provider_admin_user_personal_details_path
+  end
+
   def current_api
     (@backend_api || @service || Service.none).decorate
   end

--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -97,9 +97,7 @@ module MenuHelper
   end
 
   def settings_link
-    can?(:manage, current_account)
-      ? provider_admin_account_path
-      : edit_provider_admin_user_personal_details_path
+    can?(:manage, current_account) ? provider_admin_account_path : edit_provider_admin_user_personal_details_path
   end
 
   def current_api

--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -13,13 +13,14 @@ import type { Menu } from 'Types'
 type Props = {
   activeMenu: Menu,
   audienceLink: string,
+  settingsLink: string,
   productsLink: string,
   backendsLink: string
 }
 
 const DASHBOARD_PATH = '/p/admin/dashboard'
 
-const ContextSelector = ({ activeMenu, audienceLink, productsLink, backendsLink }: Props) => {
+const ContextSelector = ({ activeMenu, audienceLink, settingsLink, productsLink, backendsLink }: Props) => {
   const [isOpen, setIsOpen] = useState(false)
   const ref = useRef(null)
   useClickOutside(ref, () => setIsOpen(false))
@@ -29,8 +30,9 @@ const ContextSelector = ({ activeMenu, audienceLink, productsLink, backendsLink 
     const isAudienceSelected = menu === 'audience' && (['buyers', 'finance', 'cms', 'site'].indexOf(activeMenu) !== -1)
     const isProductsSelected = menu === 'products' && (['serviceadmin', 'monitoring', 'products'].indexOf(activeMenu) !== -1)
     const isBackendsSelected = menu === 'backend_api' && (['backend_api', 'backend_apis'].indexOf(activeMenu) !== -1)
+    const isSettingsSelected = menu === 'account' && (['account', 'personal', 'active_docs'].indexOf(activeMenu) !== -1)
 
-    if (isDashboardSelected || isAudienceSelected || isProductsSelected || isBackendsSelected) {
+    if (isDashboardSelected || isAudienceSelected || isProductsSelected || isBackendsSelected || isSettingsSelected) {
       return 'PopNavigation-link current-context'
     }
 
@@ -64,6 +66,11 @@ const ContextSelector = ({ activeMenu, audienceLink, productsLink, backendsLink 
           <li className="PopNavigation-listItem">
             <a className={getClassNamesForMenu('backend_api')} href={backendsLink}>
               <i className='fa fa-cube' />Backends
+            </a>
+          </li>
+          <li className="PopNavigation-listItem">
+            <a className={getClassNamesForMenu('account')} href={settingsLink}>
+              <i className='fa fa-cog' />Account Settings
             </a>
           </li>
         </ul>

--- a/app/views/shared/_api_selector.html.slim
+++ b/app/views/shared/_api_selector.html.slim
@@ -1,6 +1,9 @@
 = javascript_pack_tag 'api_selector'
 
+- settings_link = can?(:manage, current_account) ? provider_admin_account_path : edit_provider_admin_user_personal_details_path
+
 #api_selector data={ 'active-menu': active_menu,
                      'audience-link': audience_link,
+                     'settings-link': settings_link,
                      'products-link': admin_services_path,
                      'backends-link': provider_admin_backend_apis_path }

--- a/app/views/shared/_api_selector.html.slim
+++ b/app/views/shared/_api_selector.html.slim
@@ -1,7 +1,5 @@
 = javascript_pack_tag 'api_selector'
 
-- settings_link = can?(:manage, current_account) ? provider_admin_account_path : edit_provider_admin_user_personal_details_path
-
 #api_selector data={ 'active-menu': active_menu,
                      'audience-link': audience_link,
                      'settings-link': settings_link,

--- a/app/views/shared/provider/_header.html.slim
+++ b/app/views/shared/provider/_header.html.slim
@@ -11,12 +11,6 @@ header.pf-c-page__header id="user_widget" class='Header' class=('Header--master'
     = render 'shared/api_selector'
 
   .pf-c-page__header-tools
-    .PopNavigation.PopNavigation--account
-      - link = can?(:manage, current_account) ? provider_admin_account_path : edit_provider_admin_user_personal_details_path
-
-      a.PopNavigation-trigger class=('is-current' if active_menu?(:topmenu, :account)) href="#{link}"  title="Account Settings"
-        => icon('cog')
-
     // HACK of the month. See features/support/current_user.rb if you are hungry for reasons
     div class="username" style="display:none;"
       = current_user.username

--- a/features/old/accounts/accounts.feature
+++ b/features/old/accounts/accounts.feature
@@ -88,10 +88,11 @@ Feature: Account management
       And I go to the provider account page
     Then I should not be able to edit the value of the customers type field
 
+  @javascript
   Scenario: Edit personal details with invalid data
     And current domain is the admin domain of provider "foo.3scale.localhost"
     When I log in as provider "foo.3scale.localhost"
-    And I follow "Account Settings"
+    And I navigate to the Account Settings
     And I follow "Personal"
     And I follow "Personal Details"
     When I fill in "Email" with ""

--- a/features/old/accounts/password_change.feature
+++ b/features/old/accounts/password_change.feature
@@ -3,12 +3,13 @@ Feature: Password change
   As an user
   I want to change my password from time to time
 
+  @javascript
   Scenario: Provider password change
     Given a provider "foo.3scale.localhost"
 
     Given current domain is the admin domain of provider "foo.3scale.localhost"
     When I log in as provider "foo.3scale.localhost" with password "supersecret"
-    When I follow "Account Settings"
+    When I navigate to the Account Settings
     And I follow "Personal"
     And I follow "Personal Details"
     And I fill in "Password" with "monkey"

--- a/features/old/accounts/personal_details.feature
+++ b/features/old/accounts/personal_details.feature
@@ -7,11 +7,12 @@ Feature: Personal Details
     Given a provider "foo.3scale.localhost"
     And provider "foo.3scale.localhost" has multiple applications enabled
 
+  @javascript
   Scenario: Edit personal details as provider
    Given current domain is the admin domain of provider "foo.3scale.localhost"
     And I log in as provider "foo.3scale.localhost"
 
-   When I follow "Account Settings"
+   When I navigate to the Account Settings
     And I follow "Personal"
     And I follow "Personal Details"
     And I fill in "Email" with "john.doe@foo.3scale.localhost"

--- a/features/old/providers/invitations.feature
+++ b/features/old/providers/invitations.feature
@@ -9,6 +9,7 @@ Feature: Invitations
     And provider "foo.3scale.localhost" has multiple applications enabled
     And provider "foo.3scale.localhost" has "multiple_users" switch allowed
 
+  @javascript
   Scenario: Sending an invitation as provider
     Given the admin domain of provider "foo.3scale.localhost" is "admin.foo.3scale.localhost"
       And current domain is the admin domain of provider "foo.3scale.localhost"

--- a/features/step_definitions/invitations_steps.rb
+++ b/features/step_definitions/invitations_steps.rb
@@ -85,7 +85,7 @@ When(/^I request the url of the invitations of the partner "([^\"]*)"$/) do |org
 end
 
 When(/^I send a provider invitation to "([^\"]*)"$/) do |address|
-  click_link 'Account'
+  step %(I navigate to the Account Settings)
   click_link 'Users'
   click_link 'Listing'
   click_link 'Invite a New User'

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -81,3 +81,8 @@ When /^I navigate to the buyers service contracts page$/ do
   step 'I navigate to the accounts page'
   click_link 'Subscriptions'
 end
+
+When "I navigate to the Account Settings" do
+  find('#api_selector').click
+  step %(I follow "Account Settings")
+end

--- a/spec/javascripts/Navigation/ContextSelector.spec.jsx
+++ b/spec/javascripts/Navigation/ContextSelector.spec.jsx
@@ -24,7 +24,7 @@ it('should render itself', () => {
   expect(getWrapper().find(ContextSelector).exists()).toEqual(true)
 })
 
-it('should have Dashboard, Audience, Products and Backends', () => {
+it('should have Dashboard, Audience, Products, Backends and Settings', () => {
   const wrapper = getWrapper()
   wrapper.find('.PopNavigation-trigger').simulate('click')
   expect(wrapper).toMatchSnapshot()
@@ -60,6 +60,26 @@ it('should highlight the selected context', () => {
   wrapper.setProps({ activeMenu: 'dashboard', currentApi })
   expect(wrapper.find('.current-context')).toHaveLength(1)
   expect(wrapper.find('.current-context').text()).toEqual('Dashboard')
+
+  wrapper.setProps({ activeMenu: 'personal', currentApi })
+  expect(wrapper.find('.current-context')).toHaveLength(1)
+  expect(wrapper.find('.current-context').text()).toEqual('Account Settings')
+
+  wrapper.setProps({ activeMenu: 'account', currentApi })
+  expect(wrapper.find('.current-context')).toHaveLength(1)
+  expect(wrapper.find('.current-context').text()).toEqual('Account Settings')
+
+  wrapper.setProps({ activeMenu: 'active_docs', currentApi })
+  expect(wrapper.find('.current-context')).toHaveLength(1)
+  expect(wrapper.find('.current-context').text()).toEqual('Account Settings')
+
+  wrapper.setProps({ activeMenu: 'serviceadmin', currentApi })
+  expect(wrapper.find('.current-context')).toHaveLength(1)
+  expect(wrapper.find('.current-context').text()).toEqual('Products')
+
+  wrapper.setProps({ activeMenu: 'backend_api', currentApi })
+  expect(wrapper.find('.current-context')).toHaveLength(1)
+  expect(wrapper.find('.current-context').text()).toEqual('Backends')
 })
 
 it('should display the current api', () => {

--- a/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.jsx.snap
+++ b/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should have Dashboard, Audience, Products and Backends 1`] = `
+exports[`should have Dashboard, Audience, Products, Backends and Settings 1`] = `
 <ContextSelector
   activeMenu=""
   audienceLink="/audience"

--- a/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.jsx.snap
+++ b/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.jsx.snap
@@ -88,6 +88,18 @@ exports[`should have Dashboard, Audience, Products and Backends 1`] = `
           Backends
         </a>
       </li>
+      <li
+        className="PopNavigation-listItem"
+      >
+        <a
+          className="PopNavigation-link"
+        >
+          <i
+            className="fa fa-cog"
+          />
+          Account Settings
+        </a>
+      </li>
     </ul>
   </div>
 </ContextSelector>
@@ -165,6 +177,18 @@ exports[`should not have Audience if not provided 1`] = `
             className="fa fa-cube"
           />
           Backends
+        </a>
+      </li>
+      <li
+        className="PopNavigation-listItem"
+      >
+        <a
+          className="PopNavigation-link"
+        >
+          <i
+            className="fa fa-cog"
+          />
+          Account Settings
         </a>
       </li>
     </ul>


### PR DESCRIPTION
**Which issue(s) this PR fixes** 

[THREESCALE-6241: Move "Settings" inside Context Switcher](https://issues.redhat.com/browse/THREESCALE-6241)

<img width="1283" alt="Screenshot 2020-10-28 at 10 54 01" src="https://user-images.githubusercontent.com/11672286/97420677-ec9d5280-190b-11eb-9b5c-d957c7aec281.png">


**Verification steps** 

1. Account Settings can be accessed from Context Switcher
2. Item gets highlighted inside ContextSwitcher when in Account Settings

