### PR TITLE
🐛 Hide Service Plan select when they're switched off

### DIFF
--- a/app/decorators/provider_decorator.rb
+++ b/app/decorators/provider_decorator.rb
@@ -2,15 +2,19 @@
 
 class ProviderDecorator < ApplicationDecorator
   include System::UrlHelpers.system_url_helpers
+  include PlansHelper
+
+  delegate :can?, :settings, to: :h
 
   self.include_root_in_json = false
 
   def new_application_form_data(buyer: nil, service: nil, cinstance: nil)
+    # TODO: Reduce data by not including service_plans when service_plans_management_visible? is false
     data = {
       'create-application-plan-path': new_admin_service_application_plan_path(':id'),
       'create-service-plan-path': new_admin_service_service_plan_path(':id'),
       'service-subscriptions-path': admin_buyers_account_service_contracts_path(':id'),
-      'service-plans-allowed': settings.service_plans.allowed?.to_json,
+      'service-plans-allowed': service_plans_management_visible?.to_json,
       'defined-fields': application_defined_fields_data.to_json
     }
     data[:errors] = cinstance.errors.to_json if cinstance

--- a/app/helpers/plans_helper.rb
+++ b/app/helpers/plans_helper.rb
@@ -1,8 +1,15 @@
+# frozen_string_literal: true
+
 module PlansHelper
 
+  delegate :settings, to: :current_account
+
   def account_plans_management_visible?
-    settings = current_account.settings
     can?(:manage, :account_plans) && settings.account_plans.allowed? && settings.account_plans_ui_visible?
+  end
+
+  def service_plans_management_visible?
+    can?(:manage, :service_contracts) && settings.service_plans.allowed? && settings.service_plans_ui_visible?
   end
 
   def can_create_plan?(plan)

--- a/app/helpers/provider/admin/dashboards_helper.rb
+++ b/app/helpers/provider/admin/dashboards_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Provider::Admin::DashboardsHelper
-
+  include PlansHelper
   include ApplicationHelper
 
   # @param name [Symbol]
@@ -66,7 +66,7 @@ module Provider::Admin::DashboardsHelper
   end
 
   def show_subscriptions_on_dashboard?(service)
