### PR TITLE
Remove `context` and `should` from another bunch of tests

### DIFF
--- a/test/integration/finance/charging_invoice_states_test.rb
+++ b/test/integration/finance/charging_invoice_states_test.rb
@@ -1,51 +1,46 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Finance::ChargingInvoiceStatesTest < ActionDispatch::IntegrationTest
-
-  context 'when unpaid' do
-
+  class UnpaidTest < Finance::ChargingInvoiceStatesTest
     setup do
-      @invoice = FactoryBot.create(:invoice,
-                                :period => Month.new(Time.zone.local(1984, 1, 1)))
+      @invoice = FactoryBot.create(:invoice, period: Month.new(Time.zone.local(1984, 1, 1)))
 
       @invoice.stubs(:cost).returns(100.to_has_money('EUR'))
       @invoice.issue_and_pay_if_free!
       @invoice.mark_as_unpaid!
     end
 
-    should 'charge the buyer' do
+    test 'charge the buyer' do
       @invoice.buyer_account.stubs(:charge!).with(any_parameters).returns(true)
       @invoice.charge!
       assert @invoice.paid?, 'Should be paid after successful charge'
     end
 
-    should 'be markable as paid' do
+    test 'be markable as paid' do
       @invoice.pay!
       assert @invoice.paid?
     end
-
   end
 
-  context 'when 3scale charging provider' do
-      setup do
-        @master = master_account
-        @provider =  FactoryBot.create(:provider_account)
-        @invoice = FactoryBot.create(:invoice,
-                                  provider_account: @master,
-                                  buyer_account: @provider,
-                                  period:  Month.new(Time.zone.local(1984, 1, 1)))
+  class ChargingProviderTest < Finance::ChargingInvoiceStatesTest
+    setup do
+      @master = master_account
+      @provider = FactoryBot.create(:provider_account)
+      @invoice = FactoryBot.create(:invoice, provider_account: @master,
+                                             buyer_account: @provider,
+                                             period:  Month.new(Time.zone.local(1984, 1, 1)))
 
-        @invoice.stubs(:cost).returns(100.to_has_money('EUR'))
-        @invoice.issue_and_pay_if_free!
-        @invoice.mark_as_unpaid!
-      end
+      @invoice.stubs(:cost).returns(100.to_has_money('EUR'))
+      @invoice.issue_and_pay_if_free!
+      @invoice.mark_as_unpaid!
+    end
 
-
-
-    should 'charge the provider' do
+    test 'charge the provider' do
       @invoice.buyer_account.stubs(:charge!).with(any_parameters).returns(true)
 
-      @invoice.buyer_account.bought_plan.update_attributes!(name: 'Paid', cost_per_month: 100)
+      @invoice.buyer_account.bought_plan.update!(name: 'Paid', cost_per_month: 100)
 
       ThreeScale::Analytics.expects(:track).with(@provider.first_admin!, 'Charged Invoice',
                                                  {plan: 'Paid', period: 'January 01, 1984 - January 31, 1984', revenue: 100.0})
@@ -53,8 +48,5 @@ class Finance::ChargingInvoiceStatesTest < ActionDispatch::IntegrationTest
       @invoice.charge!
       assert @invoice.paid?, 'Should be paid after successful charge'
     end
-
-
   end
-
 end

--- a/test/integration/finance/charging_invoice_states_test.rb
+++ b/test/integration/finance/charging_invoice_states_test.rb
@@ -30,7 +30,7 @@ class Finance::ChargingInvoiceStatesTest < ActionDispatch::IntegrationTest
       @provider = FactoryBot.create(:provider_account)
       @invoice = FactoryBot.create(:invoice, provider_account: @master,
                                              buyer_account: @provider,
-                                             period:  Month.new(Time.zone.local(1984, 1, 1)))
+                                             period: Month.new(Time.zone.local(1984, 1, 1)))
 
       @invoice.stubs(:cost).returns(100.to_has_money('EUR'))
       @invoice.issue_and_pay_if_free!

