### PR TITLE
Use key arguments in http methods under test/integration

### DIFF
--- a/test/integration/admin/account/payment_gateways_controller_test.rb
+++ b/test/integration/admin/account/payment_gateways_controller_test.rb
@@ -12,10 +12,10 @@ class Admin::Account::PaymentGatewaysControllerTest < ActionDispatch::Integratio
   end
 
   test 'update' do
-    put admin_account_payment_gateway_path(@provider), account: {
+    put admin_account_payment_gateway_path(@provider), params: { account: {
       payment_gateway_type: 'stripe',
       payment_gateway_options: { 'login' => 'bob', 'publishable_key' => 'monkey', 'endpoint_secret' => 'some-secret' }
-    }
+    } }
 
     @provider.reload
     @provider.gateway_setting.reload
@@ -38,10 +38,10 @@ class Admin::Account::PaymentGatewaysControllerTest < ActionDispatch::Integratio
       deprecated_gateway = PaymentGateway.new(:bogus, deprecated: true, foo: 'Foo')
       PaymentGateway.stubs(all: [deprecated_gateway])
 
-      put admin_account_payment_gateway_path(@provider), account: {
+      put admin_account_payment_gateway_path(@provider), params: { account: {
         payment_gateway_type: 'bogus',
         payment_gateway_options: { foo: :bar }
-      }
+      } }
     end
   end
 
@@ -52,10 +52,10 @@ class Admin::Account::PaymentGatewaysControllerTest < ActionDispatch::Integratio
     @provider.gateway_setting.gateway_type = :bogus
     @provider.gateway_setting.save(validate: false)
 
-    put admin_account_payment_gateway_path(@provider), account: {
+    put admin_account_payment_gateway_path(@provider), params: { account: {
       payment_gateway_type: 'stripe',
       payment_gateway_options: { 'login' => 'bob', 'publishable_key' => 'monkey', 'endpoint_secret' => 'some-secret' }
-    }
+    } }
 
     @provider.reload
     @provider.gateway_setting.reload
@@ -74,10 +74,10 @@ class Admin::Account::PaymentGatewaysControllerTest < ActionDispatch::Integratio
     deprecated_gateway = PaymentGateway.new(:bogus, deprecated: true, foo: 'Foo')
     PaymentGateway.stubs(all: [deprecated_gateway])
 
-    put admin_account_payment_gateway_path(@provider), account: {
+    put admin_account_payment_gateway_path(@provider), params: { account: {
       payment_gateway_type: 'bogus',
       payment_gateway_options: { foo: :baz }
-    }
+    } }
 
     @provider.reload
     @provider.gateway_setting.reload

--- a/test/integration/admin/api/accounts_controller_test.rb
+++ b/test/integration/admin/api/accounts_controller_test.rb
@@ -57,7 +57,7 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
       rolling_updates_on
       rolling_update(:service_permissions, enabled: true)
 
-      put admin_api_account_path(buyer, format: :xml), update_params
+      put admin_api_account_path(buyer, format: :xml), params: update_params
       assert_response :ok
       assert_xml '//account/id'
       assert buyer.reload.settings.monthly_billing_enabled
@@ -67,7 +67,7 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
       rolling_updates_on
       rolling_update(:service_permissions, enabled: false)
 
-      put admin_api_account_path(buyer, format: :xml), update_params
+      put admin_api_account_path(buyer, format: :xml), params: update_params
       assert_xml_403
       refute buyer.reload.settings.monthly_billing_enabled
     end
@@ -76,7 +76,7 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
       rolling_updates_on
       rolling_update(:service_permissions, enabled: false)
 
-      put admin_api_account_path(buyer, format: :json), update_params
+      put admin_api_account_path(buyer, format: :json), params: update_params
       assert_equal 'Forbidden', JSON.parse(response.body).dig('status')
       assert_response :forbidden
       refute buyer.reload.settings.monthly_billing_enabled
@@ -144,7 +144,7 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
       FactoryBot.create(:webhook, account: provider, account_updated_on: true, active: true)
 
       assert_difference(WebHookWorker.jobs.method(:size)) do
-        put admin_api_account_path(buyer, format: :json), { monthly_billing_enabled: true, access_token: token.value }
+        put admin_api_account_path(buyer, format: :json), params: { monthly_billing_enabled: true, access_token: token.value }
         assert_response :success
       end
     end
@@ -154,7 +154,7 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
       FactoryBot.create(:webhook, account: provider, account_updated_on: true, active: true)
 
       assert_no_difference(WebHookWorker.jobs.method(:size)) do
-        put admin_api_account_path(buyer, format: :json), { monthly_billing_enabled: true, provider_key: provider.provider_key }
+        put admin_api_account_path(buyer, format: :json), params: { monthly_billing_enabled: true, provider_key: provider.provider_key }
         assert_response :success
       end
     end

--- a/test/integration/admin/api/api_docs_services_controller_test.rb
+++ b/test/integration/admin/api/api_docs_services_controller_test.rb
@@ -41,7 +41,7 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
 
     def test_create_sets_all_attributes
       assert_difference ::ApiDocs::Service.method(:count) do
-        post admin_api_active_docs_path(access_token: @token), create_params(service_id: service.id, system_name: 'smart_service')
+        post admin_api_active_docs_path(access_token: @token), params: create_params(service_id: service.id, system_name: 'smart_service')
         assert_response :created
       end
 
@@ -56,7 +56,7 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
     end
 
     def test_update_with_right_params
-      put admin_api_active_doc_path(api_docs_service, access_token: @token), update_params(service_id: service.id)
+      put admin_api_active_doc_path(api_docs_service, access_token: @token), params: update_params(service_id: service.id)
       assert_response :success
 
       api_docs_service.reload
@@ -69,28 +69,28 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
 
     def test_update_can_remove_service
       api_docs_service.update_attribute(:service_id, provider.default_service_id)
-      put admin_api_active_doc_path(api_docs_service, access_token: @token), update_params(service_id: '')
+      put admin_api_active_doc_path(api_docs_service, access_token: @token), params: update_params(service_id: '')
       assert_response :success
       assert_nil api_docs_service.reload.service_id
     end
 
     def test_system_name_is_not_updated
       old_system_name = api_docs_service.system_name
-      put admin_api_active_doc_path(api_docs_service, access_token: @token), update_params(system_name: "#{old_system_name}-2")
+      put admin_api_active_doc_path(api_docs_service, access_token: @token), params: update_params(system_name: "#{old_system_name}-2")
       assert_response :success
       assert_equal old_system_name, api_docs_service.reload.system_name
     end
 
     def test_update_invalid_params
       old_body = api_docs_service.body
-      put admin_api_active_doc_path(api_docs_service, format: :json, access_token: @token), update_params(body: '{apis: []}')
+      put admin_api_active_doc_path(api_docs_service, format: :json, access_token: @token), params: update_params(body: '{apis: []}')
       assert_response :unprocessable_entity
       assert_contains JSON.parse(response.body).dig('errors', 'body'), 'JSON Spec is invalid'
       assert_equal old_body, api_docs_service.reload.body
     end
 
     def test_update_unexistent_service
-      put admin_api_active_doc_path(api_docs_service, format: :json, access_token: @token), update_params(service_id: Service.last.id + 1)
+      put admin_api_active_doc_path(api_docs_service, format: :json, access_token: @token), params: update_params(service_id: Service.last.id + 1)
       assert_response :unprocessable_entity
       assert_equal 'Service not found', JSON.parse(response.body)['error']
     end
@@ -141,12 +141,12 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
       end
 
       test 'create with forbidden service' do
-        post admin_api_active_docs_path(path_params), api_doc_params(service_id: forbidden_service.id)
+        post admin_api_active_docs_path(path_params), params: api_doc_params(service_id: forbidden_service.id)
         assert_response :unprocessable_entity
       end
 
       test 'update to forbidden service' do
-        put admin_api_active_doc_path(accessible_api_docs_service, **path_params), { service_id: forbidden_service.id }
+        put admin_api_active_doc_path(accessible_api_docs_service, **path_params), params: { service_id: forbidden_service.id }
         assert_response :unprocessable_entity
       end
 

--- a/test/integration/admin/api/buyers_applications_controller_test.rb
+++ b/test/integration/admin/api/buyers_applications_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::BuyersApplicationsControllerTest < ActionDispatch::IntegrationTest
@@ -109,7 +111,7 @@ class Admin::Api::BuyersApplicationsControllerTest < ActionDispatch::Integration
 
     def request_plan_change(new_plan = create_new_plan_same_service)
       params = { access_token: @access_token.value, plan_id: new_plan.id }
-      put change_plan_admin_api_account_application_path(account_id: @buyer.id, id: @application.id, format: :xml), params
+      put change_plan_admin_api_account_application_path(account_id: @buyer.id, id: @application.id, format: :xml), params: params
     end
 
     def create_new_plan_same_service

--- a/test/integration/admin/api/buyers_users_controller_test.rb
+++ b/test/integration/admin/api/buyers_users_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::BuyersUsersControllerTest < ActionDispatch::IntegrationTest
 
   test 'creates a user for its buyer' do
     assert_difference(buyer.users.method(:count)) do
-      post admin_api_account_users_path(buyer), params
+      post admin_api_account_users_path(buyer), params: params
     end
 
     user = buyer.users.order(created_at: :asc).last!

--- a/test/integration/admin/api/member_permissions_controller_test.rb
+++ b/test/integration/admin/api/member_permissions_controller_test.rb
@@ -21,7 +21,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
   test "PUT: enable 'analytics' section for service 1" do
     params = { allowed_sections: ['monitoring'], allowed_service_ids: [@services.first.id], access_token: @token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_not_nil (permissions = JSON.parse(response.body)['permissions'])
     assert_equal ['monitoring'], permissions['allowed_sections']
@@ -36,7 +36,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     @user.update_attributes({ allowed_sections: ['partners'], allowed_service_ids: [@services.first.id] })
     params = { allowed_sections: ['settings'], access_token: @token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_not_nil (permissions = JSON.parse(response.body)['permissions'])
     assert_equal ['settings'], permissions['allowed_sections']
@@ -51,7 +51,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     @user.update_attributes({ allowed_sections: ['partners'], allowed_service_ids: [@services.first.id] })
     params = { allowed_service_ids: [@services.last.id.to_s], access_token: @token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_not_nil (permissions = JSON.parse(response.body)['permissions'])
     assert_equal ['partners'], permissions['allowed_sections']
@@ -67,7 +67,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     # allowed_sections%5B%5D=settings&allowed_service_ids%5B%5D
     params = { allowed_sections: ['settings'], allowed_service_ids: '', access_token: @token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_not_nil (permissions = JSON.parse(response.body)['permissions'])
     assert_equal ['settings'], permissions['allowed_sections']
@@ -83,7 +83,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     # allowed_sections%5B%5D=settings&allowed_service_ids%5B%5D=%5B%5D
     params = { allowed_sections: ['settings'], allowed_service_ids: ["[]"], access_token: @token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_not_nil (permissions = JSON.parse(response.body)['permissions'])
     assert_equal ['settings'], permissions['allowed_sections']
@@ -98,7 +98,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     @user.update_attribute :role, 'admin'
     params = { allowed_sections: ['monitoring'], allowed_service_ids: [@services.first.id], access_token: @token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_response :forbidden
     assert_equal '{"status":"Forbidden"}', response.body
@@ -110,7 +110,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     # allowed_sections%5B%5D=settings&allowed_service_ids%5B%5D
     params = { allowed_sections: ['settings'], allowed_service_ids: '', access_token: token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_response :forbidden
     assert_equal '{"error":"Your access token does not have the correct permissions"}', response.body
@@ -124,7 +124,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     # allowed_sections%5B%5D=settings&allowed_service_ids%5B%5D
     params = { allowed_sections: ['settings'], allowed_service_ids: '', access_token: @token }
 
-    put admin_api_permissions_path(id: another_user.id, format: :json), params
+    put admin_api_permissions_path(id: another_user.id, format: :json), params: params
 
     assert_response :forbidden
   end
@@ -133,7 +133,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     @user.update_attributes({ allowed_sections: ['partners'], allowed_service_ids: [@services.first.id] })
     params = { allowed_sections: ['invalid'], access_token: @token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_response :success
     assert_not_nil (permissions = JSON.parse(response.body)['permissions'])
@@ -149,7 +149,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     @user.update_attributes({ allowed_sections: ['partners'], allowed_service_ids: [@services.first.id] })
     params = { allowed_sections: ['invalid', 'settings'], access_token: @token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_response :success
     assert_not_nil (permissions = JSON.parse(response.body)['permissions'])
@@ -165,7 +165,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     @user.update_attributes({ allowed_sections: ['partners'], allowed_service_ids: [@services.first.id] })
     params = { allowed_service_ids: [[@services.last.id.to_s],'22'], access_token: @token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_response :success
     assert_not_nil (permissions = JSON.parse(response.body)['permissions'])
@@ -181,7 +181,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     @user.update_attributes({ allowed_sections: ['partners'], allowed_service_ids: [@services.first.id] })
     params = { allowed_service_ids: ['22'], access_token: @token }
 
-    put admin_api_permissions_path(id: @user.id, format: :json), params
+    put admin_api_permissions_path(id: @user.id, format: :json), params: params
 
     assert_response :success
     assert_not_nil (permissions = JSON.parse(response.body)['permissions'])
@@ -196,7 +196,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
   test 'disable all allowed_sections' do
     @user.update_attributes({ allowed_sections: ['partners'], allowed_service_ids: [@services.first.id] })
 
-    put admin_api_permissions_path(id: @user.id, format: :json, access_token: @token), { allowed_sections: ['[]'] }
+    put admin_api_permissions_path(id: @user.id, format: :json, access_token: @token), params: { allowed_sections: ['[]'] }
 
     @user.member_permissions.reload
     assert_empty @user.allowed_sections.to_a

--- a/test/integration/admin/api/metric_methods_controller_test.rb
+++ b/test/integration/admin/api/metric_methods_controller_test.rb
@@ -22,7 +22,7 @@ class Admin::Api::MetricMethodsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'create' do
-    post admin_api_service_metric_methods_path(path_params), metric: { system_name: 'alaska', friendly_name: 'alaska' }
+    post admin_api_service_metric_methods_path(path_params), params: { metric: { system_name: 'alaska', friendly_name: 'alaska' } }
     assert_response :success
   end
 
@@ -30,19 +30,19 @@ class Admin::Api::MetricMethodsControllerTest < ActionDispatch::IntegrationTest
     Admin::Api::MetricMethodsController.any_instance.stubs(:create).raises(
       ActiveRecord::RecordNotUnique, 'Mysql2::Error: Duplicate entry')
 
-    post admin_api_service_metric_methods_path(path_params), metric: { system_name: 'alaska', friendly_name: 'alaska' }
+    post admin_api_service_metric_methods_path(path_params), params: { metric: { system_name: 'alaska', friendly_name: 'alaska' } }
     assert_response :conflict
   end
 
   test 'update' do
-    put admin_api_service_metric_method_path(path_params(id: method_metric.id)), metric: { friendly_name: 'new friendly name' }
+    put admin_api_service_metric_method_path(path_params(id: method_metric.id)), params: { metric: { friendly_name: 'new friendly name' } }
     assert_response :success
     assert_equal 'new friendly name', method_metric.reload.friendly_name
   end
 
   test 'cannot update system_name' do
     old_system_name = method_metric.system_name
-    put admin_api_service_metric_method_path(path_params(id: method_metric.id)), metric: { system_name: 'new_system_name' }
+    put admin_api_service_metric_method_path(path_params(id: method_metric.id)), params: { metric: { system_name: 'new_system_name' } }
     assert_response :success
     assert_equal old_system_name, method_metric.reload.system_name
   end

--- a/test/integration/admin/api/signups_controller_test.rb
+++ b/test/integration/admin/api/signups_controller_test.rb
@@ -19,7 +19,7 @@ class Admin::Api::SignupsControllerTest < ActionDispatch::IntegrationTest
 
       assert_difference(provider.buyers.method(:count)) do
         assert_difference(WebHookWorker.jobs.method(:size)) do
-          post(admin_api_signup_path, format: :json, access_token: token.value, org_name: 'company', username: 'person')
+          post(admin_api_signup_path, params: { format: :json, access_token: token.value, org_name: 'company', username: 'person' })
           assert_response :created
         end
       end
@@ -31,7 +31,7 @@ class Admin::Api::SignupsControllerTest < ActionDispatch::IntegrationTest
 
       assert_difference(provider.buyers.method(:count)) do
         assert_no_difference(WebHookWorker.jobs.method(:size)) do
-          post(admin_api_signup_path, format: :json, provider_key: provider.provider_key, org_name: 'company', username: 'person')
+          post(admin_api_signup_path, params: { format: :json, provider_key: provider.provider_key, org_name: 'company', username: 'person' })
           assert_response :created
         end
       end

--- a/test/integration/admin/api_docs/account_api_docs_controller_test.rb
+++ b/test/integration/admin/api_docs/account_api_docs_controller_test.rb
@@ -125,7 +125,7 @@ class Admin::ApiDocs::AccountApiDocsControllerTest < ActionDispatch::Integration
       put toggle_visible_admin_api_docs_service_path(forbidden_api_docs_service)
       assert_response :not_found
 
-      put admin_api_docs_service_path(forbidden_api_docs_service), api_docs_service: { service_id: forbidden_api_docs_service.id }
+      put admin_api_docs_service_path(forbidden_api_docs_service), params: { api_docs_service: { service_id: forbidden_api_docs_service.id } }
       assert_response :not_found
 
       delete admin_api_docs_service_path(forbidden_api_docs_service)

--- a/test/integration/api/access_tokens_test.rb
+++ b/test/integration/api/access_tokens_test.rb
@@ -80,7 +80,7 @@ class Admin::Api::AccessTokensTest < ActionDispatch::IntegrationTest
   end
 
   def post_request(user_id, authentication = {}, different_params = {})
-    post admin_api_user_access_tokens_path(authentication.merge({user_id: user_id, format: :json})), access_token_params.merge(different_params)
+    post admin_api_user_access_tokens_path(authentication.merge({user_id: user_id, format: :json})), params: access_token_params.merge(different_params)
   end
 
   def access_token_params

--- a/test/integration/api/alerts_controller_test.rb
+++ b/test/integration/api/alerts_controller_test.rb
@@ -29,13 +29,13 @@ class Api::AlertsControllerTest < ActionDispatch::IntegrationTest
     get admin_alerts_path
     assert_equal 2, assigns(:alerts).count
 
-    get admin_alerts_path, account_id: buyer1.id
+    get admin_alerts_path, params: { account_id: buyer1.id }
 
     alerts = assigns(:alerts)
     assert_equal 1, alerts.count
     assert_equal buyer1, alerts.first.cinstance.buyer_account
 
-    get admin_alerts_path, cinstance_id: cinstance2.id
+    get admin_alerts_path, params: { cinstance_id: cinstance2.id }
 
     alerts = assigns(:alerts)
     assert_equal 1, alerts.count
@@ -43,7 +43,7 @@ class Api::AlertsControllerTest < ActionDispatch::IntegrationTest
 
     Account.expects(:search_ids).with(buyer1.name).returns([buyer1.id])
 
-    get admin_alerts_path, search: {account: { query: buyer1.name} }
+    get admin_alerts_path, params: { search: {account: { query: buyer1.name} } }
 
     alerts = assigns(:alerts)
     assert_equal 1, alerts.count

--- a/test/integration/api/errors_controller_test.rb
+++ b/test/integration/api/errors_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Api::ErrorsControllerTest < ActionDispatch::IntegrationTest
@@ -11,7 +13,7 @@ class Api::ErrorsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'index with pagination' do
-    get admin_service_errors_path(@service), {per_page: 1, page: 2}
+    get admin_service_errors_path(@service), params: { per_page: 1, page: 2 }
     assigned_errors = assigns(:errors)
     assert_equal 2, assigned_errors.size
     assigned_errors.each { |error| assert_instance_of(ThreeScale::Core::ServiceError, error) }

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -62,7 +62,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
         proxy_rule_1.id => { id: proxy_rule_1.id, last: true }
       }
     }
-    put admin_service_integration_path(service_id: service.id), proxy: proxy_rules_attributes
+    put admin_service_integration_path(service_id: service.id), params: { proxy: proxy_rules_attributes }
     assert_response :redirect
     assert proxy_rule_1.reload.last
   end
@@ -75,7 +75,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
 
     Service.any_instance.expects(:using_proxy_pro?).returns(true).at_least_once
     # call update as proxy_pro updates endpoint through staging section
-    put admin_service_integration_path(service_id: service.id), proxy: {endpoint: 'http://example.com:80'}
+    put admin_service_integration_path(service_id: service.id), params: { proxy: {endpoint: 'http://example.com:80'} }
     assert_equal 'http://example.com:80', proxy.reload.endpoint
   end
 
@@ -87,7 +87,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     ProxyTestService.any_instance.stubs(:disabled?).returns(true)
 
     assert_difference proxy.proxy_configs.method(:count) do
-      put admin_service_integration_path(service_id: service.id), proxy: {endpoint: 'http://example.com'}
+      put admin_service_integration_path(service_id: service.id), params: { proxy: {endpoint: 'http://example.com'} }
       assert_response :redirect
     end
   end
@@ -106,7 +106,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
         proxy_rule_2.id => { id: proxy_rule_2.id, position: 1 }
       }
     }
-    put admin_service_integration_path(service_id: service.id), proxy: proxy_rules_attributes
+    put admin_service_integration_path(service_id: service.id), params: { proxy: proxy_rules_attributes }
     assert_response :redirect
 
     proxy_rule_1.reload
@@ -120,7 +120,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
         proxy_rule_1.id => { id: proxy_rule_1.id, position: 1 }
       }
     }
-    put admin_service_integration_path(service_id: service.id), proxy: proxy_rules_attributes
+    put admin_service_integration_path(service_id: service.id), params: { proxy: proxy_rules_attributes }
     assert_response :redirect
 
     proxy_rule_1.reload
@@ -137,7 +137,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
         proxy_rule_1.id => { id: proxy_rule_1.id, position: 4 }
       }
     }
-    put admin_service_integration_path(service_id: service.id), proxy: proxy_rules_attributes
+    put admin_service_integration_path(service_id: service.id), params: { proxy: proxy_rules_attributes }
     assert_response :redirect
 
     proxy_rule_1.reload
@@ -151,7 +151,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
   test 'deploy is called when saving proxy info' do
     Proxy.any_instance.expects(:save_and_deploy).once
 
-    put admin_service_integration_path(service_id: service.id), proxy: {api_backend: '1'}
+    put admin_service_integration_path(service_id: service.id), params: { proxy: {api_backend: '1'} }
   end
 
   test 'deploy is never called when saving proxy info for proxy pro users' do
@@ -167,7 +167,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     service.update_column(:deployment_option, 'self_managed')
     proxy.update_column(:apicast_configuration_driven, false)
 
-    put admin_service_integration_path(service_id: service.id), proxy: {api_backend: '1'}
+    put admin_service_integration_path(service_id: service.id), params: { proxy: {api_backend: '1'} }
   end
 
   test 'updating proxy' do

--- a/test/integration/api/metrics_controller_test.rb
+++ b/test/integration/api/metrics_controller_test.rb
@@ -32,14 +32,14 @@ class Api::MetricsControllerTest < ActionDispatch::IntegrationTest
 
   test 'create metric' do
     assert_difference @service.metrics.method(:count) do
-      post admin_service_metrics_path(service_id: @service.id), metric: { system_name: 'upgrades', friendly_name: 'upgrades', unit: 'upgrades' }
+      post admin_service_metrics_path(service_id: @service.id), params: { metric: { system_name: 'upgrades', friendly_name: 'upgrades', unit: 'upgrades' } }
       assert_response :redirect
     end
   end
 
   test 'create method' do
     assert_difference @service.metrics.method(:count) do
-      post admin_service_metrics_path(service_id: @service.id, metric_id: @service.metrics.hits), metric: { system_name: 'alaska', friendly_name: 'alaska' }
+      post admin_service_metrics_path(service_id: @service.id, metric_id: @service.metrics.hits), params: { metric: { system_name: 'alaska', friendly_name: 'alaska' } }
       assert_response :redirect
     end
   end
@@ -51,14 +51,14 @@ class Api::MetricsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'update' do
-    patch admin_service_metric_path(service_id: @service.id, id: @metric.id), metric: { friendly_name: 'new friendly name' }
+    patch admin_service_metric_path(service_id: @service.id, id: @metric.id), params: { metric: { friendly_name: 'new friendly name' } }
     assert_response :redirect
     assert_equal 'new friendly name', @metric.reload.friendly_name
   end
 
   test 'cannot update system_name' do
     assert_equal 'super_metric', @metric.system_name
-    patch admin_service_metric_path(service_id: @service.id, id: @metric.id), metric: { system_name: 'new_system_name' }
+    patch admin_service_metric_path(service_id: @service.id, id: @metric.id), params: { metric: { system_name: 'new_system_name' } }
     assert_response :redirect
     assert_equal 'super_metric', @metric.reload.system_name
   end

--- a/test/integration/api/personal/access_tokens_test.rb
+++ b/test/integration/api/personal/access_tokens_test.rb
@@ -71,7 +71,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
   class Admin::Api::Personal::CreateAccessTokenTest < Admin::Api::Personal::AccessTokensTest
     test 'POST creates an access token for the admin user of the access token' do
       assert_difference @admin.access_tokens.method(:count) do
-        post admin_api_personal_access_tokens_path({access_token: @admin_access_token.value}), access_token_params
+        post admin_api_personal_access_tokens_path({access_token: @admin_access_token.value}), params: access_token_params
         assert_response :created
         assert JSON.parse(response.body).dig('access_token', 'value')
       end
@@ -110,7 +110,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
     end
 
     def perform_request(authentication: {access_token: @admin_access_token.value}, different_params: {})
-      post admin_api_personal_access_tokens_path(authentication.merge(different_params)), access_token_params
+      post admin_api_personal_access_tokens_path(authentication.merge(different_params)), params: access_token_params
     end
   end
 

--- a/test/integration/api/policies_controller_test.rb
+++ b/test/integration/api/policies_controller_test.rb
@@ -21,7 +21,7 @@ class Api::PoliciesControllerTest < ActionDispatch::IntegrationTest
         "version" => "builtin", "enabled" => true, "removable" => false, "id" => "apicast-policy"
       }
     ]
-    put admin_service_policies_path(@service), proxy: {policies_config: config}
+    put admin_service_policies_path(@service), params: { proxy: {policies_config: config} }
     # Checking flash won't work anymore in rails 5+
     assert_equal 'The policies are saved successfully', flash[:notice]
     assert_equal Proxy::PoliciesConfig.new(expected_policies), @service.proxy.policies_config
@@ -30,14 +30,14 @@ class Api::PoliciesControllerTest < ActionDispatch::IntegrationTest
 
   test 'invalid config - does not update policies' do
     invalid_config = 'invalid-config'.to_json
-    put admin_service_policies_path(@service), proxy: { policies_config: invalid_config }
+    put admin_service_policies_path(@service), params: { proxy: { policies_config: invalid_config } }
     assert_equal 'The policies cannot be saved', flash[:error]
     assert_response :unprocessable_entity
   end
 
   test 'update policies config with errors' do
     invalid_config = [{ 'name' => 'foo' }].to_json
-    put admin_service_policies_path(@service), proxy: {policies_config: invalid_config}
+    put admin_service_policies_path(@service), params: { proxy: {policies_config: invalid_config} }
     # Checking flash won't work anymore in rails 5+
     assert_equal 'The policies cannot be saved', flash[:error]
     assert_equal Proxy::PoliciesConfig.new([Proxy::PolicyConfig::DEFAULT_POLICY]), @service.proxy.policies_config

--- a/test/integration/api/proxy_rules_controller_test.rb
+++ b/test/integration/api/proxy_rules_controller_test.rb
@@ -43,14 +43,14 @@ class Api::ProxyRulesControllerTest < ActionDispatch::IntegrationTest
     proxy_rule_params = FactoryBot.attributes_for(:proxy_rule, proxy: @service.proxy, metric_id: @service.metrics.last.id)
 
     assert_difference -> { @service.proxy.proxy_rules.count }, 1 do
-      post admin_service_proxy_rules_path(@service), proxy_rule: proxy_rule_params
+      post admin_service_proxy_rules_path(@service), params: { proxy_rule: proxy_rule_params }
     end
   end
 
   test '#update saves the new attributes' do
     proxy_rule = FactoryBot.create(:proxy_rule, proxy: @service.proxy)
 
-    patch admin_service_proxy_rule_path(@service, proxy_rule), proxy_rule: { pattern: '/testing' }
+    patch admin_service_proxy_rule_path(@service, proxy_rule), params: { proxy_rule: { pattern: '/testing' } }
     follow_redirect!
     proxy_rule.reload
 

--- a/test/integration/api/sso_tokens_controller_test.rb
+++ b/test/integration/api/sso_tokens_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::SsoTokensControllerTest < ActionDispatch::IntegrationTest
@@ -39,7 +41,7 @@ class Admin::Api::SsoTokensControllerTest < ActionDispatch::IntegrationTest
 
     test 'provider_create' do
       FactoryBot.create(:simple_admin, account: @provider, username: ThreeScale.config.impersonation_admin['username'])
-      post provider_create_admin_api_sso_tokens_path(format: :json), provider_id: @provider.id, access_token: @access_token.value
+      post provider_create_admin_api_sso_tokens_path(format: :json), params: { provider_id: @provider.id, access_token: @access_token.value }
       assert_response :success
 
       assert sso_token = JSON.parse(response.body)['sso_token']
@@ -51,7 +53,7 @@ class Admin::Api::SsoTokensControllerTest < ActionDispatch::IntegrationTest
       FactoryBot.create(:simple_admin, account: @provider, username: ThreeScale.config.impersonation_admin['username'])
 
       Timecop.freeze do
-        post provider_create_admin_api_sso_tokens_path(format: :json), provider_id: @provider.id, access_token: @access_token.value, expires_in: 60
+        post provider_create_admin_api_sso_tokens_path(format: :json), params: { provider_id: @provider.id, access_token: @access_token.value, expires_in: 60 }
         assert_response :success
 
         assert_equal (Time.now.utc + 60).httpdate, response.headers['Expires']

--- a/test/integration/buyers/accounts/bulk/change_plans_controller_test.rb
+++ b/test/integration/buyers/accounts/bulk/change_plans_controller_test.rb
@@ -14,7 +14,7 @@ class Buyers::Accounts::Bulk::ChangePlansControllerTest < ActionDispatch::Integr
   attr_reader :buyer
 
   test '#new displays the buyer\'s admin_user_display_name' do
-    get new_admin_buyers_accounts_bulk_change_plan_path, selected: [buyer.id]
+    get new_admin_buyers_accounts_bulk_change_plan_path, params: { selected: [buyer.id] }
 
     assert_xpath('//main//span', buyer.decorate.admin_user_display_name)
   end

--- a/test/integration/buyers/accounts_controller_test.rb
+++ b/test/integration/buyers/accounts_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
@@ -14,12 +16,10 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
     test 'POST creates the user and the account also when extra_fields are sent' do
       FactoryBot.create(:fields_definition, account: @provider, target: 'User', name: 'created_by')
 
-      post admin_buyers_accounts_path, {
-          account: {
+      post admin_buyers_accounts_path, params: { account: {
               org_name: 'Alaska',
               user: { email: 'foo@example.com', extra_fields: { created_by: 'hi' }, password: '123456', username: 'hello' }
-          }
-      }
+          } }
 
       account = Account.last
       user = User.last
@@ -40,10 +40,10 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
 
       assert_difference @provider.buyers.method(:count) do
         assert_equal 0, WebHookWorker.jobs.size
-        post admin_buyers_accounts_path, account: {
+        post admin_buyers_accounts_path, params: { account: {
             org_name: 'hello', org_legaladdress: 'address',
             user: { username: 'hello', email: 'foo@example.com', password: 'password'}
-        }
+        } }
         assert_equal 1, WebHookWorker.jobs.size
 
         assert_response :redirect
@@ -176,12 +176,10 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
       @provider.account_plans.delete_all
       @provider.account_plans.create!(name: 'non default account plan')
 
-      post admin_buyers_accounts_path, {
-        account: {
+      post admin_buyers_accounts_path, params: { account: {
           org_name: 'Alaska',
           user: { email: 'foo@example.com', password: '123456', username: 'hello' }
-        }
-      }
+        } }
 
       assert_redirected_to admin_buyers_account_plans_path
       assert_equal 'Please, create an Account Plan first', flash[:alert]
@@ -193,12 +191,10 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
       errors.add(:base, 'another error')
       Signup::Result.any_instance.stubs(errors: errors)
 
-      post admin_buyers_accounts_path, {
-        account: {
+      post admin_buyers_accounts_path, params: { account: {
           org_name: 'Alaska',
           user: { email: 'foo@example.com', password: '123456', username: 'hello' }
-        }
-      }
+        } }
 
       assert_equal 'error that is not in "user" or "account". another error', flash[:error]
     end
@@ -240,22 +236,22 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
 
     test '#create' do
       assert_no_difference(-> { @provider.buyers.count }) do
-        post admin_buyers_accounts_path, account: {
+        post admin_buyers_accounts_path, params: { account: {
             org_name: 'My organization'
-        }
+        } }
         assert_select '#account_user_username_input.required.error'
         assert_response :success
       end
 
       assert_difference(-> { @provider.buyers.count }) do
-        post admin_buyers_accounts_path, account: {
+        post admin_buyers_accounts_path, params: { account: {
             org_name: 'My organization',
             user: {
                 username: 'johndoe',
                 email: 'user@example.org',
                 password: 'secretpassword'
             }
-        }
+        } }
         assert_response :redirect
       end
     end
@@ -296,12 +292,12 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'User with invalid data shows an flash error' do
-      post admin_buyers_accounts_path, account: {
+      post admin_buyers_accounts_path, params: { account: {
           org_name: 'My organization',
           user: {
             username: 'hello'
           }
-      }
+      } }
       assert_equal 'Users invalid', flash[:error]
     end
   end

--- a/test/integration/buyers/applications/bulk/change_plans_controller_test.rb
+++ b/test/integration/buyers/applications/bulk/change_plans_controller_test.rb
@@ -13,7 +13,7 @@ class Buyers::Applications::Bulk::ChangePlansControllerTest < ActionDispatch::In
   test '#new renders with the display_name in the title of the contract' do
     contracts = FactoryBot.create_list(:cinstance, 2, plan: FactoryBot.create(:application_plan, service: tenant.default_service))
 
-    get new_admin_buyers_applications_bulk_change_plan_path, selected: contracts.map(&:id)
+    get new_admin_buyers_applications_bulk_change_plan_path, params: { selected: contracts.map(&:id) }
 
     page = Nokogiri::HTML::Document.parse(response.body)
     expected_display_names = contracts.map { |contract| contract.decorate.account_admin_user_display_name }

--- a/test/integration/buyers/service_contracts/bulk/change_plans_controller_test.rb
+++ b/test/integration/buyers/service_contracts/bulk/change_plans_controller_test.rb
@@ -17,7 +17,7 @@ class Buyers::ServiceContracts::Bulk::ChangePlansControllerTest < ActionDispatch
       errors.add(:base, 'any error')
       false
     end
-    post admin_buyers_service_contracts_bulk_change_plan_path, selected: [service_contract.id], change_plans: {plan_id: change_service_plan.id}, action: 'create'
+    post admin_buyers_service_contracts_bulk_change_plan_path, params: { selected: [service_contract.id], change_plans: {plan_id: change_service_plan.id}, action: 'create' }
     assert_response :unprocessable_entity
     assert_template 'buyers/applications/bulk/shared/errors.html'
   end
@@ -28,7 +28,7 @@ class Buyers::ServiceContracts::Bulk::ChangePlansControllerTest < ActionDispatch
 
     tenant.settings.service_plans_ui_visible = true
 
-    get new_admin_buyers_service_contracts_bulk_change_plan_path, selected: contracts.map(&:id)
+    get new_admin_buyers_service_contracts_bulk_change_plan_path, params: { selected: contracts.map(&:id) }
 
     page = Nokogiri::HTML::Document.parse(response.body)
 

--- a/test/integration/buyers/service_contracts_controller_test.rb
+++ b/test/integration/buyers/service_contracts_controller_test.rb
@@ -129,16 +129,16 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
         { params: { service_id: service.id } }
       }
 
-      get new_admin_buyers_account_service_contract_path(account_id: buyer1.id), request_options.call(service)
+      get new_admin_buyers_account_service_contract_path(account_id: buyer1.id), params: request_options.call(service)
       assert_response :forbidden
 
       member.member_permission_ids = ['partners']
       member.save!
 
-      get new_admin_buyers_account_service_contract_path(account_id: buyer1.id), request_options.call(service)
+      get new_admin_buyers_account_service_contract_path(account_id: buyer1.id), params: request_options.call(service)
       assert_response :success
 
-      get new_admin_buyers_account_service_contract_path(account_id: buyer1.id), request_options.call(forbidden_service)
+      get new_admin_buyers_account_service_contract_path(account_id: buyer1.id), params: request_options.call(forbidden_service)
       assert_response :not_found
     end
 
@@ -154,16 +154,16 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
         }
       }
 
