### PR TITLE
PF compliant buttons: Audience

### DIFF
--- a/app/assets/stylesheets/provider/layouts/_main.scss
+++ b/app/assets/stylesheets/provider/layouts/_main.scss
@@ -37,13 +37,8 @@ body {
   }
 }
 
-// HACK: links and buttons with icons are showing double icons
-// One because of PatternFly, one because our own styles
-// We can't remove icons from our codebase, as not all links are using PF
-a.action.pf-c-button:not(.preserve-icons)::before,
-button.action.pf-c-button:not(.preserve-icons)::before {
-  content: none;
-}
+// HACK: Some PF classes still collapses with ours.
+// As we are still using both PF and not-PF links, we need this
 a.action.pf-c-button {
   color: $success-color;
 }

--- a/app/assets/stylesheets/provider/layouts/_main.scss
+++ b/app/assets/stylesheets/provider/layouts/_main.scss
@@ -41,6 +41,44 @@ body {
 // As we are still using both PF and not-PF links, we need this
 a.action.pf-c-button {
   color: $success-color;
+
+  &.add,
+  &.new,
+  &.approve,
+  &.activate,
+  &.ok,
+  &.enable,
+  &.resume {
+    color: $create-color;
+
+    &:hover {
+      color: $link-hover-color;
+    }
+  }
+
+  &.bolt,
+  &.fire,
+  &.off,
+  &.eye,
+  &.revert {
+    color: $warning-color;
+
+    &:hover {
+      color: $link-hover-color;
+    }
+  }
+
+  &.delete,
+  &.reject,
+  &.eye-slash,
+  &.suspend,
+  &.disable {
+    color: $delete-color;
+
+    &:hover {
+      color: $link-hover-color;
+    }
+  }
 }
 
 @mixin white-box-shadow {

--- a/app/assets/stylesheets/provider/layouts/_main.scss
+++ b/app/assets/stylesheets/provider/layouts/_main.scss
@@ -1,3 +1,5 @@
+// scss-lint:disable SelectorFormat
+
 body {
   min-width: $layout-wrapper-min-width;
 }

--- a/app/assets/stylesheets/provider/layouts/_main.scss
+++ b/app/assets/stylesheets/provider/layouts/_main.scss
@@ -37,6 +37,14 @@ body {
   }
 }
 
+// HACK: links and buttons with icons are showing double icons
+// One because of PatternFly, one because our own styles
+// We can't remove icons from our codebase, as not all links are using PF
+a.action.pf-c-button:not(.preserve-icons)::before,
+button.action.pf-c-button:not(.preserve-icons)::before {
+  content: none;
+}
+
 @mixin white-box-shadow {
   background-color: $white;
   box-shadow: $whiteBoxShadow;

--- a/app/assets/stylesheets/provider/layouts/_main.scss
+++ b/app/assets/stylesheets/provider/layouts/_main.scss
@@ -44,6 +44,9 @@ a.action.pf-c-button:not(.preserve-icons)::before,
 button.action.pf-c-button:not(.preserve-icons)::before {
   content: none;
 }
+a.action.pf-c-button {
+  color: $success-color;
+}
 
 @mixin white-box-shadow {
   background-color: $white;

--- a/app/assets/stylesheets/provider/layouts/_main.scss
+++ b/app/assets/stylesheets/provider/layouts/_main.scss
@@ -41,6 +41,21 @@ body {
 
 // HACK: Some PF classes still collapses with ours.
 // As we are still using both PF and not-PF links, we need this
+button.action.pf-c-button {
+
+  padding: 0 var(--pf-global--spacer--md);
+
+  &.pf-m-primary,
+  &.pf-m-danger {
+    color: $white;
+  }
+
+  &.pf-m-secondary {
+    color: var(--pf-c-button--m-secondary--Color);
+  }
+
+}
+
 a.action.pf-c-button {
   color: $success-color;
 

--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -79,7 +79,7 @@ module AccountHelper
     alert = t('buyers.accounts.edit.delete.admin_restricted', admin: current_account.first_admin.try(:email))
 
     url = can?(:destroy, account) ? admin_buyers_account_path(account) : javascript_alert_url(alert)
-    delete_link_for(url, confirm: msg)
+    pf_delete_link_for(url, confirm: msg)
   end
 
   def master_on_premises?

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ButtonsHelper
 
   DATA_ATTRIBUTES = [:confirm, :method, :remote, :'disable-with', :disabled]
@@ -142,57 +144,36 @@ module ButtonsHelper
     end
   end
 
+  PATTERNFLY_LINK_CLASS = 'pf-c-button pf-m-link'
+
   def pf_link_to(name, path, options)
-    options[:class] = join_dom_classes(options[:class], ' pf-c-button pf-m-link preserve-icons')
+    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
     link_to(name, path, options)
-  end
-  
-
-  def pf_link_with_icon(text, url, options)
-    a_class = "pf-c-button pf-m-#{options[:type] || 'link'} #{options[:class]}"
-    span_class = "pf-c-button__icon pf-m-#{options[:position] || 'start'}"
-    icon_class = "fa fa-#{options[:icon]}"
-
-    span_icon_tag = content_tag :span, (content_tag :i, nil, :class => icon_class, "aria-hidden" => true), :class => span_class
-
-    content_tag :a, class: a_class, href: url do
-      options[:position] == 'start' ?  (
-        concat span_icon_tag
-        concat text
-      ) : (
-        concat text
-        concat span_icon_tag
-      )
-    end
   end
 
   def pf_action_link_to(action, url, options = {})
-    options[:class] = add_pf_classes_to_options("pf-c-button pf-m-link preserve-icons", options[:class])
+    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
     action_link_to(action, url, options)
   end
 
   def pf_fancy_button_to(label, url, options = {})
-    options[:class] = add_pf_classes_to_options("pf-c-button pf-m-link preserve-icons", options[:class])
+    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
     fancy_button_to(label, url, options)
   end
 
   def pf_fancy_link_to(label, url, options = {})
-    options[:class] = add_pf_classes_to_options("pf-c-button pf-m-link preserve-icons", options[:class])
+    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
     fancy_link_to(label, url, options)
   end
 
   def pf_delete_button_for(url, options = {})
-    options[:class] = add_pf_classes_to_options("pf-c-button pf-m-link", options[:class])
+    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
     delete_button_for(url, options)
   end
 
   def pf_delete_link_for(url, options = {})
-    options[:class] = add_pf_classes_to_options("pf-c-button pf-m-link preserve-icons", options[:class])
+    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
     delete_link_for(url, options)
-  end
-
-  def add_pf_classes_to_options(pf_class, options_class)
-    "#{pf_class} #{options_class}"
   end
 
   protected

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -176,8 +176,13 @@ module ButtonsHelper
   end
 
   def pf_delete_button_for(url, options = {})
-    options[:class] = add_pf_classes_to_options("pf-c-button pf-c-link", options[:class])
+    options[:class] = add_pf_classes_to_options("pf-c-button pf-m-link", options[:class])
     delete_button_for(url, options)
+  end
+
+  def pf_delete_link_for(url, options = {})
+    options[:class] = add_pf_classes_to_options("pf-c-button pf-m-link preserve-icons", options[:class])
+    delete_link_for(url, options)
   end
 
   def add_pf_classes_to_options(pf_class, options_class)

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -142,6 +142,48 @@ module ButtonsHelper
     end
   end
 
+  def pf_link_with_icon(text, url, options)
+    a_class = "pf-c-button pf-m-#{options[:type] || 'link'} #{options[:class]}"
+    span_class = "pf-c-button__icon pf-m-#{options[:position] || 'start'}"
+    icon_class = "fa fa-#{options[:icon]}"
+
+    span_icon_tag = content_tag :span, (content_tag :i, nil, :class => icon_class, "aria-hidden" => true), :class => span_class
+
+    content_tag :a, class: a_class, href: url do
+      options[:position] == 'start' ?  (
+        concat span_icon_tag
+        concat text
+      ) : (
+        concat text
+        concat span_icon_tag
+      )
+    end
+  end
+
+  def pf_action_link_to(action, url, options = {})
+    options[:class] = add_pf_classes_to_options("pf-c-button pf-m-link preserve-icons", options[:class])
+    action_link_to(action, url, options)
+  end
+
+  def pf_fancy_button_to(label, url, options = {})
+    options[:class] = add_pf_classes_to_options("pf-c-button pf-m-link preserve-icons", options[:class])
+    fancy_button_to(label, url, options)
+  end
+
+  def pf_fancy_link_to(label, url, options = {})
+    options[:class] = add_pf_classes_to_options("pf-c-button pf-m-link preserve-icons", options[:class])
+    fancy_link_to(label, url, options)
+  end
+
+  def pf_delete_button_for(url, options = {})
+    options[:class] = add_pf_classes_to_options("pf-c-button pf-c-link", options[:class])
+    delete_button_for(url, options)
+  end
+
+  def add_pf_classes_to_options(pf_class, options_class)
+    "#{pf_class} #{options_class}"
+  end
+
   protected
 
   def javascript_alert_url(text)

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -142,6 +142,12 @@ module ButtonsHelper
     end
   end
 
+  def pf_link_to(name, path, options)
+    options[:class] = join_dom_classes(options[:class], ' pf-c-button pf-m-link preserve-icons')
+    link_to(name, path, options)
+  end
+  
+
   def pf_link_with_icon(text, url, options)
     a_class = "pf-c-button pf-m-#{options[:type] || 'link'} #{options[:class]}"
     span_class = "pf-c-button__icon pf-m-#{options[:position] || 'start'}"

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -146,34 +146,13 @@ module ButtonsHelper
 
   PATTERNFLY_LINK_CLASS = 'pf-c-button pf-m-link'
 
-  def pf_link_to(name, path, options)
-    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
-    link_to(name, path, options)
-  end
-
-  def pf_action_link_to(action, url, options = {})
-    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
-    action_link_to(action, url, options)
-  end
-
-  def pf_fancy_button_to(label, url, options = {})
-    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
-    fancy_button_to(label, url, options)
-  end
-
-  def pf_fancy_link_to(label, url, options = {})
-    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
-    fancy_link_to(label, url, options)
-  end
-
-  def pf_delete_button_for(url, options = {})
-    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
-    delete_button_for(url, options)
-  end
-
-  def pf_delete_link_for(url, options = {})
-    options[:class] = join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class])
-    delete_link_for(url, options)
+  %w[link_to action_link_to fancy_button_to fancy_link_to delete_button_for delete_link_for].each do |method_sym|
+    define_method("pf_#{method_sym}") do |*args, options|
+      opts = options.respond_to?(:merge) ?
+        [options.merge(class: join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class]))] :
+        [options, { class: PATTERNFLY_LINK_CLASS }]
+      public_send(method_sym, *args, *opts)
+    end
   end
 
   protected

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -144,7 +144,8 @@ module ButtonsHelper
     end
   end
 
-  PATTERNFLY_LINK_CLASS = 'pf-c-button pf-m-link'
+  PATTERNFLY_BUTTON_CLASS = 'pf-c-button'
+  PATTERNFLY_LINK_CLASS = "#{PATTERNFLY_BUTTON_CLASS} pf-m-link"
 
   %i[link_to action_link_to fancy_button_to fancy_link_to delete_button_for delete_link_for].each do |method_sym|
     define_method("pf_#{method_sym}") do |*args, options|
@@ -153,6 +154,13 @@ module ButtonsHelper
         [options, { class: PATTERNFLY_LINK_CLASS }]
       public_send(method_sym, *args, *opts)
     end
+  end
+
+  def pf_link_as_button(label, url, options)
+    pf_class = "#{PATTERNFLY_BUTTON_CLASS} pf-m-#{options[:modifier]}"
+    options[:class] = join_dom_classes(pf_class, options[:class])
+    
+    link_to label, url, options
   end
 
   protected

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -146,7 +146,7 @@ module ButtonsHelper
 
   PATTERNFLY_LINK_CLASS = 'pf-c-button pf-m-link'
 
-  %w[link_to action_link_to fancy_button_to fancy_link_to delete_button_for delete_link_for].each do |method_sym|
+  %i[link_to action_link_to fancy_button_to fancy_link_to delete_button_for delete_link_for].each do |method_sym|
     define_method("pf_#{method_sym}") do |*args, options|
       opts = options.respond_to?(:merge) ?
         [options.merge(class: join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class]))] :