--- a/test/integration/user-management-api/accounts_test.rb
+++ b/test/integration/user-management-api/accounts_test.rb
@@ -113,11 +113,9 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
         end
 
         test 'changing billing status' do
-          put admin_api_account_path(@buyer, format: :xml), params: params.merge({
-            monthly_billing_enabled: true,
-            monthly_charging_enabled: true,
-            org_name: 'ooooooooo'
-          })
+          put admin_api_account_path(@buyer, format: :xml), params: params.merge({ monthly_billing_enabled: true,
+                                                                                   monthly_charging_enabled: true,
+                                                                                   org_name: 'ooooooooo' })
           assert_response :forbidden
         end
 
@@ -147,8 +145,6 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
           put change_plan_admin_api_account_path(@buyer, format: :xml), params: params.merge({ plan_id: plan.id })
           assert_response :forbidden
         end
-
-        # pending_test 'change plan'
       end
 
       class WithAdminSectionsTest < MemberUserTest
@@ -333,7 +329,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     end
 
     test 'index returns extra fields escaped' do
-      field_defined(@provider, { target: "Account", "name" => "some_extra_field" })
+      field_defined(@provider, { target: "Account", name: "some_extra_field" })
 
       @buyer.reload
       @buyer.extra_fields = { some_extra_field: "< > &" }
@@ -518,7 +514,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     end
 
     test 'update with extra fields' do
-      field_defined(@provider, { target: "Account", "name" => "some_extra_field" })
+      field_defined(@provider, { target: "Account", name: "some_extra_field" })
 
       put admin_api_account_path(@buyer, format: :xml), params: params.merge({ some_extra_field: "stuff", vat_rate: 33 })
 

--- a/test/integration/user-management-api/accounts_test.rb
+++ b/test/integration/user-management-api/accounts_test.rb
@@ -26,41 +26,42 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
       assert_response :forbidden
     end
 
-    context 'admin' do
-      setup do
+    class AdminUserTest < AccessTokenTest
+      def setup
+        super
         admin = FactoryBot.create(:admin, account: @provider, admin_sections: [])
         @token = FactoryBot.create(:access_token, owner: admin, scopes: 'account_management')
       end
 
-      should 'admin can update' do
+      test 'admin can update' do
         put admin_api_account_path(@buyer, format: :xml), params: params.merge({ org_name: 'alaska' })
         assert_response :success
       end
 
-      should '#destroy' do
+      test '#destroy' do
         delete admin_api_account_path(format: :xml, id: @buyer.id), params: params
         assert_response :success
       end
 
-      should 'change plan' do
+      test 'change plan' do
         plan = FactoryBot.create(:account_plan, issuer: @provider)
         put change_plan_admin_api_account_path(@buyer, format: :xml), params: params.merge({ plan_id: plan.id })
         assert_response :success
       end
 
-      should '#approve' do
+      test '#approve' do
         Account.any_instance.expects(:approve).returns(true)
         put approve_admin_api_account_path(@buyer, format: :xml), params: params
         assert_response :success
       end
 
-      should '#reject' do
+      test '#reject' do
         Account.any_instance.expects(:reject).returns(true)
         put reject_admin_api_account_path(@buyer, format: :xml), params: params
         assert_response :success
       end
 
-      should 'update billing_address' do
+      test 'update billing_address' do
         put admin_api_account_path(@buyer, format: :xml), params: params.merge({ org_name: 'alaska', billing_address: 'Calle Napoles 187, Barcelona. Spain' })
         assert_response :unprocessable_entity
 
@@ -69,13 +70,13 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
         assert_response :success
       end
 
-      should '#update' do
+      test '#update' do
         rolling_updates_off
         put admin_api_account_path(@buyer, format: :xml), params: params.merge({ org_name: 'alaska' })
         assert_response :success
       end
 
-      should '#change_plan' do
+      test '#change_plan' do
         rolling_updates_off
         plan = FactoryBot.create(:account_plan, issuer: @provider)
         put change_plan_admin_api_account_path(@buyer, format: :xml), params: params.merge({ plan_id: plan.id })
