### PR TITLE
Stripe async payment intents Improvements

### DIFF
--- a/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
+++ b/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
@@ -47,11 +47,9 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::
     end
   end
 
-  PAYMENT_INTENT_SUCCEEDED_STATUS = [Stripe::PaymentIntent::OBJECT_NAME, 'succeeded'].join('.').freeze
-
   def extract_payment_intent_data
     case stripe_event.type # Also checked by PaymentIntent#update_from_stripe_event, but here it can save us some processing and ensure an immediate response at the level of the controller in case of unsupported event types
-    when PAYMENT_INTENT_SUCCEEDED_STATUS
+    when PaymentIntent::STRIPE_PAYMENT_INTENT_SUCCEEDED
       stripe_event.data.object
     else
       raise InvalidStripeEvent

--- a/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
+++ b/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
@@ -20,38 +20,45 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::
 
   # Undocumented endpoint used for update callbacks of async-authorized payment transactions (mostly due to SCA regulations)
   def create
-    sig_header = request.headers['Stripe-Signature']
-    endpoint_secret = payment_gateway_options[:endpoint_secret].presence
+    return head(:no_content) if payment_intent.update_from_stripe_event(stripe_event)
 
-    raise MissingStripeEndpointSecret unless endpoint_secret
-
-    stripe_event = Stripe::Webhook.construct_event(request.raw_post, sig_header, endpoint_secret)
-    payment_intent_data = case stripe_event.type # Also checked by PaymentIntent#update_from_stripe_event, but here it can save us some processing and ensure an immediate response at the level of the controller in case of unsupported event types
-                          when 'payment_intent.succeeded'
-                            stripe_event.data.object
-                          else
-                            raise InvalidStripeEvent
-                          end
-
-    payment_intent = PaymentIntent.by_invoice(current_account.buyer_invoices).find_by!(payment_intent_id: payment_intent_data['id'])
-
-    unless payment_intent.update_from_stripe_event(stripe_event)
-      exception = StripeCallbackError.new('Cannot update Stripe payment intent')
-      report_error(exception, event: stripe_event, payment_intent: payment_intent)
-    end
-
-    head :ok
+    exception = StripeCallbackError.new('Cannot update Stripe payment intent')
+    report_error(exception, event: stripe_event, payment_intent: payment_intent)
   end
 
   protected
 
   def ensure_stripe_payment_gateway
     return if payment_gateway_type == :stripe
+
     render_error(:not_found, status: :not_found)
-    false
   end
 
   delegate :payment_gateway_type, :payment_gateway_options, to: :current_account
 
   delegate :report_error, to: System::ErrorReporting
+
+  def stripe_event
+    @stripe_event ||= begin
+      endpoint_secret = payment_gateway_options[:endpoint_secret].presence
+      raise MissingStripeEndpointSecret unless endpoint_secret
+
+      Stripe::Webhook.construct_event(request.raw_post, request.headers['Stripe-Signature'], endpoint_secret)
+    end
+  end
+
+  PAYMENT_INTENT_SUCCEEDED_STATUS = [Stripe::PaymentIntent::OBJECT_NAME, 'succeeded'].join('.').freeze
+
+  def extract_payment_intent_data
+    case stripe_event.type # Also checked by PaymentIntent#update_from_stripe_event, but here it can save us some processing and ensure an immediate response at the level of the controller in case of unsupported event types
+    when PAYMENT_INTENT_SUCCEEDED_STATUS
+      stripe_event.data.object
+    else
+      raise InvalidStripeEvent
+    end
+  end
+
+  def payment_intent
+    @payment_intent ||= PaymentIntent.by_invoice(current_account.buyer_invoices).find_by!(payment_intent_id: extract_payment_intent_data['id'])
+  end
 end

--- a/app/lib/three_scale/money.rb
+++ b/app/lib/three_scale/money.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ThreeScale
 
   # This class represents some amount of money with currency. It behaves more or
@@ -14,6 +16,10 @@ module ThreeScale
     attr_reader :amount
     attr_reader :currency
     attr_reader :date
+
+    def self.cents(amount, currency, date = nil)
+      new(amount.to_i / 100.to_d, currency, date)
+    end
 
     def initialize(amount, currency, date = nil)
       @amount = amount

