### PR TITLE
[mailers] Make them async

### DIFF
--- a/app/controllers/master/api/providers_controller.rb
+++ b/app/controllers/master/api/providers_controller.rb
@@ -62,7 +62,7 @@ class Master::Api::ProvidersController < Master::Api::BaseController
 
     if signup_result.persisted?
       signup_result.account_approve! unless signup_result.account_approval_required?
-      ProviderUserMailer.activation(signup_result.user).deliver_now
+      ProviderUserMailer.activation(signup_result.user).deliver_later
     end
 
     respond_with(signup_result)

--- a/app/controllers/provider/admin/accounts_controller.rb
+++ b/app/controllers/provider/admin/accounts_controller.rb
@@ -21,7 +21,7 @@ class Provider::Admin::AccountsController < Provider::Admin::Account::BaseContro
 
     if signup_result.persisted?
       signup_result.account_approve! unless signup_result.account_approval_required?
-      ProviderUserMailer.activation(@user).deliver_now
+      ProviderUserMailer.activation(@user).deliver_later
       flash[:notice] = 'Tenant account was successfully created.'
       redirect_to admin_buyers_account_path(@provider)
     else

--- a/app/controllers/provider/domains_controller.rb
+++ b/app/controllers/provider/domains_controller.rb
@@ -8,6 +8,6 @@ class Provider::DomainsController < Provider::BaseController
   def recover
     domains = site_account.managed_users.where(email: params[:email]).map{|p| p.account.self_domain}.uniq
 
-    ProviderUserMailer.lost_domain(params[:email], domains).deliver_now unless domains.empty?
+    ProviderUserMailer.lost_domain(params[:email], domains).deliver_later unless domains.empty?
   end
 end

--- a/app/lib/authentication/strategy/provider_oauth2.rb
+++ b/app/lib/authentication/strategy/provider_oauth2.rb
@@ -34,7 +34,7 @@ module Authentication
           if strategy.instance_variable_set(:@new_user_created, user.save)
             # FIXME: this should be handled by some of the on_* callbacks
             unless user.activate_email(user_data.verified_email)
-              ProviderUserMailer.activation(user).deliver_now
+              ProviderUserMailer.activation(user).deliver_later
               ActivationReminderWorker.enqueue(user)
             end
           end

--- a/app/lib/messenger/base.rb
+++ b/app/lib/messenger/base.rb
@@ -42,7 +42,7 @@ module Messenger
       @_message.deliver!
     end
 
-    alias deliver_now deliver
+    alias deliver_later deliver
 
     def message(options = {})
       m = @_message

--- a/app/lib/pdf/report.rb
+++ b/app/lib/pdf/report.rb
@@ -65,7 +65,7 @@ module Pdf
     def send_notification!
       account.admins.map do |admin|
         if deliver_notification?(admin)
-          NotificationMailer.public_send(notification_name, self, admin).deliver_now
+          NotificationMailer.public_send(notification_name, self, admin).deliver_later
         else
           Rails.logger.info "[PDF::Report] Skipping delivery of #{period} report to #{admin}"
         end
@@ -82,7 +82,7 @@ module Pdf
 
     # REFACTOR: this class should not be responsible for mailing
     def mail_report
-      PostOffice.report(self, print_period).deliver_now
+      PostOffice.report(self, print_period).deliver_later
     end
 
     def pdf_file_name

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -169,8 +169,8 @@ module Account::States
   def deliver_confirmed_notification
     if admins.present? && provider_account
       run_after_commit do
-        AccountMessenger.new_signup(self).deliver_now
-        AccountMailer.confirmed(self).deliver_now
+        AccountMessenger.new_signup(self).deliver_later
+        AccountMailer.confirmed(self).deliver_later
       end
     end
   end
@@ -179,7 +179,7 @@ module Account::States
     if buyer? && approval_required?
       unless admins.empty? || admins.first.created_by_provider_signup?
         run_after_commit do
-          AccountMailer.approved(self).deliver_now
+          AccountMailer.approved(self).deliver_later
         end
       end
     end
@@ -188,7 +188,7 @@ module Account::States
   def deliver_rejected_notification
     unless admins.empty? || self.provider_account.nil?
       run_after_commit do
