### PR TITLE
Remove private_endpoint from Proxy

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -12,6 +12,8 @@ class BackendApi < ApplicationRecord
   DELETED_STATE = :deleted
   ECHO_API_HOST = 'echo-api.3scale.net'
 
+  after_create :create_default_metrics
+
   before_destroy :validate_destroyed_by_association_or_not_used_by_services
 
   has_many :proxy_rules, as: :owner, dependent: :destroy, inverse_of: :owner
@@ -37,9 +39,6 @@ class BackendApi < ApplicationRecord
     non_localhost: { message: :protected_domain }
 
   alias_attribute :api_backend, :private_endpoint
-
-  before_validation :set_private_endpoint, :set_port_private_endpoint
-  after_create :create_default_metrics
 
   has_system_name(uniqueness_scope: [:account_id])
 
@@ -105,15 +104,6 @@ class BackendApi < ApplicationRecord
 
   def schedule_deletion
     DeleteObjectHierarchyWorker.perform_later(self)
-  end
-
-  def set_private_endpoint
-    return if account.provider_can_use?(:api_as_product)
-    self.private_endpoint ||= default_api_backend
-  end
-
-  def set_port_private_endpoint
-    Proxy::PortGenerator.new(self).call(:private_endpoint)
   end
 
   def validate_destroyed_by_association_or_not_used_by_services

--- a/test/models/backend_api_test.rb
+++ b/test/models/backend_api_test.rb
@@ -21,7 +21,7 @@ class BackendApiTest < ActiveSupport::TestCase
     @account.stubs(:provider_can_use?).with(:apicast_v1).returns(true)
     @account.stubs(:provider_can_use?).with(:apicast_v2).returns(true)
     @account.expects(:provider_can_use?).with(:proxy_private_base_path).at_least_once.returns(false)
-    @account.expects(:provider_can_use?).with(:api_as_product).at_least_once.returns(false)
+    @account.expects(:provider_can_use?).with(:api_as_product).at_least_once.returns(true)
     @backend_api.private_endpoint = 'https://example.org:3/path'
     @backend_api.valid?
     assert_equal [@backend_api.errors.generate_message(:private_endpoint, :invalid)], @backend_api.errors.messages[:private_endpoint]

--- a/test/unit/apicast/sandbox_provider_conf_generator_test.rb
+++ b/test/unit/apicast/sandbox_provider_conf_generator_test.rb
@@ -63,12 +63,4 @@ class Apicast::SandboxProviderConfGeneratorTest < ActiveSupport::TestCase
     generator = Apicast::SandboxProviderConfGenerator.new(@provider.id)
     assert_equal 0, generator.services.size
   end
-
-  class WithoutRollingUpdate < self
-    def setup
-      Logic::RollingUpdates.stubs(skipped?: true)
-      super
-      assert_equal :provider_key, @service.backend_authentication_type
-    end
-  end
 end

--- a/test/unit/backend_version_test.rb
+++ b/test/unit/backend_version_test.rb
@@ -10,6 +10,7 @@ class BackendVersionTest < ActiveSupport::TestCase
 
   def test_visible_versions_oidc
     rolling_updates_off
+    rolling_update(:api_as_product, enabled: true)
     rolling_update(:apicast_oidc, enabled: false)
     service = FactoryBot.create(:simple_service)
     versions = BackendVersion.visible_versions(service: service)

--- a/test/unit/messengers/plans_messenger_test.rb
+++ b/test/unit/messengers/plans_messenger_test.rb
@@ -1,12 +1,10 @@
 require 'test_helper'
 
 class PlansMessengerTest < ActiveSupport::TestCase
-
-  setup do
-    Logic::RollingUpdates.expects(skipped?: true).at_least_once
-  end
-
   test '#plan_change_request' do
+    rolling_updates_off
+    rolling_update(:api_as_product, enabled: true)
+
     cinstance = FactoryBot.create(:cinstance)
     plan = FactoryBot.create(:account_plan)
     PlansMessenger.plan_change_request(cinstance, plan).deliver

