### PR TITLE
Fix New Application Form 🐛 

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,4 +17,4 @@ experimental.const_params=true
 max_header_tokens=1
 module.name_mapper='.*\(.s?css\)' -> 'empty/object'
 module.system=haste
-module.name_mapper='^\(ActiveDocs\|Applications\|BackendApis\|ChangePassword\|Common\|Settings\|Dashboard\|LoginPage\|MappingRules\|Navigation\|NewApplication\|Onboarding\|PaymentGateways\|Plans\|Policies\|Products\|services\|Stats\|Types\|Users\|utilities\|NewService\)\(.*\)$' -> '<PROJECT_ROOT>/app/javascript/src/\1/\2'
+module.name_mapper='^\(ActiveDocs\|Applications\|BackendApis\|ChangePassword\|Common\|Settings\|Dashboard\|Logic\|LoginPage\|MappingRules\|Navigation\|NewApplication\|Onboarding\|PaymentGateways\|Plans\|Policies\|Products\|services\|Stats\|Types\|Users\|utilities\|NewService\)\(.*\)$' -> '<PROJECT_ROOT>/app/javascript/src/\1/\2'

--- a/app/javascript/src/Logic/BuyerLogic.js
+++ b/app/javascript/src/Logic/BuyerLogic.js
@@ -1,0 +1,18 @@
+// @flow
+
+import type { Buyer, Product, ServicePlan } from 'NewApplication/types'
+
+class BuyerLogic {
+  buyer: Buyer
+
+  constructor (buyer: Buyer) {
+    this.buyer = buyer
+  }
+
+  getContractedServicePlan (product: Product): ServicePlan | null {
+    const contract = this.buyer.contractedProducts.find(p => String(p.id) === product.id)
+    return (contract && contract.withPlan) || (product && product.defaultServicePlan) || null
+  }
+}
+
+export { BuyerLogic }

--- a/app/javascript/src/Logic/index.js
+++ b/app/javascript/src/Logic/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export * from './BuyerLogic'

--- a/app/javascript/src/NewApplication/components/NewApplicationForm.jsx
+++ b/app/javascript/src/NewApplication/components/NewApplicationForm.jsx
@@ -16,6 +16,7 @@ import {
   ServicePlanSelect
 } from 'NewApplication'
 import { UserDefinedField } from 'Common'
+import { BuyerLogic } from 'Logic'
 import { createReactWrapper, CSRFToken } from 'utilities'
 import * as flash from 'utilities/alert'
 
