### PR TITLE
update audited to 5.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem 'yabeda-rails'
 gem 'yabeda-sidekiq'
 
 gem 'activemerchant', '~> 1.107.4'
-gem 'audited'
+gem 'audited', '~> 5.0.2'
 gem 'stripe', '~> 5.28.0' # we need the stripe gem because activemerchant can not generate Stripe's "customers"
 
 gem 'acts_as_list', '~> 0.9.17'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,8 +168,8 @@ GEM
     ansi (1.5.0)
     arel (7.1.4)
     ast (2.4.1)
-    audited (4.8.0)
-      activerecord (>= 4.0, < 5.3)
+    audited (5.0.2)
+      activerecord (>= 5.0, < 7.1)
     aws-eventstream (1.2.0)
     aws-partitions (1.496.0)
     aws-sdk (3.1.0)
@@ -1990,7 +1990,7 @@ DEPENDENCIES
   addressable
   after_commit_queue (~> 1.1.0)
   analytics-ruby
-  audited
+  audited (~> 5.0.2)
   aws-sdk (~> 3)
   aws-sdk-rails (~> 2)
   aws-sdk-s3 (~> 1)

--- a/config/initializers/audited_hacks.rb
+++ b/config/initializers/audited_hacks.rb
@@ -109,32 +109,28 @@ module AuditedHacks
       self.disable_auditing if Rails.env.test?
 
       include InstanceMethods
+      class << self
+        prepend ClassMethods
+      end
     end
 
     def synchronous
-      original = Thread.current[:audit_hacks_synchronous]
+      original = Thread.current.thread_variable_get(:audit_hacks_synchronous)
 
-      Thread.current[:audit_hacks_synchronous] = true
-
+      Thread.current.thread_variable_set(:audit_hacks_synchronous, true)
       yield if block_given?
 
       original
     ensure
-      Thread.current[:audit_hacks_synchronous] = original
+      Thread.current.thread_variable_set(:audit_hacks_synchronous, original)
     end
 
     def with_auditing
-      original_state = auditing_enabled
-      enable_auditing
-
-      synchronous {  yield }
-    ensure
-      self.auditing_enabled = original_state
+      synchronous { super { yield } }
     end
   end
 
   module InstanceMethods
-
     def auditing_enabled?
       auditing_enabled
     end

--- a/db/migrate/20210914124206_revert_polymorphic_indexes_order.rb
+++ b/db/migrate/20210914124206_revert_polymorphic_indexes_order.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class RevertPolymorphicIndexesOrder < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction! if System::Database.postgres?
+
+  def self.up
+    fix_index_order_for [:associated_id, :associated_type], 'associated_index'
+    fix_index_order_for [:auditable_id, :auditable_type], 'auditable_index'
+  end
+
+  def self.down
+    fix_index_order_for [:associated_type, :associated_id], 'associated_index'
+    fix_index_order_for [:auditable_type, :auditable_id], 'auditable_index'
+  end
+
+  private
+
+  def fix_index_order_for(columns, index_name)
+    if index_exists? :audits, columns, name: index_name
+      remove_index :audits, name: index_name
+
+      index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+      add_index :audits, columns.reverse, name: index_name, **index_options
+    end
+  end
+end

--- a/db/migrate/20210917163154_add_version_to_auditable_index.rb
+++ b/db/migrate/20210917163154_add_version_to_auditable_index.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AddVersionToAuditableIndex < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction! if System::Database.postgres?
+
+  def self.up
+    if index_exists?(:audits, [:auditable_type, :auditable_id], name: index_name)
+      remove_index :audits, name: index_name
+      add_index :audits, [:auditable_type, :auditable_id, :version], name: index_name, **index_options
+    end
+  end
+
+  def self.down
+    if index_exists?(:audits, [:auditable_type, :auditable_id, :version], name: index_name)
+      remove_index :audits, name: index_name
+      add_index :audits, [:auditable_type, :auditable_id], name: index_name, **index_options
+    end
+  end
+
+  private
+
+  def index_name
+    'auditable_index'
+  end
+
+  def index_options
+    System::Database.postgres? ? { algorithm: :concurrently } : {}
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210708100519) do
+ActiveRecord::Schema.define(version: 20210917163154) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer  "owner_id",   precision: 38, null: false
@@ -171,9 +171,9 @@ ActiveRecord::Schema.define(version: 20210708100519) do
   end
 
   add_index "audits", ["action"], name: "index_audits_on_action"
-  add_index "audits", ["associated_id", "associated_type"], name: "associated_index"
+  add_index "audits", ["associated_type", "associated_id"], name: "associated_index"
   add_index "audits", ["auditable_id", "auditable_type", "version"], name: "index_audits_on_auditable_id_and_auditable_type_and_version"
-  add_index "audits", ["auditable_id", "auditable_type"], name: "auditable_index"
+  add_index "audits", ["auditable_type", "auditable_id", "version"], name: "auditable_index"
   add_index "audits", ["created_at"], name: "index_audits_on_created_at"
   add_index "audits", ["kind"], name: "index_audits_on_kind"
   add_index "audits", ["provider_id"], name: "index_audits_on_provider_id"

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210708100519) do
+ActiveRecord::Schema.define(version: 20210917163154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -168,9 +168,9 @@ ActiveRecord::Schema.define(version: 20210708100519) do
     t.string   "remote_address",  limit: 255
     t.string   "request_uuid",    limit: 255
     t.index ["action"], name: "index_audits_on_action", using: :btree
-    t.index ["associated_id", "associated_type"], name: "associated_index", using: :btree
+    t.index ["associated_type", "associated_id"], name: "associated_index", using: :btree
     t.index ["auditable_id", "auditable_type", "version"], name: "index_audits_on_auditable_id_and_auditable_type_and_version", using: :btree
-    t.index ["auditable_id", "auditable_type"], name: "auditable_index", using: :btree
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index", using: :btree
     t.index ["created_at"], name: "index_audits_on_created_at", using: :btree
     t.index ["kind"], name: "index_audits_on_kind", using: :btree
     t.index ["provider_id"], name: "index_audits_on_provider_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210708100519) do
+ActiveRecord::Schema.define(version: 20210917163154) do
 
   create_table "access_tokens", id: :bigint, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.bigint   "owner_id",                 null: false
@@ -167,9 +167,9 @@ ActiveRecord::Schema.define(version: 20210708100519) do
     t.string   "remote_address"
     t.string   "request_uuid"
     t.index ["action"], name: "index_audits_on_action", using: :btree
-    t.index ["associated_id", "associated_type"], name: "associated_index", using: :btree
+    t.index ["associated_type", "associated_id"], name: "associated_index", using: :btree
     t.index ["auditable_id", "auditable_type", "version"], name: "index_audits_on_auditable_id_and_auditable_type_and_version", using: :btree
-    t.index ["auditable_id", "auditable_type"], name: "auditable_index", using: :btree
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index", using: :btree
     t.index ["created_at"], name: "index_audits_on_created_at", using: :btree
     t.index ["kind"], name: "index_audits_on_kind", using: :btree
     t.index ["provider_id"], name: "index_audits_on_provider_id", using: :btree


### PR DESCRIPTION
This should preserve Rails lazy initialization order.
Also fixes deprecation warnings with Rails 6.1 and adds support for 7

supersedes #2616