--- a/test/unit/observers/message_observer_test.rb
+++ b/test/unit/observers/message_observer_test.rb
@@ -45,15 +45,6 @@ class MessageObserverTest < ActiveSupport::TestCase
     ContractMessenger.expects(:plan_change_for_buyer).once.returns(mock(deliver: true))
 
     cinstance.change_plan! FactoryBot.create(:simple_application_plan, service: @service)
-
-    Logic::RollingUpdates.stubs(skipped?: true)
-
-    Cinstances::CinstancePlanChangedEvent.expects(:create).never
-    ContractMessenger.expects(:plan_change).once.returns(mock(deliver: true))
-
-    ContractMessenger.expects(:plan_change_for_buyer).once.returns(mock(deliver: true))
-
-    cinstance.change_plan! FactoryBot.create(:simple_application_plan, service: @service)
   end
 
   context "after_commit_on_create" do

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -309,28 +309,13 @@ class ServiceTest < ActiveSupport::TestCase
   end
 
   def test_default_published_service_plan
-    Logic::RollingUpdates.stubs(skipped?: true)
-
     service = FactoryBot.build(:simple_service)
     service.account.settings.service_plans_ui_visible = false
 
     service.save!
 
     service_plan = service.service_plans.first!
-    assert_equal 'hidden', service_plan.state
-  end
-
-  def test_default_published_service_plan_with_rolling_update
-    Logic::RollingUpdates.stubs(enabled?: true, skipped?: false)
-
-    service = FactoryBot.build(:simple_service)
-    service.account.settings.service_plans_ui_visible = false
-
-    Logic::RollingUpdates.feature(:published_service_plan_signup).any_instance.expects(:missing_config).returns(true)
-    service.save!
-
-    service_plan = service.service_plans.first!
-    assert_equal 'published', service_plan.state
+    assert service_plan.published?
   end
 
   class DestroyingServiceTest < ActiveSupport::TestCase

--- a/test/unit/services/apicast_v1_deployment_service_test.rb
+++ b/test/unit/services/apicast_v1_deployment_service_test.rb
@@ -1,18 +1,10 @@
 require 'test_helper'
 
 class ApicastV1DeploymentServiceTest < ActiveSupport::TestCase
-
-  class_attribute :rolling_updates
-  self.rolling_updates = false
-
   def setup
-    Logic::RollingUpdates.stubs(skipped?: !rolling_updates)
-
     @provider = FactoryBot.create(:provider_account)
     @provider.proxies.update_all(apicast_configuration_driven: false)
     @service = ApicastV1DeploymentService.new(@provider)
-
-    Logic::RollingUpdates.stubs(skipped?: true)
   end
 
   def test_deploy_success
@@ -79,9 +71,5 @@ class ApicastV1DeploymentServiceTest < ActiveSupport::TestCase
     assert_raise ConfContentFailure do
       @service.deploy(Proxy.new)
     end
-  end
-
-  class WithRollingUpdate < ApicastV1DeploymentServiceTest
-    self.rolling_updates = true
   end
 end

--- a/test/unit/signup/account_manager_test.rb
+++ b/test/unit/signup/account_manager_test.rb
@@ -125,15 +125,6 @@ module Signup
         assert_equal 'API', account.first_service!.name
       end
 
-      test 'first service has a private endpoint in order to be functional for non-APIAP accounts' do
-        Account.any_instance.stubs(:provider_can_use?).returns(false)
-        Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false)
-
-        account = signup_account_manager.create(signup_params).account
-        assert_equal 1, account.first_service!.backend_apis.count
-        assert_equal BackendApi.default_api_backend, account.first_service!.backend_apis.first!.private_endpoint
-      end
-
       test 'first service has a complete backend api for APIAP accounts' do
         Account.any_instance.stubs(:provider_can_use?).returns(false)
         Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true)


### PR DESCRIPTION
**What this PR does / why we need it**:

Since APIAP is now the default, there's no need for this rolling update

**Which issue(s) this PR fixes** 

TBD
