### PR TITLE
Remove `context` and `should` from a bunch smaller test files

### DIFF
--- a/test/functional/developer_portal/admin/account/personal_details_controller_test.rb
+++ b/test/functional/developer_portal/admin/account/personal_details_controller_test.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DeveloperPortal::Admin::Account::PersonalDetailsControllerTest < DeveloperPortal::ActionController::TestCase
-
   def setup
     super
     @provider = FactoryBot.create(:provider_account)
+    @request.host = @provider.domain
+    @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
   end
 
   test 'no access granted for provider admin' do
     # now exists other routes in provider side
-
     @request.host = @provider.admin_domain
 
     login_as @provider.admins.first
@@ -22,7 +24,7 @@ class DeveloperPortal::Admin::Account::PersonalDetailsControllerTest < Developer
     # now exists other routes in provider side
     @request.host = @provider.admin_domain
 
-    provider_member = FactoryBot.create :active_user, :account => @provider
+    provider_member = FactoryBot.create(:active_user, account: @provider)
     assert provider_member.member?
 
     login_as provider_member
@@ -31,28 +33,20 @@ class DeveloperPortal::Admin::Account::PersonalDetailsControllerTest < Developer
     assert_response 404
   end
 
-  context 'buyer' do
-    setup do
-      @request.host = @provider.domain
-      @buyer = FactoryBot.create :buyer_account, :provider_account => @provider
-    end
+  test 'grant access to admin' do
+    login_as @buyer.admins.first
+    get :show
 
-    should 'grant access to admin' do
-      login_as @buyer.admins.first
-      get :show
-
-      assert_response :success
-    end
-
-    should 'grant access to member' do
-      buyer_member = FactoryBot.create :active_user, :account => @buyer
-      assert buyer_member.member?
-
-      login_as buyer_member
-      get :show
-
-      assert_response :success
-    end
+    assert_response :success
   end
 
+  test 'grant access to member' do
+    buyer_member = FactoryBot.create(:active_user, account: @buyer)
+    assert buyer_member.member?
+
+    login_as buyer_member
+    get :show
+
+    assert_response :success
+  end
 end

--- a/test/integration/utilization_test.rb
+++ b/test/integration/utilization_test.rb
@@ -1,13 +1,12 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UtilizationTest < ActionDispatch::IntegrationTest
-
   include TestHelpers::BackendClientStubs
 
-  context :no_metrics_on_applications do
-
+  class NoMetricsOnApplicationsTest < ActionDispatch::IntegrationTest
     setup do
-
       @provider = FactoryBot.create :provider_account
       @plan1 = FactoryBot.create :application_plan, :issuer => @provider.default_service
 
@@ -42,7 +41,7 @@ class UtilizationTest < ActionDispatch::IntegrationTest
 
     end
 
-    should 'application is unmetered' do
+    test 'application is unmetered' do
       stub_backend_utilization(@data_empty)
       stub_backend_get_keys
 
@@ -55,7 +54,7 @@ class UtilizationTest < ActionDispatch::IntegrationTest
       assert_equal doc.search("div[@id='application-utilization']").children.first.class, Nokogiri::XML::Text
     end
 
-    should 'application has metrics' do
+    test 'application has metrics' do
       stub_backend_utilization(@data_full)
       stub_backend_get_keys
 
@@ -73,7 +72,7 @@ class UtilizationTest < ActionDispatch::IntegrationTest
       assert_equal table.search("td[@class='infinity']").size, 0*2
     end
 
-    should 'application has metrics with one disabled over the limit' do
+    test 'application has metrics with one disabled over the limit' do
       stub_backend_utilization(@data_infinity)
       stub_backend_get_keys
 
@@ -91,7 +90,5 @@ class UtilizationTest < ActionDispatch::IntegrationTest
       assert_equal table.search("td[@class='above-0']").size, 2*2
       assert_equal table.search("td[@class='infinity']").size, 1*2
     end
-
   end
-
 end

--- a/test/integration/utilization_test.rb
+++ b/test/integration/utilization_test.rb
@@ -5,90 +5,84 @@ require 'test_helper'
 class UtilizationTest < ActionDispatch::IntegrationTest
   include TestHelpers::BackendClientStubs
 
-  class NoMetricsOnApplicationsTest < ActionDispatch::IntegrationTest
-    setup do
-      @provider = FactoryBot.create :provider_account
-      @plan1 = FactoryBot.create :application_plan, :issuer => @provider.default_service
+  setup do
+    provider = FactoryBot.create(:provider_account)
+    buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+    service = FactoryBot.create(:service, account: provider, name: "API1")
+    plan = FactoryBot.create(:application_plan, issuer: service)
+    @application = plan.create_contract_with(buyer)
+    @metrics = FactoryBot.create_list(:metric, 4, service: service)
 
-      @service1 = FactoryBot.create :service, :account => @provider, :name => "API1"
+    host! provider.admin_domain
+    provider_login_with provider.admins.first.username, 'supersecret'
+  end
 
