### PR TITLE
Prevent ThinkingSphinx from searching class names on all no-inheritance indices

### DIFF
--- a/config/initializers/sphinx.rb
+++ b/config/initializers/sphinx.rb
@@ -1,3 +1,20 @@
 SPHINX_DELTA_INTERVAL = 90.minutes
 
+# Patches ThinkingSphinx so `sphinx_internal_class_name` field is avoided
+# for no inheritance indices despite other indices with inheritance defined
+ThinkingSphinx::Configuration::MinimumFields.prepend(Module.new do
+  private
+
+  def indices
+    super.reject do |index|
+      model = index.model
+      model.table_exists? && model.column_names.include?(model.inheritance_column)
+    end
+  end
+
+  def no_inheritance_columns?
+    true
+  end
+end)
+
 ThinkingSphinx::Callbacks.suspend!


### PR DESCRIPTION
Patches ThinkingSphinx so the `sphinx_internal_class_name` field is avoided for no inheritance indices despite other indices with inheritance defined.

ThinkingSphinx v3 by default will only remove the class name field if there's no index with inheritance at all among the ones defined ([here](https://github.com/pat/thinking-sphinx/blob/2ae0c98b8b08242eb623e8eb5e364c4ed0fd3fcb/lib/thinking_sphinx/configuration/minimum_fields.rb#L7)). In Porta we have at least the `CMS::Page` index with inheritance involved, thus preventing the removal of the unnecessary field in all other indices. As a consequence, searching for terms like 'service' among `Service`s or 'api' among `BackendApi`s causes ALL records to match, because the term is present in the name of the model class.

This PR is a wider alternative to #2263, which addressed the issue in _search-time_ only for the models `Service` and `BackendApi`. This PR's approach ensures that the unnecessary `sphinx_internal_class_name` field is removed from the rendered _sphinx configuration file_ instead of avoiding it in search-time.

Rolling out the fix requires regenerating Sphinx's config and reindexing of the entire database. The latter can be significantly costly in some cases.

```
rake ts:configure ts:rt:rebuild
```

We can also expect an improvement of search performance after the removal of the `sphinx_internal_class_name` field from the config (see https://github.com/pat/thinking-sphinx/issues/568)