### PR TITLE
[THREESCALE-5010] sphinx 5.3 does not set default value

### DIFF
--- a/config/docker/thinking_sphinx.yml
+++ b/config/docker/thinking_sphinx.yml
@@ -1,5 +1,5 @@
 common: &sphinx
-  configuration_file: <%= ENV['THINKING_SPHINX_CONFIGURATION_FILE'] %>
+  configuration_file: <%= ENV.fetch('THINKING_SPHINX_CONFIGURATION_FILE') { Rails.root.join("config/#{Rails.env}.sphinx.conf")} %>
   big_document_ids: true
   html_strip: 1
   html_remove_elements: "style, script"

--- a/config/thinking_sphinx.yml
+++ b/config/thinking_sphinx.yml
@@ -1,5 +1,5 @@
 common: &sphinx
-  configuration_file: <%= ENV['THINKING_SPHINX_CONFIGURATION_FILE'] %>
+  configuration_file: <%= ENV.fetch('THINKING_SPHINX_CONFIGURATION_FILE') { Rails.root.join("config/#{Rails.env}.sphinx.conf")} %>
   big_document_ids: true
   html_strip: 1
   html_remove_elements: "style, script"


### PR DESCRIPTION
Upgrading to Rails 5.1 benefits from Sphinx update to 5.3.0. In that version
Sphinx does not set default configuration file path value and starting
Sphinx locally in dev mode fails.

Emulating same behavior in the configuration file.