### PR TITLE
Fixed THREESCALE-6428 - Add APIAP Routing policy just before APICast policy

### DIFF
--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -10,17 +10,12 @@ module BackendApiLogic
       other_routing_rules = other_routing_policies.flat_map { |policy| policy['configuration']['rules'] }
 
       routing_policy = Builder.new(service).to_h
-      
+
       return other_policies if routing_policy['configuration']['rules'].concat(other_routing_rules).empty?
 
-      index_apicast = other_policies.index { |policy| policy['name'] == 'apicast'}
-      result = []
-      if index_apicast > 0
-        result.push(*other_policies[0..index_apicast - 1])
-      end
-      result << routing_policy
-      result.push(*other_policies[index_apicast..-1])
-      return result
+      apicast_policy_index = other_policies.index { |policy| policy['name'] == 'apicast'}
+      other_policies.insert(apicast_policy_index, routing_policy).compact
+
     end
 
     def with_subpaths?

--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -15,7 +15,6 @@ module BackendApiLogic
 
       apicast_policy_index = other_policies.index { |policy| policy['name'] == 'apicast'}
       other_policies.insert(apicast_policy_index, routing_policy).compact
-
     end
 
     def with_subpaths?

--- a/app/lib/backend_api_logic/routing_policy.rb
+++ b/app/lib/backend_api_logic/routing_policy.rb
@@ -10,10 +10,17 @@ module BackendApiLogic
       other_routing_rules = other_routing_policies.flat_map { |policy| policy['configuration']['rules'] }
 
       routing_policy = Builder.new(service).to_h
-
+      
       return other_policies if routing_policy['configuration']['rules'].concat(other_routing_rules).empty?
 
-      [routing_policy, *other_policies].compact
+      index_apicast = other_policies.index { |policy| policy['name'] == 'apicast'}
+      result = []
+      if index_apicast > 0
+        result.push(*other_policies[0..index_apicast - 1])
+      end
+      result << routing_policy
+      result.push(*other_policies[index_apicast..-1])
+      return result
     end
 
     def with_subpaths?

--- a/test/unit/backend_api_logic/routing_policy_test.rb
+++ b/test/unit/backend_api_logic/routing_policy_test.rb
@@ -68,8 +68,8 @@ module BackendApiLogic
 
 
     test 'routing policy before apicast policy' do
-      policy_1 = { name: 'abc', version: 'builtin', enabled: true, configuration: {} }
-      policy_2 = { name: 'lmn', version: 'builtin', enabled: true, configuration: {} }
+      mock_policy1 = { name: 'abc', version: 'builtin', enabled: true, configuration: {} }
+      mock_policy2 = { name: 'lmn', version: 'builtin', enabled: true, configuration: {} }
       apicast_policy = { name: 'apicast', version: 'builtin', enabled: true, configuration: {} }
       backend_api1 = backend_apis.first
       backend_api2 = backend_apis.last
@@ -77,7 +77,6 @@ module BackendApiLogic
         { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/foo/.*|/foo/?)'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
         { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/.*)'] } }
       ]
-      # apicast_policy = { name: 'apicast', version: 'builtin', configuration: {} }
       injected_policy = {
         name: "routing",
         version: "builtin",
@@ -85,14 +84,14 @@ module BackendApiLogic
         configuration: { rules: injected_rules }
       }
 
-      proxy.stubs(:policies_config).returns([apicast_policy, policy_1, policy_2].as_json)
-      assert_equal [injected_policy, apicast_policy.except(:enabled), policy_1.except(:enabled), policy_2.except(:enabled)].as_json, proxy.policy_chain
+      proxy.stubs(:policies_config).returns([apicast_policy, mock_policy1, mock_policy2].as_json)
+      assert_equal [injected_policy, apicast_policy.except(:enabled), mock_policy1.except(:enabled), mock_policy2.except(:enabled)].as_json, proxy.policy_chain
 
-      proxy.stubs(:policies_config).returns([policy_1, apicast_policy, policy_2].as_json)
-      assert_equal [policy_1.except(:enabled), injected_policy, apicast_policy.except(:enabled), policy_2.except(:enabled)].as_json, proxy.policy_chain
+      proxy.stubs(:policies_config).returns([mock_policy1, apicast_policy, mock_policy2].as_json)
+      assert_equal [mock_policy1.except(:enabled), injected_policy, apicast_policy.except(:enabled), mock_policy2.except(:enabled)].as_json, proxy.policy_chain
 
-      proxy.stubs(:policies_config).returns([policy_1, policy_2, apicast_policy].as_json)
-      assert_equal [policy_1.except(:enabled), policy_2.except(:enabled), injected_policy, apicast_policy.except(:enabled)].as_json, proxy.policy_chain
+      proxy.stubs(:policies_config).returns([mock_policy1, mock_policy2, apicast_policy].as_json)
+      assert_equal [mock_policy1.except(:enabled), mock_policy2.except(:enabled), injected_policy, apicast_policy.except(:enabled)].as_json, proxy.policy_chain
 
     end
 

