### PR TITLE
Braintree: Handle empty billing address

### DIFF
--- a/app/views/payment_gateways/_braintree_customer_form.html.erb
+++ b/app/views/payment_gateways/_braintree_customer_form.html.erb
@@ -79,7 +79,7 @@
                       required: "required",
                       class: "form-control col-md-6",
                       style: "width:50%;",
-                      value: billing_address_data.name
+                      value: billing_address_data ? billing_address_data.name : ''
                     },
                     wrapper_html: {class: "form-group"},
                     label_html: {class: "col-md-4 control-label" }
@@ -90,7 +90,7 @@
                       required: "required",
                       class: "form-control col-md-6",
                       style: "width:50%;",
-                      value: billing_address_data.address1
+                      value: billing_address_data ? billing_address_data.address1 : ''
                     },
                     wrapper_html: {class: "form-group"},
                     label_html: {class: "col-md-4 control-label" }
@@ -101,7 +101,7 @@
                       required: "required",
                       class: "form-control col-md-6",
                       style: "width:50%;",
-                      value: billing_address_data.zip
+                      value: billing_address_data ? billing_address_data.zip : ''
                     },
                     wrapper_html: {class: "form-group"},
                     label: "ZIP / Postal Code",
@@ -114,7 +114,7 @@
                       required: "required",
                       class: "form-control col-md-6",
                       style: "width:50%;",
-                      value: billing_address_data.city
+                      value: billing_address_data ? billing_address_data.city : ''
                     },
                     wrapper_html: {class: "form-group"},
                     label: "City",
@@ -136,7 +136,7 @@
 
                   <%= billing_address.input :country_name,
                     as: :select,
-                    collection:  options_for_select(merchant_countries, get_country_code(billing_address_data)),
+                    collection:  options_for_select(merchant_countries, billing_address_data ? get_country_code(billing_address_data) : ''),
                     input_html: {required: "required", class: "form-control col-md-6", style: "width:50%;" },
                     wrapper_html: {class: "form-group"},
                     label:  "Country",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Improvement to https://github.com/3scale/porta/pull/2394
It handles the case where billing address is empty (if that's possible).

**Which issue(s) this PR fixes** 

Part of https://issues.redhat.com/browse/THREESCALE-6495

**Verification steps** 

Same as https://github.com/3scale/porta/pull/2394
