### PR TITLE
Bumps braintree gem

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -66,7 +66,7 @@ gem 'stripe', '~> 5.28.0' # we need the stripe gem because activemerchant can no
 gem 'audited'
 
 gem 'acts_as_list', '~> 0.9.17'
-gem 'braintree', '~> 2.89'
+gem 'braintree', '~> 2.93'
 gem 'cancancan', '~> 2.3.0'
 gem 'formtastic', '~> 1.2.4'
 gem 'rmagick', '~> 2.15.3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
-    braintree (2.91.0)
+    braintree (2.104.1)
       builder (>= 2.0.0)
     browser (2.6.1)
     bugsnag (6.11.1)
@@ -837,7 +837,7 @@ DEPENDENCIES
   baby_squeel (~> 1.3.1)
   bcrypt (~> 3.1.7)
   bootsnap (~> 1.4)
-  braintree (~> 2.89)
+  braintree (~> 2.93)
   browser
   bugsnag (~> 6.11)
   bullet (~> 5.6)

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -192,7 +192,7 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
-    braintree (2.91.0)
+    braintree (2.104.1)
       builder (>= 2.0.0)
     browser (2.6.1)
     bugsnag (6.11.1)
@@ -838,7 +838,7 @@ DEPENDENCIES
   baby_squeel (~> 1.3.1)
   bcrypt (~> 3.1.7)
   bootsnap (~> 1.4)
-  braintree (~> 2.89)
+  braintree (~> 2.93)
   browser
   bugsnag (~> 6.11)
   bullet (~> 5.6)


### PR DESCRIPTION
It bumps https://github.com/braintree/braintree_ruby to [v2.104.1](https://github.com/braintree/braintree_ruby/tree/2.104.1), which (among other things) extends risk data support (adding `fraud_service_provider` and other fields) and introduces some 3D-Secure-related enhancements.

Closes [THREESCALE-6558](https://issues.redhat.com/browse/THREESCALE-6558) and possibly [THREESCALE-6550](https://issues.redhat.com/browse/THREESCALE-6550).

----

**Tested in preview (without 3D-Secure):**

<img width="1441" alt="cc-in-3scale" src="https://user-images.githubusercontent.com/1842261/103905355-c9a6d000-50fe-11eb-9546-c86e890d543c.png">
<img width="1613" alt="customer-in-braintree" src="https://user-images.githubusercontent.com/1842261/103905368-cdd2ed80-50fe-11eb-8236-68171fb3281d.png">
<img width="1614" alt="invoice-in-3scale" src="https://user-images.githubusercontent.com/1842261/103905521-01ae1300-50ff-11eb-814b-d95d4d8f1e99.png">
<img width="1612" alt="transaction-in-braintree" src="https://user-images.githubusercontent.com/1842261/103905369-ce6b8400-50fe-11eb-95e7-92a5b8e1d79e.png">
