### PR TITLE
✅ Replaces deprecated ActiveModel::Errors#get

### DIFF
--- a/app/validators/nested_association_validator.rb
+++ b/app/validators/nested_association_validator.rb
@@ -9,7 +9,7 @@ class NestedAssociationValidator < ActiveModel::EachValidator
   def validate_each(record, _attribute, value)
     return if !value || value.valid? || value.marked_for_destruction?
     options[:report].each do |alternate, attr|
-      errors = value.errors.get(alternate)
+      errors = value.errors.messages[alternate]
       record.errors[attr || alternate].concat(errors) if errors.present?
     end
   end


### PR DESCRIPTION
Fixes deprecation:
```
Onboarding::ApiFormTest#test_invalid_backend DEPRECATION WARNING: ActiveModel::Errors#get is
deprecated and will be removed in Rails 5.1. To achieve the same use model.errors[:private_endpoint].
(called from block in validate_each at /opt/app-root/src/project/app/validators/nested_association_validator.rb:12)
```
