### PR TITLE
Remove `context` and `should` from integration/stats

### DIFF
--- a/test/integration/stats/applications_test.rb
+++ b/test/integration/stats/applications_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class Stats::ApplicationsTest < ActionDispatch::IntegrationTest
-
   def setup
     @provider    = FactoryBot.create(:provider_account)
     @service     = @provider.default_service
@@ -14,7 +13,7 @@ class Stats::ApplicationsTest < ActionDispatch::IntegrationTest
     login_provider @provider
   end
 
-  should '#show nonexistent application does not check permissions' do
+  test '#show nonexistent application does not check permissions' do
     User.any_instance.expects(:has_access_to_all_services?).never
     User.any_instance.expects(:member_permission_service_ids).never
 
@@ -22,33 +21,24 @@ class Stats::ApplicationsTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  context 'with access to all services' do
-    setup do
-      User.any_instance.expects(:has_access_to_all_services?).returns(true).at_least_once
-    end
-
-    should '#show does not check member permission' do
-      User.any_instance.expects(:member_permission_service_ids).never
-      get admin_buyers_stats_application_path(id: @application.id)
-      assert_response :success
-    end
+  test '#show does not check member permission with access to all services' do
+    User.any_instance.expects(:has_access_to_all_services?).returns(true).at_least_once
+    User.any_instance.expects(:member_permission_service_ids).never
+    get admin_buyers_stats_application_path(id: @application.id)
+    assert_response :success
   end
 
-  context 'without access to all services' do
-    setup do
-      User.any_instance.expects(:has_access_to_all_services?).returns(false).at_least_once
-    end
+  test '#show needs member permission' do
+    User.any_instance.expects(:has_access_to_all_services?).returns(false)
+    User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
+    get admin_buyers_stats_application_path(id: @application.id)
+    assert_response :success
+  end
 
-    should '#show needs member permission' do
-      User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
-      get admin_buyers_stats_application_path(id: @application.id)
-      assert_response :success
-    end
-
-    should '#show is forbidden without member permission' do
-      User.any_instance.expects(:member_permission_service_ids).returns([]).at_least_once
-      get admin_buyers_stats_application_path(id: @application.id)
-      assert_response :forbidden
-    end
+  test '#show is forbidden without member permission' do
+    User.any_instance.expects(:has_access_to_all_services?).returns(false)
+    User.any_instance.expects(:member_permission_service_ids).returns([]).at_least_once
+    get admin_buyers_stats_application_path(id: @application.id)
+    assert_response :forbidden
   end
 end

--- a/test/integration/stats/applications_test.rb
+++ b/test/integration/stats/applications_test.rb
@@ -4,9 +4,9 @@ require 'test_helper'
 
 class Stats::ApplicationsTest < ActionDispatch::IntegrationTest
   def setup
-    @provider    = FactoryBot.create(:provider_account)
-    @service     = @provider.default_service
-    @plan        = FactoryBot.create(:simple_application_plan, issuer: @service)
+    @provider = FactoryBot.create(:provider_account)
+    @service = @provider.default_service
+    @plan = FactoryBot.create(:simple_application_plan, issuer: @service)
     @application = FactoryBot.create(:simple_cinstance, plan: @plan)
 
     host! @provider.admin_domain

--- a/test/integration/stats/services_test.rb
+++ b/test/integration/stats/services_test.rb
@@ -11,6 +11,7 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     Stats::Base.storage.flushdb
 
     host! @provider_account.admin_domain
+    provider_login_with @provider_account.admins.first.username, 'supersecret'
   end
 
   def teardown
@@ -22,7 +23,6 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     plan = FactoryBot.create(:application_plan, issuer: @provider_account.default_service)
     @cinstance = FactoryBot.create(:cinstance, plan: plan)
 
-    provider_login_with @provider_account.admins.first.username, 'supersecret'
     get usage_response_code_stats_api_services_path(@cinstance.service_id, format: :json), params: { period: 'day', response_code: 200, timezone: 'Madrid', skip_change: false }
 
     assert_response :success
@@ -45,7 +45,6 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     plan = FactoryBot.create(:application_plan, issuer: @provider_account.default_service)
     @cinstance = FactoryBot.create(:cinstance, plan: plan)
 
-    provider_login_with @provider_account.admins.first.username, 'supersecret'
     get usage_stats_api_services_path(@cinstance.service_id, format: :json), params: { period: 'day', metric_name: @metric.system_name, timezone: 'Madrid', skip_change: false }
 
     assert_response :success
