### PR TITLE
Removes hidden element from Service overview

### DIFF
--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -116,39 +116,10 @@ section class="service-widget"
           =< link_to 'Settings', settings_admin_service_path(service), :title => "Edit service settings"
 
         ul.service-settings[data-hint="basics"]
-          - if service.deployment_option.present?
-            - deployment_option_phrased = t(service.proxy.deployment_option, scope: "deployment_options.phrased")
-          - unless service.has_traffic?
-            / TODO: THREESCALE-3759 verify if this is always hidden, and remove if required
-            li class=("item integration is-hidden")
-              - case service.proxy.deployment_option.presence
-              - when 'hosted'
-                / TODO: THREESCALE-3759 remove associated code
-                  p On the #{link_to( 'Integration page', edit_admin_service_integration_path(service, :anchor => 'staging') )}, add your <em>API base URL</em> to the <em>Private Base URL</em> field in the staging box and hit <strong>Update & Test</strong>. Once the staging box is green, hit <strong>Deploy</strong> in the production box and you have completed a basic integration.
-                  = important_icon_link "Configure #{deployment_option_phrased}",
-                    'hdd-o', edit_admin_service_integration_path(service, :anchor => 'staging'), :class => "outline-button next"
-              - when 'self_managed'
-                / TODO: THREESCALE-3759 remove associated code
-                  p On the #{link_to( 'Integration page', edit_admin_service_integration_path(service, :anchor => 'staging') )}, add your <em>API base URL</em> to the <em>Private Base URL</em> field in the staging box and hit <strong>Update & Test</strong>. Once the staging box is green, proceed to download the NGINX config files for your On-premises NGINX reverse proxy server. Once you've added these config files to your Nginx server you have completed a basic integration.
-                  = important_icon_link "Configure #{deployment_option_phrased}",
-                    'hdd-o', edit_admin_service_integration_path(service, :anchor => 'staging'), :class => "outline-button next"
-              - when 'plugin_rest'
-                p Follow the instructions on the #{link_to('Integration page', admin_service_integration_path(service))} to integrate your API using #{deployment_option_phrased} the against 3scale Service Management API endpoints.
-                = important_icon_link "Get started with #{deployment_option_phrased}",
-                  'hdd-o', admin_service_integration_path(service), class: "outline-button next"
-              - when nil
-                p = t("deployment_options.missing")
-                = important_icon_link 'Pick a deployment option now',
-                  'hdd-o', admin_service_integration_path(service), class: "outline-button next"
-              - else
-                p Follow the instructions on the #{link_to( 'Integration page', admin_service_integration_path(service) )} to download and install the #{deployment_option_phrased} into your codebase.
-                = important_icon_link "Get started with the #{deployment_option_phrased}",
-                  'hdd-o',admin_service_integration_path(service), class: "outline-button next"
-
           - if service.deployment_option.present? && service.has_traffic?
             li.item
               ' Integrated through
-              strong => deployment_option_phrased
+              strong => t(service.deployment_option, scope: "deployment_options.phrased")
 
           li.item
             ' Authenticated by


### PR DESCRIPTION
This is part of the cleanup of APIAP. I noticed it causes a null pointer exception in preview due to proxy being `nil`, even when this element is going to be hidden because of the `is-hidden` class.

The element was previously rendered here:
![Screenshot 2021-05-10 at 17 26 54](https://user-images.githubusercontent.com/11672286/117684532-606ec080-b1b5-11eb-90d8-ce87bf5b5804.png)


[THREESCALE-7061: Remove permanently hidden elements from service overview](https://issues.redhat.com/browse/THREESCALE-7061)