### PR TITLE
Add fileattribute to junit formatter for Cucumber

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -2,7 +2,7 @@
 default: <%= std_opts %>
 <% tags = %w[ @backend @emails @stats @no-txn ] %>
 list: --dry-run --format Cucumber::Formatter::List
-ci: --profile default --backtrace --strict --verbose --format junit --out tmp/junit/cucumber --format progress
+ci: --profile default --backtrace --strict --verbose --format junit,fileattribute=true --out tmp/junit/cucumber --format progress
 txn: --profile default --tags='not @javascript' <%= tags.map { |tag| "--tags='not #{tag}'" }.join(' ') %>
 no-txn: --profile default --tags='not @javascript' --tags=<%= tags.join(',') %>
 javascript: --profile default --tags='not @ignore' --tags=@javascript


### PR DESCRIPTION
So we can split files by timings!

`circleci tests split --split-by=timings` returned an error:

```
Error autodetecting timing type, falling back to weighting by name. Autodetect no matching filename or classname.  If file names are used, double check paths for absolute vs relative.
Example input file: "features/access_tokens/show.feature"
Example file from timings: ""
```