### PR TITLE
[fix] Ignore error reporting on misused liquid macro `do_not_send`

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -12,4 +12,8 @@ Bugsnag.configure do |config|
   config.ignore_classes << ->(error) do
     ignore_error_names.include?(error.class.name)
   end
+
+  config.ignore_classes << ->(error) do
+    error.is_a?(Liquid::SyntaxError) && error.message.include?("Unknown tag 'do_not_send'")
+  end
 end


### PR DESCRIPTION
The do_not_send macro is ugly and misuse of it happens a lot
This macro documented in https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.5/html/liquid_reference/liquid-reference#tag-email
should discard an email. The API Provider thinks it is working but in fact it is generating an error because of the liquid syntax error, which prevents the email to be sent.

The proper way to do it would be:

- add a checkbox to each customizable email to opt-out if you do not want to send an email
- validate and parse all emails that have this `do_not_send` macro and set this new setting to false