### PR TITLE
THREESCALE-7852 fixed deprecated positional arguments in functional buyers test

### DIFF
--- a/app/controllers/buyers/users_controller.rb
+++ b/app/controllers/buyers/users_controller.rb
@@ -92,8 +92,6 @@ class Buyers::UsersController < Buyers::BaseController
   end
 
   def redirect_back_or_show_detail
-    redirect_back(fallback_location: root_path)
-  rescue ActionController::RedirectBackError
-    redirect_to admin_buyers_account_user_path(account_id: user.account_id, id: user.id)
+    redirect_back(fallback_location: admin_buyers_account_user_path(account_id: user.account_id, id: user.id))
   end
 end

--- a/app/controllers/buyers/users_controller.rb
+++ b/app/controllers/buyers/users_controller.rb
@@ -92,7 +92,7 @@ class Buyers::UsersController < Buyers::BaseController
   end
 
   def redirect_back_or_show_detail
-    redirect_to(:back)
+    redirect_back(fallback_location: root_path)
   rescue ActionController::RedirectBackError
     redirect_to admin_buyers_account_user_path(account_id: user.account_id, id: user.id)
   end

--- a/test/functional/buyers/account_plans_controller_test.rb
+++ b/test/functional/buyers/account_plans_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Buyers::AccountPlansControllerTest < ActionController::TestCase
@@ -102,6 +104,6 @@ class Buyers::AccountPlansControllerTest < ActionController::TestCase
 
     login_as(@provider.first_admin)
     AccountPlan.any_instance.expects(can_be_destroyed?: false).at_least_once
-    delete :destroy, id: @provider.account_plans.first.id
+    delete :destroy, params: { id: @provider.account_plans.first.id }
   end
 end

--- a/test/functional/buyers/applications_controller_test.rb
+++ b/test/functional/buyers/applications_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Buyers::ApplicationsControllerTest < ActionController::TestCase
@@ -16,9 +18,9 @@ class Buyers::ApplicationsControllerTest < ActionController::TestCase
     buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
 
     assert_no_difference Cinstance.method(:count) do
-      post :create, account_id: buyer.id, cinstance: {
+      post :create, params: { account_id: buyer.id, cinstance: {
         plan_id: @plan.id, service_plan_id: service_plan.id
-      }
+      } }
     end
     assert_response 200
   end
@@ -28,10 +30,10 @@ class Buyers::ApplicationsControllerTest < ActionController::TestCase
     buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
 
     assert_difference Cinstance.method(:count) do
-      post :create, account_id: buyer.id, cinstance: {
+      post :create, params: { account_id: buyer.id, cinstance: {
         plan_id: @plan.id, service_plan_id: service_plan.id,
-        :name => 'whatever'
-      }
+        name: 'whatever'
+      } }
     end
     assert_response :redirect
   end
@@ -42,9 +44,9 @@ class Buyers::ApplicationsControllerTest < ActionController::TestCase
 
     buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
 
-    post :create, account_id: buyer.id, cinstance: {
+    post :create, params: { account_id: buyer.id, cinstance: {
       name: 'whatever', plan_id: @plan.id, service_plan_id: service_plan2.id
-    }
+    } }
 
     buyer.reload
     assert buyer.bought_service_contracts.map(&:service_plan).include?(service_plan2), "Should include the service_plan2"
@@ -54,16 +56,16 @@ class Buyers::ApplicationsControllerTest < ActionController::TestCase
     service_plan = FactoryBot.create(:service_plan, service: @service)
     buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
 
-    post :create, account_id: buyer.id, cinstance: {
+    post :create, params: { account_id: buyer.id, cinstance: {
       name: 'whatever', plan_id: @plan.id, service_plan_id: service_plan.id
-    }
+    } }
 
     buyer.reload
     assert_equal buyer.bought_service_contracts.count, 1
 
-    post :create, account_id: buyer.id, cinstance: {
+    post :create, params: { account_id: buyer.id, cinstance: {
       name: 'whatever', plan_id: @plan.id, service_plan_id: service_plan.id
-    }
+    } }
 
     buyer.reload
     assert_equal buyer.bought_service_contracts.count, 1
