### PR TITLE
Removes assert_nothing_raised with parameter

### DIFF
--- a/test/workers/delete_plain_object_worker_test.rb
+++ b/test/workers/delete_plain_object_worker_test.rb
@@ -69,7 +69,8 @@ class DeletePlainObjectWorkerTest < ActiveSupport::TestCase
     def test_perform_destroy_by_association
       DeletePlainObjectWorker.perform_now(object, %w[HTestClass123 HTestClass1123])
       System::ErrorReporting.expects(:report_error).never
-      assert_nothing_raised(ActiveRecord::RecordNotDestroyed) { DeletePlainObjectWorker.perform_now(object, %w[HTestClass123 HTestClass1123]) }
+      # shouldn't raise anything
+      DeletePlainObjectWorker.perform_now(object, %w[HTestClass123 HTestClass1123])
       refute object.destroyed?
     end
 
@@ -80,7 +81,8 @@ class DeletePlainObjectWorkerTest < ActiveSupport::TestCase
           && parameters[:caller_worker_hierarchy] == ['Hierarchy-TestClass-123', "Plain-#{object.class}-#{object.id}"] \
           && parameters[:error_messages] == ['This product cannot be removed']
       end
-      assert_nothing_raised(ActiveRecord::RecordNotDestroyed) { DeletePlainObjectWorker.perform_now(object, %w[Hierarchy-TestClass-123]) }
+      # shouldn't raise anything
+      DeletePlainObjectWorker.perform_now(object, %w[Hierarchy-TestClass-123])
       refute object.destroyed?
     end
   end

--- a/test/workers/index_proxy_rule_worker_test.rb
+++ b/test/workers/index_proxy_rule_worker_test.rb
@@ -2,9 +2,8 @@ require 'test_helper'
 
 class IndexProxyRuleWorkerTest < ActiveSupport::TestCase
   test 'it does not raises RecordNotFound if id does not exist' do
-    assert_nothing_raised ActiveRecord::RecordNotFound do
-      IndexProxyRuleWorker.perform_now(42)
-    end
+    # shouldn't raise anything
+    IndexProxyRuleWorker.perform_now(42)
   end
 
   test 'indexes the proxy rule in Sphinx if record exists' do


### PR DESCRIPTION
…ils 5.1

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

In our rails upgrade branch, those tests are failing. Since the assert_nothing_raised is noop we can remove it.
