### PR TITLE
ThreeScale::Settings

### DIFF
--- a/app/lib/active_merchant_hacks.rb
+++ b/app/lib/active_merchant_hacks.rb
@@ -9,7 +9,7 @@ class ActiveMerchant::Billing::Gateway
   def threescale_unstore(identification, *args)
     return nil unless identification.present? && respond_to?(:unstore)
 
-    if System::Application.config.three_scale.payments.enabled
+    if ThreeScale::Settings.get('payments.enabled')
       unstore(identification, *args)
     else
       "Skipping card unstore: Not enabled on this environment"

--- a/app/models/finance/billing_strategy.rb
+++ b/app/models/finance/billing_strategy.rb
@@ -56,7 +56,7 @@ class Finance::BillingStrategy < ApplicationRecord
   end
 
   def self.canaries
-    ThreeScale.config.payments.billing_canaries || []
+    ThreeScale::Settings.get('payments.billing_canaries') || []
   end
 
   # Supported options

--- a/app/models/payment_transaction.rb
+++ b/app/models/payment_transaction.rb
@@ -20,7 +20,7 @@ class PaymentTransaction < ApplicationRecord
   scope :oldest_first, -> { order(:created_at) }
 
   def process!(credit_card_auth_code, gateway, options)
-    unless System::Application.config.three_scale.payments.enabled
+    unless ThreeScale::Settings.get('payments.enabled')
       logger.info "Skipping payment transaction #process! - not in production"
       return
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -200,13 +200,6 @@ module System
     three_scale = config_for(:settings).symbolize_keys
     three_scale[:error_reporting_stages] = three_scale[:error_reporting_stages].to_s.split(/\W+/)
 
-    payment_settings = three_scale.extract!(:active_merchant_mode, :active_merchant_logging, :billing_canaries)
-    config.three_scale.payments = ActiveSupport::OrderedOptions.new
-    config.three_scale.payments.enabled = false
-    config.three_scale.payments.merge!(payment_settings)
-    config.three_scale.payments.merge!(try_config_for(:payments) || {})
-    config.three_scale.payments.active_merchant_mode ||= Rails.env.production? ? :production : :test
-
     email_sanitizer_configs = (three_scale.delete(:email_sanitizer) || {}).symbolize_keys
     config.three_scale.email_sanitizer.merge!(email_sanitizer_configs)
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,8 +82,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.three_scale.payments.enabled = ENV.fetch('THREESCALE_PAYMENTS_ENABLED', '0') == '1'
-
   config.three_scale.rolling_updates.raise_error_unknown_features = true
   config.three_scale.rolling_updates.enabled = ENV.fetch('THREESCALE_ROLLING_UPDATES', '0') == '0'
 

--- a/config/environments/preview.rb
+++ b/config/environments/preview.rb
@@ -29,8 +29,6 @@ System::Application.configure do
 
   config.liquid.resolver_caching = true
 
-  config.three_scale.payments.enabled = false
-
   config.three_scale.rolling_updates.raise_error_unknown_features = false
   config.three_scale.rolling_updates.enabled = ENV.fetch('THREESCALE_ROLLING_UPDATES', '0') == '0'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,8 +119,6 @@ Rails.application.configure do
 
   config.liquid.resolver_caching = true
 
-  config.three_scale.payments.enabled = true
-
   config.three_scale.rolling_updates.raise_error_unknown_features = false
   config.three_scale.rolling_updates.enabled = ENV.fetch('THREESCALE_ROLLING_UPDATES', '0') == '0'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,8 +43,6 @@ Rails.application.configure do
 
   config.active_support.test_order = :sorted # who has the balls can set it to :random
 
-  config.three_scale.payments.merge!(enabled: true, active_merchant_mode: :test, active_merchant_logging: false)
-
   config.three_scale.rolling_updates.raise_error_unknown_features = true
   config.three_scale.rolling_updates.enabled = false
   config.representer.default_url_options = { host: 'example.org' }

