### PR TITLE
[Threescale-7189] Fixes position of the fields definitions

### DIFF
--- a/app/models/fields_definition.rb
+++ b/app/models/fields_definition.rb
@@ -18,7 +18,7 @@ class FieldsDefinition < ApplicationRecord
   serialize :choices, Array
 
   belongs_to :account, :inverse_of => :fields_definitions
-  acts_as_list :scope => :account, :column => :pos
+  acts_as_list :scope => [:account_id, :target], :column => :pos
 
   scope :by_provider,  ->(provider) { where(['account_id = ?', provider.id]) }
   scope :by_target, ->(class_name) { where(['target = ?', class_name])}

--- a/app/models/fields_definition.rb
+++ b/app/models/fields_definition.rb
@@ -18,7 +18,7 @@ class FieldsDefinition < ApplicationRecord
   serialize :choices, Array
 
   belongs_to :account, :inverse_of => :fields_definitions
-  acts_as_list :scope => [:account_id, :target], :column => :pos
+  acts_as_list :scope => %i[account_id target], :column => :pos
 
   scope :by_provider,  ->(provider) { where(['account_id = ?', provider.id]) }
   scope :by_target, ->(class_name) { where(['target = ?', class_name])}

--- a/test/functional/admin/fields_definitions_controller_test.rb
+++ b/test/functional/admin/fields_definitions_controller_test.rb
@@ -80,4 +80,24 @@ class Admin::FieldsDefinitionsControllerTest < ActionController::TestCase
     assert_equal [1, 2], fields.pluck(:pos)
     assert_equal [field_definition, other],fields.to_a
   end
+
+  test 'sort wont break other positions' do
+    FieldsDefinition.delete_all
+
+    account = FactoryBot.create(:fields_definition, account: @provider, target: 'Account')
+    account2 = FactoryBot.create(:fields_definition, account: @provider, target: 'Account')
+    user = FactoryBot.create(:fields_definition, account: @provider, target: 'User')
+    user2 = FactoryBot.create(:fields_definition, account: @provider, target: 'User')
+
+    account_pos, account2_pos = account.pos, account2.pos
+    user_pos, user2_pos = user.pos, user2.pos
+
+    post :sort, fields_definition: [ account2.id, account.id ]
+    assert_response :success
+
+    assert account.reload.pos == account2_pos
+    assert account2.reload.pos == account_pos
+    assert user.reload.pos == user_pos
+    assert user2.reload.pos == user2_pos
+  end
 end

--- a/test/functional/admin/fields_definitions_controller_test.rb
+++ b/test/functional/admin/fields_definitions_controller_test.rb
@@ -85,19 +85,19 @@ class Admin::FieldsDefinitionsControllerTest < ActionController::TestCase
     FieldsDefinition.delete_all
 
     account = FactoryBot.create(:fields_definition, account: @provider, target: 'Account')
-    account2 = FactoryBot.create(:fields_definition, account: @provider, target: 'Account')
+    another_account = FactoryBot.create(:fields_definition, account: @provider, target: 'Account')
     user = FactoryBot.create(:fields_definition, account: @provider, target: 'User')
-    user2 = FactoryBot.create(:fields_definition, account: @provider, target: 'User')
+    another_user = FactoryBot.create(:fields_definition, account: @provider, target: 'User')
 
-    account_pos, account2_pos = account.pos, account2.pos
-    user_pos, user2_pos = user.pos, user2.pos
+    account_pos, account2_pos = account.pos, another_account.pos
+    user_pos, user2_pos = user.pos, another_user.pos
 
-    post :sort, fields_definition: [ account2.id, account.id ]
+    post :sort, fields_definition: [ another_account.id, account.id ]
     assert_response :success
 
     assert account.reload.pos == account2_pos
-    assert account2.reload.pos == account_pos
+    assert another_account.reload.pos == account_pos
     assert user.reload.pos == user_pos
-    assert user2.reload.pos == user2_pos
+    assert another_user.reload.pos == user2_pos
   end
 end

--- a/test/unit/fields_definition_test.rb
+++ b/test/unit/fields_definition_test.rb
@@ -258,8 +258,8 @@ class FieldsDefinitionTest < ActiveSupport::TestCase
       @hidden = FactoryBot.create(:fields_definition, :account => @provider, :name => "hidden", :hidden => true)
       @read_only = FactoryBot.create(:fields_definition, :account => @provider, :name => "read_only", :read_only => true)
       @required = FactoryBot.create(:fields_definition, :account => @provider, :name => "required", :required => true)
