### PR TITLE
SCSS lint: remove SelectorFormat rule

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -101,10 +101,7 @@ linters:
         max_depth: 3
 
     SelectorFormat:
-        enabled: true
-        convention: ^(([A-Z][a-z]*)+$|(([A-Z][a-z]*)+|u|is|js)(-|--)([a-z]+([a-z]|[A-Z])*)+|(([A-Z][a-z]*)+|u|is|js)(-|--)([a-z]+([a-z]|[A-Z])*)+(--[a-z]+([a-z]|[A-Z])*)+)|[ng]-(\w)+(-(\w)*)*$
-        ignored_names: ["better-timeinput"]
-        ignored_types: ["attribute", "element", "pseudo-selector"]
+        enabled: false
 
     Shorthand:
         enabled: true

--- a/app/assets/stylesheets/provider/_commons.scss
+++ b/app/assets/stylesheets/provider/_commons.scss
@@ -241,7 +241,7 @@ hr, {
   background: $select-color;
 }
 
-.ui-sortable-handler { // scss-lint:disable SelectorFormat
+.ui-sortable-handler {
   color: $success-color;
   cursor: move;
 }

--- a/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
+++ b/app/assets/stylesheets/provider/_patternfly_tabs_fake.scss
@@ -1,5 +1,3 @@
-// scss-lint:disable SelectorFormat
-
 /**
  * This are styles to fake Tab component without using PF4 css.
  *

--- a/app/assets/stylesheets/provider/_pop_navigation.scss
+++ b/app/assets/stylesheets/provider/_pop_navigation.scss
@@ -113,7 +113,6 @@ $pf4-sidebar-width: 18.125rem;
 /* This is a temporary fix, should be removed when the context selector
 is moved to the right, to match PF4 style */
 
-// scss-lint:disable SelectorFormat
 .pf-c-page__header-tools {
   .PopNavigation-trigger {
     margin-left: line-height-times(2);

--- a/app/assets/stylesheets/provider/_vertical_nav.scss
+++ b/app/assets/stylesheets/provider/_vertical_nav.scss
@@ -6,7 +6,6 @@
     margin-top: 2rem;
   }
 
-  // scss-lint:disable SelectorFormat
   .pf-c-nav__item {
     &.outdated-config:not(.pf-m-expanded) > a::before {
       content: '\f071';

--- a/app/assets/stylesheets/provider/layouts/_main.scss
+++ b/app/assets/stylesheets/provider/layouts/_main.scss
@@ -1,5 +1,3 @@
-// scss-lint:disable SelectorFormat
-
 body {
   min-width: $layout-wrapper-min-width;
 }

--- a/app/javascript/src/LoginPage/assets/styles/loginPage.scss
+++ b/app/javascript/src/LoginPage/assets/styles/loginPage.scss
@@ -14,7 +14,6 @@
 
 // End of HACK
 
-// scss-lint:disable SelectorFormat
 $pf-black-500:  #8b8d8f; // $osloGray
 $--pf-global--danger-color--100: #c9190b;
 $--pf-global--info-color--200:	#004368;

--- a/app/javascript/src/PaymentGateways/stripe/styles/stripe.scss
+++ b/app/javascript/src/PaymentGateways/stripe/styles/stripe.scss
@@ -1,4 +1,3 @@
-// scss-lint:disable SelectorFormat
 // scss-lint:disable IdSelector
 $white: white;
 $stripe-form-border-color: rgba(50, 50, 93, .1);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

scss-lint `SelectorFormat` rule is not useful anymore, since it's not compatible with Patternfly at all.
Instead of disabling the rule everywhere, we should remove it.

**Which issue(s) this PR fixes** 

None ;)