-        AccountMailer.rejected(self).deliver_now
+        AccountMailer.rejected(self).deliver_later
       end
     end
   end

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -133,7 +133,7 @@ class ApiDocs::Service < ApplicationRecord
   end
 
   def notify_new_base_path
-    ApiDocs::Mailer.new_path_notification(self).deliver_now if @send_notification
+    ApiDocs::Mailer.new_path_notification(self).deliver_later if @send_notification
     @send_notification = nil
   end
 

--- a/app/models/finance/billing_strategy.rb
+++ b/app/models/finance/billing_strategy.rb
@@ -109,7 +109,7 @@ class Finance::BillingStrategy < ApplicationRecord
   end
 
   def self.notify_billing_results(results)
-    BillingMailer.billing_finished(results).deliver_now unless results.successful?
+    BillingMailer.billing_finished(results).deliver_later unless results.successful?
   rescue => error
     System::ErrorReporting.report_error(error)
     env = Rails.env

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -203,7 +203,7 @@ class Message < ApplicationRecord
   end
 
   def attempt_to_send_message(recipient)
-    PostOffice.message_notification(self, recipient).deliver_now
+    PostOffice.message_notification(self, recipient).deliver_later
   rescue ArgumentError => error
     System::ErrorReporting.report_error error_class: error,
                     error_message: "Got #{error} for message_id: `#{recipient.message_id}' and recipient `#{recipient.id}' -- #{recipient.emails.inspect}"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -244,9 +244,9 @@ class User < ApplicationRecord
   def generate_lost_password_token!
     if generate_lost_password_token
       if account.provider?
-        ProviderUserMailer.lost_password(self).deliver_now
+        ProviderUserMailer.lost_password(self).deliver_later
       else
-        UserMailer.lost_password(self).deliver_now
+        UserMailer.lost_password(self).deliver_later
       end
     end
   end

--- a/app/observers/post_observer.rb
+++ b/app/observers/post_observer.rb
@@ -24,7 +24,7 @@ class PostObserver < ActiveRecord::Observer
     message.system_operation = SystemOperation.for('new_forum_post')
 
     (post.topic.subscribers - [user]).each do |subscriber|
-      TopicMailer.new_post(subscriber, post).deliver_now unless subscriber.email_unverified?
+      TopicMailer.new_post(subscriber, post).deliver_later unless subscriber.email_unverified?
     end
 
     url = admin_forum_topic_url(post.topic, host: post.forum.account.self_domain)

--- a/app/observers/user_observer.rb
+++ b/app/observers/user_observer.rb
@@ -8,10 +8,10 @@ class UserObserver < ActiveRecord::Observer
 
       if user.new_signup?
         if user.account.provider?
-          ProviderUserMailer.activation(user).deliver_now
+          ProviderUserMailer.activation(user).deliver_later
           ActivationReminderWorker.enqueue(user)
         else
-          UserMailer.signup_notification(user).deliver_now
+          UserMailer.signup_notification(user).deliver_later
         end
       end
     end

--- a/app/services/support_entitlements_service.rb
+++ b/app/services/support_entitlements_service.rb
@@ -76,10 +76,10 @@ class SupportEntitlementsService
   end
 
   def notify_entitlements_assigned
-    AccountMailer.support_entitlements_assigned(account, notification_options).deliver_now
+    AccountMailer.support_entitlements_assigned(account, notification_options).deliver_later
   end
 
   def notify_entitlements_revoked
-    AccountMailer.support_entitlements_revoked(account, notification_options).deliver_now
+    AccountMailer.support_entitlements_revoked(account, notification_options).deliver_later
   end
 end

--- a/app/workers/activation_reminder_worker.rb
+++ b/app/workers/activation_reminder_worker.rb
@@ -11,7 +11,7 @@ class ActivationReminderWorker
     user = User.find(user_id)
 
     if user.pending?
-      ProviderUserMailer.activation_reminder(user).deliver_now
+      ProviderUserMailer.activation_reminder(user).deliver_later
     end
   rescue ActiveRecord::RecordNotFound
     # nothing, user was deleted

