### PR TITLE
[Bugfix] Braintree: Do not save CC that failed 3DSecure verification

### DIFF
--- a/app/javascript/src/PaymentGateways/braintree/BraintreeCustomerForm.scss
+++ b/app/javascript/src/PaymentGateways/braintree/BraintreeCustomerForm.scss
@@ -16,3 +16,11 @@
   font-style: italic;
   margin-bottom: 2rem;
 }
+
+.list-unstyled {
+  .form-control.col-md-6 {
+    // Hack: needed because Braintree styles are colliding with ours
+    // scss-lint:disable ImportantRule
+    width: 50% !important;
+  }
+}

--- a/app/javascript/src/PaymentGateways/braintree/BraintreeForm.jsx
+++ b/app/javascript/src/PaymentGateways/braintree/BraintreeForm.jsx
@@ -57,14 +57,8 @@ const BraintreeForm = ({
   }, [braintreeNonceValue])
 
   const get3DSecureError = (response) => {
-    if (
-      response.name === 'BraintreeError' ||
-      response.threeDSecureInfo.status !== 'authenticate_successful' ||
-      response.threeDSecureInfo.status !== 'authenticate_attempt_successful'
-    ) {
-      return CC_ERROR_MESSAGE
-    }
-    return null
+    const { threeDSecureInfo: { status: message } = { status: null } } = response
+    return message && message.match(/authenticate_(attempt_)?successful/) ? null : CC_ERROR_MESSAGE
   }
 
   const get3DSecureNonce = async (payload) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

When saving Credit Card details for Braintree, some CC that should be rejected are being stored.

The reasons why a CC may be rejected are multiple, some related to the card itself (wrong data entered by user, etc.), some to another issues (timeouts, etc). 

Braintree errors are a bit cryptic and technical (e.g: "THREEDS_LOOKUP_VALIDATION_ERROR"), and not very useful for regular users. For this reason, a generic error is shown when validation fails:

"An error occurred, please review your CC details or try later."

Later, we should improve error messages.

Additionally, fixing some alignment issues in Braintree injected form fields.

**Which issue(s) this PR fixes** 
Related to 
https://issues.redhat.com/browse/THREESCALE-6860

**Verification steps** 

You can use Braintree test cards:
https://developer.paypal.com/braintree/docs/guides/3d-secure/testing-go-live#testing

![01](https://user-images.githubusercontent.com/13486237/129336303-b7e6bcdf-ac59-4d6c-809a-a84ba77c87de.png)
