### PR TITLE
[THREESCALE-7604] Update 3scale_v2.js

### DIFF
--- a/lib/developer_portal/app/views/developer_portal/javascripts/3scale_v2.js
+++ b/lib/developer_portal/app/views/developer_portal/javascripts/3scale_v2.js
@@ -70,7 +70,7 @@ var hljs=new function(){function e(e){return e.replace(/&/gm,"&amp;").replace(/<
   }
 
   if ( alreadyInitialized() ) {
-    $.fail('jquery-ujs has already been loaded!');
+    $.error('jquery-ujs has already been loaded!');
   }
 
   // Shorthand to make it a little easier to call public rails functions from within rails.js
@@ -529,7 +529,7 @@ var hljs=new function(){function e(e){return e.replace(/&/gm,"&amp;").replace(/<
 
 	    var toDeleteFlag = false;
 
-      $(iframe).on(function() {
+      $(iframe).on("load", function() {
   	    if (iframe.src == "about:blank") {
   				// First time around, do not delete.
 	  			if (toDeleteFlag) {


### PR DESCRIPTION
Update API's in 3scale_v2.js- 
1. Update API .load() to .on() 
From:
$(iframe).load(function()

To:
 $(iframe).on("load", function()

2. Update API .error() to .fail() 
From:
 $.error('jquery-ujs has already been loaded!')
 $ handleRemote.error( function() { rails.enableElement(link); } )

To:
 $.fail('jquery-ujs has already been loaded!')
 $ handleRemote.fail( function() { rails.enableElement(link); } )

3. Update API .load() to .on()
From:
$(iframe).load(function()

To:
$(iframe).on(function()

**What this PR does / why we need it**:

Updating some Obsolete API's in 3scale_v2.js .

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/THREESCALE-7604

