### PR TITLE
Stripe async payment intents

### DIFF
--- a/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
+++ b/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::BaseController
+  before_action :ensure_stripe_payment_gateway
+
+  class StripeCallbackError < StandardError; end
+  class InvalidStripeEvent < StripeCallbackError; end
+
+  # Undocumented endpoint used for update callbacks of async-authorized payment transactions (mostly due to SCA regulations)
+  def create
+    sig_header = request.headers['Stripe-Signature']
+    endpoint_secret = 'whsec_6LXKKvZM3Sbf4gv5dHoZ7WTXB08vp14N' # TODO: fetch from provider's payment gateway settings
+
+    stripe_event = Stripe::Webhook.construct_event(request.raw_post, sig_header, endpoint_secret)
+    payment_intent_data = case stripe_event.type # Also checked by PaymentIntent#update_from_stripe_event, but here it can save us some processing and ensure an immediate response at the level of the controller in case of unsupported event types
+                          when 'payment_intent.succeeded'
+                            stripe_event.data.object
+                          else
+                            raise InvalidStripeEvent
+                          end
+
+    payment_intent = PaymentIntent.by_invoice(current_account.buyer_invoices).find_by!(payment_intent_id: payment_intent_data['id'])
+
+    unless payment_intent.update_from_stripe_event(stripe_event)
+      exception = StripeCallbackError.new('Cannot update Stripe payment intent')
+      System::ErrorReporting.report_error(exception, event: stripe_event, payment_intent: payment_intent)
+    end
+
+    head :ok
+  rescue JSON::ParserError, Stripe::SignatureVerificationError
+    render_error('Signature verification failed', status: :bad_request)
+  rescue InvalidStripeEvent
+    render_error(:not_found, status: :not_found)
+  end
+
+  protected
+
+  def ensure_stripe_payment_gateway
+    return if current_account.payment_gateway_type == :stripe
+    render_error(:not_found, status: :not_found)
+    false
+  end
+end

--- a/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
+++ b/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
@@ -5,11 +5,14 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::
 
   class StripeCallbackError < StandardError; end
   class InvalidStripeEvent < StripeCallbackError; end
+  class MissingStripeEndpointSecret < StripeCallbackError; end
 
   # Undocumented endpoint used for update callbacks of async-authorized payment transactions (mostly due to SCA regulations)
   def create
     sig_header = request.headers['Stripe-Signature']
-    endpoint_secret = 'whsec_6LXKKvZM3Sbf4gv5dHoZ7WTXB08vp14N' # TODO: fetch from provider's payment gateway settings
+    endpoint_secret = payment_gateway_options[:endpoint_secret].presence
+
+    raise MissingStripeEndpointSecret unless endpoint_secret
 
     stripe_event = Stripe::Webhook.construct_event(request.raw_post, sig_header, endpoint_secret)
     payment_intent_data = case stripe_event.type # Also checked by PaymentIntent#update_from_stripe_event, but here it can save us some processing and ensure an immediate response at the level of the controller in case of unsupported event types
@@ -23,7 +26,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::
 
     unless payment_intent.update_from_stripe_event(stripe_event)
       exception = StripeCallbackError.new('Cannot update Stripe payment intent')
-      System::ErrorReporting.report_error(exception, event: stripe_event, payment_intent: payment_intent)
+      report_error(exception, event: stripe_event, payment_intent: payment_intent)
     end
 
     head :ok
@@ -31,13 +34,20 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::
     render_error('Signature verification failed', status: :bad_request)
   rescue InvalidStripeEvent
     render_error(:not_found, status: :not_found)
+  rescue MissingStripeEndpointSecret => exception
+    report_error(exception)
+    render_error('Configuration is missing', status: :unprocessable_entity)
   end
 
   protected
 
   def ensure_stripe_payment_gateway
-    return if current_account.payment_gateway_type == :stripe
+    return if payment_gateway_type == :stripe
     render_error(:not_found, status: :not_found)
     false
   end
+
+  delegate :payment_gateway_type, :payment_gateway_options, to: :current_account
+
+  delegate :report_error, to: System::ErrorReporting
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -37,6 +37,7 @@ class Invoice < ApplicationRecord
   has_many :line_items, -> { oldest_first }, dependent: :destroy, inverse_of: :invoice
 
   has_many :payment_transactions, -> { oldest_first }, dependent: :nullify, inverse_of: :invoice
+  has_many :payment_intents, dependent: :destroy, inverse_of: :invoice
 
   has_attached_file :pdf, url: ':url_root/:class/:id/:attachment/:style/:basename.:extension'
   do_not_validate_attachment_file_type :pdf
@@ -518,6 +519,10 @@ class Invoice < ApplicationRecord
 
   def chargeable?
     !reason_cannot_charge
+  end
+
+  def latest_pending_payment_intent
+    payment_intents.latest_pending.first
   end
 
   def self.opened_by_buyer(buyer)

--- a/app/models/payment_gateway.rb
+++ b/app/models/payment_gateway.rb
@@ -14,7 +14,7 @@ class PaymentGateway
     PaymentGateway.new(:authorize_net, deprecated: true, login: 'LoginID', password: 'Transaction Key'),
     PaymentGateway.new(:braintree_blue, public_key: 'Public Key', merchant_id: 'Merchant ID', private_key: 'Private Key'),
     PaymentGateway.new(:ogone, deprecated: true, login: 'PSPID', password: 'Password', user: 'User Id', signature: "SHA-IN Pass phrase", signature_out: "SHA-OUT Pass phrase"),
