### PR TITLE
[gem] Remove sidekiq-pro

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@
 
 eval_gemfile 'Gemfile.base'
 gem 'pg', '~> 0.21.0'
-gem 'sidekiq-batch', '~> 0.1.6'

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -50,6 +50,7 @@ gem 'sinatra', require: false # for sidekiq web
 
 # Sidekiq
 gem 'sidekiq', '< 6', require: %w(sidekiq sidekiq/web)
+gem 'sidekiq-batch', '~> 0.1.6'
 gem 'sidekiq-cron', require: %w(sidekiq/cron sidekiq/cron/web)
 gem 'sidekiq-lock'
 gem 'sidekiq-throttled'

--- a/Gemfile.prod
+++ b/Gemfile.prod
@@ -1,9 +1,5 @@
 eval_gemfile 'Gemfile.base'
 
-source 'https://gems.contribsys.com/' do
-  gem 'sidekiq-pro', '~> 3.4', require: %w(sidekiq-pro sidekiq/pro/web)
-end
-
 # one of the license terms does not permit modifications and presents unclear risk to redhat
 # NewRelic RPM
 # docs says it should be loaded latest as possible

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -94,7 +94,6 @@ PATH
 
 GEM
   remote: https://rubygems.org/
-  remote: https://gems.contribsys.com/
   specs:
     3scale_client (2.11.0)
       nokogiri
@@ -677,14 +676,14 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 4.2)
+    sidekiq-batch (0.1.6)
+      sidekiq (>= 3)
     sidekiq-cron (1.0.4)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
     sidekiq-lock (0.4.0)
       redis (>= 3.0.5)
       sidekiq (>= 2.14.0)
-    sidekiq-pro (3.7.1)
-      sidekiq (>= 4.1.5)
     sidekiq-prometheus-exporter (0.1.13)
       sidekiq (>= 3.3.1)
     sidekiq-throttled (0.11.0)
@@ -953,9 +952,9 @@ DEPENDENCIES
   shoulda-context (~> 1.2.2)
   shoulda-matchers (~> 2.8.0)
   sidekiq (< 6)
+  sidekiq-batch (~> 0.1.6)
   sidekiq-cron
   sidekiq-lock
-  sidekiq-pro (~> 3.4)!
   sidekiq-prometheus-exporter
   sidekiq-throttled
   simplecov (~> 0.21.2)

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -66,12 +66,6 @@
     :versions: []
     :when: 2016-11-23 12:31:29.289170000 Z
 - - :approve
-  - sidekiq-pro
-  - :who: 
-    :why: 
-    :versions: []
-    :when: 2016-11-23 13:43:07.881188000 Z
-- - :approve
   - 3scale_core
   - :who: 
     :why: 

--- a/features/support/sidekiq.rb
+++ b/features/support/sidekiq.rb
@@ -41,17 +41,9 @@ module Sidekiq
 
       private
 
-      def handle_callbacks(batch, batch_id, status)
-        if batch.respond_to?(:callbacks) # sidekiq-pro
-          batch.callbacks.fetch('complete', []).each do |complete_callback|
-            complete_callback.each do |type, options|
-              type.constantize.new.on_complete(status, options)
-            end
-          end
-        else # sidekiq-batch
-          Sidekiq::Batch.enqueue_callbacks(:complete, batch_id)
-          Sidekiq::Batch.enqueue_callbacks(:success, batch_id)
-        end
+      def handle_callbacks(_batch, batch_id, _status)
+        Sidekiq::Batch.enqueue_callbacks(:complete, batch_id)
+        Sidekiq::Batch.enqueue_callbacks(:success, batch_id)
       end
     end
 


### PR DESCRIPTION
Context: we have it used on one of our production deployment.
We mainly rely on 2 features for it:

- Reliability
- Batches

First, after years used by customers on their own deployments without sidekiq-pro, no issues reported to us so far about reliability
We think it is time to say goodbye on this awesome gem.

Second, we successfully make use of an alternative to Pro batches sidekiq-batch

All in one, the necessity of sidekiq-pro dimmed so the decision is to take it down for good