### PR TITLE
[Bugfix][Stripe - Save CC] When a human clicks on 'Save', confirm to Stripe; When Stripe confirms, Submit form to the 3scale Porta server

### DIFF
--- a/app/views/payment_gateways/_stripe.html.erb
+++ b/app/views/payment_gateways/_stripe.html.erb
@@ -96,38 +96,33 @@
 
       document.getElementById('stripe_payment_method_id').value = setupIntent.payment_method;
 
-      stripeForm.submit();
+      stripeForm[0].submit();
     } else {
       alert(result.error.message);
     }
   }
 
   stripeForm.submit(function(e) {
-    if (e.originalEvent === undefined) {
-      return true;
-    } else {
-      e.preventDefault();
-      var intentSecret = stripeForm.data('secret');
+    e.preventDefault();
+    var intentSecret = stripeForm.data('secret');
 
-      var billingAddressDetails = {
-        line1: "<%= j billing_address.address1 %>",
-        line2: "<%= j billing_address.address2 %>",
-        city: "<%= j billing_address.city %>",
-        state: "<%= j billing_address.state %>",
-        postal_code: "<%= j billing_address.zip %>",
-        country: "<%= j billing_address.country %>"
-      }
-
-      stripe.confirmCardSetup(intentSecret, {
-        payment_method: {
-          card: card,
-          billing_details: {
-            address: billingAddressDetails
-          }
-        }
-      }).then(handleIntentResult);
-      return false;
+    var billingAddressDetails = {
+      line1: "<%= j billing_address.address1 %>",
+      line2: "<%= j billing_address.address2 %>",
+      city: "<%= j billing_address.city %>",
+      state: "<%= j billing_address.state %>",
+      postal_code: "<%= j billing_address.zip %>",
+      country: "<%= j billing_address.country %>"
     }
+
+    stripe.confirmCardSetup(intentSecret, {
+      payment_method: {
+        card: card,
+        billing_details: {
+          address: billingAddressDetails
+        }
+      }
+    }).then(handleIntentResult);
   });
 
 </script>

--- a/app/views/payment_gateways/_stripe.html.erb
+++ b/app/views/payment_gateways/_stripe.html.erb
@@ -103,26 +103,31 @@
   }
 
   stripeForm.submit(function(e) {
-    e.preventDefault();
-    var intentSecret = stripeForm.data('secret');
+    if (e.originalEvent === undefined) {
+      return true;
+    } else {
+      e.preventDefault();
+      var intentSecret = stripeForm.data('secret');
 
-    var billingAddressDetails = {
-      line1: "<%= j billing_address.address1 %>",
-      line2: "<%= j billing_address.address2 %>",
-      city: "<%= j billing_address.city %>",
-      state: "<%= j billing_address.state %>",
-      postal_code: "<%= j billing_address.zip %>",
-      country: "<%= j billing_address.country %>"
-    }
-
-    stripe.confirmCardSetup(intentSecret, {
-      payment_method: {
-        card: card,
-        billing_details: {
-          address: billingAddressDetails
-        }
+      var billingAddressDetails = {
+        line1: "<%= j billing_address.address1 %>",
+        line2: "<%= j billing_address.address2 %>",
+        city: "<%= j billing_address.city %>",
+        state: "<%= j billing_address.state %>",
+        postal_code: "<%= j billing_address.zip %>",
+        country: "<%= j billing_address.country %>"
       }
-    }).then(handleIntentResult);
+
+      stripe.confirmCardSetup(intentSecret, {
+        payment_method: {
+          card: card,
+          billing_details: {
+            address: billingAddressDetails
+          }
+        }
+      }).then(handleIntentResult);
+      return false;
+    }
   });
 
 </script>


### PR DESCRIPTION
Closes [THREESCALE-6573](https://issues.redhat.com/browse/THREESCALE-6573)

It is not the cleanest solution, but the cleaning process must be inside #2334, and this way, we allow customers to save credit cards in the meantime.