### PR TITLE
Fixes deprecation in constructor of ActiveRecord exceptions

### DIFF
--- a/test/workers/persist_event_worker_test.rb
+++ b/test/workers/persist_event_worker_test.rb
@@ -28,7 +28,7 @@ class PersistEventWorkerTest < ActiveSupport::TestCase
   end
 
   test "perform handle ActiveRecord::RecordNotUnique" do
-    BackendEvent.any_instance.expects(:save!).raises(ActiveRecord::RecordNotUnique.new("forced error", nil))
+    BackendEvent.any_instance.expects(:save!).raises(ActiveRecord::RecordNotUnique.new("forced error"))
     event_attrs = {id: 213, foo: :bar}
     assert_difference "BackendEvent.count", 0 do
       PersistEventWorker.new.perform(event_attrs)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Fixes deprecation of ActiveRecord exceptions.

https://github.com/rails/rails/blob/v5.0.7.2/activerecord/lib/active_record/errors.rb#L102