### PR TITLE
Replace context selector classes with Patternfly equivalents

### DIFF
--- a/app/javascript/src/Navigation/components/ActiveMenuTitle.jsx
+++ b/app/javascript/src/Navigation/components/ActiveMenuTitle.jsx
@@ -50,11 +50,13 @@ const ActiveMenuTitle = ({ activeMenu }: Props) => {
   const [icon, text] = getIconAndText()
 
   return (
-    <span className="ActiveMenuTitle">
-      <i className={`fa ${icon}`} />
-      {text}
-      <i className='fa fa-chevron-down' />
-    </span>
+    <>
+      <span className="pf-c-context-selector__toggle-text">
+        <i className={`fa ${icon}` + ' header-context-selector__toggle-text-icon'} />
+        {text}
+      </span>
+      <i className='fa fa-chevron-down  pf-c-context-selector__toggle-icon' />
+    </>
   )
 }
 

--- a/app/javascript/src/Navigation/components/ContextSelector.jsx
+++ b/app/javascript/src/Navigation/components/ContextSelector.jsx
@@ -33,47 +33,49 @@ const ContextSelector = ({ activeMenu, audienceLink, settingsLink, productsLink,
     const isSettingsSelected = menu === 'account' && (['account', 'personal', 'active_docs'].indexOf(activeMenu) !== -1)
 
     if (isDashboardSelected || isAudienceSelected || isProductsSelected || isBackendsSelected || isSettingsSelected) {
-      return 'PopNavigation-link current-context'
+      return 'pf-c-context-selector__menu-list-item current-context'
     }
 
-    return 'PopNavigation-link'
+    return 'pf-c-context-selector__menu-list-item'
   }
 
   return (
-    <div className={`PopNavigation PopNavigation--context${isOpen ? ' pf-m-expanded' : ''}`} ref={ref}>
-      <a className="PopNavigation-trigger" href="#context-menu" title="Context Selector" onClick={() => setIsOpen(!isOpen)}>
+    <div className={`pf-c-context-selector header-context-selector ${isOpen ? ' pf-m-expanded' : ''}`} ref={ref}>
+      <a className="pf-c-context-selector__toggle " href="#context-menu" title="Context Selector" onClick={() => setIsOpen(!isOpen)}>
         <ActiveMenuTitle activeMenu={activeMenu} />
       </a>
       {isOpen && (
-        <ul id="context-menu" className="PopNavigation-list">
-          <li className="PopNavigation-listItem">
-            <a className={getClassNamesForMenu('dashboard')} href={DASHBOARD_PATH}>
-              <i className='fa fa-home' />Dashboard
-            </a>
-          </li>
-          {audienceLink && (
-            <li className="PopNavigation-listItem">
-              <a className={getClassNamesForMenu('audience')} href={audienceLink}>
-                <i className='fa fa-bullseye' />Audience
+        <div className="pf-c-context-selector__menu">
+          <ul id="context-menu" className="pf-c-context-selector__menu-list">
+            <li>
+              <a className={getClassNamesForMenu('dashboard')} href={DASHBOARD_PATH}>
+                <i className='fa fa-home header-context-selector__item-icon' />Dashboard
               </a>
             </li>
-          )}
-          <li className="PopNavigation-listItem">
-            <a className={getClassNamesForMenu('products')} href={productsLink}>
-              <i className='fa fa-cubes' />Products
-            </a>
-          </li>
-          <li className="PopNavigation-listItem">
-            <a className={getClassNamesForMenu('backend_api')} href={backendsLink}>
-              <i className='fa fa-cube' />Backends
-            </a>
-          </li>
-          <li className="PopNavigation-listItem">
-            <a className={getClassNamesForMenu('account')} href={settingsLink}>
-              <i className='fa fa-cog' />Account Settings
-            </a>
-          </li>
-        </ul>
+            {audienceLink && (
+              <li>
+                <a className={getClassNamesForMenu('audience')} href={audienceLink}>
+                  <i className='fa fa-bullseye header-context-selector__item-icon' />Audience
+                </a>
+              </li>
+            )}
+            <li>
+              <a className={getClassNamesForMenu('products')} href={productsLink}>
+                <i className='fa fa-cubes header-context-selector__item-icon' />Products
+              </a>
+            </li>
+            <li>
+              <a className={getClassNamesForMenu('backend_api')} href={backendsLink}>
+                <i className='fa fa-cube header-context-selector__item-icon' />Backends
+              </a>
+            </li>
+            <li>
+              <a className={getClassNamesForMenu('account')} href={settingsLink}>
+                <i className='fa fa-cog header-context-selector__item-icon' />Account Settings
+              </a>
+            </li>
+          </ul>
+        </div>
       )}
     </div >
   )

--- a/app/javascript/src/Navigation/styles/ContextSelector.scss
+++ b/app/javascript/src/Navigation/styles/ContextSelector.scss
@@ -23,32 +23,6 @@
   color: var(--pf-global--active-color--100);
 }
 
-
-// // Copied from colors.scss
-// $lochMaraBlue: #0088ce; //pf-blue-400
-// $font-color: #393f44; // pf-black-800
-
-// // scss-lint:disable SelectorFormat IdSelector
-// #api_selector {
-//   margin-bottom: 0.5rem; // var(--pf-c-page__header-tools--MarginTop)
-//   margin-top: 0.5rem;
-// }
-
-// .current-context {
-//   color: $lochMaraBlue;
-// }
-// .PopNavigation-list {
-//   animation: none;
-// }
-
-// .PopNavigation-link > i {
-//   padding-right: 0.5rem;
-// }
-
-// .unauthorized {
-//   cursor: not-allowed;
-
-//   &:hover {
-//     color: $font-color;
-//   }
-// }
+a.pf-c-context-selector__menu-list-item {
+  color: var(--pf-global--Color--100);
+}

--- a/app/javascript/src/Navigation/styles/ContextSelector.scss
+++ b/app/javascript/src/Navigation/styles/ContextSelector.scss
@@ -23,6 +23,10 @@
   color: var(--pf-global--active-color--100);
 }
 
+.pf-c-context-selector__menu-list {
+  overflow-y: auto;
+}
+
 a.pf-c-context-selector__menu-list-item {
   color: var(--pf-global--Color--100);
 }

