### PR TITLE
🐛 Buyers and Products are limited to 20 items in New Application page

### DIFF
--- a/app/concerns/applications.rb
+++ b/app/concerns/applications.rb
@@ -49,9 +49,21 @@ module Applications
     raw_products.paginate(pagination_params)
   end
 
+  # TODO: use most_recently_updated_products when SelectWithModal updated
+  def buyers
+    BuyerDecorator.decorate_collection(raw_buyers)
+                  .map(&:new_application_data)
+  end
+
   def most_recently_created_buyers
     BuyerDecorator.decorate_collection(raw_buyers.limit(20))
                   .map(&:new_application_data)
+  end
+
+  # TODO: use most_recently_updated_products when SelectWithModal updated
+  def products
+    ServiceDecorator.decorate_collection(raw_products)
+                    .map(&:new_application_data)
   end
 
   def most_recently_updated_products

--- a/app/presenters/api/applications_new_presenter.rb
+++ b/app/presenters/api/applications_new_presenter.rb
@@ -21,7 +21,7 @@ class Api::ApplicationsNewPresenter
     data = {
       'create-application-path': admin_service_applications_path(service),
       product: ServiceDecorator.new(service).new_application_data.to_json,
-      'most-recently-created-buyers': most_recently_created_buyers.to_json,
+      'most-recently-created-buyers': buyers.to_json,
       'buyers-count': raw_buyers.size,
     }
     data.merge new_application_form_base_data(provider, cinstance)

--- a/app/presenters/buyers/applications_new_presenter.rb
+++ b/app/presenters/buyers/applications_new_presenter.rb
@@ -21,7 +21,7 @@ class Buyers::ApplicationsNewPresenter
     data = {
       'create-application-path': admin_buyers_account_applications_path(buyer),
       buyer: BuyerDecorator.new(buyer).new_application_data.to_json,
-      'most-recently-updated-products': most_recently_updated_products.to_json,
+      'most-recently-updated-products': products.to_json,
       'products-count': raw_products.size,
     }
     data.merge new_application_form_base_data(provider, cinstance)

--- a/app/presenters/provider/admin/applications_new_presenter.rb
+++ b/app/presenters/provider/admin/applications_new_presenter.rb
@@ -19,9 +19,9 @@ class Provider::Admin::ApplicationsNewPresenter
   def new_application_form_data
     data = {
       'create-application-path': provider_admin_applications_path,
-      'most-recently-created-buyers': most_recently_created_buyers.to_json,
+      'most-recently-created-buyers': buyers.to_json,
       'buyers-count': raw_buyers.size,
-      'most-recently-updated-products': most_recently_updated_products.to_json,
+      'most-recently-updated-products': products.to_json,
       'products-count': raw_products.size,
     }
     data.merge new_application_form_base_data(provider, cinstance)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently `New Application` page has no pagination implemented: it loads all products and buyers from the server. However, as part of https://github.com/3scale/porta/pull/2459 some commits have been mixed up with master (rebases...) and the items are being limited to 20.

The items will be limited to 20 once the new Async select with modal is merged (see mentioned PR).

Bug reported in 
- [THREESCALE-6878: [3scale][2.11][HI-prio] Improve Select in 'Create new Application' form](https://issues.redhat.com/browse/THREESCALE-6878)
- [THREESCALE-6879: [3scale][2.11][HI-prio] Add 'Create new Application' flow to Product > Applications index](https://issues.redhat.com/browse/THREESCALE-6879)