### PR TITLE
Can't promote product config with Istio through UI

### DIFF
--- a/app/models/proxy_config.rb
+++ b/app/models/proxy_config.rb
@@ -26,7 +26,7 @@ class ProxyConfig < ApplicationRecord
   validates :content, :version, :environment, presence: true
   validates :environment, inclusion: { in: ENVIRONMENTS }
   validate :service_token_exists
-  validate :api_backend_exists, on: :create, if: -> { !service_mesh_integration? }
+  validate :api_backend_exists, on: :create, unless: :service_mesh_integration?
   validates :content, length: { maximum: MAX_CONTENT_LENGTH }
 
   before_create :denormalize_hosts

--- a/test/unit/proxy_config_test.rb
+++ b/test/unit/proxy_config_test.rb
@@ -113,6 +113,17 @@ class ProxyConfigTest < ActiveSupport::TestCase
     assert proxy_config.valid?
   end
 
+  test 'missing api backend when service_mesh' do
+    service = FactoryBot.create(:simple_service)
+    proxy = service.proxy
+    proxy.stubs(:service_mesh_integration?).returns(true)
+    proxy_config = FactoryBot.build(:proxy_config, proxy: proxy)
+
+    proxy.backend_api_configs.delete_all
+    proxy.reload
+    assert proxy_config.valid?
+  end
+
   def test_maximum_length
     proxy_config = FactoryBot.build(:proxy_config)
     content = proxy_config.content


### PR DESCRIPTION
**What this PR does / why we need it**:

Istio was never made APIAP-compatible so now promoting a product's integration config may throw an error. This depends on whether the Product had any associated Backend prior changing to Istio.

This change removes the validation `api_backend_exists?` in ProxyConfig when the proxy belongs to an Isito product.

**Which issue(s) this PR fixes** 

[THREESCALE-6348: Unable to create product with Istio through UI](https://issues.redhat.com/browse/THREESCALE-6348)

**Verification steps** 

> Create a product
> In Integration > Backend remove all backends
> In Integration > Settings set deployment to Istio
> In Integration > Configuration it should be possible to Update Config