--- a/app/workers/data_exports_worker.rb
+++ b/app/workers/data_exports_worker.rb
@@ -13,7 +13,7 @@ class DataExportsWorker
     if provider.provider_can_use?(:new_notification_system)
       publish_event!(provider, recipient, type, period)
     else
-      email(provider, recipient, type, period).deliver_now
+      email(provider, recipient, type, period).deliver_later
     end
   end
 

--- a/app/workers/send_user_invitation_worker.rb
+++ b/app/workers/send_user_invitation_worker.rb
@@ -20,7 +20,7 @@ class SendUserInvitationWorker < ApplicationJob
 
   def perform(invitation)
     mailer = invitation.account.provider? ? ProviderInvitationMailer : InvitationMailer
-    mailer.invitation(invitation).deliver_now!
+    mailer.invitation(invitation).deliver_later!
 
     invitation.update(sent_at: Time.zone.now)
   rescue *RETRY_ERRORS => e

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -18,7 +18,7 @@ namespace :sidekiq do
 
     args = []
     args.push(['--index', ENV.fetch('INDEX', '0')])
-    args.push(%w[backend_sync billing critical default deletion events low priority web_hooks zync].flat_map { |queue| ['--queue', queue] })
+    args.push(%w[backend_sync billing critical mailers default deletion events low priority web_hooks zync].flat_map { |queue| ['--queue', queue] })
 
     exec(envs, 'sidekiq', *args.flatten)
   end

--- a/test/integration/developer_portal/passwords_controller_test.rb
+++ b/test/integration/developer_portal/passwords_controller_test.rb
@@ -93,7 +93,7 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
     ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: true)
     Recaptcha::Verify.stubs(skip?: true)
 
-    UserMailer.expects(:lost_password).returns(mock('mail', deliver_now: true)).once
+    UserMailer.expects(:lost_password).returns(mock('mail', deliver_later: true)).once
 
     assert_change of: lambda { user.reload.lost_password_token.present? }, from: false, to: true do
       post developer_portal.admin_account_password_path(email: user.email)

--- a/test/integration/master/api/providers_controller_test.rb
+++ b/test/integration/master/api/providers_controller_test.rb
@@ -20,7 +20,7 @@ class Master::Api::ProvidersControllerTest < ActionDispatch::IntegrationTest
     AccessToken.stubs(:random_id).returns('randomValue')
 
     # sends activation email
-    ProviderUserMailer.expects(:activation).returns(mock(deliver_now: true))
+    ProviderUserMailer.expects(:activation).returns(mock(deliver_later: true))
 
     # persists the new provider
     assert_difference Account.method(:count), 1 do

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -142,7 +142,7 @@ class NotificationsTest < ActiveSupport::TestCase
      should 'be sent to provider when dispatch rule is true' do
        @rule = FactoryBot.create :mail_dispatch_rule, :account => @provider, :dispatch => true, :system_operation => @operation
 
-       PostOffice.message_notification(@message, @provider_recipient).deliver_now
+       PostOffice.message_notification(@message, @provider_recipient).deliver_later
        @email = ActionMailer::Base.deliveries.last
        expected = [@provider.admins.first.email]
        assert_same_elements @email.bcc, expected
@@ -152,7 +152,7 @@ class NotificationsTest < ActiveSupport::TestCase
       SystemOperation.delete_all
       @message.update_attribute(:system_operation, nil)
       @message.reload
-      PostOffice.message_notification(@message, @provider_recipient).deliver_now
+      PostOffice.message_notification(@message, @provider_recipient).deliver_later
       @email = ActionMailer::Base.deliveries.last
       expected = [@provider.admins.first.email]
       assert_same_elements @email.bcc, expected

--- a/test/integration/provider/admin/accounts_controller_test.rb
+++ b/test/integration/provider/admin/accounts_controller_test.rb
@@ -16,7 +16,7 @@ class Provider::Admin::AccountsControllerTest < ActionDispatch::IntegrationTest
 
   test '#create without approval required' do
     # sends activation email
-    ProviderUserMailer.expects(:activation).returns(mock(deliver_now: true))
+    ProviderUserMailer.expects(:activation).returns(mock(deliver_later: true))
 
     account_plan.update_attribute(:approval_required, false)
     post provider_admin_accounts_path, valid_params

