### PR TITLE
Nightly build push to quay.io

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,28 @@
+name: Nightly build
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Login to Quay.pio
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER_NAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: openshift/system
+          push: true
+          tags: quay.io/3scale/porta:nightly


### PR DESCRIPTION
Use Github actions to build and push the nightly to quay.io

I need to merge this first then I can use the workflow to refine it.
See https://github.community/t/workflow-files-only-picked-up-from-master/16129/16