--- a/app/lib/three_scale/money.rb
+++ b/app/lib/three_scale/money.rb
@@ -18,7 +18,7 @@ module ThreeScale
     attr_reader :date
 
     def self.cents(amount, currency, date = nil)
-      new(amount.to_i / 100.to_d, currency, date)
+      new(amount.to_d / 100, currency, date)
     end
 
     def initialize(amount, currency, date = nil)

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -29,7 +29,7 @@ class PaymentIntent < ApplicationRecord
     transaction do
       self.state = payment_intent_data['status']
       currency = payment_intent_data['currency']&.upcase || invoice.currency
-      amount = ThreeScale::Money.cents(payment_intent_data['amount'], currency)
+      amount = ThreeScale::Money.cents(payment_intent_data['amount'].presence || 0, currency)
       payment_transaction = build_payment_transaction(amount: amount, reference: payment_intent_data['id'], params: event.to_hash)
       save && payment_transaction.save && invoice.pay
     end

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -5,8 +5,11 @@ class PaymentIntent < ApplicationRecord
 
   belongs_to :invoice, inverse_of: :payment_intents
 
-  validates :invoice, :payment_intent_id, :state, presence: true
-  validates :payment_intent_id, :state, length: { maximum: 255 }
+  self.ignored_columns = %w[payment_intent_id]
+
+  validates :invoice, :reference, :state, presence: true
+  validates :reference, :state, length: { maximum: 255 }
+  validates :reference, uniqueness: true
 
   scope :latest, -> (count = 1) { reorder(created_at: :desc, id: :desc).limit(count) }
   scope :latest_pending, -> (count = 1) { where.not(state: SUCCEEDED_STATES).latest(count) }

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 class PaymentIntent < ApplicationRecord
-  STRIPE_STATUS_SUCCEEDED = 'succeeded'
-  SUCCEEDED_STATES = [STRIPE_STATUS_SUCCEEDED].freeze
-
-  STRIPE_PAYMENT_INTENT_SUCCEEDED = [Stripe::PaymentIntent::OBJECT_NAME, STRIPE_STATUS_SUCCEEDED].join('.').freeze
+  SUCCEEDED_STATES = [Finance::StripeChargeService::PAYMENT_INTENT_SUCCEEDED].freeze
 
   belongs_to :invoice, inverse_of: :payment_intents
 
@@ -18,27 +15,5 @@ class PaymentIntent < ApplicationRecord
 
   def succeeded?
     SUCCEEDED_STATES.include?(state)
-  end
-
-  def update_from_stripe_event(event)
-    return unless event.type == STRIPE_PAYMENT_INTENT_SUCCEEDED
-    return if succeeded? || invoice.paid?
-
-    payment_intent_data = event.data.object
-
-    transaction do
-      self.state = payment_intent_data['status']
-      currency = payment_intent_data['currency']&.upcase || invoice.currency
-      amount = ThreeScale::Money.cents(payment_intent_data['amount'].presence || 0, currency)
-      payment_transaction = build_payment_transaction(amount: amount, reference: payment_intent_data['id'], params: event.to_hash)
-      save && payment_transaction.save && invoice.pay
-    end
-  end
-
-  protected
-
-  def build_payment_transaction(attrs)
-    attributes = attrs.reverse_merge(action: :purchase, success: true, message: 'Payment confirmed')
-    invoice.payment_transactions.build(attributes, without_protection: true)
   end
 end

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -28,7 +28,8 @@ class PaymentIntent < ApplicationRecord
 
     transaction do
       self.state = payment_intent_data['status']
-      amount = payment_intent_data['amount'].to_has_money(payment_intent_data['currency']&.upcase || invoice.currency) / 100.0
+      currency = payment_intent_data['currency']&.upcase || invoice.currency
+      amount = ThreeScale::Money.cents(payment_intent_data['amount'], currency)
       payment_transaction = build_payment_transaction(amount: amount, reference: payment_intent_data['id'], params: event.to_hash)
       save && payment_transaction.save && invoice.pay
     end

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class PaymentIntent < ApplicationRecord
-  SUCCEEDED_STATES = %w[succeeded].freeze
+  STRIPE_STATUS_SUCCEEDED = 'succeeded'
+  SUCCEEDED_STATES = [STRIPE_STATUS_SUCCEEDED].freeze
+
+  STRIPE_PAYMENT_INTENT_SUCCEEDED = [Stripe::PaymentIntent::OBJECT_NAME, STRIPE_STATUS_SUCCEEDED].join('.').freeze
 
   belongs_to :invoice, inverse_of: :payment_intents
 
