### PR TITLE
Remove provider_can_use usages

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
-
 class Api::IntegrationsController < Api::BaseController
   before_action :find_service
   before_action :find_proxy
@@ -63,10 +61,10 @@ class Api::IntegrationsController < Api::BaseController
   def update_onpremises_production
     if @proxy.update_attributes(proxy_params)
       flash[:notice] = flash_message(:update_onpremises_production_success)
-      # TODO: THREESCALE-3759 it'll be changed to :show in https://github.com/3scale/porta/pull/2288
+      # TODO: THREESCALE-3759 it'll be changed in https://github.com/3scale/porta/pull/2288
       redirect_to action: :edit, anchor: 'production'
     else
-      # TODO: THREESCALE-3759 it'll be changed to :show in https://github.com/3scale/porta/pull/2288
+      # TODO: THREESCALE-3759 it'll be changed in https://github.com/3scale/porta/pull/2288
       render :edit
     end
   end
@@ -250,17 +248,12 @@ class Api::IntegrationsController < Api::BaseController
   ].freeze
 
   def proxy_params
-    permitted_fields = PROXY_BASIC_PARAMS
+    permitted_fields = PROXY_BASIC_PARAMS.dup
 
     permitted_fields << :sandbox_endpoint if Rails.application.config.three_scale.apicast_custom_url || @proxy.saas_configuration_driven_apicast_self_managed?
     permitted_fields << :endpoint if @service.using_proxy_pro? || @proxy.self_managed?
 
-    if provider_can_use?(:apicast_oidc)
-      permitted_fields << :oidc_issuer_endpoint
-      permitted_fields << :oidc_issuer_type
-      permitted_fields << :jwt_claim_with_client_id
-      permitted_fields << :jwt_claim_with_client_id_type
-    end
+    permitted_fields.merge!(%i[oidc_issuer_endpoint oidc_issuer_type jwt_claim_with_client_id jwt_claim_with_client_id_type]) if provider_can_use?(:apicast_oidc)
 
     params.require(:proxy).permit(*permitted_fields)
   end
@@ -283,5 +276,3 @@ class Api::IntegrationsController < Api::BaseController
     redirect_to :show
   end
 end
-
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -252,12 +252,8 @@ class Api::IntegrationsController < Api::BaseController
   def proxy_params
     permitted_fields = PROXY_BASIC_PARAMS
 
-    if Rails.application.config.three_scale.apicast_custom_url || @proxy.saas_configuration_driven_apicast_self_managed?
-      permitted_fields << :endpoint
-      permitted_fields << :sandbox_endpoint
-    end
-
-    permitted_fields << :endpoint if @service.using_proxy_pro? || @proxy.saas_script_driven_apicast_self_managed?
+    permitted_fields << :sandbox_endpoint if Rails.application.config.three_scale.apicast_custom_url || @proxy.saas_configuration_driven_apicast_self_managed?
+    permitted_fields << :endpoint if @service.using_proxy_pro? || @proxy.self_managed?
 
     if provider_can_use?(:apicast_oidc)
       permitted_fields << :oidc_issuer_endpoint

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
+
 class Api::IntegrationsController < Api::BaseController
   before_action :find_service
   before_action :find_proxy
@@ -218,51 +220,53 @@ class Api::IntegrationsController < Api::BaseController
     params.fetch(:proxy, {}).fetch(:proxy_rules_attributes, {})
   end
 
+  PROXY_BASIC_PARAMS = [
+    :lock_version,
+    :auth_app_id,
+    :auth_app_key,
+    :api_backend,
+    :hostname_rewrite,
+    :oauth_login_url,
+    :secret_token,
+    :credentials_location,
+    :auth_user_key,
+    :error_status_auth_failed,
+    :error_headers_auth_failed,
+    :error_auth_failed,
+    :error_status_auth_missing,
+    :error_headers_auth_missing,
+    :error_auth_missing,
+    :error_status_no_match,
+    :error_headers_no_match,
+    :error_no_match,
+    :error_status_limits_exceeded,
+    :error_headers_limits_exceeded,
+    :error_limits_exceeded,
+    :api_test_path,
+    :policies_config,
+    { proxy_rules_attributes: %i[_destroy id http_method pattern delta metric_id redirect_url position last] },
+    { oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES + [:id] },
+    { backend_api_configs_attributes: %i[_destroy id path] }
+  ].freeze
+
   def proxy_params
