### PR TITLE
[2.11] New table "Backends used by Product" 

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,4 +17,4 @@ experimental.const_params=true
 max_header_tokens=1
 module.name_mapper='.*\(.s?css\)' -> 'empty/object'
 module.system=haste
-module.name_mapper='^\(ActiveDocs\|Applications\|BackendApis\|ChangePassword\|Common\|Settings\|Dashboard\|LoginPage\|MappingRules\|Navigation\|NewApplication\|Onboarding\|PaymentGateways\|Plans\|Policies\|services\|Stats\|Types\|Users\|utilities\|NewService\)\(.*\)$' -> '<PROJECT_ROOT>/app/javascript/src/\1/\2'
+module.name_mapper='^\(ActiveDocs\|Applications\|BackendApis\|ChangePassword\|Common\|Settings\|Dashboard\|LoginPage\|MappingRules\|Navigation\|NewApplication\|Onboarding\|PaymentGateways\|Plans\|Policies\|Products\|services\|Stats\|Types\|Users\|utilities\|NewService\)\(.*\)$' -> '<PROJECT_ROOT>/app/javascript/src/\1/\2'

--- a/app/decorators/backend_api_decorator.rb
+++ b/app/decorators/backend_api_decorator.rb
@@ -23,6 +23,14 @@ class BackendApiDecorator < ApplicationDecorator
                     .to_json
   end
 
+  def table_data
+    {
+      name: name,
+      description: private_endpoint,
+      href: link
+    }
+  end
+
   alias link api_selector_api_link
 
   private

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -67,6 +67,12 @@ class ServiceDecorator < ApplicationDecorator
     }
   end
 
+  def backends_table_data
+    BackendApiDecorator.decorate_collection(backend_apis)
+                       .map(&:table_data)
+                       .to_json
+  end
+
   private
 
   def backend_api?

--- a/app/javascript/packs/backends_used_list.js
+++ b/app/javascript/packs/backends_used_list.js
@@ -1,0 +1,22 @@
+// @flow
+
+import { BackendsUsedListCardWrapper } from 'Products'
+import { safeFromJsonString } from 'utilities'
+
+import type { CompactListItem } from 'Common'
+
+const containerId = 'backends-used-list-container'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById(containerId)
+
+  if (!container) {
+    return
+  }
+
+  const { backends } = container.dataset
+
+  BackendsUsedListCardWrapper({
+    backends: safeFromJsonString<Array<CompactListItem>>(backends) || []
+  }, containerId)
+})

--- a/app/javascript/src/Products/components/BackendsUsedListCard.jsx
+++ b/app/javascript/src/Products/components/BackendsUsedListCard.jsx
@@ -1,0 +1,46 @@
+// @flow
+
+import * as React from 'react'
+import { useState, useRef } from 'react'
+
+import { CompactListCard } from 'Common'
+import { createReactWrapper, useSearchInputEffect } from 'utilities'
+
+import type { CompactListItem } from 'Common'
+
+type Props = {
+  backends: Array<CompactListItem>
+}
+
+const BackendsUsedListCard = ({ backends }: Props): React.Node => {
+  const [page, setPage] = useState(1)
+  const [filteredBackends, setFilteredBackends] = useState(backends)
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+
+  const handleOnSearch = (term: string = '') => {
+    setFilteredBackends(backends.filter(b => {
+      const regex = new RegExp(term, 'i')
+      return regex.test(b.name)
+    }))
+    setPage(1)
+  }
+
+  useSearchInputEffect(searchInputRef, handleOnSearch)
+
+  return (
+    <CompactListCard
+      columns={['Name', 'Private Endpoint']}
+      items={filteredBackends}
+      searchInputRef={searchInputRef}
+      onSearch={handleOnSearch}
+      page={page}
+      setPage={setPage}
+      searchInputPlaceholder="Find a Backend"
+      tableAriaLabel="Backends used by this product"
+    />
+  )
+}
+
+const BackendsUsedListCardWrapper = (props: Props, containerId: string): void => createReactWrapper(<BackendsUsedListCard {...props} />, containerId)
+
+export { BackendsUsedListCard, BackendsUsedListCardWrapper }

--- a/app/javascript/src/Products/index.js
+++ b/app/javascript/src/Products/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export * from './components/BackendsUsedListCard'

--- a/app/views/api/services/cards/_backends_table.html.slim
+++ b/app/views/api/services/cards/_backends_table.html.slim
@@ -1,0 +1,3 @@
+h2 Backends used in this Product
+div id='backends-used-list-container' data-backends=product.decorate.backends_table_data
+  = javascript_pack_tag 'backends_used_list'

--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -100,13 +100,6 @@ section class="service-widget"
     - if current_user.accessible_services.empty?
       = render 'shared/service_access'
 
-    section[name="activity"]
-
-      - if can? :manage, :monitoring
-        h2 = link_to 'Analytics', admin_service_stats_usage_path(service), :title => 'Show more stats for this service'
-        = render 'stats/inlinechart',
-                 :metrics => service.metrics.top_level
-
       - if can? :manage, :partners
         h2
           = link_to 'Configuration', admin_service_integration_path(service), title: 'Change integration settings for this service'
@@ -136,12 +129,14 @@ section class="service-widget"
           - [:buyers_manage_keys, :buyers_manage_apps, :buyer_plan_change_permission, :buyer_can_select_plan ].map { |setting| friendly_service_setting(service, setting) }.compact.each do |setting|
             li.item
               = setting