--- a/test/mailers/validate_email_interceptor_test.rb
+++ b/test/mailers/validate_email_interceptor_test.rb
@@ -12,15 +12,15 @@ class ValidateEmailInterceptorTest < ActionMailer::TestCase
 
   def test_validate_to_attribute
     assert_difference(ActionMailer::Base.deliveries.method(:count), +1) do
-      DoubleMailer.new_account(to: 'bar@example.com').deliver_now
+      DoubleMailer.new_account(to: 'bar@example.com').deliver_later
     end
 
     assert_difference(ActionMailer::Base.deliveries.method(:count), +1) do
-      DoubleMailer.new_account(bcc: ['bar@example.com']).deliver_now
+      DoubleMailer.new_account(bcc: ['bar@example.com']).deliver_later
     end
 
     assert_no_difference(ActionMailer::Base.deliveries.method(:count)) do
-      DoubleMailer.new_account(to: nil, bcc: nil).deliver_now
+      DoubleMailer.new_account(to: nil, bcc: nil).deliver_later
     end
   end
 end

--- a/test/unit/billing_mailer_test.rb
+++ b/test/unit/billing_mailer_test.rb
@@ -7,7 +7,7 @@ class BillingMailerTest < ActionMailer::TestCase
   test "success" do
     results = Finance::BillingStrategy::Results.new(Time.now)
 
-    BillingMailer.billing_finished(results).deliver_now
+    BillingMailer.billing_finished(results).deliver_later
 
     email = ActionMailer::Base.deliveries.last
     assert_match "Billing and charging succeeded", email.subject
@@ -18,7 +18,7 @@ class BillingMailerTest < ActionMailer::TestCase
     results = Finance::BillingStrategy::Results.new(Time.now)
     results.stubs(:successful?).returns(false)
 
-    BillingMailer.billing_finished(results).deliver_now
+    BillingMailer.billing_finished(results).deliver_later
 
     email = ActionMailer::Base.deliveries.last
     assert_match "Billing and charging failed", email.subject

--- a/test/unit/cms/email_template_test.rb
+++ b/test/unit/cms/email_template_test.rb
@@ -184,7 +184,7 @@ class EmailTemplateTest < ActiveSupport::TestCase
       assert_equal "cc@mail.example.com", mail.header['cc'].to_s
       assert_equal @custom, mail.header['custom'].to_s
 
-      mail.deliver_now
+      mail.deliver_later
 
       assert_match /poweredby/, mail.body.to_s
     end

--- a/test/unit/finance/billing_strategy_test.rb
+++ b/test/unit/finance/billing_strategy_test.rb
@@ -263,7 +263,7 @@ class Finance::BillingStrategyTest < ActiveSupport::TestCase
   test 'notifies billing failure' do
     buyer = FactoryBot.build_stubbed(:simple_buyer, provider_account: @provider)
     results = mock_billing_failure(Time.utc(2018, 3, 17, 18, 15), @provider, [buyer.id])
-    BillingMailer.expects(:billing_finished).with(results).returns(mock(deliver_now: true))
+    BillingMailer.expects(:billing_finished).with(results).returns(mock(deliver_later: true))
     @bs.notify_billing_results(results)
   end
 

--- a/test/unit/mailers/account_mailer_test.rb
+++ b/test/unit/mailers/account_mailer_test.rb
@@ -8,9 +8,9 @@ class AccountMailerTest < ActionMailer::TestCase
 
   test 'send mails' do
     assert_difference -> {ActionMailer::Base.deliveries.count}, 3 do
-      AccountMailer.confirmed(@account).deliver_now!
-      AccountMailer.approved(@account).deliver_now!
-      AccountMailer.rejected(@account).deliver_now!
+      AccountMailer.confirmed(@account).deliver_later!
+      AccountMailer.approved(@account).deliver_later!
+      AccountMailer.rejected(@account).deliver_later!
     end
   end
 