@@ -18,7 +21,7 @@ class PaymentIntent < ApplicationRecord
   end
 
   def update_from_stripe_event(event)
-    return unless event.type == 'payment_intent.succeeded'
+    return unless event.type == STRIPE_PAYMENT_INTENT_SUCCEEDED
     return if succeeded? || invoice.paid?
 
     payment_intent_data = event.data.object

--- a/app/services/finance/stripe_charge_service.rb
+++ b/app/services/finance/stripe_charge_service.rb
@@ -28,7 +28,7 @@ class Finance::StripeChargeService
     with_payment_intent_data_from(response) do |payment_intent_data|
       next unless invoice
 
-      payment_intent = invoice.payment_intents.create!(payment_intent_id: payment_intent_data['id'], state: payment_intent_data['status'])
+      payment_intent = invoice.payment_intents.create!(reference: payment_intent_data['id'], state: payment_intent_data['status'])
 
       # For PaymentIntent statuses and corresponding recommended actions see https://stripe.com/docs/payments/accept-a-payment-synchronously
       # - succeeded                => no additional action > the payment has succeeded
@@ -49,7 +49,7 @@ class Finance::StripeChargeService
     # Passing the gateway option `off_session: false` will cause a `requires_action` status on the payment intent in cases where otherwise it would be `requires_payment_method`.
     # This happens even when the payment intent has been originally created with `off_session: true` – i.e. Stripe allows us to turn an "off_session" payment intent into an "on_session" one.
     # Along with the `requires_action` status, the param `next_action.use_stripe_sdk.stripe_js` holds the next-step link to get the transaction authenticated
-    response = gateway.confirm_intent(payment_intent.payment_intent_id, payment_method_id, gateway_options)
+    response = gateway.confirm_intent(payment_intent.reference, payment_method_id, gateway_options)
 
     with_payment_intent_data_from(response) do |payment_intent_data|
       payment_intent_status = payment_intent_data['status']

--- a/app/services/finance/stripe_charge_service.rb
+++ b/app/services/finance/stripe_charge_service.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Finance::StripeChargeService
+  PAYMENT_INTENT_SUCCEEDED = 'succeeded'
+  PAYMENT_INTENT_REQUIRES_CONFIRMATION = 'requires_confirmation'
+
   def initialize(gateway, payment_method_id:, invoice: nil, gateway_options: {})
     @gateway = gateway
     @payment_method_id = payment_method_id
@@ -34,9 +37,9 @@ class Finance::StripeChargeService
       # - requires_payment_method  => do not retry > the payment attempt has failed > ask cardholder to replace card data
 
       case payment_intent.state
-      when 'succeeded'
+      when PAYMENT_INTENT_SUCCEEDED
         next
-      when 'requires_confirmation'
+      when PAYMENT_INTENT_REQUIRES_CONFIRMATION
         confirm_payment_intent(payment_intent)
       end
     end
@@ -52,7 +55,7 @@ class Finance::StripeChargeService
       payment_intent_status = payment_intent_data['status']
       payment_intent.update!(state: payment_intent_status)
 
-      next if payment_intent_status == 'succeeded' || !response.success?
+      next if payment_intent_status == PAYMENT_INTENT_SUCCEEDED || !response.success?
 
       # Because in some cases Stripe won't wrap the response of `/payment_intents/:id/confirm` into an 'error' and ActiveMerchant may think it was a success when it wasn't.
       # See https://github.com/activemerchant/active_merchant/blob/b2f5e89eb383429d47e446f248d7bfe4f95ac3d0/lib/active_merchant/billing/gateways/stripe_payment_intents.rb#L299-L307

--- a/app/services/finance/stripe_payment_intent_update_service.rb
+++ b/app/services/finance/stripe_payment_intent_update_service.rb
@@ -4,7 +4,7 @@ class Finance::StripePaymentIntentUpdateService
   def initialize(provider_account, stripe_event)
     @stripe_event = stripe_event
     @payment_intent_data = stripe_event.data.object
