### PR TITLE
PF compliant buttons: Account settings

### DIFF
--- a/app/views/provider/admin/account/authentication_providers/form/_form.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/form/_form.html.slim
@@ -23,7 +23,7 @@
              locals: { f: f, authentication_provider: authentication_provider }
 
   = f.buttons do
-    = f.button 'Create Authentication provider', button_html: { class: 'pf-c-button pf-m-primary' }
+    = f.button I18n.t('provider.admin.authentication_providers.form.submit_button_label'), button_html: { class: 'pf-c-button pf-m-primary' }
     - unless authentication_provider.new_record?
       = pf_link_to 'Delete',
                 provider_admin_account_authentication_provider_path(@authentication_provider),

--- a/app/views/provider/admin/account/authentication_providers/form/_form.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/form/_form.html.slim
@@ -23,9 +23,9 @@
              locals: { f: f, authentication_provider: authentication_provider }
 
   = f.buttons do
-    = f.commit_button
+    = f.button 'Create Authentication provider', button_html: { class: 'pf-c-button pf-m-primary' }
     - unless authentication_provider.new_record?
-      = link_to 'Delete',
+      = pf_link_to 'Delete',
                 provider_admin_account_authentication_provider_path(@authentication_provider),
                 data: {confirm: 'Are you sure?'}, method: :delete,
                 title: 'Delete authentication provider', class: 'action delete'

--- a/app/views/provider/admin/account/authentication_providers/show.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/show.html.slim
@@ -4,7 +4,7 @@ h1.title
 
 .SettingsBox
 
-  = link_to "edit", edit_provider_admin_account_authentication_provider_path(@presenter.authentication_provider), class: 'SettingsBox-toggle edit' unless @presenter.cannot_edit?
+  = pf_link_to "edit", edit_provider_admin_account_authentication_provider_path(@presenter.authentication_provider), class: 'SettingsBox-toggle edit' unless @presenter.cannot_edit?
 
   dl.SettingsBox-summary.u-dl
     dt.u-dl-term
@@ -52,11 +52,11 @@ h1.title
 
     - if @presenter.authentication_provider.published?
       - if @presenter.publishing_service.valid?
-        = f.submit 'Unpublish', class: 'important-button button next update'
+        = f.submit 'Unpublish', class: 'pf-c-button pf-m-primary button next update'
       - else
-        = f.submit 'Unpublish', class: 'important-button button next update disabled-button', disabled: true
+        = f.submit 'Unpublish', class: 'pf-c-button pf-m-primary button next update', disabled: true
     - else
       - if @presenter.publishing_service.valid?
-        = f.submit 'Publish', class: 'important-button button next update'
+        = f.submit 'Publish', class: 'pf-c-button pf-m-primary button next update'
       - else
-        = f.submit 'Publish', class: 'important-button button next update disabled-button', disabled: true
+        = f.submit 'Publish', class: 'pf-c-button pf-m-primary button next update', disabled: true

--- a/app/views/provider/admin/account/users/_form.html.erb
+++ b/app/views/provider/admin/account/users/_form.html.erb
@@ -67,7 +67,7 @@
 <% end %>
 
 <%= form.buttons do %>
-  <%= form.commit_button %>
+  <%= form.button 'Update User', button_html: { class: 'pf-c-button pf-m-primary' } %>
 <% end %>
 
 <%= javascript_include_tag 'custom_profiles_input_texts' %>

--- a/app/views/provider/admin/account/users/_form.html.erb
+++ b/app/views/provider/admin/account/users/_form.html.erb
@@ -67,7 +67,7 @@
 <% end %>
 
 <%= form.buttons do %>
-  <%= form.button 'Update User', button_html: { class: 'pf-c-button pf-m-primary' } %>
+  <%= form.button I18n.t('provider.admin.account.users.form.submit_button_label'), button_html: { class: 'pf-c-button pf-m-primary' } %>
 <% end %>
 
 <%= javascript_include_tag 'custom_profiles_input_texts' %>

--- a/app/views/provider/admin/accounts/_form.html.erb
+++ b/app/views/provider/admin/accounts/_form.html.erb
@@ -5,9 +5,9 @@
 
 <%= form.buttons do %>
   <% if params[:next_step] == 'credit_card' %>
-    <%= form.commit_button 'Save and continue with payment details' %>
+    <%= form.button 'Save and continue with payment details', button_html: { class: 'pf-c-button pf-m-primary' } %>
   <% else %>
