### PR TITLE
Remove `context` and `should` from invoices_controller_test

### DIFF
--- a/test/integration/provider/invoices_controller_test.rb
+++ b/test/integration/provider/invoices_controller_test.rb
@@ -76,7 +76,7 @@ class Finance::Provider::InvoicesControllerTest < ActionDispatch::IntegrationTes
       Invoice.any_instance.stubs("transition_allowed?").returns(true)
       Invoice.any_instance.stubs("#{action}!").returns(true)
 
-      put url_for([action, :admin, :finance, @invoice]), :format => 'js'
+      put url_for([action, :admin, :finance, @invoice]), format: 'js'
       assert_response :success
     end
 
@@ -84,7 +84,7 @@ class Finance::Provider::InvoicesControllerTest < ActionDispatch::IntegrationTes
       Invoice.any_instance.stubs("transition_allowed?").returns(true)
       Invoice.any_instance.stubs("#{action}!").returns(false)
 
-      put url_for([action, :admin, :finance, @invoice]), :format => 'js'
+      put url_for([action, :admin, :finance, @invoice]), format: 'js'
       assert_response :success
       # TODO: update error messages
     end

--- a/test/integration/provider/invoices_controller_test.rb
+++ b/test/integration/provider/invoices_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Finance::Provider::InvoicesControllerTest < ActionDispatch::IntegrationTest
@@ -8,125 +10,107 @@ class Finance::Provider::InvoicesControllerTest < ActionDispatch::IntegrationTes
     @provider_account.create_billing_strategy
     @provider_account.settings.allow_finance!
 
-    # @provider_account.settings.allow_finance
-    # @provider_account.settings.show_finance
+    @invoice = FactoryBot.create(:invoice, buyer_account: @cinstance.buyer_account, provider_account: @cinstance.provider_account)
+    Invoice.any_instance.stubs(:find).returns(@invoice)
+
+    @line_item = FactoryBot.create(:line_item, invoice: @invoice, cost: 2000)
 
     login_provider @provider_account
   end
 
-  context 'InvoicesController' do
+  test 'list all invoices' do
+    get admin_finance_account_invoices_path @buyer
+    assert_response :success
+    assert_template 'finance/provider/invoices/index'
+    assert_not_nil assigns(:invoices)
+    assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
+  end
 
-    should 'list all invoices' do
+  test 'list invoices by month' do
+    get admin_finance_invoices_path @buyer, month: '2009-11'
+    assert_response :success
+    assert_template 'finance/provider/invoices/index'
+  end
 
-      get admin_finance_account_invoices_path @buyer
-      assert_response :success
-      assert_template 'finance/provider/invoices/index'
-      assert_not_nil assigns(:invoices)
-      assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
-    end
+  test 'show' do
+    get admin_finance_invoice_path @invoice
+    assert_response :success
+    assert_equal @invoice, assigns(:invoice)
+    assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
+  end
 
-    should 'list invoices by month' do
-      get admin_finance_invoices_path @buyer, month: '2009-11'
-      assert_response :success
-      assert_template 'finance/provider/invoices/index'
-    end
+  test 'show without buyer_account' do
+    # Invoice should be settled before destroying buyer account
+    buyer = FactoryBot.create(:buyer_account)
+    invoice = FactoryBot.create(:invoice, buyer_account: buyer, provider_account: @cinstance.provider_account)
+    invoice.issue_and_pay_if_free!
+    invoice.buyer_account.destroy!
+    get admin_finance_invoice_path invoice
+    assert_response :success
+    assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
+  end
 
-    context 'with existing Invoice' do
-      setup do
-        @invoice = FactoryBot.create(:invoice,
-                                     buyer_account: @cinstance.buyer_account,
-                                     provider_account: @cinstance.provider_account)
-        Invoice.any_instance.stubs(:find).returns(@invoice)
-      end
+  test 'edit' do
+    get edit_admin_finance_invoice_path @invoice
+    assert_response :success
+    assert_equal @invoice, assigns(:invoice)
+    assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
+  end
 