-      @plan1 = FactoryBot.create :application_plan, :issuer => @service1
+  teardown do
+    @utilization = nil
+  end
 
-      @buyer = FactoryBot.create :buyer_account, :provider_account => @provider
+  test 'application is unmetered' do
+    stub_backend_utilization([])
+    stub_backend_get_keys
 
-      @application1 = @plan1.create_contract_with(@buyer)
+    get provider_admin_application_path(@application)
+    assert_response :success
 
-      host! @provider.admin_domain
-      provider_login_with @provider.admins.first.username, 'supersecret'
+    assert_equal 1, utilization.size
+    assert_equal 0, utilization.search("table").size
+    assert_equal Nokogiri::XML::Text, utilization.children.first.class
+  end
 
-      metrics = FactoryBot.create_list(:metric, 4, service: @service1)
+  test 'application has metrics' do
+    data_full = [
+      { period: 'day', metric: @metrics[0], max_value: 5000, current_value: 6000 },
+      { period: 'year', metric: @metrics[1], max_value: 10000, current_value: 9000 },
+      { period: 'minute', metric: @metrics[2], max_value: 666, current_value: 0},
+      { period: 'minute', metric: @metrics[3], max_value: 0, current_value: 0},
+    ].map { |attr| UtilizationRecord.new(attr) }
 
-      @data_empty = []
+    stub_backend_utilization(data_full)
+    stub_backend_get_keys
 
-      @data_full = [
-        { period: 'day', metric: metrics[0], max_value: 5000, current_value: 6000 },
-        { period: 'year', metric: metrics[1], max_value: 10000, current_value: 9000 },
-        { period: 'minute', metric: metrics[2], max_value: 666, current_value: 0},
-        { period: 'minute', metric: metrics[3], max_value: 0, current_value: 0},
-      ].map { |attr| UtilizationRecord.new(attr) }
+    get provider_admin_application_path(@application)
+    assert_response :success
 
-      @data_infinity = [
-        { period: 'day', metric: metrics[0], max_value: 5000, current_value: 4010 },
-        { period: 'year', metric: metrics[1], max_value: 10000, current_value: 4000 },
-        { period: 'minute', metric: metrics[2], max_value: 666, current_value: 0},
-        { period: 'minute', metric: metrics[3], max_value: 0, current_value: 6},
-      ].map { |attr| UtilizationRecord.new(attr) }
+    assert_equal 1, utilization.size
 
-    end
+    table = utilization.search("table[@class='data']")
+    assert_equal 1, table.size
+    assert_equal 1*2, table.search("td[@class='above-100']").size
+    assert_equal 1*2, table.search("td[@class='above-80']").size
+    assert_equal 2*2, table.search("td[@class='above-0']").size
+    assert_equal 0*2, table.search("td[@class='infinity']").size
+  end
 
-    test 'application is unmetered' do
-      stub_backend_utilization(@data_empty)
-      stub_backend_get_keys
+  test 'application has metrics with one disabled over the limit' do
+    data_infinity = [
+      { period: 'day', metric: @metrics[0], max_value: 5000, current_value: 4010 },
+      { period: 'year', metric: @metrics[1], max_value: 10000, current_value: 4000 },
+      { period: 'minute', metric: @metrics[2], max_value: 666, current_value: 0},
+      { period: 'minute', metric: @metrics[3], max_value: 0, current_value: 6},
+    ].map { |attr| UtilizationRecord.new(attr) }
+    stub_backend_utilization(data_infinity)
+    stub_backend_get_keys
 
-      get provider_admin_application_path(@application1)
-      assert_response :success
+    get provider_admin_application_path(@application)
+    assert_response :success
 
-      doc = Nokogiri::XML.parse(body)
-      assert_equal doc.search("div[@id='application-utilization']").size, 1
-      assert_equal doc.search("div[@id='application-utilization']").search("table").size, 0
-      assert_equal doc.search("div[@id='application-utilization']").children.first.class, Nokogiri::XML::Text
-    end
+    assert_equal 1, utilization.size
 
-    test 'application has metrics' do
-      stub_backend_utilization(@data_full)
-      stub_backend_get_keys
+    table = utilization.search("table[@class='data']")
+    assert_equal 1, table.size
+    assert_equal 0*2, table.search("td[@class='above-100']").size
+    assert_equal 1*2, table.search("td[@class='above-80']").size
+    assert_equal 2*2, table.search("td[@class='above-0']").size
+    assert_equal 1*2, table.search("td[@class='infinity']").size
+  end
 
-      get provider_admin_application_path(@application1)
-      assert_response :success
+  private
 
