### PR TITLE
🐛 Prevents New Application from returning 404 when no service plan selected

### DIFF
--- a/app/lib/applications_controller_methods.rb
+++ b/app/lib/applications_controller_methods.rb
@@ -78,9 +78,12 @@ module ApplicationsControllerMethods
   end
 
   def find_service_plan
-    return unless (service_plan_id = params[:cinstance].delete(:service_plan_id))
-
-    @service_plan = @service.service_plans.find(service_plan_id)
+    service_plans = @service.service_plans
+    @service_plan = if (service_plan_id = params[:cinstance].delete(:service_plan_id))
+                      service_plans.find(service_plan_id)
+                    else
+                      @service.default_service_plan || service_plans.first
+                    end
   end
 
   def plan_id

--- a/test/integration/api/applications_controller_test.rb
+++ b/test/integration/api/applications_controller_test.rb
@@ -71,6 +71,62 @@ class Api::ApplicationsControllerTest < ActionDispatch::IntegrationTest
         refute page.xpath("//tr").text.match /Service/
       end
     end
+
+    class Create < TenantLoggedInTest
+      def setup
+        @service = provider.default_service
+        @application_plan = FactoryBot.create(:application_plan, issuer: service)
+        @service_plan = FactoryBot.create(:service_plan, service: service)
+        @buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+      end
+
+      attr_reader :service_plan, :buyer, :application_plan, :service
+
+      test 'crate application redirects to the provider admin index page' do
+        post admin_service_applications_path(service), params: { account_id: buyer.id,
+                                                                 cinstance: { service_plan_id: service_plan.id, plan_id: application_plan.id, name: 'My Application' } }
+
+        assert_redirected_to provider_admin_application_path(Cinstance.last)
+      end
+
+      test 'crate application with no service plan selected' do
+        post admin_service_applications_path(service), params: { account_id: buyer.id,
+                                                                 cinstance: { plan_id: application_plan.id, name: 'My Application' } }
+
+        application = Cinstance.last
+        assert_redirected_to provider_admin_application_path(application)
+      end
+
+      test 'crate application with no service plan selected and a default service plan' do
+        default_service_plan = FactoryBot.create(:service_plan, service: service)
+        service.update(default_service_plan: default_service_plan)
+        post admin_service_applications_path(service), params: { account_id: buyer.id,
+                                                                 cinstance: { plan_id: application_plan.id, name: 'My Application' } }
+
+        assert_response :redirect
+        assert_equal default_service_plan, buyer.bought_service_contracts.first.service_plan
+      end
+
+      test 'crate application with no service plan selected and no default service plan' do
+        other_service_plan = FactoryBot.create(:service_plan, service: service)
+        service.update(default_service_plan: nil)
+        post admin_service_applications_path(service), params: { account_id: buyer.id,
+                                                                 cinstance: { plan_id: application_plan.id, name: 'My Application' } }
+
+        assert_response :redirect
+        assert_not_equal other_service_plan, buyer.bought_service_contracts.first.service_plan
+      end
+
+      test 'crate application with no service plan selected and a subscription' do
+        subscribed_service_plan = FactoryBot.create(:service_plan, service: service)
+        buyer.bought_service_contracts.create(plan: subscribed_service_plan)
+        post admin_service_applications_path(service), params: { account_id: buyer.id,
+                                                                 cinstance: { plan_id: application_plan.id, name: 'My Application' } }
+
+        assert_response :redirect
+        assert_equal subscribed_service_plan, buyer.bought_service_contracts.first.service_plan
+      end
+    end
   end
 
 end

--- a/test/integration/buyers/applications_controller_test.rb
+++ b/test/integration/buyers/applications_controller_test.rb
@@ -3,50 +3,91 @@
 require 'test_helper'
 
 class Buyers::ApplicationsTest < ActionDispatch::IntegrationTest
-  def setup
-    @provider = FactoryBot.create(:provider_account)
+  class TenantLoggedInTest < Buyers::ApplicationsTest
+    setup do
+      @provider = FactoryBot.create(:provider_account)
+      login! @provider
+    end
 
-    login! provider
+    attr_reader :provider
 
-    #TODO: dry with @ignore-backend tag on cucumber
-    stub_backend_get_keys
-    stub_backend_referrer_filters
-    stub_backend_utilization
-  end
+    class Create < TenantLoggedInTest
+      def setup
+        @service = provider.default_service
+        @application_plan = FactoryBot.create(:application_plan, issuer: service)
+        @service_plan = FactoryBot.create(:service_plan, service: service)
+        @buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+      end
 
-  attr_reader :provider
+      attr_reader :service_plan, :buyer, :application_plan, :service
 
