### PR TITLE
[payment-gateway] Add three_ds_enabled settings

### DIFF
--- a/app/javascript/packs/braintree3DSecuredisabled.js
+++ b/app/javascript/packs/braintree3DSecuredisabled.js
@@ -1,0 +1,67 @@
+var $form = $('#customer_form')
+var submit = document.querySelector('input[type="submit"]')
+var braintree = window.braintree
+var braintreeAuthorization = $form.attr('data-client-token')
+
+if (typeof braintree !== 'undefined') {
+  braintree.client.create({
+    authorization: braintreeAuthorization
+  }, function (clientErr, clientInstance) {
+    if (clientErr) {
+      console.error(clientErr)
+      return
+    }
+
+    // This example shows Hosted Fields, but you can also use this
+    // client instance to create additional components here, such as:qa
+    // PayPal or Data Collector.
+
+    braintree.hostedFields.create({
+      client: clientInstance,
+      styles: {
+        'input': {
+          'font-size': '14px'
+        },
+        'input.invalid': {
+          'color': 'red'
+        },
+        'input.valid': {
+          'color': 'green'
+        }
+      },
+      fields: {
+        number: {
+          selector: '#customer_credit_card_number',
+          placeholder: '4111 1111 1111 1111'
+        },
+        cvv: {
+          selector: '#customer_credit_card_cvv',
+          placeholder: '123'
+        },
+        expirationDate: {
+          selector: '#customer_credit_card_expiration_date',
+          placeholder: 'MM/YY'
+        }
+      }
+    }, function (hostedFieldsErr, hostedFieldsInstance) {
+      if (hostedFieldsErr) {
+        console.error(hostedFieldsErr)
+        return
+      }
+
+      submit.removeAttribute('disabled')
+
+      $form.on('submit', function (event) {
+        event.preventDefault()
+        hostedFieldsInstance.tokenize(function (tokenizeErr, payload) {
+          if (tokenizeErr) {
+            console.error(tokenizeErr)
+            return
+          }
+          $('#braintree_nonce').val(payload['nonce'])
+          $form.get(0).submit()
+        })
+      })
+    })
+  })
+}

--- a/app/models/payment_gateway.rb
+++ b/app/models/payment_gateway.rb
@@ -4,16 +4,15 @@ class PaymentGateway
   def initialize(type, options = {})
     @type = type
     @deprecated = options.delete(:deprecated).presence
-    @boolean_fields = options.delete(:boolean) || []
+    @boolean_field_keys = options.delete(:boolean) || []
     @fields = options
   end
 
   def non_boolean_fields
-    fields - boolean_fields
+    fields.except(*boolean_field_keys)
   end
 