-      doc = Nokogiri::XML.parse(body)
-      assert_equal doc.search("div[@id='application-utilization']").size, 1
-      table = doc.search("div[@id='application-utilization']").search("table[@class='data']")
-      assert_equal table.size, 1
-
-      assert_equal table.search("td[@class='above-100']").size, 1*2
-      assert_equal table.search("td[@class='above-80']").size, 1*2
-      assert_equal table.search("td[@class='above-0']").size, 2*2
-      assert_equal table.search("td[@class='infinity']").size, 0*2
-    end
-
-    test 'application has metrics with one disabled over the limit' do
-      stub_backend_utilization(@data_infinity)
-      stub_backend_get_keys
-
-      get provider_admin_application_path(@application1)
-      assert_response :success
-
-      doc = Nokogiri::XML.parse(body)
-      assert_equal doc.search("div[@id='application-utilization']").size, 1
-      table = doc.search("div[@id='application-utilization']").search("table[@class='data']")
-      assert_equal table.size, 1
-
-
-      assert_equal table.search("td[@class='above-100']").size, 0*2
-      assert_equal table.search("td[@class='above-80']").size, 1*2
-      assert_equal table.search("td[@class='above-0']").size, 2*2
-      assert_equal table.search("td[@class='infinity']").size, 1*2
-    end
+  def utilization
+    @utilization ||= Nokogiri::XML.parse(body).search("div[@id='application-utilization']")
   end
 end

--- a/test/unit/abilities/cms_test.rb
+++ b/test/unit/abilities/cms_test.rb
@@ -1,17 +1,17 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module Abilities
   class CmsTest < ActiveSupport::TestCase
     #TODO: update/finish this? they can be a bit undry/unneeded with features/authorization/*.feature
-    context 'enterprise mode provider admin' do
-      setup do
-        @provider = FactoryBot.create(:provider_account)
-      end
+    setup do
+      @provider = FactoryBot.create(:provider_account)
+    end
 
-      should "manage the portal" do
-        ability = Ability.new(@provider.admins.first)
-        assert ability.can?(:manage, :portal)
-      end
+    test "enterprise mode provider admin should manage the portal" do
+      ability = Ability.new(@provider.admins.first)
+      assert ability.can?(:manage, :portal)
     end
   end
 end

--- a/test/unit/abilities/multiple_applications_test.rb
+++ b/test/unit/abilities/multiple_applications_test.rb
@@ -7,7 +7,7 @@ module Abilities
     def setup
       @provider = FactoryBot.create(:provider_account)
       @admin = @provider.admins.first
-      @member = FactoryBot.create(:user, :account => @provider, :role => :member)
+      @member = FactoryBot.create(:member, account: @provider)
     end
 
     class SwitchDeniedTest < MultipleApplicationsTest
@@ -20,7 +20,6 @@ module Abilities
         admin_ability = Ability.new(@admin)
 
         assert_can    admin_ability, :admin,  :multiple_applications
-
         assert_cannot admin_ability, :see,    :multiple_applications
         assert_cannot admin_ability, :manage, :multiple_applications
       end
@@ -58,10 +57,8 @@ module Abilities
       end
 
       test "should member with partners group can manage multiple apps" do
-        #setup
-        @member.admin_sections=['partners']
-
-        partners_ability = Ability.new(@member)
+        member = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
+        partners_ability = Ability.new(member)
 
         assert_can partners_ability, :see,    :multiple_applications
         assert_can partners_ability, :admin,  :multiple_applications

--- a/test/unit/abilities/multiple_applications_test.rb
+++ b/test/unit/abilities/multiple_applications_test.rb
@@ -1,20 +1,22 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module Abilities
   class MultipleApplicationsTest < ActiveSupport::TestCase
-
     def setup
       @provider = FactoryBot.create(:provider_account)
       @admin = @provider.admins.first
       @member = FactoryBot.create(:user, :account => @provider, :role => :member)
     end
 
-    context "switch multiple applications denied" do
-      setup do
+    class SwitchDeniedTest < MultipleApplicationsTest
+      def setup
+        super
         assert @provider.settings.multiple_applications.denied?
       end
 
-      should "admin cannot manage multiple apps" do
+      test "should admin cannot manage multiple apps" do
         admin_ability = Ability.new(@admin)
 
         assert_can    admin_ability, :admin,  :multiple_applications
@@ -23,7 +25,7 @@ module Abilities
         assert_cannot admin_ability, :manage, :multiple_applications
       end
 
-      should "member cannot manage multiple apps" do
+      test "should member cannot manage multiple apps" do
         member_ability = Ability.new(@member)
 
         assert_cannot member_ability, :see,    :multiple_applications
@@ -32,13 +34,14 @@ module Abilities
       end
     end
 
-    context "switch multiple applications allowed" do
-      setup do
+    class SwitchAllowedTest < MultipleApplicationsTest
+      def setup
+        super
         @provider.settings.allow_multiple_applications!
         assert @provider.settings.multiple_applications.allowed?
       end
 
-      should "admin can manage multiple apps" do
+      test "should admin can manage multiple apps" do
         admin_ability = Ability.new(@admin)
 
         assert_can admin_ability, :see,    :multiple_applications