--- a/app/helpers/finance/invoices_helper.rb
+++ b/app/helpers/finance/invoices_helper.rb
@@ -47,7 +47,7 @@ module Finance::InvoicesHelper
 
   def invoice_action_button(name, action)
     url = send("#{action}_admin_finance_invoice_path", @invoice.id, :format => :js)
-    fancy_button_to(name, url, :method => :put, :remote => true)
+    pf_fancy_button_to(name, url, :method => :put, :remote => true)
   end
 
   def invoice_pdf_link(invoice, label = 'Download PDF')

--- a/app/helpers/finance/invoices_helper.rb
+++ b/app/helpers/finance/invoices_helper.rb
@@ -45,14 +45,24 @@ module Finance::InvoicesHelper
             :title => "Current invoice for #{h(buyer.org_name)}"
   end
 
-  def invoice_action_button(name, action)
+  def invoice_action_button(name, action, modifier)
     url = send("#{action}_admin_finance_invoice_path", @invoice.id, :format => :js)
-    pf_fancy_button_to(name, url, :method => :put, :remote => true)
+    pf_class = "pf-c-button pf-m-#{modifier}"
+    fancy_button_to(name, url, :method => :put, :remote => true, :class => pf_class)
   end
+
 
   def invoice_pdf_link(invoice, label = 'Download PDF')
     if invoice.pdf.file?
       link_to(label, invoice.pdf.expiring_url)
