### PR TITLE
Fixes usage of action controller parameters in integration/admin tests

### DIFF
--- a/app/controllers/admin/api/account/authentication_providers_controller.rb
+++ b/app/controllers/admin/api/account/authentication_providers_controller.rb
@@ -42,7 +42,7 @@ class Admin::Api::Account::AuthenticationProvidersController < Admin::Api::BaseC
   #
   def create
     attributes = authentication_provider_create_params
-    @authentication_provider = self_authentication_providers.build_kind(kind: attributes.require(:kind), **attributes.symbolize_keys)
+    @authentication_provider = self_authentication_providers.build_kind(kind: attributes.require(:kind), **attributes.to_h.symbolize_keys)
     authentication_provider.save
     respond_with authentication_provider_presenter
   end

--- a/app/controllers/admin/api/authentication_providers_controller.rb
+++ b/app/controllers/admin/api/authentication_providers_controller.rb
@@ -142,7 +142,7 @@ class Admin::Api::AuthenticationProvidersController < Admin::Api::BaseController
 
   def build_authentication_provider
     attributes = authentication_provider_create_params
-    @authentication_provider = authentication_providers.build_kind(kind: attributes.require(:kind), **attributes.symbolize_keys)
+    @authentication_provider = authentication_providers.build_kind(kind: attributes.require(:kind), **attributes.to_h.symbolize_keys)
   end
 
   def authorize_authentication_provider

--- a/app/controllers/admin/api/services_controller.rb
+++ b/app/controllers/admin/api/services_controller.rb
@@ -52,7 +52,7 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   def create
     service = current_account.services.build
     create_service = ServiceCreator.new(service: service)
-    create_service.call(service_params)
+    create_service.call(service_params.to_h)
     service.reload if service.persisted? # It has been touched
     respond_with(service)
   end
@@ -91,7 +91,7 @@ class Admin::Api::ServicesController < Admin::Api::ServiceBaseController
   ##~ op.parameters.add :name => " ", :dataType => "custom", :paramType => "query", :allowMultiple => true, :description => "Extra parameters"
   #
   def update
-    service.update(service_params)
+    service.update(service_params.to_h)
 
     respond_with(service)
   end

--- a/app/controllers/provider/admin/account/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/account/authentication_providers_controller.rb
@@ -14,7 +14,7 @@ class Provider::Admin::Account::AuthenticationProvidersController < Provider::Ad
 
   def create
     attributes = authentication_provider_params
-    @authentication_provider = self_authentication_providers.build_kind(kind: attributes.require(:kind), **attributes.symbolize_keys)
+    @authentication_provider = self_authentication_providers.build_kind(kind: attributes.require(:kind), **attributes.to_h.symbolize_keys)
 
     if @authentication_provider.save
       redirect_to provider_admin_account_authentication_provider_path(@authentication_provider), notice: 'SSO integration created'

--- a/app/controllers/provider/admin/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/authentication_providers_controller.rb
@@ -84,7 +84,7 @@ class Provider::Admin::AuthenticationProvidersController < FrontendController
   end
 
   def build_authentication_provider
-    @authentication_provider = authentication_providers.build_kind(kind: create_params.require(:kind), **create_params.symbolize_keys)
+    @authentication_provider = authentication_providers.build_kind(kind: create_params.require(:kind), **create_params.to_h.symbolize_keys)
   end
 
   def authorize_authentication_provider(action = action_name)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

In Rails 5, ActionController::Parameters no longer inherit from Hash.
