### PR TITLE
Sort plans alphabetically in Create Application form

### DIFF
--- a/app/presenters/service_presenter.rb
+++ b/app/presenters/service_presenter.rb
@@ -26,8 +26,8 @@ class ServicePresenter < SimpleDelegator
       name: name,
       systemName: system_name,
       updatedAt: updated_at.to_s(:long),
-      appPlans: plans.stock.select(:id, :name).as_json(root: false),
-      servicePlans: service_plans.select(:id, :name).as_json(root: false),
+      appPlans: plans.reorder(:name).stock.select(:id, :name).as_json(root: false),
+      servicePlans: service_plans.reorder(:name).select(:id, :name).as_json(root: false),
       defaultServicePlan: default_service_plan.as_json(root: false, only: %i[id name]),
       defaultAppPlan: default_application_plan.as_json(root: false, only: %i[id name])
     }

--- a/test/unit/presenters/service_presenter_test.rb
+++ b/test/unit/presenters/service_presenter_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class ServicePresenterTest < ActiveSupport::TestCase
-  test 'new application application and service plans are sorted alphabetically' do
+  test 'new application plan and service plans are sorted alphabetically' do
     service = FactoryBot.create(:simple_service)
     FactoryBot.create(:application_plan, issuer: service, position: 1, name: 'Application Plan 3')
     FactoryBot.create(:application_plan, issuer: service, position: 3, name: 'Application Plan 1')

--- a/test/unit/presenters/service_presenter_test.rb
+++ b/test/unit/presenters/service_presenter_test.rb
@@ -19,6 +19,6 @@ class ServicePresenterTest < ActiveSupport::TestCase
     assert_equal app_plans, (app_plans.sort_by { |p| p[:name] })
 
     service_plans = data[:servicePlans]
-    assert_equal service_plans, (service_plans.sort_by { |p| p[:name] })
+    assert_equal (service_plans.sort_by { |p| p[:name] }), service_plans
   end
 end

--- a/test/unit/presenters/service_presenter_test.rb
+++ b/test/unit/presenters/service_presenter_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ServicePresenterTest < ActiveSupport::TestCase
+  test 'new application application and service plans are sorted alphabetically' do
+    service = FactoryBot.create(:simple_service)
+    FactoryBot.create(:application_plan, issuer: service, position: 1, name: 'Application Plan 3')
+    FactoryBot.create(:application_plan, issuer: service, position: 3, name: 'Application Plan 1')
+    FactoryBot.create(:application_plan, issuer: service, position: 2, name: 'Application Plan 2')
+
+    FactoryBot.create(:service_plan, issuer: service, position: 1, name: 'Service Plan 3')
+    FactoryBot.create(:service_plan, issuer: service, position: 3, name: 'Service Plan 1')
+    FactoryBot.create(:service_plan, issuer: service, position: 2, name: 'Service Plan 2')
+
+    data = ServicePresenter.new(service).new_application_data
+
+    app_plans = data[:appPlans]
+    assert_equal app_plans, (app_plans.sort_by { |p| p[:name] })
+
+    service_plans = data[:servicePlans]
+    assert_equal service_plans, (service_plans.sort_by { |p| p[:name] })
+  end
+end

--- a/test/unit/presenters/service_presenter_test.rb
+++ b/test/unit/presenters/service_presenter_test.rb
@@ -16,7 +16,7 @@ class ServicePresenterTest < ActiveSupport::TestCase
     data = ServicePresenter.new(service).new_application_data
 
     app_plans = data[:appPlans]
-    assert_equal app_plans, (app_plans.sort_by { |p| p[:name] })
+    assert_equal (app_plans.sort_by { |p| p[:name] }), app_plans
 
     service_plans = data[:servicePlans]
     assert_equal (service_plans.sort_by { |p| p[:name] }), service_plans


### PR DESCRIPTION
**What this PR does / why we need it**:

Because it's required

**Which issue(s) this PR fixes** 

Bug reported for [THREESCALE-6879: [3scale][2.11][HI-prio] Add 'Create new Application' flow to Product > Applications index](https://issues.redhat.com/browse/THREESCALE-6879)

**Note**: plans in the images have been created in reverse order so that it doesn't coincide with created_at order.
![Screenshot 2021-11-16 at 13 10 34](https://user-images.githubusercontent.com/11672286/141985973-661d99ea-69e8-438f-aeca-01424f440167.png)
![Screenshot 2021-11-16 at 13 10 28](https://user-images.githubusercontent.com/11672286/141985978-cae827f9-79fa-48df-bd43-7f90ba552131.png)

