### PR TITLE
Remove `context` and `should` from invoices_test

### DIFF
--- a/test/integration/finance/api/invoices_test.rb
+++ b/test/integration/finance/api/invoices_test.rb
@@ -14,165 +14,152 @@ module Finance::Api
       host! @provider.admin_domain
     end
 
-    test 'deny access without provider key' do
-      get "/api/#{@context}invoices.xml"
-      assert_response :forbidden
-    end
+    class WithoutExistingInvoices < InvoicesTestCommonCases
+      test 'deny access without provider key' do
+        get "/api/#{@context}invoices.xml"
+        assert_response :forbidden
+      end
 
-    test 'deny access if finance module is disabled' do
-      without_finance = FactoryBot.create(:provider_account, billing_strategy: nil)
-      host! without_finance.self_domain
-      get "/api/#{@context}invoices.xml?provider_key=#{without_finance.api_key}"
-      assert_response :forbidden
-      assert_match 'Finance module not enabled for the account', @response.body
-    end
+      test 'deny access if finance module is disabled' do
+        without_finance = FactoryBot.create(:provider_account, billing_strategy: nil)
+        host! without_finance.self_domain
+        get "/api/#{@context}invoices.xml?provider_key=#{without_finance.api_key}"
+        assert_response :forbidden
+        assert_match 'Finance module not enabled for the account', @response.body
+      end
 
-    test 'deny access if access token does not include finance scope' do
-      @provider.settings.allow_finance!
-      member = FactoryBot.create(:member, account: @provider, admin_sections: [:finance])
-      token = FactoryBot.create(:access_token, owner: member)
+      test 'deny access if access token does not include finance scope' do
+        @provider.settings.allow_finance!
+        member = FactoryBot.create(:member, account: @provider, admin_sections: [:finance])
+        token = FactoryBot.create(:access_token, owner: member)
 
-      get "/api/invoices.xml?access_token=#{token.value}"
+        get "/api/invoices.xml?access_token=#{token.value}"
 
-      assert_response :forbidden
-    end
+        assert_response :forbidden
+      end
 
-    test 'allow access if access token include finance scope' do
-      @provider.settings.allow_finance!
-      member = FactoryBot.create(:member, account: @provider, admin_sections: [:finance])
-      token = FactoryBot.create(:access_token, owner: member, scopes: ['finance'])
+      test 'allow access if access token include finance scope' do
+        @provider.settings.allow_finance!
+        member = FactoryBot.create(:member, account: @provider, admin_sections: [:finance])
+        token = FactoryBot.create(:access_token, owner: member, scopes: ['finance'])
 
-      get "/api/invoices.xml?access_token=#{token.value}"
+        get "/api/invoices.xml?access_token=#{token.value}"
 
-      assert_response :success
-    end
+        assert_response :success
+      end
 
-    test 'deny access if member does not have finance permission' do
-      @provider.settings.allow_finance!
-      member = FactoryBot.create(:member, account: @provider, admin_sections: [])
-      token = FactoryBot.create(:access_token, owner: member, scopes: ['finance'])
+      test 'deny access if member does not have finance permission' do
+        @provider.settings.allow_finance!
+        member = FactoryBot.create(:member, account: @provider, admin_sections: [])
+        token = FactoryBot.create(:access_token, owner: member, scopes: ['finance'])
 
-      get "/api/invoices.xml?access_token=#{token.value}"
+        get "/api/invoices.xml?access_token=#{token.value}"
 
-      assert_response :forbidden
-    end
+        assert_response :forbidden
+      end
 
