### PR TITLE
Remove non-APIAP code in Account Signup / Service creation

### DIFF
--- a/app/services/service_creator.rb
+++ b/app/services/service_creator.rb
@@ -37,12 +37,8 @@ class ServiceCreator
   end
 
   def save_default_backend_api(params)
-    if provider_can_use?(:api_as_product)
-      return true if %i[path private_endpoint].none? { |key| params.key?(key) }
-      backend_api_proxy.update!(params)
-    else
-      backend_api_proxy.update!(private_endpoint: BackendApi.default_api_backend)
-    end
+    return true if %i[path private_endpoint].none? { |key| params.key?(key) }
+    backend_api_proxy.update!(params)
   end
 
   def save_assigned_backend_api(attrs)

--- a/test/unit/db/seeds_test.rb
+++ b/test/unit/db/seeds_test.rb
@@ -75,6 +75,9 @@ class SeedsTest < ActiveSupport::TestCase
 
     assert master_service.default_service_plan
 
+    assert_equal 1, master_service.backend_apis.count
+    assert_equal BackendApi.default_api_backend, master_service.backend_apis.first!.private_endpoint
+
     master_app_plan = master_service.default_application_plan
     assert_equal master_service.id, master_app_plan.issuer_id
     assert_equal 'enterprise', master_app_plan.name
@@ -135,6 +138,15 @@ class SeedsTest < ActiveSupport::TestCase
     assert_equal '3scale', impersonation_user.first_name
     assert_equal 'Admin', impersonation_user.last_name
 
+    tenant_service = Account.tenants.first!.default_service
+    assert_equal 1, tenant_service.backend_apis.count
+    tenant_backend_api = tenant_service.backend_apis.accessible.first
+    assert_equal BackendApi.default_api_backend, tenant_backend_api.private_endpoint
+    assert_equal tenant_service.system_name, tenant_backend_api.system_name
+    assert_equal "#{tenant_service.name} Backend", tenant_backend_api.name
+    assert_equal "Backend of #{tenant_service.name}", tenant_backend_api.description
+    assert_equal tenant_service.account_id, tenant_backend_api.account_id
+
     Settings.basic_enabled_switches.each do |switch_name|
       assert provider.settings.public_send(switch_name).visible?
     end
@@ -142,22 +154,6 @@ class SeedsTest < ActiveSupport::TestCase
     Settings.basic_disabled_switches.each do |switch_name|
       assert provider.settings.public_send(switch_name).hidden?
     end
-  end
-
-  test 'creates the backend api for the first tenant if has RU api_as_product enabled' do
-    Account.any_instance.stubs(provider_can_use?: true)
-
-    Rails.application.load_seed
-
-    assert_expected_backend_api
-  end
-
-  test 'creates the backend api for the first tenant if has RU api_as_product disabled' do
-    Account.any_instance.stubs(provider_can_use?: false)
-
-    Rails.application.load_seed
-
-    assert_expected_backend_api
   end
 
   test 'with ENV as params' do
@@ -202,18 +198,5 @@ class SeedsTest < ActiveSupport::TestCase
     [Account, User, Service, Plan, AccessToken, Metric, CMS::Template].each do |model|
       assert_equal 0, model.count, "#{model} did not rollback"
     end
-  end
-
-  private
-
-  def assert_expected_backend_api
-    service = Account.tenants.first!.default_service
-    assert_equal 1, service.backend_apis.count
-    backend_api = service.backend_apis.accessible.first
-    assert_equal BackendApi.default_api_backend, backend_api.private_endpoint
-    assert_equal service.system_name, backend_api.system_name
-    assert_equal "#{service.name} Backend", backend_api.name
-    assert_equal "Backend of #{service.name}", backend_api.description
-    assert_equal service.account_id, backend_api.account_id
   end
 end

--- a/test/unit/services/service_creator_test.rb
+++ b/test/unit/services/service_creator_test.rb
@@ -7,7 +7,6 @@ class ServiceCreatorTest < ActiveSupport::TestCase
     creator.call
     assert service.persisted?
     assert service.backend_api_proxy.backend_api.new_record?
-    ::Account.any_instance.stubs(:provider_can_use).with(:api_as_product).returns(true)
   end
 
   test 'service creation with path and private_endpoint' do

--- a/test/unit/services/service_creator_test.rb
+++ b/test/unit/services/service_creator_test.rb
@@ -7,18 +7,21 @@ class ServiceCreatorTest < ActiveSupport::TestCase
     creator.call
     assert service.persisted?
     assert service.backend_api_proxy.backend_api.new_record?
+    ::Account.any_instance.stubs(:provider_can_use).with(:api_as_product).returns(true)
   end
 
   test 'service creation with path and private_endpoint' do
     service = FactoryBot.build(:service)
     creator = ServiceCreator.new(service: service)
-    creator.call(path: 'foo', private_endpoint: 'http://example.com')
+    creator.call(path: 'new', private_endpoint: 'http://new.example.com')
 
     assert service.persisted?
     backend_api = service.backend_api_proxy.backend_api
     backend_api_config = service.backend_api_proxy.backend_api_config
     assert backend_api.persisted?
     assert backend_api_config.persisted?
+    assert_equal '/new', backend_api_config.path
+    assert_equal 'http://new.example.com:80', backend_api.private_endpoint
   end
 
   test 'service creation with invalid private_endpoint' do

--- a/test/unit/signup/account_manager_test.rb
+++ b/test/unit/signup/account_manager_test.rb
@@ -125,18 +125,9 @@ module Signup
         assert_equal 'API', account.first_service!.name
       end
 
-      test 'first service has a private endpoint in order to be functional for non-APIAP accounts' do
+      test 'first service has a complete backend api' do
         Account.any_instance.stubs(:provider_can_use?).returns(false)
         Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false)
-
-        account = signup_account_manager.create(signup_params).account
-        assert_equal 1, account.first_service!.backend_apis.count
-        assert_equal BackendApi.default_api_backend, account.first_service!.backend_apis.first!.private_endpoint
-      end
-
-      test 'first service has a complete backend api for APIAP accounts' do
-        Account.any_instance.stubs(:provider_can_use?).returns(false)
-        Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(true)
 
         account = signup_account_manager.create(signup_params).account
         assert_equal 1, account.backend_apis.count

--- a/test/unit/signup/account_manager_test.rb
+++ b/test/unit/signup/account_manager_test.rb
@@ -126,9 +126,6 @@ module Signup
       end
 
       test 'first service has a complete backend api' do
-        Account.any_instance.stubs(:provider_can_use?).returns(false)
-        Account.any_instance.stubs(:provider_can_use?).with(:api_as_product).returns(false)
-
         account = signup_account_manager.create(signup_params).account
         assert_equal 1, account.backend_apis.count
         assert (service = account.default_service)


### PR DESCRIPTION
* Test BackendAPI in Seeds for Tenant & Master (only APIAP)
* Test Backend API attributes for a Service in ServiceCreator (only APIAP)
* ServiceCreator with only APIAP code
* Test only Backend API of APIAP for ProviderAccountManager