### PR TITLE
Fix deprecation of render text in the application controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -182,7 +182,7 @@ class ApplicationController < ActionController::Base
     options = options.dup
 
     respond_to do |format|
-      format.text { options[:text] = error }
+      format.text { options[:plain] = error }
       format.json { options[:json] = {:error => error} }
 
       format.xml do
@@ -192,7 +192,7 @@ class ApplicationController < ActionController::Base
 
       format.any do
         headers['Content-Type'] = 'text/plain'
-        options[:text] = error
+        options[:plain] = error
       end
     end
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Fixes deprecation:
```
DEPRECATION WARNING: `render :text` is deprecated because it does not actually render a `text/plain` response. Switch to `render plain: 'plain text'` to render as `text/plain`, `render html: '<strong>HTML</strong>'` to render as `text/html`, or `render body: 'raw'` to match the deprecated behavior and render with the default Content-Type, which is `text/html`. (called from render_error at /opt/app-root/src/project/app/controllers/application_controller.rb:199)
```