-  attr_reader :type, :deprecated, :fields, :boolean_fields
-
+  attr_reader :type, :deprecated, :fields, :boolean_field_keys
 
   # So far hardcoded list of gateways, later maybe this will be loaded from a config file or db.
   GATEWAYS = [

--- a/app/models/payment_gateway.rb
+++ b/app/models/payment_gateway.rb
@@ -4,15 +4,21 @@ class PaymentGateway
   def initialize(type, options = {})
     @type = type
     @deprecated = options.delete(:deprecated).presence
+    @boolean_fields = options.delete(:boolean) || []
     @fields = options
   end
 
-  attr_reader :type, :deprecated, :fields
+  def non_boolean_fields
+    fields - boolean_fields
+  end
+
+  attr_reader :type, :deprecated, :fields, :boolean_fields
+
 
   # So far hardcoded list of gateways, later maybe this will be loaded from a config file or db.
   GATEWAYS = [
     PaymentGateway.new(:authorize_net, deprecated: true, login: 'LoginID', password: 'Transaction Key'),
-    PaymentGateway.new(:braintree_blue, public_key: 'Public Key', merchant_id: 'Merchant ID', private_key: 'Private Key'),
+    PaymentGateway.new(:braintree_blue, public_key: 'Public Key', merchant_id: 'Merchant ID', private_key: 'Private Key', three_ds_enabled: '3D Secure enabled', boolean: %i[three_ds_enabled]),
     PaymentGateway.new(:ogone, deprecated: true, login: 'PSPID', password: 'Password', user: 'User Id', signature: "SHA-IN Pass phrase", signature_out: "SHA-OUT Pass phrase"),
     PaymentGateway.new(:stripe, login: 'Secret Key', publishable_key: 'Publishable Key', endpoint_secret: 'Webhook Signing Secret')
   ].freeze

--- a/app/models/payment_gateway_setting.rb
+++ b/app/models/payment_gateway_setting.rb
@@ -27,10 +27,19 @@ class PaymentGatewaySetting < ApplicationRecord
   # I prefer validating manually in places where it is needed. Do not break things.
   def configured?
     return false if gateway_type.blank?
-    fields = PaymentGateway.find(gateway_type).fields.keys
+
+    fields = PaymentGateway.find(gateway_type).non_boolean_fields.keys
     fields.all? do |field|
       symbolized_settings[field].present?
     end
+  end
+
+  def gateway_settings=(hash)
+    gateway = PaymentGateway.find(gateway_type)
+    gateway.boolean_fields.each do |field|
+      hash[field] = ActiveModel::Type::Boolean.new.cast(hash[field])
+    end
+    super(hash)
   end
 
   def active_gateway_type

--- a/app/models/payment_gateway_setting.rb
+++ b/app/models/payment_gateway_setting.rb
@@ -28,17 +28,53 @@ class PaymentGatewaySetting < ApplicationRecord
   def configured?
     return false if gateway_type.blank?
 
-    fields = PaymentGateway.find(gateway_type).non_boolean_fields.keys
-    fields.all? do |field|
+    gateway = PaymentGateway.find(gateway_type)
+
+    return false unless gateway
+
+    fields = gateway.non_boolean_fields
+
+    fields.all? do |field, _label|
       symbolized_settings[field].present?
     end
   end
 
+  # Overrides the {#gateway_setting} attribute by ensuring boolean fields are cast correctly
+  # @note It would be nice to combine this with `attribute "#{boolean_field}"` and `gateway_setting` as an ActiveModel::Model
+  # Sadly the attributes are dynamic, and meta-programming in this case would be overkill, still can be considered...
+  # @param [Hash] hash with correct PaymentGateway fields
+  # @return [Hash]
+  #
+  #   @example:
+  #
+  #   class GatewaySetting
+  #     include ActiveModel::Model
+  #
+  #     attribute :name
+  #     attribute :three_ds_enabled, :boolean
+  #
+  #     def self.load(str)
+  #       new(JSON.load(str))
+  #     end
+  #
+  #     def self.dump(obj)
+  #       JSON.dump(obj.attributes)
+  #     end
+  #   end
+  #
+  #   class PaymentGatewaySetting < Gateway
+  #     serialize :gateway_settings, GatewaySetting
+  #   end
+  #
   def gateway_settings=(hash)
     gateway = PaymentGateway.find(gateway_type)
-    gateway.boolean_fields.each do |field|
+
+    return super unless gateway
+
+    gateway.boolean_field_keys.each do |field|
       hash[field] = ActiveModel::Type::Boolean.new.cast(hash[field])
     end
+
     super(hash)
   end
 

--- a/app/services/finance/charging_service.rb
+++ b/app/services/finance/charging_service.rb
@@ -63,7 +63,7 @@ module Finance
     end
 
     def charge_with_braintree_blue
-      gateway.purchase(amount.cents, buyer_reference, options.merge(transaction_source: 'recurring'))
+      gateway.purchase(amount.cents, buyer_reference, options.merge(transaction_source: 'unscheduled'))
     end
   end
 end

--- a/app/views/finance/provider/settings/show.html.slim
+++ b/app/views/finance/provider/settings/show.html.slim
@@ -77,17 +77,21 @@
               = form.inputs "#{link_to payment_gateway.display_name, payment_gateway.homepage_url} Options" do
                 - payment_gateway.fields.each do |name, label|
                   li class="string"
-                    = fields.label name, label
-                    - if enabled
-                      - if payment_gateway.boolean_fields.include?(name)
-                          = fields.check_box name, data: {val: @account.payment_gateway_options[name].presence }, checked: @account.payment_gateway_options[name].present?
-                      - else
-                          = fields.text_field name, value: @account.payment_gateway_options[name]
-                    - else
-                        - if payment_gateway.boolean_fields.include?(name)
-                          = fields.check_box name, checked: false, disabled: true
+                    - if payment_gateway.boolean_field_keys.include?(name)
+                      = fields.label name, for: ['account', 'payment', payment_gateway.type, name].join('_') do
+                        - if enabled
+                          = fields.check_box name, checked: @account.payment_gateway_options[name].present?, id: ['account', 'payment', payment_gateway.type, name].join('_')
                         - else
-                          = fields.text_field name, value: '', disabled: true
+                          = fields.check_box name, checked: false, disabled: true, id: ['account', 'payment', payment_gateway.type, name].join('_')
+
+                        = label
+
+                    - else
+                      = fields.label name, label
+                      - if enabled
+                        = fields.text_field name, value: @account.payment_gateway_options[name]
+                      - else
+                        = fields.text_field name, value: '', disabled: true
 
       = form.buttons do
         = form.button 'Save changes', button_html: { class: 'pf-c-button pf-m-primary' }

--- a/app/views/finance/provider/settings/show.html.slim
+++ b/app/views/finance/provider/settings/show.html.slim
@@ -85,6 +85,7 @@
                           = fields.check_box name, checked: false, disabled: true, id: ['account', 'payment', payment_gateway.type, name].join('_')
 
                         = label
+                      p.inline-hints Make sure your Braintree account has 3D Secure enabled before you enable it here as otherwise payments initiated from the developer portal will fail.
 
                     - else
                       = fields.label name, label

--- a/app/views/finance/provider/settings/show.html.slim
+++ b/app/views/finance/provider/settings/show.html.slim
@@ -79,11 +79,15 @@
                   li class="string"
                     = fields.label name, label
                     - if enabled
-                      = fields.text_field name,
-                                          value: @account.payment_gateway_options[name]
+                      - if payment_gateway.boolean_fields.include?(name)
+                          = fields.check_box name, data: {val: @account.payment_gateway_options[name].presence }, checked: @account.payment_gateway_options[name].present?
+                      - else
+                          = fields.text_field name, value: @account.payment_gateway_options[name]
                     - else
-                      = fields.text_field name,
-                                          value: '', disabled: true
+                        - if payment_gateway.boolean_fields.include?(name)
+                          = fields.check_box name, checked: false, disabled: true
+                        - else
+                          = fields.text_field name, value: '', disabled: true
 
       = form.buttons do
         = form.button 'Save changes', button_html: { class: 'pf-c-button pf-m-primary' }

--- a/app/views/payment_gateways/_braintree_customer_form.html.erb
+++ b/app/views/payment_gateways/_braintree_customer_form.html.erb
@@ -160,4 +160,10 @@
     </fieldset>
     <%= hidden_field_tag 'braintree[nonce]', nil, id: 'braintree_nonce' %>
 <% end %>
-<%= javascript_pack_tag 'braintree3DSecureCustomerForm'%>
+<% if site_account.payment_gateway_options[:three_ds_enabled] %>
+  <%= javascript_pack_tag 'braintree3DSecureCustomerForm'%>
+<% else %>
+  <script src="https://js.braintreegateway.com/web/3.70.0/js/client.min.js"></script>
+  <script src="https://js.braintreegateway.com/web/3.70.0/js/hosted-fields.min.js"></script>
+  <%= javascript_pack_tag 'braintree3DSecuredisabled'%>
+<% end %>

--- a/test/integration/admin/account/payment_gateways_controller_test.rb
+++ b/test/integration/admin/account/payment_gateways_controller_test.rb
@@ -22,10 +22,12 @@ class Admin::Account::PaymentGatewaysControllerTest < ActionDispatch::Integratio
     assert_redirected_to admin_finance_settings_url
     assert_equal 'Payment gateway details were successfully saved.', flash[:notice]
     assert_equal({
-      'gateway_type' => 'stripe',
-      'gateway_settings' => { 'login' => 'bob', 'publishable_key' => 'monkey', 'endpoint_secret' => 'some-secret' }
-    },
-    @provider.gateway_setting.attributes.slice('gateway_type', 'gateway_settings'))
+                   'gateway_type' => 'stripe',
+                   'gateway_settings' => {
+                     'login' => 'bob', 'publishable_key' => 'monkey', 'endpoint_secret' => 'some-secret'
+                   }
+                 },
+                 @provider.gateway_setting.attributes.slice('gateway_type', 'gateway_settings'))
   end
 
   test 'cannot set a deprecated payment gateway' do
