### PR TITLE
PF compliant buttons: Products

### DIFF
--- a/app/helpers/api/integrations_helper.rb
+++ b/app/helpers/api/integrations_helper.rb
@@ -91,12 +91,12 @@ module Api::IntegrationsHelper
   PROMOTE_BUTTON_COMMON_OPTIONS = { button_html: { class: 'PromoteButton', data: { disable_with: 'promoting…' } } }.freeze
 
   def promote_button_options(label = 'Promote')
-    options = PROMOTE_BUTTON_COMMON_OPTIONS.deep_merge(button_html: { class: 'PromoteButton important-button' })
+    options = PROMOTE_BUTTON_COMMON_OPTIONS.deep_merge(button_html: { class: 'PromoteButton pf-c-button pf-m-primary' })
     [label, options]
   end
 
   def disabled_promote_button_options
-    options = PROMOTE_BUTTON_COMMON_OPTIONS.deep_merge(button_html: { class: 'PromoteButton disabled-button', disabled: true })
+    options = PROMOTE_BUTTON_COMMON_OPTIONS.deep_merge(button_html: { class: 'PromoteButton pf-c-button pf-m-primary', disabled: true })
     ['Nothing to promote', options]
   end
 

--- a/app/helpers/api/services_helper.rb
+++ b/app/helpers/api/services_helper.rb
@@ -47,7 +47,7 @@ module Api::ServicesHelper
 
   def delete_service_link(service, options = {})
     msg = t('api.services.forms.definition_settings.delete_confirmation', name: j(service.name))
-    delete_link_for(admin_service_path(service), {data: { confirm: msg }, method: :delete}.merge(options) )
+    pf_delete_link_for(admin_service_path(service), {data: { confirm: msg }, method: :delete}.merge(options) )
   end
 
   def refresh_service_link(service, options = {})

--- a/app/helpers/cinstances_helper.rb
+++ b/app/helpers/cinstances_helper.rb
@@ -54,6 +54,6 @@ Are you sure?}
 
   def delete_application_link(application)
     msg = t('api.applications.edit.delete_confirmation', name: j(application.name))
-    delete_link_for(admin_buyers_application_path(application), confirm: msg, title: 'Delete Application')
+    pf_delete_link_for(admin_buyers_application_path(application), confirm: msg, title: 'Delete Application')
   end
 end

--- a/app/javascript/src/NewService/components/FormElements/FormWrapper.jsx
+++ b/app/javascript/src/NewService/components/FormElements/FormWrapper.jsx
@@ -29,7 +29,7 @@ const FormWrapper = (props: FormProps) => {
           type="submit"
           name="commit"
           value={submitText}
-          className="important-button create"/>
+          className="pf-c-button pf-m-primary create" />
       </fieldset>
     </form>
   )

--- a/app/javascript/src/NewService/components/FormElements/FormWrapper.jsx
+++ b/app/javascript/src/NewService/components/FormElements/FormWrapper.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import type {FormProps} from 'NewService/types'
 import {CSRFToken} from 'utilities/utils'
 import {HiddenServiceDiscoveryInput} from 'NewService/components/FormElements'
