### PR TITLE
[Rails upgrade] Move condition from delete_all to where

### DIFF
--- a/test/unit/fields_definition_test.rb
+++ b/test/unit/fields_definition_test.rb
@@ -49,7 +49,7 @@ class FieldsDefinitionTest < ActiveSupport::TestCase
   context "validations" do
     setup do
       @provider = FactoryBot.create(:provider_account)
-      FieldsDefinition.delete_all(:account_id => @provider.id) # removing default ones
+      FieldsDefinition.where(:account_id => @provider.id).delete_all # removing default ones
       @field_definition1 = FieldsDefinition.create(:account => @provider, :name => 'org_name', :target => 'Account', :label => 'foo')
     end
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Part of the https://github.com/3scale/porta/pull/2648 that can be merge now.

Fixing:
> DEPRECATION WARNING: Passing conditions to delete_all is deprecated and will be removed in Rails 5.1. To achieve the same use where(conditions).delete_all.