@@ -74,7 +73,6 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     @cinstance = FactoryBot.create(:cinstance, plan: plan)
     @provider_account.update(timezone: 'Madrid')
 
-    provider_login_with @provider_account.admins.first.username, 'supersecret'
     opts = { period: 'day', metric_name: @metric.system_name }
     get usage_stats_api_services_path(@cinstance.service_id, format: :json), params: opts
 
@@ -93,7 +91,6 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     plan = FactoryBot.create(:application_plan, issuer: @service)
     @cinstance = FactoryBot.create(:cinstance, plan: plan)
 
-    provider_login_with @provider_account.admins.first.username, 'supersecret'
     opts = { period: 'day', metric_name: @metric.system_name, timezone: 'Kamchatka' }
     get usage_stats_api_services_path(@cinstance.service_id, format: :json), params: opts
 
@@ -119,7 +116,6 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     make_transaction_at(Time.utc(2009, 12, 11, 18, 45), cinstance_id: cinstance.id)
 
     Timecop.freeze(Time.utc(2009, 12, 11, 19, 10))
-    provider_login_with @provider_account.admins.first.username, 'supersecret'
     get usage_stats_api_services_path(@provider_account.default_service, format: :json), params: { period: 'day', metric_name: @metric.system_name, timezone: 'UTC', skip_change: false }
 
     assert_response :success
@@ -156,7 +152,6 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     # This is out
     make_transaction_at(Time.utc(2011, 1, 1, 23, 21), cinstance_id: cinstance.id)
 
-    provider_login_with @provider_account.admins.first.username, 'supersecret'
     get usage_stats_api_services_path(@provider_account.default_service, format: :json), params: { period: 'year', metric_name: @metric.system_name, timezone: 'Madrid', since: "2010-01-01", skip_change: false }
 
     assert_response :success
@@ -192,7 +187,6 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     # This is out
     make_transaction_at(Time.utc(2011, 1, 1, 1, 21), cinstance_id: cinstance.id)
 
-    provider_login_with @provider_account.admins.first.username, 'supersecret'
     get usage_stats_api_services_path(@provider_account.default_service, format: :json), params: { period: 'year', metric_name: @metric.system_name, timezone: 'Azores', since: "2010-01-01", skip_change: false }
 
     assert_response :success
@@ -223,7 +217,6 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     make_transaction_at(Time.utc(2009, 12, 15), cinstance_id: cinstance1.id)
 
     Timecop.freeze(Time.utc(2009, 12, 22))
-    provider_login_with @provider_account.admins.first.username, 'supersecret'
     get top_applications_stats_api_services_path(@provider_account.default_service, format: :json), params: { period: :month, metric_name: @metric.system_name }
 
     assert_response :success

--- a/test/integration/stats/services_test.rb
+++ b/test/integration/stats/services_test.rb
@@ -28,18 +28,16 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_content_type 'application/json'
 
-    assert_json  "period"=> { "name" => "day",
+    assert_json "period" => { "name" => "day",
                               "granularity" => "hour",
                               "since" => Time.zone.parse("2009-12-03T12:00:00+01:00"),
                               "until" => Time.zone.parse("2009-12-04T12:59:59+01:00"),
-                              "timezone"=>"Europe/Madrid"},
-                  "total" => 0,
-                  "values" => [0] * 25,
-                  "previous_total" => 0,
-                  "change"=>0.0,
-                  "response_code" => {'code' => '200'}
-
-
+                              "timezone" => "Europe/Madrid" },
+                "total" => 0,
+                "values" => [0] * 25,
+                "previous_total" => 0,
+                "change" =>0.0,
+                "response_code" => { 'code' => '200' }
   end
 
   test 'usage with no data as json' do
@@ -53,19 +51,19 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_content_type 'application/json'
 
-    assert_json  "period"=> { "name" => "day",
+    assert_json "period" => { "name" => "day",
                               "granularity" => "hour",
                               "since" => Time.zone.parse("2009-12-03T12:00:00+01:00"),
                               "until" => Time.zone.parse("2009-12-04T12:59:59+01:00"),
-                              "timezone"=>"Europe/Madrid"},
-                  "total" => 0,
-                  "values" => [0] * 25,
-                  "previous_total" => 0,
-                  "change"=>0.0,
-                  "metric" => { "name" => @metric.friendly_name,
-                                "id" => @metric.id,
-                                "unit" => @metric.unit,
-                                "system_name" => @metric.system_name }
+                              "timezone" => "Europe/Madrid" },
+                "total" => 0,
+                "values" => [0] * 25,
+                "previous_total" => 0,
+                "change" =>0.0,
+                "metric" => { "name" => @metric.friendly_name,
+                               "id" => @metric.id,
+                               "unit" => @metric.unit,
+                               "system_name" => @metric.system_name }
 
 
   end
