### PR TITLE
[email-async] Support entitlements

### DIFF
--- a/app/services/support_entitlements_service.rb
+++ b/app/services/support_entitlements_service.rb
@@ -76,10 +76,10 @@ class SupportEntitlementsService
   end
 
   def notify_entitlements_assigned
-    AccountMailer.support_entitlements_assigned(account, notification_options).deliver_now
+    AccountMailer.support_entitlements_assigned(account, notification_options).deliver_later
   end
 
   def notify_entitlements_revoked
-    AccountMailer.support_entitlements_revoked(account, notification_options).deliver_now
+    AccountMailer.support_entitlements_revoked(account, notification_options).deliver_later
   end
 end

--- a/config/initializers/active_job_hooks.rb
+++ b/config/initializers/active_job_hooks.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# TODO: Remove when migrated to Rails 6.1.4.1+
+#
+# This is extracted from Rails 6.1.4.1
+# Once we migrate there we can remove those files
+# Those are located in lib/active_job
+require 'active_job/arguments'
+require 'active_job/serializers'

--- a/lib/active_job/arguments.rb
+++ b/lib/active_job/arguments.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/hash"
+
+module ActiveJob
+  # Raised when an exception is raised during job arguments deserialization.
+  #
+  # Wraps the original exception raised as +cause+.
+  class DeserializationError < StandardError
+    def initialize #:nodoc:
+      super("Error while trying to deserialize arguments: #{$!.message}")
+      set_backtrace $!.backtrace
+    end
+  end
+
+  # Raised when an unsupported argument type is set as a job argument. We
+  # currently support String, Integer, Float, NilClass, TrueClass, FalseClass,
+  # BigDecimal, Symbol, Date, Time, DateTime, ActiveSupport::TimeWithZone,
+  # ActiveSupport::Duration, Hash, ActiveSupport::HashWithIndifferentAccess,
+  # Array or GlobalID::Identification instances, although this can be extended
+  # by adding custom serializers.
+  # Raised if you set the key for a Hash something else than a string or
+  # a symbol. Also raised when trying to serialize an object which can't be
+  # identified with a GlobalID - such as an unpersisted Active Record model.
+  class SerializationError < ArgumentError; end
+
+  module Arguments
+    extend self
+    # Serializes a set of arguments. Intrinsic types that can safely be
+    # serialized without mutation are returned as-is. Arrays/Hashes are
+    # serialized element by element. All other types are serialized using
+    # GlobalID.
+    def serialize(arguments)
+      arguments.map { |argument| serialize_argument(argument) }
+    end
+
+    # Deserializes a set of arguments. Intrinsic types that can safely be
+    # deserialized without mutation are returned as-is. Arrays/Hashes are
+    # deserialized element by element. All other types are deserialized using
+    # GlobalID.
+    def deserialize(arguments)
+      arguments.map { |argument| deserialize_argument(argument) }
+    rescue
+      raise DeserializationError
+    end
+
+    private
+    # :nodoc:
+    PERMITTED_TYPES = [ NilClass, String, Integer, Float, BigDecimal, TrueClass, FalseClass ]
+    # :nodoc:
+    GLOBALID_KEY = "_aj_globalid"
+    # :nodoc:
+    SYMBOL_KEYS_KEY = "_aj_symbol_keys"
+    # :nodoc:
+    RUBY2_KEYWORDS_KEY = "_aj_ruby2_keywords"
+    # :nodoc:
+    WITH_INDIFFERENT_ACCESS_KEY = "_aj_hash_with_indifferent_access"
+    # :nodoc:
+    OBJECT_SERIALIZER_KEY = "_aj_serialized"
+
+    # :nodoc:
+    RESERVED_KEYS = [
+      GLOBALID_KEY, GLOBALID_KEY.to_sym,
+      SYMBOL_KEYS_KEY, SYMBOL_KEYS_KEY.to_sym,
+      RUBY2_KEYWORDS_KEY, RUBY2_KEYWORDS_KEY.to_sym,
+      OBJECT_SERIALIZER_KEY, OBJECT_SERIALIZER_KEY.to_sym,
+      WITH_INDIFFERENT_ACCESS_KEY, WITH_INDIFFERENT_ACCESS_KEY.to_sym,
+    ]
+    private_constant :PERMITTED_TYPES, :RESERVED_KEYS, :GLOBALID_KEY,
+                     :SYMBOL_KEYS_KEY, :RUBY2_KEYWORDS_KEY, :WITH_INDIFFERENT_ACCESS_KEY
+
+    unless Hash.respond_to?(:ruby2_keywords_hash?) && Hash.respond_to?(:ruby2_keywords_hash)
+      using Module.new {
+        refine Hash do
+          class << Hash
+            if RUBY_VERSION >= "2.7"
+              def ruby2_keywords_hash?(hash)
+                !new(*[hash]).default.equal?(hash)
+              end
+            else
+              def ruby2_keywords_hash?(hash)
+                false
+              end
+            end
+
+            def ruby2_keywords_hash(hash)
+              _ruby2_keywords_hash(**hash)
+            end
+
+            private def _ruby2_keywords_hash(*args)
+              args.last
+            end
+            ruby2_keywords(:_ruby2_keywords_hash) if respond_to?(:ruby2_keywords, true)
+          end
+        end
+      }
+    end
+
+    def serialize_argument(argument)
+      case argument
+      when *PERMITTED_TYPES
+        argument
+      when GlobalID::Identification
+        convert_to_global_id_hash(argument)
+      when Array
+        argument.map { |arg| serialize_argument(arg) }
+      when ActiveSupport::HashWithIndifferentAccess
+        serialize_indifferent_hash(argument)
+      when Hash
+        symbol_keys = argument.each_key.grep(Symbol).map!(&:to_s)
+        aj_hash_key = if Hash.ruby2_keywords_hash?(argument)
+                        RUBY2_KEYWORDS_KEY
+                      else
+                        SYMBOL_KEYS_KEY
+                      end
+        result = serialize_hash(argument)
+        result[aj_hash_key] = symbol_keys
+        result
+      when -> (arg) { arg.respond_to?(:permitted?) }
+        serialize_indifferent_hash(argument.to_h)
+      else
+        Serializers.serialize(argument)
+      end
+    end
+
+    def deserialize_argument(argument)
+      case argument
+      when String
+        argument
+      when *PERMITTED_TYPES
+        argument
+      when Array
+        argument.map { |arg| deserialize_argument(arg) }
+      when Hash
+        if serialized_global_id?(argument)
+          deserialize_global_id argument
+        elsif custom_serialized?(argument)
+          Serializers.deserialize(argument)
+        else
+          deserialize_hash(argument)
+        end
+      else
+        raise ArgumentError, "Can only deserialize primitive arguments: #{argument.inspect}"
+      end
+    end
+
+    def serialized_global_id?(hash)
+      hash.size == 1 && hash.include?(GLOBALID_KEY)
+    end
+
+    def deserialize_global_id(hash)
+      GlobalID::Locator.locate hash[GLOBALID_KEY]
+    end
+
+    def custom_serialized?(hash)
+      hash.key?(OBJECT_SERIALIZER_KEY)
+    end
+
+    def serialize_hash(argument)
+      argument.each_with_object({}) do |(key, value), hash|
+        hash[serialize_hash_key(key)] = serialize_argument(value)
+      end
+    end
+
+    def deserialize_hash(serialized_hash)
+      result = serialized_hash.transform_values { |v| deserialize_argument(v) }
+      if result.delete(WITH_INDIFFERENT_ACCESS_KEY)
+        result = result.with_indifferent_access
+      elsif symbol_keys = result.delete(SYMBOL_KEYS_KEY)
+        result = transform_symbol_keys(result, symbol_keys)
+      elsif symbol_keys = result.delete(RUBY2_KEYWORDS_KEY)
+        result = transform_symbol_keys(result, symbol_keys)
+        result = Hash.ruby2_keywords_hash(result)
+      end
+      result
+    end
+
+    def serialize_hash_key(key)
+      case key
+      when *RESERVED_KEYS
+        raise SerializationError.new("Can't serialize a Hash with reserved key #{key.inspect}")
+      when String, Symbol
+        key.to_s
+      else
+        raise SerializationError.new("Only string and symbol hash keys may be serialized as job arguments, but #{key.inspect} is a #{key.class}")
+      end
+    end
+
+    def serialize_indifferent_hash(indifferent_hash)
+      result = serialize_hash(indifferent_hash)
+      result[WITH_INDIFFERENT_ACCESS_KEY] = serialize_argument(true)
+      result
+    end
+
+    def transform_symbol_keys(hash, symbol_keys)
+      # NOTE: HashWithIndifferentAccess#transform_keys always
+      # returns stringified keys with indifferent access
+      # so we call #to_h here to ensure keys are symbolized.
+      hash.to_h.transform_keys do |key|
+        if symbol_keys.include?(key)
+          key.to_sym
+        else
+          key
+        end
+      end
+    end
+
+    def convert_to_global_id_hash(argument)
+      { GLOBALID_KEY => argument.to_global_id.to_s }
+    rescue URI::GID::MissingModelIdError
+      raise SerializationError, "Unable to serialize #{argument.class} " \
+          "without an id. (Maybe you forgot to call save?)"
+    end
+  end
+end

