### PR TITLE
Make APIAP always enabled in code level; ignore yaml config

### DIFF
--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -301,11 +301,7 @@ module Logic
 
       class ApiAsProduct < Base
         def enabled?
-          super && !master?
-        end
-
-        def missing_config
-          false
+          !master?
         end
       end
 


### PR DESCRIPTION
This way it will be safe to assume at the code level that `provider_can_use?(:api_as_product)` is always true (except for master).
This will allow us to safely merge to master and deploy small chunks of removing the non-APIAP logic.