@@ -46,7 +49,7 @@ module Abilities
         assert_can admin_ability, :manage, :multiple_applications
       end
 
-      should "member cannot manage multiple apps" do
+      test "should member cannot manage multiple apps" do
         member_ability = Ability.new(@member)
 
         assert_can    member_ability, :see,    :multiple_applications
@@ -54,7 +57,7 @@ module Abilities
         assert_cannot member_ability, :manage, :multiple_applications
       end
 
-      should "member with partners group can manage multiple apps" do
+      test "should member with partners group can manage multiple apps" do
         #setup
         @member.admin_sections=['partners']
 

--- a/test/unit/alert_test.rb
+++ b/test/unit/alert_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class AlertTest < ActiveSupport::TestCase
-  subject { @alert || Alert.new }
+  subject { Alert.new }
 
   should belong_to(:account)
   should belong_to(:cinstance)
@@ -20,12 +20,12 @@ class AlertTest < ActiveSupport::TestCase
   end
 
   test 'Alert#kind should return :alert if its alert' do
-    assert_equal :alert, Alert.new(:level => 99).kind
-    assert_equal :alert, Alert.new(:level => 0).kind
+    assert_equal :alert, Alert.new(level: 99).kind
+    assert_equal :alert, Alert.new(level: 0).kind
   end
 
   test 'Alert#kind should return :violation if its violation' do
-    assert_equal :violation, Alert.new(:level => 100).kind
-    assert_equal :violation, Alert.new(:level => 300).kind
+    assert_equal :violation, Alert.new(level: 100).kind
+    assert_equal :violation, Alert.new(level: 300).kind
   end
 end

--- a/test/unit/alert_test.rb
+++ b/test/unit/alert_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class AlertTest < ActiveSupport::TestCase
@@ -17,16 +19,13 @@ class AlertTest < ActiveSupport::TestCase
     assert_equal [alert], Alert.by_level(80).to_a
   end
 
-  context 'Alert#kind' do
-    should 'should return :alert if its alert' do
-      assert_equal :alert, Alert.new(:level => 99).kind
-      assert_equal :alert, Alert.new(:level => 0).kind
-    end
-
-    should 'should return :violation if its violation' do
-      assert_equal :violation, Alert.new(:level => 100).kind
-      assert_equal :violation, Alert.new(:level => 300).kind
-    end
+  test 'Alert#kind should return :alert if its alert' do
+    assert_equal :alert, Alert.new(:level => 99).kind
+    assert_equal :alert, Alert.new(:level => 0).kind
   end
 
+  test 'Alert#kind should return :violation if its violation' do
+    assert_equal :violation, Alert.new(:level => 100).kind
+    assert_equal :violation, Alert.new(:level => 300).kind
+  end
 end

--- a/test/unit/backend/model_extensions/provider_test.rb
+++ b/test/unit/backend/model_extensions/provider_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Backend::ModelExtensions::ProviderTest < ActiveSupport::TestCase
@@ -6,10 +8,15 @@ class Backend::ModelExtensions::ProviderTest < ActiveSupport::TestCase
     @storage.flushdb
   end
 
-  context "provider account" do
-    subject { FactoryBot.create :provider_account }
+  class ProviderAccountTest < Backend::ModelExtensions::ProviderTest
+    def setup
+      super
+      @subject = FactoryBot.create :provider_account
+    end
 
-    should "update backend default_service when set and saved" do
+    attr_reader :subject
+
+    test "update backend default_service when set and saved" do
       service = subject.first_service!
 
       assert_nil subject.default_service_id
@@ -22,5 +29,4 @@ class Backend::ModelExtensions::ProviderTest < ActiveSupport::TestCase
       assert_equal service, subject.default_service
     end
   end
-
 end

--- a/test/unit/backend/model_extensions/provider_test.rb
+++ b/test/unit/backend/model_extensions/provider_test.rb
@@ -11,19 +11,17 @@ class Backend::ModelExtensions::ProviderTest < ActiveSupport::TestCase
   class ProviderAccountTest < Backend::ModelExtensions::ProviderTest
     def setup
       super
-      @subject = FactoryBot.create :provider_account
+      @subject = FactoryBot.create(:provider_account)
     end
 
     attr_reader :subject
 
     test "update backend default_service when set and saved" do
       service = subject.first_service!
-
       assert_nil subject.default_service_id
 
-      subject.default_service_id = service.id
-
       Service.any_instance.expects(:update_backend_service)
+      subject.default_service_id = service.id
       subject.save!
 
       assert_equal service, subject.default_service

--- a/test/unit/exception_reporting_test.rb
+++ b/test/unit/exception_reporting_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ExceptionReportingTest < ActiveSupport::TestCase
@@ -5,48 +7,52 @@ class ExceptionReportingTest < ActiveSupport::TestCase
     raise 'Booom!'
   end
 
