### PR TITLE
includes field Redirect to Proxy Rule edit form

### DIFF
--- a/app/views/api/proxy_rules/edit.html.slim
+++ b/app/views/api/proxy_rules/edit.html.slim
@@ -1,4 +1,7 @@
 = content_for :sublayout_title, 'Edit Mapping Rule'
 
 = semantic_form_for @proxy_rule, url: admin_service_proxy_rule_path(@service, @proxy_rule) do |form|
-  = render 'shared/proxy_rules/form', form: form, proxy_rule: @proxy_rule, metrics: @service.metrics
+  = render 'shared/proxy_rules/form', form: form,
+                                      proxy_rule: @proxy_rule,
+                                      metrics: @service.metrics,
+                                      include_redirect: @service.using_proxy_pro?

--- a/app/views/api/proxy_rules/new.html.slim
+++ b/app/views/api/proxy_rules/new.html.slim
@@ -1,5 +1,7 @@
 = content_for :sublayout_title, 'New Mapping Rule'
 
 = semantic_form_for @proxy_rule, url: admin_service_proxy_rules_path(@service) do |form|
-  = render 'shared/proxy_rules/form', form: form, proxy_rule: @proxy_rule, metrics: @service.metrics,
+  = render 'shared/proxy_rules/form', form: form,
+                                      proxy_rule: @proxy_rule,
+                                      metrics: @service.metrics,
                                       include_redirect: @service.using_proxy_pro?


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow editting Proxy pro feature adds a redirect url field to the mapping rule object which a user can edit in the UI.

<img width="1281" alt="Screenshot 2020-10-30 at 11 19 12" src="https://user-images.githubusercontent.com/11672286/97699060-d62cfd80-1aa9-11eb-8d95-20385e8455be.png">

**Which issue(s) this PR fixes** 

[THREESCALE-6210: Redirect url field is not rendered when editing a mapping rule](https://issues.redhat.com/browse/THREESCALE-6210)


