### PR TITLE
Add current API title above left nav

### DIFF
--- a/app/javascript/packs/vertical_nav.js
+++ b/app/javascript/packs/vertical_nav.js
@@ -12,9 +12,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const apiSelector = document.getElementById(containerId)
   const { currentApi } = apiSelector.dataset
 
-  console.log('what is the sections' + sections + JSON.stringify(sections))
-  console.log('what is the activeSection' + sections + JSON.stringify(activeSection))
-
   // TODO: where does this go?
   // - if can?(:manage, :plans)
   //   { title: 'Integration Errors', path: admin_service_errors_path(@service) },

--- a/app/javascript/packs/vertical_nav.js
+++ b/app/javascript/packs/vertical_nav.js
@@ -11,5 +11,5 @@ document.addEventListener('DOMContentLoaded', () => {
   // TODO: where does this go?
   // - if can?(:manage, :plans)
   //   { title: 'Integration Errors', path: admin_service_errors_path(@service) },
-  VerticalNav({ sections, activeSection, activeItem, currentApi: JSON.parse(currentApi) }, 'vertical-nav-wrapper')
+  VerticalNav({ sections, activeSection, activeItem, currentApi: safeFromJsonString(currentApi) }, 'vertical-nav-wrapper')
 })

--- a/app/javascript/packs/vertical_nav.js
+++ b/app/javascript/packs/vertical_nav.js
@@ -1,7 +1,7 @@
 import { VerticalNavWrapper as VerticalNav } from 'Navigation/components/VerticalNav'
 import { safeFromJsonString } from 'utilities/json-utils'
 
-const containerId = 'api_selector'
+const apiSelectorId = 'api_selector'
 
 document.addEventListener('DOMContentLoaded', () => {
   const dataset = document.getElementById('vertical-nav-wrapper').dataset
@@ -9,11 +9,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const activeSection = dataset.active_section
   const activeItem = dataset.active_item
 
-  const apiSelector = document.getElementById(containerId)
+  const apiSelector = document.getElementById(apiSelectorId)
   const { currentApi } = apiSelector.dataset
 
   // TODO: where does this go?
   // - if can?(:manage, :plans)
   //   { title: 'Integration Errors', path: admin_service_errors_path(@service) },
-  VerticalNav({ sections, activeSection, activeItem, currentApi: JSON.parse(currentApi) }, 'vertical-nav-wrapper')
+  VerticalNav({ sections, activeSection, activeItem, currentApi: safeFromJsonString(currentApi) }, 'vertical-nav-wrapper')
 })

--- a/app/javascript/packs/vertical_nav.js
+++ b/app/javascript/packs/vertical_nav.js
@@ -1,19 +1,15 @@
 import { VerticalNavWrapper as VerticalNav } from 'Navigation/components/VerticalNav'
 import { safeFromJsonString } from 'utilities/json-utils'
 
-const apiSelectorId = 'api_selector'
-
 document.addEventListener('DOMContentLoaded', () => {
   const dataset = document.getElementById('vertical-nav-wrapper').dataset
   const sections = safeFromJsonString(dataset.sections)
   const activeSection = dataset.active_section
   const activeItem = dataset.active_item
-
-  const apiSelector = document.getElementById(apiSelectorId)
-  const { currentApi } = apiSelector.dataset
+  const currentApi = dataset.current_api
 
   // TODO: where does this go?
   // - if can?(:manage, :plans)
   //   { title: 'Integration Errors', path: admin_service_errors_path(@service) },
-  VerticalNav({ sections, activeSection, activeItem, currentApi: safeFromJsonString(currentApi) }, 'vertical-nav-wrapper')
+  VerticalNav({ sections, activeSection, activeItem, currentApi: JSON.parse(currentApi) }, 'vertical-nav-wrapper')
 })

