### PR TITLE
signup controller handles CORS by itself

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -227,7 +227,7 @@ module System
     config.middleware.use ThreeScale::Middleware::Multitenant, :tenant_id
     config.middleware.insert_before Rack::Runtime, Rack::UTF8Sanitizer
     config.middleware.insert_before Rack::Runtime, Rack::XServedBy # we can pass hashed hostname as parameter
-    config.middleware.insert_before 0, ThreeScale::Middleware::Cors
+    config.middleware.insert_before 0, ThreeScale::Middleware::Cors if config.three_scale.cors.enabled
 
     config.unicorn = ActiveSupport::OrderedOptions[after_fork: []]
 

--- a/config/docker/cors.yml
+++ b/config/docker/cors.yml
@@ -8,6 +8,8 @@ cors: &default
     methods: :get
     max_age: 3628800
     credentials: false
+  exclude:
+    - path_prefix: /p/signup
 
 development:
   <<: *default

--- a/config/examples/cors.yml
+++ b/config/examples/cors.yml
@@ -8,6 +8,8 @@ cors: &default
     methods: :get
     max_age: 3628800
     credentials: false
+  exclude:
+    - path_prefix: /p/signup
 
 development:
   <<: *default

--- a/lib/three_scale/middleware/cors.rb
+++ b/lib/three_scale/middleware/cors.rb
@@ -6,12 +6,12 @@ module ThreeScale::Middleware
       super(app, opts) { set_config }
       set_excludes
 
-      if block_given? # rubocop:disable Style/GuardClause why: keep copy from superclass
-        if block.arity == 1
-          block.call(self) # rubocop:disable Performance/RedundantBlockCall why: keep copy from superclass
-        else
-          instance_eval(&block)
-        end
+      return unless block_given?
+
+      if block.arity == 1
+        yield(self)
+      else
+        instance_eval(&block)
       end
     end
 

--- a/lib/three_scale/middleware/cors.rb
+++ b/lib/three_scale/middleware/cors.rb
@@ -15,7 +15,7 @@ module ThreeScale::Middleware
     end
 
     def call(env)
-      return @app.call(env) unless enabled?
+      return @app.call(env) if disabled? || signup_controller?(env)
 
       super
     end
@@ -26,6 +26,10 @@ module ThreeScale::Middleware
 
     delegate :enabled, to: :config
     alias enabled? enabled
+
+    def disabled?
+      !enabled?
+    end
 
     private
 
@@ -44,6 +48,10 @@ module ThreeScale::Middleware
           end
         end
       end
+    end
+
+    def signup_controller?(env)
+      evaluate_path(env).start_with? '/p/signup'
     end
   end
 end

--- a/lib/three_scale/middleware/cors.rb
+++ b/lib/three_scale/middleware/cors.rb
@@ -2,6 +2,8 @@
 
 module ThreeScale::Middleware
   class Cors < Rack::Cors
+    include Rails.application.routes.url_helpers
+
     def initialize(app, opts = {}, &block)
       super(app, opts) { set_config }
 
@@ -51,7 +53,7 @@ module ThreeScale::Middleware
     end
 
     def signup_controller?(env)
-      evaluate_path(env).start_with? '/p/signup'
+      evaluate_path(env).start_with? provider_signup_path # '/p/signup'
     end
   end
 end

--- a/test/unit/three_scale/middleware/cors_test.rb
+++ b/test/unit/three_scale/middleware/cors_test.rb
@@ -3,6 +3,8 @@
 require 'test_helper'
 
 class ThreeScale::Middleware::CorsTest < ActiveSupport::TestCase
+  include Rails.application.routes.url_helpers
+
   setup do
     provider = FactoryBot.create(:simple_provider)
     @provider_domain = provider.external_self_domain
@@ -68,10 +70,10 @@ class ThreeScale::Middleware::CorsTest < ActiveSupport::TestCase
   end
 
   test 'signup path ignored' do
-    Rails.configuration.three_scale.cors.stubs(enabled: true, resources: '/p/signup')
+    Rails.configuration.three_scale.cors.stubs(enabled: true, resources: provider_signup_path)
 
     middleware = ThreeScale::Middleware::Cors.new(app)
