### PR TITLE
Upgrade to nodejs 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/3scale/system-builder:ruby26
+FROM quay.io/3scale/system-builder:ruby26-nodejs12
 
 ARG CUSTOM_DB=mysql
 
@@ -9,7 +9,7 @@ ENV DISABLE_SPRING="true" \
     MASTER_PASSWORD="p" \
     USER_PASSWORD="p" \
     LC_ALL="en_US.UTF-8" \
-    PATH="./node_modules/.bin:/opt/rh/rh-nodejs10/root/usr/bin:$PATH" \
+    PATH="./node_modules/.bin:/opt/rh/rh-nodejs12/root/usr/bin:$PATH" \
     DNSMASQ="#" \
     BUNDLE_FROZEN=1 \
     BUNDLE_JOBS=5 \

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -7,7 +7,7 @@ ENV BUNDLER_ENV="${BUNDLER_ENV}" \
     TZ=:/etc/localtime \
     BUNDLE_GEMFILE=Gemfile \
     BUNDLE_WITHOUT=development:test \
-    NODEJS_SCL=rh-nodejs10
+    NODEJS_SCL=rh-nodejs12
 
 WORKDIR /opt/system
 
@@ -26,7 +26,7 @@ RUN yum-config-manager --save --setopt=cbs.centos.org_repos_sclo7-rh-ruby25-rh-c
               mysql \
               postgresql10 postgresql10-devel postgresql10-libs \
               file \
-              rh-nodejs10 \
+              rh-nodejs12 \
     && rpm -i /tmp/sphinxsearch.rpm \
     && rm /tmp/*.rpm \
     && yum install -y epel-release \


### PR DESCRIPTION
Warning, we must not upgrade any packages that might use nodejs runtime.

Example https://www.npmjs.com/package/node-sass
=> Please make sure node-saas version is compatible with nodejs 10

This is temporary as we need to migrate all deployments of Porta to nodejs 12+