-    basic_fields = [
-      :lock_version,
-      :auth_app_id,
-      :auth_app_key,
-      :api_backend,
-      :hostname_rewrite,
-      :oauth_login_url,
-      :secret_token,
-      :credentials_location,
-      :auth_user_key,
-      :error_status_auth_failed,
-      :error_headers_auth_failed,
-      :error_auth_failed,
-      :error_status_auth_missing,
-      :error_headers_auth_missing,
-      :error_auth_missing,
-      :error_status_no_match,
-      :error_headers_no_match,
-      :error_no_match,
-      :error_status_limits_exceeded,
-      :error_headers_limits_exceeded,
-      :error_limits_exceeded,
-      :api_test_path,
-      :policies_config,
-      proxy_rules_attributes: %i[_destroy id http_method pattern delta metric_id redirect_url position last],
-      oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES + [:id],
-      backend_api_configs_attributes: %i[_destroy id path]
-    ]
+    permitted_fields = PROXY_BASIC_PARAMS
 
     if Rails.application.config.three_scale.apicast_custom_url || @proxy.saas_configuration_driven_apicast_self_managed?
-      basic_fields << :endpoint
-      basic_fields << :sandbox_endpoint
+      permitted_fields << :endpoint
+      permitted_fields << :sandbox_endpoint
     end
 
-    basic_fields << :endpoint if @service.using_proxy_pro? || @proxy.saas_script_driven_apicast_self_managed?
+    permitted_fields << :endpoint if @service.using_proxy_pro? || @proxy.saas_script_driven_apicast_self_managed?
 
     if provider_can_use?(:apicast_oidc)
-      basic_fields << :oidc_issuer_endpoint
-      basic_fields << :oidc_issuer_type
-      basic_fields << :jwt_claim_with_client_id
-      basic_fields << :jwt_claim_with_client_id_type
+      permitted_fields << :oidc_issuer_endpoint
+      permitted_fields << :oidc_issuer_type
+      permitted_fields << :jwt_claim_with_client_id
+      permitted_fields << :jwt_claim_with_client_id_type
     end
 
-    params.require(:proxy).permit(*basic_fields)
+    params.require(:proxy).permit(*permitted_fields)
   end
 
   def deploying_hosted_proxy_key
@@ -283,3 +287,5 @@ class Api::IntegrationsController < Api::BaseController
     redirect_to :show
   end
 end
+
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -61,8 +61,10 @@ class Api::IntegrationsController < Api::BaseController
   def update_onpremises_production
     if @proxy.update_attributes(proxy_params)
       flash[:notice] = flash_message(:update_onpremises_production_success)
+      # TODO: THREESCALE-3759 it'll be changed to :show in https://github.com/3scale/porta/pull/2288
       redirect_to action: :edit, anchor: 'production'
     else
+      # TODO: THREESCALE-3759 it'll be changed to :show in https://github.com/3scale/porta/pull/2288
       render :edit
     end
   end
@@ -219,14 +221,31 @@ class Api::IntegrationsController < Api::BaseController
   def proxy_params
     basic_fields = [
       :lock_version,
-
-      :auth_app_id, :auth_app_key, :api_backend, :hostname_rewrite, :oauth_login_url,
-      :secret_token, :credentials_location, :auth_user_key, :error_status_auth_failed,
-      :error_headers_auth_failed, :error_auth_failed, :error_status_auth_missing,
-      :error_headers_auth_missing, :error_auth_missing, :error_status_no_match,
-      :error_headers_no_match, :error_no_match, :error_status_limits_exceeded, :error_headers_limits_exceeded, :error_limits_exceeded,
-      :api_test_path, :policies_config, proxy_rules_attributes: %i[_destroy id http_method pattern delta metric_id
-                                                                   redirect_url position last], oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES + [:id]
+      :auth_app_id,
+      :auth_app_key,
+      :api_backend,
+      :hostname_rewrite,
+      :oauth_login_url,
+      :secret_token,
+      :credentials_location,
+      :auth_user_key,
+      :error_status_auth_failed,
+      :error_headers_auth_failed,
+      :error_auth_failed,
+      :error_status_auth_missing,
+      :error_headers_auth_missing,
+      :error_auth_missing,
+      :error_status_no_match,
+      :error_headers_no_match,
+      :error_no_match,
+      :error_status_limits_exceeded,
+      :error_headers_limits_exceeded,
+      :error_limits_exceeded,
+      :api_test_path,
+      :policies_config,
+      proxy_rules_attributes: %i[_destroy id http_method pattern delta metric_id redirect_url position last],
+      oidc_configuration_attributes: OIDCConfiguration::Config::ATTRIBUTES + [:id],
+      backend_api_configs_attributes: %i[_destroy id path]
     ]
 
     if Rails.application.config.three_scale.apicast_custom_url || @proxy.saas_configuration_driven_apicast_self_managed?