-    test 'return 404 on non-existent invoice' do
-      get "/api/#{@context}invoices/42_ID.xml?provider_key=#{@key}"
-      assert_response :not_found
-    end
-
-    test 'return XML invoice specified by ID' do
-      setup_existing_invoices_test
-      get "/api/#{@context}invoices/#{@invoice.id}.xml?provider_key=#{@key}"
-
-      assert_response :success
-      assert_select 'invoice' do
-        assert_select 'invoice > id', text: @invoice.id.to_s
-        assert_select 'invoice > friendly_id', text: @invoice.friendly_id.to_s
-        assert_select 'invoice > buyer > id', @invoice.buyer_account.id.to_s
-        assert_select 'line-items > line-item > cost', '10.0'
-        assert_select 'invoice > cost', '20.0'
-        # vat_rate and vat_amount do not show when vat_rate = 0
-        assert_select 'invoice > vat_rate', text: "0", count: 0
-        assert_select 'invoice > vat_amount', text: "0", count: 0
-        assert_select 'invoice > cost_without_vat', '20.0'
-        assert_select 'invoice > payment_transactions_count', "0"
+      test 'return 404 on non-existent invoice' do
+        get "/api/#{@context}invoices/42_ID.xml?provider_key=#{@key}"
+        assert_response :not_found
       end
     end
 
-    test 'work fine with deleted account' do
-      setup_existing_invoices_test
-      @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
-      @invoice = FactoryBot.create(:invoice, provider_account: @provider, buyer_account: @buyer)
-      @buyer.delete # destroy
-
-      get "/api/invoices/#{@invoice.id}.xml?provider_key=#{@key}"
-
-      assert_response :success
-      assert_select 'invoice' do
-        assert_select 'invoice > buyer > id', @buyer.id.to_s
-        assert_select 'invoice > buyer > status', "deleted"
-      end
-    end
-
-    test "have vat_rate if non negative" do
-      setup_existing_invoices_test
-      @buyer.vat_rate = 10.0
-      @buyer.save
-
-      get "/api/#{@context}invoices.xml?provider_key=#{@key}"
-
-      assert_response :success
-      assert_select 'invoice' do
-        assert_select 'invoice > id', text: @invoice.id.to_s
-        assert_select 'invoice > cost', '22.0'
-        assert_select 'invoice > vat_rate', text: "10.0"
-        assert_select 'invoice > vat_amount', '2.0'
-        assert_select 'invoice > cost_without_vat', '20.0'
-      end
-    end
-
-    test 'provide list of invoices' do
-      setup_existing_invoices_test
-      buyer = @buyer || FactoryBot.create(:buyer_account, provider_account: @provider)
-
-      25.times do
-        FactoryBot.create(:invoice, provider_account: @provider, buyer_account: buyer)
+    class WithExistingInvoices < InvoicesTestCommonCases
+      def setup
+        super
+        @invoice = FactoryBot.create(:invoice, provider_account: @provider, buyer_account: @buyer)
+        2.times { FactoryBot.create(:line_item_plan_cost, invoice: @invoice, name: 'fake', cost: 10.0) }
       end
 
-      get "/api/#{@context}invoices.xml?provider_key=#{@key}&page=1&per_page=21"
+      test 'return XML invoice specified by ID' do
+        get "/api/#{@context}invoices/#{@invoice.id}.xml?provider_key=#{@key}"
 
-      assert_response :success
-      assert_select 'invoices > pagination[total_pages=?]', '2'
-      assert_select 'invoices > pagination[current_page=?]', '1'
-      assert_select 'invoices > pagination[per_page=?]', '21'
-      assert_select 'invoices > invoice', count: 21
-    end
+        assert_response :success
+        assert_select 'invoice' do
+          assert_select 'invoice > id', text: @invoice.id.to_s
+          assert_select 'invoice > friendly_id', text: @invoice.friendly_id.to_s
+          assert_select 'invoice > buyer > id', @invoice.buyer_account.id.to_s
+          assert_select 'line-items > line-item > cost', '10.0'
+          assert_select 'invoice > cost', '20.0'
+          # vat_rate and vat_amount do not show when vat_rate = 0
+          assert_select 'invoice > vat_rate', text: "0", count: 0
+          assert_select 'invoice > vat_amount', text: "0", count: 0
+          assert_select 'invoice > cost_without_vat', '20.0'
+          assert_select 'invoice > payment_transactions_count', "0"
+        end
+      end
 
