### PR TITLE
Fix provider host passed in the Zync update tenant request

### DIFF
--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -326,7 +326,7 @@ class ZyncWorker
     return root_url if root_url
 
     # This is far for perfect, but there is no request in workers to infer the domain from.
-    options = { host: provider.admin_domain }
+    options = { host: provider.external_admin_domain }
     options.reverse_merge!(Rails.env.development? ? { port: 3000 } : ActionMailer::Base.default_url_options)
     System::UrlHelpers.system_url_helpers.root_url(options)
   end


### PR DESCRIPTION
Otherwise it will break when domain substitution is enabled.