### PR TITLE
add CircleCI caching for compiled assets

### DIFF
--- a/.circleci/asset_paths
+++ b/.circleci/asset_paths
@@ -1,0 +1,17 @@
+Gemfile.lock
+yarn.lock
+.babelrc
+.postcssrc.yml
+app/javascript
+app/assets
+app/lib/pdf/images
+cdn
+config/compass.rb
+config/webpack
+lib/developer_portal/app/assets
+lib/developer_portal/app/views/developer_portal/css
+lib/developer_portal/app/views/developer_portal/javascripts
+lib/developer_portal/app/views/developer_portal/images
+vendor/active-docs/app/assets
+vendor/active-docs/vendor/assets
+vendor/assets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ store-log-artifacts: &store-log-artifacts
 flow-type-key: &flow-typed-cache-key flow-typed-{{ checksum "yarn.lock" }}-5
 npm-cache-key: &npm-cache-key node-v10-{{ checksum "yarn.lock" }}-5
 bundle-cache-key: &bundle-cache-key v2-bundler-gems-{{ .Environment.DB }}-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+assets-cache-key: &assets-cache-key v1-asset-cache-{{ checksum "tmp/assets_related_checksums" }}
 
 save-flow-typed-cache: &save-flow-typed-cache
   save_cache:
@@ -52,6 +53,24 @@ save-npm-cache: &save-npm-cache
 restore-flow-typed-cache: &restore-flow-typed-cache
   restore_cache:
     key: *flow-typed-cache-key
+
+save-assets-cache: &save-assets-cache
+  save_cache:
+    key: *assets-cache-key
+    paths:
+      - public/assets
+      - public/packs-test
+      - tmp/cache/assets
+      - tmp/cache/webpacker
+
+restore-assets-cache: &restore-assets-cache
+  restore_cache:
+    key: *assets-cache-key
+
+generate-assets-checksums: &generate-assets-checksums
+  run:
+    name: Generate assets precompilation checksum data
+    command: git ls-tree -r HEAD $(<.circleci/asset_paths) > tmp/assets_related_checksums
 
 use-example-config-files: &use-example-config-files
   run:
@@ -427,6 +446,8 @@ jobs:
     steps:
       - checkout
       - *attach-to-workspace
+      - *generate-assets-checksums
+      - *restore-assets-cache
       - run:
           name: Precompile assets
           command: |
@@ -434,6 +455,7 @@ jobs:
             bundle exec rake assets:precompile NODE_ENV=test RAILS_ENV=test
           environment:
             RAILS_GROUPS: assets
+      - *save-assets-cache
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
When no changes to cached assets are needed, on my laptop `rake
assets:precompile assets:clean` takes around 12 seconds while without it
takes almost 2 minutes.