### PR TITLE
Display Application menu items according to permissions

### DIFF
--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -193,7 +193,7 @@ module VerticalNavHelper
     return sections unless @service
     sections << {id: :overview,      title: 'Overview',      path: admin_service_path(@service)} if can? :manage, :plans
     sections << {id: :monitoring,    title: 'Analytics',     items: service_analytics}           if can? :manage, :monitoring
-    sections << {id: :applications,  title: 'Applications',  items: service_applications}        if can? :manage, :applications
+    sections << {id: :applications,  title: 'Applications',  items: service_applications}        if (can? :manage, :plans) || (can? :manage, :applications)
     sections << {id: :subscriptions, title: 'Subscriptions', items: service_subscriptions}       if can?(:manage, :service_plans) && current_account.settings.service_plans_ui_visible?
 
     if can? :manage, :plans
@@ -218,7 +218,7 @@ module VerticalNavHelper
 
   def service_applications
     items = []
-    items << {id: :listing,           title: 'Listing',           path: admin_service_applications_path(@service)}
+    items << {id: :listing,           title: 'Listing',           path: admin_service_applications_path(@service)}      if can? :manage, :applications
     items << {id: :application_plans, title: 'Application Plans', path: admin_service_application_plans_path(@service)} if can?(:manage, :plans)
     if current_account.provider_can_use?(:api_as_product) && !master_on_premises?
       items << {title: 'Settings'}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Vertical menu is not showing some items for member users with permissions for **Application > Application Plans** and **Application > Settings > Usage rules** even when they have the right permissions

**Which issue(s) this PR fixes** 

Part of https://issues.redhat.com/browse/THREESCALE-6154

**Verification steps** 

1. Create a member user with the following permissions:
___
<img width="775" alt="Screenshot 2020-11-16 at 11 26 23" src="https://user-images.githubusercontent.com/13486237/99241821-aba7a800-27fe-11eb-8e31-cc01f2c03fd5.png">

___


2. Login as member user
3. Vertical menu should look like:

<img width="971" alt="Screenshot 2020-11-16 at 11 29 15" src="https://user-images.githubusercontent.com/13486237/99242395-7059a900-27ff-11eb-836f-0b37fbde90e1.png">

4. And user should be able to navigate to both **Listing** and **Usage Rules**
