### PR TITLE
Add missing integration tests for ProxyConfig endpoints

### DIFF
--- a/test/integration/admin/api/account/proxy_configs_controller_test.rb
+++ b/test/integration/admin/api/account/proxy_configs_controller_test.rb
@@ -11,11 +11,11 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
   attr_reader :provider
 
   test '#index for admin user of one provider for an specific environment' do
-    accessible_service_1, accessible_service_2, deleted_service = FactoryBot.create_list(:simple_service, 3, :with_default_backend_api, account: provider)
+    accessible_service1, accessible_service2, deleted_service = FactoryBot.create_list(:simple_service, 3, :with_default_backend_api, account: provider)
     deleted_service.mark_as_deleted!
     active_service_another_provider = FactoryBot.create(:simple_service, :with_default_backend_api, account: FactoryBot.create(:simple_provider))
 
-    [accessible_service_1, accessible_service_2, deleted_service, active_service_another_provider]
+    [accessible_service1, accessible_service2, deleted_service, active_service_another_provider]
       .product(%w[sandbox production])
       .map do |service, environment|
         FactoryBot.create_list(:proxy_config, 2, proxy: service.proxy, environment: environment)
@@ -28,7 +28,7 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
 
       expected_ids = ProxyConfig
                       .joins(:proxy)
-                      .where(proxies: { service_id: [accessible_service_1, accessible_service_2].map(&:id) })
+                      .where(proxies: { service_id: [accessible_service1, accessible_service2].map(&:id) })
                       .by_environment(environment)
                       .order(:id)
                       .pluck(:id)
@@ -56,7 +56,7 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
     assert_response :forbidden
     assert_empty response_proxy_config_ids
 
-    member.admin_sections = [:services, :partners]
+    member.admin_sections = %i[services partners]
     member.member_permission_service_ids = '[]'
     member.save!
 
@@ -64,7 +64,7 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
     assert_response :success
     assert_empty response_proxy_config_ids
 
-    member.admin_sections = [:services, :partners]
+    member.admin_sections = %i[services partners]
     member.member_permission_service_ids = [services[0].id]
     member.save!
 
@@ -86,29 +86,6 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
     assert_response :success
 
     assert_equal service.proxy.proxy_configs.order(:id).offset(3).limit(3).select(:id).map(&:id), response_proxy_config_ids
-  end
-
-  test '#index can be filtered by host' do
-    services = FactoryBot.create_list(:simple_service, 2, :with_default_backend_api, account: provider)
-    services.each do |service|
-      [
-        %w[3scale.localhost example.org],
-        %w[3scale.net example.org 3sca.net],
-        %w[3scale.localhost example.com]
-      ].each do |hosts|
-        FactoryBot.create(:proxy_config, proxy: service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: ( { proxy: { hosts: hosts } }.to_json ) )
-      end
-    end
-
-    get admin_api_account_proxy_configs_path(
-      environment: ProxyConfig::ENVIRONMENTS.first,
-      access_token: access_token_value(user: provider.admin_user)
-    ), params: {host: 'example.org'}
-
-    assert_response :success
-
-    expected_proxy_config_ids = services.map { |service| service.proxy.proxy_configs.by_host('example.org').select(:id).map(&:id) }.flatten
-    assert_same_elements expected_proxy_config_ids, response_proxy_config_ids
   end
 
   test '#index can be filtered by version' do
@@ -140,7 +117,43 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
     assert_same_elements expected_proxy_config_ids_latest_version, response_proxy_config_ids
   end
 
