### PR TITLE
[Refactor] Contract.permitted_for(user)

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -63,6 +63,12 @@ class Contract < ApplicationRecord
     where.has { plan_id.in( scope ) }
   end
 
+  scope :permitted_for, ->(user) {
+    next all unless user.forbidden_some_services?
+
+    where(service_id: user.member_permission_service_ids)
+  }
+
   # Return contracts bought by given account.
   scope :bought_by, ->(account) {
     where({:user_account_id => account.id})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -211,19 +211,11 @@ class User < ApplicationRecord
   end
 
   def accessible_cinstances
-    cinstances = account.provided_cinstances
+    account.provided_cinstances.permitted_for(self)
 
     # TODO: this has no clear migration path
     # once we would enable the :service_permissions feature for everyone
     # members that have no access to service would stop seeing applications
-    case
-    when has_access_to_all_services?
-        cinstances
-    when account.provider_can_use?(:service_permissions)
-        cinstances.where(service_id: member_permission_service_ids)
-    else
-        cinstances
-    end
   end
 
   def accessible_service_contracts

--- a/test/unit/contract_test.rb
+++ b/test/unit/contract_test.rb
@@ -106,6 +106,18 @@ class ContractTest < ActiveSupport::TestCase
     end
   end #paid?
 
+  test '.permitted_for' do
+    cinstances = FactoryBot.create_list(:simple_cinstance, 2)
+    user = FactoryBot.build(:member)
+
+    user.stubs(forbidden_some_services?: false)
+    permitted_contract_ids = Contract.permitted_for(user).pluck(:id)
+    cinstances.each { |contract| assert_includes(permitted_contract_ids, contract.id) }
+
+    user.stubs(forbidden_some_services?: true)
+    user.stubs(member_permission_service_ids: [cinstances.first.service_id])
+    assert_equal [cinstances.first.id], Contract.permitted_for(user).pluck(:id)
+  end
 
   def test_bill_for
     invoice = FactoryBot.create(:invoice)


### PR DESCRIPTION
Fixing [this circleci bug in 2.10](https://app.circleci.com/pipelines/github/3scale/porta/14930/workflows/a797b03a-82a2-4bc1-a767-9b1bf35bfde9/jobs/193871):

![image](https://user-images.githubusercontent.com/11318903/100374314-5c3a5680-300c-11eb-96a1-16e337a9d414.png)


I see that it was introduced in [this commit](https://github.com/3scale/porta/commit/8bbb177d5ebf8ee684d090b07f13e1fe700df9a2) so I am just cherry-picking it.

### Verification steps

`bundle exec rails t test/integration/buyers/service_contracts_controller_test.rb`

