### PR TITLE
[email-async] Generate email async for lost password token

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -244,9 +244,9 @@ class User < ApplicationRecord
   def generate_lost_password_token!
     if generate_lost_password_token
       if account.provider?
-        ProviderUserMailer.lost_password(self).deliver_now
+        ProviderUserMailer.lost_password(self).deliver_later
       else
-        UserMailer.lost_password(self).deliver_now
+        UserMailer.lost_password(self).deliver_later
       end
     end
   end

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -18,7 +18,7 @@ namespace :sidekiq do
 
     args = []
     args.push(['--index', ENV.fetch('INDEX', '0')])
-    args.push(%w[backend_sync billing critical default deletion events low priority web_hooks zync].flat_map { |queue| ['--queue', queue] })
+    args.push(%w[backend_sync billing critical default deletion events low mailers priority web_hooks zync].flat_map { |queue| ['--queue', queue] })
 
     exec(envs, 'sidekiq', *args.flatten)
   end

--- a/test/integration/developer_portal/passwords_controller_test.rb
+++ b/test/integration/developer_portal/passwords_controller_test.rb
@@ -93,7 +93,7 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
     ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: true)
     Recaptcha::Verify.stubs(skip?: true)
 
-    UserMailer.expects(:lost_password).returns(mock('mail', deliver_now: true)).once
+    UserMailer.expects(:lost_password).returns(mock('mail', deliver_later: true)).once
 
     assert_change of: lambda { user.reload.lost_password_token.present? }, from: false, to: true do
       post developer_portal.admin_account_password_path(email: user.email)

--- a/test/unit/tasks/sidekiq_test.rb
+++ b/test/unit/tasks/sidekiq_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 module Tasks
   class SidekiqTest < ActiveSupport::TestCase
     test 'sidekiq:worker' do
-      queues = %w[backend_sync billing critical default deletion events low priority web_hooks zync]
+      queues = %w[backend_sync billing critical default deletion events low mailers priority web_hooks zync]
                  .flat_map { |queue| ['--queue', queue] }
 
       Object.any_instance.expects(:exec).with({ 'RAILS_MAX_THREADS' => '1' }, 'sidekiq', '--index', '0', *queues)


### PR DESCRIPTION
We do not want to keep the web server busy sending email

Requires: https://github.com/3scale/deploy/pull/721

Tested and working

![image](https://user-images.githubusercontent.com/64276/140304525-e47637b8-771a-49cb-85f6-cb4493f2e0c1.png)


Part of THREESCALE-7574
