### PR TITLE
configurable user session TTL

### DIFF
--- a/app/errors/application_configuration_error.rb
+++ b/app/errors/application_configuration_error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationConfigurationError <  StandardError
+end

--- a/app/lib/authentication/by_cookie_token.rb
+++ b/app/lib/authentication/by_cookie_token.rb
@@ -25,7 +25,7 @@ module Authentication
 
       # These create and unset the fields required for remembering users between browser closes
       def remember_me
-        remember_me_for 2.weeks
+        remember_me_for UserSession::TTL
       end
 
       def remember_me_for(time)

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,7 +1,5 @@
 class UserSession < ApplicationRecord
 
-  TTL = 2.weeks.freeze
-
   belongs_to :user
   belongs_to :sso_authorization, required: false
   has_one :account, through: :user
@@ -60,4 +58,18 @@ class UserSession < ApplicationRecord
     def set_unique_key
       self.key = SecureRandom.urlsafe_base64(32)
     end
+
+  class << self
+    def ttl_value(duration)
+
+      return 2.weeks if duration.blank?
+
+      ActiveSupport::Duration.seconds(Integer(duration))
+    rescue ArgumentError
+      raise ApplicationConfigurationError, "user session TTL should be specified as a number of seconds"
+    end
+  end
+
+  TTL = ttl_value(Rails.configuration.three_scale.user_session_ttl).freeze
+
 end

--- a/config/docker/settings.yml
+++ b/config/docker/settings.yml
@@ -14,6 +14,7 @@ base: &default
   events_shared_secret: <%= ENV['EVENTS_SHARED_SECRET'] %>
   recaptcha_public_key: <%= ENV.fetch('RECAPTCHA_PUBLIC_KEY', 'YOUR_RECAPTCHA_PUBLIC_KEY') %>
   recaptcha_private_key: <%= ENV['RECAPTCHA_PRIVATE_KEY'] %>
+  user_session_ttl: <%= ENV.fetch('USER_SESSION_TTL', 2.weeks) %>
   impersonation_admin:
     username: <%= ENV.fetch('IMPERSONATION_ADMIN_USERNAME', '3scaleadmin') %>
     domain: <%= ENV.fetch('IMPERSONATION_ADMIN_DOMAIN', '3scale.net') %>

--- a/config/examples/settings.yml
+++ b/config/examples/settings.yml
@@ -14,6 +14,7 @@ base: &default
   events_shared_secret: <%= ENV['EVENTS_SHARED_SECRET'] %>
   recaptcha_public_key: <%= ENV.fetch('RECAPTCHA_PUBLIC_KEY', 'YOUR_RECAPTCHA_PUBLIC_KEY') %>
   recaptcha_private_key: <%= ENV['RECAPTCHA_PRIVATE_KEY'] %>
+  user_session_ttl: <%= ENV.fetch('USER_SESSION_TTL', 2.weeks) %>
   impersonation_admin:
     username: <%= ENV.fetch('IMPERSONATION_ADMIN_USERNAME', '3scaleadmin') %>
     domain: <%= ENV.fetch('IMPERSONATION_ADMIN_DOMAIN', '3scale.net') %>

--- a/openshift/system/config/settings.yml
+++ b/openshift/system/config/settings.yml
@@ -14,6 +14,7 @@ base: &default
   onpremises: true
   recaptcha_public_key: <%= ENV.fetch('RECAPTCHA_PUBLIC_KEY', 'YOUR_RECAPTCHA_PUBLIC_KEY') %>
   recaptcha_private_key: <%= ENV['RECAPTCHA_PRIVATE_KEY'] %>
+  user_session_ttl: <%= ENV.fetch('USER_SESSION_TTL', 2.weeks) %>
 
   # System Emails
   noreply_email: <%= ENV.fetch('NOREPLY_EMAIL', "no-reply@#{superdomain}") %>

--- a/test/unit/user_session_test.rb
+++ b/test/unit/user_session_test.rb
@@ -72,4 +72,15 @@ class UserSessionTest < ActiveSupport::TestCase
     assert_includes stale, session2
     refute_includes stale, session3
   end
+
+  test 'parse session ttl settings value' do
+    assert_kind_of ActiveSupport::Duration, UserSession::TTL
+    assert UserSession::TTL.frozen?
+
+    assert_equal 2.weeks, UserSession.send(:ttl_value, nil)
+    assert_equal 2.weeks, UserSession.send(:ttl_value, "")
+    assert_equal 1.week, UserSession.send(:ttl_value, 1.week.seconds.to_i)
+    assert_equal 3.weeks, UserSession.send(:ttl_value, 3.weeks.seconds.to_s)
+    assert_raise(ApplicationConfigurationError) { UserSession.send(:ttl_value, "123p") }
+  end
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Add support to configure user session time to live [THREESCALE-693](https://issues.redhat.com/browse/THREESCALE-693)

**Which issue(s) this PR fixes** 

fixes THREESCALE-693

**Verification steps** 

1. set `user_sesion_ttl` in `settings.yml` to something small, like 1 minute `PT1M`
2. run porta 
3. open some porta provider console
4. login
5. check that you can navigate between pages
6. wait without activity for more than 1 minute
7. try to navigate to another page
8. you should be asked to login again

**Special notes for your reviewer**:

I couldn't figure out what other tests I can add. Existing tests already vefiry default TTL of 2 weeks

Still under investigation what needs to be added to OpenShift operator. In any case it should work as before OOB so operator changes can be applied any time after this is merged.

Another question is where should we document this?