-      should 'show' do
-        get admin_finance_invoice_path @invoice
-        assert_response :success
-        assert_equal @invoice, assigns(:invoice)
-        assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
-      end
-
-      should 'show without buyer_account' do
-        # Invoice should be settled before destroying buyer account
-        @invoice.issue_and_pay_if_free!
-        @invoice.buyer_account.destroy!
-        get admin_finance_invoice_path @invoice
-        assert_response :success
-        assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
-      end
-
-      should 'edit' do
-        get edit_admin_finance_invoice_path @invoice
-        assert_response :success
-        assert_equal @invoice, assigns(:invoice)
-        assert_active_menus({main_menu: :audience, submenu: :finance, sidebar: :invoices, topmenu: :dashboard})
-      end
-
-      should 'update' do
-        put admin_finance_invoice_path @invoice
-        assert_response :redirect
-        assert_equal @invoice, assigns(:invoice)
-      end
-
-      [ :cancel, :pay, :generate_pdf, :charge ].each do |action|
-        should "respond to AJAX action #{action}" do
-          Invoice.any_instance.stubs("transition_allowed?").returns(true)
-          Invoice.any_instance.stubs("#{action}!").returns(true)
-
-          put url_for([action, :admin, :finance, @invoice, format: 'js'])
-          assert_response :success
-        end
-
-        should "handle '#{action}' action failure" do
-          Invoice.any_instance.stubs("transition_allowed?").returns(true)
-          Invoice.any_instance.stubs("#{action}!").returns(false)
-
-          put url_for([action, :admin, :finance, @invoice, format: 'js'])
-          assert_response :success
-          # TODO: update error messages
-        end
-      end
-
-      context 'with line items' do
-        setup do
-          @line_item = FactoryBot.create(:line_item, invoice: @invoice, cost: 2000)
-        end
-
-        should 'show with current invoice renders link to add custom line item' do
-          Invoice.any_instance.stubs(:current?).returns(true)
-          get admin_finance_invoice_path @invoice
-          assert_response :success
-        end
-
-        should 'show with past invoice does not render link to add custom line item' do
-          Invoice.any_instance.stubs(:editable?).returns(false)
-          get admin_finance_invoice_path @invoice
-          assert_response :success
-        end
-
-        should 'show with past invoice does not render button to delete custom line item' do
-          Invoice.any_instance.stubs(:editable?).returns(false)
-          get admin_finance_invoice_path @invoice
-          assert_response :success
-        end
-
-        should 'show with open invoice renders button to delete custom line item' do
-          Invoice.any_instance.stubs(:editable?).returns(true)
-          get admin_finance_invoice_path @invoice
-          assert_response :success
-        end
-
-      end
-    end
+  test 'update' do
+    put admin_finance_invoice_path @invoice
+    assert_response :redirect
+    assert_equal @invoice, assigns(:invoice)
   end
 
   test '#charge does not invoke invoice automatic charging' do
-    invoice = FactoryBot.create(:invoice,
-                                buyer_account: @buyer, provider_account: @provider_account)
     Invoice.any_instance.stubs('transition_allowed?').returns(true)
     Invoice.any_instance.expects(:charge!).with(false).returns(true)
 
-    put charge_admin_finance_invoice_path invoice, params: { format: :js }
+    put charge_admin_finance_invoice_path @invoice, params: { format: :js }
+    assert_response :success
+  end
+
+  %i[cancel pay generate_pdf charge].each do |action|
+    should "respond to AJAX action #{action}" do
+      Invoice.any_instance.stubs("transition_allowed?").returns(true)
+      Invoice.any_instance.stubs("#{action}!").returns(true)
+
+      put url_for([action, :admin, :finance, @invoice]), :format => 'js'
+      assert_response :success
+    end
+
+    should "handle '#{action}' action failure" do
+      Invoice.any_instance.stubs("transition_allowed?").returns(true)
+      Invoice.any_instance.stubs("#{action}!").returns(false)
+
+      put url_for([action, :admin, :finance, @invoice]), :format => 'js'
+      assert_response :success
+      # TODO: update error messages
+    end
+  end
+
+  test 'show with current invoice renders link to add custom line item' do
+    Invoice.any_instance.stubs(:current?).returns(true)
+    get admin_finance_invoice_path @invoice
+    assert_response :success
+  end
+
+  test 'show with past invoice does not render link to add custom line item' do
+    Invoice.any_instance.stubs(:editable?).returns(false)
+    get admin_finance_invoice_path @invoice
+    assert_response :success
+  end
+
+  test 'show with past invoice does not render button to delete custom line item' do
+    Invoice.any_instance.stubs(:editable?).returns(false)
+    get admin_finance_invoice_path @invoice
+    assert_response :success
+  end
+
+  test 'show with open invoice renders button to delete custom line item' do
+    Invoice.any_instance.stubs(:editable?).returns(true)
+    get admin_finance_invoice_path @invoice
     assert_response :success
   end
 end


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/integration/provider/invoices_controller_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)