### PR TITLE
DB index on metrics.parent_id

### DIFF
--- a/db/migrate/20210708100519_add_index_on_metrics_parent_id.rb
+++ b/db/migrate/20210708100519_add_index_on_metrics_parent_id.rb
@@ -1,0 +1,8 @@
+class AddIndexOnMetricsParentId < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction! if System::Database.postgres?
+
+  def change
+    index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+    add_index :metrics, :parent_id, index_options
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210128155025) do
+ActiveRecord::Schema.define(version: 20210708100519) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer  "owner_id",   precision: 38, null: false
@@ -824,6 +824,7 @@ ActiveRecord::Schema.define(version: 20210128155025) do
 
   add_index "metrics", ["owner_type", "owner_id", "system_name"], name: "index_metrics_on_owner_type_and_owner_id_and_system_name", unique: true
   add_index "metrics", ["owner_type", "owner_id"], name: "index_metrics_on_owner_type_and_owner_id"
+  add_index "metrics", ["parent_id"], name: "index_metrics_on_parent_id"
   add_index "metrics", ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", unique: true
   add_index "metrics", ["service_id"], name: "index_metrics_on_service_id"
 

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210128155025) do
+ActiveRecord::Schema.define(version: 20210708100519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -785,6 +785,7 @@ ActiveRecord::Schema.define(version: 20210128155025) do
     t.string   "owner_type"
     t.index ["owner_type", "owner_id", "system_name"], name: "index_metrics_on_owner_type_and_owner_id_and_system_name", unique: true, using: :btree
     t.index ["owner_type", "owner_id"], name: "index_metrics_on_owner_type_and_owner_id", using: :btree
+    t.index ["parent_id"], name: "index_metrics_on_parent_id", using: :btree
     t.index ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", unique: true, using: :btree
     t.index ["service_id"], name: "index_metrics_on_service_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210128155025) do
+ActiveRecord::Schema.define(version: 20210708100519) do
 
   create_table "access_tokens", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.bigint   "owner_id",                 null: false
@@ -784,6 +784,7 @@ ActiveRecord::Schema.define(version: 20210128155025) do
     t.string   "owner_type"
     t.index ["owner_type", "owner_id", "system_name"], name: "index_metrics_on_owner_type_and_owner_id_and_system_name", unique: true, using: :btree
     t.index ["owner_type", "owner_id"], name: "index_metrics_on_owner_type_and_owner_id", using: :btree
+    t.index ["parent_id"], name: "index_metrics_on_parent_id", using: :btree
     t.index ["service_id", "system_name"], name: "index_metrics_on_service_id_and_system_name", unique: true, using: :btree
     t.index ["service_id"], name: "index_metrics_on_service_id", using: :btree
   end


### PR DESCRIPTION
In some large databases, `metric.children` can currently take several milliseconds to execute. This can cause pages such as the application plan show page of the Admin Portal to fail with a 502 when either the API product or any of the API backends has a considerable number of top level metrics to render.

Performance can be improved with a database index defined on `metrics.parent_id`.

```ruby
::Benchmark.ms { Metric.find(9).children.count } # environment with hundreds of thousands of metrics
=> 78.72738316655159

Metric.find(9).children.to_sql # from https://github.com/amerine/acts_as_tree
=> "SELECT `metrics`.* FROM `metrics` WHERE `metrics`.`parent_id` = 9 ORDER BY `metrics`.`id` ASC"
```

**Before:**

```sql
mysql> EXPLAIN SELECT `metrics`.* FROM `metrics` WHERE `metrics`.`parent_id` = 9 ORDER BY `metrics`.`id` ASC \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: metrics
   partitions: NULL
         type: index
possible_keys: NULL
          key: PRIMARY
      key_len: 8
          ref: NULL
         rows: 12
     filtered: 10.00
        Extra: Using where
1 row in set, 1 warning (0.00 sec)
```

**After:**

```sql
mysql> EXPLAIN SELECT `metrics`.* FROM `metrics` WHERE `metrics`.`parent_id` = 9 ORDER BY `metrics`.`id` ASC \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: metrics
   partitions: NULL
         type: ref
possible_keys: index_metrics_on_parent_id
          key: index_metrics_on_parent_id
      key_len: 9
          ref: const
         rows: 1
     filtered: 100.00
        Extra: Using index condition
1 row in set, 1 warning (0.01 sec)
```

----

Closes [THREESCALE-7213](https://issues.redhat.com/browse/THREESCALE-7213)