### PR TITLE
Gem activemerchant version '1.107.4' before Ruby 2.4 deprecation (with monkeypatch)

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -61,7 +61,7 @@ gem 'yabeda-prometheus-mmap'
 gem 'yabeda-rails'
 gem 'yabeda-sidekiq'
 
-gem 'activemerchant', '~> 1.113.0'
+gem 'activemerchant', '~> 1.107.4'
 gem 'stripe', '~> 5.28.0' # we need the stripe gem because activemerchant can not generate Stripe's "customers"
 gem 'audited'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     activejob (5.0.7.2)
       activesupport (= 5.0.7.2)
       globalid (>= 0.3.6)
-    activemerchant (1.113.0)
+    activemerchant (1.107.4)
       activesupport (>= 4.2)
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.9)
@@ -822,7 +822,7 @@ DEPENDENCIES
   3scale_time_range (= 0.0.6)
   RedCloth (~> 4.3)
   active-docs!
-  activemerchant (~> 1.113.0)
+  activemerchant (~> 1.107.4)
   activemodel-serializers-xml
   activerecord-oracle_enhanced-adapter (~> 1.7.0)
   acts-as-taggable-on (~> 4.0)

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -128,7 +128,7 @@ GEM
     activejob (5.0.7.2)
       activesupport (= 5.0.7.2)
       globalid (>= 0.3.6)
-    activemerchant (1.113.0)
+    activemerchant (1.107.4)
       activesupport (>= 4.2)
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.9)
@@ -823,7 +823,7 @@ DEPENDENCIES
   3scale_time_range (= 0.0.6)
   RedCloth (~> 4.3)
   active-docs!
-  activemerchant (~> 1.113.0)
+  activemerchant (~> 1.107.4)
   activemodel-serializers-xml
   activerecord-oracle_enhanced-adapter (~> 1.7.0)
   acts-as-taggable-on (~> 4.0)

--- a/config/initializers/active_merchant.rb
+++ b/config/initializers/active_merchant.rb
@@ -9,3 +9,21 @@ if Rails.application.config.three_scale.active_merchant_logging
   ActiveMerchant::Billing::Gateway.wiredump_device = Rails.root.join('log/activemerchant.log').open('a')
   ActiveMerchant::Billing::Gateway.wiredump_device.sync = true
 end
+
+ActiveMerchant::Billing::StripeGateway.prepend(Module.new do
+  def headers(options = {})
+    key = options[:key] || @api_key
+    idempotency_key = options[:idempotency_key]
+
+    headers = {
+      'Authorization' => 'Basic ' + Base64.encode64(key.to_s + ':').strip.delete("\n"),
+      'User-Agent' => "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
+      'Stripe-Version' => api_version(options),
+      'X-Stripe-Client-User-Agent' => stripe_client_user_agent(options),
+      'X-Stripe-Client-User-Metadata' => {ip: options[:ip]}.to_json
+    }
+    headers['Idempotency-Key'] = idempotency_key if idempotency_key
+    headers['Stripe-Account'] = options[:stripe_account] if options[:stripe_account]
+    headers
+  end
+end)


### PR DESCRIPTION
Fixes [THREESCALE-6534](https://issues.redhat.com/browse/THREESCALE-6534) 🤞🏼 

I've also tested in Preview to ensure that it works for Ruby 2.4 just as we have it in Production. However, testing this in Preview is not as trivial as just following the PDF guide in the Jira Epic for a couple of reasons:
1. [This configuration for preview](https://github.com/3scale/porta/blob/091832b55730a9145c2cf1f6190663145f99f790/config/environments/preview.rb#L32) and [this line of logic in the code](https://github.com/3scale/porta/blob/091832b55730a9145c2cf1f6190663145f99f790/app/models/payment_transaction.rb#L27) together reject payments in preview, which is good for security, but for testing what I have personally done is deploying to preview with a branch changing that line of code for this: `if System::Application.config.three_scale.payments.enabled || %w[2445583175001 2445583388807].include?(account.provider_account.id.to_s)`, being those 2 ids my tenants so I can test with them and I also keep the safety of not making real payments for everybody else.
2. [THREESCALE-6541](https://issues.redhat.com/browse/THREESCALE-6541)