--- a/app/javascript/src/Navigation/styles/ContextSelector.scss
+++ b/app/javascript/src/Navigation/styles/ContextSelector.scss
@@ -1,5 +1,3 @@
-@import '~@patternfly/patternfly/components/ContextSelector/context-selector.css';
-
 // Adjust styles for a context selector that is within the (dark) header
 .header-context-selector {
   --pf-c-context-selector__toggle--BorderTopColor: transparent;

--- a/app/javascript/src/Navigation/styles/ContextSelector.scss
+++ b/app/javascript/src/Navigation/styles/ContextSelector.scss
@@ -1,28 +1,54 @@
-// Copied from colors.scss
-$lochMaraBlue: #0088ce; //pf-blue-400
-$font-color: #393f44; // pf-black-800
+@import '~@patternfly/patternfly/components/ContextSelector/context-selector.css';
 
-// scss-lint:disable SelectorFormat IdSelector
-#api_selector {
-  margin-bottom: 0.5rem; // var(--pf-c-page__header-tools--MarginTop)
-  margin-top: 0.5rem;
+// Adjust styles for a context selector that is within the (dark) header
+.header-context-selector {
+  --pf-c-context-selector__toggle--BorderTopColor: transparent;
+  --pf-c-context-selector__toggle--BorderRightColor: transparent;
+  --pf-c-context-selector__toggle--BorderBottomColor: transparent;
+  --pf-c-context-selector__toggle--BorderLeftColor: transparent;
+  --pf-c-context-selector__toggle--active--BorderBottomColor: transparent;
+  --pf-c-context-selector__toggle--expanded--BorderBottomColor: transparent;
+  --pf-c-context-selector__toggle--hover--BorderBottomColor: transparent;
+  --pf-c-context-selector--Width: initial;
 }
 
-.current-context {
-  color: $lochMaraBlue;
-}
-.PopNavigation-list {
-  animation: none;
-}
-
-.PopNavigation-link > i {
-  padding-right: 0.5rem;
+.header-context-selector__item-icon {
+  // color: var(--pf-global--active-color--100);
+  margin-right: var(--pf-global--spacer--sm);
+  min-width: var(--pf-global--spacer--lg);
 }
 
-.unauthorized {
-  cursor: not-allowed;
-
-  &:hover {
-    color: $font-color;
-  }
+.header-context-selector__toggle-text-icon {
+  margin-right: var(--pf-global--spacer--sm);
+  color: var(--pf-global--active-color--100);
 }
+
+
+// // Copied from colors.scss
+// $lochMaraBlue: #0088ce; //pf-blue-400
+// $font-color: #393f44; // pf-black-800
+
+// // scss-lint:disable SelectorFormat IdSelector
+// #api_selector {
+//   margin-bottom: 0.5rem; // var(--pf-c-page__header-tools--MarginTop)
+//   margin-top: 0.5rem;
+// }
+
+// .current-context {
+//   color: $lochMaraBlue;
+// }
+// .PopNavigation-list {
+//   animation: none;
+// }
+
+// .PopNavigation-link > i {
+//   padding-right: 0.5rem;
+// }
+
+// .unauthorized {
+//   cursor: not-allowed;
+
+//   &:hover {
+//     color: $font-color;
+//   }
+// }

--- a/app/javascript/src/patternflyStyles/pf4Base.css
+++ b/app/javascript/src/patternflyStyles/pf4Base.css
@@ -7,6 +7,8 @@
 
 @import '~@patternfly/patternfly/components/Page/page.css';
 @import '~@patternfly/patternfly/components/Nav/nav.css';
+/* @import '~@patternfly/patternfly/components/ContextSelector/context-selector.css'; */
+@import '~@patternfly/patternfly/layouts/Level/level.css';
 @import '~@patternfly/patternfly/patternfly-fonts.css';
 
 /****** HACK ******/

--- a/app/javascript/src/patternflyStyles/pf4Base.css
+++ b/app/javascript/src/patternflyStyles/pf4Base.css
@@ -7,7 +7,7 @@
 
 @import '~@patternfly/patternfly/components/Page/page.css';
 @import '~@patternfly/patternfly/components/Nav/nav.css';
-/* @import '~@patternfly/patternfly/components/ContextSelector/context-selector.css'; */
+@import '~@patternfly/patternfly/components/ContextSelector/context-selector.css';
 @import '~@patternfly/patternfly/layouts/Level/level.css';
 @import '~@patternfly/patternfly/patternfly-fonts.css';
 

--- a/app/views/shared/provider/_header.html.slim
+++ b/app/views/shared/provider/_header.html.slim
@@ -7,7 +7,7 @@ header.pf-c-page__header id="user_widget" class='Header' class=('Header--master'
       .Header-logo class=('Header-logo--withIcon' if active_menu?(:main_menu, :dashboard))
         span Red Hat 3scale API Management
 
-  .pf-c-page__header-nav
+  div
     = render 'shared/api_selector'
 
   .pf-c-page__header-tools


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR replaces custom styling classes with the Patternfly equivalents for the context selector in the header. It also updates the styling to match current Patternfly.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-6693

**Verification steps** 

Use the content selector in the masthead to verify it still operates. Inspect the elements to see that the context selector Patternfly classes are now included instead of custom "PopNavigation" classes.

**Special notes for your reviewer**:
![image](https://user-images.githubusercontent.com/19825616/108269195-a0d11c00-713b-11eb-8a4a-4e4b99fead52.png)
