### PR TITLE
PoliciesConfig custom attribute type

### DIFF
--- a/app/controllers/admin/api/services/proxy/policies_controller.rb
+++ b/app/controllers/admin/api/services/proxy/policies_controller.rb
@@ -18,8 +18,7 @@ class Admin::Api::Services::Proxy::PoliciesController < Admin::Api::Services::Ba
   ##~ op.parameters.add @parameter_service_id_by_id_name
   #
   def show
-    policies_config = Proxy::PoliciesConfig.new(proxy.policies_config)
-    respond_with(policies_config, represent_on_error: :resource)
+    respond_with(proxy.policies_config, represent_on_error: :resource)
   end
 
   ##~ e = sapi.apis.add
@@ -41,9 +40,7 @@ class Admin::Api::Services::Proxy::PoliciesController < Admin::Api::Services::Ba
       ApicastV2DeploymentService.new(@proxy).call(environment: :sandbox)
     end
 
-    policies_config = Proxy::PoliciesConfig.new(proxy.policies_config)
-    policies_config.valid? # Needed to set errors if any
-    respond_with(policies_config, represent_on_error: :resource)
+    respond_with(proxy.policies_config, represent_on_error: :resource)
   end
 
   private

--- a/app/models/attributes/policies_config.rb
+++ b/app/models/attributes/policies_config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Attributes::PoliciesConfig < ActiveRecord::Type::Text
+  def cast(value)
+    Proxy::PoliciesConfig.new(value)
+  end
+
+  def serialize(value)
+    value.to_json
+  end
+
+  def changed_in_place?(raw_old_value, new_value)
+    new_value != cast(raw_old_value)
+  end
+end

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -14,11 +14,9 @@ class Proxy < ApplicationRecord
 
   self.background_deletion = [:proxy_rules, [:proxy_configs, { action: :delete }], [:oidc_configuration, { action: :delete, has_many: false }]]
 
-  DEFAULT_POLICY = { 'name' => 'apicast', 'humanName' => 'APIcast policy', 'description' => 'Main functionality of APIcast.',
-                     'configuration' => {}, 'version' => 'builtin', 'enabled' => true, 'removable' => false, 'id' => 'apicast-policy'  }.freeze
-
   belongs_to :service, touch: true, inverse_of: :proxy, required: true
   attr_readonly :service_id
+  attribute :policies_config, Attributes::PoliciesConfig.new
 
   has_many :proxy_rules, -> { order(position: :asc) }, dependent: :destroy, inverse_of: :proxy
   has_many :proxy_configs, dependent: :delete_all, inverse_of: :proxy
@@ -131,31 +129,7 @@ class Proxy < ApplicationRecord
     deployment_option&.inquiry
   end
 
-  def policies_config
-    parsed_config = read_and_parse_policies_config
-    return parsed_config if errors[:policies_config].present?
-
-    if parsed_config.detect { |c| c['name'] == DEFAULT_POLICY['name'] }
-      parsed_config
-    else
-      parsed_config.push(DEFAULT_POLICY)
-    end
-  end
-
-  def policies_config=(attr_policies_config)
-    super(attr_policies_config.is_a?(String) ? attr_policies_config : attr_policies_config.to_json)
-  end
-
-  def find_policy_config_by(name:, version:)
-    policies_config.find { |config| config['name'] == name && config['version'] == version }
-  end
-
-  def policy_chain
-    (policies_config.presence || []).each_with_object([]) do |config, chain|
-      chain << config.slice('name', 'version', 'configuration') if config['enabled']
-    end
-  end
-
+  delegate :find_policy_config_by, :policy_chain, to: :policies_config
   delegate :self_managed?, :hosted?, to: :deployment_option
   delegate :service_token, to: :service, allow_nil: true
 
@@ -502,7 +476,12 @@ class Proxy < ApplicationRecord
   class PolicyConfig
     include ActiveModel::Validations
 