@@ -242,8 +261,6 @@ class Api::IntegrationsController < Api::BaseController
       basic_fields << :jwt_claim_with_client_id
       basic_fields << :jwt_claim_with_client_id_type
     end
-
-    basic_fields << { backend_api_configs_attributes: %i[_destroy id path] } if provider_can_use?(:api_as_product)
 
     params.require(:proxy).permit(*basic_fields)
   end

--- a/app/controllers/api/policies_controller.rb
+++ b/app/controllers/api/policies_controller.rb
@@ -28,7 +28,6 @@ class Api::PoliciesController < Api::BaseController
   end
 
   def check_permission
-    provider_can_use! :api_as_product
     authorize! :edit, service
     raise Cancan::AccessDenied unless service.can_use_policies?
   end

--- a/app/controllers/api_docs/services_controller.rb
+++ b/app/controllers/api_docs/services_controller.rb
@@ -125,7 +125,7 @@ class ApiDocs::ServicesController < FrontendController
   def exclude_forbidden_endpoints(apis)
     apis.select do |api|
       path = api['path']
-      (!master_on_premises? || path.exclude?('plan')) && (provider_can_use?(:api_as_product) || !path.match(/backend_(api|usage)/))
+      !master_on_premises? || path.exclude?('plan')
     end
   end
 

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -220,7 +220,7 @@ module VerticalNavHelper
     items = []
     items << {id: :listing,           title: 'Listing',           path: admin_service_applications_path(@service)}      if can? :manage, :applications
     items << {id: :application_plans, title: 'Application Plans', path: admin_service_application_plans_path(@service)} if can?(:manage, :plans)
-    if current_account.provider_can_use?(:api_as_product) && !master_on_premises?
+    unless master_on_premises?
       items << {title: 'Settings'}
       items << {id: :usage_rules, title: 'Usage Rules', path: usage_rules_admin_service_path(@service)}
     end
@@ -238,10 +238,8 @@ module VerticalNavHelper
     items << {id: :configuration,       title: 'Configuration',     path: admin_service_integration_path(@service), itemOutOfDateConfig: has_out_of_date_configuration?(@service)}
     items << {id: :methods_metrics,     title: 'Methods & Metrics', path: admin_service_metrics_path(@service)}
     items << {id: :mapping_rules,       title: 'Mapping Rules',     path: admin_service_proxy_rules_path(@service)}
-    if current_account.provider_can_use?(:api_as_product)
-      items << {id: :policies,            title: 'Policies',          path: edit_admin_service_policies_path(@service)} if @service.can_use_policies?
-      items << {id: :backend_api_configs, title: 'Backends',        path: admin_service_backend_usages_path(@service)} if @service.can_use_backends?
-    end
+    items << {id: :policies,            title: 'Policies',          path: edit_admin_service_policies_path(@service)} if @service.can_use_policies?
+    items << {id: :backend_api_configs, title: 'Backends',        path: admin_service_backend_usages_path(@service)} if @service.can_use_backends?
     items << {id: :settings,            title: 'Settings',        path: settings_admin_service_path(@service)}
   end
 

--- a/app/lib/backend_api_logic/proxy_extension.rb
+++ b/app/lib/backend_api_logic/proxy_extension.rb
@@ -24,7 +24,7 @@ module BackendApiLogic
     protected
 
     def validate_backend_api?
-      !account.provider_can_use?(:api_as_product) || backend_api.private_endpoint_changed?
+      backend_api.private_endpoint_changed?
     end
 
     def save_backend_api

--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -107,10 +107,8 @@ class BackendApi < ApplicationRecord
     DeleteObjectHierarchyWorker.perform_later(self)
   end
 
