### PR TITLE
removes unused class Header-logo--withIcon

### DIFF
--- a/app/views/shared/provider/_header.html.slim
+++ b/app/views/shared/provider/_header.html.slim
@@ -4,7 +4,7 @@
 header.pf-c-page__header id="user_widget" class='Header' class=('Header--master' if current_account.master?) role='banner'
 
   = link_to provider_admin_dashboard_path, class: 'pf-c-page__header-brand Header-link', title: 'Dashboard' do
-      .Header-logo class=('Header-logo--withIcon' if active_menu?(:main_menu, :dashboard))
+      .Header-logo
         span Red Hat 3scale API Management
 
   .pf-c-page__header-nav


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes an unused class `Header-logo--withIcon`

**Which issue(s) this PR fixes** 

Fixes https://issues.redhat.com/browse/THREESCALE-6694

**Verification steps** 

Verify that the logo in the upper left on the dashboards still appears correctly

**Special notes for your reviewer**:
