### PR TITLE
[domain substitution] Use external_* when needed

### DIFF
--- a/app/controllers/admin/api_docs/base_controller.rb
+++ b/app/controllers/admin/api_docs/base_controller.rb
@@ -46,7 +46,7 @@ class Admin::ApiDocs::BaseController < FrontendController
         format.json { render json: swagger_spec }
       end
     else
-      @host = current_account.domain
+      @host = current_account.external_domain
       @resource = api_docs_service.system_name
       @spec = ApiDocs::Service.spec_for api_docs_service
       render 'active_docs'

--- a/app/controllers/master/devportal/auth_controller.rb
+++ b/app/controllers/master/devportal/auth_controller.rb
@@ -9,13 +9,13 @@ class Master::Devportal::AuthController < ApplicationController
   def show
     account = Account.find_by!(domain: params.require(:domain))
 
-    redirect_to callback_url(account, domain: account.domain)
+    redirect_to callback_url(account, domain: account.external_domain)
   end
 
   def show_self
     account = Account.find_by!(self_domain: params.require(:self_domain))
 
-    redirect_to callback_url(account, domain: account.self_domain)
+    redirect_to callback_url(account, domain: account.external_self_domain)
   end
 
   protected

--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -55,10 +55,10 @@ module AccountHelper
   #TODO: test this helper
   def path_to_personal_details
     if current_account.provider?
-      host = current_account.admin_domain + request.port_string
+      host = current_account.external_admin_domain + request.port_string
       edit_provider_admin_user_personal_details_url(host: host, protocol: 'https')
     else
-      developer_portal.admin_account_personal_details_url(host: current_account.domain)
+      developer_portal.admin_account_personal_details_url(host: current_account.external_domain)
     end
   end
 

--- a/app/helpers/buyers/accounts_helper.rb
+++ b/app/helpers/buyers/accounts_helper.rb
@@ -4,7 +4,7 @@ module Buyers::AccountsHelper
 
   def public_domain(account)
     access_code = "/access_code?access_code=#{account.site_access_code}" if account.site_access_code
-    "http://#{account.domain}#{access_code}".html_safe
+    "http://#{account.external_domain}#{access_code}".html_safe
   end
 
   def account_title(account)

--- a/app/helpers/payment_details_helper.rb
+++ b/app/helpers/payment_details_helper.rb
@@ -33,18 +33,6 @@ module PaymentDetailsHelper
     ActiveMerchant::Country::COUNTRIES.map{|c| [c[:name], c[:alpha2]] }
   end
 
-  #TODO: move these two methods to another helper
-  def build_url(path)
-    full_path = "#{site_account.domain}#{local_postfix_and_port}/#{path}".gsub(/[\/]+/, '/')
-    "https://#{full_path}"
-  end
-
-  def local_postfix_and_port
-    if ["test", "development"].include?(Rails.env)
-      request.host_with_port.gsub(site_account.domain, '').gsub(/\/.*/, '/')
-    end
-  end
-
   def payment_details_definition_list_item(name, account)
     value = account.public_send("billing_address_#{name}")
     return unless value.present?

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -143,7 +143,7 @@ module VerticalNavHelper
     end
 
     items << {title: ' '} # Blank space
-    items << {title: 'Visit Portal', path: access_code_url(host: current_account.domain, cms_token: current_account.settings.cms_token!, access_code: current_account.site_access_code).html_safe, target: '_blank'}
+    items << {title: 'Visit Portal', path: access_code_url(host: current_account.external_domain, cms_token: current_account.settings.cms_token!, access_code: current_account.site_access_code).html_safe, target: '_blank'}
 
     if can?(:manage, :portal)
       items << {                                   title: 'Legal Terms'}

--- a/app/messengers/account_messenger.rb
+++ b/app/messengers/account_messenger.rb
@@ -20,7 +20,7 @@ class AccountMessenger < Messenger::Base
   # This is call by master, sending notifications to providers.
   # Those messages are liquid thus using developer_portal, where we don't have access to System::Application. routes
   def invoices_to_review(provider)
