### PR TITLE
ENV THREESCALE_PAYMENTS_ENABLED to be able to 'charge' payments in Development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.three_scale.payments.enabled = false
+  config.three_scale.payments.enabled = ENV.fetch('THREESCALE_PAYMENTS_ENABLED', '0') == '1'
 
   config.three_scale.rolling_updates.raise_error_unknown_features = true
   config.three_scale.rolling_updates.enabled = ENV.fetch('THREESCALE_ROLLING_UPDATES', '0') == '0'


### PR DESCRIPTION
To be able to test charging payments locally without having to edit the file with `true` or `false` all the time and then remember to skip it from `git` changes.

Usage: `THREESCALE_PAYMENTS_ENABLED=1`
For example: `THREESCALE_PAYMENTS_ENABLED=1 bundle exec rails console` or `THREESCALE_PAYMENTS_ENABLED=1 UNICORN_WORKERS=8 RAILS_LOG_TO_STDOUT=1 bundle exec rails server`

Just to be clear, 'charging' payments does not necessarily mean moving real money... it can be done with a testing environment payment gateway integration like I am doing 😄 