### PR TITLE
Remove `context` and `should` from cinstance_test

### DIFF
--- a/test/factories/cinstance.rb
+++ b/test/factories/cinstance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory(:contract) do
     association :user_account, :factory => :pending_buyer_account
@@ -17,21 +19,14 @@ FactoryBot.define do
         contract.plan.provider_account.buyer_accounts << contract.user_account
       end
     end
-
   end
 
-  factory(:cinstance, :parent => :contract, :class => Cinstance) do
+  factory(:cinstance, :aliases => %i[application application_contract], :parent => :contract, :class => Cinstance) do
     association :plan, :factory => :application_plan
-  end
 
-# Alias for future renaming
-  factory(:application_contract, :parent => :cinstance)
-
-# Alias for future renaming
-  factory(:application, :parent => :cinstance)
-
-  factory(:pending_application, parent: :application) do
-    plan { FactoryBot.create(:application_plan, approval_required: true) }
+    factory(:pending_application) do
+      plan { FactoryBot.create(:application_plan, approval_required: true) }
+    end
   end
 
   factory(:account_contract, :parent => :contract, :class => AccountContract) do

--- a/test/factories/cinstance.rb
+++ b/test/factories/cinstance.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
   factory(:cinstance, :aliases => %i[application application_contract], :parent => :contract, :class => Cinstance) do
     association :plan, :factory => :application_plan
 
-    factory(:pending_application) do
+    trait :as_pending do
       plan { FactoryBot.create(:application_plan, approval_required: true) }
     end
   end

--- a/test/factories/cinstance.rb
+++ b/test/factories/cinstance.rb
@@ -30,6 +30,9 @@ FactoryBot.define do
 # Alias for future renaming
   factory(:application, :parent => :cinstance)
 
+  factory(:pending_application, parent: :application) do
+    plan { FactoryBot.create(:application_plan, approval_required: true) }
+  end
 
   factory(:account_contract, :parent => :contract, :class => AccountContract) do
     association :plan, :factory => :account_plan

--- a/test/test_helpers/cinstance.rb
+++ b/test/test_helpers/cinstance.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module TestHelpers
+  module Cinstance
+    def create_pending_cinstance
+      FactoryBot.create(:cinstance, plan: FactoryBot.create(:application_plan, approval_required: true))
+    end
+  end
+end

--- a/test/test_helpers/cinstance.rb
+++ b/test/test_helpers/cinstance.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module TestHelpers
-  module Cinstance
-    def create_pending_cinstance
-      FactoryBot.create(:cinstance, plan: FactoryBot.create(:application_plan, approval_required: true))
-    end
-  end
-end

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -6,8 +6,6 @@ require 'test_helper'
 # Finished in 170.63189s
 # 87 tests, 160 assertions, 0 failures, 0 errors, 0 skips
 class CinstanceTest < ActiveSupport::TestCase
-  include TestHelpers::Cinstance
-
   def teardown
     Timecop.return
   end
@@ -119,7 +117,7 @@ class CinstanceTest < ActiveSupport::TestCase
     service = FactoryBot.create(:service)
     plan = FactoryBot.create(:application_plan, issuer: service, approval_required: true)
 
-    pending_cinstance = create_pending_cinstance
+    pending_cinstance = FactoryBot.create(:pending_application)
 
     destroyed_pending_cinstance = FactoryBot.create(:cinstance, plan: plan)
     Timecop.freeze(1.hour.ago) { destroyed_pending_cinstance.destroy }
@@ -133,7 +131,7 @@ class CinstanceTest < ActiveSupport::TestCase
 
   test 'Cinstance.by_state(:live) returns only live cinstances' do
     live_cinstance = FactoryBot.create(:cinstance)
-    pending_cinstance = create_pending_cinstance
+    pending_cinstance = FactoryBot.create(:pending_application)
 
     destroyed_live_cinstance = FactoryBot.create(:cinstance)
     Timecop.freeze(1.hour.ago) { destroyed_live_cinstance.destroy }
@@ -248,26 +246,26 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test 'Cinstance#live? returns false when cinstance is pending' do
-    cinstance = create_pending_cinstance
+    cinstance = FactoryBot.create(:pending_application)
     assert_not cinstance.live?
   end
 
   test 'Cinstance#accept! transitions from pending to live state' do
-    cinstance = create_pending_cinstance
+    cinstance = FactoryBot.create(:pending_application)
 
     cinstance.accept!
     assert cinstance.live?
   end
 
   test 'Cinstance#reject! destroys pending cinstance' do
-    cinstance = create_pending_cinstance
+    cinstance = FactoryBot.create(:pending_application)
 
     cinstance.reject!('because whatever reason')
     assert_does_not_contain Cinstance.all, cinstance
   end
 
   test 'Cinstance#reject! sets rejection reason' do
-    cinstance = create_pending_cinstance
+    cinstance = FactoryBot.create(:pending_application)
     cinstance.reject!('because whatever reason')
 
     assert_equal 'because whatever reason', cinstance.rejection_reason

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -161,7 +161,7 @@ class CinstanceTest < ActiveSupport::TestCase
 
     cinstance_two = buyer_account.buy(plan) # no bang!
     cinstance_two.validate_plan_is_unique!
-    assert_not cinstance_two.valid?
+    assert cinstance_two.invalid?
   end
 
   test 'there can be more cinstances per plan if they have different user_accounts' do
@@ -338,7 +338,7 @@ class CinstanceTest < ActiveSupport::TestCase
     FactoryBot.create(:cinstance, plan: plan, user_key: 'foo')
     cinstance_two = FactoryBot.build(:cinstance, plan: plan, user_key: 'foo')
 
-    assert_not cinstance_two.valid?
+    assert cinstance_two.invalid?
     assert_match /has already been taken/, cinstance_two.errors[:user_key].to_s
 
     cinstance_two.user_key = 'bar'
@@ -354,7 +354,7 @@ class CinstanceTest < ActiveSupport::TestCase
 
     Rails.configuration.three_scale.rolling_updates.stubs(features: {duplicate_user_key: []})
     assert FactoryBot.create(:cinstance, plan: plan1, user_key: 'foo')
-    assert_not FactoryBot.build(:cinstance, plan: plan2, user_key: 'foo').valid?
+    assert FactoryBot.build(:cinstance, plan: plan2, user_key: 'foo').invalid?
 
     Rails.configuration.three_scale.rolling_updates.stubs(features: {duplicate_user_key: [provider.id]})
     assert FactoryBot.build(:cinstance, plan: plan2, user_key: 'foo').valid?
@@ -447,7 +447,7 @@ class CinstanceTest < ActiveSupport::TestCase
     other_service = FactoryBot.create(:service, account: cinstance.provider_account)
     other_plan_diff_service = FactoryBot.create(:application_plan, service: other_service, name: "other plan of different service")
     cinstance.plan = other_plan_diff_service
-    assert_not cinstance.valid?
+    assert cinstance.invalid?
     assert_includes cinstance.errors['plan'], 'not allowed in this context'
 
     other_plan_same_service = FactoryBot.build_stubbed(:application_plan, service: cinstance.service, name: "other plan of same service")
@@ -470,7 +470,7 @@ class CinstanceTest < ActiveSupport::TestCase
 
     cinstance.user_key = "you-&$#!!!"
 
-    assert_not cinstance.valid?
+    assert cinstance.invalid?
     assert cinstance.errors[:user_key].present?
 
     cinstance.user_key = "you-awesome-man"
@@ -480,7 +480,7 @@ class CinstanceTest < ActiveSupport::TestCase
     assert cinstance.valid?
 
     cinstance.user_key << "k"
-    assert_not cinstance.valid?
+    assert cinstance.invalid?
     assert cinstance.errors[:user_key].present?
   end
 
