### PR TITLE
Adding missing title for line items in Invoices

### DIFF
--- a/app/lib/pdf/finance/invoice_generator.rb
+++ b/app/lib/pdf/finance/invoice_generator.rb
@@ -102,7 +102,7 @@ module Pdf
       end
 
       def print_line_items
-        @pdf.text "Line items"
+        subtitle('<b>Line items</b>')
         opts = { width: TABLE_FULL_WIDTH, headers: InvoiceReportData::LINE_ITEMS_HEADING }
         @pdf.table(@data.line_items, @style.table_style.merge(opts))
         move_down

--- a/app/lib/pdf/finance/invoice_generator.rb
+++ b/app/lib/pdf/finance/invoice_generator.rb
@@ -102,6 +102,7 @@ module Pdf
       end
 
       def print_line_items
+        @pdf.text "Line items"
         opts = { width: TABLE_FULL_WIDTH, headers: InvoiceReportData::LINE_ITEMS_HEADING }
         @pdf.table(@data.line_items, @style.table_style.merge(opts))
         move_down

--- a/app/views/finance/provider/shared/_line_items.html.erb
+++ b/app/views/finance/provider/shared/_line_items.html.erb
@@ -1,4 +1,7 @@
 <table id="line_items" class="invoice">
+  <caption>
+    Line Items
+  </caption>
   <thead>
   <tr>
     <th>Name</th>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

When creating an invoice manually, the Line Items section is missing a title

**Which issue(s) this PR fixes** 

None, but follow-up of https://github.com/3scale/porta/pull/2350

**Verification steps** 

- Go to `/buyers/accounts/[id]/invoices`:
   ![link](https://user-images.githubusercontent.com/13486237/107514362-db6e0e00-6ba9-11eb-9174-92301ec98b27.png)
- Create an Invoice
- Add line items

**Before**:
<img width="1192" alt="Screenshot 2021-02-10 at 14 07 31" src="https://user-images.githubusercontent.com/13486237/107514522-14a67e00-6baa-11eb-9dc4-1edd6791efe0.png">

**After**:
<img width="1194" alt="Screenshot 2021-02-10 at 14 07 53" src="https://user-images.githubusercontent.com/13486237/107514568-21c36d00-6baa-11eb-9e7f-ed5acc25a9c8.png">