--- a/lib/active_job/serializers.rb
+++ b/lib/active_job/serializers.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "set"
+
+module ActiveJob
+  # The <tt>ActiveJob::Serializers</tt> module is used to store a list of known serializers
+  # and to add new ones. It also has helpers to serialize/deserialize objects.
+  module Serializers # :nodoc:
+    extend ActiveSupport::Autoload
+
+    autoload :ObjectSerializer
+    autoload :TimeObjectSerializer
+    autoload :SymbolSerializer
+    autoload :DurationSerializer
+    autoload :DateTimeSerializer
+    autoload :DateSerializer
+    autoload :TimeWithZoneSerializer
+    autoload :TimeSerializer
+    autoload :ModuleSerializer
+
+    mattr_accessor :_additional_serializers
+    self._additional_serializers = Set.new
+
+    class << self
+      # Returns serialized representative of the passed object.
+      # Will look up through all known serializers.
+      # Raises <tt>ActiveJob::SerializationError</tt> if it can't find a proper serializer.
+      def serialize(argument)
+        serializer = serializers.detect { |s| s.serialize?(argument) }
+        raise SerializationError.new("Unsupported argument type: #{argument.class.name}") unless serializer
+        serializer.serialize(argument)
+      end
+
+      # Returns deserialized object.
+      # Will look up through all known serializers.
+      # If no serializer found will raise <tt>ArgumentError</tt>.
+      def deserialize(argument)
+        serializer_name = argument[Arguments::OBJECT_SERIALIZER_KEY]
+        raise ArgumentError, "Serializer name is not present in the argument: #{argument.inspect}" unless serializer_name
+
+        serializer = serializer_name.safe_constantize
+        raise ArgumentError, "Serializer #{serializer_name} is not known" unless serializer
+
+        serializer.deserialize(argument)
+      end
+
+      # Returns list of known serializers.
+      def serializers
+        self._additional_serializers
+      end
+
+      # Adds new serializers to a list of known serializers.
+      def add_serializers(*new_serializers)
+        self._additional_serializers += new_serializers.flatten
+      end
+    end
+
+    add_serializers SymbolSerializer,
+      DurationSerializer,
+      DateTimeSerializer,
+      DateSerializer,
+      TimeWithZoneSerializer,
+      TimeSerializer,
+      ModuleSerializer
+  end
+end