-      @account_target = FactoryBot.create(:fields_definition, :account => @provider, :name => "other", :required => true, target: 'Account')
-      @account_target2 = FactoryBot.create(:fields_definition, :account => @provider, :name => "other2", :required => true, target: 'Account')
+      @acc_target = FactoryBot.create(:fields_definition, :account => @provider, :name => "other", :required => true, target: 'Account')
+      @acc_target_another = FactoryBot.create(:fields_definition, :account => @provider, :name => "other2", :required => true, target: 'Account')
     end
     should 'return correct positions' do
       assert @hidden.pos    == @read_only.pos - 1
@@ -267,22 +267,22 @@ class FieldsDefinitionTest < ActiveSupport::TestCase
     end
     should 'change position when updated' do
       hidden_pos, read_only_pos = @hidden.pos, @read_only.pos
-      required_pos, acc_target_pos = @required.pos, @account_target.pos
-      acc_target_pos_2 = @account_target2.pos
+      required_pos, acc_target_pos = @required.pos, @acc_target.pos
+      acc_target_another_pos = @acc_target_another.pos
 
       @read_only.update_attribute(:pos, read_only_pos - 1)
 
       assert @read_only.reload.pos == hidden_pos
       assert @hidden.reload.pos == read_only_pos
       assert @required.reload.pos == required_pos
-      assert @account_target.reload.pos == acc_target_pos
-      assert @account_target2.reload.pos == acc_target_pos_2
+      assert @acc_target.reload.pos == acc_target_pos
+      assert @acc_target_another.reload.pos == acc_target_another_pos
     end
 
     should 'not change the position when update fails' do
       hidden_pos, read_only_pos = @hidden.pos, @read_only.pos
-      required_pos, acc_target_pos = @required.pos, @account_target.pos
-      acc_target_pos_2 = @account_target2.pos
+      required_pos, acc_target_pos = @required.pos, @acc_target.pos
+      acc_target_another_pos = @acc_target_another.pos
 
       @required.update(position: 1, name: '%*&#^%@)*$')
 
@@ -290,8 +290,8 @@ class FieldsDefinitionTest < ActiveSupport::TestCase
       assert @hidden.reload.pos == hidden_pos
       assert @read_only.reload.pos == read_only_pos
       assert @required.reload.pos == required_pos
-      assert @account_target.reload.pos == acc_target_pos
-      assert @account_target2.reload.pos == acc_target_pos_2
+      assert @acc_target.reload.pos == acc_target_pos
+      assert @acc_target_another.reload.pos == acc_target_another_pos
     end
   end
 end

--- a/test/unit/fields_definition_test.rb
+++ b/test/unit/fields_definition_test.rb
@@ -251,4 +251,47 @@ class FieldsDefinitionTest < ActiveSupport::TestCase
 
   end
 
+  context 'positions' do
+    setup do
+      @provider = FactoryBot.create :provider_account
+      FieldsDefinition.delete_all
+      @hidden = FactoryBot.create(:fields_definition, :account => @provider, :name => "hidden", :hidden => true)
+      @read_only = FactoryBot.create(:fields_definition, :account => @provider, :name => "read_only", :read_only => true)
+      @required = FactoryBot.create(:fields_definition, :account => @provider, :name => "required", :required => true)
+      @account_target = FactoryBot.create(:fields_definition, :account => @provider, :name => "other", :required => true, target: 'Account')
+      @account_target2 = FactoryBot.create(:fields_definition, :account => @provider, :name => "other2", :required => true, target: 'Account')
+    end
+    should 'return correct positions' do
+      assert @hidden.pos    == @read_only.pos - 1
+      assert @read_only.pos == @required.pos  - 1
+    end
+    should 'change position when updated' do
+      hidden_pos, read_only_pos = @hidden.pos, @read_only.pos
+      required_pos, acc_target_pos = @required.pos, @account_target.pos
+      acc_target_pos_2 = @account_target2.pos
+
+      @read_only.update_attribute(:pos, read_only_pos - 1)
+
+      assert @read_only.reload.pos == hidden_pos
+      assert @hidden.reload.pos == read_only_pos
+      assert @required.reload.pos == required_pos
+      assert @account_target.reload.pos == acc_target_pos
+      assert @account_target2.reload.pos == acc_target_pos_2
+    end
+
+    should 'not change the position when update fails' do
+      hidden_pos, read_only_pos = @hidden.pos, @read_only.pos
+      required_pos, acc_target_pos = @required.pos, @account_target.pos
+      acc_target_pos_2 = @account_target2.pos
+
+      @required.update(position: 1, name: '%*&#^%@)*$')
+
+      assert !@required.errors.empty?
+      assert @hidden.reload.pos == hidden_pos
+      assert @read_only.reload.pos == read_only_pos
+      assert @required.reload.pos == required_pos
+      assert @account_target.reload.pos == acc_target_pos
+      assert @account_target2.reload.pos == acc_target_pos_2
+    end
+  end
 end