@@ -608,10 +608,10 @@ class CinstanceTest < ActiveSupport::TestCase
     cinstance = FactoryBot.build(:cinstance)
 
     cinstance.application_id = ''
-    assert_not cinstance.valid?
+    assert cinstance.invalid?
 
     cinstance.application_id = 'a' * 3
-    assert_not cinstance.valid?
+    assert cinstance.invalid?
 
     cinstance.application_id = 'a' * 4
     assert cinstance.valid?
@@ -682,7 +682,7 @@ class ValidationsTest < ActiveSupport::TestCase
       @provider.settings.show_multiple_applications!
       @cinstance.validate_human_edition!
 
-      assert_not @cinstance.valid?
+      assert @cinstance.invalid?
       assert @cinstance.errors[:name].presence
     end
   end
@@ -703,7 +703,7 @@ class ValidationsTest < ActiveSupport::TestCase
       @provider.settings.show_multiple_applications!
       @cinstance.validate_human_edition!
 
-      assert_not @cinstance.valid?
+      assert @cinstance.invalid?
       assert @cinstance.errors[:description].presence
     end
 
@@ -716,7 +716,7 @@ class ValidationsTest < ActiveSupport::TestCase
       @service.update(intentions_required: true)
       @cinstance.validate_human_edition!
 
-      assert_not @cinstance.valid?
+      assert @cinstance.invalid?
       assert @cinstance.errors[:description].presence
     end
   end

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -114,9 +114,9 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test 'Cinstance.by_state(:pending) returns only pending cinstances' do
-    pending_cinstance = FactoryBot.create(:pending_application)
+    pending_cinstance = FactoryBot.create(:application, :as_pending)
 
-    destroyed_pending_cinstance = FactoryBot.create(:pending_application)
+    destroyed_pending_cinstance = FactoryBot.create(:application, :as_pending)
     Timecop.freeze(1.hour.ago) { destroyed_pending_cinstance.destroy }
 
     live_cinstance = FactoryBot.create(:cinstance)
@@ -128,7 +128,7 @@ class CinstanceTest < ActiveSupport::TestCase
 
   test 'Cinstance.by_state(:live) returns only live cinstances' do
     live_cinstance = FactoryBot.create(:cinstance)
-    pending_cinstance = FactoryBot.create(:pending_application)
+    pending_cinstance = FactoryBot.create(:application, :as_pending)
 
     destroyed_live_cinstance = FactoryBot.create(:cinstance)
     Timecop.freeze(1.hour.ago) { destroyed_live_cinstance.destroy }
@@ -243,26 +243,26 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test 'Cinstance#live? returns false when cinstance is pending' do
-    cinstance = FactoryBot.create(:pending_application)
+    cinstance = FactoryBot.create(:application, :as_pending)
     assert_not cinstance.live?
   end
 
   test 'Cinstance#accept! transitions from pending to live state' do
-    cinstance = FactoryBot.create(:pending_application)
+    cinstance = FactoryBot.create(:application, :as_pending)
 
     cinstance.accept!
     assert cinstance.live?
   end
 
   test 'Cinstance#reject! destroys pending cinstance' do
-    cinstance = FactoryBot.create(:pending_application)
+    cinstance = FactoryBot.create(:application, :as_pending)
 
     cinstance.reject!('because whatever reason')
     assert_does_not_contain Cinstance.all, cinstance
   end
 
   test 'Cinstance#reject! sets rejection reason' do
-    cinstance = FactoryBot.create(:pending_application)
+    cinstance = FactoryBot.create(:application, :as_pending)
     cinstance.reject!('because whatever reason')
 
     assert_equal 'because whatever reason', cinstance.rejection_reason

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -1,172 +1,21 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # TODO: Please split this file. It is too huge and takes too long
 # Finished in 170.63189s
 # 87 tests, 160 assertions, 0 failures, 0 errors, 0 skips
 class CinstanceTest < ActiveSupport::TestCase
-
-  subject { @cinstance || FactoryBot.create(:cinstance) }
-
-  context 'validations' do
-    should validate_presence_of(:plan)
-    should validate_acceptance_of(:conditions).with_message(/you should agree/i)
-
-    context 'name' do
-      setup do
-        @provider = FactoryBot.create :provider_account
-        @service = FactoryBot.create :service, :account => @provider
-        plan = FactoryBot.create :application_plan, :issuer => @service
-        @cinstance = FactoryBot.build :cinstance, :plan => plan
-      end
-
-      should 'not require name as default' do
-        assert @cinstance.valid?
-      end
-
-      context 'provider has multi apps enabled' do
-        setup do
-          @provider.settings.allow_multiple_applications!
-          @provider.settings.show_multiple_applications!
-        end
-
-        should 'not require name' do
-          assert @cinstance.valid?
-        end
-
-        should 'require name if a human interaction is happening' do
-          @cinstance.validate_human_edition!
-
-          assert !@cinstance.valid?
-          assert @cinstance.errors[:name].presence
-        end
-
-      end # provider has multi apps enabled
-    end #name
-
-    context 'description' do
-      setup do
-        @provider = FactoryBot.create :provider_account
-        @service = FactoryBot.create :service, :account => @provider
-        plan = FactoryBot.create :application_plan, :issuer => @service
-        @cinstance = FactoryBot.build :cinstance, :plan => plan
-      end
-
-      should 'not require description as default' do
-        assert @cinstance.valid?
-      end
-
-      context 'provider has multi apps enabled' do
-        setup do
-          @provider.settings.allow_multiple_applications!
-          @provider.settings.show_multiple_applications!
-        end
-
-        should 'not require description' do
-          assert @cinstance.valid?
-        end
-
-        should 'require description if a human interaction is happening' do
-          @cinstance.validate_human_edition!
-
-          assert !@cinstance.valid?
-          assert @cinstance.errors[:description].presence
-        end
-
-      end # provider has multi apps enabled
-
-      context 'service requires intentions' do
-        setup do
-          @service.update_attribute :intentions_required, true
-        end
-
-        should 'not require description' do
-          assert @cinstance.valid?
-        end
-
-        should 'require description if a human interaction is happening' do
-          @cinstance.validate_human_edition!
-
-          assert !@cinstance.valid?
-          assert @cinstance.errors[:description].presence
-        end
-
-      end # service requires intentions
-    end #description
-
-    context 'plan class validation' do
-
-      should 'be valid with an application plan' do
-        app_plan = FactoryBot.create :application_plan
-        app_contract = Cinstance.new :plan => app_plan
-
-        assert app_contract.valid?
-      end
-
-      should 'not be valid with a service plan' do
-        service_plan = FactoryBot.create :service_plan
-        assert_raises(ActiveRecord::AssociationTypeMismatch) do
-          Cinstance.new(plan: service_plan)
-        end
-      end
-
-      should 'not be valid with an account plan' do
-        account_plan = FactoryBot.create :account_plan
-        assert_raises(ActiveRecord::AssociationTypeMismatch) do
-          Cinstance.new(plan: account_plan)
-        end
-      end
-
-    end
-
-  end
+  include TestHelpers::Cinstance
 
   def teardown
     Timecop.return
   end
 
