### PR TITLE
Upgrade pgsql libs to v10

### DIFF
--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -16,12 +16,15 @@ ARG SPHINX_VERSION=2.2.11-1
 ADD openshift/system/sphinx-${SPHINX_VERSION}.rhel7.x86_64.rpm /tmp/sphinxsearch.rpm
 
 RUN yum-config-manager --save --setopt=cbs.centos.org_repos_sclo7-rh-ruby25-rh-candidate_x86_64_os_.skip_if_unavailable=true \
+    && rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && yum -y update \
+    && yum remove -y postgresql \
     && yum -y install centos-release-scl-rh \
               ImageMagick \
               ImageMagick-devel \
               unixODBC-devel \
               mysql \
+              postgresql10 postgresql10-devel postgresql10-libs \
               file \
               rh-nodejs10 \
     && rpm -i /tmp/sphinxsearch.rpm \
@@ -47,6 +50,7 @@ ENV BASH_ENV=/opt/system/etc/scl_enable \
 RUN export ${BUNDLER_ENV} >/dev/null\
     && source /opt/system/etc/scl_enable \
     && gem install bundler --version 2.2.18 \
+    && bundle config build.pg --with-pg-config=/usr/pgsql-10/bin/pg_config \
     && bundle install --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
 
 RUN chgrp root /opt/system/


### PR DESCRIPTION
This is related to [CVE-2020-25695](https://www.postgresql.org/support/security/CVE-2020-25695/) ([THREESCALE-7225](https://issues.redhat.com/browse/THREESCALE-7225)).

Although the CVE does not directly affect PostgreSQL client libs,
1. matching versions of PostgreSQL client libs and PostgreSQL server is a good practice as some client ("frontend") apps are, according to [documentation](https://www.postgresql.org/docs/9.0/app-psql.html#AEN75717), _"only guaranteed to work smoothly with servers of the same version"_, in spite of PotgreSQL's frontend/backend protocol [kept stable at v3 since PostreSQL v7.4](https://www.postgresql.org/docs/10/protocol.html)) – Note: our [tests](https://github.com/3scale/porta/blob/2e2b870ed4983c5375525049390c14c1448b56dd/.circleci/config.yml#L99) currently run on PostgreSQL v10.5 and 3scale-operator's [non-HA deployments](https://github.com/3scale/3scale-operator/blob/00393b1609a8008ff76e77c5b8c8a279a121adee/pkg/3scale/amp/auto-generated-templates/amp/amp-postgresql.yml#L4159) install by default v10.17;
2. one who currently checks the version of the PostgreSQL libs installed in the upstream (e.g., by running `psql --version`) might inadvertently assume that the system is unprotected for the attacks decribed by CVE-2020-25695, though this actually depends on the version of the server, not the client libs.

This change does not affect Red Hat downstream images whose versions of PotsgreSQL client libs are given at the level of the base image and/or Red Hat Software Collections (RHSCL) enablement.

**Before:**

```
$ docker run --rm=True quay.io/3scale/porta:latest -- psql --version
psql (PostgreSQL) 9.2.24
```

**After:**

```
$ docker build -t porta:pgsql-10 . # <======== this branch
$ docker run --rm=True porta:pgsql-10 -- psql --version
psql (PostgreSQL) 10.17
```

----

TODO:
- [x] push similar changes to https://github.com/3scale/system-builder - https://github.com/3scale/system-builder/pull/28