@@ -60,7 +62,7 @@ class Admin::Account::PaymentGatewaysControllerTest < ActionDispatch::Integratio
     assert_redirected_to admin_finance_settings_url
     assert_equal 'Payment gateway details were successfully saved.', flash[:notice]
     assert_equal(
-      { 'gateway_type' => 'stripe', 'gateway_settings' => { 'login' => 'bob', 'publishable_key' => 'monkey', 'endpoint_secret' => 'some-secret' } },
+      { 'gateway_type' => 'stripe', 'gateway_settings' => { 'login' => 'bob', 'publishable_key' => 'monkey', 'endpoint_secret' => 'some-secret'} },
       @provider.gateway_setting.attributes.slice('gateway_type', 'gateway_settings')
     )
   end

--- a/test/unit/payment_gateway_setting_test.rb
+++ b/test/unit/payment_gateway_setting_test.rb
@@ -98,4 +98,15 @@ class PaymentGatewaySettingTest < ActiveSupport::TestCase
     assert gateway_setting.valid?
     refute gateway_setting.errors.added?(:gateway_type, :invalid)
   end
+
+  test 'with boolean fields' do
+    @gateway_setting.gateway_type = :braintree_blue
+    @gateway_setting.gateway_settings = { public_key: 'Public Key', merchant_id: 'Merchant ID', private_key: 'Private Key'}
+    assert @gateway_setting.configured?
+
+    refute @gateway_setting.gateway_settings[:three_ds_enabled], 'three_ds_enabled should be falsey'
+
+    @gateway_setting.gateway_settings = { public_key: 'Public Key', merchant_id: 'Merchant ID', private_key: 'Private Key', three_ds_enabled: true}
+    assert @gateway_setting.gateway_settings[:three_ds_enabled], 'three_ds_enabled should be truthy'
+  end
 end