+    else
+      content_tag(:em,'not yet generated')
+    end
+  end
+
+  def pf_invoice_pdf_link(invoice, label = 'Download PDF')
+    if invoice.pdf.file?
+      pf_link_as_button(label, invoice.pdf.expiring_url, modifier: 'secondary')
     else
       content_tag(:em,'not yet generated')
     end

--- a/app/views/admin/fields_definitions/index.html.erb
+++ b/app/views/admin/fields_definitions/index.html.erb
@@ -16,7 +16,9 @@ Here you can manage all the information you gather from your users. You can add 
   <h2>
     <%= class_name.constantize.model_name.human %>
   </h2>
-  <%= fancy_link_to "Create", new_admin_fields_definition_path(:fields_definition => {:target => class_name}), :title => "Create new field for #{class_name.constantize.model_name.human}", :class => 'new-field-definition new action add' %>
+  <%= pf_fancy_link_to "Create", new_admin_fields_definition_path(:fields_definition=> {:target => class_name}),
+    :title => "Create new field for #{class_name.constantize.model_name.human}", :class => 'new-field-definition new
+    action add' %>
 
   <% if @fields_definitions.by_target(class_name).blank? %>
     <i>No extra fields for this element.</i>

--- a/app/views/admin/fields_definitions/index.html.erb
+++ b/app/views/admin/fields_definitions/index.html.erb
@@ -31,7 +31,7 @@ Here you can manage all the information you gather from your users. You can add 
 	<span>"<%= h truncate(fields_definition.label, :length => 50) %>"</span>
 	<span class="action-set">
 	  <span class="properties"><%=h retrieve_properties_of fields_definition %></span>
