### PR TITLE
CI based on system-builder-ruby25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ attach-to-workspace: &attach-to-workspace
     at: .
 
 system-builder-ruby25: &system-builder-ruby25
-  image: quay.io/3scale/system-builder:ruby25-bundler-2.2.18
+  image: quay.io/3scale/system-builder:ruby25
   environment:
     BUNDLE_FROZEN: true
     BUNDLE_PATH: 'vendor/bundle'


### PR DESCRIPTION
Run CI on quay.io/3scale/system-builder:ruby25, as this image now also contains bundler v2.2.18 and there is no need for fetching a different one.