### PR TITLE
[2.11] Implement inline errors to the Add Backend form

### DIFF
--- a/app/controllers/api/backend_usages_controller.rb
+++ b/app/controllers/api/backend_usages_controller.rb
@@ -30,6 +30,7 @@ class Api::BackendUsagesController < Api::BaseController
       redirect_to admin_service_backend_usages_path(@service)
     else
       flash[:error] = "Couldn't add Backend to Product"
+      @inline_errors = @backend_api_config.errors.as_json
       render 'new'
     end
   end
@@ -74,6 +75,10 @@ class Api::BackendUsagesController < Api::BaseController
   end
 
   def ensure_same_account_backend_api
-    current_account.backend_apis.find(backend_api_config_params[:backend_api_id])
+    return if current_account.backend_apis.find_by(id: backend_api_config_params[:backend_api_id])
+
+    flash[:error] = "Couldn't add Backend to Product"
+    @inline_errors = { backend_api_id: ['Not a valid backend'] }
+    render 'new'
   end
 end

--- a/app/javascript/packs/add_backend_usage.js
+++ b/app/javascript/packs/add_backend_usage.js
@@ -3,6 +3,8 @@
 import { AddBackendFormWrapper } from 'BackendApis'
 import { safeFromJsonString } from 'utilities/json-utils'
 
