### PR TITLE
self_managed apicast v2 no need to override method

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -224,10 +224,6 @@ class Proxy < ApplicationRecord
   end
 
   class SelfManagedAPIcast < DeploymentStrategy
-    def default_staging_endpoint
-      staging_endpoint = proxy.apicast_configuration_driven ? nil : :sandbox_endpoint
-      generate(staging_endpoint)
-    end
   end
 
   class HostedAPIcast < DeploymentStrategy


### PR DESCRIPTION
THREESCALE-7134

I'm using assumptions here but as far as I can understand the branch
`apicast_configuration_driven` means that v2 is used, v1 otherwise.

If this assumption is correct, then `generate(nil)` will return `nil` so
there is no point in overriding the method.

But there might be a third option I don't know about.