-      post admin_buyers_account_service_contracts_path(account_id: buyer1.id), request_options.call(service, other_service_plan)
+      post admin_buyers_account_service_contracts_path(account_id: buyer1.id), params: request_options.call(service, other_service_plan)
       assert_response :forbidden
 
       member.member_permission_ids = ['partners']
       member.save!
 
-      post admin_buyers_account_service_contracts_path(account_id: buyer1.id), request_options.call(service, other_service_plan)
+      post admin_buyers_account_service_contracts_path(account_id: buyer1.id), params: request_options.call(service, other_service_plan)
       assert_response :success
 
-      post admin_buyers_account_service_contracts_path(account_id: buyer1.id), request_options.call(forbidden_service, forbidden_service_plan)
+      post admin_buyers_account_service_contracts_path(account_id: buyer1.id), params: request_options.call(forbidden_service, forbidden_service_plan)
       assert_response :not_found
     end
 
@@ -190,35 +190,35 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
         }
       }
 
-      put admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), request_options.call(other_service_plan)
+      put admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), params: request_options.call(other_service_plan)
       assert_response :forbidden
 
       member.member_permission_ids = ['partners']
       member.save!
 
-      put admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), request_options.call(other_service_plan)
+      put admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), params: request_options.call(other_service_plan)
       assert_response :success
 
-      put admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), request_options.call(forbidden_service_plan)
+      put admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), params: request_options.call(forbidden_service_plan)
       assert_response :not_found
 
-      put admin_buyers_account_service_contract_path(forbidden_service_contract.id, account_id: buyer1.id), request_options.call(other_service_plan)
+      put admin_buyers_account_service_contract_path(forbidden_service_contract.id, account_id: buyer1.id), params: request_options.call(other_service_plan)
       assert_response :not_found
     end
 
     test 'approve' do
       request_options = { headers: { 'HTTP_REFERER' => admin_buyers_service_contracts_path } }
 
-      post approve_admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), request_options
+      post approve_admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), params: request_options
       assert_response :forbidden
 
       member.member_permission_ids = ['partners']
       member.save!
 
-      post approve_admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), request_options
+      post approve_admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), params: request_options
       assert_response :redirect
 
-      post approve_admin_buyers_account_service_contract_path(forbidden_service_contract.id, account_id: buyer1.id), request_options
+      post approve_admin_buyers_account_service_contract_path(forbidden_service_contract.id, account_id: buyer1.id), params: request_options
       assert_response :not_found
     end
 
@@ -226,17 +226,17 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
       buyer1.bought_cinstances.by_service_id(service_contract.service_id).update_all(state: 'suspended')
       request_options = { headers: { 'HTTP_REFERER' => admin_buyers_service_contracts_path } }
 
-      delete admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), request_options
+      delete admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), params: request_options
       assert_response :forbidden
 
       member.member_permission_ids = ['partners']
       member.save!
 
-      delete admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), request_options
+      delete admin_buyers_account_service_contract_path(service_contract.id, account_id: buyer1.id), params: request_options
       assert_response :redirect
       assert_raise(ActiveRecord::RecordNotFound) { service_contract.reload }
 
-      delete admin_buyers_account_service_contract_path(forbidden_service_contract.id, account_id: buyer1.id), request_options
+      delete admin_buyers_account_service_contract_path(forbidden_service_contract.id, account_id: buyer1.id), params: request_options
       assert_response :not_found
     end
   end

--- a/test/integration/buyers/users_controller_integration_test.rb
+++ b/test/integration/buyers/users_controller_integration_test.rb
@@ -52,14 +52,12 @@ class Buyers::UsersControllerIntegrationTest < ActionDispatch::IntegrationTest
     FactoryBot.create(:fields_definition, account: provider, target: 'User', name: 'country')
     user = FactoryBot.create(:member, account: buyer)
 
-    put admin_buyers_account_user_path(account_id: buyer.id, id: user.id), {
-      user: {
+    put admin_buyers_account_user_path(account_id: buyer.id, id: user.id), params: { user: {
         role: 'admin',
         username: 'updatedusername',
         email: 'newemail@example.org',
         country: 'Japan'
-      }
-    }
+      } }
 
     assert user.reload.admin?
     assert_equal 'updatedusername', user.username

--- a/test/integration/by_access_token_integration_test.rb
+++ b/test/integration/by_access_token_integration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ApiAuthentication::ByAccessTokenIntegrationTest < ActionDispatch::IntegrationTest
@@ -15,32 +17,32 @@ class ApiAuthentication::ByAccessTokenIntegrationTest < ActionDispatch::Integrat
 
     provider_2 = FactoryBot.create(:simple_provider)
     # none token
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key)
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key })
     assert_response :success
 
     # blank token
-    get(admin_api_accounts_path(format: :xml), access_token: '')
+    get(admin_api_accounts_path(format: :xml), params: { access_token: '' })
     assert_response :forbidden
 
     # valid token
-    get(admin_api_accounts_path(format: :xml), access_token: @token.value)
+    get(admin_api_accounts_path(format: :xml), params: { access_token: @token.value })
     assert_response :success
 
     # token belongs to a different admin domain
     host! provider_2.admin_domain
-    get(admin_api_accounts_path(format: :xml), access_token: @token.value)
+    get(admin_api_accounts_path(format: :xml), params: { access_token: @token.value })
     assert_response :forbidden
 
     host! @provider.admin_domain
     # invalid token
-    get(admin_api_accounts_path(format: :xml), access_token: 'alaska')
+    get(admin_api_accounts_path(format: :xml), params: { access_token: 'alaska' })
     assert_response :forbidden
 
     @token.scopes = ['finance']
     @token.save!
 
     # invalid scope
-    get(admin_api_accounts_path(format: :xml), access_token: @token.value)
+    get(admin_api_accounts_path(format: :xml), params: { access_token: @token.value })
     assert_response :forbidden
 
     @token.scopes = ['account_management']
@@ -49,7 +51,7 @@ class ApiAuthentication::ByAccessTokenIntegrationTest < ActionDispatch::Integrat
     @user.save!
 
     # user does not have a permission
-    get(admin_api_accounts_path(format: :xml), access_token: @token.value)
+    get(admin_api_accounts_path(format: :xml), params: { access_token: @token.value })
     assert_response :forbidden
   end
 

--- a/test/integration/by_sso_token_test.rb
+++ b/test/integration/by_sso_token_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ApiAuthentication::BySsoTokenTest < ActionDispatch::IntegrationTest
@@ -10,7 +12,7 @@ class ApiAuthentication::BySsoTokenTest < ActionDispatch::IntegrationTest
     # apicast mapping service use case
     FactoryBot.create(:active_admin, account: @account, username: ThreeScale.config.impersonation_admin['username'])
     host! Account.master.admin_domain
-    post '/admin/api/sso_tokens/provider_create.json', provider_key: @master.api_key, provider_id: @account.id
+    post '/admin/api/sso_tokens/provider_create.json', params: { provider_key: @master.api_key, provider_id: @account.id }
     sso_token = JSON.parse(response.body)['sso_token']
 
     host! @account.admin_domain

--- a/test/integration/cms/api/files_test.rb
+++ b/test/integration/cms/api/files_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module CMS
@@ -19,7 +21,7 @@ module CMS
 
       test 'index' do
         21.times { create_file }
-        get admin_api_cms_files_path, provider_key: @provider.provider_key, format: :xml
+        get admin_api_cms_files_path, params: { provider_key: @provider.provider_key, format: :xml }
         assert_response :success
 
         doc = Nokogiri::XML::Document.parse(@response.body)
@@ -31,7 +33,7 @@ module CMS
         FactoryBot.create :cms_file, provider: @provider, title: 'file-in-root-section'
         FactoryBot.create :cms_file, provider: @provider, section_id: section.id, title: 'a file'
 
-        get admin_api_cms_section_files_path(section, format: :xml), provider_key: @provider.provider_key
+        get admin_api_cms_section_files_path(section, format: :xml), params: { provider_key: @provider.provider_key }
 
         assert_response :success
         assert_not_match 'file-in-root-section', response.body
@@ -39,14 +41,14 @@ module CMS
 
         other_provider = FactoryBot.create :provider_account
         other_section  = FactoryBot.create :cms_section, provider: other_provider, parent: other_provider.sections.root
-        get admin_api_cms_section_files_path(other_section, format: :xml), provider_key: @provider.provider_key
+        get admin_api_cms_section_files_path(other_section, format: :xml), params: { provider_key: @provider.provider_key }
         assert_response :not_found
 
-        get admin_api_cms_section_files_path(@provider.sections.root.system_name, format: :json), provider_key: @provider.provider_key
+        get admin_api_cms_section_files_path(@provider.sections.root.system_name, format: :json), params: { provider_key: @provider.provider_key }
         assert_response :success
         assert_match 'file-in-root-section', response.body
 
-        get admin_api_cms_section_files_path('yada', format: :json), provider_key: @provider.provider_key
+        get admin_api_cms_section_files_path('yada', format: :json), params: { provider_key: @provider.provider_key }
         assert_response :not_found
       end
 
@@ -54,7 +56,7 @@ module CMS
         21.times { create_file  }
 
         # first page
-        get admin_api_cms_files_path, provider_key: @provider.provider_key, format: :xml
+        get admin_api_cms_files_path, params: { provider_key: @provider.provider_key, format: :xml }
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
 
@@ -64,7 +66,7 @@ module CMS
         assert_equal 20, doc.xpath('/files/*').size
 
         # second page
-        get admin_api_cms_files_path, provider_key: @provider.provider_key, page: 2, format: :xml
+        get admin_api_cms_files_path, params: { provider_key: @provider.provider_key, page: 2, format: :xml }
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
         assert_equal 1, doc.xpath('/files/*').size
@@ -74,7 +76,7 @@ module CMS
         11.times { create_file  }
 
         common = { provider_key: @provider.provider_key, format: :xml }
-        get admin_api_cms_files_path, common.merge(per_page: 5)
+        get admin_api_cms_files_path, params: common.merge(per_page: 5)
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
 
@@ -86,7 +88,7 @@ module CMS
 
       test 'show file' do
         file = create_file
-        get admin_api_cms_file_path(file), provider_key: @provider.provider_key, format: :xml
+        get admin_api_cms_file_path(file), params: { provider_key: @provider.provider_key, format: :xml }
         assert_response :success
 
         doc = Nokogiri::XML::Document.parse(@response.body)
@@ -101,7 +103,7 @@ module CMS
       test 'update' do
         file = create_file
 
-        put admin_api_cms_file_path(file, format: :xml), provider_key: @provider.provider_key, attachment: attachment_for_upload
+        put admin_api_cms_file_path(file, format: :xml), params: { provider_key: @provider.provider_key, attachment: attachment_for_upload }
 
         file.reload
 
@@ -110,7 +112,7 @@ module CMS
       end
 
       test 'create' do
-        post admin_api_cms_files_path,  provider_key: @provider.provider_key, format: :xml, path: "/foo.bar", attachment: attachment_for_upload, section_id: @provider.sections.root.id
+        post admin_api_cms_files_path, params: { provider_key: @provider.provider_key, format: :xml, path: "/foo.bar", attachment: attachment_for_upload, section_id: @provider.sections.root.id }
         assert_response :success
 
         doc = Nokogiri::XML(@response.body)
@@ -120,7 +122,7 @@ module CMS
       end
 
       test 'create with errors' do
-        post admin_api_cms_files_path(format: :xml), provider_key: @provider.provider_key
+        post admin_api_cms_files_path(format: :xml), params: { provider_key: @provider.provider_key }
 
         assert_response :unprocessable_entity
 
@@ -128,7 +130,7 @@ module CMS
       end
 
       test 'create without section will put the file in root section' do
-        post admin_api_cms_files_path(format: :json),  provider_key: @provider.provider_key, path: "/foo.script", attachment: attachment_for_upload
+        post admin_api_cms_files_path(format: :json), params: { provider_key: @provider.provider_key, path: "/foo.script", attachment: attachment_for_upload }
         assert_response :success
 
         assert_equal @provider.sections.root.id, JSON.parse(response.body)['file']['section_id']
@@ -136,7 +138,7 @@ module CMS
 
       test 'delete' do
         file = create_file
-        delete admin_api_cms_file_path(file), provider_key: @provider.provider_key, format: :xml
+        delete admin_api_cms_file_path(file), params: { provider_key: @provider.provider_key, format: :xml }
         assert_nil CMS::File.find_by_id(file.id)
       end
 

--- a/test/integration/cms/api/sections_test.rb
+++ b/test/integration/cms/api/sections_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module CMS
@@ -16,7 +18,7 @@ module CMS
       test 'index' do
         20.times { create_section }
 
-        get admin_api_cms_sections_path, provider_key: @provider.provider_key, format: :xml
+        get admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, format: :xml }
         assert_response :success
 
         doc = Nokogiri::XML::Document.parse(@response.body)
@@ -28,7 +30,7 @@ module CMS
         20.times { create_section  }
 
         # first page
-        get admin_api_cms_sections_path, provider_key: @provider.provider_key, format: :xml
+        get admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, format: :xml }
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
 
@@ -38,7 +40,7 @@ module CMS
         assert_equal 20, doc.xpath('/sections/*').size
 
         # second page
-        get admin_api_cms_sections_path, provider_key: @provider.provider_key, page: 2, format: :xml
+        get admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, page: 2, format: :xml }
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
         assert_equal 1, doc.xpath('/sections/*').size
@@ -48,7 +50,7 @@ module CMS
         10.times { create_section  }
 
         common = { provider_key: @provider.provider_key, format: :xml }
-        get admin_api_cms_sections_path, common.merge(per_page: 5)
+        get admin_api_cms_sections_path, params: common.merge(per_page: 5)
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
 
@@ -60,7 +62,7 @@ module CMS
 
       test 'show section' do
         section = create_section
-        get admin_api_cms_section_path(section), provider_key: @provider.provider_key, format: :xml
+        get admin_api_cms_section_path(section), params: { provider_key: @provider.provider_key, format: :xml }
         assert_response :success
 
         doc = Nokogiri::XML::Document.parse(@response.body)
@@ -74,19 +76,19 @@ module CMS
       end
 
       test 'find section by system name' do
-        get admin_api_cms_section_path(id: 'root', format: :json), provider_key: @provider.provider_key
+        get admin_api_cms_section_path(id: 'root', format: :json), params: { provider_key: @provider.provider_key }
         assert_response :success
         assert_equal 'root', JSON.parse(response.body)['section']['system_name']
       end
 
       test 'invalid system name or id' do
-        get admin_api_cms_section_path(id: 'lamb', format: :json), provider_key: @provider.provider_key
+        get admin_api_cms_section_path(id: 'lamb', format: :json), params: { provider_key: @provider.provider_key }
         assert_response :not_found
       end
 
       test 'update' do
         section = create_section
-        put admin_api_cms_section_path(section), provider_key: @provider.provider_key, format: :xml, title: 'foo'
+        put admin_api_cms_section_path(section), params: { provider_key: @provider.provider_key, format: :xml, title: 'foo' }
         assert_response :success
 
         section.reload
@@ -95,7 +97,7 @@ module CMS
 
       test 'create' do
 
-        post admin_api_cms_sections_path, { provider_key: @provider.provider_key, format: :xml, title: 'Foo Bar Lol' }
+        post admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, format: :xml, title: 'Foo Bar Lol' }
 
         assert_response :success
 

--- a/test/integration/cms/api/templates_test.rb
+++ b/test/integration/cms/api/templates_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module CMS
@@ -16,7 +18,7 @@ module CMS
         FactoryBot.create(:cms_builtin_page, :provider => @provider,
                 :section => @provider.sections.root)
 
-        get admin_api_cms_templates_path(format: :xml), provider_key: @provider.provider_key
+        get admin_api_cms_templates_path(format: :xml), params: { provider_key: @provider.provider_key }
         assert_response :success
 
         doc = Nokogiri::XML::Document.parse(@response.body)
@@ -28,7 +30,7 @@ module CMS
         assert_equal 1, doc.xpath('/templates/builtin_page').size
         assert_equal 1, doc.xpath('/templates/layout').size
 
-        get admin_api_cms_templates_path(format: :json), provider_key: @provider.provider_key
+        get admin_api_cms_templates_path(format: :json), params: { provider_key: @provider.provider_key }
         assert_response :success
       end
 
@@ -36,7 +38,7 @@ module CMS
         23.times { FactoryBot.create(:cms_page, :provider => @provider)  }
 
         # first page
-        get admin_api_cms_templates_path(format: :xml), provider_key: @provider.provider_key
+        get admin_api_cms_templates_path(format: :xml), params: { provider_key: @provider.provider_key }
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
 
@@ -46,7 +48,7 @@ module CMS
         assert_equal 20, doc.xpath('/templates/*').size
 
         # second page
-        get admin_api_cms_templates_path(format: :xml), provider_key: @provider.provider_key, page: 2
+        get admin_api_cms_templates_path(format: :xml), params: { provider_key: @provider.provider_key, page: 2 }
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
         assert_equal 3, doc.xpath('/templates/*').size
@@ -57,7 +59,7 @@ module CMS
         FactoryBot.create :cms_page,   provider: @provider, published: "mushrooms and pepperoni.",              draft: "yo que se"
         FactoryBot.create :cms_builtin_partial, provider: @provider, published: "storing the cheese at room temperature"
 
-        get admin_api_cms_templates_path(format: :json), provider_key: @provider.provider_key
+        get admin_api_cms_templates_path(format: :json), params: { provider_key: @provider.provider_key }
         assert_response :success
 
         assert_not_match 'mushrooms', response.body
@@ -68,7 +70,7 @@ module CMS
         10.times { FactoryBot.create(:cms_layout, :provider => @provider) }
 
         common = { provider_key: @provider.provider_key, format: :xml }
-        get admin_api_cms_templates_path, common.merge(per_page: 5)
+        get admin_api_cms_templates_path, params: common.merge(per_page: 5)
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
 
@@ -84,7 +86,7 @@ module CMS
         1.times { FactoryBot.create(:cms_builtin_legal_term, :provider => @provider)  }
 
         # first page
-        get admin_api_cms_templates_path, provider_key: @provider.provider_key, format: :xml
+        get admin_api_cms_templates_path, params: { provider_key: @provider.provider_key, format: :xml }
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
 
@@ -95,14 +97,14 @@ module CMS
       test 'show partial' do
         partial = FactoryBot.create(:cms_partial, provider: @provider)
 
-        get admin_api_cms_template_path(partial), provider_key: @provider.provider_key, id: partial.id, format: :xml
+        get admin_api_cms_template_path(partial), params: { provider_key: @provider.provider_key, id: partial.id, format: :xml }
         assert_response :success
       end
 
       test 'show builtin page' do
         builtin = FactoryBot.create(:cms_builtin_page, provider: @provider)
 
-        get admin_api_cms_template_path(builtin), provider_key: @provider.provider_key, id: builtin.id, format: :xml
+        get admin_api_cms_template_path(builtin), params: { provider_key: @provider.provider_key, id: builtin.id, format: :xml }
         assert_response :success
 
         doc = Nokogiri::XML::Document.parse(@response.body)
@@ -112,12 +114,12 @@ module CMS
       test 'show static build in page' do
         static = FactoryBot.create(:cms_builtin_static_page, provider: @provider)
 
-        get admin_api_cms_template_path(static, format: :json), provider_key: @provider.provider_key, id: static.id
+        get admin_api_cms_template_path(static, format: :json), params: { provider_key: @provider.provider_key, id: static.id }
 
         assert_response :success
         assert_equal static.system_name, JSON.parse(response.body)['builtin_page']['system_name']
 
-        get admin_api_cms_template_path(static, format: :xml), provider_key: @provider.provider_key, id: static.id
+        get admin_api_cms_template_path(static, format: :xml), params: { provider_key: @provider.provider_key, id: static.id }
         assert_response :success
 
         doc = Nokogiri::XML::Document.parse(response.body)
@@ -126,7 +128,7 @@ module CMS
 
       test 'show page' do
         page = FactoryBot.create(:cms_page, provider: @provider, path: '/cool')
-        get admin_api_cms_template_path(page), provider_key: @provider.provider_key, id: page.id, format: :xml
+        get admin_api_cms_template_path(page), params: { provider_key: @provider.provider_key, id: page.id, format: :xml }
         assert_response :success
 
         doc = Nokogiri::XML::Document.parse(@response.body)
@@ -136,7 +138,7 @@ module CMS
       test 'publish' do
         page = FactoryBot.create(:cms_page, :provider => @provider, draft: 'new', published: 'old' )
 
-        put publish_admin_api_cms_template_path(page), provider_key: @provider.provider_key, format: :xml
+        put publish_admin_api_cms_template_path(page), params: { provider_key: @provider.provider_key, format: :xml }
         assert_response :success
 
         assert_equal 'new', page.reload.published
@@ -144,7 +146,7 @@ module CMS
 
       test 'invalid update' do
         page = FactoryBot.create(:cms_page, :provider => @provider)
-        put admin_api_cms_template_path(page), :provider_key => @provider.provider_key, :id => page.id, :path => 'invalid-path/', format: :xml
+        put admin_api_cms_template_path(page), params: { :provider_key => @provider.provider_key, :id => page.id, :path => 'invalid-path/', format: :xml }
         assert_response :unprocessable_entity
       end
 
@@ -152,10 +154,7 @@ module CMS
         new_layout = FactoryBot.create(:cms_layout, :system_name => 'NEW', :provider => @provider)
         page = FactoryBot.create(:cms_page, :provider => @provider)
 
-        put admin_api_cms_template_path(page), provider_key: @provider.provider_key, id: page.id, format: :xml,
-        title: 'new title',
-        content_type: 'text/xml',
-        layout_name: 'NEW'
+        put admin_api_cms_template_path(page), params: { provider_key: @provider.provider_key, id: page.id, format: :xml, title: 'new title', content_type: 'text/xml', layout_name: 'NEW' }
 
         assert_response :success
 
@@ -176,7 +175,7 @@ module CMS
         assert_not_equal page.draft, params[:draft]
         assert_not_equal page.title, params[:title]
 
-        put admin_api_cms_template_path(page), params, { 'CONTENT_TYPE' => 'multipart/form-data' }
+        put admin_api_cms_template_path(page), params: params, session: { 'CONTENT_TYPE' => 'multipart/form-data' }
 
         page.reload
 
@@ -189,30 +188,24 @@ module CMS
         new_layout = FactoryBot.create(:cms_layout, :system_name => 'NEW', :provider => @provider)
         page = FactoryBot.create(:cms_page, :provider => @provider)
 
-        put admin_api_cms_template_path(page), :provider_key => @provider.provider_key, :id => page.id, format: :xml,
-        :template => {:layout_id => new_layout.id }
+        put admin_api_cms_template_path(page), params: { :provider_key => @provider.provider_key, :id => page.id, format: :xml, :template => {:layout_id => new_layout.id } }
 
         assert_response :success
         assert_equal new_layout, page.reload.layout
       end
 
       test 'create with missing or invalid type fails' do
-        post admin_api_cms_templates_path, provider_key: @provider.provider_key, format: :xml, type: 'INVALID'
+        post admin_api_cms_templates_path, params: { provider_key: @provider.provider_key, format: :xml, type: 'INVALID' }
         assert_response :not_acceptable
 
-        post admin_api_cms_templates_path, provider_key: @provider.provider_key, format: :xml
+        post admin_api_cms_templates_path, params: { provider_key: @provider.provider_key, format: :xml }
         assert_response :not_acceptable
       end
 
       test 'create' do
         layout = FactoryBot.create(:cms_layout, :system_name => 'new-layout', :provider => @provider)
 
-        post admin_api_cms_templates_path, { provider_key: @provider.provider_key, format: :xml,
-          type: 'page',
-          path: '/',
-          content_type: 'text/html',
-          title: 'Rake 5000',
-          layout_name: 'new-layout' }, nil
+        post admin_api_cms_templates_path, params: { provider_key: @provider.provider_key, format: :xml, type: 'page', path: '/', content_type: 'text/html', title: 'Rake 5000', layout_name: 'new-layout' }, session: nil
 
         assert_response :success
 
@@ -229,11 +222,7 @@ module CMS
       test 'create a page within a section and check it out' do
         section = FactoryBot.create :cms_section, title: "important", parent: @provider.sections.root, provider: @provider
 
-        post admin_api_cms_templates_path(format: :json), {
-          provider_key: @provider.provider_key, type: "page", path: "/important/page.html",
-          content_type: "text/html", title: "Over 9000", liquid_enabled: true,
-          draft: "The page Over 9000", section_id: section.id
-        }
+        post admin_api_cms_templates_path(format: :json), params: { provider_key: @provider.provider_key, type: "page", path: "/important/page.html", content_type: "text/html", title: "Over 9000", liquid_enabled: true, draft: "The page Over 9000", section_id: section.id }
 
         assert_response :success
 
@@ -241,7 +230,7 @@ module CMS
         assert_equal section, page.section
 
         # publish this page
-        put publish_admin_api_cms_template_path(page, format: :json), provider_key: @provider.provider_key
+        put publish_admin_api_cms_template_path(page, format: :json), params: { provider_key: @provider.provider_key }
         assert_response :success
 
         host! @provider.domain
@@ -255,12 +244,7 @@ module CMS
       end
 
       test 'create a layout' do
-        post admin_api_cms_templates_path, provider_key: @provider.provider_key, format: :xml,
-          type: 'layout',
-          system_name: 'foo',
-          draft: 'bar',
-          title: 'a title',
-          liquid_enabled: true
+        post admin_api_cms_templates_path, params: { provider_key: @provider.provider_key, format: :xml, type: 'layout', system_name: 'foo', draft: 'bar', title: 'a title', liquid_enabled: true }
 
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
@@ -271,10 +255,7 @@ module CMS
       end
 
       test 'create a partial' do
-        post admin_api_cms_templates_path, provider_key: @provider.provider_key, format: :xml,
-          type: 'partial',
-          system_name: 'foo',
-          draft: 'bar'
+        post admin_api_cms_templates_path, params: { provider_key: @provider.provider_key, format: :xml, type: 'partial', system_name: 'foo', draft: 'bar' }
         assert_response :success
         doc = Nokogiri::XML::Document.parse(@response.body)
 

--- a/test/integration/cms/base_controller_test.rb
+++ b/test/integration/cms/base_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
     test 'admin user with cms scope has permission' do
       token = FactoryBot.create(:access_token, owner: @provider.admin_users.first, scopes: ['cms'], permission: 'rw')
       with_api_routes do
-        get '/cms_api', access_token: token.value
+        get '/cms_api', params: { access_token: token.value }
         assert_response :ok
       end
     end
@@ -22,7 +22,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
     test 'admin user without cms scope does not have permission' do
       with_api_routes do
         token = FactoryBot.create(:access_token, owner: @provider.admin_users.first)
-        get '/cms_api', access_token: token.value
+        get '/cms_api', params: { access_token: token.value }
         assert_response :forbidden
       end
     end
@@ -31,7 +31,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
       member = FactoryBot.create(:member, account: @provider, admin_sections: ['portal'])
       token  = FactoryBot.create(:access_token, owner: member, scopes: ['cms'], permission: 'rw')
       with_api_routes do
-        get '/cms_api', access_token: token.value
+        get '/cms_api', params: { access_token: token.value }
         assert_response :ok
       end
     end
@@ -40,7 +40,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
       member = FactoryBot.create(:member, account: @provider, admin_sections: ['portal'])
       token  = FactoryBot.create(:access_token, owner: member)
       with_api_routes do
-        get '/cms_api', access_token: token.value
+        get '/cms_api', params: { access_token: token.value }
         assert_response :forbidden
       end
     end
@@ -49,7 +49,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
       member = FactoryBot.create(:member, account: @provider)
       token  = FactoryBot.create(:access_token, owner: member, scopes: ['cms'], permission: 'rw')
       with_api_routes do
-        get '/cms_api', access_token: token.value
+        get '/cms_api', params: { access_token: token.value }
         assert_response :forbidden
       end
     end
@@ -72,7 +72,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
           token = FactoryBot.create(:access_token, owner: user, permission: 'rw')
           token.update_column(:scopes, ['cms']) # It must be done this way because it is invalid now.
           with_api_routes do
-            get '/cms_api', access_token: token.value
+            get '/cms_api', params: { access_token: token.value }
             assert_response :forbidden
           end
         end
@@ -84,7 +84,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
         [admin, member].each do |user|
           token  = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'], permission: 'rw')
           with_api_routes do
-            get '/cms_api', access_token: token.value
+            get '/cms_api', params: { access_token: token.value }
             assert_response :forbidden
           end
         end
@@ -98,7 +98,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
         [admin, member].each do |user|
           token  = FactoryBot.create(:access_token, owner: user, scopes: ['cms'], permission: 'rw')
           with_api_routes do
-            get '/cms_api', access_token: token.value
+            get '/cms_api', params: { access_token: token.value }
             assert_response :success
           end
         end
@@ -110,7 +110,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
         [admin, member].each do |user|
           token  = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'], permission: 'rw')
           with_api_routes do
-            get '/cms_api', access_token: token.value
+            get '/cms_api', params: { access_token: token.value }
             assert_response :success
           end
         end

--- a/test/integration/cms/pages_test.rb
+++ b/test/integration/cms/pages_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module CMS
@@ -12,12 +14,11 @@ module CMS
       new_layout = FactoryBot.create(:cms_layout, system_name: 'NEW', provider: @provider)
       page = FactoryBot.create(:cms_page, provider: @provider, layout: new_layout)
 
-      patch provider_admin_cms_page_path(page), provider_key: @provider.provider_key, id: page.id, format: :js,
-        cms_template: {
+      patch provider_admin_cms_page_path(page), params: { provider_key: @provider.provider_key, id: page.id, format: :js, cms_template: {
         title: 'new title',
         content_type: 'text/xml',
         layout_id: ''
-      }
+      } }
 
       assert_response :success
 

--- a/test/integration/developer_portal/admin/account/payment_details_base_controller_test.rb
+++ b/test/integration/developer_portal/admin/account/payment_details_base_controller_test.rb
@@ -28,6 +28,6 @@ class DeveloperPortal::Admin::Account::PaymentDetailsBaseTest < ActionDispatch::
     }.deep_stringify_keys
 
     Account.any_instance.expects(:update_attributes).with(account_params).returns(true)
-    put admin_account_payment_details_path, { account: account_params.deep_merge('billing_address' => { 'injected_param' => 'unauthorized' }) }
+    put admin_account_payment_details_path, params: { account: account_params.deep_merge('billing_address' => { 'injected_param' => 'unauthorized' }) }
   end
 end

--- a/test/integration/developer_portal/admin/applications/referrer_filters_controller_test.rb
+++ b/test/integration/developer_portal/admin/applications/referrer_filters_controller_test.rb
@@ -29,7 +29,7 @@ class DeveloperPortal::Admin::Applications::ReferrerFiltersControllerTest < Acti
     end
 
     assert_no_difference(ReferrerFilter.method(:count)) do
-      post admin_application_referrer_filters_path(cinstance), {referrer_filter: "#{cinstance.filters_limit + 1}.example.org"}
+      post admin_application_referrer_filters_path(cinstance), params: { referrer_filter: "#{cinstance.filters_limit + 1}.example.org" }
     end
 
     assert_equal 'Limit reached', flash[:error]
@@ -51,7 +51,7 @@ class DeveloperPortal::Admin::Applications::ReferrerFiltersControllerTest < Acti
 
     test 'Creating referrer filter is forbidden if not logged in' do
       assert_no_difference(ReferrerFilter.method(:count)) do
-        post admin_application_referrer_filters_path(cinstance), {referrer_filter: 'only.my.example.com'}
+        post admin_application_referrer_filters_path(cinstance), params: { referrer_filter: 'only.my.example.com' }
       end
 
       assert_redirected_to login_path
@@ -73,7 +73,7 @@ class DeveloperPortal::Admin::Applications::ReferrerFiltersControllerTest < Acti
     login_buyer another_buyer
 
     assert_no_difference(ReferrerFilter.method(:count)) do
-      post admin_application_referrer_filters_path(cinstance), {referrer_filter: 'only.my.example.com'}
+      post admin_application_referrer_filters_path(cinstance), params: { referrer_filter: 'only.my.example.com' }
     end
 
     assert_response :not_found

--- a/test/integration/developer_portal/admin/applications_controller_test.rb
+++ b/test/integration/developer_portal/admin/applications_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DeveloperPortal::Admin::ApplicationsControllerTest < ActionDispatch::IntegrationTest
@@ -110,7 +112,7 @@ class DeveloperPortal::Admin::ApplicationsControllerTest < ActionDispatch::Integ
           @provider.settings.allow_multiple_applications!
           @provider.settings.show_multiple_applications!
 
-          patch admin_application_url(cinstance), application: { redirect_url: "http://example.com" }
+          patch admin_application_url(cinstance), params: { application: { redirect_url: "http://example.com" } }
           cinstance.reload
           assert_equal 'http://example.com', cinstance.redirect_url
         end
@@ -124,7 +126,7 @@ class DeveloperPortal::Admin::ApplicationsControllerTest < ActionDispatch::Integ
           @provider.settings.allow_multiple_applications!
           @provider.settings.show_multiple_applications!
 
-          patch admin_application_url(cinstance), application: { redirect_url: "http://example.com", name: "foo" }
+          patch admin_application_url(cinstance), params: { application: { redirect_url: "http://example.com", name: "foo" } }
           assert assigns(:cinstance).errors[:lol].present?
         end
 
@@ -183,7 +185,7 @@ class DeveloperPortal::Admin::ApplicationsControllerTest < ActionDispatch::Integ
           @buyer_auth.buy! @plan
           @buyer_auth.reload
 
-          put admin_application_url(@buyer_auth.bought_cinstance), cinstance: { "name" => "updated" }
+          put admin_application_url(@buyer_auth.bought_cinstance), params: { cinstance: { "name" => "updated" } }
           assert_response :redirect
           assert_equal "updated", @buyer_auth.bought_cinstance.name
         end
@@ -258,7 +260,7 @@ class DeveloperPortal::Admin::ApplicationsControllerTest < ActionDispatch::Integ
         end
 
         should 'allow access to update' do
-          put admin_application_url(@buyer_auth.bought_cinstance), cinstance: { "name" => "updated" }
+          put admin_application_url(@buyer_auth.bought_cinstance), params: { cinstance: { "name" => "updated" } }
           assert_response :redirect
           assert_equal "updated", @buyer_auth.bought_cinstance.name
         end

--- a/test/integration/developer_portal/signup_test.rb
+++ b/test/integration/developer_portal/signup_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DeveloperPortal::SignupTest < ActionDispatch::IntegrationTest
@@ -33,13 +35,13 @@ class DeveloperPortal::SignupTest < ActionDispatch::IntegrationTest
     post session_path(system_name: @auth.system_name, code: 'alaska')
     assert_redirected_to signup_path
 
-    post(signup_path, {account: {
+    post(signup_path, params: { account: {
         org_name:   'alaska',
         user: {
             email:    'foo@example.edu',
             username: 'supertramp',
         }
-    }})
+    } })
 
     user = @provider.buyer_users.find_by!(email: 'foo@example.edu')
     assert user.active?
@@ -52,11 +54,11 @@ class DeveloperPortal::SignupTest < ActionDispatch::IntegrationTest
 
     assert_response :success
 
-    get signup_path, plan_ids: ''
+    get signup_path, params: { plan_ids: '' }
 
     assert_response :success
 
-    get signup_path, plan_ids: nil
+    get signup_path, params: { plan_ids: nil }
 
     assert_response :success
 
@@ -66,11 +68,11 @@ class DeveloperPortal::SignupTest < ActionDispatch::IntegrationTest
 
     plan_id = @provider.provided_plans.published.first.id
 
-    get signup_path, plan_ids: plan_id
+    get signup_path, params: { plan_ids: plan_id }
 
     assert_response :success
 
-    get signup_path, plan_ids: Array(plan_id)
+    get signup_path, params: { plan_ids: Array(plan_id) }
 
     assert_response :success
   end

--- a/test/integration/dns_controller_test.rb
+++ b/test/integration/dns_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Sites::DnsControllerTest < ActionDispatch::IntegrationTest
@@ -17,7 +19,7 @@ class Sites::DnsControllerTest < ActionDispatch::IntegrationTest
     }
 
     Rails.configuration.three_scale.stubs(readonly_custom_domains_settings: true)
-    put admin_site_dns_path, account_params
+    put admin_site_dns_path, params: account_params
 
     @provider.reload
     assert_equal 'abcdefgh', @provider.site_access_code
@@ -26,7 +28,7 @@ class Sites::DnsControllerTest < ActionDispatch::IntegrationTest
 
 
     Rails.configuration.three_scale.stubs(readonly_custom_domains_settings: false)
-    put admin_site_dns_path, account_params
+    put admin_site_dns_path, params: account_params
 
     @provider.reload
     assert_equal 'abcdefgh', @provider.site_access_code
@@ -37,7 +39,7 @@ class Sites::DnsControllerTest < ActionDispatch::IntegrationTest
 
   test 'update shows an error message when fails' do
     Rails.application.config.three_scale.stubs(readonly_custom_domains_settings: false)
