### PR TITLE
[feature] K8s management tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'dotenv-rails', '~> 2.7'
 gem 'rails', '~> 5.0.7'
 
 # Needed for XML serialization of ActiveRecord::Base
+gem "activejob-uniqueness", "~> 0.2.0"
 gem 'activemodel-serializers-xml'
 
 gem 'protected_attributes_continued', '~> 1.3.0'
@@ -244,6 +245,7 @@ group :test do
 
   # performance tests
   gem 'ruby-prof'
+  gem 'with_env'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,9 @@ GEM
     activejob (5.0.7.2)
       activesupport (= 5.0.7.2)
       globalid (>= 0.3.6)
+    activejob-uniqueness (0.2.0)
+      activejob (>= 4.2, < 7)
+      redlock (>= 1.2, < 2)
     activemerchant (1.107.4)
       activesupport (>= 4.2)
       builder (>= 2.1.2, < 4.0.0)
@@ -569,6 +572,8 @@ GEM
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
     redis-prescription (1.0.0)
+    redlock (1.2.1)
+      redis (>= 3.0.0, < 5.0)
     reform (2.0.5)
       disposable (~> 0.1.11)
       uber (~> 0.0.11)
@@ -824,6 +829,7 @@ DEPENDENCIES
   3scale_time_range (= 0.0.6)
   RedCloth (~> 4.3)
   active-docs!
+  activejob-uniqueness (~> 0.2.0)
   activemerchant (~> 1.107.4)
   activemodel-serializers-xml
   activerecord-oracle_enhanced-adapter (~> 1.7.0)
@@ -981,6 +987,7 @@ DEPENDENCIES
   webpacker (~> 4)
   whenever (~> 0.9.7)
   will_paginate (~> 3.1.6)
+  with_env
   xpath (~> 2.1)
   yabeda-prometheus-mmap
   yabeda-rails

--- a/app/workers/create_default_proxy_worker.rb
+++ b/app/workers/create_default_proxy_worker.rb
@@ -12,6 +12,7 @@ class CreateDefaultProxyWorker < ApplicationJob
   end
 
   class BatchEnqueueWorker < ApplicationJob
+    unique :until_executed
 
     # :reek:UtilityFunction
     def perform(*)

--- a/app/workers/restore_apicast_master_token_worker.rb
+++ b/app/workers/restore_apicast_master_token_worker.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This will only perform in the context of k8s or OpenShift
+# It sets the value of the access token from an environment variable
+class RestoreApicastMasterTokenWorker < ApplicationJob
+  unique :until_executed
+
+
+  def perform(*)
+    if ENV['APICAST_ACCESS_TOKEN'].blank?
+      Rails.logger.info 'Cannot execute this job without an access token'
+      return
+    end
+
+    token_name = ENV.fetch('APICAST_TOKEN_NAME', 'APIcast mapping-service')
+    token = ENV.fetch('APICAST_ACCESS_TOKEN')
+    master = Account.master
+    access_token = master.access_tokens.find_by!(name: token_name)
+    # Need to do that because `:value` is a readonly attribute
+    AccessToken.where(id: access_token.id).limit(1).update_all(value: token) # rubocop:disable Rails/SkipsModelValidations
+  end
+end

--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -1,40 +1,44 @@
 # frozen_string_literal: true
 
-ActiveJob::Uniqueness.configure do |config|
-  # Global default expiration for lock keys. Each job can define its own ttl via :lock_ttl option.
-  # Stategy :until_and_while_executing also accept :on_runtime_ttl option.
-  #
-  # config.lock_ttl = 1.day
+Rails.application.configure do
+  config.after_initialize do
+    ActiveJob::Uniqueness.configure do |config|
+      # Global default expiration for lock keys. Each job can define its own ttl via :lock_ttl option.
+      # Stategy :until_and_while_executing also accept :on_runtime_ttl option.
+      #
+      # config.lock_ttl = 1.day
 
-  # Prefix for lock keys. Can not be set per job.
-  #
-  # config.lock_prefix = 'activejob_uniqueness'
+      # Prefix for lock keys. Can not be set per job.
+      #
+      # config.lock_prefix = 'activejob_uniqueness'
 
-  # Default action on lock conflict. Can be set per job.
-  # Stategy :until_and_while_executing also accept :on_runtime_conflict option.
-  # Allowed values are
-  #   :raise - raises ActiveJob::Uniqueness::JobNotUnique
-  #   :log - instruments ActiveSupport::Notifications and logs event to the ActiveJob::Logger
-  #   proc - custom Proc. For example, ->(job) { job.logger.info('Oops') }
-  #
-  config.on_conflict = ->(job) { job.logger.info "Another job is already scheduled for: #{job.class} #{job.arguments}" }
+      # Default action on lock conflict. Can be set per job.
+      # Stategy :until_and_while_executing also accept :on_runtime_conflict option.
+      # Allowed values are
+      #   :raise - raises ActiveJob::Uniqueness::JobNotUnique
+      #   :log - instruments ActiveSupport::Notifications and logs event to the ActiveJob::Logger
+      #   proc - custom Proc. For example, ->(job) { job.logger.info('Oops') }
+      #
+      config.on_conflict = ->(job) { job.logger.info "Another job is already scheduled for: #{job.class} #{job.arguments}" }
 
