### PR TITLE
Clean up APIAP traces in Integration Controller

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -36,7 +36,7 @@ class Api::IntegrationsController < Api::BaseController
       flash.now[:error] = flash_message(:update_error)
       @api_test_form_error = true
 
-      render_edit_or_show
+      render :show
     end
   end
 
@@ -109,7 +109,7 @@ class Api::IntegrationsController < Api::BaseController
     @proxy.reload
     @proxy.assign_attributes(proxy_params.except(:lock_version))
 
-    render_edit_or_show status: :conflict
+    render :show, status: :conflict
   end
 
   def flash_message(key, opts = {})
@@ -120,9 +120,9 @@ class Api::IntegrationsController < Api::BaseController
     if @proxy.update_attributes(proxy_params)
       update_mapping_rules_position
       flash[:notice] = flash_message(:proxy_pro_update_sucess)
-      redirect_to_edit_or_show
+      redirect_to :show
     else
-      render_edit_or_show
+      render :show
     end
   end
 
@@ -140,7 +140,7 @@ class Api::IntegrationsController < Api::BaseController
       @api_test_form_error = true
     end
 
-    render_edit_or_show
+    render :show
   end
 
   def find_proxy
@@ -226,15 +226,5 @@ class Api::IntegrationsController < Api::BaseController
 
   def toggle_land_path
     @proxy.apicast_configuration_driven ? admin_service_integration_path(@service) : edit_admin_service_integration_path(@service)
-  end
-
-  # TODO: THREESCALE-3759 remove this method
-  def render_edit_or_show(opts = {})
-    render :show, opts
-  end
-
-  # TODO: THREESCALE-3759 remove this method
-  def redirect_to_edit_or_show
-    redirect_to :show
   end
 end

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -109,8 +109,6 @@ class Api::IntegrationsController < Api::BaseController
     @proxy.reload
     @proxy.assign_attributes(proxy_params.except(:lock_version))
 
-    @last_message_bus_id = nil # don't want MessageBus showing flash message
-
     render_edit_or_show status: :conflict
   end
 
@@ -145,21 +143,8 @@ class Api::IntegrationsController < Api::BaseController
     render_edit_or_show
   end
 
-  # TODO: THREESCALE-3759 remove this method and related code
-  def edit_path
-    last_message_id = @last_message_bus_id
-
-    {
-      action: :edit,
-      last_id: last_message_id,
-      anchor: last_message_id ? 'second_nav' : 'proxy'
-    }.compact
-  end
-
   def find_proxy
     @proxy = @service.proxy
-
-    @last_message_bus_id = params.fetch(:last_id) { last_message_bus_id(@proxy) } if message_bus?(@proxy)
   end
 
   def last_message_bus_id(proxy)


### PR DESCRIPTION
Clean up old APIAP related methods from `IntegrationsController`.

[THREESCALE-7064: Clean up integration controller unused methods](https://issues.redhat.com/browse/THREESCALE-7064)