### PR TITLE
Bugfix: get billing adress for braintree

### DIFF
--- a/app/helpers/payment_details_helper.rb
+++ b/app/helpers/payment_details_helper.rb
@@ -68,4 +68,8 @@ module PaymentDetailsHelper
     }.to_json
   end
 
+  def get_country_code(billing_address_data)
+    merchant_countries.select {|c| c.include? billing_address_data.country}.first[1]
+  end 
+
 end

--- a/app/helpers/payment_details_helper.rb
+++ b/app/helpers/payment_details_helper.rb
@@ -69,7 +69,8 @@ module PaymentDetailsHelper
   end
 
   def get_country_code(billing_address_data)
-    merchant_countries.select {|c| c.include? billing_address_data.country}.first[1]
+    _label, code = merchant_countries.find {|label, code| label.downcase == billing_address_data.country.to_s.downcase }
+    code
   end 
 
 end

--- a/app/javascript/packs/braintree3DSecureCustomerForm.js
+++ b/app/javascript/packs/braintree3DSecureCustomerForm.js
@@ -6,14 +6,16 @@ const form = document.querySelector('#customer_form')
 const clientToken = form.dataset.clientToken
 const braintreeNonce = document.querySelector('#braintree_nonce')
 
-const billingAdressInfo = {
-  company: document.querySelector('#customer_credit_card_billing_address_company').value,
-  streetAddress: document.querySelector('#customer_credit_card_billing_address_street_address').value,
-  postalCode: document.querySelector('#customer_credit_card_billing_address_postal_code').value,
-  locality: document.querySelector('#customer_credit_card_billing_address_locality').value,
-  region: document.querySelector('#customer_credit_card_billing_address_region').value,
-  countryCodeAlpha2: document.querySelector('#customer_credit_card_billing_address_country_name').value
-}
+const getBillingAdressInfo = () => (
+  {
+    company: document.querySelector('#customer_credit_card_billing_address_company').value,
+    streetAddress: document.querySelector('#customer_credit_card_billing_address_street_address').value,
+    postalCode: document.querySelector('#customer_credit_card_billing_address_postal_code').value,
+    locality: document.querySelector('#customer_credit_card_billing_address_locality').value,
+    region: document.querySelector('#customer_credit_card_billing_address_region').value,
+    countryCodeAlpha2: document.querySelector('#customer_credit_card_billing_address_country_name').value
+  }
+)
 
 const hostedFieldOptions = {
   styles: {
@@ -43,15 +45,14 @@ const hostedFieldOptions = {
   }
 }
 
-const threeDSecureParameters = {
-  amount: '00.00',
-  billingAddress: billingAdressInfo,
-  onLookupComplete: function (data, next) {
-    next()
-  }
-}
-
 const veryfyCard = (threeDSecureInstance, payload) => {
+  const threeDSecureParameters = {
+    amount: '00.00',
+    billingAddress: getBillingAdressInfo(),
+    onLookupComplete: function (data, next) {
+      next()
+    }
+  }
   const options = {
     nonce: payload.nonce,
     bin: payload.details.bin,

--- a/app/javascript/packs/braintree3DSecureCustomerForm.js
+++ b/app/javascript/packs/braintree3DSecureCustomerForm.js
@@ -8,11 +8,11 @@ const braintreeNonce = document.querySelector('#braintree_nonce')
 
 const getBillingAdressInfo = () => (
   {
-    company: document.querySelector('#customer_credit_card_billing_address_company').value,
+    givenName: document.querySelector('#customer_credit_card_billing_address_company').value,
     streetAddress: document.querySelector('#customer_credit_card_billing_address_street_address').value,
     postalCode: document.querySelector('#customer_credit_card_billing_address_postal_code').value,
     locality: document.querySelector('#customer_credit_card_billing_address_locality').value,
-    region: document.querySelector('#customer_credit_card_billing_address_region').value,
+    region: document.querySelector('#customer_credit_card_billing_address_region').value || null,
     countryCodeAlpha2: document.querySelector('#customer_credit_card_billing_address_country_name').value
   }
 )

--- a/app/views/payment_gateways/_braintree_customer_form.html.erb
+++ b/app/views/payment_gateways/_braintree_customer_form.html.erb
@@ -123,17 +123,17 @@
 
                   <%= billing_address.input :region,
                     input_html: {
-                      required: "required",
                       class: "form-control col-md-6",
                       style: "width:50%;",
-                      value: billing_address_data.state
+                      maxlength: 3
                     },
                     wrapper_html: {class: "form-group"},
                     label: "State/Region",
+                    hint: "<div class='col-md-6 col-md-offset-4'>The 2 letter code for US states or an ISO-3166-2 country subdivision code of up to three letters. <strong>If unsure, left blank</strong></div>",
                     label_html: {class: "col-md-4 control-label" },
                     allow_blank: false
                   %>
-                  
+
                   <%= billing_address.input :country_name,
                     as: :select,
                     collection:  options_for_select(merchant_countries, get_country_code(billing_address_data)),

--- a/app/views/payment_gateways/_braintree_customer_form.html.erb
+++ b/app/views/payment_gateways/_braintree_customer_form.html.erb
@@ -10,17 +10,24 @@
     </div>
 <% end %>
 <% client_token = j @braintree_authorization %>
+<% billing_address_data = current_account.has_billing_address? ? current_account.billing_address : nil %>
 <%= semantic_form_for :customer,
                       url: developer_portal.hosted_success_admin_account_braintree_blue_path,
                       html: { class: "form-horizontal",
                               id: 'customer_form',
-                              data: { 'client-token': client_token } } do |form|
+                              data: {
+                                'client-token': client_token,
+                              } } do |form|
 %>
 
   <fieldset>
       <ol class="list-unstyled">
         <%= form.input :first_name,
-          input_html: {required: "required", class: "form-control col-md-6", style: "width:50%;"},
+          input_html: {
+            required: "required",
+            class: "form-control col-md-6",
+            style: "width:50%;"
+          },
           wrapper_html: {class: "form-group"},
           label_html: {class: "col-md-4 control-label" },
           required: false
@@ -68,44 +75,69 @@
                 <ol class="list-unstyled">
 
                   <%= billing_address.input :company,
-                    input_html: {required: "required", class: "form-control col-md-6", style: "width:50%;"},
+                    input_html: {
+                      required: "required",
+                      class: "form-control col-md-6",
+                      style: "width:50%;",
+                      value: billing_address_data.name
+                    },
                     wrapper_html: {class: "form-group"},
                     label_html: {class: "col-md-4 control-label" }
                   %>
 
                   <%= billing_address.input :street_address,
-                    input_html: {required: "required", class: "form-control col-md-6", style: "width:50%;"},
+                    input_html: {
+                      required: "required",
+                      class: "form-control col-md-6",
+                      style: "width:50%;",
+                      value: billing_address_data.address1
+                    },
                     wrapper_html: {class: "form-group"},
                     label_html: {class: "col-md-4 control-label" }
                   %>
 
                   <%= billing_address.input :postal_code,
-                    input_html: {required: "required", class: "form-control col-md-6", style: "width:50%;"},
+                    input_html: {
+                      required: "required",
+                      class: "form-control col-md-6",
+                      style: "width:50%;",
+                      value: billing_address_data.zip
+                    },
                     wrapper_html: {class: "form-group"},
                     label: "ZIP / Postal Code",
                     label_html: {class: "col-md-4 control-label" },
                     allow_blank: false
                   %>
 
-                  <%= billing_address.input :locality ,
-                    input_html: {required: "required", class: "form-control col-md-6", style: "width:50%;"},
+                  <%= billing_address.input :locality,
+                    input_html: {
+                      required: "required",
+                      class: "form-control col-md-6",
+                      style: "width:50%;",
+                      value: billing_address_data.city
+                    },
                     wrapper_html: {class: "form-group"},
                     label: "City",
                     label_html: {class: "col-md-4 control-label" }
                   %>
 
                   <%= billing_address.input :region,
-                    input_html: {required: "required", class: "form-control col-md-6", style: "width:50%;"},
+                    input_html: {
+                      required: "required",
+                      class: "form-control col-md-6",
+                      style: "width:50%;",
+                      value: billing_address_data.state
+                    },
                     wrapper_html: {class: "form-group"},
                     label: "State/Region",
                     label_html: {class: "col-md-4 control-label" },
                     allow_blank: false
                   %>
-
+                  
                   <%= billing_address.input :country_name,
                     as: :select,
-                    collection:  options_for_select(merchant_countries),
-                    input_html: {required: "required", class: "form-control col-md-6", style: "width:50%;"},
+                    collection:  options_for_select(merchant_countries, get_country_code(billing_address_data)),
+                    input_html: {required: "required", class: "form-control col-md-6", style: "width:50%;" },
                     wrapper_html: {class: "form-group"},
                     label:  "Country",
                     label_html: {class: "col-md-4 control-label" },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

- It fixes an issue where the billing address was not pre-filled when going to the edit form.
- When Braintree fraud detection is enabled, billing address validation is failing because the region is in an unexpected format: it should be a two or three chars code, see [docs](https://braintree.github.io/braintree-web/current/ThreeDSecure.html#~billingAddress).

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-6495

**Verification steps** 

- To enable Billing and adding Braintree to the Admin Portal, follow the instructions in https://github.com/3scale/porta/pull/2322

- In Dev Portal:
Go to **Settings** > **Credit Card Details**
Click on **Edit Credit Card Details and Billing Address**

![brain](https://user-images.githubusercontent.com/13486237/111303990-79477380-8655-11eb-991f-61e4e7aff148.png)

