### PR TITLE
Billing summary should expire

### DIFF
--- a/app/models/billing_summary.rb
+++ b/app/models/billing_summary.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class BillingSummary
+  TTL = 1.day.to_i
 
   delegate :redis, to: :System
 
@@ -11,7 +12,9 @@ class BillingSummary
   attr_reader :id
 
   def store(account_id, billing_result)
-    redis.zadd(summary_key, score_from_result(billing_result), account_id.to_s)
+    key = summary_key
+    redis.zadd(key, score_from_result(billing_result), account_id.to_s)
+    redis.expire(key, TTL)
   end
 
   def unstore

--- a/test/unit/billing_summary_test.rb
+++ b/test/unit/billing_summary_test.rb
@@ -44,6 +44,13 @@ class BillingSummaryTest < ActiveSupport::TestCase
     assert_equal stored_summary, @billing_summary.to_hash
   end
 
+  test 'ttl' do
+    @billing_summary.expects(:summary_key).returns('my-key')
+
+    @billing_summary.store('1', { success: true, errors: [] })
+    assert_equal BillingSummary::TTL, @billing_summary.redis.ttl('my-key')
+  end
+
   test 'unstore' do
     @billing_summary.stubs(summary_key: 'my-key')
     @billing_summary.store(1, { success: false, errors: [3] })


### PR DESCRIPTION
Issue:

Sometimes it does not unstore the results, because the batch callback was not called
The root cause is not yet found, this still ensures that Redis memory usage won't grow indefinitely