### PR TITLE
Adding flash message when the user data is not valid

### DIFF
--- a/app/controllers/buyers/accounts_controller.rb
+++ b/app/controllers/buyers/accounts_controller.rb
@@ -53,7 +53,7 @@ class Buyers::AccountsController < Buyers::BaseController
       redirect_to admin_buyers_account_path(@buyer)
     else
       @user = signup_result.user
-      flash.now[:error] = signup_result.errors.messages.without(:account, :user).values.join('. ')
+      flash.now[:error] = signup_result.errors.messages.without(:user).values.join('. ')
       render action: :new
     end
   end

--- a/test/integration/buyers/accounts_controller_test.rb
+++ b/test/integration/buyers/accounts_controller_test.rb
@@ -294,6 +294,16 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
       get admin_buyers_accounts_path(id: @buyer.id)
       assert_xpath('//tbody/tr/td[2]/a', @buyer.decorate.admin_user_display_name)
     end
+
+    test 'User with invalid data shows an flash error' do
+      post admin_buyers_accounts_path, account: {
+          org_name: 'My organization',
+          user: {
+            username: 'hello'
+          }
+      }
+      assert_equal 'Users invalid', flash[:error]
+    end
   end
 
   class MasterLoggedInTest < Buyers::AccountsControllerTest


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding flash message when the user data is not valid 

**Which issue(s) this PR fixes** 
 closes [THREESCALE-6633](https://issues.redhat.com/browse/THREESCALE-6633)

**Verification steps** 
**Before** 
<img width="1035" alt="Screenshot 2021-01-28 at 15 45 36" src="https://user-images.githubusercontent.com/53568062/107606379-e5e8e000-6c5b-11eb-9adf-1c9ee93ea51b.png">

**After**
![Screenshot from 2021-02-11 11-10-43](https://user-images.githubusercontent.com/53568062/107606402-f8631980-6c5b-11eb-8bd9-25d8d9caf0d1.png)