-    test 'redirect when asked for PDF' do
-      setup_existing_invoices_test
-      get "/api/#{@context}invoices/#{@invoice.id}.pdf?provider_key=#{@key}"
-      assert_response :found
-    end
+      test 'work fine with deleted account' do
+        buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+        invoice = FactoryBot.create(:invoice, provider_account: @provider, buyer_account: buyer)
+        buyer.delete # destroy
 
-    test 'filter by month' do
-      setup_existing_invoices_test
-      setup_filter_tests
-      @invoice.update(period: Month.new(1022,5))
+        get "/api/invoices/#{invoice.id}.xml?provider_key=#{@key}"
 
-      get "/api/#{@context}invoices.xml?provider_key=#{@key}&month=1022-05"
+        assert_response :success
+        assert_select 'invoice' do
+          assert_select 'invoice > buyer > id', buyer.id.to_s
+          assert_select 'invoice > buyer > status', "deleted"
+        end
+      end
 
-      assert_response :success
+      test "have vat_rate if non negative" do
+        @buyer.vat_rate = 10.0
+        @buyer.save
 
-      assert_select 'invoices > invoice', count: 1
-    end
+        get "/api/#{@context}invoices.xml?provider_key=#{@key}"
 
-    test 'filter by state' do
-      setup_existing_invoices_test
-      setup_filter_tests
-      @invoice.cancel!
+        assert_response :success
+        assert_select 'invoice' do
+          assert_select 'invoice > id', text: @invoice.id.to_s
+          assert_select 'invoice > cost', '22.0'
+          assert_select 'invoice > vat_rate', text: "10.0"
+          assert_select 'invoice > vat_amount', '2.0'
+          assert_select 'invoice > cost_without_vat', '20.0'
+        end
+      end
 
-      get "/api/#{@context}invoices.xml?provider_key=#{@key}&state=cancelled"
+      test 'provide list of invoices' do
+        25.times do
+          FactoryBot.create(:invoice, provider_account: @provider, buyer_account: @buyer)
+        end
 
-      assert_response :success
+        per_page = 21
+        get "/api/#{@context}invoices.xml?provider_key=#{@key}&page=1&per_page=#{per_page}"
 
-      assert_select 'invoices > invoice', count: 1
-      assert_select 'invoices > invoice > id', text: @invoice.id.to_s
-      assert_select 'invoices > invoice > state', text: 'cancelled'
-    end
+        assert_response :success
+        assert_select 'invoices > pagination', total_pages: '2'
+        assert_select 'invoices > pagination', current_page: '1'
+        assert_select 'invoices > pagination', per_page: per_page.to_s
+        assert_select 'invoices > invoice', count: per_page
+      end
 
-    def setup_existing_invoices_test
-      @buyer ||= FactoryBot.create(:buyer_account, provider_account: @provider)
-      @invoice = FactoryBot.create(:invoice, provider_account: @provider, buyer_account: @buyer)
-      2.times { FactoryBot.create(:line_item_plan_cost, invoice: @invoice, name: 'fake', cost: 10.0) }
-    end
+      test 'redirect when asked for PDF' do
+        get "/api/#{@context}invoices/#{@invoice.id}.pdf?provider_key=#{@key}"
+        assert_response :found
+      end
 
-    def setup_filter_tests
-      buyer = @buyer || FactoryBot.create(:buyer_account, provider_account: @provider)
+      test 'filter by month' do
+        FactoryBot.create(:invoice, provider_account: @provider, buyer_account: @buyer, period: Month.new(1022,5))
 
-      2.times do
-        FactoryBot.create(:invoice, provider_account: @provider, buyer_account: buyer)
+        get "/api/#{@context}invoices.xml?provider_key=#{@key}&month=1022-05"
+
+        assert_response :success
+
+        assert_select 'invoices > invoice', count: 1
+      end
+
+      test 'filter by state' do
+        invoice = FactoryBot.create(:invoice, provider_account: @provider, buyer_account: @buyer)
+        invoice.cancel!
+
+        get "/api/#{@context}invoices.xml?provider_key=#{@key}&state=cancelled"
+
+        assert_response :success
+
+        assert_select 'invoices > invoice', count: 1
+        assert_select 'invoices > invoice > id', text: invoice.id.to_s
+        assert_select 'invoices > invoice > state', text: 'cancelled'
       end
     end
   end

--- a/test/integration/finance/api/invoices_test.rb
+++ b/test/integration/finance/api/invoices_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 module Finance::Api
-  class InvoicesTestCommonCases < ActionDispatch::IntegrationTest
+  class InvoicesUnscopedTest < ActionDispatch::IntegrationTest
     def setup
       @provider = FactoryBot.create(:provider_account)
       @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
@@ -12,9 +12,10 @@ module Finance::Api
       @key = @provider.api_key
 
       host! @provider.admin_domain
+      @context = ''
     end
 
-    class WithoutExistingInvoices < InvoicesTestCommonCases
+    class WithoutExistingInvoices < InvoicesUnscopedTest
       test 'deny access without provider key' do
         get "/api/#{@context}invoices.xml"
         assert_response :forbidden
@@ -64,7 +65,7 @@ module Finance::Api
       end
     end
 
-    class WithExistingInvoices < InvoicesTestCommonCases
+    class WithExistingInvoices < InvoicesUnscopedTest
       def setup
         super
         @invoice = FactoryBot.create(:invoice, provider_account: @provider, buyer_account: @buyer)
@@ -164,23 +165,10 @@ module Finance::Api
     end
   end
 
-  class InvoicesNoScopeTest < InvoicesTestCommonCases
-    def setup
-      super
-      @context = ''
-    end
-  end
-
-  class InvoicesBuyersScopeTest < InvoicesTestCommonCases
+  class InvoicesBuyersScopedTest < InvoicesUnscopedTest
     def setup
       super
       @context = "accounts/#{@buyer.id}/"
     end
-  end
-
-  def self.runnable_methods
-    return [] if self == InvoicesTestCommonCases
-
-    super
   end
 end

--- a/test/integration/finance/api/invoices_test.rb
+++ b/test/integration/finance/api/invoices_test.rb
@@ -1,210 +1,199 @@
-# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module Finance::Api
-  class InvoicesTest < ActionDispatch::IntegrationTest
+  class InvoicesTestCommonCases < ActionDispatch::IntegrationTest
+    def setup
+      @provider = FactoryBot.create(:provider_account)
+      @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
+      @provider.create_billing_strategy
+      @provider.save!
+      @key = @provider.api_key
 
-    @@common_cases = Proc.new do
+      host! @provider.admin_domain
+    end
 
-      context '(security)' do
+    test 'deny access without provider key' do
+      get "/api/#{@context}invoices.xml"
+      assert_response :forbidden
+    end
 
-        should 'deny access without provider key' do
-          get "/api/#{@context}invoices.xml"
-          assert_response :forbidden
-        end
+    test 'deny access if finance module is disabled' do
+      without_finance = FactoryBot.create(:provider_account, :billing_strategy => nil)
+      host! without_finance.self_domain
+      get "/api/#{@context}invoices.xml?provider_key=#{without_finance.api_key}"
+      assert_response :forbidden
+      assert_match 'Finance module not enabled for the account', @response.body
+    end
 
-        should 'deny access if finance module is disabled' do
-          without_finance = FactoryBot.create(:provider_account, :billing_strategy => nil)
-          host! without_finance.self_domain
-          get "/api/#{@context}invoices.xml?provider_key=#{without_finance.api_key}"
-          assert_response :forbidden
-          assert_match 'Finance module not enabled for the account', @response.body
-        end
+    test 'deny access if access token does not include finance scope' do
+      @provider.settings.allow_finance!
+      member = FactoryBot.create(:member, account: @provider, admin_sections: [:finance])
+      token  = FactoryBot.create(:access_token, owner: member)
 
-        should 'deny access if access token does not include finance scope' do
-          @provider.settings.allow_finance!
-          member = FactoryBot.create(:member, account: @provider, admin_sections: [:finance])
-          token  = FactoryBot.create(:access_token, owner: member)
+      get "/api/invoices.xml?access_token=#{token.value}"
 