+  test '#index with host param: it searches first for latest version of each proxy/service and then filters that result by host (the order of this matters)' do
+    service1 = FactoryBot.create(:simple_service, :with_default_backend_api, account: provider)
+    service2 = FactoryBot.create(:simple_service, :with_default_backend_api, account: provider)
+
+    proxy_config_service1_version1 = FactoryBot.create(:proxy_config, proxy: service1.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v1.example.com'))
+    proxy_config_service2_version1 = FactoryBot.create(:proxy_config, proxy: service2.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v1.example.com'))
+
+    get admin_api_account_proxy_configs_path(
+      environment: ProxyConfig::ENVIRONMENTS.first,
+      access_token: access_token_value(user: provider.admin_user)
+    ), params: {host: 'v1.example.com', version: 'latest'}
+
+    assert_same_elements [proxy_config_service1_version1.id, proxy_config_service2_version1.id], response_proxy_config_ids
+
+
+    proxy_config_service2_version2 = FactoryBot.create(:proxy_config, proxy: service2.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v2.example.com'))
+
+    get admin_api_account_proxy_configs_path(
+      environment: ProxyConfig::ENVIRONMENTS.first,
+      access_token: access_token_value(user: provider.admin_user)
+    ), params: {host: 'v1.example.com', version: 'latest'}
+
+    assert_equal [proxy_config_service1_version1.id], response_proxy_config_ids
+
+    get admin_api_account_proxy_configs_path(
+      environment: ProxyConfig::ENVIRONMENTS.first,
+      access_token: access_token_value(user: provider.admin_user)
+    ), params: {host: 'v2.example.com', version: 'latest'}
+
+    assert_equal [proxy_config_service2_version2.id], response_proxy_config_ids
+  end
+
   private
+
+  def content_hosts(*hosts)
+    { proxy: { hosts: hosts } }.to_json
+  end
 
   def access_token_value(user:)
     FactoryBot.create(:access_token, owner: user, scopes: %w[account_management]).value

--- a/test/integration/master/api/proxy/configs_controller_test.rb
+++ b/test/integration/master/api/proxy/configs_controller_test.rb
@@ -32,7 +32,7 @@ class Master::Api::Proxy::ConfigsControllerTest < ActionDispatch::IntegrationTes
     get master_api_proxy_configs_path(environment: 'sandbox'), params: {access_token: @token.value, host: 'v2.example.com'}
 
     assert_response :success
-    assert_same_elements [latest_proxy_config.id], proxy_config_ids(response.body)
+    assert_equal [latest_proxy_config.id], proxy_config_ids(response.body)
 
 
     FactoryBot.create(:proxy_config, proxy: proxy, environment: 'sandbox', hosts: %w[example.com])
@@ -41,6 +41,13 @@ class Master::Api::Proxy::ConfigsControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :success
     assert_empty proxy_config_ids(response.body)
+
+
+    _old_proxy_config, new_proxy_config = FactoryBot.create_list(:proxy_config, 2, proxy: proxy, environment: 'sandbox', content: content_hosts('foo.example.com'))
+
+    get master_api_proxy_configs_path(environment: 'sandbox'), params: {access_token: @token.value, host: 'foo.example.com'}
+
+    assert_equal [new_proxy_config.id], proxy_config_ids(response.body)
   end
 
   protected

--- a/test/integration/master/api/proxy/configs_controller_test.rb
+++ b/test/integration/master/api/proxy/configs_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Master::Api::Proxy::ConfigsControllerTest < ActionDispatch::IntegrationTest
@@ -15,27 +17,37 @@ class Master::Api::Proxy::ConfigsControllerTest < ActionDispatch::IntegrationTes
       FactoryBot.create_list(:proxy_config, 3, proxy: proxy, environment: 'production')
     end
 
-    get master_api_proxy_configs_path(environment: 'production'), access_token: @token.value
+    get master_api_proxy_configs_path(environment: 'production'), params: {access_token: @token.value}
     assert_response :success
 
-    assert_same_elements ProxyConfig.current_versions.by_environment('production').map(&:id),
+    assert_same_elements ProxyConfig.current_versions.by_environment('production').select(:id, :version).map(&:id),
                          proxy_config_ids(response.body)
   end
 
-  test '#index filter by host' do
+  test '#index filter by host (among the latest versions)' do
     proxy = FactoryBot.create(:proxy)
-    FactoryBot.create(:proxy_config, proxy: proxy, environment: 'sandbox', hosts: %w[example.com])
-    proxy_config = FactoryBot.create(:proxy_config, proxy: proxy, environment: 'sandbox', hosts: %w[lvh.me])
+    FactoryBot.create(:proxy_config, proxy: proxy, environment: 'sandbox', content: content_hosts('v1.example.com'))
+    latest_proxy_config = FactoryBot.create(:proxy_config, proxy: proxy, environment: 'sandbox', content: content_hosts('v2.example.com'))
 
-    get master_api_proxy_configs_path(environment: 'sandbox', host: 'lvh.me'), access_token: @token.value
+    get master_api_proxy_configs_path(environment: 'sandbox'), params: {access_token: @token.value, host: 'v2.example.com'}
+
     assert_response :success
+    assert_same_elements [latest_proxy_config.id], proxy_config_ids(response.body)
 
-    assert_same_elements [ proxy_config.id ],
-                         proxy_config_ids(response.body)
 
+    FactoryBot.create(:proxy_config, proxy: proxy, environment: 'sandbox', hosts: %w[example.com])
+
+    get master_api_proxy_configs_path(environment: 'sandbox'), params: {access_token: @token.value, host: 'v1.example.com'}
+
+    assert_response :success
+    assert_empty proxy_config_ids(response.body)
   end
 
   protected
+
+  def content_hosts(*hosts)
+    { proxy: { hosts: hosts } }.to_json
+  end
 
   def proxy_config_ids(json)
     JSON.parse(json).fetch('proxy_configs').map { |h| h.dig('proxy_config', 'id') }

--- a/test/integration/user-management-api/services/proxy/configs_test.rb
+++ b/test/integration/user-management-api/services/proxy/configs_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
@@ -11,7 +13,7 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
     host! @account.admin_domain
   end
 
-  def test_latest
+  test 'latest' do
     params = valid_params
 
     get latest_admin_api_service_proxy_configs_path(params)
@@ -70,7 +72,7 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
     assert_equal 1, parsed_response['proxy_configs'].count
   end
 
-  def test_index_by_host
+  test 'index by host' do
     get "/admin/api/services/proxy/configs/#{ProxyConfig::ENVIRONMENTS.first}.json?#{host_valid_params.to_query}"
     assert_response :success
     assert_equal 1, parsed_response['proxy_configs'].count
@@ -84,8 +86,8 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
   end
 
   test 'index_by_host only finds the host in the latest version' do
-    proxy_config_old = FactoryBot.create(:proxy_config, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v1.example.com'))
-    proxy_config_new = FactoryBot.create(:proxy_config, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v2.example.com'))
+    _proxy_config_old = FactoryBot.create(:proxy_config, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v1.example.com'))
+    proxy_config_new  = FactoryBot.create(:proxy_config, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v2.example.com'))
 
     get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'v1.example.com', access_token: @token.value }
     assert_empty proxy_config_ids

--- a/test/integration/user-management-api/services/proxy/configs_test.rb
+++ b/test/integration/user-management-api/services/proxy/configs_test.rb
@@ -92,6 +92,12 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
 
     get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'v2.example.com', access_token: @token.value }
     assert_equal [proxy_config_new.id], proxy_config_ids
+
+
+    _proxy_config_old, proxy_config_new = FactoryBot.create_list(:proxy_config, 2, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('foo.example.com'))
+
+    get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'foo.example.com', access_token: @token.value }
+    assert_equal [proxy_config_new.id], proxy_config_ids
   end
 
   def test_promote

--- a/test/integration/user-management-api/services/proxy/configs_test.rb
+++ b/test/integration/user-management-api/services/proxy/configs_test.rb
@@ -3,13 +3,12 @@ require 'test_helper'
 class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
 
   def setup
-    account  = FactoryBot.create(:provider_account)
-    @service = FactoryBot.create(:simple_service, :with_default_backend_api, account: account)
+    @account = FactoryBot.create(:provider_account)
+    @service = FactoryBot.create(:simple_service, :with_default_backend_api, account: @account)
     @config  = FactoryBot.create(:proxy_config, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first)
-    admin    = FactoryBot.create(:admin, account: account)
-    @token   = FactoryBot.create(:access_token, owner: admin, scopes: 'account_management')
+    @token   = FactoryBot.create(:access_token, owner: @account.admin_user, scopes: 'account_management')
 
-    host! account.admin_domain
+    host! @account.admin_domain
   end
 
   def test_latest
@@ -84,6 +83,17 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
     assert_equal new_config.version, parsed_response['proxy_configs'].first['proxy_config']['version']
   end
 
+  test 'index_by_host only finds the host in the latest version' do
+    proxy_config_old = FactoryBot.create(:proxy_config, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v1.example.com'))
+    proxy_config_new = FactoryBot.create(:proxy_config, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v2.example.com'))
+
+    get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'v1.example.com', access_token: @token.value }
+    assert_empty proxy_config_ids
+
+    get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'v2.example.com', access_token: @token.value }
+    assert_equal [proxy_config_new.id], proxy_config_ids
+  end
+
   def test_promote
     params = valid_params.merge(version: @config.version, to: 'production')
 
@@ -100,15 +110,22 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
 
   private
 
+  def proxy_config_ids
+    (parsed_response['proxy_configs'] || {}).map { |h| h.dig('proxy_config', 'id') }
+  end
+
   def parsed_response
     JSON.parse(response.body)
+  end
+
+  def content_hosts(*hosts)
+    { proxy: { hosts: hosts } }.to_json
   end
 
   def host_valid_params
     {
       host:         @config.hosts.first,
       access_token: @token.value,
-
     }
   end
 


### PR DESCRIPTION
Extracted from #2230 . I need them to ensure that the refactoring won't break anything.