### PR TITLE
Adds eslint warning for console

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,12 +16,20 @@
     "fixture": true,
     "spyOnEvent": true
   },
-  "extends" : "standard",
+  "extends": "standard",
   "plugins": [
     "flowtype",
     "react"
   ],
   "rules": {
+    "no-console": [
+      "warn",
+      {
+        "allow": [
+          "error"
+        ]
+      }
+    ],
     "no-duplicate-imports": 0,
     "react/sort-comp": [
       2,
@@ -36,9 +44,9 @@
       }
     ],
     "react/no-unused-prop-types": 0,
-    "react/jsx-uses-react" : 2,
-    "react/jsx-uses-vars" : 2,
-    "react/react-in-jsx-scope" : 2,
+    "react/jsx-uses-react": 2,
+    "react/jsx-uses-vars": 2,
+    "react/react-in-jsx-scope": 2,
     "flowtype/boolean-style": [
       2,
       "boolean"


### PR DESCRIPTION
We should have eslint warn us when we forget to remove our console logs. I would rather have it throw an error but then it would make it impossible to compile assets (since it needs a green lint check).