-    @payment_intent = PaymentIntent.by_invoice(provider_account.buyer_invoices).find_by!(payment_intent_id: payment_intent_data['id'])
+    @payment_intent = PaymentIntent.by_invoice(provider_account.buyer_invoices).find_by!(reference: payment_intent_data['id'])
   end
 
   attr_reader :stripe_event, :payment_intent_data, :payment_intent

--- a/app/services/finance/stripe_payment_intent_update_service.rb
+++ b/app/services/finance/stripe_payment_intent_update_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Finance::StripePaymentIntentUpdateService
+  def initialize(provider_account, stripe_event)
+    @stripe_event = stripe_event
+    @payment_intent_data = stripe_event.data.object
+    @payment_intent = PaymentIntent.by_invoice(provider_account.buyer_invoices).find_by!(payment_intent_id: payment_intent_data['id'])
+  end
+
+  attr_reader :stripe_event, :payment_intent_data, :payment_intent
+
+  delegate :invoice, :succeeded?, to: :payment_intent
+  delegate :payment_transactions, to: :invoice
+
+  def call
+    payment_intent.with_lock do
+      payment_intent.state = payment_intent_data['status']
+      payment_intent.save && create_payment_transaction && (!succeeded? || invoice.pay)
+    end
+  end
+
+  protected
+
+  def create_payment_transaction
+    attributes = {
+      action: :purchase,
+      amount: ThreeScale::Money.cents(payment_intent_data['amount'].presence || 0, payment_intent_data['currency']&.upcase || invoice.currency),
+      reference: payment_intent_data['id'],
+      success: succeeded?,
+      message: succeeded? ? 'Payment confirmed' : payment_intent_data['status'].humanize,
+      params: stripe_event.to_hash
+    }
+
+    payment_transactions.create(attributes, without_protection: true)
+  end
+end

--- a/db/migrate/20210128155025_add_reference_to_payment_intents.rb
+++ b/db/migrate/20210128155025_add_reference_to_payment_intents.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddReferenceToPaymentIntents < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :payment_intents, :reference, :string
+
+    index_options = { unique: true }
+    index_options[:algorithm] = :concurrently if System::Database.postgres?
+    add_index :payment_intents, :reference, index_options
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210119101158) do
+ActiveRecord::Schema.define(version: 20210128155025) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer  "owner_id",   precision: 38, null: false
@@ -925,10 +925,12 @@ ActiveRecord::Schema.define(version: 20210119101158) do
     t.integer  "tenant_id",         precision: 38
     t.datetime "created_at",        precision: 6,  null: false
     t.datetime "updated_at",        precision: 6,  null: false
+    t.string   "reference"
   end
 
   add_index "payment_intents", ["invoice_id"], name: "index_payment_intents_on_invoice_id"
   add_index "payment_intents", ["payment_intent_id"], name: "index_payment_intents_on_payment_intent_id"
+  add_index "payment_intents", ["reference"], name: "index_payment_intents_on_reference", unique: true
   add_index "payment_intents", ["state"], name: "index_payment_intents_on_state"
 
   create_table "payment_transactions", force: :cascade do |t|

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210119101158) do
+ActiveRecord::Schema.define(version: 20210128155025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -882,8 +882,10 @@ ActiveRecord::Schema.define(version: 20210119101158) do
     t.bigint   "tenant_id"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
+    t.string   "reference"
     t.index ["invoice_id"], name: "index_payment_intents_on_invoice_id", using: :btree
     t.index ["payment_intent_id"], name: "index_payment_intents_on_payment_intent_id", using: :btree
+    t.index ["reference"], name: "index_payment_intents_on_reference", unique: true, using: :btree
     t.index ["state"], name: "index_payment_intents_on_state", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210119101158) do
+ActiveRecord::Schema.define(version: 20210128155025) do
 
   create_table "access_tokens", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.bigint   "owner_id",                 null: false
@@ -881,8 +881,10 @@ ActiveRecord::Schema.define(version: 20210119101158) do
     t.bigint   "tenant_id"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