--- a/config/initializers/active_merchant.rb
+++ b/config/initializers/active_merchant.rb
@@ -1,11 +1,44 @@
 # frozen_string_literal: true
 
+require 'three_scale/settings'
+
+ThreeScale::Settings.configure('payments.enabled') do
+  case Rails.env
+  when 'production', 'test'
+    true
+  when 'development'
+    ENV.fetch('THREESCALE_PAYMENTS_ENABLED', '0') == '1'
+  end
+end
+
+ThreeScale::Settings.configure('payments.active_merchant_mode') do
+  case Rails.env
+  when 'test'
+    :test
+  else
+    Rails.application.config.three_scale.try(:active_merchant_mode)&.to_sym || (Rails.env.production? ? :production : :test)
+  end
+end
+
+ThreeScale::Settings.configure('payments.active_merchant_logging') do
+  case Rails.env
+  when 'test'
+    false
+  else
+    Rails.application.config.three_scale.try(:active_merchant_logging)
+  end
+end
+
+ThreeScale::Settings.configure('payments.billing_canaries') { Rails.application.config.three_scale.try(:billing_canaries) }
+
+ThreeScale::Settings.merge!((Rails.application.try_config_for(:payments) || {}).transform_keys { |key| "payments.#{key}" })
+
 require 'active_merchant_hacks'
 
-ActiveMerchant::Billing::Base.mode = Rails.application.config.three_scale.payments.active_merchant_mode.to_sym
+ActiveMerchant::Billing::Base.mode = ThreeScale::Settings.get('payments.active_merchant_mode')
 Rails.logger.info("ActiveMerchant MODE set to '#{ActiveMerchant::Billing::Base.mode}'")
 
-if Rails.application.config.three_scale.payments.active_merchant_logging
+if ThreeScale::Settings.get('payments.active_merchant_logging')
   ActiveMerchant::Billing::Gateway.wiredump_device = Rails.root.join('log/activemerchant.log').open('a')
   ActiveMerchant::Billing::Gateway.wiredump_device.sync = true
 end

--- a/lib/three_scale/settings.rb
+++ b/lib/three_scale/settings.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ThreeScale
+  class Settings
+    include Singleton
+
+    attr_reader :config
+
+    class << self
+      delegate :configure, :merge!, :get, :key?, to: :instance
+    end
+
+    delegate :key?, to: :config
+
+    def initialize
+      @config = ActiveSupport::Configurable::Configuration.new
+      super
+    end
+
+    def configure(key, &processor)
+      config[key] = processor.call
+    end
+
+    def merge!(hash)
+      config.merge! hash.symbolize_keys
+    end
+
+    def get(key)
+      config.fetch key.to_sym
+    end
+  end
+end

--- a/test/unit/active_merchant/stripe_fix_test.rb
+++ b/test/unit/active_merchant/stripe_fix_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 class StripeFixTest < ActiveSupport::TestCase
   def test_threescale_unstore
-    System::Application.config.three_scale.payments.stubs(enabled: true)
+    ThreeScale::Settings.stubs(:get).with('payments.enabled').returns(true)
     stripe = ActiveMerchant::Billing::StripeGateway.new login: 'apitoken'
 
     auth = Base64.strict_encode64('apitoken:')

--- a/test/unit/three_scale/settings_test.rb
+++ b/test/unit/three_scale/settings_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ThreeScale::SettingsTest < ActiveSupport::TestCase
+  test 'configure' do
+    key = "my.setting-#{random_suffix}"
+    ThreeScale::Settings.configure(key) { 'value' }
+    assert_equal 'value', ThreeScale::Settings.get(key)
+  end
+
+  test 'missing key' do
+    assert_raises(KeyError) { ThreeScale::Settings.get("missing-setting-#{random_suffix}") }
+  end
+
+  test 'merge' do
+    key = "my.setting-#{random_suffix}"
+    refute ThreeScale::Settings.key?(key.to_sym)
+    ThreeScale::Settings.merge!(key => 'value')
+    assert_equal 'value', ThreeScale::Settings.get(key)
+  end
+
+  private
+
+  # to avoid conflicts with other tests
+  def random_suffix
+    SecureRandom.hex(6)
+  end
+end


