### PR TITLE
moves "Add Backend" button from backends table into page header

### DIFF
--- a/app/views/api/backend_usages/index.html.slim
+++ b/app/views/api/backend_usages/index.html.slim
@@ -1,6 +1,8 @@
 h1 Backends
 p.intro For a Product to work, it needs to have at least one Backend with a Private Base URL (your API). If multiple Backends are added to a Product, each Backend should have a unique Public Path.
 
+= pf_button_in_title 'Add Backend', new_admin_service_backend_usage_path(@service)
+
 
 table#backend_api_configs.data
   thead
@@ -9,8 +11,7 @@ table#backend_api_configs.data
       th = sortable('backend_apis.private_endpoint', 'Private Base URL')
       th
         = sortable('backend_api_configs.path', 'Public Path')
-      th.actions
-        = action_link_to :add, new_admin_service_backend_usage_path(@service), label: 'Add Backend'
+      th
   tbody
     - @backend_api_configs.each do |config|
       tr


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves "Add Backend" button to the page header.

Before:
![Screenshot 2021-09-06 at 12 36 54](https://user-images.githubusercontent.com/11672286/132204909-b88f64e0-db71-4883-907c-5746a2a23ba5.png)

After:
![Screenshot 2021-09-06 at 12 37 22](https://user-images.githubusercontent.com/11672286/132204918-a309ab28-8f19-4be1-8b87-ca16858d7018.png)


**Which issue(s) this PR fixes** 
[THREESCALE-7519: Move "Add Backend" button from table to page header](https://issues.redhat.com/browse/THREESCALE-7519)

**Verification steps** 

Check button at `Product > Integation > Backends`
