### PR TITLE
Change `redirect_to :back` with new method `redirect_back`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,7 +66,7 @@ class ApplicationController < ActionController::Base
   helper_method :sublayout
 
   def redirect_back_or_to(*fallback_params)
-    redirect_back(fallback_location: root_path)
+    redirect_to :back
   rescue ActionController::RedirectBackError
     redirect_to(*fallback_params)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,7 +66,7 @@ class ApplicationController < ActionController::Base
   helper_method :sublayout
 
   def redirect_back_or_to(*fallback_params)
-    redirect_to :back
+    redirect_back(fallback_location: root_path)
   rescue ActionController::RedirectBackError
     redirect_to(*fallback_params)
   end

--- a/app/controllers/finance/provider/billing_strategies_controller.rb
+++ b/app/controllers/finance/provider/billing_strategies_controller.rb
@@ -11,7 +11,7 @@ class Finance::Provider::BillingStrategiesController < Finance::Provider::BaseCo
 
     if type
       @billing_strategy.change_mode(type)
-      redirect_back(fallback_location: @billing_strategy)
+      redirect_back(fallback_location: admin_finance_billing_strategy_path)
     else
       render_error(:not_found)
     end

--- a/app/controllers/finance/provider/billing_strategies_controller.rb
+++ b/app/controllers/finance/provider/billing_strategies_controller.rb
@@ -11,7 +11,7 @@ class Finance::Provider::BillingStrategiesController < Finance::Provider::BaseCo
 
     if type
       @billing_strategy.change_mode(type)
-      redirect_to :back
+      redirect_back(fallback_location: @billing_strategy)
     else
       render_error(:not_found)
     end

--- a/app/controllers/provider/admin/applications_controller.rb
+++ b/app/controllers/provider/admin/applications_controller.rb
@@ -103,7 +103,7 @@ class Provider::Admin::ApplicationsController < FrontendController
       redirect_to provider_admin_applications_path
     else
       flash[:notice] = 'Not possible to delete application'
-      redirect_back(fallback_location: root_path)
+      redirect_back(fallback_location: provider_admin_applications_path)
     end
   end
 

--- a/app/controllers/provider/admin/applications_controller.rb
+++ b/app/controllers/provider/admin/applications_controller.rb
@@ -103,7 +103,7 @@ class Provider::Admin::ApplicationsController < FrontendController
       redirect_to provider_admin_applications_path
     else
       flash[:notice] = 'Not possible to delete application'
-      redirect_to :back
+      redirect_back(fallback_location: root_path)
     end
   end
 

--- a/app/controllers/provider/admin/cms/builtin_legal_terms_controller.rb
+++ b/app/controllers/provider/admin/cms/builtin_legal_terms_controller.rb
@@ -13,7 +13,7 @@ class Provider::Admin::CMS::BuiltinLegalTermsController < Sites::BaseController
   def update
     if @page.update_attributes(params[:cms_template])
       flash[:info] = 'Legal terms saved.'
-      redirect_to :back # action: :edit, id: @page.id
+      redirect_back(fallback_location: { action: "edit", id: @page.id})
     else
       render :edit
     end

--- a/app/controllers/provider/admin/cms/versions_controller.rb
+++ b/app/controllers/provider/admin/cms/versions_controller.rb
@@ -25,7 +25,7 @@ class Provider::Admin::CMS::VersionsController < Provider::Admin::CMS::BaseContr
       redirect_to polymorphic_path([:edit, :provider, :admin, @page])
     else
       flash[:error] = "Problem reverting version"
-      redirect_to :back
+      redirect_back(fallback_location: root_path)
     end
   end
 

--- a/app/controllers/provider/admin/cms/versions_controller.rb
+++ b/app/controllers/provider/admin/cms/versions_controller.rb
@@ -25,7 +25,7 @@ class Provider::Admin::CMS::VersionsController < Provider::Admin::CMS::BaseContr
       redirect_to polymorphic_path([:edit, :provider, :admin, @page])
     else
       flash[:error] = "Problem reverting version"
-      redirect_back(fallback_location: root_path)
+      redirect_back(fallback_location: provider_admin_cms_template_version_path(@page, version))
     end
   end
 

--- a/app/controllers/provider/passwords_controller.rb
+++ b/app/controllers/provider/passwords_controller.rb
@@ -8,7 +8,7 @@ class Provider::PasswordsController < FrontendController
   before_action :instantiate_presenter, only: %i(show update)
 
   def new
-    return redirect_to :back, error: t('.has_password') if current_user.using_password?
+    return redirect_back(fallback_location: root_path), error: t('.has_password') if current_user.using_password?
 
     reset_session_password_token
     token = current_user.generate_lost_password_token

--- a/app/controllers/sites/usage_rules_controller.rb
+++ b/app/controllers/sites/usage_rules_controller.rb
@@ -9,7 +9,7 @@ class Sites::UsageRulesController < Sites::BaseController
   def update
     if @settings.update_attributes(params[:settings])
       flash[:notice] = 'Settings updated.'
-      redirect_to :back rescue redirect_to admin_site_settings_url
+      redirect_back(fallback_location: admin_site_settings_url)
     else
       render :edit
     end

--- a/app/lib/forum_support/user_topics.rb
+++ b/app/lib/forum_support/user_topics.rb
@@ -27,7 +27,7 @@ module ForumSupport
 
       respond_to do |format|
         flash[:notice] = 'You have successfully subscribed to the thread.' if @user_topic.save
-        format.html { redirect_to :back }
+        format.html { redirect_back(fallback_location: @user_topic) }
       end
     end
 
@@ -39,7 +39,8 @@ module ForumSupport
 
       respond_to do |format|
         flash[:notice] = 'You have successfully unsubscribed from the thread.'
-        format.html { redirect_to :back }
+
+        format.html { redirect_back(fallback_location: root_path) }
       end
     end
   end

--- a/app/lib/forum_support/user_topics.rb
+++ b/app/lib/forum_support/user_topics.rb
@@ -27,7 +27,8 @@ module ForumSupport
 
       respond_to do |format|
         flash[:notice] = 'You have successfully subscribed to the thread.' if @user_topic.save
-        format.html { redirect_back(fallback_location: @user_topic) }
+
+        format.html { redirect_back(fallback_location: forum_subscriptions_path) }
       end
     end
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications/user_keys_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications/user_keys_controller.rb
@@ -9,7 +9,7 @@ class DeveloperPortal::Admin::Applications::UserKeysController < ::DeveloperPort
     @cinstance.change_user_key!
 
     flash[:notice] = 'The user key was regenerated.'
-    redirect_back(fallback_location: @cinstance)
+    redirect_back(fallback_location: admin_application_user_key_path(@cinstance.id))
   end
 
   private

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications/user_keys_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications/user_keys_controller.rb
@@ -9,8 +9,7 @@ class DeveloperPortal::Admin::Applications::UserKeysController < ::DeveloperPort
     @cinstance.change_user_key!
 
     flash[:notice] = 'The user key was regenerated.'
-
-    redirect_to :back
+    redirect_back(fallback_location: @cinstance)
   end
 
   private


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR removes the depreciated warning for redirect_to :back

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/THREESCALE-7759