-    <%= form.commit_button  %>
+    <%= form.button 'Update Account', button_html: { class: 'pf-c-button pf-m-primary' }  %>
   <% end %>
 <% end %>
 <%= javascript_include_tag 'custom_profiles_input_texts' %>

--- a/app/views/provider/admin/accounts/_form.html.erb
+++ b/app/views/provider/admin/accounts/_form.html.erb
@@ -5,9 +5,9 @@
 
 <%= form.buttons do %>
   <% if params[:next_step] == 'credit_card' %>
-    <%= form.button 'Save and continue with payment details', button_html: { class: 'pf-c-button pf-m-primary' } %>
+    <%= form.button I18n.t('provider.admin.accounts.form.submit_button_next_step_label'), button_html: { class: 'pf-c-button pf-m-primary' } %>
   <% else %>
-    <%= form.button 'Update Account', button_html: { class: 'pf-c-button pf-m-primary' }  %>
+    <%= form.button I18n.t('provider.admin.accounts.form.submit_button_label'), button_html: { class: 'pf-c-button pf-m-primary' }  %>
   <% end %>
 <% end %>
 <%= javascript_include_tag 'custom_profiles_input_texts' %>

--- a/app/views/provider/admin/accounts/show.html.slim
+++ b/app/views/provider/admin/accounts/show.html.slim
@@ -26,7 +26,7 @@ div id="account-column-wrapper"
       ' Account Details
       - if @presenter.show_edit_account_link?
         span class="operations"
-          = link_to 'Edit', edit_provider_admin_account_path, class: 'action edit'
+          = pf_link_to 'Edit', edit_provider_admin_account_path, class: 'action edit'
 
     table class="list"
       tbody

--- a/app/views/provider/admin/user/notification_preferences/_form.html.slim
+++ b/app/views/provider/admin/user/notification_preferences/_form.html.slim
@@ -13,4 +13,5 @@
               hint_method: ->(value) { t(value, scope: :notification_preference_hints) }
 
   = f.buttons do
-    = f.commit_button 'Update Notification Preferences'
+    = f.button 'Update Notification Preferences', button_html: { class: 'pf-c-button pf-m-primary' }
+

--- a/app/views/provider/admin/user/notification_preferences/_form.html.slim
+++ b/app/views/provider/admin/user/notification_preferences/_form.html.slim
@@ -13,5 +13,5 @@
               hint_method: ->(value) { t(value, scope: :notification_preference_hints) }
 
   = f.buttons do
-    = f.button 'Update Notification Preferences', button_html: { class: 'pf-c-button pf-m-primary' }
+    = f.button I18n.t('provider.admin.user.notification_preferences.form.submit_button_label'), button_html: { class: 'pf-c-button pf-m-primary' }
 

--- a/app/views/provider/admin/user/personal_details/edit.html.slim
+++ b/app/views/provider/admin/user/personal_details/edit.html.slim
@@ -14,7 +14,7 @@ h1 Personal Details
     = form.inputs name: "Provide your current password and update your personal details" do
       = form.input :current_password, required: true
   = form.buttons do
-    = form.commit_button 'Update Details'
+    = form.button 'Update Details', button_html: { class: 'pf-c-button pf-m-primary' }
 
 - if current_user.can_set_password? && !current_account.settings.enforce_sso?
   p You have no password set. If you'd like to set one use the

--- a/app/views/provider/admin/user/personal_details/edit.html.slim
+++ b/app/views/provider/admin/user/personal_details/edit.html.slim
@@ -14,7 +14,7 @@ h1 Personal Details
     = form.inputs name: "Provide your current password and update your personal details" do
       = form.input :current_password, required: true
   = form.buttons do
-    = form.button 'Update Details', button_html: { class: 'pf-c-button pf-m-primary' }
+    = form.button I18n.t('provider.admin.user.personal_details.edit.form.submit_button_label'), button_html: { class: 'pf-c-button pf-m-primary' }
 
 - if current_user.can_set_password? && !current_account.settings.enforce_sso?
   p You have no password set. If you'd like to set one use the

--- a/app/views/provider/admin/webhooks/edit.html.slim
+++ b/app/views/provider/admin/webhooks/edit.html.slim
@@ -9,4 +9,4 @@ p.help
   = render 'form', form: f
 
   = f.buttons do
-    = f.button 'Update webhooks settings',  button_html: { class: 'pf-c-button pf-m-primary' }
+    = f.button I18n.t('provider.admin.webhooks.edit.form.submit_button_label'),  button_html: { class: 'pf-c-button pf-m-primary' }

