### PR TITLE
Replace font_assets with rack-cors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ C:\\nppdf32Log\\debuglog.txt
 /config/application.yml
 /config/backend.yml
 /config/backend_redis.yml
+/config/cors.yml
 /config/database.yml
 /config/domain_substitution.yml
 /config/redis.yml

--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,7 @@ gem 'acts_as_tree'
 gem 'addressable', require: false
 gem 'hashie', require: false
 gem 'rack-x_served_by', '~> 0.1.1'
+gem 'rack-cors'
 gem 'roar-rails'
 
 gem 'reform', '~> 2.0.3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -43,9 +43,7 @@ gem 'i18n'
 # Apisonator client
 gem 'pisoni', '~> 1.29'
 
-# 3scale fork that allows OPTIONS passthrough
 gem '3scale_time_range', '0.0.6'
-gem 'font_assets', git: 'https://github.com/3scale/font_assets.git', ref: 'da97b8601528ee189795cc94b953ec9a30f47e83', groups: %i[production preview]
 
 gem 'statsd-ruby', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,6 +534,8 @@ GEM
     public_suffix (4.0.6)
     raabro (1.4.0)
     rack (2.1.4)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-no_animations (1.0.3)
     rack-openid (1.4.2)
       rack (>= 1.1.0)
@@ -966,6 +968,7 @@ DEPENDENCIES
   pry-shell
   pry-stack_explorer
   rack (~> 2.1.4)
