### PR TITLE
[Openshift] core.yml - backend setting

### DIFF
--- a/openshift/system/config/core.yml
+++ b/openshift/system/config/core.yml
@@ -1,5 +1,5 @@
 base: &default
-  url: <%= ENV.fetch('THREESCALE_CORE_INTERNAL_API', 'http://backend-listener:3000/internal/') %>
+  url: <%= ENV.fetch('BACKEND_ROUTE', 'http://backend-listener:3000/internal/') %>
   fake_server: false
   username: <%= ENV.fetch('CONFIG_INTERNAL_API_USER', nil) %>
   password: <%= ENV.fetch('CONFIG_INTERNAL_API_PASSWORD', nil) %>


### PR DESCRIPTION
related to: https://github.com/3scale/platform/pull/322

```
[Core] Using http://backend-listener:3000/internal/ as URL
```

Porta is taking the default value for CORE URL as it's being read from the wrong ENV variable. 