### PR TITLE
Remove `context` and `should` from mandatory_keys_test

### DIFF
--- a/test/integration/mandatory_keys_test.rb
+++ b/test/integration/mandatory_keys_test.rb
@@ -1,42 +1,43 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MandatoryKeysTest < ActionDispatch::IntegrationTest
-  context 'Mandatory keys: ' do
+  setup do
+    @provider = FactoryBot.create :provider_account, :domain => 'provider.example.com'
+    @plan = FactoryBot.create :application_plan, :issuer => @provider.default_service
+    @service = @provider.first_service!
+    @service.update_attribute(:backend_version, '2')
+    @buyer = FactoryBot.create :buyer_account, :provider_account => @provider
 
-    setup do
-      @provider = FactoryBot.create :provider_account, :domain => 'provider.example.com'
-      @plan = FactoryBot.create :application_plan, :issuer => @provider.default_service
-      @service = @provider.first_service!
-      @service.update_attribute(:backend_version, '2')
-      @buyer = FactoryBot.create :buyer_account, :provider_account => @provider
+    ApplicationKey.disable_backend!
+  end
 
-      ApplicationKey.disable_backend!
+  class ServiceWithMandatoryAppKeyTest < self
+    def setup
+      super
+      @service.update_attribute(:mandatory_app_key, true)
     end
 
-    context 'service has mandatory_app_key' do
-      setup do
-        @service.update_attribute(:mandatory_app_key, true)
-      end
+    test 'create a key on app creation' do
+      app = @buyer.buy! @plan
 
-      should 'create a key on app creation' do
-        app = @buyer.buy! @plan
-
-        assert_equal 1, app.application_keys.size
-      end
-
-      should 'create not be able to delete the last key'
+      assert_equal 1, app.application_keys.size
     end
 
-    context "service hasn't mandatory_app_key" do
-      setup do
-        @service.update_attribute(:mandatory_app_key, false)
-      end
+    pending_test 'create not be able to delete the last key'
+  end
 
-      should 'not create a key on app creation' do
-        app = @buyer.buy! @plan
+  class ServiceWithoutMandatoryAppKeyTest < self
+    def setup
+      super
+      @service.update_attribute(:mandatory_app_key, false)
+    end
 
-        assert_equal 0, app.application_keys.size
-      end
+    test 'not create a key on app creation' do
+      app = @buyer.buy! @plan
+
+      assert_equal 0, app.application_keys.size
     end
   end
 end

--- a/test/integration/mandatory_keys_test.rb
+++ b/test/integration/mandatory_keys_test.rb
@@ -24,7 +24,13 @@ class MandatoryKeysTest < ActionDispatch::IntegrationTest
       assert_equal 1, app.application_keys.size
     end
 
-    pending_test 'create not be able to delete the last key'
+    test 'not be able to delete the last key' do
+      app = @buyer.buy! @plan
+      assert_not app.can_delete_key?
+
+      app.application_keys.new
+      assert app.can_delete_key?
+    end
   end
 
   class ServiceWithoutMandatoryAppKeyTest < self
@@ -37,6 +43,11 @@ class MandatoryKeysTest < ActionDispatch::IntegrationTest
       app = @buyer.buy! @plan
 
       assert_equal 0, app.application_keys.size
+    end
+
+    test 'be able to delete keys' do
+      app = @buyer.buy! @plan
+      assert app.can_delete_key?
     end
   end
 end

--- a/test/integration/mandatory_keys_test.rb
+++ b/test/integration/mandatory_keys_test.rb
@@ -4,11 +4,10 @@ require 'test_helper'
 
 class MandatoryKeysTest < ActionDispatch::IntegrationTest
   setup do
-    @provider = FactoryBot.create :provider_account, :domain => 'provider.example.com'
-    @plan = FactoryBot.create :application_plan, :issuer => @provider.default_service
-    @service = @provider.first_service!
-    @service.update_attribute(:backend_version, '2')
-    @buyer = FactoryBot.create :buyer_account, :provider_account => @provider
+    provider = FactoryBot.create(:provider_account, domain: 'provider.example.com')
+    @service = FactoryBot.create(:simple_service, account: provider, backend_version: 2)
+    @plan = FactoryBot.create(:application_plan, issuer: @service)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: provider)
 
     ApplicationKey.disable_backend!
   end
@@ -16,7 +15,7 @@ class MandatoryKeysTest < ActionDispatch::IntegrationTest
   class ServiceWithMandatoryAppKeyTest < self
     def setup
       super
-      @service.update_attribute(:mandatory_app_key, true)
+      @service.update(mandatory_app_key: true)
     end
 
     test 'create a key on app creation' do
@@ -31,7 +30,7 @@ class MandatoryKeysTest < ActionDispatch::IntegrationTest
   class ServiceWithoutMandatoryAppKeyTest < self
     def setup
       super
-      @service.update_attribute(:mandatory_app_key, false)
+      @service.update(mandatory_app_key: false)
     end
 
     test 'not create a key on app creation' do


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/integration/mandatory_keys_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)