### PR TITLE
Hide services when user has no permission

### DIFF
--- a/app/decorators/account_decorator.rb
+++ b/app/decorators/account_decorator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AccountDecorator < ApplicationDecorator
-  delegate :display_name, to: :admin_user, prefix: true
+  delegate :display_name, :email, to: :admin_user, prefix: true
 
   private
 

--- a/app/models/admin_section.rb
+++ b/app/models/admin_section.rb
@@ -12,7 +12,7 @@ class AdminSection
     plans: 'API backends, API products',
     policy_registry: 'policies'
   }
-  SERVICE_PERMISSIONS = %i[partners plans monitoring]
+  SERVICE_PERMISSIONS = %i[partners plans monitoring].freeze
   NO_SERVICE_PERMISSIONS = PERMISSIONS - SERVICE_PERMISSIONS
 
   def self.permissions

--- a/app/models/admin_section.rb
+++ b/app/models/admin_section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AdminSection
 
   PERMISSIONS = %I[ portal finance settings partners monitoring plans policy_registry ].freeze
@@ -10,6 +12,8 @@ class AdminSection
     plans: 'API backends, API products',
     policy_registry: 'policies'
   }
+  SERVICE_PERMISSIONS = %i[partners plans monitoring]
+  NO_SERVICE_PERMISSIONS = PERMISSIONS - SERVICE_PERMISSIONS
 
   def self.permissions
     if ThreeScale.master_on_premises?

--- a/app/models/user/permissions.rb
+++ b/app/models/user/permissions.rb
@@ -99,6 +99,10 @@ module User::Permissions
     !has_access_to_all_services? && account.provider_can_use?(:service_permissions)
   end
 
+  def has_access_to_service_admin_sections?
+    (member_permission_ids & %i[partners plans monitoring]).any? && accessible_services?
+  end
+
   def reload(*)
     @_admin_sections = nil
     super

--- a/app/models/user/permissions.rb
+++ b/app/models/user/permissions.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require 'admin_section'
+
 module User::Permissions
   extend ActiveSupport::Concern
 
@@ -100,7 +104,7 @@ module User::Permissions
   end
 
   def access_to_service_admin_sections?
-    (member_permission_ids & %i[partners plans monitoring]).any? && accessible_services?
+    (member_permission_ids & AdminSection::SERVICE_PERMISSIONS).any? && accessible_services?
   end
 
   def reload(*)

--- a/app/models/user/permissions.rb
+++ b/app/models/user/permissions.rb
@@ -99,7 +99,7 @@ module User::Permissions
     !has_access_to_all_services? && account.provider_can_use?(:service_permissions)
   end
 
-  def has_access_to_service_admin_sections?
+  def access_to_service_admin_sections?
     (member_permission_ids & %i[partners plans monitoring]).any? && accessible_services?
   end
 

--- a/app/views/provider/admin/dashboards/show.html.slim
+++ b/app/views/provider/admin/dashboards/show.html.slim
@@ -27,7 +27,7 @@
       = dashboard_widget :potential_upgrades if can?(:manage, :plans)
 
     section#apis.DashboardSection.DashboardSection--services class=('DashboardSection--wide' unless can?(:manage, :plans))
-      - unless current_user.accessible_services?
+      - unless current_user.has_access_to_service_admin_sections?
         = render 'shared/service_access'
       - else
         h1 APIs

--- a/app/views/provider/admin/dashboards/show.html.slim
+++ b/app/views/provider/admin/dashboards/show.html.slim
@@ -27,7 +27,7 @@
       = dashboard_widget :potential_upgrades if can?(:manage, :plans)
 
     section#apis.DashboardSection.DashboardSection--services class=('DashboardSection--wide' unless can?(:manage, :plans))
-      - unless current_user.has_access_to_service_admin_sections?
+      - unless current_user.access_to_service_admin_sections?
         = render 'shared/service_access'
       - else
         h1 APIs

