### PR TITLE
API Accounts/ProxyConfigs GET by host/version

### DIFF
--- a/app/controllers/admin/api/account/proxy_configs_controller.rb
+++ b/app/controllers/admin/api/account/proxy_configs_controller.rb
@@ -25,7 +25,8 @@ class Admin::Api::Account::ProxyConfigsController < Admin::Api::BaseController
   #
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_environment
-  ##~ op.parameters.add :name => "host", :description => "Find by host", :dataType => "string", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "host",    :description => "Find by host",    :dataType => "string", :required => false, :paramType => "query"
+  ##~ op.parameters.add :name => "version", :description => "Find by version", :dataType => "string", :required => false, :paramType => "query"
   #
   def index
     respond_with proxy_configs.order(:id).paginate(pagination_params)
@@ -38,6 +39,7 @@ class Admin::Api::Account::ProxyConfigsController < Admin::Api::BaseController
       .where(proxies: { service_id: accessible_services.pluck(:id) })
       .by_environment(environment)
       .by_host(host)
+      .by_version(version)
   end
 
   def accessible_services
@@ -50,5 +52,9 @@ class Admin::Api::Account::ProxyConfigsController < Admin::Api::BaseController
 
   def host
     params.permit(:host)[:host]
+  end
+
+  def version
+    params.permit(:version)[:version]
   end
 end

--- a/app/controllers/admin/api/account/proxy_configs_controller.rb
+++ b/app/controllers/admin/api/account/proxy_configs_controller.rb
@@ -43,7 +43,7 @@ class Admin::Api::Account::ProxyConfigsController < Admin::Api::BaseController
   end
 
   def accessible_services
-    (current_user || current_account).accessible_services.order(:id)
+    (current_user || current_account).accessible_services
   end
 
   def environment

--- a/app/controllers/admin/api/account/proxy_configs_controller.rb
+++ b/app/controllers/admin/api/account/proxy_configs_controller.rb
@@ -35,7 +35,7 @@ class Admin::Api::Account::ProxyConfigsController < Admin::Api::BaseController
 
   def proxy_configs
     @proxy_configs ||= ProxyConfig.joins(:proxy)
-      .where(proxies: { service_id: (System::Database.oracle? ? accessible_services.pluck(:id) : accessible_services.select(:id)) })
+      .where(proxies: { service_id: accessible_services.pluck(:id) })
       .by_environment(environment)
       .by_host(host)
   end

--- a/app/models/proxy_config.rb
+++ b/app/models/proxy_config.rb
@@ -47,6 +47,13 @@ class ProxyConfig < ApplicationRecord
     System::Database.mysql? ? scope : where(id: scope.group(:version).select(:id))
   end
 
+  scope :by_version, ->(version) do
+    next unless version
+    next current_versions if version == 'latest'
+
+    where(version: version)
+  end
+
   def differs_from?(comparable)
     return true if comparable.blank?
 

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -278,6 +278,13 @@
               "dataType": "string",
               "required": false,
               "paramType": "query"
+            },
+            {
+              "name": "version",
+              "description": "Find by version",
+              "dataType": "string",
+              "required": false,
+              "paramType": "query"
             }
           ]
         }

--- a/doc/active_docs/Account Management API.json
+++ b/doc/active_docs/Account Management API.json
@@ -271,6 +271,13 @@
               "required": true,
               "paramType": "path",
               "threescale_name": "environment"
+            },
+            {
+              "name": "host",
+              "description": "Find by host",
+              "dataType": "string",
+              "required": false,
+              "paramType": "query"
             }
           ]
         }

--- a/test/integration/admin/api/account/proxy_configs_controller_test.rb
+++ b/test/integration/admin/api/account/proxy_configs_controller_test.rb
@@ -26,14 +26,13 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
 
       assert_response :success
 
-      proxy_config_ids = (JSON.parse(response.body)['proxy_configs'] || []).map { |api_doc| api_doc.dig('proxy_config', 'id') }
       expected_ids = ProxyConfig
                       .joins(:proxy)
                       .where(proxies: { service_id: [accessible_service_1, accessible_service_2].map(&:id) })
                       .by_environment(environment)
                       .order(:id)
                       .pluck(:id)
-      assert_equal expected_ids, proxy_config_ids # The order matters for this endpoint bcz it is paginated and we cannot afford random/different/unexpected results for each request
+      assert_equal expected_ids, response_proxy_config_ids # The order matters for this endpoint bcz it is paginated and we cannot afford random/different/unexpected results for each request
     end
   end
 