+import { Button } from '@patternfly/react-core'
 
 const FormWrapper = (props: FormProps) => {
   const {id, formActionPath, hasHiddenServiceDiscoveryInput, submitText} = props
@@ -25,11 +26,10 @@ const FormWrapper = (props: FormProps) => {
         </ol>
       </fieldset>
       <fieldset className="buttons">
-        <input
+        <Button
           type="submit"
           name="commit"
-          value={submitText}
-          className="pf-c-button pf-m-primary create" />
+          className="create">{ submitText }</Button>
       </fieldset>
     </form>
   )

--- a/app/javascript/src/Policies/components/HeaderButton.jsx
+++ b/app/javascript/src/Policies/components/HeaderButton.jsx
@@ -1,6 +1,8 @@
 // @flow
 
 import * as React from 'react'
+import { Button } from '@patternfly/react-core'
+import { PlusIcon, TimesIcon } from '@patternfly/react-icons'
 
 import type { ThunkAction } from 'Policies/types'
 
@@ -15,15 +17,20 @@ const classNames = {
   cancel: 'PolicyChain-addPolicy--cancel'
 }
 
-const icons = {
-  add: 'fa fa-plus-circle',
-  cancel: 'fa fa-times-circle'
-}
+const Icon = ({type}) => (
+  type === 'add' ? <PlusIcon/> : <TimesIcon/>
+)
 
 const HeaderButton = ({ type, onClick, children }: Props) => (
-  <div className={classNames[type]} onClick={onClick}>
-    <i className={icons[type]} />{children}
-  </div>
+  <Button
+    className={classNames[type]}
+    variant="link"
+    icon={<Icon type={type}/>}
+    iconPosition="left"
+    onClick={onClick}
+  >
+    {children}
+  </Button>
 )
 
 export { HeaderButton }

--- a/app/javascript/src/Policies/components/PoliciesWidget.jsx
+++ b/app/javascript/src/Policies/components/PoliciesWidget.jsx
@@ -67,12 +67,8 @@ const PolicyList = ({ registry, chain, originalChain, policyConfig, ui, boundAct
     // classList.toggle second argument is not supported in IE11
     if (isPolicyChainChanged(chain, originalChain)) {
       submitButton.removeAttribute('disabled')
-      submitButton.classList.remove('disabled-button')
-      submitButton.classList.add('important-button')
     } else {
       submitButton.setAttribute('disabled', '')
-      submitButton.classList.add('disabled-button')
-      submitButton.classList.remove('important-button')
     }
   }
 

--- a/app/javascript/src/Policies/components/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/components/PolicyConfig.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Form from 'react-jsonschema-form'
+import { Button } from '@patternfly/react-core'
 
 import { isNotApicastPolicy } from 'Policies/util'
 import { HeaderButton } from 'Policies/components/HeaderButton'
@@ -68,16 +69,17 @@ const PolicyConfig = ({policy, actions}: Props) => {
           formData={data}
           onSubmit={onSubmit(policy)}
         >
-          <button className="btn btn-info" type="submit">Update Policy</button>
+          <Button className="btn-info" type="submit">Update Policy</Button>
         </Form>
       }
       { removable &&
-        <div
-          className="PolicyConfiguration-remove btn btn-danger btn-sm"
+        <Button
+          className="PolicyConfiguration-remove"
+          variant="danger"
           onClick={remove}
         >
-          <i className="fa fa-trash"/> Remove
-        </div>
+          Remove
+        </Button>
       }
     </section>
   )

--- a/app/javascript/src/Policies/components/PolicyConfig.jsx
+++ b/app/javascript/src/Policies/components/PolicyConfig.jsx
@@ -74,7 +74,6 @@ const PolicyConfig = ({policy, actions}: Props) => {
       }
       { removable &&
         <Button
-          className="PolicyConfiguration-remove"
           variant="danger"
           onClick={remove}
         >

--- a/app/javascript/src/Policies/styles/policies.scss
+++ b/app/javascript/src/Policies/styles/policies.scss
@@ -1,3 +1,5 @@
+// scss-lint:disable SelectorFormat
+
 $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 .PolicyConfiguration {
   @import "~bootstrap-sass/assets/stylesheets/_bootstrap.scss";
@@ -74,12 +76,6 @@ $error-color: #c00;
       width: 100%;
     }
 
-    &-remove {
-      background-color: white;
-      border-color: $dontColor;
-      color: $dontColor;
-    }
-
     &-description {
       margin: 1rem 0 2rem;
       white-space: pre-line;
@@ -88,10 +84,15 @@ $error-color: #c00;
     .btn-info {
       background-color: $doColor;
       border-color: $doColor;
-      width: 33.33%;
       float: right;
-      padding-left: 6px;
-      padding-right: 6px;
+
+      &.btn-add.col-xs-12 {
+        max-width: 1rem;
+      }
+
+      i.glyphicon {
+        top: -1px;
+      }
     }
 
     .btn-group > button.btn-danger:first-child {

--- a/app/views/admin/api_docs/base/_form.html.slim
+++ b/app/views/admin/api_docs/base/_form.html.slim
@@ -17,7 +17,7 @@
   = form.semantic_errors :base_path
   = form.input :skip_swagger_validations, as: :boolean
 = form.buttons do
-  = form.commit_button commit_button_label
+  = form.button commit_button_label, button_html: { class: 'pf-c-button pf-m-primary' } 
 
 css:
   #api_docs_service_body_input .CodeMirror {

--- a/app/views/admin/api_docs/base/_menu.html.erb
+++ b/app/views/admin/api_docs/base/_menu.html.erb
@@ -2,12 +2,12 @@
 
 <div class="operations">
   <%- if @api_docs_service.published? -%>
-    <%= link_to 'Hide', toggle_visible_admin_api_docs_service_path(@api_docs_service), class: 'action eye-slash', method: 'put' -%>
+    <%= pf_link_to 'Hide', toggle_visible_admin_api_docs_service_path(@api_docs_service), class: 'action eye-slash', method: 'put' -%>
   <%- else -%>
-    <%= link_to 'Publish', toggle_visible_admin_api_docs_service_path(@api_docs_service), class: 'action eye', method: 'put' -%>
+    <%= pf_link_to 'Publish', toggle_visible_admin_api_docs_service_path(@api_docs_service), class: 'action eye', method: 'put' -%>
   <%- end -%>
   |
-  <%= link_to 'Edit', edit_admin_api_docs_service_path(@api_docs_service), class: 'action edit' -%>
+  <%= pf_link_to 'Edit', edit_admin_api_docs_service_path(@api_docs_service), class: 'action edit' -%>
   |
-  <%= delete_link_for admin_api_docs_service_path(@api_docs_service), data: {:confirm => 'Are you sure?'} -%>
+  <%= pf_delete_link_for admin_api_docs_service_path(@api_docs_service), data: {:confirm => 'Are you sure?'} -%>
 </div>

--- a/app/views/api/applications/edit.html.slim
+++ b/app/views/api/applications/edit.html.slim
@@ -12,6 +12,6 @@ h2
     = form.user_defined_form
 
   = form.buttons do
-    = form.commit_button
+    = form.button 'Update Application', button_html: {class: 'pf-c-button pf-m-primary' }
     li
       = delete_application_link(@cinstance)

--- a/app/views/api/applications/show.html.slim
+++ b/app/views/api/applications/show.html.slim
@@ -2,7 +2,7 @@
 
 h1
   => @cinstance.display_name
-  = link_to 'Edit',
+  = pf_link_to 'Edit',
             edit_admin_service_application_path(@cinstance.service, @cinstance),
             class: 'action edit'
 

--- a/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
+++ b/app/views/api/integrations/apicast/configuration_driven/_apicast.html.slim
@@ -44,7 +44,7 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
   section style="margin-top: 48px;"
 
     .SettingsBox.Environment class=('Environment--is-promoted' if @show_presenter.environments_have_same_config?)
-      = link_to 'Configuration history', admin_service_proxy_configs_path(@service, environment: 'staging'), class: 'SettingsBox-toggle'
+      = pf_link_to 'Configuration history', admin_service_proxy_configs_path(@service, environment: 'staging'), class: 'SettingsBox-toggle'
       article.Environment-summary data-state="open"
         h3.Environment-title Staging APIcast
         - if @show_presenter.any_sandbox_configs?
@@ -76,7 +76,7 @@ section.Configuration class=('Configuration--is-promoted' unless deployment_opti
 
     .SettingsBox.Environment
       - if @show_presenter.any_production_configs?
-        = link_to 'Configuration history', admin_service_proxy_configs_path(@service, environment: 'production'), class: 'SettingsBox-toggle'
+        = pf_link_to 'Configuration history', admin_service_proxy_configs_path(@service, environment: 'production'), class: 'SettingsBox-toggle'
       article.Environment-summary data-state="open" style="margin-top: 24px;"
         h3.Environment-title Production APIcast
         - if @show_presenter.any_production_configs?

--- a/app/views/api/metrics/_form.html.slim
+++ b/app/views/api/metrics/_form.html.slim
@@ -5,4 +5,4 @@
   = form.input :description, input_html: { rows: 3 }
 
 = form.buttons do
-  = form.commit_button "#{@metric.new_record? ? 'Create' : 'Update'} #{@metric.child? ? 'Method' : 'Metric'}"
+  = form.button "#{@metric.new_record? ? 'Create' : 'Update'} #{@metric.child? ? 'Method' : 'Metric'}", button_html: { class: 'pf-c-button pf-m-primary' } 

--- a/app/views/api/policies/edit.html.slim
+++ b/app/views/api/policies/edit.html.slim
@@ -3,5 +3,5 @@
 = semantic_form_for @proxy, url: admin_service_policies_path(@service) do |f|
   = render '/api/integrations/apicast/shared/policies', f: f
   = f.buttons do
-    = f.button t('formtastic.actions.policies.update'), button_html: {class: "update #{@error ? 'disabled-button' : 'important-button'}", name: 'update', value: '1',
+    = f.button t('formtastic.actions.policies.update'), button_html: {class: "pf-c-button pf-m-primary update", name: 'update', value: '1',
       id: 'policies-button-sav', title: 'Update Policies', disabled: (@error ? true : nil) }

--- a/app/views/api/services/edit.html.slim
+++ b/app/views/api/services/edit.html.slim
@@ -3,6 +3,6 @@
 = semantic_form_for @service, url: admin_service_path(@service) do |form|
   = render partial: 'api/services/forms/naming', locals: { form: form }
   = form.buttons do
-    = form.commit_button 'Update Product'
+    = form.button 'Update Product', button_html: { class: 'pf-c-button pf-m-primary' }
 
 = render partial: 'api/services/delete', locals: { service: @service }

--- a/app/views/api/services/settings_apiap.html.slim
+++ b/app/views/api/services/settings_apiap.html.slim
@@ -3,4 +3,4 @@
 = semantic_form_for @service, :url => admin_service_path(@service) do |form|
   = render :partial => 'api/services/forms/integration_settings_apiap', :locals => {:form => form}
   = form.buttons do
-    = form.commit_button "Update Product", button_html: { name: 'update_settings' }
+    = form.commit_button "Update Product", button_html: { name: 'update_settings', class: 'pf-c-button pf-m-primary' }

--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -5,7 +5,7 @@ h1 Overview
 
 section.Section
   .SettingsBox
-    = link_to 'edit', edit_admin_service_path(@service), class: "SettingsBox-toggle"
+    = pf_link_to 'edit', edit_admin_service_path(@service), class: "SettingsBox-toggle"
     dl.SettingsBox-summary.u-dl data-state="open"
       dt.u-dl-term Name
       dd.u-dl-definition = @service.name
@@ -58,7 +58,7 @@ section class="service-widget"
           h2.flex-item
             '  Published
             => link_to 'Application Plans', admin_service_application_plans_path(service)
-          = action_link_to :new, new_admin_service_application_plan_path(service),
+          = pf_action_link_to :new, new_admin_service_application_plan_path(service),
             label: 'Create Application Plan', class: 'flex-item'
 
         ul.application-plans[data-hint="published"]
@@ -79,7 +79,7 @@ section class="service-widget"
             h2.flex-item
               '  Published
               => link_to 'Service plans', admin_service_service_plans_path(service)
-            = action_link_to :new,  new_admin_service_service_plan_path(service),
+            = pf_action_link_to :new,  new_admin_service_service_plan_path(service),
               label: 'Create Service Plan', class: 'flex-item'
 
           ul.service-plans[data-hint="published"]

--- a/app/views/api/services/usage_rules.html.slim
+++ b/app/views/api/services/usage_rules.html.slim
@@ -19,4 +19,4 @@
 = semantic_form_for @service, :url => admin_service_path(@service) do |form|
   = render :partial => 'api/services/forms/usage_rules', :locals => { :form => form }
   = form.buttons do
-    = form.commit_button 'Update Product'
+    = form.button 'Update Product', button_html: { class: 'pf-c-button pf-m-primary' }

--- a/app/views/buyers/applications/_api_credentials.html.erb
+++ b/app/views/buyers/applications/_api_credentials.html.erb
@@ -43,11 +43,11 @@
     <td>
       <span id="cinstance-user-key"><%= cinstance.user_key %></span>
       <% if cinstance.custom_keys_enabled? %>
-        <%= link_to '', edit_provider_admin_application_key_path(cinstance, cinstance.user_key),
+        <%= pf_link_to '', edit_provider_admin_application_key_path(cinstance, cinstance.user_key),
                     :class => 'fancybox action edit', 'data-autodimensions' => 'true', title: "Set Custom Key" %>
       <% end %>
       <% if defined?(regenerate) && regenerate %>
-        <%= link_to 'Regenerate', change_user_key_admin_buyers_application_path(cinstance), :method => :put, data: {:confirm => "Are you sure?"}, class: ' action refresh' %>
+        <%= pf_link_to 'Regenerate', change_user_key_admin_buyers_application_path(cinstance), :method => :put, data: {:confirm => "Are you sure?"}, class: ' action refresh' %>
       <% end %>
     </td>
   </tr>

--- a/app/views/buyers/applications/_change_plan.html.erb
+++ b/app/views/buyers/applications/_change_plan.html.erb
@@ -19,7 +19,7 @@
       <fieldset class="buttons">
         <ol>
           <li class="commit">
-            <%= form.submit 'Change Plan', class: 'important-button' %>
+            <%= form.submit 'Change Plan', class: 'pf-c-button pf-m-primary' %>
           </li>
         </ol>
       </fieldset>

--- a/app/views/buyers/applications/_plan.html.erb
+++ b/app/views/buyers/applications/_plan.html.erb
@@ -10,7 +10,7 @@
         <%= delete_button_for admin_buyers_contract_custom_application_plan_path(contract, contract.plan),
                               :label => 'Remove customization' %>
       <% else %>
-        <%= fancy_link_to 'Convert to a Custom Plan',
+        <%= pf_fancy_link_to 'Convert to a Custom Plan',
                            admin_buyers_contract_custom_application_plans_path(contract),
                            :method => :post,
                            :class => 'new',

--- a/app/views/buyers/applications/_state.html.slim
+++ b/app/views/buyers/applications/_state.html.slim
@@ -7,10 +7,10 @@ dl#cinstance_state.u-dl.u-dl--skinny
     - if @cinstance.pending?
       = render :partial => 'buyers/applications/accept_reject'
     - elsif @cinstance.live?
-      = fancy_link_to 'Suspend', suspend_admin_buyers_application_path(@cinstance),
+      = pf_fancy_link_to 'Suspend', suspend_admin_buyers_application_path(@cinstance),
                       :method => :post, :remote => true, data: {:confirm => suspend_application_confirmation(@cinstance)}, class: 'action suspend'
     - elsif @cinstance.suspended?
-      = fancy_link_to 'Resume', resume_admin_buyers_application_path(@cinstance), :method => :post, :remote => true, class: 'action resume'
+      = pf_fancy_link_to 'Resume', resume_admin_buyers_application_path(@cinstance), :method => :post, :remote => true, class: 'action resume'
 
   - if @cinstance.trial?
     dt.u-dl-term

--- a/app/views/shared/proxy_rules/_form.html.slim
+++ b/app/views/shared/proxy_rules/_form.html.slim
@@ -8,4 +8,4 @@
   = form.input :position
 
 = form.buttons do
-  = form.commit_button "#{proxy_rule.new_record? ? 'Create' : 'Update'} Mapping Rule"
+  = form.button "#{proxy_rule.new_record? ? 'Create' : 'Update'} Mapping Rule", button_html: { class: 'pf-c-button pf-m-primary' }

--- a/spec/javascripts/NewService/NewServiceForm.spec.jsx
+++ b/spec/javascripts/NewService/NewServiceForm.spec.jsx
@@ -79,7 +79,7 @@ describe('when Api as Product is enabled', () => {
 
     wrapper.update()
     expect(wrapper.find('h1').text()).toEqual('New Product')
-    expect(wrapper.find('.important-button.create').props().value).toEqual('Create Product')
+    expect(wrapper.find('.pf-c-button.create').props().value).toEqual('Create Product')
   })
 })
 

--- a/spec/javascripts/NewService/NewServiceForm.spec.jsx
+++ b/spec/javascripts/NewService/NewServiceForm.spec.jsx
@@ -79,7 +79,7 @@ describe('when Api as Product is enabled', () => {
 
     wrapper.update()
     expect(wrapper.find('h1').text()).toEqual('New Product')
-    expect(wrapper.find('.pf-c-button.create').props().value).toEqual('Create Product')
+    expect(wrapper.find('.pf-c-button.create').text()).toEqual('Create Product')
   })
 })
 

--- a/spec/javascripts/NewService/ServiceDiscoveryForm.spec.jsx
+++ b/spec/javascripts/NewService/ServiceDiscoveryForm.spec.jsx
@@ -71,6 +71,6 @@ describe('when Api as Product is enabled', () => {
   props.apiap = true
   it('should render itself', () => {
     const wrapper = mount(<ServiceDiscoveryForm {...props}/>)
-    expect(wrapper.find('.important-button.create').props().value).toEqual('Create Product')
+    expect(wrapper.find('.pf-c-button.create').props().value).toEqual('Create Product')
   })
 })

--- a/spec/javascripts/NewService/ServiceDiscoveryForm.spec.jsx
+++ b/spec/javascripts/NewService/ServiceDiscoveryForm.spec.jsx
@@ -71,6 +71,6 @@ describe('when Api as Product is enabled', () => {
   props.apiap = true
   it('should render itself', () => {
     const wrapper = mount(<ServiceDiscoveryForm {...props}/>)
-    expect(wrapper.find('.pf-c-button.create').props().value).toEqual('Create Product')
+    expect(wrapper.find('.pf-c-button.create').text()).toEqual('Create Product')
   })
 })

--- a/spec/javascripts/NewService/formElements/FormWrapper.spec.jsx
+++ b/spec/javascripts/NewService/formElements/FormWrapper.spec.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import {shallow} from 'enzyme'
+import { shallow, mount } from 'enzyme'
 
 import {FormWrapper} from 'NewService/components/FormElements'
 import {HiddenServiceDiscoveryInput} from 'NewService/components/FormElements'
@@ -26,10 +26,10 @@ it('should render an empty input', () => {
 })
 
 it('should render submit button with proper text', () => {
-  const wrapper = shallow(<FormWrapper {...props}/>)
-  const button = wrapper.find(`input[type='submit']`)
+  const wrapper = mount(<FormWrapper { ...props } />)
+  const button = wrapper.find(`button[type='submit']`)
   expect(button.exists()).toBe(true)
-  expect(button.prop('value')).toEqual(submitText)
+  expect(button.text()).toEqual(submitText)
 })
 
 it('should render a hidden input for service discovery when required', () => {

--- a/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
@@ -92,7 +92,7 @@ describe('PolicyConfig Component', () => {
 
   it('should have a remove button', () => {
     const {policyConfigWrapper, props} = setup()
-    const removePolicyButton = policyConfigWrapper.find('.PolicyConfiguration-remove')
+    const removePolicyButton = policyConfigWrapper.find('.pf-c-button.PolicyConfiguration-remove')
     expect(removePolicyButton.exists()).toBe(true)
 
     removePolicyButton.simulate('click')
@@ -101,7 +101,7 @@ describe('PolicyConfig Component', () => {
 
   it('should have a submit button', () => {
     const {policyConfigWrapper} = setup()
-    const submitPolicyButton = policyConfigWrapper.find('button').first()
+    const submitPolicyButton = policyConfigWrapper.find('.PolicyConfiguration-form .pf-c-button[type="submit"]')
     expect(submitPolicyButton.text()).toBe('Update Policy')
   })
 

--- a/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
@@ -92,7 +92,7 @@ describe('PolicyConfig Component', () => {
 
   it('should have a remove button', () => {
     const {policyConfigWrapper, props} = setup()
-    const removePolicyButton = policyConfigWrapper.find('.pf-c-button.PolicyConfiguration-remove')
+    const removePolicyButton = policyConfigWrapper.find('.pf-c-button')
     expect(removePolicyButton.exists()).toBe(true)
 
     removePolicyButton.simulate('click')

--- a/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
+++ b/spec/javascripts/Policies/components/PolicyConfig.spec.jsx
@@ -92,7 +92,7 @@ describe('PolicyConfig Component', () => {
 
   it('should have a remove button', () => {
     const {policyConfigWrapper, props} = setup()
-    const removePolicyButton = policyConfigWrapper.find('.pf-c-button')
+    const removePolicyButton = policyConfigWrapper.find('.pf-c-button.pf-m-danger')
     expect(removePolicyButton.exists()).toBe(true)
 
     removePolicyButton.simulate('click')

--- a/spec/javascripts/Policies/components/__snapshots__/HeaderButton.spec.jsx.snap
+++ b/spec/javascripts/Policies/components/__snapshots__/HeaderButton.spec.jsx.snap
@@ -1,21 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should be able to render a "cancel" button variant 1`] = `
-<div
-  class="PolicyChain-addPolicy--cancel"
+<button
+  class="pf-c-button pf-m-link PolicyChain-addPolicy--cancel"
+  type="button"
 >
-  <i
-    class="fa fa-times-circle"
+  <span
+    class="pf-c-button__icon"
+  >
+    <svg
+      aria-hidden="true"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align:-0.125em"
+      viewBox="0 0 352 512"
+      width="1em"
+    >
+      <path
+        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        transform=""
+      />
+    </svg>
+  </span>
+  <span
+    class="pf-c-button__text"
   />
-</div>
+</button>
 `;
 
 exports[`should be able to render an "add" button variant 1`] = `
-<div
-  class="PolicyChain-addPolicy"
+<button
+  class="pf-c-button pf-m-link PolicyChain-addPolicy"
+  type="button"
 >
-  <i
-    class="fa fa-plus-circle"
+  <span
+    class="pf-c-button__icon"
+  >
+    <svg
+      aria-hidden="true"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align:-0.125em"
+      viewBox="0 0 448 512"
+      width="1em"
+    >
+      <path
+        d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+        transform=""
+      />
+    </svg>
+  </span>
+  <span
+    class="pf-c-button__text"
   />
-</div>
+</button>
 `;

--- a/test/integration/api/applications_controller_test.rb
+++ b/test/integration/api/applications_controller_test.rb
@@ -160,7 +160,7 @@ class Api::ApplicationsControllerTest < ActionDispatch::IntegrationTest
         page = Nokogiri::HTML::Document.parse(response.body)
         assert_equal 'example-name',  page.xpath("//input[@id='cinstance_name']").map { |node| node['value'] }.join
         assert_equal "\nexample-description", page.xpath("//textarea[@id='cinstance_description']").text
-        assert_equal 1, page.xpath("//input[@type='submit']").length
+        assert_equal 1, page.xpath("//button[@type='submit']").length
       end
     end
   end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It standardize links and buttons using patternfly guidelines.

Example:
`<a class="pf-c-button pf-m-link action edit">`
Instead of 
`<a class="action edit">`

Needed for QE automation

**Which issue(s) this PR fixes** 

Fixes https://issues.redhat.com/browse/THREESCALE-6691
Sub task of https://issues.redhat.com/browse/THREESCALE-6691

**IMPORTANT:** 
Part of a series of PR's starting with https://github.com/3scale/porta/pull/2363
Merge after https://github.com/3scale/porta/pull/2363

**PAGES AFFECTED:**

/apiconfig/services:
![01](https://user-images.githubusercontent.com/13486237/109506321-cb0ccd00-7a9d-11eb-9d8c-9b7cfb4a87b0.png)

/apiconfig/services/new
![02](https://user-images.githubusercontent.com/13486237/109506610-2048de80-7a9e-11eb-9064-1f59f6a310b6.png)

/apiconfig/services/{product_id}
![03](https://user-images.githubusercontent.com/13486237/109506862-6aca5b00-7a9e-11eb-9e5b-682630d7f7dc.png)

/apiconfig/services/{product_id}/edit
![04](https://user-images.githubusercontent.com/13486237/109507041-9a796300-7a9e-11eb-9c85-5035f3f3cfaa.png)

/apiconfig/services/{product_id}/applications/{application_id}
![05](https://user-images.githubusercontent.com/13486237/109507574-2c816b80-7a9f-11eb-8dd2-5f9c9cde42c0.png)

/apiconfig/services/{product_id}/applications/{application_id}/edit
![06](https://user-images.githubusercontent.com/13486237/109507759-589cec80-7a9f-11eb-97df-0f8601b3902e.png)

/apiconfig/services/{product_id}/usage_rules
![07](https://user-images.githubusercontent.com/13486237/109507923-8b46e500-7a9f-11eb-9400-dc34f5f7718f.png)

/apiconfig/services/{product_id}/api_docs/{api_doc_id}/preview
![08](https://user-images.githubusercontent.com/13486237/109508114-c77a4580-7a9f-11eb-872b-69c12b14d174.png)

/apiconfig/services/{product_id}/api_docs/{api_doc_id}/edit
![09](https://user-images.githubusercontent.com/13486237/109508239-eed11280-7a9f-11eb-822f-359a78ce6dfd.png)

/apiconfig/services/{product_id}/integration
![10](https://user-images.githubusercontent.com/13486237/109508616-54250380-7aa0-11eb-9195-d5c4b09c0873.png)

/apiconfig/services/{product_id}/metrics/{metric_id}/children/new
![11](https://user-images.githubusercontent.com/13486237/109508867-964e4500-7aa0-11eb-9561-f1480d8ad899.png)

/apiconfig/services/{product_id}/metrics/new
![12](https://user-images.githubusercontent.com/13486237/109509150-e3321b80-7aa0-11eb-906a-665ebbe75442.png)

/apiconfig/services/{product_id}/proxy_rules/new
![13](https://user-images.githubusercontent.com/13486237/109510371-3789cb00-7aa2-11eb-9be4-96fdaf1926ee.png)

/apiconfig/services/{product_id}/proxy_rules/{proxy_rule_id}/edit
![14](https://user-images.githubusercontent.com/13486237/109511005-ecbc8300-7aa2-11eb-928d-4c656161d9c5.png)

/apiconfig/services/{product_id}/policies/edit
![15](https://user-images.githubusercontent.com/13486237/109511803-b6cbce80-7aa3-11eb-9e0e-1ceb1e7b5bb1.png)
![16](https://user-images.githubusercontent.com/13486237/109511819-bb908280-7aa3-11eb-9699-c5272c1d921b.png)

/apiconfig/services/{product_id}/settings
![17](https://user-images.githubusercontent.com/13486237/109512525-7ae53900-7aa4-11eb-8e2b-5d42b11be389.png)