--- a/app/views/shared/_service_access.slim
+++ b/app/views/shared/_service_access.slim
@@ -1,7 +1,8 @@
 p
   ' You don't have access to any API on the
   => current_account.org_name
-  ' account. Please
-  - admin = current_account.admin_user
-  => mail_to admin.email, "contact #{current_account.admin_user_display_name}"
-  | to request access.
+  ' account.
+  - if admin = current_account.admin_user
+    ' Please
+    => mail_to admin.email, "contact #{current_account.admin_user_display_name}"
+    ' to request access.

--- a/app/views/shared/_service_access.slim
+++ b/app/views/shared/_service_access.slim
@@ -1,8 +1,6 @@
 p
   ' You don't have access to any API on the
   => current_account.org_name
-  ' account.
-  - if admin = current_account.admin_user
-    ' Please
-    => mail_to admin.email, "contact #{current_account.admin_user_display_name}"
+  ' account. Please '
+    => mail_to current_account.admin_user_email, "contact #{current_account.admin_user_display_name}"
     ' to request access.

--- a/features/old/authorization/provider_plans_section.feature
+++ b/features/old/authorization/provider_plans_section.feature
@@ -44,9 +44,9 @@ Feature: Provider plans section authorization
      And current domain is the admin domain of provider "foo.3scale.localhost"
      When I log in as provider "member"
       And I go to the provider dashboard
-    Then I should see "APIs" in the apis dashboard widget
-    Then I should see "Products" in the apis dashboard widget
-    Then I should see "Backends" in the apis dashboard widget
+    Then I should not see "APIs" in the apis dashboard widget
+    Then I should not see "Products" in the apis dashboard widget
+    Then I should not see "Backends" in the apis dashboard widget
 
     When I request the url of the '<page>' page then I should see an exception
 

--- a/test/unit/user/permissions_test.rb
+++ b/test/unit/user/permissions_test.rb
@@ -153,25 +153,25 @@ class User::PermissionsTest < ActiveSupport::TestCase
   SERVICE_ADMIN_SECTIONS = %i[partners plans monitoring]
   NO_SERVICE_ADMIN_SECTIONS = %i[services portal finance settings]
 
-  test '#has_access_to_service_admin_sections? when no accessible services' do
+  test '#access_to_service_admin_sections? when no accessible services' do
     user = FactoryBot.build(:simple_user, admin_sections: NO_SERVICE_ADMIN_SECTIONS)
     user.stubs(:accessible_services?).returns(false)
-    refute user.has_access_to_service_admin_sections?
+    refute user.access_to_service_admin_sections?
 
     SERVICE_ADMIN_SECTIONS.each do |section|
       user.member_permission_ids = [section]
-      refute user.has_access_to_service_admin_sections?
+      refute user.access_to_service_admin_sections?
     end
   end
 
-  test '#has_access_to_service_admin_sections? when any accessible services' do
+  test '#access_to_service_admin_sections? when any accessible services' do
     user = FactoryBot.build(:simple_user, admin_sections: NO_SERVICE_ADMIN_SECTIONS)
     user.stubs(:accessible_services?).returns(true)
-    refute user.has_access_to_service_admin_sections?
+    refute user.access_to_service_admin_sections?
 
     SERVICE_ADMIN_SECTIONS.each do |section|
       user.member_permission_ids = [section]
-      assert user.has_access_to_service_admin_sections?
+      assert user.access_to_service_admin_sections?
     end
   end
 end

--- a/test/unit/user/permissions_test.rb
+++ b/test/unit/user/permissions_test.rb
@@ -150,4 +150,28 @@ class User::PermissionsTest < ActiveSupport::TestCase
     assert user.forbidden_some_services?
   end
 