@@ -105,8 +106,7 @@ const NewApplicationForm = ({
 
   const url = buyer ? createApplicationPath.replace(':id', buyer.id) : createApplicationPath
 
-  const contract = (buyer && product && buyer.contractedProducts.find(p => p.id === product.id)) || null
-  const contractedServicePlan: ServicePlan | null = (contract && contract.withPlan) || (product && product.defaultServicePlan)
+  const contractedServicePlan = (buyer && product) ? new BuyerLogic(buyer).getContractedServicePlan(product) : null
 
   if (error) {
     flash.error(error)
@@ -142,7 +142,7 @@ const NewApplicationForm = ({
 
         {servicePlansAllowed && (
           <ServicePlanSelect
-            servicePlan={servicePlan}
+            servicePlan={contractedServicePlan || servicePlan}
             servicePlans={product ? product.servicePlans : []}
             onSelect={setServicePlan}
             showHint={product !== null && buyer !== null}

--- a/app/javascript/src/NewApplication/components/NewApplicationForm.jsx
+++ b/app/javascript/src/NewApplication/components/NewApplicationForm.jsx
@@ -69,16 +69,6 @@ const NewApplicationForm = ({
     setDefinedFieldsState(state => ({ ...state, [id]: value }))
   }
 
-  const buyerValid = buyer && (buyer.id !== undefined || buyer !== null)
-  const servicePlanValid = !servicePlansAllowed || servicePlan !== null
-  const definedFieldsValid = definedFields === undefined || definedFields.every(f => !f.required || definedFieldsState[f.id] !== '')
-  const isFormComplete = buyer !== null &&
-    product !== null &&
-    servicePlanValid &&
-    appPlan !== null &&
-    buyerValid &&
-    definedFieldsValid
-
   const resetServicePlan = () => {
     let plan = null
 
@@ -107,6 +97,16 @@ const NewApplicationForm = ({
   const url = buyer ? createApplicationPath.replace(':id', buyer.id) : createApplicationPath
 
   const contractedServicePlan = (buyer && product) ? new BuyerLogic(buyer).getContractedServicePlan(product) : null
+
+  const buyerValid = buyer && (buyer.id !== undefined || buyer !== null)
+  const servicePlanValid = !servicePlansAllowed || servicePlan !== null || contractedServicePlan !== null
+  const definedFieldsValid = definedFields === undefined || definedFields.every(f => !f.required || definedFieldsState[f.id] !== '')
+  const isFormComplete = buyer !== null &&
+    product !== null &&
+    servicePlanValid &&
+    appPlan !== null &&
+    buyerValid &&
+    definedFieldsValid
 
   if (error) {
     flash.error(error)

--- a/features/old/applications/providers/create_application.feature
+++ b/features/old/applications/providers/create_application.feature
@@ -23,7 +23,6 @@
        And I go to the account context create application page for "bob"
      Then I should see "New Application"
       And I select "API" from "Product"
-      And I select "Default" from "Service plan"
       But the application plans select should not contain custom plans of provider "foo.3scale.localhost"
       And I select "Basic" from "Application plan"
       And I fill in "Name" with "UltimateWidget"
@@ -42,7 +41,6 @@
        And I go to the account context create application page for "bob"
      Then I should see "New Application"
       And I select "API" from "Product"
-      And I select "Default" from "Service plan"
       But the application plans select should not contain custom plans of provider "foo.3scale.localhost"
       And I select "Basic" from "Application plan"
       And I fill in "Name" with "UltimateWidget"
@@ -58,7 +56,6 @@
       And I go to the product context create application page for "API"
       Then I should see "New Application"
       And I select "bob" from "Account"
-      And I select "Default" from "Service plan"
       But the application plans select should not contain custom plans of provider "foo.3scale.localhost"
       And I select "Basic" from "Application plan"
       And I fill in "Name" with "UltimateWidget"
@@ -75,7 +72,6 @@
       Then I should see "New Application"
       And I select "bob" from "Account"
       And I select "API" from "Product"
-      And I select "Default" from "Service plan"
       But the application plans select should not contain custom plans of provider "foo.3scale.localhost"
       And I select "Basic" from "Application plan"
       And I fill in "Name" with "UltimateWidget"
@@ -133,7 +129,6 @@
       And I fill in "Womm" with "12/10"
       And I select "API" from "Product"
       And I select "Basic" from "Application plan"
-      And I select "Default" from "Service plan"
       And I press "Create Application"
      Then I should be on the provider side "UltimateWidget" application page
       And should see "Application was successfully created"
@@ -149,8 +144,6 @@
       And I should see button "Create Application" disabled
      Then I select "API" from "Product"
       And I should see button "Create Application" disabled
-     Then I select "Default" from "Service plan"
-     And I should see button "Create Application" disabled
      Then I select "Basic" from "Application plan"
      And I should see button "Create Application"
 
@@ -159,7 +152,6 @@
      And  I go to the account context create application page for "bob"
      When I should see "New Application"
      And I select "API" from "Product"
-     And I select "Default" from "Service plan"
      And I select "Basic" from "Application plan"
      And I fill in "Name" with "name"
      And I fill in "Description" with "description"

--- a/spec/javascripts/Logic/BuyerLogic.spec.jsx
+++ b/spec/javascripts/Logic/BuyerLogic.spec.jsx
@@ -1,0 +1,45 @@
+// @flow
+
+import { BuyerLogic } from 'Logic'
+
+import type { Buyer, Product, ServicePlan } from 'NewApplication/types'
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+const buyer: Buyer = {
+  id: '0',
+  name: 'Mr. Buyer',
+  admin: 'The Admin',
+  createApplicationPath: '',
+  createdAt: '',
+  contractedProducts: []
+}
+const plan: $Shape<ServicePlan> = { id: 10, name: 'The Plan' }
+const product: $Shape<Product> = { id: '1', name: 'The Product' }
+
+describe('getContractedServicePlan', () => {
+  it('should return the contracted product', () => {
+    const logic = new BuyerLogic({ ...buyer, contractedProducts: [{ id: 1, name: 'The Product', withPlan: plan }] })
+
+    expect(logic.getContractedServicePlan(product)).toEqual(plan)
+  })
+
+  it('should return null when no contracted products', () => {
+    const logic = new BuyerLogic({ ...buyer, contractedProducts: [] })
+
+    expect(logic.getContractedServicePlan(product)).toEqual(null)
+  })
+
+  it('should return null when product is not contracted ', () => {
+    const logic = new BuyerLogic({ ...buyer, contractedProducts: [{ id: 999, name: 'The Other product', withPlan: plan }] })
+
+    expect(logic.getContractedServicePlan(product)).toEqual(null)
+  })
+  it('should return null when no product contracted with a different plan', () => {
+    const logic = new BuyerLogic({ ...buyer, contractedProducts: [{ id: 999, name: 'The Other product', withPlan: { id: 50, name: 'The Other Plan' } }] })
+
+    expect(logic.getContractedServicePlan(product)).toEqual(null)
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

The logic around contracted service plans is broken (thank you Flow).

The logic has been extracted to a different file and tested.

**Which issue(s) this PR fixes** 

- [x] Service plan dropdown is always enabled, but it should be fixed when the selected product is subscribed to a service plan.

**Verification steps** 

* Product with no service plan: can't fill form, need to create a plan first.
* Product with no subscription: need to select a plan in Service Plan dropdown
* Product with subscription: dropdown is disabled and the plan selected, user can't change it
