### PR TITLE
Use ORACLE_DB_IMAGE oracle:19.3.0-ee in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ default: all
 
 ## This image is private and cannot be accessed by another third party than redhat.com employees
 ## You will need to build your own image as instructed in https://github.com/oracle/docker-images/tree/master/OracleDatabase/SingleInstance
-ORACLE_DB_IMAGE := quay.io/3scale/oracle:12.2.0.1-ee
+ORACLE_DB_IMAGE := quay.io/3scale/oracle:19.3.0-ee
 
 include wget.mk
 include openshift.mk
@@ -121,7 +121,7 @@ oracle-database:
 		-e ORACLE_SID=threescale \
 		-e ORACLE_PWD=threescalepass \
 		-e ORACLE_CHARACTERSET=AL32UTF8 \
-		quay.io/3scale/oracle:19.3.0-ee-ci-prebuilt
+		$(ORACLE_DB_IMAGE)
 
 # Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help: ## Print this help


### PR DESCRIPTION
- `Use 19.3.0-ee` instead of `19.3.0-ee-ci-prebuilt` in the Makefile
- Define the Oracle image url only once