+  SERVICE_ADMIN_SECTIONS = %i[partners plans monitoring]
+  NO_SERVICE_ADMIN_SECTIONS = %i[services portal finance settings]
+
+  test '#has_access_to_service_admin_sections? when no accessible services' do
+    user = FactoryBot.build(:simple_user, admin_sections: NO_SERVICE_ADMIN_SECTIONS)
+    user.stubs(:accessible_services?).returns(false)
+    refute user.has_access_to_service_admin_sections?
+
+    SERVICE_ADMIN_SECTIONS.each do |section|
+      user.member_permission_ids = [section]
+      refute user.has_access_to_service_admin_sections?
+    end
+  end
+
+  test '#has_access_to_service_admin_sections? when any accessible services' do
+    user = FactoryBot.build(:simple_user, admin_sections: NO_SERVICE_ADMIN_SECTIONS)
+    user.stubs(:accessible_services?).returns(true)
+    refute user.has_access_to_service_admin_sections?
+
+    SERVICE_ADMIN_SECTIONS.each do |section|
+      user.member_permission_ids = [section]
+      assert user.has_access_to_service_admin_sections?
+    end
+  end
 end

--- a/test/unit/user/permissions_test.rb
+++ b/test/unit/user/permissions_test.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'test_helper'
+require 'admin_section'
 
 class User::PermissionsTest < ActiveSupport::TestCase
-
   test 'has_permission' do
     user = FactoryBot.build_stubbed(:simple_user)
 
@@ -150,26 +152,23 @@ class User::PermissionsTest < ActiveSupport::TestCase
     assert user.forbidden_some_services?
   end
 
-  SERVICE_ADMIN_SECTIONS = %i[partners plans monitoring]
-  NO_SERVICE_ADMIN_SECTIONS = %i[services portal finance settings]
-
   test '#access_to_service_admin_sections? when no accessible services' do
-    user = FactoryBot.build(:simple_user, admin_sections: NO_SERVICE_ADMIN_SECTIONS)
+    user = FactoryBot.build(:simple_user)
     user.stubs(:accessible_services?).returns(false)
     refute user.access_to_service_admin_sections?
 
-    SERVICE_ADMIN_SECTIONS.each do |section|
+    AdminSection::SERVICE_PERMISSIONS.each do |section|
       user.member_permission_ids = [section]
       refute user.access_to_service_admin_sections?
     end
   end
 
   test '#access_to_service_admin_sections? when any accessible services' do
-    user = FactoryBot.build(:simple_user, admin_sections: NO_SERVICE_ADMIN_SECTIONS)
+    user = FactoryBot.build(:simple_user)
     user.stubs(:accessible_services?).returns(true)
     refute user.access_to_service_admin_sections?
 
-    SERVICE_ADMIN_SECTIONS.each do |section|
+    AdminSection::SERVICE_PERMISSIONS.each do |section|
       user.member_permission_ids = [section]
       assert user.access_to_service_admin_sections?
     end


### PR DESCRIPTION
Any member user has an array of "accessible services IDs" which correspond to the list at the bottom of the following image:
<img width="800" alt="Screenshot 2020-11-06 at 17 33 23" src="https://user-images.githubusercontent.com/11672286/98391055-7361d600-2056-11eb-8c73-7d09ac74ad0d.png">

Even if all permission are revoked, such array of services doesn't necessarily have to be empty. That causes those services to be visible in the Dashboard, even if the user cannot interact with them in any way.

This PR adds a new check precisely to hide any "allowed services" when a user doesn't have the necessary permission to interact with them.

**Which issue(s) this PR fixes** 

[THREESCALE-6278: Remove items from Products/Backends widgets for unauthorized users](https://issues.redhat.com/browse/THREESCALE-6278)

**Verification steps** 

1. Create a member user and go to its edit page.
2. Leave some or all services checked but then uncheck all service-related permissions.
3. Log in as this member user and verify there are no services visible in the Dashboard.

<img width="1283" alt="Screenshot 2020-11-06 at 17 27 24" src="https://user-images.githubusercontent.com/11672286/98390230-5bd61d80-2055-11eb-83dd-7d11943adf1f.png">