+    DEFAULT_POLICY = { 'name' => 'apicast', 'humanName' => 'APIcast policy', 'description' => 'Main functionality of APIcast.',
+                       'configuration' => {}, 'version' => 'builtin', 'enabled' => true, 'removable' => false, 'id' => 'apicast-policy'  }.freeze
+
     attr_accessor :name, :version, :configuration, :enabled
+
+    delegate :to_json, :as_json, to: :to_h
 
     validates :name, :version, presence: true
     validate :configuration_is_object
@@ -519,6 +498,37 @@ class Proxy < ApplicationRecord
       @enabled = symbolized_attributes[:enabled]
     end
 
+    def matches?(name:, version:)
+      self.name == name && self.version == version
+    end
+
+    def default?
+      name == DEFAULT_POLICY["name"]
+    end
+
+    def self.create_default
+      new(DEFAULT_POLICY)
+    end
+
+    def to_chain_value
+      to_h.slice('name', 'version', 'configuration')
+    end
+
+    def to_h
+      %i[name version configuration enabled].each_with_object({}) do |key, obj|
+        obj[key] = public_send key
+      end.compact.as_json
+    end
+
+    def ==(other)
+      %i[name version configuration enabled].all? { |key| send(key) == other.send(key) }
+    end
+    alias eql? ==
+
+    def hash
+      to_h.hash
+    end
+
     private
 
     def configuration_is_object
@@ -528,50 +538,73 @@ class Proxy < ApplicationRecord
 
   class PoliciesConfig
     include ActiveModel::Validations
+    include Enumerable
 
-    delegate :each, to: :policies_config
+    delegate :each, :to_json, :as_json, to: :policies_config
     attr_reader :policies_config
+    protected :policies_config
 
     validate :policies_configs_are_correct
 
     def initialize(policies_config)
-      @policies_config = policies_config.map { |attrs| PolicyConfig.new(attrs) }
+      parsed = policies_config.presence || []
+      parsed = parsed.is_a?(Array) ? parsed.as_json : Array(JSON.parse(parsed))
+
+      @policies_config = policies_normalize(parsed)
+    rescue JSON::ParserError
+      @policies_config = policies_config
     end
 
     def self.name
       'PoliciesConfig'
     end
 
+    def find_by(name:, version:)
+      find { |config| config.matches?(name: name, version: version) }
+    end
+    alias find_policy_config_by find_by
+
+    def chain
+      select(&:enabled).map(&:to_chain_value)
+    end
+    alias policy_chain chain
+    alias to_chain chain
+
+    def ==(other)
+      policies_config == other.policies_config
+    end
+    alias eql? ==
+
+    def hash
+      policies_config.hash
+    end
+
     private
 
-    def policies_configs_are_correct
-      policies_config.each do |policy_config|
-        # TODO: 5: errors.merge!(policy_config.errors)
-        policy_config.errors.each { |attribute, message| errors.add(attribute, message) } unless policy_config.valid?
-      end
+    def policies_normalize(parsed_policies)
+      policies = parsed_policies.map { |attrs| PolicyConfig.new(attrs) }
+      policies.tap { |list| list.push(PolicyConfig.create_default) if policies.none?(&:default?) }
     end
-  end
 
-  def read_and_parse_policies_config
-    read_and_parse_policies_config!
-  rescue JSON::ParserError
-    []
-  end
-
-  def read_and_parse_policies_config!
-    attr_policies_config = read_attribute(:policies_config)
-    attr_policies_config.blank? ? [] : Array(JSON.parse(attr_policies_config))
+    def policies_configs_are_correct
+      # TODO: 5: errors.merge!(policy_config.errors)
+      select(&:invalid?).map(&:errors).each do |policy_errors|
+        policy_errors.each do |attribute, message|
+          errors.add(attribute, errors.full_message(attribute, message).downcase)
+        end
+      end
+      errors.add(:base, :missing_apicast) unless detect(&:default?)
+    rescue NoMethodError
+      errors.add(:base, :invalid_format)
+    end
   end
 
   def policies_config_structure
