### PR TITLE
allow running tests with intellij IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 .deploy_info
 .ruby-gemset
 .ruby-version
-.tool-versions
 .pt
 .pivotalrc
 .pivotal_cache

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,10 @@ require File.expand_path('../lib/developer_portal/test/test_helper.rb', __dir__)
 require 'minitest/reporters'
 
 junit = MiniTest::Reporters::JUnitReporter.new([junit_reporter_path, Process.pid].compact.join('-'))
-MiniTest::Reporters.use!([junit, MiniTest::Reporters::DefaultReporter.new])
+unless ENV['RM_INFO']
+  # we skip this for IntelliJ IDEA compatibility
+  MiniTest::Reporters.use!([junit, MiniTest::Reporters::DefaultReporter.new])
+end
 
 require 'webmock/minitest'
 WebMock.enable!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,7 @@ require File.expand_path('../lib/developer_portal/test/test_helper.rb', __dir__)
 require 'minitest/reporters'
 
 junit = MiniTest::Reporters::JUnitReporter.new([junit_reporter_path, Process.pid].compact.join('-'))
+# this environment variable is set by Intellij IDEA which is not compatible with those reporters
 unless ENV['RM_INFO']
   # we skip this for IntelliJ IDEA compatibility
   MiniTest::Reporters.use!([junit, MiniTest::Reporters::DefaultReporter.new])


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow running tests with Intellyj IDEA after git clean clone.

- custom reporters are not supported by IDEA
- without the /tmp/metrics directory many tests fail, so ensure it exists after clone

**Verification steps** 

1. git clone porta
2. import in IDEA
3. run some unit tests