--- a/test/unit/backend_api_logic/routing_policy_test.rb
+++ b/test/unit/backend_api_logic/routing_policy_test.rb
@@ -66,6 +66,37 @@ module BackendApiLogic
       assert_equal [injected_routing_policy, apicast_policy.except(:enabled)].as_json, proxy.policy_chain
     end
 
+
+    test 'routing policy before apicast policy' do
+      policy_1 = { name: 'abc', version: 'builtin', enabled: true, configuration: {} }
+      policy_2 = { name: 'lmn', version: 'builtin', enabled: true, configuration: {} }
+      apicast_policy = { name: 'apicast', version: 'builtin', enabled: true, configuration: {} }
+      backend_api1 = backend_apis.first
+      backend_api2 = backend_apis.last
+      injected_rules = [
+        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/foo/.*|/foo/?)'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
+        { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/.*)'] } }
+      ]
+      # apicast_policy = { name: 'apicast', version: 'builtin', configuration: {} }
+      injected_policy = {
+        name: "routing",
+        version: "builtin",
+        enabled: true,
+        configuration: { rules: injected_rules }
+      }
+
+      proxy.stubs(:policies_config).returns([apicast_policy, policy_1, policy_2].as_json)
+      assert_equal [injected_policy, apicast_policy.except(:enabled), policy_1.except(:enabled), policy_2.except(:enabled)].as_json, proxy.policy_chain
+
+      proxy.stubs(:policies_config).returns([policy_1, apicast_policy, policy_2].as_json)
+      assert_equal [policy_1.except(:enabled), injected_policy, apicast_policy.except(:enabled), policy_2.except(:enabled)].as_json, proxy.policy_chain
+
+      proxy.stubs(:policies_config).returns([policy_1, policy_2, apicast_policy].as_json)
+      assert_equal [policy_1.except(:enabled), policy_2.except(:enabled), injected_policy, apicast_policy.except(:enabled)].as_json, proxy.policy_chain
+
+    end
+
+
     class RuleTest < ActiveSupport::TestCase
       setup do
         @rule_class = RoutingPolicy.const_get(:Builder).const_get(:Rule)

--- a/test/unit/backend_api_logic/routing_policy_test.rb
+++ b/test/unit/backend_api_logic/routing_policy_test.rb
@@ -6,13 +6,12 @@ module BackendApiLogic
   class RoutingPolicyTest < ActiveSupport::TestCase
     setup do
       @service = FactoryBot.create(:simple_service)
-      first_backend_api = FactoryBot.create(:backend_api_config, path: '', service: @service).backend_api
-      other_backend_api = FactoryBot.create(:backend_api, system_name: 'foo')
-      @backend_apis = [first_backend_api, other_backend_api]
+      @first_backend_api = FactoryBot.create(:backend_api_config, path: '', service: @service).backend_api
+      @other_backend_api = FactoryBot.create(:backend_api, system_name: 'foo')
       @service.backend_api_configs.create(backend_api: other_backend_api, path: 'foo')
     end
 
-    attr_reader :service, :backend_apis
+    attr_reader :service, :first_backend_api, :other_backend_api
     delegate :proxy, to: :service
 
     test '#with_subpaths?' do
@@ -22,20 +21,19 @@ module BackendApiLogic
     end
 
     test '#policy_chain' do
-      backend_api1 = backend_apis.first
-      backend_api2 = backend_apis.last
-      injected_rules = [
-        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/foo/.*|/foo/?)'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
-        { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/.*)'] } }
-      ]
-      apicast_policy = { name: 'apicast', 'version': 'builtin', 'configuration': {} }
       injected_policy = {
-        name: "routing",
-        version: "builtin",
+        name: 'routing',
+        version: 'builtin',
         enabled: true,
-        configuration: { rules: injected_rules }
+        configuration: {
+          rules: [
+            { url: other_backend_api.private_endpoint, owner_id: other_backend_api.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/foo/.*|/foo/?)'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
+            { url: first_backend_api.private_endpoint, owner_id: first_backend_api.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/.*)'] } }
+          ]
+        }
       }
-      assert_equal [injected_policy, apicast_policy].as_json, proxy.policy_chain
+
+      assert_equal [injected_policy, apicast_policy.except(:enabled)].as_json, proxy.policy_chain
     end
 
     test 'other routing policies are merged' do
@@ -46,53 +44,47 @@ module BackendApiLogic
         enabled: true,
         configuration: { rules: [routing_rule] }
       }
-      apicast_policy = { name: 'apicast', version: 'builtin', enabled: true, configuration: {} }
       proxy.stubs(:policies_config).returns([routing_policy, apicast_policy].as_json)
 
