### PR TITLE
🐛 Sort "Backends used by product" list alphabetically

### DIFF
--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -68,7 +68,7 @@ class ServiceDecorator < ApplicationDecorator
   end
 
   def backends_table_data
-    BackendApiDecorator.decorate_collection(backend_apis.sort_by(&:name))
+    BackendApiDecorator.decorate_collection(backend_apis.reorder(name: :asc))
                        .map(&:table_data)
                        .to_json
   end

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -68,7 +68,7 @@ class ServiceDecorator < ApplicationDecorator
   end
 
   def backends_table_data
-    BackendApiDecorator.decorate_collection(backend_apis)
+    BackendApiDecorator.decorate_collection(backend_apis.sort_by(&:name))
                        .map(&:table_data)
                        .to_json
   end

--- a/features/api/overview.feature
+++ b/features/api/overview.feature
@@ -1,0 +1,16 @@
+Feature: Product > Overview page
+  Background:
+    Given a provider is logged in with a product "My Product"
+    And it uses the following backends:
+      | Name      | path |
+      | Backend 3 | /v3  |
+      | Backend 2 | /v2  |
+      | Backend 1 | /v1  |
+
+  @javascript
+  Scenario: List of backends used is ordered alphabetically
+    When I go to the overview page of product "My Product"
+    Then I should see the following backends being used:
+      | Backend 1 |
+      | Backend 2 |
+      | Backend 3 |

--- a/features/step_definitions/provider_steps.rb
+++ b/features/step_definitions/provider_steps.rb
@@ -145,6 +145,15 @@ Given('stub integration errors dashboard') do
 end
 
 Given(/^a provider( is logged in)?$/) do |login|
+  setup_provider(login)
+end
+
+Given(/^a provider( is logged in)? with a product "([^"]*)"$/) do |login, name|
+  setup_provider(login)
+  @service = @provider.services.create!(name: name, mandatory_app_key: false)
+end
+
+def setup_provider(login)
   step 'a provider "foo.3scale.localhost"'
   step 'current domain is the admin domain of provider "foo.3scale.localhost"'
   step 'stub integration errors dashboard'

--- a/features/step_definitions/service_steps.rb
+++ b/features/step_definitions/service_steps.rb
@@ -70,3 +70,23 @@ end
 Given(/^the service "([^"]*)" does not have service plan$/) do |name|
   Service.find_by(name: name).service_plans.destroy_all
 end
+
+Given /^it uses the following backends:$/ do |table|
+  transform_table(table).hashes.each do |hash|
+    name, path = hash.values_at(:name, :path)
+    backend = @provider.backend_apis.create!(name: name, private_endpoint: 'https://foo')
+    @service.backend_api_configs.create!(backend_api: backend, path: path)
+  end
+end
+
+Then /^I should see the following backends being used:$/ do |table|
+  within backends_used_table do
+    table.raw.each do |row|
+      should have_css('[data-label="Name"]', text: row[0])
+    end
+  end
+end
+
+def backends_used_table
+  find('#backends-used-list-container')
+end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -235,6 +235,8 @@ World(Module.new do
 
     when /(the )?API dashboard( page)?/
       admin_service_path provider_first_service!
+    when /^the overview page of product "([^"]+)"$/
+      admin_service_path @provider.services.find_by!(name: $1)
 
     when 'the API alerts page'
       admin_alerts_path


### PR DESCRIPTION
**What this PR does / why we need it**:

backends have to be sorted by name.

<img width="761" alt="Screenshot 2021-09-07 at 14 42 38" src="https://user-images.githubusercontent.com/11672286/132346621-c5ef8d4f-b52d-4995-aa8d-1bb6235c6b0b.png">


**Which issue(s) this PR fixes** 

Bug reported in: [THREESCALE-6866: [3scale][2.11][LO-prio] Improve list of Backends in Product overview page](https://issues.redhat.com/browse/THREESCALE-6866)

**Verification steps** 

Go to some product overview page and check the list.