-    parsed_config = read_and_parse_policies_config!
-    policies_object = PoliciesConfig.new(parsed_config)
-    return if policies_object.valid?
-    policies_object.errors.each do |attribute, message|
-      errors.add(:policies_config, errors.full_message(attribute, message).downcase)
+    return if policies_config.valid?
+
+    policies_config.errors.each do |attribute, message|
+      errors.add(:policies_config, errors.full_message(attribute, message))
     end
-  rescue JSON::ParserError
-    errors.add(:policies_config, :invalid_format)
   end
 
   def create_default_secret_token
@@ -653,4 +686,5 @@ class Proxy < ApplicationRecord
   def generate_port(proxy_attribute)
     PortGenerator.new(self).call(proxy_attribute)
   end
+
 end

--- a/app/representers/proxy_representer.rb
+++ b/app/representers/proxy_representer.rb
@@ -31,7 +31,7 @@ class ProxyRepresenter < ThreeScale::Representer
   property  :sandbox_endpoint
   property  :api_test_path
   property  :api_test_success
-  property  :policies_config
+  property  :policies_config, exec_context: :decorator
 
   property :created_at
   property :updated_at
@@ -46,6 +46,10 @@ class ProxyRepresenter < ThreeScale::Representer
 
   property :jwt_claim_with_client_id, if: ->(*) { oidc? }
   property :jwt_claim_with_client_id_type, if: ->(*) { oidc? }
+
+  def policies_config
+    represented.policies_config.to_json
+  end
 
   class JSON < ProxyRepresenter
     include Roar::JSON

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -739,6 +739,11 @@ en:
         street_address: Street Address
     errors:
       models:
+        policies_config:
+          attributes:
+            base:
+              invalid_format: "has invalid format. The Correct format is: [{ \"name\": \"apicast\"... }]"
+              missing_apicast: "is missing apicast policy"
         sso_token:
           cannot_be_generated: SSO Token cannot be generated
           one_of_user_id_or_username_is_required: One of user_id or username is required
@@ -815,8 +820,6 @@ en:
               invalid: "the accepted format is 'scheme://address(:port)(/path)'. Accepted schemes are http, https, ws and wss"
         proxy:
           attributes:
-            policies_config:
-              invalid_format: "has invalid format. The Correct format is: [{ \"name\": \"apicast\"... }]"
             api_backend:
               invalid: "the accepted format is 'scheme://address(:port)(/path)'. Accepted schemes are http, https, ws and wss"
             api_test_path:

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -221,10 +221,12 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     proxy_attributes = attrs['proxy']
     proxy_attributes.delete('proxy_rules_attributes')
     api_backend = proxy_attributes.delete 'api_backend'
+    policies_config = proxy_attributes.delete 'policies_config'
     proxy.reload
 
     assert_equal proxy.attributes.slice(*proxy_attributes.keys), proxy_attributes
     assert_equal 'http://bye-world-api.3scale.net:80', proxy.api_backend
+    assert_includes proxy.policies_config.map(&:to_h), *JSON.parse(policies_config)
 
     assert_equal 1, proxy.proxy_rules.count
 

--- a/test/integration/api/policies_controller_test.rb
+++ b/test/integration/api/policies_controller_test.rb
@@ -24,7 +24,7 @@ class Api::PoliciesControllerTest < ActionDispatch::IntegrationTest
     put admin_service_policies_path(@service), proxy: {policies_config: config}
     # Checking flash won't work anymore in rails 5+
     assert_equal 'The policies are saved successfully', flash[:notice]
-    assert_equal expected_policies, @service.proxy.policies_config
+    assert_equal Proxy::PoliciesConfig.new(expected_policies), @service.proxy.policies_config
     assert_redirected_to edit_admin_service_policies_path(@service)
   end
 
