### PR TITLE
Remove `context` and `should` from notifications_test

### DIFF
--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -1,59 +1,62 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class NotificationsTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
-  setup do
+  def setup
     Logic::RollingUpdates.stubs(skipped?: true)
   end
 
-  context "mail dispatch rules for account" do
-    setup do
-      ['plan_change', 'weekly_reports', 'daily_reports'].each do |o|
+  class MailDispatchRulesForAccountTest < NotificationsTest
+    def setup
+      super
+      %w[plan_change weekly_reports daily_reports].each do |o|
         SystemOperation.for(o)
       end
       @account = FactoryBot.create(:account_without_users)
       @admin = FactoryBot.create(:admin, :account => @account)
     end
 
-    should 'have dispatch rule created when called for the first time' do
+    test 'have dispatch rule created when called for the first time' do
       assert_equal 0, @account.mail_dispatch_rules.count
       @account.dispatch_rule_for(SystemOperation.for(:weekly_reports)).dispatch?
       assert_equal 1, @account.mail_dispatch_rules.count
     end
 
-    should 'not have dispatch rule duplicated' do
+    test 'not have dispatch rule duplicated' do
       @account.dispatch_rule_for(SystemOperation.for(:weekly_reports)).dispatch?
       assert_equal 1, @account.mail_dispatch_rules.count
       @account.dispatch_rule_for(SystemOperation.for(:weekly_reports)).dispatch?
       assert_equal 1, @account.mail_dispatch_rules.count
     end
 
-    should 'have dispatch rules for reports set to false, by default' do
+    test 'have dispatch rules for reports set to false, by default' do
       assert_equal false, @account.dispatch_rule_for(SystemOperation.for(:weekly_reports)).dispatch?
       assert_equal false, @account.dispatch_rule_for(SystemOperation.for(:daily_reports)).dispatch?
     end
 
-    should 'have dispatch rules for plan change set to true, by default' do
+    test 'have dispatch rules for plan change set to true, by default' do
       assert_equal true, @account.dispatch_rule_for(SystemOperation.for(:plan_change)).dispatch?
     end
   end
 
-  context 'receiving a message with mail dispatch rule set' do
-    setup do
+  class ReceivingMessageWithMailDispatchRuleSetTest < NotificationsTest
+    def setup
+      super
       @operation = SystemOperation.for('plan_change')
       @buyer_sender = FactoryBot.create :buyer_account
       @provider_recipient = FactoryBot.create :provider_account
 
       @message = @buyer_sender.messages.build(
-      :to => @provider_recipient,
-      :subject => 'Plan Change',
-      :body => "Hello",
-      :system_operation => @operation)
-
+        :to => @provider_recipient,
+        :subject => 'Plan Change',
+        :body => "Hello",
+        :system_operation => @operation)
     end
 
-    should 'notify recipient by email when no rules exist and operation is not a report' do
+    test 'notify recipient by email when no rules exist and operation is not a report' do
       MailDispatchRule.delete_all
 
       @message.save!
@@ -61,10 +64,9 @@ class NotificationsTest < ActiveSupport::TestCase
 
       @message_recipient = @provider_recipient.received_messages.last
       assert_equal true, @message_recipient.notifiable?
-
     end
 
-    should 'not notify recipient by email when no rules exist and operation is a report' do
+    test 'not notify recipient by email when no rules exist and operation is a report' do
       MailDispatchRule.delete_all
       @operation = SystemOperation.for('weekly_reports')
       @message.system_operation = @operation
@@ -74,11 +76,9 @@ class NotificationsTest < ActiveSupport::TestCase
 
       @message_recipient = @provider_recipient.received_messages.last
       assert_equal false, @message_recipient.notifiable?
-
     end
 
-    should 'notify recipient by email when rule for operation is set to true' do
-
+    test 'notify recipient by email when rule for operation is set to true' do
       @rule = FactoryBot.create :mail_dispatch_rule, :account => @provider_recipient, :dispatch => true, :system_operation => @operation
 
       assert_difference ActionMailer::Base.deliveries.method(:count) do
@@ -90,7 +90,7 @@ class NotificationsTest < ActiveSupport::TestCase
       assert_equal true, @message_recipient.notifiable?
     end
 
-    should 'NOT notify recipient when dispatch rule is set to true and notification preferences are enabled' do
+    test 'NOT notify recipient when dispatch rule is set to true and notification preferences are enabled' do
       @rule = FactoryBot.create(:mail_dispatch_rule, account: @provider_recipient, dispatch: true, system_operation: @operation)
 
       Logic::RollingUpdates.stubs(skipped?: false, disabled?: true)
@@ -101,7 +101,7 @@ class NotificationsTest < ActiveSupport::TestCase
       end
     end
 
-    should 'NOT notify recipient when dispatch rule for operation is set to false' do
+    test 'NOT notify recipient when dispatch rule for operation is set to false' do
       @rule = FactoryBot.create :mail_dispatch_rule, :account => @provider_recipient, :dispatch => false,  :system_operation => @operation
 
       @message.save!
@@ -112,7 +112,7 @@ class NotificationsTest < ActiveSupport::TestCase
       assert_equal @message_recipient.notifiable?, false
     end
 
-    should 'notify recipient when operation has no corresponding system operation' do
+    test 'notify recipient when operation has no corresponding system operation' do
       @message.update_attribute(:system_operation, nil)
       @message.save!
       perform_enqueued_jobs(only: ActionMailer::DeliveryJob) { @message.deliver! }
