### PR TITLE
Fix Application plans select

### DIFF
--- a/app/javascript/src/NewApplication/components/ApplicationPlanSelect.jsx
+++ b/app/javascript/src/NewApplication/components/ApplicationPlanSelect.jsx
@@ -40,7 +40,7 @@ const ApplicationPlanSelect = ({ appPlan, product, onSelect, createApplicationPl
       name="cinstance[plan_id]"
       placeholderText="Select an application plan"
       hint={showHint && hint}
-      isDisabled={product === null || !product.buyerCanSelectPlan || !appPlans.length}
+      isDisabled={product === null || !appPlans.length}
       isRequired
     />
   )

--- a/app/javascript/src/NewApplication/types.js
+++ b/app/javascript/src/NewApplication/types.js
@@ -17,7 +17,6 @@ export type Product = {
   updatedAt: string,
   appPlans: ApplicationPlan[],
   servicePlans: ServicePlan[],
-  buyerCanSelectPlan: boolean,
   defaultAppPlan: ApplicationPlan | null,
   defaultServicePlan: ServicePlan | null
 }

--- a/app/presenters/service_presenter.rb
+++ b/app/presenters/service_presenter.rb
@@ -29,8 +29,7 @@ class ServicePresenter < SimpleDelegator
       appPlans: plans.stock.select(:id, :name).as_json(root: false),
       servicePlans: service_plans.select(:id, :name).as_json(root: false),
       defaultServicePlan: default_service_plan.as_json(root: false, only: %i[id name]),
-      defaultAppPlan: default_application_plan.as_json(root: false, only: %i[id name]),
-      buyerCanSelectPlan: buyer_can_select_plan?
+      defaultAppPlan: default_application_plan.as_json(root: false, only: %i[id name])
     }
   end
 

--- a/features/old/api/applications/create_application.feature
+++ b/features/old/api/applications/create_application.feature
@@ -36,7 +36,6 @@ Feature: Create application from product context
   Scenario: Create an application for a service that doesn't allow choosing the plan
     Given a service "My API" of provider "foo.3scale.localhost"
     And a default application plan "Default Plan" of service "My API"
-    And service "My API" does not allow to change application plan
     When I create an application "My App" from the product "My API" context
     Then I should be on the provider side "My App" application page
     And should see "Application was successfully created"
@@ -48,14 +47,12 @@ Feature: Create application from product context
     Then I won't be able to select an application plan
 
   Scenario: Create an application for a service that doesn't allow choosing the plan and no default plan
-    Given a service "Broken API" of provider "foo.3scale.localhost"
-    And a published application plan "App plan" of service "Broken API"
-    And service "Broken API" does not allow to change application plan
-    When I go to the product context create application page for "Broken API"
-    Then I won't be able to select an application plan
+    Given a service "Not Broken API" of provider "foo.3scale.localhost"
+    And a published application plan "App plan" of service "Not Broken API"
+    When I go to the product context create application page for "Not Broken API"
+    Then I fill in the new application form
+    And I should see button "Create Application"
 
-  # FIXME: Unsubscribed API do not have any application plans
-  @wip
   Scenario: Create an application when the service doesn't have a service plan
     Given provider "foo.3scale.localhost" has "service_plans" switch allowed
     And a service "Unsubscribed API" of provider "foo.3scale.localhost" with no service plans

--- a/features/old/api/applications/create_application.feature
+++ b/features/old/api/applications/create_application.feature
@@ -46,13 +46,6 @@ Feature: Create application from product context
     When I go to the product context create application page for "No plans API"
     Then I won't be able to select an application plan
 
-  Scenario: Create an application for a service that doesn't allow choosing the plan and no default plan
-    Given a service "Not Broken API" of provider "foo.3scale.localhost"
-    And a published application plan "App plan" of service "Not Broken API"
-    When I go to the product context create application page for "Not Broken API"
-    Then I fill in the new application form
-    And I should see button "Create Application"
-
   Scenario: Create an application when the service doesn't have a service plan
     Given provider "foo.3scale.localhost" has "service_plans" switch allowed
     And a service "Unsubscribed API" of provider "foo.3scale.localhost" with no service plans

--- a/features/old/buyers/applications/create_application.feature
+++ b/features/old/buyers/applications/create_application.feature
@@ -34,7 +34,6 @@ Feature: Create application from Account
     And buyer "bob" should have 1 cinstance
 
   Scenario: Create an application for a service that doesn't allow choosing the plan
-    Given service "API" does not allow to change application plan
     When I create an application "My App" from the account "bob" context
     Then I should be on the provider side "My App" application page
     And should see "Application was successfully created"
@@ -43,28 +42,28 @@ Feature: Create application from Account
   Scenario: Create an application with no application plans
     Given a service "No plans API" of provider "foo.3scale.localhost"
     When I go to the account context create application page for "bob"
-    And I fill in the new application form
+    And I select "No plans API" from "Product"
     Then I won't be able to select an application plan
 
   Scenario: Create an application for a service that doesn't allow choosing the plan and no default plan
-    Given a service "Broken API" of provider "foo.3scale.localhost"
-    And an application plan "Not a default plan" of service "Broken API"
+    Given a service "Not Broken API" of provider "foo.3scale.localhost"
+    And an application plan "Not a default plan" of service "Not Broken API"
     When I go to the account context create application page for "bob"
-    And I fill in the new application form
-    Then I won't be able to select an application plan
+    And I select "Not Broken API" from "Product"
+    Then I should select an application plan myself
 
   Scenario: Create an application when the service doesn't have a service plan
     Given provider "foo.3scale.localhost" has "service_plans" switch allowed
     And a service "Unsubscribed API" of provider "foo.3scale.localhost" with no service plans
     When I go to the account context create application page for "bob"
-    And I fill in the new application form
+    And I fill in the new application form for product "Unsubscribed API"
     Then I should see "In order to subscribe the Application to a Product’s Application plan, this Account needs to subscribe to a Product’s Service plan."
 
   Scenario: Create an application when the service doesn't have a service plan
     Given provider "foo.3scale.localhost" has "service_plans" switch allowed
     And a service "Unsubscribed API" of provider "foo.3scale.localhost" with no service plans
     When I go to the account context create application page for "bob"
-    And I fill in the new application form
+    And I fill in the new application form for product "Unsubscribed API"
     Then I should see "In order to subscribe the Application to a Product’s Application plan, this Account needs to subscribe to a Product’s Service plan."
 
   Scenario: Create an application with a required extra field

--- a/features/old/buyers/applications/create_application.feature
+++ b/features/old/buyers/applications/create_application.feature
@@ -45,13 +45,6 @@ Feature: Create application from Account
     And I select "No plans API" from "Product"
     Then I won't be able to select an application plan
 
-  Scenario: Create an application for a service that doesn't allow choosing the plan and no default plan
-    Given a service "Not Broken API" of provider "foo.3scale.localhost"
-    And an application plan "Not a default plan" of service "Not Broken API"
-    When I go to the account context create application page for "bob"
-    And I select "Not Broken API" from "Product"
-    Then I should select an application plan myself
-
   Scenario: Create an application when the service doesn't have a service plan
     Given provider "foo.3scale.localhost" has "service_plans" switch allowed
     And a service "Unsubscribed API" of provider "foo.3scale.localhost" with no service plans

--- a/features/old/provider/admin/applications/create_application.feature
+++ b/features/old/provider/admin/applications/create_application.feature
@@ -34,7 +34,6 @@ Feature: Create application from Audience
     And buyer "bob" should have 1 cinstance
 
   Scenario: Create an application for a service that doesn't allow choosing the plan
-    Given service "API" does not allow to change application plan
     When I create an application "My App" from the audience context
     Then I should be on the provider side "My App" application page
     And should see "Application was successfully created"
@@ -43,21 +42,14 @@ Feature: Create application from Audience
   Scenario: Create an application with no application plans
     Given a service "No plans API" of provider "foo.3scale.localhost"
     When I go to the provider new application page
-    And I fill in the new application form
-    Then I won't be able to select an application plan
-
-  Scenario: Create an application for a service that doesn't allow choosing the plan and no default plan
-    Given a service "Broken API" of provider "foo.3scale.localhost"
-    And an application plan "Not a default plan" of service "Broken API"
-    When I go to the provider new application page
-    And I fill in the new application form
+    And I fill in the new application form for product "No plans API"
     Then I won't be able to select an application plan
 
   Scenario: Create an application when the service doesn't have a service plan
     Given provider "foo.3scale.localhost" has "service_plans" switch allowed
     And a service "Unsubscribed API" of provider "foo.3scale.localhost" with no service plans
     When I go to the provider new application page
-    And I fill in the new application form
+    And I fill in the new application form for product "Unsubscribed API"
     Then I should see "In order to subscribe the Application to a Product’s Application plan, this Account needs to subscribe to a Product’s Service plan."
 
   Scenario: Create an application with a required extra field
@@ -73,7 +65,6 @@ Feature: Create application from Audience
     And buyer "bob" should have 1 cinstance
 
   Scenario: Submit button should be disabled until form is filled
-    Given service "API" allows to choose plan on app creation
     When I go to the provider new application page
     And I should see button "Create Application" disabled
     And I select "bob" from "Account"