@@ -83,65 +84,65 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
       end
     end
 
-    context 'member' do
-      context 'without admin sections' do
-        setup do
+    class MemberUserTest < AccessTokenTest
+      class WithoutAdminSectionsTest < MemberUserTest
+        def setup
+          super
           member = FactoryBot.create(:member, account: @provider, admin_sections: [])
           @token = FactoryBot.create(:access_token, owner: member, scopes: 'account_management')
         end
 
-        should '#index' do
+        test '#index' do
           get admin_api_accounts_path(format: :xml), params: params
           assert_response :forbidden
         end
 
-        should '#show' do
+        test '#show' do
           get admin_api_account_path(@buyer, format: :xml), params: params
           assert_response :forbidden
         end
 
-        should '#find without id' do
+        test '#find without id' do
           get find_admin_api_accounts_path(format: :xml), params: params
           assert_response :forbidden
         end
 
-        should '#find' do
+        test '#find' do
           get find_admin_api_accounts_path(format: :xml), params: params.merge({ username: @buyer.users.first.username })
           assert_response :forbidden
         end
 
-        should 'changing billing status' do
-          put admin_api_account_path(@buyer, format: :xml), params: {
-            access_token: token.value,
+        test 'changing billing status' do
+          put admin_api_account_path(@buyer, format: :xml), params: params.merge({
             monthly_billing_enabled: true,
             monthly_charging_enabled: true,
             org_name: 'ooooooooo'
-          }
+          })
           assert_response :forbidden
         end
 
-        should '#destroy' do
+        test '#destroy' do
           delete admin_api_account_path(format: :xml, id: @buyer.id), params: params
           assert_response :forbidden
         end
 
-        should '#reject' do
+        test '#reject' do
           put reject_admin_api_account_path(@buyer, format: :xml), params: params
           assert_response :forbidden
         end
 
-        should '#approve' do
+        test '#approve' do
           put approve_admin_api_account_path(@buyer, format: :xml), params: params
           assert_response :forbidden
         end
 
-        should '#update' do
+        test '#update' do
           rolling_updates_on
           put admin_api_account_path(@buyer, format: :xml), params: params.merge({ org_name: 'alaska' })
           assert_response :forbidden
         end
 
-        should '#change_plan' do
+        test '#change_plan' do
           plan = FactoryBot.create(:account_plan, issuer: @provider)
           put change_plan_admin_api_account_path(@buyer, format: :xml), params: params.merge({ plan_id: plan.id })
           assert_response :forbidden
@@ -150,35 +151,36 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
         # pending_test 'change plan'
       end
 
-      context 'with admin sections' do
-        setup do
+      class WithAdminSectionsTest < MemberUserTest
+        def setup
+          super
           member = FactoryBot.create(:member, account: @provider, admin_sections: %w[partners])
           @token = FactoryBot.create(:access_token, owner: member, scopes: 'account_management')
         end
 
         attr_reader :token
 
-        should '#index' do
+        test '#index' do
           get admin_api_accounts_path(format: :xml), params: params
           assert_response :success
         end
 
-        should '#show' do
+        test '#show' do
           get admin_api_account_path(@buyer, format: :xml), params: params
           assert_response :success
         end
 
-        should '#find without id' do
+        test '#find without id' do
           get find_admin_api_accounts_path(format: :xml), params: params
           assert_response :not_found
         end
 
-        should '#find' do
+        test '#find' do
           get find_admin_api_accounts_path(format: :xml), params: params.merge({ username: @buyer.users.first.username })
           assert_response :success
         end
 
-        should 'changing billing status' do
+        test 'changing billing status' do
           settings = @buyer.settings
           settings.update!(monthly_charging_enabled: false, monthly_billing_enabled: false)
           assert_not settings.monthly_charging_enabled
@@ -197,60 +199,47 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
           assert settings.monthly_billing_enabled
         end
 