-	  <%= link_to 'Edit', edit_admin_fields_definition_path(fields_definition), :class => 'action edit' %>
+	  <%= pf_link_to 'Edit', edit_admin_fields_definition_path(fields_definition), :class => 'action edit' %>
       </li>
     <% end %>
   </ol>

--- a/app/views/buyers/accounts/_account_plan.html.erb
+++ b/app/views/buyers/accounts/_account_plan.html.erb
@@ -6,10 +6,12 @@
   <% if can? :manage, :plans -%>
     <div class="operations">
       <% if plan.customized? %>
-        <%= link_to 'Edit', edit_admin_account_plan_path(plan.id), :class => 'action edit' %>
-        <%= delete_button_for admin_buyers_contract_custom_plan_path(contract, plan), :label => 'Remove customization' %>
+        <%= pf_link_with_icon 'Edit' , edit_admin_account_plan_path(plan.id), :class=> 'action edit', :type => 'link', :icon =>
+          'pencil', :position => 'start' %>
+          <%= pf_delete_button_for admin_buyers_contract_custom_plan_path(contract, plan), :label=> 'Remove customization' %>
       <% else %>
-        <%= fancy_link_to 'Convert to a Custom Plan', admin_buyers_contract_custom_plans_path(contract), :method => :post, :class => 'new', :remote => true %>
+      <%= pf_fancy_link_to 'Convert to a Custom Plan' , admin_buyers_contract_custom_plans_path(contract), :method=> :post,
+        :class => 'new', :remote => true %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/buyers/accounts/_account_plan.html.erb
+++ b/app/views/buyers/accounts/_account_plan.html.erb
@@ -6,8 +6,7 @@
   <% if can? :manage, :plans -%>
     <div class="operations">
       <% if plan.customized? %>
-        <%= pf_link_with_icon 'Edit' , edit_admin_account_plan_path(plan.id), :class=> 'action edit', :type => 'link', :icon =>
-          'pencil', :position => 'start' %>
+      <%= pf_link_to 'Edit', edit_admin_account_plan_path(plan.id), :class => 'action edit' %>
           <%= pf_delete_button_for admin_buyers_contract_custom_plan_path(contract, plan), :label=> 'Remove customization' %>
       <% else %>
       <%= pf_fancy_link_to 'Convert to a Custom Plan' , admin_buyers_contract_custom_plans_path(contract), :method=> :post,

--- a/app/views/buyers/accounts/_monthly_charging.html.erb
+++ b/app/views/buyers/accounts/_monthly_charging.html.erb
@@ -11,7 +11,7 @@
       Monthly billing is <%= status %>.
     </td>
     <td>
-      <%= fancy_button_to action,
+      <%= pf_fancy_button_to action,
                           toggle_monthly_billing_admin_buyers_account_path(account),
                           :method => :put,
                           id: "#{action.downcase}-monthly-billing",
