### PR TITLE
Remove `context` and `should` from account_plans_controller_test

### DIFF
--- a/test/functional/buyers/account_plans_controller_test.rb
+++ b/test/functional/buyers/account_plans_controller_test.rb
@@ -6,104 +6,98 @@ class Buyers::AccountPlansControllerTest < ActionController::TestCase
   # we don't have show action
   #
 
-  context 'provider account_plans switch' do
-    setup do
+  class ProviderAccountPlansTest < Buyers::AccountPlansControllerTest
+    def setup
       @provider = FactoryBot.create :provider_account
       @request.host = @provider.domain
 
       login_as(@provider.admins.first)
+
+      assert @provider.settings.account_plans_denied?
     end
 
-    context 'is denied' do
-      setup do
-        assert @provider.settings.account_plans_denied?
-      end
+    test 'forbid new' do
+      get :new
+      assert_equal 403, response.status
+      assert_template 'errors/forbidden'
+    end
 
-      should 'forbid new' do
-        get :new
-        assert_equal 403, response.status
-        assert_template 'errors/forbidden'
-      end
+    test 'forbid create' do
+      post :create
+      assert_equal 403, response.status
+      assert_template 'errors/forbidden'
+    end
 
-      should 'forbid create' do
-        post :create
-        assert_equal 403, response.status
-        assert_template 'errors/forbidden'
-      end
+    test 'render index' do
+      get :index
+      assert_equal 200, response.status
+      assert_template 'api/plans/_default_plan'
+    end
 
-      should 'render index' do
-        get :index
-        assert_equal 200, response.status
-        assert_template 'api/plans/_default_plan'
-      end
+    test 'destroy account plan, when account plan cant be destroyed, should not raise error' do
+      AccountPlan.any_instance.expects(can_be_destroyed?: false).at_least_once
+      delete :destroy, params: { id: @provider.account_plans.first.id }
     end
   end
 
-  context 'master account_plans switch' do
-    setup do
+  class MasterAccountPlansTest < Buyers::AccountPlansControllerTest
+    def setup
       @master = master_account
       @request.host = @master.domain
 
       login_as(@master.admins.first)
     end
 
-    context 'Not on-premises' do
-      setup do
+    class NotOnPremisesTest < MasterAccountPlansTest
+      def setup
+        super
         ThreeScale.config.stubs(onpremises: false)
         assert @master.settings.account_plans_denied?
       end
 
-      should 'forbid new' do
+      test 'forbid new' do
         get :new
         assert_equal 403, response.status
         assert_template 'errors/provider/forbidden'
       end
 
-      should 'forbid create' do
+      test 'forbid create' do
         post :create
         assert_equal 403, response.status
         assert_template 'errors/provider/forbidden'
       end
 
-      should 'render index' do
+      test 'render index' do
         get :index
         assert_equal 200, response.status
         assert_template 'api/plans/_default_plan'
       end
     end
 
-    context 'On-premises' do
-      setup do
+    class OnPremisesTest < MasterAccountPlansTest
+      def setup
+        super
         ThreeScale.config.stubs(onpremises: true)
         assert @master.settings.account_plans_denied?
       end
 
-      should 'forbid new' do
+      test 'forbid new' do
         get :new
         assert_equal 403, response.status
         assert_template 'errors/provider/forbidden'
       end
 
-      should 'forbid create' do
+      test 'forbid create' do
         post :create
         assert_equal 403, response.status
         assert_template 'errors/provider/forbidden'
       end
 
-      should 'forbid index' do
+      test 'forbid index' do
         get :index
         assert_equal 403, response.status
         assert_template 'errors/provider/forbidden'
       end
     end
-  end
-
-  test 'destroy account plan, when account plan cant be destroyed, should not raise error' do
-    @provider = FactoryBot.create :provider_account
-    @request.host = @provider.domain
-
-    login_as(@provider.first_admin)
-    AccountPlan.any_instance.expects(can_be_destroyed?: false).at_least_once
-    delete :destroy, params: { id: @provider.account_plans.first.id }
   end
 end


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* account_plans_controller_test

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)