### PR TITLE
Disable messagebus as it was removed from the UI

### DIFF
--- a/config/examples/zync.yml
+++ b/config/examples/zync.yml
@@ -1,6 +1,6 @@
 default: &base
   endpoint: <%= ENV['ZYNC_ENDPOINT'] %>
-  message_bus: true
+  message_bus: false
   authentication:
     token: <%= ENV['ZYNC_AUTHENTICATION_TOKEN'] %>
   connect_timeout: 2


### PR DESCRIPTION
It is not used in the UI see https://github.com/3scale/porta/commit/9da51ed20f2fb7db4396c71459d3bf6c739bc039