@@ -40,7 +40,7 @@ class Api::PoliciesControllerTest < ActionDispatch::IntegrationTest
     put admin_service_policies_path(@service), proxy: {policies_config: invalid_config}
     # Checking flash won't work anymore in rails 5+
     assert_equal 'The policies cannot be saved', flash[:error]
-    assert_equal [Proxy::DEFAULT_POLICY], @service.proxy.policies_config
+    assert_equal Proxy::PoliciesConfig.new([Proxy::PolicyConfig::DEFAULT_POLICY]), @service.proxy.policies_config
     assert_response :unprocessable_entity
   end
 

--- a/test/integration/user-management-api/services/proxy/policies_test.rb
+++ b/test/integration/user-management-api/services/proxy/policies_test.rb
@@ -30,11 +30,10 @@ class Admin::Api::Services::Proxy::PoliciesTest < ActionDispatch::IntegrationTes
 
   def test_update_without_errors
     example_policy = {'name' => 'alaska', 'version' => '1', 'configuration' => {}}
-
     put admin_api_service_proxy_policies_path(valid_params.merge({ proxy: { policies_config: [example_policy].to_json }}))
     assert_response :success
 
-    get admin_api_service_proxy_policies_path(format: :json, **valid_params)
+    get admin_api_service_proxy_policies_path(**valid_params)
     assert_response :success
     assert_equal JSON.parse(response.body)["policies_config"], [example_policy, DEFAULT_POLICY]
   end

--- a/test/unit/backend_api_logic/routing_policy_test.rb
+++ b/test/unit/backend_api_logic/routing_policy_test.rb
@@ -44,7 +44,7 @@ module BackendApiLogic
         enabled: true,
         configuration: { rules: [routing_rule] }
       }
-      proxy.stubs(:policies_config).returns([routing_policy, apicast_policy].as_json)
+      proxy.stubs(:policies_config).returns(Proxy::PoliciesConfig.new([routing_policy, apicast_policy]))
 
       injected_policy = {
         name: 'routing',
@@ -77,13 +77,13 @@ module BackendApiLogic
       policy_blah = { name: 'blah', version: 'builtin', enabled: true, configuration: {} }
       policy_bleh = { name: 'bleh', version: 'builtin', enabled: true, configuration: {} }
 
-      proxy.stubs(:policies_config).returns([apicast_policy, policy_blah, policy_bleh].as_json)
+      proxy.stubs(:policies_config).returns(Proxy::PoliciesConfig.new([apicast_policy, policy_blah, policy_bleh]))
       assert_equal [injected_policy, apicast_policy.except(:enabled), policy_blah.except(:enabled), policy_bleh.except(:enabled)].as_json, proxy.policy_chain
 
-      proxy.stubs(:policies_config).returns([policy_blah, apicast_policy, policy_bleh].as_json)
+      proxy.stubs(:policies_config).returns(Proxy::PoliciesConfig.new([policy_blah, apicast_policy, policy_bleh]))
       assert_equal [policy_blah.except(:enabled), injected_policy, apicast_policy.except(:enabled), policy_bleh.except(:enabled)].as_json, proxy.policy_chain
 
-      proxy.stubs(:policies_config).returns([policy_blah, policy_bleh, apicast_policy].as_json)
+      proxy.stubs(:policies_config).returns(Proxy::PoliciesConfig.new([policy_blah, policy_bleh, apicast_policy]))
       assert_equal [policy_blah.except(:enabled), policy_bleh.except(:enabled), injected_policy, apicast_policy.except(:enabled)].as_json, proxy.policy_chain
     end
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

This is in relation to #2496 where we hit a reek error with the `#policy_chain`
method. By refactoring `policies_config` attribute to be a custom type
we can avoid this style error and hopefully make things more organized overal.

Now this PR is not complete and is only a rough PoC. Other files need to be changed
also tests to be fixed and added.

I'm submitting it to get feedback whether this direction is desirable and also
to get feedback on validation and other approaches used.

**Special notes for your reviewer**:

Please check only last commit as this refactoring is on top of unmerged #2496.