### PR TITLE
Fix DefaultPlanSelect's Typeahead

### DIFF
--- a/app/javascript/src/Plans/components/DefaultPlanSelect.jsx
+++ b/app/javascript/src/Plans/components/DefaultPlanSelect.jsx
@@ -29,6 +29,17 @@ const DefaultPlanSelect = ({ plan, plans, onSelectPlan, isDisabled = false }: Pr
     }
   }
 
+  const handleOnFilter = (e: SyntheticEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget
+    const term = new RegExp(value, 'i')
+
+    const filteredPlans = value !== '' ? plans.filter(b => term.test(b.name)) : plans
+
+    // $FlowIssue[prop-missing] description is optional
+    // $FlowIssue[incompatible-call] should not complain about plan having id as number, since Record has union "number | string"
+    return filteredPlans.map(toSelectOption)
+  }
+
   return (
     <Select
       id="default-plan-select"
@@ -42,6 +53,7 @@ const DefaultPlanSelect = ({ plan, plans, onSelectPlan, isDisabled = false }: Pr
       isDisabled={isDisabled}
       selections={selection}
       isCreatable={false}
+      onFilter={handleOnFilter}
     >
       {/* $FlowIssue[prop-missing] description is optional */}
       {/* $FlowIssue[incompatible-call] should not complain about plan having id as number, since Record has union "number | string" */}


### PR DESCRIPTION
**What this PR does / why we need it**:

For a set of plans:
```
plans = ['Plan A', 'A plan B', 'The plan C']
```

Before:
```
plans.search('A')
// -> ['A plan B']

plans.search('plan')
// -> ['Plan A']
```

After:
```
plans.search('A')
// -> ['Plan A', 'A plan B', 'The plan C']

plans.search('plan')
// -> ['Plan A', 'A plan B', 'The plan C']
```

**Verification steps** 

1. Go to Application Plans index
2. Play with the default plan select