+import type { Backend } from 'Types'
+
 const containerId = 'add-backend-form'
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -12,10 +14,17 @@ document.addEventListener('DOMContentLoaded', () => {
     return
   }
 
-  const { backends, url, backendsPath } = container.dataset
+  const { dataset } = container
+  const { url, backendsPath, backendApiId } = dataset
+
+  const backends = safeFromJsonString<Backend[]>(dataset.backends) || []
+  const backend = backends.find(b => String(b.id) === backendApiId) || null
+  const inlineErrors = safeFromJsonString(dataset.inlineErrors)
 
   AddBackendFormWrapper({
-    backends: safeFromJsonString(backends) || [],
+    backends,
+    backend,
+    inlineErrors,
     url,
     backendsPath
   }, containerId)

--- a/app/javascript/packs/add_backend_usage.js
+++ b/app/javascript/packs/add_backend_usage.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const backends = safeFromJsonString<Backend[]>(dataset.backends) || []
   const backend = backends.find(b => String(b.id) === backendApiId) || null
-  const inlineErrors = safeFromJsonString(dataset.inlineErrors)
+  const inlineErrors = safeFromJsonString(dataset.inlineErrors) || null
 
   AddBackendFormWrapper({
     backends,

--- a/app/javascript/src/BackendApis/components/AddBackendForm.jsx
+++ b/app/javascript/src/BackendApis/components/AddBackendForm.jsx
@@ -20,13 +20,18 @@ import type { Backend } from 'Types'
 import './AddBackendForm.scss'
 
 type Props = {
+  backend: Backend | null,
   backends: Backend[],
   url: string,
+  inlineErrors: null | {
+    backend_api_id?: Array<string>,
+    path?: Array<string>
+  },
   backendsPath: string
 }
 
-const AddBackendForm = ({ backends, url, backendsPath }: Props): React.Node => {
-  const [backend, setBackend] = useState<Backend | null>(null)
+const AddBackendForm = ({ backend: initialBackend, backends, url, backendsPath, inlineErrors }: Props): React.Node => {
+  const [backend, setBackend] = useState<Backend | null>(initialBackend)
   const [updatedBackends, setUpdatedBackends] = useState(backends)
   const [path, setPath] = useState('')
   const [loading, setLoading] = useState(false)
@@ -60,9 +65,14 @@ const AddBackendForm = ({ backends, url, backendsPath }: Props): React.Node => {
             backends={updatedBackends}
             onSelect={setBackend}
             onCreateNewBackend={() => setIsModalOpen(true)}
+            error={inlineErrors ? inlineErrors.backend_api_id && inlineErrors.backend_api_id[0] : undefined}
           />
 
-          <PathInput path={path} setPath={setPath} />
+          <PathInput
+            path={path}
+            setPath={setPath}
+            error={inlineErrors ? inlineErrors.path && inlineErrors.path[0] : undefined}
+          />
 
           <ActionGroup>
             <Button

--- a/app/javascript/src/BackendApis/components/AddBackendForm.jsx
+++ b/app/javascript/src/BackendApis/components/AddBackendForm.jsx
@@ -37,7 +37,7 @@ const AddBackendForm = ({ backend: initialBackend, backends, url, backendsPath, 
   const [loading, setLoading] = useState(false)
   const [isModalOpen, setIsModalOpen] = useState(false)
 
-  const isFormComplete = backend !== null && path !== ''
+  const isFormComplete = backend !== null
 
   const handleOnCreateBackend = (backend: Backend) => {
     notice('Backend created')

--- a/app/javascript/src/BackendApis/components/BackendSelect.jsx
+++ b/app/javascript/src/BackendApis/components/BackendSelect.jsx
@@ -14,10 +14,11 @@ type Props = {
   backend: Backend | null,
   backends: Backend[],
   onCreateNewBackend: () => void,
+  error?: string,
   onSelect: (Backend | null) => void
 }
 
-const BackendSelect = ({ backend, backends, onSelect, onCreateNewBackend }: Props): React.Node => {
+const BackendSelect = ({ backend, backends, onSelect, onCreateNewBackend, error }: Props): React.Node => {
   const cells = [
     { title: 'Name', propName: 'name' },
     { title: 'Private Base URL', propName: 'privateEndpoint' },
@@ -25,34 +26,34 @@ const BackendSelect = ({ backend, backends, onSelect, onCreateNewBackend }: Prop
   ]
 
   return (
-    <SelectWithModal
-      label="Backend"
-      fieldId="backend_api_config_backend_api_id"
-      id="backend_api_config_backend_api_id"
-      name="backend_api_config[backend_api_id]"
-      // $FlowIssue[incompatible-type] backend is compatible with null
-      item={backend}
-      items={backends.map(b => ({ ...b, description: b.privateEndpoint }))}
-      cells={cells}
-      helperText={(
-        <p className="hint">
-          <Button
-            isInline
-            variant="link"
-            icon={<PlusCircleIcon />}
-            onClick={onCreateNewBackend}
-            data-testid="newBackendCreateBackend-buttonLink"
-          >
-            Create new Backend
-          </Button>
-        </p>
-      )}
-      modalTitle="Select a Backend"
-      // $FlowIssue[incompatible-type] It should not complain since Record.id has union "number | string"
-      onSelect={onSelect}
-      header="Most recently created Backends"
-      footer="View all Backends"
-    />
+    <>
+      <SelectWithModal
+        label="Backend"
+        fieldId="backend_api_config_backend_api_id"
+        id="backend_api_config_backend_api_id"
+        name="backend_api_config[backend_api_id]"
+        // $FlowIssue[incompatible-type] backend is compatible with null
+        item={backend}
+        items={backends.map(b => ({ ...b, description: b.privateEndpoint }))}
+        cells={cells}
+        helperTextInvalid={error}
+        isValid={!error}
+        modalTitle="Select a Backend"
+        // $FlowIssue[incompatible-type] It should not complain since Record.id has union "number | string"
+        onSelect={onSelect}
+        header="Most recently created Backends"
+        footer="View all Backends"
+      />
+      <Button
+        variant="link"
+        icon={<PlusCircleIcon />}
+        onClick={onCreateNewBackend}
+        data-testid="newBackendCreateBackend-buttonLink"
+        className="pf-c-button__as-hint"
+      >
+        Create new Backend
+      </Button>
+    </>
   )
 }
 export { BackendSelect }

--- a/app/javascript/src/BackendApis/components/BackendSelect.scss
+++ b/app/javascript/src/BackendApis/components/BackendSelect.scss
@@ -1,9 +1,8 @@
-.hint {
-  margin-bottom: 0;
-
-  .pf-c-button {
-    text-decoration: none;
-  }
+.pf-c-button.pf-c-button__as-hint {
+  margin-top: -1rem;
+  padding-left: unset;
+  text-align: left;
+  text-decoration: none;
 }
 
 .pf-c-select__menu {

--- a/app/javascript/src/BackendApis/components/PathInput.jsx
+++ b/app/javascript/src/BackendApis/components/PathInput.jsx
@@ -5,16 +5,18 @@ import * as React from 'react'
 import { FormGroup, TextInput } from '@patternfly/react-core'
 
 type Props = {
+  error?: string,
   path: string,
   setPath: string => void
 }
 
-const PathInput = ({ path, setPath }: Props): React.Node => (
+const PathInput = ({ error, path, setPath }: Props): React.Node => (
   <FormGroup
-    isRequired
     label="Path"
     validated="default"
     fieldId="backend_api_config_path"
+    isValid={!error}
+    helperTextInvalid={error}
   >
     <TextInput
       type="text"
@@ -22,6 +24,8 @@ const PathInput = ({ path, setPath }: Props): React.Node => (
       name="backend_api_config[path]"
       value={path}
       onChange={setPath}
+      placeholder="/"
+      isValid={!error}
     />
   </FormGroup>
 )

--- a/app/javascript/src/Common/components/SelectWithModal.jsx
+++ b/app/javascript/src/Common/components/SelectWithModal.jsx
@@ -21,10 +21,12 @@ type Props<T: Record> = {
   items: T[],
   onSelect: (T | null) => void,
   isDisabled?: boolean,
+  isValid?: boolean,
   label: string,
   id: string,
   name?: string,
   helperText?: React.Node,
+  helperTextInvalid?: string,
   placeholderText?: string,
   maxItems?: number,
   header?: string,
@@ -42,10 +44,12 @@ const SelectWithModal = <T: Record>({
   items,
   onSelect,
   isDisabled,
+  isValid,
   label,
   id,
   name,
   helperText,
+  helperTextInvalid,
   placeholderText,
   maxItems = MAX_ITEMS,
   header = HEADER,
@@ -100,6 +104,8 @@ const SelectWithModal = <T: Record>({
         label={label}
         fieldId={id}
         helperText={helperText}
+        helperTextInvalid={helperTextInvalid}
+        isValid={isValid}
       >
         {item && <input type="hidden" name={name} value={item.id} />}
         <Select

--- a/app/views/api/backend_usages/new.html.slim
+++ b/app/views/api/backend_usages/new.html.slim
@@ -1,5 +1,5 @@
 h2 Add a Backend
 
-div id="add-backend-form" data=add_backend_usage_form_data(@service) data-inline-errors=@inline_errors.to_json data-backend-api-id=@backend_api_config.backend_api_id
+div id="add-backend-form" data=add_backend_usage_form_data(@service) data-inline-errors=@inline_errors.to_json data-backend-api-id=@backend_api_config&.backend_api_id
   = javascript_pack_tag 'add_backend_usage'
   = javascript_pack_tag 'PF4Styles/modal'

--- a/app/views/api/backend_usages/new.html.slim
+++ b/app/views/api/backend_usages/new.html.slim
@@ -1,5 +1,5 @@
 h2 Add a Backend
 
-div id="add-backend-form" data=add_backend_usage_form_data(@service)
+div id="add-backend-form" data=add_backend_usage_form_data(@service) data-inline-errors=@inline_errors.to_json data-backend-api-id=@backend_api_config.backend_api_id
   = javascript_pack_tag 'add_backend_usage'
   = javascript_pack_tag 'PF4Styles/modal'

--- a/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
+++ b/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
@@ -33,10 +33,30 @@ it('should enable submit button only when form is filled', () => {
   expect(isSubmitButtonDisabled(wrapper)).toBe(true)
 
   act(() => {
-    wrapper.find('BackendSelect').prop('onSelect')(backend)
-    wrapper.find('PathInput').prop('setPath')('/foo')
+    wrapper.find('BackendSelect').props().onSelect(null)
+    wrapper.find('PathInput').props().setPath('')
   })
+  wrapper.update()
+  expect(wrapper.find('button[data-testid="submit"]').prop('disabled')).toBe(true)
 
+  act(() => {
+    wrapper.find('BackendSelect').props().onSelect(backend)
+    wrapper.find('PathInput').props().setPath('')
+  })
+  wrapper.update()
+  expect(wrapper.find('button[data-testid="submit"]').prop('disabled')).toBe(false)
+
+  act(() => {
+    wrapper.find('BackendSelect').props().onSelect(null)
+    wrapper.find('PathInput').props().setPath('/path')
+  })
+  wrapper.update()
+  expect(wrapper.find('button[data-testid="submit"]').prop('disabled')).toBe(true)
+
+  act(() => {
+    wrapper.find('BackendSelect').props().onSelect(backend)
+    wrapper.find('PathInput').props().setPath('/path')
+  })
   wrapper.update()
   expect(isSubmitButtonDisabled(wrapper)).toBe(false)
 })

--- a/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
+++ b/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
@@ -37,21 +37,21 @@ it('should enable submit button only when form is filled', () => {
     wrapper.find('PathInput').props().setPath('')
   })
   wrapper.update()
-  expect(wrapper.find('button[data-testid="submit"]').prop('disabled')).toBe(true)
+  expect(isSubmitButtonDisabled(wrapper)).toBe(true)
 
   act(() => {
     wrapper.find('BackendSelect').props().onSelect(backend)
     wrapper.find('PathInput').props().setPath('')
   })
   wrapper.update()
-  expect(wrapper.find('button[data-testid="submit"]').prop('disabled')).toBe(false)
+  expect(isSubmitButtonDisabled(wrapper)).toBe(false)
 
   act(() => {
     wrapper.find('BackendSelect').props().onSelect(null)
     wrapper.find('PathInput').props().setPath('/path')
   })
   wrapper.update()
-  expect(wrapper.find('button[data-testid="submit"]').prop('disabled')).toBe(true)
+  expect(isSubmitButtonDisabled(wrapper)).toBe(true)
 
   act(() => {
     wrapper.find('BackendSelect').props().onSelect(backend)

--- a/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
+++ b/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
@@ -9,7 +9,9 @@ import { AddBackendForm } from 'BackendApis'
 const backend = { id: 0, name: 'backend', privateEndpoint: 'example.org', systemName: 'backend' }
 const backendsPath = '/backends'
 const defaultProps = {
+  backend: null,
   backends: [backend],
+  inlineErrors: null,
   url: '',
   backendsPath
 }
@@ -60,4 +62,21 @@ it('should select the new backend when created', () => {
 
   wrapper.update()
   expect(wrapper.find('BackendSelect').prop('backend')).toBe(newBackend)
+})
+
+it('should be able to have a default backend selected', () => {
+  const wrapper = mountWrapper({ backend })
+
+  expect(wrapper.find('BackendSelect .pf-c-select__toggle-typeahead').instance().value).toEqual(backend.name)
+})
+
+it('should be able to show inline errors', () => {
+  const inlineErrors = {
+    backend_api_id: ['invalid backend'],
+    path: ['invalid path']
+  }
+  const wrapper = mountWrapper({ inlineErrors })
+
+  expect(wrapper.find('BackendSelect .pf-c-form__helper-text.pf-m-error').text()).toEqual(inlineErrors.backend_api_id[0])
+  expect(wrapper.find('PathInput .pf-c-form__helper-text.pf-m-error').text()).toEqual(inlineErrors.path[0])
 })

--- a/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
+++ b/spec/javascripts/BackendApis/components/AddBackendForm.spec.jsx
@@ -87,7 +87,7 @@ it('should select the new backend when created', () => {
 it('should be able to have a default backend selected', () => {
   const wrapper = mountWrapper({ backend })
 
-  expect(wrapper.find('BackendSelect .pf-c-select__toggle-typeahead').instance().value).toEqual(backend.name)
+  expect(wrapper.find('BackendSelect .pf-c-select__toggle-typeahead').instance()?.value).toEqual(backend.name)
 })
 
 it('should be able to show inline errors', () => {
@@ -97,6 +97,8 @@ it('should be able to show inline errors', () => {
   }
   const wrapper = mountWrapper({ inlineErrors })
 
+  // $FlowIgnore[incompatible-use]
   expect(wrapper.find('BackendSelect .pf-c-form__helper-text.pf-m-error').text()).toEqual(inlineErrors.backend_api_id[0])
+  // $FlowIgnore[incompatible-use]
   expect(wrapper.find('PathInput .pf-c-form__helper-text.pf-m-error').text()).toEqual(inlineErrors.path[0])
 })

--- a/test/integration/api/backend_usages_controller_test.rb
+++ b/test/integration/api/backend_usages_controller_test.rb
@@ -57,7 +57,8 @@ class Api::BackendUsagesControllerTest < ActionDispatch::IntegrationTest
     assert_no_change of: -> { service.backend_api_configs.count } do
       backend_api_config_params = { backend_api_id: backend_api.id, path: 'foo' }
       post admin_service_backend_usages_path(service), params: { backend_api_config: backend_api_config_params }
-      assert_response :not_found
+      assert_equal "Couldn't add Backend to Product", flash[:error]
+      assert_response :ok
     end
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Renders the following inline errors whenever the form is sent with invalid data:
- Backend not found: this should never happen but the submit button can be disabled manually and the form submitted (see image).
![Screenshot 2021-04-15 at 18 28 51](https://user-images.githubusercontent.com/11672286/114904760-7a1c2280-9e18-11eb-9ceb-1e7f61d0ab0c.png)

- Path already taken: this will be returned by the server. In this case, the selected backend will still be selected despite the page refresh.

Demo:
![add-backend-usage](https://user-images.githubusercontent.com/11672286/114904402-1db90300-9e18-11eb-9032-e929df1ffd8d.gif)

**Which issue(s) this PR fixes** 

[THREESCALE-6883: Implements inline validations and flash errors upon submition](https://issues.redhat.com/browse/THREESCALE-6883)

> Subtask of [3scale][2.11][HI-prio] Improve Select in 'Add Backend to Product' form
[THREESCALE-6882: Embed New Backend form into a modal](https://issues.redhat.com/browse/THREESCALE-6882)
