### PR TITLE
Remove `context` and `should` from stats_controller_test

### DIFF
--- a/test/functional/developer_portal/buyer/stats_controller_test.rb
+++ b/test/functional/developer_portal/buyer/stats_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionController::TestCase
@@ -7,55 +9,53 @@ class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionContr
     @request.host = @provider.domain
   end
 
-  test 'login is required' do
-    get :index
-    assert_redirected_to login_url
-  end
-
-  context "buyer without live cinstances" do
-    setup do
-      @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
-      @app_plan = FactoryBot.create(:application_plan, :issuer => @provider.default_service)
-      app = @buyer.buy! @app_plan
-      app.suspend!
-
-      login_as(@buyer.admins.first)
-    end
-
-    should "be redirected to applications" do
+  class BeforeLoginTest < DeveloperPortal::Buyer::StatsControllerTest
+    test 'login is required' do
       get :index
-      assert_redirected_to admin_applications_url
+      assert_redirected_to login_url
     end
   end
 
-  context "resources for buyers" do
-    setup do
+  class AfterLoginTest < DeveloperPortal::Buyer::StatsControllerTest
+    def setup
+      super
       @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
       @app_plan = FactoryBot.create(:application_plan, :issuer => @provider.default_service)
-      @live_app1 = @buyer.buy! @app_plan
-      @hits = @provider.default_service.metrics.first
 
       login_as(@buyer.admins.first)
     end
 
-    context "#index action" do
-      setup do
-        app_plan2 = FactoryBot.create(:application_plan, :issuer => @provider.default_service)
-        app_plan3 = FactoryBot.create(:application_plan, :issuer => @provider.default_service)
-        @live_app2 = @buyer.buy! app_plan2
-        cinstance = @buyer.buy! app_plan3
+    class BuyerWithoutLiveCinstancesTest < AfterLoginTest
+      def setup
+        super
+        app = @buyer.buy! @app_plan
+        app.suspend!
+      end
+
+      test "be redirected to applications" do
+        get :index
+        assert_redirected_to admin_applications_url
+      end
+    end
+
+    class IndexMethodTest < AfterLoginTest
+      def setup
+        super
+        @live_app1 = @buyer.buy! @app_plan
+        @live_app2 = @buyer.buy! FactoryBot.create(:application_plan, :issuer => @provider.default_service)
+        cinstance = @buyer.buy! FactoryBot.create(:application_plan, :issuer => @provider.default_service)
         cinstance.suspend!
       end
 
-      should 'only return live cinstances' do
+      test '#index only returns live cinstances' do
         get :index
 
         doc = Nokogiri::HTML.parse(response.body)
         assert_equal [@live_app1, @live_app2], assigns(:applications)
-        assert_equal @live_app1.id.to_s,  doc.css('#client-name[data-client]').attr('data-client').value
+        assert_equal @live_app1.id.to_s, doc.css('#client-name[data-client]').attr('data-client').value
       end
 
-      should 'with multiapps visible' do
+      test '#index with multiapps visible' do
         @provider.settings.allow_multiple_applications!
         @provider.settings.show_multiple_applications!
 
@@ -65,52 +65,55 @@ class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionContr
         assert_equal @live_app1.id.to_s, doc.css('#client-name[data-client]').attr('data-client').value
       end
 
-      should 'return first live cinstance as default' do
+      test '#index returns first live cinstance as default' do
         get :index
         #assert_equal @live_app1, assigns(:cinstance)
         assert_equal @live_app1, @controller.instance_variable_get('@cinstance')
       end
-    end # index action
+    end
 
-    context "#metrics action" do
-      setup do
+    class MetricsActionTest < AfterLoginTest
+      def setup
+        super
+        @live_app1 = @buyer.buy! @app_plan
+        @hits = @provider.default_service.metrics.first
+
         disabled_metric = FactoryBot.create(:metric, :service => @provider.default_service)
         disabled_metric.disable_for_plan @app_plan
-        assert disabled_metric.disabled_for_plan?(@app_plan) #being paranoid about initial state
 
         hidden_metric = FactoryBot.create(:metric, :service => @provider.default_service)
         hidden_metric.toggle_visible_for_plan(@app_plan)
-        assert !hidden_metric.visible_in_plan?(@app_plan) #being paranoid about initial state
       end
 
-      should 'only return enabled and visible metrics in app plan' do
+      test '#metrics only return enabled and visible metrics in app plan' do
         get :metrics_list, params: { id: @live_app1.id }
         assert_equal [@hits], assigns(:metrics)
       end
 
