### PR TITLE
THREESCALE-7852 Fixed functional accounts test

### DIFF
--- a/test/functional/accounts/notifications_controller_test.rb
+++ b/test/functional/accounts/notifications_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # provider side
@@ -10,7 +12,7 @@ class Provider::Admin::Account::NotificationsControllerTest < ActionController::
 
   test 'success update should redirect to list notifications' do
     rule = @provider.mail_dispatch_rules.create!(system_operation: SystemOperation.for(:user_signup))
-    put :update, id: rule.id, mail_dispatch_rule: { dispatch: true }
+    put :update, params: { id: rule.id, mail_dispatch_rule: { dispatch: true } }
     assert_redirected_to provider_admin_account_notifications_path
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR fix deprecated positional arguments in functional accounts test.
Fixed rubocops

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/THREESCALE-7852