### PR TITLE
[circleci] Try Mysql 8 latest in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ system-builder-ruby25: &system-builder-ruby25
     RAILS_ENV: test
 
 mysql-container: &mysql-container
-  image: circleci/mysql:5.7-ram
+  image: circleci/mysql:8-ram
   environment:
     MYSQL_ALLOW_EMPTY_PASSWORD: yes
     MYSQL_ROOT_PASSWORD: ''

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,8 @@ system-builder-ruby25: &system-builder-ruby25
 
 mysql-container: &mysql-container
   image: circleci/mysql:8-ram
+  command:
+    - --default-authentication-plugin=mysql_native_password
   environment:
     MYSQL_ALLOW_EMPTY_PASSWORD: yes
     MYSQL_ROOT_PASSWORD: ''

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/3scale/system-builder:ruby25-oracle
+FROM quay.io/3scale/system-builder:ruby25-mysql80
 
 ARG CUSTOM_DB=mysql
 

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -21,9 +21,10 @@ RUN yum-config-manager --save --setopt=cbs.centos.org_repos_sclo7-rh-ruby25-rh-c
               ImageMagick \
               ImageMagick-devel \
               unixODBC-devel \
-              mysql \
               file \
               rh-nodejs10 \
+              rh-mysql80-mysql-devel \
+              rh-mysql80-mysql \
     && rpm -i /tmp/sphinxsearch.rpm \
     && rm /tmp/*.rpm \
     && yum install -y epel-release \

--- a/openshift/system/contrib/scl_enable
+++ b/openshift/system/contrib/scl_enable
@@ -1,4 +1,5 @@
 # This file contains automatic SCL enablement.
 unset BASH_ENV PROMPT_COMMAND ENV
 source scl_source enable rh-ruby25
+source scl_source enable rh-mysql80
 source scl_source enable $NODEJS_SCL


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/THREESCALE-6825


- [The caching_sha2_password is incompatible with RHEL 7](https://access.redhat.com/documentation/en-us/red_hat_software_collections/3/html/3.2_release_notes/chap-migration#sect-Migration-MySQL-Changes). We need to set `--default-authentication-plugin=mysql_native_password` on the server

> The MySQL 8.0 server provided by the rh-mysql80 Software Collection is configured to use mysql_native_password as the default authentication plug-in because client tools and libraries in Red Hat Enterprise Linux 7 are incompatible with the caching_sha2_password method, which is used by default in the upstream MySQL 8.0 version.
