### PR TITLE
Plans index page should show no custom plans

### DIFF
--- a/app/controllers/api/plans_base_controller.rb
+++ b/app/controllers/api/plans_base_controller.rb
@@ -43,7 +43,8 @@ class Api::PlansBaseController < Api::BaseController
 
   def find_plans
     search = ThreeScale::Search.new(params[:search] || params)
-    @plans = collection.order_by(params[:sort], params[:direction])
+    @plans = collection.not_custom
+                       .order_by(params[:sort], params[:direction])
                        .scope_search(search)
     @page_plans = @plans.paginate(pagination_params)
   end

--- a/app/helpers/api/plans_helper.rb
+++ b/app/helpers/api/plans_helper.rb
@@ -12,8 +12,7 @@ module Api::PlansHelper
   end
 
   def application_plans_data(plans)
-    plans.not_custom
-         .alphabetically
+    plans.alphabetically
          .to_json(root: false, only: %i[id name])
   end
 
@@ -30,8 +29,7 @@ module Api::PlansHelper
   end
 
   def application_plans_index_data(plans)
-    plans.not_custom
-         .alphabetically
+    plans.alphabetically
          .decorate
          .map(&:index_table_data)
   end

--- a/app/views/api/application_plans/index.html.slim
+++ b/app/views/api/application_plans/index.html.slim
@@ -10,7 +10,7 @@ p
   = pf_button_in_title 'Create Application plan', new_polymorphic_path([:admin, @service, @new_plan])
 
 section class="pf-c-page__main-section pf-m-no-padding"
-  - if @plans.not_custom.size > 0
+  - if @plans.size > 0
     div id='default_plan' data=default_application_plan_data(@service, @plans)
       = javascript_pack_tag 'default_plan_selector'
 

--- a/test/integration/api/application_plans_controller_test.rb
+++ b/test/integration/api/application_plans_controller_test.rb
@@ -73,6 +73,16 @@ class Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTest
       assert_xpath "//a[contains(@href, '#{new_admin_service_application_plan_path(service)}')]", 'Create Application plan'
     end
 
+    test 'index pagination does not count custom plans' do
+      get admin_service_application_plans_path(service)
+      table = Nokogiri::HTML.parse(response.body).xpath "//*[@id='plans_table']"
+
+      pagination_count = JSON.parse table.attribute('data-count')
+      table_count = JSON.parse(table.attribute('data-plans').value).length
+
+      assert_equal pagination_count, table_count
+    end
+
     test 'actions are authorized for Saas' do
       get admin_service_application_plans_path(service)
       assert_response :ok


### PR DESCRIPTION
**What this PR does / why we need it**:

The Plans table is showing a total number that doesn't match what is paginated. This happens because the paginated items (the ones rendered in the table) are `plans.not_custom` but the count is calculated from `plans`.

Solution: instead of filtering `not_custom` plans in the view helper, do it in the controller when `plans` is declared.
Before:
<img width="1259" alt="Screenshot 2021-08-12 at 09 39 31" src="https://user-images.githubusercontent.com/11672286/129157403-aa94e797-e05a-402d-8e0a-b995938d9942.png">
After:
<img width="1403" alt="Screenshot 2021-08-17 at 17 40 54" src="https://user-images.githubusercontent.com/11672286/129757337-91a8d4ad-d09c-48de-9a62-4f064373e8f0.png">


**Which issue(s) this PR fixes** 

[THREESCALE-7426: application plans index has empty pages](https://issues.redhat.com/browse/THREESCALE-7426)

**Verification steps** 

You'll need some plans and custom plans. In master, go to `Master API > Audience > Application Plans` and look at the table's pagination widget. Verify the number of items in the table matches the total count. For instance, "before" image there are less than 40 items but pagination says there are 170.