--- a/test/unit/mailers/post_office_test.rb
+++ b/test/unit/mailers/post_office_test.rb
@@ -24,14 +24,14 @@ class PostOfficeTest < ActionMailer::TestCase
     message   = Message.create! sender: @provider, to: [@buyer], subject: subject, body: 'W0rmDr1nk'
     recipient = message.recipients.first
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
     email = find_message_by_subject(subject)
 
     assert_match email.body, /3scale API/
 
     @provider.settings.update_attribute :skip_email_engagement_footer_switch, 'visible'
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
 
     emails = ActionMailer::Base.deliveries.select { |message| message.subject == subject }
     assert email = emails.last
@@ -46,7 +46,7 @@ class PostOfficeTest < ActionMailer::TestCase
     message   = Message.create!(:sender => Account.master, :to => [@provider], :subject => subject, :body => "message")
     recipient = message.recipients.first
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
 
     assert email = find_message_by_subject(subject)
     assert_equal @provider.admins.map(&:email), email.bcc
@@ -60,7 +60,7 @@ class PostOfficeTest < ActionMailer::TestCase
     message   = Message.create!(:sender => Account.master, :to => [@provider], :subject => subject, :body => "message")
     recipient = message.recipients.first
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
 
     assert email = find_message_by_subject(subject)
     assert_equal @provider.users.map(&:email), email.bcc
@@ -74,7 +74,7 @@ class PostOfficeTest < ActionMailer::TestCase
     message   = Message.create!(:sender => @provider, :to => [Account.master], :subject => subject, :body => "message")
     recipient = message.recipients.first
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
 
     assert email = find_message_by_subject(subject)
     assert_equal Account.master.admins.map(&:email), email.bcc
@@ -88,7 +88,7 @@ class PostOfficeTest < ActionMailer::TestCase
     message   = Message.create!(:sender => @provider, :to => [@buyer], :subject => subject, :body => "message")
     recipient = message.recipients.first
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
 
     assert email = find_message_by_subject(subject)
     assert_equal @buyer.admins.map(&:email), email.bcc
@@ -102,7 +102,7 @@ class PostOfficeTest < ActionMailer::TestCase
     message   = Message.create!(:sender => @provider, :to => [@buyer], :subject => subject, :body => "message")
     recipient = message.recipients.first
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
 
     assert email = find_message_by_subject(subject)
     assert_equal @buyer.users.map(&:email), email.bcc
@@ -116,7 +116,7 @@ class PostOfficeTest < ActionMailer::TestCase
     message   = Message.create!(:sender => @buyer, :to => [@provider], :subject => subject, :body => "message")
     recipient = message.recipients.first
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
 
     assert email = find_message_by_subject(subject)
     assert_equal @provider.admins.map(&:email), email.bcc
@@ -127,7 +127,7 @@ class PostOfficeTest < ActionMailer::TestCase
     message   = Message.create!(:sender => @provider, :to => [@buyer], :subject => subject, :body => "message")
     recipient = message.recipients.first
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
 
     assert email = find_message_by_subject(subject)
     assert_equal message.subject, email.subject
@@ -140,7 +140,7 @@ class PostOfficeTest < ActionMailer::TestCase
     message   = Message.create!(:sender => @provider, :to => [@buyer], :subject => subject, :body => "buyer", :origin => "web")
     recipient = message.recipients.first
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
 
     assert email = find_message_by_subject("[msg] #{subject}")
     assert_equal @buyer.admins.map(&:email), email.bcc
@@ -153,7 +153,7 @@ class PostOfficeTest < ActionMailer::TestCase
     message   = Message.create!(sender: @buyer, to: [@provider], subject: subject, body: "provider", origin: "web")
     recipient = message.recipients.first
 
-    PostOffice.message_notification(message, recipient).deliver_now
+    PostOffice.message_notification(message, recipient).deliver_later
 
     assert email = find_message_by_subject("[msg] #{subject}")
     assert_equal @provider.admins.map(&:email), email.bcc
@@ -168,7 +168,7 @@ class PostOfficeTest < ActionMailer::TestCase
     recipient.receiver.self_domain = nil
 
     begin
-      PostOffice.message_notification(message, recipient).deliver_now
+      PostOffice.message_notification(message, recipient).deliver_later
       flunk 'Missing host did not raise'
     rescue ArgumentError => e
       assert_match /^Message\([0-9]+\),Recipient\([0-9]+\)/, e.message
@@ -187,7 +187,7 @@ class PostOfficeTest < ActionMailer::TestCase
 
     `touch #{file}`
 