-
-  context 'dev env' do
-    setup do
+  class DevEnvTest < ExceptionReportingTest
+    def setup
       Rails.env.stubs(:test?).returns(false)
       Rails.env.stubs(:development?).returns(true)
     end
 
-    should 'raise' do
+    test 'raise' do
       assert_raise(RuntimeError) do
         report_and_supress_exceptions { raise_exception }
       end
     end
   end
 
-  context 'test env' do
-    setup do
+  class TestEnvTest < ExceptionReportingTest
+    def setup
       Rails.env.stubs(:test?).returns(true)
       Rails.env.stubs(:development?).returns(false)
     end
 
-    should 'raise' do
+    test 'raise' do
       assert_raise(RuntimeError) do
         report_and_supress_exceptions { raise_exception }
       end
     end
   end
 
-  context 'other env' do
-    setup do
+  class OtherEnvTest < ExceptionReportingTest
+    def setup
       Rails.env.stubs(:test?).returns(false)
       Rails.env.stubs(:development?).returns(false)
     end
 
-    should 'log' do
+    test 'other env log' do
       Rails.logger.expects(:error)
       report_and_supress_exceptions { raise_exception }
     end
 
-    should 'report an error' do
+    test 'other env report an error' do
       System::ErrorReporting.expects(:report_error)
       report_and_supress_exceptions { raise_exception }
     end
   end
 
+  def self.runnable_methods
+    return [] if self == ExceptionReportingTest
+
+    super
+  end
 end

--- a/test/unit/line_item_test.rb
+++ b/test/unit/line_item_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class LineItemTest < ActiveSupport::TestCase
@@ -30,16 +32,10 @@ class LineItemTest < ActiveSupport::TestCase
     assert_equal 0, LineItem.sum_by_invoice_state('finalized')
   end
 
-  context 'LineItem' do
-    setup do
-      @line_item = FactoryBot.create(:line_item_plan_cost)
-    end
-
-
-    should 'respond to #to_xml' do
-      # TODO: add content assertioins
-      assert_not_nil @line_item.to_xml
-    end
+  test 'respond to #to_xml' do
+    @line_item = FactoryBot.create(:line_item_plan_cost)
+    # TODO: add content assertioins
+    assert_not_nil @line_item.to_xml
   end
 
   test 'plan_id' do
@@ -72,9 +68,7 @@ class LineItemTest < ActiveSupport::TestCase
     end
   end
 
-
   test 'type is a String' do
     assert_equal '', LineItem.new.type
   end
-
 end

--- a/test/unit/line_item_test.rb
+++ b/test/unit/line_item_test.rb
@@ -14,14 +14,14 @@ class LineItemTest < ActiveSupport::TestCase
     provider_account_one = FactoryBot.create(:provider_with_billing)
     provider_account_two = FactoryBot.create(:provider_with_billing)
 
-    provider_account_one.billing_strategy.update_attribute(:currency, 'EUR')
-    provider_account_two.billing_strategy.update_attribute(:currency, 'USD')
+    provider_account_one.billing_strategy.update(currency: 'EUR')
+    provider_account_two.billing_strategy.update(currency: 'USD')
 
-    invoice_one = FactoryBot.create(:invoice, :provider_account => provider_account_one)
-    invoice_two = FactoryBot.create(:invoice, :provider_account => provider_account_two)
+    invoice_one = FactoryBot.create(:invoice, provider_account: provider_account_one)
+    invoice_two = FactoryBot.create(:invoice, provider_account: provider_account_two)
 
-    line_item_one = invoice_one.line_items.new(:cost => 10)
-    line_item_two = invoice_two.line_items.new(:cost => 42)
+    line_item_one = invoice_one.line_items.new(cost: 10)
+    line_item_two = invoice_two.line_items.new(cost: 42)
 
     assert_equal 'EUR', line_item_one.cost.currency
     assert_equal 'USD', line_item_two.cost.currency

--- a/test/unit/liquid/drops/service_plan_drop_test.rb
+++ b/test/unit/liquid/drops/service_plan_drop_test.rb
@@ -1,14 +1,14 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Liquid::Drops::ServicePlanDropTest < ActiveSupport::TestCase
-  context 'ServicePlanDrop' do
-    setup do
-      @plan = FactoryBot.create(:service_plan)
-      @drop = Liquid::Drops::ServicePlan.new(@plan)
-    end
+  setup do
+    @plan = FactoryBot.create(:service_plan)
+    @drop = Liquid::Drops::ServicePlan.new(@plan)
+  end
 
-    should 'return id' do
-      assert_equal @drop.id, @plan.id
-    end
+  test 'should return id' do
+    assert_equal @drop.id, @plan.id
   end
 end

--- a/test/unit/mailers/invitation_mailer_test.rb
+++ b/test/unit/mailers/invitation_mailer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class InvitationMailerTest < ActionMailer::TestCase
@@ -14,13 +16,11 @@ class InvitationMailerTest < ActionMailer::TestCase
     assert_equal [@invitation.email], @email.to
   end
 
