### PR TITLE
[DOCs] Update INSTALL.md for Mac 11.0.1 Big Sur - DEC 2020

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,7 +56,7 @@ to stop the application, run:
 make dev-stop
 ```
 
-## Manual setup on Mac OS X (10.13 - 10.15)
+## Manual setup on Mac OS X (10.13 - 11.0)
 
 ### Prerequisites
 
@@ -70,11 +70,18 @@ Verify you have a proper version by running on your terminal:
 ruby -v
 ```
 
-> Mac OS X 10.13 comes with 2.3.7 but you can also use [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/) to install other ruby version.
+> We recommend using [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/) to install any ruby version.
+
+Example with RVM:
+```bash
+gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+\curl -sSL https://get.rvm.io | bash -s stable
+rvm install 2.5
+```
 
 #### Node version
 
-The project supports **Version: 8.X.X**.
+The project supports **Version: 10.X.X**.
 
 You might want to use [nvm](https://github.com/creationix/nvm/) to install and work with specific Node versions:
 
@@ -85,14 +92,13 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | 
 Restart the terminal and install Node:
 
 ```bash
-nvm install 8
-nvm use 8
+nvm install 10 && nvm use 10
 ```
 
 ###### As an alternative for Mac OS, and if you don't want multiple Node versions, you could use homebrew:
 
 ```bash
-brew install node@8
+brew install node@10
 ```
 
 #### Xcode
@@ -163,9 +169,12 @@ cp config/examples/* config/
 
 #### Bundle
 
-On MacOS 10.15 first configure the bundle config with:
+On MacOS 10.15 or newer, first configure the bundle config with:
 ```shell
+bundle config --global build.eventmachine --with-cppflags=-I/usr/local/opt/openssl/include
 bundle config --global build.mysql2 "--with-opt-dir=/usr/local/opt/openssl"
+bundle config --local build.github-markdown --with-cflags="-Wno-error=implicit-function-declaration"
+bundle config --local build.thin --with-cflags="-Wno-error=implicit-function-declaration"
 ```
 
 Run [Bundler](https://bundler.io/) to install all required Ruby gems:
@@ -314,7 +323,7 @@ You may need to set up the database from scratch again, in that case, use `db:re
 bundle exec rake db:reset # This will drop and set up the database
 ```
 
-**NOTE:** This will seed the application and creates the Master, Provider & Developer accounts that are accessible through: `http://master-account.3scale.localhost:3000/`, `http://provider-admin.3scale.localhost:3000/`, `http://provider.3scale.localhost:3000/` respectively. 
+**NOTE:** This will seed the application and creates the Master, Provider & Developer accounts that are accessible through: `http://master-account.3scale.localhost:3000/`, `http://provider-admin.3scale.localhost:3000/`, `http://provider.3scale.localhost:3000/` respectively.
 Note down the credentials generated at this moment, to log in to each of the portals above.
 
 ## Run Porta


### PR DESCRIPTION
It was outdated. For me, it was easy to install it a few days ago, but that's because I am part of the team and for anyone new, it would be much harder.

On top of this update, I would suggest to Andreu from Product a few more things.

1. Do it all without Docker. Install directly.
2. I am using ZSH and my `~/.zshrc` contains this at the end to be able to read the PATH correctly in the terminal (`source ~/.zshrc`):
```bash
export PATH="/usr/local/opt/openssl@1.1/bin:$PATH"
export PATH="$PATH:$HOME/.rvm/bin"
export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"
export PATH="/usr/local/opt/imagemagick@6/bin:$PATH"
export NVM_DIR=~/.nvm
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
```
So my PATH looks like this: `/Users/marta/.rvm/gems/ruby-2.5.7/bin:/Users/marta/.rvm/gems/ruby-2.5.7@global/bin:/Users/marta/.rvm/rubies/ruby-2.5.7/bin:/Users/marta/.nvm/versions/node/v10.23.0/bin:/usr/local/opt/imagemagick@6/bin:/usr/local/opt/mysql@5.7/bin:/usr/local/opt/openssl@1.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/usr/local/MacGPG2/bin:/Library/Apple/usr/bin:/Users/marta/.rvm/bin`

3. Clean redis and run Sidekiq before creating the DB (`redis-cli flushall &&  bundle exec sidekiq -q default -q low `), then create the DB with `bundle exec rake db:create db:setup` and then for simplicity do this in the console (`bundle exec rails console`):
```ruby
User.find_each { |u| u.update!(password: '123456'); u.activate }
Account.find_each { |a| a.update!(site_access_code: ''); a.approve }
```
So your password will be simply '123456' and no site access code for the dev portal.

4. Start the server with these 2 tabs:
- `UNICORN_WORKERS=8 RAILS_LOG_TO_STDOUT=1 bundle exec rails server`
- `bundle exec rake webpack:dev`

Your URLs are:
- http://master-account.3scale.localhost:3000/
- http://provider-admin.3scale.localhost:3000/
- http://provider.3scale.localhost:3000/