-    put admin_site_dns_path, {account: {domain: 'INVALID'}}
+    put admin_site_dns_path, params: { account: {domain: 'INVALID'} }
     assert_match 'Domain must be downcase', flash[:error]
   end
 end

--- a/test/integration/finance/api/invoices_controller_test.rb
+++ b/test/integration/finance/api/invoices_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Finance::Api::InvoicesControllerTest < ActionDispatch::IntegrationTest
@@ -10,22 +12,22 @@ class Finance::Api::InvoicesControllerTest < ActionDispatch::IntegrationTest
     end
 
     test '#index' do
-      get api_invoices_path, nil, accept: Mime[:json], access_token: @access_token
+      get api_invoices_path, params: nil, session: { accept: Mime[:json], access_token: @access_token }
       assert_response :forbidden
     end
 
     test '#show' do
-      get api_invoice_path(1), nil, accept: Mime[:json], access_token: @access_token
+      get api_invoice_path(1), params: nil, session: { accept: Mime[:json], access_token: @access_token }
       assert_response :forbidden
     end
 
     test '#state' do
-      put state_api_invoice_path(1, state: 'cancelled'), nil, accept: Mime[:json], access_token: @access_token
+      put state_api_invoice_path(1, state: 'cancelled'), params: nil, session: { accept: Mime[:json], access_token: @access_token }
       assert_response :forbidden
     end
 
     test '#create' do
-      post api_invoices_path, nil, accept: Mime[:json], access_token: @access_token
+      post api_invoices_path, params: nil, session: { accept: Mime[:json], access_token: @access_token }
       assert_response :forbidden
     end
   end
@@ -43,93 +45,93 @@ class Finance::Api::InvoicesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test '#index' do
-    get api_invoices_path, { access_token: @access_token }, accept: Mime[:json]
+    get api_invoices_path, params: { access_token: @access_token }, session: { accept: Mime[:json] }
     assert_response :success
   end
 
   test '#show' do
-    get api_invoice_path(invoice), { access_token: @access_token }, accept: Mime[:json]
+    get api_invoice_path(invoice), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     assert_response :success
   end
 
   test '#state' do
-    put state_api_invoice_path(invoice, state: 'cancelled'), { access_token: @access_token }, accept: Mime[:json]
+    put state_api_invoice_path(invoice, state: 'cancelled'), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     invoice.reload
     assert_equal 'cancelled', invoice.state
   end
 
   test '#state fail state' do
     invoice.update_attribute(:state, 'unpaid')
-    put state_api_invoice_path(invoice, state: 'failed'), { access_token: @access_token }, accept: Mime[:json]
+    put state_api_invoice_path(invoice, state: 'failed'), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     invoice.reload
     assert_equal 'failed', invoice.state
   end
 
   test '#state mark_as_unpaid state' do
     invoice.update_attribute(:state, 'pending')
-    put state_api_invoice_path(invoice, state: 'unpaid'), { access_token: @access_token }, accept: Mime[:json]
+    put state_api_invoice_path(invoice, state: 'unpaid'), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     invoice.reload
     assert_equal 'unpaid', invoice.state
   end
 
   test '#state pay state' do
     invoice.fire_events!(:issue)
-    put state_api_invoice_path(invoice, state: 'paid'), { access_token: @access_token }, accept: Mime[:json]
+    put state_api_invoice_path(invoice, state: 'paid'), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     invoice.reload
     assert_equal 'paid', invoice.state
   end
 
   test '#state issue state' do
-    put state_api_invoice_path(invoice, state: 'pending'), { access_token: @access_token }, accept: Mime[:json]
+    put state_api_invoice_path(invoice, state: 'pending'), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     invoice.reload
     assert_equal 'pending', invoice.state
   end
 
   test '#wrong transition state' do
     invoice.update_attribute(:state, 'paid')
-    put state_api_invoice_path(invoice, state: 'pending'), { access_token: @access_token } , accept: Mime[:json]
+    put state_api_invoice_path(invoice, state: 'pending'), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     invoice.reload
     assert_equal 'paid', invoice.state
     assert_response 422
   end
 
   test '#state inalize state' do
-    put state_api_invoice_path(invoice, state: 'finalized'), { access_token: @access_token }, accept: Mime[:json]
+    put state_api_invoice_path(invoice, state: 'finalized'), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     invoice.reload
     assert_equal 'finalized', invoice.state
   end
 
   test '#state incorrect state' do
-    put state_api_invoice_path(invoice, state: 'wrong_state'), { access_token: @access_token }, accept: Mime[:json]
+    put state_api_invoice_path(invoice, state: 'wrong_state'), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     assert_equal '{"errors":{"base":["Cannot transition to wrong_state"]}}', response.body
     assert_response 422
   end
 
   test '#create' do
-    post api_invoices_path, invoice_params, accept: Mime[:json]
+    post api_invoices_path, params: invoice_params, session: { accept: Mime[:json] }
     assert_response :success
   end
 
   test '#create with attributes saved correctly' do
     assert_difference Invoice.method(:count) do
-      post api_invoices_path, invoice_params, accept: Mime[:json]
+      post api_invoices_path, params: invoice_params, session: { accept: Mime[:json] }
     end
     assert_equal invoice_new_values[:month], Invoice.find_by(provider_account_id: @provider.id, buyer_account_id: @buyer.id).period
   end
 
   test '#create with invalid period' do
-    post api_invoices_path, invoice_params.merge(period: 'abc'), accept: Mime[:json]
+    post api_invoices_path, params: invoice_params.merge(period: 'abc'), session: { accept: Mime[:json] }
     assert_response 422
     assert_contains JSON.parse(response.body)['errors']['period'], 'Billing period format should be YYYY-MM'
   end
 
   test '#update states' do
-    put api_invoice_path(invoice), invoice_params, accept: Mime[:json]
+    put api_invoice_path(invoice), params: invoice_params, session: { accept: Mime[:json] }
     assert_response :success
   end
 
   test '#update with attributes saved correctly' do
-    put api_invoice_path(invoice), invoice_params, accept: Mime[:json]
+    put api_invoice_path(invoice), params: invoice_params, session: { accept: Mime[:json] }
     invoice.reload
     assert_equal invoice_new_values[:month], invoice.period
     assert_equal invoice_new_values[:friendly_id], invoice.friendly_id
@@ -142,7 +144,7 @@ class Finance::Api::InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_difference(Audited.audit_class.method(:count)) do
       Invoice.with_auditing do
         assert_difference(Invoice.method(:count)) do
-          post api_invoices_path, invoice_params.merge!(access_token: token.value), accept: Mime[:json]
+          post api_invoices_path, params: invoice_params.merge!(access_token: token.value), session: { accept: Mime[:json] }
           assert_response :created
         end
       end
@@ -155,7 +157,7 @@ class Finance::Api::InvoicesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test '#charge' do
-    post charge_api_invoice_path(invoice), { access_token: @access_token }, accept: Mime[:json]
+    post charge_api_invoice_path(invoice), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     assert_response 422
     assert_contains JSON.parse(response.body)['errors']['state'], invoice.errors.generate_message(:state, :not_in_chargeable_state, id: invoice.id)
 
@@ -166,13 +168,13 @@ class Finance::Api::InvoicesControllerTest < ActionDispatch::IntegrationTest
     # Heavy/ugly mocking on buyer charge!
     Account.any_instance.expects(:charge!).returns(true)
 
-    post charge_api_invoice_path(invoice), { access_token: @access_token }, accept: Mime[:json]
+    post charge_api_invoice_path(invoice), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     assert_equal invoice.reload.state, 'paid'
     assert_response :success
 
     Account.any_instance.expects(:charge!).returns(false)
     invoice.update_column :state, :pending
-    post charge_api_invoice_path(invoice), { access_token: @access_token }, accept: Mime[:json]
+    post charge_api_invoice_path(invoice), params: { access_token: @access_token }, session: { accept: Mime[:json] }
     assert_response 422
     assert_contains JSON.parse(response.body)['errors']['base'], invoice.errors.generate_message(:base, :charging_failed)
   end

--- a/test/integration/finance/api/line_items_controller_test.rb
+++ b/test/integration/finance/api/line_items_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
@@ -22,32 +24,32 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
     end
 
     test '#index for provider' do
-      get api_invoice_line_items_path(@invoice.id), { access_token: @token }, accept: Mime[:json]
+      get api_invoice_line_items_path(@invoice.id), params: { access_token: @token }, session: { accept: Mime[:json] }
       assert_response :success
 
       ThreeScale.config.stubs(onpremises: true)
-      get api_invoice_line_items_path(@invoice.id), { access_token: @token }, accept: Mime[:json]
+      get api_invoice_line_items_path(@invoice.id), params: { access_token: @token }, session: { accept: Mime[:json] }
       assert_response :forbidden
     end
 
     test '#create' do
-      post api_invoice_line_items_path(@invoice.id), line_item_params, accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params, session: { accept: Mime[:json] }
       assert_response :success
 
       ThreeScale.config.stubs(onpremises: true)
-      post api_invoice_line_items_path(@invoice.id), line_item_params, accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params, session: { accept: Mime[:json] }
       assert_response :forbidden
     end
 
     test '#destroy' do
       assert_difference(LineItem.method(:count), -1 ) do
-        delete api_invoice_line_item_path(invoice_id: @line_item.invoice.id, id: @line_item.id), { access_token: @token }, accept: Mime[:json]
+        delete api_invoice_line_item_path(invoice_id: @line_item.invoice.id, id: @line_item.id), params: { access_token: @token }, session: { accept: Mime[:json] }
         assert_response :success
       end
 
       ThreeScale.config.stubs(onpremises: true)
       assert_no_difference LineItem.method(:count) do
-        delete api_invoice_line_item_path(invoice_id: @line_item.invoice.id, id: @line_item.id), { access_token: @token }, accept: Mime[:json]
+        delete api_invoice_line_item_path(invoice_id: @line_item.invoice.id, id: @line_item.id), params: { access_token: @token }, session: { accept: Mime[:json] }
         assert_response :forbidden
       end
     end
@@ -60,7 +62,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test '#index' do
-    get api_invoice_line_items_path(@invoice.id), { access_token: @token }, accept: Mime[:json]
+    get api_invoice_line_items_path(@invoice.id), params: { access_token: @token }, session: { accept: Mime[:json] }
     assert_response :success
   end
 
@@ -69,7 +71,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
     line_item = @invoice.line_items.first
     contract = @buyer.buy! plan
     line_item.update_attribute(:contract, contract)
-    get api_invoice_line_items_path(@invoice.id), { access_token: @token }, accept: Mime::XML
+    get api_invoice_line_items_path(@invoice.id), params: { access_token: @token }, session: { accept: Mime::XML }
 
     assert_response :success
     doc = Nokogiri::XML.parse(response.body)
@@ -79,7 +81,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
 
   test '#index returns plan_id' do
     @invoice.line_items.first.update_attribute(:plan_id, 2222)
-    get api_invoice_line_items_path(@invoice.id), { access_token: @token }, accept: Mime[:json]
+    get api_invoice_line_items_path(@invoice.id), params: { access_token: @token }, session: { accept: Mime[:json] }
 
     assert_response :success
     json = JSON.parse(response.body)
@@ -89,7 +91,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
 
   test '#create with attributes saved correctly' do
     assert_difference LineItem.method(:count) do
-      post api_invoice_line_items_path(@invoice.id), line_item_params, accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params, session: { accept: Mime[:json] }
     end
     new_line_item = LineItem.reorder(:id).last!
     line_item_params_without_token.each do |field_name, field_value|
@@ -99,14 +101,14 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
 
   test '#create gives the right error message when the invoice doesn\'t allow to manage its line items' do
     @invoice.update_attribute(:state, 'pending')
-    post api_invoice_line_items_path(@invoice.id), line_item_params, accept: Mime[:json]
+    post api_invoice_line_items_path(@invoice.id), params: line_item_params, session: { accept: Mime[:json] }
     assert_equal ({errors: {base: ['Invalid invoice state']}}).to_json, @response.body
     assert_response 422
   end
 
   test 'does not raise an error if the cost cannot be converted to BigDecimal' do
     assert_difference '@invoice.line_items.count', 1 do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(cost: '$5.50'), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(cost: '$5.50'), session: { accept: Mime[:json] }
     end
     assert_response :created
     line_item = @invoice.line_items.order(:id).last!
@@ -115,21 +117,21 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
 
   test '#destroy' do
     assert_difference( LineItem.method(:count), -1 ) do
-      delete api_invoice_line_item_path(invoice_id: @line_item.invoice.id, id: @line_item.id), { access_token: @token }, accept: Mime[:json]
+      delete api_invoice_line_item_path(invoice_id: @line_item.invoice.id, id: @line_item.id), params: { access_token: @token }, session: { accept: Mime[:json] }
       assert_response :success
     end
   end
 
   test '#destroy gives the right error message when the invoice doesn\'t allow to manage its line items' do
     @line_item.invoice.update_attribute(:state, 'pending')
-    delete api_invoice_line_item_path(invoice_id: @line_item.invoice.id, id: @line_item.id), { access_token: @token }, accept: Mime[:json]
+    delete api_invoice_line_item_path(invoice_id: @line_item.invoice.id, id: @line_item.id), params: { access_token: @token }, session: { accept: Mime[:json] }
     assert_equal ({errors: {base: ['Invalid invoice state']}}).to_json, @response.body
     assert_response 403
   end
 
   test '#destroy gives the right error when the line item doesn\'t belong to the send invoice' do
     another_invoice = FactoryBot.create(:invoice, provider_account: @provider)
-    delete api_invoice_line_item_path(invoice_id: another_invoice, id: @line_item.id), { access_token: @token }, accept: Mime[:json]
+    delete api_invoice_line_item_path(invoice_id: another_invoice, id: @line_item.id), params: { access_token: @token }, session: { accept: Mime[:json] }
     assert_equal ({status: 'Not found'}).to_json, @response.body
     assert_response 404
   end
@@ -137,7 +139,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
   test 'accepts adding metric_id to line_item' do
     metric = FactoryBot.create(:metric, service: @provider.services.first!)
     assert_difference '@invoice.line_items.count', 1 do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(metric_id: metric.id), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(metric_id: metric.id), session: { accept: Mime[:json] }
       @invoice.reload
       line_item = @invoice.line_items.reorder(id: :asc).last!
       assert_equal metric.id, line_item.metric_id
@@ -148,7 +150,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
     application_plan = FactoryBot.create(:simple_application_plan, issuer: @provider.services.first!)
     contract = @buyer.buy! application_plan
     assert_difference '@invoice.line_items.count', 1 do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(contract_id: contract.id), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(contract_id: contract.id), session: { accept: Mime[:json] }
       @invoice.reload
       line_item = @invoice.line_items.reorder(id: :asc).last!
       assert_equal contract.id, line_item.contract_id
@@ -160,14 +162,14 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
     plan = FactoryBot.create(:simple_application_plan, issuer: @provider.services.first!)
 
     assert_no_difference '@invoice.line_items.count' do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(plan_id: plan.id), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(plan_id: plan.id), session: { accept: Mime[:json] }
       assert_response :not_found
     end
 
     @buyer.buy! plan
 
     assert_difference '@invoice.line_items.count', 1 do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(plan_id: plan.id), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(plan_id: plan.id), session: { accept: Mime[:json] }
       @invoice.reload
       line_item = @invoice.line_items.reorder(id: :asc).last!
       assert_equal plan.id, line_item.plan_id
@@ -180,7 +182,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
     cinstance = @buyer.buy! plan
 
     assert_difference '@invoice.line_items.count', 1 do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(cinstance_id: cinstance.id), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(cinstance_id: cinstance.id), session: { accept: Mime[:json] }
       @invoice.reload
       line_item = @invoice.line_items.reorder(id: :asc).last!
       assert_equal cinstance.id, line_item.cinstance_id
@@ -189,7 +191,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
 
   test 'accepts adding type to line_item' do
     assert_difference '@invoice.line_items.count', 1 do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(type: 'LineItem::PlanCost'), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(type: 'LineItem::PlanCost'), session: { accept: Mime[:json] }
       @invoice.reload
       line_item = @invoice.line_items.reorder(id: :asc).last!
       assert_equal 'LineItem::PlanCost', line_item.type
@@ -199,7 +201,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
   test 'does not accept adding metric_id to line_item' do
     metric = FactoryBot.create(:metric, service: master_account.services.first!)
     assert_no_difference '@invoice.line_items.count' do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(metric_id: metric.id), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(metric_id: metric.id), session: { accept: Mime[:json] }
       assert_response :not_found
     end
   end
@@ -207,7 +209,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
   test 'does not accept adding contract_id to line_item' do
     contract = @provider.contracts.first!
     assert_no_difference '@invoice.line_items.count' do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(contract_id: contract.id), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(contract_id: contract.id), session: { accept: Mime[:json] }
       assert_response :not_found
     end
   end
@@ -215,7 +217,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
   test 'does not accept adding plan_id to line_item' do
     plan = FactoryBot.create(:simple_application_plan, service: master_account.services.first!)
     assert_no_difference '@invoice.line_items.count' do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(plan_id: plan.id), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(plan_id: plan.id), session: { accept: Mime[:json] }
       assert_response :not_found
     end
   end
@@ -225,14 +227,14 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
     cinstance = @provider.buy! plan
 
     assert_no_difference '@invoice.line_items.count' do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(cinstance_id: cinstance.id), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(cinstance_id: cinstance.id), session: { accept: Mime[:json] }
       assert_response :not_found
     end
   end
 
   test 'does not accept adding type to line_item' do
     assert_no_difference '@invoice.line_items.count' do
-      post api_invoice_line_items_path(@invoice.id), line_item_params.merge(type: 'Foo'), accept: Mime[:json]
+      post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(type: 'Foo'), session: { accept: Mime[:json] }
     end
   end
 

--- a/test/integration/master/api/finance/accounts/billing_jobs_controller_test.rb
+++ b/test/integration/master/api/finance/accounts/billing_jobs_controller_test.rb
@@ -16,31 +16,31 @@ class Master::Api::Finance::Accounts::BillingJobsControllerTest < ActionDispatch
 
   test 'create billing job' do
     Finance::BillingService.expects(:async_call).with(@provider, Time.utc(2018,2,8), @provider.buyers.where(id: @buyer.id)).returns(true)
-    post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), access_token: @access_token.value
+    post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: @access_token.value }
     assert_response :accepted
   end
 
   test '#create schedules a worker' do
     assert_difference BillingWorker.jobs.method(:size) do
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), access_token: @access_token.value
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: @access_token.value }
       assert_response :accepted
     end
   end
 
   test 'create billing job with invalid account_id' do
-    post master_api_provider_account_billing_jobs_path(@provider, account_id: 'invalid_account', date: '2018-02-08'), access_token: @access_token.value
+    post master_api_provider_account_billing_jobs_path(@provider, account_id: 'invalid_account', date: '2018-02-08'), params: { access_token: @access_token.value }
     assert_response :not_found
   end
 
   test 'create billing job with account_id from different scope' do
     other_provider = FactoryBot.create(:provider_with_billing)
     other_buyer = FactoryBot.create(:buyer_account, provider_account: other_provider)
-    post master_api_provider_account_billing_jobs_path(@provider, other_buyer, date: '2018-02-08'), access_token: @access_token.value
+    post master_api_provider_account_billing_jobs_path(@provider, other_buyer, date: '2018-02-08'), params: { access_token: @access_token.value }
     assert_response :not_found
   end
 
   test 'create billing job without a date' do
-    post master_api_provider_account_billing_jobs_path(@provider, @buyer), access_token: @access_token.value
+    post master_api_provider_account_billing_jobs_path(@provider, @buyer), params: { access_token: @access_token.value }
     assert_response :bad_request
   end
 
@@ -49,7 +49,7 @@ class Master::Api::Finance::Accounts::BillingJobsControllerTest < ActionDispatch
     Sidekiq::Testing.inline! do
       billing_options = { only: [@provider.id], buyer_ids: [@buyer.id], now: Time.parse(date).to_date, skip_notifications: true }
       Finance::BillingStrategy.expects(:daily).with(billing_options).returns(mock_billing_success(date, @provider))
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: date), access_token: @access_token.value
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: date), params: { access_token: @access_token.value }
       assert_response :accepted
     end
   end
@@ -60,13 +60,13 @@ class Master::Api::Finance::Accounts::BillingJobsControllerTest < ActionDispatch
     Sidekiq::Testing.inline! do
       billing_options = { only: [@provider.id], buyer_ids: [@buyer.id], now: date_utc, skip_notifications: true }
       Finance::BillingStrategy.expects(:daily).with(billing_options).returns(mock_billing_success(date_utc, @provider))
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: date), access_token: @access_token.value
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: date), params: { access_token: @access_token.value }
       assert_response :accepted
     end
   end
 
   test 'invalid date' do
-    post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: 'not a valid date'), access_token: @access_token.value
+    post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: 'not a valid date'), params: { access_token: @access_token.value }
     assert_response :bad_request
   end
 
@@ -82,33 +82,33 @@ class Master::Api::Finance::Accounts::BillingJobsControllerTest < ActionDispatch
 
     test 'scope account_management is required to create jobs' do
       unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['finance'])
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), access_token: unauthorized_token.value
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
       assert_response :forbidden
 
       authorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'])
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), access_token: authorized_token.value
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: authorized_token.value }
       assert_response :accepted
     end
 
     test 'members can create jobs with proper admin permission' do
       unauthorized_member = FactoryBot.create(:member, account: master_account, admin_sections: [])
       unauthorized_token = FactoryBot.create(:access_token, owner: unauthorized_member, scopes: ['account_management'])
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), access_token: unauthorized_token.value
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
       assert_response :forbidden
 
       authorized_member = FactoryBot.create(:member, account: master_account, admin_sections: [:partners])
       authorized_token = FactoryBot.create(:access_token, owner: authorized_member, scopes: ['account_management'])
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), access_token: authorized_token.value
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: authorized_token.value }
       assert_response :accepted
     end
 
     test 'only rw access tokens can create jobs' do
       unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'], permission: 'ro')
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), access_token: unauthorized_token.value
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
       assert_response :forbidden
 
       authorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'], permission: 'rw')
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), access_token: authorized_token.value
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: authorized_token.value }
       assert_response :accepted
     end
 

--- a/test/integration/master/api/finance/billing_jobs_controller_test.rb
+++ b/test/integration/master/api/finance/billing_jobs_controller_test.rb
@@ -16,13 +16,13 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
 
   test 'create billing job' do
     Finance::BillingService.expects(:async_call).returns(true)
-    post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: @access_token.value
+    post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.value }
     assert_response :accepted
   end
 
   test '#create schedules a worker' do
     assert_difference BillingWorker.jobs.method(:size) do
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: @access_token.value
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.value }
       assert_response :accepted
     end
   end
@@ -38,13 +38,13 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
       @provider.buyers.each do |buyer|
         Finance::BillingStrategy.expects(:daily).with(billing_options.merge(buyer_ids: [buyer.id])).returns(mock_billing_success(billing_date, @provider))
       end
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: @access_token.value
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.value }
       assert_response :accepted
     end
   end
 
   test 'create billing job without a date' do
-    post master_api_provider_billing_jobs_path(@provider), access_token: @access_token.value
+    post master_api_provider_billing_jobs_path(@provider), params: { access_token: @access_token.value }
     assert_response :bad_request
   end
 
@@ -53,7 +53,7 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
     Sidekiq::Testing.inline! do
       billing_options = { only: [@provider.id], buyer_ids: [@buyer.id], now: Time.parse(date).to_date, skip_notifications: true }
       Finance::BillingStrategy.expects(:daily).with(billing_options).returns(mock_billing_success(date, @provider))
-      post master_api_provider_billing_jobs_path(@provider, date: date), access_token: @access_token.value
+      post master_api_provider_billing_jobs_path(@provider, date: date), params: { access_token: @access_token.value }
       assert_response :accepted
     end
   end
@@ -64,25 +64,25 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
     Sidekiq::Testing.inline! do
       billing_options = { only: [@provider.id], buyer_ids: [@buyer.id], now: date_utc, skip_notifications: true }
       Finance::BillingStrategy.expects(:daily).with(billing_options).returns(mock_billing_success(date_utc, @provider))
-      post master_api_provider_billing_jobs_path(@provider, date: date), access_token: @access_token.value
+      post master_api_provider_billing_jobs_path(@provider, date: date), params: { access_token: @access_token.value }
       assert_response :accepted
     end
   end
 
   test 'invalid date' do
-    post master_api_provider_billing_jobs_path(@provider, date: 'not a valid date'), access_token: @access_token.value
+    post master_api_provider_billing_jobs_path(@provider, date: 'not a valid date'), params: { access_token: @access_token.value }
     assert_response :bad_request
   end
 
   test 'forbids for providers without billing enabled' do
     provider = FactoryBot.create(:simple_provider)
-    post master_api_provider_billing_jobs_path(provider, date: '2018-02-08'), access_token: @access_token.value
+    post master_api_provider_billing_jobs_path(provider, date: '2018-02-08'), params: { access_token: @access_token.value }
     assert_response :forbidden
     assert_equal 'Finance module not enabled for the account', JSON.parse(response.body)['error']
 
     FactoryBot.create(:prepaid_billing, account: provider)
     Finance::BillingService.expects(:async_call).returns(true)
-    post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: @access_token.value
+    post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.value }
     assert_response :accepted
   end
 
@@ -98,33 +98,33 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
 
     test 'scope account_management is required to create jobs' do
       unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['finance'])
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: unauthorized_token.value
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
       assert_response :forbidden
 
       authorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'])
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: authorized_token.value
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: authorized_token.value }
       assert_response :accepted
     end
 
     test 'members can create jobs with proper admin permission' do
       unauthorized_member = FactoryBot.create(:member, account: master_account, admin_sections: [])
       unauthorized_token = FactoryBot.create(:access_token, owner: unauthorized_member, scopes: ['account_management'])
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: unauthorized_token.value
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
       assert_response :forbidden
 
       authorized_member = FactoryBot.create(:member, account: master_account, admin_sections: [:partners])
       authorized_token = FactoryBot.create(:access_token, owner: authorized_member, scopes: ['account_management'])
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: authorized_token.value
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: authorized_token.value }
       assert_response :accepted
     end
 
     test 'only rw access tokens can create jobs' do
       unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'], permission: 'ro')
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: unauthorized_token.value
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
       assert_response :forbidden
 
       authorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'], permission: 'rw')
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), access_token: authorized_token.value
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: authorized_token.value }
       assert_response :accepted
     end
 

--- a/test/integration/master/events_importer_test.rb
+++ b/test/integration/master/events_importer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Master::EventsImporterTest < ActionDispatch::IntegrationTest
@@ -10,7 +12,7 @@ class Master::EventsImporterTest < ActionDispatch::IntegrationTest
     host! @provider.self_domain
 
     ThreeScale.config.stubs(tenant_mode: 'multitenant')
-    post master_events_import_url, secret: 'shared-secret!'
+    post master_events_import_url, params: { secret: 'shared-secret!' }
     assert_response :forbidden
   end
 
@@ -18,11 +20,11 @@ class Master::EventsImporterTest < ActionDispatch::IntegrationTest
     host! Account.master.self_domain
 
     ThreeScale.config.stubs(tenant_mode: 'multitenant')
-    post master_events_import_url, secret: 'shared-secret!'
+    post master_events_import_url, params: { secret: 'shared-secret!' }
     assert_response :success
 
     ThreeScale.config.stubs(tenant_mode: 'master')
-    post master_events_import_url, secret: 'shared-secret!'
+    post master_events_import_url, params: { secret: 'shared-secret!' }
     assert_response :success
   end
 end

--- a/test/integration/master/providers/plans_controller_test.rb
+++ b/test/integration/master/providers/plans_controller_test.rb
@@ -16,7 +16,7 @@ class Master::Providers::PlansControllerTest < ActionDispatch::IntegrationTest
   test '#update from an unauthenticated user' do
     host! master_account.self_domain
 
-    put master_provider_plan_path(tenant), plan_id: new_plan.id, format: :js
+    put master_provider_plan_path(tenant), params: { plan_id: new_plan.id, format: :js }
 
     assert_response :redirect
     assert_equal [old_plan.id], tenant.bought_application_plans.select(:id, :position).map(&:id)
@@ -25,7 +25,7 @@ class Master::Providers::PlansControllerTest < ActionDispatch::IntegrationTest
   test '#update for an admin' do
     login! master_account
 
-    put master_provider_plan_path(tenant), plan_id: new_plan.id, format: :js
+    put master_provider_plan_path(tenant), params: { plan_id: new_plan.id, format: :js }
 
     assert_response :success
     assert_equal [new_plan.id], tenant.bought_application_plans.select(:id, :position).map(&:id)
@@ -35,7 +35,7 @@ class Master::Providers::PlansControllerTest < ActionDispatch::IntegrationTest
     master_member.update!({member_permission_ids: ['partners'], member_permission_service_ids: [service.id]})
     login! master_account, user: master_member
 
-    put master_provider_plan_path(tenant), plan_id: new_plan.id, format: :js
+    put master_provider_plan_path(tenant), params: { plan_id: new_plan.id, format: :js }
 
     assert_response :success
     assert_equal [new_plan.id], tenant.bought_application_plans.select(:id, :position).map(&:id)
@@ -45,7 +45,7 @@ class Master::Providers::PlansControllerTest < ActionDispatch::IntegrationTest
     master_member.update!({member_permission_ids: [], member_permission_service_ids: [service.id]})
     login! master_account, user: master_member
 
-    put master_provider_plan_path(tenant), plan_id: new_plan.id, format: :js
+    put master_provider_plan_path(tenant), params: { plan_id: new_plan.id, format: :js }
 
     assert_response :forbidden
     assert_equal [old_plan.id], tenant.bought_application_plans.select(:id, :position).map(&:id)
@@ -55,7 +55,7 @@ class Master::Providers::PlansControllerTest < ActionDispatch::IntegrationTest
     master_member.update!({member_permission_ids: ['partners'], member_permission_service_ids: '[]'})
     login! master_account, user: master_member
 
-    put master_provider_plan_path(tenant), plan_id: new_plan.id, format: :js
+    put master_provider_plan_path(tenant), params: { plan_id: new_plan.id, format: :js }
 
     assert_response :forbidden
     assert_equal [old_plan.id], tenant.bought_application_plans.select(:id, :position).map(&:id)

--- a/test/integration/payment_gateways/ogone_test.rb
+++ b/test/integration/payment_gateways/ogone_test.rb
@@ -26,26 +26,7 @@ class OgoneTest < ActionDispatch::IntegrationTest
 
   test "receive ok for storage changes customer data" do
     assert_nil @buyer_account.credit_card_partial_number
-    get "/admin/account/ogone/hosted_success" ,
-
-    {"CN"=>"Josep Maria Pujol Serra",
-      "orderID"=>"raitest_1323947064",
-      "PAYID"=>"413811165",
-      "amount"=>"0.01",
-      "action"=>"hosted_success",
-      "ALIAS"=>"3scale-959306862-959421232",
-      "ACCEPTANCE"=>"211730",
-      "CARDNO"=>"XXXXXXXXXXXX2053",
-      "IP"=>"81.38.77.15",
-      "PM"=>"CreditCard",
-      "TRXDATE"=>"12/15/11",
-      "currency"=>"EUR",
-      "controller"=>"accounts/payment_gateways/ogone",
-      "SHASIGN"=>"B49A41EB7302FCDEAB6BDB17DE8B9045DC020096",
-      "BRAND"=>"VISA",
-      "ED"=>"0215",
-      "STATUS"=>"5",
-      "NCERROR"=>"0"}
+    get "/admin/account/ogone/hosted_success", params: { "CN"=>"Josep Maria Pujol Serra", "orderID"=>"raitest_1323947064", "PAYID"=>"413811165", "amount"=>"0.01", "action"=>"hosted_success", "ALIAS"=>"3scale-959306862-959421232", "ACCEPTANCE"=>"211730", "CARDNO"=>"XXXXXXXXXXXX2053", "IP"=>"81.38.77.15", "PM"=>"CreditCard", "TRXDATE"=>"12/15/11", "currency"=>"EUR", "controller"=>"accounts/payment_gateways/ogone", "SHASIGN"=>"B49A41EB7302FCDEAB6BDB17DE8B9045DC020096", "BRAND"=>"VISA", "ED"=>"0215", "STATUS"=>"5", "NCERROR"=>"0" }
 
     @buyer_account.reload
     assert_equal  Date.new(2015, 02, 1), @buyer_account.credit_card_expires_on_with_default
@@ -55,25 +36,7 @@ class OgoneTest < ActionDispatch::IntegrationTest
 
   test "supports empty ED" do
     assert_nil @buyer_account.credit_card_partial_number
-    get "/admin/account/ogone/hosted_success" ,
-    { "ACCEPTANCE" => "0000",
-      "BRAND" => "PAYPAL",
-      "CARDNO" => "Batman@t-XXXXXXXX-et",
-      "CN"=> "Bruce Wayne",
-      "ED"=>"", # Notice that ED is empty
-      "IP"=> "213.133.142.4",
-      "NCERROR" => "0",
-      "PAYID"=>"413811165",
-      "PM" => "PAYPAL",
-      "SHASIGN" => "077FAFE22C99336ACCFD032CA0687B76299A0112",
-      "STATUS" => "5",
-      "TRXDATE" => "10/29/14",
-      "action" => "hosted_success",
-      "amount" => "0.01",
-      "controller" => "developer_portal/admin/account/ogone",
-      "currency" => "GBP",
-      "orderID"=>"raitest_1323947064",
-    }
+    get "/admin/account/ogone/hosted_success", params: { "ACCEPTANCE" => "0000", "BRAND" => "PAYPAL", "CARDNO" => "Batman@t-XXXXXXXX-et", "CN"=> "Bruce Wayne", "ED"=>"", "IP"=> "213.133.142.4", "NCERROR" => "0", "PAYID"=>"413811165", "PM" => "PAYPAL", "SHASIGN" => "077FAFE22C99336ACCFD032CA0687B76299A0112", "STATUS" => "5", "TRXDATE" => "10/29/14", "action" => "hosted_success", "amount" => "0.01", "controller" => "developer_portal/admin/account/ogone", "currency" => "GBP", "orderID"=>"raitest_1323947064" }
 
     @buyer_account.reload
     assert_equal "X-et", @buyer_account.credit_card_partial_number
@@ -83,25 +46,7 @@ class OgoneTest < ActionDispatch::IntegrationTest
 
   test "nok status value (!=5) doesn't change customer data" do
     assert_nil @buyer_account.credit_card_partial_number
-    get "/admin/account/ogone/hosted_success" ,
-    {"CN"=>"Josep Maria Pujol Serra",
-      "orderID"=>"raitest_1323947064",
-      "PAYID"=>"413811165",
-      "amount"=>"0.01",
-      "action"=>"hosted_success",
-      "ALIAS"=>"3scale-959306862-959421232",
-      "ACCEPTANCE"=>"211730",
-      "CARDNO"=>"XXXXXXXXXXXX2053",
-      "IP"=>"81.38.77.15",
-      "PM"=>"CreditCard",
-      "TRXDATE"=>"12/15/11",
-      "currency"=>"EUR",
-      "controller"=>"accounts/payment_gateways/ogone",
-      "SHASIGN"=>"BC313E2D30365DCF887CD77CF760F8FE952BF661",
-      "BRAND"=>"VISA",
-      "ED"=>"0215",
-      "STATUS"=>"1",
-      "NCERROR"=>"0"}
+    get "/admin/account/ogone/hosted_success", params: { "CN"=>"Josep Maria Pujol Serra", "orderID"=>"raitest_1323947064", "PAYID"=>"413811165", "amount"=>"0.01", "action"=>"hosted_success", "ALIAS"=>"3scale-959306862-959421232", "ACCEPTANCE"=>"211730", "CARDNO"=>"XXXXXXXXXXXX2053", "IP"=>"81.38.77.15", "PM"=>"CreditCard", "TRXDATE"=>"12/15/11", "currency"=>"EUR", "controller"=>"accounts/payment_gateways/ogone", "SHASIGN"=>"BC313E2D30365DCF887CD77CF760F8FE952BF661", "BRAND"=>"VISA", "ED"=>"0215", "STATUS"=>"1", "NCERROR"=>"0" }
 
     @buyer_account.reload
     assert_nil @buyer_account.credit_card_partial_number
@@ -110,25 +55,7 @@ class OgoneTest < ActionDispatch::IntegrationTest
 
   test "bad sha1 hash doesn't change customer data" do
     assert_nil @buyer_account.credit_card_partial_number