-    finalized_url = app_routes.polymorphic_url([:admin, :finance, :invoices], :state => :finalized, :host => provider.admin_domain)
+    finalized_url = app_routes.polymorphic_url([:admin, :finance, :invoices], :state => :finalized, :host => provider.external_admin_domain)
 
     assign_drops  :provider => Liquid::Drops::Provider.new(provider),
                   :url => finalized_url
@@ -74,7 +74,7 @@ class AccountMessenger < Messenger::Base
     type = @provider_account.payment_gateway_type.try!(:to_sym)
 
     return '' if type.nil? || type == :bogus
-    developer_portal_routes.polymorphic_url([:admin, :account, type.to_sym], host: @provider_account.domain)
+    developer_portal_routes.polymorphic_url([:admin, :account, type.to_sym], host: @provider_account.external_domain)
   end
 
   def assign_basic_drops

--- a/app/messengers/alert_messenger.rb
+++ b/app/messengers/alert_messenger.rb
@@ -52,11 +52,11 @@ class AlertMessenger < Messenger::Base
   end
 
   def domain
-    @alert.account.provider_account.domain
+    @alert.account.provider_account.external_domain
   end
 
   def self_domain
-    @alert.account.self_domain
+    @alert.account.external_self_domain
   end
 
   def send_alert(alert, sender)

--- a/app/messengers/invitation_messenger.rb
+++ b/app/messengers/invitation_messenger.rb
@@ -2,9 +2,9 @@ class InvitationMessenger < Messenger::Base
 
   def invite(invitation)
     domain = if invitation.account.provider?
-               invitation.account.admin_domain
+               invitation.account.external_admin_domain
              else
-               invitation.account.provider_account.domain
+               invitation.account.provider_account.external_domain
              end
     @url = invitee_signup_url(:invitation_token => invitation.token,
                               :host => domain)

--- a/app/messengers/invoice_messenger.rb
+++ b/app/messengers/invoice_messenger.rb
@@ -19,9 +19,9 @@ class InvoiceMessenger < Messenger::Base
     @cost = format_cost(@invoice.cost)
 
     @invoice_url = if @buyer_account.provider?
-      app_routes.provider_admin_account_invoice_url(@invoice, :host => @buyer_account.self_domain)
+      app_routes.provider_admin_account_invoice_url(@invoice, :host => @buyer_account.external_self_domain)
                    else
-      developer_portal_routes.admin_account_invoice_url(@invoice, :host => @invoice.provider_account.domain)
+      developer_portal_routes.admin_account_invoice_url(@invoice, :host => @invoice.provider_account.external_domain)
     end
 
     setup_drops
@@ -84,9 +84,9 @@ class InvoiceMessenger < Messenger::Base
     return '' if type.nil? || type == :bogus
 
     if invoice.provider_account.master?
-      app_routes.polymorphic_url([:provider, :admin, :account, type.to_sym],host: invoice.buyer_account.self_domain)
+      app_routes.polymorphic_url([:provider, :admin, :account, type.to_sym],host: invoice.buyer_account.external_self_domain)
     else
-      developer_portal_routes.polymorphic_url([:admin, :account, type.to_sym], host: invoice.provider_account.domain)
+      developer_portal_routes.polymorphic_url([:admin, :account, type.to_sym], host: invoice.provider_account.external_domain)
     end
   end
 

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -50,7 +50,7 @@ class ApiDocs::Service < ApplicationRecord
   def self.for(account)
     services = account.api_docs_services.published
 