-    PaymentGateway.new(:stripe, login: "Secret Key", publishable_key: "Publishable Key")
+    PaymentGateway.new(:stripe, login: 'Secret Key', publishable_key: 'Publishable Key', endpoint_secret: 'Webhook Signing Secret')
   ].freeze
 
   def self.bogus_enabled?

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -1,11 +1,40 @@
 # frozen_string_literal: true
 
 class PaymentIntent < ApplicationRecord
+  SUCCEEDED_STATES = %w[succeeded].freeze
+
   belongs_to :invoice, inverse_of: :payment_intents
 
   validates :invoice, :payment_intent_id, :state, presence: true
   validates :payment_intent_id, :state, length: { maximum: 255 }
 
   scope :latest, -> (count = 1) { reorder(created_at: :desc, id: :desc).limit(count) }
-  scope :latest_pending, -> (count = 1) { where.not(state: :succeeded).latest(count) }
+  scope :latest_pending, -> (count = 1) { where.not(state: SUCCEEDED_STATES).latest(count) }
+
+  scope :by_invoice, ->(invoice) { where(invoice: invoice) }
+
+  def succeeded?
+    SUCCEEDED_STATES.include?(state)
+  end
+
+  def update_from_stripe_event(event)
+    return unless event.type == 'payment_intent.succeeded'
+    return if succeeded? || invoice.paid?
+
+    payment_intent_data = event.data.object
+
+    transaction do
+      self.state = payment_intent_data['status']
+      amount = payment_intent_data['amount'].to_has_money(payment_intent_data['currency']&.upcase || invoice.currency) / 100.0
+      payment_transaction = build_payment_transaction(amount: amount, reference: payment_intent_data['id'], params: event.to_hash)
+      save && payment_transaction.save && invoice.pay
+    end
+  end
+
+  protected
+
+  def build_payment_transaction(attrs)
+    attributes = attrs.reverse_merge(action: :purchase, success: true, message: 'Payment confirmed')
+    invoice.payment_transactions.build(attributes, without_protection: true)
+  end
 end

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class PaymentIntent < ApplicationRecord
+  belongs_to :invoice, inverse_of: :payment_intents
+
+  validates :invoice, :payment_intent_id, :state, presence: true
+  validates :payment_intent_id, :state, length: { maximum: 255 }
+
+  scope :latest, -> (count = 1) { reorder(created_at: :desc, id: :desc).limit(count) }
+  scope :latest_pending, -> (count = 1) { where.not(state: :succeeded).latest(count) }
+end

--- a/app/models/payment_transaction.rb
+++ b/app/models/payment_transaction.rb
@@ -155,7 +155,7 @@ class PaymentTransaction < ApplicationRecord
   def purchase_with_stripe(credit_card_auth_code, gateway, gateway_options)
     options = gateway_options.merge(customer: credit_card_auth_code)
     payment_method_id = options.delete(:payment_method_id)
-    gateway.purchase(amount.cents, payment_method_id, options)
+    stripe_service = Finance::StripeChargeService.new(gateway, payment_method_id: payment_method_id, invoice: invoice, gateway_options: options)
+    stripe_service.charge(amount)
   end
-
 end

--- a/app/services/finance/stripe_charge_service.rb
+++ b/app/services/finance/stripe_charge_service.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class Finance::StripeChargeService
+  def initialize(gateway, payment_method_id:, invoice: nil, gateway_options: {})
+    @gateway = gateway
+    @payment_method_id = payment_method_id
+    @invoice = invoice
+    @gateway_options = gateway_options
+  end
+
+  attr_reader :gateway, :payment_method_id, :invoice, :gateway_options
+
+  def charge(amount)
+    payment_intent = latest_pending_payment_intent
+    payment_intent ? confirm_payment_intent(payment_intent) : create_payment_intent(amount)
+  end
+
+  protected
+
+  delegate :latest_pending_payment_intent, to: :invoice, allow_nil: true
+
+  def create_payment_intent(amount)
+    response = gateway.purchase(amount.cents, payment_method_id, gateway_options)
+
+    with_payment_intent_data_from(response) do |payment_intent_data|
+      next unless invoice
+
+      payment_intent = invoice.payment_intents.create!(payment_intent_id: payment_intent_data['id'], state: payment_intent_data['status'])
+
+      # For PaymentIntent statuses and corresponding recommended actions see https://stripe.com/docs/payments/accept-a-payment-synchronously
+      # - succeeded                => no additional action > the payment has succeeded
+      # - requires_confirmation    => confirm the payment intent
+      # - requires_action          => check `payment_intent_data['next_action']` for instructions
+      # - requires_payment_method  => do not retry > the payment attempt has failed > ask cardholder to replace card data
+
+      case payment_intent.state
+      when 'succeeded'
+        next
+      when 'requires_confirmation'
+        confirm_payment_intent(payment_intent)
+      end
+    end
+  end
+
+  def confirm_payment_intent(payment_intent)
+    # Passing the gateway option `off_session: false` will cause a `requires_action` status on the payment intent in cases where otherwise it would be `requires_payment_method`.
+    # This happens even when the payment intent has been originally created with `off_session: true` – i.e. Stripe allows us to turn an "off_session" payment intent into an "on_session" one.
+    # Along with the `requires_action` status, the param `next_action.use_stripe_sdk.stripe_js` holds the next-step link to get the transaction authenticated
+    response = gateway.confirm_intent(payment_intent.payment_intent_id, payment_method_id, gateway_options)
+
+    with_payment_intent_data_from(response) do |payment_intent_data|
+      payment_intent_status = payment_intent_data['status']
+      payment_intent.update!(state: payment_intent_status)
+
+      next if payment_intent_status == 'succeeded' || !response.success?
+
+      # Because in some cases Stripe won't wrap the response of `/payment_intents/:id/confirm` into an 'error' and ActiveMerchant may think it was a success when it wasn't.
+      # See https://github.com/activemerchant/active_merchant/blob/b2f5e89eb383429d47e446f248d7bfe4f95ac3d0/lib/active_merchant/billing/gateways/stripe_payment_intents.rb#L299-L307
+      response.instance_variable_set(:@success, false)
+      response.instance_variable_set(:@message, payment_intent_status.humanize)
+    end
+  end
+
+  def with_payment_intent_data_from(response)
+    payment_intent_data = extract_payment_intent_data_from(response)
+    yield(payment_intent_data) if payment_intent_data.present?
+    response
+  end
+
+  def extract_payment_intent_data_from(response)
+    response_params = response.params
+    payment_intent_data = (response.success? ? response_params : response_params.dig('error', Stripe::PaymentIntent::OBJECT_NAME)) || {}
+    payment_intent_data if payment_intent_data['object'] == Stripe::PaymentIntent::OBJECT_NAME
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1041,6 +1041,10 @@ without fake Core server your after commit callbacks will crash and you might ge
           end
         end
 