-    get "/admin/account/ogone/hosted_success" ,
-    {"CN"=>"Josep Maria Pujol Serra",
-      "orderID"=>"raitest_1323947064",
-      "PAYID"=>"413811165",
-      "amount"=>"0.01",
-      "action"=>"hosted_success",
-      "ALIAS"=>"3scale-959306862-959421232",
-      "ACCEPTANCE"=>"211730",
-      "CARDNO"=>"XXXXXXXXXXXX2053",
-      "IP"=>"81.38.77.15",
-      "PM"=>"CreditCard",
-      "TRXDATE"=>"12/15/11",
-      "currency"=>"EUR",
-      "controller"=>"accounts/payment_gateways/ogone",
-      "SHASIGN"=>"B49A41EB7302FCDEAB6BDB17DE8B9045DC020095",
-      "BRAND"=>"VISA",
-      "ED"=>"0215",
-      "STATUS"=>"5",
-      "NCERROR"=>"0"}
+    get "/admin/account/ogone/hosted_success", params: { "CN"=>"Josep Maria Pujol Serra", "orderID"=>"raitest_1323947064", "PAYID"=>"413811165", "amount"=>"0.01", "action"=>"hosted_success", "ALIAS"=>"3scale-959306862-959421232", "ACCEPTANCE"=>"211730", "CARDNO"=>"XXXXXXXXXXXX2053", "IP"=>"81.38.77.15", "PM"=>"CreditCard", "TRXDATE"=>"12/15/11", "currency"=>"EUR", "controller"=>"accounts/payment_gateways/ogone", "SHASIGN"=>"B49A41EB7302FCDEAB6BDB17DE8B9045DC020095", "BRAND"=>"VISA", "ED"=>"0215", "STATUS"=>"5", "NCERROR"=>"0" }
 
     @buyer_account.reload
     assert_nil @buyer_account.credit_card_partial_number

--- a/test/integration/provider/admin/account/data_exports_controller_test.rb
+++ b/test/integration/provider/admin/account/data_exports_controller_test.rb
@@ -23,28 +23,28 @@ class Provider::Admin::Account::DataExportsControllerTest < ActionDispatch::Inte
   end
 
   test 'for: today/this_week/period not given' do
-    post provider_admin_account_data_exports_path, {period: 'today', data: 'messages'}
+    post provider_admin_account_data_exports_path, params: { period: 'today', data: 'messages' }
     assert_redirected_to new_provider_admin_account_data_exports_path
 
-    post provider_admin_account_data_exports_path, {period: 'this_week', data: 'messages'}
+    post provider_admin_account_data_exports_path, params: { period: 'this_week', data: 'messages' }
     assert_redirected_to new_provider_admin_account_data_exports_path
 
-    post provider_admin_account_data_exports_path, {data: 'messages'}
+    post provider_admin_account_data_exports_path, params: { data: 'messages' }
     assert_redirected_to new_provider_admin_account_data_exports_path
   end
 
   test 'invalid params to export submitted redirect to new action on empty/invalid params' do
-    post provider_admin_account_data_exports_path, {data: ''}
+    post provider_admin_account_data_exports_path, params: { data: '' }
     assert_redirected_to new_provider_admin_account_data_exports_path
 
-    post provider_admin_account_data_exports_path, {data: 'invalid'}
+    post provider_admin_account_data_exports_path, params: { data: 'invalid' }
     assert_redirected_to new_provider_admin_account_data_exports_path
   end
 
   test 'with correct params enqueue sidekiq'  do
     DataExportsWorker.jobs.clear
     assert_difference 'DataExportsWorker.jobs.size' do
-      post provider_admin_account_data_exports_path, {period: 'this_week', data: 'applications'}
+      post provider_admin_account_data_exports_path, params: { period: 'this_week', data: 'applications' }
     end
     DataExportsWorker.jobs.clear
   end

--- a/test/integration/provider/admin/account/logos_controller_test.rb
+++ b/test/integration/provider/admin/account/logos_controller_test.rb
@@ -17,7 +17,7 @@ class Provider::Admin::Account::LogosControllerTest < ActionDispatch::Integratio
 
   test 'update when it should work' do
     assert_change(of: -> { provider.profile.reload.logo_file_name }, from: nil, to: 'hypnotoad.jpg') do
-      put provider_admin_account_logo_path, {profile: {logo: logo_file}}
+      put provider_admin_account_logo_path, params: { profile: {logo: logo_file} }
     end
 
     assert_redirected_to edit_provider_admin_account_logo_path
@@ -27,7 +27,7 @@ class Provider::Admin::Account::LogosControllerTest < ActionDispatch::Integratio
 
   test 'update when it should fail' do
     assert_no_change(of: -> { provider.profile.reload.logo_file_name }) do
-      put provider_admin_account_logo_path, {profile: {logo: countries_yaml_file}}
+      put provider_admin_account_logo_path, params: { profile: {logo: countries_yaml_file} }
     end
 
     assert_redirected_to edit_provider_admin_account_logo_path
@@ -39,7 +39,7 @@ class Provider::Admin::Account::LogosControllerTest < ActionDispatch::Integratio
     provider.settings.deny_branding!
 
     assert_no_change(of: -> { provider.profile.reload.logo_file_name }) do
-      put provider_admin_account_logo_path, {profile: {logo: logo_file}}
+      put provider_admin_account_logo_path, params: { profile: {logo: logo_file} }
     end
 
     assert_response :forbidden
@@ -49,7 +49,7 @@ class Provider::Admin::Account::LogosControllerTest < ActionDispatch::Integratio
     provider.profile.update_attribute(:logo, Rack::Test::UploadedFile.new(logo_file, 'image/jpeg', true))
 
     assert_change(of: -> { provider.profile.reload.logo_file_name }, from: provider.profile.logo_file_name, to: nil) do
-      delete provider_admin_account_logo_path, {profile: {logo: logo_file}}
+      delete provider_admin_account_logo_path, params: { profile: {logo: logo_file} }
     end
 
     assert_redirected_to edit_provider_admin_account_logo_path
@@ -63,7 +63,7 @@ class Provider::Admin::Account::LogosControllerTest < ActionDispatch::Integratio
     ActiveModel::Errors.any_instance.stubs(full_messages: ['Error 1st', 'Another Error'])
 
     assert_no_change(of: -> { provider.profile.reload.logo_file_name }, to: nil) do
-      delete provider_admin_account_logo_path, {profile: {logo: logo_file}}
+      delete provider_admin_account_logo_path, params: { profile: {logo: logo_file} }
     end
 
     assert_redirected_to edit_provider_admin_account_logo_path
@@ -75,7 +75,7 @@ class Provider::Admin::Account::LogosControllerTest < ActionDispatch::Integratio
     provider.settings.deny_branding!
 
     assert_no_change(of: -> { provider.profile.reload.logo_file_name }) do
-      delete provider_admin_account_logo_path, {profile: {logo: logo_file}}
+      delete provider_admin_account_logo_path, params: { profile: {logo: logo_file} }
     end
 
     assert_response :forbidden

--- a/test/integration/provider/admin/account/payment_gateways/braintree_blue_controller_test.rb
+++ b/test/integration/provider/admin/account/payment_gateways/braintree_blue_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Provider::Admin::Account::PaymentGateways::BraintreeBlueControllerTest < ActionDispatch::IntegrationTest
@@ -64,7 +66,7 @@ class Provider::Admin::Account::PaymentGateways::BraintreeBlueControllerTest < A
     ::PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm).returns(failed_result)
     ActionLimiter.any_instance.stubs(:perform!).raises(ActionLimiter::ActionLimitsExceededError)
 
-    post hosted_success_provider_admin_account_braintree_blue_path, form_params
+    post hosted_success_provider_admin_account_braintree_blue_path, params: form_params
 
     @provider.reload
 
@@ -76,7 +78,7 @@ class Provider::Admin::Account::PaymentGateways::BraintreeBlueControllerTest < A
     @provider.provider_account.update(payment_gateway_options: gateway_options)
     ::PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm).returns(failed_result)
 
-    post hosted_success_provider_admin_account_braintree_blue_path, form_params
+    post hosted_success_provider_admin_account_braintree_blue_path, params: form_params
 
     @provider.reload
 

--- a/test/integration/provider/admin/account/users_controller_test.rb
+++ b/test/integration/provider/admin/account/users_controller_test.rb
@@ -39,7 +39,7 @@ class Provider::Admin::Account::UsersControllerTest < ActionDispatch::Integratio
   def test_update_blank_member_permission_ids
     assert_equal @default_ids, @user.admin_sections.to_a
 
-    put provider_admin_account_user_path(@user), user: {member_permission_ids: ['']}
+    put provider_admin_account_user_path(@user), params: { user: {member_permission_ids: ['']} }
 
     @user.reload
 
@@ -49,7 +49,7 @@ class Provider::Admin::Account::UsersControllerTest < ActionDispatch::Integratio
   def test_update_no_member_permission_ids
     assert_equal @default_ids, @user.admin_sections.to_a
 
-    put provider_admin_account_user_path(@user), user: {}
+    put provider_admin_account_user_path(@user), params: { user: {} }
 
     @user.reload
 
@@ -75,7 +75,7 @@ class Provider::Admin::Account::UsersControllerTest < ActionDispatch::Integratio
   test 'admin changes role of another admin' do
     user = FactoryBot.create(:admin, account: provider)
 
-    put provider_admin_account_user_path(user), user: {role: 'member'}
+    put provider_admin_account_user_path(user), params: { user: {role: 'member'} }
 
     assert user.reload.member?
   end
@@ -83,7 +83,7 @@ class Provider::Admin::Account::UsersControllerTest < ActionDispatch::Integratio
   test 'admin cannot edit his own role' do
     user = provider.admin_users.first!
 
-    put provider_admin_account_user_path(user), user: {role: 'member'}
+    put provider_admin_account_user_path(user), params: { user: {role: 'member'} }
 
     assert user.reload.admin?
   end

--- a/test/integration/provider/admin/accounts_controller_test.rb
+++ b/test/integration/provider/admin/accounts_controller_test.rb
@@ -19,7 +19,7 @@ class Provider::Admin::AccountsControllerTest < ActionDispatch::IntegrationTest
     ProviderUserMailer.expects(:activation).returns(mock(deliver_now: true))
 
     account_plan.update_attribute(:approval_required, false)
-    post provider_admin_accounts_path, valid_params
+    post provider_admin_accounts_path, params: valid_params
     user = User.find_by!(email: valid_params[:account][:user][:email])
     account = user.account
 
@@ -57,7 +57,7 @@ class Provider::Admin::AccountsControllerTest < ActionDispatch::IntegrationTest
 
   test '#create for on-prem' do
     ThreeScale.config.stubs(onpremises: true)
-    post provider_admin_accounts_path, valid_params
+    post provider_admin_accounts_path, params: valid_params
     account = User.find_by!(email: valid_params[:account][:user][:email]).account
     # account has the right plans
     assert_equal account_plan, account.bought_account_plan
@@ -69,7 +69,7 @@ class Provider::Admin::AccountsControllerTest < ActionDispatch::IntegrationTest
 
   test '#create for saas' do
     ThreeScale.config.stubs(onpremises: false)
-    post provider_admin_accounts_path, valid_params
+    post provider_admin_accounts_path, params: valid_params
     account = User.find_by!(email: valid_params[:account][:user][:email]).account
     # account has the right plans
     assert_equal account_plan, account.bought_account_plan
@@ -82,7 +82,7 @@ class Provider::Admin::AccountsControllerTest < ActionDispatch::IntegrationTest
 
   test '#create approves the account when the account plan does not require approval' do
     account_plan.update_attribute(:approval_required, true)
-    post provider_admin_accounts_path, valid_params
+    post provider_admin_accounts_path, params: valid_params
     user = User.find_by!(email: valid_params[:account][:user][:email])
     account = user.account
     refute user.can_login?

--- a/test/integration/provider/admin/authentication_providers_controller_test.rb
+++ b/test/integration/provider/admin/authentication_providers_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Provider::Admin::AuthenticationProvidersControllerTest < ActionDispatch::IntegrationTest
@@ -41,7 +43,7 @@ class Provider::Admin::AuthenticationProvidersControllerTest < ActionDispatch::I
       site: "http://site", kind: 'github', skip_ssl_certificate_verification: true
     }
     assert_difference -> {@provider.authentication_providers.count } do
-      post provider_admin_authentication_providers_path, authentication_provider: attributes
+      post provider_admin_authentication_providers_path, params: { authentication_provider: attributes }
     end
 
     github = @provider.authentication_providers.find_by! kind: :github
@@ -49,7 +51,7 @@ class Provider::Admin::AuthenticationProvidersControllerTest < ActionDispatch::I
 
     assert_equal 'client_id', github.client_id
 
-    put provider_admin_authentication_provider_path(github), authentication_provider: {client_id: 'clientID'}
+    put provider_admin_authentication_provider_path(github), params: { authentication_provider: {client_id: 'clientID'} }
     assert_template 'provider/admin/authentication_providers/show'
     github.reload
     assert_equal 'clientID', github.client_id
@@ -58,7 +60,7 @@ class Provider::Admin::AuthenticationProvidersControllerTest < ActionDispatch::I
   test 'POST create success' do
     attrs = FactoryBot.attributes_for(:authentication_provider)
     refute @provider.authentication_providers.find_by kind: attrs[:kind]
-    post provider_admin_authentication_providers_path, authentication_provider: attrs
+    post provider_admin_authentication_providers_path, params: { authentication_provider: attrs }
     authentication_provider = @provider.authentication_providers.find_by! kind: attrs[:kind]
     assert_redirected_to edit_provider_admin_authentication_provider_path(authentication_provider)
   end
@@ -66,8 +68,7 @@ class Provider::Admin::AuthenticationProvidersControllerTest < ActionDispatch::I
   test 'PUT update automatically_approve_accounts' do
     authentication_provider = FactoryBot.create(:authentication_provider, account: @provider)
     refute authentication_provider.automatically_approve_accounts
-    put provider_admin_authentication_provider_path(authentication_provider),
-        authentication_provider: {automatically_approve_accounts: true}
+    put provider_admin_authentication_provider_path(authentication_provider), params: { authentication_provider: {automatically_approve_accounts: true} }
     authentication_provider.reload
     assert authentication_provider.automatically_approve_accounts
   end

--- a/test/integration/provider/admin/referrer_filters_controller_test.rb
+++ b/test/integration/provider/admin/referrer_filters_controller_test.rb
@@ -24,7 +24,7 @@ class Provider::Admin::ReferrerFiltersControllerTest < ActionDispatch::Integrati
     end
 
     test 'create' do
-      post provider_admin_application_referrer_filters_path(application_id: cinstance.to_param, referrer_filter: referrer), {}, HEADERS_XHR
+      post provider_admin_application_referrer_filters_path(application_id: cinstance.to_param, referrer_filter: referrer), session: HEADERS_XHR
 
       assert_response :success
       assert_template 'create'
@@ -33,7 +33,7 @@ class Provider::Admin::ReferrerFiltersControllerTest < ActionDispatch::Integrati
     test 'create with error' do
       ReferrerFilter.any_instance.stubs(persisted?: false)
 
-      post provider_admin_application_referrer_filters_path(application_id: cinstance.to_param, referrer_filter: referrer), {}, HEADERS_XHR
+      post provider_admin_application_referrer_filters_path(application_id: cinstance.to_param, referrer_filter: referrer), session: HEADERS_XHR
 
       assert_response :success
       assert_template 'error'
@@ -42,7 +42,7 @@ class Provider::Admin::ReferrerFiltersControllerTest < ActionDispatch::Integrati
     test 'delete' do
       id = cinstance.referrer_filters.add(referrer).id
 
-      delete provider_admin_application_referrer_filter_path(application_id: cinstance.to_param, id: id), {}, HEADERS_XHR
+      delete provider_admin_application_referrer_filter_path(application_id: cinstance.to_param, id: id), session: HEADERS_XHR
 
       assert_response :success
     end
@@ -55,14 +55,14 @@ class Provider::Admin::ReferrerFiltersControllerTest < ActionDispatch::Integrati
     end
 
     test 'create' do
-      post provider_admin_application_referrer_filters_path(application_id: cinstance.to_param, referrer_filter: referrer), {}, HEADERS_XHR
+      post provider_admin_application_referrer_filters_path(application_id: cinstance.to_param, referrer_filter: referrer), session: HEADERS_XHR
       assert_response :not_found
     end
 
     test 'delete' do
       id = cinstance.referrer_filters.add(referrer).id
 
-      delete provider_admin_application_referrer_filter_path(application_id: cinstance.to_param, id: id), {}, HEADERS_XHR
+      delete provider_admin_application_referrer_filter_path(application_id: cinstance.to_param, id: id), session: HEADERS_XHR
 
       assert_response :not_found
     end

--- a/test/integration/provider/passwords_integration_test.rb
+++ b/test/integration/provider/passwords_integration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Provider::PasswordsControllerIntegrationTest < ActionDispatch::IntegrationTest
@@ -54,7 +56,7 @@ class Provider::PasswordsControllerIntegrationTest < ActionDispatch::Integration
     test '#destroy does not work for master account' do
       login_provider master_account
 
-      assert_raise(ActionController::RoutingError) { delete provider_password_path, email: 'example@test.com' }
+      assert_raise(ActionController::RoutingError) { delete provider_password_path, params: { email: 'example@test.com' } }
     end
   end
 end

--- a/test/integration/provider/signups_controller_integration_test.rb
+++ b/test/integration/provider/signups_controller_integration_test.rb
@@ -16,7 +16,7 @@ class Provider::SignupsControllerIntegrationTest < ActionDispatch::IntegrationTe
     ThreeScale::Analytics::UserTracking.any_instance.expects(:track).at_least_once.with('Signup', {mkt_cookie: nil, analytics: {}})
 
     assert_difference(master_account.buyer_accounts.method(:count)) do
-      post provider_signup_path, create_params({account: {name: 'theorganization'}})
+      post provider_signup_path, params: create_params({account: {name: 'theorganization'}})
     end
 
     assert_redirected_to success_provider_signup_path
@@ -40,7 +40,7 @@ class Provider::SignupsControllerIntegrationTest < ActionDispatch::IntegrationTe
 
   test 'POST without params' do
     assert_no_difference(master_account.buyer_accounts.method(:count)) do
-      post provider_signup_path, {}
+      post provider_signup_path
     end
 
     assert_response :bad_request
@@ -48,7 +48,7 @@ class Provider::SignupsControllerIntegrationTest < ActionDispatch::IntegrationTe
 
   test 'POST in case of invalid params' do
     assert_no_difference(master_account.buyer_accounts.method(:count)) do
-      post provider_signup_path, create_params({account: {user: {email: 'invalid email'}}})
+      post provider_signup_path, params: create_params({account: {user: {email: 'invalid email'}}})
     end
 
     assert_response :success
@@ -58,7 +58,7 @@ class Provider::SignupsControllerIntegrationTest < ActionDispatch::IntegrationTe
     Provider::SignupsController.any_instance.expects(:spam_check).returns(false)
 
     assert_no_difference(master_account.buyer_accounts.method(:count)) do
-      post provider_signup_path, create_params
+      post provider_signup_path, params: create_params
     end
 
     assert_response :success
@@ -66,7 +66,7 @@ class Provider::SignupsControllerIntegrationTest < ActionDispatch::IntegrationTe
 
   test 'POST accepts the subdomain if given' do
     assert_difference(master_account.buyer_accounts.method(:count)) do
-      post provider_signup_path, create_params({account: {org_name: 'organization', subdomain: 'mysubdomain', self_subdomain: 'selfsubdomain-admin'}})
+      post provider_signup_path, params: create_params({account: {org_name: 'organization', subdomain: 'mysubdomain', self_subdomain: 'selfsubdomain-admin'}})
     end
 
     provider = master_account.buyer_accounts.order(:id).last!

--- a/test/integration/service_not_deleted_test.rb
+++ b/test/integration/service_not_deleted_test.rb
@@ -19,7 +19,7 @@ class ServiceNotDeletedTest < ActionDispatch::IntegrationTest
     perform_enqueued_jobs(except: [IndexProxyRuleWorker, SphinxIndexationWorker]) do
       (ENV['BRUTOFORCE'].present? ? 2000 : 1).times do |i|
         service_name = "service foo #{i}"
-        post(admin_api_services_path, provider_key: @provider.api_key, format: :json, name: service_name)
+        post(admin_api_services_path, params: { provider_key: @provider.api_key, format: :json, name: service_name })
         assert_response :success
         assert_service(@response.body, { account_id: @provider.id, name: service_name })
         new_service = @provider.services.find_by_name(service_name)

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class SessionsTest < ActionDispatch::IntegrationTest
@@ -25,10 +27,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
   test 'sso end-to-end integration' do
     host! @provider.admin_domain
 
-    post(admin_api_sso_tokens_path, :format => :xml,
-              :provider_key => @provider.api_key,
-              :user_id => @buyer.users.first.id, :expires_in => 6000
-        )
+    post(admin_api_sso_tokens_path, params: { :format => :xml, :provider_key => @provider.api_key, :user_id => @buyer.users.first.id, :expires_in => 6000 })
 
     assert_response :created
 
@@ -51,11 +50,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
 
     host! @provider.admin_domain
 
-    post(admin_api_sso_tokens_path, :format => :xml,
-              :provider_key => @provider.api_key,
-              :user_id => user_id, :username => user.username,
-              :redirect_url => forum_path(:host => @provider.domain)
-        )
+    post(admin_api_sso_tokens_path, params: { :format => :xml, :provider_key => @provider.api_key, :user_id => user_id, :username => user.username, :redirect_url => forum_path(:host => @provider.domain) })
 
     assert_response :created
 
@@ -74,10 +69,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
   test "sso end-to-end with username and without expires_in" do
     host! @provider.admin_domain
 
-    post(admin_api_sso_tokens_path, :format => :xml,
-              :provider_key => @provider.api_key,
-              :username => @buyer.users.first.username
-        )
+    post(admin_api_sso_tokens_path, params: { :format => :xml, :provider_key => @provider.api_key, :username => @buyer.users.first.username })
 
     assert_response :created
 
@@ -222,7 +214,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
     assert_equal 1, user.user_sessions.count
 
     assert_no_difference '@provider.reload.updated_at' do
-      with_forgery_protection { put provider_admin_account_path, {account: {org_name: 'jose'}} }
+      with_forgery_protection { put provider_admin_account_path, params: { account: {org_name: 'jose'} } }
     end
 
     assert_redirected_to provider_login_url
@@ -242,10 +234,10 @@ class SessionsTest < ActionDispatch::IntegrationTest
     host! @provider.admin_domain
     provider_login_with user.username, 'supersecret'
     assert_equal 2, user.user_sessions.count
-    put provider_admin_user_personal_details_path, {user: {current_password: 'supersecret' ,
+    put provider_admin_user_personal_details_path, params: { user: {current_password: 'supersecret' ,
                                                               password: 'newpwd',
                                                               username: 'test',
-                                                              email: 'test2@example.com'}}
+                                                              email: 'test2@example.com'} }
 
     assert_equal 1, user.user_sessions.count
   end
@@ -258,10 +250,10 @@ class SessionsTest < ActionDispatch::IntegrationTest
     host! @provider.domain
     login_with user.username, 'supersecret'
     assert_equal 2, user.user_sessions.count
-    put '/admin/account/personal_details', {user: {current_password: 'supersecret' ,
+    put '/admin/account/personal_details', params: { user: {current_password: 'supersecret' ,
                                                      password: 'newpwd',
                                                      username: 'test',
-                                                     email: 'test2@example.com'}}
+                                                     email: 'test2@example.com'} }
 
     assert_equal 1, user.user_sessions.count
   end

--- a/test/integration/signup_express_test.rb
+++ b/test/integration/signup_express_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class SignupExpressTest < ActionDispatch::IntegrationTest
@@ -8,14 +10,14 @@ class SignupExpressTest < ActionDispatch::IntegrationTest
   end
 
   test 'signup express with org name' do
-    post '/admin/api/signup.xml', provider_key: @provider.api_key, org_name: 'company', name: 'example', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id
+    post '/admin/api/signup.xml', params: { provider_key: @provider.api_key, org_name: 'company', name: 'example', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id }
     assert_response :success
     doc = Nokogiri::XML::Document.parse(@response.body)
     assert_equal 'company', doc.xpath('/account/org_name').text
   end
 
   test 'signup express with account plan that requires approval' do
-    post '/admin/api/signup.xml', provider_key: @provider.api_key, org_name: 'company', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id
+    post '/admin/api/signup.xml', params: { provider_key: @provider.api_key, org_name: 'company', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id }
 
     signup_result = assigns(:signup_result)
     assert signup_result.user.pending?
@@ -26,7 +28,7 @@ class SignupExpressTest < ActionDispatch::IntegrationTest
   test 'signup express with account plan that do not requires approval' do
     @account_plan.approval_required = false
     @account_plan.save!
-    post '/admin/api/signup.xml', provider_key: @provider.api_key, org_name: 'company', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id
+    post '/admin/api/signup.xml', params: { provider_key: @provider.api_key, org_name: 'company', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id }
 
     signup_result = assigns(:signup_result)
     assert signup_result.user_active?
@@ -35,11 +37,11 @@ class SignupExpressTest < ActionDispatch::IntegrationTest
   end
 
   test 'do not raise exception when validation fails for email duplications' do
-    post '/admin/api/signup.xml', provider_key: @provider.api_key, org_name: 'company', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id
-    post '/admin/api/signup.xml', provider_key: @provider.api_key, org_name: 'company', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id
+    post '/admin/api/signup.xml', params: { provider_key: @provider.api_key, org_name: 'company', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id }
+    post '/admin/api/signup.xml', params: { provider_key: @provider.api_key, org_name: 'company', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id }
   end
 
   test 'do not raise exception when account validations fails' do
-    post '/admin/api/signup.xml', provider_key: @provider.api_key, org_name: '', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id
+    post '/admin/api/signup.xml', params: { provider_key: @provider.api_key, org_name: '', username: 'quentin', email: 'quentin@example.com', password: '12345678', account_plan_id: @account_plan.id }
   end
 end

--- a/test/integration/stats/api/applications_test.rb
+++ b/test/integration/stats/api/applications_test.rb
@@ -11,8 +11,7 @@ class Stats::Api::ApplicationsTest < ActionDispatch::IntegrationTest
 
   test 'usage_response_code with no data as json' do
     provider_login_with @admin, 'supersecret'
-    get "/stats/api/applications/#{@cinstance.id}/usage_response_code.json",
-      period: 'day', response_code: 200, timezone: 'Madrid', skip_change: false
+    get "/stats/api/applications/#{@cinstance.id}/usage_response_code.json", params: { period: 'day', response_code: 200, timezone: 'Madrid', skip_change: false }
 
     assert_response :success
     assert_content_type 'application/json'

--- a/test/integration/stats/authentication_test.rb
+++ b/test/integration/stats/authentication_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Stats::AuthenticationTest < ActionDispatch::IntegrationTest
@@ -10,18 +12,18 @@ class Stats::AuthenticationTest < ActionDispatch::IntegrationTest
 
   test 'access allowed with authentication' do
     params = { period: 'day', metric_name: 'hits' }
-    get "/stats/services/#{@service.id}/usage.json", params.merge(provider_key: @provider_account.api_key)
+    get "/stats/services/#{@service.id}/usage.json", params: params.merge(provider_key: @provider_account.api_key)
     assert_response :success
     assert_content_type 'application/json'
 
     token = FactoryBot.create(:access_token, owner: @provider_account.first_admin, scopes: ['stats'])
-    get "/stats/services/#{@service.id}/usage.json", params.merge(access_token: token.value)
+    get "/stats/services/#{@service.id}/usage.json", params: params.merge(access_token: token.value)
     assert_response :success
     assert_content_type 'application/json'
   end
 
   test 'access forbidden without authentication' do
-    get "/stats/services/#{@service.id}/usage.json", period: 'day', metric_name: "hits"
+    get "/stats/services/#{@service.id}/usage.json", params: { period: 'day', metric_name: "hits" }
 
     assert_response :forbidden
     assert_content_type 'application/json'
@@ -33,7 +35,7 @@ class Stats::AuthenticationTest < ActionDispatch::IntegrationTest
   # https://3scale.hoptoadapp.com/errors/9899473
   #
   test 'access forbidden without authentication and invalid format' do
-    get "/stats/services/#{@service.id}/usage.INVALID", period: 'day', metric_name: "hits"
+    get "/stats/services/#{@service.id}/usage.INVALID", params: { period: 'day', metric_name: "hits" }
 
     assert_response 403
   end

--- a/test/integration/stats/clients_test.rb
+++ b/test/integration/stats/clients_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Stats::ClientsTest < ActionDispatch::IntegrationTest
@@ -18,7 +20,7 @@ class Stats::ClientsTest < ActionDispatch::IntegrationTest
 
   test 'usage with invalid period' do
     login! @provider_account
-    get "/stats/api/applications/#{@cinstance.id}/usage.json", :period => 'XSScript', :metric_name => @metric.system_name
+    get "/stats/api/applications/#{@cinstance.id}/usage.json", params: { :period => 'XSScript', :metric_name => @metric.system_name }
     assert_response :bad_request
   end
 
@@ -36,7 +38,7 @@ class Stats::ClientsTest < ActionDispatch::IntegrationTest
     login! @provider_account
     @provider_account.update_attribute(:timezone, 'Madrid')
 
-    get "/stats/api/applications/#{@cinstance.id}/usage.json", period:'month', metric_name: @metric.system_name, skip_change: false
+    get "/stats/api/applications/#{@cinstance.id}/usage.json", params: { period:'month', metric_name: @metric.system_name, skip_change: false }
 
     assert_response :success
     assert_content_type 'application/json'
@@ -76,7 +78,7 @@ class Stats::ClientsTest < ActionDispatch::IntegrationTest
     login! @provider_account
     @provider_account.update_attribute(:timezone, 'Madrid')
 
-    get "/stats/api/applications/#{@cinstance.id}/usage_response_code.json", period:'month', response_code: 200
+    get "/stats/api/applications/#{@cinstance.id}/usage_response_code.json", params: { period:'month', response_code: 200 }
 
     assert_response :success
     assert_content_type 'application/json'
@@ -98,7 +100,7 @@ class Stats::ClientsTest < ActionDispatch::IntegrationTest
        "service"=>{"id"=>@cinstance.service_id}},
      "values"=> [0] * 21 + [2] + [0] * 7 + [1, 0]
 
-    get "/stats/api/applications/#{@cinstance.id}/usage_response_code.json", period:'month', response_code: 404
+    get "/stats/api/applications/#{@cinstance.id}/usage_response_code.json", params: { period:'month', response_code: 404 }
 
     assert_response :success
     assert_content_type 'application/json'

--- a/test/integration/stats/data/backend_apis_controller_test.rb
+++ b/test/integration/stats/data/backend_apis_controller_test.rb
@@ -15,7 +15,7 @@ class Stats::Data::BackendApisControllerTest < ActionDispatch::IntegrationTest
   attr_reader :provider, :backend_api, :metric, :access_token
 
   test 'usage_response_code with no data as json' do
-    get usage_stats_data_backend_apis_path(backend_api_id: backend_api.id, format: :json, access_token: access_token.value), stats_params
+    get usage_stats_data_backend_apis_path(backend_api_id: backend_api.id, format: :json, access_token: access_token.value), params: stats_params
 
     assert_response :success
     assert_content_type 'application/json'
@@ -33,17 +33,17 @@ class Stats::Data::BackendApisControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'inexistent source' do
-    get usage_stats_data_backend_apis_path(backend_api_id: 0, format: :json, access_token: access_token.value), stats_params
+    get usage_stats_data_backend_apis_path(backend_api_id: 0, format: :json, access_token: access_token.value), params: stats_params
     assert_response :not_found
   end
 
   test 'user permissions' do
     member_user = FactoryBot.create(:member, account: provider)
     member_access_token  = FactoryBot.create(:access_token, owner: member_user, scopes: ['stats'])
-    get usage_stats_data_backend_apis_path(backend_api_id: backend_api.id, format: :json, access_token: member_access_token.value), stats_params
+    get usage_stats_data_backend_apis_path(backend_api_id: backend_api.id, format: :json, access_token: member_access_token.value), params: stats_params
     assert_response :forbidden
 
-    get usage_stats_data_backend_apis_path(backend_api_id: backend_api.id, format: :json, access_token: access_token.value), stats_params
+    get usage_stats_data_backend_apis_path(backend_api_id: backend_api.id, format: :json, access_token: access_token.value), params: stats_params
     assert_response :success
   end
 

--- a/test/integration/stats/data/base_controller_test.rb
+++ b/test/integration/stats/data/base_controller_test.rb
@@ -18,26 +18,26 @@ class Stats::Data::BaseControllerTest < ActionDispatch::IntegrationTest
     url_params = { service_id: service.id, format: :json, access_token: access_token.value }
     stats_params = { metric_name: metric.system_name, period: 'day', timezone: ActiveSupport::TimeZone['UTC'].name, skip_change: false }
 
-    get usage_stats_data_services_path(url_params), stats_params
+    get usage_stats_data_services_path(url_params), params: stats_params
     assert_response :success
 
-    get usage_stats_data_services_path(url_params), stats_params.except(:metric_name)
+    get usage_stats_data_services_path(url_params), params: stats_params.except(:metric_name)
     assert_response :bad_request
     assert_equal 'Required parameter missing: metric_name', response.body
 
-    get usage_stats_data_services_path(url_params), stats_params.except(:period)
+    get usage_stats_data_services_path(url_params), params: stats_params.except(:period)
     assert_response :bad_request
     assert_equal 'Required parameter missing: granularity', response.body
 
-    get usage_stats_data_services_path(url_params), stats_params.except(:period).merge(granularity: 'hour')
+    get usage_stats_data_services_path(url_params), params: stats_params.except(:period).merge(granularity: 'hour')
     assert_response :bad_request
     assert_equal 'Required parameter missing: since', response.body
 
-    get usage_stats_data_services_path(url_params), stats_params.except(:period).merge(granularity: 'hour', since: '')
+    get usage_stats_data_services_path(url_params), params: stats_params.except(:period).merge(granularity: 'hour', since: '')
     assert_response :bad_request
     assert_equal 'Required parameter missing: since', response.body
 
-    get usage_stats_data_services_path(url_params), stats_params.except(:period).merge(granularity: 'hour', since: Time.utc(2020, 3, 19).to_date, until: Time.utc(2020, 3, 21).to_date)
+    get usage_stats_data_services_path(url_params), params: stats_params.except(:period).merge(granularity: 'hour', since: Time.utc(2020, 3, 19).to_date, until: Time.utc(2020, 3, 21).to_date)
     assert_response :success
 
     # TODO: add a test for the undocumented use case: stats_params.except(:period).merge(granularity: 'hour', range: ?)

--- a/test/integration/stats/data/requests_to_api_test.rb
+++ b/test/integration/stats/data/requests_to_api_test.rb
@@ -24,13 +24,13 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
     params = { period: 'day', metric_name: 'hits', access_token: token.value }
 
     # token includes the right scope, member has the right permission, all services are accessible
-    get "/stats/applications/#{@application.id}/usage.json", params
+    get "/stats/applications/#{@application.id}/usage.json", params: params
     assert_response :success
 
     token.scopes = ['finance']
     token.save!
     # token does not include the right scope
-    get "/stats/applications/#{@application.id}/usage.json", params
+    get "/stats/applications/#{@application.id}/usage.json", params: params
     assert_response :forbidden
 
     token.scopes = ['stats']
@@ -38,19 +38,19 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
     member.admin_sections = []
     member.save!
     # member does not have the right permission
-    get "/stats/applications/#{@application.id}/usage.json", params
+    get "/stats/applications/#{@application.id}/usage.json", params: params
     assert_response :forbidden
 
     member.admin_sections = ['monitoring']
     member.save!
     User.any_instance.expects(:has_access_to_all_services?).returns(false).at_least_once
     # the service is not accessible for the member
-    get "/stats/applications/#{@application.id}/usage.json", params
+    get "/stats/applications/#{@application.id}/usage.json", params: params
     assert_response :forbidden
 
     User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
     # the service is accessible for the member
-    get "/stats/applications/#{@application.id}/usage.json", params
+    get "/stats/applications/#{@application.id}/usage.json", params: params
     assert_response :success
   end
 
@@ -59,7 +59,7 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
     token  = FactoryBot.create(:access_token, owner: member, scopes: ['stats'])
     params = { period: 'day', metric_name: 'hits', access_token: token.value }
 
-    get "/stats/applications/#{@application.id}/summary.json", params
+    get "/stats/applications/#{@application.id}/summary.json", params: params
     assert_response :success
   end
 
@@ -67,21 +67,21 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
 
   test 'respond on json for applications' do
     params = { period: 'day', metric_name: "hits", provider_key: @provider_account.api_key }
-    get "/stats/applications/#{@application.id}/usage.json", params
+    get "/stats/applications/#{@application.id}/usage.json", params: params
     assert_response :success
     assert_content_type 'application/json'
   end
 
   test 'respond on xml for applications' do
     params = { period: 'day', metric_name: "hits", provider_key: @provider_account.api_key }
-    get "/stats/applications/#{@application.id}/usage.xml", params
+    get "/stats/applications/#{@application.id}/usage.xml", params: params
     assert_response :success
     assert_content_type 'application/xml'
   end
 
   test 'not returning change if asked' do
     params = { period: 'day', metric_name: "hits", provider_key: @provider_account.api_key, skip_change: 'false' }
-    get "/stats/applications/#{@application.id}/usage.xml", params
+    get "/stats/applications/#{@application.id}/usage.xml", params: params
     assert_response :success
     assert_content_type 'application/xml'
     refute_match 'change', @response.body
@@ -89,7 +89,7 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
 
   test 'not returning change by default' do
     params = { period: 'day', metric_name: "hits", provider_key: @provider_account.api_key }
-    get "/stats/applications/#{@application.id}/usage.json", params
+    get "/stats/applications/#{@application.id}/usage.json", params: params
     assert_response :success
     refute data['change']
     assert_content_type 'application/json'
