### PR TITLE
Remove non-APIAP code in CurlCommandBuilder

### DIFF
--- a/app/models/proxy_config.rb
+++ b/app/models/proxy_config.rb
@@ -125,14 +125,14 @@ class ProxyConfig < ApplicationRecord
     errors.add :api_backend, :missing
   end
 
+  def parsed_content
+    JSON.parse(content).deep_symbolize_keys
+  end
+
   private
 
   def extract_host(endpoint)
     URI(endpoint).host if endpoint
-  end
-
-  def parsed_content
-    JSON.parse(content).deep_symbolize_keys
   end
 
   def denormalize_hosts

--- a/test/unit/apicast/curl_command_builder_test.rb
+++ b/test/unit/apicast/curl_command_builder_test.rb
@@ -16,76 +16,6 @@ module Apicast
 
     attr_reader :proxy
 
-    class BasedOnValuesOfModel < self
-      test 'auth in query' do
-        proxy.update_attributes(credentials_location: 'query')
-        assert_match(/user_key=USER_KEY/, command.to_s)
-      end
-
-      test 'auth in headers' do
-        proxy.update_attributes(credentials_location: 'headers')
-        assert_match(/-H'user_key: USER_KEY/, command.to_s)
-      end
-
-      test 'auth basic (without password)' do
-        proxy.update_attributes(credentials_location: 'authorization')
-        assert_match %r(http://USER_KEY@), command.to_s
-      end
-
-      test 'auth basic (with password)' do
-        proxy.update_attributes(credentials_location: 'authorization')
-        proxy.service.update_attributes(backend_version: '2')
-        proxy.reload
-        assert_match %r(http://APP_ID:APP_KEY@), command.to_s
-      end
-
-      test 'auth mode app_id and app_key' do
-        proxy.service.update_attributes(backend_version: '2')
-        proxy.update_attributes(credentials_location: 'query')
-        assert_match(/&?app_key=APP_KEY/, command.to_s)
-        assert_match(/&?app_id=APP_ID/, command.to_s)
-      end
-
-      test 'app_id and app_key with customized params name' do
-        proxy.service.update_attributes(backend_version: '2')
-        proxy.update_attributes(auth_app_id: 'id')
-        proxy.update_attributes(auth_app_key: 'p-a-s-s')
-        assert_match(/id=APP_ID/, command.to_s)
-        assert_match(/p-a-s-s=APP_KEY/, command.to_s)
-      end
-
-      test 'root path' do
-        FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/', position: 1)
-        assert_match(/\?user/, command.to_s)
-      end
-
-      test 'path with wildcards' do
-        FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/{param}/path', position: 1)
-        assert_match(%r(/{param}/path), command.to_s)
-      end
-
-      test 'path with query string' do
-        FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/path?test=true', position: 1)
-        assert_match(%r(/path\?test=true), command.to_s)
-      end
-
-      test 'no double ?' do
-        FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/a?b=c', position: 1)
-        assert_match(/a\?b=c&/, command.to_s)
-      end
-
-      test 'blank endpoint' do
-        proxy.update_attributes(endpoint: '', sandbox_endpoint: '')
-        refute command.command
-      end
-
-      protected
-
-      def command
-        @command ||= CurlCommandBuilder.new(proxy, build_from_config: false, use_api_test_path: false)
-      end
-    end
-
     class BasedOnLatestProxyConfig < self
       include ConfigBasedCommandTestHelpers
 
@@ -153,7 +83,7 @@ module Apicast
       protected
 
       def command
-        @command ||= CurlCommandBuilder.new(proxy, build_from_config: true, use_api_test_path: false)
+        @command ||= CurlCommandBuilder.new(proxy)
       end
     end
 
@@ -168,76 +98,9 @@ module Apicast
         create_proxy_config(proxy: { api_test_path: '/test', proxy_rules: [{ pattern: '/foo' }] })
       end
 
-      test 'use api_test_path based on the values of the model' do
-        command = CurlCommandBuilder.new(proxy, build_from_config: false, use_api_test_path: true)
-        assert_match(/\/test\?/, command.to_s)
-      end
-
-      test 'use proxy rules based on the values of the model' do
-        command = CurlCommandBuilder.new(proxy, build_from_config: false, use_api_test_path: false)
-        assert_match(/\/foo\?/, command.to_s)
-      end
-
-      test 'use api_test_path based on the latest proxy config' do
-        command = CurlCommandBuilder.new(proxy, build_from_config: true, use_api_test_path: true)
-        assert_match(/\/test\?/, command.to_s)
-      end
-
       test 'use proxy rules based on the latest proxy config' do
-        command = CurlCommandBuilder.new(proxy, build_from_config: true, use_api_test_path: false)
+        command = CurlCommandBuilder.new(proxy)
         assert_match(/\/foo\?/, command.to_s)
-      end
-    end
-
-    class ApiapEnabledOrDisabled < self
-      include ConfigBasedCommandTestHelpers
-
-      def setup
-        super
-        create_proxy_config
-      end
-
-      test 'api as product enabled' do
-        CurlCommandBuilder::StagingBuilder.expects(:new).with(instance_of(CurlCommandBuilder::ProxyFromConfig), {})
-        CurlCommandBuilder.new(proxy)
-      end
-
-      test 'api as product disabled' do
-        disable_apiap!
-        CurlCommandBuilder::StagingBuilder.expects(:new).with(proxy, { test_path: '/test' })
-        CurlCommandBuilder.new(proxy)
-      end
-
-      protected
-
-      def disable_apiap!
-        account = proxy.service.account
-        account.stubs(:provider_can_use?).returns(true)
-        account.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-      end
-    end
-
-    class StagingOrProductionEnvironment < self
-      test 'staging environment' do
-        proxy.update_column(:sandbox_endpoint, 'http://public-staging.fake')
-        command = CurlCommandBuilder.new(proxy, environment: :staging, build_from_config: false, use_api_test_path: false)
-        assert_match %r(http://public-staging.fake/\?user_key=), command.to_s
-      end
-
-      test 'production environment' do
-        proxy.stubs(default_production_endpoint: 'http://public-production.fake')
-        command = CurlCommandBuilder.new(proxy, environment: :production, build_from_config: false, use_api_test_path: false)
-        assert_match %r(http://public-production.fake/\?user_key=), command.to_s
-      end
-    end
-
-    class InvalidEndpointTest < ActiveSupport::TestCase
-      test 'the command does not raise an error when the base_endpoint is invalid' do
-        proxy = FactoryBot.create(:proxy)
-        proxy.attributes = {sandbox_endpoint: ' https://invalid example.com'}
-        refute proxy.valid?
-
-        assert_nil Apicast::CurlCommandBuilder::StagingBuilder.new(proxy).command
       end
     end
   end

--- a/test/unit/helpers/api/integrations_helper_test.rb
+++ b/test/unit/helpers/api/integrations_helper_test.rb
@@ -32,15 +32,6 @@ class Api::IntegrationsHelperTest < ActionView::TestCase
       assert_match %r(<code.+>curl &quot;.+user_key=USER_KEY&quot; </code>), res
     end
 
-    test 'curl command when api as product is disabled' do
-      account = proxy.service.account
-      account.stubs(:provider_can_use?).returns(true)
-      account.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
-      proxy.update_attributes(api_test_path: '/api?test=true')
-      res = api_test_curl(proxy)
-      assert_match %r(<code.+>curl &quot;.+/api\?test=true&amp;user_key=USER_KEY&quot; </code>), res
-    end
-
     test 'data-credentials' do
       @proxy = FactoryBot.create(:proxy, auth_user_key: 'my_cool_name_for_user_key')
       create_proxy_config


### PR DESCRIPTION
Because I need these changes ASAP for another PR that touches the same part of the code 🙈 and the other PR will be easier after this simplification of the code