-          get "/api/invoices.xml?access_token=#{token.value}"
+      assert_response :forbidden
+    end
 
-          assert_response :forbidden
-        end
+    test 'allow access if access token include finance scope' do
+      @provider.settings.allow_finance!
+      member = FactoryBot.create(:member, account: @provider, admin_sections: [:finance])
+      token  = FactoryBot.create(:access_token, owner: member, scopes: ['finance'])
 
-        should 'allow access if access token include finance scope' do
-          @provider.settings.allow_finance!
-          member = FactoryBot.create(:member, account: @provider, admin_sections: [:finance])
-          token  = FactoryBot.create(:access_token, owner: member, scopes: ['finance'])
+      get "/api/invoices.xml?access_token=#{token.value}"
 
-          get "/api/invoices.xml?access_token=#{token.value}"
+      assert_response :success
+    end
 
-          assert_response :success
-        end
+    test 'deny access if member does not have finance permission' do
+      @provider.settings.allow_finance!
+      member = FactoryBot.create(:member, account: @provider, admin_sections: [])
+      token  = FactoryBot.create(:access_token, owner: member, scopes: ['finance'])
 
-        should 'deny access if member does not have finance permission' do
-          @provider.settings.allow_finance!
-          member = FactoryBot.create(:member, account: @provider, admin_sections: [])
-          token  = FactoryBot.create(:access_token, owner: member, scopes: ['finance'])
+      get "/api/invoices.xml?access_token=#{token.value}"
 
-          get "/api/invoices.xml?access_token=#{token.value}"
+      assert_response :forbidden
+    end
 
-          assert_response :forbidden
-        end
-      end
+    test 'return 404 on non-existent invoice' do
+      get "/api/#{@context}invoices/42_ID.xml?provider_key=#{@key}"
+      assert_response :not_found
+    end
 
-      should 'return 404 on non-existent invoice' do
-        get "/api/#{@context}invoices/42_ID.xml?provider_key=#{@key}"
-        assert_response :not_found
-      end
+    test 'return XML invoice specified by ID' do
+      setup_existing_invoices_test
+      get "/api/#{@context}invoices/#{@invoice.id}.xml?provider_key=#{@key}"
 