@@ -98,9 +100,9 @@ class Buyers::ApplicationsControllerTest < ActionController::TestCase
         fake_backend_get_keys('key', params[:id], params[:service_id], @provider.api_key)
       end
 
-      post :create, :account_id => buyer.id, :cinstance => {
-        :name => 'whatever', :plan_id => @plan.id
-      }
+      post :create, params: { account_id: buyer.id, cinstance: {
+        name: 'whatever', plan_id: @plan.id
+      } }
 
       assert_response :redirect
 

--- a/test/functional/buyers/impersonations_controller_test.rb
+++ b/test/functional/buyers/impersonations_controller_test.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Buyers::ImpersonationsControllerTest < ActionController::TestCase
 
   def setup
-    master_account.try!(:delete)
+    master_account&.delete
     @provider = FactoryBot.create :provider_account
   end
 
   test "it needs master admin" do
     login_provider @provider
 
-    post :create, :account_id => @provider.id
+    post :create, params: { account_id: @provider.id }
 
     assert_response :not_found
   end
@@ -18,7 +20,7 @@ class Buyers::ImpersonationsControllerTest < ActionController::TestCase
   test "should be forbidden to impersonate providers without impersonation_admin account" do
     login_provider master_account
 
-    post :create, :account_id => @provider.id
+    post :create, params: { account_id: @provider.id }
 
     assert_response :forbidden
   end
@@ -29,7 +31,7 @@ class Buyers::ImpersonationsControllerTest < ActionController::TestCase
 
     login_provider master_account
 
-    post :create, :account_id => @provider.id
+    post :create, params: { account_id: @provider.id }
 
     assert_response :redirect
   end
@@ -40,7 +42,7 @@ class Buyers::ImpersonationsControllerTest < ActionController::TestCase
 
     login_provider master_account
 
-    post :create, :account_id => @provider.id, :format => :json
+    post :create, params: { account_id: @provider.id, format: :json }
 
     assert_not_nil JSON.parse(response.body)["url"]
     assert_response :created

--- a/test/functional/buyers/users_controller_test.rb
+++ b/test/functional/buyers/users_controller_test.rb
@@ -14,7 +14,7 @@ class Buyers::UsersControllerTest < ActionController::TestCase
 
     login_provider @provider
 
-    post :activate, { id: user.id, account_id: @buyer.id }
+    post :activate, params: { id: user.id, account_id: @buyer.id }
 
     assert_response :redirect
     assert_not_nil flash[:error]
@@ -29,7 +29,7 @@ class Buyers::UsersControllerTest < ActionController::TestCase
 
     assert_equal false, @buyer.onboarding.persisted?
 
-    post :activate, { id: user.id, account_id: @buyer.id }
+    post :activate, params: { id: user.id, account_id: @buyer.id }
 
     assert_equal true, @buyer.reload.onboarding.persisted?
   end
@@ -42,7 +42,7 @@ class Buyers::UsersControllerTest < ActionController::TestCase
 
     login_provider @provider
 
-    post :activate, { id: first_user.id, account_id: @buyer.id }
+    post :activate, params: { id: first_user.id, account_id: @buyer.id }
 
     error_message = 'Failed to activate user: ' << I18n.t('errors.messages.duplicated_user_provider_side')
 
@@ -57,7 +57,7 @@ class Buyers::UsersControllerTest < ActionController::TestCase
 
     request.env['HTTP_REFERER'] = index_url
 
-    post :activate, { id: user.id, account_id: @buyer.id }
+    post :activate, params: { id: user.id, account_id: @buyer.id }
 
     assert_redirected_to index_url
   end
@@ -69,7 +69,7 @@ class Buyers::UsersControllerTest < ActionController::TestCase
 
     request.env['HTTP_REFERER'] = nil
 
-    post :activate, { id: user.id, account_id: @buyer.id }
+    post :activate, params: { id: user.id, account_id: @buyer.id }
 
     assert_response :redirect
   end


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR fix deprecated positional arguments in functional buyers test.
Fixed rubocops

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/THREESCALE-7852
