### PR TITLE
Remove `context` and `should` from signup_controller_test

### DIFF
--- a/test/functional/developer_portal/signup_controller_test.rb
+++ b/test/functional/developer_portal/signup_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DeveloperPortal::SignupControllerTest < DeveloperPortal::ActionController::TestCase
@@ -11,83 +13,104 @@ class DeveloperPortal::SignupControllerTest < DeveloperPortal::ActionController:
     @request.host = @provider.domain
   end
 
-  test 'should redirect out logged in users' do
-    login_as(@provider.admins.first)
-    get :show
-    assert_redirected_to '/admin'
-  end
+  class WithDefaultAccountPlan < DeveloperPortal::SignupControllerTest
+    test 'should redirect out logged in users' do
+      login_as(@provider.admins.first)
+      get :show
+      assert_redirected_to '/admin'
+    end
 
-  test '#create should login if the user can login' do
-    User.any_instance.expects(:can_login?).returns(true)
-    post :create, params: valid_buyer_params
-    assert @controller.send(:current_user)
-  end
+    test '#create should login if the user can login' do
+      User.any_instance.expects(:can_login?).returns(true)
+      post :create, params: valid_buyer_params
+      assert @controller.send(:current_user)
+    end
 
-  test '#create should send the confirmation email without the activation link' do
-    auth_provider = FactoryBot.create(:authentication_provider, account: @provider)
+    test '#create should send the confirmation email without the activation link' do
+      auth_provider = FactoryBot.create(:authentication_provider, account: @provider)
 
-    deliveries = ActionMailer::Base.deliveries
-    deliveries.clear
+      deliveries = ActionMailer::Base.deliveries
+      deliveries.clear
 
-    session[:authentication_id] = 'A1234'
-    session[:authentication_provider] = auth_provider.system_name
-    # First check that the confirmation link is send
-    perform_enqueued_jobs(only: ActionMailer::DeliveryJob) do
+      session[:authentication_id] = 'A1234'
+      session[:authentication_provider] = auth_provider.system_name
+      # First check that the confirmation link is send
+      post :create, params: valid_buyer_params
+      assert_response :redirect
+
+      mail = deliveries.last
+      assert_match(/activate/, mail.body.to_s)
+      assert_equal valid_buyer_params[:account][:user][:email], mail.to[0]
+      assert_match(/API account confirmation/, mail.subject)
+      Account.last.destroy!
+      deliveries.clear
+
+      # Now check that the link is not send
+      session[:authentication_id] = 'A1234'
+      session[:authentication_provider] = auth_provider.system_name
+      session[:authentication_email] = valid_buyer_params[:account][:user][:email]
+      post :create, params: valid_buyer_params
+      assert_response :redirect
+
+      mail = deliveries.last
+      assert_equal valid_buyer_params[:account][:user][:email], mail.to[0]
+      assert_match(/API account confirmation/, mail.subject)
+      assert_no_match(/activate/, mail.body.to_s)
+    end
+
+    test '#create should track the signup if success' do
+      ThreeScale::Analytics.expects(:track).with(@provider.first_admin, 'Acquired new Developer Account', kind_of(Hash))
       post :create, params: valid_buyer_params
     end
-    assert_response :redirect
 
-    mail = deliveries.last
-    assert_match(/activate/, mail.body.to_s)
-    assert_equal valid_buyer_params[:account][:user][:email], mail.to[0]
-    assert_match(/API account confirmation/, mail.subject)
-    Account.last.destroy!
-    deliveries.clear
-
-    # Now check that the link is not send
-    session[:authentication_id] = 'A1234'
-    session[:authentication_provider] = auth_provider.system_name
-    session[:authentication_email] = valid_buyer_params[:account][:user][:email]
-    perform_enqueued_jobs(only: ActionMailer::DeliveryJob) do
+    test '#create successfully from oauth2 should save the id_token' do
+      auth_provider = FactoryBot.create(:keycloak_authentication_provider, account: @provider)
+      session[:id_token] = 'fake-token'
+      session[:authentication_id] = 'foo'
+      session[:authentication_provider] = auth_provider.system_name
+      session[:authentication_kind] = auth_provider.kind
       post :create, params: valid_buyer_params
+      assert_equal 'fake-token', User.last.sso_authorizations.last.id_token
     end
-    assert_response :redirect
 
-    mail = deliveries.last
-    assert_equal valid_buyer_params[:account][:user][:email], mail.to[0]
-    assert_match(/API account confirmation/, mail.subject)
-    refute_match(/activate/, mail.body.to_s)
+    test "raise RecordNotFound with wrong plan ids" do
+      post :create, params: valid_buyer_params(:plans => [1, 2])
+      assert_response :not_found
+    end
   end
 