--- a/app/javascript/packs/vertical_nav.js
+++ b/app/javascript/packs/vertical_nav.js
@@ -1,14 +1,22 @@
 import { VerticalNavWrapper as VerticalNav } from 'Navigation/components/VerticalNav'
 import { safeFromJsonString } from 'utilities/json-utils'
 
+const containerId = 'api_selector'
+
 document.addEventListener('DOMContentLoaded', () => {
   const dataset = document.getElementById('vertical-nav-wrapper').dataset
   const sections = safeFromJsonString(dataset.sections)
   const activeSection = dataset.active_section
   const activeItem = dataset.active_item
 
+  const apiSelector = document.getElementById(containerId)
+  const { currentApi } = apiSelector.dataset
+
+  console.log('what is the sections' + sections + JSON.stringify(sections))
+  console.log('what is the activeSection' + sections + JSON.stringify(activeSection))
+
   // TODO: where does this go?
   // - if can?(:manage, :plans)
   //   { title: 'Integration Errors', path: admin_service_errors_path(@service) },
-  VerticalNav({ sections, activeSection, activeItem }, 'vertical-nav-wrapper')
+  VerticalNav({ sections, activeSection, activeItem, currentApi: JSON.parse(currentApi) }, 'vertical-nav-wrapper')
 })

--- a/app/javascript/src/Navigation/components/VerticalNav.jsx
+++ b/app/javascript/src/Navigation/components/VerticalNav.jsx
@@ -1,8 +1,9 @@
 // @flow
 
 import React from 'react'
-import { Nav, NavExpandable, NavItem, NavList, NavGroup } from '@patternfly/react-core'
+import { Nav, NavExpandable, NavItem, NavGroup } from '@patternfly/react-core'
 import { createReactWrapper } from 'utilities/createReactWrapper'
