### PR TITLE
Use our own node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "moment": "^2.24.0",
     "moment-range": "^4.0.2",
     "moment-timezone": "^0.5.5",
-    "node-sass": "^4.9.4",
+    "node-sass": "git://github.com/3scale/node-sass#v4",
     "null-loader": "^3.0.0",
     "numeral": "^2.0.6",
     "pluralize": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8465,10 +8465,32 @@ node-releases@^1.1.71:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
 
-node-sass@^4.13.0, node-sass@^4.9.4:
+node-sass@^4.13.0:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
   integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash "^4.17.15"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.13.2"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "2.2.5"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
+
+"node-sass@git://github.com/3scale/node-sass#v4":
+  version "4.14.1"
+  resolved "git://github.com/3scale/node-sass#0d6c3cc36a5362e83529d901484b0bbf3e96de81"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION
In order to build on ppc64le we are using our node-sass fork
See https://github.com/3scale/node-sass/pull/2

Also when upgrading to Rails 5.2.2 we will no more use node-sass but Dart sass