-  def set_private_endpoint
-    return if account.provider_can_use?(:api_as_product)
-    self.private_endpoint ||= default_api_backend
-  end
+  # TODO: THREESCALE-3759 remove this method
+  def set_private_endpoint; end
 
   def set_port_private_endpoint
     Proxy::PortGenerator.new(self).call(:private_endpoint)

--- a/app/services/proxy_test_service.rb
+++ b/app/services/proxy_test_service.rb
@@ -103,7 +103,6 @@ class ProxyTestService
   end
 
   def backend_api_config_path
-    return unless proxy.provider_can_use?(:api_as_product)
     proxy.backend_api_configs.first&.path
   end
 

--- a/app/views/api/integrations/apicast/configuration_driven/_configuration.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_configuration.html.slim
@@ -22,9 +22,6 @@
 
     div class=("feedback api #{'success' if @proxy.api_test_success} #{'no-test' if @proxy.api_test_path.blank? or @proxy.api_test_success.nil?}")
       i.fa.fa-puzzle-piece
-      - unless current_account.provider_can_use?(:api_as_product)
-        = f.inputs "API" do
-          = f.input :api_backend, input_html: { data: { default: @proxy.default_api_backend }, autofocus: (@proxy.api_backend == @proxy.default_api_backend) }, hint: api_backend_hint(@proxy.api_backend)
 
     div class=("feedback proxy #{'success' if @proxy.api_test_success} #{'no-test' if @proxy.api_test_path.blank? or @proxy.api_test_success.nil?}")
       i.fa.fa-hdd-o
@@ -40,15 +37,10 @@
                                 readonly: apicast_urls_readonly?,
                                 placeholder: "https://api.#{parameterized_org_name_of_the_current_account}.com" },
                   hint: apicast_endpoint_input_hint(@service, environment: 'production')
-        - unless current_account.provider_can_use?(:api_as_product)
-          div.help-button-constrainer
-            = render 'api/integrations/apicast/shared/mapping_rules', f: f
         div.help-button-constrainer
           = render 'api/integrations/apicast/shared/authentication_settings', f: f, oauth_hint: 'apicast_oauth'
         - if current_account.provider_can_use?(:policies)
           div.help-button-constrainer
-            - unless current_account.provider_can_use?(:api_as_product)
-              = render 'api/integrations/apicast/shared/policies', f: f
 
     = render 'api/integrations/apicast/shared/client', f: f unless @proxy.service.oauth?
 

--- a/app/views/api/integrations/apicast/script_driven/_staging.html.slim
+++ b/app/views/api/integrations/apicast/script_driven/_staging.html.slim
@@ -1,3 +1,4 @@
+/ TODO: THREESCALE-3759 this file no longer used
 = semantic_form_for @proxy,
         url: admin_service_integration_path(@service, anchor: 'proxy'),
         remote: current_account.provider_can_use?(:async_apicast_deploy),

--- a/app/views/api/plans/_metrics.html.erb
+++ b/app/views/api/plans/_metrics.html.erb
@@ -11,18 +11,13 @@
     <thead>
       <tr>
         <th colspan="<%= @plan.pricing_enabled? ? 4 : 3 %>">
-          <% if provider_can_use?(:api_as_product) -%>
-            Product Level
-          <% else -%>
-            Metric or method
-            (<%= link_to 'Define method or metric', admin_service_metrics_path(@service), title: 'Define Methods & Metrics for this service' %>)
-          <% end -%>
+          Product Level
         </th>
         <th class="operations">
-          Enabled       
+          Enabled
         </th>
         <th class="operations">
-          Visible          
+          Visible
         </th>
         <th class="operations" colspan="<%= @plan.pricing_enabled? ? 2 : 1 %>">
           Text only
@@ -43,7 +38,6 @@
     </tbody>
   </table>
 
-  <% if provider_can_use?(:api_as_product) -%>
   <table id="backend_api_metrics" class="contract_table">
     <thead>
       <tr>
@@ -51,7 +45,7 @@
           Backend Level
         </th>
         <th class="operations">
-          Enabled      
+          Enabled
         </th>
         <th class="operations">
           Visible
@@ -75,5 +69,4 @@
     </tbody>
   </table>
   <%= javascript_pack_tag 'plans-metrics' %>
-  <% end -%>
 </div>

--- a/app/views/api/services/new.html.slim
+++ b/app/views/api/services/new.html.slim
@@ -1,10 +1,11 @@
 = javascript_pack_tag 'new_service'
 