-          li.item
-            strong> Backends
-            ' used in this product:
-            ul
-              - service.backend_apis.each do |backend_api|
-                li = link_to backend_api.name, provider_admin_backend_api_path(backend_api)
+
+    section[name="activity"]
+
+      - if can? :manage, :monitoring
+        h2 = link_to 'Analytics', admin_service_stats_usage_path(service), title: 'Show more stats for this service'
+        = render 'stats/inlinechart', metrics: service.metrics.top_level
+
+      = render 'api/services/cards/backends_table', product: service
 
 javascript:
   document.addEventListener('DOMContentLoaded', function () {

--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -97,9 +97,6 @@ section class="service-widget"
             = pluralize service.contracts.service.size, 'contract'
             | .
 
-    - if current_user.accessible_services.empty?
-      = render 'shared/service_access'
-
       - if can? :manage, :partners
         h2
           = link_to 'Configuration', admin_service_integration_path(service), title: 'Change integration settings for this service'
@@ -129,6 +126,9 @@ section class="service-widget"
           - [:buyers_manage_keys, :buyers_manage_apps, :buyer_plan_change_permission, :buyer_can_select_plan ].map { |setting| friendly_service_setting(service, setting) }.compact.each do |setting|
             li.item
               = setting
+
+      - if current_user.accessible_services.empty?
+        = render 'shared/service_access'
 
     section[name="activity"]
 

--- a/app/views/provider/admin/backend_apis/cards/_products_used_list.html.slim
+++ b/app/views/provider/admin/backend_apis/cards/_products_used_list.html.slim
@@ -1,3 +1,3 @@
 h2 Products using this backend
-div id='products-used-list-container' data-products=@backend_api.decorate.products_table_data
+div id='products-used-list-container' data-products=backend_api.decorate.products_table_data
   = javascript_pack_tag 'products_used_list'

--- a/app/views/provider/admin/backend_apis/show.html.slim
+++ b/app/views/provider/admin/backend_apis/show.html.slim
@@ -18,7 +18,7 @@ section class="overview-widget"
   div
 
     div.left
-      = render 'provider/admin/backend_apis/cards/products_used_list', products: @backend_api.services.accessible
+      = render 'provider/admin/backend_apis/cards/products_used_list', backend_api: @backend_api
 
     div.right
       h2 Methods & Mapping Rules

--- a/features/provider/onboarding/wizard.feature
+++ b/features/provider/onboarding/wizard.feature
@@ -1,3 +1,4 @@
+@javascript
 Feature: Onboarding Wizard
   In order to onboard customers faster,
   we want them to go through a wizard,

--- a/spec/javascripts/Products/components/BackendsUsedListCard.spec.jsx
+++ b/spec/javascripts/Products/components/BackendsUsedListCard.spec.jsx
@@ -1,0 +1,61 @@
+// @flow
+
+import React from 'react'
+import { mount } from 'enzyme'
+
+import { BackendsUsedListCard } from 'Products'
+
+const defaultProps = {
+  backends: []
+}
+
+const mountWrapper = (props) => mount(<BackendsUsedListCard {...{ ...defaultProps, ...props }} />)
+const mockBackends = (count) => new Array(count).fill({}).map((i, j) => ({ name: `Backend ${j}`, description: `backend_${j}`, href: `/backends/${j}` }))
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+it('should render itself', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.exists()).toBe(true)
+})
+
+it('should show backends in a table', () => {
+  const backends = mockBackends(2)
+  const wrapper = mountWrapper({ backends })
+  expect(wrapper.find('tbody tr').length).toEqual(backends.length)
+})
+
+it('should be paginated and have 5 items per page', () => {
+  const backends = mockBackends(6)
+  const wrapper = mountWrapper({ backends })
+  expect(wrapper.find('tbody tr').length).toEqual(5)
+
+  wrapper.find('.pf-c-pagination button').last().simulate('click')
+  expect(wrapper.find('tbody tr').length).toEqual(1)
+})
+
+// FIXME: input not receiving change event
+it.skip('should be filterable by name', () => {
+  const Items = mockBackends(10)
+  const wrapper = mountWrapper({ Items })
+
+  wrapper.find('input[type="search"]').simulate('change', { target: { value: '1' } })
+  wrapper.find('.pf-c-input-group button').last().simulate('click')
+  wrapper.update()
+
+  expect(wrapper.find('tbody tr').length).toEqual(2)
+})
+
+// FIXME: input not receiving change event
+it.skip('should search when pressing Enter', () => {
+  const Items = mockBackends(10)
+  const wrapper = mountWrapper({ Items })
+
+  wrapper.find('input[type="search"]').simulate('change', { target: { value: '1' } })
+  wrapper.find('input[type="search"]').simulate('keydown', { key: 'Enter' })
+  wrapper.update()
+
+  expect(wrapper.find('tbody tr').length).toEqual(2)
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Extracts the current list of backends into its own card, with pagination and searching.
The other data is moved to the left column.
* The table is paginated and filtered in client side.
* In order to filter, either click the magnifier button or hit Enter.

<img width="1133" alt="Screenshot 2021-05-07 at 22 28 41" src="https://user-images.githubusercontent.com/11672286/117504998-9d537100-af83-11eb-9128-ff91ad9a692b.png">

OLD:
<img width="1133" alt="Screenshot 2021-05-07 at 21 51 12" src="https://user-images.githubusercontent.com/11672286/117501471-629b0a00-af7e-11eb-9b69-c1fcb13913da.png">

**Which issue(s) this PR fixes** 

[THREESCALE-6877: [3scale][2.11][HI-prio] Improve list of Products in Backend overview page](https://issues.redhat.com/browse/THREESCALE-6877)
