### PR TITLE
Fix Deployment radio input in Product settings

### DIFF
--- a/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
+++ b/app/views/api/integrations/apicast/shared/_proxy_endpoints.html.slim
@@ -1,3 +1,4 @@
+- proxy = service.proxy
 - is_service_mesh = proxy.service_mesh_integration?
 - is_self_managed = proxy.self_managed?
 

--- a/app/views/api/services/forms/_integration_settings.html.slim
+++ b/app/views/api/services/forms/_integration_settings.html.slim
@@ -12,14 +12,14 @@
             input_html: {class: 'integration-method'}
 
     = form.semantic_fields_for :proxy do |f|
-      = render 'api/integrations/apicast/shared/proxy_endpoints', f: f, service: @service, proxy: @service.proxy
+      = render 'api/integrations/apicast/shared/proxy_endpoints', f: f, service: service
 
   = form.inputs 'Authentication', id: 'auth-wrapper' do
     = form.input :proxy_authentication_method,
             name: 'service[backend_version]',
             as: :radio,
             required: false,
-            collection: BackendVersion.visible_versions(service: @service),
+            collection: BackendVersion.visible_versions(service: service),
             value_as_class: true,
             label: false,
             input_html: {class: 'auth-method'}

--- a/app/views/api/services/forms/_integration_settings.html.slim
+++ b/app/views/api/services/forms/_integration_settings.html.slim
@@ -1,6 +1,6 @@
 = javascript_pack_tag 'settings'
 
-- @service.deployment_option = 'hosted'
+- service.deployment_option ||= 'hosted'
 #settings
   = form.inputs 'Deployment', id: 'integration-wrapper' do
 

--- a/app/views/api/services/settings.html.slim
+++ b/app/views/api/services/settings.html.slim
@@ -1,6 +1,6 @@
 - content_for :sublayout_title, 'Settings'
 
-= semantic_form_for @service, :url => admin_service_path(@service) do |form|
-  = render :partial => 'api/services/forms/integration_settings', :locals => {:form => form}
+= semantic_form_for @service, url: admin_service_path(@service) do |form|
+  = render partial: 'api/services/forms/integration_settings', locals: { form: form, service: @service }
   = form.buttons do
     = form.commit_button 'Update Product', button_html: { name: 'update_settings', class: 'pf-c-button pf-m-primary' }

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -63,6 +63,33 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    test 'shows the correct deployment option' do
+      # Default value
+      service.stubs(:deployment_option).returns(nil)
+      get settings_admin_service_path(service)
+
+      page = Nokogiri::HTML::Document.parse(response.body)
+      hosted_option = page.at_css('#service_deployment_option_hosted')
+      assert hosted_option.attribute('checked').present?
+      service.unstub(:deployment_option)
+
+      # Self managed
+      service.update!(deployment_option: 'self_managed')
+      get settings_admin_service_path(service)
+
+      page = Nokogiri::HTML::Document.parse(response.body)
+      self_managed_option = page.at_css('#service_deployment_option_self_managed')
+      assert self_managed_option.attribute('checked').present?
+
+      # Hosted
+      service.update!(deployment_option: 'hosted')
+      get settings_admin_service_path(service)
+
+      page = Nokogiri::HTML::Document.parse(response.body)
+      hosted_option = page.at_css('#service_deployment_option_hosted')
+      assert hosted_option.attribute('checked').present?
+    end
+
     test 'update the settings' do
       Account.any_instance.stubs(:provider_can_use?).returns(true)
       service.update!(deployment_option: 'self_managed')


### PR DESCRIPTION
**Description**
The issue is only visual, caused by a typo in the Slim template that overrided the value of `deployment_option`:
```diff
- service.deployment_option = 'hosted'
+ service.deployment_option ||= 'hosted'
```

**Which issue(s) this PR fixes** 

[THREESCALE-7209: 3scale SaaS Product Settings not saving APIcast self-managed option](https://issues.redhat.com/browse/THREESCALE-7209)

**Verification steps** 

See JIRA
