### PR TITLE
[Bugfix] find or create Stripe customer whenever <dev-portal>/admin/account/stripe is loaded

### DIFF
--- a/app/lib/payment_gateways/stripe_crypt.rb
+++ b/app/lib/payment_gateways/stripe_crypt.rb
@@ -2,8 +2,6 @@
 
 module PaymentGateways
   class StripeCrypt < PaymentGatewayCrypt
-    attr_accessor :customer_id
-
     attr_reader :errors
 
     # TODO: move Errors to payment gateway base and make others use it
@@ -38,13 +36,9 @@ module PaymentGateways
 
     delegate :payment_detail, to: :account
 
-    def customer_id
-      payment_detail.credit_card_auth_code
-    end
-
     def find_or_create_customer
-      customer = Stripe::Customer.retrieve(customer_id, api_key) if customer_id
-      customer.try(:id) ? customer : create_customer
+      customer_id = payment_detail.credit_card_auth_code
+      customer_id.present? ? Stripe::Customer.retrieve(customer_id, api_key) : create_customer
     end
 
     def create_customer

--- a/app/models/account/credit_card.rb
+++ b/app/models/account/credit_card.rb
@@ -50,6 +50,8 @@ module Account::CreditCard
     case provider_account.try(:payment_gateway_type)
     when :authorize_net
       :credit_card_authorize_net_payment_profile_token
+    when :stripe
+      :credit_card_partial_number
     else
       :credit_card_auth_code
     end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -193,10 +193,12 @@ Before '@stripe' do
   customer_response_body = <<~JSON.strip
     {
       "id": "cus_IiIMv3fS4LCHwE",
-      "object": "customer"
+      "object": "customer",
+      "deleted": false
     }
   JSON
   stub_request(:post, 'https://api.stripe.com/v1/customers').to_return(status: 201, body: customer_response_body, headers: {})
