### PR TITLE
Add "is-expanded" class in Context Switcher for easier testing

### DIFF
--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -37,7 +37,7 @@ const ContextSelector = ({ currentApi, activeMenu, audienceLink, productsLink, b
   }
 
   return (
-    <div className="PopNavigation PopNavigation--context" ref={ref}>
+    <div className={`PopNavigation PopNavigation--context${isOpen ? ' pf-m-expanded' : ''}`} ref={ref}>
       <a className="PopNavigation-trigger" href="#context-menu" title="Context Selector" onClick={() => setIsOpen(!isOpen)}>
         <ActiveMenuTitle currentApi={currentApi} activeMenu={activeMenu} apiap={true}/>
       </a>

--- a/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.jsx.snap
+++ b/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.jsx.snap
@@ -9,7 +9,7 @@ exports[`should have Dashboard, Audience, Products and Backends 1`] = `
   productsLink="/products"
 >
   <div
-    className="PopNavigation PopNavigation--context"
+    className="PopNavigation PopNavigation--context pf-m-expanded"
   >
     <a
       className="PopNavigation-trigger"
@@ -104,7 +104,7 @@ exports[`should not have Audience if not provided 1`] = `
   productsLink="/products"
 >
   <div
-    className="PopNavigation PopNavigation--context"
+    className="PopNavigation PopNavigation--context pf-m-expanded"
   >
     <a
       className="PopNavigation-trigger"


### PR DESCRIPTION
As requested by QE and also to be consistent with PF components, we're adding the class `pf-m-expanded` to the dropdown.

This doesn't interfere with any existing styles.