### PR TITLE
Braintree: Detect if 3DSecure is enabled, JS side

### DIFF
--- a/app/javascript/packs/braintree3DSecuredisabled.js
+++ b/app/javascript/packs/braintree3DSecuredisabled.js
@@ -1,0 +1,67 @@
+var $form = $('#customer_form')
+var submit = document.querySelector('input[type="submit"]')
+var braintree = window.braintree
+var braintreeAuthorization = $form.attr('data-client-token')
+
+if (typeof braintree !== 'undefined') {
+  braintree.client.create({
+    authorization: braintreeAuthorization
+  }, function (clientErr, clientInstance) {
+    if (clientErr) {
+      console.error(clientErr)
+      return
+    }
+
+    // This example shows Hosted Fields, but you can also use this
+    // client instance to create additional components here, such as:qa
+    // PayPal or Data Collector.
+
+    braintree.hostedFields.create({
+      client: clientInstance,
+      styles: {
+        'input': {
+          'font-size': '14px'
+        },
+        'input.invalid': {
+          'color': 'red'
+        },
+        'input.valid': {
+          'color': 'green'
+        }
+      },
+      fields: {
+        number: {
+          selector: '#customer_credit_card_number',
+          placeholder: '4111 1111 1111 1111'
+        },
+        cvv: {
+          selector: '#customer_credit_card_cvv',
+          placeholder: '123'
+        },
+        expirationDate: {
+          selector: '#customer_credit_card_expiration_date',
+          placeholder: 'MM/YY'
+        }
+      }
+    }, function (hostedFieldsErr, hostedFieldsInstance) {
+      if (hostedFieldsErr) {
+        console.error(hostedFieldsErr)
+        return
+      }
+
+      submit.removeAttribute('disabled')
+
+      $form.on('submit', function (event) {
+        event.preventDefault()
+        hostedFieldsInstance.tokenize(function (tokenizeErr, payload) {
+          if (tokenizeErr) {
+            console.error(tokenizeErr)
+            return
+          }
+          $('#braintree_nonce').val(payload['nonce'])
+          $form.get(0).submit()
+        })
+      })
+    })
+  })
+}

--- a/app/views/payment_gateways/_braintree_customer_form.html.erb
+++ b/app/views/payment_gateways/_braintree_customer_form.html.erb
@@ -160,4 +160,10 @@
     </fieldset>
     <%= hidden_field_tag 'braintree[nonce]', nil, id: 'braintree_nonce' %>
 <% end %>
-<%= javascript_pack_tag 'braintree3DSecureCustomerForm'%>
+<% if site_account.payment_gateway_options[:three_ds_enabled] %>
+  <%= javascript_pack_tag 'braintree3DSecureCustomerForm'%>
+<% else %>
+  <script src="https://js.braintreegateway.com/web/3.70.0/js/client.min.js"></script>
+  <script src="https://js.braintreegateway.com/web/3.70.0/js/hosted-fields.min.js"></script>
+  <%= javascript_pack_tag 'braintree3DSecuredisabled'%>
+<% end %>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

This is a quickfix.
It recovers the old braintree implementation (not 3DSecure 2) from this [previous commit](https://github.com/3scale/porta/commit/c497dca4b2424fca80f7383e0f33874d49a0aae6#diff-e333f5ac348a321b5b1087b0039ffac2b5ff53e44d9bbf2478debfbf721a5b21), with small changes, when 3DSecure 2 is not enabled.
Or, uses the new 3DSecure 2 enabled implementation when it's enabed in Admin portal.
To be mergen on https://github.com/3scale/porta/pull/2400

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-6860

**Special notes for your reviewer**:
