### PR TITLE
Update bundle to 2.2.25

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1002,4 +1002,4 @@ DEPENDENCIES
   zip-zip
 
 BUNDLED WITH
-   2.2.18
+   2.2.25

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -49,7 +49,7 @@ ENV BASH_ENV=/opt/system/etc/scl_enable \
 
 RUN export ${BUNDLER_ENV} >/dev/null\
     && source /opt/system/etc/scl_enable \
-    && gem install bundler --version 2.2.18 \
+    && gem install bundler --version 2.2.25 \
     && bundle config build.pg --with-pg-config=/usr/pgsql-10/bin/pg_config \
     && bundle install --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates bundle otherwise `loofah` won't be installed.

**Which issue(s) this PR fixes** 

[THREESCALE-7398: Bundle wont install dependencies because of loofah](https://issues.redhat.com/browse/THREESCALE-7398)

**Verification steps** 

```
bundle install
```
