### PR TITLE
[mergebot] Use 3scale-ninjabot for make bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -806,7 +806,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "d8:d6:e4:53:b3:0e:22:76:01:e0:27:90:a6:c3:fa:df"
+            - "17:be:79:a1:a0:c5:38:84:a7:3c:f2:af:87:d7:f3:cf"
       - checkout-with-submodules
       - run:
           name: Keep production gemfile up to date


### PR DESCRIPTION
Replacing `@duduribeiro` by `@3scale-ninjabot` as committer for the `make bundle`

```
curl https://github.com/3scale-ninjabot.keys  2>/dev/null | tail -n1 |  ssh-keygen -E md5 -l -f -

2048 MD5:17:be:79:a1:a0:c5:38:84:a7:3c:f2:af:87:d7:f3:cf no comment (RSA)
```

This ssh key fingerprint is registered in CircleCI