-  context 'provider invitation' do
-    should 'body contains signup link to admin domain of the inviting provider' do
-      account = @invitation.account
+  test 'body contains signup link to admin domain of the inviting provider' do
+    account = @invitation.account
 
-      assert_match("https://#{account.external_admin_domain}/signup/#{@invitation.token}", @email.body.to_s)
-      assert_match(@invitation.account.org_name, @email.body.to_s)
-    end
+    assert_match("https://#{account.external_admin_domain}/signup/#{@invitation.token}", @email.body.to_s)
+    assert_match(@invitation.account.org_name, @email.body.to_s)
   end
 
   test 'buyer invitation contains signup link to public domain of the provider' do

--- a/test/unit/mailers/invitation_mailer_test.rb
+++ b/test/unit/mailers/invitation_mailer_test.rb
@@ -25,8 +25,8 @@ class InvitationMailerTest < ActionMailer::TestCase
 
   test 'buyer invitation contains signup link to public domain of the provider' do
     buyer = FactoryBot.create :buyer_account
-    buyer_invitation = FactoryBot.create(:invitation, :account => buyer)
-    buyer_email      = InvitationMailer.invitation(buyer_invitation)
+    buyer_invitation = FactoryBot.create(:invitation, account: buyer)
+    buyer_email = InvitationMailer.invitation(buyer_invitation)
 
     assert_match("https://#{buyer.provider_account.external_domain}/signup/#{buyer_invitation.token}", buyer_email.body.to_s)
   end

--- a/test/unit/payment_gateway_test.rb
+++ b/test/unit/payment_gateway_test.rb
@@ -1,27 +1,25 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PaymentGatewayTest < ActiveSupport::TestCase
-
-  should 'have display_name' do
+  test 'have display_name' do
     assert_equal 'Authorize.Net', PaymentGateway.new(:authorize_net).display_name
   end
 
-  should 'have homepage_url' do
+  test 'have homepage_url' do
     assert_equal 'http://www.authorize.net/', PaymentGateway.new(:authorize_net).homepage_url
   end
 
-  context 'method #all' do
-    setup { PaymentGateway.stubs(:bogus_enabled?).returns(false) }
+  test 'method #all contain only supported gateways' do
+    PaymentGateway.stubs(:bogus_enabled?).returns(false)
+    assert_equal %i[authorize_net braintree_blue ogone stripe], PaymentGateway.all.map(&:type).sort
+  end
 
-    should 'contain only supported gateways' do
-      assert_equal %i[authorize_net braintree_blue ogone stripe], PaymentGateway.all.map(&:type).sort
-    end
-
-    should 'include bogus when enabled' do
-      PaymentGateway.stubs(:bogus_enabled?).returns(true)
-      assert_includes PaymentGateway.all.map(&:type), :bogus
-    end
-  end # method #all
+  test 'method #all include bogus when enabled' do
+    PaymentGateway.stubs(:bogus_enabled?).returns(true)
+    assert_includes PaymentGateway.all.map(&:type), :bogus
+  end
 
   test ':login and :password order in #fields' do
     PaymentGateway::GATEWAYS.each do |gateway|

--- a/test/unit/payment_gateway_test.rb
+++ b/test/unit/payment_gateway_test.rb
@@ -3,51 +3,120 @@
 require 'test_helper'
 
 class PaymentGatewayTest < ActiveSupport::TestCase
-  test 'have display_name' do
-    assert_equal 'Authorize.Net', PaymentGateway.new(:authorize_net).display_name
+  setup do
+    @gateway = PaymentGateway::GATEWAYS.detect {|n| n.type == type }
   end
 
-  test 'have homepage_url' do
-    assert_equal 'http://www.authorize.net/', PaymentGateway.new(:authorize_net).homepage_url
+  attr_reader :gateway
+
+  class ClassMethodsTest < ActiveSupport::TestCase
+    test '#all contain only supported gateways' do
+      PaymentGateway.stubs(:bogus_enabled?).returns(false)
+      assert_equal %i[authorize_net braintree_blue ogone stripe], PaymentGateway.all.map(&:type).sort
+    end
+
+    test '#all include bogus when enabled' do
+      PaymentGateway.stubs(:bogus_enabled?).returns(true)
+      assert_includes PaymentGateway.all.map(&:type), :bogus
+    end
+
+    test '#non_boolean_fields' do
+      payment_gateway = PaymentGateway.new(:feature, name: 'Name of the feature', opt_in: 'Opt in', boolean: %i[opt_in])
+      assert_equal %i[opt_in], payment_gateway.boolean_field_keys
+      assert_equal ({ name: 'Name of the feature' }), payment_gateway.non_boolean_fields
+    end
   end
 
