### PR TITLE
Update NewApplicationForm (flow & small refactor)

### DIFF
--- a/app/javascript/packs/new_application.js
+++ b/app/javascript/packs/new_application.js
@@ -1,8 +1,10 @@
 // @flow
 
-// $FlowIgnore[missing-export] it is exported but name-mapper is failing
 import { NewApplicationFormWrapper } from 'NewApplication'
 import { safeFromJsonString } from 'utilities'
+
+import type { Buyer, Product } from 'NewApplication/types'
+import type { FieldDefinition } from 'Types'
 
 document.addEventListener('DOMContentLoaded', () => {
   const containerId = 'new-application-form'
@@ -15,12 +17,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const { dataset } = container
 
   const { createServicePlanPath, createApplicationPath, createApplicationPlanPath, serviceSubscriptionsPath } = dataset
-  const product = safeFromJsonString(dataset.product)
-  const products = safeFromJsonString(dataset.products)
-  const servicePlansAllowed = safeFromJsonString(dataset.servicePlansAllowed)
-  const buyer = safeFromJsonString(dataset.buyer)
-  const buyers = safeFromJsonString(dataset.buyers)
-  const definedFields = safeFromJsonString(dataset.definedFields)
+  const product = safeFromJsonString<Product>(dataset.product)
+  const products = safeFromJsonString<Product[]>(dataset.products)
+  const servicePlansAllowed = safeFromJsonString<boolean>(dataset.servicePlansAllowed)
+  const buyer = safeFromJsonString<Buyer>(dataset.buyer)
+  const buyers = safeFromJsonString<Buyer[]>(dataset.buyers)
+  const definedFields = safeFromJsonString<FieldDefinition[]>(dataset.definedFields)
   const validationErrors = safeFromJsonString(dataset.errors) || {}
   const error: string | void = validationErrors.hasOwnProperty('base') ? validationErrors.base[0] : undefined
 

--- a/app/javascript/src/NewApplication/components/NewApplicationForm.jsx
+++ b/app/javascript/src/NewApplication/components/NewApplicationForm.jsx
@@ -16,7 +16,7 @@ import {
   ServicePlanSelect
 } from 'NewApplication'
 import { UserDefinedField } from 'Common'
-import { CSRFToken } from 'utilities'
+import { createReactWrapper, CSRFToken } from 'utilities'
 import * as flash from 'utilities/alert'
 
 import type { Buyer, Product, ServicePlan, ApplicationPlan } from 'NewApplication/types'
@@ -31,7 +31,7 @@ type Props = {
   serviceSubscriptionsPath: string,
   product?: Product,
   products?: Product[],
-  servicePlansAllowed: boolean,
+  servicePlansAllowed?: boolean,
   buyer?: Buyer,
   buyers?: Buyer[],
   definedFields?: FieldDefinition[],
@@ -46,7 +46,7 @@ const NewApplicationForm = ({
   createApplicationPlanPath,
   createServicePlanPath,
   serviceSubscriptionsPath,
-  servicePlansAllowed,
+  servicePlansAllowed = false,
   product: defaultProduct,
   products,
   definedFields,
@@ -187,4 +187,6 @@ const NewApplicationForm = ({
   )
 }
 
-export { NewApplicationForm }
+const NewApplicationFormWrapper = (props: Props, containerId: string): void => createReactWrapper(<NewApplicationForm {...props} />, containerId)
+
+export { NewApplicationForm, NewApplicationFormWrapper }

--- a/app/javascript/src/NewApplication/components/NewApplicationFormWrapper.jsx
+++ b/app/javascript/src/NewApplication/components/NewApplicationFormWrapper.jsx
@@ -1,8 +1,0 @@
-import React from 'react'
-
-import { NewApplicationForm } from 'NewApplication'
-import { createReactWrapper } from 'utilities'
-
-const NewApplicationFormWrapper = (props, containerId) => createReactWrapper(<NewApplicationForm {...props} />, containerId)
-
-export { NewApplicationFormWrapper }

--- a/app/javascript/src/NewApplication/index.js
+++ b/app/javascript/src/NewApplication/index.js
@@ -4,7 +4,4 @@ export * from './components/BuyerSelect'
 export * from './components/ServicePlanSelect'
 export * from './components/ProductSelect'
 export * from './components/ApplicationPlanSelect'
-// $FlowIgnore[cannot-resolve-module] failing because file name contains module's name NewApplication
 export * from './components/NewApplicationForm'
-// $FlowIgnore[cannot-resolve-module] failing because file name contains module's name NewApplication
-export * from './components/NewApplicationFormWrapper'


### PR DESCRIPTION
- Adds more types
- Removes Flow suppression comments
- Move react wrapper into NewApplicationForm
- Makes `servicePlansAllowed` optional with default to `false`.