### PR TITLE
[Bugfix] 'parsed_content' must be a public method

### DIFF
--- a/app/models/proxy_config.rb
+++ b/app/models/proxy_config.rb
@@ -110,6 +110,10 @@ class ProxyConfig < ApplicationRecord
     errors.add :service_token, :missing
   end
 
+  def parsed_content
+    JSON.parse(content).deep_symbolize_keys
+  end
+
   private
 
   delegate :service_mesh_integration?, to: :proxy, allow_nil: true
@@ -127,10 +131,6 @@ class ProxyConfig < ApplicationRecord
 
   def extract_host(endpoint)
     URI(endpoint).host if endpoint
-  end
-
-  def parsed_content
-    JSON.parse(content).deep_symbolize_keys
   end
 
   def denormalize_hosts


### PR DESCRIPTION
Closes [THREESCALE-6421](https://issues.redhat.com/browse/THREESCALE-6421)

It must be a public method because it is called from the last method in the `CurlCommandBuilder`.
It was a problem of solving conflicts cherry-picking for 2.10 CR1.
It is correct in the `master` branch but not in 2.10 CR1 for now and that's a blocker for QE.

### Verification steps
`bundle exec rails t test/unit/apicast/curl_command_builder_test.rb` 😉 