--- a/lib/active_job/serializers/date_serializer.rb
+++ b/lib/active_job/serializers/date_serializer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class DateSerializer < ObjectSerializer # :nodoc:
+      def serialize(date)
+        super("value" => date.iso8601)
+      end
+
+      def deserialize(hash)
+        Date.iso8601(hash["value"])
+      end
+
+      private
+        def klass
+          Date
+        end
+    end
+  end
+end

--- a/lib/active_job/serializers/date_time_serializer.rb
+++ b/lib/active_job/serializers/date_time_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class DateTimeSerializer < TimeObjectSerializer # :nodoc:
+      def deserialize(hash)
+        DateTime.iso8601(hash["value"])
+      end
+
+      private
+        def klass
+          DateTime
+        end
+    end
+  end
+end

--- a/lib/active_job/serializers/duration_serializer.rb
+++ b/lib/active_job/serializers/duration_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class DurationSerializer < ObjectSerializer # :nodoc:
+      def serialize(duration)
+        super("value" => duration.value, "parts" => Arguments.serialize(duration.parts))
+      end
+
+      def deserialize(hash)
+        value = hash["value"]
+        parts = Arguments.deserialize(hash["parts"])
+
+        klass.new(value, parts)
+      end
+
+      private
+        def klass
+          ActiveSupport::Duration
+        end
+    end
+  end
+end