+  stub_request(:get, 'https://api.stripe.com/v1/customers/valid_code').to_return(status: 200, body: customer_response_body, headers: {})
 
   setup_intent_response_body = <<~JSON.strip
     {

--- a/test/unit/account/billing_test.rb
+++ b/test/unit/account/billing_test.rb
@@ -171,7 +171,7 @@ class Account::BillingTest < ActiveSupport::TestCase
   test 'charge! sends the payment_method_id' do
     provider = FactoryBot.build(:simple_provider, payment_gateway_type: :stripe, payment_gateway_options: {login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx'})
     buyer = FactoryBot.build(:simple_buyer, provider_account: provider)
-    buyer.payment_detail.assign_attributes(credit_card_auth_code: 'cus_IhGaGqpp6zGwyd', payment_method_id: 'pm_1I5s3n2eZvKYlo2CiO193T69')
+    buyer.payment_detail.assign_attributes(credit_card_auth_code: 'cus_IhGaGqpp6zGwyd', payment_method_id: 'pm_1I5s3n2eZvKYlo2CiO193T69', credit_card_partial_number: '4242')
 
     PaymentTransaction.any_instance.expects(:process!).with do |_customer, _payment_gateway, opts|
       opts[:payment_method_id] == buyer.payment_detail.payment_method_id

--- a/test/unit/account/credit_card_test.rb
+++ b/test/unit/account/credit_card_test.rb
@@ -24,8 +24,10 @@ class Account::CreditCardTest < ActiveSupport::TestCase
     assert_equal :credit_card_auth_code, account.credit_card_stored_attribute
 
     provider_account.payment_gateway_type = :authorize_net
-
     assert_equal :credit_card_authorize_net_payment_profile_token, account.credit_card_stored_attribute
+
+    provider_account.payment_gateway_type = :stripe
+    assert_equal :credit_card_partial_number, account.credit_card_stored_attribute
   end
 
   test 'credit_card_stored? return true when credit_card_auth_code present for payment gateways different from authorize.net' do

--- a/test/unit/lib/payment_gateways/stripe_crypt_test.rb
+++ b/test/unit/lib/payment_gateways/stripe_crypt_test.rb
@@ -25,29 +25,34 @@ module PaymentGateways
       assert_equal expected_setup_intent.id, setup_intent.id
     end
 
-    test 'create_customer' do
+    test 'customer - missing payment detail' do
       Stripe::Customer.expects(:create).with(create_customer_params, api_key).returns(mock_customer)
       refute buyer_account.payment_detail.credit_card_auth_code
-      assert_equal 'new-customer-id', stripe_crypt.send(:create_customer).id
+      assert_equal 'new-customer-id', stripe_crypt.customer.id
       assert_equal 'new-customer-id', buyer_account.payment_detail.reload.credit_card_auth_code
     end
 
-    test 'find_or_create_customer' do
-      # missing payment detail
-      Stripe::Customer.expects(:create).with(create_customer_params, api_key).returns(mock_customer)
-      assert_equal 'new-customer-id', stripe_crypt.send(:find_or_create_customer).id
-
-      # existing payment detail
+    test 'customer - existing payment detail' do
       stripe_crypt.payment_detail.delete
       payment_detail = FactoryBot.create(:payment_detail, account: buyer_account)
       stripe_crypt.account.reload
       customer_id = payment_detail.credit_card_auth_code
       Stripe::Customer.expects(:retrieve).with(customer_id, api_key).returns(mock_customer(id: customer_id))
-      assert_equal customer_id, stripe_crypt.send(:find_or_create_customer).id
+      assert_equal customer_id, stripe_crypt.customer.id
+    end
+
+    test 'customer - existing payment detail with a "deleted" customer' do
+      stripe_crypt.payment_detail.delete
+      payment_detail = FactoryBot.create(:payment_detail, account: buyer_account)
+      stripe_crypt.account.reload
+      customer_id = payment_detail.credit_card_auth_code
+      Stripe::Customer.expects(:retrieve).with(customer_id, api_key).returns(mock_customer(id: customer_id, deleted: true))
+      Stripe::Customer.expects(:create).with(create_customer_params, api_key).returns(mock_customer(id: 'new-created-customer-id'))
+      assert_equal 'new-created-customer-id', stripe_crypt.customer.id
     end
 
     test 'create_stripe_setup_intent finds existing customer' do
-      stripe_crypt.stubs(:find_or_create_customer).returns(mock_customer(id: 'existing-customer-id'))
+      stripe_crypt.stubs(:customer).returns(mock_customer(id: 'existing-customer-id'))
       setup_intent_params = { payment_method_types: ['card'], usage: 'off_session', customer: 'existing-customer-id' }
       Stripe::SetupIntent.expects(:create).with(setup_intent_params, api_key).returns(true)
       assert stripe_crypt.create_stripe_setup_intent
@@ -82,8 +87,9 @@ module PaymentGateways
       { description: buyer_account.org_name, email: buyer_user.email, metadata: { '3scale_account_reference' => buyer_reference } }
     end
 
-    def mock_customer(id: 'new-customer-id')
-      Stripe::Customer.new(id: id)
+    def mock_customer(**attrs)
+      id = attrs.delete(:id) || 'new-customer-id'
+      Stripe::Customer.new(id: id).tap { |stripe_customer| stripe_customer.update_attributes(**attrs) }
     end
   end
 end

--- a/test/unit/lib/payment_gateways/stripe_crypt_test.rb
+++ b/test/unit/lib/payment_gateways/stripe_crypt_test.rb
@@ -8,12 +8,13 @@ module PaymentGateways
       @provider_account = FactoryBot.create(:simple_provider, payment_gateway_type: :stripe, payment_gateway_options: {login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc'})
       @buyer_account = FactoryBot.create(:simple_buyer, provider_account: provider_account)
       @buyer_user = FactoryBot.create(:user, account: buyer_account)
+      @stripe_crypt = PaymentGateways::StripeCrypt.new(buyer_user)
     end
 
-    attr_reader :provider_account, :buyer_account, :buyer_user
+    attr_reader :provider_account, :buyer_account, :buyer_user, :stripe_crypt
 
     test 'create_stripe_setup_intent' do
-      customer = Stripe::Customer.new(id: 'cus_IhGaGqpp6zGwyd')
+      customer = mock_customer(id: 'cus_IhGaGqpp6zGwyd')
       Stripe::Customer.stubs(:create).returns(customer)
 
       expected_stripe_setup_intent = { payment_method_types: ['card'], usage: 'off_session', customer: customer.id }
@@ -22,6 +23,39 @@ module PaymentGateways
 
       setup_intent = stripe_crypt.create_stripe_setup_intent
       assert_equal expected_setup_intent.id, setup_intent.id
+    end
+
+    test 'create_customer' do
+      Stripe::Customer.expects(:create).with(create_customer_params, api_key).returns(mock_customer)
+      refute buyer_account.payment_detail.credit_card_auth_code
+      assert_equal 'new-customer-id', stripe_crypt.send(:create_customer).id
+      assert_equal 'new-customer-id', buyer_account.payment_detail.reload.credit_card_auth_code
+    end
+
+    test 'find_or_create_customer' do
+      # missing payment detail
+      Stripe::Customer.expects(:create).with(create_customer_params, api_key).returns(mock_customer)
+      assert_equal 'new-customer-id', stripe_crypt.send(:find_or_create_customer).id
+
+      # existing payment detail
+      stripe_crypt.payment_detail.delete
+      payment_detail = FactoryBot.create(:payment_detail, account: buyer_account)
+      stripe_crypt.account.reload
+      customer_id = payment_detail.credit_card_auth_code
+      Stripe::Customer.expects(:retrieve).with(customer_id, api_key).returns(mock_customer(id: customer_id))
+      assert_equal customer_id, stripe_crypt.send(:find_or_create_customer).id
+
+      # cannot match existing payment detail to a stripe customer
+      Stripe::Customer.expects(:retrieve).with(customer_id, api_key).returns(mock_customer(id: nil))
+      Stripe::Customer.expects(:create).with(create_customer_params, api_key).returns(mock_customer)
+      assert_equal 'new-customer-id', stripe_crypt.send(:find_or_create_customer).id
+    end
+
+    test 'create_stripe_setup_intent finds existing customer' do
+      stripe_crypt.stubs(:find_or_create_customer).returns(mock_customer(id: 'existing-customer-id'))
+      setup_intent_params = { payment_method_types: ['card'], usage: 'off_session', customer: 'existing-customer-id' }
+      Stripe::SetupIntent.expects(:create).with(setup_intent_params, api_key).returns(true)
+      assert stripe_crypt.create_stripe_setup_intent
     end
 
     test 'update!' do
@@ -45,8 +79,16 @@ module PaymentGateways
       provider_account.payment_gateway_options.fetch(:login)
     end
 
-    def stripe_crypt
-      PaymentGateways::StripeCrypt.new(buyer_user)
+    def buyer_reference
+      "3scale-#{provider_account.id}-#{buyer_account.id}"
+    end
+
+    def create_customer_params
+      { description: buyer_account.org_name, email: buyer_user.email, metadata: {  '3scale_account_reference' => buyer_reference } }
+    end
+
+    def mock_customer(id: 'new-customer-id')
+      Stripe::Customer.new(id: id)
     end
   end
 end

--- a/test/unit/lib/payment_gateways/stripe_crypt_test.rb
+++ b/test/unit/lib/payment_gateways/stripe_crypt_test.rb
@@ -44,11 +44,6 @@ module PaymentGateways
       customer_id = payment_detail.credit_card_auth_code
       Stripe::Customer.expects(:retrieve).with(customer_id, api_key).returns(mock_customer(id: customer_id))
       assert_equal customer_id, stripe_crypt.send(:find_or_create_customer).id
-
-      # cannot match existing payment detail to a stripe customer
-      Stripe::Customer.expects(:retrieve).with(customer_id, api_key).returns(mock_customer(id: nil))
-      Stripe::Customer.expects(:create).with(create_customer_params, api_key).returns(mock_customer)
-      assert_equal 'new-customer-id', stripe_crypt.send(:find_or_create_customer).id
     end
 
     test 'create_stripe_setup_intent finds existing customer' do
@@ -84,7 +79,7 @@ module PaymentGateways
     end
 
     def create_customer_params
-      { description: buyer_account.org_name, email: buyer_user.email, metadata: {  '3scale_account_reference' => buyer_reference } }
+      { description: buyer_account.org_name, email: buyer_user.email, metadata: { '3scale_account_reference' => buyer_reference } }
     end
 
     def mock_customer(id: 'new-customer-id')


### PR DESCRIPTION
Creates the customer in Stripe only once (or when the customer is deleted) and not each time that the page is loaded.
1st commit extracted from #2339 