### PR TITLE
🐛 "Create new application" button in the Developer Portal redirects to messages inbox

### DIFF
--- a/app/lib/logic/provider_settings.rb
+++ b/app/lib/logic/provider_settings.rb
@@ -24,7 +24,7 @@ module Logic
       try(:settings).try!(:forum_enabled?) && provider_can_use?(:forum)
     end
 
-    def service_items_in_menu?
+    def single_service?
       !multiservice?
     end
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -114,7 +114,7 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
 
   def service
     @service ||= if single_service?
-                   services.default
+                   services.first
                  elsif (service_id = params[:service_id])
                    services.where(id: service_id).or(services.where(system_name: service_id)).first
                  elsif current_account.services_can_create_app_on.count == 1

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -117,8 +117,8 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
                    services.find_by(id: service_id) || services.find_by(system_name: service_id)
                  elsif single_service?
                    services.default
-                 elsif (available_services = current_account.services_can_create_app_on && available_services.count == 1)
-                   available_services.first
+                 elsif current_account.services_can_create_app_on.count == 1
+                   current_account.services_can_create_app_on.first
                  end
   end
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -17,6 +17,8 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
 
   liquify prefix: 'applications'
 
+  delegate :services, :multiservice?, to: :site_account
+
   def index
     cinstances = current_account.bought_cinstances.includes(:service)
                    .order_for_dev_portal.paginate(page: params[:page])
@@ -92,9 +94,7 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
   end
 
   def choose_service
-    @services = current_account.services_can_create_app_on
-    redirect_to new_provider_admin_application_path(service_id: @services.first.id) if @services.count == 1
-    assign_drops services: Liquid::Drops::Collection.new(@services)
+    assign_drops services: Liquid::Drops::Collection.new(current_account.services_can_create_app_on)
   end
 
   def destroy
@@ -113,10 +113,12 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
   end
 
   def service
-    @service ||= if not site_account.multiservice?
-                   site_account.services.default
-                 elsif service_id = params[:service_id]
-                   site_account.services.find_by_id_or_system_name(service_id)
+    @service ||= if !multiservice?
+                   services.default
+                 elsif current_account.services_can_create_app_on.count == 1
+                   services.first
+                 elsif (service_id = params[:service_id])
+                   services.find_by(id: service_id) || services.find_by(system_name: service_id)
                  end
   end
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -113,10 +113,10 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
   end
 
   def service
-    @service ||= if (service_id = params[:service_id])
-                   services.find_by(id: service_id) || services.find_by(system_name: service_id)
-                 elsif single_service?
+    @service ||= if single_service?
                    services.default
+                 elsif (service_id = params[:service_id])
+                   services.find_by(id: service_id) || services.find_by(system_name: service_id)
                  elsif current_account.services_can_create_app_on.count == 1
                    current_account.services_can_create_app_on.first
                  end

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -17,7 +17,7 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
 
   liquify prefix: 'applications'
 
-  delegate :services, :multiservice?, to: :site_account
+  delegate :services, :single_service?, to: :site_account
 
   def index
     cinstances = current_account.bought_cinstances.includes(:service)
@@ -113,12 +113,12 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
   end
 
   def service
-    @service ||= if !multiservice?
-                   services.default
-                 elsif current_account.services_can_create_app_on.count == 1
-                   services.first
-                 elsif (service_id = params[:service_id])
+    @service ||= if (service_id = params[:service_id])
                    services.find_by(id: service_id) || services.find_by(system_name: service_id)
+                 elsif single_service?
+                   services.default
+                 elsif (available_services = current_account.services_can_create_app_on && available_services.count == 1)
+                   available_services.first
                  end
   end
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -116,7 +116,7 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
     @service ||= if single_service?
                    services.default
                  elsif (service_id = params[:service_id])
-                   services.find_by(id: service_id) || services.find_by(system_name: service_id)
+                   services.where(id: service_id).or(services.where(system_name: service_id)).first
                  elsif current_account.services_can_create_app_on.count == 1
                    current_account.services_can_create_app_on.first
                  end

--- a/test/unit/logic/provider_settings_test.rb
+++ b/test/unit/logic/provider_settings_test.rb
@@ -59,7 +59,7 @@ class Logic::ProviderSettingsTest < ActiveSupport::TestCase
     assert provider.single_service?
     assert buyer.single_service?
 
-    provider.stubs(multiple_accessible_services?: false)
+    provider.stubs(multiple_accessible_services?: true)
     refute provider.single_service?
     refute buyer.single_service?
   end

--- a/test/unit/logic/provider_settings_test.rb
+++ b/test/unit/logic/provider_settings_test.rb
@@ -50,4 +50,17 @@ class Logic::ProviderSettingsTest < ActiveSupport::TestCase
     refute provider.multiple_accessible_services?(Service.where(id: scoped_ids.first))
     assert provider.multiple_accessible_services?(Service.where(id: scoped_ids))
   end
+
+  test '#single_service?' do
+    provider = FactoryBot.build(:simple_provider)
+    buyer = FactoryBot.build(:simple_buyer, provider_account: provider)
+
+    provider.stubs(multiple_accessible_services?: false)
+    assert provider.single_service?
+    assert buyer.single_service?
+
+    provider.stubs(multiple_accessible_services?: false)
+    refute provider.single_service?
+    refute buyer.single_service?
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

The problem is when trying to find the service, if it's multi-service and there is no ID present, it redirects to `choose_service` page:
https://github.com/3scale/porta/blob/eb3a27beef090fe599ef52e0444635d99d17a654/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb#L157

Once in that page, if there's only 1 available service, it tries to redirect back to the new page with the first service's ID:
https://github.com/3scale/porta/blob/24c9bd2e6242ab1c165b9494e5ee1379ddc75e6f/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb#L96

BUT

it turns out the path is to `messages`, not the new application page:
```
# wrong path?
redirect_to new_provider_admin_application_path(2)
-> /admin/messages?action=new&controller=provider%2Fadmin%2Fapplications&service_id=2
```

SOLUTION:
Instead of redirecting twice, include a new clause to `service` in case there is only 1 service available. Redirect to choose_service as last resort.

**Which issue(s) this PR fixes** 

[THREESCALE-7317: "Create new application" button in the Developer Portal redirects to messages inbox](https://issues.redhat.com/browse/THREESCALE-7317)

**Verification steps** 

* Enable **Multiple applications** and **Multiple services** in your dev portal: /p/admin/cms/switches
* Sign up as a new user in your dev portal (confirmation code will appear in the logs)
* Go to /admin/services, make sure there are at least 2 services, only 1 subscribed:
![Screenshot 2021-07-15 at 14 00 02](https://user-images.githubusercontent.com/11672286/125784595-d8d71758-0cf0-4d53-adf6-61b079faaa60.png)

* Go to /admin/applications, click on "Create application"
* The new application form should render correctly, with the Plan of the subscribed service.