@@ -83,13 +81,11 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_content_type 'application/json'
 
-    assert_json_contains(
-      "period" => {"name"=>"day",
-      "granularity"=>"hour",
-      "since"=>Time.zone.parse("2009-12-10T20:00:00+01:00"),
-      "until"=>Time.zone.parse("2009-12-11T20:59:59+01:00"),
-      "timezone"=>"Europe/Madrid"}
-    )
+    assert_json_contains "period" => { "name" => "day",
+                                       "granularity" => "hour",
+                                       "since" => Time.zone.parse("2009-12-10T20:00:00+01:00"),
+                                       "until" => Time.zone.parse("2009-12-11T20:59:59+01:00"),
+                                       "timezone" => "Europe/Madrid" }
   end
 
   test 'with simple plan and cinstance, retrieve data with specified timezone' do
@@ -103,13 +99,11 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_content_type 'application/json'
-    assert_json_contains(
-    "period" => {"name"=>"day",
-    "granularity"=>"hour",
-    "since"=>Time.zone.parse("2009-12-11T07:00:00+12:00"),
-    "until"=>Time.zone.parse("2009-12-12T07:59:59+12:00"),
-    "timezone"=>"Asia/Kamchatka"}
-    )
+    assert_json_contains "period" => { "name" => "day",
+                                       "granularity" => "hour",
+                                       "since" => Time.zone.parse("2009-12-11T07:00:00+12:00"),
+                                       "until" => Time.zone.parse("2009-12-12T07:59:59+12:00"),
+                                       "timezone" => "Asia/Kamchatka" }
   end
 
   test 'usage with some data as json' do
@@ -131,18 +125,19 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_content_type 'application/json'
 
-
-    assert_json "period"=>
-      {"name"=>"day",
-       "granularity"=>"hour",
-       "since"=>Time.zone.parse("2009-12-10T19:00:00Z"),
-       "until"=>Time.zone.parse("2009-12-11T19:59:59Z"),
-       "timezone"=>"Etc/UTC"},
-     "total"=>4,
-     "previous_total" => 0,
-     "change"=>100.0,
-     "values"=> [0] * 15 + [1] + [0] * 7 + [3] + [0],
-     "metric"=>{"name"=>@metric.friendly_name, "id"=>@metric.id, "unit"=>@metric.unit, "system_name"=>@metric.system_name}
+    assert_json "period" => { "name" => "day",
+                              "granularity" => "hour",
+                              "since" => Time.zone.parse("2009-12-10T19:00:00Z"),
+                              "until" => Time.zone.parse("2009-12-11T19:59:59Z"),
+                              "timezone" => "Etc/UTC" },
+                "total" => 4,
+                "previous_total" => 0,
+                "change" => 100.0,
+                "values" => [0] * 15 + [1] + [0] * 7 + [3] + [0],
+                "metric" => { "name" => @metric.friendly_name,
+                              "id" => @metric.id,
+                              "unit" => @metric.unit,
+                              "system_name" => @metric.system_name }
 
   end
 
@@ -167,18 +162,19 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_content_type 'application/json'
 