-  test '#create should track the signup if success' do
-    ThreeScale::Analytics.expects(:track).with(@provider.first_admin, 'Acquired new Developer Account', kind_of(Hash))
-    post :create, params: valid_buyer_params
+  class WithoutAnyDefaultPlanTest < DeveloperPortal::SignupControllerTest
+    def setup
+      super
+      @provider.update_attribute :default_account_plan,  nil
+    end
+
+    test "not create account" do
+      post :create, params: valid_buyer_params
+
+      signup_result = assigns(:signup_result)
+
+      assert_includes signup_result.errors[:plans], 'Account plan is required'
+      assert_not signup_result.valid?
+      assert signup_result.user.valid?
+    end
   end
 
-  test '#create successfully from oauth2 should save the id_token' do
-    auth_provider = FactoryBot.create(:keycloak_authentication_provider, account: @provider)
-    session[:id_token] = 'fake-token'
-    session[:authentication_id] = 'foo'
-    session[:authentication_provider] = auth_provider.system_name
-    session[:authentication_kind] = auth_provider.kind
-    post :create, params: valid_buyer_params
-    assert_equal 'fake-token', User.last.sso_authorizations.last.id_token
-  end
-
-  context "with all default plans" do
-    setup do
-      @provider.update_attribute :default_account_plan, FactoryBot.create(:account_plan, :issuer => @provider)
-      @service.update_attribute :default_service_plan, FactoryBot.create(:service_plan, :issuer => @service)
-      @service.update_attribute :default_application_plan, FactoryBot.create(:application_plan, :issuer => @service)
+  class WithAllDefaultPlansTest < DeveloperPortal::SignupControllerTest
+    def setup
+      super
+      @provider.update_attribute :default_account_plan,  FactoryBot.create(:account_plan, :issuer => @provider)
+      @service.update_attribute :default_service_plan,  FactoryBot.create(:service_plan, :issuer => @service)
+      @service.update_attribute :default_application_plan,  FactoryBot.create(:application_plan, :issuer => @service)
     end
 
     # making sure create doesn't crash with an empty post, some browsers are weird
-    should "work with empty post" do
+    test "work with empty post" do
       post :create
       assert_response :success
     end
 
-    should "push webhooks" do
+    test "push webhooks" do
       #TODO: improve this by asserting the parameters
       WebHook::Event.expects(:enqueue).times(3)
 
@@ -95,37 +118,17 @@ class DeveloperPortal::SignupControllerTest < DeveloperPortal::ActionController:
     end
   end
 
-  context "without any default plan" do
-    setup do
-      @provider.update_attribute :default_account_plan, nil
-    end
-
-    should "not create account" do
-      post :create, params: valid_buyer_params
-
-      signup_result = assigns(:signup_result)
-
-      assert_includes signup_result.errors[:plans], 'Account plan is required'
-      refute signup_result.valid?
-      assert signup_result.user.valid?
-    end
-  end
-
-  should "raise RecordNotFound with wrong plan ids" do
-    post :create, params: valid_buyer_params(:plans => [1, 2])
-    assert_response :not_found
-  end
-
-  context "provider with multiple services and service plans" do
-    setup do
+  class WithMultipleServicesAndServicePlansTest < DeveloperPortal::SignupControllerTest
+    def setup
+      super
       @service_two = @provider.services.create :name => "Second"
       @service_two_plan = FactoryBot.create(:service_plan, :issuer => @service)
       @service_two_plan_two = FactoryBot.create(:service_plan, :issuer => @service)
 
-      [@service_two_plan, @service_two_plan_two].each &:publish!
+      [@service_two_plan, @service_two_plan_two].each(&:publish!)
     end
 
-    should "allow only one service subsription" do
+    test "allow only one service subsription" do
       post :create, params: valid_buyer_params(:plans => [@service_two_plan_two, @service_two_plan].map(&:id))
       signup_result = assigns(:signup_result)
 

--- a/test/functional/developer_portal/signup_controller_test.rb
+++ b/test/functional/developer_portal/signup_controller_test.rb
@@ -35,7 +35,9 @@ class DeveloperPortal::SignupControllerTest < DeveloperPortal::ActionController:
       session[:authentication_id] = 'A1234'
       session[:authentication_provider] = auth_provider.system_name
       # First check that the confirmation link is send
-      post :create, params: valid_buyer_params
+      perform_enqueued_jobs(only: ActionMailer::DeliveryJob) do
+        post :create, params: valid_buyer_params
+      end
       assert_response :redirect
 
       mail = deliveries.last
@@ -49,7 +51,9 @@ class DeveloperPortal::SignupControllerTest < DeveloperPortal::ActionController:
       session[:authentication_id] = 'A1234'
       session[:authentication_provider] = auth_provider.system_name
       session[:authentication_email] = valid_buyer_params.dig(:account, :user, :email)
-      post :create, params: valid_buyer_params
+      perform_enqueued_jobs(only: ActionMailer::DeliveryJob) do
+        post :create, params: valid_buyer_params
+      end
       assert_response :redirect
 
       mail = deliveries.last


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* signup_controller_test

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)