### PR TITLE
[Refactor] Shared view ServiceAccess uses current_account.admin_user_email from AccountDecorator

### DIFF
--- a/app/decorators/account_decorator.rb
+++ b/app/decorators/account_decorator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AccountDecorator < ApplicationDecorator
-  delegate :display_name, to: :admin_user, prefix: true
+  delegate :display_name, :email, to: :admin_user, prefix: true
 
   private
 

--- a/app/views/shared/_service_access.slim
+++ b/app/views/shared/_service_access.slim
@@ -1,8 +1,6 @@
 p
   ' You don't have access to any API on the
   => current_account.org_name
-  ' account.
-  - if admin = current_account.admin_user
-    ' Please
-    => mail_to admin.email, "contact #{current_account.admin_user_display_name}"
+  ' account. Please '
+    => mail_to current_account.admin_user_email, "contact #{current_account.admin_user_display_name}"
     ' to request access.


### PR DESCRIPTION
Refactor done for 2 reasons:
1. That _if_ here is a problem. The account **must** have and _admin_user_ at this point 😕
2. Law of Demeter

Josemi mentioned [this circleci issue](https://app.circleci.com/pipelines/github/3scale/porta/14574/workflows/c20b5833-d424-44c5-9541-61f4064adab4/jobs/191319):
```
Failure:
test_member_with_right_permission_and_access_to_all_services(Api::UsageLimitsControllerTest::ProviderMemberTest) [/opt/app-root/src/project/app/views/shared/_service_access.slim:6]:
ActionView::Template::Error: undefined method `email' for nil:NilClass
    app/views/shared/_service_access.slim:6:in `_app_views_shared__service_access_slim__466153237176704443_195750400'
    app/views/provider/admin/dashboards/show.html.slim:31:in `_app_views_provider_admin_dashboards_show_html_slim___4605169662788445763_142731400'
    lib/three_scale/middleware/multitenant.rb:113:in `_call'
    lib/three_scale/middleware/multitenant.rb:108:in `call'
    lib/gitlab/testing/request_inspector_middleware.rb:61:in `call'
    lib/gitlab/testing/request_blocker_middleware.rb:73:in `call'
    test/test_helpers/authentication.rb:61:in `provider_login_with'
    test/test_helpers/authentication.rb:46:in `login!'
    test/integration/api/usage_limits_controller_test.rb:83:in `block in <class:ProviderMemberTest>'
    test/test_helpers/transactional_fixtures.rb:31:in `before_setup'
```

The problem here is that we are login in [with a simple_provider factory](https://github.com/3scale/porta/blob/5c2231c7ef302781039173f4364eed78e8e692d3/test/integration/api/usage_limits_controller_test.rb#L7), without an admin_user, which does not happen in real life outside the tests, and we are only doing that for performance.

And this PR also fixes that because the AccountDecorator considers the possibility of not having an admin_user, which can happen for some views in real life but not for this one.

