### PR TITLE
Braintree transaction source recurring

### DIFF
--- a/app/services/finance/charging_service.rb
+++ b/app/services/finance/charging_service.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Finance
+  class ChargingService
+    def initialize(gateway, buyer_reference:, amount:, options: {})
+      @gateway = gateway
+      @buyer_reference = buyer_reference
+      @amount = amount
+      @options = options
+    end
+
+    attr_reader :gateway, :buyer_reference, :amount, :options
+
+    def call
+      case gateway
+      when ActiveMerchant::Billing::AuthorizeNetGateway
+        charge_with_authorize_net
+      when ActiveMerchant::Billing::StripePaymentIntentsGateway
+        charge_with_stripe_payment_intents
+      when ActiveMerchant::Billing::StripeGateway
+        charge_with_stripe
+      when ActiveMerchant::Billing::BraintreeBlueGateway
+        charge_with_braintree_blue
+      else
+        gateway.purchase(amount.cents, buyer_reference, options)
+      end
+    end
+
+    protected
+
+    def charge_with_authorize_net
+      profile_response = authorize_net_customer_profile
+      return profile_response unless profile_response.success?
+
+      payment_profiles = profile_response.params['profile']['payment_profiles']
+      payment_profile = payment_profiles.is_a?(Array) ? payment_profiles[-1] : payment_profiles # payment_profiles can be a Hash or an Array of hashes
+      payment_profile_id = payment_profile['customer_payment_profile_id']
+
+      gateway.cim_gateway.create_customer_profile_transaction(
+        transaction: {
+          customer_profile_id: buyer_reference,
+          customer_payment_profile_id: payment_profile_id,
+          type: :auth_capture,
+          amount: amount.to_f
+        }
+      )
+    end
+
+    def authorize_net_customer_profile
+      gateway.cim_gateway.get_customer_profile(customer_profile_id: buyer_reference)
+    end
+
+    def charge_with_stripe(opts = options)
+      options = opts.merge(customer: buyer_reference)
+      payment_method_id = options.delete(:payment_method_id)
+      invoice = options.delete(:invoice)
+      stripe_service = Finance::StripeChargeService.new(gateway, payment_method_id: payment_method_id, invoice: invoice, gateway_options: options)
+      stripe_service.charge(amount)
+    end
+
+    def charge_with_stripe_payment_intents
+      charge_with_stripe(options.reverse_merge(off_session: true, execute_threed: true))
+    end
+
+    def charge_with_braintree_blue
+      gateway.purchase(amount.cents, buyer_reference, options.merge(transaction_source: 'recurring'))
+    end
+  end
+end
+
+# Monkey patch to turn all AuthorizeNet gateway clients into AuthorizeNetCim ones
+class ::ActiveMerchant::Billing::AuthorizeNetGateway
+  def cim_gateway
+    @cim_gateway ||= ::ActiveMerchant::Billing::AuthorizeNetCimGateway.new(options)
+  end
+end

--- a/test/unit/payment_transaction_test.rb
+++ b/test/unit/payment_transaction_test.rb
@@ -5,105 +5,6 @@ class PaymentTransactionTest < ActiveSupport::TestCase
   should belong_to :invoice
   should validate_presence_of :amount
 