@@ -37,7 +37,7 @@
         Monthly charging is <%= status %>.
       </td>
       <td>
-          <%= fancy_button_to action, toggle_monthly_charging_admin_buyers_account_path(account),
+          <%= pf_fancy_button_to action, toggle_monthly_charging_admin_buyers_account_path(account),
                          :method => :put,
                          :id => "#{action.downcase}-monthly-charging",
                          :class => "action #{action.downcase}",

--- a/app/views/buyers/accounts/edit.html.slim
+++ b/app/views/buyers/accounts/edit.html.slim
@@ -13,6 +13,6 @@ div
       = form.user_defined_form
 
     = form.buttons do
-      = form.commit_button 'Update Account'
+      = form.commit_button 'Update Account', button_html: { class: 'pf-c-button pf-m-primary' }
       li
         = delete_buyer_link(@account)

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -2,9 +2,9 @@
 h1 data-hook="account-show"
   ' Account: #{@account.org_name}
   - if can? :update, @account
-    = pf_link_with_icon 'Edit',
+     = pf_link_to 'Edit',
         edit_admin_buyers_account_path(@account),
-        { type: 'link', position: 'start', icon: 'pencil', class: 'action edit' }
+        class: 'action edit'
 #twoCol.equal-width
   .left
     .wide_dashboard_card.round
@@ -17,9 +17,9 @@ h1 data-hook="account-show"
               => link_to 'Impersonate',
                          admin_buyers_account_impersonation_path(@account),
                          class: 'action bolt', method: 'post', target: '_blank'
-            => pf_link_with_icon 'Send message',
+            => pf_link_to 'Send message',
                        new_provider_admin_messages_outbox_path(to: @account),
-                       { type: 'link', position: 'start', icon: 'envelope-o', class: 'action message fancybox' }
+                       class: 'action message fancybox'
         - if current_account.master? && @account.provider?
           tr
             th Public domain

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -2,9 +2,9 @@
 h1 data-hook="account-show"
   ' Account: #{@account.org_name}
   - if can? :update, @account
-    = link_to 'Edit',
-              edit_admin_buyers_account_path(@account),
-              class: 'action edit'
+    = pf_link_with_icon 'Edit',
+        edit_admin_buyers_account_path(@account),
+        { type: 'link', position: 'start', icon: 'pencil', class: 'action edit' }
 #twoCol.equal-width
   .left
     .wide_dashboard_card.round
@@ -17,9 +17,9 @@ h1 data-hook="account-show"
               => link_to 'Impersonate',
                          admin_buyers_account_impersonation_path(@account),
                          class: 'action bolt', method: 'post', target: '_blank'
-            => link_to 'Send message',
+            => pf_link_with_icon 'Send message',
                        new_provider_admin_messages_outbox_path(to: @account),
-                       class: 'action message fancybox'
+                       { type: 'link', position: 'start', icon: 'envelope-o', class: 'action message fancybox' }
         - if current_account.master? && @account.provider?
           tr
             th Public domain
@@ -63,13 +63,13 @@ h1 data-hook="account-show"
                                  method: :post,
                                  class: 'reject action'
             - unless @account.suspended_or_scheduled_for_deletion?
-              = action_link_to 'Suspend',
+              = pf_action_link_to 'Suspend',
                                 suspend_admin_buyers_account_path(@account),
                                 method: :post,
                                 data: { confirm: 'Are you sure?', disable_with: 'suspending…' },
                                 class: 'action suspend'
             - if can?(:resume, @account) && @account.can_resume?
-              = action_link_to 'Resume',
+              = pf_action_link_to 'Resume',
                                resume_admin_buyers_account_path(@account),
                                method: :post,
                                data: { confirm: 'Are you sure?', disable_with: 'resuming…' },
@@ -106,6 +106,6 @@ h1 data-hook="account-show"
                 li.commit
                   = form.submit 'Change',
                                 data: { confirm: plan_confirm_message(@account.bought_account_plan) },
-                                class: "important-button"
+                                class: "pf-c-button pf-m-primary"
 
     = render 'buyers/applications/widget', account: @account

--- a/app/views/buyers/applications/new.html.erb
+++ b/app/views/buyers/applications/new.html.erb
@@ -29,7 +29,7 @@
     <%= form.user_defined_form %>
   <% end %>
   <%= form.buttons do %>
-    <%= form.commit_button button_html: {id: 'submit-new-app' } %>
+    <%= form.commit_button button_html: {id: 'submit-new-app', class: 'pf-c-button pf-m-primary' } %>
   <% end %>
 <% end %>
 