-    PostOffice.report(report, "December 2010").deliver_now
+    PostOffice.report(report, "December 2010").deliver_later
 
     assert email = find_message_by_subject("3scale: #{service.name} - December 2010")
     assert_equal [account.admins.first.email], email.bcc

--- a/test/unit/mailers/provider_invitation_mailer_test.rb
+++ b/test/unit/mailers/provider_invitation_mailer_test.rb
@@ -10,7 +10,7 @@ class ProviderInvitationMailerTest < ActionMailer::TestCase
 
   test 'deliver' do
     assert_difference ActionMailer::Base.deliveries.method(:count) do
-      @provider_invitation_email.deliver_now
+      @provider_invitation_email.deliver_later
     end
   end
 

--- a/test/unit/mailers/provider_user_mailer_test.rb
+++ b/test/unit/mailers/provider_user_mailer_test.rb
@@ -15,7 +15,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
       # ThreeScale.config.onpremises should be false by default
 
       test 'activation' do
-        ProviderUserMailer.activation(user).deliver_now
+        ProviderUserMailer.activation(user).deliver_later
         email = ActionMailer::Base.deliveries.last
         email_body = email.body.to_s
 
@@ -30,7 +30,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
       end
 
       test 'activation reminder' do
-        ProviderUserMailer.activation_reminder(user).deliver_now
+        ProviderUserMailer.activation_reminder(user).deliver_later
         email = ActionMailer::Base.deliveries.last
         email_body = email.body.to_s
 
@@ -45,7 +45,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
       end
 
       test 'lost_domain' do
-        ProviderUserMailer.lost_domain('the.one.who.forgets@example.com', [account.external_domain]).deliver_now
+        ProviderUserMailer.lost_domain('the.one.who.forgets@example.com', [account.external_domain]).deliver_later
         email = ActionMailer::Base.deliveries.last
         email_body = email.body.to_s
 
@@ -60,7 +60,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
       end
 
       test 'lost_password' do
-        ProviderUserMailer.lost_password(user).deliver_now
+        ProviderUserMailer.lost_password(user).deliver_later
         email = ActionMailer::Base.deliveries.last
         email_body = email.body.to_s
 
@@ -82,7 +82,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
       end
 
       test 'activation' do
-        ProviderUserMailer.activation(user).deliver_now
+        ProviderUserMailer.activation(user).deliver_later
         email = ActionMailer::Base.deliveries.last
         email_body = email.body.to_s
 
@@ -98,7 +98,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
       end
 
       test 'activation reminder' do
-        ProviderUserMailer.activation_reminder(user).deliver_now
+        ProviderUserMailer.activation_reminder(user).deliver_later
         email = ActionMailer::Base.deliveries.last
         email_body = email.body.to_s
 
@@ -114,7 +114,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
       end
 
       test 'lost_domain' do
-        ProviderUserMailer.lost_domain('the.one.who.forgets@example.com', [account.external_domain]).deliver_now
+        ProviderUserMailer.lost_domain('the.one.who.forgets@example.com', [account.external_domain]).deliver_later
         email = ActionMailer::Base.deliveries.last
         email_body = email.body.to_s
 
@@ -130,7 +130,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
       end
 
       test 'lost_password' do
-        ProviderUserMailer.lost_password(user).deliver_now
+        ProviderUserMailer.lost_password(user).deliver_later
         email = ActionMailer::Base.deliveries.last
         email_body = email.body.to_s
 
@@ -148,7 +148,7 @@ class ProviderUserMailerTest < ActionMailer::TestCase
       test 'lost password under https' do
         with_default_url_options protocol: 'https' do
           user.stubs lost_password_token: 'abc123'
-          ProviderUserMailer.lost_password(user).deliver_now
+          ProviderUserMailer.lost_password(user).deliver_later
           email = ActionMailer::Base.deliveries.last
           assert_match "https://#{account.external_admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
         end
@@ -179,13 +179,13 @@ class ProviderUserMailerTest < ActionMailer::TestCase
   class MasterTest < ProviderUserMailerTest
 
     test 'master user activation on saas' do
