### PR TITLE
[params] Fixes master/service_discovery/auth_controller.rb

### DIFF
--- a/app/controllers/master/service_discovery/auth_controller.rb
+++ b/app/controllers/master/service_discovery/auth_controller.rb
@@ -11,7 +11,7 @@ class Master::ServiceDiscovery::AuthController < Master::BaseController
   protected
 
   def self_domain_url(self_domain)
-    options = params.permit(:code, :referrer, :state).merge(host: self_domain, controller: 'provider/admin/service_discovery/auth', action: :show)
+    options = params.permit(%i[code referrer state]).to_h.merge(host: self_domain, controller: 'provider/admin/service_discovery/auth', action: :show)
     url_for(options)
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it:**
Fixes usage of params in the auth controller
