### PR TITLE
workaround oracle enhanced adapter calling #to_s instead of proper #serialize

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -537,6 +537,7 @@ class Proxy < ApplicationRecord
     include Enumerable
 
     delegate :each, :to_json, :as_json, to: :policies_config
+    alias to_s to_json
     attr_reader :policies_config
     protected :policies_config
 


### PR DESCRIPTION
This is a workaround for the issue is better explained #2554 and https://github.com/rsim/oracle-enhanced/issues/2200