-      ProviderUserMailer.activation(user).deliver_now
+      ProviderUserMailer.activation(user).deliver_later
       assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, ActionMailer::Base.deliveries.last.body.to_s
     end
 
     test 'master user activation on-prem' do
       ThreeScale.config.stubs(onpremises: true)
-      ProviderUserMailer.activation(user).deliver_now
+      ProviderUserMailer.activation(user).deliver_later
       assert_match %r{#{account.external_admin_domain}/p/activate/[a-z0-9]+}, ActionMailer::Base.deliveries.last.body.to_s
     end
 

--- a/test/unit/mailers/topic_mailer_test.rb
+++ b/test/unit/mailers/topic_mailer_test.rb
@@ -12,7 +12,7 @@ class TopicMailerTest < ActionMailer::TestCase
     subscriber =  FactoryBot.build_stubbed(:simple_user, account: @buyer)
 
     assert_difference ActionMailer::Base.deliveries.method(:count), +1 do
-      TopicMailer.new_post(subscriber, post).deliver_now
+      TopicMailer.new_post(subscriber, post).deliver_later
     end
   end
 

--- a/test/unit/mailers/user_mailer_test.rb
+++ b/test/unit/mailers/user_mailer_test.rb
@@ -6,12 +6,12 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   def deliver_lost_password
-    UserMailer.lost_password(@user).deliver_now
+    UserMailer.lost_password(@user).deliver_later
     ActionMailer::Base.deliveries.last
   end
 
   def deliver_signup_notification
-    UserMailer.signup_notification(@user).deliver_now
+    UserMailer.signup_notification(@user).deliver_later
     ActionMailer::Base.deliveries.last
   end
 
@@ -135,7 +135,7 @@ Customized Template
       end
 
       should "have specific body and subject" do
-        UserMailer.signup_notification(@user).deliver_now
+        UserMailer.signup_notification(@user).deliver_later
         message = ActionMailer::Base.deliveries.last
 
         # Headers

--- a/test/unit/observers/user_observer_test.rb
+++ b/test/unit/observers/user_observer_test.rb
@@ -8,7 +8,7 @@ class UserObserverTest < ActiveSupport::TestCase
 
   test 'send email when new user is created' do
     user = buyer_user(signup_type: :new_signup)
-    UserMailer.expects(:signup_notification).with(user).returns(mock(deliver_now: true))
+    UserMailer.expects(:signup_notification).with(user).returns(mock(deliver_later: true))
     user.save!
   end
 
@@ -24,7 +24,7 @@ class UserObserverTest < ActiveSupport::TestCase
 
   test 'send provider activation email when new provider user is created' do
     user = provider_user
-    ProviderUserMailer.expects(:activation).with(user).returns(mock(deliver_now: true))
+    ProviderUserMailer.expects(:activation).with(user).returns(mock(deliver_later: true))
     user.save!
   end
 

--- a/test/unit/services/support_entitlements_service_test.rb
+++ b/test/unit/services/support_entitlements_service_test.rb
@@ -36,7 +36,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     invoice = FactoryBot.create(:invoice, buyer_account: @provider_account, issued_on: Time.parse('2017-11-05'))
     FactoryBot.create(:line_item_plan_cost, invoice: invoice, contract: @provider_account.bought_cinstance, cinstance_id: @provider_account.bought_cinstance.id)
 
-    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_now: true))
+    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_later: true))
     AccountMailer.expects(:support_entitlements_revoked).never
 
     assert SupportEntitlementsService.notify_entitlements(@provider_account)
@@ -55,7 +55,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     @provider_account.buy! @trial_plan
 
     Timecop.freeze do
-      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_now: true))
+      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
       AccountMailer.expects(:support_entitlements_revoked).never
 
       assert SupportEntitlementsService.notify_entitlements(@provider_account)
@@ -67,7 +67,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
 
     Timecop.freeze do
       AccountMailer.expects(:support_entitlements_assigned).never
-      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_now: true))
+      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
 
       entitlements_options = { previous_plan: @paid_plan }
       assert SupportEntitlementsService.notify_entitlements(@provider_account, entitlements_options)
@@ -78,7 +78,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     @provider_account.buy! @trial_plan
 
     Timecop.freeze do
