### PR TITLE
Service plans controller permit parameters

### DIFF
--- a/app/controllers/api/service_plans_controller.rb
+++ b/app/controllers/api/service_plans_controller.rb
@@ -24,11 +24,11 @@ class Api::ServicePlansController < Api::PlansBaseController
   # to create plan same way as all plans
   #
   def create
-    super params[:service_plan]
+    super create_service_plan_params
   end
 
   def update
-    super params[:service_plan] do
+    super update_service_plan_params do
       redirect_to plans_index_path, :notice => "Service plan updated."
     end
   end
@@ -42,6 +42,8 @@ class Api::ServicePlansController < Api::PlansBaseController
   end
 
   protected
+
+  DEFAULT_PARAMS = %i[name state setup_fee cost_per_month trial_period_days cancellation_period approval_required].freeze
 
   def activate_sidebar_menu
     activate_menu :sidebar => :service_plans
@@ -58,5 +60,13 @@ class Api::ServicePlansController < Api::PlansBaseController
 
   def authorize_service_plans!
     authorize! :manage, :service_plans
+  end
+
+  def create_service_plan_params
+    params.require(:service_plan).permit(DEFAULT_PARAMS | %i[system_name])
+  end
+
+  def update_service_plan_params
+    params.require(:service_plan).permit(DEFAULT_PARAMS)
   end
 end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

In Rails 5, ActionController::Parameters no longer inherit from Hash. It also requires to use permit and required keys to be more secure.
