### PR TITLE
Remove Products/Backends from Master Dashboard and Context Selector

### DIFF
--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -14,8 +14,8 @@ type Props = {
   activeMenu: Menu,
   audienceLink: string,
   settingsLink: string,
-  productsLink: string,
-  backendsLink: string
+  productsLink: ?string,
+  backendsLink: ?string
 }
 
 const DASHBOARD_PATH = '/p/admin/dashboard'
@@ -58,16 +58,20 @@ const ContextSelector = ({ activeMenu, audienceLink, settingsLink, productsLink,
               </a>
             </li>
           )}
-          <li className="PopNavigation-listItem">
-            <a className={getClassNamesForMenu('products')} href={productsLink}>
-              <i className='fa fa-cubes' />Products
-            </a>
-          </li>
-          <li className="PopNavigation-listItem">
-            <a className={getClassNamesForMenu('backend_api')} href={backendsLink}>
-              <i className='fa fa-cube' />Backends
-            </a>
-          </li>
+          {productsLink && (
+            <li className="PopNavigation-listItem">
+              <a className={getClassNamesForMenu('products')} href={productsLink}>
+                <i className='fa fa-cubes' />Products
+              </a>
+            </li>
+          )}
+          {backendsLink && (
+            <li className="PopNavigation-listItem">
+              <a className={getClassNamesForMenu('backend_api')} href={backendsLink}>
+                <i className='fa fa-cube' />Backends
+              </a>
+            </li>
+          )}
           <li className="PopNavigation-listItem">
             <a className={getClassNamesForMenu('account')} href={settingsLink}>
               <i className='fa fa-cog' />Account Settings

--- a/app/views/provider/admin/dashboards/show.html.slim
+++ b/app/views/provider/admin/dashboards/show.html.slim
@@ -26,15 +26,16 @@
       = dashboard_widget :new_accounts if can?(:manage, :partners)
       = dashboard_widget :potential_upgrades if can?(:manage, :plans)
 
-    section#apis.DashboardSection.DashboardSection--services class=('DashboardSection--wide' unless can?(:manage, :plans))
-      - unless current_user.access_to_service_admin_sections?
-        = render 'shared/service_access'
-      - else
-        h1 APIs
-        div.apiContainer
-          = render 'products_widget'
-          = render 'backends_widget'
-          = javascript_pack_tag 'PF4Styles/dashboard'
+    - unless current_account.master?
+      section#apis.DashboardSection.DashboardSection--services class=('DashboardSection--wide' unless can?(:manage, :plans))
+        - unless current_user.access_to_service_admin_sections?
+          = render 'shared/service_access'
+        - else
+          h1 APIs
+          div.apiContainer
+            = render 'products_widget'
+            = render 'backends_widget'
+            = javascript_pack_tag 'PF4Styles/dashboard'
 
   div.Dashboard-events
     section.DashboardStream

--- a/app/views/shared/_api_selector.html.slim
+++ b/app/views/shared/_api_selector.html.slim
@@ -1,7 +1,8 @@
 = javascript_pack_tag 'api_selector'
+- master = current_account.master?
 
 #api_selector data={ 'active-menu': active_menu,
                      'audience-link': audience_link,
                      'settings-link': settings_link,
-                     'products-link': admin_services_path,
-                     'backends-link': provider_admin_backend_apis_path }
+                     'products-link': (admin_services_path unless master),
+                     'backends-link': (provider_admin_backend_apis_path unless master) }

--- a/features/master/menu/dashboard.feature
+++ b/features/master/menu/dashboard.feature
@@ -1,0 +1,22 @@
+@javascript
+Feature: Master finance settings
+  As a master I don't want to be able to see services in the Dashboard or the Context Selector
+
+  Background:
+    Given the master account admin has username "master" and password "supersecret"
+    And a provider "foo.3scale.localhost"
+
+  @javascript
+  Scenario: No APIs widgets
+    When I am logged in as master admin on master domain
+    And I go to the provider dashboard
+    Then I should not see "Products"
+    And I should not see "Backends"
+
+  @javascript
+  Scenario: No Products or Backends in Context Selector
+    When I am logged in as master admin on master domain
+    And I go to the provider dashboard
+    And I open the Context Selector
+    Then I should not see link "Products" within the Context Selector
+    And I should not see link "Backends" within the Context Selector

--- a/features/master/menu/dashboard.feature
+++ b/features/master/menu/dashboard.feature
@@ -6,14 +6,12 @@ Feature: Master finance settings
     Given the master account admin has username "master" and password "supersecret"
     And a provider "foo.3scale.localhost"
 
-  @javascript
   Scenario: No APIs widgets
     When I am logged in as master admin on master domain
     And I go to the provider dashboard
     Then I should not see "Products"
     And I should not see "Backends"
 
