### PR TITLE
[THREESCALE-7605] Fix type of policies config returned by the proxy

### DIFF
--- a/app/representers/proxy_representer.rb
+++ b/app/representers/proxy_representer.rb
@@ -48,7 +48,7 @@ class ProxyRepresenter < ThreeScale::Representer
   property :jwt_claim_with_client_id_type, if: ->(*) { oidc? }
 
   def policies_config
-    represented.policies_config.to_json
+    represented.policies_config.as_json
   end
 
   class JSON < ProxyRepresenter


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

With the Policies config refactoring, we introduced a bug where the type of policies_config is a string instead of an array of hashes. This PR fixes that and keeps the same format as it was used before.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7605


