### PR TITLE
[task] A task to fix services that do not have proxy

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -519,6 +519,10 @@ class Service < ApplicationRecord
     DeploymentOption.plugins.include?(deployment_option)
   end
 
+  def create_default_proxy
+    create_proxy! unless proxy
+  end
+
   private
 
   def archive_as_deleted
@@ -537,10 +541,6 @@ class Service < ApplicationRecord
 
   def destroyable?
     destroyed_by_association || !default_or_last?
-  end
-
-  def create_default_proxy
-    create_proxy! unless proxy
   end
 
   def create_default_service_plan

--- a/app/workers/create_default_proxy_worker.rb
+++ b/app/workers/create_default_proxy_worker.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateDefaultProxyWorker < ApplicationJob
+
+  rescue_from(ActiveJob::DeserializationError, ActiveRecord::RecordNotFound) do |exception|
+    Rails.logger.info "#{self.class}#perform raised #{exception.class} with message #{exception.message}"
+  end
+
+  # :reek:UtilityFunction
+  def perform(service)
+    service.create_default_proxy
+  end
+
+  class BatchEnqueueWorker < ApplicationJob
+
+    # :reek:UtilityFunction
+    def perform(*)
+      Service.includes(:proxy).where(proxies: {service_id: nil}).find_each do |service|
+        CreateDefaultProxyWorker.perform_later(service)
+      end
+    end
+  end
+end

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -24,4 +24,9 @@ namespace :services do
     end
     service.reload.mark_as_deleted!
   end
+
+  desc 'Create default proxy of a service'
+  task :create_default_proxy => :environment do
+    CreateDefaultProxyWorker::BatchEnqueueWorker.perform_later
+  end
 end

--- a/test/workers/create_default_proxy_worker_test.rb
+++ b/test/workers/create_default_proxy_worker_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CreateDefaultProxyWorkerTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test 'batch enqueue' do
+    services = FactoryBot.create_list :service, 3
+    no_proxy = services.last
+    no_proxy.proxy.destroy!
+
+    CreateDefaultProxyWorker::BatchEnqueueWorker.perform_now
+    assert_enqueued_jobs 1, only: CreateDefaultProxyWorker
+  end
+
+  test 'perform create proxy' do
+    service = FactoryBot.create :service
+    service.proxy.destroy!
+    service.expects(:create_default_proxy)
+
+    CreateDefaultProxyWorker.perform_now service
+  end
+end


### PR DESCRIPTION
Proxy is mandatory for a service to function.
The application is failing if a service does not have proxy

This is also useful when using the obfuscated database from production.
We truncate `proxies` table so we need to launch this task everytime we restore the database
