### PR TITLE
[cron] Recreate service default proxy if missing

### DIFF
--- a/config/jobs.rb
+++ b/config/jobs.rb
@@ -35,6 +35,7 @@ module ThreeScale
       Pdf::Dispatch.daily
       DeleteProvidedAccessTokensWorker.perform_async
       DestroyAllDeletedObjectsWorker.perform_later(Service.to_s)
+      CreateDefaultProxyWorker::BatchEnqueueWorker.perform_later
     ].freeze
 
     BILLING = %w[


### PR DESCRIPTION
Launch a cron job everyday that creates missing proxy for a Service

Proxy is one of the objects that 3scale Porta requires to run normally.
If it does not exist then a big chunk of the functionalities will not work:

- Anything related to Product UI/API/background jobs
- APIcast configuration

This task was created in https://github.com/3scale/porta/pull/2431
We should use it regularly to fix our db