### PR TITLE
SelectWithModal should always have a max-width

### DIFF
--- a/app/javascript/src/BackendApis/components/BackendSelect.scss
+++ b/app/javascript/src/BackendApis/components/BackendSelect.scss
@@ -4,8 +4,3 @@
   text-align: left;
   text-decoration: none;
 }
-
-.pf-c-select__menu {
-  max-height: 20em;
-  overflow: auto;
-}

--- a/app/javascript/src/Common/components/SelectWithModal.scss
+++ b/app/javascript/src/Common/components/SelectWithModal.scss
@@ -1,3 +1,8 @@
+.pf-c-select__menu {
+  max-height: 20em;
+  overflow: auto;
+}
+
 // For a select box with fixed link at the bottom, select the last li to be that sticky link
 .pf-c-select__menu--with-fixed-link li:last-of-type {
   position: sticky;

--- a/app/javascript/src/NewApplication/components/NewApplicationForm.scss
+++ b/app/javascript/src/NewApplication/components/NewApplicationForm.scss
@@ -7,9 +7,4 @@
   p.hint {
     margin-bottom: 0;
   }
-
-  .pf-c-select__menu {
-    max-height: 20em;
-    overflow: auto;
-  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves styling affecting the component `SelectWithModal` to its own scss file. Currently these styles are defined individually for `NewBackendForm` and `NewApplicationForm`.

This happens in the new Mapping Rule page
Before:
![Screenshot 2021-09-07 at 11 27 51](https://user-images.githubusercontent.com/11672286/132321061-50fcbcfd-59c8-4602-b35f-b5d4987392cc.png)

After:
![Screenshot 2021-09-07 at 11 27 22](https://user-images.githubusercontent.com/11672286/132321082-7ee09fc2-b90e-4da9-8ae9-05de8841b3a4.png)


**Which issue(s) this PR fixes** 

Bug reported for [THREESCALE-6873: [3scale][2.11][HI-prio] Improve UI for creating a Backend Mapping rule](https://issues.redhat.com/browse/THREESCALE-6873)

** Verification steps:**
Pages where `SelectWithModal` is used:

- Add backend api usage (backend select)
- New application (buyer and product selects)
- New mapping rule (metric and method selects)