--- a/features/step_definitions/applications/applications_steps.rb
+++ b/features/step_definitions/applications/applications_steps.rb
@@ -178,19 +178,19 @@ end
 
 When /^I create an application "([^"]*)" from the audience context/ do |name|
   visit path_to 'the provider new application page'
-  fill_in_new_application_form(name)
+  fill_in_new_application_form(name: name)
   click_on 'Create Application'
 end
 
 When /^I create an application "([^"]*)" from the account "([^"]*)" context/ do |name, account_name|
   visit path_to %(the account context create application page for "#{account_name}")
-  fill_in_new_application_form(name)
+  fill_in_new_application_form(name: name)
   click_on 'Create Application'
 end
 
 When /^I create an application "([^"]*)" from the product "([^"]*)" context/ do |name, service_name|
   visit path_to %(the product context create application page for "#{service_name}")
-  fill_in_new_application_form(name)
+  fill_in_new_application_form(name: name)
   click_on 'Create Application'
 end
 
@@ -199,7 +199,11 @@ When 'I fill in the new application form' do
 end
 
 When /^I fill in the new application form for "([^"]*)"/ do |name|
-  fill_in_new_application_form(name)
+  fill_in_new_application_form(name: name)
+end
+
+When 'I fill in the new application form for product {string}' do |service_name|
+  fill_in_new_application_form(service_name: service_name)
 end
 
 When 'I fill in the new application form with extra fields:' do |table|
@@ -212,21 +216,21 @@ end
 
 When 'I should not be allowed to create more applications' do
   visit path_to 'the provider new application page'
-  fill_in_new_application_form(name)
+  fill_in_new_application_form
   click_on 'Create Application'
   assert has_content?('Access Denied')
 end
 
 When /^buyer "([^"]*)" should not be allowed to create more applications/ do |buyer_name|
   visit path_to %(the account context create application page for "#{buyer_name}")
-  fill_in_new_application_form(name)
+  fill_in_new_application_form
   click_on 'Create Application'
   assert has_content?('Access Denied')
 end
 
 When /^I should not be allowed to create more applications for product "([^"]*)"/ do |service_name|
   visit path_to %(the product context create application page for "#{service_name}")
-  fill_in_new_application_form(name)
+  fill_in_new_application_form
   click_on 'Create Application'
   assert has_content?('Access Denied')
 end
@@ -237,13 +241,22 @@ When "a service {string} of {provider} with no service plans" do |service_name, 
 end
 
 When "I won't be able to select an application plan" do
-  assert find('.pf-c-form__label', text: 'Application plan').sibling('.pf-c-select').has_css?('.pf-m-disabled')
+  assert app_plan_select.has_css?('.pf-m-disabled')
 end
 
-def fill_in_new_application_form(name = 'My App')
-  pf4_select('bob', from: 'Account') if page.has_css?('.pf-c-form__label', text: 'Account')
-  pf4_select('API', from: 'Product') if page.has_css?('.pf-c-form__label', text: 'Product')
-  pf4_select('Basic', from: 'Application plan') unless find('.pf-c-form__label', text: 'Application plan').sibling('.pf-c-select').has_css?('.pf-m-disabled')
-  find('.pf-c-form__label', text: 'Name').sibling('input').set(name || 'My App')
+Then "I should select an application plan myself" do
+  assert_not app_plan_select.has_css?('.pf-m-disabled')
+  assert_not app_plan_select.find('input').value.present?
+end
+
+def fill_in_new_application_form(name: 'My App', service_name: 'API')
+  pf4_select_first(from: 'Account') if page.has_css?('.pf-c-form__label', text: 'Account')
+  pf4_select(service_name, from: 'Product') if page.has_css?('.pf-c-form__label', text: 'Product')
+  pf4_select_first(from: 'Application plan') unless app_plan_select.has_css?('.pf-m-disabled')
+  find('.pf-c-form__label', text: 'Name').sibling('input').set(name)
   find('.pf-c-form__label', text: 'Description').sibling('input').set('This is some kind of application')
+end
+
+def app_plan_select
+  find('.pf-c-form__label', text: 'Application plan').sibling('.pf-c-select')
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -107,6 +107,14 @@ def pf4_select(value, from:)
   end
 end
 
+def pf4_select_first(from:)
+  select = find('.pf-c-form__label', text: from).sibling('.pf-c-select')
+  within select do
+    find('.pf-c-select__toggle').click unless select['class'].include?('pf-m-expanded')
+    find('ul.pf-c-select__menu li button:not(.pf-m-disabled)').click
+  end
+end
+
 # Overrides Node::Actions#fill_in
 def fill_in
   if page.has_css?('.pf-c-form__label', text: field)

