### PR TITLE
THREESCALE-7676: Allow tenant_id to be propagated from account

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -99,7 +99,7 @@ class Account < ApplicationRecord
 
   before_validation(on: :create, if: :provider?) { generate_s3_prefix }
   before_validation(on: :create, if: :provider?) { generate_domains }
-  before_create :generate_site_access_code
+  before_create :generate_site_access_code, :set_default_master
 
   attr_protected :master, :provider, :buyer, :from_email, :vat_rate, :sample_data, :default_service_id, :s3_prefix,
                  :provider_account_id, :paid_at, :paid, :signs_legal_terms, :tenant_id, :default_account_plan_id,
@@ -578,6 +578,11 @@ class Account < ApplicationRecord
 
   def generate_site_access_code
     self.site_access_code ||= SecureRandom.hex(5) if provider?
+  end
+
+  def set_default_master
+    self.master = false if provider? && master.nil?
+    true
   end
 
   def destroy_all_users

--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -5,13 +5,9 @@ class SetTenantIdWorker < ApplicationJob
   def perform(provider)
     provider.update_column(:master, false)
 
-    {
-      BackendApi => :account_id,
-      LogEntry => :provider_id,
-      Alert => :account_id,
-    }.each do |model, relation|
-      model.where(relation => provider.id).find_each do |instance|
-        ModelTenantIdWorker.perform_later(instance, :tenant_id, provider)
+    [:backend_apis, :log_entries, :alerts].each do |relation|
+      provider.public_send(relation).where(tenant_id: nil).find_each do |instance|
+        ModelTenantIdWorker.perform_later(instance, provider.tenant_id)
       end
     end
   end
@@ -20,16 +16,16 @@ class SetTenantIdWorker < ApplicationJob
     unique :until_executed
 
     def perform(*)
-      Account.providers.not_master.find_each do |provider_batch|
-        SetTenantIdWorker.perform_later(provider_batch)
+      Account.providers.where(master: nil).find_each do |provider|
+        SetTenantIdWorker.perform_later(provider)
       end
     end
   end
 
   class ModelTenantIdWorker < ApplicationJob
 
-    def perform(object, attribute, provider)
-      object.update_column(attribute, provider.tenant_id)
+    def perform(object, tenant_id)
+      object.update_column(:tenant_id, tenant_id)
     end
 
   end

--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -14,7 +14,7 @@ class SetTenantIdWorker < ApplicationJob
       }.each do |model, relation|
         q = {relation => provider.id}
         
-        model.where(q).each do |instance|
+        model.where(relation => provider.id).find_each do |instance|
           instance.update!(tenant_id: provider.tenant_id)
         end
       end

--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -4,7 +4,6 @@ class SetTenantIdWorker < ApplicationJob
 
   def perform(provider_batch)
     provider_batch.each do |provider|
-      # Set the master field to false
       provider.master = false
       provider.save!
 

--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -25,7 +25,7 @@ class SetTenantIdWorker < ApplicationJob
     unique :until_executed
 
     def perform(*)
-      Account.providers.not_master.find_in_batches(batch_size: 100).each do |provider_batch|
+      Account.providers.not_master.find_each do |provider_batch|
         SetTenantIdWorker.perform_later(provider_batch)
       end
     end

--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -7,8 +7,6 @@ class SetTenantIdWorker < ApplicationJob
       provider.master = false
       provider.save!
 
-      # Update the backend_apis, log_entries and alerts to propagate the tenant_id from the updated
-      # provider
       {
         BackendApi => :account_id,
         LogEntry => :provider_id,

--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class SetTenantIdWorker < ApplicationJob
+
+  def perform(provider_batch)
+    provider_batch.each do |provider|
+      # Set the master field to false
+      provider.master = false
+      provider.save!
+
+      # Update the backend_apis, log_entries and alerts to propagate the tenant_id from the updated
+      # provider
+      {
+        BackendApi => :account_id,
+        LogEntry => :provider_id,
+        Alert => :account_id,
+      }.each do |model, relation|
+        q = {}
+        q[relation] = provider.id
+        
+        model.where(q).each do |instance|
+          instance.update!(tenant_id: provider.tenant_id)
+        end
+      end
+    end
+  end
+
+  class BatchEnqueueWorker < ApplicationJob
+    unique :until_executed
+
+    def perform(*)
+      Account.providers.not_master.find_in_batches(batch_size: 100).each do |provider_batch|
+        SetTenantIdWorker.perform_later(provider_batch)
+      end
+    end
+  end
+
+end

--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -12,8 +12,7 @@ class SetTenantIdWorker < ApplicationJob
         LogEntry => :provider_id,
         Alert => :account_id,
       }.each do |model, relation|
-        q = {}
-        q[relation] = provider.id
+        q = {relation => provider.id}
         
         model.where(q).each do |instance|
           instance.update!(tenant_id: provider.tenant_id)

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -305,4 +305,9 @@ namespace :fixes do
     exec_batch.call(:providers, Account.providers, provider_states_transitions)
     exec_batch.call(:developers, Account.buyers, buyer_states_transitions)
   end
+
+  desc 'Fix tenant_id missing in some tables'
+  task :tenant_id => :environment do
+    SetTenantIdWorker::BatchEnqueueWorker.perform_later
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

There is an issue where the `master` field of provider accounts is `null` by default. This results in triggers for the `backend_apis`, `alerts`, and `log_entries` tables, that set the `tenant_id` field from the related account **only** if the `master` field is `false` not setting the field.

This PR fixes it by adding a `before_create` callback to the Accounts model that sets the master field of provider accounts to `false` if it's not set before. For existing data, a new rake task (`fixes:tenant_id`) is added to set these missing fields.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7676

**Verification steps** 

##### Callback

Create a new account with the `provider` field set to `true` and verify that `master` is set to `false` automatically

##### Task

Run the task and verify that for an existing provider account where the `master` field was `null`, it's set to `false`