--- a/app/views/buyers/applications/new.html.erb
+++ b/app/views/buyers/applications/new.html.erb
@@ -29,7 +29,7 @@
     <%= form.user_defined_form %>
   <% end %>
   <%= form.buttons do %>
-    <%= form.commit_button button_html: {id: 'submit-new-app', class: 'pf-c-button pf-m-primary' } %>
+    <%= form.button 'Create Application', button_html: {id: 'submit-new-app', class: 'pf-c-button pf-m-primary' } %>
   <% end %>
 <% end %>
 

--- a/app/views/finance/provider/invoices/_actions.html.erb
+++ b/app/views/finance/provider/invoices/_actions.html.erb
@@ -8,10 +8,10 @@
 <%# TODO: move this to CanCan %>
 <% if @invoice.buyer %>
 <ul id="actions">
-  <%= content_tag(:li, invoice_action_button(@invoice.pdf.file? ? 'Regenerate PDF' : 'Generate PDF', :generate_pdf))  %>
-  <%= content_tag(:li, invoice_action_button('Issue invoice', :issue)) if @invoice.state_events.include?(:issue) %>
-  <%= content_tag(:li, invoice_action_button('Charge', :charge)) if @invoice.state_events.include?(:pay) %>
-  <%= content_tag(:li, invoice_action_button('Mark as paid', :pay)) if @invoice.state_events.include?(:pay) %>
-  <%= content_tag(:li, invoice_action_button('Cancel invoice', :cancel)) if @invoice.state_events.include?(:cancel) %>
+  <%= content_tag(:li, invoice_action_button(@invoice.pdf.file? ? 'Regenerate PDF' : 'Generate PDF', :generate_pdf, 'secondary'))  %>
+  <%= content_tag(:li, invoice_action_button('Issue invoice', :issue, 'primary')) if @invoice.state_events.include?(:issue) %>
+  <%= content_tag(:li, invoice_action_button('Charge', :charge, 'primary')) if @invoice.state_events.include?(:pay) %>
+  <%= content_tag(:li, invoice_action_button('Mark as paid', :pay, 'primary')) if @invoice.state_events.include?(:pay) %>
+  <%= content_tag(:li, invoice_action_button('Cancel invoice', :cancel, 'danger')) if @invoice.state_events.include?(:cancel) %>
 </ul>
 <% end %>

--- a/app/views/finance/provider/settings/show.html.slim
+++ b/app/views/finance/provider/settings/show.html.slim
@@ -13,9 +13,9 @@
 
       li
         - new_mode = @billing_strategy.is_a?(Finance::PostpaidBillingStrategy) ? 'prepaid' : 'postpaid'
-        = submit_tag "Switch to #{new_mode.upcase}",
+        = button_tag "Switch to #{new_mode.upcase}",
                      onclick: "return confirm('Are you sure you want to switch to #{new_mode} mode?');",
-                     class: "dangerous-button button next"
+                     class: "pf-c-button pf-m-danger button next"
         = hidden_field_tag 'type', new_mode
 
 = semantic_form_for @billing_strategy.becomes(Finance::BillingStrategy),
@@ -48,7 +48,7 @@
               include_blank: false
 
     = f.buttons do
-      = f.commit_button 'Save'
+      = f.commit_button 'Save', button_html: { class: 'pf-c-button pf-m-primary' }
 
 - if can?(:manage, :finance)
   - if @account.billing_strategy.try(:needs_credit_card?)
@@ -86,7 +86,7 @@
                                           value: '', disabled: true
 
       = form.buttons do