-  context 'deleted cinstance' do
-    setup do
-      @cinstance = FactoryBot.create(:cinstance)
-      @cinstance.destroy
-    end
-
-    should 'have #to_xml working' do
-      assert @cinstance.to_xml
-    end
-  end
-
-  context 'on creation' do
-    setup do
-      plan = FactoryBot.create(:application_plan, :setup_fee => 42.42, :trial_period_days => 3)
-      Timecop.freeze(Time.zone.local(1942,1,1,15,20))
-      @cinstance = Cinstance.create(:plan => plan)
-    end
-
-    should 'set setup_fee and trial from plan' do
-      assert_equal Time.zone.local(1942,1,4,15,20), @cinstance.trial_period_expires_at
-      assert_equal 42.42, @cinstance.setup_fee
-    end
-
-    # TODO: DRY with context
-    should 'be in live state' do
-      cinstance = Cinstance.new(:plan => FactoryBot.create(:application_plan),
-                                :user_account => FactoryBot.create(:buyer_account))
-      cinstance.save!
-
-      assert_equal 'live', cinstance.state
-    end
-
-    # TODO: DRY with context
-    should 'be created in pending state if service requires signup approval' do
-      service = FactoryBot.create(:service)
-      plan = FactoryBot.create(:application_plan, :issuer => service, :approval_required => true)
-
-      cinstance = Cinstance.new(:plan => plan, :user_account => FactoryBot.create(:buyer_account))
-      cinstance.save!
-
-      assert cinstance.pending?
-    end
-
+  test 'deleted cinstance have #to_xml working' do
+    @cinstance = FactoryBot.create(:cinstance)
+    @cinstance.destroy
+    assert @cinstance.to_xml
   end
 
   test "delete_all bought_cinstances of a provider" do
@@ -205,10 +54,10 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test 'Cinstance.live returns deprecated cinstances' do
-    plan = FactoryBot.create(:application_plan, :cancellation_period => 1.month)
+    plan = FactoryBot.create(:application_plan, cancellation_period: 1.month)
 
     Timecop.travel(1.year.ago)
-    cinstance = FactoryBot.create(:cinstance, :plan => plan)
+    cinstance = FactoryBot.create(:cinstance, plan: plan)
 
     Timecop.return
     cinstance.deprecate!
@@ -238,8 +87,8 @@ class CinstanceTest < ActiveSupport::TestCase
 
   test '.active_since' do
     cinstances = FactoryBot.create_list(:cinstance, 2)
-    cinstances.first.update_attribute(:first_daily_traffic_at, 1.year.ago)
-    cinstances.last.update_attribute(:first_daily_traffic_at, 1.day.ago)
+    cinstances.first.update(first_daily_traffic_at: 1.year.ago)
+    cinstances.last.update(first_daily_traffic_at: 1.day.ago)
     assert_equal [cinstances.last.id], Cinstance.active_since(1.month.ago).pluck(:id)
   end
 
@@ -259,8 +108,8 @@ class CinstanceTest < ActiveSupport::TestCase
     buyer_account_one = FactoryBot.create(:buyer_account)
     buyer_account_two = FactoryBot.create(:buyer_account)
 
-    cinstance_one = FactoryBot.create(:cinstance, :user_account => buyer_account_one)
-    cinstance_two = FactoryBot.create(:cinstance, :user_account => buyer_account_two)
+    cinstance_one = FactoryBot.create(:cinstance, user_account: buyer_account_one)
+    cinstance_two = FactoryBot.create(:cinstance, user_account: buyer_account_two)
 
     assert_contains Cinstance.bought_by(buyer_account_one), cinstance_one
     assert_does_not_contain Cinstance.bought_by(buyer_account_one), cinstance_two
@@ -268,14 +117,14 @@ class CinstanceTest < ActiveSupport::TestCase
 
   test 'Cinstance.by_state(:pending) returns only pending cinstances' do
     service = FactoryBot.create(:service)
-    plan    = FactoryBot.create(:application_plan, :issuer => service, :approval_required => true)
+    plan = FactoryBot.create(:application_plan, issuer: service, approval_required: true)
 
-    pending_cinstance = FactoryBot.create(:cinstance, :plan => plan)
+    pending_cinstance = create_pending_cinstance
 
-    destroyed_pending_cinstance = FactoryBot.create(:cinstance, :plan => plan)
+    destroyed_pending_cinstance = FactoryBot.create(:cinstance, plan: plan)
     Timecop.freeze(1.hour.ago) { destroyed_pending_cinstance.destroy }
 
-    live_cinstance    = FactoryBot.create(:cinstance)
+    live_cinstance = FactoryBot.create(:cinstance)
 
     assert_contains         Cinstance.by_state(:pending), pending_cinstance
     assert_does_not_contain Cinstance.by_state(:pending), live_cinstance
@@ -283,11 +132,8 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test 'Cinstance.by_state(:live) returns only live cinstances' do
-    service = FactoryBot.create(:service)
-    plan    = FactoryBot.create(:application_plan, :issuer => service, :approval_required => true)
-
-    live_cinstance    = FactoryBot.create(:cinstance)
-    pending_cinstance = FactoryBot.create(:cinstance, :plan => plan)
+    live_cinstance = FactoryBot.create(:cinstance)
+    pending_cinstance = create_pending_cinstance
 
     destroyed_live_cinstance = FactoryBot.create(:cinstance)
     Timecop.freeze(1.hour.ago) { destroyed_live_cinstance.destroy }
@@ -298,7 +144,7 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test 'by_active_since returns cinstances based on first_daily_traffic_at' do
-    days_to_time_format = ->(x){ x.days.ago.to_time.strftime("%Y-%m-%d") }
+    days_to_time_format = ->(x) { x.days.ago.to_time.strftime("%Y-%m-%d") }
 
     app1 = FactoryBot.create(:cinstance, first_daily_traffic_at: 3.days.ago.to_time)
     app2 = FactoryBot.create(:cinstance, first_daily_traffic_at: 1.day.ago.to_time)
@@ -311,11 +157,11 @@ class CinstanceTest < ActiveSupport::TestCase
   test 'there can be only one cinstance per plan and user_account if validate_plan_is_unique!' do
     plan = FactoryBot.create(:application_plan)
     buyer_account = FactoryBot.create(:buyer_account)
+    buyer_account.buy!(plan)
 
-    cinstance_one = buyer_account.buy!(plan)
     cinstance_two = buyer_account.buy(plan) # no bang!
     cinstance_two.validate_plan_is_unique!
-    assert !cinstance_two.valid?
+    assert_not cinstance_two.valid?
   end
 
   test 'there can be more cinstances per plan if they have different user_accounts' do
@@ -323,7 +169,7 @@ class CinstanceTest < ActiveSupport::TestCase
     buyer_account_one = FactoryBot.create(:buyer_account)
     buyer_account_two = FactoryBot.create(:buyer_account)
 
-    cinstance_one = buyer_account_one.buy!(plan)
+    buyer_account_one.buy!(plan)
     cinstance_two = buyer_account_two.buy(plan) # no bang!
 
     assert cinstance_two.valid?
@@ -342,40 +188,39 @@ class CinstanceTest < ActiveSupport::TestCase
 
   test 'Cinstance.find_by_user_key finds cinstance by valid user key' do
     cinstance = FactoryBot.create(:cinstance)
-    assert_equal cinstance, Cinstance.find_by_user_key(cinstance.user_key)
+    assert_equal cinstance, Cinstance.find_by(user_key: cinstance.user_key)
   end
 
   test 'Cinstance.find_by_user_key returns nil on nil key' do
-    cinstance = FactoryBot.create(:cinstance) # puts something in the db to avoid false positives.
-    assert_nil Cinstance.find_by_user_key(nil)
+    FactoryBot.create(:cinstance) # puts something in the db to avoid false positives.
+    assert_nil Cinstance.find_by(user_key: nil)
   end
 
   test 'Cinstance.find_by_user_key returns nil on invalid key' do
-    cinstance = FactoryBot.create(:cinstance)
-    assert_nil Cinstance.find_by_user_key('bogus-key')
+    FactoryBot.create(:cinstance)
+    assert_nil Cinstance.find_by(user_key: 'bogus-key')
   end
 
   test 'Cinstance.find_by_user_key! finds cinstance by valid user key' do
     cinstance = FactoryBot.create(:cinstance)
-    assert_equal cinstance, Cinstance.find_by_user_key!(cinstance.user_key)
+    assert_equal cinstance, Cinstance.find_by!(user_key: cinstance.user_key)
   end
 
   test 'Cinstance.find_by_user_key! raises an exception on nil key' do
-    cinstance = FactoryBot.create(:cinstance) # puts something in the db to avoid false positives.
+    FactoryBot.create(:cinstance) # puts something in the db to avoid false positives.
 
     assert_raise ActiveRecord::RecordNotFound do
-      Cinstance.find_by_user_key!(nil)
+      Cinstance.find_by!(user_key: nil)
     end
   end
 
   test 'Cinstance.find_by_user_key! raises an exception on invalid key' do
-    cinstance = FactoryBot.create(:cinstance)
+    FactoryBot.create(:cinstance)
 
     assert_raise ActiveRecord::RecordNotFound do
-      Cinstance.find_by_user_key!('bogus-key')
+      Cinstance.find_by!(user_key: 'bogus-key')
     end
   end
-
 
   test 'Cinstance.latest returns latest five cinstances' do
     plan = FactoryBot.create(:application_plan)
@@ -385,53 +230,13 @@ class CinstanceTest < ActiveSupport::TestCase
 
     6.times do
       Timecop.freeze(1.day.from_now)
-      cinstances << FactoryBot.create(:cinstance, :plan => plan)
+      cinstances << FactoryBot.create(:cinstance, plan: plan)
     end
 
     Timecop.return
 
     assert_equal([cinstances[5], cinstances[4], cinstances[3], cinstances[2], cinstances[1]],
                  plan.cinstances.latest)
-  end
-
-  class SuspendTest < ActiveSupport::TestCase
-    include ActiveJob::TestHelper
-
-    setup do
-      @cinstance = FactoryBot.create(:cinstance)
-    end
-
-    test 'transition from live to suspended state' do
-      @cinstance.suspend!
-
-      assert @cinstance.suspended?
-    end
-
-    test 'message the provider' do
-      old_mgs_count = Message.count
-
-      @cinstance.suspend!
-
-      assert old_mgs_count +1 == Message.count
-      #TODO: write some message assertion helper?
-      msg = Message.last
-      assert msg.sender == @cinstance.provider_account
-      assert msg.subject =~ /has been suspended/
-    end
-
-    test 'email the buyer if configured so' do
-      FactoryBot.create(:mail_dispatch_rule,
-              :system_operation => SystemOperation.for('app_suspended'),
-              :account => @cinstance.provider_account)
-
-      perform_enqueued_jobs(only: ActionMailer::DeliveryJob) { @cinstance.suspend! }
-
-      #TODO: write some email assertion helper?
-      assert mail = ActionMailer::Base.deliveries.last, 'missing email'
-      assert mail.bcc.include? @cinstance.user_account.admins.first.email
-      assert_match /has been suspended/, mail.subject
-      assert_match /has suspended/, mail.body.to_s
-    end
   end
 
   test 'Cinstance#resume! transitions from suspended to live state' do
@@ -444,7 +249,7 @@ class CinstanceTest < ActiveSupport::TestCase
 
   test 'Cinstance#live? returns false when cinstance is pending' do
     cinstance = create_pending_cinstance
-    assert !cinstance.live?
+    assert_not cinstance.live?
   end
 
   test 'Cinstance#accept! transitions from pending to live state' do
@@ -499,9 +304,8 @@ class CinstanceTest < ActiveSupport::TestCase
   test 'Cinstance.notify_about_expired_trial_periods does not send anything if plan is free' do
     Timecop.travel(2009, 11, 4) do
       provider_account = FactoryBot.create(:provider_account)
-      plan = FactoryBot.create(:application_plan, :issuer => provider_account.first_service!,
-                     :trial_period_days => 30, :cost_per_month => 0)
-      cinstance = FactoryBot.create(:cinstance, :plan => plan)
+      plan = FactoryBot.create(:application_plan, issuer: provider_account.first_service!, trial_period_days: 30, cost_per_month: 0)
+      FactoryBot.create(:cinstance, plan: plan)
     end
 
     Timecop.travel(2009, 11, 24) do
@@ -511,8 +315,8 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test 'Cinstance generates user_key and provider_public_key when created' do
-    cinstance = Cinstance.new(:plan => FactoryBot.create(:application_plan),
-                              :user_account => FactoryBot.create(:buyer_account))
+    cinstance = Cinstance.new(plan: FactoryBot.create(:application_plan),
+                              user_account: FactoryBot.create(:buyer_account))
     cinstance.save!
 
     assert_not_nil cinstance.user_key
@@ -529,12 +333,12 @@ class CinstanceTest < ActiveSupport::TestCase
 
   test 'user_key has to be unique per provider account' do
     provider_account = FactoryBot.create(:provider_account)
-    plan = FactoryBot.create(:application_plan, :issuer => provider_account.first_service!)
+    plan = FactoryBot.create(:application_plan, issuer: provider_account.first_service!)
 
-    cinstance_one = FactoryBot.create(:cinstance, :plan => plan, :user_key => 'foo')
-    cinstance_two = FactoryBot.build(:cinstance, :plan => plan, :user_key => 'foo')
+    FactoryBot.create(:cinstance, plan: plan, user_key: 'foo')
+    cinstance_two = FactoryBot.build(:cinstance, plan: plan, user_key: 'foo')
 
-    assert !cinstance_two.valid?
+    assert_not cinstance_two.valid?
     assert_match /has already been taken/, cinstance_two.errors[:user_key].to_s
 
     cinstance_two.user_key = 'bar'
@@ -545,105 +349,96 @@ class CinstanceTest < ActiveSupport::TestCase
     Logic::RollingUpdates.stubs(enabled?: true)
 
     provider = FactoryBot.create(:provider_account)
-    plan_1   = FactoryBot.create(:application_plan,
-                issuer: FactoryBot.create(:service, account: provider))
-    plan_2   = FactoryBot.create(:application_plan,
-                issuer: FactoryBot.create(:service, account: provider))
+    plan1 = FactoryBot.create(:application_plan, issuer: FactoryBot.create(:service, account: provider))
+    plan2 = FactoryBot.create(:application_plan, issuer: FactoryBot.create(:service, account: provider))
 
     Rails.configuration.three_scale.rolling_updates.stubs(features: {duplicate_user_key: []})
-    assert FactoryBot.create(:cinstance, plan: plan_1, user_key: 'foo')
-    refute FactoryBot.build(:cinstance, plan: plan_2, user_key: 'foo').valid?
+    assert FactoryBot.create(:cinstance, plan: plan1, user_key: 'foo')
+    assert_not FactoryBot.build(:cinstance, plan: plan2, user_key: 'foo').valid?
 
     Rails.configuration.three_scale.rolling_updates.stubs(features: {duplicate_user_key: [provider.id]})
-    assert FactoryBot.build(:cinstance, plan: plan_2, user_key: 'foo').valid?
+    assert FactoryBot.build(:cinstance, plan: plan2, user_key: 'foo').valid?
   end
 
   test 'user_key does not have to be unique if provider accounts are different' do
     provider_account_one = FactoryBot.create(:provider_account)
-    plan_one = FactoryBot.create(:application_plan, :issuer => provider_account_one.first_service!)
+    plan_one = FactoryBot.create(:application_plan, issuer: provider_account_one.first_service!)
 
     provider_account_two = FactoryBot.create(:provider_account)
-    plan_two = FactoryBot.create(:application_plan, :issuer => provider_account_two.first_service!)
+    plan_two = FactoryBot.create(:application_plan, issuer: provider_account_two.first_service!)
 
