### PR TITLE
Stats - Datepicker: Disabling future dates in 'until' field

### DIFF
--- a/app/javascript/src/Stats/lib/menu.jsx
+++ b/app/javascript/src/Stats/lib/menu.jsx
@@ -55,6 +55,7 @@ export class StatsMenu extends StatsUI {
     let untilDateHook = new Hook({
       dateFormat: 'yy-mm-dd',
       minDate: new Date(statsState.state.dateRange.since),
+      maxDate: new Date(),
       onSelect: date => {
         let dateRange = statsState.state.dateRange
         let selectedDate = new CustomRangeDate({


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Stats "until" date (datepicker) is showing and allowing to select future dates (there are no stats for future dates)

**Before:**

![01](https://user-images.githubusercontent.com/13486237/133411571-f7a1b10d-6cab-43c2-a59d-2a4bfdf96ea4.png)

**After:**

![02](https://user-images.githubusercontent.com/13486237/133411584-d12e2a16-71f0-446d-a780-70b5904a41af.png)

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-6650
