### PR TITLE
[THREESCALE-7134] Remove show method from the nginxes controller

### DIFF
--- a/app/controllers/admin/api/nginxes_controller.rb
+++ b/app/controllers/admin/api/nginxes_controller.rb
@@ -2,18 +2,6 @@ class Admin::Api::NginxesController < Admin::Api::BaseController
 
   before_action :disable_on_premises
 
-  def show
-    respond_to do |format|
-      format.zip do
-        generator = Apicast::ZipGenerator.new(apicast_source)
-        send_file generator.data,
-                    type: 'application/zip',
-                    disposition: 'attachment',
-                    filename: 'proxy_configs.zip'
-      end
-    end
-  end
-
   def spec
     spec = apicast_source.attributes_for_proxy
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -660,7 +660,7 @@ without fake Core server your after commit callbacks will crash and you might ge
 
       resources :fields_definitions, controller: 'fields_definitions', except: %i[new edit]
 
-      resource :nginx, :only => [:show], :defaults => { :format => 'zip' } do
+      resource :nginx do
         collection do
           get :spec
         end

--- a/test/functional/admin/api/nginxes_controller_test.rb
+++ b/test/functional/admin/api/nginxes_controller_test.rb
@@ -5,23 +5,6 @@ class Admin::Api::NginxesControllerTest < ActionController::TestCase
     Logic::RollingUpdates.stubs(skipped?: true)
   end
 
-  test 'show' do
-    provider = FactoryBot.create(:provider_account, domain: 'provider.example.com')
-    host! provider.admin_domain
-
-    get :show, format: :zip, provider_key: provider.api_key
-
-    assert_response :success
-    assert_equal 'application/zip', response.content_type
-    assert_includes response.headers, 'Content-Transfer-Encoding', 'Content-Disposition'
-    assert_equal 'attachment; filename="proxy_configs.zip"', response['Content-Disposition']
-    assert_equal 'binary', response['Content-Transfer-Encoding']
-
-    Zip::InputStream.open(StringIO.new(response.body)) do |zip|
-      assert zip.get_next_entry
-    end
-  end
-
   test 'spec returns a json' do
     provider = FactoryBot.create(:provider_account, domain: 'provider.example.com')
     host! provider.admin_domain

--- a/test/integration/user-management-api/nginx_test.rb
+++ b/test/integration/user-management-api/nginx_test.rb
@@ -11,22 +11,26 @@ class Admin::Api::NginxTest < ActionDispatch::IntegrationTest
     host! @provider.admin_domain
   end
 
-  test 'show' do
-    get admin_api_nginx_path, {format: :zip, provider_key: @provider.provider_key}
+  def spec_path
+    admin_api_nginx_path + '/spec.json'
+  end
+
+  test 'spec' do
+    get spec_path, { provider_key: @provider.provider_key }
     assert_response :success
-    assert_equal( "application/zip", @response.content_type )
+    assert_equal("application/json", @response.content_type)
     assert_not_nil @response.body
   end
 
-  test 'show with wrong provider_key' do
-    get admin_api_nginx_path, { format: :zip, provider_key: (0...8).map { (65 + rand(26)).chr }.join }
+  test 'spec with wrong provider_key' do
+    get spec_path, { provider_key: (0...8).map { (65 + rand(26)).chr }.join }
     assert_response :forbidden
   end
 
   test 'renders 404 on premises' do
     ThreeScale.config.stubs(apicast_custom_url: true)
 
-    get admin_api_nginx_path, {format: :zip, provider_key: @provider.provider_key}
+    get spec_path, { provider_key: @provider.provider_key }
 
     assert_response :not_found
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

Removing only the show method, which was generating the Lua-based configuration.

https://issues.redhat.com/browse/THREESCALE-7134