+        namespace 'payment_callbacks', module: 'payment_callbacks' do
+          resources :stripe_callbacks, only: :create
+        end
+
         resources :accounts, :only => [], module: 'accounts' do
           resources :invoices, :only => [:index, :show]
         end

--- a/db/migrate/20210119101158_create_payment_intents.rb
+++ b/db/migrate/20210119101158_create_payment_intents.rb
@@ -1,0 +1,17 @@
+class CreatePaymentIntents < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def change
+    create_table :payment_intents do |t|
+      t.references :invoice, null: false
+      t.string :payment_intent_id
+      t.string :state
+      t.integer :tenant_id, limit: 8
+      t.timestamps null: false
+    end
+
+    index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+    add_index :payment_intents, :payment_intent_id, index_options
+    add_index :payment_intents, :state, index_options
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201222214415) do
+ActiveRecord::Schema.define(version: 20210119101158) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer  "owner_id",   precision: 38, null: false
@@ -917,6 +917,19 @@ ActiveRecord::Schema.define(version: 20201222214415) do
     t.datetime "updated_at",       precision: 6
     t.integer  "tenant_id",        precision: 38
   end
+
+  create_table "payment_intents", force: :cascade do |t|
+    t.integer  "invoice_id",        precision: 38, null: false
+    t.string   "payment_intent_id"
+    t.string   "state"
+    t.integer  "tenant_id",         precision: 38
+    t.datetime "created_at",        precision: 6,  null: false
+    t.datetime "updated_at",        precision: 6,  null: false
+  end
+
+  add_index "payment_intents", ["invoice_id"], name: "index_payment_intents_on_invoice_id"
+  add_index "payment_intents", ["payment_intent_id"], name: "index_payment_intents_on_payment_intent_id"
+  add_index "payment_intents", ["state"], name: "index_payment_intents_on_state"
 
   create_table "payment_transactions", force: :cascade do |t|
     t.integer  "account_id",           precision: 38

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201222214415) do
+ActiveRecord::Schema.define(version: 20210119101158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -873,6 +873,18 @@ ActiveRecord::Schema.define(version: 20201222214415) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.bigint   "tenant_id"
+  end
+
+  create_table "payment_intents", force: :cascade do |t|
+    t.integer  "invoice_id",        null: false
+    t.string   "payment_intent_id"
+    t.string   "state"
+    t.bigint   "tenant_id"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.index ["invoice_id"], name: "index_payment_intents_on_invoice_id", using: :btree
+    t.index ["payment_intent_id"], name: "index_payment_intents_on_payment_intent_id", using: :btree
+    t.index ["state"], name: "index_payment_intents_on_state", using: :btree
   end
 
   create_table "payment_transactions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201222214415) do
+ActiveRecord::Schema.define(version: 20210119101158) do
 
   create_table "access_tokens", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.bigint   "owner_id",                 null: false
@@ -872,6 +872,18 @@ ActiveRecord::Schema.define(version: 20201222214415) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.bigint   "tenant_id"
+  end
+
+  create_table "payment_intents", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
+    t.integer  "invoice_id",        null: false
+    t.string   "payment_intent_id"
+    t.string   "state"
+    t.bigint   "tenant_id"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.index ["invoice_id"], name: "index_payment_intents_on_invoice_id", using: :btree
+    t.index ["payment_intent_id"], name: "index_payment_intents_on_payment_intent_id", using: :btree
+    t.index ["state"], name: "index_payment_intents_on_state", using: :btree
   end
 
   create_table "payment_transactions", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|

--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -509,6 +509,12 @@ System::Database::MySQL.define do
     SQL
   end
 
+  trigger 'payment_intents' do
+    <<~SQL
+      SET NEW.tenant_id = (SELECT tenant_id FROM invoices WHERE id = NEW.invoice_id AND tenant_id <> master_id);
+    SQL
+  end
+
   trigger 'payment_gateway_settings' do
     <<~SQL
       IF NEW.account_id <> master_id THEN

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -525,6 +525,12 @@ System::Database::Oracle.define do
     SQL
   end
 
+  trigger 'payment_intents' do
+    <<~SQL
+      SELECT tenant_id INTO :new.tenant_id FROM invoices WHERE id = :new.invoice_id AND tenant_id <> master_id;
+    SQL
+  end
+
   trigger 'payment_gateway_settings' do
     <<~SQL
       IF :new.account_id <> master_id THEN

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -525,6 +525,12 @@ System::Database::Postgres.define do
     SQL
   end
 
+  trigger 'payment_intents' do
+    <<~SQL
+      SELECT tenant_id INTO NEW.tenant_id FROM invoices WHERE id = NEW.invoice_id AND tenant_id <> master_id;
+    SQL
+  end
+
   trigger 'payment_gateway_settings' do
     <<~SQL
       IF NEW.account_id <> master_id THEN

--- a/test/factories/payment_intent.rb
+++ b/test/factories/payment_intent.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:payment_intent) do
+    association :invoice
+    sequence(:payment_intent_id) { |n| "payment-intent-id-#{n}" }
+    state 'requires_action'
+  end
+end

