### PR TITLE
HOTFIX: Flow comment has to be in the first line

### DIFF
--- a/app/javascript/src/PaymentGateways/braintree/braintree.js
+++ b/app/javascript/src/PaymentGateways/braintree/braintree.js
@@ -1,5 +1,6 @@
-/* eslint-disable flowtype/no-weak-types */
 // @flow
+
+/* eslint-disable flowtype/no-weak-types */
 
 import type { BillingAddressData, HostedFieldsOptions } from 'PaymentGateways'
 

--- a/app/javascript/src/PaymentGateways/braintree/types.js
+++ b/app/javascript/src/PaymentGateways/braintree/types.js
@@ -1,5 +1,6 @@
-/* eslint-disable flowtype/no-weak-types */
 // @flow
+
+/* eslint-disable flowtype/no-weak-types */
 
 import type { Node } from 'react'
 


### PR DESCRIPTION
Explanation: we recently updated Flow to look up for this comment in the first line of each file only (#2436), any other file is ignored.

It's similar to what happened with the refactor JS utilities PR, every time something was merged into master failed because the import statements were not updated (for instance #2437). The tests won't fail until the branch is merged but there a also no conflicts.