-        should '#destroy' do
+        test '#destroy' do
           delete admin_api_account_path(format: :xml, id: @buyer.id), params: params
           assert_response :forbidden
         end
 
-        should '#reject' do
+        test '#reject' do
           put reject_admin_api_account_path(@buyer, format: :xml), params: params
           assert_response :forbidden
         end
 
-        should '#approve' do
+        test '#approve' do
           put approve_admin_api_account_path(@buyer, format: :xml), params: params
           assert_response :forbidden
         end
 
-        context 'when service_permissions rolling update is disabled' do
-          setup do
-            rolling_updates_off
-          end
-
-          should '#update' do
-            put admin_api_account_path(@buyer, format: :xml), params: params.merge({ org_name: 'alaska' })
-            assert_response :forbidden
-          end
-
-          should '#change_plan' do
-            plan = FactoryBot.create(:account_plan, issuer: @provider)
-            put change_plan_admin_api_account_path(@buyer, format: :xml), params: params.merge({ plan_id: plan.id })
-            assert_response :forbidden
-          end
+        test '#update when service_permissions rolling update is disabled' do
+          rolling_updates_off
+          put admin_api_account_path(@buyer, format: :xml), params: params.merge({ org_name: 'alaska' })
+          assert_response :forbidden
         end
 
-        context 'when service_permissions rolling update is enabled' do
-          setup do
-            rolling_updates_off
-            rolling_update(:service_permissions, enabled: true)
-          end
-
-          should '#update' do
-            put admin_api_account_path(@buyer, format: :xml), params: params.merge({ org_name: 'alaska' })
-            assert_response :success
-          end
-
-          should '#change_plan' do
-            plan = FactoryBot.create(:account_plan, issuer: @provider)
-            put change_plan_admin_api_account_path(@buyer, format: :xml), params: params.merge({ plan_id: plan.id })
-            assert_response :success
-          end
+        test '#change_plan when service_permissions rolling update is disabled' do
+          rolling_updates_off
+          plan = FactoryBot.create(:account_plan, issuer: @provider)
+          put change_plan_admin_api_account_path(@buyer, format: :xml), params: params.merge({ plan_id: plan.id })
+          assert_response :forbidden
         end
 
-        private
+        test '#update when service_permissions rolling update is enabled' do
+          rolling_updates_off
+          rolling_update(:service_permissions, enabled: true)
+          put admin_api_account_path(@buyer, format: :xml), params: params.merge({ org_name: 'alaska' })
+          assert_response :success
+        end
 
-        def params(token = @token)
-          params
+        test '#change_plan when service_permissions rolling update is enabled' do
+          rolling_updates_off
+          rolling_update(:service_permissions, enabled: true)
+          plan = FactoryBot.create(:account_plan, issuer: @provider)
+          put change_plan_admin_api_account_path(@buyer, format: :xml), params: params.merge({ plan_id: plan.id })
+          assert_response :success
         end
       end
     end

--- a/test/unit/application_plan_test.rb
+++ b/test/unit/application_plan_test.rb
@@ -5,10 +5,8 @@ require 'test_helper'
 class ApplicationPlanTest < ActiveSupport::TestCase
   def setup
     @app_plan = FactoryBot.create(:application_plan)
-    @original_plan_metric = FactoryBot.create(:plan_metric, :plan => @app_plan,
-                                    :visible => false, :limits_only_text => false)
-    @original_usage_limit = FactoryBot.create(:usage_limit, :plan => @app_plan,
-                                    :period => "year", :value => 666)
+    @original_plan_metric = FactoryBot.create(:plan_metric, plan: @app_plan, visible: false, limits_only_text: false)
+    @original_usage_limit = FactoryBot.create(:usage_limit, plan: @app_plan, period: "year", value: 666)
   end
 
   should belong_to :partner
@@ -31,17 +29,17 @@ class ApplicationPlanTest < ActiveSupport::TestCase
     custom_plan = @app_plan.customize
     custom_plan_metric = custom_plan.plan_metrics.first
 