-    { :host => account.domain,
+    { :host => account.external_domain,
       :apis => services.map { |service| ApiDocs::Service.spec_for(service)} }
   end
 

--- a/app/models/sso_token.rb
+++ b/app/models/sso_token.rb
@@ -63,7 +63,7 @@ class SSOToken
     save if new_record?
 
     params= {
-      host: host || account.domain,
+      host: host || account.external_domain,
       protocol: protocol,
       token: encrypted_token,
       expires_at: expires_at.to_i,

--- a/app/presenters/oauth_flow_presenter.rb
+++ b/app/presenters/oauth_flow_presenter.rb
@@ -74,11 +74,11 @@ class OauthFlowPresenter
   end
 
   def callback_domain
-    authentication_provider.account.domain
+    authentication_provider.account.external_domain
   end
 
   def account_domain
-    callback_account.try(:domain)
+    callback_account.try(:external_domain)
   end
 
   class NullClient

--- a/app/views/admin/api_docs/base/active_docs.html.erb
+++ b/app/views/admin/api_docs/base/active_docs.html.erb
@@ -7,7 +7,7 @@
 <div class='api-docs-wrap'></div>
 <script>
 
-  <% domain = current_account.domain + (Rails.env.development? ? ':3000' : '') -%>
+  <% domain = current_account.external_domain + (Rails.env.development? ? ':3000' : '') -%>
   $(function(){
     ThreeScale.APIDocs.preview = true;
     ThreeScale.APIDocs.account_type = 'provider';

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -23,11 +23,11 @@ h1 data-hook="account-show"
         - if current_account.master? && @account.provider?
           tr
             th Public domain
-            td = link_to @account.domain, public_domain(@account), target: "_blank"
+            td = link_to @account.external_domain, public_domain(@account), target: "_blank"
           tr
             th Admin domain
-            td = link_to @account.self_domain,
-                         provider_admin_dashboard_url(host: @account.self_domain),
+            td = link_to @account.external_self_domain,
+                         provider_admin_dashboard_url(host: @account.external_self_domain),
                          target: "_blank"
         - if @account.admins.present?
           tr

--- a/app/views/notification_mailer/post_created.html.slim
+++ b/app/views/notification_mailer/post_created.html.slim
@@ -8,4 +8,4 @@ p
   p
     | Anonymous user has posted a new message in your forum
 
-p= link_to 'View new forum post', forum_topic_url(@post.topic, host: @provider_account.domain)
+p= link_to 'View new forum post', forum_topic_url(@post.topic, host: @provider_account.external_domain)

--- a/app/views/notification_mailer/post_created.text.erb
+++ b/app/views/notification_mailer/post_created.text.erb
@@ -4,4 +4,4 @@ Dear <%= @receiver.informal_name %>,
 <% else %>
 Anonymous user has posted a new message in your forum
 <% end %>
-To view new forum post, follow this link <%= forum_topic_url(@post.topic, host: @provider_account.domain) %>
+To view new forum post, follow this link <%= forum_topic_url(@post.topic, host: @provider_account.external_domain) %>

--- a/app/views/shared/provider/navigation/audience/_portal.html.slim
+++ b/app/views/shared/provider/navigation/audience/_portal.html.slim
@@ -34,7 +34,7 @@ li.list-group-item
   span.list-group-item-value.label
 
 li.list-group-item
-  = link_to access_code_url(host: current_account.domain, cms_token: current_account.settings.cms_token!,
+  = link_to access_code_url(host: current_account.external_domain, cms_token: current_account.settings.cms_token!,
             access_code: current_account.site_access_code).html_safe,
             target: "_blank" do
     span.fa.fa-external-link style="margin: 0 .3rem;"
@@ -92,7 +92,7 @@ li.list-group-item
 
   //= important_icon_link 'Visit Developer Portal',
                                 'external-link',
-                                access_code_url(host: current_account.domain, cms_token: current_account.settings.cms_token!,
+                                access_code_url(host: current_account.external_domain, cms_token: current_account.settings.cms_token!,
                                 access_code: current_account.site_access_code).html_safe,
                                 target: "_blank",
                                 class: "preview link--icon-last"

--- a/app/views/sites/dns/show.html.erb
+++ b/app/views/sites/dns/show.html.erb
@@ -27,7 +27,7 @@
       <li class="string">
         <% if readonly_dns_domains? %>
           <%= form.label :domain_type_subdomain, 'Developer Portal Site' %>
-          <%= form.text_field :subdomain, :value => current_account.domain , :disabled => 'disabled' %>
+          <%= form.text_field :subdomain, :value => current_account.external_domain , :disabled => 'disabled' %>
           <%= switch_link "Change", contact_3scale_admin_site_dns_path, :switch => :branding, :upgrade_notice => true, :class => "fancybox" %>
           <p class="inline-hints">You can change the domain of your
   	Developer Portal to your own domain, for instance


### PR DESCRIPTION
Some things still do not work when using domain substitution #1904
Among those, SSO authentication on developer portal which still redirects to the
domain stored in the database