### PR TITLE
[WIP] [Bugfix] ActionView::Template::Error in developer_portal/admin/accounts#show (undefined method `client_secret')

### DIFF
--- a/app/views/payment_gateways/_stripe.html.erb
+++ b/app/views/payment_gateways/_stripe.html.erb
@@ -1,6 +1,6 @@
 <div id="stripe-form-wrapper"
-  data-stripe-publishable-key="<%= @stripe_publishable_key %>"
-  data-setup-intent-secret="<%= @intent.client_secret %>"
+  data-stripe-publishable-key="<%= stripe_publishable_key %>"
+  data-setup-intent-secret="<%= intent.client_secret %>"
   data-billing-address="<%= stripe_billing_address_json %>"
   data-success-url="<%= hosted_success_admin_account_stripe_path %>"
   data-credit-card-stored="<%= current_account.credit_card_stored? %>">

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/stripe_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/stripe_controller.rb
@@ -4,8 +4,6 @@ module DeveloperPortal::Admin::Account
   class StripeController < PaymentDetailsBaseController
 
     def show
-      @stripe_publishable_key = site_account.payment_gateway_options[:publishable_key]
-      @intent = stripe_crypt.create_stripe_setup_intent
       render template: 'accounts/payment_gateways/show'
     end
 

--- a/lib/developer_portal/lib/liquid/tags/stripe_form.rb
+++ b/lib/developer_portal/lib/liquid/tags/stripe_form.rb
@@ -5,7 +5,10 @@ module Liquid
     class StripeForm < Liquid::Tags::PaymentGatewayBaseForm
       desc 'Renders the stripe form'
       def render(context)
-        render_erb context, 'payment_gateways/stripe', text: @text
+        controller = context.registers[:controller]
+        stripe_publishable_key = controller.send(:site_account).payment_gateway_options[:publishable_key]
+        intent = PaymentGateways::StripeCrypt.new(controller.send(:current_user)).create_stripe_setup_intent
+        render_erb context, 'payment_gateways/stripe', text: @text, intent: intent, stripe_publishable_key: stripe_publishable_key
       end
     end
   end

--- a/test/unit/liquid/tags/stripe_form_test.rb
+++ b/test/unit/liquid/tags/stripe_form_test.rb
@@ -1,14 +1,29 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class StripeFormTest < ActiveSupport::TestCase
-  def setup
-    @context = Liquid::Context.new
-    @context.registers[:controller] = ActionController::Base.new
-    @stripe = Liquid::Tags::StripeForm.parse 'stripe_form', '', [], {}
-  end
+  test 'renders stripe with the right params' do
+    context = Liquid::Context.new
+    controller = DeveloperPortal::BaseController.new
+    context.registers[:controller] = controller
+    stripe = Liquid::Tags::StripeForm.parse 'stripe_form', '', [], {}
 
-  def test_renders_with_stripe
-    @stripe.expects(:render_erb).with(@context, 'payment_gateways/stripe', text: 'Edit Credit Card Details')
-    @stripe.render(@context)
+    setup_intent = Stripe::SetupIntent.new(id: 'seti_1I5s0l2eZvKYlo2CjumP89gc').tap { |si| si.update_attributes(client_secret: 'seti_1I6Fs82eZvKYlo2COrbF4OYY_secret_IhfCWxVPnPaXIYPlr9ORrd5noJDnDW7') }
+    PaymentGateways::StripeCrypt.any_instance.expects(:create_stripe_setup_intent).returns(setup_intent)
+
+    provider = FactoryBot.create(:simple_provider, payment_gateway_type: :stripe, payment_gateway_options: {login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx'})
+    buyer = FactoryBot.create(:simple_buyer, provider_account: provider)
+    user = FactoryBot.create(:admin, account: buyer)
+
+    request = ActionDispatch::TestRequest.create
+    request.host = provider.domain
+    controller.stubs(request: request)
+    controller.stubs(current_user: user)
+    context.registers[:request] = request
+
+    stripe.expects(:render_erb).with(context, 'payment_gateways/stripe', text: 'Edit Credit Card Details', intent: setup_intent, stripe_publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx')
+
+    stripe.render(context)
   end
 end


### PR DESCRIPTION
Closes [THREESCALE-6590](https://issues.redhat.com/browse/THREESCALE-6590)

The problem is when loading the `stripe_form` liquid tag in a request that is not `/admin/account/stripe`. In the case of this tenant from `/account/show`. And we kinda allow that since `stripe_form` is documented liquid for tenants to use it in their Developer Portal.

But to be honest, I am not happy with this solution, because, although it works, it is taking responsibility that IMO belongs to the controller, and by allowing the use of certain liquid outside their intended controllers, we will end up moving a lot of the responsibility of the controllers to the inside of this `render` of each liquid.

### TODO
I've spoken with Hery and the solution will be from the JS making an AJAX call to our server to retrieve the setup intent client secret and needed data as JSON instead of just doing this in rendering the view.
You can use it or cache it for later.
Because adding a drop just for creating setup intent is a no-no. And it should always live in a controller.
Customers could build their own checkout page anywhere as they will have the setup intent created already, closer to an API drive dev portal.