### PR TITLE
fixes Developers can manage keys and Allow developers to regenerate a…

### DIFF
--- a/app/views/api/services/forms/_usage_rules.html.slim
+++ b/app/views/api/services/forms/_usage_rules.html.slim
@@ -6,17 +6,17 @@
 
   = form.input :buyers_manage_apps
 
-  - if @service.backend_version.app_keys_allowed?
+  - if @service.backend_version == "2"
     = form.input :buyers_manage_keys
+    = form.input :mandatory_app_key
+
+  - if @service.backend_version > "2"
+    = form.input :buyer_key_regenerate_enabled
 
   = form.input :referrer_filters_required, as: :boolean
 
   = form.input :custom_keys_enabled
-
-  - if @service.backend_version == "2"
-    = form.input :buyer_key_regenerate_enabled
-    = form.input :mandatory_app_key
-
+  
 = form.inputs "Application Plans" do
   = form.input  :buyer_can_select_plan
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1265,7 +1265,7 @@ en:
         buyers_manage_keys: "Developers can manage Keys"
         referrer_filters_required: "Require referrer filtering"
         custom_keys_enabled: "Enable custom keys"
-        buyer_key_regenerate_enabled: "Allow developers to regenerate access keys"
+        buyer_key_regenerate_enabled: "Allow developers to regenerate Client Secret"
         mandatory_app_key: "Require at least 1 application key"
         buyer_can_select_plan: "Developers can select a plan when creating a new application"
         backend_version: "Authentication: Parameters developers must send to the API in order to identify themselves:"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Prevents rendering the _Regenerate_ button for the Client Secret in the Developer Portal when developers are not allowed to regenerate the Client Secret. 
- Updates the feature description from _Allow developers to regenerate access keys_ to _Allow developers to regenerate Client Secret_ under _Product > Applications - Settings > Usage Rules_ in the Admin Portal when using OIDC authentication mode. 
- When using _app_id & app_key_ authentication mode the option under _Product > Applications - Settings > Usage Rules_ in the Admin Portal _Allow developers to regenerate access keys_ is no longer shown.

**Which issue(s) this PR fixes** 
Fixes [THREESCALE-6295](https://issues.redhat.com/browse/THREESCALE-6295) and [THREESCALE-6296](https://issues.redhat.com/browse/THREESCALE-6296).

**Verification steps** 
_Product with OIDC authentication mode:_
- Go to the Admin Portal  _Product > Applications - Settings > Usage Rules_.
- Under APPLICATION REQUIREMENTS it should be displayed the option _Allow developers to regenerate Client Secret_.
- Enable _Allow developers to regenerate Client Secret_ and make sure to click at the bottom _Update Service_.
  - Go to the Developer Portal > Applications, check one application subscribed to the Product. The regenerate button under Client Secret should appear in red and when using it the Client Secret is regenerated. 
- Disable _Allow developers to regenerate Client Secret_ and make sure to click at the bottom _Update Service_.
  - Go to the Developer Portal > Applications, check one application subscribed to the Product. The regenerate button under Client Secret shouldn't appear. 

_Product with app_id & app_key authentication mode:_
- Go to  the Admin Portal _Product > Applications - Settings > Usage Rules_.
- Under APPLICATION REQUIREMENTS it should be displayed the option _Developers can manage Keys_ but not the option _Allow developers to regenerate Client Secret_.
- Enable _Developers can manage Keys_  and make sure to click at the bottom _Update Service._
  - Go to the Developer Portal > Applications, check one application subscribed to the Product. You should be able to see the _Application ID_ and _Application Keys_ as well as be able to create/delete new _Application Keys_. 
- Disable _Developers can manage Keys_ and make sure to click at the bottom _Update Service_.
  - Go to the Developer Portal > Applications, check one application subscribed to the Product. You can only see _Application ID_ but not _Application Keys_.