### PR TITLE
[gem] Use 3scale/activejob-uniqueness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'dotenv-rails', '~> 2.7'
 gem 'rails', '~> 5.0.7'
 
 # Needed for XML serialization of ActiveRecord::Base
-gem "activejob-uniqueness", "~> 0.2.0"
+gem "activejob-uniqueness", github: "3scale/activejob-uniqueness", branch: "main"
 gem 'activemodel-serializers-xml'
 
 gem 'protected_attributes_continued', '~> 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/3scale/activejob-uniqueness.git
+  revision: fc560d1ab5552dc3a1602d4aaa7caaa8eba5791f
+  branch: main
+  specs:
+    activejob-uniqueness (0.2.0)
+      activejob (>= 4.2, < 7)
+      redlock (>= 1.2, < 2)
+
+GIT
   remote: https://github.com/3scale/ci_reporter_shell.git
   revision: 30b30d655512891f56463e5f1fa125ea1f2df886
   specs:
@@ -127,9 +136,6 @@ GEM
     activejob (5.0.7.2)
       activesupport (= 5.0.7.2)
       globalid (>= 0.3.6)
-    activejob-uniqueness (0.2.0)
-      activejob (>= 4.2, < 7)
-      redlock (>= 1.2, < 2)
     activemerchant (1.107.4)
       activesupport (>= 4.2)
       builder (>= 2.1.2, < 4.0.0)
@@ -249,7 +255,7 @@ GEM
       compass (~> 1.0.0)
       sass-rails (< 5.1)
       sprockets (< 4.0)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
     crack (0.4.5)
       rexml
@@ -769,7 +775,7 @@ GEM
     ts-datetime-delta (2.0.2)
       thinking-sphinx (>= 1.3.8)
     ttfunk (1.5.1)
-    tzinfo (1.2.7)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uber (0.0.15)
     uglifier (4.1.19)
@@ -829,7 +835,7 @@ DEPENDENCIES
   3scale_time_range (= 0.0.6)
   RedCloth (~> 4.3)
   active-docs!
-  activejob-uniqueness (~> 0.2.0)
+  activejob-uniqueness!
   activemerchant (~> 1.107.4)
   activemodel-serializers-xml
   activerecord-oracle_enhanced-adapter (~> 1.7.0)


### PR DESCRIPTION
For Ruby 2.4 support, as some older deployments still uses this EOL Ruby