### PR TITLE
Fix ParameterType "date"

### DIFF
--- a/features/step_definitions/credit_card_steps.rb
+++ b/features/step_definitions/credit_card_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Given "{provider_or_buyer} has last digits of credit card number {string} and expiration date {date}" do |account, partial_number, expiration_date|
+Given "{provider_or_buyer} has last digits of credit card number {string} and {expiration_date}" do |account, partial_number, expiration_date|
   account.credit_card_partial_number = partial_number
   account.credit_card_auth_code = 'valid_code'
   account.credit_card_expires_on = expiration_date

--- a/features/support/parameter_types.rb
+++ b/features/support/parameter_types.rb
@@ -254,8 +254,8 @@ ParameterType(
 )
 
 ParameterType(
-  name: 'date',
-  regexp: /(.*)/,
+  name: 'expiration_date',
+  regexp: /expiration date (\w+, *\d+|\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))/,
   transformer: ->(date) { Date.parse(date) }
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Cucumber is not able to suggest new step definitions (a very useful feature IMO) because there is a parameter type with a "catch-all" regexp. As a result, Cucumber will always suggest to use it:
<img width="887" alt="Screenshot 2021-09-10 at 10 05 28" src="https://user-images.githubusercontent.com/11672286/132823030-76db3878-8728-4592-afac-93025fffbabe.png">