-    assert custom_plan.plan_metrics.count == @app_plan.plan_metrics.count
-    assert custom_plan_metric.visible == @original_plan_metric.visible
-    assert custom_plan_metric.limits_only_text == @original_plan_metric.limits_only_text
+    assert_equal app_plan.plan_metrics.count, custom_plan.plan_metrics.count
+    assert_equal @original_plan_metric.visible, custom_plan_metric.visible
+    assert_equal @original_plan_metric.limits_only_text, custom_plan_metric.limits_only_text
   end
 
   test '#customize clone usage_limits' do
     custom_plan = @app_plan.customize
     custom_usage_limit = custom_plan.usage_limits.first
 
-    assert custom_plan.usage_limits.count == @app_plan.usage_limits.count
-    assert custom_usage_limit.period == @original_usage_limit.period
-    assert custom_usage_limit.value == @original_usage_limit.value
+    assert_equal @app_plan.usage_limits.count, custom_plan.usage_limits.count
+    assert_equal @original_usage_limit.period, custom_usage_limit.period
+    assert_equal @original_usage_limit.value, custom_usage_limit.value
   end
 end

--- a/test/unit/application_plan_test.rb
+++ b/test/unit/application_plan_test.rb
@@ -29,7 +29,7 @@ class ApplicationPlanTest < ActiveSupport::TestCase
     custom_plan = @app_plan.customize
     custom_plan_metric = custom_plan.plan_metrics.first
 
-    assert_equal app_plan.plan_metrics.count, custom_plan.plan_metrics.count
+    assert_equal @app_plan.plan_metrics.count, custom_plan.plan_metrics.count
     assert_equal @original_plan_metric.visible, custom_plan_metric.visible
     assert_equal @original_plan_metric.limits_only_text, custom_plan_metric.limits_only_text
   end

--- a/test/unit/application_plan_test.rb
+++ b/test/unit/application_plan_test.rb
@@ -1,6 +1,15 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ApplicationPlanTest < ActiveSupport::TestCase
+  def setup
+    @app_plan = FactoryBot.create(:application_plan)
+    @original_plan_metric = FactoryBot.create(:plan_metric, :plan => @app_plan,
+                                    :visible => false, :limits_only_text => false)
+    @original_usage_limit = FactoryBot.create(:usage_limit, :plan => @app_plan,
+                                    :period => "year", :value => 666)
+  end
 
   should belong_to :partner
 
@@ -18,32 +27,21 @@ class ApplicationPlanTest < ActiveSupport::TestCase
     end
   end
 
-  context '#customize' do
-    setup do
-      @app_plan = FactoryBot.create(:application_plan)
-      @original_plan_metric = FactoryBot.create(:plan_metric, :plan => @app_plan,
-                                      :visible => false, :limits_only_text => false)
-      @original_usage_limit = FactoryBot.create(:usage_limit, :plan => @app_plan,
-                                      :period => "year", :value => 666)
-    end
+  test '#customize clone plan_metrics' do
+    custom_plan = @app_plan.customize
+    custom_plan_metric = custom_plan.plan_metrics.first
 
-    should 'clone plan_metrics' do
-      custom_plan = @app_plan.customize
-      custom_plan_metric = custom_plan.plan_metrics.first
+    assert custom_plan.plan_metrics.count == @app_plan.plan_metrics.count
+    assert custom_plan_metric.visible == @original_plan_metric.visible
+    assert custom_plan_metric.limits_only_text == @original_plan_metric.limits_only_text
+  end
 
-      assert custom_plan.plan_metrics.count == @app_plan.plan_metrics.count
-      assert custom_plan_metric.visible == @original_plan_metric.visible
-      assert custom_plan_metric.limits_only_text == @original_plan_metric.limits_only_text
-    end
+  test '#customize clone usage_limits' do
+    custom_plan = @app_plan.customize
+    custom_usage_limit = custom_plan.usage_limits.first
 