-    assert_json "period"=>
-                  { "name"=>"year",
-                    "granularity"=>"month",
-                    "since"=>Time.zone.parse("2010-01-01T00:00:00+01:00"),
-                    "until"=>Time.zone.parse("2010-12-31T23:59:59+01:00"),
-                    "timezone"=>"Europe/Madrid"},
-                  "total"=>3,
-                  "previous_total" => 1,
-                  "change"=>200.0,
-                  "values"=>[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-                  "metric"=>{"name"=>@metric.friendly_name, "id"=>@metric.id, "unit"=>@metric.unit, "system_name"=>@metric.system_name}
-
+    assert_json "period" => { "name" => "year",
+                              "granularity" => "month",
+                              "since" => Time.zone.parse("2010-01-01T00:00:00+01:00"),
+                              "until" => Time.zone.parse("2010-12-31T23:59:59+01:00"),
+                              "timezone" => "Europe/Madrid" },
+                "total" => 3,
+                "previous_total" => 1,
+                "change" => 200.0,
+                "values" => [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+                "metric" => { "name" => @metric.friendly_name,
+                              "id" => @metric.id,
+                              "unit" => @metric.unit,
+                              "system_name" => @metric.system_name }
   end
 
   test 'negative timezone shifting' do
@@ -202,18 +198,19 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_content_type 'application/json'
 
-    assert_json "period"=>
-      {"name"=>"year",
-       "granularity"=>"month",
-       "since"=>Time.zone.parse("2010-01-01T00:00:00-01:00"),
-       "until"=>Time.zone.parse("2010-12-31T23:59:59-01:00"),
-       "timezone"=>"Atlantic/Azores"},
-     "total"=>3,
-     "previous_total" => 1,
-     "change"=>200.0,
-     "values"=>[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-     "metric"=>{"name"=>@metric.friendly_name, "id"=>@metric.id, "unit"=>@metric.unit, "system_name"=>@metric.system_name}
-
+    assert_json "period" => { "name" => "year",
+                              "granularity" => "month",
+                              "since" => Time.zone.parse("2010-01-01T00:00:00-01:00"),
+                              "until" => Time.zone.parse("2010-12-31T23:59:59-01:00"),
+                              "timezone" => "Atlantic/Azores" },
+                "total" => 3,
+                "previous_total" => 1,
+                "change" => 200.0,
+                "values" => [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+                "metric" => { "name" => @metric.friendly_name,
+                              "id" => @metric.id,
+                              "unit" => @metric.unit,
+                              "system_name" => @metric.system_name }
   end
 
   test 'top_clients as json' do
@@ -223,7 +220,6 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
 
     make_transaction_at(Time.utc(2009, 12,  2), cinstance_id: cinstance1.id)
     make_transaction_at(Time.utc(2009, 12,  3), cinstance_id: cinstance2.id)
-
     make_transaction_at(Time.utc(2009, 12, 15), cinstance_id: cinstance1.id)
 
     Timecop.freeze(Time.utc(2009, 12, 22))
@@ -232,24 +228,19 @@ class Stats::ServicesTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_content_type 'application/json'
-    assert_json "period"=>
-      {"name"=>"month",
-       "since"=>"2009-12-01T00:00:00Z",
-       "until"=>"2009-12-31T23:59:59Z"},
-     "applications"=>
-      [{"name"=>nil,
-        "plan"=>{"name"=>plan.name, "id"=>plan.id},
-        "id"=>cinstance1.id,
-        "value"=>"2",
-        "account"=>{"name"=>cinstance1.user_account.org_name, "id"=>cinstance1.user_account.id},
-        "service"=>{"id"=>cinstance1.service_id}},
-       {"name"=>nil,
-        "plan"=>{"name"=>plan.name, "id"=>plan.id},
-        "id"=>cinstance2.id,
-        "value"=>"1",
-        "account"=>{"name"=>cinstance2.user_account.org_name, "id"=>cinstance2.user_account.id},
-        "service"=>{"id"=>cinstance2.service_id}}],
-     "metric"=>{"name"=>@metric.friendly_name, "id"=>@metric.id, "unit"=>@metric.unit, "system_name"=>@metric.system_name}
-
+    assert_json "period" => { "name" => "month", "since" => "2009-12-01T00:00:00Z", "until" => "2009-12-31T23:59:59Z" },
+                "applications" => [{ "name" =>nil,
+                                     "plan" => { "name" => plan.name, "id" => plan.id },
+                                     "id" => cinstance1.id,
+                                     "value" => "2",
+                                     "account" => { "name" => cinstance1.user_account.org_name, "id" => cinstance1.user_account.id },
+                                     "service" => { "id" => cinstance1.service_id } },
+                                   { "name" => nil,
+                                     "plan" => { "name" => plan.name, "id" => plan.id },
+                                     "id" => cinstance2.id,
+                                     "value" => "1",
+                                     "account" => { "name" => cinstance2.user_account.org_name, "id" => cinstance2.user_account.id },
+                                     "service" => { "id" => cinstance2.service_id } }],
+                "metric" => { "name" => @metric.friendly_name, "id" => @metric.id, "unit" => @metric.unit, "system_name" => @metric.system_name }
   end
 end


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/integration/stats/applications_test.rb
* test/integration/stats/services_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)