### PR TITLE
[2.11] Embed New Backend form into a modal

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -169,7 +169,6 @@
     // Response of this form will be presented inside a colorbox.
     $("form.colorbox[data-remote]").live("submit", function(e) {
       $(this).on('ajax:complete', function(event, xhr, status){
-        console.log('ajax:complete')
         var form = $(this).closest('form');
         var width = form.data('width');
         $.colorbox({
@@ -237,9 +236,10 @@
       location.href = "?view=" + view + "&s=" + param + "&for_category=" + category;
     });
 
-    // DEPRECATED: since the introduction of PF4 and React, colorbox is being removed. Also jquery-ujs has been replaced with rails-ujs
+    // DEPRECATED: since the introduction of PF4 and React, colorbox is being removed. Also jquery-ujs has been replaced with rails-ujs.
+    // Added #colorbox selector to target only non-React forms
     // show errors from ajax in formtastic
-    $('form.colorbox').live('ajax:error', function(event, xhr, status, error) {
+    $('#colorbox form').live('ajax:error', function(event, xhr, status, error) {
       switch(status){
         case 'error':
           $.colorbox({html: xhr.responseText});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -165,10 +165,11 @@
       attachEvents();
     })();
 
-
+    // DEPRECATED: since the introduction of PF4 and React, colorbox is being removed.
     // Response of this form will be presented inside a colorbox.
     $("form.colorbox[data-remote]").live("submit", function(e) {
       $(this).on('ajax:complete', function(event, xhr, status){
+        console.log('ajax:complete')
         var form = $(this).closest('form');
         var width = form.data('width');
         $.colorbox({
@@ -236,8 +237,9 @@
       location.href = "?view=" + view + "&s=" + param + "&for_category=" + category;
     });
 
+    // DEPRECATED: since the introduction of PF4 and React, colorbox is being removed. Also jquery-ujs has been replaced with rails-ujs
     // show errors from ajax in formtastic
-    $('form').live('ajax:error', function(event, xhr, status, error) {
+    $('form.colorbox').live('ajax:error', function(event, xhr, status, error) {
       switch(status){
         case 'error':
           $.colorbox({html: xhr.responseText});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -239,7 +239,7 @@
     // DEPRECATED: since the introduction of PF4 and React, colorbox is being removed. Also jquery-ujs has been replaced with rails-ujs.
     // Added #colorbox selector to target only non-React forms
     // show errors from ajax in formtastic
-    $('#form:not(.pf-c-form)').live('ajax:error', function(event, xhr, status, error) {
+    $('form:not(.pf-c-form)').live('ajax:error', function(event, xhr, status, error) {
       switch(status){
         case 'error':
           $.colorbox({html: xhr.responseText});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -239,7 +239,7 @@
     // DEPRECATED: since the introduction of PF4 and React, colorbox is being removed. Also jquery-ujs has been replaced with rails-ujs.
     // Added #colorbox selector to target only non-React forms
     // show errors from ajax in formtastic
-    $('#colorbox form').live('ajax:error', function(event, xhr, status, error) {
+    $('#form:not(.pf-c-form)').live('ajax:error', function(event, xhr, status, error) {
       switch(status){
         case 'error':
           $.colorbox({html: xhr.responseText});

--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -25,12 +25,15 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   end
 
   def create
-    if @backend_api.save
-      redirect_to provider_admin_backend_api_path(@backend_api), notice: 'Backend created'
-    else
-      flash.now[:error] = 'Backend could not be created'
-      activate_menu :backend_apis
-      render :new
+    respond_to do |format|
+      if @backend_api.save
+        format.json { render json: @backend_api.decorate.add_backend_usage_backends_data, status: :created }
+        format.html { redirect_to provider_admin_backend_api_path(@backend_api), notice: 'Backend created' }
+      else
+        flash.now[:error] = 'Backend could not be created'
+        format.json { render json: @backend_api.errors, status: :unprocessable_entity }
+        format.html { render :new }
+      end
     end
   end
 

--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -13,11 +13,11 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
     activate_menu :backend_apis
     search = ThreeScale::Search.new(params[:search] || params)
     @backend_apis = current_account.backend_apis
-                                            .order(updated_at: :desc)
-                                            .scope_search(search)
+                                   .order(updated_at: :desc)
+                                   .scope_search(search)
     @page_backend_apis = @backend_apis.paginate(pagination_params)
-                                          .decorate
-                                          .to_json(only: %i[name updated_at id private_endpoint system_name], methods: %i[links products_count])
+                                      .decorate
+                                      .to_json(only: %i[name updated_at id private_endpoint system_name], methods: %i[links products_count])
   end
 
   def new

--- a/app/helpers/api/backend_usages_helper.rb
+++ b/app/helpers/api/backend_usages_helper.rb
@@ -5,7 +5,7 @@ module Api::BackendUsagesHelper
     {
       backends: backends(service.id).to_json,
       url: admin_service_backend_usages_path(service),
-      'new-backend-path': new_provider_admin_backend_api_path
+      'backends-path': provider_admin_backend_apis_path
     }
   end
 

--- a/app/javascript/packs/add_backend_usage.js
+++ b/app/javascript/packs/add_backend_usage.js
@@ -12,11 +12,11 @@ document.addEventListener('DOMContentLoaded', () => {
     return
   }
 
-  const { backends, url, newBackendPath } = container.dataset
+  const { backends, url, backendsPath } = container.dataset
 
   AddBackendFormWrapper({
     backends: safeFromJsonString(backends) || [],
     url,
-    newBackendPath
+    backendsPath
   }, containerId)
 })

--- a/app/javascript/src/BackendApis/components/AddBackendForm.jsx
+++ b/app/javascript/src/BackendApis/components/AddBackendForm.jsx
@@ -21,10 +21,10 @@ import './AddBackendForm.scss'
 type Props = {
   backends: Backend[],
   url: string,
-  newBackendPath: string
+  backendsPath: string
 }
 
-const AddBackendForm = ({ backends, url, newBackendPath }: Props): React.Node => {
+const AddBackendForm = ({ backends, url, backendsPath }: Props): React.Node => {
   const [backend, setBackend] = useState<Backend | null>(null)
   const [path, setPath] = useState('')
   const [loading, setLoading] = useState(false)

--- a/app/javascript/src/BackendApis/components/AddBackendForm.jsx
+++ b/app/javascript/src/BackendApis/components/AddBackendForm.jsx
@@ -10,9 +10,10 @@ import {
   PageSection,
   PageSectionVariants
 } from '@patternfly/react-core'
-import { BackendSelect, PathInput } from 'BackendApis'
+import { BackendSelect, PathInput, NewBackendModal } from 'BackendApis'
 import { CSRFToken } from 'utilities/utils'
 import { createReactWrapper } from 'utilities/createReactWrapper'
+import { notice } from 'utilities/alert'
 
 import type { Backend } from 'Types'
 
@@ -26,45 +27,63 @@ type Props = {
 
 const AddBackendForm = ({ backends, url, backendsPath }: Props): React.Node => {
   const [backend, setBackend] = useState<Backend | null>(null)
+  const [updatedBackends, setUpdatedBackends] = useState(backends)
   const [path, setPath] = useState('')
   const [loading, setLoading] = useState(false)
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   const isFormComplete = backend !== null && path !== ''
 
+  const handleOnCreateBackend = (backend: Backend) => {
+    notice('Backend created')
+    setIsModalOpen(false)
+    setBackend(backend)
+    setUpdatedBackends([backend, ...updatedBackends])
+  }
+
   return (
-    <PageSection variant={PageSectionVariants.light}>
-      <Form
-        id="new_backend_api_config"
-        acceptCharset='UTF-8'
-        method='post'
-        action={url}
-        onSubmit={e => setLoading(true)}
-        // isWidthLimited TODO: use when available instead of hardcoded css
-      >
-        <CSRFToken />
-        <input name='utf8' type='hidden' value='✓' />
+    <>
+      <PageSection variant={PageSectionVariants.light}>
+        <Form
+          id="new_backend_api_config"
+          acceptCharset='UTF-8'
+          method='post'
+          action={url}
+          onSubmit={e => setLoading(true)}
+          // isWidthLimited TODO: use when available instead of hardcoded css
+        >
+          <CSRFToken />
+          <input name='utf8' type='hidden' value='✓' />
 
-        <BackendSelect
-          backend={backend}
-          backends={backends}
-          newBackendPath={newBackendPath}
-          onSelect={setBackend}
-        />
+          <BackendSelect
+            backend={backend}
+            backends={updatedBackends}
+            onSelect={setBackend}
+            onCreateNewBackend={() => setIsModalOpen(true)}
+          />
 
-        <PathInput path={path} setPath={setPath} />
+          <PathInput path={path} setPath={setPath} />
 
-        <ActionGroup>
-          <Button
-            variant='primary'
-            type='submit'
-            isDisabled={!isFormComplete || loading}
-            data-testid="submit"
-          >
-            Add to Product
-          </Button>
-        </ActionGroup>
-      </Form>
-    </PageSection>
+          <ActionGroup>
+            <Button
+              variant='primary'
+              type='submit'
+              isDisabled={!isFormComplete || loading}
+              data-testid="submit"
+            >
+              Add to Product
+            </Button>
+          </ActionGroup>
+        </Form>
+      </PageSection>
+
+      <NewBackendModal
+        backendsPath={backendsPath}
+        onClose={() => setIsModalOpen(false)}
+        isOpen={isModalOpen}
+        onCreateBackend={handleOnCreateBackend}
+      />
+    </>
   )
 }
 

--- a/app/javascript/src/BackendApis/components/AddBackendForm.jsx
+++ b/app/javascript/src/BackendApis/components/AddBackendForm.jsx
@@ -69,7 +69,7 @@ const AddBackendForm = ({ backends, url, backendsPath }: Props): React.Node => {
               variant='primary'
               type='submit'
               isDisabled={!isFormComplete || loading}
-              data-testid="submit"
+              data-testid="addBackend-buttonSubmit"
             >
               Add to Product
             </Button>

--- a/app/javascript/src/BackendApis/components/BackendSelect.jsx
+++ b/app/javascript/src/BackendApis/components/BackendSelect.jsx
@@ -13,11 +13,11 @@ import './BackendSelect.scss'
 type Props = {
   backend: Backend | null,
   backends: Backend[],
-  newBackendPath: string,
+  onCreateNewBackend: () => void,
   onSelect: (Backend | null) => void
 }
 
-const BackendSelect = ({ backend, backends, newBackendPath, onSelect }: Props): React.Node => {
+const BackendSelect = ({ backend, backends, onSelect, onCreateNewBackend }: Props): React.Node => {
   const cells = [
     { title: 'Name', propName: 'name' },
     { title: 'Private Base URL', propName: 'privateEndpoint' },
@@ -36,7 +36,13 @@ const BackendSelect = ({ backend, backends, newBackendPath, onSelect }: Props): 
       cells={cells}
       helperText={(
         <p className="hint">
-          <Button variant="link" icon={<PlusCircleIcon />} component="a" href={newBackendPath} isInline>
+          <Button
+            isInline
+            variant="link"
+            icon={<PlusCircleIcon />}
+            onClick={onCreateNewBackend}
+            data-testid="create-new-backend"
+          >
             Create new Backend
           </Button>
         </p>

--- a/app/javascript/src/BackendApis/components/BackendSelect.jsx
+++ b/app/javascript/src/BackendApis/components/BackendSelect.jsx
@@ -41,7 +41,7 @@ const BackendSelect = ({ backend, backends, onSelect, onCreateNewBackend }: Prop
             variant="link"
             icon={<PlusCircleIcon />}
             onClick={onCreateNewBackend}
-            data-testid="create-new-backend"
+            data-testid="newBackendCreateBackend-buttonLink"
           >
             Create new Backend
           </Button>

--- a/app/javascript/src/BackendApis/components/DescriptionInput.jsx
+++ b/app/javascript/src/BackendApis/components/DescriptionInput.jsx
@@ -1,0 +1,27 @@
+// @flow
+
+import * as React from 'react'
+
+import { FormGroup, TextArea } from '@patternfly/react-core'
+
+type Props = {
+  description: string,
+  setDescription: string => void
+}
+
+const DescriptionInput = ({ description, setDescription }: Props): React.Node => (
+  <FormGroup
+    label="Description"
+    validated="default"
+    fieldId="backend_api_description"
+  >
+    <TextArea
+      id="backend_api_description"
+      description="backend_api[description]"
+      value={description}
+      onChange={setDescription}
+    />
+  </FormGroup>
+)
+
+export { DescriptionInput }

--- a/app/javascript/src/BackendApis/components/NameInput.jsx
+++ b/app/javascript/src/BackendApis/components/NameInput.jsx
@@ -1,0 +1,29 @@
+// @flow
+
+import * as React from 'react'
+
+import { FormGroup, TextInput } from '@patternfly/react-core'
+
+type Props = {
+  name: string,
+  setName: string => void
+}
+
+const NameInput = ({ name, setName }: Props): React.Node => (
+  <FormGroup
+    isRequired
+    label="Name"
+    validated="default"
+    fieldId="backend_api_name"
+  >
+    <TextInput
+      type="text"
+      id="backend_api_name"
+      name="backend_api[name]"
+      value={name}
+      onChange={setName}
+    />
+  </FormGroup>
+)
+
+export { NameInput }

--- a/app/javascript/src/BackendApis/components/NewBackendForm.jsx
+++ b/app/javascript/src/BackendApis/components/NewBackendForm.jsx
@@ -1,0 +1,77 @@
+// @flow
+
+import * as React from 'react'
+import { useState } from 'react'
+
+import { ActionGroup, Button, Form } from '@patternfly/react-core'
+import validate from 'validate.js'
+import {
+  NameInput,
+  SystemNameInput,
+  DescriptionInput,
+  PrivateEndpointInput
+} from 'BackendApis'
+import { CSRFToken } from 'utilities/utils'
+
+type Props = {
+  action: string,
+  onCancel: () => void,
+  isLoading?: boolean,
+  errors?: {
+    private_endpoint: Array<string>
+  }
+}
+
+const VALIDATION_CONSTRAINTS = {
+  name: { length: { minimum: 1 } },
+  privateEndpoint: { url: { schemes: ['http', 'https', 'ws', 'wss'] } }
+}
+
+const NewBackendForm = ({ action, onCancel, isLoading = false, errors = {} }: Props): React.Node => {
+  const [name, setName] = useState('')
+  const [systemName, setSystemName] = useState('')
+  const [description, setDescription] = useState('')
+  const [privateEndpoint, setPrivateEndpoint] = useState('')
+
+  const validationErrors = validate({ name, privateEndpoint }, VALIDATION_CONSTRAINTS)
+
+  return (
+    <Form
+      id="new_backend_api_config"
+      acceptCharset="UTF-8"
+      method="post"
+      action={action}
+      // isWidthLimited TODO: use when available instead of hardcoded css
+      data-remote
+    >
+      <CSRFToken />
+      <input name="utf8" type="hidden" value="✓" />
+
+      <NameInput name={name} setName={setName} />
+      <SystemNameInput systemName={systemName} setSystemName={setSystemName} />
+      <DescriptionInput description={description} setDescription={setDescription} />
+      <PrivateEndpointInput privateEndpoint={privateEndpoint} setPrivateEndpoint={setPrivateEndpoint} errors={errors.private_endpoint} />
+
+      <ActionGroup>
+        <Button
+          variant="primary"
+          type="submit"
+          isDisabled={validationErrors !== undefined || isLoading}
+          data-testid="submit"
+        >
+          Create Backend
+        </Button>
+        <Button
+          variant="secondary"
+          type="button"
+          data-testid="cancel"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </ActionGroup>
+    </Form>
+  )
+}
+
+export { NewBackendForm }

--- a/app/javascript/src/BackendApis/components/NewBackendForm.jsx
+++ b/app/javascript/src/BackendApis/components/NewBackendForm.jsx
@@ -57,7 +57,7 @@ const NewBackendForm = ({ action, onCancel, isLoading = false, errors = {} }: Pr
           variant="primary"
           type="submit"
           isDisabled={validationErrors !== undefined || isLoading}
-          data-testid="submit"
+          data-testid="newBackendCreateBackend-buttonSubmit"
         >
           Create Backend
         </Button>

--- a/app/javascript/src/BackendApis/components/NewBackendModal.jsx
+++ b/app/javascript/src/BackendApis/components/NewBackendModal.jsx
@@ -1,0 +1,77 @@
+// @flow
+
+import * as React from 'react'
+
+import {
+  BaseSizes,
+  Modal,
+  Spinner,
+  Title,
+  TitleLevel
+} from '@patternfly/react-core'
+// $FlowFixMe[missing-export] To fix this: rename src/Form si that name-mapper does not mess up
+import { NewBackendForm } from 'BackendApis'
+
+import './NewBackendModal.scss'
+
+import type { Backend } from 'Types'
+
+type Props = {
+  backendsPath: string,
+  isOpen?: boolean,
+  onClose: () => void,
+  onCreateBackend: (Backend) => void
+}
+
+const NewBackendModal = ({ backendsPath, isOpen = false, onClose, onCreateBackend }: Props): React.Node => {
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [errors, setErrors] = React.useState()
+
+  const handleOnAjaxComplete = (_event, xhr: { responseText: string }, status: string) => {
+    setIsLoading(false)
+
+    if (status === 'success') {
+      const backend = JSON.parse(xhr.responseText)
+      onCreateBackend(backend)
+    } else if (status === 'error') {
+      const errors = JSON.parse(xhr.responseText)
+      setErrors(errors)
+    }
+  }
+
+  React.useEffect(() => {
+    $('form#new_backend_api_config')
+      // $FlowFixMe[prop-missing] jquery-ujs is deprecated, in rails 5 we should use rails-ujs. However, the former is broadly used so it's not trivial.
+      .live('ajax:send', () => setIsLoading(true))
+      .live('ajax:complete', handleOnAjaxComplete)
+    // No need for cleanup
+  }, [])
+
+  const header = (
+    <React.Fragment>
+      <Title headingLevel={TitleLevel.h1} size={BaseSizes['2xl']} className="with-spinner">
+        Create Backend
+      </Title>
+      {isLoading && <Spinner size='md' className='pf-u-ml-md' />}
+    </React.Fragment>
+  )
+
+  return (
+    <Modal
+      isSmall
+      title="Create Backend"
+      header={header}
+      isOpen={isOpen}
+      onClose={onClose}
+    >
+      <NewBackendForm
+        action={backendsPath}
+        onCancel={onClose}
+        isLoading={isLoading}
+        errors={errors}
+      />
+    </Modal>
+  )
+}
+
+export { NewBackendModal }

--- a/app/javascript/src/BackendApis/components/NewBackendModal.jsx
+++ b/app/javascript/src/BackendApis/components/NewBackendModal.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react'
+import { useState } from 'react'
 
 import {
   BaseSizes,
@@ -24,8 +25,8 @@ type Props = {
 }
 
 const NewBackendModal = ({ backendsPath, isOpen = false, onClose, onCreateBackend }: Props): React.Node => {
-  const [isLoading, setIsLoading] = React.useState(false)
-  const [errors, setErrors] = React.useState()
+  const [isLoading, setIsLoading] = useState(false)
+  const [errors, setErrors] = useState()
 
   const handleOnAjaxComplete = (_event, xhr: { responseText: string }, status: string) => {
     setIsLoading(false)

--- a/app/javascript/src/BackendApis/components/NewBackendModal.scss
+++ b/app/javascript/src/BackendApis/components/NewBackendModal.scss
@@ -1,0 +1,25 @@
+// HACK: this is to prevent app/assets/javascripts/ajax_events.js from adding a spinner.
+// ajax_events and jquery-ujs should be replaced with rails-ujs used directly inside React components
+#ajax-in-progress {
+  display: none;
+}
+
+.pf-c-modal-box {
+  .pf-c-title.with-spinner {
+    display: inline;
+    margin-right: 6px;
+  }
+
+  form#new_backend_api_config {
+    max-width: 80%;
+
+    .pf-c-form__group {
+      text-align: left;
+    }
+
+    .pf-c-form__actions {
+      // HACK: since the buttons belongs to the form and not the modal, the PF4 css breaks a bit.
+      margin-bottom: -6px;
+    }
+  }
+}

--- a/app/javascript/src/BackendApis/components/PrivateEndpointInput.jsx
+++ b/app/javascript/src/BackendApis/components/PrivateEndpointInput.jsx
@@ -1,0 +1,34 @@
+// @flow
+
+import * as React from 'react'
+
+import { FormGroup, TextInput } from '@patternfly/react-core'
+
+type Props = {
+  privateEndpoint: string,
+  setPrivateEndpoint: string => void,
+  errors?: Array<string>
+}
+
+const PrivateEndpointInput = ({ privateEndpoint, setPrivateEndpoint, errors = [] }: Props): React.Node => (
+  <FormGroup
+    isRequired
+    label="Private Base URL"
+    validated="default"
+    fieldId="backend_api_private_endpoint"
+    helperText="Private address of your API that will be called by the API gateway. For end-to-end encryption your private base URL scheme should use a secure protocol (https or wss)."
+    helperTextInvalid={errors ? errors[0] : ''}
+    isValid={errors.length === 0}
+  >
+    <TextInput
+      type="text"
+      id="backend_api_private_endpoint"
+      name="backend_api[private_endpoint]"
+      value={privateEndpoint}
+      onChange={setPrivateEndpoint}
+      isValid={errors.length === 0}
+    />
+  </FormGroup>
+)
+
+export { PrivateEndpointInput }

--- a/app/javascript/src/BackendApis/components/SystemNameInput.jsx
+++ b/app/javascript/src/BackendApis/components/SystemNameInput.jsx
@@ -1,0 +1,29 @@
+// @flow
+
+import * as React from 'react'
+
+import { FormGroup, TextInput } from '@patternfly/react-core'
+
+type Props = {
+  systemName: string,
+  setSystemName: string => void
+}
+
+const SystemNameInput = ({ systemName, setSystemName }: Props): React.Node => (
+  <FormGroup
+    label="SystemName"
+    validated="default"
+    fieldId="backend_api_system_name"
+    helperText="Only ASCII letters, numbers, dashes and underscores are allowed."
+  >
+    <TextInput
+      type="text"
+      id="backend_api_system_name"
+      name="backend_api[system_name]"
+      value={systemName}
+      onChange={setSystemName}
+    />
+  </FormGroup>
+)
+
+export { SystemNameInput }

--- a/app/javascript/src/BackendApis/index.js
+++ b/app/javascript/src/BackendApis/index.js
@@ -3,3 +3,10 @@
 export * from './components/AddBackendForm'
 export * from './components/BackendSelect'
 export * from './components/PathInput'
+export * from './components/NewBackendModal'
+// $FlowIgnore[cannot-resolve-module] need to rename src/Form since name-mapper messes it up
+export * from './components/NewBackendForm'
+export * from './components/NameInput'
+export * from './components/DescriptionInput'
+export * from './components/PrivateEndpointInput'
+export * from './components/SystemNameInput'

--- a/app/javascript/src/Types/index.js
+++ b/app/javascript/src/Types/index.js
@@ -35,5 +35,7 @@ export type Product = {
 export type Backend = {
   id: number,
   name: string,
+  systemName: string,
+  description?: string,
   privateEndpoint: string
 }

--- a/app/javascript/src/utilities/patternfly-utils.jsx
+++ b/app/javascript/src/utilities/patternfly-utils.jsx
@@ -20,7 +20,7 @@ export interface SelectOptionObject {
 export const toSelectOptionObject = (item: Record): SelectOptionObject => ({
   id: String(item.id),
   name: item.name,
-  toString: () => item.description ? `${item.name} (${item.description})` : item.name
+  toString: () => item.name
 })
 
 type Props = Record & {

--- a/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
+++ b/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme'
 
 import { AddBackendForm } from 'BackendApis'
 
-const backend = { id: 0, name: 'backend', privateEndpoint: 'example.org' }
+const backend = { id: 0, name: 'backend', privateEndpoint: 'example.org', systemName: 'backend' }
 const backendsPath = '/backends'
 const defaultProps = {
   backends: [backend],

--- a/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
+++ b/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
@@ -27,7 +27,8 @@ it('should render itself', () => {
 
 it('should enable submit button only when form is filled', () => {
   const wrapper = mountWrapper()
-  expect(wrapper.find('button[data-testid="submit"]').prop('disabled')).toBe(true)
+  const isSubmitButtonDisabled = wrapper => wrapper.find('button[data-testid="addBackend-buttonSubmit"]').prop('disabled')
+  expect(isSubmitButtonDisabled(wrapper)).toBe(true)
 
   act(() => {
     wrapper.find('BackendSelect').prop('onSelect')(backend)
@@ -35,14 +36,14 @@ it('should enable submit button only when form is filled', () => {
   })
 
   wrapper.update()
-  expect(wrapper.find('button[data-testid="submit"]').prop('disabled')).toBe(false)
+  expect(isSubmitButtonDisabled(wrapper)).toBe(false)
 })
 
 it('should open/close a modal with a form to create a new backend', () => {
   const wrapper = mountWrapper()
   expect(wrapper.find('NewBackendModal').prop('isOpen')).toBe(false)
 
-  act(() => wrapper.find('button[data-testid="create-new-backend"]').props().onClick())
+  act(() => wrapper.find('button[data-testid="newBackendCreateBackend-buttonLink"]').props().onClick())
   wrapper.update()
   expect(wrapper.find('NewBackendModal').prop('isOpen')).toBe(true)
 

--- a/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
+++ b/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
@@ -7,11 +7,11 @@ import { mount } from 'enzyme'
 import { AddBackendForm } from 'BackendApis'
 
 const backend = { id: 0, name: 'backend', privateEndpoint: 'example.org' }
-const newBackendPath = '/backend/new'
+const backendsPath = '/backends'
 const defaultProps = {
   backends: [backend],
   url: '',
-  newBackendPath
+  backendsPath
 }
 
 const mountWrapper = (props) => mount(<AddBackendForm {...{ ...defaultProps, ...props }} />)
@@ -38,7 +38,25 @@ it('should enable submit button only when form is filled', () => {
   expect(wrapper.find('button[data-testid="submit"]').prop('disabled')).toBe(false)
 })
 
-it('should have a button to create a new backend', () => {
+it('should open/close a modal with a form to create a new backend', () => {
   const wrapper = mountWrapper()
-  expect(wrapper.find(`a[href="${newBackendPath}"]`))
+  expect(wrapper.find('NewBackendModal').prop('isOpen')).toBe(false)
+
+  act(() => wrapper.find('button[data-testid="create-new-backend"]').props().onClick())
+  wrapper.update()
+  expect(wrapper.find('NewBackendModal').prop('isOpen')).toBe(true)
+
+  act(() => wrapper.find('button[data-testid="cancel"]').props().onClick())
+  wrapper.update()
+  expect(wrapper.find('NewBackendModal').prop('isOpen')).toBe(false)
+})
+
+it('should select the new backend when created', () => {
+  const wrapper = mountWrapper()
+  const newBackend = { id: 1, name: 'New backend', privateEndpoint: 'example.org' }
+
+  act(() => wrapper.find('NewBackendModal').props().onCreateBackend(newBackend))
+
+  wrapper.update()
+  expect(wrapper.find('BackendSelect').prop('backend')).toBe(newBackend)
 })

--- a/spec/javascripts/BackendApis/components/BackendSelect.spec.jsx
+++ b/spec/javascripts/BackendApis/components/BackendSelect.spec.jsx
@@ -5,18 +5,20 @@ import { mount } from 'enzyme'
 
 import { BackendSelect } from 'BackendApis'
 
+const onCreateBackendSpy = jest.fn()
 const onShowAllSpy = jest.fn()
 const onSelectSpy = jest.fn()
 
 const newBackendPath = '/backends/new'
 const backends = [
-  { id: 0, name: 'API A', privateEndpoint: 'a.com' },
-  { id: 1, name: 'API B', privateEndpoint: 'b.com' }
+  { id: 0, name: 'API A', privateEndpoint: 'a.com', systemName: 'API_A' },
+  { id: 1, name: 'API B', privateEndpoint: 'b.com', systemName: 'API_B' }
 ]
 const defaultProps = {
   newBackendPath,
   backend: null,
   backends,
+  onCreateNewBackend: onCreateBackendSpy,
   onShowAll: onShowAllSpy,
   onSelect: onSelectSpy
 }

--- a/spec/javascripts/BackendApis/components/DescriptionInput.spec.jsx
+++ b/spec/javascripts/BackendApis/components/DescriptionInput.spec.jsx
@@ -1,0 +1,35 @@
+// @flow
+
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { mount } from 'enzyme'
+
+import { DescriptionInput } from 'BackendApis'
+
+const setDescription = jest.fn()
+
+const defaultProps = {
+  description: '',
+  setDescription
+}
+
+const mountWrapper = (props) => mount(<DescriptionInput {...{ ...defaultProps, ...props }} />)
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+it('should render itself', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.exists()).toBe(true)
+})
+
+it('should work', () => {
+  const value = 'foo'
+  const wrapper = mountWrapper()
+
+  act(() => wrapper.find(DescriptionInput).props().setDescription(value))
+
+  wrapper.update()
+  expect(setDescription).toHaveBeenCalledWith(value)
+})

--- a/spec/javascripts/BackendApis/components/NameInput.spec.jsx
+++ b/spec/javascripts/BackendApis/components/NameInput.spec.jsx
@@ -1,0 +1,35 @@
+// @flow
+
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { mount } from 'enzyme'
+
+import { NameInput } from 'BackendApis'
+
+const setName = jest.fn()
+
+const defaultProps = {
+  name: '',
+  setName
+}
+
+const mountWrapper = (props) => mount(<NameInput {...{ ...defaultProps, ...props }} />)
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+it('should render itself', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.exists()).toBe(true)
+})
+
+it('should work', () => {
+  const value = 'foo'
+  const wrapper = mountWrapper()
+
+  act(() => wrapper.find(NameInput).props().setName(value))
+
+  wrapper.update()
+  expect(setName).toHaveBeenCalledWith(value)
+})

--- a/spec/javascripts/BackendApis/components/NewBackendForm.spec.jsx
+++ b/spec/javascripts/BackendApis/components/NewBackendForm.spec.jsx
@@ -1,0 +1,101 @@
+// @flow
+
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { mount } from 'enzyme'
+
+// $FlowFixMe[missing-export] To fix this: rename src/Form si that name-mapper does not mess up
+import { NewBackendForm } from 'BackendApis'
+
+const validPaths = [
+  'http://example.com',
+  'https://example.com',
+  'ws://example.com',
+  'wss://example.com',
+  'http://example.com:3000'
+]
+
+const invalidPaths = [
+  'foo',
+  'ftp://exaple.org',
+  'www.example.org'
+]
+
+const defaultProps = {
+  action: '/backends',
+  onCancel: () => {},
+  isLoading: false,
+  errors: undefined
+}
+
+const mountWrapper = (props) => mount(<NewBackendForm {...{ ...defaultProps, ...props }} />)
+const isSubmitButtonDisabled = wrapper => wrapper.find('button[data-testid="submit"]').prop('disabled')
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+it('should render itself', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.exists()).toBe(true)
+})
+
+it('should enable submit button only when form is filled', () => {
+  const wrapper = mountWrapper()
+  expect(isSubmitButtonDisabled(wrapper)).toBe(true)
+
+  act(() => {
+    wrapper.find('NameInput').props().setName('My Backend API')
+    wrapper.find('PrivateEndpointInput').props().setPrivateEndpoint('')
+  })
+  wrapper.update()
+  expect(isSubmitButtonDisabled(wrapper)).toBe(true)
+
+  act(() => {
+    wrapper.find('NameInput').props().setName('')
+    wrapper.find('PrivateEndpointInput').props().setPrivateEndpoint(validPaths[0])
+  })
+  wrapper.update()
+  expect(isSubmitButtonDisabled(wrapper)).toBe(true)
+
+  act(() => {
+    wrapper.find('NameInput').props().setName('My Backend API')
+    wrapper.find('PrivateEndpointInput').props().setPrivateEndpoint(validPaths[0])
+  })
+  wrapper.update()
+  expect(isSubmitButtonDisabled(wrapper)).toBe(false)
+})
+
+it('should enable submit button only when form is valid', () => {
+  const wrapper = mountWrapper()
+  expect(isSubmitButtonDisabled(wrapper)).toBe(true)
+  act(() => wrapper.find('NameInput').props().setName('My Backend API'))
+
+  invalidPaths.forEach(path => {
+    act(() => wrapper.find('PrivateEndpointInput').props().setPrivateEndpoint(path))
+    wrapper.update()
+    expect(isSubmitButtonDisabled(wrapper)).toBe(true)
+  })
+
+  validPaths.forEach(path => {
+    act(() => wrapper.find('PrivateEndpointInput').props().setPrivateEndpoint(path))
+    wrapper.update()
+    expect(isSubmitButtonDisabled(wrapper)).toBe(false)
+  })
+})
+
+describe('when loading', () => {
+  const props = { isLoading: true }
+
+  it('should have its submit button disabled', () => {
+    const wrapper = mountWrapper(props)
+
+    act(() => {
+      wrapper.find('NameInput').props().setName('My Backend API')
+      wrapper.find('PrivateEndpointInput').props().setPrivateEndpoint(validPaths[0])
+    })
+
+    wrapper.update()
+    expect(isSubmitButtonDisabled(wrapper)).toBe(true)
+  })
+})

--- a/spec/javascripts/BackendApis/components/NewBackendForm.spec.jsx
+++ b/spec/javascripts/BackendApis/components/NewBackendForm.spec.jsx
@@ -29,7 +29,7 @@ const defaultProps = {
 }
 
 const mountWrapper = (props) => mount(<NewBackendForm {...{ ...defaultProps, ...props }} />)
-const isSubmitButtonDisabled = wrapper => wrapper.find('button[data-testid="submit"]').prop('disabled')
+const isSubmitButtonDisabled = wrapper => wrapper.find('button[data-testid="newBackendCreateBackend-buttonSubmit"]').prop('disabled')
 
 afterEach(() => {
   jest.resetAllMocks()

--- a/spec/javascripts/BackendApis/components/NewBackendModal.spec.jsx
+++ b/spec/javascripts/BackendApis/components/NewBackendModal.spec.jsx
@@ -1,0 +1,29 @@
+// @flow
+
+import React from 'react'
+import { mount } from 'enzyme'
+
+import { NewBackendModal } from 'BackendApis'
+
+const defaultProps = {
+  backendsPath: '/backends',
+  isOpen: true,
+  onClose: () => {},
+  onCreateBackend: () => {}
+}
+
+const mountWrapper = (props) => mount(<NewBackendModal {...{ ...defaultProps, ...props }} />)
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+it('should render itself', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.exists()).toBe(true)
+})
+
+// This component is really hard to test via JS since it uses jQuery and jquery-ujs.
+it.todo('should display a spinner when loading')
+it.todo('should close after creating a backend')
+it.todo('should show validation errors when creation fails')

--- a/spec/javascripts/BackendApis/components/PrivateEndpointInput.spec.jsx
+++ b/spec/javascripts/BackendApis/components/PrivateEndpointInput.spec.jsx
@@ -1,0 +1,35 @@
+// @flow
+
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { mount } from 'enzyme'
+
+import { PrivateEndpointInput } from 'BackendApis'
+
+const setPrivateEndpoint = jest.fn()
+
+const defaultProps = {
+  privateEndpoint: '',
+  setPrivateEndpoint
+}
+
+const mountWrapper = (props) => mount(<PrivateEndpointInput {...{ ...defaultProps, ...props }} />)
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+it('should render itself', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.exists()).toBe(true)
+})
+
+it('should work', () => {
+  const value = 'foo'
+  const wrapper = mountWrapper()
+
+  act(() => wrapper.find(PrivateEndpointInput).props().setPrivateEndpoint(value))
+
+  wrapper.update()
+  expect(setPrivateEndpoint).toHaveBeenCalledWith(value)
+})

--- a/spec/javascripts/BackendApis/components/SystemNameInput.spec.jsx
+++ b/spec/javascripts/BackendApis/components/SystemNameInput.spec.jsx
@@ -1,0 +1,35 @@
+// @flow
+
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { mount } from 'enzyme'
+
+import { SystemNameInput } from 'BackendApis'
+
+const setSystemName = jest.fn()
+
+const defaultProps = {
+  systemName: '',
+  setSystemName
+}
+
+const mountWrapper = (props) => mount(<SystemNameInput {...{ ...defaultProps, ...props }} />)
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+it('should render itself', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.exists()).toBe(true)
+})
+
+it('should work', () => {
+  const value = 'foo'
+  const wrapper = mountWrapper()
+
+  act(() => wrapper.find(SystemNameInput).props().setSystemName(value))
+
+  wrapper.update()
+  expect(setSystemName).toHaveBeenCalledWith(value)
+})

--- a/spec/javascripts/__mocks__/global-mocks.js
+++ b/spec/javascripts/__mocks__/global-mocks.js
@@ -1,7 +1,14 @@
 global.fetch = () => {}
-global.$ = {
-  flash: {
-    notice: () => {},
-    error: () => {}
-  }
+
+const jQueryMock = () => $
+
+// rails flash
+jQueryMock.flash = {
+  notice: () => {},
+  error: () => {}
 }
+
+// rails ujs
+jQueryMock.live = () => jQueryMock
+
+global.$ = jQueryMock


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces the link to the Backend's `new` page with a button that displays a modal containing the form. Once a backend is created it will be selected in the dropdown.

![Screenshot 2021-04-14 at 13 17 13](https://user-images.githubusercontent.com/11672286/114701950-bd489980-9d23-11eb-941a-b11ee38c21e3.png)

![modal](https://user-images.githubusercontent.com/11672286/114702240-19abb900-9d24-11eb-83bd-aa11fe9805c3.gif)

**Which issue(s) this PR fixes** 

> Subtask of [3scale][2.11][HI-prio] Improve Select in 'Add Backend to Product' form
[THREESCALE-6882: Embed New Backend form into a modal](https://issues.redhat.com/browse/THREESCALE-6882)
