### PR TITLE
💄 Fixes css overflow in VerticalNav

### DIFF
--- a/app/javascript/src/Navigation/styles/VerticalNav.scss
+++ b/app/javascript/src/Navigation/styles/VerticalNav.scss
@@ -1,9 +1,6 @@
-.pf-c-nav__section-title {
+.pf-c-nav > .pf-c-nav__section > .pf-c-nav__section-title {
   border-bottom: 1px solid #3c3f42;
   margin-bottom: 8px;
-  font-weight: 400;
-}
-
-.pf-c-page__sidebar .pf-c-nav__section-title {
   margin-top: 0;
+  font-weight: 400;
 }


### PR DESCRIPTION
Section not selected:
<img width="404" alt="Screenshot 2020-11-04 at 23 23 29" src="https://user-images.githubusercontent.com/11672286/98174443-329e7b80-1ef5-11eb-9f68-a21ed5a246fe.png">

Section selected:
<img width="289" alt="Screenshot 2020-11-04 at 23 27 14" src="https://user-images.githubusercontent.com/11672286/98174512-49dd6900-1ef5-11eb-9b1f-71b29de48fa2.png">

No title:
<img width="299" alt="Screenshot 2020-11-04 at 23 27 54" src="https://user-images.githubusercontent.com/11672286/98174573-61b4ed00-1ef5-11eb-92a8-fdffd08a6037.png">