-  # Digest method for lock keys generating. Expected to have `hexdigest` class method.
-  #
-  # config.digest_method = OpenSSL::Digest::MD5
+      # Digest method for lock keys generating. Expected to have `hexdigest` class method.
+      #
+      # config.digest_method = OpenSSL::Digest::MD5
 
-  # Array of redis servers for Redlock quorum.
-  # Read more at https://github.com/leandromoreira/redlock-rb#redis-client-configuration
-  #
-  config.redlock_servers = [System.redis]
+      # Array of redis servers for Redlock quorum.
+      # Read more at https://github.com/leandromoreira/redlock-rb#redis-client-configuration
+      #
+      config.redlock_servers = [System.redis]
 
-  # Custom options for Redlock.
-  # Read more at https://github.com/leandromoreira/redlock-rb#redlock-configuration
-  #
-  # config.redlock_options = { retry_count: 0 }
+      # Custom options for Redlock.
+      # Read more at https://github.com/leandromoreira/redlock-rb#redlock-configuration
+      #
+      # config.redlock_options = { retry_count: 0 }
 
-  # Custom strategies.
-  # config.lock_strategies = { my_strategy: MyStrategy }
-  #
-  # config.lock_strategies = {}
+      # Custom strategies.
+      # config.lock_strategies = { my_strategy: MyStrategy }
+      #
+      # config.lock_strategies = {}
+    end
+  end
 end

--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+ActiveJob::Uniqueness.configure do |config|
+  # Global default expiration for lock keys. Each job can define its own ttl via :lock_ttl option.
+  # Stategy :until_and_while_executing also accept :on_runtime_ttl option.
+  #
+  # config.lock_ttl = 1.day
+
+  # Prefix for lock keys. Can not be set per job.
+  #
+  # config.lock_prefix = 'activejob_uniqueness'
+
+  # Default action on lock conflict. Can be set per job.
+  # Stategy :until_and_while_executing also accept :on_runtime_conflict option.
+  # Allowed values are
+  #   :raise - raises ActiveJob::Uniqueness::JobNotUnique
+  #   :log - instruments ActiveSupport::Notifications and logs event to the ActiveJob::Logger
+  #   proc - custom Proc. For example, ->(job) { job.logger.info('Oops') }
+  #
+  config.on_conflict = ->(job) { job.logger.info "Another job is already scheduled for: #{job.class} #{job.arguments}" }
+
+  # Digest method for lock keys generating. Expected to have `hexdigest` class method.
+  #
+  # config.digest_method = OpenSSL::Digest::MD5
+
+  # Array of redis servers for Redlock quorum.
+  # Read more at https://github.com/leandromoreira/redlock-rb#redis-client-configuration
+  #
+  config.redlock_servers = [System.redis]
+
+  # Custom options for Redlock.
+  # Read more at https://github.com/leandromoreira/redlock-rb#redlock-configuration
+  #
+  # config.redlock_options = { retry_count: 0 }
+
+  # Custom strategies.
+  # config.lock_strategies = { my_strategy: MyStrategy }
+  #
+  # config.lock_strategies = {}
+end

--- a/lib/tasks/access_tokens.rake
+++ b/lib/tasks/access_tokens.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :access_tokens do
+  desc 'Enqueues a job to restore APIcast master access token from the environment'
+  task :restore_master_apicast => :environment do
+    RestoreApicastMasterTokenWorker.perform_later
+  end
+end

--- a/lib/tasks/k8s.rake
+++ b/lib/tasks/k8s.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :k8s do
+  desc <<-DESC
+  Restore missing objects:
+   - create default proxies
+   - TODO: Restore Master APIcast access token from the environment variables
+  DESC
+  task :deploy => %w[services:create_default_proxy access_tokens:restore_master_apicast]
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,3 +75,5 @@ Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |file| require file }
 
 include TestHelpers::XmlAssertions
 include TestHelpers::SectionsPermissions
+
+ActiveJob::Uniqueness.test_mode!

--- a/test/unit/tasks/access_tokens_task_test.rb
+++ b/test/unit/tasks/access_tokens_task_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AccessTokensTaskTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  def test_update_apicast_master_token
+    assert_enqueued_jobs 1, only: RestoreApicastMasterTokenWorker do
+      execute_rake_task 'access_tokens.rake', 'access_tokens:restore_master_apicast'
+    end
+  end
+end

--- a/test/workers/restore_apicast_master_access_token_worker_test.rb
+++ b/test/workers/restore_apicast_master_access_token_worker_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RestoreApicastMasterTokenWorkerTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+  include WithEnv
+
+  def test_update_apicast_master_token
+    FactoryBot.create_list(:access_token, 2)
+    apicast_token_name = 'APIcast master token'
+    master_token = FactoryBot.create(:access_token, name: apicast_token_name, owner: master_account.first_admin!)
+    random_token = SecureRandom.hex
+
+    with_env 'APICAST_ACCESS_TOKEN' => random_token, 'APICAST_TOKEN_NAME' => apicast_token_name do
+      RestoreApicastMasterTokenWorker.new.perform
+    end
+
+    master_token.reload
+    assert_equal random_token, master_token.value
+  end
+end


### PR DESCRIPTION
In K8s context, pods are deployed and we spin off some management tasks like:

- Create a default proxy for services that do not have one
- Restore the Master APIcast access token to the one set in pod environment

We need to make those tasks reboot proof thus introducing activejob unique jobs