-  test "purchase_with_authorize_net with arrays" do
-    payment_transaction = PaymentTransaction.new
-
-    gateway = stubs(:gateway)
-    profile_response = stubs(:profile_response)
-    profile_response.stubs(:success?).returns(true)
-    profile_response.stubs(:params).returns({'profile' => {'payment_profiles' => [{},{"customer_payment_profile_id" => '5678'}]}})
-    payment_transaction.stubs(get_profile_response: profile_response)
-
-    cim_gateway = stubs(:cim_gateway)
-
-    expected_hash = {:transaction => {
-        :customer_profile_id => '1234',
-        :customer_payment_profile_id => '5678',
-        :type => :auth_capture,
-        :amount => 10.0 }
-    }
-
-    payment_transaction.stubs(amount: 10)
-    cim_gateway.expects(:create_customer_profile_transaction).with(expected_hash)
-    gateway.stubs(cim_gateway: cim_gateway)
-
-    payment_transaction.send(:purchase_with_authorize_net, '1234', gateway)
-  end
-
-  test "purchase_with_authorize_net with hashes" do
-    payment_transaction = PaymentTransaction.new
-
-    gateway = stubs(:gateway)
-    profile_response = stubs(:profile_response)
-    profile_response.stubs(:success?).returns(true)
-    profile_response.stubs(:params).returns({'profile' => {'payment_profiles' => {"customer_payment_profile_id" => '5678'}}})
-    payment_transaction.stubs(get_profile_response: profile_response)
-
-    cim_gateway = stubs(:cim_gateway)
-
-    expected_hash = {:transaction => {
-        :customer_profile_id => '1234',
-        :customer_payment_profile_id => '5678',
-        :type => :auth_capture,
-        :amount => 10.0 }
-    }
-
-    payment_transaction.stubs(amount: 10)
-    cim_gateway.expects(:create_customer_profile_transaction).with(expected_hash)
-    gateway.stubs(cim_gateway: cim_gateway)
-
-    payment_transaction.send(:purchase_with_authorize_net, '1234', gateway)
-  end
-
-  class PurchaseThroughStripeGatewayTest < ActiveSupport::TestCase
-    def setup
-      @order_id = 3
-      @payment_transaction = PaymentTransaction.new(amount: 100, action: :purchase, currency: 'EUR')
-      @payment_gateway_options = { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx', endpoint_secret: 'some-secret' }
-      @credit_card_auth_code = 'cus_IhGaGqpp6zGwyd'
-    end
-
-    attr_reader :order_id, :payment_transaction, :payment_gateway_options, :credit_card_auth_code
-
-    test 'purchase through Stripe with SCA (without extra authorization step required by the bank)' do
-      payment_method_id = 'pm_1I5s3n2eZvKYlo2CiO193T69'
-
-      stripe_payment_intents_gateway = ActiveMerchant::Billing::StripePaymentIntentsGateway.new(payment_gateway_options)
-
-      expected_options = {off_session: true, execute_threed: true, order_id: order_id, currency: payment_transaction.currency, customer: credit_card_auth_code}
-      response_params = {'id' => 'pi_1I1EAnIxGJbGz9puiiI6e10D', 'paid' => true, 'payment_method' => payment_method_id}
-      active_merchant_response = ActiveMerchant::Billing::Response.new(true, 'Transaction approved', response_params, test: false, authorization: response_params['id'], error_code: nil)
-      stripe_payment_intents_gateway.expects(:purchase).with(payment_transaction.amount.cents, payment_method_id, expected_options).returns(active_merchant_response)
-
-      assert payment_transaction.process!(credit_card_auth_code, stripe_payment_intents_gateway, {order_id: order_id, payment_method_id: payment_method_id})
-
-      assert_payment_transaction_attributes(payment_transaction, active_merchant_response)
-    end
-
-    test 'purchase through Stripe without SCA' do
-      stripe_gateway = ActiveMerchant::Billing::StripeGateway.new(payment_gateway_options)
-
-      expected_options = {order_id: order_id, currency: payment_transaction.currency, customer: credit_card_auth_code}
-      response_params = {'id' => 'ch_1HxxDgIxGJbGz9puarvnHz6X', 'paid' => true, 'payment_method' => 'card_1HxtiHIxGJbGz9pusM7rTEYS'}
-      active_merchant_response = ActiveMerchant::Billing::Response.new(true, 'Transaction approved', response_params, test: false, authorization: response_params['id'], error_code: nil)
-      stripe_gateway.expects(:purchase).with(payment_transaction.amount.cents, nil, expected_options).returns(active_merchant_response)
-
-      assert payment_transaction.process!(credit_card_auth_code, stripe_gateway, {order_id: order_id})
-
-      assert_payment_transaction_attributes(payment_transaction, active_merchant_response)
-    end
-
-    private
-
-    def assert_payment_transaction_attributes(payment_transaction, active_merchant_response)
-      assert_equal active_merchant_response.success?, payment_transaction.success
-      assert_equal active_merchant_response.authorization, payment_transaction.reference
-      assert_equal active_merchant_response.message, payment_transaction.message
-      assert_equal active_merchant_response.params, payment_transaction.params
-      assert_equal active_merchant_response.test, payment_transaction.test
-    end
-  end
-
   context "PaymentTransaction" do
     setup do
       @transaction = PaymentTransaction.new(:amount => 1000.to_has_money('JPY'))
@@ -117,7 +18,7 @@ class PaymentTransactionTest < ActiveSupport::TestCase
 
     context "with card stored in BogusGateway" do
       setup do
-        @gateway =  ActiveMerchant::Billing::BogusGateway.new
+        @gateway = ActiveMerchant::Billing::BogusGateway.new
       end
 
       should 'process without problems' do
@@ -130,7 +31,6 @@ class PaymentTransactionTest < ActiveSupport::TestCase
       end
     end
   end
-
 
   context "with many transactions" do
     setup do

--- a/test/unit/services/finance/charging_service_test.rb
+++ b/test/unit/services/finance/charging_service_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Finance
+  class ChargingServiceTest < ActiveSupport::TestCase
+    class ChargeWithAuthorizeNetGatewayTest < ActiveSupport::TestCase
+      setup do
+        gateway_options = { login: 'login_authorize_net', password: 'password_authorize_net' }
+        @gateway = ActiveMerchant::Billing::AuthorizeNetGateway.new(gateway_options)
+        @cim_gateway = ActiveMerchant::Billing::AuthorizeNetCimGateway.new(gateway_options)
+        gateway.stubs(cim_gateway: cim_gateway)
+        @service = ChargingService.new(gateway, buyer_reference: '1234', amount: ThreeScale::Money.new(10, 'EUR'))
+      end
+
+      attr_reader :gateway, :cim_gateway, :service
+
+      test '#charge_with_authorize_net with arrays' do
+        array_of_profile_hashes = [{}, { 'customer_payment_profile_id' => '5678' }]
+        stub_profile_response_with(array_of_profile_hashes)
+
+        cim_gateway.expects(:create_customer_profile_transaction).with(create_customer_profile_hash).returns(true)
+        assert service.send(:charge_with_authorize_net)
+      end
+
+      test '#charge_with_authorize_net with hashes' do
+        single_profile_hash = { 'customer_payment_profile_id' => '5678' }
+        stub_profile_response_with(single_profile_hash)
+
+        cim_gateway.expects(:create_customer_profile_transaction).with(create_customer_profile_hash).returns(true)
+        assert service.send(:charge_with_authorize_net)
+      end
+
+      private
+
+      def stub_profile_response_with(payment_profiles)
+        profile_response = stubs(:profile_response)
+        profile_response.stubs(:success?).returns(true)
+        profile_response.stubs(:params).returns({ 'profile' => { 'payment_profiles' => payment_profiles } })
+        service.stubs(authorize_net_customer_profile: profile_response)
+      end
+
+      def create_customer_profile_hash
+        {
+          transaction: {
+            customer_profile_id: '1234',
+            customer_payment_profile_id: '5678',
+            type: :auth_capture,
+            amount: 10.0
+          }
+        }
+      end
+    end
+
+    class ChargeWithStripeGatewayTest < ActiveSupport::TestCase
+      def setup
+        @order_id = 3
+        @currency = 'EUR'
+        @amount = ThreeScale::Money.new(10, currency)
+        @buyer_reference = 'cus_IhGaGqpp6zGwyd'
+        @common_options = payment_gateway_options.merge(order_id: order_id)
+      end
+
+      attr_reader :order_id, :currency, :amount, :buyer_reference, :common_options
+
+      test 'charge with Stripe' do
+        stripe_gateway = build_payment_gateway(:stripe)
+        service = ChargingService.new(stripe_gateway, buyer_reference: buyer_reference, amount: amount, options: common_options)
+
+        expected_options = common_options.merge(customer: buyer_reference)
+        response_params = { 'id' => 'ch_1HxxDgIxGJbGz9puarvnHz6X', 'paid' => true, 'payment_method' => 'card_1HxtiHIxGJbGz9pusM7rTEYS' }
+        stripe_gateway.expects(:purchase).with(amount.cents, nil, expected_options).returns(active_merchant_response(response_params))
+
+        assert service.call
+      end
+
+      test 'charge with Stripe payment intents (SCA-compliant)' do
+        payment_method_id = 'pm_1I5s3n2eZvKYlo2CiO193T69'
+
+        stripe_gateway = build_payment_gateway(:stripe_payment_intents)
+        service = ChargingService.new(stripe_gateway, buyer_reference: buyer_reference, amount: amount, options: common_options.merge(payment_method_id: payment_method_id))
+
+        expected_options = common_options.merge(customer: buyer_reference, off_session: true, execute_threed: true)
+        response_params = { 'id' => 'pi_1I1EAnIxGJbGz9puiiI6e10D', 'paid' => true, 'payment_method' => payment_method_id }
+        stripe_gateway.expects(:purchase).with(amount.cents, payment_method_id, expected_options).returns(active_merchant_response(response_params))
+
+        assert service.call
+      end
+
+      private
+
+      def active_merchant_response(params)
+        ActiveMerchant::Billing::Response.new(true, 'Transaction approved', params, test: false, authorization: params['id'], error_code: nil)
+      end
+
+      def build_payment_gateway(type)
+        ActiveMerchant::Billing::Base.gateway(type).new(payment_gateway_options)
+      end
+
+      def payment_gateway_options
+        { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx', endpoint_secret: 'some-secret' }
+      end
+    end
+  end
+
+  class ChargeWithBraintreeBlueGatewayTest < ActiveSupport::TestCase
+    test 'charge' do
+      gateway_options = { merchant_id: 'merchid_braintree', public_key: 'pubkey_braintree', private_key: 'privkey_braintree'}
+      gateway = ActiveMerchant::Billing::BraintreeBlueGateway.new(gateway_options)
+      amount = ThreeScale::Money.new(45, 'EUR')
+      service = ChargingService.new(gateway, buyer_reference: '1234', amount: amount)
+      gateway.expects(:purchase).with(amount.cents, '1234', { transaction_source: 'recurring' }).returns(true)
+      assert service.call
+    end
+  end
+end


### PR DESCRIPTION
- Adds `transaction_source: 'recurring'` to purchase with braintree
- New service `Finance::ChargingService` (to remove charign logic from `PaymentTransaction`