-  @javascript
   Scenario: No Products or Backends in Context Selector
     When I am logged in as master admin on master domain
     And I go to the provider dashboard

--- a/features/old/menu/dashboard.feature
+++ b/features/old/menu/dashboard.feature
@@ -27,6 +27,14 @@ Feature: Dashboard
     And I should see the link "Create Backend" in the apis dashboard backends widget
 
   @javascript
+  Scenario: Products or Backends in Context Selector
+    When I log in as provider "foo.3scale.localhost"
+    And I go to the provider dashboard
+    And I open the Context Selector
+    Then I should see link "Products" within the Context Selector
+    And I should see link "Backends" within the Context Selector
+
+  @javascript
   Scenario: first API widget
     When I log in as provider "foo.3scale.localhost"
     And I should see "API" in the first api dashboard widget

--- a/features/step_definitions/header_steps.rb
+++ b/features/step_definitions/header_steps.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+When "I open the Context Selector" do
+  find('#api_selector').click
+end

--- a/features/support/selectors.rb
+++ b/features/support/selectors.rb
@@ -32,6 +32,8 @@ module HtmlSelectorsHelper
       'table.notification-settings tbody'
     when 'service widget'
       '.service-widget'
+    when 'the Context Selector'
+      '#api_selector'
 
     #
     # Invoicing helpers

--- a/spec/javascripts/Navigation/ContextSelector.spec.jsx
+++ b/spec/javascripts/Navigation/ContextSelector.spec.jsx
@@ -30,9 +30,13 @@ it('should have Dashboard, Audience, Products, Backends and Settings', () => {
   expect(wrapper).toMatchSnapshot()
 })
 
-it('should not have Audience if not provided', () => {
+it('should not have Audience, Products or Backends if not provided', () => {
   const wrapper = getWrapper()
-  wrapper.setProps({ audienceLink: undefined })
+  wrapper.setProps({
+    audienceLink: undefined,
+    productsLink: undefined,
+    backendsLink: undefined
+  })
   wrapper.find('.PopNavigation-trigger').simulate('click')
   expect(wrapper).toMatchSnapshot()
 })
@@ -82,7 +86,7 @@ it('should highlight the selected context', () => {
   expect(wrapper.find('.current-context').text()).toEqual('Backends')
 })
 
-it('should display the current api', () => {
+it('should not display the current api', () => {
   const wrapper = getWrapper({ activeMenu: 'serviceadmin', currentApi })
 
   expect(wrapper.find('.fa-cubes').exists()).toBe(true)

--- a/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.jsx.snap
+++ b/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.jsx.snap
@@ -105,12 +105,10 @@ exports[`should have Dashboard, Audience, Products, Backends and Settings 1`] = 
 </ContextSelector>
 `;
 
-exports[`should not have Audience if not provided 1`] = `
+exports[`should not have Audience, Products or Backends if not provided 1`] = `
 <ContextSelector
   activeMenu=""
-  backendsLink="/backends"
   currentApi={null}
-  productsLink="/products"
 >
   <div
     className="PopNavigation PopNavigation--context pf-m-expanded"
@@ -151,32 +149,6 @@ exports[`should not have Audience if not provided 1`] = `
             className="fa fa-home"
           />
           Dashboard
-        </a>
-      </li>
-      <li
-        className="PopNavigation-listItem"
-      >
-        <a
-          className="PopNavigation-link"
-          href="/products"
-        >
-          <i
-            className="fa fa-cubes"
-          />
-          Products
-        </a>
-      </li>
-      <li
-        className="PopNavigation-listItem"
-      >
-        <a
-          className="PopNavigation-link"
-          href="/backends"
-        >
-          <i
-            className="fa fa-cube"
-          />
-          Backends
         </a>
       </li>
       <li


### PR DESCRIPTION
**What this PR does / why we need it**:

* Provider
<img width="1283" alt="Screenshot 2020-11-16 at 10 35 17" src="https://user-images.githubusercontent.com/11672286/99236636-c0cd0880-27f7-11eb-9d0e-530ef617196f.png">

* Master
<img width="1283" alt="Screenshot 2020-11-16 at 10 35 30" src="https://user-images.githubusercontent.com/11672286/99236643-c32f6280-27f7-11eb-9cb6-624d85286b52.png">

**Which issue(s) this PR fixes** 

[THREESCALE-6222: In master tenant products aren't accessible but there are links/pages to navigate to them](https://issues.redhat.com/browse/THREESCALE-6222)

**Verification steps** 

Log in as master, take a look at Dashboard, open the Context Selector.

**Notes**
Denial of access to `apiconfig/services` and `p/admin/backend_apis` will be dealt with by https://issues.redhat.com/browse/THREESCALE-6223