### PR TITLE
New active docs tweak

### DIFF
--- a/app/views/admin/api_docs/base/_form.html.slim
+++ b/app/views/admin/api_docs/base/_form.html.slim
@@ -1,6 +1,8 @@
 - content_for :javascripts do
   = javascript_include_tag 'provider/codemirror'
 
+- commit_button_label = action_name == 'edit' ? 'Update Spec' : 'Create Spec'
+
 = form.inputs do
   = form.input :name
   - if @api_docs_service.new_record?
@@ -15,7 +17,7 @@
   = form.semantic_errors :base_path
   = form.input :skip_swagger_validations, as: :boolean
 = form.buttons do
-  = form.commit_button
+  = form.commit_button commit_button_label
 
 css:
   #api_docs_service_body_input .CodeMirror {

--- a/app/views/admin/api_docs/base/edit.html.erb
+++ b/app/views/admin/api_docs/base/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :sublayout_title, 'ActiveDocs' %>
-<h2>ActiveDocs: Edit Service Spec</h2>
-<%= semantic_form_for @api_docs_service, url: update_api_docs_service_path(@api_docs_service), html: {id: 'new-api-docs'} do |form| %>
+
+<%= semantic_form_for @api_docs_service, url: update_api_docs_service_path(@api_docs_service), html: {id: 'edit-api-docs'} do |form| %>
   <%= render partial: 'form', locals: {form: form} %>
 <% end %>

--- a/app/views/admin/api_docs/base/new.html.erb
+++ b/app/views/admin/api_docs/base/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :sublayout_title, 'ActiveDocs' %>
-<h2>ActiveDocs: New Service Spec</h2>
+
 <%= semantic_form_for @api_docs_service, url: create_api_docs_service_path(@api_docs_service.service), html: {id: 'new-api-docs'} do |form| %>
   <%= render partial: 'form', locals: {form: form} %>
 <% end %>

--- a/features/old/providers/active_docs_v2.feature
+++ b/features/old/providers/active_docs_v2.feature
@@ -45,7 +45,6 @@ Feature: ActiveDocs
     When I go to the provider active docs page
     Then I should see "ActiveDocs"
     When I follow "Edit" within the row for echo active docs
-    Then I should see "Edit Service Spec"
     And I press "Update Spec"
     Then I should see "ActiveDocs Spec was successfully updated."
 

--- a/features/old/providers/active_docs_v2.feature
+++ b/features/old/providers/active_docs_v2.feature
@@ -37,7 +37,7 @@ Feature: ActiveDocs
         }
     }
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then I should see "ActiveDocs Spec was successfully saved."
     And I should see "Product API"
 
@@ -46,7 +46,7 @@ Feature: ActiveDocs
     Then I should see "ActiveDocs"
     When I follow "Edit" within the row for echo active docs
     Then I should see "Edit Service Spec"
-    And I press "Update Service"
+    And I press "Update Spec"
     Then I should see "ActiveDocs Spec was successfully updated."
 
   Scenario: CRUD -- Create / Publish / Hide / Delete
@@ -58,13 +58,13 @@ Feature: ActiveDocs
     """
     {"name":"godzilla"}
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then I should see "JSON Spec is invalid"
     When I fill in the API JSON Spec with:
     """
     {"swaggerVersion":"1.2", "basePath": "https://echo-api.3scale.net", "apis":[]}
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then I should see "ActiveDocs Spec was successfully saved."
     When I follow "Publish"
     Then I should see "Spec UberAPI published"
@@ -110,7 +110,7 @@ Feature: ActiveDocs
  ]
 }
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then I should see "ActiveDocs Spec was successfully saved."
     And the swagger autocomplete should work for "user_key" with "user_keys"
 
@@ -155,7 +155,7 @@ Feature: ActiveDocs
    }
 }
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then should see "ActiveDocs Spec was successfully saved."
     And the swagger autocomplete should work for "user_key" with "user_keys"
 
@@ -198,6 +198,6 @@ Feature: ActiveDocs
    }
 }
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then should see "ActiveDocs Spec was successfully saved."
     And swagger should escape properly the curl string

--- a/features/old/providers/active_docs_v3.feature
+++ b/features/old/providers/active_docs_v3.feature
@@ -44,7 +44,7 @@ Feature: ActiveDocs
       }
     }
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then I should see "ActiveDocs Spec was successfully saved."
     And I should see "Simple API overview"
 
@@ -57,7 +57,7 @@ Feature: ActiveDocs
     """
     {"name":"godzilla"}
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then I should see "JSON Spec is invalid"
     When I fill in the API JSON Spec with:
     """
@@ -89,7 +89,7 @@ Feature: ActiveDocs
       }
     }
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then I should see "ActiveDocs Spec was successfully saved."
     When I follow "Publish"
     Then I should see "Spec UberAPI published"
@@ -140,7 +140,7 @@ Feature: ActiveDocs
       }
     }
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then should see "ActiveDocs Spec was successfully saved."
     And the swagger v3 autocomplete should work for "user_key" with "user_keys"
 
@@ -186,6 +186,6 @@ Feature: ActiveDocs
       }
     }
     """
-    And I press "Create Service"
+    And I press "Create Spec"
     Then should see "ActiveDocs Spec was successfully saved."
     And swagger v3 should escape properly the curl string

--- a/features/step_definitions/active_docs_steps.rb
+++ b/features/step_definitions/active_docs_steps.rb
@@ -11,7 +11,7 @@ When /^I try to (create|update) the active docs( of the service)? with (in)?vali
   fill_in('Name', with: 'ActiveDocsName')
   api_spec = invalid ? 'invalid' : FactoryBot.build(:api_docs_service).body
   fill_in('API JSON Spec', with: api_spec)
-  click_on "#{action.capitalize!} Service"
+  click_on "#{action.capitalize!} Spec"
 end
 
 When /^I select a service from the service selector$/ do


### PR DESCRIPTION
2 minor changes to the "new active doc" page.
Current:
<img width="888" alt="Screenshot 2020-12-11 at 18 49 05" src="https://user-images.githubusercontent.com/11672286/101937053-a5c89b00-3be1-11eb-83c2-70206d689fae.png">

New:
<img width="888" alt="Screenshot 2020-12-11 at 18 46 50" src="https://user-images.githubusercontent.com/11672286/101937078-ac571280-3be1-11eb-82a1-9a005dda2c5c.png">
