### PR TITLE
PF compliant buttons: Backends

### DIFF
--- a/app/views/provider/admin/backend_apis/edit.html.slim
+++ b/app/views/provider/admin/backend_apis/edit.html.slim
@@ -3,6 +3,6 @@ h2 Edit Backend
 = semantic_form_for @backend_api, url: provider_admin_backend_api_path(@backend_api) do |form|
   = render partial: 'provider/admin/backend_apis/forms/naming', locals: { form: form }
   = form.buttons do
-    = form.commit_button 'Update Backend'
+    = form.button 'Update Backend', button_html: { class: 'pf-c-button pf-m-primary' }
 
 = render partial: 'provider/admin/backend_apis/forms/delete', locals: { backend_api: @backend_api }

--- a/app/views/provider/admin/backend_apis/forms/_delete.html.slim
+++ b/app/views/provider/admin/backend_apis/forms/_delete.html.slim
@@ -27,4 +27,4 @@
     p
       - msg = t('api.backend_apis.edit.delete_confirmation', name: j(backend_api.name))
       - delete_options = { data: { confirm: msg }, method: :delete, label: "I understand the consequences, proceed to delete '#{j(backend_api.name)}' backend" }
-      = delete_link_for(provider_admin_backend_api_path(backend_api), delete_options)
+      = pf_delete_link_for(provider_admin_backend_api_path(backend_api), delete_options)

--- a/app/views/provider/admin/backend_apis/metrics/_form.html.slim
+++ b/app/views/provider/admin/backend_apis/metrics/_form.html.slim
@@ -5,4 +5,4 @@
   = form.input :description, input_html: { rows: 3 }
 
 = form.buttons do
-  = form.commit_button "#{@metric.new_record? ? 'Create' : 'Update'} #{@metric.child? ? 'Method' : 'Metric'}"
+  = form.button "#{@metric.new_record? ? 'Create' : 'Update'} #{@metric.child? ? 'Method' : 'Metric'}", button_html: { class: 'pf-c-button pf-m-primary' }

--- a/app/views/provider/admin/backend_apis/metrics/edit.html.erb
+++ b/app/views/provider/admin/backend_apis/metrics/edit.html.erb
@@ -1,3 +1,4 @@
+
 <% method_or_metric = @metric.child? ? "method" : "metric" %>
 <% content_for :sublayout_title, "Edit #{method_or_metric.capitalize}" %>
 
@@ -5,5 +6,5 @@
   <%= render 'form', :form => form %>
 <% end %>
 <% unless @metric.default?(:hits) %>
-  <%= delete_button_for provider_admin_backend_api_metric_path(@backend_api, @metric), data: {:confirm => "Removing this #{method_or_metric} will affect all plans that contain this #{method_or_metric}, all associated mapping rules will be deleted too. Are you sure? "} %>
+  <%= pf_delete_button_for provider_admin_backend_api_metric_path(@backend_api, @metric), data: {:confirm => "Removing this #{method_or_metric} will affect all plans that contain this #{method_or_metric}, all associated mapping rules will be deleted too. Are you sure? "} %>
 <% end %>

--- a/app/views/provider/admin/backend_apis/show.html.slim
+++ b/app/views/provider/admin/backend_apis/show.html.slim
@@ -2,7 +2,7 @@ h1 Backend Overview
 
 section.Section
   .SettingsBox
-    = link_to 'edit', edit_provider_admin_backend_api_path(@backend_api), class: 'SettingsBox-toggle'
+    = pf_link_to 'edit', edit_provider_admin_backend_api_path(@backend_api), class: 'SettingsBox-toggle'
     dl.SettingsBox-summary.u-dl data-state="open"
       dt.u-dl-term Name
       dd.u-dl-definition = @backend_api.name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It standardize links and buttons using patternfly guidelines.

Example:
`<a class="pf-c-button pf-m-link action edit">`
Instead of 
`<a class="action edit">`

Needed for QE automation

**Which issue(s) this PR fixes** 

Fixes https://issues.redhat.com/browse/THREESCALE-6720
Sub task of https://issues.redhat.com/browse/THREESCALE-6691

**IMPORTANT:** 
PR 3 of a series
Merge after:
https://github.com/3scale/porta/pull/2363
https://github.com/3scale/porta/pull/2376


**PAGES AFFECTED:**

/p/admin/backend_apis
![01](https://user-images.githubusercontent.com/13486237/109621803-b7b03f00-7b3b-11eb-835e-36342fe6467d.png)

/p/admin/backend_apis/{backend_id}
![02](https://user-images.githubusercontent.com/13486237/109622072-01008e80-7b3c-11eb-9f9c-db9b8be40882.png)

/p/admin/backend_apis/{backend_id}/edit
![04](https://user-images.githubusercontent.com/13486237/109623013-05797700-7b3d-11eb-9568-65d26c08d222.png)

/p/admin/backend_apis/{backend_id}/metrics/{metric_id}/children/new
![05](https://user-images.githubusercontent.com/13486237/109623205-30fc6180-7b3d-11eb-9338-751284b7bc81.png)

/p/admin/backend_apis/{backend_id}/metrics/{metric_id}/edit
![06](https://user-images.githubusercontent.com/13486237/109623657-a831f580-7b3d-11eb-8171-24bca1573fe5.png)

/p/admin/backend_apis/{backend_id}/metrics/new
![07](https://user-images.githubusercontent.com/13486237/109624225-3efeb200-7b3e-11eb-8300-27feded81bca.png)

/p/admin/backend_apis/{backend_id}/metrics/edit
![08](https://user-images.githubusercontent.com/13486237/109624416-7bcaa900-7b3e-11eb-957f-d1361eb06adf.png)

/p/admin/backend_apis/{backend_id}/mapping_rules/new
![09](https://user-images.githubusercontent.com/13486237/109624614-b46a8280-7b3e-11eb-971a-f3440e573768.png)

p/admin/backend_apis/{backend_id}2483/mapping_rules/{mapping_rule_id}/edit
![10](https://user-images.githubusercontent.com/13486237/109624800-e7147b00-7b3e-11eb-92e2-6df49549a1d5.png)
