### PR TITLE
Payments settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ C:\\nppdf32Log\\debuglog.txt
 /config/zync.yml
 /config/redhat_customer_portal.yml
 /config/prometheus.yml
+/config/payments.yml
 /db/*.sql
 /db/safe.json
 /db/*.sql*

--- a/app/models/finance/billing_strategy.rb
+++ b/app/models/finance/billing_strategy.rb
@@ -56,7 +56,7 @@ class Finance::BillingStrategy < ApplicationRecord
   end
 
   def self.canaries
-    ThreeScale.config.billing_canaries || []
+    ThreeScale.config.payments.billing_canaries || []
   end
 
   # Supported options

--- a/config/application.rb
+++ b/config/application.rb
@@ -156,7 +156,6 @@ module System
     config.three_scale = ActiveSupport::OrderedOptions.new
     config.three_scale.core = ActiveSupport::OrderedOptions.new
 
-    config.three_scale.payments = ActiveSupport::OrderedOptions.new
     config.three_scale.rolling_updates = ActiveSupport::OrderedOptions.new
     config.three_scale.email_sanitizer = ActiveSupport::OrderedOptions.new
     config.three_scale.sandbox_proxy = ActiveSupport::OrderedOptions.new
@@ -175,9 +174,6 @@ module System
     config.three_scale.redhat_customer_portal = ActiveSupport::OrderedOptions.new
     config.three_scale.redhat_customer_portal.enabled = false
     config.three_scale.redhat_customer_portal.merge!(try_config_for(:redhat_customer_portal) || {})
-
-    config.three_scale.payments.enabled = false
-    config.three_scale.active_merchant_mode ||= Rails.env.production? ? :production : :test
 
     config.three_scale.rolling_updates.features = try_config_for(:rolling_updates).deep_merge(try_config_for(:"extra-rolling_updates") || {})
 
@@ -203,6 +199,13 @@ module System
 
     three_scale = config_for(:settings).symbolize_keys
     three_scale[:error_reporting_stages] = three_scale[:error_reporting_stages].to_s.split(/\W+/)
+
+    payment_settings = three_scale.extract!(:active_merchant_mode, :active_merchant_logging, :billing_canaries)
+    config.three_scale.payments = ActiveSupport::OrderedOptions.new
+    config.three_scale.payments.enabled = false
+    config.three_scale.payments.merge!(payment_settings)
+    config.three_scale.payments.merge!(try_config_for(:payments) || {})
+    config.three_scale.payments.active_merchant_mode ||= Rails.env.production? ? :production : :test
 
     email_sanitizer_configs = (three_scale.delete(:email_sanitizer) || {}).symbolize_keys
     config.three_scale.email_sanitizer.merge!(email_sanitizer_configs)

--- a/config/docker/settings.yml
+++ b/config/docker/settings.yml
@@ -37,11 +37,13 @@ base: &default
     enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %>
     to: <%= ENV.fetch('EMAIL_SANITIZER_TO', 'sanitizer@example.com') %>
   onpremises: true
-  active_merchant_logging: <%= ENV.fetch('ACTIVE_MERCHANT_LOGGING', false) %>
   janitor_worker_enabled: true
-  billing_canaries:
   apicast_staging_url: <%= ENV.fetch('APICAST_STAGING_URL', 'apicast-staging:8090') %>
   zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATON_TOKEN', '') %>
+
+  # deprecated: use payments.yaml to configure payments instead
+  active_merchant_logging: <%= ENV.fetch('ACTIVE_MERCHANT_LOGGING', false) %>
+  billing_canaries:
 
 development:
   <<: *default

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,9 +43,7 @@ Rails.application.configure do
 
   config.active_support.test_order = :sorted # who has the balls can set it to :random
 
-  config.three_scale.payments.enabled = true
-  config.three_scale.active_merchant_mode = :test
-  config.three_scale.active_merchant_logging = false
+  config.three_scale.payments.merge!(enabled: true, active_merchant_mode: :test, active_merchant_logging: false)
 
   config.three_scale.rolling_updates.raise_error_unknown_features = true
   config.three_scale.rolling_updates.enabled = false

--- a/config/examples/settings.yml
+++ b/config/examples/settings.yml
@@ -37,18 +37,22 @@ base: &default
     enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %>
     to: <%= ENV.fetch('EMAIL_SANITIZER_TO', 'saniziter@example.com') %>
   onpremises: false
-  active_merchant_logging: <%= ENV.fetch('ACTIVE_MERCHANT_LOGGING', false) %>
   error_reporting_stages: <%= ENV.fetch('ERROR_REPORTING_STAGES', 'production') %>
-  billing_canaries:
   apicast_staging_url: <%= ENV.fetch('APICAST_STAGING_URL', 'apicast-staging:8090') %>
   zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATON_TOKEN', '') %>
   access_code: <%= ENV.fetch('ACCESS_CODE', '') %>
+
+  # deprecated: use payments.yaml to configure payments instead
+  active_merchant_logging: <%= ENV.fetch('ACTIVE_MERCHANT_LOGGING', false) %>
+  billing_canaries:
 
 development:
   <<: *default
   secure_cookie: false
   force_ssl: false
   report_traffic: false
+
+  # deprecated: use payments.yaml to configure payments instead
   active_merchant_logging: true
 
 test:

--- a/config/initializers/active_merchant.rb
+++ b/config/initializers/active_merchant.rb
@@ -2,10 +2,10 @@
 
 require 'active_merchant_hacks'
 
-ActiveMerchant::Billing::Base.mode = Rails.application.config.three_scale.active_merchant_mode.to_sym
+ActiveMerchant::Billing::Base.mode = Rails.application.config.three_scale.payments.active_merchant_mode.to_sym
 Rails.logger.info("ActiveMerchant MODE set to '#{ActiveMerchant::Billing::Base.mode}'")
 
-if Rails.application.config.three_scale.active_merchant_logging
+if Rails.application.config.three_scale.payments.active_merchant_logging
   ActiveMerchant::Billing::Gateway.wiredump_device = Rails.root.join('log/activemerchant.log').open('a')
   ActiveMerchant::Billing::Gateway.wiredump_device.sync = true
 end

--- a/openshift/system/config/settings.yml
+++ b/openshift/system/config/settings.yml
@@ -42,6 +42,7 @@ base: &default
 
   janitor_worker_enabled: true
 
+  # deprecated: use payments.yaml to configure payments instead
   active_merchant_logging: false
   billing_canaries:
 

--- a/test/unit/finance/billing_strategy_test.rb
+++ b/test/unit/finance/billing_strategy_test.rb
@@ -65,7 +65,7 @@ class Finance::BillingStrategyTest < ActiveSupport::TestCase
 
   test 'all providers but canaries' do
     canaries = FactoryBot.create_list(:provider_with_billing, 4).map(&:id)
-    ThreeScale.config.expects(:billing_canaries).at_least_once.returns(canaries)
+    ThreeScale.config.payments.expects(:billing_canaries).at_least_once.returns(canaries)
 
     all_but_canaries = Finance::BillingStrategy.all.pluck(:account_id) - canaries
     Finance::BillingStrategy.expects(:daily_async).with { |scope| scope.pluck(:account_id) == all_but_canaries }.returns(true)
@@ -74,7 +74,7 @@ class Finance::BillingStrategyTest < ActiveSupport::TestCase
 
   test 'canaries' do
     canaries = FactoryBot.create_list(:provider_with_billing, 4).map(&:id)
-    ThreeScale.config.expects(:billing_canaries).at_least_once.returns(canaries)
+    ThreeScale.config.payments.expects(:billing_canaries).at_least_once.returns(canaries)
 
     Finance::BillingStrategy.expects(:daily_async).with { |scope| scope.pluck(:account_id) == canaries }.returns(true)
     assert Finance::BillingStrategy.daily_canaries
@@ -83,7 +83,7 @@ class Finance::BillingStrategyTest < ActiveSupport::TestCase
   test 'empty canaries' do
     2.times { FactoryBot.create(:prepaid_billing, :account => FactoryBot.create(:simple_provider)) }
     2.times { FactoryBot.create(:postpaid_billing, :account => FactoryBot.create(:simple_provider)) }
-    ThreeScale.config.stubs(billing_canaries: nil)
+    ThreeScale.config.payments.stubs(billing_canaries: nil)
 
     Finance::BillingStrategy.expects(:daily_async).never
     refute Finance::BillingStrategy.daily_canaries


### PR DESCRIPTION
Adds support for `config/payments.yml` to set configs such as `active_merchant_mode`, `active_merchant_logging` and `billing_canaries`. This is especially useful for running integration tests with `Rails.env == 'production'`.

No default or sample `payments.yml` file will be provided; the settings continue to default to values in `config/settings.yaml` and safe defaults enforced by code, according to each application environment.

The environment variables `THREESCALE_PAYMENTS_ENABLED` and `ACTIVE_MERCHANT_LOGGING` continue to be supported as before.

In test environment specifically, as before, the following settings are enforced regardless of any values in the YAML files:
- `enabled: true`
- `active_merchant_mode: :test`
- `active_merchant_logging: false`

<br/>

**Default (i.e., based on `config/settings.yml`):**

```sh
rails runner -e development "puts Rails.configuration.three_scale.payments"
# {:enabled=>false, :active_merchant_logging=>true, :billing_canaries=>nil, :active_merchant_mode=>:test}

THREESCALE_PAYMENTS_ENABLED=1 rails runner -e development "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>true, :billing_canaries=>nil, :active_merchant_mode=>:test}

ACTIVE_MERCHANT_LOGGING=true rails runner -e development "puts Rails.configuration.three_scale.payments"
# {:enabled=>false, :active_merchant_logging=>true, :billing_canaries=>nil, :active_merchant_mode=>:test}

ACTIVE_MERCHANT_LOGGING=false rails runner -e development "puts Rails.configuration.three_scale.payments"
# {:enabled=>false, :active_merchant_logging=>true, :billing_canaries=>nil, :active_merchant_mode=>:test}

rails runner -e test "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>false, :billing_canaries=>nil, :active_merchant_mode=>:test}

ACTIVE_MERCHANT_LOGGING=true rails runner -e test "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>false, :billing_canaries=>nil, :active_merchant_mode=>:test}

ACTIVE_MERCHANT_LOGGING=false rails runner -e test "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>false, :billing_canaries=>nil, :active_merchant_mode=>:test}

rails runner -e production "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>false, :billing_canaries=>nil, :active_merchant_mode=>:production}

ACTIVE_MERCHANT_LOGGING=true rails runner -e production "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>true, :billing_canaries=>nil, :active_merchant_mode=>:production}

ACTIVE_MERCHANT_LOGGING=false rails runner -e production "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>false, :billing_canaries=>nil, :active_merchant_mode=>:production}
```

**Openshift (i.e., based on `openshift/system/config/settings.yml`):**

```sh
rails runner -e production "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>false, :billing_canaries=>nil, :active_merchant_mode=>:production}

ACTIVE_MERCHANT_LOGGING=true rails runner -e production "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>false, :billing_canaries=>nil, :active_merchant_mode=>:production}

ACTIVE_MERCHANT_LOGGING=false rails runner -e production "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>false, :billing_canaries=>nil, :active_merchant_mode=>:production}
```

**Openshift with `config/payments.yml`:**

```yaml
# config/payments.yml
production:
  active_merchant_mode: :test
  active_merchant_logging: true
  billing_canaries: [1, 2, 3]
```

```sh
rails runner -e production "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>true, :billing_canaries=>[1, 2, 3], :active_merchant_mode=>:test}

ACTIVE_MERCHANT_LOGGING=true rails runner -e production "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>true, :billing_canaries=>[1, 2, 3], :active_merchant_mode=>:test}

ACTIVE_MERCHANT_LOGGING=false rails runner -e production "puts Rails.configuration.three_scale.payments"
# {:enabled=>true, :active_merchant_logging=>true, :billing_canaries=>[1, 2, 3], :active_merchant_mode=>:test}
```