-    should 'clone usage_limits' do
-      custom_plan = @app_plan.customize
-      custom_usage_limit = custom_plan.usage_limits.first
-
-      assert custom_plan.usage_limits.count == @app_plan.usage_limits.count
-      assert custom_usage_limit.period == @original_usage_limit.period
-      assert custom_usage_limit.value == @original_usage_limit.value
-    end
-
-  end # customize
+    assert custom_plan.usage_limits.count == @app_plan.usage_limits.count
+    assert custom_usage_limit.period == @original_usage_limit.period
+    assert custom_usage_limit.value == @original_usage_limit.value
+  end
 end

--- a/test/unit/service_contract_test.rb
+++ b/test/unit/service_contract_test.rb
@@ -1,31 +1,29 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ServiceContractTest < ActiveSupport::TestCase
-  context 'plan class validation' do
+  test 'plan class should be valid with an service plan' do
+    service_plan = FactoryBot.create :service_plan
+    service_contract = ServiceContract.new :plan => service_plan
 
-    should 'be valid with an service plan' do
-      service_plan = FactoryBot.create :service_plan
-      service_contract = ServiceContract.new :plan => service_plan
+    assert service_contract.valid?
+  end
 
-      assert service_contract.valid?
-    end
+  test 'plan class should not be valid with an application plan' do
+    app_plan = FactoryBot.create :application_plan
+    service_contract = ServiceContract.new :plan => app_plan
 
-    should 'not be valid with an application plan' do
-      app_plan = FactoryBot.create :application_plan
-      service_contract = ServiceContract.new :plan => app_plan
+    assert_not service_contract.valid?
+    assert_match /must be a ServicePlan/, service_contract.errors[:plan].first
+  end
 
-      assert !service_contract.valid?
-      assert_match /must be a ServicePlan/, service_contract.errors[:plan].first
-    end
+  test 'plan class should not be valid with an account plan' do
+    acc_plan = FactoryBot.create :account_plan
+    service_contract = ServiceContract.new :plan => acc_plan
 
-    should 'not be valid with an account plan' do
-      acc_plan = FactoryBot.create :account_plan
-      service_contract = ServiceContract.new :plan => acc_plan
-
-      assert !service_contract.valid?
-      assert_match /must be a ServicePlan/, service_contract.errors[:plan].first
-    end
-
+    assert_not service_contract.valid?
+    assert_match /must be a ServicePlan/, service_contract.errors[:plan].first
   end
 
   test 'bought_service_contracts' do

--- a/test/unit/service_contract_test.rb
+++ b/test/unit/service_contract_test.rb
@@ -4,23 +4,23 @@ require 'test_helper'
 
 class ServiceContractTest < ActiveSupport::TestCase
   test 'plan class should be valid with an service plan' do
-    service_plan = FactoryBot.create :service_plan
-    service_contract = ServiceContract.new :plan => service_plan
+    service_plan = FactoryBot.create(:service_plan)
+    service_contract = ServiceContract.new(plan: service_plan)
 
     assert service_contract.valid?
   end
 
   test 'plan class should not be valid with an application plan' do
-    app_plan = FactoryBot.create :application_plan
-    service_contract = ServiceContract.new :plan => app_plan
+    app_plan = FactoryBot.create(:application_plan)
+    service_contract = ServiceContract.new(plan: app_plan)
 
     assert_not service_contract.valid?
     assert_match /must be a ServicePlan/, service_contract.errors[:plan].first
   end
 
   test 'plan class should not be valid with an account plan' do
-    acc_plan = FactoryBot.create :account_plan
-    service_contract = ServiceContract.new :plan => acc_plan
+    acc_plan = FactoryBot.create(:account_plan)
+    service_contract = ServiceContract.new(plan: acc_plan)
 
     assert_not service_contract.valid?
     assert_match /must be a ServicePlan/, service_contract.errors[:plan].first


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/integration/finance/charging_invoice_states_test.rb
* test/integration/user-management-api/accounts_test.rb
* test/unit/application_plan_test.rb
* test/unit/contract_test.rb
* test/unit/service_contract_test.rb
* test/unit/service_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)