+  rack-cors
   rack-no_animations (~> 1.0.3)
   rack-utf8_sanitizer
   rack-x_served_by (~> 0.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,14 +15,6 @@ GIT
       ci_reporter (~> 2.0)
 
 GIT
-  remote: https://github.com/3scale/font_assets.git
-  revision: da97b8601528ee189795cc94b953ec9a30f47e83
-  ref: da97b8601528ee189795cc94b953ec9a30f47e83
-  specs:
-    font_assets (0.1.11)
-      rack
-
-GIT
   remote: https://github.com/3scale/json-schema.git
   revision: 26487618a68443e94d623bb585cb464b07d36702
   specs:
@@ -921,7 +913,6 @@ DEPENDENCIES
   faraday (~> 0.15.3)
   faraday_middleware (~> 0.13.1)
   font-awesome-rails (~> 4.7.0.5)
-  font_assets!
   formtastic (~> 1.2.4)
   github-markdown
   gruff (~> 0.3)

--- a/config/application.rb
+++ b/config/application.rb
@@ -200,6 +200,10 @@ module System
     config.domain_substitution = ActiveSupport::OrderedOptions.new
     config.domain_substitution.merge!(try_config_for(:domain_substitution) || {})
 
+    config.three_scale.cors = ActiveSupport::OrderedOptions.new
+    config.three_scale.cors.enabled = false
+    config.three_scale.cors.merge!(try_config_for(:cors) || {})
+
     three_scale = config_for(:settings).symbolize_keys
     three_scale[:error_reporting_stages] = three_scale[:error_reporting_stages].to_s.split(/\W+/)
 
@@ -221,10 +225,12 @@ module System
     require 'three_scale/deprecation'
     require 'three_scale/domain_substitution'
     require 'three_scale/middleware/multitenant'
+    require 'three_scale/middleware/cors'
 
     config.middleware.use ThreeScale::Middleware::Multitenant, :tenant_id
     config.middleware.insert_before Rack::Runtime, Rack::UTF8Sanitizer
     config.middleware.insert_before Rack::Runtime, Rack::XServedBy # we can pass hashed hostname as parameter
+    config.middleware.insert_before 0, ThreeScale::Middleware::Cors
 
     config.unicorn = ActiveSupport::OrderedOptions[after_fork: []]
     config.unicorn.after_fork << MessageBus.method(:after_fork)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,10 +15,11 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
   # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
   config.public_file_server.enabled = true
+  config.public_file_server.headers = {
+    'Cache-Control' => "public, max-age=#{(config.assets.digest ? 1.year : 1.minute).to_i}",
+  }
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = Uglifier.new(harmony: true)
@@ -114,7 +115,6 @@ Rails.application.configure do
   # https://github.com/3scale/puppet/blob/ac161671aee2019eefa87b51b150cb78fcb417e9/modules/logstash/templates/config/system-mt/filter.erb
   config.log_tags = [ :uuid, :host, :remote_ip ]
 
-  config.public_file_server.headers = { 'Cache-Control' => "public, max-age=#{(config.assets.digest ? 1.year : 1.minute).to_i}" }
   config.middleware.insert_before ActionDispatch::Static, Rack::Deflater
 
   config.liquid.resolver_caching = true

--- a/config/examples/cors.yml
+++ b/config/examples/cors.yml
@@ -1,0 +1,17 @@
+cors: &default
+  enabled: false
+  origins: '*'
+
+development:
+  <<: *default
+  enabled: true
+  resources:
+    - '/admin/api/*'
+    - '/stats/*'
+
+test:
+  <<: *default
+
+production:
+
+preview:

--- a/config/examples/cors.yml
+++ b/config/examples/cors.yml
@@ -1,17 +1,24 @@
 cors: &default
   enabled: false
-  origins: '*'
+  allow:
+  - origins: '*'
+    resources:
+    - !ruby/regexp /\.(?:woff2?|otf|ttf|svg|eot)$/
+    headers: 'x-requested-with'
+    methods: :get
+    max_age: 3628800
+    credentials: false
 
 development:
   <<: *default
-  enabled: true
-  resources:
-    - '/admin/api/*'
-    - '/stats/*'
 
 test:
   <<: *default
 
 production:
+  <<: *default
+  enabled: true
 
 preview:
+  <<: *default
+  enabled: true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,5 +8,7 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 
 # Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+# application.js, application.css, and all non-JS/CSS in the app/assets
+# folder are already added.
+
+# Rails.application.config.assets.precompile += %w( admin.js admin.css )

--- a/doc/licenses/licenses.xml
+++ b/doc/licenses/licenses.xml
@@ -5062,16 +5062,6 @@
                   </licenses>
       </dependency>
           <dependency>
-        <packageName>font_assets</packageName>
-        <version>0.1.11</version>
-        <licenses>
-                      <license>
-              <name>MIT</name>
-              <url>http://opensource.org/licenses/mit-license</url>
-            </license>
-                  </licenses>
-      </dependency>
-          <dependency>
         <packageName>for-in</packageName>
         <version>1.0.2</version>
         <licenses>

--- a/lib/three_scale/middleware/cors.rb
+++ b/lib/three_scale/middleware/cors.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ThreeScale::Middleware
+  class Cors < Rack::Cors
+    def initialize(app, opts = {}, &block)
+      origins = config.origins.presence || '*'
+      resources = config.resources.presence || '*'
+
+      super(app, opts) do
+        allow do
+          self.origins origins
+          [*resources].each do |resource|
+            self.resource resource, headers: :any, methods: [:get, :post, :patch, :put, :delete]
+          end
+        end
+      end
+
+      if block_given?
+        if block.arity == 1
+          block.call(self)
+        else
+          instance_eval(&block)
+        end
+      end
+    end
+
+    def call(env)
+      return @app.call(env) unless enabled?
+      super
+    end
+
+    def config
+      Rails.configuration.three_scale.cors
+    end
+
+    delegate :enabled, to: :config
+    alias enabled? enabled
+  end
+end

--- a/test/unit/three_scale/middleware/cors_test.rb
+++ b/test/unit/three_scale/middleware/cors_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ThreeScale::Middleware::CorsTest < ActiveSupport::TestCase
+  setup do
+    provider = FactoryBot.create(:simple_provider)
+    @provider_domain = provider.external_self_domain
+    @app = ->(env) { [403, {}, []] }
+  end
+
+  attr_reader :provider_domain, :app
+
+  test 'cors disabled' do
+    Rails.configuration.three_scale.cors.stubs(enabled: false)
+
+    middleware = ThreeScale::Middleware::Cors.new(app)
+    status, _ = middleware.call(env.merge('REQUEST_METHOD' => 'OPTIONS', 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET'))
+    assert_equal 403, status
+  end
+
+  test 'allowed origin and resource' do
+    Rails.configuration.three_scale.cors.stubs(enabled: true, origins: '*', resources: '*')
+
+    middleware = ThreeScale::Middleware::Cors.new(app)
+    status, _ = middleware.call(env.merge('REQUEST_METHOD' => 'OPTIONS', 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET'))
+    assert_equal 200, status
+
+    middleware = ThreeScale::Middleware::Cors.new(app)
+    status, headers, _ = middleware.call(env.merge('REQUEST_METHOD' => 'GET'))
+    assert_equal 403, status
+    assert headers['Access-Control-Allow-Origin']
+  end
+
+  test 'disallowed origin' do
+    Rails.configuration.three_scale.cors.stubs(enabled: true, origins: 'http://ui.other', resources: '/foo/*')
+
+    middleware = ThreeScale::Middleware::Cors.new(app)
+    status, _ = middleware.call(env.merge('REQUEST_METHOD' => 'OPTIONS', 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET'))
+    assert_equal 200, status
+
+    middleware = ThreeScale::Middleware::Cors.new(app)
+    status, headers, _ = middleware.call(env.merge('REQUEST_METHOD' => 'GET'))
+    assert_equal 403, status
+    refute headers['Access-Control-Allow-Origin']
+  end
+
+  test 'disallowed resource' do
+    Rails.configuration.three_scale.cors.stubs(enabled: true, origins: '*', resources: '/foo/*')
+
+    middleware = ThreeScale::Middleware::Cors.new(app)
+    status, _ = middleware.call(env.merge('REQUEST_METHOD' => 'OPTIONS', 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET'))
+    assert_equal 200, status
+
+    middleware = ThreeScale::Middleware::Cors.new(app)
+    status, headers, _ = middleware.call(env.merge('REQUEST_METHOD' => 'GET'))
+    assert_equal 403, status
+    refute headers['Access-Control-Allow-Origin']
+  end
+
+  protected
+
+  def env
+    { 'HTTP_HOST' => provider_domain, 'PATH_INFO' => '/admin/api/services.json', 'HTTP_ORIGIN' => 'http://my.ui' }
+  end
+end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

font_assets is obsolete and unsupported. rack-cors open possibilities for a richer CORS support when needed.

**Which issue(s) this PR fixes** 

THREESCALE-7515

**Verification steps** 

For font_assets behavior see https://github.com/3scale/porta/pull/2581#issuecomment-911502552

This is GET request with rack-cors:
```
🐚 curl -v -H "Origin: localhost" -H "Access-Control-Request-Method: GET" http://provider-admin.3scale.localhost:3000/packs/media/overpass-webfont/overpass-light-c97e1959.woff2
*   Trying ::1:3000...
* connect to ::1 port 3000 failed: Connection refused
*   Trying 127.0.0.1:3000...
* Connected to provider-admin.3scale.localhost (127.0.0.1) port 3000 (#0)
> GET /packs/media/overpass-webfont/overpass-light-c97e1959.woff2 HTTP/1.1
> Host: provider-admin.3scale.localhost:3000
> User-Agent: curl/7.76.1
> Accept: */*
> Origin: localhost
> Access-Control-Request-Method: GET
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: GET
< Access-Control-Max-Age: 3628800
< Last-Modified: Wed, 01 Sep 2021 08:28:04 GMT
< Content-Type: application/font-woff2
< Cache-Control: public, max-age=31557600
< Content-Length: 34472
< Vary: Accept-Encoding, Origin
< X-Rack-CORS: hit
< X-Frame-Options: DENY
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Connection: keep-alive
< Server: thin
< 
...
```

For OPTIONS requests with rack-cors:
```
🐚 curl -v -X OPTIONS -H "Origin: localhost" -H "Access-Control-Request-Method: GET" http://provider-admin.3scale.localhost:3000/packs/media/overpass-webfont/overpass-light-c97e1959.woff2
*   Trying ::1:3000...
* connect to ::1 port 3000 failed: Connection refused
*   Trying 127.0.0.1:3000...
* Connected to provider-admin.3scale.localhost (127.0.0.1) port 3000 (#0)
> OPTIONS /packs/media/overpass-webfont/overpass-light-c97e1959.woff2 HTTP/1.1
> Host: provider-admin.3scale.localhost:3000
> User-Agent: curl/7.76.1
> Accept: */*
> Origin: localhost
> Access-Control-Request-Method: GET
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: GET
< Access-Control-Max-Age: 3628800
< X-Frame-Options: DENY
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Connection: close
< Server: thin
< 
* Closing connection 0
```