### PR TITLE
[THREESCALE-7475] Api docs calls won't destroy user session because of CSRF

### DIFF
--- a/app/controllers/admin/api/base_controller.rb
+++ b/app/controllers/admin/api/base_controller.rb
@@ -71,6 +71,10 @@ class Admin::Api::BaseController < ApplicationController
                  represent_with: AccountBillingAddressErrorRepresenter
   end
 
+  def is_api_controller?
+    true
+  end
+
   private
 
   def accessible_services

--- a/app/controllers/admin/api/base_controller.rb
+++ b/app/controllers/admin/api/base_controller.rb
@@ -71,7 +71,7 @@ class Admin::Api::BaseController < ApplicationController
                  represent_with: AccountBillingAddressErrorRepresenter
   end
 
-  def is_api_controller?
+  def api_controller?
     true
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
 
   # Disable CSRF protection for non xml requests.
   skip_before_action :verify_authenticity_token, if: -> do
-    (params.key?(:provider_key) || params.key?(:access_token)) && request.format.xml?
+    (params.key?(:provider_key) || params.key?(:access_token)) && !request.format.xml?
   end
 
   before_action :set_timezone

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
 
   # Disable CSRF protection for requests to REST API.
   skip_before_action :verify_authenticity_token, if: -> do
-    (params.key?(:provider_key) || params.key?(:access_token)) && api_controller?
+    api_controller? && (params.key?(:provider_key) || params.key?(:access_token))
   end
 
   before_action :set_timezone

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
 
   # Disable CSRF protection for requests to REST API.
   skip_before_action :verify_authenticity_token, if: -> do
-    (params.key?(:provider_key) || params.key?(:access_token)) && is_api_controller?
+    (params.key?(:provider_key) || params.key?(:access_token)) && api_controller?
   end
 
   before_action :set_timezone
@@ -133,7 +133,7 @@ class ApplicationController < ActionController::Base
     ReportTrafficWorker.enqueue(current_account, metric_to_report, request, response)
   end
 
-  def is_api_controller?
+  def api_controller?
     false
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,9 +14,9 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :reset_session # See ActionController::RequestForgeryProtection for details
 
-  # Disable CSRF protection for non xml requests.
+  # Disable CSRF protection for requests to REST API.
   skip_before_action :verify_authenticity_token, if: -> do
-    (params.key?(:provider_key) || params.key?(:access_token)) && !request.format.xml?
+    (params.key?(:provider_key) || params.key?(:access_token)) && is_api_controller?
   end
 
   before_action :set_timezone
@@ -131,6 +131,10 @@ class ApplicationController < ActionController::Base
 
   def report_traffic
     ReportTrafficWorker.enqueue(current_account, metric_to_report, request, response)
+  end
+
+  def is_api_controller?
+    false
   end
 
   private

--- a/app/controllers/master/api/base_controller.rb
+++ b/app/controllers/master/api/base_controller.rb
@@ -18,7 +18,7 @@ class Master::Api::BaseController < Master::BaseController
     render plain: 'unauthorized', status: 401 unless logged_in?
   end
 
-  def is_api_controller?
+  def api_controller?
     true
   end
 

--- a/app/controllers/master/api/base_controller.rb
+++ b/app/controllers/master/api/base_controller.rb
@@ -18,6 +18,10 @@ class Master::Api::BaseController < Master::BaseController
     render plain: 'unauthorized', status: 401 unless logged_in?
   end
 
+  def is_api_controller?
+    true
+  end
+
   ## Defining common parameters
 
   ##~ @parameter_access_token = { :name => "access_token", :description => "A personal Access Token", :dataType => "string", :required => true, :paramType => "query", :threescale_name => "access_token"}


### PR DESCRIPTION

**What this PR does / why we need it**:

Adds CSRF token to the HTTP calls that are made through the 3scale API Docs.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7475