-    status, = middleware.call(env.merge('REQUEST_METHOD' => 'OPTIONS', 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/p/signup'))
+    status, = middleware.call(env.merge('REQUEST_METHOD' => 'OPTIONS', 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET', 'PATH_INFO' => provider_signup_path))
     assert_equal 403, status
   end
 

--- a/test/unit/three_scale/middleware/cors_test.rb
+++ b/test/unit/three_scale/middleware/cors_test.rb
@@ -67,6 +67,14 @@ class ThreeScale::Middleware::CorsTest < ActiveSupport::TestCase
     assert headers['Access-Control-Allow-Origin']
   end
 
+  test 'signup path ignored' do
+    Rails.configuration.three_scale.cors.stubs(enabled: true, resources: '/p/signup')
+
+    middleware = ThreeScale::Middleware::Cors.new(app)
+    status, = middleware.call(env.merge('REQUEST_METHOD' => 'OPTIONS', 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/p/signup'))
+    assert_equal 403, status
+  end
+
   protected
 
   def env


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

`rack-cors` gem handles all pre-flight requests but signup controller has its
own way of handling these. So we make rack-cors skip handling of requests
with the signup controller path.

Otherwise 3scale.net signup form gets broken.

To test you need cors enabled in `config/cors.yml`. The this is with the fix:
```
$ curl -v 'http://master-account.3scale.localhost:3000/p/signup?signup_origin=website-signup' -X OPTIONS -H 'User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0' -H 'Accept: */*' -H 'Accept-Language: en-US,en;q=0.7,bg;q=0.3' --compressed -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: 3scale-origin,x-requested-with' -H 'Referer: https://www.3scale.net/' -H 'Origin: https://www.3scale.net' -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: same-site' -H 'Pragma: no-cache' -H 'Cache-Control: no-cache'
*   Trying ::1:3000...
* connect to ::1 port 3000 failed: Connection refused
*   Trying 127.0.0.1:3000...
* Connected to master-account.3scale.localhost (127.0.0.1) port 3000 (#0)
> OPTIONS /p/signup?signup_origin=website-signup HTTP/1.1
> Host: master-account.3scale.localhost:3000
> Accept-Encoding: deflate, gzip, br
> User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0
> Accept: */*
> Accept-Language: en-US,en;q=0.7,bg;q=0.3
> Access-Control-Request-Method: GET
> Access-Control-Request-Headers: 3scale-origin,x-requested-with
> Referer: https://www.3scale.net/
> Origin: https://www.3scale.net
> DNT: 1
> Connection: keep-alive
> Sec-Fetch-Dest: empty
> Sec-Fetch-Mode: cors
> Sec-Fetch-Site: same-site
> Pragma: no-cache
> Cache-Control: no-cache
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Mon, 15 Nov 2021 21:21:34 GMT
< Connection: close
< Access-Control-Allow-Origin: https://www.3scale.net
< Access-Control-Allow-Methods: GET, POST
< Access-Control-Allow-Headers: Origin, Accept, Cookie, Content-Type, X-Requested-With, X-CSRF-Token, 3scale-Origin
< Access-Control-Allow-Credentials: true
< Content-Type: text/html
< Cache-Control: no-cache
< Set-Cookie: _system_session=TzxcFDSlkjxkvFDAzhjv3ZnUDM5b3F4eDBjWHc9PS0tVXZpU1VtaFhiQkZUU3hwTVRTTGQ5dz09--a4bb8c1f611b5d2e19ace44da48c9ce3920a9dbb; path=/; HttpOnly; SameSite=Lax
< X-Request-Id: 17d731b0-8e68-449b-a1fa-641ca5d56e56
< X-Runtime: 0.542218
< X-Served-By: Horak
< Vary: Accept-Encoding
< Content-Encoding: gzip
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< 
* Closing connection 0
```

Without the fix:
```
curl -v 'http://master-account.3scale.localhost:3000/p/signup?signup_origin=website-signup' -X OPTIONS -H 'User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0' -H 'Accept: */*' -H 'Accept-Language: en-US,en;q=0.7,bg;q=0.3' --compressed -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: 3scale-origin,x-requested-with' -H 'Referer: https://www.3scale.net/' -H 'Origin: https://www.3scale.net' -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: same-site' -H 'Pragma: no-cache' -H 'Cache-Control: no-cache'
*   Trying ::1:3000...
* connect to ::1 port 3000 failed: Connection refused
*   Trying 127.0.0.1:3000...
* Connected to master-account.3scale.localhost (127.0.0.1) port 3000 (#0)
> OPTIONS /p/signup?signup_origin=website-signup HTTP/1.1
> Host: master-account.3scale.localhost:3000
> Accept-Encoding: deflate, gzip, br
> User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0
> Accept: */*
> Accept-Language: en-US,en;q=0.7,bg;q=0.3
> Access-Control-Request-Method: GET
> Access-Control-Request-Headers: 3scale-origin,x-requested-with
> Referer: https://www.3scale.net/
> Origin: https://www.3scale.net
> DNT: 1
> Connection: keep-alive
> Sec-Fetch-Dest: empty
> Sec-Fetch-Mode: cors
> Sec-Fetch-Site: same-site
> Pragma: no-cache
> Cache-Control: no-cache
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Mon, 15 Nov 2021 21:22:21 GMT
< Connection: close
< X-Frame-Options: DENY
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< 
* Closing connection 0
```