-    can?(:manage, :service_contracts) && current_account.settings.service_plans.allowed? && current_account.settings.service_plans_ui_visible? && current_account.service_plans.not_custom.size > 1
+    service_plans_management_visible? && current_account.service_plans.not_custom.size > 1
   end
 
   def show_service_plans_on_dashboard?(service)

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module VerticalNavHelper
+  include PlansHelper
+
   def vertical_nav_data
     {
       'current-api': current_api.to_json(root: false, only: %i[name]),
@@ -90,8 +92,8 @@ module VerticalNavHelper
   def audience_accounts_items
     items = []
     items << {id: :listing,       title: 'Listing',       path: admin_buyers_accounts_path}           if can?(:manage, :partners)
-    items << {id: :account_plans,  title: 'Account Plans', path: admin_buyers_account_plans_path}      if can?(:manage, :plans) && current_account.settings.account_plans.allowed? && current_account.settings.account_plans_ui_visible?
-    items << {id: :subscriptions, title: 'Subscriptions', path: admin_buyers_service_contracts_path}  if can?(:manage, :service_contracts) && current_account.settings.service_plans.allowed? && current_account.settings.service_plans_ui_visible?
+    items << {id: :account_plans,  title: 'Account Plans', path: admin_buyers_account_plans_path}     if account_plans_management_visible?
+    items << {id: :subscriptions, title: 'Subscriptions', path: admin_buyers_service_contracts_path}  if service_plans_management_visible?
 
     if can?(:manage, :settings)
       items << {                          title: 'Settings'}

--- a/app/views/shared/provider/navigation/audience/_accounts.html.slim
+++ b/app/views/shared/provider/navigation/audience/_accounts.html.slim
@@ -8,7 +8,7 @@
        title: 'Account Plans',
        path:   admin_buyers_account_plans_path
 
-- if can?(:manage, :service_contracts) && current_account.settings.service_plans.allowed? && current_account.settings.service_plans_ui_visible?
+- if service_plans_management_visible?
    = render vertical_nav_item,
         title: 'Subscriptions',
         path: admin_buyers_service_contracts_path

--- a/features/old/applications/providers/create_application.feature
+++ b/features/old/applications/providers/create_application.feature
@@ -83,7 +83,6 @@
 
    Scenario: Create a new application without having a service subscription
      Given a service "second" of provider "foo.3scale.localhost"
-       And provider has "service_plans_ui_visible" hidden
        And a published service plan "non_default" of service "second" of provider "foo.3scale.localhost"
        And a published application plan "second_app_plan" of service "second" of provider "foo.3scale.localhost"
        And buyer "bob" is not subscribed to the default service of provider "foo.3scale.localhost"
@@ -168,7 +167,6 @@
       And I press "Update Application"
       And should see "can't be blank"
 
-
    Scenario: Edit an application
      Given buyer "bob" has application "UltraWidget" with description "Slightly less awesome widget"
      And I go to the buyer account page for "bob"
@@ -180,7 +178,6 @@
      Then I should see "Application was successfully updated"
      And I should be on the provider side "Not So Ultra Widget" application page
      And I should see "Not So Ultra Widget" in a header
-
 
    # TODO: also in single app mode
    Scenario: Edit an application with extra fields

--- a/test/decorators/provider_decorator_test.rb
+++ b/test/decorators/provider_decorator_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProviderDecoratorTest < Draper::TestCase
+
+  def setup
+    provider = FactoryBot.create(:provider_account)
+    @decorator = ProviderDecorator.new provider
+    @decorator.stubs(:service_plans_management_visible?).returns(true)
+  end
+
+  test 'new_application_form_data in Dashboard context' do
+    @decorator.expects(:audience_context_new_application_form_data).returns({}).once
+
+    assert @decorator.new_application_form_data
+  end
+
+  test 'new_application_form_data in Account context' do
+    buyer = FactoryBot.create(:buyer_account)
+    @decorator.expects(:buyer_context_new_application_form_data).with(buyer).returns({}).once
+
+    assert @decorator.new_application_form_data(buyer: buyer)
+  end
+
+  test 'new_application_form_data in Product context' do
+    service = FactoryBot.create(:service)
+    @decorator.expects(:product_context_new_application_form_data).with(service).returns({}).once
+
+    assert @decorator.new_application_form_data(service: service)
+  end
+
+  test 'new_application_form_data inline errors' do
+    cinstance = FactoryBot.create(:cinstance)
+    errors = ['Name is required']
+    cinstance.stubs(:errors).returns(errors)
+    @decorator.expects(:audience_context_new_application_form_data).returns({}).once
+
+    assert_equal errors.to_json, @decorator.new_application_form_data(cinstance: cinstance)[:errors]
+  end
+end

--- a/test/unit/helpers/buyers/applications_helper_test.rb
+++ b/test/unit/helpers/buyers/applications_helper_test.rb
@@ -4,55 +4,12 @@ require 'test_helper'
 
 class Buyers::ApplicationsHelperTest < ActionView::TestCase
 
-  def setup
-    @product = { name: 'Service' }
-    ServiceDecorator.any_instance.stubs(:new_application_data).returns(@product)
-    ProviderDecorator.any_instance.stubs(:application_products_data).returns([@product])
-
-    @buyer = { name: 'Buyer' }
-    BuyerDecorator.any_instance.stubs(:new_application_data).returns(@buyer)
-    ProviderDecorator.any_instance.stubs(:application_buyers_data).returns([@buyer])
-
-    @fields = { name: 'Field' }
-    ProviderDecorator.any_instance.stubs(:application_defined_fields_data).returns([@fields])
-  end
-
-  test 'new_application_form_metadata in Dashboard context' do
+  test 'new_application_form_metadata' do
+    data = { foo: 'bar' }
+    ProviderDecorator.any_instance.stubs(:new_application_form_data).returns(data)
     provider = FactoryBot.create(:provider_account)
 
-    data = new_application_form_metadata(provider)
-    assert_equal data[:products], [@product].to_json
-    assert_equal data[:buyers], [@buyer].to_json
-    assert_equal data[:'defined-fields'], [@fields].to_json
-  end
-
-  test 'new_application_form_metadata in Account context' do
-    provider = FactoryBot.create(:provider_account)
-    buyer = FactoryBot.create(:buyer_account)
-
-    data = new_application_form_metadata(provider, buyer: buyer)
-    assert_equal data[:buyer], @buyer.to_json
-    assert_equal data[:products], [@product].to_json
-    assert data[:'create-application-path']
-  end
-
-  test 'new_application_form_metadata in Product context' do
-    provider = FactoryBot.create(:provider_account)
-    service = FactoryBot.create(:simple_service)
-
-    data = new_application_form_metadata(provider, service: service)
-    assert_equal data[:product], @product.to_json
-    assert_equal data[:buyers], [@buyer].to_json
-  end
-
-  test 'new_application_form_metadata inline errors' do
-    provider = FactoryBot.create(:provider_account)
-    cinstance = FactoryBot.create(:cinstance)
-    errors = ['Name is required']
-    cinstance.stubs(:errors).returns(errors)
-
-    data = new_application_form_metadata(provider, cinstance: cinstance)
-    assert_equal data[:errors], errors.to_json
+    assert_equal data, new_application_form_metadata(provider)
   end
 
   test "remaining_trial_days should return the right expiration date text" do


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now, Service plan select is always visible because  of `servicePlansAllwed` not being calculated correctly.

**Which issue(s) this PR fixes** 

[THREESCALE-7120: Create application page has Service plan field despite service plan option is turned off](https://issues.redhat.com/browse/THREESCALE-7120)

**Verification steps** 

See JIRA