-      should 'return 404 for non-existent app' do
+      test '#metrics return 404 for non-existent app' do
         get :metrics_list, params: { id: 'NON_EXISTENT' }
         assert_response :not_found
       end
+    end
 
-    end # metrics action
+    class MethodsActionTest < AfterLoginTest
+      def setup
+        super
+        @live_app1 = @buyer.buy! @app_plan
+        @hits = @provider.default_service.metrics.first
 
-    context "#methods action" do
-      setup do
         @method = @hits.children.create! :system_name => "method", :friendly_name => "method"
         disabled_method = @hits.children.create! :system_name => "disabled", :friendly_name => "disabled"
         disabled_method.disable_for_plan @app_plan
-        assert disabled_method.disabled_for_plan?(@app_plan) #being paranoid about initial state
 
         hidden_method = @hits.children.create! :system_name => "hidden", :friendly_name => "hidden"
         hidden_method.toggle_visible_for_plan(@app_plan)
-        assert !hidden_method.visible_in_plan?(@app_plan) #being paranoid about initial state
       end
 
-      should 'only return enabled and visible methods in app plan' do
+      test '#methods only return enabled and visible methods in app plan' do
         get :methods_list, params: { id: @live_app1.id }
         assert_equal [@method], assigns(:methods)
       end
-    end # methods action
-  end # buyer resources
+    end
+  end
 end

--- a/test/functional/developer_portal/buyer/stats_controller_test.rb
+++ b/test/functional/developer_portal/buyer/stats_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionController::TestCase
   def setup
     super
-    @provider = FactoryBot.create :provider_account
+    @provider = FactoryBot.create(:provider_account)
     @request.host = @provider.domain
   end
 
@@ -19,8 +19,8 @@ class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionContr
   class AfterLoginTest < DeveloperPortal::Buyer::StatsControllerTest
     def setup
       super
-      @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
-      @app_plan = FactoryBot.create(:application_plan, :issuer => @provider.default_service)
+      @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+      @app_plan = FactoryBot.create(:application_plan, issuer: @provider.default_service)
 
       login_as(@buyer.admins.first)
     end
@@ -42,8 +42,8 @@ class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionContr
       def setup
         super
         @live_app1 = @buyer.buy! @app_plan
-        @live_app2 = @buyer.buy! FactoryBot.create(:application_plan, :issuer => @provider.default_service)
-        cinstance = @buyer.buy! FactoryBot.create(:application_plan, :issuer => @provider.default_service)
+        @live_app2 = @buyer.buy! FactoryBot.create(:application_plan, issuer: @provider.default_service)
+        cinstance = @buyer.buy! FactoryBot.create(:application_plan, issuer: @provider.default_service)
         cinstance.suspend!
       end
 
@@ -67,7 +67,6 @@ class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionContr
 
       test '#index returns first live cinstance as default' do
         get :index
-        #assert_equal @live_app1, assigns(:cinstance)
         assert_equal @live_app1, @controller.instance_variable_get('@cinstance')
       end
     end
@@ -78,10 +77,10 @@ class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionContr
         @live_app1 = @buyer.buy! @app_plan
         @hits = @provider.default_service.metrics.first
 
-        disabled_metric = FactoryBot.create(:metric, :service => @provider.default_service)
+        disabled_metric = FactoryBot.create(:metric, service: @provider.default_service)
         disabled_metric.disable_for_plan @app_plan
 
-        hidden_metric = FactoryBot.create(:metric, :service => @provider.default_service)
+        hidden_metric = FactoryBot.create(:metric, service: @provider.default_service)
         hidden_metric.toggle_visible_for_plan(@app_plan)
       end
 
@@ -102,11 +101,11 @@ class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionContr
         @live_app1 = @buyer.buy! @app_plan
         @hits = @provider.default_service.metrics.first
 
-        @method = @hits.children.create! :system_name => "method", :friendly_name => "method"
-        disabled_method = @hits.children.create! :system_name => "disabled", :friendly_name => "disabled"
+        @method = @hits.children.create!(system_name: "method", friendly_name: "method")
+        disabled_method = @hits.children.create!(system_name: "disabled", friendly_name: "disabled")
         disabled_method.disable_for_plan @app_plan
 
-        hidden_method = @hits.children.create! :system_name => "hidden", :friendly_name => "hidden"
+        hidden_method = @hits.children.create!(system_name: "hidden", friendly_name: "hidden")
         hidden_method.toggle_visible_for_plan(@app_plan)
       end
 


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/functional/developer_portal/buyer/stats_controller_test

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)