@@ -97,7 +97,7 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
 
   test 'returning change if asked' do
     params = { period: 'day', metric_name: "hits", provider_key: @provider_account.api_key, skip_change: 'false' }
-    get "/stats/applications/#{@application.id}/usage.json", params
+    get "/stats/applications/#{@application.id}/usage.json", params: params
     assert_response :success
     assert data['change'], "#{data} should have change key"
     assert_content_type 'application/json'
@@ -105,14 +105,14 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
 
   test 'respond when missing params for applications' do
     params = { period: 'day', provider_key: @provider_account.api_key }
-    get "/stats/applications/#{@application.id}/usage.xml", params
+    get "/stats/applications/#{@application.id}/usage.xml", params: params
     assert_response :bad_request
     assert_content_type 'text/plain'
   end
 
   test 'response when application not found' do
     params = { period: 'day', metric_name: "hits", provider_key: @provider_account.api_key }
-    get "/stats/applications/XXX/usage.json", params
+    get "/stats/applications/XXX/usage.json", params: params
     assert_response :not_found
     assert_content_type 'application/json'
     assert_equal '{"error":"Application not found"}', @response.body
@@ -120,7 +120,7 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
 
   test 'respond when provided with non-existent metric for applications' do
     params = { period: 'day', metric_name: "xxxx", provider_key: @provider_account.api_key }
-    get "/stats/applications/#{@application.id}/usage.json", params
+    get "/stats/applications/#{@application.id}/usage.json", params: params
     assert_response :bad_request
     assert_content_type 'application/json'
     assert_equal '{"error":"metric xxxx not found"}', @response.body
@@ -131,50 +131,50 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
 
   test 'respond on json for services' do
     params = { period: 'day', metric_name: "hits", provider_key: @provider_account.api_key }
-    get "/stats/services/#{@service.id}/usage.json", params
+    get "/stats/services/#{@service.id}/usage.json", params: params
     assert_response :success
     assert_content_type 'application/json'
   end
 
   test 'respond on json for services in negative timezone and very old times' do
     params = { period: 'month', since: '0150-12-01', timezone: 'Pacific Time (US & Canada)', metric_name: "hits", provider_key: @provider_account.api_key }
-    get "/stats/services/#{@service.id}/usage.json", params
+    get "/stats/services/#{@service.id}/usage.json", params: params
     assert_response :success
     assert_content_type 'application/json'
 
     # to trigger the shift > 0 conditions
-    get "/stats/services/#{@service.id}/usage.json", params.merge(timezone: 'New Delhi')
+    get "/stats/services/#{@service.id}/usage.json", params: params.merge(timezone: 'New Delhi')
     assert_response :success
     assert_content_type 'application/json'
 
     # to trigger the granularity == :month condition
-    get "/stats/services/#{@service.id}/usage.json", params.merge(period: 'year')
+    get "/stats/services/#{@service.id}/usage.json", params: params.merge(period: 'year')
     assert_response :success
     assert_content_type 'application/json'
 
     # to trigger both the shift > 0 conditions and granularity == :month
-    get "/stats/services/#{@service.id}/usage.json", params.merge(period: 'year', timezone: 'New Delhi')
+    get "/stats/services/#{@service.id}/usage.json", params: params.merge(period: 'year', timezone: 'New Delhi')
     assert_response :success
     assert_content_type 'application/json'
   end
 
   test 'respond on xml for services' do
     params = { period: 'day', metric_name: "hits", provider_key: @provider_account.api_key }
-    get "/stats/services/#{@service.id}/usage.xml", params
+    get "/stats/services/#{@service.id}/usage.xml", params: params
     assert_response :success
     assert_content_type 'application/xml'
   end
 
   test 'respond when missing params for services' do
     params = { period: 'day', provider_key: @provider_account.api_key }
-    get "/stats/services/#{@service.id}/usage.xml", params
+    get "/stats/services/#{@service.id}/usage.xml", params: params
     assert_response :bad_request
     assert_content_type 'text/plain'
   end
 
   test 'respond when provided with non-existent metric for services' do
     params = { period: 'day', metric_name: "xxxx", provider_key: @provider_account.api_key }
-    get "/stats/services/#{@service.id}/usage.json", params
+    get "/stats/services/#{@service.id}/usage.json", params: params
     assert_response :bad_request
     assert_content_type 'application/json'
     assert_equal '{"error":"metric xxxx not found"}', @response.body
@@ -182,7 +182,7 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
 
   test 'response when service not found' do
     params = { period: 'day', metric_name: "hits", provider_key: @provider_account.api_key }
-    get "/stats/services/XXX/usage.json", params
+    get "/stats/services/XXX/usage.json", params: params
     assert_response :not_found
     assert_content_type 'application/json'
     assert_equal '{"error":"Service not found"}', @response.body

--- a/test/integration/stats/services_test.rb
+++ b/test/integration/stats/services_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Stats::ServicesTest < ActionDispatch::IntegrationTest
@@ -21,7 +23,7 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     @cinstance = FactoryBot.create(:cinstance, :plan => plan)
 
     provider_login_with @provider_account.admins.first.username, 'supersecret'
-    get "/stats/api/services/#{@cinstance.service_id}/usage_response_code.json", period:'day', :response_code => 200, timezone:'Madrid', skip_change: false
+    get "/stats/api/services/#{@cinstance.service_id}/usage_response_code.json", params: { period:'day', :response_code => 200, timezone:'Madrid', skip_change: false }
 
     assert_response :success
     assert_content_type 'application/json'
@@ -46,7 +48,7 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     @cinstance = FactoryBot.create(:cinstance, :plan => plan)
 
     provider_login_with @provider_account.admins.first.username, 'supersecret'
-    get "/stats/api/services/#{@cinstance.service_id}/usage.json", period:'day', :metric_name => @metric.system_name, timezone:'Madrid', skip_change: false
+    get "/stats/api/services/#{@cinstance.service_id}/usage.json", params: { period:'day', :metric_name => @metric.system_name, timezone:'Madrid', skip_change: false }
 
     assert_response :success
     assert_content_type 'application/json'
@@ -81,7 +83,7 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
       @provider_account.update_attribute(:timezone, 'Madrid')
 
       opts = { :period => 'day', :metric_name => @metric.system_name }
-      get "/stats/api/services/#{@cinstance.service_id}/usage.json", opts
+      get "/stats/api/services/#{@cinstance.service_id}/usage.json", params: opts
 
       assert_response :success
       assert_content_type 'application/json'
@@ -97,7 +99,7 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
 
     should 'retrieve data with specified timezone' do
       opts = { :period => 'day', :metric_name => @metric.system_name, :timezone => 'Kamchatka' }
-      get "/stats/api/services/#{@cinstance.service_id}/usage.json", opts
+      get "/stats/api/services/#{@cinstance.service_id}/usage.json", params: opts
 
       assert_response :success
       assert_content_type 'application/json'
@@ -126,7 +128,7 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
 
     Timecop.freeze(Time.utc(2009, 12, 11, 19, 10))
     provider_login_with @provider_account.admins.first.username, 'supersecret'
-    get "/stats/api/services/#{@provider_account.default_service.id}/usage.json", period:'day', metric_name: @metric.system_name, timezone:'UTC', skip_change: false
+    get "/stats/api/services/#{@provider_account.default_service.id}/usage.json", params: { period:'day', metric_name: @metric.system_name, timezone:'UTC', skip_change: false }
 
     assert_response :success
     assert_content_type 'application/json'
@@ -162,7 +164,7 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     make_transaction_at(Time.utc(2011, 01, 01, 23, 21), :cinstance_id => cinstance.id)
 
     provider_login_with @provider_account.admins.first.username, 'supersecret'
-    get "/stats/api/services/#{@provider_account.default_service.id}/usage.json", period: 'year', metric_name: @metric.system_name, timezone: 'Madrid', since: "2010-01-01", skip_change: false
+    get "/stats/api/services/#{@provider_account.default_service.id}/usage.json", params: { period: 'year', metric_name: @metric.system_name, timezone: 'Madrid', since: "2010-01-01", skip_change: false }
 
     assert_response :success
     assert_content_type 'application/json'
@@ -197,7 +199,7 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     make_transaction_at(Time.utc(2011, 01, 01, 01, 21), :cinstance_id => cinstance.id)
 
     provider_login_with @provider_account.admins.first.username, 'supersecret'
-    get "/stats/api/services/#{@provider_account.default_service.id}/usage.json", :period => 'year', :metric_name => @metric.system_name, :timezone => 'Azores', "since"=>"2010-01-01", skip_change: false
+    get "/stats/api/services/#{@provider_account.default_service.id}/usage.json", params: { :period => 'year', :metric_name => @metric.system_name, :timezone => 'Azores', "since"=>"2010-01-01", skip_change: false }
 
     assert_response :success
     assert_content_type 'application/json'
@@ -228,7 +230,7 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
 
     Timecop.freeze(Time.utc(2009, 12, 22))
     provider_login_with @provider_account.admins.first.username, 'supersecret'
-    get "/stats/api/services/#{@provider_account.default_service.id}/top_applications.json", period: :month, metric_name: @metric.system_name
+    get "/stats/api/services/#{@provider_account.default_service.id}/top_applications.json", params: { period: :month, metric_name: @metric.system_name }
 
     assert_response :success
     assert_content_type 'application/json'

--- a/test/integration/user-management-api/account_plan_features_test.rb
+++ b/test/integration/user-management-api/account_plan_features_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::AccountPlanFeaturesTest < ActionDispatch::IntegrationTest
@@ -14,8 +16,7 @@ class Admin::Api::AccountPlanFeaturesTest < ActionDispatch::IntegrationTest
     @account_plan.features << feat
     @account_plan.save!
 
-    get(admin_api_account_plan_features_path(@account_plan.id),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_account_plan_features_path(@account_plan.id), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -25,17 +26,14 @@ class Admin::Api::AccountPlanFeaturesTest < ActionDispatch::IntegrationTest
   end
 
   test 'not found account_plan replies 404' do
-    get(admin_api_account_plan_features_path(0),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_account_plan_features_path(0), params: { :provider_key => @provider.api_key, :format => :xml })
     assert_xml_404
   end
 
   test 'enable new feature' do
     feat = FactoryBot.create :feature, :featurable => @provider
 
-    post(admin_api_account_plan_features_path(@account_plan.id),
-              :feature_id => feat.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_account_plan_features_path(@account_plan.id), params: { :feature_id => feat.id, :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -49,9 +47,7 @@ class Admin::Api::AccountPlanFeaturesTest < ActionDispatch::IntegrationTest
                                      :featurable => FactoryBot.create(:provider_account),
                                      :scope => "AccountPlan")
 
-    post(admin_api_account_plan_features_path(@account_plan.id),
-              :feature_id => feature_not_in_account.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_account_plan_features_path(@account_plan.id), params: { :feature_id => feature_not_in_account.id, :provider_key => @provider.api_key, :format => :xml })
     assert_xml_404
   end
 
@@ -60,9 +56,7 @@ class Admin::Api::AccountPlanFeaturesTest < ActionDispatch::IntegrationTest
   test 'disable feature' do
     feat = FactoryBot.create :feature, :featurable => @provider
 
-    post(admin_api_account_plan_features_path(@account_plan.id),
-              :feature_id => feat.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_account_plan_features_path(@account_plan.id), params: { :feature_id => feat.id, :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 

--- a/test/integration/user-management-api/account_plans_test.rb
+++ b/test/integration/user-management-api/account_plans_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
@@ -23,13 +25,13 @@ class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
 
     # member does not have the plans permission
-    get(admin_api_account_plans_path(format: :xml), access_token: token.value)
+    get(admin_api_account_plans_path(format: :xml), params: { access_token: token.value })
     assert_response :forbidden
 
     user.admin_sections = ['partners', 'plans']
     user.save!
 
-    get(admin_api_account_plans_path(format: :xml), access_token: token.value)
+    get(admin_api_account_plans_path(format: :xml), params: { access_token: token.value })
     assert_response :success
 
     user.admin_sections = []
@@ -37,21 +39,20 @@ class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
     user.save!
 
     # provider admin
-    get(admin_api_account_plans_path(format: :xml), access_token: token.value)
+    get(admin_api_account_plans_path(format: :xml), params: { access_token: token.value })
     assert_response :success
 
     Account.any_instance.expects(:master?).returns(true).at_least_once
 
     # master admin
-    get(admin_api_account_plans_path(format: :xml), access_token: token.value)
+    get(admin_api_account_plans_path(format: :xml), params: { access_token: token.value })
     assert_response :success
   end
 
   # Provider key
 
   test 'index' do
-    get(admin_api_account_plans_path(:format => :xml),
-             :provider_key => @provider.api_key)
+    get(admin_api_account_plans_path(:format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
 
@@ -64,8 +65,7 @@ class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
 
   test 'security wise: index is access denied in buyer side' do
     host! @provider.domain
-    get(admin_api_account_plans_path(:format => :xml),
-             :provider_key => @provider.api_key)
+    get(admin_api_account_plans_path(:format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :forbidden
   end
@@ -74,17 +74,14 @@ class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
     host! @provider.admin_domain
     Account.master.update_attribute :site_access_code, "123456"
 
-    get(admin_api_account_plans_path(:format => :xml),
-             :provider_key => @provider.api_key)
+    get(admin_api_account_plans_path(:format => :xml), params: { :provider_key => @provider.api_key })
 
     assert @response.body =~ /Access code/
   end
 
   test 'show' do
     # admin_account_plan
-    get("/admin/api/account_plans/#{@provider.account_plans.first.id}",
-             :format => :xml,
-             :provider_key => @provider.api_key)
+    get("/admin/api/account_plans/#{@provider.account_plans.first.id}", params: { :format => :xml, :provider_key => @provider.api_key })
 
     assert_response :success
 
@@ -97,10 +94,7 @@ class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
   end
 
   test 'create' do
-    post(admin_api_account_plans_path(:format => :xml),
-              :name => 'awesome account plan',
-              :state_event => 'publish',
-              :provider_key => @provider.api_key)
+    post(admin_api_account_plans_path(:format => :xml), params: { :name => 'awesome account plan', :state_event => 'publish', :provider_key => @provider.api_key })
 
     assert_response :success
 
@@ -115,10 +109,7 @@ class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
   test 'update' do
     plan = FactoryBot.create :account_plan, :issuer => @provider, :name => 'namy'
 
-    put("/admin/api/account_plans/#{plan.id}.xml",
-             :state_event => 'publish',
-             :name => 'new name',
-             :provider_key => @provider.api_key)
+    put("/admin/api/account_plans/#{plan.id}.xml", params: { :state_event => 'publish', :name => 'new name', :provider_key => @provider.api_key })
 
     assert_response :success
 

--- a/test/integration/user-management-api/accounts_test.rb
+++ b/test/integration/user-management-api/accounts_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
@@ -28,7 +30,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     get(admin_api_accounts_path(format: :xml))
     assert_response :forbidden
 
-    get(admin_api_accounts_path(format: :xml), access_token: token.value)
+    get(admin_api_accounts_path(format: :xml), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -36,13 +38,13 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
 
-    get(admin_api_account_path(@buyer, format: :xml), access_token: token.value)
+    get(admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :success
 
     user.admin_sections = []
     user.save!
 
-    get(admin_api_account_path(@buyer, format: :xml), access_token: token.value)
+    get(admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :forbidden
   end
 
@@ -50,16 +52,16 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
 
-    get(find_admin_api_accounts_path(format: :xml), access_token: token.value)
+    get(find_admin_api_accounts_path(format: :xml), params: { access_token: token.value })
     assert_response :not_found
 
-    get(find_admin_api_accounts_path(format: :xml), access_token: token.value, username: @buyer.users.first.username)
+    get(find_admin_api_accounts_path(format: :xml), params: { access_token: token.value, username: @buyer.users.first.username })
     assert_response :success
 
     user.admin_sections = []
     user.save!
 
-    get(find_admin_api_accounts_path(format: :xml), access_token: token.value, username: @buyer.users.first.username)
+    get(find_admin_api_accounts_path(format: :xml), params: { access_token: token.value, username: @buyer.users.first.username })
     assert_response :forbidden
   end
 
@@ -69,18 +71,18 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     # member cannot update an account
     rolling_updates_off
-    put(admin_api_account_path(@buyer, format: :xml), access_token: token.value, org_name: 'alaska')
+    put(admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value, org_name: 'alaska' })
     assert_response :forbidden
 
     # member cann update an account when service_permissions rolling update is enabled
     rolling_update(:service_permissions, enabled: true)
-    put(admin_api_account_path(@buyer, format: :xml), access_token: token.value, org_name: 'alaska')
+    put(admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value, org_name: 'alaska' })
     assert_response :success
 
     user.role = 'admin'
     user.save!
 
-    put(admin_api_account_path(@buyer, format: :xml), access_token: token.value, org_name: 'alaska')
+    put(admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value, org_name: 'alaska' })
     assert_response :success
   end
 
@@ -93,7 +95,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     assert_equal false, settings.monthly_charging_enabled
     assert_equal false, settings.monthly_billing_enabled
 
-    put(admin_api_account_path(@buyer, format: :xml), access_token: token.value, monthly_billing_enabled: true, monthly_charging_enabled: true, org_name: 'ooooooooo')
+    put(admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value, monthly_billing_enabled: true, monthly_charging_enabled: true, org_name: 'ooooooooo' })
 
     settings.reload
     assert_response :success
@@ -106,13 +108,13 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
 
     # member cannot destroy an account
-    delete(admin_api_account_path(format: :xml, id: @buyer.id), access_token: token.value)
+    delete(admin_api_account_path(format: :xml, id: @buyer.id), params: { access_token: token.value })
     assert_response :forbidden
 
     user.role = 'admin'
     user.save!
 
-    delete(admin_api_account_path(format: :xml, id: @buyer.id), access_token: token.value)
+    delete(admin_api_account_path(format: :xml, id: @buyer.id), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -123,18 +125,18 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     # member cannot update an account
     rolling_updates_off
-    put(change_plan_admin_api_account_path(@buyer, format: :xml), access_token: token.value, plan_id: plan.id)
+    put(change_plan_admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value, plan_id: plan.id })
     assert_response :forbidden
 
     # member can update an account when service_permissions rolling update is enabled
     rolling_update(:service_permissions, enabled: true)
-    put(change_plan_admin_api_account_path(@buyer, format: :xml), access_token: token.value, plan_id: plan.id)
+    put(change_plan_admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value, plan_id: plan.id })
     assert_response :success
 
     user.role = 'admin'
     user.save!
 
-    put(change_plan_admin_api_account_path(@buyer, format: :xml), access_token: token.value, plan_id: plan.id)
+    put(change_plan_admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value, plan_id: plan.id })
     assert_response :success
   end
 
@@ -143,26 +145,26 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
 
     # member cannot reject or approve an account
-    put(approve_admin_api_account_path(@buyer, format: :xml), access_token: token.value)
+    put(approve_admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :forbidden
-    put(reject_admin_api_account_path(@buyer, format: :xml), access_token: token.value)
+    put(reject_admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :forbidden
 
     user.role = 'admin'
     user.save!
 
     Account.any_instance.expects(:approve).returns(true)
-    put(approve_admin_api_account_path(@buyer, format: :xml), access_token: token.value)
+    put(approve_admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :success
     Account.any_instance.expects(:reject).returns(true)
-    put(reject_admin_api_account_path(@buyer, format: :xml), access_token: token.value)
+    put(reject_admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :success
   end
 
   # Provider key
 
   test 'index' do
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key)
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key })
 
     assert_response :success
     assert_accounts @response.body
@@ -171,8 +173,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
   test 'pagination is off unless needed' do
     buyers_max = @provider.buyers.count
 
-    get(admin_api_accounts_path(format: :xml),
-             provider_key: @provider.api_key, per_page: (buyers_max +1))
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, per_page: (buyers_max +1) })
 
     assert_response :success
     assert_not_pagination @response.body, "accounts"
@@ -184,7 +185,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     buyers_max = @provider.buyers.count
 
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, per_page: (buyers_max -1))
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, per_page: (buyers_max -1) })
 
     assert_response :success
     assert_pagination @response.body, "accounts"
@@ -196,7 +197,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
     buyer.buy! @provider.default_account_plan
 
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, per_page: (max_per_page +1))
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, per_page: (max_per_page +1) })
 
     assert_response :success
     assert_pagination(@response.body, "accounts", per_page: max_per_page)
@@ -208,7 +209,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     max_per_page = set_api_pagination_max_per_page(to: 1)
 
-    get(admin_api_accounts_path, provider_key: @provider.api_key, page: "invalid")
+    get(admin_api_accounts_path, params: { provider_key: @provider.api_key, page: "invalid" })
 
     assert_response :success
     assert_pagination @response.body, "accounts", current_page: "1"
@@ -220,7 +221,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     max_per_page = set_api_pagination_max_per_page(to: 1)
 
-    get(admin_api_accounts_path, provider_key: @provider.api_key, per_page: "invalid")
+    get(admin_api_accounts_path, params: { provider_key: @provider.api_key, per_page: "invalid" })
 
     assert_response :success
     assert_pagination @response.body, "accounts", per_page: max_per_page
@@ -234,7 +235,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     max_per_page = set_api_pagination_max_per_page(to: 2)
 
-    get(admin_api_accounts_path, provider_key: @provider.api_key, per_page: "-1")
+    get(admin_api_accounts_path, params: { provider_key: @provider.api_key, per_page: "-1" })
 
     assert_response :success
     assert_pagination @response.body, "accounts", per_page: "2"
@@ -247,7 +248,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     @buyer.extra_fields = { some_extra_field: "< > &" }
     @buyer.save
 
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key)
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key })
 
     assert_response :success
     assert_accounts(@response.body, extra_fields: { some_extra_field: '&lt; &gt; &amp;' })
@@ -255,7 +256,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
   test 'security wise: index is access denied in buyer side' do
     host! @provider.domain
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key)
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key })
 
     assert_response :forbidden
   end
@@ -268,7 +269,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     buyer.make_pending!
     assert_equal 'pending', buyer.state # I lol'd
 
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, state: 'approved')
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, state: 'approved' })
 
     assert_response :success
     assert_accounts @response.body, state: 'approved'
@@ -282,7 +283,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
       assert buyer.state == 'pending'
     end
 
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, state: 'pending', per_page: 1, page: 1)
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, state: 'pending', per_page: 1, page: 1 })
 
     assert_response :success
     assert_pagination @response.body, "accounts"
@@ -294,7 +295,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     buyer.make_pending!
     assert buyer.state == 'pending'
 
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, state: 'pending')
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, state: 'pending' })
 
     assert_response :success
     assert_accounts @response.body, state: 'pending'
@@ -306,7 +307,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     buyer.reject!
     assert buyer.state == 'rejected'
 
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, state: 'rejected')
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, state: 'rejected' })
 
     assert_response :success
     assert_accounts @response.body, state: 'rejected'
@@ -328,16 +329,16 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     assert_equal 3, @provider.buyer_users.size
 
-    get(find_admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, username: "#{buyer1.users.first.username}_fake")
+    get(find_admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, username: "#{buyer1.users.first.username}_fake" })
     assert_xml_404
 
-    get(find_admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, user_id: - 1)
+    get(find_admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, user_id: - 1 })
     assert_xml_404
 
-    get(find_admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, email: "#{buyer2.emails.first}_fake")
+    get(find_admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, email: "#{buyer2.emails.first}_fake" })
     assert_xml_404
 
-    get(find_admin_api_accounts_path(format: :xml), provider_key: @provider.api_key)
+    get(find_admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key })
     assert_xml_404
   end
 
@@ -362,28 +363,28 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     assert_equal 3, @provider.buyer_users.size
 
-    get(find_admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, username: buyer1.users.first.username)
+    get(find_admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, username: buyer1.users.first.username })
 
     assert_response :success
     assert_equal @response.body, buyer1.to_xml
 
-    get(find_admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, user_id: buyer1.users.first.id)
+    get(find_admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, user_id: buyer1.users.first.id })
 
     assert_response :success
     assert_equal @response.body, buyer1.to_xml
 
-    get(find_admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, username: "#{buyer1.users.first.username}_fake", email: buyer2.emails.first)
+    get(find_admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, username: "#{buyer1.users.first.username}_fake", email: buyer2.emails.first })
 
     assert_xml_404
 
-    get(find_admin_api_accounts_path(format: :xml), provider_key: @provider.api_key, email: buyer2.emails.first)
+    get(find_admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key, email: buyer2.emails.first })
 
     assert_response :success
     assert_equal @response.body, buyer2.to_xml
   end
 
   test 'show' do
-    get(admin_api_account_path(@buyer, format: :xml), provider_key: @provider.api_key)
+    get(admin_api_account_path(@buyer, format: :xml), params: { provider_key: @provider.api_key })
 
     assert_response :success
     assert_account(@response.body, { created_at: @buyer.created_at.xmlschema, updated_at: @buyer.updated_at.xmlschema })
@@ -397,7 +398,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     @buyer.update_attributes org_legaladdress: "non < > &", country_id: country.id
 
-    get(admin_api_account_path(@buyer, format: :xml), provider_key: @provider.api_key)
+    get(admin_api_account_path(@buyer, format: :xml), params: { provider_key: @provider.api_key })
 
     assert_response :success
     assert_account(@response.body, {org_legaladdress: "non &lt; &gt; &amp;", country: country.name})
@@ -408,7 +409,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     assert @buyer.defined_fields.map(&:name).exclude?(:org_legaladdress)
 
-    get(admin_api_account_path(@buyer, format: :xml), provider_key: @provider.api_key)
+    get(admin_api_account_path(@buyer, format: :xml), params: { provider_key: @provider.api_key })
 
     assert_response :success
     xml = Nokogiri::XML::Document.parse(@response.body)
@@ -416,7 +417,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
   end
 
   test 'update' do
-    put(admin_api_account_path(@buyer, format: :xml), org_name: "updated", provider_key: @provider.api_key)
+    put(admin_api_account_path(@buyer, format: :xml), params: { org_name: "updated", provider_key: @provider.api_key })
 
     assert_response :success
     assert_account(@response.body, { id: @buyer.id, org_name: "updated" })
@@ -428,7 +429,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
   test 'update with extra fields' do
     field_defined(@provider, { target: "Account", "name" => "some_extra_field" })
 
-    put(admin_api_account_path(@buyer, format: :xml), some_extra_field: "stuff", vat_rate: 33, provider_key: @provider.api_key)
+    put(admin_api_account_path(@buyer, format: :xml), params: { some_extra_field: "stuff", vat_rate: 33, provider_key: @provider.api_key })
 
     assert_response :success
     assert_account(@response.body, { id: @buyer.id, extra_fields: { some_extra_field: "stuff" }})
@@ -444,23 +445,23 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     user.save!
 
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
-    put(admin_api_account_path(@buyer, format: :xml), access_token: token.value, org_name: 'alaska', billing_address: 'Calle Napoles 187, Barcelona. Spain')
+    put(admin_api_account_path(@buyer, format: :xml), params: { access_token: token.value, org_name: 'alaska', billing_address: 'Calle Napoles 187, Barcelona. Spain' })
     assert_response :unprocessable_entity
 
     billing_address =  {name: '3scale', address1: 'Calle Napoles 187', city: 'Barcelona', country:  'Spain'}.transform_keys { |k| "billing_address[#{k}]"}
-    put(admin_api_account_path(@buyer, format: :xml), billing_address.merge(access_token: token.value, org_name: 'alaska'))
+    put(admin_api_account_path(@buyer, format: :xml), params: billing_address.merge(access_token: token.value, org_name: 'alaska'))
     assert_response :success
   end
 
   test 'destroy' do
-    delete(admin_api_account_path(format: :xml, id: @buyer.id), provider_key: @provider.api_key)
+    delete(admin_api_account_path(format: :xml, id: @buyer.id), params: { provider_key: @provider.api_key })
 
     assert_response :success
     assert_empty_xml response.body
   end
 
   test 'destroy not found' do
-    delete(admin_api_account_path(format: :xml, id: 0), provider_key: @provider.api_key)
+    delete(admin_api_account_path(format: :xml, id: 0), params: { provider_key: @provider.api_key })
 
     assert_xml_404
   end
@@ -468,7 +469,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
   test 'make_pending' do
     assert @buyer.pending? == false
 
-    put(make_pending_admin_api_account_path(@buyer, format: :xml), provider_key: @provider.api_key)
+    put(make_pending_admin_api_account_path(@buyer, format: :xml), params: { provider_key: @provider.api_key })
 
     assert_response :success
     assert_account(@response.body, { id: @buyer.id, state: "pending" })
@@ -481,7 +482,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     @buyer.make_pending!
     assert @buyer.pending?
 
-    put(approve_admin_api_account_path(@buyer, format: :xml), provider_key: @provider.api_key)
+    put(approve_admin_api_account_path(@buyer, format: :xml), params: { provider_key: @provider.api_key })
 
     assert_response :success
     assert_account(@response.body, { id: @buyer.id, state: "approved" })
@@ -493,7 +494,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
   test 'reject' do
     assert @buyer.rejected? == false
 
-    put(reject_admin_api_account_path(@buyer, format: :xml), provider_key: @provider.api_key)
+    put(reject_admin_api_account_path(@buyer, format: :xml), params: { provider_key: @provider.api_key })
 
     assert_response :success
     assert_account(@response.body, { id: @buyer.id, state: "rejected" })
@@ -509,7 +510,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     Admin::Api::AccountsController.any_instance.expects(:report_traffic)
 
-    get(admin_api_accounts_path(format: :xml), provider_key: @provider.api_key)
+    get(admin_api_accounts_path(format: :xml), params: { provider_key: @provider.api_key })
     assert_response :success
     assert_accounts @response.body
   end

--- a/test/integration/user-management-api/active_docs_test.rb
+++ b/test/integration/user-management-api/active_docs_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::ActiveDocsTest < ActionDispatch::IntegrationTest
@@ -12,21 +14,21 @@ class Admin::Api::ActiveDocsTest < ActionDispatch::IntegrationTest
   end
 
   test 'list active docs as json' do
-    get admin_api_active_docs_path(:format => :json), :provider_key => @provider.api_key
+    get admin_api_active_docs_path(:format => :json), params: { :provider_key => @provider.api_key }
     assert_response :success
 
     assert_equal [@active_doc1, @active_doc2].extend(::ApiDocs::ServicesRepresenter).to_json, response.body
   end
 
   test 'list active docs as xml' do
-    get admin_api_active_docs_path(:format => :xml), :provider_key => @provider.api_key
+    get admin_api_active_docs_path(:format => :xml), params: { :provider_key => @provider.api_key }
     assert_response :success
 
     assert_equal [@active_doc1, @active_doc2].extend(::ApiDocs::ServicesRepresenter).to_xml, response.body
   end
 
   test 'create the json spec' do
-    post admin_api_active_docs_path(:format => :json), :provider_key => @provider.api_key, api_docs_service: { :name => 'test', :system_name => 'test_system_name', :body => '{"basePath":"https://example.com", "apis":[{"zoo":"pop"}]}', :description => 'test1' }
+    post admin_api_active_docs_path(:format => :json), params: { :provider_key => @provider.api_key, api_docs_service: { :name => 'test', :system_name => 'test_system_name', :body => '{"basePath":"https://example.com", "apis":[{"zoo":"pop"}]}', :description => 'test1' } }
 
     assert_response :success
 
@@ -37,7 +39,7 @@ class Admin::Api::ActiveDocsTest < ActionDispatch::IntegrationTest
   end
 
   test 'create the xml spec' do
-    post admin_api_active_docs_path(:format => :xml), :provider_key => @provider.api_key, api_docs_service: { :name => 'test', :system_name => 'test_system_name', :body => '{"basePath":"https://example.com", "apis":[{"zoo":"pop"}]}', :description => 'test1' }
+    post admin_api_active_docs_path(:format => :xml), params: { :provider_key => @provider.api_key, api_docs_service: { :name => 'test', :system_name => 'test_system_name', :body => '{"basePath":"https://example.com", "apis":[{"zoo":"pop"}]}', :description => 'test1' } }
 
     assert_response :success
 
@@ -103,14 +105,14 @@ class Admin::Api::ActiveDocsTest < ActionDispatch::IntegrationTest
   end
 
   test 'delete the json spec' do
-    delete admin_api_active_doc_path(:format => :json, :id => @active_doc1.id), :provider_key => @provider.api_key
+    delete admin_api_active_doc_path(:format => :json, :id => @active_doc1.id), params: { :provider_key => @provider.api_key }
     assert_response :success
 
     assert_raise(ActiveRecord::RecordNotFound){ @active_doc1.reload }
   end
 
   test 'delete the xml spec' do
-    delete admin_api_active_doc_path(:format => :xml, :id => @active_doc1.id), :provider_key => @provider.api_key
+    delete admin_api_active_doc_path(:format => :xml, :id => @active_doc1.id), params: { :provider_key => @provider.api_key }
     assert_response :success
 
     assert_raise(ActiveRecord::RecordNotFound){ @active_doc1.reload }
@@ -133,7 +135,7 @@ class Admin::Api::ActiveDocsTest < ActionDispatch::IntegrationTest
   end
 
   test 'active id not found behaves properly with json' do
-    put admin_api_active_doc_path(:format => :json, :id => 0), :provider_key => @provider.api_key
+    put admin_api_active_doc_path(:format => :json, :id => 0), params: { :provider_key => @provider.api_key }
     assert_response :not_found
     assert_equal @response.body, '{"status":"Not found"}'
     assert_equal @active_doc1.reload.body, '{"basePath":"http://zebra.example.net", "apis":[]}'
@@ -142,7 +144,7 @@ class Admin::Api::ActiveDocsTest < ActionDispatch::IntegrationTest
 
   test 'security wise: active docs is access denied in buyer side' do
     host! @provider.domain
-    get admin_api_active_doc_path(:format => :json, :id => @active_doc1.id), :provider_key => @provider.api_key
+    get admin_api_active_doc_path(:format => :json, :id => @active_doc1.id), params: { :provider_key => @provider.api_key }
     assert_response :forbidden
   end
 

--- a/test/integration/user-management-api/application_plan_features_test.rb
+++ b/test/integration/user-management-api/application_plan_features_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::ApplicationPlanFeaturesTest < ActionDispatch::IntegrationTest
@@ -19,10 +21,10 @@ class Admin::Api::ApplicationPlanFeaturesTest < ActionDispatch::IntegrationTest
 
     get(admin_api_application_plan_features_path(@app_plan))
     assert_response :forbidden
-    get(admin_api_application_plan_features_path(@app_plan), access_token: token.value)
+    get(admin_api_application_plan_features_path(@app_plan), params: { access_token: token.value })
     assert_response :not_found
     User.any_instance.expects(:member_permission_service_ids).returns([@provider.default_service.id]).at_least_once
