### PR TITLE
Bugfix: create mapping rule fails because of pattern validation

### DIFF
--- a/app/javascript/packs/new_mapping_rule.js
+++ b/app/javascript/packs/new_mapping_rule.js
@@ -12,13 +12,14 @@ document.addEventListener('DOMContentLoaded', () => {
     return
   }
 
-  const { url, httpMethods, topLevelMetrics, methods, isProxyProEnabled } = container.dataset
+  const { url, httpMethods, topLevelMetrics, methods, isProxyProEnabled, errors } = container.dataset
 
   NewMappingRuleWrapper({
     url,
     topLevelMetrics: safeFromJsonString(topLevelMetrics) || [],
     methods: safeFromJsonString(methods) || [],
     isProxyProEnabled: isProxyProEnabled !== undefined,
-    httpMethods: safeFromJsonString<Array<string>>(httpMethods) || []
+    httpMethods: safeFromJsonString<Array<string>>(httpMethods) || [],
+    errors: safeFromJsonString(errors)
   }, CONTAINER_ID)
 })

--- a/app/javascript/src/MappingRules/components/NewMappingRule.jsx
+++ b/app/javascript/src/MappingRules/components/NewMappingRule.jsx
@@ -24,17 +24,26 @@ import type { Metric } from 'Types'
 
 import './NewMappingRule.scss'
 
+type Error = {
+  [string]: Array<string>
+}
+
 type Props = {
   url: string,
   isProxyProEnabled?: boolean,
   topLevelMetrics: Array<Metric>,
   methods: Array<Metric>,
-  httpMethods: Array<string>
+  httpMethods: Array<string>,
+  errors?: Error
 }
 
