### PR TITLE
Clean proxy configs curl command builder and model scope for services

### DIFF
--- a/app/lib/apicast/curl_command_builder.rb
+++ b/app/lib/apicast/curl_command_builder.rb
@@ -134,9 +134,8 @@ module Apicast
     end
 
     def proxy_from_config
-      proxy_configs = proxy.proxy_configs.by_environment(environment.to_s).current_versions.to_a
-      return if proxy_configs.empty?
-      ProxyFromConfig.new(proxy_configs.first.send(:parsed_content))
+      proxy_config = proxy.proxy_configs.by_environment(environment.to_s).current_versions.order(:id).first
+      ProxyFromConfig.new(proxy_config.parsed_content) if proxy_config
     end
   end
 end

--- a/app/models/proxy_config.rb
+++ b/app/models/proxy_config.rb
@@ -35,9 +35,7 @@ class ProxyConfig < ApplicationRecord
   scope :newest_first,   -> { order(version: :desc) }
   scope :by_environment, ->(env) { where(environment: VALID_ENVIRONMENTS[env]) }
   scope :by_host,        ->(host) { where.has { hosts =~ "%|#{host}|%" } if host }
-  scope :for_services,   ->(services) do
-    joins(:proxy).merge(::Proxy.where(service_id: services))
-  end
+
   scope :current_versions, -> do
     table = BabySqueel[:proxy_configs].alias(:versions)
     scope = joining { table.on((table.proxy_id == proxy_id) & (table.environment == environment)) }

--- a/app/models/proxy_config.rb
+++ b/app/models/proxy_config.rb
@@ -105,10 +105,6 @@ class ProxyConfig < ApplicationRecord
     raw_write_attribute :version, version
   end
 
-  def max_version
-    ProxyConfig.select(:version).from(relation_scope.selecting { coalesce(max(version), 0).as('version') })
-  end
-
   def clone_to(environment:)
     EnvironmentClone.new(self, environment).call
   end
@@ -128,6 +124,10 @@ class ProxyConfig < ApplicationRecord
   end
 
   private
+
+  def max_version
+    ProxyConfig.select(:version).from(relation_scope.selecting { coalesce(max(version), 0).as('version') })
+  end
 
   def extract_host(endpoint)
     URI(endpoint).host if endpoint


### PR DESCRIPTION
Just a previous small cleanup for #2230
What this does:
1. Remove unused scope `for_services`
2. Makes the method `max_version` private because it is meant to be used only inside the `update_version` method in the same model.
3. Refactor `Apicast::CurlCommandBuilder::Builder#proxy_from_config` to don't fetch an entire array from the DB only to take the first record if there is any. Plus, now the request is ordered.