### PR TITLE
[cve] Update bundler to 2.2.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ attach-to-workspace: &attach-to-workspace
     at: .
 
 system-builder-ruby25: &system-builder-ruby25
-  image: quay.io/3scale/system-builder:ruby25
+  image: quay.io/3scale/system-builder:ruby25-bundler-2.2.18
   environment:
     BUNDLE_FROZEN: true
     BUNDLE_PATH: 'vendor/bundle'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1005,4 +1005,4 @@ DEPENDENCIES
   zip-zip
 
 BUNDLED WITH
-   1.17.3
+   2.2.18

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -46,7 +46,7 @@ ENV BASH_ENV=/opt/system/etc/scl_enable \
 
 RUN export ${BUNDLER_ENV} >/dev/null\
     && source /opt/system/etc/scl_enable \
-    && gem install bundler --version 1.17.3 \
+    && gem install bundler --version 2.2.18 \
     && bundle install --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
 
 RUN chgrp root /opt/system/


### PR DESCRIPTION
Closes CVE-2020-36327 https://issues.redhat.com/browse/THREESCALE-7085

Is required by https://github.com/3scale/deploy/pull/706