### PR TITLE
[gh-actions] To fast forward the candidate branch to default branch HEAD

### DIFF
--- a/.github/workflows/fast-forward-candidate-branch.yml
+++ b/.github/workflows/fast-forward-candidate-branch.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       release:
-        description: 'The release version number e.g (2.11 or 2.12)'
+        description: 'The release version number (e.g, 2.11)'
         required: true
       ref:
         description: 'The SHA1 or branch name the candidate branch will point to'

--- a/.github/workflows/fast-forward-candidate-branch.yml
+++ b/.github/workflows/fast-forward-candidate-branch.yml
@@ -1,0 +1,21 @@
+name: Fast-forward candidate branch to HEAD of default branch
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'The release version number e.g (2.11 or 2.12)'
+        required: true
+      ref:
+        description: 'The SHA1 or branch name the candidate branch will point to'
+        required: true
+        default: refs/heads/master
+
+jobs:
+  fast-forward:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - run: git push origin HEAD:3scale-${{ github.event.inputs.release }}-candidate
+        name: Push to candidate branch


### PR DESCRIPTION
So we just have to press a button to do that

* the new candidate points by default to the current refs/heads/master
* the release version is required, it can be 2.11 or 2.12
  the workflow will create or update a branch named 3scale-{{ release }}-candidate