### PR TITLE
Fix Typeahead select filter

### DIFF
--- a/app/javascript/src/Common/components/Select.jsx
+++ b/app/javascript/src/Common/components/Select.jsx
@@ -45,6 +45,19 @@ const Select = <T: Record>({
     onSelect(selected || null)
   }
 
+  const handleFilter = (e: SyntheticInputEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget
+    let filteredItems = items
+
+    if (value !== '') {
+      const term = new RegExp(value, 'i')
+      filteredItems = items.filter(i => term.test(i.name))
+    }
+
+    // $FlowIssue[prop-missing] className and disabled are optional
+    return filteredItems.map(toSelectOption)
+  }
+
   return (
     <FormGroup
       isRequired={isRequired}
@@ -65,6 +78,7 @@ const Select = <T: Record>({
         onClear={() => onSelect(null)}
         aria-labelledby={fieldId}
         isDisabled={isDisabled}
+        onFilter={handleFilter}
       >
         {/* $FlowIssue[prop-missing] className and disabled are optional */}
         {items.map(toSelectOption)}

--- a/app/javascript/src/Common/components/SelectWithModal.jsx
+++ b/app/javascript/src/Common/components/SelectWithModal.jsx
@@ -85,8 +85,8 @@ const SelectWithModal = <T: Record>({
 
   const options = getItems(items).map(toSelectOption)
 
-  const handleOnFilter = (e) => {
-    const { value } = e.target
+  const handleOnFilter = (e: SyntheticEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget
     const term = new RegExp(value, 'i')
 
     const filteredRecords: T[] = value !== '' ? items.filter(b => term.test(b.name)) : items

--- a/spec/javascripts/Common/components/Select.spec.jsx
+++ b/spec/javascripts/Common/components/Select.spec.jsx
@@ -47,6 +47,22 @@ it('should filter via typeahead', () => {
   wrapper.find('.pf-c-select__toggle-button').simulate('click')
   expect(wrapper.find('ul button').length).toEqual(items.length)
 
-  wrapper.find('.pf-c-select__toggle-typeahead').simulate('change', { target: { value: 'troll' } })
+  const input = wrapper.find('.pf-c-select__toggle-typeahead')
+  // $FlowIgnore[incompatible-type]
+  const inputElement: HTMLInputElement = input.getDOMNode()
+
+  inputElement.value = 'o'
+  input.update()
+  input.simulate('change')
+  expect(wrapper.find('ul button').length).toEqual(2)
+
+  inputElement.value = 'oll'
+  input.update()
+  input.simulate('change')
+  expect(wrapper.find('ul button').length).toEqual(1)
+
+  inputElement.value = 'TROLL'
+  input.update()
+  input.simulate('change')
   expect(wrapper.find('ul button').length).toEqual(1)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

The typeahead filter in our Select component does not work as it should. In order to fix it we need to define our own `onFilter` callback.

Before:
<img width="648" alt="Screenshot 2021-05-17 at 13 20 53" src="https://user-images.githubusercontent.com/11672286/118480752-f1dcb600-b712-11eb-85c2-cafdf7601f71.png">

Now:
<img width="648" alt="Screenshot 2021-05-17 at 13 20 23" src="https://user-images.githubusercontent.com/11672286/118480783-facd8780-b712-11eb-8bac-9fa556b21891.png">
