### PR TITLE
Defaults Paperclip S3 URL style to :s3_domain_url instead of :s3_path_url

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -45,6 +45,13 @@ Paperclip.interpolates :s3_prefix do |attachment, style|
   attachment.instance.provider.s3_prefix
 end
 
+Paperclip.interpolates(:s3_path_url) do |attachment, style|
+  if attachment.options.dig(:s3_options, :force_path_style) || attachment.bucket_name =~ /\./
+    "#{attachment.s3_protocol(style, true)}//#{attachment.s3_host_name}/#{attachment.bucket_name}/#{attachment.path(style).sub(%r{\A/}, ''.freeze)}"
+  else
+    "#{attachment.s3_protocol(style, true)}//#{attachment.bucket_name}.#{attachment.s3_host_name}/#{attachment.path(style).sub(%r{\A/}, ''.freeze)}"
+  end
+end
 
 begin
   CMS::S3.enable!

--- a/test/unit/paperclip_test.rb
+++ b/test/unit/paperclip_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PaperclipTest < ActiveSupport::TestCase
+  setup do
+    @account = FactoryBot.build_stubbed(:simple_provider, s3_prefix: 'fake-s3-prefix')
+    account.stubs(account: account)
+  end
+
+  attr_reader :account
+
+  class S3StorageTest < PaperclipTest
+    setup do
+      default_options = Paperclip::Attachment.default_options.merge(
+        storage: :s3,
+        bucket: 'my-bucket',
+        s3_region: 'us-east',
+        path: ':rails_root/public/system/:url',
+      )
+      Paperclip::Attachment.stubs(default_options: default_options)
+    end
+
+    test 's3_domain_url' do
+      attachment = Paperclip::Attachment.new(:attachment, account, url: ':url_root/:account_id/:class/:attachment/:style/:basename.:extension')
+      attachment.stubs(original_filename: 'fake_attachment.png')
+
+      assert_equal ':s3_path_url', attachment.options[:url]
+      assert_equal "https://my-bucket.s3.amazonaws.com/fake-s3-prefix/#{account.id}/accounts/attachments/medium/fake_attachment.png", attachment.url(:medium)
+    end
+
+    test 'force_path_style' do
+      Paperclip::Attachment.default_options.merge!(s3_options: { force_path_style: true })
+      attachment = Paperclip::Attachment.new(:attachment, account, url: ':url_root/:account_id/:class/:attachment/:style/:basename.:extension')
+      attachment.stubs(original_filename: 'fake_attachment.png')
+
+      assert_equal "https://s3.amazonaws.com/my-bucket/fake-s3-prefix/#{account.id}/accounts/attachments/medium/fake_attachment.png", attachment.url(:medium)
+    end
+
+    test 'bucket name contaning a dot' do
+      Paperclip::Attachment.default_options.merge!(bucket: 'test.my-bucket')
+      attachment = Paperclip::Attachment.new(:attachment, account, url: ':url_root/:account_id/:class/:attachment/:style/:basename.:extension')
+      attachment.stubs(original_filename: 'fake_attachment.png')
+
+      assert_equal "https://s3.amazonaws.com/test.my-bucket/fake-s3-prefix/#{account.id}/accounts/attachments/medium/fake_attachment.png", attachment.url(:medium)
+    end
+  end
+end


### PR DESCRIPTION
This is because we provide two storage options ('filesystem' and 's3'), and the Paperclip `url` option is set in the models to what will actually be the `path` of the attachments, instead of the desired S3 URL style. This used to be OK because Paperclip moves the value set for the `url` option to the `path` option, whenever the storage is 's3'. The problem is that, when Paperclip moves the value from `url` to `path`, it also sets the URL style to `:s3_path_url` (see https://github.com/thoughtbot/paperclip/blob/de92a5a44bae7ed20c33356de5cce584dc9125ae/lib/paperclip/storage/s3.rb#L154-L157), and AWS has [deprecated](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) the path style for S3 URLs in favour of the domain style (called "virtual-host style" by Amazon).

So we do not break deployments based on old S3 buckets created before September 30, 2020 (Amazon's cut-off) or integrations with other storage providers compatible with the S3 protocol (e.g. Minio), the override of the default URL style will be avoided and the old default to path style URL reinstated, in case the user opts-in for the `force_path_style` S3 option (https://github.com/3scale/porta/commit/4eb33e94bbc82c5c4963dba252f51844ddd0f7b1).

Closes [THREESCALE-6955](https://issues.redhat.com/browse/THREESCALE-6955)