--- a/test/unit/payment_gateway_test.rb
+++ b/test/unit/payment_gateway_test.rb
@@ -46,4 +46,10 @@ class PaymentGatewayTest < ActiveSupport::TestCase
     assert_equal ActiveMerchant::Billing::StripeGateway,               PaymentGateway.implementation(:stripe)
     assert_equal ActiveMerchant::Billing::StripePaymentIntentsGateway, PaymentGateway.implementation(:stripe, sca: true)
   end
+
+  test 'non_boolean_fields' do
+    payment_gateway = PaymentGateway.new(:feature, name: 'Name of the feature', opt_in: 'Opt in', boolean: %i[opt_in])
+    assert_equal %i[opt_in], payment_gateway.boolean_field_keys
+    assert_equal({name: 'Name of the feature'}, payment_gateway.non_boolean_fields)
+  end
 end

--- a/test/unit/services/finance/charging_service_test.rb
+++ b/test/unit/services/finance/charging_service_test.rb
@@ -109,7 +109,7 @@ module Finance
       gateway = ActiveMerchant::Billing::BraintreeBlueGateway.new(gateway_options)
       amount = ThreeScale::Money.new(45, 'EUR')
       service = ChargingService.new(gateway, buyer_reference: '1234', amount: amount)
-      gateway.expects(:purchase).with(amount.cents, '1234', { transaction_source: 'recurring' }).returns(true)
+      gateway.expects(:purchase).with(amount.cents, '1234', { transaction_source: 'unscheduled' }).returns(true)
       assert service.call
     end
   end


### PR DESCRIPTION
This is the base for allowing customers to opt-in for 3DS secure

* Added `:boolean` option to `PaymentGateway`
* Added `three_ds_enabled` option to Braintree

## TODO:

- [x] Add and fix tests
- [x] Adapt the JS part to take care of this new option
- [x] [Adapt the Ruby part to send the correct `verify_card` to the Payment Gateway](https://github.com/3scale/porta/pull/2403) Doing separately
- [x] set `transaction_source: 'unscheduled'`


As commented by Braintree support;

> **Question: About metered recurring transactions**
> We do metered recurring payment, so we set transaction_source: 'recurring' in later transaction sales, what will be the result:
> If the payment method is subjected to SCA andwe use verify_card: true to create the payment_method
> we use verify_card: false to create the payment_method

> **Braintree Support answer:**
> The result will still ultimately depend on the card-issuing bank's decision. However, if there is a transaction or verification with 3DS information associated, subsequent recurring/unscheduled transactions are much more likely to be approved. If no transaction or verification has 3DS information, subsequent transaction attempts will more likely be 2099 declined for lack of 3DS.
>
> Please note, if the amount is not fixed, it may be more appropriate to pass `transaction_source: unscheduled`.

## Screenshots

**Before**

![image](https://user-images.githubusercontent.com/64276/112140211-08afd200-8bd4-11eb-898d-5d45a5fbbbda.png)

------------------------

**After**
![image](https://user-images.githubusercontent.com/64276/114426631-8c992080-9bba-11eb-9f29-1e0b8a101e39.png)