-        = form.commit_button 'Save changes'
+        = form.commit_button 'Save changes', button_html: { class: 'pf-c-button pf-m-primary' }
 
   javascript:
     $(function() {

--- a/app/views/finance/provider/settings/show.html.slim
+++ b/app/views/finance/provider/settings/show.html.slim
@@ -48,7 +48,7 @@
               include_blank: false
 
     = f.buttons do
-      = f.commit_button 'Save', button_html: { class: 'pf-c-button pf-m-primary' }
+      = f.button 'Save', button_html: { class: 'pf-c-button pf-m-primary' }
 
 - if can?(:manage, :finance)
   - if @account.billing_strategy.try(:needs_credit_card?)
@@ -86,7 +86,7 @@
                                           value: '', disabled: true
 
       = form.buttons do
-        = form.commit_button 'Save changes', button_html: { class: 'pf-c-button pf-m-primary' }
+        = form.button 'Save changes', button_html: { class: 'pf-c-button pf-m-primary' }
 
   javascript:
     $(function() {

--- a/app/views/finance/provider/shared/_invoice_header.html.erb
+++ b/app/views/finance/provider/shared/_invoice_header.html.erb
@@ -4,7 +4,7 @@
   <table class="invoice">
     <caption>
       Details
-      <%= link_to 'Edit', polymorphic_path([:edit, :admin, *edit_link_scope, @invoice]), :class => 'action edit next' if @invoice.editable? && can?(:update, @invoice)  %>
+      <%= pf_link_to 'Edit', polymorphic_path([:edit, :admin, *edit_link_scope, @invoice]), :class => 'action edit next' if @invoice.editable? && can?(:update, @invoice)  %>
     </caption>
     <%= invoice_field(:friendly_id, "#{@invoice.friendly_id} #{' (This invoice id is already in use and should probably be changed)' if @invoice.friendly_id_already_used? && @invoice.editable? }") %>
     <%= invoice_field(:state, @invoice.state.to_s.capitalize) %>

--- a/app/views/finance/provider/shared/_invoice_header.html.erb
+++ b/app/views/finance/provider/shared/_invoice_header.html.erb
@@ -13,7 +13,7 @@
     <%= invoice_field(:issued_on, invoice_date_format(@invoice.issued_on))  %>
     <%= invoice_field(:due_on, invoice_date_format(@invoice.due_on)) %>
     <%= invoice_field(:paid_on, invoice_date_format(@invoice.paid_at))  %>
-    <%= invoice_field('PDF', invoice_pdf_link(@invoice)) %>
+    <%= invoice_field('PDF', pf_invoice_pdf_link(@invoice)) %>
 
   </table>
 

--- a/app/views/finance/provider/shared/_line_item.html.erb
+++ b/app/views/finance/provider/shared/_line_item.html.erb
@@ -8,7 +8,7 @@
     <% if line_item.invoice.editable? && editable %>
       <%= form_tag admin_finance_account_invoice_line_item_path(line_item.invoice.buyer_account, line_item.invoice, line_item),
         :method => 'delete', :class => 'remote' do %>
-        <button type="submit" class="action delete">Delete</button>
+        <button type="submit" class="pf-c-button pf-m-link preserve-icons action delete">Delete</button>
       <% end %>
     <% end %>
   </td>

--- a/app/views/finance/provider/shared/_line_item.html.erb
+++ b/app/views/finance/provider/shared/_line_item.html.erb
@@ -8,7 +8,7 @@
     <% if line_item.invoice.editable? && editable %>
       <%= form_tag admin_finance_account_invoice_line_item_path(line_item.invoice.buyer_account, line_item.invoice, line_item),
         :method => 'delete', :class => 'remote' do %>
-        <button type="submit" class="pf-c-button pf-m-link preserve-icons action delete">Delete</button>
+        <button type="submit" class="pf-c-button pf-m-link action delete">Delete</button>
       <% end %>
     <% end %>
   </td>

--- a/app/views/finance/provider/shared/_line_items.html.erb
+++ b/app/views/finance/provider/shared/_line_items.html.erb
@@ -11,7 +11,7 @@
     <th>Charged</th>
     <th>
       <% if @invoice.editable? && editable %>
-        <%= link_to 'Add',new_admin_finance_account_invoice_line_item_path(@invoice.buyer_account, @invoice),
+        <%= pf_link_to 'Add', new_admin_finance_account_invoice_line_item_path(@invoice.buyer_account, @invoice),
                     :title => 'Add Custom Charge',
                     :class => 'action add fancybox',
                     :'data-autodimensions' => 'true'

--- a/app/views/sites/settings/edit.html.erb
+++ b/app/views/sites/settings/edit.html.erb
@@ -10,6 +10,6 @@
   <% end %>
 
   <%= form.buttons do %>
-    <%= form.commit_button 'Save',  button_html: { class: 'pf-c-button pf-m-primary' } %>
+    <%= form.button 'Save',  button_html: { class: 'pf-c-button pf-m-primary' } %>
   <% end %>
 <% end %>

--- a/app/views/sites/settings/edit.html.erb
+++ b/app/views/sites/settings/edit.html.erb
@@ -10,6 +10,6 @@
   <% end %>
 
   <%= form.buttons do %>
-    <%= form.commit_button 'Save' %>
+    <%= form.commit_button 'Save',  button_html: { class: 'pf-c-button pf-m-primary' } %>
   <% end %>
 <% end %>

--- a/app/views/sites/usage_rules/edit.html.slim
+++ b/app/views/sites/usage_rules/edit.html.slim
@@ -49,7 +49,7 @@
             = render 'shared/plan_change_settings', form: form, permission: :change_service_plan_permission, label: ''
 
     = form.buttons do
-      = form.commit_button 'Update Settings', button_html: { class: 'pf-c-button pf-m-primary' }
+      = form.button 'Update Settings', button_html: { class: 'pf-c-button pf-m-primary' }
 
 = javascript_include_tag 'sites/general_settings.js'
 javascript:

--- a/app/views/sites/usage_rules/edit.html.slim
+++ b/app/views/sites/usage_rules/edit.html.slim
@@ -49,7 +49,7 @@
             = render 'shared/plan_change_settings', form: form, permission: :change_service_plan_permission, label: ''
 
     = form.buttons do
-      = form.commit_button
+      = form.commit_button 'Update Settings', button_html: { class: 'pf-c-button pf-m-primary' }
 
 = javascript_include_tag 'sites/general_settings.js'
 javascript:

--- a/lib/developer_portal/app/views/developer_portal/invoices/show.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/invoices/show.html.liquid
@@ -39,7 +39,7 @@ table#line-items {
           <dd>{{ invoice.paid_on | date: i18n.long_date }}</dd>
           {% if invoice.exists_pdf? %}
           <dt>PDF</dt>
-          <dd>{{ 'Download PDF' | link_to: invoice.pdf_url, title: 'Show pdf', class: 'link' }}</dd>
+          <dd>{{ 'Download PDF' | pf_link_to: invoice.pdf_url, title: 'Show pdf', class: 'link' }}</dd>
           {% endif %}
         </dl>
 

--- a/lib/developer_portal/app/views/developer_portal/invoices/show.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/invoices/show.html.liquid
@@ -39,7 +39,7 @@ table#line-items {
           <dd>{{ invoice.paid_on | date: i18n.long_date }}</dd>
           {% if invoice.exists_pdf? %}
           <dt>PDF</dt>
-          <dd>{{ 'Download PDF' | pf_link_to: invoice.pdf_url, title: 'Show pdf', class: 'link' }}</dd>
+          <dd>{{ 'Download PDF' | link_to: invoice.pdf_url, title: 'Show pdf', class: 'link' }}</dd>
           {% endif %}
         </dl>
 

--- a/test/functional/finance/provider/settings_controller_test.rb
+++ b/test/functional/finance/provider/settings_controller_test.rb
@@ -32,7 +32,7 @@ class Finance::Provider::SettingsControllerTest < ActionController::TestCase
 
     assert_select_form admin_account_payment_gateway_path, :method => :patch do
       assert_select 'select[name=?]', 'account[payment_gateway_type]'
-      assert_select 'input[type=submit]'
+      assert_select 'button[type=submit]'
 
       assert_select 'input[type=text][name=?]', 'account[payment_gateway_options][login]'
       assert_select 'input[type=text][name=?]', 'account[payment_gateway_options][publishable_key]'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It standardize links and buttons using patternfly guidelines.

Example:
`<a class="pf-c-button pf-m-link action edit">`
Instead of 
`<a class="action edit">`

Needed for QE automation

**Which issue(s) this PR fixes** 

Fixes https://issues.redhat.com/browse/THREESCALE-6717
Sub task of https://issues.redhat.com/browse/THREESCALE-6691

**Verification steps** 

Inspect the HTML markup of the following buttons

**/buyers/accounts/{account_id}**

> ![01](https://user-images.githubusercontent.com/13486237/108383674-481c8480-720a-11eb-9f2d-5f3e4f091259.png)

**/buyers/accounts/{account_id}/edit**

> ![02](https://user-images.githubusercontent.com/13486237/108383860-739f6f00-720a-11eb-89ab-82445b4fec31.png)

**/site/usage_rules/edit**
![03](https://user-images.githubusercontent.com/13486237/108384020-9f225980-720a-11eb-832d-c561c99f8698.png)

**/admin/fields_definitions**
> ![fields](https://user-images.githubusercontent.com/13486237/108490356-f83dcc00-72a2-11eb-9e7a-3cfbc739f199.png)

**/finance/invoices/{invoice_id}** 
![invoice](https://user-images.githubusercontent.com/13486237/108490679-4bb01a00-72a3-11eb-9887-4c986125cd11.png)

**/finance/settings**

> ![charging](https://user-images.githubusercontent.com/13486237/108491250-f7596a00-72a3-11eb-8ab7-c40a0a46eb79.png)

**/site/settings/edit**
![card](https://user-images.githubusercontent.com/13486237/108491494-46070400-72a4-11eb-8d2f-5b77621ef44f.png)

**/buyers/accounts/{account_id}/applications/new**
![new-app](https://user-images.githubusercontent.com/13486237/108492009-eceba000-72a4-11eb-9b03-64d7927431e9.png)






