### PR TITLE
Fixed the title mismatch on the product page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
                     scope: [:controller, :action, name],
                     default: action.humanize)
 
-    "#{controller_name} - #{action_name}"
+    "#{controller_name == "Services" ? "Products" : controller_name} - #{action_name}"
   end
 
   def link_to_unless_current_styled(text, url, options = {})


### PR DESCRIPTION
Signed-off-by: Srijita Mukherjee <srmukher@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

> This PR updates the page title from Services to Products for the Products page.

**Which issue(s) this PR fixes** 

> https://issues.redhat.com/browse/THREESCALE-7123


**Verification steps** 

> On visiting the Products page, the html title shows Products instead of Services.


**Special notes for your reviewer**:
> IMO, there are 2 ways to solve this. 

> 1. Just update the services to products in the page title. This is what is done in this PR.
> 2. To convert all service controllers to product, which might cause more regressions. 