--- a/test/functional/finance/provider/settings_controller_test.rb
+++ b/test/functional/finance/provider/settings_controller_test.rb
@@ -36,6 +36,7 @@ class Finance::Provider::SettingsControllerTest < ActionController::TestCase
 
       assert_select 'input[type=text][name=?]', 'account[payment_gateway_options][login]'
       assert_select 'input[type=text][name=?]', 'account[payment_gateway_options][publishable_key]'
+      assert_select 'input[type=text][name=?]', 'account[payment_gateway_options][endpoint_secret]'
     end
   end
 

--- a/test/integration/admin/account/payment_gateways_controller_test.rb
+++ b/test/integration/admin/account/payment_gateways_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::Account::PaymentGatewaysControllerTest < ActionDispatch::Integratio
   test 'update' do
     put admin_account_payment_gateway_path(@provider), account: {
       payment_gateway_type: 'stripe',
-      payment_gateway_options: { 'login' => 'bob', 'publishable_key' => 'monkey' }
+      payment_gateway_options: { 'login' => 'bob', 'publishable_key' => 'monkey', 'endpoint_secret' => 'some-secret' }
     }
 
     @provider.reload
@@ -23,7 +23,7 @@ class Admin::Account::PaymentGatewaysControllerTest < ActionDispatch::Integratio
     assert_equal 'Payment gateway details were successfully saved.', flash[:notice]
     assert_equal({
       'gateway_type' => 'stripe',
-      'gateway_settings' => {'login' => 'bob', 'publishable_key' => 'monkey'}
+      'gateway_settings' => { 'login' => 'bob', 'publishable_key' => 'monkey', 'endpoint_secret' => 'some-secret' }
     },
     @provider.gateway_setting.attributes.slice('gateway_type', 'gateway_settings'))
   end
@@ -52,7 +52,7 @@ class Admin::Account::PaymentGatewaysControllerTest < ActionDispatch::Integratio
 
     put admin_account_payment_gateway_path(@provider), account: {
       payment_gateway_type: 'stripe',
-      payment_gateway_options: { 'login' => 'bob', 'publishable_key' => 'monkey' }
+      payment_gateway_options: { 'login' => 'bob', 'publishable_key' => 'monkey', 'endpoint_secret' => 'some-secret' }
     }
 
     @provider.reload
@@ -60,7 +60,7 @@ class Admin::Account::PaymentGatewaysControllerTest < ActionDispatch::Integratio
     assert_redirected_to admin_finance_settings_url
     assert_equal 'Payment gateway details were successfully saved.', flash[:notice]
     assert_equal(
-      { 'gateway_type' => 'stripe', 'gateway_settings' => {'login' => 'bob', 'publishable_key' => 'monkey'} },
+      { 'gateway_type' => 'stripe', 'gateway_settings' => { 'login' => 'bob', 'publishable_key' => 'monkey', 'endpoint_secret' => 'some-secret' } },
       @provider.gateway_setting.attributes.slice('gateway_type', 'gateway_settings')
     )
   end

