### PR TITLE
[2.11] Move Create Mapping Rule button to header

### DIFF
--- a/app/views/api/proxy_rules/index.html.slim
+++ b/app/views/api/proxy_rules/index.html.slim
@@ -1,6 +1,3 @@
-- content_for :sublayout_title, 'Mapping Rules'
-
-= render 'shared/proxy_rules/table', proxy_rules: @proxy_rules,
-                                     new_rule_path: new_admin_service_proxy_rule_path(@service),
-                                     owner: @service,
-                                     include_redirect: @service.using_proxy_pro?
+= render 'shared/proxy_rules/header_section', new_rule_path: new_admin_service_proxy_rule_path(@service)
+= render 'shared/proxy_rules/body_section', proxy_rules: @proxy_rules,
+                                            include_redirect: @service.using_proxy_pro?

--- a/app/views/provider/admin/backend_apis/mapping_rules/index.html.slim
+++ b/app/views/provider/admin/backend_apis/mapping_rules/index.html.slim
@@ -1,5 +1,2 @@
-h2 Mapping Rules
-
-= render 'shared/proxy_rules/table', proxy_rules: @proxy_rules,
-                                     new_rule_path: new_provider_admin_backend_api_mapping_rule_path(@backend_api),
-                                     owner: @backend_api
+= render 'shared/proxy_rules/header_section', new_rule_path: new_provider_admin_backend_api_mapping_rule_path(@backend_api)
+= render 'shared/proxy_rules/body_section', proxy_rules: @proxy_rules

--- a/app/views/shared/proxy_rules/_body_section.html.slim
+++ b/app/views/shared/proxy_rules/_body_section.html.slim
@@ -9,8 +9,7 @@ table#mapping_rules.data
       th = sortable('metrics.friendly_name', 'Metric or Method')
       th = sortable('proxy_rules.last', 'Last?')
       th = sortable('proxy_rules.position', 'Position')
-      th.actions
-        = link_to 'Add Mapping Rule', new_rule_path, class: 'action add'
+      th
     tr.search
       = search_form do |s|
         th

--- a/app/views/shared/proxy_rules/_header_section.html.slim
+++ b/app/views/shared/proxy_rules/_header_section.html.slim
@@ -1,0 +1,3 @@
+h1 Mapping Rules
+a.pf-c-button.pf-m-primary.pf-c-button__in-title href=new_rule_path
+  | Create Mapping rule

--- a/app/views/shared/proxy_rules/_header_section.html.slim
+++ b/app/views/shared/proxy_rules/_header_section.html.slim
@@ -1,3 +1,3 @@
 h1 Mapping Rules
 a.pf-c-button.pf-m-primary.pf-c-button__in-title href=new_rule_path
-  | Create Mapping rule
+  | Create Mapping Rule

--- a/features/backend_apis/mapping_rules.feature
+++ b/features/backend_apis/mapping_rules.feature
@@ -1,23 +1,17 @@
-Feature: Proxy integration
-  In order to integrate with 3scale via a on-premise proxy
+@javascript
+Feature: Backend API mapping rules
+  In order to integrate my backend api
   As a provider
-  I want to download config files from the inteface
+  I want to be able to manage my mapping rules
 
   Background:
-    Given all the rolling updates features are off
-    And I have apicast_v2 feature enabled
-    And I have oauth_api feature enabled
     Given a provider "foo.3scale.localhost"
-    And a default service of provider "foo.3scale.localhost" has name "one"
-    And the service "one" of provider "foo.3scale.localhost" has deployment option "self_managed"
+    And a backend api "My Backend"
     And current domain is the admin domain of provider "foo.3scale.localhost"
     And I log in as provider "foo.3scale.localhost"
-    And apicast registry is stubbed
-    And the default proxy does not use apicast configuration driven
 
   Scenario: Sorting mapping rules
-    When I go to the integration show page for service "one"
-    And I follow "Mapping Rules"
+    When I go to the mapping rules index page for backend "My Backend"
     And I add a new mapping rule with method "POST" pattern "/beers" position "2" and metric "Hits"
     Then the mapping rules should be in the following order:
       | http_method | pattern | position | metric |
@@ -32,7 +26,7 @@ Feature: Proxy integration
     And I add a new mapping rule with method "GET" pattern "/gins" position "1" and metric "Hits"
     Then the mapping rules should be in the following order:
       | http_method | pattern | position | metric |
