### PR TITLE
[gem] Update webmock to 3.8.0 to support ruby 2.6

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -207,7 +207,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'email_spec', require: false
   gem 'fakefs', '~>0.18.0', require: 'fakefs/safe'
-  gem 'webmock', '~> 2.3.2'
+  gem 'webmock', '~> 3.8.0'
   gem 'launchy'
   gem 'mechanize'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,8 +157,8 @@ GEM
       activerecord (>= 3.0)
     acts_as_tree (2.9.0)
       activerecord (>= 3.0.0)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     after_commit_queue (1.1.0)
       rails (>= 3.0)
     aggregate_root (0.3.6)
@@ -248,8 +248,8 @@ GEM
       sprockets (< 4.0)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     cucumber (2.99.0)
       builder (>= 2.1.2)
@@ -335,7 +335,7 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
-    hashdiff (0.3.9)
+    hashdiff (1.0.1)
     hashie (3.6.0)
     hiredis (0.6.3)
     html-pipeline (2.12.3)
@@ -495,7 +495,7 @@ GEM
     pry-stack_explorer (0.4.12)
       binding_of_caller (~> 0.7)
       pry (~> 0.13)
-    public_suffix (3.1.1)
+    public_suffix (4.0.6)
     raabro (1.1.6)
     rack (2.1.4)
     rack-no_animations (1.0.3)
@@ -586,7 +586,7 @@ GEM
       netrc (~> 0.8)
     reverse_markdown (2.0.0)
       nokogiri
-    rexml (3.2.4)
+    rexml (3.2.5)
     riddle (2.4.0)
     rmagick (2.15.4)
     roar (1.0.4)
@@ -653,7 +653,6 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_event_store (0.9.0)
     rubyzip (1.3.0)
-    safe_yaml (1.0.5)
     sass (3.4.25)
     sass-rails (5.0.7)
       railties (>= 4.0.0, < 6)
@@ -781,10 +780,10 @@ GEM
       rack
       unicorn
     uniform_notifier (1.10.0)
-    webmock (2.3.2)
+    webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (4.3.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -978,7 +977,7 @@ DEPENDENCIES
   uglifier
   unicorn
   unicorn-rails
-  webmock (~> 2.3.2)
+  webmock (~> 3.8.0)
   webpacker (~> 4)
   whenever (~> 0.9.7)
   will_paginate (~> 3.1.6)

--- a/Gemfile.prod.lock
+++ b/Gemfile.prod.lock
@@ -157,8 +157,8 @@ GEM
       activerecord (>= 3.0)
     acts_as_tree (2.9.0)
       activerecord (>= 3.0.0)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     after_commit_queue (1.1.0)
       rails (>= 3.0)
     aggregate_root (0.3.6)
@@ -248,8 +248,8 @@ GEM
       sprockets (< 4.0)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     cucumber (2.99.0)
       builder (>= 2.1.2)
@@ -335,7 +335,7 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
-    hashdiff (0.3.9)
+    hashdiff (1.0.1)
     hashie (3.6.0)
     hiredis (0.6.3)
     html-pipeline (2.12.3)
@@ -495,7 +495,7 @@ GEM
     pry-stack_explorer (0.4.12)
       binding_of_caller (~> 0.7)
       pry (~> 0.13)
-    public_suffix (3.1.1)
+    public_suffix (4.0.6)
     raabro (1.1.6)
     rack (2.1.4)
     rack-no_animations (1.0.3)
@@ -586,7 +586,7 @@ GEM
       netrc (~> 0.8)
     reverse_markdown (2.0.0)
       nokogiri
-    rexml (3.2.4)
+    rexml (3.2.5)
     riddle (2.4.0)
     rmagick (2.15.4)
     roar (1.0.4)
@@ -653,7 +653,6 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_event_store (0.9.0)
     rubyzip (1.3.0)
-    safe_yaml (1.0.5)
     sass (3.4.25)
     sass-rails (5.0.7)
       railties (>= 4.0.0, < 6)
@@ -781,10 +780,10 @@ GEM
       rack
       unicorn
     uniform_notifier (1.10.0)
-    webmock (2.3.2)
+    webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (4.3.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -978,7 +977,7 @@ DEPENDENCIES
   uglifier
   unicorn
   unicorn-rails
-  webmock (~> 2.3.2)
+  webmock (~> 3.8.0)
   webpacker (~> 4)
   whenever (~> 0.9.7)
   will_paginate (~> 3.1.6)


### PR DESCRIPTION
We need to support ruby 2.6 soon while still supporting ruby 2.4
This is the last version of webmock supporting both