-  test 'method #all contain only supported gateways' do
-    PaymentGateway.stubs(:bogus_enabled?).returns(false)
-    assert_equal %i[authorize_net braintree_blue ogone stripe], PaymentGateway.all.map(&:type).sort
-  end
+  class AuthorizeNetTest < PaymentGatewayTest
+    def type
+      :authorize_net
+    end
 
-  test 'method #all include bogus when enabled' do
-    PaymentGateway.stubs(:bogus_enabled?).returns(true)
-    assert_includes PaymentGateway.all.map(&:type), :bogus
-  end
+    test 'have display_name' do
+      assert_equal 'Authorize.Net', gateway.display_name
+    end
 
-  test ':login and :password order in #fields' do
-    PaymentGateway::GATEWAYS.each do |gateway|
+    test 'have homepage_url' do
+      assert_equal 'http://www.authorize.net/', gateway.homepage_url
+    end
+
+    test ':login and :password order in #fields' do
       fields = gateway.fields.keys
 
-      assert [nil, 0].include?(fields.index(:login)), ":login must be the first field declared in Gateway[#{gateway.type}]"
-      if gateway.fields.keys.index(:login)
-        assert [nil, 1].include?(fields.index(:password)), ":password must be the second field declared in Gateway[#{gateway.type}]"
-      else
-        assert [nil, 0].include?(fields.index(:password)), ":password must be the first field declared in Gateway[#{gateway.type}]"
-      end
+      assert_equal 0, fields.index(:login), ":login must be the first field declared in Gateway[#{type}]"
+      assert_equal 1, fields.index(:password), ":password must be the second field declared in Gateway[#{type}]"
     end
   end
 
-  test '::find' do
-    PaymentGateway.types.each do |type|
-      assert_not_nil PaymentGateway.find(type)
+  class BraintreeBlueTest < PaymentGatewayTest
+    def type
+      :braintree_blue
+    end
+
+    test 'have display_name' do
+      assert_equal 'Braintree (Blue Platform)', gateway.display_name
+    end
+
+    test 'have homepage_url' do
+      assert_equal 'http://www.braintreepaymentsolutions.com', gateway.homepage_url
+    end
+
+    test ':login and :password order in #fields' do
+      assert_not_includes gateway.fields.keys, %i[login password], ":login and :password must not be fields declared in Gateway[#{type}]"
     end
   end
 
-  test '.implementation for stripe with and without SCA' do
-    assert_equal ActiveMerchant::Billing::StripeGateway,               PaymentGateway.implementation(:stripe)
-    assert_equal ActiveMerchant::Billing::StripePaymentIntentsGateway, PaymentGateway.implementation(:stripe, sca: true)
+  class OgoneTest < PaymentGatewayTest
+    def type
+      :ogone
+    end
+
+    test 'have display_name' do
+      assert_equal 'Ogone', gateway.display_name
+    end
+
+    test 'have homepage_url' do
+      assert_equal 'http://www.ogone.com/', gateway.homepage_url
+    end
+
+    test ':login and :password order in #fields' do
+      assert_not_includes gateway.fields.keys, %i[login password], ":login and :password must not be a field declared in Gateway[#{type}]"
+    end
   end
 
-  test 'non_boolean_fields' do
-    payment_gateway = PaymentGateway.new(:feature, name: 'Name of the feature', opt_in: 'Opt in', boolean: %i[opt_in])
-    assert_equal %i[opt_in], payment_gateway.boolean_field_keys
-    assert_equal({name: 'Name of the feature'}, payment_gateway.non_boolean_fields)
+  class StripeTest < PaymentGatewayTest
+    def type
+      :stripe
+    end
+
+    test 'have display_name' do
+      assert_equal 'Stripe', gateway.display_name
+    end
+
+    test 'have homepage_url' do
+      assert_equal 'https://stripe.com/', gateway.homepage_url
+    end
+
+    test ':login and :password order in #fields' do
+      fields = gateway.fields.keys
+
+      assert_equal 0, fields.index(:login), ":login must be the first field declared in Gateway[#{type}]"
+      assert_not_includes fields, :password, ":password must not be the a field declared in Gateway[#{type}]"
+    end
+
+    test '#implementation with and without SCA' do
+      assert_equal ActiveMerchant::Billing::StripeGateway,               PaymentGateway.implementation(type)
+      assert_equal ActiveMerchant::Billing::StripePaymentIntentsGateway, PaymentGateway.implementation(type, sca: true)
+    end
+  end
+
+  test '#find' do
+    assert_not_nil PaymentGateway.find(type)
+  end
+
+  def self.runnable_methods
+    return [] if self == PaymentGatewayTest
+
+    super
   end
 end

--- a/test/unit/web_hook_test.rb
+++ b/test/unit/web_hook_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class WebHookTest < ActiveSupport::TestCase
   should validate_presence_of :account_id
+  should validate_uniqueness_of :account_id
 
   def test_switchable_attributes
     WebHook.stubs(:column_names).returns(['alaska'])
