### PR TITLE
Fix OAS3 mapping error

### DIFF
--- a/app/lib/three_scale/open_api/url_resolver.rb
+++ b/app/lib/three_scale/open_api/url_resolver.rb
@@ -18,6 +18,8 @@ module ThreeScale
       end
 
       def self.resolve_servers_from_variables(server_url, variables = {})
+        variables.keys = {} if variables.keys.empty?
+        variables.values = {} if variables.values.empty?
         variable_names = variables.keys
         variable_values = variables.values.map { |variable| variable['enum'] || [variable['default']] }
         value_combinations = variable_values.reduce(&:product).map(&Array.method(:wrap)).map { |values| variable_names.zip(values).to_h }

--- a/app/lib/three_scale/open_api/url_resolver.rb
+++ b/app/lib/three_scale/open_api/url_resolver.rb
@@ -13,13 +13,11 @@ module ThreeScale
         @specification.fetch('servers', []).map do |server|
           url = server['url']
           variables = server['variables']
-          variables ? resolve_servers_from_variables(url, variables) : url
+          variables && !variables.empty? ? resolve_servers_from_variables(url, variables) : url
         end.flatten
       end
 
       def self.resolve_servers_from_variables(server_url, variables = {})
-        variables.keys = {} if variables.keys.empty?
-        variables.values = {} if variables.values.empty?
         variable_names = variables.keys
         variable_values = variables.values.map { |variable| variable['enum'] || [variable['default']] }
         value_combinations = variable_values.reduce(&:product).map(&Array.method(:wrap)).map { |values| variable_names.zip(values).to_h }

--- a/app/lib/three_scale/open_api/url_resolver.rb
+++ b/app/lib/three_scale/open_api/url_resolver.rb
@@ -13,7 +13,7 @@ module ThreeScale
         @specification.fetch('servers', []).map do |server|
           url = server['url']
           variables = server['variables']
-          variables && !variables.empty? ? resolve_servers_from_variables(url, variables) : url
+          variables.present? ? resolve_servers_from_variables(url, variables) : url
         end.flatten
       end
 

--- a/test/unit/three_scale/open_api/url_resolver_test.rb
+++ b/test/unit/three_scale/open_api/url_resolver_test.rb
@@ -39,6 +39,17 @@ class ThreeScale::OpenApi::UrlResolverTest < ActiveSupport::TestCase
     assert_equal ['https://api.example.com'], resolver.servers
   end
 
+  test 'url empty variable' do
+    specification = {
+      'servers' => [{
+        'url' => '{protocol}://api.example.com',
+        'variables' => {}
+      }]
+    }
+    resolver = UrlResolver.new(specification)
+    assert_equal ['https://api.example.com'], resolver.servers
+  end
+
   test 'url with enum variable' do
     specification = {
       'servers' => [{

--- a/test/unit/three_scale/open_api/url_resolver_test.rb
+++ b/test/unit/three_scale/open_api/url_resolver_test.rb
@@ -42,7 +42,7 @@ class ThreeScale::OpenApi::UrlResolverTest < ActiveSupport::TestCase
   test 'url empty variable' do
     specification = {
       'servers' => [{
-        'url' => '{protocol}://api.example.com',
+        'url' => 'https://api.example.com',
         'variables' => {}
       }]
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempting to import an OAS3 spec into 3scale with an empty variables declaration in one or more server blocks will fail

**Which issue(s) this PR fixes** 

fixes: https://issues.redhat.com/browse/THREESCALE-7109

**Verification steps** 

1.  upload an example OAS spec with an unpopulated variables declaration

**Special notes for your reviewer**:
