### PR TITLE
Fixes integration proxy configs tests to be compatible with rails 5.1

### DIFF
--- a/test/integration/user-management-api/services/proxy/configs_test.rb
+++ b/test/integration/user-management-api/services/proxy/configs_test.rb
@@ -23,7 +23,7 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
       'HTTP_IF_MODIFIED_SINCE' => response.header['Last-Modified'],
       'HTTP_IF_NONE_MATCH'     => response.header['ETag']
     }
-    get(latest_admin_api_service_proxy_configs_path(params), {}, headers)
+    get latest_admin_api_service_proxy_configs_path(params), headers: headers
     assert_response :not_modified
 
     get latest_admin_api_service_proxy_configs_path(params.merge(format: :xml))
@@ -48,7 +48,7 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
       'HTTP_IF_MODIFIED_SINCE' => response.header['Last-Modified'],
       'HTTP_IF_NONE_MATCH'     => response.header['ETag']
     }
-    get(admin_api_service_proxy_config_path(params), {}, headers)
+    get admin_api_service_proxy_config_path(params), headers: headers
     assert_response :not_modified
 
     get admin_api_service_proxy_config_path(params.merge(version: 'non-existing-version'))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Fixes proxy/configs_test to be compatible with rails 5.1