-      | GET         | /gins   | 1        | hits   |
-      | GET         | /       | 2        | hits   |
+      | GET         | /       | 1        | hits   |
+      | GET         | /gins   | 2        | hits   |
       | PUT         | /mixers | 3        | hits   |
       | POST        | /beers  | 4        | hits   |

--- a/features/services/mapping_rules.feature
+++ b/features/services/mapping_rules.feature
@@ -1,0 +1,39 @@
+@javascript
+Feature: Product mapping rules
+  In order to integrate with 3scale via a on-premise proxy
+  As a provider
+  I want to download config files from the inteface
+
+  Background:
+    Given all the rolling updates features are off
+    And I have apicast_v2 feature enabled
+    And I have oauth_api feature enabled
+    Given a provider "foo.3scale.localhost"
+    And a default service of provider "foo.3scale.localhost" has name "one"
+    And the service "one" of provider "foo.3scale.localhost" has deployment option "self_managed"
+    And current domain is the admin domain of provider "foo.3scale.localhost"
+    And I log in as provider "foo.3scale.localhost"
+    And apicast registry is stubbed
+    And the default proxy does not use apicast configuration driven
+
+  Scenario: Sorting mapping rules
+    When I go to the mapping rules index page for service "one"
+    And I add a new mapping rule with method "POST" pattern "/beers" position "2" and metric "Hits"
+    Then the mapping rules should be in the following order:
+      | http_method | pattern | position | metric |
+      | GET         | /       | 1        | hits   |
+      | POST        | /beers  | 2        | hits   |
+    And I add a new mapping rule with method "PUT" pattern "/mixers" position "2" and metric "Hits"
+    Then the mapping rules should be in the following order:
+      | http_method | pattern | position | metric |
+      | GET         | /       | 1        | hits   |
+      | PUT         | /mixers | 2        | hits   |
+      | POST        | /beers  | 3        | hits   |
+    And I add a new mapping rule with method "GET" pattern "/gins" position "1" and metric "Hits"
+    Then the mapping rules should be in the following order:
+      | http_method | pattern | position | metric |
+      | GET         | /gins   | 1        | hits   |
+      | GET         | /       | 2        | hits   |
+      | PUT         | /mixers | 3        | hits   |
+      | POST        | /beers  | 4        | hits   |
+

--- a/features/step_definitions/proxy_steps.rb
+++ b/features/step_definitions/proxy_steps.rb
@@ -56,7 +56,7 @@ Given(%r{^the service uses app_id/app_key as authentication method$}) do
 end
 
 Given(/^I add a new mapping rule with method "([^"]*)" pattern "([^"]*)" position "([^"]*)" and metric "([^"]*)"$/) do |method, pattern, position, metric|
-  click_on 'Add Mapping Rule'
+  visit "#{URI.parse(current_url).path}/new"
   within(page.find('form.proxy_rule')) do
     find("select#proxy_rule_http_method option[value='#{method}']").select_option
     find('input#proxy_rule_pattern').set pattern

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -612,6 +612,10 @@ World(Module.new do
       admin_service_metrics_path(provider_first_service!)
     when /^the integration show page for (service ".+?")/
       admin_service_integration_path(Transform $1)
+    when /^the mapping rules index page for (service ".+?")/
+      admin_service_proxy_rules_path(Transform $1)
+    when /^the mapping rules index page for backend "(.+?)"/
+      provider_admin_backend_api_mapping_rules_path(BackendApi.find_by!(name: $1))
     when /^the integration page for (service ".+?")/
       # TODO: THREESCALE-3759 edit page no longer exist, remove or replace
       edit_admin_service_integration_path(Transform $1)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Move create button to main section
- Prepare structure for PF4 re-implementation

Product:
![Screenshot 2021-04-19 at 12 01 23](https://user-images.githubusercontent.com/11672286/115219080-7550ba80-a107-11eb-8536-fc83f8b33f40.png)

Backend API:
![Screenshot 2021-04-19 at 12 01 28](https://user-images.githubusercontent.com/11672286/115219114-7da8f580-a107-11eb-84ea-d92b98ee5128.png)


**Which issue(s) this PR fixes** 

[THREESCALE-6874 Improve UI for creating a Product Mapping rule > THREESCALE-6954 Implement Create button with PF4](https://issues.redhat.com/browse/THREESCALE-6954)