-  test 'member cannot create an application when lacking access to a service' do
-    forbidden_service = FactoryBot.create(:service, account: provider)
-    forbidden_plan = FactoryBot.create(:application_plan, issuer: forbidden_service)
-    forbidden_service_plan = FactoryBot.create(:service_plan, issuer: forbidden_service)
+      test 'crate application redirects to the provider admin index page' do
+        post admin_buyers_account_applications_path(buyer), params: { cinstance: { service_plan_id: service_plan.id, plan_id: application_plan.id, name: 'My Application' } }
 
-    authorized_service = FactoryBot.create(:service, account: provider)
-    authorized_plan = FactoryBot.create(:application_plan, issuer: authorized_service)
-    authorized_service_plan = FactoryBot.create(:service_plan, issuer: authorized_service)
+        assert_redirected_to provider_admin_application_path(Cinstance.last)
+      end
 
-    buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+      test 'crate application with no service plan selected' do
+        post admin_buyers_account_applications_path(buyer), params: { cinstance: { plan_id: application_plan.id, name: 'My Application' } }
 
-    member = FactoryBot.create(:member, account: provider, member_permission_ids: [:partners])
-    member.activate!
-    FactoryBot.create(:member_permission, user: member, admin_section: :services, service_ids: [authorized_service.id])
+        application = Cinstance.last
+        assert_redirected_to provider_admin_application_path(application)
+      end
 
-    login_provider provider, user: member
+      test 'crate application with no service plan selected and a default service plan' do
+        default_service_plan = FactoryBot.create(:service_plan, service: service)
+        service.update(default_service_plan: default_service_plan)
+        post admin_buyers_account_applications_path(buyer), params: { cinstance: { plan_id: application_plan.id, name: 'My Application' } }
 
-    post admin_buyers_account_applications_path(account_id: buyer.id), cinstance: {
-      plan_id: forbidden_plan.id,
-      name: 'Not Allowed!',
-      service_plan_id: forbidden_service_plan.id
-    }
+        assert_response :redirect
+        assert_equal default_service_plan, buyer.bought_service_contracts.first.service_plan
+      end
 
-    assert_response :not_found
+      test 'crate application with no service plan selected and no default service plan' do
+        other_service_plan = FactoryBot.create(:service_plan, service: service)
+        service.update(default_service_plan: nil)
+        post admin_buyers_account_applications_path(buyer), params: { cinstance: { plan_id: application_plan.id, name: 'My Application' } }
 
-    post admin_buyers_account_applications_path(account_id: buyer.id), cinstance: {
-      plan_id: authorized_plan.id,
-      name: 'Allowed',
-      service_plan_id: authorized_service_plan.id
-    }
+        assert_response :redirect
+        assert_not_equal other_service_plan, buyer.bought_service_contracts.first.service_plan
+      end
 
-    assert_response :found
+      test 'crate application with no service plan selected and a subscription' do
+        subscribed_service_plan = FactoryBot.create(:service_plan, service: service)
+        buyer.bought_service_contracts.create(plan: subscribed_service_plan)
+        post admin_buyers_account_applications_path(buyer), params: { cinstance: { plan_id: application_plan.id, name: 'My Application' } }
+
+        assert_response :redirect
+        assert_equal subscribed_service_plan, buyer.bought_service_contracts.first.service_plan
+      end
+
+      test 'member cannot create an application when lacking access to a service' do
+        stub_backend_get_keys
+        stub_backend_referrer_filters
+        stub_backend_utilization
+
+        forbidden_service = FactoryBot.create(:service, account: provider)
+        forbidden_plan = FactoryBot.create(:application_plan, issuer: forbidden_service)
+        forbidden_service_plan = FactoryBot.create(:service_plan, issuer: forbidden_service)
+
+        authorized_service = FactoryBot.create(:service, account: provider)
+        authorized_plan = FactoryBot.create(:application_plan, issuer: authorized_service)
+        authorized_service_plan = FactoryBot.create(:service_plan, issuer: authorized_service)
+
+        member = FactoryBot.create(:member, account: provider, member_permission_ids: [:partners])
+        member.activate!
+        FactoryBot.create(:member_permission, user: member, admin_section: :services, service_ids: [authorized_service.id])
+
+        login_provider provider, user: member
+
+        post admin_buyers_account_applications_path(buyer), params: { cinstance: { service_plan_id: forbidden_service_plan.id, plan_id: forbidden_plan.id, name: 'Not Allowed!' } }
+
+        assert_response :not_found
+
+        post admin_buyers_account_applications_path(buyer), params: { cinstance: { service_plan_id: authorized_service_plan.id, plan_id: authorized_plan.id, name: 'Allowed' } }
+
+        assert_response :found
+      end
+    end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Current implementation relies on a service subscription to exist OR a service plan id being sent in the request. When neither of those happen, 404 is return.

After this fix, the server will try to get the `default_service_plan` and if no one exist, the first one available.

**Which issue(s) this PR fixes** 

[THREESCALE-7246: Cannot create application on saas](https://issues.redhat.com/browse/THREESCALE-7246)

**Verification steps** 

TBD