+import 'Navigation/styles/VerticalNav.scss'
 
 type Item = {
   id: string,
@@ -20,19 +21,20 @@ type Section = Item & {
 type Props = {
   sections: Section[],
   activeSection: ?string,
-  activeItem: ?string
+  activeItem: ?string,
+  currentApi: ?string
 }
 
-const VerticalNav = ({ sections, activeSection, activeItem }: Props) => (
+const VerticalNav = ({ sections, activeSection, activeItem, currentApi }: Props) => (
   <div className="pf-c-page__sidebar-body">
     <Nav id='mainmenu' theme='dark'>
-      <NavList>
+      <NavGroup title={currentApi.name}>
         {sections.map(({ id, title, path, items, outOfDateConfig }) => {
           return items
             ? <NavSection title={title} isSectionActive={id === activeSection} activeItem={activeItem} items={items} key={title} outOfDateConfig={outOfDateConfig}/>
             : <NavItem to={path} isActive={activeSection === id} key={title}>{title}</NavItem>
         })}
-      </NavList>
+      </NavGroup>
     </Nav>
   </div>
 )

--- a/app/javascript/src/Navigation/components/VerticalNav.jsx
+++ b/app/javascript/src/Navigation/components/VerticalNav.jsx
@@ -27,7 +27,7 @@ type Props = {
 }
 
 const VerticalNav = ({ sections, activeSection, activeItem, currentApi }: Props) => {
-  var navSections = sections.map(({ id, title, path, items, outOfDateConfig }) => {
+  const navSections = sections.map(({ id, title, path, items, outOfDateConfig }) => {
     return items
       ? <NavSection title={title} isSectionActive={id === activeSection} activeItem={activeItem} items={items} key={title} outOfDateConfig={outOfDateConfig}/>
       : <NavItem to={path} isActive={activeSection === id} key={title}>{title}</NavItem>

--- a/app/javascript/src/Navigation/components/VerticalNav.jsx
+++ b/app/javascript/src/Navigation/components/VerticalNav.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { Nav, NavExpandable, NavItem, NavGroup } from '@patternfly/react-core'
+import { Nav, NavExpandable, NavItem, NavList, NavGroup } from '@patternfly/react-core'
 import { createReactWrapper } from 'utilities/createReactWrapper'
 import 'Navigation/styles/VerticalNav.scss'
 import type { Api } from 'Types'
@@ -29,13 +29,23 @@ type Props = {
 const VerticalNav = ({ sections, activeSection, activeItem, currentApi }: Props) => (
   <div className="pf-c-page__sidebar-body">
     <Nav id='mainmenu' theme='dark'>
-      <NavGroup title={currentApi.name ? currentApi.name : ''}>
-        {sections.map(({ id, title, path, items, outOfDateConfig }) => {
-          return items
-            ? <NavSection title={title} isSectionActive={id === activeSection} activeItem={activeItem} items={items} key={title} outOfDateConfig={outOfDateConfig}/>
-            : <NavItem to={path} isActive={activeSection === id} key={title}>{title}</NavItem>
-        })}
-      </NavGroup>
+      { currentApi ? (
+        <NavGroup title={currentApi.name}>
+          {sections.map(({ id, title, path, items, outOfDateConfig }) => {
+            return items
+              ? <NavSection title={title} isSectionActive={id === activeSection} activeItem={activeItem} items={items} key={title} outOfDateConfig={outOfDateConfig}/>
+              : <NavItem to={path} isActive={activeSection === id} key={title}>{title}</NavItem>
+          })}
+        </NavGroup>
+      ) : (
+        <NavList>
+          {sections.map(({ id, title, path, items, outOfDateConfig }) => {
+            return items
+              ? <NavSection title={title} isSectionActive={id === activeSection} activeItem={activeItem} items={items} key={title} outOfDateConfig={outOfDateConfig}/>
+              : <NavItem to={path} isActive={activeSection === id} key={title}>{title}</NavItem>
+          })}
+        </NavList>
+      )}
     </Nav>
   </div>
 )

--- a/app/javascript/src/Navigation/components/VerticalNav.jsx
+++ b/app/javascript/src/Navigation/components/VerticalNav.jsx
@@ -26,29 +26,29 @@ type Props = {
   currentApi: ?Api
 }
 
-const VerticalNav = ({ sections, activeSection, activeItem, currentApi }: Props) => (
-  <div className="pf-c-page__sidebar-body">
-    <Nav id='mainmenu' theme='dark'>
-      { currentApi ? (
-        <NavGroup title={currentApi.name}>
-          {sections.map(({ id, title, path, items, outOfDateConfig }) => {
-            return items
-              ? <NavSection title={title} isSectionActive={id === activeSection} activeItem={activeItem} items={items} key={title} outOfDateConfig={outOfDateConfig}/>
-              : <NavItem to={path} isActive={activeSection === id} key={title}>{title}</NavItem>
-          })}
-        </NavGroup>
-      ) : (
-        <NavList>
-          {sections.map(({ id, title, path, items, outOfDateConfig }) => {
-            return items
-              ? <NavSection title={title} isSectionActive={id === activeSection} activeItem={activeItem} items={items} key={title} outOfDateConfig={outOfDateConfig}/>
-              : <NavItem to={path} isActive={activeSection === id} key={title}>{title}</NavItem>
-          })}
-        </NavList>
-      )}
-    </Nav>
-  </div>
-)
+const VerticalNav = ({ sections, activeSection, activeItem, currentApi }: Props) => {
+  var navSections = sections.map(({ id, title, path, items, outOfDateConfig }) => {
+    return items
+      ? <NavSection title={title} isSectionActive={id === activeSection} activeItem={activeItem} items={items} key={title} outOfDateConfig={outOfDateConfig}/>
+      : <NavItem to={path} isActive={activeSection === id} key={title}>{title}</NavItem>
+  })
+
+  return (
+    <div className="pf-c-page__sidebar-body">
+      <Nav id='mainmenu' theme='dark'>
+        { currentApi ? (
+          <NavGroup title={currentApi.name}>
+            {navSections}
+          </NavGroup>
+        ) : (
+          <NavList>
+            {navSections}
+          </NavList>
+        )}
+      </Nav>
+    </div>
+  )
+}
 
 const NavSection = ({title, isSectionActive, activeItem, items, outOfDateConfig}) => {
   return (

--- a/app/javascript/src/Navigation/components/VerticalNav.jsx
+++ b/app/javascript/src/Navigation/components/VerticalNav.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Nav, NavExpandable, NavItem, NavGroup } from '@patternfly/react-core'
 import { createReactWrapper } from 'utilities/createReactWrapper'
 import 'Navigation/styles/VerticalNav.scss'
+import type { Api } from 'Types'
 
 type Item = {
   id: string,
@@ -22,13 +23,13 @@ type Props = {
   sections: Section[],
   activeSection: ?string,
   activeItem: ?string,
-  currentApi: ?string
+  currentApi: ?Api
 }
 
 const VerticalNav = ({ sections, activeSection, activeItem, currentApi }: Props) => (
   <div className="pf-c-page__sidebar-body">
     <Nav id='mainmenu' theme='dark'>
-      <NavGroup title={currentApi.name}>
+      <NavGroup title={currentApi.name ? currentApi.name : ''}>
         {sections.map(({ id, title, path, items, outOfDateConfig }) => {
           return items
             ? <NavSection title={title} isSectionActive={id === activeSection} activeItem={activeItem} items={items} key={title} outOfDateConfig={outOfDateConfig}/>

--- a/app/javascript/src/Navigation/components/VerticalNav.jsx
+++ b/app/javascript/src/Navigation/components/VerticalNav.jsx
@@ -35,7 +35,7 @@ const VerticalNav = ({ sections, activeSection, activeItem, currentApi }: Props)
 
   return (
     <div className="pf-c-page__sidebar-body">
-      <Nav id='mainmenu' theme='dark'>
+      <Nav id="mainmenu" theme="dark">
         { currentApi ? (
           <NavGroup title={currentApi.name}>
             {navSections}

--- a/app/javascript/src/Navigation/styles/VerticalNav.scss
+++ b/app/javascript/src/Navigation/styles/VerticalNav.scss
@@ -1,0 +1,10 @@
+
+.pf-c-nav__section-title {
+  border-bottom: 1px solid #3c3f42;
+  margin-bottom: 8px;
+  font-weight: 400;
+}
+
+.pf-c-page__sidebar .pf-c-nav__section-title {
+  margin-top: 0;
+}

--- a/app/javascript/src/Navigation/styles/VerticalNav.scss
+++ b/app/javascript/src/Navigation/styles/VerticalNav.scss
@@ -1,4 +1,3 @@
-
 .pf-c-nav__section-title {
   border-bottom: 1px solid #3c3f42;
   margin-bottom: 8px;

--- a/app/views/shared/provider/navigation/_vertical_nav.html.slim
+++ b/app/views/shared/provider/navigation/_vertical_nav.html.slim
@@ -5,7 +5,7 @@
 - active_section = active_submenu
 - active_item = active_sidebar
 
-#vertical-nav-wrapper class='pf-c-page__sidebar pf-m-dark' data={ current_api: current_api,
+#vertical-nav-wrapper class='pf-c-page__sidebar pf-m-dark' data={ current_api: api,
                                                                   sections: sections.to_json,
                                                                   active_section: active_section,
                                                                   active_item: active_item }.compact


### PR DESCRIPTION
**What this PR does / why we need it**:

Apart of the UX-UI-Improvements in the 2.10 ER2 release. It moves the current API name from the Context Selector to the top of the navigation in the left side.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/APPDUX-598

**Verification steps** 

1. Click on a Product
2. Inside the Product page check to see that the product name is on top of the left vertical navigation.

**Special notes for your reviewer**:

<img width="1134" alt="Screen Shot 2020-10-26 at 1 26 41 PM" src="https://user-images.githubusercontent.com/20118816/97207093-f732dd00-178f-11eb-920f-f44ca3269691.png">