-    get(admin_api_application_plan_features_path(@app_plan), access_token: token.value)
+    get(admin_api_application_plan_features_path(@app_plan), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -33,8 +35,7 @@ class Admin::Api::ApplicationPlanFeaturesTest < ActionDispatch::IntegrationTest
     @app_plan.features << feat
     @app_plan.save!
 
-    get(admin_api_application_plan_features_path(@app_plan),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_application_plan_features_path(@app_plan), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -44,8 +45,7 @@ class Admin::Api::ApplicationPlanFeaturesTest < ActionDispatch::IntegrationTest
   end
 
   test 'not found application_plan replies 404' do
-    get(admin_api_application_plan_features_path(0),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_application_plan_features_path(0), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_xml_404
   end
@@ -56,9 +56,7 @@ class Admin::Api::ApplicationPlanFeaturesTest < ActionDispatch::IntegrationTest
   test 'enable new feature' do
     feat = FactoryBot.create :feature, :featurable => @provider.default_service
 
-    post(admin_api_application_plan_features_path(@app_plan),
-              :feature_id => feat.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_application_plan_features_path(@app_plan), params: { :feature_id => feat.id, :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -71,9 +69,7 @@ class Admin::Api::ApplicationPlanFeaturesTest < ActionDispatch::IntegrationTest
     feature_not_in_service = FactoryBot.create(:feature, :featurable => @provider,
                                      :scope => "AccountPlan")
 
-    post(admin_api_application_plan_features_path(@app_plan),
-              :feature_id => feature_not_in_service.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_application_plan_features_path(@app_plan), params: { :feature_id => feature_not_in_service.id, :provider_key => @provider.api_key, :format => :xml })
 
     assert_xml_404
   end
@@ -82,9 +78,7 @@ class Admin::Api::ApplicationPlanFeaturesTest < ActionDispatch::IntegrationTest
     wrong_feature = FactoryBot.create(:feature, :featurable => @provider.default_service,
                             :scope => "ServicePlan")
 
-    post(admin_api_application_plan_features_path(@app_plan),
-              :feature_id => wrong_feature.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_application_plan_features_path(@app_plan), params: { :feature_id => wrong_feature.id, :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :unprocessable_entity
     assert_xml_error @response.body, "Plan type mismatch"
@@ -95,9 +89,7 @@ class Admin::Api::ApplicationPlanFeaturesTest < ActionDispatch::IntegrationTest
   test 'disable feature' do
     feat = FactoryBot.create :feature, :featurable => @provider.default_service
 
-    post(admin_api_application_plan_features_path(@app_plan),
-              :feature_id => feat.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_application_plan_features_path(@app_plan), params: { :feature_id => feat.id, :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 

--- a/test/integration/user-management-api/application_plan_limits_test.rb
+++ b/test/integration/user-management-api/application_plan_limits_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::ApplicationPlanLimitsTest < ActionDispatch::IntegrationTest
@@ -21,26 +23,24 @@ class Admin::Api::ApplicationPlanLimitsTest < ActionDispatch::IntegrationTest
 
     get(admin_api_application_plan_limits_path(@app_plan))
     assert_response :forbidden
-    get(admin_api_application_plan_limits_path(@app_plan), access_token: token.value)
+    get(admin_api_application_plan_limits_path(@app_plan), params: { access_token: token.value })
     assert_response :not_found
     User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
-    get(admin_api_application_plan_limits_path(@app_plan), access_token: token.value)
+    get(admin_api_application_plan_limits_path(@app_plan), params: { access_token: token.value })
     assert_response :success
   end
 
   # Provider key
 
   test 'application_plan not found' do
-    get(admin_api_application_plan_limits_path(:application_plan_id => 0),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_application_plan_limits_path(:application_plan_id => 0), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
 
 
   test 'application_plan_limits_index' do
-    get(admin_api_application_plan_limits_path(@app_plan),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_application_plan_limits_path(@app_plan), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 

--- a/test/integration/user-management-api/application_plan_metric_limits_test.rb
+++ b/test/integration/user-management-api/application_plan_metric_limits_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationTest
@@ -20,10 +22,10 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
 
     get(admin_api_application_plan_metric_limits_path(@app_plan, @metric))
     assert_response :forbidden
-    get(admin_api_application_plan_metric_limits_path(@app_plan, @metric), access_token: token.value)
+    get(admin_api_application_plan_metric_limits_path(@app_plan, @metric), params: { access_token: token.value })
     assert_response :not_found
     User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
-    get(admin_api_application_plan_metric_limits_path(@app_plan, @metric), access_token: token.value)
+    get(admin_api_application_plan_metric_limits_path(@app_plan, @metric), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -31,16 +33,14 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
 
   test 'application_plan not found' do
     get(admin_api_application_plan_metric_limits_path(:application_plan_id => 0,
-                                                           :metric_id => @metric.id),
-             :provider_key => @provider.api_key, :format => :xml)
+                                                           :metric_id => @metric.id), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
 
   test 'application metric not found' do
     get(admin_api_application_plan_metric_limits_path(:application_plan_id => @app_plan.id,
-                                                    :metric_id => 0),
-             :provider_key => @provider.api_key, :format => :xml)
+                                                    :metric_id => 0), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
@@ -50,8 +50,7 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
     another_metric = FactoryBot.create :metric, :service => @service
     alien_limit    = FactoryBot.create :usage_limit, :plan => @app_plan, :metric => another_metric
 
-    get(admin_api_application_plan_metric_limits_path(@app_plan, @metric),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_application_plan_metric_limits_path(@app_plan, @metric), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -65,8 +64,7 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
     metric  = FactoryBot.create(:metric, owner: backend)
     FactoryBot.create(:backend_api_config, backend_api: backend, service: @app_plan.service)
 
-    get(admin_api_application_plan_metric_limits_path(@app_plan, metric),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_application_plan_metric_limits_path(@app_plan, metric), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
   end
@@ -75,15 +73,13 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
     backend = FactoryBot.create(:backend_api)
     metric  = FactoryBot.create(:metric, owner: backend)
 
-    get(admin_api_application_plan_metric_limits_path(@app_plan, metric),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_application_plan_metric_limits_path(@app_plan, metric), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
 
   test 'application_plan_metric_limit_show' do
-    get(admin_api_application_plan_metric_limit_path(@app_plan, @metric, @limit),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_application_plan_metric_limit_path(@app_plan, @metric, @limit), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -96,16 +92,13 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
   test 'application_plan_plan_metric show not found' do
     get(admin_api_application_plan_metric_limit_path(:application_plan_id => @app_plan.id,
                                                           :metric_id => @metric.id,
-                                                          :id => 0),
-             :provider_key => @provider.api_key, :format => :xml)
+                                                          :id => 0), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
 
   test 'application_plan_metric create' do
-    post(admin_api_application_plan_metric_limits_path(@app_plan, @metric),
-              :provider_key => @provider.api_key, :format => :xml,
-              :period => 'week', :value => 15)
+    post(admin_api_application_plan_metric_limits_path(@app_plan, @metric), params: { :provider_key => @provider.api_key, :format => :xml, :period => 'week', :value => 15 })
 
     assert_response :success
 
@@ -121,9 +114,7 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
   end
 
   test 'application_plan_metric create errors' do
-    post(admin_api_application_plan_metric_limits_path(@app_plan, @metric),
-              :provider_key => @provider.api_key, :format => :xml,
-              :period => 'a-while')
+    post(admin_api_application_plan_metric_limits_path(@app_plan, @metric), params: { :provider_key => @provider.api_key, :format => :xml, :period => 'a-while' })
 
     assert_response :unprocessable_entity
     assert_xml_error body, "Period is invalid"
@@ -133,9 +124,7 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
     assert @limit.period != "month"
     assert @limit.value  != 20
 
-    put("/admin/api/application_plans/#{@app_plan.id}/metrics/#{@metric.id}/limits/#{@limit.id}",
-             :provider_key => @provider.api_key,
-             :format => :xml, :period => 'month', :value => "20")
+    put("/admin/api/application_plans/#{@app_plan.id}/metrics/#{@metric.id}/limits/#{@limit.id}", params: { :provider_key => @provider.api_key, :format => :xml, :period => 'month', :value => "20" })
 
 
     assert_response :success
@@ -151,16 +140,13 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
   end
 
   test 'application_plan_metrics_limit update not found' do
-    put("/admin/api/application_plans/#{@app_plan.id}/metrics/#{@metric.id}/limits/0",
-             :provider_key => @provider.api_key, :format => :xml)
+    put("/admin/api/application_plans/#{@app_plan.id}/metrics/#{@metric.id}/limits/0", params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
 
   test 'application_plan_metrics_limit update errors' do
-    put("/admin/api/application_plans/#{@app_plan.id}/metrics/#{@metric.id}/limits/#{@limit.id}",
-             :provider_key => @provider.api_key,
-             :format => :xml, :period => 'century')
+    put("/admin/api/application_plans/#{@app_plan.id}/metrics/#{@metric.id}/limits/#{@limit.id}", params: { :provider_key => @provider.api_key, :format => :xml, :period => 'century' })
 
     assert_response :unprocessable_entity
 

--- a/test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
+++ b/test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::ApplicationPlanMetricPricingRulesTest < ActionDispatch::IntegrationTest
@@ -24,10 +26,10 @@ class Admin::Api::ApplicationPlanMetricPricingRulesTest < ActionDispatch::Integr
 
     get(admin_api_application_plan_metric_pricing_rules_path(@app_plan, @metric.id))
     assert_response :forbidden
-    get(admin_api_application_plan_metric_pricing_rules_path(@app_plan, @metric.id), access_token: token.value)
+    get(admin_api_application_plan_metric_pricing_rules_path(@app_plan, @metric.id), params: { access_token: token.value })
     assert_response :not_found
     User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
-    get(admin_api_application_plan_metric_pricing_rules_path(@app_plan, @metric.id), access_token: token.value)
+    get(admin_api_application_plan_metric_pricing_rules_path(@app_plan, @metric.id), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -35,24 +37,21 @@ class Admin::Api::ApplicationPlanMetricPricingRulesTest < ActionDispatch::Integr
 
   test 'application_plan not found' do
     get(admin_api_application_plan_metric_pricing_rules_path(:application_plan_id => 0,
-                                                                  :metric_id => @metric.id),
-             :provider_key => @provider.api_key, :format => :xml)
+                                                                  :metric_id => @metric.id), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
 
   test 'application metric not found' do
     get(admin_api_application_plan_metric_pricing_rules_path(:application_plan_id => @app_plan.id,
-                                                             :metric_id => 0),
-        :provider_key => @provider.api_key, :format => :xml)
+                                                             :metric_id => 0), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
 
   test 'application_plan_metric_pricing_rules_index' do
     get(admin_api_application_plan_metric_pricing_rules_path(:application_plan_id => @app_plan,
-                                                                  :metric_id => @metric.id),
-             :provider_key => @provider.api_key, :format => :xml)
+                                                                  :metric_id => @metric.id), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 

--- a/test/integration/user-management-api/application_plan_pricing_rules_test.rb
+++ b/test/integration/user-management-api/application_plan_pricing_rules_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::ApplicationPlanPricingRulesTest < ActionDispatch::IntegrationTest
@@ -20,25 +22,23 @@ class Admin::Api::ApplicationPlanPricingRulesTest < ActionDispatch::IntegrationT
 
     get(admin_api_application_plan_pricing_rules_path(@app_plan))
     assert_response :forbidden
-    get(admin_api_application_plan_pricing_rules_path(@app_plan), access_token: token.value)
+    get(admin_api_application_plan_pricing_rules_path(@app_plan), params: { access_token: token.value })
     assert_response :not_found
     User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
-    get(admin_api_application_plan_pricing_rules_path(@app_plan), access_token: token.value)
+    get(admin_api_application_plan_pricing_rules_path(@app_plan), params: { access_token: token.value })
     assert_response :success
   end
 
   # Provider key
 
   test 'application_plan not found' do
-    get(admin_api_application_plan_pricing_rules_path(:application_plan_id => 0),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_application_plan_pricing_rules_path(:application_plan_id => 0), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
 
   test 'application_plan_pricing_rules_index' do
-    get(admin_api_application_plan_pricing_rules_path(:application_plan_id => @app_plan),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_application_plan_pricing_rules_path(:application_plan_id => @app_plan), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
     assert_pricing_rules(body, {

--- a/test/integration/user-management-api/application_plans_test.rb
+++ b/test/integration/user-management-api/application_plans_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::ApplicationPlansTest < ActionDispatch::IntegrationTest
@@ -24,10 +26,10 @@ class Admin::Api::ApplicationPlansTest < ActionDispatch::IntegrationTest
 
     get(admin_api_service_application_plans_path(service))
     assert_response :forbidden
-    get(admin_api_service_application_plans_path(service), access_token: token.value)
+    get(admin_api_service_application_plans_path(service), params: { access_token: token.value })
     assert_response :not_found
     User.any_instance.expects(:member_permission_service_ids).returns([service.id]).at_least_once
-    get(admin_api_service_application_plans_path(service), access_token: token.value)
+    get(admin_api_service_application_plans_path(service), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -88,10 +90,7 @@ class Admin::Api::ApplicationPlansTest < ActionDispatch::IntegrationTest
   end
 
   test 'create' do
-    post admin_api_service_application_plans_path(@provider.default_service, format: :xml),
-                                                       :name => 'awesome application plan',
-                                                       :state_event => 'publish',
-                                                       :provider_key => @provider.api_key
+    post admin_api_service_application_plans_path(@provider.default_service, format: :xml), params: { :name => 'awesome application plan', :state_event => 'publish', :provider_key => @provider.api_key }
 
     assert_response :success
 
@@ -107,9 +106,7 @@ class Admin::Api::ApplicationPlansTest < ActionDispatch::IntegrationTest
 
 
   test 'create without name fails' do
-    post admin_api_service_application_plans_path(@provider.default_service, format: :xml),
-                                                       :name => '',
-                                                       :provider_key => @provider.api_key
+    post admin_api_service_application_plans_path(@provider.default_service, format: :xml), params: { :name => '', :provider_key => @provider.api_key }
     assert_equal '422', response.code
   end
 
@@ -117,10 +114,7 @@ class Admin::Api::ApplicationPlansTest < ActionDispatch::IntegrationTest
   test 'update' do
     plan = FactoryBot.create :application_plan, :issuer => @provider.default_service, :name => 'namy'
 
-    put admin_api_service_application_plan_path(@provider.default_service, plan, format: :xml),
-                                                     :state_event => 'publish',
-                                                     :name => 'new name',
-                                                     :provider_key => @provider.api_key
+    put admin_api_service_application_plan_path(@provider.default_service, plan, format: :xml), params: { :state_event => 'publish', :name => 'new name', :provider_key => @provider.api_key }
 
     assert_response :success
 

--- a/test/integration/user-management-api/applications_test.rb
+++ b/test/integration/user-management-api/applications_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
@@ -32,10 +34,10 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
 
     get(admin_api_applications_path)
     assert_response :forbidden
-    get(admin_api_applications_path, access_token: token.value)
+    get(admin_api_applications_path, params: { access_token: token.value })
     assert_response :success
     User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
-    get(admin_api_applications_path, access_token: token.value, service_id: @service.id)
+    get(admin_api_applications_path, params: { access_token: token.value, service_id: @service.id })
     assert_response :success
   end
 
@@ -44,7 +46,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
   test 'index on backend v2' do
     @service.backend_version = '2'
     @service.save!
-    get admin_api_applications_path(:format => :xml), :provider_key => @provider.api_key
+    get admin_api_applications_path(:format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_response :success
     assert_applications @response.body, :backend => "2"
@@ -54,7 +56,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
     @service.backend_version = '1'
     @service.save!
 
-    get admin_api_applications_path(:format => :xml), :provider_key => @provider.api_key
+    get admin_api_applications_path(:format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_response :success
     assert_applications @response.body, :backend => "1"
@@ -64,14 +66,14 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
     @service.backend_version = 'oauth'
     @service.save!
 
-    get admin_api_applications_path(:format => :xml), :provider_key => @provider.api_key
+    get admin_api_applications_path(:format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_response :success
     assert_applications @response.body, :backend => :oauth
   end
 
   test 'pagination is off unless needed' do
-    get admin_api_applications_path(:format => :xml), :provider_key => @provider.api_key
+    get admin_api_applications_path(:format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_response :success
     assert_not_pagination @response.body, "applications"
@@ -86,8 +88,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
     @application_plan.publish!
     buyer.buy! @application_plan
 
-    get(admin_api_applications_path(:format => :xml), :provider_key => @provider.api_key,
-             :per_page => 1)
+    get(admin_api_applications_path(:format => :xml), params: { :provider_key => @provider.api_key, :per_page => 1 })
 
     assert_response :success
     assert_pagination @response.body, "applications"
@@ -100,8 +101,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
 
     max_per_page = set_api_pagination_max_per_page(:to => 1)
 
-    get(admin_api_applications_path(:format => :xml), :provider_key => @provider.api_key,
-             :per_page => (max_per_page +1))
+    get(admin_api_applications_path(:format => :xml), params: { :provider_key => @provider.api_key, :per_page => (max_per_page +1) })
 
     assert_response :success
     assert_pagination @response.body, "applications", :per_page => max_per_page
@@ -114,7 +114,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
 
     max_per_page = set_api_pagination_max_per_page(:to => 1)
 
-    get(admin_api_applications_path(:format => :xml), :provider_key => @provider.api_key, :page => "invalid")
+    get(admin_api_applications_path(:format => :xml), params: { :provider_key => @provider.api_key, :page => "invalid" })
 
     assert_response :success
     assert_pagination @response.body, "applications", :current_page => "1"
@@ -127,7 +127,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
 
     max_per_page = set_api_pagination_max_per_page(:to => 1)
 
-    get(admin_api_applications_path(:format => :xml), :provider_key => @provider.api_key, :per_page => "invalid")
+    get(admin_api_applications_path(:format => :xml), params: { :provider_key => @provider.api_key, :per_page => "invalid" })
 
     assert_response :success
     assert_pagination @response.body, "applications", :per_page => max_per_page
@@ -141,7 +141,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
 
     max_per_page = set_api_pagination_max_per_page(:to => 2)
 
-    get(admin_api_applications_path(:format => :xml), :provider_key => @provider.api_key, :per_page => "-1")
+    get(admin_api_applications_path(:format => :xml), params: { :provider_key => @provider.api_key, :per_page => "-1" })
 
     assert_response :success
     assert_pagination @response.body, "applications", :per_page => "2"
@@ -156,9 +156,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
     end
 
     should 'return 404 on non found app' do
-      get(find_admin_api_applications_path(:format => :xml),
-               :user_key => "SHAWARMA",
-               :provider_key => @provider.api_key)
+      get(find_admin_api_applications_path(:format => :xml), params: { :user_key => "SHAWARMA", :provider_key => @provider.api_key })
 
       assert_xml_404
     end
@@ -167,9 +165,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
       @service.backend_version = '1'
       @service.save!
 
-      get(find_admin_api_applications_path(:format => :xml),
-               :user_key => @application.user_key,
-               :provider_key => @provider.api_key)
+      get(find_admin_api_applications_path(:format => :xml), params: { :user_key => @application.user_key, :provider_key => @provider.api_key })
 
       assert_response :success
       assert_application(@response.body,
@@ -181,9 +177,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
       @service.backend_version = '2'
       @service.save!
 
-      get(find_admin_api_applications_path(:format => :xml),
-               :app_id => @application.application_id,
-               :provider_key => @provider.api_key)
+      get(find_admin_api_applications_path(:format => :xml), params: { :app_id => @application.application_id, :provider_key => @provider.api_key })
 
       assert_response :success
       assert_application(@response.body,
@@ -196,9 +190,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
       @service.backend_version = 'oauth'
       @service.save!
 
-      get(find_admin_api_applications_path(:format => :xml),
-               :app_id => @application.application_id,
-               :provider_key => @provider.api_key)
+      get(find_admin_api_applications_path(:format => :xml), params: { :app_id => @application.application_id, :provider_key => @provider.api_key })
 
       assert_response :success
       assert_application(@response.body,
@@ -213,9 +205,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
       @service.backend_version = 'oidc'
       @service.save!
 
-      get(find_admin_api_applications_path(:format => :xml),
-          :app_id => @application.application_id,
-          :provider_key => @provider.api_key)
+      get(find_admin_api_applications_path(:format => :xml), params: { :app_id => @application.application_id, :provider_key => @provider.api_key })
 
       assert_response :success
       assert_application(@response.body,
@@ -232,9 +222,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
       config.service_accounts_enabled = true
       config.save!
 
-      get(find_admin_api_applications_path(:format => :json),
-          :app_id => @application.application_id,
-          :provider_key => @provider.api_key)
+      get(find_admin_api_applications_path(:format => :json), params: { :app_id => @application.application_id, :provider_key => @provider.api_key })
 
       assert_response :success
 
@@ -249,9 +237,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
       @service.backend_version = 'oauth'
       @service.save!
 
-      get(find_admin_api_applications_path(:format => :xml),
-               :application_id => @application.id,
-               :provider_key => @provider.api_key)
+      get(find_admin_api_applications_path(:format => :xml), params: { :application_id => @application.id, :provider_key => @provider.api_key })
 
       assert_response :success
       assert_application(@response.body,
@@ -262,9 +248,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
       @service.backend_version = '2'
       @service.save!
 
-      get(find_admin_api_applications_path(:format => :xml),
-               :application_id => @application.id,
-               :provider_key => @provider.api_key)
+      get(find_admin_api_applications_path(:format => :xml), params: { :application_id => @application.id, :provider_key => @provider.api_key })
 
       assert_response :success
       assert_application(@response.body,
@@ -275,9 +259,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
       @service.backend_version = '1'
       @service.save!
 
-      get(find_admin_api_applications_path(:format => :xml),
-               :application_id => @application.id,
-               :provider_key => @provider.api_key)
+      get(find_admin_api_applications_path(:format => :xml), params: { :application_id => @application.id, :provider_key => @provider.api_key })
 
       assert_response :success
       assert_application(@response.body,
@@ -291,7 +273,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
 
   test 'security wise: applications is access denied in buyer side' do
     host! @provider.domain
-    get admin_api_applications_path(:format => :xml), :provider_key => @provider.api_key
+    get admin_api_applications_path(:format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_response :forbidden
   end

--- a/test/integration/user-management-api/buyers_account_plans_test.rb
+++ b/test/integration/user-management-api/buyers_account_plans_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::BuyerAccountPlansTest < ActionDispatch::IntegrationTest
@@ -14,7 +16,7 @@ class Admin::Api::BuyerAccountPlansTest < ActionDispatch::IntegrationTest
   end
 
   test 'account plans listing' do
-    get admin_api_account_buyer_account_plan_path(:account_id => @buyer.id, :format => :xml), :provider_key => @provider.api_key
+    get admin_api_account_buyer_account_plan_path(:account_id => @buyer.id, :format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_response :success
 
@@ -30,13 +32,13 @@ class Admin::Api::BuyerAccountPlansTest < ActionDispatch::IntegrationTest
   end
 
   test 'account plans for an inexistent buyer replies 404' do
-    get admin_api_account_buyer_account_plan_path(0, :format => :xml), :provider_key => @provider.api_key
+    get admin_api_account_buyer_account_plan_path(0, :format => :xml), params: { :provider_key => @provider.api_key }
     assert_xml_404
   end
 
   test 'security wise: buyers account plans is access denied in buyer side' do
     host! @provider.domain
-    get admin_api_account_buyer_account_plan_path(@buyer, :format => :xml), :provider_key => @provider.api_key
+    get admin_api_account_buyer_account_plan_path(@buyer, :format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_response :forbidden
   end

--- a/test/integration/user-management-api/buyers_application_keys_test.rb
+++ b/test/integration/user-management-api/buyers_application_keys_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::BuyersApplicationKeysTest < ActionDispatch::IntegrationTest
@@ -29,10 +31,10 @@ class Admin::Api::BuyersApplicationKeysTest < ActionDispatch::IntegrationTest
 
     post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'))
     assert_response :forbidden
-    post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'), access_token: token.value)
+    post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'), params: { access_token: token.value })
     assert_response :not_found
     User.any_instance.expects(:member_permission_service_ids).returns([app.issuer.id]).at_least_once
-    post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'), access_token: token.value)
+    post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -44,8 +46,7 @@ class Admin::Api::BuyersApplicationKeysTest < ActionDispatch::IntegrationTest
 
     post(admin_api_account_application_keys_path(@buyer, application,
                                                       :key => new_key,
-                                                      :format => :xml),
-              :provider_key => @provider.api_key)
+                                                      :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_application(body,
@@ -61,8 +62,7 @@ class Admin::Api::BuyersApplicationKeysTest < ActionDispatch::IntegrationTest
 
     post(admin_api_account_application_keys_path(@buyer, application,
                                                       :key => key,
-                                                      :format => :xml),
-              :provider_key => @provider.api_key)
+                                                      :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_application(@response.body,
@@ -100,9 +100,7 @@ class Admin::Api::BuyersApplicationKeysTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
 
-    delete(admin_api_account_application_key_path(@buyer.id, application.id, rm_key),
-                :provider_key => @provider.api_key,
-                :format => :xml)
+    delete(admin_api_account_application_key_path(@buyer.id, application.id, rm_key), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 

--- a/test/integration/user-management-api/buyers_application_plans_test.rb
+++ b/test/integration/user-management-api/buyers_application_plans_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::BuyersApplicationPlansTest < ActionDispatch::IntegrationTest
@@ -58,7 +60,7 @@ class Admin::Api::BuyersApplicationPlansTest < ActionDispatch::IntegrationTest
   end
 
   test 'index for an inexistent account replies 404' do
-    get admin_api_account_application_plans_path(0, :format => :xml), :provider_key => @provider.api_key
+    get admin_api_account_application_plans_path(0, :format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_xml_404
   end
@@ -74,9 +76,7 @@ class Admin::Api::BuyersApplicationPlansTest < ActionDispatch::IntegrationTest
   test 'buy' do
     app_plan = FactoryBot.create :application_plan, :issuer => @provider.default_service
 
-    post("/admin/api/accounts/#{@buyer.id}/application_plans/#{app_plan.id}/buy",
-              :provider_key => @provider.api_key,
-              :format => :xml, :name => "name", :description => "description")
+    post("/admin/api/accounts/#{@buyer.id}/application_plans/#{app_plan.id}/buy", params: { :provider_key => @provider.api_key, :format => :xml, :name => "name", :description => "description" })
 
     assert_response :success
     assert @buyer.reload.bought_cinstances.detect{|c| c.plan_id == app_plan.id}
@@ -95,9 +95,7 @@ class Admin::Api::BuyersApplicationPlansTest < ActionDispatch::IntegrationTest
 
     @buyer.buy! app_plan, {:name => "name1", :description => "description1"}
 
-    post("/admin/api/accounts/#{@buyer.id}/application_plans/#{app_plan.id}/buy",
-              :provider_key => @provider.api_key,
-              :format => :xml, :name => "name2", :description => "description2")
+    post("/admin/api/accounts/#{@buyer.id}/application_plans/#{app_plan.id}/buy", params: { :provider_key => @provider.api_key, :format => :xml, :name => "name2", :description => "description2" })
 
     assert_response :success
     assert_equal 2, @buyer.reload.bought_cinstances.select{|c| c.plan_id == app_plan.id}.size
@@ -114,9 +112,7 @@ class Admin::Api::BuyersApplicationPlansTest < ActionDispatch::IntegrationTest
     app_plan = FactoryBot.create :application_plan, :issuer => @provider.default_service
     custom_plan = app_plan.customize
 
-    post("/admin/api/accounts/#{@buyer.id}/application_plans/#{custom_plan.id}/buy",
-              :provider_key => @provider.api_key,
-              :format => :xml, :name => "name", :description => "desc")
+    post("/admin/api/accounts/#{@buyer.id}/application_plans/#{custom_plan.id}/buy", params: { :provider_key => @provider.api_key, :format => :xml, :name => "name", :description => "desc" })
 
     assert_xml_404
   end

--- a/test/integration/user-management-api/buyers_application_referrer_filters_test.rb
+++ b/test/integration/user-management-api/buyers_application_referrer_filters_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::BuyersApplicationReferrerFiltersTest < ActionDispatch::IntegrationTest
@@ -27,10 +29,10 @@ class Admin::Api::BuyersApplicationReferrerFiltersTest < ActionDispatch::Integra
 
     get(admin_api_account_application_referrer_filters_path(@buyer, app))
     assert_response :forbidden
-    get(admin_api_account_application_referrer_filters_path(@buyer, app), access_token: token.value)
+    get(admin_api_account_application_referrer_filters_path(@buyer, app), params: { access_token: token.value })
     assert_response :not_found
     User.any_instance.expects(:member_permission_service_ids).returns([app.issuer.id]).at_least_once
-    get(admin_api_account_application_referrer_filters_path(@buyer, app), access_token: token.value)
+    get(admin_api_account_application_referrer_filters_path(@buyer, app), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -42,7 +44,7 @@ class Admin::Api::BuyersApplicationReferrerFiltersTest < ActionDispatch::Integra
     referrer = 'foo.example.org'
     expect_backend_create_referrer_filter(application, referrer)
 
-    post(admin_api_account_application_referrer_filters_path(@buyer, application, :referrer_filter => referrer, :format => :xml), :provider_key => @provider.api_key)
+    post(admin_api_account_application_referrer_filters_path(@buyer, application, :referrer_filter => referrer, :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_application(response.body, { :id => application.id, "referrer_filters/referrer_filter" => referrer })
@@ -60,8 +62,7 @@ class Admin::Api::BuyersApplicationReferrerFiltersTest < ActionDispatch::Integra
     expect_backend_create_referrer_filter(application, referrer)
     filter = application.referrer_filters.add(referrer)
 
-    delete(admin_api_account_application_referrer_filter_path(@buyer.id, application.id, filter.id),
-                :provider_key => @provider.api_key, :format => :xml)
+    delete(admin_api_account_application_referrer_filter_path(@buyer.id, application.id, filter.id), params: { :provider_key => @provider.api_key, :format => :xml })
     assert_response :success
   end
 
@@ -82,8 +83,7 @@ class Admin::Api::BuyersApplicationReferrerFiltersTest < ActionDispatch::Integra
     #delete(admin_api_account_application_referrer_filter_path(@buyer.id, application.id, referrer, :format => :xml),
     #            :provider_key => @provider.api_key, :method => "_destroy")
 
-    delete("/admin/api/accounts/#{@buyer.id}/applications/#{application.id}/referrer_filters/#{filter.id}.xml",
-              :provider_key => @provider.api_key, :format => :xml)
+    delete("/admin/api/accounts/#{@buyer.id}/applications/#{application.id}/referrer_filters/#{filter.id}.xml", params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
   end
@@ -101,12 +101,10 @@ class Admin::Api::BuyersApplicationReferrerFiltersTest < ActionDispatch::Integra
     expect_backend_create_referrer_filter(application, referrer)
     filter = application.referrer_filters.add(referrer)
 
-    delete(admin_api_account_application_referrer_filter_path(@buyer.id, application.id, filter.id + 1),
-                :provider_key => @provider.api_key, :format => :xml)
+    delete(admin_api_account_application_referrer_filter_path(@buyer.id, application.id, filter.id + 1), params: { :provider_key => @provider.api_key, :format => :xml })
     assert_response :not_found
 
-    delete(admin_api_account_application_referrer_filter_path(@buyer.id, application.id, filter.id),
-                :provider_key => @provider.api_key, :format => :xml)
+    delete(admin_api_account_application_referrer_filter_path(@buyer.id, application.id, filter.id), params: { :provider_key => @provider.api_key, :format => :xml })
     assert_response :success
 
   end

--- a/test/integration/user-management-api/buyers_applications_test.rb
+++ b/test/integration/user-management-api/buyers_applications_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
@@ -29,7 +31,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
   end
 
   test 'index' do
-    get admin_api_account_applications_path(@buyer, :format => :xml), :provider_key => @provider.api_key
+    get admin_api_account_applications_path(@buyer, :format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_response :success
 
@@ -54,9 +56,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     assert @buyer.bought_cinstances.find_by_plan_id(suspend_plan.id).suspended?
 
     [:pending, :live, :suspended].each do |state|
-      get(admin_api_account_applications_path(@buyer, :format => :xml),
-               :state => state,
-               :provider_key => @provider.api_key)
+      get(admin_api_account_applications_path(@buyer, :format => :xml), params: { :state => state, :provider_key => @provider.api_key })
 
       assert_response :success
 
@@ -69,7 +69,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
 
   test 'security wise: buyers applications is access denied in buyer side' do
     host! @provider.domain
-    get admin_api_account_applications_path(@buyer, :format => :xml), :provider_key => @provider.api_key
+    get admin_api_account_applications_path(@buyer, :format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_response :forbidden
   end
@@ -77,7 +77,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
   test 'show' do
     application = @buyer.bought_cinstances.last
 
-    get(admin_api_account_application_path(@buyer, :id => application.id, :format => :xml), :provider_key => @provider.api_key)
+    get(admin_api_account_application_path(@buyer, :id => application.id, :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
 
@@ -92,7 +92,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     application = @buyer.bought_cinstances.last
     application.update_attributes :name => "tomatoes < > &", :description => "rotten < > &"
 
-    get(admin_api_account_application_path(@buyer, :id => application.id, :format => :xml), :provider_key => @provider.api_key)
+    get(admin_api_account_application_path(@buyer, :id => application.id, :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
 
@@ -103,7 +103,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     application = @buyer.bought_cinstances.last
     application.update_attributes :name => "CoinBase", :description => "Mining bitcoins in your screesaver like a boss"
 
-    get(admin_api_account_application_path(@buyer, :id => application.id, :format => :json), :provider_key => @provider.api_key)
+    get(admin_api_account_application_path(@buyer, :id => application.id, :format => :json), params: { :provider_key => @provider.api_key })
 
     assert_response :success
 
@@ -119,7 +119,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     app.extra_fields = { :some_extra_field => "< > &" }
     app.save
 
-    get(admin_api_account_application_path(@buyer, :id => app.id, :format => :xml), :provider_key => @provider.api_key)
+    get(admin_api_account_application_path(@buyer, :id => app.id, :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_application(response.body, :extra_fields => { :some_extra_field => '&lt; &gt; &amp;' })
@@ -133,7 +133,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     app.extra_fields = { "mind-control" => "", "spiciness_level" => "Habanero" }
     app.save
 
-    get(admin_api_account_application_path(@buyer, id: app.id, format: :json), provider_key: @provider.api_key)
+    get(admin_api_account_application_path(@buyer, id: app.id, format: :json), params: { provider_key: @provider.api_key })
 
     assert_response :success
 
@@ -150,7 +150,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     expect_backend_create_referrer_filter(application, "foo.example.org")
     application.referrer_filters.add('foo.example.org')
 
-    get(admin_api_account_application_path(@buyer, :id => application.id, :format => :xml), :provider_key => @provider.api_key)
+    get(admin_api_account_application_path(@buyer, :id => application.id, :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_application(response.body, { :id => application.id, "referrer_filters/referrer_filter" => "foo.example.org" })
@@ -163,7 +163,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     stub_backend_referrer_filters("foo.example.org")
     expect_backend_create_referrer_filter(application, "foo.example.org")
 
-    post(admin_api_account_application_referrer_filters_path(@buyer, application, :referrer_filter => "foo.example.org", :format => :xml), :provider_key => @provider.api_key)
+    post(admin_api_account_application_referrer_filters_path(@buyer, application, :referrer_filter => "foo.example.org", :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_application(response.body, { :id => application.id, "referrer_filters/referrer_filter" => "foo.example.org" })
@@ -176,7 +176,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     end
 
     should 'return 404 on non found app' do
-      get(find_admin_api_account_applications_path(@buyer.id, :format => :xml), :user_key => "SHAWARMA", :provider_key => @provider.api_key)
+      get(find_admin_api_account_applications_path(@buyer.id, :format => :xml), params: { :user_key => "SHAWARMA", :provider_key => @provider.api_key })
       assert_xml_404
     end
 
@@ -185,9 +185,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
       @service.save!
 
       get(find_admin_api_account_applications_path(@buyer.id,
-                                                   :format => :xml),
-                                                   :user_key => @application.user_key,
-                                                   :provider_key => @provider.api_key)
+                                                   :format => :xml), params: { :user_key => @application.user_key, :provider_key => @provider.api_key })
 
       assert_response :success
       assert_application(@response.body,
@@ -201,9 +199,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
       @service.save!
 
       get(find_admin_api_account_applications_path(@buyer.id,
-                                                   :format => :xml),
-                                                   :app_id => @application.application_id,
-                                                   :provider_key => @provider.api_key)
+                                                   :format => :xml), params: { :app_id => @application.application_id, :provider_key => @provider.api_key })
 
       assert_response :success
       assert_application(@response.body,
@@ -217,9 +213,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
       @service.save!
 
       get(find_admin_api_account_applications_path(@buyer.id,
-                                                   :format => :xml),
-                                                   :app_id => @application.application_id,
-                                                   :provider_key => @provider.api_key)
+                                                   :format => :xml), params: { :app_id => @application.application_id, :provider_key => @provider.api_key })
 
       assert_response :success
       assert_application(@response.body,
@@ -232,10 +226,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
 
   test 'create' do
     post(admin_api_account_applications_path(@buyer,
-                                             :format => :xml),
-                                             :plan_id => @hidden_app_plan.id,
-                                             :name => "chucky", :description => "rocks awesome",
-                                             :provider_key => @provider.api_key)
+                                             :format => :xml), params: { :plan_id => @hidden_app_plan.id, :name => "chucky", :description => "rocks awesome", :provider_key => @provider.api_key })
 
     assert_response :success
     assert_application(response.body, { :name => "chucky",
@@ -251,10 +242,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     @buyer.bought_service_contracts.map &:destroy
 
     post(admin_api_account_applications_path(@buyer,
-                                             :format => :xml),
-                                             :plan_id => @hidden_app_plan.id,
-                                             :name => "chucky", :description => "rocks awesome",
-                                             :provider_key => @provider.api_key)
+                                             :format => :xml), params: { :plan_id => @hidden_app_plan.id, :name => "chucky", :description => "rocks awesome", :provider_key => @provider.api_key })
 
     assert_response :success
     assert_application(response.body, { :name => "chucky",
@@ -270,10 +258,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     @service.update_attribute(:backend_version, '2')
 
     post(admin_api_account_applications_path(@buyer,
-                                             :format => :xml),
-                                             :plan_id => @hidden_app_plan.id,
-                                             :name => "chucky", :description => "rocks awesome", :application_id => "superawesomeid",
-                                             :provider_key => @provider.api_key)
+                                             :format => :xml), params: { :plan_id => @hidden_app_plan.id, :name => "chucky", :description => "rocks awesome", :application_id => "superawesomeid", :provider_key => @provider.api_key })
 
     assert_response :success
     assert_application(response.body, { :name => "chucky",
@@ -293,12 +278,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
                   { :target => "Cinstance", "name" => "some_other_extra_field" })
 
     post(admin_api_account_applications_path(@buyer,
-                                             :format => :xml),
-                                             :plan_id => @hidden_app_plan.id,
-                                             :name => "extra app", :description => "extra app",
-                                             "some_extra_field" => 'extra value',
-                                             "some_other_extra_field" => 'other extra value',
-                                             :provider_key => @provider.api_key)
+                                             :format => :xml), params: { :plan_id => @hidden_app_plan.id, :name => "extra app", :description => "extra app", "some_extra_field" => 'extra value', "some_other_extra_field" => 'other extra value', :provider_key => @provider.api_key })
 
     extra_fields = {
       "some_extra_field" => 'extra value',
@@ -316,8 +296,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
 
   test 'update' do
     app = @buyer.bought_cinstances.last
-    put(admin_api_account_application_path(@buyer, id: app.id, format: :xml), name: "descriptive",
-        provider_key: @provider.api_key, redirect_url: 'http://example.com')
+    put(admin_api_account_application_path(@buyer, id: app.id, format: :xml), params: { name: "descriptive", provider_key: @provider.api_key, redirect_url: 'http://example.com' })
 
     assert_response :success
     assert_application response.body, { :name => "descriptive" }
@@ -335,8 +314,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     key = "k"*256
 
     put(admin_api_account_application_path(@buyer, :id => app.id,
-                                           :format => :xml),
-                                           :user_key => key, :provider_key => @provider.api_key)
+                                           :format => :xml), params: { :user_key => key, :provider_key => @provider.api_key })
 
     assert_response :success
 
@@ -357,8 +335,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
       "some_other_extra_field" => 'other extra value'}
 
       app = @buyer.bought_cinstances.last
-      put(admin_api_account_application_path(@buyer, :id => app.id, :format => :xml),
-          extra_fields.merge(:provider_key => @provider.api_key))
+      put(admin_api_account_application_path(@buyer, :id => app.id, :format => :xml), params: extra_fields.merge(:provider_key => @provider.api_key))
 
       assert_response :success
       assert_application(response.body, :extra_fields => extra_fields)
@@ -372,9 +349,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     plan = application.plan
 
     assert_difference plan.method(:contracts_count), -1 do
-      put(customize_plan_admin_api_account_application_path(@buyer, application),
-          provider_key: @provider.api_key,
-          format: :xml)
+      put(customize_plan_admin_api_account_application_path(@buyer, application), params: { provider_key: @provider.api_key, format: :xml })
 
       assert_response :success
       plan.reload
@@ -398,9 +373,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     original = plan.original.reload
 
     assert_difference original.method(:contracts_count), +1 do
-      put(decustomize_plan_admin_api_account_application_path(@buyer, application),
-          provider_key: @provider.api_key,
-          format: :xml)
+      put(decustomize_plan_admin_api_account_application_path(@buyer, application), params: { provider_key: @provider.api_key, format: :xml })
       assert_response :success
       original.reload
     end

--- a/test/integration/user-management-api/buyers_service_plans_test.rb
+++ b/test/integration/user-management-api/buyers_service_plans_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::BuyersServicePlansTest < ActionDispatch::IntegrationTest
@@ -34,7 +36,7 @@ class Admin::Api::BuyersServicePlansTest < ActionDispatch::IntegrationTest
   end
 
   test 'index for an inexistent account replies 404' do
-    get admin_api_account_service_plans_path(0, :format => :xml), :provider_key => @provider.api_key
+    get admin_api_account_service_plans_path(0, :format => :xml), params: { :provider_key => @provider.api_key }
 
     assert_xml_404
   end
@@ -51,9 +53,7 @@ class Admin::Api::BuyersServicePlansTest < ActionDispatch::IntegrationTest
     service = FactoryBot.create(:service, account: @provider)
     service_plan = FactoryBot.create(:service_plan, :issuer => service)
 
-    post("/admin/api/accounts/#{@buyer.id}/service_plans/#{service_plan.id}/buy",
-              :provider_key => @provider.api_key,
-              :format => :xml)
+    post("/admin/api/accounts/#{@buyer.id}/service_plans/#{service_plan.id}/buy", params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -68,9 +68,7 @@ class Admin::Api::BuyersServicePlansTest < ActionDispatch::IntegrationTest
   test 'buy an already subscribed service' do
     service_plan = FactoryBot.create(:service_plan, :issuer => @provider.first_service!)
 
-    post("/admin/api/accounts/#{@buyer.id}/service_plans/#{service_plan.id}/buy",
-              :provider_key => @provider.api_key,
-              :format => :xml)
+    post("/admin/api/accounts/#{@buyer.id}/service_plans/#{service_plan.id}/buy", params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response 422
     assert_match 'already subscribed to this service', @response.body
@@ -81,9 +79,7 @@ class Admin::Api::BuyersServicePlansTest < ActionDispatch::IntegrationTest
     service_plan = FactoryBot.create(:service_plan, :issuer => service)
 
     assert service_plan.hidden?
-    post("/admin/api/accounts/#{@buyer.id}/service_plans/#{service_plan.id}/buy",
-              :provider_key => @provider.api_key,
-              :format => :xml)
+    post("/admin/api/accounts/#{@buyer.id}/service_plans/#{service_plan.id}/buy", params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
   end
@@ -93,9 +89,7 @@ class Admin::Api::BuyersServicePlansTest < ActionDispatch::IntegrationTest
     service_plan = FactoryBot.create(:service_plan, :issuer => service)
     custom_plan = service_plan.customize
 
-    post("/admin/api/accounts/#{@buyer.id}/service_plans/#{custom_plan.id}/buy",
-              :provider_key => @provider.api_key,
-              :format => :xml)
+    post("/admin/api/accounts/#{@buyer.id}/service_plans/#{custom_plan.id}/buy", params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_xml_404
   end

--- a/test/integration/user-management-api/buyers_users_test.rb
+++ b/test/integration/user-management-api/buyers_users_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # TODO: Split this file as it takes too long.
@@ -34,8 +36,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
       User.any_instance.expects(:forget_me).never
 
-      post(admin_api_account_users_path(@buyer, format: :xml),
-           username: 'alex', email: 'alex@alaska.hu', access_token: token.value)
+      post(admin_api_account_users_path(@buyer, format: :xml), params: { username: 'alex', email: 'alex@alaska.hu', access_token: token.value })
       assert_response :success
     end
   end
@@ -47,17 +48,17 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider)
     token = FactoryBot.create(:access_token, owner: user)
 
-    get(admin_api_account_users_path(@buyer, format: :xml), access_token: token.value)
+    get(admin_api_account_users_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :forbidden
 
     user.admin_sections = ['partners']
     user.save!
-    get(admin_api_account_users_path(@buyer, format: :xml), access_token: token.value)
+    get(admin_api_account_users_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :forbidden
 
     token.scopes = ['account_management']
     token.save!
-    get(admin_api_account_users_path(@buyer, format: :xml), access_token: token.value)
+    get(admin_api_account_users_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -66,12 +67,12 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
-    get(admin_api_account_user_path(@buyer, id: @member.id, format: :xml), access_token: token.value)
+    get(admin_api_account_user_path(@buyer, id: @member.id, format: :xml), params: { access_token: token.value })
     assert_response :success
 
     user.role = 'admin'
     user.save!
-    get(admin_api_account_user_path(@buyer, id: @member.id, format: :xml), access_token: token.value)
+    get(admin_api_account_user_path(@buyer, id: @member.id, format: :xml), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -80,14 +81,12 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
-    put(admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'Alex', access_token: token.value)
+    put(admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'Alex', access_token: token.value })
     assert_response :success
 
     user.role = 'admin'
     user.save!
-    put(admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'Alex', access_token: token.value)
+    put(admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'Alex', access_token: token.value })
     assert_response :success
   end
 
@@ -96,14 +95,12 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
-    post(admin_api_account_users_path(@buyer, format: :xml),
-           username: 'alex', email: 'alex@alaska.hu', access_token: token.value)
+    post(admin_api_account_users_path(@buyer, format: :xml), params: { username: 'alex', email: 'alex@alaska.hu', access_token: token.value })
     assert_response :forbidden
 
     user.role = 'admin'
     user.save!
-    post(admin_api_account_users_path(@buyer, format: :xml),
-           username: 'alex', email: 'alex@alaska.hu', access_token: token.value)
+    post(admin_api_account_users_path(@buyer, format: :xml), params: { username: 'alex', email: 'alex@alaska.hu', access_token: token.value })
     assert_response :success
   end
 
@@ -112,20 +109,16 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
-    put(admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
-    put(activate_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(activate_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
 
     user.role = 'admin'
     user.save!
-    put(admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
-    put(activate_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(activate_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
   end
 
@@ -134,20 +127,16 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
-    put(admin_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(admin_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
-    put(member_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(member_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
 
     user.role = 'admin'
     user.save!
-    put(admin_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(admin_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
-    put(member_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(member_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
   end
 
@@ -157,13 +146,13 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
     User.any_instance.expects(:destroy).returns(true)
-    delete(admin_api_account_user_path(@buyer, format: :xml, id: @member.id), access_token: token.value)
+    delete(admin_api_account_user_path(@buyer, format: :xml, id: @member.id), params: { access_token: token.value })
     assert_response :success
 
     user.role = 'admin'
     user.save!
     User.any_instance.expects(:destroy).returns(true)
-    delete(admin_api_account_user_path(@buyer, format: :xml, id: @member.id), access_token: token.value)
+    delete(admin_api_account_user_path(@buyer, format: :xml, id: @member.id), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -173,23 +162,19 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
     User.any_instance.expects(:suspend!).returns(true)
-    put(suspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(suspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
     User.any_instance.expects(:unsuspend).returns(true)
-    put(unsuspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(unsuspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
 
     user.role = 'admin'
     user.save!
     User.any_instance.expects(:suspend!).returns(true)
-    put(suspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(suspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
     User.any_instance.expects(:unsuspend).returns(true)
-    put(unsuspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml),
-          username: 'alex', access_token: token.value)
+    put(unsuspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value })
     assert_response :success
   end
 
@@ -202,15 +187,13 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     other_buyer.buy! other_provider.account_plans.first
 
     get(admin_api_account_users_path(:account_id => other_buyer.id,
-                                          :format => :xml),
-             :provider_key => @provider.api_key)
+                                          :format => :xml), params: { :provider_key => @provider.api_key })
     assert_xml_404
   end
 
   test 'index' do
     get(admin_api_account_users_path(:account_id => @buyer.id,
-                                          :format => :xml),
-             :provider_key => @provider.api_key)
+                                          :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_users @response.body, { :account_id => @buyer.id }
@@ -219,8 +202,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
   #TODO: dry these roles tests
   test 'admins' do
     get(admin_api_account_users_path(:account_id => @buyer.id,
-                                          :format => :xml),
-             :provider_key => @provider.api_key, :role => 'admin')
+                                          :format => :xml), params: { :provider_key => @provider.api_key, :role => 'admin' })
 
     assert_response :success
     assert_users @response.body, { :account_id => @buyer.id, :role => "admin" }
@@ -228,8 +210,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'members' do
     get(admin_api_account_users_path(:account_id => @buyer.id,
-                                          :format => :xml),
-             :provider_key => @provider.api_key, :role => 'member')
+                                          :format => :xml), params: { :provider_key => @provider.api_key, :role => 'member' })
 
     assert_response :success
     assert_users @response.body, { :account_id => @buyer.id, :role => "member" }
@@ -238,8 +219,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
   #TODO: dry these states tests
   test 'actives' do
     get(admin_api_account_users_path(:account_id => @buyer.id,
-                                          :format => :xml),
-             :provider_key => @provider.api_key, :state => 'active')
+                                          :format => :xml), params: { :provider_key => @provider.api_key, :state => 'active' })
 
     assert_response :success
     assert_users @response.body, { :account_id => @buyer.id, :state => "active" }
@@ -247,8 +227,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'pendings' do
     get(admin_api_account_users_path(:account_id => @buyer.id,
-                                          :format => :xml),
-             :provider_key => @provider.api_key, :state => 'pending')
+                                          :format => :xml), params: { :provider_key => @provider.api_key, :state => 'pending' })
 
     assert_response :success
     assert_users @response.body, { :account_id => @buyer.id, :state => "pending" }
@@ -260,8 +239,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     chuck.suspend!
 
     get(admin_api_account_users_path(:account_id => @buyer.id,
-                                          :format => :xml),
-             :provider_key => @provider.api_key, :state => 'suspended')
+                                          :format => :xml), params: { :provider_key => @provider.api_key, :state => 'suspended' })
 
     assert_response :success
     assert_users @response.body, {:account_id => @buyer.id, :state => "suspended"}
@@ -269,8 +247,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'invalid role' do
     get(admin_api_account_users_path(:account_id => @buyer.id,
-                                          :format => :xml),
-             :provider_key => @provider.api_key, :role => 'invalid')
+                                          :format => :xml), params: { :provider_key => @provider.api_key, :role => 'invalid' })
 
     assert_response :success
 
@@ -281,10 +258,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'create defaults is pending member' do
     post(admin_api_account_users_path(:account_id => @buyer.id,
-                                           :format => :xml),
-              :username => 'chuck',
-              :email => 'chuck@norris.us',
-              :provider_key => @provider.api_key)
+                                           :format => :xml), params: { :username => 'chuck', :email => 'chuck@norris.us', :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body,
@@ -298,10 +272,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
   test "create sends no email" do
     assert_no_change :of => -> { ActionMailer::Base.deliveries.count } do
       post(admin_api_account_users_path(:account_id => @buyer.id,
-                                             :format => :xml),
-                :username => 'chuck',
-                :email => 'chuck@norris.us',
-                :provider_key => @provider.api_key)
+                                             :format => :xml), params: { :username => 'chuck', :email => 'chuck@norris.us', :provider_key => @provider.api_key })
     end
 
     assert_response :success
@@ -309,10 +280,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'create does not creates admins nor active users' do
     post(admin_api_account_users_path(:account_id => @buyer.id,
-                                           :format => :xml),
-              :username => 'chuck', :role => "admin",
-              :email => 'chuck@norris.us', :state => "active",
-              :provider_key => @provider.api_key)
+                                           :format => :xml), params: { :username => 'chuck', :role => "admin", :email => 'chuck@norris.us', :state => "active", :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body,
@@ -326,11 +294,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'create also sets user password' do
     post(admin_api_account_users_path(:account_id => @buyer.id,
-                                           :format => :xml),
-              :username => 'chuck', :email => 'chuck@norris.us',
-              :password => "posted-password",
-              :password_confirmation => "posted-password",
-              :provider_key => @provider.api_key)
+                                           :format => :xml), params: { :username => 'chuck', :email => 'chuck@norris.us', :password => "posted-password", :password_confirmation => "posted-password", :provider_key => @provider.api_key })
 
     chuck = User.last
     assert chuck.authenticate("posted-password")
@@ -342,11 +306,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
                   { :target => "User", "name" => "some_extra_field" })
 
     post(admin_api_account_users_path(:account_id => @buyer.id,
-                                          :format => :xml),
-              :username => 'chuck',
-              :email => 'chuck@norris.us',
-              :some_extra_field => "extra value",
-              :provider_key => @provider.api_key)
+                                          :format => :xml), params: { :username => 'chuck', :email => 'chuck@norris.us', :some_extra_field => "extra value", :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body,
@@ -359,9 +319,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'create errors' do
     post(admin_api_account_users_path(:account_id => @buyer.id,
-                                           :format => :xml),
-              :username => 'chuck', :role => "admin",
-              :provider_key => @provider.api_key)
+                                           :format => :xml), params: { :username => 'chuck', :role => "admin", :provider_key => @provider.api_key })
 
     assert_response :unprocessable_entity
     assert_xml_error @response.body, "Email should look like an email address"
@@ -369,8 +327,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'show' do
     get(admin_api_account_user_path(:account_id => @buyer.id,
-                                         :format => :xml, :id => @member.id),
-             :provider_key => @provider.api_key)
+                                         :format => :xml, :id => @member.id), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user @response.body, { :account_id => @buyer.id, :role => "member" }
@@ -378,8 +335,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'show user not found' do
     get(admin_api_account_user_path(:account_id => @buyer.id,
-                                         :format => :xml, :id => 0),
-             :provider_key => @provider.api_key)
+                                         :format => :xml, :id => 0), params: { :provider_key => @provider.api_key })
     assert_xml_404
   end
 
@@ -393,8 +349,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
                               :last_name => "last non < > &")
 
     get(admin_api_account_user_path(:account_id => @buyer.id,
-                                         :format => :xml, :id => @member.id),
-             :provider_key => @provider.api_key)
+                                         :format => :xml, :id => @member.id), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body,
@@ -408,8 +363,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     assert @member.defined_fields.map(&:name).exclude?(:title)
 
     get(admin_api_account_user_path(:account_id => @buyer.id,
-                                         :format => :xml, :id => @member.id),
-             :provider_key => @provider.api_key)
+                                         :format => :xml, :id => @member.id), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     xml = Nokogiri::XML::Document.parse(@response.body)
@@ -422,9 +376,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     assert chuck.member?
 
     put(admin_api_account_user_path(:account_id => @buyer.id,
-                                         :format => :xml, :id => chuck.id),
-             :username => 'chuck', :role => "admin", :state => "active",
-             :provider_key => @provider.api_key)
+                                         :format => :xml, :id => chuck.id), params: { :username => 'chuck', :role => "admin", :state => "active", :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body,
@@ -445,8 +397,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     put(admin_api_account_user_path(:account_id => @buyer.id,
                                          :format => :xml, :id => chuck.id,
                                          :password => "updated-password",
-                                         :password_confirmation => "updated-password"),
-             :provider_key => @provider.api_key)
+                                         :password_confirmation => "updated-password"), params: { :provider_key => @provider.api_key })
 
     chuck.reload
     assert_response :success
@@ -460,8 +411,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     chuck = FactoryBot.create :user, :account => @buyer, :role => "member"
     put(admin_api_account_user_path(:account_id => @buyer.id,
                                          :format => :xml, :id => chuck.id,
-                                         :some_extra_field => "extra value" ),
-             :provider_key => @provider.api_key)
+                                         :some_extra_field => "extra value" ), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body, { :account_id => @buyer.id,
@@ -473,22 +423,19 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'update not found' do
     put(admin_api_account_user_path(:account_id => @buyer.id,
-                                         :format => :xml, :id => 0),
-             :provider_key => @provider.api_key)
+                                         :format => :xml, :id => 0), params: { :provider_key => @provider.api_key })
     assert_xml_404
   end
 
   test 'destroy' do
     delete(admin_api_account_user_path(:account_id => @buyer.id,
-                                            :format => :xml, :id => @member.id),
-                :provider_key => @provider.api_key)
+                                            :format => :xml, :id => @member.id), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_empty_xml @response.body
 
     delete(admin_api_account_user_path(:account_id => @buyer.id,
-                                       :format => :xml, :id => @buyer.users.first.id),
-           :provider_key => @provider.api_key)
+                                       :format => :xml, :id => @buyer.users.first.id), params: { :provider_key => @provider.api_key })
 
     assert_response :forbidden, "last buyer's user should not be deleteable"
     assert_xml_error @response.body, 'last admin'
@@ -496,8 +443,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   test 'destroy not found' do
     delete(admin_api_account_user_path(:account_id => @buyer.id,
-                                            :format => :xml, :id => 0),
-                :provider_key => @provider.api_key)
+                                            :format => :xml, :id => 0), params: { :provider_key => @provider.api_key })
     assert_xml_404
   end
 

--- a/test/integration/user-management-api/credit_cards_test.rb
+++ b/test/integration/user-management-api/credit_cards_test.rb
@@ -30,13 +30,13 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['finance'])
     token = FactoryBot.create(:access_token, owner: user, scopes: 'finance')
 
-    put(admin_api_account_credit_card_path(@buyer, format: :xml), valid_params(token))
+    put(admin_api_account_credit_card_path(@buyer, format: :xml), params: valid_params(token))
     assert_response :success
 
     user.admin_sections = []
     user.save!
 
-    put(admin_api_account_credit_card_path(@buyer, format: :xml), valid_params(token))
+    put(admin_api_account_credit_card_path(@buyer, format: :xml), params: valid_params(token))
     assert_response :forbidden
 
     user.admin_sections = ['finance']
@@ -44,7 +44,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     token.scopes = ['cms']
     token.save!
 
-    put(admin_api_account_credit_card_path(@buyer, format: :xml), valid_params(token))
+    put(admin_api_account_credit_card_path(@buyer, format: :xml), params: valid_params(token))
     assert_response :forbidden
   end
 
@@ -52,13 +52,13 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['finance'])
     token = FactoryBot.create(:access_token, owner: user, scopes: 'finance')
 
-    delete(admin_api_account_credit_card_path(@buyer, format: :xml), access_token: token.value)
+    delete(admin_api_account_credit_card_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :success
 
     user.role = 'admin'
     user.save!
 
-    delete(admin_api_account_credit_card_path(@buyer, format: :xml), access_token: token.value)
+    delete(admin_api_account_credit_card_path(@buyer, format: :xml), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -67,8 +67,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
   test 'credit_card_stored is false if buyer has no cc' do
     @provider.update!(payment_gateway_type: :bogus)
 
-    get(admin_api_account_path(@buyer, :format => :xml),
-             :provider_key => @provider.api_key)
+    get(admin_api_account_path(@buyer, :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
 
@@ -81,8 +80,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
 
     @buyer.credit_card_auth_code = 'foo'
     @buyer.save!
-    get(admin_api_account_path(@buyer, :format => :xml),
-             :provider_key => @provider.api_key)
+    get(admin_api_account_path(@buyer, :format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
 
@@ -96,8 +94,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     @provider.save!
     @provider.reload
 
-    put(admin_api_account_credit_card_path(@buyer, :format => :xml),
-             :provider_key => @provider.api_key)
+    put(admin_api_account_credit_card_path(@buyer, :format => :xml), params: { :provider_key => @provider.api_key })
     @buyer.reload
     assert !@buyer.credit_card_stored?
   end
@@ -108,16 +105,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     @provider.save!
     @provider.reload
 
-    put(admin_api_account_credit_card_path(@buyer, :format => :xml),
-             :credit_card_token => 'secret',
-             :credit_card_partial_number => '1234',
-             :billing_address_name => 'foo',
-             :billing_address_address => 'elm street',
-             :billing_address_city => 'sin city',
-             :billing_address_country => 'spain',
-             :credit_card_expiration_year => '2013',
-             :credit_card_expiration_month => '13',
-             :provider_key => @provider.api_key)
+    put(admin_api_account_credit_card_path(@buyer, :format => :xml), params: { :credit_card_token => 'secret', :credit_card_partial_number => '1234', :billing_address_name => 'foo', :billing_address_address => 'elm street', :billing_address_city => 'sin city', :billing_address_country => 'spain', :credit_card_expiration_year => '2013', :credit_card_expiration_month => '13', :provider_key => @provider.api_key })
 
     assert_response :unprocessable_entity
 
@@ -131,16 +119,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     @provider.save!
     @provider.reload
 
-    put(admin_api_account_credit_card_path(@buyer, :format => :xml),
-             :credit_card_token => 'secret',
-             :credit_card_partial_number => '1234',
-             :billing_address_name => 'foo',
-             :billing_address_address => ' ',
-             :billing_address_city => 'sin city',
-             :billing_address_country => 'spain',
-             :credit_card_expiration_year => '2013',
-             :credit_card_expiration_month => '13',
-             :provider_key => @provider.api_key)
+    put(admin_api_account_credit_card_path(@buyer, :format => :xml), params: { :credit_card_token => 'secret', :credit_card_partial_number => '1234', :billing_address_name => 'foo', :billing_address_address => ' ', :billing_address_city => 'sin city', :billing_address_country => 'spain', :credit_card_expiration_year => '2013', :credit_card_expiration_month => '13', :provider_key => @provider.api_key })
 
     assert_response :unprocessable_entity
 
@@ -153,8 +132,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     assert !@buyer.credit_card_stored?
     @provider.update_attribute(:payment_gateway_type, :authorize_net) # to prevent ActiveRecord::RecordInvalid since the payment gateway has been deprecated
     @provider.reload
-    put(admin_api_account_credit_card_path(@buyer, :format => :xml), :credit_card_token => 'fdsa',
-             :provider_key => @provider.api_key)
+    put(admin_api_account_credit_card_path(@buyer, :format => :xml), params: { :credit_card_token => 'fdsa', :provider_key => @provider.api_key })
 
     @buyer.reload
     assert_response :unprocessable_entity
@@ -167,16 +145,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     @provider.save!
     @provider.reload
 
-    put(admin_api_account_credit_card_path(@buyer, :format => :xml),
-             :credit_card_token => 'secret',
-             :credit_card_partial_number => '1234',
-             :billing_address_name => 'foo',
-             :billing_address_address => 'elm street',
-             :billing_address_city => 'sin city',
-             :billing_address_country => 'spain',
-             :credit_card_expiration_year => '2013',
-             :credit_card_expiration_month => '12',
-             :provider_key => @provider.api_key)
+    put(admin_api_account_credit_card_path(@buyer, :format => :xml), params: { :credit_card_token => 'secret', :credit_card_partial_number => '1234', :billing_address_name => 'foo', :billing_address_address => 'elm street', :billing_address_city => 'sin city', :billing_address_country => 'spain', :credit_card_expiration_year => '2013', :credit_card_expiration_month => '12', :provider_key => @provider.api_key })
     @buyer.reload
 
     assert @buyer.credit_card_stored?
@@ -194,17 +163,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     @provider.update_attribute(:payment_gateway_type, :authorize_net) # to prevent ActiveRecord::RecordInvalid since the payment gateway has been deprecated
     @provider.reload
 
-    put(admin_api_account_credit_card_path(@buyer, :format => :xml),
-             :credit_card_token => 'secret',
-             :credit_card_authorize_net_payment_profile_token => 'cctoken',
-             :credit_card_partial_number => '1234',
-             :billing_address_name => 'foo',
-             :billing_address_address => 'elm street',
-             :billing_address_city => 'sin city',
-             :billing_address_country => 'spain',
-             :credit_card_expiration_year => '2013',
-             :credit_card_expiration_month => '12',
-             :provider_key => @provider.api_key)
+    put(admin_api_account_credit_card_path(@buyer, :format => :xml), params: { :credit_card_token => 'secret', :credit_card_authorize_net_payment_profile_token => 'cctoken', :credit_card_partial_number => '1234', :billing_address_name => 'foo', :billing_address_address => 'elm street', :billing_address_city => 'sin city', :billing_address_country => 'spain', :credit_card_expiration_year => '2013', :credit_card_expiration_month => '12', :provider_key => @provider.api_key })
     @buyer.reload
 
     assert @buyer.credit_card_stored?
@@ -224,7 +183,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     FactoryBot.create(:payment_detail, account: @buyer)
     assert @buyer.reload.credit_card_stored?
 
-    delete(admin_api_account_credit_card_path(@buyer, :format => :xml), :provider_key => @provider.api_key)
+    delete(admin_api_account_credit_card_path(@buyer, :format => :xml), params: { :provider_key => @provider.api_key })
     @buyer.reload
 
     assert !@buyer.credit_card_stored?

--- a/test/integration/user-management-api/messages_test.rb
+++ b/test/integration/user-management-api/messages_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: utf-8
 require 'test_helper'
 
@@ -11,14 +13,14 @@ class Admin::Api::MessagesTest < ActionDispatch::IntegrationTest
   end
 
   test 'create' do
-    post(admin_api_account_messages_path(@buyer, format: :json), message: { body: "Lluís Companys is calling" }, provider_key: @provider.api_key)
+    post(admin_api_account_messages_path(@buyer, format: :json), params: { message: { body: "Lluís Companys is calling" }, provider_key: @provider.api_key })
 
     assert_response :success
     assert_equal 'sent', JSON.parse(@response.body)['message']['state']
   end
 
   test "create with string 'message' returns 422" do
-    post(admin_api_account_messages_path(@buyer, format: :xml), message: "text-inline", provider_key: @provider.api_key)
+    post(admin_api_account_messages_path(@buyer, format: :xml), params: { message: "text-inline", provider_key: @provider.api_key })
 
     assert_response 422
   end
@@ -32,7 +34,7 @@ class Admin::Api::MessagesTest < ActionDispatch::IntegrationTest
   # this test is not a good idea. but anyway...
   test 'security: access denied in buyer side' do
     host! @provider.domain
-    get admin_api_account_applications_path(@buyer, format: :xml), provider_key: @provider.api_key
+    get admin_api_account_applications_path(@buyer, format: :xml), params: { provider_key: @provider.api_key }
 
     assert_response :forbidden
   end

--- a/test/integration/user-management-api/nginx_test.rb
+++ b/test/integration/user-management-api/nginx_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::NginxTest < ActionDispatch::IntegrationTest
@@ -16,21 +18,21 @@ class Admin::Api::NginxTest < ActionDispatch::IntegrationTest
   end
 
   test 'spec' do
-    get spec_path, { provider_key: @provider.provider_key }
+    get spec_path, params: { provider_key: @provider.provider_key }
     assert_response :success
     assert_equal("application/json", @response.content_type)
     assert_not_nil @response.body
   end
 
   test 'spec with wrong provider_key' do
-    get spec_path, { provider_key: (0...8).map { (65 + rand(26)).chr }.join }
+    get spec_path, params: { provider_key: (0...8).map { (65 + rand(26)).chr }.join }
     assert_response :forbidden
   end
 
   test 'renders 404 on premises' do
     ThreeScale.config.stubs(apicast_custom_url: true)
 
-    get spec_path, { provider_key: @provider.provider_key }
+    get spec_path, params: { provider_key: @provider.provider_key }
 
     assert_response :not_found
   end

--- a/test/integration/user-management-api/policies_test.rb
+++ b/test/integration/user-management-api/policies_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::PoliciesTest < ActionDispatch::IntegrationTest
@@ -11,7 +13,7 @@ class Admin::Api::PoliciesTest < ActionDispatch::IntegrationTest
   def test_index
     rolling_updates_on
     Policies::PoliciesListService.expects(:call).with(@provider).returns("{\"cors\":[{\"schema\":\"1\"}]}")
-    get admin_api_policies_path(format: :json), provider_key: @provider.api_key
+    get admin_api_policies_path(format: :json), params: { provider_key: @provider.api_key }
     assert_match "{\"cors\":[{\"schema\":\"1\"}]}", response.body
   end
 end

--- a/test/integration/user-management-api/provider_features_test.rb
+++ b/test/integration/user-management-api/provider_features_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EnterpriseApiProviderFeaturesTest < ActionDispatch::IntegrationTest
@@ -11,9 +13,7 @@ class EnterpriseApiProviderFeaturesTest < ActionDispatch::IntegrationTest
   test 'index' do
     FactoryBot.create :feature, :featurable => @provider
 
-    get(admin_api_features_path,
-             :provider_key => @provider.api_key,
-             :format => :xml)
+    get(admin_api_features_path, params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -25,8 +25,7 @@ class EnterpriseApiProviderFeaturesTest < ActionDispatch::IntegrationTest
   test 'show' do
     feature = FactoryBot.create :feature, :featurable => @provider
 
-    get(admin_api_feature_path(feature),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_feature_path(feature), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -38,9 +37,7 @@ class EnterpriseApiProviderFeaturesTest < ActionDispatch::IntegrationTest
   end
 
   test 'create' do
-    post(admin_api_features_path,
-              :provider_key => @provider.api_key, :format => :xml,
-              :name => 'example', :system_name => 'system_example')
+    post(admin_api_features_path, params: { :provider_key => @provider.api_key, :format => :xml, :name => 'example', :system_name => 'system_example' })
 
     assert_response :success
 
@@ -63,9 +60,7 @@ class EnterpriseApiProviderFeaturesTest < ActionDispatch::IntegrationTest
     feature = FactoryBot.create(:feature, :featurable => @provider,
                       :name => 'old name', :system_name => 'old_system_name')
 
-    put("/admin/api/features/#{feature.id}",
-             :provider_key => @provider.api_key, :format => :xml,
-             :name => 'new name', :system_name => 'new_system_name')
+    put("/admin/api/features/#{feature.id}", params: { :provider_key => @provider.api_key, :format => :xml, :name => 'new name', :system_name => 'new_system_name' })
 
     assert_response :success
 

--- a/test/integration/user-management-api/providers_test.rb
+++ b/test/integration/user-management-api/providers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::ProvidersTest < ActionDispatch::IntegrationTest
@@ -9,7 +11,7 @@ class Admin::Api::ProvidersTest < ActionDispatch::IntegrationTest
   end
 
   test 'get to show' do
-    get admin_api_provider_path(format: :json), provider_key: @provider.api_key
+    get admin_api_provider_path(format: :json), params: { provider_key: @provider.api_key }
 
     assert_response :success
 
@@ -20,8 +22,7 @@ class Admin::Api::ProvidersTest < ActionDispatch::IntegrationTest
   end
 
   test 'update support emails test' do
-    put admin_api_provider_path(format: :json), provider_key: @provider.api_key, from_email: 'from@op.pl',
-                                  support_email: 'supsup@ssup.pl', finance_support_email: 'fino@op.pl'
+    put admin_api_provider_path(format: :json), params: { provider_key: @provider.api_key, from_email: 'from@op.pl', support_email: 'supsup@ssup.pl', finance_support_email: 'fino@op.pl' }
 
     assert_response :success
     @provider.reload

--- a/test/integration/user-management-api/service_features_test.rb
+++ b/test/integration/user-management-api/service_features_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
@@ -20,10 +22,10 @@ class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
 
     get(admin_api_service_feature_path(@service, feature))
     assert_response :forbidden
-    get(admin_api_service_feature_path(@service, feature), access_token: token.value)
+    get(admin_api_service_feature_path(@service, feature), params: { access_token: token.value })
     assert_response :not_found
     User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
-    get(admin_api_service_feature_path(@service, feature), access_token: token.value)
+    get(admin_api_service_feature_path(@service, feature), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -33,8 +35,7 @@ class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
     service = FactoryBot.create :service, :account => @provider
     FactoryBot.create :feature, :featurable => service
 
-    get(admin_api_service_features_path(service),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_features_path(service), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -46,8 +47,7 @@ class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
   test 'show' do
     feature = FactoryBot.create :feature, :featurable => @service
 
-    get(admin_api_service_feature_path(@service, feature),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_feature_path(@service, feature), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -60,9 +60,7 @@ class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
   end
 
   test 'create' do
-    post(admin_api_service_features_path(@service),
-              :provider_key => @provider.api_key, :format => :xml,
-              :name => 'example', :system_name => 'system_example')
+    post(admin_api_service_features_path(@service), params: { :provider_key => @provider.api_key, :format => :xml, :name => 'example', :system_name => 'system_example' })
 
     assert_response :success
 
@@ -81,9 +79,7 @@ class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
   end
 
   test 'create with scope == service_account' do
-    post(admin_api_service_features_path(@service),
-              :provider_key => @provider.api_key, :format => :xml,
-              :scope => 'ServicePlan')
+    post(admin_api_service_features_path(@service), params: { :provider_key => @provider.api_key, :format => :xml, :scope => 'ServicePlan' })
 
     assert_response :success
 
@@ -97,9 +93,7 @@ class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
   end
 
   test 'create with wrong scope' do
-    post(admin_api_service_features_path(@service),
-              :provider_key => @provider.api_key, :format => :xml,
-              :scope => 'AccountPlan')
+    post(admin_api_service_features_path(@service), params: { :provider_key => @provider.api_key, :format => :xml, :scope => 'AccountPlan' })
 
     assert_response :unprocessable_entity
     assert_xml_error @response.body, "Scope"
@@ -112,9 +106,7 @@ class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
     feature = FactoryBot.create(:feature, :featurable => @service,
                       :name => 'old name', :system_name => 'old_system_name')
 
-    put("/admin/api/services/#{@service.id}/features/#{feature.id}",
-             :provider_key => @provider.api_key, :format => :xml,
-             :name => 'new name', :system_name => 'new_system_name')
+    put("/admin/api/services/#{@service.id}/features/#{feature.id}", params: { :provider_key => @provider.api_key, :format => :xml, :name => 'new name', :system_name => 'new_system_name' })
 
     assert_response :success
 

--- a/test/integration/user-management-api/service_metric_methods_test.rb
+++ b/test/integration/user-management-api/service_metric_methods_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::ServiceMetricMethodsTest < ActionDispatch::IntegrationTest
@@ -14,14 +16,12 @@ class Admin::Api::ServiceMetricMethodsTest < ActionDispatch::IntegrationTest
   end
 
   test 'service not found' do
-    get(admin_api_service_metric_methods_path(:service_id => 0, :metric_id => @metric.id),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_metric_methods_path(:service_id => 0, :metric_id => @metric.id), params: { :provider_key => @provider.api_key, :format => :xml })
     assert_response :not_found
   end
 
   test 'service api metric not found' do
-    get(admin_api_service_metric_methods_path(:service_id => @service.id, :metric_id => 0),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_metric_methods_path(:service_id => @service.id, :metric_id => 0), params: { :provider_key => @provider.api_key, :format => :xml })
     assert_response :not_found
   end
 
@@ -30,8 +30,7 @@ class Admin::Api::ServiceMetricMethodsTest < ActionDispatch::IntegrationTest
     other_metric  = other_service.metrics.hits
     FactoryBot.create(:metric, :service => other_service, :parent_id => other_metric.id)
 
-    get(admin_api_service_metric_methods_path(@service, @metric),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_metric_methods_path(@service, @metric), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -39,8 +38,7 @@ class Admin::Api::ServiceMetricMethodsTest < ActionDispatch::IntegrationTest
   end
 
   test 'service api metrics show' do
-    get(admin_api_service_metric_method_path(@service, @metric, @metric_method),
-        :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_metric_method_path(@service, @metric, @metric_method), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -50,16 +48,13 @@ class Admin::Api::ServiceMetricMethodsTest < ActionDispatch::IntegrationTest
   end
 
   test 'service api metrics show not found' do
-    get(admin_api_service_metric_method_path(@service, @metric, :id => 0),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_metric_method_path(@service, @metric, :id => 0), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
 
   test 'service api metric create' do
-    post(admin_api_service_metric_methods_path(@service, @metric),
-         :provider_key => @provider.api_key, :format => :xml,
-         :system_name => 'example', :friendly_name => 'friendly example')
+    post(admin_api_service_metric_methods_path(@service, @metric), params: { :provider_key => @provider.api_key, :format => :xml, :system_name => 'example', :friendly_name => 'friendly example' })
 
     assert_response :success
 
@@ -73,8 +68,7 @@ class Admin::Api::ServiceMetricMethodsTest < ActionDispatch::IntegrationTest
   end
 
   test 'service api metric create errors xml' do
-    post(admin_api_service_metric_methods_path(@service, @metric),
-         :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_service_metric_methods_path(@service, @metric), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :unprocessable_entity
 
@@ -85,9 +79,7 @@ class Admin::Api::ServiceMetricMethodsTest < ActionDispatch::IntegrationTest
     metric_method = @metric.children.create!(:system_name => 'old_name',
         :friendly_name => "old friendly")
 
-    put("/admin/api/services/#{@service.id}/metrics/#{@metric.id}/methods/#{metric_method.id}",
-        :provider_key => @provider.api_key, :format => :xml,
-        :system_name => 'new_name', :friendly_name => "new friendly")
+    put("/admin/api/services/#{@service.id}/metrics/#{@metric.id}/methods/#{metric_method.id}", params: { :provider_key => @provider.api_key, :format => :xml, :system_name => 'new_name', :friendly_name => "new friendly" })
 
     assert_response :success
 
@@ -101,17 +93,13 @@ class Admin::Api::ServiceMetricMethodsTest < ActionDispatch::IntegrationTest
   end
 
   test 'service api metric update with wrong id' do
-    put("/admin/api/services/#{@service.id}/metrics/#{@metric.id}/methods/0",
-             :provider_key => @provider.api_key)
+    put("/admin/api/services/#{@service.id}/metrics/#{@metric.id}/methods/0", params: { :provider_key => @provider.api_key })
 
     assert_response :not_found
   end
 
   test 'service api metric update errors xml' do
-    put("/admin/api/services/#{@service.id}/metrics/#{@metric.id}/methods/#{@metric_method.id}",
-             :provider_key => @provider.api_key,
-             :format => :xml,
-             :friendly_name => "")
+    put("/admin/api/services/#{@service.id}/metrics/#{@metric.id}/methods/#{@metric_method.id}", params: { :provider_key => @provider.api_key, :format => :xml, :friendly_name => "" })
 
     assert_response :unprocessable_entity
     assert_xml_error @response.body, "Friendly name can't be blank"

--- a/test/integration/user-management-api/service_metrics_test.rb
+++ b/test/integration/user-management-api/service_metrics_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
@@ -12,8 +14,7 @@ class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
     service = FactoryBot.create :service, :account => @provider
     FactoryBot.create :metric, :service => service
 
-    get(admin_api_service_metrics_path(service),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_metrics_path(service), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -25,7 +26,7 @@ class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
   test 'show' do
     metric = FactoryBot.create :metric, :service => @service
 
-    get(admin_api_service_metric_path(@service, metric), :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_metric_path(@service, metric), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -46,14 +47,13 @@ class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
     # a metric of another service
     metric = FactoryBot.create :metric, :service => FactoryBot.create(:service, :account => @provider)
 
-    get(admin_api_service_metric_path(@service, metric), :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_metric_path(@service, metric), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end
 
   test 'create' do
-    post(admin_api_service_metrics_path(@service), :provider_key => @provider.api_key, :format => :xml,
-         :system_name => 'example', :friendly_name => 'friendly example', :unit => 'Mb')
+    post(admin_api_service_metrics_path(@service), params: { :provider_key => @provider.api_key, :format => :xml, :system_name => 'example', :friendly_name => 'friendly example', :unit => 'Mb' })
 
     assert_response :success
 
@@ -69,7 +69,7 @@ class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
   end
 
   test 'create errors xml' do
-    post(admin_api_service_metrics_path(@service), :provider_key => @provider.api_key, :format => :xml, :unit => "pounds")
+    post(admin_api_service_metrics_path(@service), params: { :provider_key => @provider.api_key, :format => :xml, :unit => "pounds" })
 
     assert_response :unprocessable_entity
 
@@ -79,9 +79,7 @@ class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
   test 'update' do
     metric = @service.metrics.create!(:system_name => 'old_name', :friendly_name => "old friendly", :unit => 'Mb')
 
-    put("/admin/api/services/#{@service.id}/metrics/#{metric.id}",
-        :provider_key => @provider.api_key, :format => :xml,
-        :system_name => 'new_name', :friendly_name => "new friendly", :unit => 'bucks')
+    put("/admin/api/services/#{@service.id}/metrics/#{metric.id}", params: { :provider_key => @provider.api_key, :format => :xml, :system_name => 'new_name', :friendly_name => "new friendly", :unit => 'bucks' })
 
     assert_response :success
 
@@ -96,7 +94,7 @@ class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
   end
 
   test 'update with wrong id' do
-    put("/admin/api/services/#{@service.id}/metrics/libanana", :provider_key => @provider.api_key, :format => :xml, :system_name => "jk")
+    put("/admin/api/services/#{@service.id}/metrics/libanana", params: { :provider_key => @provider.api_key, :format => :xml, :system_name => "jk" })
 
     assert_response :not_found
   end
@@ -104,8 +102,7 @@ class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
   test 'destroy' do
     metric = FactoryBot.create :metric, :service => @service
 
-    delete("/admin/api/services/#{@service.id}/metrics/#{metric.id}",
-           :provider_key => @provider.api_key, :format => :xml)
+    delete("/admin/api/services/#{@service.id}/metrics/#{metric.id}", params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -117,7 +114,7 @@ class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
   end
 
   test 'destroy with wrong id' do
-    delete("/admin/api/services/#{@service.id}/metrics/libanana", :provider_key => @provider.api_key, :format => :xml)
+    delete("/admin/api/services/#{@service.id}/metrics/libanana", params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :not_found
   end

--- a/test/integration/user-management-api/service_plan_features_test.rb
+++ b/test/integration/user-management-api/service_plan_features_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EnterpriseApiServicePlanFeaturesTest < ActionDispatch::IntegrationTest
@@ -16,8 +18,7 @@ class EnterpriseApiServicePlanFeaturesTest < ActionDispatch::IntegrationTest
     @service_plan.features << feat
     @service_plan.save!
 
-    get(admin_api_service_plan_features_path(@service_plan),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_plan_features_path(@service_plan), params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -27,8 +28,7 @@ class EnterpriseApiServicePlanFeaturesTest < ActionDispatch::IntegrationTest
   end
 
   test 'not found service_plan replies 404' do
-    get(admin_api_service_plan_features_path(0),
-             :provider_key => @provider.api_key, :format => :xml)
+    get(admin_api_service_plan_features_path(0), params: { :provider_key => @provider.api_key, :format => :xml })
     assert_xml_404
   end
 
@@ -39,9 +39,7 @@ class EnterpriseApiServicePlanFeaturesTest < ActionDispatch::IntegrationTest
     feat = FactoryBot.create(:feature, :featurable => @provider.default_service,
                    :scope => "ServicePlan")
 
-    post(admin_api_service_plan_features_path(@service_plan),
-              :feature_id => feat.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_service_plan_features_path(@service_plan), params: { :feature_id => feat.id, :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 
@@ -54,9 +52,7 @@ class EnterpriseApiServicePlanFeaturesTest < ActionDispatch::IntegrationTest
     feature_not_in_service = FactoryBot.create(:feature, :featurable => @provider,
                                      :scope => "AccountPlan")
 
-    post(admin_api_service_plan_features_path(@service_plan),
-              :feature_id => feature_not_in_service.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_service_plan_features_path(@service_plan), params: { :feature_id => feature_not_in_service.id, :provider_key => @provider.api_key, :format => :xml })
     assert_xml_404
   end
 
@@ -64,9 +60,7 @@ class EnterpriseApiServicePlanFeaturesTest < ActionDispatch::IntegrationTest
     wrong_feature = FactoryBot.create(:feature, :featurable => @provider.default_service,
                             :scope => "ApplicationPlan")
 
-    post(admin_api_service_plan_features_path(@service_plan),
-              :feature_id => wrong_feature.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_service_plan_features_path(@service_plan), params: { :feature_id => wrong_feature.id, :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :unprocessable_entity
     assert_xml_error @response.body, "Plan type mismatch"
@@ -78,9 +72,7 @@ class EnterpriseApiServicePlanFeaturesTest < ActionDispatch::IntegrationTest
     feat = FactoryBot.create(:feature, :featurable => @provider.default_service,
                    :scope => "ServicePlan")
 
-    post(admin_api_service_plan_features_path(@service_plan),
-              :feature_id => feat.id,
-              :provider_key => @provider.api_key, :format => :xml)
+    post(admin_api_service_plan_features_path(@service_plan), params: { :feature_id => feat.id, :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
 

--- a/test/integration/user-management-api/service_plans_test.rb
+++ b/test/integration/user-management-api/service_plans_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::ServicePlansTest < ActionDispatch::IntegrationTest
@@ -26,10 +28,10 @@ class Admin::Api::ServicePlansTest < ActionDispatch::IntegrationTest
 
     get(admin_api_service_service_plan_path(service, plan))
     assert_response :forbidden
-    get(admin_api_service_service_plan_path(service, plan), access_token: token.value)
+    get(admin_api_service_service_plan_path(service, plan), params: { access_token: token.value })
     assert_response :not_found
     User.any_instance.expects(:member_permission_service_ids).returns([service.id]).at_least_once
-    get(admin_api_service_service_plan_path(service, plan), access_token: token.value)
+    get(admin_api_service_service_plan_path(service, plan), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -92,10 +94,7 @@ class Admin::Api::ServicePlansTest < ActionDispatch::IntegrationTest
   end
 
   test 'create' do
-    post admin_api_service_service_plans_path(@provider.default_service, format: :xml),
-                                                   :name => 'awesome service plan',
-                                                   :state_event => 'publish',
-                                                   :provider_key => @provider.api_key
+    post admin_api_service_service_plans_path(@provider.default_service, format: :xml), params: { :name => 'awesome service plan', :state_event => 'publish', :provider_key => @provider.api_key }
 
     assert_response :success
 
@@ -111,10 +110,7 @@ class Admin::Api::ServicePlansTest < ActionDispatch::IntegrationTest
   test 'update' do
     plan = FactoryBot.create(:service_plan, issuer: @provider.default_service, name: 'namy')
 
-    put admin_api_service_service_plan_path(@provider.default_service, plan, format: :xml),
-                                                 :state_event => 'publish',
-                                                 :name => 'new name',
-                                                 :provider_key => @provider.api_key
+    put admin_api_service_service_plan_path(@provider.default_service, plan, format: :xml), params: { :state_event => 'publish', :name => 'new name', :provider_key => @provider.api_key }
 
     assert_response :success
 
@@ -131,8 +127,7 @@ class Admin::Api::ServicePlansTest < ActionDispatch::IntegrationTest
     plan = FactoryBot.create :service_plan, :issuer => @provider.default_service, :name => 'namy'
     plan.publish!
 
-    put default_admin_api_service_service_plan_path(@provider.default_service, plan, format: :xml),
-                                                    :provider_key => @provider.api_key
+    put default_admin_api_service_service_plan_path(@provider.default_service, plan, format: :xml), params: { :provider_key => @provider.api_key }
 
     assert_response :success
 
@@ -150,9 +145,7 @@ class Admin::Api::ServicePlansTest < ActionDispatch::IntegrationTest
   test 'destroy' do
     service_plan = FactoryBot.create :service_plan, :issuer => @provider.default_service
 
-    delete("/admin/api/services/#{@provider.default_service.id}/service_plans/#{service_plan.id}",
-                :provider_key => @provider.api_key,
-                :format => :xml)
+    delete("/admin/api/services/#{@provider.default_service.id}/service_plans/#{service_plan.id}", params: { :provider_key => @provider.api_key, :format => :xml })
 
     assert_response :success
     refute @response.body.presence

--- a/test/integration/user-management-api/services/proxy/configs_test.rb
+++ b/test/integration/user-management-api/services/proxy/configs_test.rb
@@ -23,7 +23,7 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
       'HTTP_IF_MODIFIED_SINCE' => response.header['Last-Modified'],
       'HTTP_IF_NONE_MATCH'     => response.header['ETag']
     }
-    get(latest_admin_api_service_proxy_configs_path(params), {}, headers)
+    get(latest_admin_api_service_proxy_configs_path(params), session: headers)
     assert_response :not_modified
 
     get latest_admin_api_service_proxy_configs_path(params.merge(format: :xml))
@@ -48,7 +48,7 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
       'HTTP_IF_MODIFIED_SINCE' => response.header['Last-Modified'],
       'HTTP_IF_NONE_MATCH'     => response.header['ETag']
     }
-    get(admin_api_service_proxy_config_path(params), {}, headers)
+    get(admin_api_service_proxy_config_path(params), session: headers)
     assert_response :not_modified
 
     get admin_api_service_proxy_config_path(params.merge(version: 'non-existing-version'))

--- a/test/integration/user-management-api/signup_test.rb
+++ b/test/integration/user-management-api/signup_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
@@ -33,7 +35,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider)
     token = FactoryBot.create(:access_token, owner: user)
 
-    post(admin_api_signup_path, format: :xml, access_token: token.value, org_name: 'fiona', username: 'fiona')
+    post(admin_api_signup_path, params: { format: :xml, access_token: token.value, org_name: 'fiona', username: 'fiona' })
     assert_response :forbidden
 
     user.admin_sections = ['partners']
@@ -41,7 +43,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     token.scopes = ['account_management']
     token.save!
 
-    post(admin_api_signup_path, format: :xml, access_token: token.value, org_name: 'fiona', username: 'fiona')
+    post(admin_api_signup_path, params: { format: :xml, access_token: token.value, org_name: 'fiona', username: 'fiona' })
     assert_response :created
   end
 
@@ -55,10 +57,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
   end
 
   test 'successful api signup creates app with default fields' do
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              org_name: 'fiona',
-              username: 'fiona')
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, org_name: 'fiona', username: 'fiona' })
 
     assert_response :created
     buyer = Account.buyers.find_by_org_name('fiona')
@@ -72,11 +71,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
   end
 
   test 'successful api signup with country' do
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              org_name: 'fiona',
-              username: 'fiona',
-              country: 'Spain')
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, org_name: 'fiona', username: 'fiona', country: 'Spain' })
 
     assert_response :created
     buyer = Account.buyers.find_by_org_name('fiona')
@@ -91,10 +86,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
   test 'api signup successful with minimal fields (default plans)' do
     UserMailer.expects(:deliver_signup_notification).never
 
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              org_name: 'fiona',
-              username: 'fiona')
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, org_name: 'fiona', username: 'fiona' })
 
     assert_response :created
 
@@ -126,14 +118,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     field_defined(@provider,
                   { target: "User", "name" => "user_extra_field" })
 
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              org_name: 'fiona', org_legaladdress: "account address",
-              account_extra_field: "account extra value",
-              username: 'fiona', email: "mail@example.com",
-              user_extra_field: "user extra value",
-              vat_rate: 33
-        )
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, org_name: 'fiona', org_legaladdress: "account address", account_extra_field: "account extra value", username: 'fiona', email: "mail@example.com", user_extra_field: "user extra value", vat_rate: 33 })
 
     assert_response :created
 
@@ -169,11 +154,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     field_defined(@provider,
                   { target: "User", name: "address", required: true })
 
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              org_name: 'fiona',
-              username: 'fiona', email: "mail@example.com",
-              address: "Rue del Percebe, 13")
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, org_name: 'fiona', username: 'fiona', email: "mail@example.com", address: "Rue del Percebe, 13" })
 
     assert_response :created
 
@@ -197,13 +178,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
   test 'api signup with plans params passed' do
     UserMailer.expects(:deliver_signup_notification).never
 
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              account_plan_id: @account_plan1.id,
-              service_plan_id: @service_plan1.id,
-              application_plan_id: @application_plan1.id,
-              org_name: 'fiona',
-              username: 'fiona')
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, account_plan_id: @account_plan1.id, service_plan_id: @service_plan1.id, application_plan_id: @application_plan1.id, org_name: 'fiona', username: 'fiona' })
 
     assert_response :created
 
@@ -220,11 +195,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     service = @provider.services.first
     service.update_attribute :default_application_plan, @application_plan1
 
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              application_plan_id: @application_plan2.id,
-              org_name: 'fiona',
-              username: 'fiona')
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, application_plan_id: @application_plan2.id, org_name: 'fiona', username: 'fiona' })
 
     assert_response :created
 
@@ -245,20 +216,13 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
 
     UserMailer.expects(:deliver_signup_notification).never
 
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              application_plan_id: @application_plan1.id,
-              org_name: 'fiona',
-              username: 'fiona')
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, application_plan_id: @application_plan1.id, org_name: 'fiona', username: 'fiona' })
 
     assert_response :created
   end
 
   test 'api signup failure and account and user errors' do
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              org_name: nil,
-              username: nil)
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, org_name: nil, username: nil })
 
     assert_response :unprocessable_entity
 
@@ -270,10 +234,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
 
   test 'security wise: api signup is access denied in buyer side' do
     host! @provider.domain # buyer domain
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              org_name: 'fiona',
-              username: 'fiona')
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, org_name: 'fiona', username: 'fiona' })
 
     assert_response :forbidden
   end
@@ -282,10 +243,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     @provider.account_plans.destroy_all
     assert @provider.account_plans.empty?
 
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              org_name: 'fiona',
-              username: 'fiona')
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, org_name: 'fiona', username: 'fiona' })
 
     assert_xml_404
   end
@@ -294,11 +252,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     @provider.account_plans.destroy_all
     assert @provider.account_plans.empty?
 
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              org_name: 'fiona',
-              username: 'fiona',
-              plan_id: 0)
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, org_name: 'fiona', username: 'fiona', plan_id: 0 })
 
     assert_xml_404
   end
@@ -318,13 +272,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     usage_limit2.metric = metric_local
     usage_limit2.save!
 
-    post(admin_api_signup_path, format: :xml,
-              provider_key: @provider.api_key,
-              account_plan_id: @account_plan1.id,
-              service_plan_id: @service_plan1.id,
-              application_plan_id: application_plan_local.id,
-              org_name: 'fiona',
-              username: 'fiona')
+    post(admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, account_plan_id: @account_plan1.id, service_plan_id: @service_plan1.id, application_plan_id: application_plan_local.id, org_name: 'fiona', username: 'fiona' })
 
     xml = Nokogiri::XML::Document.parse @response.body
 

--- a/test/integration/user-management-api/sso_tokens_test.rb
+++ b/test/integration/user-management-api/sso_tokens_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::SsoTokensTest < ActionDispatch::IntegrationTest
@@ -17,11 +19,7 @@ class Admin::Api::SsoTokensTest < ActionDispatch::IntegrationTest
   test 'creating a valid sso token' do
     buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
 
-    post(admin_api_sso_tokens_path,
-          :format => :xml,
-          :provider_key => @provider.api_key,
-          :user_id => buyer.users.first.id, :expires_in => 6000
-        )
+    post(admin_api_sso_tokens_path, params: { :format => :xml, :provider_key => @provider.api_key, :user_id => buyer.users.first.id, :expires_in => 6000 })
 
     assert_response :created
   end
@@ -29,12 +27,7 @@ class Admin::Api::SsoTokensTest < ActionDispatch::IntegrationTest
   test 'creating an sso token for ssl' do
     buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
 
-    post(admin_api_sso_tokens_path,
-          :format => :xml,
-          :protocol => 'https',
-          :provider_key => @provider.api_key,
-          :user_id => buyer.users.first.id, :expires_in => 6000
-        )
+    post(admin_api_sso_tokens_path, params: { :format => :xml, :protocol => 'https', :provider_key => @provider.api_key, :user_id => buyer.users.first.id, :expires_in => 6000 })
 
     assert_response :created
   end
@@ -46,10 +39,7 @@ class Admin::Api::SsoTokensTest < ActionDispatch::IntegrationTest
   test 'creating an sso token for another provider buyer' do
     buyer = FactoryBot.create(:buyer_account, :provider_account => FactoryBot.create(:simple_provider))
 
-    post(admin_api_sso_tokens_path, :format => :xml,
-              :provider_key => @provider.api_key,
-              :sso_token => { :username => buyer.users.first.username }
-        )
+    post(admin_api_sso_tokens_path, params: { :format => :xml, :provider_key => @provider.api_key, :sso_token => { :username => buyer.users.first.username } })
 
     assert_response 422
 

--- a/test/integration/user-management-api/users_test.rb
+++ b/test/integration/user-management-api/users_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
@@ -20,7 +22,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   test 'index with access token as a member' do
     token = FactoryBot.create(:access_token, owner: @member, scopes: ['account_management'])
 
-    get(admin_api_users_path(format: :xml), access_token: token.value)
+    get(admin_api_users_path(format: :xml), params: { access_token: token.value })
 
     assert_response :forbidden
   end
@@ -29,11 +31,11 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(false)
-    get(admin_api_users_path(format: :xml), access_token: token.value)
+    get(admin_api_users_path(format: :xml), params: { access_token: token.value })
     assert_response :forbidden
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    get(admin_api_users_path(format: :xml), access_token: token.value)
+    get(admin_api_users_path(format: :xml), params: { access_token: token.value })
     assert_response :success
   end
 
@@ -43,7 +45,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     impersonation_admin.save!
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    get(admin_api_users_path(format: :xml), access_token: token.value)
+    get(admin_api_users_path(format: :xml), params: { access_token: token.value })
     assert_response :success
     refute_xpath ".//username", /impersonation_admin/
   end
@@ -52,18 +54,18 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: @member, scopes: ['account_management'])
 
     # member's opening his page
-    get(admin_api_user_path(format: :xml, id: @member.id), access_token: token.value)
+    get(admin_api_user_path(format: :xml, id: @member.id), params: { access_token: token.value })
     assert_response :success
 
     # member's opening admin's page
-    get(admin_api_user_path(format: :xml, id: admin.id), access_token: token.value)
+    get(admin_api_user_path(format: :xml, id: admin.id), params: { access_token: token.value })
     assert_response :forbidden
   end
 
   test 'show with access token as an admin' do
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
 
-    get(admin_api_user_path(format: :xml, id: @member.id), access_token: token.value)
+    get(admin_api_user_path(format: :xml, id: @member.id), params: { access_token: token.value })
 
     assert_response :success
   end
@@ -72,11 +74,11 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(false)
-    post(admin_api_users_path(format: :xml), username: 'aaa', email: 'aaa@aaa.hu', access_token: token.value)
+    post(admin_api_users_path(format: :xml), params: { username: 'aaa', email: 'aaa@aaa.hu', access_token: token.value })
     assert_response :forbidden
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    post(admin_api_users_path(format: :xml), username: 'aaa', email: 'aaa@aaa.hu', access_token: token.value)
+    post(admin_api_users_path(format: :xml), params: { username: 'aaa', email: 'aaa@aaa.hu', access_token: token.value })
     assert_response :success
   end
 
@@ -134,8 +136,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
     service = @provider.services.default
 
-    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.value),
-        { member_permission_service_ids: [ service.id ], member_permission_ids: %w[monitoring services] }
+    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.value), params: { member_permission_service_ids: [ service.id ], member_permission_ids: %w[monitoring services] }
 
     assert_response :success
 
@@ -149,8 +150,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     service = @provider.services.default
     admin_sections = @member.admin_sections
 
-    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.value),
-        { member_permission_service_ids: [ service.id], member_permission_ids: %w[monitoring] }
+    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.value), params: { member_permission_service_ids: [ service.id], member_permission_ids: %w[monitoring] }
 
     assert_response :success
 
@@ -188,8 +188,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   #TODO: explicitly test the extra fields
   test 'index' do
-    get(admin_api_users_path(:format => :xml),
-             :provider_key => @provider.api_key)
+    get(admin_api_users_path(:format => :xml), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_users @response.body, { :account_id => @provider.id }
@@ -197,16 +196,14 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   #TODO: dry these roles tests
   test 'admins' do
-    get(admin_api_users_path(:format => :xml),
-             :provider_key => @provider.api_key, :role => 'admin')
+    get(admin_api_users_path(:format => :xml), params: { :provider_key => @provider.api_key, :role => 'admin' })
 
     assert_response :success
     assert_users @response.body, { :account_id => @provider.id, :role => "admin" }
   end
 
   test 'members' do
-    get(admin_api_users_path(:format => :xml),
-             :provider_key => @provider.api_key, :role => 'member')
+    get(admin_api_users_path(:format => :xml), params: { :provider_key => @provider.api_key, :role => 'member' })
 
     assert_response :success
     assert_users @response.body, { :account_id => @provider.id, :role => "member" }
@@ -214,16 +211,14 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   #TODO: dry these states tests
   test 'actives' do
-    get(admin_api_users_path(:format => :xml),
-             :provider_key => @provider.api_key, :state => 'active')
+    get(admin_api_users_path(:format => :xml), params: { :provider_key => @provider.api_key, :state => 'active' })
 
     assert_response :success
     assert_users @response.body, { :account_id => @provider.id, :state => "active" }
   end
 
   test 'pendings' do
-    get(admin_api_users_path(:format => :xml),
-             :provider_key => @provider.api_key, :state => 'pending')
+    get(admin_api_users_path(:format => :xml), params: { :provider_key => @provider.api_key, :state => 'pending' })
 
     assert_response :success
     assert_users @response.body, { :account_id => @provider.id, :state => "pending" }
@@ -234,16 +229,14 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     chuck.activate!
     chuck.suspend!
 
-    get(admin_api_users_path(:format => :xml),
-             :provider_key => @provider.api_key, :state => 'suspended')
+    get(admin_api_users_path(:format => :xml), params: { :provider_key => @provider.api_key, :state => 'suspended' })
 
     assert_response :success
     assert_users @response.body, {:account_id => @provider.id, :state => "suspended"}
   end
 
   test 'invalid role' do
-    get(admin_api_users_path(:format => :xml),
-             :provider_key => @provider.api_key, :role => 'invalid')
+    get(admin_api_users_path(:format => :xml), params: { :provider_key => @provider.api_key, :role => 'invalid' })
 
     assert_response :success
 
@@ -254,10 +247,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   test 'create defaults is pending member' do
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    post(admin_api_users_path(:format => :xml),
-              :username => 'chuck',
-              :email => 'chuck@norris.us',
-              :provider_key => @provider.api_key)
+    post(admin_api_users_path(:format => :xml), params: { :username => 'chuck', :email => 'chuck@norris.us', :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body,
@@ -273,11 +263,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     field_defined(@master,
                   { :target => "User", "name" => "some_extra_field" })
 
-    post(admin_api_users_path(:format => :xml),
-              :username => 'chuck',
-              :email => 'chuck@norris.us',
-              :some_extra_field => "extra value",
-              :provider_key => @provider.api_key)
+    post(admin_api_users_path(:format => :xml), params: { :username => 'chuck', :email => 'chuck@norris.us', :some_extra_field => "extra value", :provider_key => @provider.api_key })
 
     assert_response :success
 
@@ -290,10 +276,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   test "create sends no email" do
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
     assert_no_change :of => -> { ActionMailer::Base.deliveries.count } do
-      post(admin_api_users_path(:format => :xml),
-                :username => 'chuck',
-                :email => 'chuck@norris.us',
-                :provider_key => @provider.api_key)
+      post(admin_api_users_path(:format => :xml), params: { :username => 'chuck', :email => 'chuck@norris.us', :provider_key => @provider.api_key })
     end
 
     assert_response :success
@@ -301,11 +284,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   test "create with cas_identifier" do
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    post(admin_api_users_path(:format => :xml),
-                :username => 'luis',
-                :email => 'luis@norris.us',
-                :cas_identifier => 'luis',
-                :provider_key => @provider.api_key)
+    post(admin_api_users_path(:format => :xml), params: { :username => 'luis', :email => 'luis@norris.us', :cas_identifier => 'luis', :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user body, {:cas_identifier => 'luis'}
@@ -313,10 +292,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   test 'create does not creates admins nor active users' do
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    post(admin_api_users_path(:format => :xml),
-              :username => 'chuck', :role => "admin",
-              :email => 'chuck@norris.us', :state => "active",
-              :provider_key => @provider.api_key)
+    post(admin_api_users_path(:format => :xml), params: { :username => 'chuck', :role => "admin", :email => 'chuck@norris.us', :state => "active", :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body,
@@ -330,11 +306,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   test 'create also sets user password' do
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    post(admin_api_users_path(:format => :xml),
-              :username => 'chuck', :email => 'chuck@norris.us',
-              :password => "posted-password",
-              :password_confirmation => "posted-password",
-              :provider_key => @provider.api_key)
+    post(admin_api_users_path(:format => :xml), params: { :username => 'chuck', :email => 'chuck@norris.us', :password => "posted-password", :password_confirmation => "posted-password", :provider_key => @provider.api_key })
 
     chuck = User.last
     assert chuck.authenticated?('posted-password')
@@ -342,9 +314,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   test 'create errors' do
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    post(admin_api_users_path(:format => :xml),
-              :username => 'chuck', :role => "admin",
-              :provider_key => @provider.api_key)
+    post(admin_api_users_path(:format => :xml), params: { :username => 'chuck', :role => "admin", :provider_key => @provider.api_key })
 
     assert_response :unprocessable_entity
     assert_xml_error @response.body, "Email should look like an email address"
@@ -352,18 +322,14 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
   test "create forbidden if multiple_users is not allowed" do
     assert_no_change :of => -> { ActionMailer::Base.deliveries.count } do
-      post(admin_api_users_path(:format => :xml),
-                :username => 'chuck',
-                :email => 'chuck@norris.us',
-                :provider_key => @provider.api_key)
+      post(admin_api_users_path(:format => :xml), params: { :username => 'chuck', :email => 'chuck@norris.us', :provider_key => @provider.api_key })
     end
 
     assert_response :forbidden
   end
 
   test 'show' do
-    get(admin_api_user_path(:format => :xml, :id => @member.id),
-             :provider_key => @provider.api_key)
+    get(admin_api_user_path(:format => :xml, :id => @member.id), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body, {
@@ -377,8 +343,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     impersonation_admin  = Signup::ImpersonationAdminBuilder.build(account: @provider)
     impersonation_admin.save!
 
-    get(admin_api_user_path(:format => :xml, :id => impersonation_admin.id),
-        :provider_key => @provider.api_key)
+    get(admin_api_user_path(:format => :xml, :id => impersonation_admin.id), params: { :provider_key => @provider.api_key })
 
     assert_response :not_found
     assert_empty_xml @response.body
@@ -387,8 +352,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   test 'show with cas identifier' do
     cas_user = FactoryBot.create :user, :account => @provider, :role => 'member', :cas_identifier => 'xxx-enterprise'
 
-    get(admin_api_user_path(:format => :xml, :id => cas_user.id),
-             :provider_key => @provider.api_key)
+    get(admin_api_user_path(:format => :xml, :id => cas_user.id), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user body, :cas_identifier => 'xxx-enterprise'
@@ -403,8 +367,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
     @member.save
 
-    get(admin_api_user_path(:format => :xml, :id => @member.id),
-                                 :provider_key => @provider.api_key)
+    get(admin_api_user_path(:format => :xml, :id => @member.id), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body, :extra_fields => {
@@ -412,8 +375,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   end
 
   test 'show user not found' do
-    get(admin_api_user_path(:format => :xml, :id => 0),
-             :provider_key => @provider.api_key)
+    get(admin_api_user_path(:format => :xml, :id => 0), params: { :provider_key => @provider.api_key })
 
     assert_response :not_found
     assert_empty_xml @response.body
@@ -425,8 +387,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
     chuck = FactoryBot.create :user, :account => @provider, :role => "member"
     put(admin_api_user_path(:format => :xml, :id => chuck.id,
-                                 :some_extra_field => "extra value" ),
-             :provider_key => @provider.api_key)
+                                 :some_extra_field => "extra value" ), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body, { :account_id => @provider.id,
@@ -442,8 +403,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
     put(admin_api_user_path(:format => :xml, :id => chuck.id,
                                  :password => "updated-password",
-                                 :password_confirmation => "updated-password"),
-             :provider_key => @provider.api_key)
+                                 :password_confirmation => "updated-password"), params: { :provider_key => @provider.api_key })
 
     chuck.reload
     assert_response :success
@@ -455,9 +415,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     assert chuck.pending?
     assert chuck.member?
 
-    put(admin_api_user_path(:format => :xml, :id => chuck.id),
-             :username => 'chuck', :role => "admin", :state => "active",
-             :provider_key => @provider.api_key)
+    put(admin_api_user_path(:format => :xml, :id => chuck.id), params: { :username => 'chuck', :role => "admin", :state => "active", :provider_key => @provider.api_key })
 
     assert_response :success
     assert_user(@response.body,
@@ -471,24 +429,21 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   end
 
   test 'update not found' do
-    put(admin_api_user_path(:format => :xml, :id => 0),
-             :provider_key => @provider.api_key)
+    put(admin_api_user_path(:format => :xml, :id => 0), params: { :provider_key => @provider.api_key })
 
     assert_response :not_found
     assert_empty_xml @response.body
   end
 
   test 'destroy' do
-    delete(admin_api_user_path(:format => :xml, :id => @member.id),
-                :provider_key => @provider.api_key)
+    delete(admin_api_user_path(:format => :xml, :id => @member.id), params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_empty_xml @response.body
   end
 
   test 'destroy not found' do
-    delete(admin_api_user_path(:format => :xml, :id => 0),
-                :provider_key => @provider.api_key)
+    delete(admin_api_user_path(:format => :xml, :id => 0), params: { :provider_key => @provider.api_key })
 
     assert_response :not_found
     assert_empty_xml @response.body

--- a/test/integration/user-management-api/web_hooks_failures_test.rb
+++ b/test/integration/user-management-api/web_hooks_failures_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Admin::Api::WebHooksFailuresTest < ActionDispatch::IntegrationTest
@@ -17,16 +19,16 @@ class Admin::Api::WebHooksFailuresTest < ActionDispatch::IntegrationTest
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
     # member should not be able to work with webhooks at all
-    get(admin_api_webhooks_failures_path, access_token: token.value)
+    get(admin_api_webhooks_failures_path, params: { access_token: token.value })
     assert_response :forbidden
 
     user.role = 'admin'
     user.save!
-    get(admin_api_webhooks_failures_path, access_token: token.value)
+    get(admin_api_webhooks_failures_path, params: { access_token: token.value })
     assert_response :success
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(false)
-    get(admin_api_webhooks_failures_path, access_token: token.value)
+    get(admin_api_webhooks_failures_path, params: { access_token: token.value })
     assert_response :forbidden
   end
 
@@ -35,7 +37,7 @@ class Admin::Api::WebHooksFailuresTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
 
-    delete(admin_api_webhooks_failures_path, access_token: token.value)
+    delete(admin_api_webhooks_failures_path, params: { access_token: token.value })
     assert_response :success
   end
 
@@ -44,7 +46,7 @@ class Admin::Api::WebHooksFailuresTest < ActionDispatch::IntegrationTest
   test '#show' do
     WebHookFailures.add @provider.id, "FakedException", 'uuid', 'url', '<fake><xml/></fake>'
 
-    get("/admin/api/webhooks/failures.xml", :provider_key => @provider.api_key)
+    get("/admin/api/webhooks/failures.xml", params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_equal @response.body,  WebHookFailures.new(@provider.id).to_xml
@@ -53,7 +55,7 @@ class Admin::Api::WebHooksFailuresTest < ActionDispatch::IntegrationTest
   test '#delete empties the list if no time passed' do
     WebHookFailures.new(@provider.id).add("id" => "2")
 
-    delete("/admin/api/webhooks/failures.xml", :provider_key => @provider.api_key)
+    delete("/admin/api/webhooks/failures.xml", params: { :provider_key => @provider.api_key })
 
     assert_response :success
     assert_empty_xml @response.body
@@ -64,8 +66,7 @@ class Admin::Api::WebHooksFailuresTest < ActionDispatch::IntegrationTest
     WebHookFailures.new(@provider.id).add("id" => "2", time: '2010-01-01')
     WebHookFailures.new(@provider.id).add("id" => "3", time: '2011-01-01')
 
-    delete("/admin/api/webhooks/failures.xml", :provider_key => @provider.api_key,
-                "time" => '2010-01-01')
+    delete("/admin/api/webhooks/failures.xml", params: { :provider_key => @provider.api_key, "time" => '2010-01-01' })
 
     assert_response :success
     assert_empty_xml @response.body


### PR DESCRIPTION
Fixes the following deprecation warning:
```
DeveloperPortal::Admin::Applications::ReferrerFiltersControllerTest::NotLoggedInTest#test_Creating_referrer_filter_is_forbidden_if_not_logged_in DEPRECATION WARNING: Using positional arguments in integration tests has been deprecated,
in favor of keyword arguments, and will be removed in Rails 5.1.
```
with `rubocop` autofix.