### PR TITLE
Remove unused methods & paths 'edit', 'update*production' of Api/IntegrationsController

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -818,10 +818,8 @@ without fake Core server your after commit callbacks will crash and you might ge
 
           resources :backend_usages, except: :show
 
-          resource :integration, :except => [ :create, :destroy, :edit ] do
+          resource :integration, except: %i[create destroy edit] do
             member do
-              patch 'update_production'
-              patch 'update_onpremises_production'
               patch 'promote_to_production'
               patch 'toggle_apicast_version'
             end


### PR DESCRIPTION
The reason for this PR/proposal is that the problem of redirecting to a legit action (`show`) is that then it seems like this is also a reachable legit path, and it isn't 😄 so I propose removing it directly since it is not used anymore (for APIAP) 😉 

What this PR does:
* Remove unused methods and paths: 'update_production' & 'update_onpremises_production'
* 'find_registry_policies' only for update
* Remove 'edit' method
* Clean Array of symbols in routes.rb