-      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_now: true))
+      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
       AccountMailer.expects(:support_entitlements_revoked).never
 
       entitlements_options = { previous_plan: @free_plan }
@@ -103,7 +103,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
 
     invoice = FactoryBot.create(:invoice, buyer_account: @provider_account, issued_on: Time.parse('2017-11-05'))
 
-    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_now: true))
+    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_later: true))
     AccountMailer.expects(:support_entitlements_revoked).never
 
     entitlements_options = { previous_plan: @free_plan, invoice: invoice }
@@ -115,7 +115,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
 
     Timecop.freeze do
       AccountMailer.expects(:support_entitlements_assigned).never
-      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_now: true))
+      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
 
       entitlements_options = { previous_plan: @paid_plan }
       assert SupportEntitlementsService.notify_entitlements(@provider_account, entitlements_options)
@@ -142,7 +142,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     FactoryBot.create(:line_item_plan_cost, invoice: invoice, contract: @provider_account.bought_cinstance, cinstance_id: @provider_account.bought_cinstance.id)
 
     AccountMailer.expects(:support_entitlements_assigned).never
-    AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_now: true))
+    AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_later: true))
 
     assert SupportEntitlementsService.notify_entitlements(@provider_account)
   end
@@ -172,7 +172,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     @provider_account.buy! @paid_plan
 
     Timecop.freeze do
-      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_now: true))
+      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
       AccountMailer.expects(:support_entitlements_revoked).never
 
       assert SupportEntitlementsService.notify_entitlements(@provider_account)

--- a/test/unit/three_scale/email_do_not_send_interceptor_test.rb
+++ b/test/unit/three_scale/email_do_not_send_interceptor_test.rb
@@ -18,8 +18,8 @@ class ThreeScale::EmailDoNotSendInterceptorTest < ActiveSupport::TestCase
   test "action mailer" do
     ActionMailer::Base.deliveries.clear
 
-    DasMailer.willkommen.deliver_now
-    DasMailer.nachrichten.deliver_now
+    DasMailer.willkommen.deliver_later
+    DasMailer.nachrichten.deliver_later
 
     assert_equal 1, ActionMailer::Base.deliveries.size
   end

--- a/test/unit/three_scale/email_engagement_footer_test.rb
+++ b/test/unit/three_scale/email_engagement_footer_test.rb
@@ -17,11 +17,11 @@ end
 class ThreeScale::EmailEngagementFooterTest < ActiveSupport::TestCase
 
   test "interceptor for action mailer" do
-    email = LeMailer.bienvenu.deliver_now
+    email = LeMailer.bienvenu.deliver_later
 
     assert_match email.body, /3scale API/
 
-    email = LeMailer.aurevoir.deliver_now
+    email = LeMailer.aurevoir.deliver_later
     assert_equal email.body, "Le test."
   end
 end

--- a/test/workers/activation_reminder_worker_test.rb
+++ b/test/workers/activation_reminder_worker_test.rb
@@ -7,7 +7,7 @@ class ActivationReminderWorkerTest < ActiveSupport::TestCase
   end
 
   should "send reminder if user is pending" do
-    ProviderUserMailer.expects(:activation_reminder).returns(mock('mail', deliver_now: true)).once
+    ProviderUserMailer.expects(:activation_reminder).returns(mock('mail', deliver_later: true)).once
     ActivationReminderWorker.new.perform(@user.id)
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now we send the email synchronously with the request or job (in case of billing)
While this is OK, it is preferable to enqueue those emails and another job could handle it. In this case ActiveJob

**Which issue(s) this PR fixes** 

None (for now)
This is a proposed improvement in order to separate logic.
Also we are investigating on memory leaks and we suppose there are some in rendering liquid or templates in general
Doing so allows us to separate and isolate better the issue


**Verification steps**

- Make any action that sends an email
- A job should be queued in the +mailers+ queue of Sidekiq
- Run sidekiq
- You should be able to receive the email, or at least it should be generated 

**Special notes for your reviewer**:

Verify that the logic of delivering later does not break the functionality.
Examples:
- if the email is not sent we should rollback the transaction.
- If we use transient states (like `record.changes`) in the email, those will not be available anymore
- if we send an email concerning a deleted record (again this is a transient state)
