### PR TITLE
"Update Product" button, using button instead of input

### DIFF
--- a/app/views/api/services/settings_apiap.html.slim
+++ b/app/views/api/services/settings_apiap.html.slim
@@ -3,4 +3,4 @@
 = semantic_form_for @service, :url => admin_service_path(@service) do |form|
   = render :partial => 'api/services/forms/integration_settings_apiap', :locals => {:form => form}
   = form.buttons do
-    = form.commit_button "Update Product", button_html: { name: 'update_settings', class: 'pf-c-button pf-m-primary' }
+    = form.button "Update Product", button_html: { name: 'update_settings', class: 'pf-c-button pf-m-primary' }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

**Update Product** buttons at `apiconfig/services/{service_id}/edit` and  `/apiconfig/services/{service_id}/settings` have different formats.
Using same format (button instead of input)

**Which issue(s) this PR fixes** 

Follow-up of https://issues.redhat.com/browse/THREESCALE-6719
Requested by QE