+    t.string   "reference"
     t.index ["invoice_id"], name: "index_payment_intents_on_invoice_id", using: :btree
     t.index ["payment_intent_id"], name: "index_payment_intents_on_payment_intent_id", using: :btree
+    t.index ["reference"], name: "index_payment_intents_on_reference", unique: true, using: :btree
     t.index ["state"], name: "index_payment_intents_on_state", using: :btree
   end
 

--- a/lib/tasks/finance.rake
+++ b/lib/tasks/finance.rake
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
+require 'progress_counter'
+
 desc "Manual checks for finance operations"
 namespace :finance do
-
   desc "Print buyers' traffic and cost (requires month in form of date [2012-08-01])"
   task :estimate_variable, [:month] => [:environment] do |task, args|
     if args[:month]
@@ -26,4 +29,16 @@ namespace :finance do
     end
   end
 
+  namespace :payment_intents do
+    desc 'Copies all data from payment_intents.payment_intent_id to new column reference'
+    task backfill_reference: :environment do
+      progress = ProgressCounter.new(PaymentIntent.count)
+      PaymentIntent.find_in_batches(batch_size: 1000) do |batch|
+        batch.each do |payment_intent|
+          payment_intent.update!(reference: payment_intent.attributes['payment_intent_id'])
+        end
+        progress.call(increment: batch.size)
+      end
+    end
+  end
 end

--- a/test/factories/payment_intent.rb
+++ b/test/factories/payment_intent.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory(:payment_intent) do
     association :invoice
-    sequence(:payment_intent_id) { |n| "payment-intent-id-#{n}" }
+    sequence(:reference) { |n| "payment-intent-#{n}" }
     state 'requires_action'
   end
 end

--- a/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
+++ b/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
@@ -71,9 +71,6 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
     test 'fails to update payment intent' do
       stripe_event = self.stripe_event(type: 'payment_intent.succeeded', payment_intent_data: { id: 'some-payment-intent-id' })
       Stripe::Webhook.expects(:construct_event).returns(stripe_event)
-      invoices = provider_account.buyer_invoices
-      PaymentIntent.expects(:by_invoice).returns(invoices)
-      invoices.expects(:find_by!).with(reference: 'some-payment-intent-id').returns(payment_intent)
       payment_intent_update_service = Finance::StripePaymentIntentUpdateService.new(provider_account, stripe_event)
       Finance::StripePaymentIntentUpdateService.expects(:new).with(provider_account, stripe_event).returns(payment_intent_update_service)
       payment_intent_update_service.expects(:call).returns(false)

--- a/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
+++ b/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
@@ -74,7 +74,9 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       invoices = provider_account.buyer_invoices
       PaymentIntent.expects(:by_invoice).returns(invoices)
       invoices.expects(:find_by!).with(payment_intent_id: 'some-payment-intent-id').returns(payment_intent)
-      payment_intent.expects(:update_from_stripe_event).returns(false)
+      payment_intent_update_service = Finance::StripePaymentIntentUpdateService.new(provider_account, stripe_event)
+      Finance::StripePaymentIntentUpdateService.expects(:new).with(provider_account, stripe_event).returns(payment_intent_update_service)
+      payment_intent_update_service.expects(:call).returns(false)
       System::ErrorReporting.expects(:report_error).at_least_once # because the setup doesn't really build all required objects
       System::ErrorReporting.expects(:report_error).with(instance_of(Finance::Api::PaymentCallbacks::StripeCallbacksController::StripeCallbackError), event: stripe_event, payment_intent: payment_intent)
 

--- a/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
+++ b/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
@@ -12,7 +12,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
 
       buyer_account = FactoryBot.create(:simple_buyer, provider_account: provider_account)
       invoice = FactoryBot.create(:invoice, buyer_account: buyer_account, provider_account: provider_account)
-      @payment_intent = FactoryBot.create(:payment_intent, invoice: invoice, payment_intent_id: 'some-payment-intent-id')
+      @payment_intent = FactoryBot.create(:payment_intent, invoice: invoice, reference: 'some-payment-intent-id')
 
       login! provider_account
     end
@@ -73,7 +73,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       Stripe::Webhook.expects(:construct_event).returns(stripe_event)
       invoices = provider_account.buyer_invoices
       PaymentIntent.expects(:by_invoice).returns(invoices)
-      invoices.expects(:find_by!).with(payment_intent_id: 'some-payment-intent-id').returns(payment_intent)
+      invoices.expects(:find_by!).with(reference: 'some-payment-intent-id').returns(payment_intent)
       payment_intent_update_service = Finance::StripePaymentIntentUpdateService.new(provider_account, stripe_event)
       Finance::StripePaymentIntentUpdateService.expects(:new).with(provider_account, stripe_event).returns(payment_intent_update_service)
       payment_intent_update_service.expects(:call).returns(false)

--- a/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
+++ b/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
@@ -24,7 +24,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       Stripe::Webhook.expects(:construct_event).returns(stripe_event)
 
       post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
-      assert_response :ok
+      assert_response :no_content
     end
 
     test 'missing stripe webhook signing secret' do
@@ -79,7 +79,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       System::ErrorReporting.expects(:report_error).with(instance_of(Finance::Api::PaymentCallbacks::StripeCallbacksController::StripeCallbackError), event: stripe_event, payment_intent: payment_intent)
 
       post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
-      assert_response :ok
+      assert_response :no_content
     end
 
     test 'not stripe gateway' do

--- a/test/models/payment_intent_test.rb
+++ b/test/models/payment_intent_test.rb
@@ -17,11 +17,11 @@ class PaymentIntentTest < ActiveSupport::TestCase
     assert record.valid?
   end
 
-  test 'requires a payment_intent_id' do
-    record = FactoryBot.build(:payment_intent, payment_intent_id: nil)
+  test 'requires a reference' do
+    record = FactoryBot.build(:payment_intent, reference: nil)
     refute record.valid?
-    assert record.errors[:payment_intent_id].include?("can't be blank")
-    record.payment_intent_id = 'foo'
+    assert record.errors[:reference].include?("can't be blank")
+    record.reference = 'foo'
     assert record.valid?
   end
 

--- a/test/unit/services/finance/stripe_payment_intent_update_service_test.rb
+++ b/test/unit/services/finance/stripe_payment_intent_update_service_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Finance::StripePaymentIntentUpdateServiceTest < ActiveSupport::TestCase
+  setup do
+    @provider_account = FactoryBot.create(:simple_provider)
+    buyer_account = FactoryBot.create(:simple_buyer, provider_account: provider_account)
+    @invoice = FactoryBot.create(:invoice, buyer_account: buyer_account, provider_account: provider_account)
+    FactoryBot.create(:line_item, invoice: invoice, cost: 250)
+    invoice.send(:issue!)
+    @payment_intent = FactoryBot.create(:payment_intent, invoice: invoice, state: 'submitted')
+  end
+
+  attr_reader :provider_account, :invoice, :payment_intent
+
+  test 'succeeded' do
+    stripe_event = build_stripe_event(type: 'payment_intent.succeeded', payment_intent_data: { status: 'succeeded' })
+    service = Finance::StripePaymentIntentUpdateService.new(provider_account, stripe_event)
+
+    assert_difference(payment_transactions.method(:count)) do
+      assert service.call
+      assert_equal 'succeeded', payment_intent.reload.state
+      assert invoice.reload.paid?
+    end
+
+    expected_payment_transaction = { action: 'purchase', amount: charge_cost, success: true, message: 'Payment confirmed', reference: payment_intent_data[:id], params: stripe_event.to_hash }.deep_stringify_keys
+    assert_equal expected_payment_transaction, payment_transactions.last.attributes.slice(*%w[action amount success message reference params]).deep_stringify_keys
+  end
+
+  test 'not succeeded' do
+    stripe_event = build_stripe_event(type: 'payment_intent.requires_action', payment_intent_data: { status: 'requires_action' })
+    service = Finance::StripePaymentIntentUpdateService.new(provider_account, stripe_event)
+
+    assert_difference(payment_transactions.method(:count)) do
+      assert service.call
+      assert_equal 'requires_action', payment_intent.reload.state
+      refute invoice.reload.paid?
+    end
+
+    expected_payment_transaction = { action: 'purchase', amount: charge_cost, success: false, message: 'Requires action', reference: payment_intent_data[:id], params: stripe_event.to_hash }.deep_stringify_keys
+    assert_equal expected_payment_transaction, payment_transactions.last.attributes.slice(*%w[action amount success message reference params]).deep_stringify_keys
+  end
+
+  protected
+
+  def stripe_event_data
+    { id: 'event-id', object: 'event', type: 'payment_intent.succeeded', data: { object: { id: 'payment-intent-id', object: 'payment_intent', status: 'succeeded', amount: 85000, currency: 'eur' } } }
+  end
+
+  def payment_intent_data
+    { id: payment_intent.payment_intent_id, amount: charge_cost.cents }
+  end
+
+  def build_stripe_event(type:, payment_intent_data: {})
+    payment_intent_object = self.payment_intent_data.merge(payment_intent_data)
+    Stripe::Event.construct_from(stripe_event_data.deep_merge(type: type, data: { object: payment_intent_object }))
+  end
+
+  delegate :payment_transactions, :charge_cost, to: :invoice
+end

--- a/test/unit/services/finance/stripe_payment_intent_update_service_test.rb
+++ b/test/unit/services/finance/stripe_payment_intent_update_service_test.rb
@@ -49,7 +49,7 @@ class Finance::StripePaymentIntentUpdateServiceTest < ActiveSupport::TestCase
   end
 
   def payment_intent_data
-    { id: payment_intent.payment_intent_id, amount: charge_cost.cents }
+    { id: payment_intent.reference, amount: charge_cost.cents }
   end
 
   def build_stripe_event(type:, payment_intent_data: {})

--- a/test/unit/tasks/finance_test.rb
+++ b/test/unit/tasks/finance_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Tasks
+  class FinanceTest < ActiveSupport::TestCase
+    test 'payment_intents:backfill_reference' do
+      payment_intent_ids = FactoryBot.create_list(:payment_intent, 5).map(&:id)
+      relation = PaymentIntent.where(id: payment_intent_ids)
+
+      # creates the state to be fixed with the rake task
+      relation.update_all('payment_intent_id=reference, reference=NULL')
+
+      execute_rake_task 'finance.rake', 'finance:payment_intents:backfill_reference'
+
+      relation.reload.each do |payment_intent|
+        assert_equal payment_intent.attributes['payment_intent_id'], payment_intent.reference, "It looks like reference of payment intent ID #{payment_intent.id} wasn't back filled"
+      end
+    end
+  end
+end

--- a/test/unit/three_scale/money_test.rb
+++ b/test/unit/three_scale/money_test.rb
@@ -8,6 +8,9 @@ module ThreeScale
       amount = Money.cents(450, 'EUR').amount
       assert_equal 4.5, amount
       assert_instance_of BigDecimal, amount
+
+      fraction = Money.cents(0.13, 'EUR').amount
+      assert_equal 0.0013, fraction
     end
   end
 end

--- a/test/unit/three_scale/money_test.rb
+++ b/test/unit/three_scale/money_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ThreeScale
+  class MoneyTest < ActiveSupport::TestCase
+    test 'initialize from cents' do
+      amount = Money.cents(450, 'EUR').amount
+      assert_equal 4.5, amount
+      assert_instance_of BigDecimal, amount
+    end
+  end
+end


### PR DESCRIPTION
Some improvements following #2339.

- [x] Some CodeClimate: https://codeclimate.com/github/3scale/porta/pull/2339
- [x] Replace `rescue` in #create with `rescue_from` in `Finance::Api::PaymentCallbacks::StripeCallbacksController`
- [x] Move `’payment_intent.succeeded’` to a constant
- [x] Fix division of a `ThreeScale::Money` by a `Float`
- [x] Check on the issue of multiple invocations of the Stripe callback within a short period of time
- [x] "Rename" `payment_intents.payment_intent_id` to `payment_intents.reference`
    - Added a rake task to back fill existing records: `bundle exec rake finance:payment_intents:backfill_reference`
- [x] Make `payment_intents.reference` unique

**For future PR:**
- Remove column `payment_intents.payment_intent_id`
- Remove rake task `finance:payment_intents:backfill_reference`

----

Related to [THREESCALE-6531](https://issues.redhat.com/browse/THREESCALE-6531).