### PR TITLE
THREESCALE-7134 removing :policies rolling update

### DIFF
--- a/app/controllers/admin/api/policies_controller.rb
+++ b/app/controllers/admin/api/policies_controller.rb
@@ -2,8 +2,6 @@
 
 class Admin::Api::PoliciesController < Admin::Api::BaseController
 
-  before_action :authorize_rolling_update
-
   ##~ sapi = source2swagger.namespace("Account Management API")
   ##~ e = sapi.apis.add
   ##~ e.path = "/admin/api/policies.json"
@@ -23,11 +21,5 @@ class Admin::Api::PoliciesController < Admin::Api::BaseController
     respond_to do |format|
       format.json { render json: policies }
     end
-  end
-
-  private
-
-  def authorize_rolling_update
-    provider_can_use!(:policies)
   end
 end

--- a/app/controllers/admin/api/services/proxy/policies_controller.rb
+++ b/app/controllers/admin/api/services/proxy/policies_controller.rb
@@ -4,8 +4,6 @@ class Admin::Api::Services::Proxy::PoliciesController < Admin::Api::Services::Ba
   wrap_parameters ::Proxy
   representer Proxy::PoliciesConfig
 
-  before_action :authorize_rolling_update
-
   ##~ e = sapi.apis.add
   ##~ e.path = "/admin/api/services/{service_id}/proxy/policies.json"
   ##~ e.responseClass = "json"
@@ -49,10 +47,6 @@ class Admin::Api::Services::Proxy::PoliciesController < Admin::Api::Services::Ba
   end
 
   private
-
-  def authorize_rolling_update
-    provider_can_use!(:policies)
-  end
 
   def proxy_params
     proxy_params = params.require(:proxy).dup

--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -64,6 +64,9 @@ module Logic
         OPENSHIFT_PROVIDER_ID = 2
 
         def initialize(provider)
+          if deprecated?
+            Rails.logger.warn "Deprecated rolling update used: #{name} at:\n\t" + caller(4).join("\n\t")
+          end
           @provider = provider
         end
 
@@ -86,6 +89,10 @@ module Logic
           else
             raise_invalid_config
           end
+        end
+
+        def deprecated?
+          false
         end
 
         def raise_invalid_config
@@ -268,6 +275,16 @@ module Logic
       class BillableContracts < Base
         def missing_config
           false
+        end
+      end
+
+      class Policies < Base
+        def enabled?
+          true
+        end
+
+        def deprecated?
+          true
         end
       end
 

--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -271,17 +271,7 @@ module Logic
         end
       end
 
-      class Policies < Base
-        def missing_config
-          false
-        end
-      end
-
       class PolicyRegistry < Base
-        def enabled?
-          super && provider_can_use?(:policies)
-        end
-
         def missing_config
           false
         end

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -151,8 +151,6 @@ class Proxy < ApplicationRecord
   end
 
   def policy_chain
-    # TODO: We need to remove this rolling update as it should be available for everyone using APIcast V2
-    return [] unless provider_can_use?(:policies)
     (policies_config.presence || []).each_with_object([]) do |config, chain|
       chain << config.slice('name', 'version', 'configuration') if config['enabled']
     end

--- a/config/docker/rolling_updates.yml
+++ b/config/docker/rolling_updates.yml
@@ -12,7 +12,6 @@ base: &default
   new_notification_system: true
   cms_api: false
   forum: true
-  policies: false
   policy_registry: false
   apicast_v2: true
   proxy_private_base_path: true

--- a/config/examples/rolling_updates.yml
+++ b/config/examples/rolling_updates.yml
@@ -12,7 +12,6 @@ base: &default
   new_notification_system: true
   cms_api: false
   forum: true
-  policies: true
   policy_registry: true
   proxy_private_base_path: true
   service_mesh_integration: false

--- a/openshift/system/config/rolling_updates.yml
+++ b/openshift/system/config/rolling_updates.yml
@@ -16,7 +16,6 @@ base: &default
   forum: false
   published_service_plan_signup: true
   apicast_oidc: true
-  policies: true
   policy_registry: true
   proxy_private_base_path: true
   service_mesh_integration: true

--- a/test/integration/user-management-api/policies_test.rb
+++ b/test/integration/user-management-api/policies_test.rb
@@ -8,12 +8,6 @@ class Admin::Api::PoliciesTest < ActionDispatch::IntegrationTest
     host! @provider.admin_domain
   end
 
-  def test_index_forbidden
-    rolling_updates_off
-    get(admin_api_policies_path, format: :json, provider_key: @provider.api_key)
-    assert_response :not_found
-  end
-
   def test_index
     rolling_updates_on
     Policies::PoliciesListService.expects(:call).with(@provider).returns("{\"cors\":[{\"schema\":\"1\"}]}")

--- a/test/integration/user-management-api/services/proxy/policies_test.rb
+++ b/test/integration/user-management-api/services/proxy/policies_test.rb
@@ -18,12 +18,6 @@ class Admin::Api::Services::Proxy::PoliciesTest < ActionDispatch::IntegrationTes
     assert_match "{\"name\":\"schema\",\"version\":\"1\",\"configuration\":{}}", response.body
   end
 
-  def test_show_forbidden
-    rolling_updates_off
-    get admin_api_service_proxy_policies_path(valid_params)
-    assert_response :not_found
-  end
-
   def test_update_without_errors
     put admin_api_service_proxy_policies_path(valid_params.merge(
       { proxy: { policies_config: [{'name' => 'alaska', 'version' => '1', 'configuration' => {}}].to_json }}))

--- a/test/unit/logic/rolling_updates_test.rb
+++ b/test/unit/logic/rolling_updates_test.rb
@@ -7,29 +7,13 @@ class Logic::RollingUpdatesTest < ActiveSupport::TestCase
     System::ErrorReporting.expects(:report_error).never
   end
 
-  def test_policies
-    account = FactoryBot.build_stubbed(:simple_account)
-
-    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policies: true })
-    assert account.provider_can_use?(:policies)
-
-    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policies: false })
-    refute account.provider_can_use?(:policies)
-  end
-
   def test_policy_registry
     account = FactoryBot.build_stubbed(:simple_account)
 
-    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policies: true, policy_registry: true })
+    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policy_registry: true })
     assert account.provider_can_use?(:policy_registry)
 
-    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policies: true, policy_registry: false })
-    refute account.provider_can_use?(:policy_registry)
-
-    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policies: false, policy_registry: false })
-    refute account.provider_can_use?(:policy_registry)
-
-    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policies: false, policy_registry: true })
+    Logic::RollingUpdates::Features::Yaml.stubs(:config).returns({ policy_registry: false })
     refute account.provider_can_use?(:policy_registry)
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

THREESCALE-7134

removing the `:policies` rolling update based on the comment in `Proxy#policy_chain`