--- a/lib/active_job/serializers/module_serializer.rb
+++ b/lib/active_job/serializers/module_serializer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class ModuleSerializer < ObjectSerializer # :nodoc:
+      def serialize(constant)
+        super("value" => constant.name)
+      end
+
+      def deserialize(hash)
+        hash["value"].constantize
+      end
+
+      private
+        def klass
+          Module
+        end
+    end
+  end
+end

--- a/lib/active_job/serializers/object_serializer.rb
+++ b/lib/active_job/serializers/object_serializer.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    # Base class for serializing and deserializing custom objects.
+    #
+    # Example:
+    #
+    #   class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
+    #     def serialize(money)
+    #       super("amount" => money.amount, "currency" => money.currency)
+    #     end
+    #
+    #     def deserialize(hash)
+    #       Money.new(hash["amount"], hash["currency"])
+    #     end
+    #
+    #     private
+    #
+    #       def klass
+    #         Money
+    #       end
+    #   end
+    class ObjectSerializer
+      include Singleton
+
+      class << self
+        delegate :serialize?, :serialize, :deserialize, to: :instance
+      end
+
+      # Determines if an argument should be serialized by a serializer.
+      def serialize?(argument)
+        argument.is_a?(klass)
+      end
+
+      # Serializes an argument to a JSON primitive type.
+      def serialize(hash)
+        { Arguments::OBJECT_SERIALIZER_KEY => self.class.name }.merge!(hash)
+      end
+
+      # Deserializes an argument from a JSON primitive type.
+      def deserialize(json)
+        raise NotImplementedError
+      end
+
+      private
+        # The class of the object that will be serialized.
+        def klass # :doc:
+          raise NotImplementedError
+        end
+    end
+  end
+end

--- a/lib/active_job/serializers/symbol_serializer.rb
+++ b/lib/active_job/serializers/symbol_serializer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class SymbolSerializer < ObjectSerializer # :nodoc:
+      def serialize(argument)
+        super("value" => argument.to_s)
+      end
+
+      def deserialize(argument)
+        argument["value"].to_sym
+      end
+
+      private
+        def klass
+          Symbol
+        end
+    end
+  end
+end

--- a/lib/active_job/serializers/time_object_serializer.rb
+++ b/lib/active_job/serializers/time_object_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class TimeObjectSerializer < ObjectSerializer # :nodoc:
+      NANO_PRECISION = 9
+
+      def serialize(time)
+        super("value" => time.iso8601(NANO_PRECISION))
+      end
+    end
+  end
+end

--- a/lib/active_job/serializers/time_serializer.rb
+++ b/lib/active_job/serializers/time_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class TimeSerializer < TimeObjectSerializer # :nodoc:
+      def deserialize(hash)
+        Time.iso8601(hash["value"])
+      end
+
+      private
+        def klass
+          Time
+        end
+    end
+  end
+end