@@ -120,12 +120,12 @@ class NotificationsTest < ActiveSupport::TestCase
       @message_recipient = @provider_recipient.received_messages.last
 
       assert_equal @message_recipient.notifiable?, true
-
     end
   end
 
-  context 'The email' do
-    setup do
+  class TheMainTest < NotificationsTest
+    def setup
+      super
       ActionMailer::Base.deliveries = []
 
       @operation = SystemOperation.for('plan_change')
@@ -140,17 +140,16 @@ class NotificationsTest < ActiveSupport::TestCase
       @provider_recipient = @message.recipients.first
     end
 
+    test 'be sent to provider when dispatch rule is true' do
+      @rule = FactoryBot.create :mail_dispatch_rule, :account => @provider, :dispatch => true, :system_operation => @operation
 
-     should 'be sent to provider when dispatch rule is true' do
-       @rule = FactoryBot.create :mail_dispatch_rule, :account => @provider, :dispatch => true, :system_operation => @operation
+      PostOffice.message_notification(@message, @provider_recipient).deliver_now
+      @email = ActionMailer::Base.deliveries.last
+      expected = [@provider.admins.first.email]
+      assert_same_elements @email.bcc, expected
+    end
 
-       PostOffice.message_notification(@message, @provider_recipient).deliver_now
-       @email = ActionMailer::Base.deliveries.last
-       expected = [@provider.admins.first.email]
-       assert_same_elements @email.bcc, expected
-     end
-
-    should 'be sent to provider when no corresponding system operation object exists' do
+    test 'be sent to provider when no corresponding system operation object exists' do
       SystemOperation.delete_all
       @message.update_attribute(:system_operation, nil)
       @message.reload
@@ -158,15 +157,12 @@ class NotificationsTest < ActiveSupport::TestCase
       @email = ActionMailer::Base.deliveries.last
       expected = [@provider.admins.first.email]
       assert_same_elements @email.bcc, expected
-
     end
-
   end
 
-
-  context 'notify' do
-
-    setup do
+  class NotifyTest < NotificationsTest
+    def setup
+      super
       @system_operation = SystemOperation.for('plan_change')
 
       buyer = FactoryBot.create :buyer_account
@@ -176,17 +172,16 @@ class NotificationsTest < ActiveSupport::TestCase
         :sender => buyer, :to => provider,
         :subject => 'Changed plan', :body => "plan has changed",
         :system_operation => @system_operation)
-
     end
 
-    should "have an operation attribute" do
+    test "have an operation attribute" do
       assert_equal @system_operation, @message.system_operation
     end
-
   end
 
-  context 'application creation' do
-    setup do
+  class ApplicationCreationTest < NotificationsTest
+    def setup
+      super
       @provider = FactoryBot.create :provider_account
       @admin = @provider.admins.first
       @admin.update_attribute :email, "provider-admin@example.com"
@@ -196,12 +191,12 @@ class NotificationsTest < ActiveSupport::TestCase
       ActionMailer::Base.deliveries.clear
     end
 
-    should 'be notified' do
+    test 'be notified' do
       perform_enqueued_jobs(only: ActionMailer::DeliveryJob) { @buyer.buy! @plan }
       assert ActionMailer::Base.deliveries.last.bcc.include?(@admin.email)
     end
 
-    should 'not be notified if mail_dispatch_rule denies it' do
+    test 'not be notified if mail_dispatch_rule denies it' do
       op = SystemOperation.create_with(name: 'New Application created').find_or_create_by!(ref: 'new_app')
       rule = @provider.mail_dispatch_rules.create! :system_operation => op, :emails => @admin.email
       rule.update_attribute :dispatch, false
@@ -212,8 +207,9 @@ class NotificationsTest < ActiveSupport::TestCase
     end
   end
 
-  context 'account signup on confirmation' do
-    setup do
+  class AccountSignupOnConfirmationTest < NotificationsTest
+    def setup
+      super
       @provider = FactoryBot.create :provider_account
       @admin = @provider.admins.first
       @admin.update_attribute :email, "provider-admin@example.com"
@@ -225,7 +221,7 @@ class NotificationsTest < ActiveSupport::TestCase
       @mail_rule = @provider.mail_dispatch_rules.create! :system_operation => op
     end
 
-    should 'notify admins' do
+    test 'notify admins' do
       @mail_rule.update_attribute :dispatch, true
 
       perform_enqueued_jobs(only: ActionMailer::DeliveryJob) { @buyer.make_pending! }
@@ -233,13 +229,12 @@ class NotificationsTest < ActiveSupport::TestCase
       assert ActionMailer::Base.deliveries.map(&:bcc).flatten.include?(@admin.email)
     end
 
-    should 'not notify admins if mail_dispatch_rule denies it' do
+    test 'not notify admins if mail_dispatch_rule denies it' do
       @mail_rule.update_attribute :dispatch, false
 
       perform_enqueued_jobs(only: ActionMailer::DeliveryJob) { @buyer.make_pending! }
 
-      assert false == ActionMailer::Base.deliveries.map(&:bcc).flatten.include?(@admin.email)
+      assert ActionMailer::Base.deliveries.map(&:bcc).flatten.include?(@admin.email) == false
     end
-
   end
 end


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/integration/notifications_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)