### PR TITLE
Fixes deprecation of association reload

### DIFF
--- a/test/integration/user-management-api/signup_test.rb
+++ b/test/integration/user-management-api/signup_test.rb
@@ -113,7 +113,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
 
     # are these assertions testing too much!?
     buyer = Account.buyers.find_by_org_name('fiona')
-    assert @provider.buyers(true).include? buyer
+    assert @provider.buyers.reload.include? buyer
     assert buyer.admins.include? User.find_by_username('fiona')
     assert_equal @provider.default_account_plan, buyer.bought_account_plan
   end
@@ -154,7 +154,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     # testing objects creation
     # are these assertions testing too much!?
     buyer = Account.buyers.find_by_org_name('fiona')
-    assert @provider.buyers(true).include? buyer
+    assert @provider.buyers.reload.include? buyer
     assert_equal  "account address", buyer.org_legaladdress
     assert_equal "account extra value", buyer.extra_fields["account_extra_field"]
     assert_equal 33, buyer.vat_rate

--- a/test/unit/cms/section_test.rb
+++ b/test/unit/cms/section_test.rb
@@ -59,7 +59,7 @@ class CMS::SectionTest < ActiveSupport::TestCase
     sec3 = @root.children.create!(:title => 'sec3', :system_name => 'sec3', :provider => @provider)
 
     sec2.add_remove_by_ids(:section, [sec3.id])
-    assert_contains sec2.children(true), sec3
+    assert_contains sec2.children.reload, sec3
   end
 
   test "adding child sections" do
@@ -68,7 +68,7 @@ class CMS::SectionTest < ActiveSupport::TestCase
     sec3 = @root.children.create!(:title => 'sec3', :system_name => 'sec3', :provider => @provider)
 
     sec2.add_remove_by_ids(:section, [sec3.id])
-    assert_contains sec2.children(true), sec3
+    assert_contains sec2.children.reload, sec3
   end
 
   test "cannot include itself as a child" do
@@ -77,7 +77,7 @@ class CMS::SectionTest < ActiveSupport::TestCase
     sec3 = @root.children.create!(:title => 'sec3', :system_name => 'sec3', :provider => @provider)
 
     sec2.add_remove_by_ids(:section, [sec2.id])
-    assert !(sec2.children(true).member? sec2)
+    assert !(sec2.children.reload.member? sec2)
   end
 
   test "cannot include itself as a child of a child" do
@@ -86,7 +86,7 @@ class CMS::SectionTest < ActiveSupport::TestCase
     sec3 = @root.children.create!(:title => 'sec3', :system_name => 'sec3', :provider => @provider)
 
     sec3.add_remove_by_ids(:section, [sec2.id])
-    assert !(sec2.children(true).member? sec2)
+    assert !(sec2.children.reload.member? sec2)
   end
 
   test "removes subsections" do
@@ -96,7 +96,7 @@ class CMS::SectionTest < ActiveSupport::TestCase
 
     sec2.add_remove_by_ids(:section, [sec3.id])
 
-    assert !(sec2.children(true).member? sec3)
+    assert !(sec2.children.reload.member? sec3)
     assert_contains @root.children, sec3
   end
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Fixes deprecation:
```
DEPRECATION WARNING: Passing an argument to force an association to reload is now deprecated and will be removed in Rails 5.1. Please call `reload` on the result collection proxy instead.
```