### PR TITLE
Updating SDK version in Braintree

### DIFF
--- a/app/views/payment_gateways/_braintree_customer_form.html.erb
+++ b/app/views/payment_gateways/_braintree_customer_form.html.erb
@@ -127,8 +127,8 @@
     <%= hidden_field_tag 'braintree[nonce]', nil, id: 'braintree_nonce' %>
 <% end %>
 
-<script src="https://js.braintreegateway.com/web/3.46.0/js/client.min.js"></script>
-<script src="https://js.braintreegateway.com/web/3.46.0/js/hosted-fields.min.js"></script>
+<script src="https://js.braintreegateway.com/web/3.69.0/js/client.min.js"></script>
+<script src="https://js.braintreegateway.com/web/3.69.0/js/hosted-fields.min.js"></script>
 <script type="text/javascript" charset="utf-8">
     var $form = $('#customer_form');
     var submit = document.querySelector('input[type="submit"]');

--- a/app/views/provider/admin/account/payment_gateways/braintree_blue/edit.html.slim
+++ b/app/views/provider/admin/account/payment_gateways/braintree_blue/edit.html.slim
@@ -95,8 +95,8 @@ p
     li.commit
       = form.submit 'Save credit card', class: 'important-button'
 
-script src="https://js.braintreegateway.com/web/3.46.0/js/client.min.js"
-script src="https://js.braintreegateway.com/web/3.46.0/js/hosted-fields.min.js"
+script src="https://js.braintreegateway.com/web/3.69.0/js/client.min.js"
+script src="https://js.braintreegateway.com/web/3.69.0/js/hosted-fields.min.js"
 javascript:
   var $form = $('#new_customer');
   var submit = document.querySelector('input[type="submit"]');


### PR DESCRIPTION
3D Secure 2.0 requires SDK version 3.52.0 or higher.
Closes [THREESCALE-6527](https://issues.redhat.com/browse/THREESCALE-6527)