### PR TITLE
[WIP] THREESCALE-6916 change to load_from_hash! method

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -26,7 +26,7 @@ Sidekiq.configure_server do |config|
   schedule_file = Rails.root.join('config', 'sidekiq_schedule.yml')
 
   if File.exist?(schedule_file) && Sidekiq.server?
-    Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+    Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file)
   end
   # This will start a webrick server in another thread
   # where the Sidekiq processes are spawned


### PR DESCRIPTION
Fixes THREESCALE-6916 - See JIRA for details.

Summary of what this PR does:

- Uses the `load_from_hash!` method instead of `load_from_hash` so that jobs which have been removed can be deleted before injecting new jobs. `SPHINX_DELTA` & `SPHINX_INDEX` were both removed in tagged release 2.9 and caused issues reported in the JIRA.