--- a/test/unit/fields_definition_test.rb
+++ b/test/unit/fields_definition_test.rb
@@ -255,16 +255,18 @@ class FieldsDefinitionTest < ActiveSupport::TestCase
     setup do
       @provider = FactoryBot.create :provider_account
       FieldsDefinition.delete_all
-      @hidden = FactoryBot.create(:fields_definition, :account => @provider, :name => "hidden", :hidden => true)
-      @read_only = FactoryBot.create(:fields_definition, :account => @provider, :name => "read_only", :read_only => true)
-      @required = FactoryBot.create(:fields_definition, :account => @provider, :name => "required", :required => true)
-      @acc_target = FactoryBot.create(:fields_definition, :account => @provider, :name => "other", :required => true, target: 'Account')
-      @acc_target_another = FactoryBot.create(:fields_definition, :account => @provider, :name => "other2", :required => true, target: 'Account')
+      @hidden = FactoryBot.create(:fields_definition, account: @provider, name: 'hidden', hidden: true)
+      @read_only = FactoryBot.create(:fields_definition, account: @provider, name: 'read_only', read_only: true)
+      @required = FactoryBot.create(:fields_definition, account: @provider, name: 'required', required: true)
+      @acc_target = FactoryBot.create(:fields_definition, account: @provider, name: 'other', required: true, target: 'Account')
+      @acc_target_another = FactoryBot.create(:fields_definition, account: @provider, name: 'other2', required: true, target: 'Account')
     end
+
     should 'return correct positions' do
-      assert @hidden.pos    == @read_only.pos - 1
-      assert @read_only.pos == @required.pos  - 1
+      assert_equal @hidden.pos, @read_only.pos - 1
+      assert_equal @read_only.pos, @required.pos  - 1
     end
+
     should 'change position when updated' do
       hidden_pos, read_only_pos = @hidden.pos, @read_only.pos
       required_pos, acc_target_pos = @required.pos, @acc_target.pos
@@ -272,11 +274,11 @@ class FieldsDefinitionTest < ActiveSupport::TestCase
 
       @read_only.update_attribute(:pos, read_only_pos - 1)
 
-      assert @read_only.reload.pos == hidden_pos
-      assert @hidden.reload.pos == read_only_pos
-      assert @required.reload.pos == required_pos
-      assert @acc_target.reload.pos == acc_target_pos
-      assert @acc_target_another.reload.pos == acc_target_another_pos
+      assert_equal @read_only.reload.pos, hidden_pos
+      assert_equal @hidden.reload.pos, read_only_pos
+      assert_equal @required.reload.pos, required_pos
+      assert_equal @acc_target.reload.pos, acc_target_pos
+      assert_equal @acc_target_another.reload.pos, acc_target_another_pos
     end
 
     should 'not change the position when update fails' do
@@ -286,12 +288,12 @@ class FieldsDefinitionTest < ActiveSupport::TestCase
 
       @required.update(position: 1, name: '%*&#^%@)*$')
 
-      assert !@required.errors.empty?
-      assert @hidden.reload.pos == hidden_pos
-      assert @read_only.reload.pos == read_only_pos
-      assert @required.reload.pos == required_pos
-      assert @acc_target.reload.pos == acc_target_pos
-      assert @acc_target_another.reload.pos == acc_target_another_pos
+      assert_not @required.errors.empty?
+      assert_equal @hidden.reload.pos, hidden_pos
+      assert_equal @read_only.reload.pos, read_only_pos
+      assert_equal @required.reload.pos, required_pos
+      assert_equal @acc_target.reload.pos, acc_target_pos
+      assert_equal @acc_target_another.reload.pos, acc_target_another_pos
     end
   end
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

The introduction of the API (https://github.com/3scale/porta/pull/2480) for the field's definition pointed out an old bug with positions.
The fields definition uses the position column for the order of the fields. The `act_as_list` library doesn't know how to handle the list where the position is based on the `target` field, so it tries to update the position for every field, and it breaks the positions.

This PR introduces a fix for it. It overrides the update and corrects the positions of the fields. 

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7189

**Verification steps** 

The position is not visible yet, but https://github.com/3scale/porta/pull/2480 introduces the API, which will expose the position.

**Special notes for your reviewer**:
