### PR TITLE
ActiveDocs: Do not inject autocomplete fields in plain/text responses

### DIFF
--- a/app/javascript/packs/OAS3Autocomplete.js
+++ b/app/javascript/packs/OAS3Autocomplete.js
@@ -59,8 +59,8 @@ const injectParametersToPath = (path: PathItemObject, commonParameters?: Array<P
   }, {})
 )
 
-const injectAutocompleteToResponseBody = (responseBody: ResponseBody, accountData: AccountData): ResponseBody => (
-  {
+const injectAutocompleteToResponseBody = (responseBody: ResponseBody, accountData: AccountData): ResponseBody => {
+  const res = (responseBody.paths && accountData) ? {
     ...responseBody,
     paths: Object.keys(responseBody.paths).reduce(
       (paths, path) => {
@@ -69,10 +69,15 @@ const injectAutocompleteToResponseBody = (responseBody: ResponseBody, accountDat
         paths[path] = injectParametersToPath(responseBody.paths[path], commonParameters, accountData)
         return paths
       }, {})
-  }
-)
+  } : responseBody
+  return res
+}
 
-const injectServerToResponseBody = (responseBody: ResponseBody, serviceEndpoint: string): ResponseBody => {
+const injectServerToResponseBody = (responseBody: ResponseBody | string, serviceEndpoint: string): ResponseBody => {
+  if (typeof responseBody === 'string') {
+    return responseBody
+  }
+
   const originalServers = responseBody.servers || []
   const servers = serviceEndpoint ? [{ url: serviceEndpoint }] : originalServers
 

--- a/app/javascript/packs/OAS3Autocomplete.js
+++ b/app/javascript/packs/OAS3Autocomplete.js
@@ -59,8 +59,8 @@ const injectParametersToPath = (path: PathItemObject, commonParameters?: Array<P
   }, {})
 )
 
-const injectAutocompleteToResponseBody = (responseBody: ResponseBody, accountData: AccountData): ResponseBody => {
-  const res = (responseBody.paths && accountData) ? {
+const injectAutocompleteToResponseBody = (responseBody: ResponseBody | string, accountData: AccountData): ResponseBody | string => {
+  const res = (typeof responseBody !== 'string' && responseBody.paths && accountData) ? {
     ...responseBody,
     paths: Object.keys(responseBody.paths).reduce(
       (paths, path) => {
@@ -73,7 +73,7 @@ const injectAutocompleteToResponseBody = (responseBody: ResponseBody, accountDat
   return res
 }
 
-const injectServerToResponseBody = (responseBody: ResponseBody | string, serviceEndpoint: string): ResponseBody => {
+const injectServerToResponseBody = (responseBody: ResponseBody | string, serviceEndpoint: string): ResponseBody | string => {
   if (typeof responseBody === 'string') {
     return responseBody
   }
@@ -88,15 +88,7 @@ const injectServerToResponseBody = (responseBody: ResponseBody | string, service
   }
 }
 
-// response.body.method is not present when fetching the spec,
-// is present when doing a request to one of the paths
-const isSpecFetched = (response: SwaggerResponse): boolean => !!response.body.method
-
 export const autocompleteOAS3 = async (response: SwaggerResponse, accountDataUrl: string, serviceEndpoint: string): Promise<SwaggerResponse> => {
-  if (isSpecFetched(response)) {
-    return response
-  }
-
   const bodyWithServer = injectServerToResponseBody(response.body, serviceEndpoint)
   const body = await fetchData(accountDataUrl)
     .then(data => (

--- a/app/javascript/src/Types/SwaggerTypes.jsx
+++ b/app/javascript/src/Types/SwaggerTypes.jsx
@@ -58,7 +58,7 @@ export type ResponseBody = {
 }
 
 export type SwaggerResponse = {
- body: ResponseBody,
+ body: ResponseBody | string,
  data: string,
  headers: {},
  obj: {},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

When testing an API using swagger-ui, if the response returns just plain text (not json), it will be displayed as array of chars.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-6379

**Verification steps** 

- You need an OAS v3, with and endpoint that returns only plain text.
  - You can use this example I've created to test it:
  - https://gist.github.com/damianpm/93d5876313a75ac7807fb6c4a5dc3da5
- In Admin portal, create a new ActiveDoc
![01](https://user-images.githubusercontent.com/13486237/128847169-bc3e0e3b-08ae-4920-b504-c1c7b27f01ed.png)
- Be sure the new ActiveDoc is NOT associated to any service ("Service" field must be empty)
  - In this way, swagger-ui will make the requests directly to the test API I've created to test. If you select a service, then Apicast will be used as proxy and you'll need to configure Apicast to avoid CORS issues.
![02](https://user-images.githubusercontent.com/13486237/128847214-8eed2aaa-b329-4c8f-870c-13f51e8afcce.png)

**Before:**
![03](https://user-images.githubusercontent.com/13486237/128848861-eb23e40a-0c6f-47bd-bfcd-63711ccbd823.png)


**After:**
![04](https://user-images.githubusercontent.com/13486237/128848870-fe0a8001-0dae-4aec-a7eb-a41e534693a8.png)