-    cinstance_one = FactoryBot.create(:cinstance, :plan => plan_one, :user_key => 'foo')
-    cinstance_two = FactoryBot.build(:cinstance, :plan => plan_two, :user_key => 'foo')
+    FactoryBot.create(:cinstance, plan: plan_one, user_key: 'foo')
+    cinstance_two = FactoryBot.build(:cinstance, plan: plan_two, user_key: 'foo')
 
     assert cinstance_two.valid?
   end
 
   test '#display_name returns #name if present' do
-    cinstance = Cinstance.new(:name => 'Cool stuff')
+    cinstance = Cinstance.new(name: 'Cool stuff')
 
     assert_equal 'Cool stuff', cinstance.display_name
   end
 
   test '#display_name returns automatic name containing plan name if #name is blank' do
-    plan = FactoryBot.create(:application_plan, :name => 'Insane')
-    cinstance = Cinstance.new(:plan => plan)
+    plan = FactoryBot.create(:application_plan, name: 'Insane')
+    cinstance = Cinstance.new(plan: plan)
 
     assert_equal 'Application on plan Insane', cinstance.display_name
   end
 
-  context 'customize_plan! method' do
-    should 'do nothing if plan fails to customize' do
-      cinstance = FactoryBot.create(:cinstance)
-      app_plan = cinstance.plan
+  test 'customize_plan! method do nothing if plan fails to customize' do
+    cinstance = FactoryBot.create(:cinstance)
+    app_plan = cinstance.plan
 
-      app_plan.stubs(:customize).returns(ApplicationPlan.new)
+    app_plan.stubs(:customize).returns(ApplicationPlan.new)
 
-      cinstance.customize_plan!
+    cinstance.customize_plan!
 
-      assert_equal app_plan, cinstance.plan
-      assert !cinstance.plan.customized?
-    end
-
-    should 'change the plan to a customized one if on stock plan' do
-      cinstance = FactoryBot.create(:cinstance)
-      plan = cinstance.plan
-      service = cinstance.service
-
-      assert_difference 'service.plans.count', 1 do
-        cinstance.customize_plan!
-      end
-
-      assert_not_equal plan, cinstance.plan
-      assert cinstance.plan.customized?
-    end
-
-    should 'not change anything if already on custom plan' do
-      cinstance = FactoryBot.create(:cinstance)
-      cinstance.customize_plan!
-      plan = cinstance.plan
-      service = plan.service
-
-      assert_no_difference 'service.plans.count' do
-        cinstance.customize_plan!
-      end
-
-      assert_equal plan, cinstance.plan
-    end
+    assert_equal app_plan, cinstance.plan
+    assert_not cinstance.plan.customized?
   end
 
-  context 'decustomize_plan! method' do
-    should 'change the plan back to the stock one' do
-      cinstance = FactoryBot.create(:cinstance)
-      stock_plan = cinstance.plan
-      service = stock_plan.service
+  test 'change the plan to a customized one if on stock plan' do
+    cinstance = FactoryBot.create(:cinstance)
+    plan = cinstance.plan
 
+    assert_difference 'plan.service.plans.count', 1 do
       cinstance.customize_plan!
-      custom_plan = cinstance.plan
-
-      assert_difference 'service.plans.count', -1 do
-        assert_no_difference 'Cinstance.count' do
-          cinstance.decustomize_plan!
-          cinstance.reload
-        end
-      end
-
-      assert_not_equal custom_plan, cinstance.plan
-      assert_equal stock_plan, cinstance.plan
-      assert !cinstance.plan.customized?
     end
+
+    assert_not_equal plan, cinstance.plan
+    assert cinstance.plan.customized?
+  end
+
+  test 'not change anything if already on custom plan' do
+    cinstance = FactoryBot.create(:cinstance)
+    cinstance.customize_plan!
+    plan = cinstance.plan
+
+    assert_no_difference 'plan.service.plans.count' do
+      cinstance.customize_plan!
+    end
+
+    assert_equal plan, cinstance.plan
+  end
+
+  test 'decustomize_plan! method change the plan back to the stock one' do
+    cinstance = FactoryBot.create(:cinstance)
+    stock_plan = cinstance.plan
+
+    cinstance.customize_plan!
+    custom_plan = cinstance.plan
+
+    assert_difference 'stock_plan.service.plans.count', -1 do
+      assert_no_difference 'Cinstance.count' do
+        cinstance.decustomize_plan!
+        cinstance.reload
+      end
+    end
+
+    assert_not_equal custom_plan, cinstance.plan
+    assert_equal stock_plan, cinstance.plan
+    assert_not cinstance.plan.customized?
   end
 
   test "validate cinstance's service and cinstance's plan's service are the same" do
@@ -652,7 +447,7 @@ class CinstanceTest < ActiveSupport::TestCase
     other_service = FactoryBot.create(:service, account: cinstance.provider_account)
     other_plan_diff_service = FactoryBot.create(:application_plan, service: other_service, name: "other plan of different service")
     cinstance.plan = other_plan_diff_service
-    refute cinstance.valid?
+    assert_not cinstance.valid?
     assert_includes cinstance.errors['plan'], 'not allowed in this context'
 
     other_plan_same_service = FactoryBot.build_stubbed(:application_plan, service: cinstance.service, name: "other plan of same service")
@@ -660,169 +455,13 @@ class CinstanceTest < ActiveSupport::TestCase
     assert cinstance.valid?
   end
 
-  class ChangePlanTest < ActiveSupport::TestCase
-    setup do
-      service = FactoryBot.create(:service)
-      stock = FactoryBot.create(:application_plan, :issuer => service)
-      @another_plan = FactoryBot.create(:application_plan, :issuer => service,
-                              :name => "another plan")
-
-      @cinstance = FactoryBot.create(:cinstance, :plan => stock)
-      @cinstance.customize_plan!
-      @custom = Plan.find @cinstance.plan.id
-    end
-
-    test 'delete custom plan' do
-      @cinstance.change_plan! @another_plan
-      assert @cinstance.reload.plan_id == @another_plan.id
-
-      assert_raises(ActiveRecord::RecordNotFound) { @custom.reload }
-    end
-
-    test 'cannot change to a plan of different service' do
-      other_service = FactoryBot.create(:service, account: @cinstance.provider_account)
-      other_plan = FactoryBot.create(:application_plan, service: other_service, name: "other plan")
-      refute @cinstance.change_plan other_plan
-      assert_includes @cinstance.errors['plan'], 'not allowed in this context'
-    end
-
-    test 'does not change plan to no plan at all' do
-      previous_plan = @cinstance.plan
-      refute @cinstance.change_plan nil
-      assert_empty @cinstance.errors['plan']
-      assert_equal previous_plan, @cinstance.reload.plan
-    end
+  test 'fields and extra fields be' do
+    assert FieldsDefinition.targets.include?("Cinstance")
   end
-
-  class WebHooksTest < ActiveSupport::TestCase
-    include WebHookTestHelpers
-
-    subject { @cinstance || FactoryBot.create(:cinstance) }
-
-    setup do
-      @buyer = FactoryBot.create :buyer_account
-      @provider = @buyer.provider_account
-      @user = @buyer.admins.first
-      @app_plan = FactoryBot.create(:application_plan,
-                          :issuer => @provider.services.first!)
-    end
-
-    should 'be pushed if the cinstance is created by user' do
-      User.current = @user
-      cinstance = Cinstance.new :plan => @app_plan, :user_account => @buyer
-
-      fires_webhook(cinstance)
-
-      cinstance.save!
-    end
-
-    should 'not be pushed if the cinstance was not created by user' do
-      User.current = nil
-      cinstance = Cinstance.new :plan => @app_plan, :user_account => @buyer
-
-      fires_webhook.never
-      cinstance.save!
-    end
-
-    should 'be pushed if the cinstance is updated by user' do
-      cinstance = Cinstance.create! :plan => @app_plan, :user_account => @buyer
-
-      User.current = @user
-      fires_webhook(cinstance)
-
-      cinstance.update_attribute :name, "changed"
-    end
-
-    should 'not be pushed if the cinstance is not updated by user' do
-      User.current = nil
-      cinstance = Cinstance.create! :plan => @app_plan, :user_account => @buyer
-
-      fires_webhook.never
-      cinstance.update_attribute :name, "changed"
-    end
-
-    should 'be pushed if user_key is updated by user' do
-      cinstance = Cinstance.create! :plan => @app_plan, :user_account => @buyer
-
-      User.current = @user
-      fires_webhook(cinstance, 'user_key_updated')
-      fires_webhook(cinstance, 'key_updated')
-      cinstance.change_user_key!
-
-    end
-
-    should 'not be pushed if user_key is not updated by user' do
-      User.current = nil
-      cinstance = Cinstance.create! :plan => @app_plan, :user_account => @buyer
-
-      fires_webhook.never
-      cinstance.change_user_key!
-    end
-
-    should 'be pushed if plan is changed by user' do
-      another_plan = FactoryBot.create(:application_plan,
-                             :issuer => @buyer.provider_account.services.first,
-                             :name => "another plan")
-      @cinstance = Cinstance.create! :plan => @app_plan, :user_account => @buyer
-      User.current = @user
-
-      # this is because of BillingObserver#bill_variable_for_plan_changed is saving the old contract `paid_until`
-      fires_webhook(@cinstance)
-      fires_webhook(@cinstance, 'plan_changed')
-
-      @cinstance.change_plan! another_plan
-    end
-
-    should 'not be pushed if plan is not changed by user' do
-      another_plan = FactoryBot.create(:application_plan,
-                             :issuer => @buyer.provider_account.services.first,
-                             :name => "another plan")
-      @cinstance = Cinstance.create! :plan => @app_plan, :user_account => @buyer
-      User.current = nil
-
-      fires_webhook.never
-      @cinstance.change_plan! another_plan
-    end
-
-    context 'suspend event' do
-      setup do
-        @cinstance = FactoryBot.create(:cinstance, :plan => @app_plan,
-                             :user_account => @buyer)
-      end
-
-      should 'not be pushed if not done by user' do
-        User.current = nil
-
-        fires_webhook.never
-
-        @cinstance.suspend!
-      end
-
-      should 'be pushed if done by user' do
-        provider_admin = @buyer.provider_account.admins.first
-        User.current = provider_admin
-
-        fires_webhook(@cinstance, "suspended")
-
-        @cinstance.suspend!
-      end
-
-    end # suspend event
-
-  end # webhooks
-
-  context 'fields and extra fields' do
-
-    should 'be' do
-      assert FieldsDefinition.targets.include?("Cinstance")
-    end
-
-  end # fields and extra fields
 
   test '.model_name.human is application' do
-    assert Cinstance.model_name.human == "Application"
+    assert_equal "Application", Cinstance.model_name.human
   end
-
 
   test 'user_key should validate user key' do
     cinstance = FactoryBot.create(:cinstance)
@@ -831,7 +470,7 @@ class CinstanceTest < ActiveSupport::TestCase
 
     cinstance.user_key = "you-&$#!!!"
 
-    assert !cinstance.valid?
+    assert_not cinstance.valid?
     assert cinstance.errors[:user_key].present?
 
     cinstance.user_key = "you-awesome-man"
@@ -841,73 +480,13 @@ class CinstanceTest < ActiveSupport::TestCase
     assert cinstance.valid?
 
     cinstance.user_key << "k"
-    assert !cinstance.valid?
+    assert_not cinstance.valid?
     assert cinstance.errors[:user_key].present?
-  end
-
-  class KeysTest < ActiveSupport::TestCase
-
-    test 'creating keys in backend is fired only when app is created' do
-      app = FactoryBot.build(:cinstance)
-
-      app.expects(:create_key_after_create?).returns(true)
-
-      creation = sequence('creation')
-
-      app.expects(:update_backend_application).in_sequence(creation)
-      ThreeScale::Core::ApplicationKey.expects(:save).in_sequence(creation)
-
-      BackendClient::ToggleBackend.enable_all!
-
-      assert app.save!
-      assert app.application_keys.presence
-
-      app.expects(:create_key_after_create?).never
-      app.expects(:create_first_key).never
-
-      app.destroy
-    end
-  end
-
-  class ApplicationUpdatedSavedEventTest < ActiveSupport::TestCase
-    disable_transactional_fixtures!
-
-    def setup
-      @cinstance = FactoryBot.create(:cinstance)
-    end
-
-    attr_reader :cinstance
-
-    test 'ApplicationUpdatedEvent is created after an update' do
-      assert_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
-        cinstance.update!({description: 'example description to update cinstance'})
-      end
-    end
-
-    test 'ApplicationUpdatedEvent is not created after an update if the only changes are for first_traffic_at or first_daily_traffic_at' do
-      assert_no_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
-        cinstance.update_attribute(:first_traffic_at, 2.days.ago.round)
-      end
-
-      assert_no_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
-        cinstance.update_attribute(:first_daily_traffic_at, 2.days.ago.round)
-      end
-
-      assert_no_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
-        cinstance.update!({first_traffic_at: 1.day.ago.round, first_daily_traffic_at: 1.day.ago.round}, without_protection: true)
-      end
-    end
-
-    test 'ApplicationUpdatedEvent is created after an update when there are updated traffic and non-traffic attributes' do
-      assert_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
-        cinstance.update!({name: 'mycinstance', first_traffic_at: 1.day.ago.round, first_daily_traffic_at: 1.day.ago.round}, without_protection: true)
-      end
-    end
   end
 
   test 'validate_plan_is_unique' do
     cinstance = Cinstance.new
-    refute cinstance.validate_plan_is_unique?
+    assert_not cinstance.validate_plan_is_unique?
     cinstance.expects(:plan_is_unique).never
     cinstance.save
 
@@ -918,10 +497,10 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   def test_available_application_plans_only_include_stock_plans_other_than_own
-    application = subject
-    other_plan = FactoryBot.create(:application_plan, :issuer => application.service)
-    other_application = FactoryBot.create(:cinstance, :user_account => application.user_account,
-                                            :plan => other_plan)
+    buyer = FactoryBot.create(:buyer_account)
+    application = FactoryBot.create(:cinstance, user_account: buyer)
+    other_plan = FactoryBot.create(:application_plan, issuer: application.service)
+    other_application = FactoryBot.create(:cinstance, user_account: buyer, plan: other_plan)
     other_application.customize_plan!
 
     assert_same_elements [other_plan], application.available_application_plans.to_a
@@ -941,15 +520,6 @@ class CinstanceTest < ActiveSupport::TestCase
     assert_equal 'Service', deleted_object_entry.owner_type
   end
 
-  private
-
-  #TODO: take this method to another place, and make it build cinstances in a proper way
-  def create_pending_cinstance
-    cinstance = FactoryBot.create(:cinstance)
-    cinstance.update_attribute(:state, 'pending')
-    cinstance
-  end
-
   test 'application_id uniqueness' do
     provider = FactoryBot.create(:provider_account)
     service_one = provider.first_service!
@@ -958,12 +528,12 @@ class CinstanceTest < ActiveSupport::TestCase
     plan_two = FactoryBot.create(:application_plan, issuer: service_two)
 
     app_one = FactoryBot.create(:cinstance, plan: plan_one, application_id: 'app1')
-    app_two = FactoryBot.create(:cinstance, plan: plan_two, application_id: 'app2')
+    FactoryBot.create(:cinstance, plan: plan_two, application_id: 'app2')
 
     dup = app_one.dup
     dup.user_key = 'fobar'
 
-    refute dup.save
+    assert_not dup.save
 
     assert dup.errors[:application_id].presence
   end
@@ -971,7 +541,7 @@ class CinstanceTest < ActiveSupport::TestCase
   test 'buyer_alerts_enabled??' do
     app = Cinstance.new
 
-    refute app.buyer_alerts_enabled?
+    assert_not app.buyer_alerts_enabled?
 
     app.service = Service.new(notification_settings: { web_buyer: [100] })
 
@@ -996,10 +566,10 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test '.by_plan_system_name' do
-    id_cinstance_with_pro_plan               = FactoryBot.create(:application_contract, plan: FactoryBot.create(:application_plan, system_name: 'pro')).id
-    id_cinstance_with_enterprise_plan        = FactoryBot.create(:application_contract, plan: FactoryBot.create(:application_plan, system_name: 'enterprise')).id
-    id_cinstance_with_another_plan           = FactoryBot.create(:application_contract, plan: FactoryBot.create(:application_plan, system_name: 'system_name_1')).id
-    id_service_contract_with_enterprise_plan = FactoryBot.create(:service_contract,     plan: FactoryBot.create(:service_plan, system_name: 'enterprise')).id
+    id_cinstance_with_pro_plan = FactoryBot.create(:application_contract, plan: FactoryBot.create(:application_plan, system_name: 'pro')).id
+    id_cinstance_with_enterprise_plan = FactoryBot.create(:application_contract, plan: FactoryBot.create(:application_plan, system_name: 'enterprise')).id
+    id_cinstance_with_another_plan = FactoryBot.create(:application_contract, plan: FactoryBot.create(:application_plan, system_name: 'system_name_1')).id
+    id_service_contract_with_enterprise_plan = FactoryBot.create(:service_contract, plan: FactoryBot.create(:service_plan, system_name: 'enterprise')).id
 
     ids_cinstances_enterprise = Cinstance.by_plan_system_name('enterprise').pluck(:id)
     assert_includes     ids_cinstances_enterprise, id_cinstance_with_enterprise_plan
@@ -1038,15 +608,374 @@ class CinstanceTest < ActiveSupport::TestCase
     cinstance = FactoryBot.build(:cinstance)
 
     cinstance.application_id = ''
-    refute cinstance.valid?
+    assert_not cinstance.valid?
 
     cinstance.application_id = 'a' * 3
-    refute cinstance.valid?
+    assert_not cinstance.valid?
 
     cinstance.application_id = 'a' * 4
     assert cinstance.valid?
 
     cinstance.application_id = 'a' * 255
     assert cinstance.valid?
+  end
+end
+
+class OnCreationTest < ActiveSupport::TestCase
+  def setup
+    plan = FactoryBot.create(:application_plan, setup_fee: 42.42, trial_period_days: 3)
+    Timecop.freeze(Time.zone.local(1942,1,1,15,20))
+    @cinstance = Cinstance.create(plan: plan)
+  end
+
+  test 'set setup_fee and trial from plan' do
+    assert_equal Time.zone.local(1942,1,4,15,20), @cinstance.trial_period_expires_at
+    assert_equal 42.42, @cinstance.setup_fee
+  end
+
+  # TODO: DRY
+  test 'be in live state' do
+    cinstance = Cinstance.new(plan: FactoryBot.create(:application_plan), user_account: FactoryBot.create(:buyer_account))
+    cinstance.save!
+
+    assert_equal 'live', cinstance.state
+  end
+
+  # TODO: DRY
+  test 'be created in pending state if service requires signup approval' do
+    service = FactoryBot.create(:service)
+    plan = FactoryBot.create(:application_plan, issuer: service, approval_required: true)
+
+    cinstance = Cinstance.new(plan: plan, user_account: FactoryBot.create(:buyer_account))
+    cinstance.save!
+
+    assert cinstance.pending?
+  end
+end
+
+class ValidationsTest < ActiveSupport::TestCase
+  subject { FactoryBot.create(:cinstance) }
+
+  should validate_presence_of(:plan)
+  should validate_acceptance_of(:conditions).with_message(/you should agree/i)
+
+  def setup
+    @provider = FactoryBot.create :provider_account
+    @service = FactoryBot.create :service, account: @provider
+    plan = FactoryBot.create :application_plan, issuer: @service
+    @cinstance = FactoryBot.build :cinstance, plan: plan
+  end
+
+  class NameValidationTest < ValidationsTest
+    test 'not require name as default' do
+      assert @cinstance.valid?
+    end
+
+    test 'provider has multi apps enabled: not require name' do
+      @provider.settings.allow_multiple_applications!
+      @provider.settings.show_multiple_applications!
+      assert @cinstance.valid?
+    end
+
+    test 'provider has multi apps enabled: require name if a human interaction is happening' do
+      @provider.settings.allow_multiple_applications!
+      @provider.settings.show_multiple_applications!
+      @cinstance.validate_human_edition!
+
+      assert_not @cinstance.valid?
+      assert @cinstance.errors[:name].presence
+    end
+  end
+
+  class DescriptionValidationTest < ValidationsTest
+    test 'not require description as default' do
+      assert @cinstance.valid?
+    end
+
+    test 'provider has multi apps enabled: not require description' do
+      @provider.settings.allow_multiple_applications!
+      @provider.settings.show_multiple_applications!
+      assert @cinstance.valid?
+    end
+
+    test 'provider has multi apps enabled: require description if a human interaction is happening' do
+      @provider.settings.allow_multiple_applications!
+      @provider.settings.show_multiple_applications!
+      @cinstance.validate_human_edition!
+
+      assert_not @cinstance.valid?
+      assert @cinstance.errors[:description].presence
+    end
+
+    test 'service requires intentions: not require description' do
+      @service.update(intentions_required: true)
+      assert @cinstance.valid?
+    end
+
+    test 'service requires intentions: require description if a human interaction is happening' do
+      @service.update(intentions_required: true)
+      @cinstance.validate_human_edition!
+
+      assert_not @cinstance.valid?
+      assert @cinstance.errors[:description].presence
+    end
+  end
+
+  class PlanClassValidation < ValidationsTest
+    test 'be valid with an application plan' do
+      app_plan = FactoryBot.create(:application_plan)
+      app_contract = Cinstance.new(plan: app_plan)
+
+      assert app_contract.valid?
+    end
+
+    test 'not be valid with a service plan' do
+      service_plan = FactoryBot.create(:service_plan)
+      assert_raises(ActiveRecord::AssociationTypeMismatch) do
+        Cinstance.new(plan: service_plan)
+      end
+    end
+
+    test 'not be valid with an account plan' do
+      account_plan = FactoryBot.create(:account_plan)
+      assert_raises(ActiveRecord::AssociationTypeMismatch) do
+        Cinstance.new(plan: account_plan)
+      end
+    end
+  end
+end
+
+class SuspendTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @cinstance = FactoryBot.create(:cinstance)
+  end
+
+  test 'transition from live to suspended state' do
+    @cinstance.suspend!
+
+    assert @cinstance.suspended?
+  end
+
+  test 'message the provider' do
+    old_mgs_count = Message.count
+
+    @cinstance.suspend!
+
+    assert_equal old_mgs_count+1, Message.count
+    #TODO: write some message assertion helper?
+    msg = Message.last
+    assert_equal msg.sender, @cinstance.provider_account
+    assert msg.subject.include? 'has been suspended'
+  end
+
+  test 'email the buyer if configured so' do
+    FactoryBot.create(:mail_dispatch_rule, system_operation: SystemOperation.for('app_suspended'), account: @cinstance.provider_account)
+
+    perform_enqueued_jobs(only: ActionMailer::DeliveryJob) { @cinstance.suspend! }
+
+    #TODO: write some email assertion helper?
+    assert mail = ActionMailer::Base.deliveries.last, 'missing email'
+    assert mail.bcc.include? @cinstance.user_account.admins.first.email
+    assert mail.subject.include? 'has been suspended'
+    assert mail.body.to_s.include? 'has suspended'
+  end
+end
+
+class ChangePlanTest < ActiveSupport::TestCase
+  setup do
+    service = FactoryBot.create(:service)
+    stock = FactoryBot.create(:application_plan, issuer: service)
+    @another_plan = FactoryBot.create(:application_plan, issuer: service, name: "another plan")
+
+    @cinstance = FactoryBot.create(:cinstance, plan: stock)
+    @cinstance.customize_plan!
+    @custom = Plan.find @cinstance.plan.id
+  end
+
+  test 'delete custom plan' do
+    @cinstance.change_plan! @another_plan
+    assert_equal @another_plan.id, @cinstance.reload.plan_id
+
+    assert_raises(ActiveRecord::RecordNotFound) { @custom.reload }
+  end
+
+  test 'cannot change to a plan of different service' do
+    other_service = FactoryBot.create(:service, account: @cinstance.provider_account)
+    other_plan = FactoryBot.create(:application_plan, service: other_service, name: "other plan")
+    assert_not @cinstance.change_plan other_plan
+    assert_includes @cinstance.errors['plan'], 'not allowed in this context'
+  end
+
+  test 'does not change plan to no plan at all' do
+    previous_plan = @cinstance.plan
+    assert_not @cinstance.change_plan nil
+    assert_empty @cinstance.errors['plan']
+    assert_equal previous_plan, @cinstance.reload.plan
+  end
+end
+
+class WebHooksTest < ActiveSupport::TestCase
+  include WebHookTestHelpers
+
+  subject { @cinstance || FactoryBot.create(:cinstance) }
+
+  setup do
+    @buyer = FactoryBot.create :buyer_account
+    @provider = @buyer.provider_account
+    @user = @buyer.admins.first
+    @app_plan = FactoryBot.create(:application_plan, issuer: @provider.services.first!)
+  end
+
+  test 'be pushed if the cinstance is created by user' do
+    User.current = @user
+    cinstance = Cinstance.new(plan: @app_plan, user_account: @buyer)
+
+    fires_webhook(cinstance)
+
+    cinstance.save!
+  end
+
+  test 'not be pushed if the cinstance was not created by user' do
+    User.current = nil
+    cinstance = Cinstance.new(plan: @app_plan, user_account: @buyer)
+
+    fires_webhook.never
+    cinstance.save!
+  end
+
+  test 'be pushed if the cinstance is updated by user' do
+    cinstance = Cinstance.create!(plan: @app_plan, user_account: @buyer)
+
+    User.current = @user
+    fires_webhook(cinstance)
+
+    cinstance.update(name: "changed")
+  end
+
+  test 'not be pushed if the cinstance is not updated by user' do
+    User.current = nil
+    cinstance = Cinstance.create!(plan: @app_plan, user_account: @buyer)
+
+    fires_webhook.never
+    cinstance.update(name: "changed")
+  end
+
+  test 'be pushed if user_key is updated by user' do
+    cinstance = Cinstance.create!(plan: @app_plan, user_account: @buyer)
+
+    User.current = @user
+    fires_webhook(cinstance, 'user_key_updated')
+    fires_webhook(cinstance, 'key_updated')
+    cinstance.change_user_key!
+
+  end
+
+  test 'not be pushed if user_key is not updated by user' do
+    User.current = nil
+    cinstance = Cinstance.create!(plan: @app_plan, user_account: @buyer)
+
+    fires_webhook.never
+    cinstance.change_user_key!
+  end
+
+  test 'be pushed if plan is changed by user' do
+    another_plan = FactoryBot.create(:application_plan, issuer: @buyer.provider_account.services.first, name: "another plan")
+    @cinstance = Cinstance.create!(plan: @app_plan, user_account: @buyer)
+    User.current = @user
+
+    # this is because of BillingObserver#bill_variable_for_plan_changed is saving the old contract `paid_until`
+    fires_webhook(@cinstance)
+    fires_webhook(@cinstance, 'plan_changed')
+
+    @cinstance.change_plan! another_plan
+  end
+
+  test 'not be pushed if plan is not changed by user' do
+    another_plan = FactoryBot.create(:application_plan, issuer: @buyer.provider_account.services.first, name: "another plan")
+    @cinstance = Cinstance.create!(plan: @app_plan, user_account: @buyer)
+    User.current = nil
+
+    fires_webhook.never
+    @cinstance.change_plan! another_plan
+  end
+
+  test 'suspend event not be pushed if not done by user' do
+    cinstance = FactoryBot.create(:cinstance, plan: @app_plan, user_account: @buyer)
+    User.current = nil
+
+    fires_webhook.never
+
+    cinstance.suspend!
+  end
+
+  test 'suspend event be pushed if done by user' do
+    cinstance = FactoryBot.create(:cinstance, plan: @app_plan, user_account: @buyer)
+    provider_admin = @buyer.provider_account.admins.first
+    User.current = provider_admin
+
+    fires_webhook(cinstance, "suspended")
+
+    cinstance.suspend!
+  end
+end
+
+class KeysTest < ActiveSupport::TestCase
+  test 'creating keys in backend is fired only when app is created' do
+    app = FactoryBot.build(:cinstance)
+
+    app.expects(:create_key_after_create?).returns(true)
+
+    creation = sequence('creation')
+
+    app.expects(:update_backend_application).in_sequence(creation)
+    ThreeScale::Core::ApplicationKey.expects(:save).in_sequence(creation)
+
+    BackendClient::ToggleBackend.enable_all!
+
+    assert app.save!
+    assert app.application_keys.presence
+
+    app.expects(:create_key_after_create?).never
+    app.expects(:create_first_key).never
+
+    app.destroy
+  end
+end
+
+class ApplicationUpdatedSavedEventTest < ActiveSupport::TestCase
+  disable_transactional_fixtures!
+
+  def setup
+    @cinstance = FactoryBot.create(:cinstance)
+  end
+
+  attr_reader :cinstance
+
+  test 'ApplicationUpdatedEvent is created after an update' do
+    assert_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
+      cinstance.update!({ description: 'example description to update cinstance' })
+    end
+  end
+
+  test 'ApplicationUpdatedEvent is not created after an update if the only changes are for first_traffic_at or first_daily_traffic_at' do
+    assert_no_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
+      cinstance.update(first_traffic_at: 2.days.ago.round)
+    end
+
+    assert_no_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
+      cinstance.update(first_daily_traffic_at: 2.days.ago.round)
+    end
+
+    assert_no_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
+      cinstance.update!({ first_traffic_at: 1.day.ago.round, first_daily_traffic_at: 1.day.ago.round }, without_protection: true)
+    end
+  end
+
+  test 'ApplicationUpdatedEvent is created after an update when there are updated traffic and non-traffic attributes' do
+    assert_difference(EventStore::Event.where(event_type: Applications::ApplicationUpdatedEvent).method(:count)) do
+      cinstance.update!({ name: 'mycinstance', first_traffic_at: 1.day.ago.round, first_daily_traffic_at: 1.day.ago.round }, without_protection: true)
+    end
   end
 end

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -114,12 +114,9 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test 'Cinstance.by_state(:pending) returns only pending cinstances' do
-    service = FactoryBot.create(:service)
-    plan = FactoryBot.create(:application_plan, issuer: service, approval_required: true)
-
     pending_cinstance = FactoryBot.create(:pending_application)
 
-    destroyed_pending_cinstance = FactoryBot.create(:cinstance, plan: plan)
+    destroyed_pending_cinstance = FactoryBot.create(:pending_application)
     Timecop.freeze(1.hour.ago) { destroyed_pending_cinstance.destroy }
 
     live_cinstance = FactoryBot.create(:cinstance)


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/unit/cinstance_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)