### PR TITLE
Fix CircleCI Random Failure for Test Provider::Admin::DashboardsController

### DIFF
--- a/test/integration/provider/admin/dashboards_controller_test.rb
+++ b/test/integration/provider/admin/dashboards_controller_test.rb
@@ -4,12 +4,13 @@ require 'test_helper'
 
 class Provider::Admin::DashboardsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @org_name = 'Company'
-    provider = FactoryBot.create(:provider_account, org_name: @org_name)
+    @provider = FactoryBot.create(:provider_account, org_name: 'Company')
     user = FactoryBot.create(:admin, account: provider)
     user.activate!
     login!(provider, user: user)
   end
+
+  attr_reader :provider
 
   test 'products and backends widgets' do
     xpath_selector = './/section[@id="apis"]'
@@ -22,7 +23,7 @@ class Provider::Admin::DashboardsControllerTest < ActionDispatch::IntegrationTes
 
   test 'products and backends widgets no access' do
     xpath_selector = './/section[@id="apis"]'
-    element_text = "You don't have access to any API on the #{@org_name} account. Please contact #{@org_name} to request access."
+    element_text = "You don't have access to any API on the #{provider.org_name} account. Please contact #{provider.decorate.admin_user_display_name} to request access."
 
     User.any_instance.stubs(:access_to_service_admin_sections?).returns(false)
     get provider_admin_dashboard_path


### PR DESCRIPTION
Test recently introduced in #2249. However, `display_name` and `org_name` aren't always the same thing.
Fixes [this random CircleCI failure](https://app.circleci.com/pipelines/github/3scale/porta/14664/workflows/b554e868-6a3d-4f3a-bde8-44f257a6db98/jobs/192061).

> test_products_and_backends_widgets_no_access - Provider::Admin::DashboardsControllerTest
> --- expected...
> 
> Failure:
> test_products_and_backends_widgets_no_access(Provider::Admin::DashboardsControllerTest) [/opt/app-root/src/project/test/integration/provider/admin/dashboards_controller_test.rb:29]:
> --- expected
> +++ actual
> @@ -1 +1 @@
> -"You don't have access to any API on the Company account. Please contact Company to request access."
> +"You don't have access to any API on the Company account. Please contact dude37 to request access."