### PR TITLE
fix unit tests failing sometimes

### DIFF
--- a/test/unit/abilities/provider_any_test.rb
+++ b/test/unit/abilities/provider_any_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 module Abilities
-  class ProviderAdminTest < ActiveSupport::TestCase
+  class ProviderAnyTest < ActiveSupport::TestCase
     setup do
       @account = Account.new
       @account.stubs(provider?: true)


### PR DESCRIPTION
Sometimes unit tests failed in CI [1] due to conflicting class names
depending on test classes load order. Probably the `#setup` method
is overridden by one class or another causing the problem sometimes.


[1] https://app.circleci.com/pipelines/github/3scale/porta/18159/workflows/088e04a0-e741-4629-ac31-23e0bb2e41ea/jobs/220255/tests#failed-test-0