+/ TODO: THREESCALE-3759 remove apiap parameter
 #new_service_wrapper data-new-service-data={ isServiceDiscoveryAccessible: service_discovery_accessible?,
                                              template: @service.as_json,
                                              isServiceDiscoveryUsable: service_discovery_usable?,
                                              serviceDiscoveryAuthenticateUrl: service_discovery_presenter.authorize_url,
                                              providerAdminServiceDiscoveryServicesPath: provider_admin_service_discovery_services_path,
                                              adminServicesPath: admin_services_path,
-                                             apiap: current_account.provider_can_use?(:api_as_product),
+                                             apiap: true,
                                              backendApis: current_account.backend_apis.as_json(only: [:id, :name], root: false) }.to_json

--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -165,13 +165,12 @@ section class="service-widget"
           - [:buyers_manage_keys, :buyers_manage_apps, :buyer_plan_change_permission, :buyer_can_select_plan ].map { |setting| friendly_service_setting(service, setting) }.compact.each do |setting|
             li.item
               = setting
-          - if provider_can_use?(:api_as_product)
-            li.item
-              strong> Backends
-              ' used in this product:
-              ul
-                - service.backend_apis.each do |backend_api|
-                  li = link_to backend_api.name, provider_admin_backend_api_path(backend_api)
+          li.item
+            strong> Backends
+            ' used in this product:
+            ul
+              - service.backend_apis.each do |backend_api|
+                li = link_to backend_api.name, provider_admin_backend_api_path(backend_api)
 
 javascript:
   document.addEventListener('DOMContentLoaded', function () {

--- a/app/views/shared/provider/navigation/service/_integration.html.slim
+++ b/app/views/shared/provider/navigation/service/_integration.html.slim
@@ -2,15 +2,14 @@
       title: 'Configuration',
       path: admin_service_integration_path(@service)
 
-- unless current_account.provider_can_use?(:api_as_product)
-  = render vertical_nav_item,
-         title: 'Methods & Metrics',
-         path: admin_service_metrics_path(@service)
+= render vertical_nav_item,
+      title: 'Methods & Metrics',
+      path: admin_service_metrics_path(@service)
 
 = render vertical_nav_item,
       title: 'Mapping Rules',
       path: admin_service_proxy_rules_path(@service)
 
 = render vertical_nav_item,
-     title: 'Settings',
-     path: settings_admin_service_path(@service)
+      title: 'Settings',
+      path: settings_admin_service_path(@service)

--- a/features/old/menu/api_menu.feature
+++ b/features/old/menu/api_menu.feature
@@ -37,28 +37,7 @@ Feature: API menu
     | Listing                   |
     | Application Plans         |
 
-  Scenario: Integration sub menu structure provider has api as product enabled
-    Given the account has api_as_product rolling update enabled
-    And I have api_as_product feature disabled
-    When I follow "Overview"
-    When I follow "Integration" within the main menu
-    Then I should see menu items
-    | Configuration             |
-    | Methods & Metrics         |
-    | Mapping Rules             |
-    | Settings                  |
-
-  Scenario: Integration sub menu structure when provider does not have api as product enabled
-    Given I have api_as_product feature disabled
-    When I follow "Overview"
-    And I follow "Integration" within the main menu
-    Then I should see menu items
-    | Configuration             |
-    | Methods & Metrics         |
-    | Settings                  |
-
-  Scenario: Integration sub menu structure for API as Product
-    Given I have api_as_product feature enabled
+  Scenario: Integration sub menu structure
     When I follow "Overview"
     And I follow "Integration" within the main menu
     Then I should see menu items

--- a/features/provider/onboarding/wizard.feature
+++ b/features/provider/onboarding/wizard.feature
@@ -9,7 +9,6 @@ Feature: Onboarding Wizard
   @emails
   Scenario: Provider goes through the wizard
     Given a provider signs up and activates his account
-     And I have rolling updates "api_as_product" enabled
     When user starts the onboarding wizard
      And goes to Add a Backend page
      And adds the echo Backend

--- a/features/step_definitions/provider_steps.rb
+++ b/features/step_definitions/provider_steps.rb
@@ -291,7 +291,3 @@ Then(/^new tenant should be not created$/) do
     assert_selector('.inline-errors', :text => error_message[:message])
   end
 end
-
-Given /^the account has api_as_product rolling update enabled$/ do
-  @provider.stubs(:provider_can_use?).with(:api_as_product).returns(true)
-end

--- a/features/step_definitions/proxy_steps.rb
+++ b/features/step_definitions/proxy_steps.rb
@@ -2,16 +2,6 @@ Then /^I should be offered to download an? "(.+?)" file$/ do |mime_type|
   assert_equal mime_type, page.response_headers['Content-Type']
 end
 
-Given(/^I'm using a custom API Backend$/) do
-  steps %{
-    When I go to the integration page for service "one"
-    And I fill in "Private Base URL" with "http://www.google.com"
-  }
-  stub_deploy_calls!
-
-  click_on 'proxy-button-save-and-deploy'
-end
-
 Then(/^I can edit the proxy public endpoint$/) do
 
   step %(I go to the integration page for service "#{@provider.first_service!.name}")

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -609,8 +609,11 @@ World(Module.new do
     when /^the integration show page for (service ".+?")/
       admin_service_integration_path(Transform $1)
     when /^the integration page for (service ".+?")/
+      # TODO: THREESCALE-3759 edit page no longer exist, remove and replace for show
       edit_admin_service_integration_path(Transform $1)
     when 'the service integration page'
+      # TODO: THREESCALE-3759 edit page no longer exist, change for
+      # settings_admin_service_path(provider_first_service!)
       edit_admin_service_integration_path(provider_first_service!)
 
     when 'the 404 page'

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -609,7 +609,7 @@ World(Module.new do
     when /^the integration show page for (service ".+?")/
       admin_service_integration_path(Transform $1)
     when /^the integration page for (service ".+?")/
-      # TODO: THREESCALE-3759 edit page no longer exist, remove and replace for show
+      # TODO: THREESCALE-3759 edit page no longer exist, remove or replace
       edit_admin_service_integration_path(Transform $1)
     when 'the service integration page'
       # TODO: THREESCALE-3759 edit page no longer exist, change for

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -611,10 +611,6 @@ World(Module.new do
     when /^the integration page for (service ".+?")/
       # TODO: THREESCALE-3759 edit page no longer exist, remove or replace
       edit_admin_service_integration_path(Transform $1)
-    when 'the service integration page'
-      # TODO: THREESCALE-3759 edit page no longer exist, change for
-      # settings_admin_service_path(provider_first_service!)
-      edit_admin_service_integration_path(provider_first_service!)
 
     when 'the 404 page'
       '/the-404-page'

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -156,7 +156,6 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'deploy is never called when saving proxy info for proxy pro users' do
     rolling_updates_on
-    Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false)
     Account.any_instance.stubs(:provider_can_use?).with(:proxy_pro).returns(true)
 
     Proxy.any_instance.expects(:save_and_deploy).never
@@ -171,7 +170,8 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     put admin_service_integration_path(service_id: service.id), proxy: {api_backend: '1'}
   end
 
-  def test_edit
+  # Regression test for pre-APIAP
+  def test_edit_not_found
     get edit_admin_service_integration_path(service_id: 'no-such-service')
     assert_response :not_found
 
@@ -250,7 +250,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_no_change of: -> { proxy.reload.oidc_configuration.id } do
       put admin_service_integration_path(service_id: service.id, proxy: oidc_params)
     end
-    assert_response :redirect
+    assert_response :success
 
     service.reload
     refute proxy.oidc_configuration.standard_flow_enabled
@@ -266,11 +266,6 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_no_change of: -> { proxy.reload.oidc_configuration.id } do
       put admin_service_integration_path(service_id: service.id, proxy: oidc_params)
     end
-    assert_response :not_found
-  end
-
-  test 'edit not found for apiap' do
-    get edit_admin_service_integration_path(service_id: service.id)
     assert_response :not_found
   end
 
@@ -296,7 +291,6 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     config = FactoryBot.create(:proxy_config, proxy: proxy, version: 3, environment: 'sandbox')
 
     Account.any_instance.stubs(:provider_can_use?).returns(true)
-    Account.any_instance.expects(:provider_can_use?).with(:api_as_product).returns(false).at_least_once
 
     get admin_service_integration_path(service_id: service.id)
 

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -156,6 +156,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'deploy is never called when saving proxy info for proxy pro users' do
     rolling_updates_on
+    Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false)
     Account.any_instance.stubs(:provider_can_use?).with(:proxy_pro).returns(true)
 
     Proxy.any_instance.expects(:save_and_deploy).never

--- a/test/integration/api_docs/services_controller_test.rb
+++ b/test/integration/api_docs/services_controller_test.rb
@@ -83,14 +83,10 @@ class ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
         collection_paths << path if path.match(name_or_path_regex)
       end
 
-      Logic::RollingUpdates::Features::ApiAsProduct.any_instance.stubs(enabled?: true)
+      Logic::RollingUpdates::Features::ApiAsProduct.any_instance.stubs(enabled?: true) # TODO: THREESCALE-3759 remove this line
       get '/api_docs/services/account_management_api.json'
       actual_backed_api_routes = Rails.application.routes.named_routes.select { |name, route| name.to_s.match(name_or_path_regex) }
       assert_equal actual_backed_api_routes.length, JSON.parse(response.body)['apis'].each_with_object(Set.new, &select_endpoints).length
-
-      Logic::RollingUpdates::Features::ApiAsProduct.any_instance.stubs(enabled?: false)
-      get '/api_docs/services/account_management_api.json'
-      assert_empty JSON.parse(response.body)['apis'].each_with_object(Set.new, &select_endpoints)
     end
   end
 

--- a/test/integration/api_docs/services_controller_test.rb
+++ b/test/integration/api_docs/services_controller_test.rb
@@ -83,7 +83,6 @@ class ApiDocs::ServicesControllerTest < ActionDispatch::IntegrationTest
         collection_paths << path if path.match(name_or_path_regex)
       end
 
-      Logic::RollingUpdates::Features::ApiAsProduct.any_instance.stubs(enabled?: true) # TODO: THREESCALE-3759 remove this line
       get '/api_docs/services/account_management_api.json'
       actual_backed_api_routes = Rails.application.routes.named_routes.select { |name, route| name.to_s.match(name_or_path_regex) }
       assert_equal actual_backed_api_routes.length, JSON.parse(response.body)['apis'].each_with_object(Set.new, &select_endpoints).length

--- a/test/models/backend_api_test.rb
+++ b/test/models/backend_api_test.rb
@@ -21,7 +21,6 @@ class BackendApiTest < ActiveSupport::TestCase
     @account.stubs(:provider_can_use?).with(:apicast_v1).returns(true)
     @account.stubs(:provider_can_use?).with(:apicast_v2).returns(true)
     @account.expects(:provider_can_use?).with(:proxy_private_base_path).at_least_once.returns(false)
-    @account.expects(:provider_can_use?).with(:api_as_product).at_least_once.returns(false)
     @backend_api.private_endpoint = 'https://example.org:3/path'
     @backend_api.valid?
     assert_equal [@backend_api.errors.generate_message(:private_endpoint, :invalid)], @backend_api.errors.messages[:private_endpoint]

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -294,7 +294,6 @@ class ProxyTest < ActiveSupport::TestCase
     @account.stubs(:provider_can_use?).with(:apicast_v1).returns(true)
     @account.stubs(:provider_can_use?).with(:apicast_v2).returns(true)
     @account.expects(:provider_can_use?).with(:proxy_private_base_path).at_least_once.returns(false)
-    @account.expects(:provider_can_use?).with(:api_as_product).at_least_once.returns(false)
     backend_api = @proxy.backend_api
     backend_api.stubs(account: @account)
     @proxy.api_backend = 'https://example.org:3/path'

--- a/test/unit/services/service_discovery/import_cluster_definitions_service_test.rb
+++ b/test/unit/services/service_discovery/import_cluster_definitions_service_test.rb
@@ -93,7 +93,6 @@ module ServiceDiscovery
       @account.stubs(:provider_can_use?).with(:apicast_v1).returns(true)
       @account.stubs(:provider_can_use?).with(:apicast_v2).returns(true)
       @account.stubs(:provider_can_use?).with(:proxy_private_base_path).returns(false)
-      @account.expects(:provider_can_use?).with(:api_as_product).at_least_once.returns(false)
       @service.backend_api.stubs(account: @account)
 
       System::ErrorReporting.expects(:report_error).with(responds_with(:message, 'Could not save API backend URL'), any_parameters)


### PR DESCRIPTION
First part of [THREESCALE-3759: Remove (deprecated) non-APIAP code](https://issues.redhat.com/browse/THREESCALE-3759).

Removes all uses of `provider_can_use?(:api_as_product)`.