### PR TITLE
Latest container build should use quay.io registry

### DIFF
--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/ruby-25-centos7
+FROM quay.io/centos7/ruby-25-centos7
 
 USER root
 


### PR DESCRIPTION
Otherwise we will be limited by docker rate limits

```
Could not pull base image: API error (500): toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```