### PR TITLE
Order all plans alphabetically by default

### DIFF
--- a/app/controllers/api/plans_base_controller.rb
+++ b/app/controllers/api/plans_base_controller.rb
@@ -44,7 +44,7 @@ class Api::PlansBaseController < Api::BaseController
   def find_plans
     search = ThreeScale::Search.new(params[:search] || params)
     @plans = collection.not_custom
-                       .order_by(params[:sort] || :name, params[:direction] || :asc)
+                       .order_by(params[:sort].presence || :name, params[:direction].presence || :asc)
                        .scope_search(search)
     @page_plans = @plans.paginate(pagination_params)
   end

--- a/app/controllers/api/plans_base_controller.rb
+++ b/app/controllers/api/plans_base_controller.rb
@@ -44,7 +44,7 @@ class Api::PlansBaseController < Api::BaseController
   def find_plans
     search = ThreeScale::Search.new(params[:search] || params)
     @plans = collection.not_custom
-                       .order_by(params[:sort], params[:direction])
+                       .order_by(params[:sort] || :name, params[:direction] || :asc)
                        .scope_search(search)
     @page_plans = @plans.paginate(pagination_params)
   end

--- a/app/helpers/api/plans_helper.rb
+++ b/app/helpers/api/plans_helper.rb
@@ -4,7 +4,7 @@ module Api::PlansHelper
 
   def change_application_plan_data(application)
     {
-      'application-plans': application_plans_data(application.available_application_plans),
+      'application-plans': application.available_application_plans.order_by(:name, :asc).to_json(root: false, only: %i[id name]),
       'path': change_plan_provider_admin_application_path
     }
   end
@@ -12,15 +12,10 @@ module Api::PlansHelper
   def default_application_plan_data(service, plans)
     {
       'service': service.to_json(root: false, only: %i[id name]),
-      'application-plans': application_plans_data(plans),
+      'application-plans': plans.to_json(root: false, only: %i[id name]),
       'current-plan': current_application_plan_data(service),
       'path': masterize_admin_service_application_plans_path(':id')
     }
-  end
-
-  def application_plans_data(plans)
-    plans.order(name: :asc)
-         .to_json(root: false, only: %i[id name])
   end
 
   def current_application_plan_data(service)

--- a/app/helpers/api/plans_helper.rb
+++ b/app/helpers/api/plans_helper.rb
@@ -19,7 +19,7 @@ module Api::PlansHelper
   end
 
   def application_plans_data(plans)
-    plans.alphabetically
+    plans.order(name: :asc)
          .to_json(root: false, only: %i[id name])
   end
 
@@ -36,8 +36,7 @@ module Api::PlansHelper
   end
 
   def application_plans_index_data(plans)
-    plans.alphabetically
-         .decorate
+    plans.decorate
          .map(&:index_table_data)
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Force all plans to be listed alphabetically by default.

**Which issue(s) this PR fixes** 

Bug reported in:
- [THREESCALE-6875: [3scale][2.11][LO-prio] Improve list of Application plans in Application plans index page](https://issues.redhat.com/browse/THREESCALE-6875)
- [THREESCALE-6871: [3scale][2.11][LO-prio] Improve UI for changing Application plan for existing Application](https://issues.redhat.com/browse/THREESCALE-6871)
