### PR TITLE
🗑️  AWS auto_load no longer needed

### DIFF
--- a/config/initializers/autoload_aws.rb
+++ b/config/initializers/autoload_aws.rb
@@ -1,3 +1,0 @@
-# Needed to fix https://github.com/3scale/system/issues/7661
-
-Aws.eager_autoload!(services: %w(S3)) if Rails.application.config.eager_load && defined?(Aws)


### PR DESCRIPTION
When running cucumbers:
```
Aws.eager_autoload is no longer needed, usage of autoload has been replaced with require statements
```

[THREESCALE-7539: Resolve Cucumber deprecation warnings](https://issues.redhat.com/browse/THREESCALE-7539)