--- a/app/views/provider/admin/webhooks/edit.html.slim
+++ b/app/views/provider/admin/webhooks/edit.html.slim
@@ -9,4 +9,4 @@ p.help
   = render 'form', form: f
 
   = f.buttons do
-    = f.commit_button label: 'Update webhooks settings'
+    = f.button 'Update webhooks settings',  button_html: { class: 'pf-c-button pf-m-primary' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1244,7 +1244,7 @@ en:
         update: "%{action} Staging Environment"
       policies:
         update: "Update Policy Chain"
-    l abels:
+    labels:
       service:
         intentions_required: "Signup requires a description of intended use"
         buyers_manage_apps: "Developers can manage applications"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -366,9 +366,19 @@ en:
         has_password: 'User already has a password. Use it to change the password.'
 
     admin:
+      account:
+        users:
+          form:
+            submit_button_label: 'Update User'
+      accounts:
+        form:
+          submit_button_label: 'Update Account'
+          submit_button_next_step_label: 'Save and continue with payment details'
+
       authentication_providers:
         form:
           automatically_approve_accounts_hint_html: "<br /> Even if the <a href=%{link}>account approval settings</a> say otherwise"
+          submit_button_label: 'Create Authentication provider'
       messages:
         no_metrics: "You have no metrics"
         no_methods: "You have no methods"
@@ -394,6 +404,12 @@ en:
             no_notification_preferences_html: |
               You don't have access to any notifications on the %{account_name} account.
               Please contact <a href="mailto:%{email}">%{username}</a> to request access.
+          form:
+            submit_button_label: 'Update Notification Preferences'
+        personal_details:
+          edit:
+            form:
+              submit_button_label: 'Update Details'
 
       dashboards:
         show:
@@ -405,6 +421,10 @@ en:
           no_messages_4: "Blue skies ahead…"
           no_messages_5: "Inbox Zero"
           no_messages_6: "The sound of silence"
+      webhooks:
+        edit:
+          form:
+            submit_button_label: 'Update webhooks settings'
 
   buyers:
     accounts:
@@ -1224,7 +1244,7 @@ en:
         update: "%{action} Staging Environment"
       policies:
         update: "Update Policy Chain"
-    labels:
+    l abels:
       service:
         intentions_required: "Signup requires a description of intended use"
         buyers_manage_apps: "Developers can manage applications"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

It standardize links and buttons using patternfly guidelines.

Example:
`<a class="pf-c-button pf-m-link action edit">`
Instead of 
`<a class="action edit">`

Needed for QE automation

**Which issue(s) this PR fixes** 

Fixes https://issues.redhat.com/browse/THREESCALE-6721
Sub task of https://issues.redhat.com/browse/THREESCALE-6691

**IMPORTANT:** 
PR 4 of a series
Merge after:
https://github.com/3scale/porta/pull/2363
https://github.com/3scale/porta/pull/2376
https://github.com/3scale/porta/pull/2384

**PAGES AFFECTED:**

/p/admin/account
![01](https://user-images.githubusercontent.com/13486237/109644659-0a96f000-7b56-11eb-9603-967314d017a3.png)

/p/admin/account/edit
![02](https://user-images.githubusercontent.com/13486237/109644740-2d290900-7b56-11eb-8881-888831894751.png)

/p/admin/user/personal_details/edit
![03](https://user-images.githubusercontent.com/13486237/109644862-55186c80-7b56-11eb-8118-3dabeb93f478.png)

/p/admin/user/notification_preferences
![04](https://user-images.githubusercontent.com/13486237/109644948-724d3b00-7b56-11eb-9956-4d84d8e54be6.png)

/p/admin/account/users/{user_id}/edit
![05](https://user-images.githubusercontent.com/13486237/109645041-9446bd80-7b56-11eb-997a-14370b466021.png)

/p/admin/account/authentication_providers/new
![06](https://user-images.githubusercontent.com/13486237/109645127-b2acb900-7b56-11eb-8d6c-c1c0fbfed12d.png)

/p/admin/account/authentication_providers/{auth_provider_id}
![07](https://user-images.githubusercontent.com/13486237/109645571-54cca100-7b57-11eb-93b5-717cbf96d446.png)

/p/admin/account/authentication_providers/{auth_provider_id}/edit
![08](https://user-images.githubusercontent.com/13486237/109645728-85acd600-7b57-11eb-820c-0f8f45f21cb7.png)

/p/admin/webhooks/edit
![09](https://user-images.githubusercontent.com/13486237/109645843-affe9380-7b57-11eb-9dc5-aafccf96d2c8.png)
