### PR TITLE
Fix resync of API backend-owned metrics with the 3scale backend via storage rewrite task

### DIFF
--- a/app/lib/backend/storage_rewrite.rb
+++ b/app/lib/backend/storage_rewrite.rb
@@ -60,7 +60,7 @@ module Backend
 
       bought_cinstances = provider.bought_cinstances
 
-      metrics = provider.metrics.includes(:service, :parent)
+      metrics = Metric.by_provider(provider).includes(:parent)
       usage_limits = provider.usage_limits.includes(plan: :service)
 
       total_count = services.size + cinstances.size + metrics.size + usage_limits.size + bought_cinstances.size

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -46,6 +46,10 @@ class Metric < ApplicationRecord
   scope :top_level, -> { where(parent_id: nil) }
   scope :order_by_unit, -> { order('unit') }
 
+  scope :by_provider, ->(provider) {
+    where.has { ((owner_type == 'Service') & owner_id.in(provider.services.pluck(:id))) | ((owner_type == 'BackendApi') & owner_id.in(provider.backend_apis.pluck(:id))) }
+  }
+
   # Create one of the predefined, default metrics.
   #
   # == Arguments

--- a/test/unit/backend/storage_rewrite_test.rb
+++ b/test/unit/backend/storage_rewrite_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Backend
+  class StorageRewriteTest < ActiveSupport::TestCase
+    test 'rewrite provider resyncs all metrics of the provider' do
+      provider = FactoryBot.create(:simple_provider)
+      service = FactoryBot.create(:simple_service, account: provider)
+      backend_api = FactoryBot.create(:backend_api, account: provider)
+      service.backend_api_configs.create!(backend_api: backend_api, path: '/')
+      [service.metrics.hits, backend_api.metrics.hits].each do |metric|
+        ::BackendMetricWorker.expects(:perform_now).with(service.backend_id, metric.id)
+      end
+      StorageRewrite.rewrite_provider(provider.id)
+    end
+  end
+end

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MetricTest < ActiveSupport::TestCase
@@ -103,7 +105,7 @@ class MetricTest < ActiveSupport::TestCase
     method = hits.children.create(system_name: 'meth1')
     assert_equal backend_api, method.owner
   end
-  
+
   context 'on :destroy' do
     should 'destroy pricing_rules'
     should 'destroy usage_limits'
@@ -367,6 +369,21 @@ class MetricTest < ActiveSupport::TestCase
       @metric1.enable_for_plan(@plan)
       assert @metric1.enabled_for_plan?(@plan)
     end
-
   end # enabled or disabled for plan
+
+  test '.by_provider' do
+    provider, other_provider = FactoryBot.create_list(:simple_provider, 2)
+
+    service = FactoryBot.create(:simple_service, account: provider)
+    backend_api = FactoryBot.create(:backend_api, account: provider)
+    service_metric = FactoryBot.create(:metric, owner: service)
+    backend_metric = FactoryBot.create(:metric, owner: backend_api)
+
+    other_service = FactoryBot.create(:simple_service, account: other_provider)
+    other_backend_api = FactoryBot.create(:backend_api, account: other_provider)
+    other_service_metric = FactoryBot.create(:metric, owner: other_service)
+    other_backend_metric = FactoryBot.create(:metric, owner: other_backend_api)
+
+    assert_same_elements [service.metrics.hits, service_metric, backend_api.metrics.hits, backend_metric], Metric.by_provider(provider)
+  end
 end


### PR DESCRIPTION
Closes [THREESCALE-6491](https://issues.redhat.com/browse/THREESCALE-6491)