### PR TITLE
[feature] Github action for stale PRs

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,14 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 3 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-pr-message: 'This PR is stale because it has not received activity for more than 14 days. Remove stale label or comment or this will be closed in 7 days.'
+          days-before-stale: 14
+          days-before-close: 7


### PR DESCRIPTION
* PRs are marked stale (label stale) after 14 days of inactivity
* stale PRs are closed after 7 days roting

It will run early in the morning at 3:30am UTC