@@ -55,8 +54,7 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
 
     get admin_api_account_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, access_token: access_token_value(user: member))
     assert_response :forbidden
-    proxy_config_ids = (JSON.parse(response.body)['proxy_configs'] || []).map { |api_doc| api_doc.dig('proxy_config', 'id') }
-    assert_empty proxy_config_ids
+    assert_empty response_proxy_config_ids
 
     member.admin_sections = [:services, :partners]
     member.member_permission_service_ids = '[]'
@@ -64,8 +62,7 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
 
     get admin_api_account_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, access_token: access_token_value(user: member))
     assert_response :success
-    proxy_config_ids = (JSON.parse(response.body)['proxy_configs'] || []).map { |api_doc| api_doc.dig('proxy_config', 'id') }
-    assert_empty proxy_config_ids
+    assert_empty response_proxy_config_ids
 
     member.admin_sections = [:services, :partners]
     member.member_permission_service_ids = [services[0].id]
@@ -73,8 +70,7 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
 
     get admin_api_account_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, access_token: access_token_value(user: member))
     assert_response :success
-    proxy_config_ids = (JSON.parse(response.body)['proxy_configs'] || []).map { |api_doc| api_doc.dig('proxy_config', 'id') }
-    assert_equal services[0].proxy.proxy_configs.order(:id).pluck(:id), proxy_config_ids
+    assert_equal services[0].proxy.proxy_configs.order(:id).pluck(:id), response_proxy_config_ids
   end
 
   test '#index accepts pagination params' do
@@ -89,8 +85,7 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
 
     assert_response :success
 
-    proxy_config_ids = (JSON.parse(response.body)['proxy_configs'] || []).map { |api_doc| api_doc.dig('proxy_config', 'id') }
-    assert_equal service.proxy.proxy_configs.order(:id).offset(3).limit(3).select(:id).map(&:id), proxy_config_ids
+    assert_equal service.proxy.proxy_configs.order(:id).offset(3).limit(3).select(:id).map(&:id), response_proxy_config_ids
   end
 
   test '#index can be filtered by host' do
@@ -112,7 +107,6 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
 
     assert_response :success
 
-    response_proxy_config_ids = (JSON.parse(response.body)['proxy_configs'] || []).map { |api_doc| api_doc.dig('proxy_config', 'id') }
     expected_proxy_config_ids = services.map { |service| service.proxy.proxy_configs.by_host('example.org').select(:id).map(&:id) }.flatten
     assert_same_elements expected_proxy_config_ids, response_proxy_config_ids
   end
@@ -130,7 +124,6 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
     )
 
     assert_response :success
-    response_proxy_config_ids = (JSON.parse(response.body)['proxy_configs'] || []).map { |api_doc| api_doc.dig('proxy_config', 'id') }
     expected_proxy_config_ids_specific_version = services.map { |service| service.proxy.proxy_configs.where(version: proxy_configs.first.version).select(:id).map(&:id) }.flatten
     assert_same_elements expected_proxy_config_ids_specific_version, response_proxy_config_ids
 
@@ -143,7 +136,6 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
     )
 
     assert_response :success
-    response_proxy_config_ids = (JSON.parse(response.body)['proxy_configs'] || []).map { |api_doc| api_doc.dig('proxy_config', 'id') }
     expected_proxy_config_ids_latest_version = services.map { |service| service.proxy.proxy_configs.where(version: proxy_configs.last.version).select(:id).map(&:id) }.flatten
     assert_same_elements expected_proxy_config_ids_latest_version, response_proxy_config_ids
   end
@@ -152,5 +144,9 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
 
   def access_token_value(user:)
     FactoryBot.create(:access_token, owner: user, scopes: %w[account_management]).value
+  end
+
+  def response_proxy_config_ids
+    (JSON.parse(response.body)['proxy_configs'] || []).map { |proxy_config| proxy_config.dig('proxy_config', 'id') }
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-6310](https://issues.redhat.com/browse/THREESCALE-6310)
⚠️ Blocks [THREESCALE-6237](https://issues.redhat.com/browse/THREESCALE-6237)

![image](https://user-images.githubusercontent.com/11318903/98350875-3973de00-201c-11eb-9446-8799e246b43c.png)

![image](https://user-images.githubusercontent.com/11318903/98350909-442e7300-201c-11eb-9345-4c5365c96419.png)

Request: `curl -v  -X GET "http://provider-admin.3scale.localhost:3000/admin/api/account/proxy_configs/production.json?access_token=1&host=example.com&version=3"`
