### PR TITLE
use context for Quay password instead of global env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,8 @@ postgres-container: &postgres-container
 oracle-db-container: &oracle-db-container
   image: quay.io/3scale/oracle:19.3.0-ee-ci-prebuilt
   auth:
-    username: $DOCKER_USER
-    password: $DOCKER_PASS
+    username: $DOCKER_USERNAME
+    password: $DOCKER_PASSWORD
   environment:
     ORACLE_CHARACTERSET: 'AL32UTF8'
     ORACLE_SID: 'threescale'
@@ -902,18 +902,28 @@ workflows:
       - unit-oracle:
           requires:
             - deps_bundler_oracle
+          context:
+            - quay
       - functional-oracle:
           requires:
             - assets_precompile
+          context:
+            - quay
       - integration-oracle:
           requires:
             - assets_precompile
+          context:
+            - quay
       - rspec-oracle:
           requires:
             - deps_bundler_oracle
+          context:
+            - quay
       - cucumber-oracle:
           requires:
             - assets_precompile
+          context:
+            - quay
       - notify_success:
           requires:
             - rspec-oracle


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Use circle CI context for quay credentials instead of global env.

**Which issue(s) this PR fixes** 

One could run oracle tests without creating a branch in main repo when part of the org. Or so I assume.

Also perhaps there is a way to approve such runs from external contributors?

**Verification steps** 

Oracle tests should run properly, at least DB container should be created properly.

**Special notes for your reviewer**:
I'm not sure how to test this PR. Will try to run from my fork branch. If this doesn't work, I'm not sure.

Also I'm not aware how this will affect workflow when we want changes from an external contributor to be tested on oracle. I think at least it will not become harder than before.