### PR TITLE
Bugfix: render braintree form without billing address

### DIFF
--- a/app/javascript/packs/braintree_customer_form.js
+++ b/app/javascript/packs/braintree_customer_form.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const { clientToken, billingAddress, threeDSecureEnabled, formActionPath, countriesList, selectedCountryCode } = container.dataset
-  const billingAddressParsed = safeFromJsonString(billingAddress)
+  const billingAddressParsed = safeFromJsonString(billingAddress) || {}
   for (let key in billingAddressParsed) {
     if (billingAddressParsed[key] === null) {
       billingAddressParsed[key] = ''

--- a/app/views/payment_gateways/_braintree_customer_form.html.erb
+++ b/app/views/payment_gateways/_braintree_customer_form.html.erb
@@ -6,7 +6,9 @@
   data-form-action-path="<%= developer_portal.hosted_success_admin_account_braintree_blue_path %>"
   data-three-d-secure-enabled="<%= site_account.payment_gateway_options[:three_ds_enabled] %>"
   data-client-token="<%= client_token = j @braintree_authorization %>"
-  data-billing-address="<%= billing_address_data ? billing_address_data.to_json : nil %>"
+  <% unless billing_address_data == nil %>
+    data-billing-address="<%= billing_address_data.to_json  %>"
+  <% end %>
   data-countries-list="<%= merchant_countries.to_json %>"
   data-selected-country-code="<%= selected_country_code %>"
 ></div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

In Developer Portal, Braintree form doesn't render when account has no billing address previously stored.


**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7221

**Verification steps** 

- You need an account without billing address.
- If you don't have one, you can modify it directly in rails console ans set to `nil` these fields:

```
billing_address_name: nil,
billing_address_address1: nil,
billing_address_address2: nil,
billing_address_city: nil,
billing_address_state: nil,
billing_address_country: nil,
billing_address_zip: nil,
billing_address_phone: nil, 
```

- In Dev Portal, login, then go to: 

http://provider.3scale.localhost:3000/admin/account/braintree_blue

- Click on "Add Credit Card Details and Billing Address"  (not billing address) link.
- Form should display without errors


