### PR TITLE
🐛  Fix wrong strings in ProductSelect

### DIFF
--- a/app/javascript/src/NewApplication/components/ProductSelect.jsx
+++ b/app/javascript/src/NewApplication/components/ProductSelect.jsx
@@ -28,11 +28,11 @@ const ProductSelect = ({ product, products, onSelectProduct, isDisabled }: Props
       item={product}
       items={products.map(p => ({ ...p, description: p.systemName }))}
       cells={cells}
-      modalTitle="Select an Account"
+      modalTitle="Select a Product"
       // $FlowIssue[incompatible-type] It should not complain since Record.id has union "number | string"
       onSelect={onSelectProduct}
-      header="Most recently created Accounts"
-      footer="View all Accounts"
+      header="Most recently updated Products"
+      footer="View all Products"
       isDisabled={isDisabled}
     />
   )


### PR DESCRIPTION
**What this PR does / why we need it**:

`ProductsSelect` mentions _Accounts_ instead of _Products_.

After fix:
<img width="524" alt="Screenshot 2021-09-10 at 08 39 08" src="https://user-images.githubusercontent.com/11672286/132811509-1519081d-c4d5-4785-8ad2-d5d166a61b39.png">

<img width="1116" alt="Screenshot 2021-09-10 at 08 39 14" src="https://user-images.githubusercontent.com/11672286/132811503-dcefd488-5b33-4931-bc4e-22c7cee3d2d6.png">

**Verification steps** 

The account needs to have >20 products.
In New Application page, inspect Product input and the modal.