-      context 'with existing invoices' do
-
-        setup do
-          @buyer ||= FactoryBot.create(:buyer_account, :provider_account => @provider)
-          @invoice = FactoryBot.create(:invoice, :provider_account => @provider, :buyer_account => @buyer)
-          2.times { FactoryBot.create(:line_item_plan_cost, :invoice => @invoice, :name => 'fake', :cost => 10.0) }
-        end
-
-        should 'return XML invoice specified by ID' do
-          get "/api/#{@context}invoices/#{@invoice.id}.xml?provider_key=#{@key}"
-
-          assert_response :success
-          assert_select 'invoice' do
-            assert_select 'invoice > id', :text => @invoice.id.to_s
-            assert_select 'invoice > friendly_id', :text => @invoice.friendly_id.to_s
-            assert_select 'invoice > buyer > id', @invoice.buyer_account.id.to_s
-            assert_select 'line-items > line-item > cost', '10.0'
-            assert_select 'invoice > cost', '20.0'
-            # vat_rate and vat_amount do not show when vat_rate = 0
-            assert_select 'invoice > vat_rate', :text => "0", :count => 0
-            assert_select 'invoice > vat_amount', :text => "0", :count => 0
-            assert_select 'invoice > cost_without_vat', '20.0'
-            assert_select 'invoice > payment_transactions_count', "0"
-          end
-        end
-
-        context 'with deleted account' do
-          setup do
-            @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
-
-            @invoice = FactoryBot.create(:invoice, :provider_account => @provider, :buyer_account => @buyer)
-            # @invoice.finalize!
-            # @invoice.pay!
-
-            @buyer.delete # destroy
-          end
-
-          should 'work fine' do
-            get "/api/invoices/#{@invoice.id}.xml?provider_key=#{@key}"
-
-            assert_response :success
-            assert_select 'invoice' do
-              assert_select 'invoice > buyer > id', @buyer.id.to_s
-              assert_select 'invoice > buyer > status', "deleted"
-            end
-          end
-        end # with deleted account
-
-        should "have vat_rate if non negative" do
-          @buyer.vat_rate = 10.0
-          @buyer.save
-
-          get "/api/#{@context}invoices.xml?provider_key=#{@key}"
-
-          assert_response :success
-          assert_select 'invoice' do
-            assert_select 'invoice > id', :text => @invoice.id.to_s
-            assert_select 'invoice > cost', '22.0'
-            assert_select 'invoice > vat_rate', :text => "10.0"
-            assert_select 'invoice > vat_amount', '2.0'
-            assert_select 'invoice > cost_without_vat', '20.0'
-          end
-        end
-
-        should 'provide list of invoices' do
-          buyer = @buyer || FactoryBot.create(:buyer_account, :provider_account => @provider)
-
-          25.times do
-            FactoryBot.create(:invoice, :provider_account => @provider, :buyer_account => buyer)
-          end
-
-          get "/api/#{@context}invoices.xml?provider_key=#{@key}&page=1&per_page=21"
-
-          assert_response :success
-          assert_select 'invoices > pagination[total_pages=?]', '2'
-          assert_select 'invoices > pagination[current_page=?]', '1'
-          assert_select 'invoices > pagination[per_page=?]', '21'
-          assert_select 'invoices > invoice', :count => 21
-        end
-
-        should 'redirect when asked for PDF' do
-          get "/api/#{@context}invoices/#{@invoice.id}.pdf?provider_key=#{@key}"
-          assert_response :found
-        end
-
-        context 'filter' do
-          setup do
-            buyer = @buyer || FactoryBot.create(:buyer_account, :provider_account => @provider)
-
-            2.times do
-              FactoryBot.create(:invoice, :provider_account => @provider, :buyer_account => buyer)
-            end
-          end
-
-          should 'by month' do
-            @invoice.update_attribute :period, Month.new(1022,5)
-
-            get "/api/#{@context}invoices.xml?provider_key=#{@key}&month=1022-05"
-
-            assert_response :success
-
-            assert_select 'invoices > invoice', :count => 1
-          end
-
-          should 'filter by state' do
-            @invoice.cancel!
-
-            get "/api/#{@context}invoices.xml?provider_key=#{@key}&state=cancelled"
-
-            assert_response :success
-
-            assert_select 'invoices > invoice', :count => 1
-            assert_select 'invoices > invoice > id', :text => @invoice.id.to_s
-            assert_select 'invoices > invoice > state', :text => 'cancelled'
-          end
-        end
+      assert_response :success
+      assert_select 'invoice' do
+        assert_select 'invoice > id', :text => @invoice.id.to_s
+        assert_select 'invoice > friendly_id', :text => @invoice.friendly_id.to_s
+        assert_select 'invoice > buyer > id', @invoice.buyer_account.id.to_s
+        assert_select 'line-items > line-item > cost', '10.0'
+        assert_select 'invoice > cost', '20.0'
+        # vat_rate and vat_amount do not show when vat_rate = 0
+        assert_select 'invoice > vat_rate', :text => "0", :count => 0
+        assert_select 'invoice > vat_amount', :text => "0", :count => 0
+        assert_select 'invoice > cost_without_vat', '20.0'
+        assert_select 'invoice > payment_transactions_count', "0"
       end
     end
 
-    context 'Invoice API[not-scoped]' do
-      setup do
-        @provider = FactoryBot.create(:provider_account)
-        @provider.create_billing_strategy
-        @provider.save!
-        @key = @provider.api_key
+    test 'work fine with deleted account' do
+      setup_existing_invoices_test
+      @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
+      @invoice = FactoryBot.create(:invoice, :provider_account => @provider, :buyer_account => @buyer)
+      @buyer.delete # destroy
 
-        @context = ''
-        host! @provider.admin_domain
+      get "/api/invoices/#{@invoice.id}.xml?provider_key=#{@key}"
+
+      assert_response :success
+      assert_select 'invoice' do
+        assert_select 'invoice > buyer > id', @buyer.id.to_s
+        assert_select 'invoice > buyer > status', "deleted"
       end
-
-      @@common_cases.call
     end
 
-    context 'Invoice API[by buyers]' do
-      setup do
-        @provider = FactoryBot.create(:provider_account)
-        @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
+    test "have vat_rate if non negative" do
+      setup_existing_invoices_test
+      @buyer.vat_rate = 10.0
+      @buyer.save
 
-        @provider.create_billing_strategy
-        @provider.save!
-        @key = @provider.api_key
+      get "/api/#{@context}invoices.xml?provider_key=#{@key}"
 
-        @context = "accounts/#{@buyer.id}/"
-        host! @provider.admin_domain
+      assert_response :success
+      assert_select 'invoice' do
+        assert_select 'invoice > id', :text => @invoice.id.to_s
+        assert_select 'invoice > cost', '22.0'
+        assert_select 'invoice > vat_rate', :text => "10.0"
+        assert_select 'invoice > vat_amount', '2.0'
+        assert_select 'invoice > cost_without_vat', '20.0'
       end
-
-      @@common_cases.call
     end
 
+    test 'provide list of invoices' do
+      setup_existing_invoices_test
+      buyer = @buyer || FactoryBot.create(:buyer_account, :provider_account => @provider)
+
+      25.times do
+        FactoryBot.create(:invoice, :provider_account => @provider, :buyer_account => buyer)
+      end
+
+      get "/api/#{@context}invoices.xml?provider_key=#{@key}&page=1&per_page=21"
+
+      assert_response :success
+      assert_select 'invoices > pagination[total_pages=?]', '2'
+      assert_select 'invoices > pagination[current_page=?]', '1'
+      assert_select 'invoices > pagination[per_page=?]', '21'
+      assert_select 'invoices > invoice', :count => 21
+    end
+
+    test 'redirect when asked for PDF' do
+      setup_existing_invoices_test
+      get "/api/#{@context}invoices/#{@invoice.id}.pdf?provider_key=#{@key}"
+      assert_response :found
+    end
+
+    test 'filter by month' do
+      setup_existing_invoices_test
+      setup_filter_tests
+      @invoice.update_attribute :period, Month.new(1022,5)
+
+      get "/api/#{@context}invoices.xml?provider_key=#{@key}&month=1022-05"
+
+      assert_response :success
+
+      assert_select 'invoices > invoice', :count => 1
+    end
+
+    test 'filter by state' do
+      setup_existing_invoices_test
+      setup_filter_tests
+      @invoice.cancel!
+
+      get "/api/#{@context}invoices.xml?provider_key=#{@key}&state=cancelled"
+
+      assert_response :success
+
+      assert_select 'invoices > invoice', :count => 1
+      assert_select 'invoices > invoice > id', :text => @invoice.id.to_s
+      assert_select 'invoices > invoice > state', :text => 'cancelled'
+    end
+
+    def setup_existing_invoices_test
+      @buyer ||= FactoryBot.create(:buyer_account, :provider_account => @provider)
+      @invoice = FactoryBot.create(:invoice, :provider_account => @provider, :buyer_account => @buyer)
+      2.times { FactoryBot.create(:line_item_plan_cost, :invoice => @invoice, :name => 'fake', :cost => 10.0) }
+    end
+
+    def setup_filter_tests
+      buyer = @buyer || FactoryBot.create(:buyer_account, :provider_account => @provider)
+
+      2.times do
+        FactoryBot.create(:invoice, :provider_account => @provider, :buyer_account => buyer)
+      end
+    end
+  end
+
+  class InvoicesNoScopeTest < InvoicesTestCommonCases
+    def setup
+      super
+      @context = ''
+    end
+  end
+
+  class InvoicesBuyersScopeTest < InvoicesTestCommonCases
+    def setup
+      super
+      @context = "accounts/#{@buyer.id}/"
+    end
+  end
+
+  def self.runnable_methods
+    return [] if self == InvoicesTestCommonCases
+
+    super
   end
 end


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/integration/finance/api/invoices_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)