-const NewMappingRule = ({ url, isProxyProEnabled = false, topLevelMetrics, methods, httpMethods }: Props): React.Node => {
+type Validated = 'success' | 'warning' | 'error' | 'default'
+
+const NewMappingRule = ({ url, isProxyProEnabled = false, topLevelMetrics, methods, httpMethods, errors }: Props): React.Node => {
   const [httpMethod, setHttpMethod] = React.useState(httpMethods[0])
   const [pattern, setPattern] = React.useState('')
+  const [patternValidated, setPatternValidated] = React.useState<Validated>('default')
+  const [helperTextInvalid, setHelperTextInvalid] = React.useState('')
   const [metric, setMetric] = React.useState<Metric | null>(null)
   const [redirectUrl, setRedirectUrl] = React.useState('')
   const [increment, setIncrement] = React.useState(1)
@@ -42,8 +51,21 @@ const NewMappingRule = ({ url, isProxyProEnabled = false, topLevelMetrics, metho
   const [position, setPosition] = React.useState(0)
   const [loading, setLoading] = React.useState(false)
 
+  React.useEffect(() => {
+    if (errors && errors.pattern) {
+      setPatternValidated('error')
+      setHelperTextInvalid(errors.pattern.slice().join())
+    }
+  }, [])
+
+  const validatePattern = (value, _event) => {
+    setPattern(value)
+    setPatternValidated('default')
+  }
+
   const isFormComplete = httpMethod &&
     pattern &&
+    patternValidated !== 'error' &&
     metric !== null &&
     increment > 0 &&
     position >= 0
@@ -62,7 +84,7 @@ const NewMappingRule = ({ url, isProxyProEnabled = false, topLevelMetrics, metho
         <input name="utf8" type="hidden" value="✓" />
 
         <HttpMethodSelect httpMethod={httpMethod} httpMethods={httpMethods} setHttpMethod={setHttpMethod} />
-        <PatternInput pattern={pattern} setPattern={setPattern} />
+        <PatternInput pattern={pattern} validatePattern={validatePattern} validated={patternValidated} helperTextInvalid={helperTextInvalid}/>
         {/* $FlowIssue[incompatible-type] Yes it can be null, that's the whole point */}
         <MetricInput metric={metric} topLevelMetrics={topLevelMetrics} methods={methods} setMetric={setMetric} />
         {isProxyProEnabled && <RedirectUrlInput redirectUrl={redirectUrl} setRedirectUrl={setRedirectUrl} />}

--- a/app/javascript/src/MappingRules/components/NewMappingRule.scss
+++ b/app/javascript/src/MappingRules/components/NewMappingRule.scss
@@ -19,5 +19,9 @@
 
   #proxy_rule_pattern-helper {
     font-family: monospace;
+
+    &::first-letter {
+      text-transform: capitalize;
+    }
   }
 }

--- a/app/javascript/src/MappingRules/components/PatternInput.jsx
+++ b/app/javascript/src/MappingRules/components/PatternInput.jsx
@@ -6,25 +6,30 @@ import { FormGroup, TextInput } from '@patternfly/react-core'
 
 type Props = {
   pattern: string,
-  setPattern: string => void
+  validatePattern: string => void,
+  validated: string,
+  helperTextInvalid: string
 }
 
-const PatternInput = ({ pattern, setPattern }: Props): React.Node => (
-  <FormGroup
-    isRequired
-    label="Pattern"
-    validated="default"
-    fieldId="proxy_rule_pattern"
-    helperText="Examples: /my-path/{some-id}, /collection/{id}?filter={value}"
-  >
-    <TextInput
-      type="text"
-      id="proxy_rule_pattern"
-      name="proxy_rule[pattern]"
-      value={pattern}
-      onChange={setPattern}
-    />
-  </FormGroup>
-)
+const PatternInput = ({ pattern, validatePattern, validated = 'default', helperTextInvalid = '' }: Props): React.Node => {
+  return (
+    <FormGroup
+      isRequired
+      label="Pattern"
+      validated={validated}
+      fieldId="proxy_rule_pattern"
+      helperText="Examples: /my-path/{someid}, /collection/{id}?filter={value}"
+      helperTextInvalid={helperTextInvalid}
+    >
+      <TextInput
+        type="text"
+        id="proxy_rule_pattern"
+        name="proxy_rule[pattern]"
+        value={pattern}
+        onChange={validatePattern}
+      />
+    </FormGroup>
+  )
+}
 
 export { PatternInput }

--- a/app/views/api/proxy_rules/new.html.slim
+++ b/app/views/api/proxy_rules/new.html.slim
@@ -4,5 +4,6 @@ div{ id="new-mapping-rule-form" data-url=admin_service_proxy_rules_path(@service
                                 data-http-methods=ProxyRule::ALLOWED_HTTP_METHODS
                                 data-is-proxy-pro-enabled=@service.using_proxy_pro?
                                 data-top-level-metrics=@service.top_level_metrics.decorate.map(&:new_mapping_rule_data).to_json
+                                data-errors=@proxy_rule.errors.to_json
                                 data-methods=@service.method_metrics.decorate.map(&:new_mapping_rule_data).to_json}
   = javascript_pack_tag 'new_mapping_rule'

--- a/spec/javascripts/MappingRules/PatternInput.spec.jsx
+++ b/spec/javascripts/MappingRules/PatternInput.spec.jsx
@@ -7,7 +7,9 @@ import { PatternInput } from 'MappingRules'
 
 const defaultProps = {
   pattern: '',
-  setPattern: () => {}
+  validatePattern: () => {},
+  validated: 'default',
+  helperTextInvalid: ''
 }
 
 const mountWrapper = (props) => mount(<PatternInput {...{ ...defaultProps, ...props }} />)

--- a/spec/javascripts/MappingRules/components/PatternInput.spec.jsx
+++ b/spec/javascripts/MappingRules/components/PatternInput.spec.jsx
@@ -7,7 +7,9 @@ import { PatternInput } from 'MappingRules'
 
 const defaultProps = {
   pattern: '',
-  setPattern: () => {}
+  validatePattern: () => {},
+  validated: 'default',
+  helperTextInvalid: ''
 }
 
 const mountWrapper = (props) => mount(<PatternInput {...{ ...defaultProps, ...props }} />)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Creating new mapping rule fails when the pattern validation fails.
The pattern is being validated by Rails, but the error is not passed to React.

This PR:

- Pass the error to React
- Shows the error message
- Update the helper text, it was misleading, suggesting the use of unsupported characters ("-")

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7510

**Verification steps** 

- Go to **Product > Integration > Mapping rules > Create Mapping rule**
- Create a Mapping rule with an invalid pattern: missing the initial "/" or including an unsupported character like "-" or "*"
- Create a mapping rule with a valid pattern


https://user-images.githubusercontent.com/13486237/132003834-e8ad4e35-cb9c-4dc2-9ee4-b33345ee88ae.mov






