### PR TITLE
🐛  Fix CSRFToken import

### DIFF
--- a/app/javascript/src/NewApplication/components/NewApplicationForm.jsx
+++ b/app/javascript/src/NewApplication/components/NewApplicationForm.jsx
@@ -16,7 +16,7 @@ import {
   ServicePlanSelect
 } from 'NewApplication'
 import { UserDefinedField } from 'Common'
-import { CSRFToken } from 'utilities/utils'
+import { CSRFToken } from 'utilities/CSRFToken'
 import * as flash from 'utilities/alert'
 
 import type { Buyer, Product, ServicePlan, ApplicationPlan } from 'NewApplication/types'


### PR DESCRIPTION
Because https://github.com/3scale/porta/pull/2364 was a long running branch, utilities were reworked https://github.com/3scale/porta/pull/2426
No merging conflicts detected but still issue while compiling assets on the default branch after merge.

```

ERROR in ./app/javascript/src/NewApplication/components/NewApplicationForm.jsx 126:38-47
"export 'CSRFToken' was not found in 'utilities/utils'
 @ ./app/javascript/src/NewApplication/index.js
 @ ./app/javascript/packs/new_application.js
```