-      backend_api1 = backend_apis.first
-      backend_api2 = backend_apis.last
-      injected_rules = [
-        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/foo/.*|/foo/?)'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
-        { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/.*)'] } },
-        routing_rule
-      ]
-      injected_routing_policy = {
-        name: "routing",
-        version: "builtin",
+      injected_policy = {
+        name: 'routing',
+        version: 'builtin',
         enabled: true,
-        configuration: { rules: injected_rules }
+        configuration: {
+          rules: [
+            { url: other_backend_api.private_endpoint, owner_id: other_backend_api.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/foo/.*|/foo/?)'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
+            { url: first_backend_api.private_endpoint, owner_id: first_backend_api.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/.*)'] } },
+            routing_rule
+          ]
+        }
       }
 
-      assert_equal [injected_routing_policy, apicast_policy.except(:enabled)].as_json, proxy.policy_chain
+      assert_equal [injected_policy, apicast_policy.except(:enabled)].as_json, proxy.policy_chain
     end
 
-
     test 'routing policy before apicast policy' do
-      mock_policy1 = { name: 'abc', version: 'builtin', enabled: true, configuration: {} }
-      mock_policy2 = { name: 'lmn', version: 'builtin', enabled: true, configuration: {} }
-      apicast_policy = { name: 'apicast', version: 'builtin', enabled: true, configuration: {} }
-      backend_api1 = backend_apis.first
-      backend_api2 = backend_apis.last
-      injected_rules = [
-        { url: backend_api2.private_endpoint, owner_id: backend_api2.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/foo/.*|/foo/?)'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
-        { url: backend_api1.private_endpoint, owner_id: backend_api1.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/.*)'] } }
-      ]
       injected_policy = {
-        name: "routing",
-        version: "builtin",
+        name: 'routing',
+        version: 'builtin',
         enabled: true,
-        configuration: { rules: injected_rules }
+        configuration: {
+          rules: [
+            { url: other_backend_api.private_endpoint, owner_id: other_backend_api.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/foo/.*|/foo/?)'] }, replace_path: "{{uri | remove_first: '/foo'}}" },
+            { url: first_backend_api.private_endpoint, owner_id: first_backend_api.id, owner_type: 'BackendApi', condition: { operations: [match: :path, op: :matches, value: '^(/.*)'] } },
+          ]
+        }
       }
+      policy_blah = { name: 'blah', version: 'builtin', enabled: true, configuration: {} }
+      policy_bleh = { name: 'bleh', version: 'builtin', enabled: true, configuration: {} }
 
-      proxy.stubs(:policies_config).returns([apicast_policy, mock_policy1, mock_policy2].as_json)
-      assert_equal [injected_policy, apicast_policy.except(:enabled), mock_policy1.except(:enabled), mock_policy2.except(:enabled)].as_json, proxy.policy_chain
+      proxy.stubs(:policies_config).returns([apicast_policy, policy_blah, policy_bleh].as_json)
+      assert_equal [injected_policy, apicast_policy.except(:enabled), policy_blah.except(:enabled), policy_bleh.except(:enabled)].as_json, proxy.policy_chain
 
-      proxy.stubs(:policies_config).returns([mock_policy1, apicast_policy, mock_policy2].as_json)
-      assert_equal [mock_policy1.except(:enabled), injected_policy, apicast_policy.except(:enabled), mock_policy2.except(:enabled)].as_json, proxy.policy_chain
+      proxy.stubs(:policies_config).returns([policy_blah, apicast_policy, policy_bleh].as_json)
+      assert_equal [policy_blah.except(:enabled), injected_policy, apicast_policy.except(:enabled), policy_bleh.except(:enabled)].as_json, proxy.policy_chain
 
-      proxy.stubs(:policies_config).returns([mock_policy1, mock_policy2, apicast_policy].as_json)
-      assert_equal [mock_policy1.except(:enabled), mock_policy2.except(:enabled), injected_policy, apicast_policy.except(:enabled)].as_json, proxy.policy_chain
-
+      proxy.stubs(:policies_config).returns([policy_blah, policy_bleh, apicast_policy].as_json)
+      assert_equal [policy_blah.except(:enabled), policy_bleh.except(:enabled), injected_policy, apicast_policy.except(:enabled)].as_json, proxy.policy_chain
     end
 
 
@@ -121,6 +113,12 @@ module BackendApiLogic
         refute rule_class.new(stub(backend_api_id: 1, private_endpoint: 'http://whatever', path: '/')).as_json.has_key?(:replace_path)
         assert rule_class.new(stub(backend_api_id: 2, private_endpoint: 'http://whatever', path: 'foo')).as_json.has_key?(:replace_path)
       end
+    end
+
+    protected
+
+    def apicast_policy
+      { name: 'apicast', version: 'builtin', enabled: true, configuration: {} }
     end
   end
 end


### PR DESCRIPTION


Signed-off-by: Srijita Mukherjee <srmukher@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Currently, when using APIAP some policies are broken because Routing policy is
always first.
hence placing the Routing policy just above the Apicast policy.

**Which issue(s) this PR fixes** 

> Closes THREESCALE-6428 


**Verification steps** 
To be documented.

**Special notes for your reviewer**:
