### PR TITLE
Remove `context` and `should`  from application_plan_*_test

### DIFF
--- a/test/integration/user-management-api/application_plan_features_test.rb
+++ b/test/integration/user-management-api/application_plan_features_test.rb
@@ -114,16 +114,18 @@ class Admin::Api::ApplicationPlanFeaturesTest < ActionDispatch::IntegrationTest
 
     test 'remove association of feature' do
       feat = FactoryBot.create(:feature, featurable: @provider.default_service)
+      @app_plan.features << feat
+      @app_plan.save!
 
       assert_difference @app_plan.features.method(:count), -1 do
-        post admin_api_application_plan_features_path(@app_plan, format: :xml), params: params.merge({ feature_id: feat.id })
+        delete admin_api_application_plan_feature_path(@app_plan, feat, format: :xml), params: params
         assert_response :success
-        assert_equal xml.xpath('.//feature/id').children.first.text, feat.id.to_s
+        assert_not_includes @app_plan.features.reload, feat
       end
     end
 
     test 'remove association of non-existing feature' do
-      post admin_api_application_plan_features_path(@app_plan, format: :xml), params: params.merge({ feature_id: 'XXX' })
+      delete admin_api_application_plan_feature_path(@app_plan, id: 'XXX', format: :xml), params: params
       assert_xml_404
     end
 

--- a/test/integration/user-management-api/application_plan_pricing_rules_test.rb
+++ b/test/integration/user-management-api/application_plan_pricing_rules_test.rb
@@ -5,9 +5,9 @@ require 'test_helper'
 class Admin::Api::ApplicationPlanPricingRulesTest < ActionDispatch::IntegrationTest
   def setup
     @provider = FactoryBot.create(:provider_account, domain: 'provider.example.com')
-    @service  = FactoryBot.create(:service, account: @provider)
+    @service = FactoryBot.create(:service, account: @provider)
     @app_plan = FactoryBot.create(:application_plan, issuer: @service)
-    @metric   = FactoryBot.create(:metric, service: @service)
+    @metric = FactoryBot.create(:metric, service: @service)
     @pricing_rule = FactoryBot.create(:pricing_rule, plan: @app_plan, metric: @metric)
 
     host! @provider.admin_domain
@@ -18,41 +18,32 @@ class Admin::Api::ApplicationPlanPricingRulesTest < ActionDispatch::IntegrationT
       super
       user = FactoryBot.create(:member, account: @provider, admin_sections: %w[partners plans])
       @token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
+
+      User.any_instance.stubs(:has_access_to_all_services?).returns(false)
     end
 
-    context 'without access to all services' do
-      setup do
-        User.any_instance.stubs(:has_access_to_all_services?).returns(false)
-      end
-
-      should 'index with no token' do
-        get admin_api_application_plan_pricing_rules_path(@app_plan)
-        assert_response :forbidden
-      end
-
-      should 'index with access to no services' do
-        User.any_instance.expects(:member_permission_service_ids).returns([]).at_least_once
-        get admin_api_application_plan_pricing_rules_path(@app_plan), params: params
-        assert_response :not_found
-      end
-
-      should 'index with access to some service' do
-        User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
-        get admin_api_application_plan_pricing_rules_path(@app_plan), params: params
-        assert_response :success
-      end
+    test 'index with no token' do
+      get admin_api_application_plan_pricing_rules_path(@app_plan)
+      assert_response :forbidden
     end
 
-    context 'with access to all services' do
-      setup do
-        User.any_instance.stubs(:has_access_to_all_services?).returns(true)
-      end
+    test 'index with access to no services' do
+      User.any_instance.expects(:member_permission_service_ids).returns([]).at_least_once
+      get admin_api_application_plan_pricing_rules_path(@app_plan), params: params
+      assert_response :not_found
+    end
 
-      should 'index' do
-        User.any_instance.expects(:member_permission_service_ids).never
-        get admin_api_application_plan_pricing_rules_path(@app_plan), params: params
-        assert_response :success
-      end
+    test 'index with access to some service' do
+      User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
+      get admin_api_application_plan_pricing_rules_path(@app_plan), params: params
+      assert_response :success
+    end
+
+    test 'index with access to all services' do
+      User.any_instance.stubs(:has_access_to_all_services?).returns(true)
+      User.any_instance.expects(:member_permission_service_ids).never
+      get admin_api_application_plan_pricing_rules_path(@app_plan), params: params
+      assert_response :success
     end
 
     private


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/integration/user-management-api/application_plan_features_test.rb
* test/integration/user-management-api/application_plan_limits_test.rb
* test/integration/user-management-api/application_plan_metric_limits_test.rb
* test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
* test/integration/user-management-api/application_plan_pricing_rules_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)