### PR TITLE
Signup form: validate just required fields

### DIFF
--- a/app/javascript/packs/validateSignup.js
+++ b/app/javascript/packs/validateSignup.js
@@ -3,7 +3,15 @@
 import validate from 'validate.js'
 
 document.addEventListener('DOMContentLoaded', () => {
-  const constraints = {
+  // $FlowFixMe[incompatible-type] should be safe to assume it is HTMLFormElement
+  const form: HTMLFormElement = document.querySelector('#signup_form')
+  // $FlowFixMe[incompatible-type] should be safe to assume it is HTMLInputElement
+  const submitBtn: HTMLInputElement = document.querySelector('input[type="submit"]')
+  // $FlowFixMe[incompatible-type] should be safe to assume it is HTMLInputElement
+  const captchaInput: HTMLInputElement = document.querySelector('#captchaChecked')
+
+  // Fields 'org_name', 'username' and 'email' are always required
+  const mandatoryFields = {
     'account[org_name]': {
       presence: true,
       length: { minimum: 1 }
@@ -16,7 +24,11 @@ document.addEventListener('DOMContentLoaded', () => {
       presence: true,
       email: true,
       length: { minimum: 1 }
-    },
+    }
+  }
+  // Fields 'password' and 'password_confirmation' are optional (can be disabled)
+  const isPasswordRequired = document.querySelectorAll('input[type="password"]').length > 0
+  const passwordFields = isPasswordRequired ? {
     'account[user][password]': {
       presence: true,
       length: { minimum: 1 }
@@ -24,22 +36,21 @@ document.addEventListener('DOMContentLoaded', () => {
     'account[user][password_confirmation]': {
       presence: true,
       equality: 'account[user][password]'
-    },
+    }
+  } : null
+
+  // Captcha fields are optional
+  const captchaRequired: boolean = !!document.querySelector('.g-recaptcha')
+  const captchaFields = captchaRequired ? {
     'captchaChecked': {
       presence: true,
       length: { minimum: 1 }
     }
-  }
+  } : null
 
-  // $FlowFixMe[incompatible-type] should be safe to assume it is HTMLFormElement
-  const form: HTMLFormElement = document.querySelector('#signup_form')
-  // $FlowFixMe[incompatible-type] should be safe to assume it is HTMLInputElement
-  const submitBtn: HTMLInputElement = document.querySelector('input[type="submit"]')
-  // $FlowFixMe[incompatible-type] should be safe to assume it is HTMLInputElement
-  const captchaInput: HTMLInputElement = document.querySelector('#captchaChecked')
+  const constraints = Object.assign({}, mandatoryFields, passwordFields, captchaFields)
 
-  const captchaRequired: boolean = !!document.querySelector('.g-recaptcha')
-  submitBtn.disabled = true
+  submitBtn.disabled = !!validate(form, constraints)
   captchaInput.value = captchaRequired ? '' : 'ok'
 
   const inputs = document.querySelectorAll('input')

--- a/app/javascript/packs/validateSignup.js
+++ b/app/javascript/packs/validateSignup.js
@@ -4,11 +4,11 @@ import validate from 'validate.js'
 
 document.addEventListener('DOMContentLoaded', () => {
   // $FlowFixMe[incompatible-type] should be safe to assume it is HTMLFormElement
-  const form: HTMLFormElement = document.querySelector('#signup_form')
+  const form: HTMLFormElement = document.getElementById('signup_form')
   // $FlowFixMe[incompatible-type] should be safe to assume it is HTMLInputElement
   const submitBtn: HTMLInputElement = document.querySelector('input[type="submit"]')
   // $FlowFixMe[incompatible-type] should be safe to assume it is HTMLInputElement
-  const captchaInput: HTMLInputElement = document.querySelector('#captchaChecked')
+  const captchaInput: HTMLInputElement = document.getElementById('captchaChecked')
 
   // Fields 'org_name', 'username' and 'email' are always required
   const mandatoryFields = {
@@ -39,8 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   } : null
 
-  // Captcha fields are optional
-  const captchaRequired: boolean = !!document.querySelector('.g-recaptcha')
+  const captchaRequired: boolean = document.querySelector('.g-recaptcha') !== null
   const captchaFields = captchaRequired ? {
     'captchaChecked': {
       presence: true,
@@ -50,7 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const constraints = Object.assign({}, mandatoryFields, passwordFields, captchaFields)
 
-  submitBtn.disabled = !!validate(form, constraints)
+  submitBtn.disabled = validate(form, constraints) !== undefined
   captchaInput.value = captchaRequired ? '' : 'ok'
 
   const inputs = document.querySelectorAll('input')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Developer Portal's signup form can conditionally render **password** and **password confirmation** fields.
When not displayed, form validation fails, being unable to validate them.

This PR improves form validation, validating  **password** and **password confirmation**  only when present

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7633

**Note:** This issue was reported as happening when using SSO Integrations (and no _password_ and _password confirmation_ fileds). But, in fact, it can happen without SSO integrations.

**Verification steps** 

**To test with SSO integrations enabled:**
In Admin Portal
Go to **Audience > Developer Portal > SSO Integrations**
Enable one of the SSO Integrations available (e.g. Git Hub):
![gh](https://user-images.githubusercontent.com/13486237/135622708-9d0dcdbe-f573-4578-bf2c-8b200e2783b7.png)

**To test without password and password confirmation fields:**

An easy way to test with or without _password_ and _password confirmation_ fields, is editing the `signup > show` layout in the Developer Portal editor:
![edit](https://user-images.githubusercontent.com/13486237/135624282-2cbd3cd0-3ac6-437b-a317-c81f0e02678b.png)

In the layout, delete/comment the content of the block `{% if user.password_required? %}`:

![edit](https://user-images.githubusercontent.com/13486237/135624509-9a8f859a-a21a-4d44-8886-804b35d8c39c.png)

**Note: Remember to not save this changes, after testing**

**In the Developer Portal**
Go to the Signup page (e.g. http://provider.3scale.localhost:3000/signup)

**With password and password confirmation:**

https://user-images.githubusercontent.com/13486237/135625304-210c4d54-6945-44f1-98d9-279e797bcdf5.mov

**Without password and password confirmation:**

https://user-images.githubusercontent.com/13486237/135625347-d3043777-b72e-4ce3-b073-604d83bc5f9f.mov



