### PR TITLE
Prevent ThinkingSphinx from searching Service's and BackendApi's class names

### DIFF
--- a/app/concerns/searchable.rb
+++ b/app/concerns/searchable.rb
@@ -12,8 +12,9 @@ module Searchable
     self.allowed_search_scopes = %i[query]
 
     scope :by_query, ->(query) do
-      options = {ids_only: true, per_page: 1_000_000, star: true, ignore_scopes: true, with: { }}
-      where(id: search(ThinkingSphinx::Query.escape(query), options))
+      options = { ids_only: true, per_page: 1_000_000, star: false, ignore_scopes: true, with: {} }
+      term = "@!sphinx_internal_class_name #{ThinkingSphinx::Query.wildcard(ThinkingSphinx::Query.escape(query))}"
+      where(id: search(term, options))
     end
 
     private

--- a/test/unit/concerns/searchable_test.rb
+++ b/test/unit/concerns/searchable_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SearchableTest < ActiveSupport::TestCase
+  class ProtectedApi < ApplicationRecord
+    self.table_name = 'protected_apis'
+    include Searchable
+  end
+
+  test 'by_query' do
+    ProtectedApi.expects(:search).returns([1, 2, 3])
+    ProtectedApi.expects(:where).with(id: [1, 2, 3]).returns(true)
+    ProtectedApi.by_query('api')
+  end
+
+  test "by_query excludes sphinx_internal_class_name" do
+    term = 'api'
+    escaped_term = "@!sphinx_internal_class_name *#{term}*"
+    sphinx_options = { ids_only: true, per_page: 1_000_000, star: false, ignore_scopes: true, with: {} }
+    ProtectedApi.expects(:search).with(escaped_term, sphinx_options).returns([1, 2, 3])
+    ProtectedApi.expects(:where).with(id: [1, 2, 3]).returns(true)
+    ProtectedApi.by_query(term)
+  end
+end


### PR DESCRIPTION
For some reason ThinkingSphinx [fix](https://github.com/pat/thinking-sphinx/commit/48921d6b28ef8fcd59be460404af90937473e55e) to not include the `sphinx_internal_class_name` field in the indexes definitions is not working for our real-time indexes. Until we figure that out, this PR manually excludes this field from the searches on models that include the `Searchable` module (i.e. `Service` and `BackendApi`).

Without this fix, the name of the model class is included as a field of the index and therefore searching API backends, e.g., by 'api' will cause ALL API backends to match. In the same way, searching 'service' among API products will return ALL API products.