### PR TITLE
✅ Fix deprecated Params#symbolize_keys

### DIFF
--- a/app/controllers/stats/api/base_controller.rb
+++ b/app/controllers/stats/api/base_controller.rb
@@ -36,7 +36,7 @@ class Stats::Api::BaseController < ApplicationController
   private
 
   def render_usage(parameter)
-    options = slice_and_use_defaults(usage_params(parameter), parameter,
+    options = permit_and_use_defaults(usage_params(parameter), parameter,
                                      :period, :since, :timezone, :granularity, :until, :skip_change)
     @data = @source.usage(options)
 
@@ -61,8 +61,8 @@ class Stats::Api::BaseController < ApplicationController
   # Slices supplied params to allowed set, using defaults
   # when some neccessary are missing (like timezone)
   #
-  def slice_and_use_defaults(params, *allowed)
-    options = params.slice(*allowed)
+  def permit_and_use_defaults(params, *allowed)
+    options = params.permit(*allowed)
 
     options[:skip_change] = (options[:skip_change] == 'false') ? false : true
 

--- a/app/controllers/stats/api/services_controller.rb
+++ b/app/controllers/stats/api/services_controller.rb
@@ -4,7 +4,7 @@ class Stats::Api::ServicesController < Stats::Api::BaseController
   before_action :set_source
 
   def top_applications
-    options = slice_and_use_defaults(params, :metric_name, :period, :since, :timezone)
+    options = permit_and_use_defaults(params, :metric_name, :period, :since, :timezone)
 
     begin
       @data = @source.top_clients(options)

--- a/app/lib/stats/backend_api.rb
+++ b/app/lib/stats/backend_api.rb
@@ -90,7 +90,7 @@ module Stats
     protected
 
     def metric_and_period_details(options)
-      metric = extract_metric(options.symbolize_keys)
+      metric = extract_metric(options.to_h.symbolize_keys)
       metric_name = metric.class.name.underscore.to_sym
 
       { metric_name => detail(metric), period: period_detail(options) }

--- a/app/lib/stats/views/top.rb
+++ b/app/lib/stats/views/top.rb
@@ -6,7 +6,7 @@ module Stats
 
 
       def top(name, options)
-        options = options.symbolize_keys
+        options = options.to_h.symbolize_keys
         options.assert_valid_keys(:period, :since, :metric, :metric_name, :limit, :timezone, :skip_change)
         options.assert_required_keys(:period)
 

--- a/app/lib/stats/views/usage.rb
+++ b/app/lib/stats/views/usage.rb
@@ -121,7 +121,7 @@ module Stats
       end
 
       def extract_range_and_granularity_and_metric(options)
-        options = options.symbolize_keys
+        options = options.to_h.symbolize_keys
 
         range, granularity = extract_range_and_granularity(options)
         validate_time_range(range, granularity)


### PR DESCRIPTION
Fixes warning:
```
.DEPRECATION WARNING: Method symbolize_keys is deprecated and will be removed in Rails 5.1, as 
`ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes 
potential security problems. If you continue to use this method you may be creating a security
vulnerability in your app that can be exploited. Instead, consider using one of these documented
methods which are not deprecated: 
http://api.rubyonrails.org/v5.0.7.2/classes/ActionController/Parameters.html
(called from extract_range_and_granularity_and_metric at 
/opt/app-root/src/project/app/lib/stats/views/usage.rb:124)
```
By:
* Calling `permit` instead of `slice`
* Converting `to_h` params before `symbolize_keys`