@@ -11,18 +12,6 @@ class WebHookTest < ActiveSupport::TestCase
 
     WebHook.stubs(:column_names).returns(['alaska_on'])
     assert_equal ['alaska_on'], WebHook.switchable_attributes
-  end
-
-  # could not get it with shoulda :-(
-  test "validate uniqueness of account_id" do
-    wk1 = WebHook.new :url => "http://foo.example.com"
-    wk1.account_id = 1
-    wk1.save!
-    wk2 = WebHook.new :url => "http://bar.example.com"
-    wk2.account_id = 1
-
-    assert_not wk2.valid?
-    assert wk2.errors[:account_id].present?
   end
 
   class PushingBehaviourTest < ActiveSupport::TestCase
@@ -34,69 +23,58 @@ class WebHookTest < ActiveSupport::TestCase
       @provider = FactoryBot.create(:provider_account)
       Account.any_instance.stubs(:web_hooks_allowed?).returns(true)
 
-      @service = FactoryBot.create :simple_service, backend_version: '2', :account => @provider
-      app_plan = FactoryBot.create :simple_application_plan, :issuer => @service
-      @app_plan = app_plan
-      @wh = WebHook.create!(:account => @provider, :url => "http://#{@provider.domain}",
-                            :active => true)
+      @service = FactoryBot.create(:simple_service, backend_version: '2', account: @provider)
+      @app_plan = FactoryBot.create(:simple_application_plan, issuer: @service)
 
-      # no idea how, but buyer from factory comes with strange user
-      # user has account association preloaded to nil
-      @buyer = FactoryBot.create(:simple_buyer, :provider_account => @provider)
-      @user  = FactoryBot.create(:simple_user, :account => @buyer)
+      @wh = WebHook.create!(account: @provider, url: "http://#{@provider.domain}", active: true)
 
-      @buyer.buy! @provider.account_plans.first
-      @application = @buyer.buy! app_plan
+      @buyer = FactoryBot.create(:simple_buyer, provider_account: @provider)
     end
 
     test 'fire webhook' do
-      @wh.update :provider_actions => true,
-                            :account_deleted_on => true,
-                            :user_deleted_on => false
+      @wh.update provider_actions: true,
+                 account_deleted_on: true,
+                 user_deleted_on: false
 
-      User.current = FactoryBot.create(:simple_user, :account => @provider)
+      User.current = FactoryBot.create(:simple_user, account: @provider)
       @buyer.destroy
 
-      job = WebHookWorker.jobs.first
+      assert job = WebHookWorker.jobs.first
 
-      assert job
-
-      xml =  job['args'][1]['xml']
+      xml = job.dig('args', 1, 'xml')
 
       assert_equal Hash.from_xml(@buyer.to_xml),
-                   Hash.from_xml(xml)['event']['object']
+                   Hash.from_xml(xml).dig('event', 'object')
 
       RestClient.expects(:post).once
       WebHookWorker.drain
     end
 
     test 'fire webhook on create app' do
-      @service.update_column(:backend_version, 2)
       @wh.update provider_actions: true,
-                            account_deleted_on: false,
-                            application_created_on: true,
-                            application_updated_on: false,
-                            application_deleted_on: false,
-                            user_deleted_on: false
+                 account_deleted_on: false,
+                 application_created_on: true,
+                 application_updated_on: false,
+                 application_deleted_on: false,
+                 user_deleted_on: false
 
-      User.current = FactoryBot.create(:simple_user, :account => @provider)
+      User.current = FactoryBot.create(:simple_user, account: @provider)
 
       Cinstance.any_instance.stubs(create_key_after_create?: true)
       application = @buyer.buy!(@app_plan)
 
-
       job = WebHookWorker.jobs.first
-      hash = Hash.from_xml(job['args'][1]['xml'])
-      keys_hash = hash["event"]["object"]["application"]["keys"]
+      hash = Hash.from_xml(job.dig('args', 1, 'xml'))
+      keys_hash = hash.dig("event", "object", "application", "keys")
       assert keys_hash.present?
       assert_equal application.keys, keys_hash.values
     end
   end
 
   test '#ping' do
-    hook = WebHook.new :url => "http://foo"
+    hook = WebHook.new(url: "http://foo")
 
-    HTTPClient.stubs(:get).returns(stub(:status => 200))
+    HTTPClient.stubs(:get).returns(stub(status: 200))
     assert_equal 200, hook.ping.status
 
     HTTPClient.stubs(:get).raises(RuntimeError.new('E_NO_POTATOES'))


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/integration/utilization_test
* test/unit/abilities/cms_test
* test/unit/abilities/multiple_applications_test
* test/unit/alert_test
* test/unit/backend/model_extensions/provider_test
* test/unit/exception_reporting_test
* test/unit/line_item_test
* test/unit/liquid/drops/service_plan_drop_test
* test/unit/mailers/invitation_mailer_test
* test/unit/payment_gateway_test
* test/unit/web_hook_test

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)