### PR TITLE
Cucumber tests won't use zync even if it's configured

### DIFF
--- a/config/examples/zync.yml
+++ b/config/examples/zync.yml
@@ -12,6 +12,7 @@ development:
 
 test:
   <<: *base
+  endpoint:
 
 production:
   <<: *base


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Disables zync in the cucumber tests.
When you have the zync configure locally (`ZYNC_ENDPOINT` env exists) the cucumber tests will fail.