### PR TITLE
Disabling ApiDocs Proxy should be an active setting

### DIFF
--- a/app/assets/javascripts/swagger-ui/threescale.coffee.erb
+++ b/app/assets/javascripts/swagger-ui/threescale.coffee.erb
@@ -40,10 +40,13 @@ class ThreeScaleHttp
   constructor: (swagger_http) ->
     @swagger_http = swagger_http
 
+  enableApiDocsProxy: ->
+    window.enableApiDocsProxy
+
   execute: (obj) ->
-    <% if Rails.configuration.three_scale.active_docs_proxy_disabled %>
-    if @originHttps() then obj.url = @forceHttpsProtocol obj.url
-    <% end %>
+    unless @enableApiDocsProxy()
+      if @originHttps() then obj.url = @forceHttpsProtocol obj.url
+
     @createLinkElement obj.url
     obj.useJQuery = true
     obj.originalUrl = obj.url
@@ -94,11 +97,7 @@ class ThreeScaleHttp
     @linkElement
 
   sameOrigin: ->
-    <% if Rails.configuration.three_scale.active_docs_proxy_disabled %>
-      true
-    <% else %>
-      @desiredOrigin() == @locationOrigin()
-    <% end %>
+      !@enableApiDocsProxy() || @desiredOrigin() == @locationOrigin()
 
   desiredOrigin: ->
      # This is to make IE happy.

--- a/app/assets/javascripts/swagger-ui2/api_docs_proxy.coffee.erb
+++ b/app/assets/javascripts/swagger-ui2/api_docs_proxy.coffee.erb
@@ -9,9 +9,9 @@ class ApiDocsProxy
   NO_CACHE_HEADERS = { "Cache-Control": "no-cache"  }
 
   execute: (httpClient, obj) ->
-    <% if Rails.configuration.three_scale.active_docs_proxy_disabled %>
-    if @originHttps() then obj.url = @forceHttpsProtocol obj.url
-    <% end %>
+    unless @enableApiDocsProxy()
+      if @originHttps() then obj.url = @forceHttpsProtocol obj.url
+
     @createLinkElement obj.url
     obj.originalUrl = obj.url
     # console.log "[ApiDocsProxy] incoming url #{obj.url}"
@@ -51,12 +51,11 @@ class ApiDocsProxy
     @linkElement
 
   sameOrigin: ->
-    <% if Rails.configuration.three_scale.active_docs_proxy_disabled %>
-      true
-    <% else %>
-      @desiredOrigin() == @locationOrigin()
-    <% end %>
+    !@enableApiDocsProxy() || @desiredOrigin() == @locationOrigin()
 
+
+  enableApiDocsProxy: ->
+    window.enableApiDocsProxy
 
   apiDocsPath: ->
     # In some browsers like IE pathname do not includes (/) slash at the

--- a/app/views/admin/api_docs/base/swagger.html.erb
+++ b/app/views/admin/api_docs/base/swagger.html.erb
@@ -1,4 +1,10 @@
 <% content_for :sublayout_title, 'ActiveDocs' %>
+<% content_for :javascripts do %>
+  <%= javascript_tag do %>
+    window.enableApiDocsProxy = <%= Rails.configuration.three_scale.active_docs_proxy_disabled.blank? %>;
+  <% end %>
+<% end %>
+
 <%= render "menu" -%>
 
 <div class="swagger-section">

--- a/app/views/provider/admin/api_docs/show-v2.html.erb
+++ b/app/views/provider/admin/api_docs/show-v2.html.erb
@@ -1,3 +1,6 @@
+<%= javascript_tag do %>
+  window.enableApiDocsProxy = <%= Rails.configuration.three_scale.active_docs_proxy_disabled.blank? %>;
+<% end %>
 <%= javascript_include_tag "swagger-ui2" -%>
 <%= javascript_include_tag "swagger-ui2/api_docs_proxy" %>
 <%= javascript_include_tag "swagger-ui2/autocomplete" %>

--- a/app/views/provider/admin/api_docs/show.html.erb
+++ b/app/views/provider/admin/api_docs/show.html.erb
@@ -1,4 +1,7 @@
 <%= stylesheet_link_tag 'active-docs/application.css' %>
+<%= javascript_tag do %>
+  window.enableApiDocsProxy = <%= Rails.configuration.three_scale.active_docs_proxy_disabled.blank? %>;
+<% end %>
 <%= javascript_include_tag 'active-docs/application.js' %>
 
 <% content_for :title do %>

--- a/lib/developer_portal/app/views/shared/_swagger.html.erb
+++ b/lib/developer_portal/app/views/shared/_swagger.html.erb
@@ -1,3 +1,6 @@
+<%= javascript_tag do %>
+  window.enableApiDocsProxy = <%= Rails.configuration.three_scale.active_docs_proxy_disabled.blank? %>;
+<% end %>
 <%= javascript_include_tag "swagger-ui" -%>
 <%= javascript_include_tag "swagger-ui/threescale" -%>
 <%= javascript_include_tag "swagger-ui/extensions" -%>

