### PR TITLE
Fix item count in Products and BackendApis pagination

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -19,12 +19,12 @@ class Api::ServicesController < Api::BaseController
   def index
     activate_menu :products
     search = ThreeScale::Search.new(params[:search] || params)
-    @raw_services = current_user.accessible_services
-    @services = @raw_services.order(updated_at: :desc)
-                             .paginate(pagination_params)
-                             .scope_search(search)
-                             .decorate
-                             .to_json(only: %i[name updated_at id system_name], methods: %i[links apps_count backends_count unread_alerts_count])
+    @services = current_user.accessible_services
+                            .order(updated_at: :desc)
+                            .scope_search(search)
+    @page_services = @services.paginate(pagination_params)
+                              .decorate
+                              .to_json(only: %i[name updated_at id system_name], methods: %i[links apps_count backends_count unread_alerts_count])
   end
 
   def show

--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -12,12 +12,12 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   def index
     activate_menu :backend_apis
     search = ThreeScale::Search.new(params[:search] || params)
-    @raw_backend_apis = current_account.backend_apis
-    @backend_apis = @raw_backend_apis.order(updated_at: :desc)
-                                     .paginate(pagination_params)
-                                     .scope_search(search)
-                                     .decorate
-                                     .to_json(only: %i[name updated_at id private_endpoint system_name], methods: %i[links products_count])
+    @backend_apis = current_account.backend_apis
+                                            .order(updated_at: :desc)
+                                            .scope_search(search)
+    @page_backend_apis = @backend_apis.paginate(pagination_params)
+                                          .decorate
+                                          .to_json(only: %i[name updated_at id private_endpoint system_name], methods: %i[links products_count])
   end
 
   def new

--- a/app/views/api/services/index.html.slim
+++ b/app/views/api/services/index.html.slim
@@ -1,4 +1,4 @@
 = javascript_pack_tag 'products_index'
 = javascript_pack_tag 'PF4Styles/dashboard'
 
-div#products data-products=(@services) data-products-count=(@raw_services.size)
+div#products data-products=(@page_services) data-products-count=(@services.size)

--- a/app/views/provider/admin/backend_apis/index.html.slim
+++ b/app/views/provider/admin/backend_apis/index.html.slim
@@ -1,4 +1,4 @@
 = javascript_pack_tag 'backend_apis_index'
 = javascript_pack_tag 'PF4Styles/dashboard'
 
-div#backend-apis data-backends=(@backend_apis) data-backends-count=(@raw_backend_apis.count)
+div#backend-apis data-backends=(@page_backend_apis) data-backends-count=(@backend_apis.count)


### PR DESCRIPTION
**What this PR does / why we need it**:

It fixes a bug in pagination showing always the count of all items regardless of search.

**Which issue(s) this PR fixes** 

[THREESCALE-6385: Products/Backends pagination shows all pages even when filtering](https://issues.redhat.com/browse/THREESCALE-6385)

**Verification steps** 

> Go to Products/Backends index pages
> Search using Sphinx and check the count of items is reduced.

**Special notes for your reviewer**:
Sphinx is probably not going to work properly but having a result of '0' is actually good for verifying this PR.