### PR TITLE
🐛 Fix wrong slim syntax in "service_access" partial

### DIFF
--- a/app/views/shared/_service_access.slim
+++ b/app/views/shared/_service_access.slim
@@ -1,6 +1,6 @@
 p
   ' You don't have access to any API on the
   => current_account.org_name
-  ' account. Please '
-    => mail_to current_account.admin_user_email, "contact #{current_account.admin_user_display_name}"
-    ' to request access.
+  ' account. Please
+  => mail_to current_account.admin_user_email, "contact #{current_account.admin_user_display_name}"
+  | to request access.

--- a/test/integration/provider/admin/dashboards_controller_test.rb
+++ b/test/integration/provider/admin/dashboards_controller_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Provider::Admin::DashboardsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @org_name = 'Company'
+    provider = FactoryBot.create(:provider_account, org_name: @org_name)
+    user = FactoryBot.create(:admin, account: provider)
+    user.activate!
+    login!(provider, user: user)
+  end
+
+  test 'products and backends widgets' do
+    xpath_selector = './/section[@id="apis"]'
+    element_text = 'APIs'
+
+    User.any_instance.stubs(:access_to_service_admin_sections?).returns(true)
+    get provider_admin_dashboard_path
+    assert_xpath(xpath_selector, element_text)
+  end
+
+  test 'products and backends widgets no access' do
+    xpath_selector = './/section[@id="apis"]'
+    element_text = "You don't have access to any API on the #{@org_name} account. Please contact #{@org_name} to request access."
+
+    User.any_instance.stubs(:access_to_service_admin_sections?).returns(false)
+    get provider_admin_dashboard_path
+    assert_xpath(xpath_selector, element_text)
+  end
+end


### PR DESCRIPTION
Current:
<img width="1283" alt="Screenshot 2020-11-10 at 17 10 27" src="https://user-images.githubusercontent.com/11672286/98699671-acac8580-2377-11eb-93f5-7c0a0128a56a.png">

New:
<img width="1283" alt="Screenshot 2020-11-10 at 17 07 26" src="https://user-images.githubusercontent.com/11672286/98699684-afa77600-2377-11eb-9b14-19669416d390.png">