--- a/lib/developer_portal/app/views/shared/_swagger_2_0.html.erb
+++ b/lib/developer_portal/app/views/shared/_swagger_2_0.html.erb
@@ -1,3 +1,6 @@
+<%= javascript_tag do %>
+  window.enableApiDocsProxy = <%= Rails.configuration.three_scale.active_docs_proxy_disabled.blank? %>;
+<% end %>
 <%= javascript_include_tag "swagger-ui2" -%>
 <%= javascript_include_tag "swagger-ui2/api_docs_proxy" %>
 <%= javascript_include_tag "swagger-ui2/autocomplete" %>

--- a/lib/developer_portal/lib/liquid/filters/rails_helpers.rb
+++ b/lib/developer_portal/lib/liquid/filters/rails_helpers.rb
@@ -13,6 +13,7 @@ module Liquid
       THREESCALE_JAVASCRIPTS = %w[buyer/1/analytics plans_widget.js plans_widget_v2.js active-docs/application.js stats.js].freeze
       THREESCALE_WEBPACK_PACKS = %w[stats.js active_docs.js load_stripe.js].freeze
       THREESCALE_IMAGES      = %w[spinner.gif tick.png cross.png].freeze
+      ACTIVE_DOCS_JS = %w[active-docs/application.js active_docs.js].freeze
 
       desc "Group collection by some key."
       example "Group applications by service.", %(
@@ -50,9 +51,9 @@ module Liquid
         js = RailsHelpers.replace_googleapis(name)
         case
         when THREESCALE_WEBPACK_PACKS.include?(name) # TODO: This is an intermediate step in order to tackle webpack assets in dev portal. A final solution might be needed easing the update of templates/assets.
-          view.javascript_pack_tag(name, options)
+          active_docs_proxy(name) + view.javascript_pack_tag(name, options)
         when js != name || THREESCALE_JAVASCRIPTS.include?(js)
-          view.javascript_include_tag(js)
+          active_docs_proxy(js) + view.javascript_include_tag(js)
         else
           RailsHelpers.content_tag(:script, '', src: get_path(name))
         end
@@ -267,6 +268,16 @@ module Liquid
 
       def button(title, url, method, options={})
         view.button_to title.to_s, url.to_s, {method: method}.merge(options)
+      end
+
+      ENABLE_API_DOCS_PROXY = "window.enableApiDocsProxy = #{Rails.configuration.three_scale.active_docs_proxy_disabled.blank?};\n"
+
+      def active_docs_proxy(name)
+        if name.in?(ACTIVE_DOCS_JS)
+          view.javascript_tag ENABLE_API_DOCS_PROXY
+        else
+          "".html_safe
+        end
       end
     end
   end

--- a/vendor/active-docs/app/assets/javascripts/active-docs/classes/resources_controller.js.erb
+++ b/vendor/active-docs/app/assets/javascripts/active-docs/classes/resources_controller.js.erb
@@ -1,16 +1,12 @@
 (function(global, $){
 
+  function apiDocsProxyEnabled(){
+    window.enableApiDocsProxy;
+  }
+
   function ResourcesController(){
     this.path = "/api_docs/services.json";
-    <% if Rails.configuration.three_scale.active_docs_proxy_disabled %>
-      if(originHttps()) {
-        this.url = forceHttpsProtocol(global.host) + this.path
-      } else {
-        this.url = global.host + this.path;
-      }
-    <% else %>
-      this.url = global.host + this.path;
-    <% end %>
+    this.url = (!apiDocsProxyEnabled() && originHttps()) ?  forceHttpsProtocol(global.host) + this.path : global.host + this.path;
   }
 
   function originHttps() {

--- a/vendor/active-docs/app/assets/javascripts/active-docs/form_handler.js.erb
+++ b/vendor/active-docs/app/assets/javascripts/active-docs/form_handler.js.erb
@@ -105,13 +105,17 @@
     return (xhr.getResponseHeader('Content-Type').search(/xml/) > -1) ? true : false;
   }
 
+  function apiDocsProxyEnabled(){
+    window.enableApiDocsProxy;
+  }
+
   function dispatch(){
-    <% if Rails.configuration.three_scale.active_docs_proxy_disabled %>
+    if (apiDocsProxyEnabled() && !(getHost()) === window.location.origin) {
+       dispatchProxy();
+    }
+    else{
       dispatchDirect();
-    <% else %>
-      if((getHost()) === window.location.origin) { dispatchDirect(); }
-      else { dispatchProxy(); }
-    <% end %>
+    }
   }
 
   /**


### PR DESCRIPTION
The issue is that this setting is used in coffee files.
Meaning on container image build it enables or disables ApiDocs proxy on asset compilation time

Closing https://issues.redhat.com/browse/THREESCALE-7320

Requires https://github.com/3scale/deploy/pull/714