### PR TITLE
Allow safeFromJsonString to parse "undefined"

### DIFF
--- a/app/javascript/src/utilities/json-utils.jsx
+++ b/app/javascript/src/utilities/json-utils.jsx
@@ -5,7 +5,12 @@ const toJsonString = (val: Object): string => JSON.stringify(val, null, 2)
 
 const fromJsonString = (json: string) => JSON.parse(json)
 
-const safeFromJsonString = <T>(json: string): (T | void) => {
+const safeFromJsonString = <T>(json: string | void): (T | void) => {
+  if (json === undefined) {
+    // Explicitly return undefined to prevent JSON.parse from throwing an error
+    return undefined
+  }
+
   try {
     return fromJsonString(json)
   } catch (err) {

--- a/spec/javascripts/utilities/json-utils.spec.jsx
+++ b/spec/javascripts/utilities/json-utils.spec.jsx
@@ -13,6 +13,10 @@ describe('fromJsonString', () => {
   it('should throw error when parsing a bad formatted json string', () => {
     expect(() => fromJsonString(badOlJsonString)).toThrow('Unexpected token a in JSON at position 1')
   })
+
+  it('should throw an error when parsing undefined', () => {
+    expect(() => fromJsonString(undefined)).toThrow()
+  })
 })
 
 describe('safeFromJsonString', () => {
@@ -22,5 +26,9 @@ describe('safeFromJsonString', () => {
 
   it('should return undefined when parsing a bad formatted json string', () => {
     expect(safeFromJsonString(badOlJsonString)).toBe(undefined)
+  })
+
+  it('should not throw an error when parsing undefined', () => {
+    expect(safeFromJsonString(undefined)).toEqual(undefined)
   })
 })


### PR DESCRIPTION
Sometimes our method tries to parse `undefined` and it's very annoying (and also misleading) to see this error in the console, since `undefined` is actually the expected parsed value:

![Screenshot 2021-02-25 at 13 32 51](https://user-images.githubusercontent.com/11672286/109154011-fc1f9180-776d-11eb-87e0-d42f71437756.png)
*Yes it does! 🙂*

The log error should be used when the passed string is actually not correctly formatted, such as when we passed data from rails without calling `to_json`.