--- a/spec/javascripts/NewApplication/components/ApplicationPlanSelect.spec.jsx
+++ b/spec/javascripts/NewApplication/components/ApplicationPlanSelect.spec.jsx
@@ -41,48 +41,34 @@ describe('when a product is selected', () => {
     updatedAt: '1 Jan 2021',
     appPlans: [{ id: 0, name: 'The Plan' }],
     servicePlans: [],
-    buyerCanSelectPlan: false,
     defaultServicePlan: null,
     defaultAppPlan: null
   }
+  const props = { product }
 
-  describe('and buyer can select plan', () => {
-    const productCanSelectPlan = { ...product, buyerCanSelectPlan: true }
-    const props = { product: productCanSelectPlan }
+  it('should not be disabled', () => {
+    const wrapper = mountWrapper(props)
+    expectToBeDisabled(wrapper, false)
+  })
+
+  describe('and the product has some application plans', () => {
+    const props = { product: { ...product, appPlans: [appPlan] } }
 
     it('should not be disabled', () => {
       const wrapper = mountWrapper(props)
       expectToBeDisabled(wrapper, false)
     })
-
-    describe('and the product has some application plans', () => {
-      const props = { product: { ...productCanSelectPlan, appPlans: [appPlan] } }
-
-      it('should not be disabled', () => {
-        const wrapper = mountWrapper(props)
-        expectToBeDisabled(wrapper, false)
-      })
-    })
-
-    describe('but the product has no application plans', () => {
-      const props = { product: { ...productCanSelectPlan, appPlans: [] } }
-
-      it('should show a hint with a link to create a plan', () => {
-        const wrapper = mountWrapper(props)
-        const hint = wrapper.find('.hint')
-        expect(hint.exists()).toBe(true)
-        expect(hint.find('a').props().href).toEqual(createApplicationPlanPath)
-      })
-
-      it('should be disabled', () => {
-        const wrapper = mountWrapper(props)
-        expectToBeDisabled(wrapper)
-      })
-    })
   })
 
-  describe('and buyer cannot select plan', () => {
-    const props = { product: { ...product, buyerCanSelectPlan: false } }
+  describe('but the product has no application plans', () => {
+    const props = { product: { ...product, appPlans: [] } }
+
+    it('should show a hint with a link to create a plan', () => {
+      const wrapper = mountWrapper(props)
+      const hint = wrapper.find('.hint')
+      expect(hint.exists()).toBe(true)
+      expect(hint.find('a').props().href).toEqual(createApplicationPlanPath)
+    })
 
     it('should be disabled', () => {
       const wrapper = mountWrapper(props)

--- a/spec/javascripts/NewApplication/components/NewApplicationForm.spec.jsx
+++ b/spec/javascripts/NewApplication/components/NewApplicationForm.spec.jsx
@@ -11,8 +11,8 @@ const errorSpy = jest.spyOn(alert, 'error')
 
 const appPlans = [{ id: 0, name: 'Basic Plan', issuer_id: 0, default: false }]
 const products = [
-  { id: 0, name: 'API 0', systemName: 'api-0', description: '', updatedAt: '', appPlans, servicePlans: [], defaultServicePlan: null, defaultAppPlan: null, buyerCanSelectPlan: true },
-  { id: 1, name: 'API 1', systemName: 'api-1', description: '', updatedAt: '', appPlans, servicePlans: [], defaultServicePlan: null, defaultAppPlan: null, buyerCanSelectPlan: true }
+  { id: 0, name: 'API 0', systemName: 'api-0', description: '', updatedAt: '', appPlans, servicePlans: [], defaultServicePlan: null, defaultAppPlan: null },
+  { id: 1, name: 'API 1', systemName: 'api-1', description: '', updatedAt: '', appPlans, servicePlans: [], defaultServicePlan: null, defaultAppPlan: null }
 ]
 const buyers = [
   { id: 0, name: 'Buyer 0', admin: '', createdAt: '', contractedProducts: [], createApplicationPath: '/buyers/0/applications/new' },
@@ -68,7 +68,6 @@ describe('when in Service context', () => {
     updatedAt: '',
     appPlans,
     servicePlans: [servicePlan],
-    buyerCanSelectPlan: true,
     defaultServicePlan: null,
     defaultAppPlan: null,
     systemName: 'current_api'
@@ -90,48 +89,18 @@ describe('when in Service context', () => {
       expect(wrapper.find(`ApplicationPlanSelect .hint a[href="${props.createApplicationPlanPath}"]`).exists()).toBe(true)
     })
 
-    describe('when buyer can select plan', () => {
-      const productCanChangePlan = { ...productWithNoAppPlans, buyerCanSelectPlan: true }
-
-      beforeEach(() => {
-        props.product = productCanChangePlan
-      })
-
-      it('should disable the application plan select', () => {
-        const wrapper = mountWrapper(props)
-        const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
-        expect(isDisabled()).toBe(true)
-      })
-
-      it('should not be able to submit', () => {
-        const wrapper = mountWrapper(props)
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-
-        expect(() => selectApplicationPlan(wrapper, appPlans[0])).toThrowError('the select is disabled')
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-      })
+    it('should disable the application plan select', () => {
+      const wrapper = mountWrapper(props)
+      const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
+      expect(isDisabled()).toBe(true)
     })
 
-    describe('when buyer cannot select plan', () => {
-      const productCannotChangePlan = { ...productWithNoAppPlans, buyerCanSelectPlan: false }
+    it('should not be able to submit', () => {
+      const wrapper = mountWrapper(props)
+      expect(isSubmitDisabled(wrapper)).toBe(true)
 
-      beforeEach(() => {
-        props.product = productCannotChangePlan
-      })
-
-      it('should disable the application plan select', () => {
-        const wrapper = mountWrapper(props)
-        const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
-        expect(isDisabled()).toBe(true)
-      })
-
-      it('should not be able to submit', () => {
-        const wrapper = mountWrapper(props)
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-
-        expect(() => selectApplicationPlan(wrapper, appPlans[0])).toThrowError('the select is disabled')
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-      })
+      expect(() => selectApplicationPlan(wrapper, appPlans[0])).toThrowError('the select is disabled')
+      expect(isSubmitDisabled(wrapper)).toBe(true)
     })
   })
 
@@ -147,72 +116,58 @@ describe('when in Service context', () => {
       expect(wrapper.find(`ApplicationPlanSelect .hint a[href="${defaultProps.createApplicationPlanPath}"]`).exists()).toBe(false)
     })
 
-    describe('when buyer can select plan', () => {
-      const productCanChangePlan = { ...productWithAppPlans, buyerCanSelectPlan: true }
+    it('should enable the application plan select', () => {
+      const wrapper = mountWrapper(props)
+      const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
+      expect(isDisabled()).toBe(false)
+    })
+
+    it('should be able to submit only when form is complete', () => {
+      const wrapper = mountWrapper(props)
+      expect(isSubmitDisabled(wrapper)).toBe(true)
+
+      selectBuyer(wrapper, buyers[0])
+      expect(isSubmitDisabled(wrapper)).toBe(true)
+
+      selectApplicationPlan(wrapper, productWithAppPlans.appPlans[0])
+      expect(isSubmitDisabled(wrapper)).toBe(false)
+    })
+
+    describe('and it has a default application plan', () => {
+      const defaultAppPlan = productWithAppPlans.appPlans[0]
+      const productWithDefaultAppPlan = { ...productWithAppPlans, defaultAppPlan }
 
       beforeEach(() => {
-        props.product = productCanChangePlan
+        props.product = productWithDefaultAppPlan
       })
 
-      it('should enable the application plan select', () => {
+      it('should have the default plan selected', () => {
         const wrapper = mountWrapper(props)
-        const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
-        expect(isDisabled()).toBe(false)
+        selectBuyer(wrapper, buyers[0])
+
+        expect(wrapper.find('ApplicationPlanSelect').props().appPlan).toBe(defaultAppPlan)
       })
 
-      it('should be able to submit only when form is complete', () => {
+      it('should not need to select a plan to submit', () => {
         const wrapper = mountWrapper(props)
         expect(isSubmitDisabled(wrapper)).toBe(true)
 
         selectBuyer(wrapper, buyers[0])
-        expect(isSubmitDisabled(wrapper)).toBe(true)
 
-        selectApplicationPlan(wrapper, productCanChangePlan.appPlans[0])
         expect(isSubmitDisabled(wrapper)).toBe(false)
       })
     })
 
-    describe('when buyer cannot select plan', () => {
-      const productCannotChangePlan = { ...productWithAppPlans, buyerCanSelectPlan: false }
+    describe('but it has no default application plan', () => {
+      const productWithNoDefaultAppPlan = { ...productWithAppPlans, defaultAppPlan: null }
 
       beforeEach(() => {
-        props.product = productCannotChangePlan
+        props.product = productWithNoDefaultAppPlan
       })
 
-      it('should disable the application plan select', () => {
+      it('should have no default plan selected', () => {
         const wrapper = mountWrapper(props)
-        const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
-        expect(isDisabled()).toBe(true)
-      })
-
-      describe('and it has a default application plan', () => {
-        const productWithDefaultAppPlan = { ...productCannotChangePlan, defaultAppPlan: productWithAppPlans.appPlans[0] }
-
-        beforeEach(() => {
-          props.product = productWithDefaultAppPlan
-        })
-
-        it('should be able to submit without selecting a plan', () => {
-          const wrapper = mountWrapper(props)
-          expect(isSubmitDisabled(wrapper)).toBe(true)
-
-          expect(() => selectApplicationPlan(wrapper, appPlans[0])).toThrowError('select is disabled')
-        })
-      })
-
-      describe('but it has no default application plan', () => {
-        const productWithNoDefaultAppPlan = { ...productCannotChangePlan, defaultAppPlan: null }
-
-        beforeEach(() => {
-          props.product = productWithNoDefaultAppPlan
-        })
-
-        it('should not be able to submit', () => {
-          const wrapper = mountWrapper(props)
-          expect(isSubmitDisabled(wrapper)).toBe(true)
-
-          expect(() => selectApplicationPlan(wrapper, appPlans[0])).toThrowError('select is disabled')
-        })
+        expect(wrapper.find('ApplicationPlanSelect').props().appPlan).toBe(null)
       })
     })
   })
@@ -435,50 +390,23 @@ describe('when in Account context', () => {
       expect(findHint()).toBe(true)
     })
 
-    describe('when buyer can select plan', () => {
-      const productCanChangePlan = { ...productWithNoAppPlans, buyerCanSelectPlan: true }
+    it('should disable the application plan select', () => {
+      const wrapper = mountWrapper({ ...props, products: [productWithNoAppPlans] })
+      const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
 
-      it('should disable the application plan select', () => {
-        const wrapper = mountWrapper({ ...props, products: [productCanChangePlan] })
-        const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
-
-        selectProduct(wrapper, productCanChangePlan)
-        expect(isDisabled()).toBe(true)
-      })
-
-      it('should not be able to submit', () => {
-        const wrapper = mountWrapper({ ...props, products: [productCanChangePlan] })
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-
-        selectProduct(wrapper, productCanChangePlan)
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-
-        expect(() => selectApplicationPlan(wrapper, appPlans[0])).toThrowError('the select is disabled')
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-      })
+      selectProduct(wrapper, productWithNoAppPlans)
+      expect(isDisabled()).toBe(true)
     })
 
-    describe('when buyer cannot select plan', () => {
-      const productCannotChangePlan = { ...productWithNoAppPlans, buyerCanSelectPlan: false }
+    it('should not be able to submit', () => {
+      const wrapper = mountWrapper({ ...props, products: [productWithNoAppPlans] })
+      expect(isSubmitDisabled(wrapper)).toBe(true)
 
-      it('should disable the application plan select', () => {
-        const wrapper = mountWrapper({ ...props, products: [productCannotChangePlan] })
-        const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
+      selectProduct(wrapper, productWithNoAppPlans)
+      expect(isSubmitDisabled(wrapper)).toBe(true)
 
-        selectProduct(wrapper, productCannotChangePlan)
-        expect(isDisabled()).toBe(true)
-      })
-
-      it('should not be able to submit', () => {
-        const wrapper = mountWrapper({ ...props, products: [productCannotChangePlan] })
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-
-        selectProduct(wrapper, productCannotChangePlan)
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-
-        expect(() => selectApplicationPlan(wrapper, appPlans[0])).toThrowError('the select is disabled')
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-      })
+      expect(() => selectApplicationPlan(wrapper, appPlans[0])).toThrowError('the select is disabled')
+      expect(isSubmitDisabled(wrapper)).toBe(true)
     })
   })
 
@@ -493,66 +421,53 @@ describe('when in Account context', () => {
       expect(findHint()).toBe(false)
     })
 
-    describe('when buyer can select plan', () => {
-      const productCanChangePlan = { ...productWithAppPlans, buyerCanSelectPlan: true }
+    it('should enable the application plan select', () => {
+      const wrapper = mountWrapper({ ...props, products: [productWithAppPlans] })
+      const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
 
-      it('should enable the application plan select', () => {
-        const wrapper = mountWrapper({ ...props, products: [productCanChangePlan] })
-        const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
+      selectProduct(wrapper, productWithAppPlans)
+      expect(isDisabled()).toBe(false)
+    })
 
-        selectProduct(wrapper, productCanChangePlan)
-        expect(isDisabled()).toBe(false)
+    it('should be able to submit only when form is complete', () => {
+      const wrapper = mountWrapper({ ...props, products: [productWithAppPlans] })
+      expect(isSubmitDisabled(wrapper)).toBe(true)
+
+      selectProduct(wrapper, productWithAppPlans)
+      expect(isSubmitDisabled(wrapper)).toBe(true)
+
+      selectApplicationPlan(wrapper, productWithAppPlans.appPlans[0])
+      expect(isSubmitDisabled(wrapper)).toBe(false)
+    })
+
+    describe('and it has a default application plan', () => {
+      const defaultAppPlan = appPlans[0]
+      const productWithDefaultAppPlan = { ...productWithAppPlans, defaultAppPlan }
+
+      it('should have the default plan selected', () => {
+        const wrapper = mountWrapper({ ...props, products: [productWithDefaultAppPlan] })
+        selectProduct(wrapper, productWithAppPlans)
+
+        expect(wrapper.find('ApplicationPlanSelect').props().appPlan).toEqual(defaultAppPlan)
       })
 
-      it('should be able to submit only when form is complete', () => {
-        const wrapper = mountWrapper({ ...props, products: [productCanChangePlan] })
+      it('should not need to select a plan to submit', () => {
+        const wrapper = mountWrapper({ ...props, products: [productWithDefaultAppPlan] })
         expect(isSubmitDisabled(wrapper)).toBe(true)
 
-        selectProduct(wrapper, productCanChangePlan)
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-
-        selectApplicationPlan(wrapper, productCanChangePlan.appPlans[0])
+        selectProduct(wrapper, productWithAppPlans)
         expect(isSubmitDisabled(wrapper)).toBe(false)
       })
     })
 
-    describe('when buyer cannot select plan', () => {
-      const productCannotChangePlan = { ...productWithAppPlans, buyerCanSelectPlan: false }
+    describe('but it has no default application plan', () => {
+      const productWithNoDefaultAppPlan = { ...productWithAppPlans, defaultAppPlan: null }
 
-      it('should disable the application plan select', () => {
-        const wrapper = mountWrapper({ ...props, products: [productCannotChangePlan] })
-        const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
+      it('should have no plan selected by default', () => {
+        const wrapper = mountWrapper({ ...props, products: [productWithNoDefaultAppPlan] })
+        selectProduct(wrapper, productWithAppPlans)
 
-        selectProduct(wrapper, productCannotChangePlan)
-        expect(isDisabled()).toBe(true)
-      })
-
-      describe('and it has a default application plan', () => {
-        const productWithDefaultAppPlan = { ...productCannotChangePlan, defaultAppPlan: appPlans[0] }
-
-        it('should be able to submit without selecting a plan', () => {
-          const wrapper = mountWrapper({ ...props, products: [productWithDefaultAppPlan] })
-          expect(isSubmitDisabled(wrapper)).toBe(true)
-
-          selectProduct(wrapper, productWithDefaultAppPlan)
-          expect(isSubmitDisabled(wrapper)).toBe(false)
-
-          expect(() => selectApplicationPlan(wrapper, appPlans[0])).toThrowError('select is disabled')
-        })
-      })
-
-      describe('but it has no default application plan', () => {
-        const productWithNoDefaultAppPlan = { ...productCannotChangePlan, defaultAppPlan: null }
-
-        it('should not be able to submit', () => {
-          const wrapper = mountWrapper({ ...props, products: [productWithNoDefaultAppPlan] })
-          expect(isSubmitDisabled(wrapper)).toBe(true)
-
-          selectProduct(wrapper, productWithNoDefaultAppPlan)
-          expect(isSubmitDisabled(wrapper)).toBe(true)
-
-          expect(() => selectApplicationPlan(wrapper, appPlans[0])).toThrowError('select is disabled')
-        })
+        expect(wrapper.find('ApplicationPlanSelect').props().appPlan).toEqual(null)
       })
     })
   })
@@ -810,21 +725,21 @@ describe('when in Audience context', () => {
     expect(isSubmitDisabled(wrapper)).toBe(false)
   })
 
-  describe('when selected product allows changing the Application plan', () => {
-    const productCanChangePlan = { ...products[0], buyerCanSelectPlan: true }
+  describe('when selected product has application plans', () => {
+    const productWithAppPlans = { ...products[0], appPlans }
 
     beforeEach(() => {
-      props.products = [productCanChangePlan]
+      props.products = [productWithAppPlans]
     })
 
     it('should enable the Application plan select', () => {
-      const wrapper = mountWrapper({ ...props, products: [productCanChangePlan] })
+      const wrapper = mountWrapper({ ...props, products: [productWithAppPlans] })
       const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
 
       selectBuyer(wrapper, buyers[0])
       expect(isDisabled()).toBe(true)
 
-      selectProduct(wrapper, productCanChangePlan)
+      selectProduct(wrapper, productWithAppPlans)
       expect(isDisabled()).toBe(false)
     })
 
@@ -841,54 +756,56 @@ describe('when in Audience context', () => {
       selectApplicationPlan(wrapper, appPlans[0])
       expect(isSubmitDisabled(wrapper)).toBe(false)
     })
-  })
-
-  describe('when selected product disallows changing the Application plan', () => {
-    const productCannotSelectPlan = { ...products[0], buyerCanSelectPlan: false }
-
-    beforeEach(() => {
-      props.products = [productCannotSelectPlan]
-    })
-
-    it('should disable the Application plan select', () => {
-      const wrapper = mountWrapper({ ...props, products: [productCannotSelectPlan] })
-      const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
-
-      selectBuyer(wrapper, buyers[0])
-      expect(isDisabled()).toBe(true)
-
-      selectProduct(wrapper, productCannotSelectPlan)
-      expect(isDisabled()).toBe(true)
-    })
 
     describe('and it has a default application plan', () => {
-      const productWithDefaultPlan = { ...productCannotSelectPlan, defaultAppPlan: appPlans[0] }
+      const defaultAppPlan = appPlans[0]
+      const productWithDefaultPlan = { ...productWithAppPlans, defaultAppPlan }
 
-      it('should be able to submit only when form is complete', () => {
+      it('should have the default plan selected', () => {
+        const wrapper = mountWrapper({ ...props, products: [productWithDefaultPlan] })
+        selectBuyer(wrapper, buyers[0])
+        selectProduct(wrapper, productWithDefaultPlan)
+
+        expect(wrapper.find('ApplicationPlanSelect').props().appPlan).toBe(defaultAppPlan)
+      })
+
+      it('should not need to select a plan to submit', () => {
         const wrapper = mountWrapper({ ...props, products: [productWithDefaultPlan] })
         expect(isSubmitDisabled(wrapper)).toBe(true)
 
         selectBuyer(wrapper, buyers[0])
-        expect(isSubmitDisabled(wrapper)).toBe(true)
+        selectProduct(wrapper, productWithDefaultPlan)
 
-        selectProduct(wrapper, productCannotSelectPlan)
         expect(isSubmitDisabled(wrapper)).toBe(false)
       })
     })
 
     describe('but it does not have a default application plan', () => {
-      const productNoDefaultPlan = { ...productCannotSelectPlan, defaultAppPlan: null }
+      const productNoDefaultPlan = { ...productWithAppPlans, defaultAppPlan: null }
 
-      it('should not be able to submit only when form is complete', () => {
+      it('should have no plan selected', () => {
         const wrapper = mountWrapper({ ...props, products: [productNoDefaultPlan] })
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-
-        selectBuyer(wrapper, buyers[0])
-        expect(isSubmitDisabled(wrapper)).toBe(true)
-
-        selectProduct(wrapper, productCannotSelectPlan)
-        expect(isSubmitDisabled(wrapper)).toBe(true)
+        expect(wrapper.find('ApplicationPlanSelect').props().appPlan).toBe(null)
       })
+    })
+  })
+
+  describe('when selected product has no application plans', () => {
+    const productWithNoAppPlans = { ...products[0], appPlans: [] }
+
+    beforeEach(() => {
+      props.products = [productWithNoAppPlans]
+    })
+
+    it('should disable the Application plan select', () => {
+      const wrapper = mountWrapper({ ...props, products: [productWithNoAppPlans] })
+      const isDisabled = () => wrapper.find('ApplicationPlanSelect .pf-c-select .pf-m-disabled').exists()
+
+      selectBuyer(wrapper, buyers[0])
+      expect(isDisabled()).toBe(true)
+
+      selectProduct(wrapper, productWithNoAppPlans)
+      expect(isDisabled()).toBe(true)
     })
   })
 

--- a/spec/javascripts/NewApplication/components/ProductSelect.spec.jsx
+++ b/spec/javascripts/NewApplication/components/ProductSelect.spec.jsx
@@ -15,8 +15,7 @@ const product: Product = {
   appPlans: [],
   servicePlans: [],
   defaultServicePlan: null,
-  defaultAppPlan: null,
-  buyerCanSelectPlan: false
+  defaultAppPlan: null
 }
 const products = [product]
 const props = {


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes `buyerCanSelectPlan` parameter, which in fact means _developer can select plan_ and it shouldn't affect the New Application page.

**Which issue(s) this PR fixes** 

[THREESCALE-7834: admin can't create application when developer is not allowed to pick a plan](https://issues.redhat.com/browse/THREESCALE-7834)

**Verification steps** 

See JIRA
