### PR TITLE
Use request.internal_host to find provider by provider_key

### DIFF
--- a/app/lib/api_authentication/by_provider_key.rb
+++ b/app/lib/api_authentication/by_provider_key.rb
@@ -17,7 +17,7 @@ module ApiAuthentication::ByProviderKey
                          elsif provider_key.present?
                            Account
                                .providers_with_master
-                               .by_self_domain(request.host)
+                               .by_self_domain(request.internal_host)
                                .first_by_provider_key(provider_key)
                          end
   end

--- a/test/unit/api/by_provider_key_test.rb
+++ b/test/unit/api/by_provider_key_test.rb
@@ -20,13 +20,16 @@ class ApiAuthentication::ByProviderKeyTest < ActiveSupport::TestCase
     p1 = FactoryBot.create(:provider_account)
     p2 = FactoryBot.create(:provider_account)
 
+    request = ActionDispatch::TestRequest.create
+    request.host = p2.self_domain
+
     object = Params.new(:provider_key => p2.api_key)
-    object.request = mock(:host => p2.self_domain)
+    object.request = request
 
     assert object.current_account
 
     object = Params.new(:provider_key => p1.api_key)
-    object.request = mock(:host => p2.self_domain)
+    object.request = request
     assert ! object.current_account
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-6309](https://issues.redhat.com/browse/THREESCALE-6309)