--- a/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
+++ b/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDispatch::IntegrationTest
+  class CreateTest < self
+    setup do
+      @provider_account = FactoryBot.create(:simple_provider, payment_gateway_type: :stripe, payment_gateway_options: { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc' })
+      provider_account.settings.allow_finance!
+      provider_admin = FactoryBot.create(:admin, account: provider_account)
+      @access_token = FactoryBot.create(:access_token, owner: provider_admin, scopes: %w[finance])
+
+      buyer_account = FactoryBot.create(:simple_buyer, provider_account: provider_account)
+      invoice = FactoryBot.create(:invoice, buyer_account: buyer_account, provider_account: provider_account)
+      @payment_intent = FactoryBot.create(:payment_intent, invoice: invoice, payment_intent_id: 'some-payment-intent-id')
+
+      login! provider_account
+    end
+
+    attr_reader :provider_account, :access_token, :payment_intent
+
+    test 'updates existing payment intent' do
+      stripe_event = self.stripe_event(type: 'payment_intent.succeeded', payment_intent_data: { id: 'some-payment-intent-id' })
+      Stripe::Webhook.expects(:construct_event).returns(stripe_event)
+
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      assert_response :ok
+    end
+
+    test 'invalid stripe signature' do
+      exception = Stripe::SignatureVerificationError.new('invalid signature', 'invalid header content')
+      Stripe::Webhook.expects(:construct_event).raises(exception)
+
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      assert_response :bad_request
+    end
+
+    test 'invalid json payload' do
+      Stripe::Webhook.expects(:construct_event).raises(JSON::ParserError)
+
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      assert_response :bad_request
+    end
+
+    test 'invalid event' do
+      stripe_event = self.stripe_event(type: 'payment_intent.requires_action', payment_intent_data: { id: 'some-payment-intent-id' })
+      Stripe::Webhook.expects(:construct_event).returns(stripe_event)
+
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      assert_response :not_found
+    end
+
+    test 'cannot find payment intent' do
+      stripe_event = self.stripe_event(type: 'payment_intent.requires_action', payment_intent_data: { id: 'non-existent-payment-intent-id' })
+      Stripe::Webhook.expects(:construct_event).returns(stripe_event)
+
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      assert_response :not_found
+    end
+
+    test 'fails to update payment intent' do
+      stripe_event = self.stripe_event(type: 'payment_intent.succeeded', payment_intent_data: { id: 'some-payment-intent-id' })
+      Stripe::Webhook.expects(:construct_event).returns(stripe_event)
+      invoices = provider_account.buyer_invoices
+      PaymentIntent.expects(:by_invoice).returns(invoices)
+      invoices.expects(:find_by!).with(payment_intent_id: 'some-payment-intent-id').returns(payment_intent)
+      payment_intent.expects(:update_from_stripe_event).returns(false)
+      System::ErrorReporting.expects(:report_error).at_least_once # because the setup doesn't really build all required objects
+      System::ErrorReporting.expects(:report_error).with(instance_of(Finance::Api::PaymentCallbacks::StripeCallbacksController::StripeCallbackError), event: stripe_event, payment_intent: payment_intent)
+
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      assert_response :ok
+    end
+
+    test 'not stripe gateway' do
+      provider_account.payment_gateway_type = :bogus
+      provider_account.save!
+
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      assert_response :not_found
+    end
+  end
+
+  protected
+
+  def stripe_payment_intent_data
+    { id: 'payment-intent-id', object: 'payment_intent', status: 'succeeded', amount: 85000, currency: 'eur' }
+  end
+
+  def stripe_event_data
+    { id: 'event-id', object: 'event', type: 'payment_intent.succeeded', data: { object: stripe_payment_intent_data } }
+  end
+
+  def stripe_event(type:, payment_intent_data: {})
+    Stripe::Event.construct_from(stripe_event_data.deep_merge(type: type, data: { object: payment_intent_data }))
+  end
+end

--- a/test/models/payment_intent_test.rb
+++ b/test/models/payment_intent_test.rb
@@ -38,6 +38,40 @@ class PaymentIntentTest < ActiveSupport::TestCase
     assert_same_elements records[1..-1], relation.latest_pending(2)
   end
 
+  test 'by_invoice' do
+    records = create_payment_intents
+    other_invoice = FactoryBot.create(:invoice)
+    other_record = FactoryBot.create(:payment_intent, invoice: other_invoice)
+
+    assert_same_elements records.map(&:id), PaymentIntent.by_invoice(invoice).pluck(:id)
+    assert_same_elements [other_record.id], PaymentIntent.by_invoice(other_invoice).pluck(:id)
+  end
+
+  test '#update_from_stripe_event' do
+    FactoryBot.create(:line_item, invoice: invoice, cost: 250)
+    invoice.send(:issue!)
+    invoice_cost = invoice.charge_cost
+    payment_intent = FactoryBot.create(:payment_intent, invoice: invoice, state: 'submitted')
+    payment_intent_data = { id: payment_intent.payment_intent_id, amount: invoice_cost.cents }
+    payment_transactions = invoice.payment_transactions
+
+    invalid_event = stripe_event(type: 'payment_intent.required_action', payment_intent_data: payment_intent_data)
+    assert_no_difference(payment_transactions.method(:count)) do
+      refute payment_intent.update_from_stripe_event(invalid_event)
+      assert_equal 'submitted', payment_intent.reload.state
+      refute invoice.reload.paid?
+    end
+
+    valid_event = stripe_event(type: 'payment_intent.succeeded', payment_intent_data: payment_intent_data)
+    assert_difference(payment_transactions.method(:count)) do
+      assert payment_intent.update_from_stripe_event(valid_event)
+      assert_equal 'succeeded', payment_intent.reload.state
+      assert invoice.reload.paid?
+    end
+    expected_payment_transaction = { action: 'purchase', amount: invoice_cost, success: true, message: 'Payment confirmed', reference: payment_intent_data[:id], params: valid_event.to_hash }.deep_stringify_keys
+    assert_equal expected_payment_transaction, payment_transactions.last.attributes.slice(*%w[action amount success message reference params]).deep_stringify_keys
+  end
+
   private
 
   def create_payment_intents
@@ -46,5 +80,17 @@ class PaymentIntentTest < ActiveSupport::TestCase
 
   def relation
     PaymentIntent.where(invoice: invoice)
+  end
+
+  def stripe_payment_intent_data
+    { id: 'payment-intent-id', object: 'payment_intent', status: 'succeeded', amount: 85000, currency: 'eur' }
+  end
+
+  def stripe_event_data
+    { id: 'event-id', object: 'event', type: 'payment_intent.succeeded', data: { object: stripe_payment_intent_data } }
+  end
+
+  def stripe_event(type:, payment_intent_data: {})
+    Stripe::Event.construct_from(stripe_event_data.deep_merge(type: type, data: { object: payment_intent_data }))
   end
 end

--- a/test/models/payment_intent_test.rb
+++ b/test/models/payment_intent_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PaymentIntentTest < ActiveSupport::TestCase
+  setup do
+    @invoice = FactoryBot.create(:invoice)
+  end
+
+  attr_reader :invoice
+
+  test 'requires an invoice' do
+    record = FactoryBot.build(:payment_intent, invoice: nil)
+    refute record.valid?
+    assert record.errors[:invoice].include?("can't be blank")
+    record.invoice = invoice
+    assert record.valid?
+  end
+
+  test 'requires a payment_intent_id' do
+    record = FactoryBot.build(:payment_intent, payment_intent_id: nil)
+    refute record.valid?
+    assert record.errors[:payment_intent_id].include?("can't be blank")
+    record.payment_intent_id = 'foo'
+    assert record.valid?
+  end
+
+  test 'latest' do
+    records = create_payment_intents
+    assert_same_elements [records.first], relation.latest
+    assert_same_elements records.first(2), relation.latest(2)
+  end
+
+  test 'latest_pending' do
+    records = create_payment_intents
+    records.first.update!(state: 'succeeded')
+    assert_same_elements [records.second], relation.latest_pending
+    assert_same_elements records[1..-1], relation.latest_pending(2)
+  end
+
+  private
+
+  def create_payment_intents
+    FactoryBot.create_list(:payment_intent, 3, invoice: invoice).sort_by(&:id).reverse
+  end
+
+  def relation
+    PaymentIntent.where(invoice: invoice)
+  end
+end

--- a/test/unit/account/billing_test.rb
+++ b/test/unit/account/billing_test.rb
@@ -48,7 +48,7 @@ class Account::BillingTest < ActiveSupport::TestCase
   end
 
   test 'unstore credit card when destroyed' do
-    provider = Account.new(payment_gateway_type: :stripe, payment_gateway_options: {login: 'private_key', publishable_key: 'public_key'})
+    provider = Account.new(payment_gateway_type: :stripe, payment_gateway_options: { login: 'private_key', publishable_key: 'public_key', endpoint_secret: 'some-secret' })
     buyer = Account.new(provider_account: provider)
     buyer.payment_detail.credit_card_auth_code = 'SOMESTRING'
 
@@ -169,7 +169,7 @@ class Account::BillingTest < ActiveSupport::TestCase
   end
 
   test 'charge! sends the payment_method_id' do
-    provider = FactoryBot.build(:simple_provider, payment_gateway_type: :stripe, payment_gateway_options: {login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx'})
+    provider = FactoryBot.build(:simple_provider, payment_gateway_type: :stripe, payment_gateway_options: { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx', endpoint_secret: 'some-secret' })
     buyer = FactoryBot.build(:simple_buyer, provider_account: provider)
     buyer.payment_detail.assign_attributes(credit_card_auth_code: 'cus_IhGaGqpp6zGwyd', payment_method_id: 'pm_1I5s3n2eZvKYlo2CiO193T69', credit_card_partial_number: '4242')
 

--- a/test/unit/account/gateway_test.rb
+++ b/test/unit/account/gateway_test.rb
@@ -106,7 +106,7 @@ class Account::GatewayTest  < ActiveSupport::TestCase
     assert_equal provider.payment_gateway_options,                    provider.payment_gateway.options
 
     provider.payment_gateway_type    = :stripe
-    provider.payment_gateway_options = {login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx'}
+    provider.payment_gateway_options = { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx', endpoint_secret: 'some-secret' }
     assert_instance_of ActiveMerchant::Billing::StripeGateway, provider.payment_gateway
     refute_instance_of ActiveMerchant::Billing::StripePaymentIntentsGateway, provider.payment_gateway # this test is necessary because StripePaymentIntentsGateway is a subclass of StripeGateway
     assert_equal provider.payment_gateway_options, provider.payment_gateway.options
@@ -128,7 +128,7 @@ class Account::GatewayTest  < ActiveSupport::TestCase
     assert_instance_of ActiveMerchant::Billing::BraintreeBlueGateway, buyer.provider_payment_gateway
 
     buyer.provider_account.payment_gateway_type = :stripe
-    buyer.provider_account.payment_gateway_options = {login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx'}
+    buyer.provider_account.payment_gateway_options = { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx', endpoint_secret: 'some-secret' }
     assert_instance_of ActiveMerchant::Billing::StripeGateway, buyer.provider_payment_gateway
     refute_instance_of ActiveMerchant::Billing::StripePaymentIntentsGateway, buyer.provider_payment_gateway # this test is necessary because StripePaymentIntentsGateway is a subclass of StripeGateway
     buyer.payment_detail.payment_method_id = 'pm_1I5s3n2eZvKYlo2CiO193T69'

--- a/test/unit/payment_gateway_setting_test.rb
+++ b/test/unit/payment_gateway_setting_test.rb
@@ -40,7 +40,7 @@ class PaymentGatewaySettingTest < ActiveSupport::TestCase
 
   test '#configured? failed if any gateway_settings missing for stripe' do
     @gateway_setting.gateway_type = :stripe
-    @gateway_setting.gateway_settings = {login: "Secret Key", publishable_key: ""}
+    @gateway_setting.gateway_settings = { login: 'Secret Key', publishable_key: '', endpoint_secret: 'some-secret' }
     refute @gateway_setting.configured?
 
     @gateway_setting.gateway_settings[:publishable_key] = 'PUBKEY'
@@ -79,7 +79,7 @@ class PaymentGatewaySettingTest < ActiveSupport::TestCase
     gateway_setting.save(validate: false)
 
     gateway_setting.gateway_type = :stripe
-    gateway_setting.gateway_settings = { login: 'Secret Key', publishable_key: '' }
+    gateway_setting.gateway_settings = { login: 'Secret Key', publishable_key: '', endpoint_secret: 'some-secret' }
 
     assert gateway_setting.valid?
     refute gateway_setting.errors.added?(:gateway_type, :invalid)

--- a/test/unit/payment_transaction_test.rb
+++ b/test/unit/payment_transaction_test.rb
@@ -59,7 +59,7 @@ class PaymentTransactionTest < ActiveSupport::TestCase
     def setup
       @order_id = 3
       @payment_transaction = PaymentTransaction.new(amount: 100, action: :purchase, currency: 'EUR')
-      @payment_gateway_options = {login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx'}
+      @payment_gateway_options = { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx', endpoint_secret: 'some-secret' }
       @credit_card_auth_code = 'cus_IhGaGqpp6zGwyd'
     end
 

--- a/test/unit/services/finance/stripe_charge_service_test.rb
+++ b/test/unit/services/finance/stripe_charge_service_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Finance::StripeChargeServiceTest < ActiveSupport::TestCase
+  setup do
+    provider_account = FactoryBot.create(:simple_provider, payment_gateway_type: :stripe, payment_gateway_options: { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc' })
+    buyer_account = FactoryBot.create(:simple_buyer, provider_account: provider_account)
+    @gateway = provider_account.payment_gateway(sca: true)
+    @invoice = FactoryBot.create(:invoice, buyer_account: buyer_account, provider_account: provider_account)
+    @amount = ThreeScale::Money.new(150.0, 'EUR')
+    @service = build_charge_service(invoice: invoice)
+  end
+
+  attr_reader :gateway, :invoice, :amount, :service
+
+  test 'charge' do
+    service.expects(:create_payment_intent).with(amount).returns(true)
+    assert service.charge(amount)
+  end
+
+  test 'charge with existing payment intent' do
+    payment_intent = FactoryBot.create(:payment_intent, invoice: invoice, payment_intent_id: 'some-payment-intent-id', state: 'pending')
+    service.expects(:confirm_payment_intent).with(payment_intent).returns(true)
+    assert service.charge(amount)
+  end
+
+  test 'create payment intent' do
+    response = build_response(true, 'Transaction Approved', object: 'payment_intent', id: 'new-payment-intent-id', status: 'succeeded')
+    gateway.expects(:purchase).returns(response)
+
+    assert_difference(invoice.payment_intents.method(:count)) do
+      assert_equal response, service.send(:create_payment_intent, amount)
+      assert (payment_intent = invoice.payment_intents.latest.first)
+      assert_equal 'new-payment-intent-id', payment_intent.payment_intent_id
+      assert_equal 'succeeded', payment_intent.state
+      refute invoice.latest_pending_payment_intent
+    end
+  end
+
+  test 'new payment intent requires action' do
+    response = build_response(false, 'Authentication required', status: 'authentication_required', error: { payment_intent: { object: 'payment_intent', id: 'new-payment-intent-id', status: 'requires_payment_method' } })
+    gateway.expects(:purchase).returns(response)
+
+    assert_difference(invoice.payment_intents.method(:count)) do
+      assert_equal response, service.send(:create_payment_intent, amount)
+      assert (payment_intent = invoice.latest_pending_payment_intent)
+      assert_equal 'new-payment-intent-id', payment_intent.payment_intent_id
+      assert_equal 'requires_payment_method', payment_intent.state
+    end
+  end
+
+  test 'new payment intent requires confirmation' do
+    response = build_response(false, 'Authentication required', status: 'authentication_required', error: { payment_intent: { object: 'payment_intent', id: 'new-payment-intent-id', status: 'requires_confirmation' } })
+    gateway.expects(:purchase).returns(response)
+
+    payment_intent = FactoryBot.create(:payment_intent, invoice: invoice, payment_intent_id: 'new-payment-intent-id', state: 'requires_confirmation')
+    invoice.payment_intents.expects(:create!).returns(payment_intent)
+
+    service.expects(:confirm_payment_intent).with(payment_intent).returns(true)
+    assert_equal response, service.send(:create_payment_intent, amount)
+  end
+
+  test 'create with error' do
+    response = build_response(false, 'Failed', status: 'failed', error: { message: 'No error details' })
+    gateway.expects(:purchase).returns(response)
+
+    assert_no_difference(invoice.payment_intents.method(:count)) do
+      assert_equal response, service.send(:create_payment_intent, amount)
+    end
+  end
+
+  test 'create payment intent without invoice' do
+    response = build_response(true, 'Transaction Approved', object: 'payment_intent', id: 'new-payment-intent-id', status: 'succeeded')
+    gateway.expects(:purchase).returns(response)
+
+    assert_no_difference(invoice.payment_intents.method(:count)) do
+      assert_equal response, build_charge_service.send(:create_payment_intent, amount)
+    end
+  end
+
+  test 'successful confirm payment intent' do
+    payment_intent_id = 'some-payment-intent-id'
+    payment_intent = FactoryBot.create(:payment_intent, invoice: invoice, payment_intent_id: payment_intent_id, state: 'pending')
+
+    response = build_response(true, 'Transaction Approved', object: 'payment_intent', id: payment_intent_id, status: 'succeeded')
+    gateway.expects(:confirm_intent).with(payment_intent_id, service.payment_method_id, service.gateway_options).returns(response)
+
+    assert_equal 'pending', payment_intent.state
+    assert_equal response, service.send(:confirm_payment_intent, payment_intent)
+    assert_equal 'succeeded', payment_intent.reload.state
+  end
+
+  test 'failed confirm payment intent' do
+    payment_intent_id = 'some-payment-intent-id'
+    payment_intent = FactoryBot.create(:payment_intent, invoice: invoice, payment_intent_id: payment_intent_id, state: 'pending')
+
+    response = build_response(true, 'Transaction Approved', object: 'payment_intent', id: 'some-payment-intent-id', status: 'requires_payment_method')
+    gateway.expects(:confirm_intent).with(payment_intent_id, service.payment_method_id, service.gateway_options).returns(response)
+
+    assert_equal 'pending', payment_intent.state
+    assert service.send(:confirm_payment_intent, payment_intent)
+    refute response.success?
+    assert_equal 'Requires payment method', response.message
+    assert_equal 'requires_payment_method', payment_intent.reload.state
+  end
+
+  private
+
+  def build_charge_service(opts = {})
+    gateway_options = { customer: 'a-customer-id', off_session: true, execute_threed: true }
+    options = { payment_method_id: 'a-payment-method-id', gateway_options: gateway_options }
+    Finance::StripeChargeService.new(gateway, **options.deep_merge(opts))
+  end
+
+  def build_response(success, message, params)
+    ActiveMerchant::Billing::Response.new(success, message, params.deep_stringify_keys)
+  end
+end

--- a/test/unit/tasks/payments_test.rb
+++ b/test/unit/tasks/payments_test.rb
@@ -20,7 +20,7 @@ module Tasks
 
       providers_with_stripe_configured.each do |provider|
         provider.payment_gateway_type = :stripe
-        provider.payment_gateway_options = {login: "sk_test_example#{provider.id}", publishable_key: "pk_test_example#{provider.id}"}
+        provider.payment_gateway_options = { login: "sk_test_example#{provider.id}", publishable_key: "pk_test_example#{provider.id}", endpoint_secret: 'some-secret' }
         provider.save!
       end
 


### PR DESCRIPTION
### TODOs
- [x] [bugfix] New Stripe customer whenever `<dev-portal>/admin/account/stripe` is loaded -- extracted to #2342 
- [x] New `payment_intents` table
- [x] Create/confirm payment intent on purchase with stripe
- [x] New API endpoint `POST /api/payment_callbacks/stripe_callbacks`
- [x] Refactor `PaymentTransaction#purchase_with_stripe` and related methods (move them to another class)
- [x] Write tests for all the above :P
- [x] Add `endpoint_secret` as another payment gateway setting field of the provider

In separate PRs:
- [ ] Show in the UI (provider billing settings page) some instructions to configure the Stripe webhook
- [ ] Act on payment intent return statuses `requires_action` and `requires_payment_method` -- i.e. build a checkout page in the Dev Portal for buyers to pay for failed-to-charge invoices online

### How to try this locally
- Run porta and migrations
- Create a Stripe test merchant account (in case you don't have one already)
- Create a RW access token with the Billing API scope
- Download and run the [Stripe CLI](https://stripe.com/docs/cli) pointing it to `<provider-domain>/api/payment_callbacks/stripe_callbacks?access_token=<access-token>`
- Add credit card to developer accounts
- Create and charge invoices (You may need to hit charge more than once depending on the credit card used.)
- In the Rails console, check for the `params.dig('next_action', 'use_stripe_sdk', 'stripe_js')` of a payment transaction with message "Requires action". You need to paste that link into the browser and authenticate the transaction.
- Check in the [Stripe Dashboard](https://dashboard.stripe.com) for customers, setup intents, payment methods and payment intents created

Stripe test credit card numbers for 3D Secure available [here](https://stripe.com/docs/payments/3d-secure#three-ds-cards).

----

Closes [THREESCALE-6531](https://issues.redhat.com/browse/THREESCALE-6531)

Contains commits of #2342