### PR TITLE
Remove "create application" button in multitenant portal

### DIFF
--- a/app/views/api/applications/index.html.slim
+++ b/app/views/api/applications/index.html.slim
@@ -1,4 +1,4 @@
 h1 Applications
-= pf_button_in_title 'Create Application', new_admin_service_application_path(@service)
+= pf_button_in_title 'Create Application', new_admin_service_application_path(@service) unless current_account.master?
 
 = render 'shared/applications/listing'

--- a/app/views/buyers/applications/index.html.slim
+++ b/app/views/buyers/applications/index.html.slim
@@ -13,7 +13,7 @@ h1
     ' for
     = @account.name
 
-= pf_button_in_title 'Create Application', create_application_link_href(@account)
+= pf_button_in_title 'Create Application', create_application_link_href(@account) unless current_account.master?
 
 - if current_user.accessible_services.empty?
   = render 'shared/service_access'


### PR DESCRIPTION
Since the New Application form doesn't have server-side pagination, the page freezes due to the large amount of Accounts in Multitenant. We're hiding the buttons for now while we work on a more scalable solution.