--- a/lib/active_job/serializers/time_with_zone_serializer.rb
+++ b/lib/active_job/serializers/time_with_zone_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class TimeWithZoneSerializer < TimeObjectSerializer # :nodoc:
+      def deserialize(hash)
+        Time.iso8601(hash["value"]).in_time_zone
+      end
+
+      private
+        def klass
+          ActiveSupport::TimeWithZone
+        end
+    end
+  end
+end

--- a/test/unit/services/support_entitlements_service_test.rb
+++ b/test/unit/services/support_entitlements_service_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class SupportEntitlementsServiceTest < ActiveSupport::TestCase
   include FieldsDefinitionsHelpers
+  include ActiveJob::TestHelper
 
   setup do
     @service = FactoryBot.create(:service, account: master_account)
@@ -36,7 +37,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     invoice = FactoryBot.create(:invoice, buyer_account: @provider_account, issued_on: Time.parse('2017-11-05'))
     FactoryBot.create(:line_item_plan_cost, invoice: invoice, contract: @provider_account.bought_cinstance, cinstance_id: @provider_account.bought_cinstance.id)
 
-    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_now: true))
+    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_later: true))
     AccountMailer.expects(:support_entitlements_revoked).never
 
     assert SupportEntitlementsService.notify_entitlements(@provider_account)
@@ -55,7 +56,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     @provider_account.buy! @trial_plan
 
     Timecop.freeze do
-      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_now: true))
+      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
       AccountMailer.expects(:support_entitlements_revoked).never
 
       assert SupportEntitlementsService.notify_entitlements(@provider_account)
@@ -67,7 +68,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
 
     Timecop.freeze do
       AccountMailer.expects(:support_entitlements_assigned).never
-      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_now: true))
+      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
 
       entitlements_options = { previous_plan: @paid_plan }
       assert SupportEntitlementsService.notify_entitlements(@provider_account, entitlements_options)
@@ -78,7 +79,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     @provider_account.buy! @trial_plan
 
     Timecop.freeze do
-      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_now: true))
+      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
       AccountMailer.expects(:support_entitlements_revoked).never
 
       entitlements_options = { previous_plan: @free_plan }
@@ -103,7 +104,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
 
     invoice = FactoryBot.create(:invoice, buyer_account: @provider_account, issued_on: Time.parse('2017-11-05'))
 
-    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_now: true))
+    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_later: true))
     AccountMailer.expects(:support_entitlements_revoked).never
 
     entitlements_options = { previous_plan: @free_plan, invoice: invoice }
@@ -115,7 +116,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
 
     Timecop.freeze do
       AccountMailer.expects(:support_entitlements_assigned).never
-      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_now: true))
+      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
 
       entitlements_options = { previous_plan: @paid_plan }
       assert SupportEntitlementsService.notify_entitlements(@provider_account, entitlements_options)
@@ -142,7 +143,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     FactoryBot.create(:line_item_plan_cost, invoice: invoice, contract: @provider_account.bought_cinstance, cinstance_id: @provider_account.bought_cinstance.id)
 
     AccountMailer.expects(:support_entitlements_assigned).never
-    AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_now: true))
+    AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_later: true))
 
     assert SupportEntitlementsService.notify_entitlements(@provider_account)
   end
@@ -172,7 +173,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     @provider_account.buy! @paid_plan
 
     Timecop.freeze do
-      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_now: true))
+      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
       AccountMailer.expects(:support_entitlements_revoked).never
 
       assert SupportEntitlementsService.notify_entitlements(@provider_account)


### PR DESCRIPTION
**What this PR does / why we need it**:

It enqueues Entitlement support email in ActionMailer::DeliveryJob
Instead of sending it along the web request

It will suppress some 5xx errors when the SMTP server is not available at the time of the web request


**Which issue(s) this PR fixes** 

Part of THREESCALE-7574


**Special notes for your reviewer**:

- Imported ActiveJob::Arguments and ActiveJob::Serializers from Rails 6.1.4.1
  in order to have Time serialization

I thought this is a good addition. ActiveJob arguments and serializers should be compatible with Rails 5.x