### PR DESCRIPTION
Adds a new singleton class `ThreeScale::Settings` that allows to remove the logics related to settings from `config/application.rb` and `config/environment/*` files, and have them in a domain-specific initializer instead.

To configure a setting:

```ruby
ThreeScale.configure('my.setting') do
  'value'
end
```

To retrieve a setting value:
```ruby
ThreeScale.get('my.setting')
#=> 'value'
```

The PR also moves the payment settings to the new approach.

**Default (i.e., based on `config/settings.yml`):**

```sh
rails runner -e development "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>false, :"payments.active_merchant_mode"=>:test, :"payments.active_merchant_logging"=>true, :"payments.billing_canaries"=>nil}

THREESCALE_PAYMENTS_ENABLED=1 rails runner -e development "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:test, :"payments.active_merchant_logging"=>true, :"payments.billing_canaries"=>nil}

ACTIVE_MERCHANT_LOGGING=true rails runner -e development "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>false, :"payments.active_merchant_mode"=>:test, :"payments.active_merchant_logging"=>true, :"payments.billing_canaries"=>nil}

ACTIVE_MERCHANT_LOGGING=false rails runner -e development "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>false, :"payments.active_merchant_mode"=>:test, :"payments.active_merchant_logging"=>true, :"payments.billing_canaries"=>nil}

rails runner -e test "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:test, :"payments.active_merchant_logging"=>false, :"payments.billing_canaries"=>nil}

ACTIVE_MERCHANT_LOGGING=true rails runner -e test "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:test, :"payments.active_merchant_logging"=>false, :"payments.billing_canaries"=>nil}

ACTIVE_MERCHANT_LOGGING=false rails runner -e test "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:test, :"payments.active_merchant_logging"=>false, :"payments.billing_canaries"=>nil}

rails runner -e production "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:production, :"payments.active_merchant_logging"=>false, :"payments.billing_canaries"=>nil}

ACTIVE_MERCHANT_LOGGING=true rails runner -e production "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:production, :"payments.active_merchant_logging"=>true, :"payments.billing_canaries"=>nil}

ACTIVE_MERCHANT_LOGGING=false rails runner -e production "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:production, :"payments.active_merchant_logging"=>false, :"payments.billing_canaries"=>nil}
```

**Openshift (i.e., based on `openshift/system/config/settings.yml`):**

```sh
rails runner -e production "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:production, :"payments.active_merchant_logging"=>false, :"payments.billing_canaries"=>nil}

ACTIVE_MERCHANT_LOGGING=true rails runner -e production "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:production, :"payments.active_merchant_logging"=>false, :"payments.billing_canaries"=>nil}

ACTIVE_MERCHANT_LOGGING=false rails runner -e production "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:production, :"payments.active_merchant_logging"=>false, :"payments.billing_canaries"=>nil}
```

**Openshift with `config/payments.yml`:**

```yaml
# config/payments.yml
production:
  active_merchant_mode: :test
  active_merchant_logging: true
  billing_canaries: [1, 2, 3]
```

```sh
rails runner -e production "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:test, :"payments.active_merchant_logging"=>true, :"payments.billing_canaries"=>[1, 2, 3]}

ACTIVE_MERCHANT_LOGGING=true rails runner -e production "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:test, :"payments.active_merchant_logging"=>true, :"payments.billing_canaries"=>[1, 2, 3]}

ACTIVE_MERCHANT_LOGGING=false rails runner -e production "puts ThreeScale::Settings.instance.config.inspect"
# {:"payments.enabled"=>true, :"payments.active_merchant_mode"=>:test, :"payments.active_merchant_logging"=>true, :"payments.billing_canaries"=>[1, 2, 3]}
```
