### PR TITLE
Remove `context` and `should` from unit/account_test

### DIFF
--- a/test/unit/account/buyer_test.rb
+++ b/test/unit/account/buyer_test.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Account::BuyerTest < ActiveSupport::TestCase
-
   subject { @account || Account.new }
+
   should belong_to(:provider_account)
 
   should have_many(:contracts)
@@ -20,7 +22,7 @@ class Account::BuyerTest < ActiveSupport::TestCase
   test '#has_bought_cinstance?' do
     buyer = FactoryBot.create(:simple_buyer)
 
-    refute buyer.has_bought_cinstance?
+    assert_not buyer.has_bought_cinstance?
 
     FactoryBot.create(:cinstance, user_account: buyer)
     assert buyer.has_bought_cinstance?
@@ -37,138 +39,88 @@ class Account::BuyerTest < ActiveSupport::TestCase
     assert_match(/simple/, buyer.domain)
   end
 
-  context 'after created' do
-    #TODO: when the separation of accounts in Buyer, Provider and Master is done
-    # this test will make no sense, now is kind of paranoic
-    should 'have no services and no s3_prefix' do
-      @provider =  FactoryBot.create :provider_account
-      buyer = Account.new :org_name => "buyer", :provider_account => @provider
-      buyer.buyer = true
-      buyer.save!
+  # TODO: when the separation of accounts in Buyer, Provider and Master is done
+  # this test will make no sense, now is kind of paranoic
+  test 'after created should have no services and no s3_prefix' do
+    @provider = FactoryBot.create(:provider_account)
+    buyer = Account.new(org_name: "buyer", provider_account: @provider)
+    buyer.buyer = true
+    buyer.save!
 
-      assert buyer.buyer?
-      assert buyer.services.empty?
-      assert_nil buyer.s3_prefix
-    end
+    assert buyer.buyer?
+    assert buyer.services.empty?
+    assert_nil buyer.s3_prefix
   end
 
-  context "for buyer" do
-
+  class BuyerWithBoughtPlansTest < ActiveSupport::TestCase
     setup do
-      @provider =  FactoryBot.create(:provider_account)
-      @acc_plan = FactoryBot.create(:account_plan, :issuer => @provider)
-      @buyer = FactoryBot.create(:simple_buyer, :provider_account => @provider)
-      @acc_contract =  FactoryBot.create(:account_contract, :plan => @acc_plan, :user_account => @buyer)
+      @provider = FactoryBot.create(:provider_account)
+      @acc_plan = FactoryBot.create(:account_plan, issuer: @provider)
+      @buyer = FactoryBot.create(:simple_buyer, provider_account: @provider)
+      @acc_contract = FactoryBot.create(:account_contract, plan: @acc_plan, user_account: @buyer)
+
+      @provider.config.set!(:multiple_applications, true)
+      @provider.save!
+
+      services = FactoryBot.create_list(:service, 2, account: @provider)
+      @service_one, @service_two = services
+
+      @service_plans = services.map { |service| FactoryBot.create(:service_plan, issuer: service) }
+      @service_contracts = @service_plans.map { |plan| FactoryBot.create(:service_contract, plan: plan, user_account: @buyer) }
+
+      @application_plans = services.map { |service| FactoryBot.create_list(:application_plan, 2, issuer: service) }.flatten
+      @cinstances = @application_plans.map.with_index { |plan, i| FactoryBot.create(:cinstance, plan: plan, user_account: @buyer) }
+
+      @contracts = @service_contracts + @cinstances + [@acc_contract]
+      @plans = @service_plans + @application_plans + [@acc_plan]
     end
 
-    context 'with bought plans' do
-      setup do
-        @provider.config.set!(:multiple_applications, true)
-        @provider.save!
-
-        @service_one = FactoryBot.create(:service, :account => @provider)
-        @service_two = FactoryBot.create(:service, :account => @provider)
-        @service_three = FactoryBot.create(:service, :account => @provider)
-
-        FactoryBot.create(:service_plan, :issuer => @service_one)
-        FactoryBot.create(:service_plan, :issuer => @service_two)
-        FactoryBot.create(:application_plan, :issuer => @service_two)
-
-        @plans = {
-            :service => [
-              FactoryBot.create(:service_plan, :issuer => @service_one),
-              FactoryBot.create(:service_plan, :issuer => @service_two)
-            ],
-            :application => [
-              FactoryBot.create(:application_plan, :issuer => @service_one),
-              FactoryBot.create(:application_plan, :issuer => @service_one),
-              FactoryBot.create(:application_plan, :issuer => @service_two),
-              FactoryBot.create(:application_plan, :issuer => @service_two)
-            ]
-        }
-        @contracts = []
-
-        @plans[:service].each do |plan|
-          @contracts << FactoryBot.create(:service_contract, :plan => plan, :user_account => @buyer)
-        end
-
-        i = 0
-        name = "app"
-        @plans[:application].each do |plan|
-          @contracts << FactoryBot.create(:cinstance, :plan => plan, :user_account => @buyer, :name => (name + (i += 1).to_s), :description => 'Desc')
-        end
-
-        @contracts << @acc_contract
-        @plans[:account] = @acc_plan
-
-        @plans = @plans.values.flatten
-
-        @buyer.reload
-      end
-
-      context 'Account#bought_account_contract' do
-        should 'return only one bought account contract' do
-          assert_equal @acc_contract, @buyer.bought_account_contract
-        end
-      end
-
-      context 'Account#bought_account_plan' do
-        should 'return only one bought account plan' do
-          assert_equal @acc_plan, @buyer.bought_account_plan
-        end
-      end
-
-      context 'Account#bought_cinstances' do
-        should 'return all bought cinstances' do
-          assert_same_elements @contracts.select{|c| c.is_a? Cinstance },
-                               @buyer.bought_cinstances
-        end
-      end
-
-      context 'Account#bought_application_plans' do
-        should 'return all bought application plans' do
-          assert_same_elements @contracts.select{|c| c.is_a? Cinstance }.map{|c| c.plan },
-                               @buyer.bought_application_plans
-        end
-        should 'return only scoped plans when called with issued_by scope' do
-          assert_same_elements @plans.select{|p| p.is_a?(ApplicationPlan) && p.issuer == @service_one },
-                               @buyer.bought_application_plans.issued_by(@service_one)
-        end
-
-      end
-
-      context 'Account#bought_plans' do
-        should 'return all bought plans' do
-          assert_same_elements @plans, @buyer.bought_plans
-        end
-
-        should 'return only scoped plans when called with issued_by scope' do
-          assert_same_elements @plans.select{|plan| plan.issuer == @service_one },
-                               @buyer.bought_plans.issued_by(@service_one)
-        end
-      end
-
-      context 'Account#contracts' do
-        should 'return all contracts' do
-          assert_same_elements @contracts, @buyer.contracts
-        end
-
-        should 'return only scoped contracts when called with issued_by scope' do
-          assert_same_elements @plans.select{|plan| plan.issuer == @service_two },
-                               @buyer.bought_plans.issued_by(@service_two)
-        end
-      end
-
+    test 'Account#bought_account_contract should return only one bought account contract' do
+      assert_equal @acc_contract, @buyer.bought_account_contract
     end
 
+    test 'Account#bought_account_plan should return only one bought account plan' do
+      assert_equal @acc_plan, @buyer.bought_account_plan
+    end
+
+    test 'Account#bought_cinstances should return all bought cinstances' do
+      assert_same_elements @cinstances, @buyer.bought_cinstances
+    end
+
+    test 'Account#bought_application_plans should return all bought application plans' do
+      assert_same_elements @cinstances.map(&:plan), @buyer.bought_application_plans
+    end
+
+    test 'Account#bought_application_plans should return only scoped plans when called with issued_by scope' do
+      assert_same_elements @application_plans.select {|p| p.issuer == @service_one },
+                           @buyer.bought_application_plans.issued_by(@service_one)
+    end
+
+    test 'Account#bought_plans should return all bought plans' do
+      assert_same_elements @plans, @buyer.bought_plans
+    end
+
+    test 'Account#bought_plans should return only scoped plans when called with issued_by scope' do
+      assert_same_elements @plans.select {|plan| plan.issuer == @service_one },
+                           @buyer.bought_plans.issued_by(@service_one)
+    end
+
+    test 'Account#contracts should return all contracts' do
+      assert_same_elements @contracts, @buyer.contracts
+    end
+
+    test 'Account#contracts should return only scoped contracts when called with issued_by scope' do
+      assert_same_elements @plans.select {|plan| plan.issuer == @service_two },
+                           @buyer.bought_plans.issued_by(@service_two)
+    end
   end
 
   test 'Account#bought_plan' do
     provider_account = FactoryBot.create(:provider_account)
-    service = FactoryBot.create(:simple_service, :account => provider_account)
-    plan = FactoryBot.create(:application_plan, :service => service)
+    service = FactoryBot.create(:simple_service, account: provider_account)
+    plan = FactoryBot.create(:application_plan, service: service)
 
-    buyer_account = FactoryBot.create(:simple_buyer, :provider_account => provider_account)
+    buyer_account = FactoryBot.create(:simple_buyer, provider_account: provider_account)
     buyer_account.buy(plan)
 
     assert_equal plan, buyer_account.bought_plan
@@ -176,14 +128,14 @@ class Account::BuyerTest < ActiveSupport::TestCase
 
   test 'Account#feature_allowed? return false if account has no bought cinstance' do
     provider_account = FactoryBot.create(:simple_provider)
-    buyer_account = FactoryBot.create(:simple_account, :provider_account => provider_account)
+    buyer_account = FactoryBot.create(:simple_account, provider_account: provider_account)
 
-    assert !buyer_account.feature_allowed?(:world_domination)
+    assert_not buyer_account.feature_allowed?(:world_domination)
   end
 
   test 'forum is not created for buyers' do
-     account = FactoryBot.create(:simple_buyer)
-     assert_nil account.forum
+    account = FactoryBot.create(:simple_buyer)
+    assert_nil account.forum
   end
 
   test '#destroy returns false if buyer has unresolved invoices' do

--- a/test/unit/account/buyer_test.rb
+++ b/test/unit/account/buyer_test.rb
@@ -48,7 +48,7 @@ class Account::BuyerTest < ActiveSupport::TestCase
     buyer.save!
 
     assert buyer.buyer?
-    assert buyer.services.empty?
+    assert_empty buyer.services
     assert_nil buyer.s3_prefix
   end
 

--- a/test/unit/account/fields_test.rb
+++ b/test/unit/account/fields_test.rb
@@ -1,28 +1,29 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Account::FieldsTest < ActiveSupport::TestCase
+  class BuyerTest < Account::FieldsTest
+    def setup
+      @user_attrs = { username: 'buyer', email: 'email@buyer.com', password: 'password', password_confirmation: 'password' }
 
-  def setup
-    @user_attrs = { :username => 'buyer', :email => 'email@buyer.com', :password => 'password', :password_confirmation => 'password' }
-  end
-
-  context 'source of field definitions for buyer' do
-
-    should 'built by normal association' do
       @provider = FactoryBot.create(:simple_provider)
-      buyer = @provider.buyers.build :org_name => 'buyer'
+      @buyer = FactoryBot.create(:simple_buyer, provider_account: @provider, org_name: 'buyer')
+    end
+
+    attr_reader :buyer
+
+    test 'built by normal association' do
       assert_equal @provider, buyer.fields_definitions_source_root
 
       user = buyer.users.build_with_fields(@user_attrs)
       assert_equal @provider, user.fields_definitions_source_root
 
       buyer.save!
-      assert_equal @provider, Account.find_by_org_name!('buyer').fields_definitions_source_root
+      assert_equal @provider, Account.find_by!(org_name: 'buyer').fields_definitions_source_root
     end
 
-    should 'buit with fields' do
-      @provider = FactoryBot.create(:simple_provider)
-      buyer = @provider.buyers.build_with_fields :org_name => 'buyer'
+    test 'built with fields' do
       assert_equal @provider, buyer.fields_definitions_source_root
 
       user = buyer.users.build_with_fields(@user_attrs)
@@ -30,12 +31,11 @@ class Account::FieldsTest < ActiveSupport::TestCase
 
       buyer.save!
 
-      assert_equal @provider, Account.find_by_org_name!('buyer').fields_definitions_source_root
-      assert_equal @provider, User.find_by_username!('buyer').fields_definitions_source_root
+      assert_equal @provider, Account.find_by!(org_name: 'buyer').fields_definitions_source_root
+      assert_equal @provider, User.find_by!(username: 'buyer').fields_definitions_source_root
     end
 
-    should 'which exists' do
-      buyer = FactoryBot.create(:simple_buyer)
+    test 'which exists' do
       assert_equal buyer.provider_account, buyer.fields_definitions_source_root
 
       user = buyer.users.build(@user_attrs)
@@ -43,33 +43,33 @@ class Account::FieldsTest < ActiveSupport::TestCase
     end
   end
 
-  context 'source of field definitions for provider' do
-    setup do
+  class ProviderTest < Account::FieldsTest
+    def setup
+      super
       @master = master_account
+      @provider = FactoryBot.create(:simple_provider, provider: master_account, org_name: 'provider')
     end
 
-    should 'buit by normal association' do
-      provider = @master.buyers.build :org_name => 'provider'
+    attr_reader :provider
+
+    test 'built by normal association' do
       assert_equal @master, provider.fields_definitions_source_root
       provider.save!
-      assert_equal @master, Account.find_by_org_name!('provider').fields_definitions_source_root
+      assert_equal @master, Account.find_by!(org_name: 'provider').fields_definitions_source_root
     end
 
-    should 'built with fields' do
-      provider = @master.buyers.build_with_fields :org_name => 'provider'
+    test 'built with fields' do
       assert_equal @master, provider.fields_definitions_source_root
       provider.save!
-      assert_equal @master, Account.find_by_org_name!('provider').fields_definitions_source_root
+      assert_equal @master, Account.find_by!(org_name: 'provider').fields_definitions_source_root
     end
 
-    should 'which exists' do
-      provider = FactoryBot.create(:simple_provider)
+    test 'which exists' do
       assert_equal provider.provider_account, provider.fields_definitions_source_root
     end
-  end
 
-  test 'source of field definitions for master' do
-    master = master_account
-    assert_equal master, master.fields_definitions_source_root
+    test 'source of field definitions for master' do
+      assert_equal @master, @master.fields_definitions_source_root
+    end
   end
 end

--- a/test/unit/account/gateway_test.rb
+++ b/test/unit/account/gateway_test.rb
@@ -1,41 +1,38 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # TODO: will become a CreditCard model by itself soon
 class Account::GatewayTest  < ActiveSupport::TestCase
-
   test 'serializes payment_gateway_options' do
-    account = FactoryBot.create(:simple_account, :payment_gateway_options => {:foo => 'bar'})
+    account = FactoryBot.create(:simple_account, payment_gateway_options: {foo: 'bar'})
     account.reload
 
     assert_equal 'bar', account.payment_gateway_options[:foo]
   end
 
   test 'symbolizes keys of payment_gateway_options' do
-    account = FactoryBot.create(:simple_account, :payment_gateway_options => {'foo' => 'bar'})
+    account = FactoryBot.create(:simple_account, payment_gateway_options: {foo: 'bar'})
     account.reload
 
     assert_equal 'bar', account.payment_gateway_options[:foo]
-    assert_nil          account.payment_gateway_options['foo']
+    assert_nil account.payment_gateway_options['foo']
   end
 
-  context 'payment_gateway' do
-    should 'be nil by default' do
-      account = FactoryBot.create(:simple_account)
-      assert_nil account.payment_gateway
-    end
+  test 'payment_gateway should be nil by default' do
+    account = FactoryBot.create(:simple_account)
+    assert_nil account.payment_gateway
+  end
 
-    should 'return active merchant gateway according to type and options' do
-      account = FactoryBot.create(:simple_account, :payment_gateway_type => :braintree_blue,
-                        :payment_gateway_options => {:public_key => 'foo',
-                          :merchant_id => 'bar',
-                          :private_key => 'pkey'})
+  test 'payment_gateway should return active merchant gateway according to type and options' do
+    account = FactoryBot.create(:simple_account, payment_gateway_type: :braintree_blue,
+                                                 payment_gateway_options: {public_key: 'foo', merchant_id: 'bar', private_key: 'pkey'})
 
-      assert_not_nil account.payment_gateway
-      assert_instance_of ActiveMerchant::Billing::BraintreeBlueGateway, account.payment_gateway
-      assert_equal 'foo', account.payment_gateway.options[:public_key]
-      assert_equal 'bar', account.payment_gateway.options[:merchant_id]
-      assert_equal 'pkey', account.payment_gateway.options[:private_key]
-    end
+    assert_not_nil account.payment_gateway
+    assert_instance_of ActiveMerchant::Billing::BraintreeBlueGateway, account.payment_gateway
+    assert_equal 'foo', account.payment_gateway.options[:public_key]
+    assert_equal 'bar', account.payment_gateway.options[:merchant_id]
+    assert_equal 'pkey', account.payment_gateway.options[:private_key]
   end
 
   test '#payment_gateway_setting does not save empty settings' do
@@ -43,7 +40,7 @@ class Account::GatewayTest  < ActiveSupport::TestCase
     account = FactoryBot.create(:simple_account)
     account.gateway_setting
     account.save!
-    refute account.gateway_setting.persisted?, "payment gateway settings must not be saved"
+    assert_not account.gateway_setting.persisted?, "payment gateway settings must not be saved"
   end
 
   test '#payment_gateway_type is saved in `payment_gateway_setting association' do
@@ -75,22 +72,19 @@ class Account::GatewayTest  < ActiveSupport::TestCase
     account = FactoryBot.create(:simple_account, payment_gateway_options: {foo: 'bar', test: '1'})
     gateway_setting = account.gateway_setting
 
-    refute  gateway_setting.symbolized_settings.has_key?(:test)
+    assert_not gateway_setting.symbolized_settings.key?(:test)
 
     assert_equal({foo: 'bar'}, account.payment_gateway_options)
   end
 
   test '#payment_gateway_configured?' do
-
     account = FactoryBot.create(:simple_account)
     account.gateway_setting.save!
 
     account.gateway_setting.stubs(configured?: false)
-
-    refute account.payment_gateway_configured?
+    assert_not account.payment_gateway_configured?
 
     account.gateway_setting.stubs(configured?: true)
-
     assert account.payment_gateway_configured?
   end
 
@@ -100,15 +94,15 @@ class Account::GatewayTest  < ActiveSupport::TestCase
     provider.payment_gateway_type = nil
     assert_nil provider.payment_gateway
 
-    provider.payment_gateway_type    = :braintree_blue
+    provider.payment_gateway_type = :braintree_blue
     provider.payment_gateway_options = {merchant_id: 'foo', public_key: 'bar', private_key: 'baz'}
     assert_instance_of ActiveMerchant::Billing::BraintreeBlueGateway, provider.payment_gateway
-    assert_equal provider.payment_gateway_options,                    provider.payment_gateway.options
+    assert_equal provider.payment_gateway_options, provider.payment_gateway.options
 
-    provider.payment_gateway_type    = :stripe
+    provider.payment_gateway_type = :stripe
     provider.payment_gateway_options = { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx', endpoint_secret: 'some-secret' }
     assert_instance_of ActiveMerchant::Billing::StripeGateway, provider.payment_gateway
-    refute_instance_of ActiveMerchant::Billing::StripePaymentIntentsGateway, provider.payment_gateway # this test is necessary because StripePaymentIntentsGateway is a subclass of StripeGateway
+    assert_not_instance_of ActiveMerchant::Billing::StripePaymentIntentsGateway, provider.payment_gateway # this test is necessary because StripePaymentIntentsGateway is a subclass of StripeGateway
     assert_equal provider.payment_gateway_options, provider.payment_gateway.options
     assert_instance_of ActiveMerchant::Billing::StripePaymentIntentsGateway, provider.payment_gateway(sca: true)
     assert_equal provider.payment_gateway_options, provider.payment_gateway(sca: true).options
@@ -116,11 +110,9 @@ class Account::GatewayTest  < ActiveSupport::TestCase
 
   test 'provider_payment_gateway' do
     buyer = Account.new
-
     assert_nil buyer.provider_payment_gateway
 
     buyer.provider_account = Account.new
-
     assert_nil buyer.provider_payment_gateway
 
     buyer.provider_account.payment_gateway_type = :braintree_blue
@@ -130,7 +122,7 @@ class Account::GatewayTest  < ActiveSupport::TestCase
     buyer.provider_account.payment_gateway_type = :stripe
     buyer.provider_account.payment_gateway_options = { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx', endpoint_secret: 'some-secret' }
     assert_instance_of ActiveMerchant::Billing::StripeGateway, buyer.provider_payment_gateway
-    refute_instance_of ActiveMerchant::Billing::StripePaymentIntentsGateway, buyer.provider_payment_gateway # this test is necessary because StripePaymentIntentsGateway is a subclass of StripeGateway
+    assert_not_instance_of ActiveMerchant::Billing::StripePaymentIntentsGateway, buyer.provider_payment_gateway # this test is necessary because StripePaymentIntentsGateway is a subclass of StripeGateway
     buyer.payment_detail.payment_method_id = 'pm_1I5s3n2eZvKYlo2CiO193T69'
     assert_instance_of ActiveMerchant::Billing::StripePaymentIntentsGateway, buyer.provider_payment_gateway
   end

--- a/test/unit/account/provider_test.rb
+++ b/test/unit/account/provider_test.rb
@@ -1,56 +1,55 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Account::ProviderTest < ActiveSupport::TestCase
+  test 'destroy dependent' do
+    account = FactoryBot.create(:simple_provider)
+    FactoryBot.create(:authentication_provider, account: account)
+    FactoryBot.create(:self_authentication_provider, account: account)
+    assert_difference('AuthenticationProvider.count', -2) { account.destroy! }
+  end
 
-  context 'authentication_providers' do
-    setup do
-      @account = FactoryBot.create(:simple_provider)
+  test 'authentication_providers build_kind' do
+    account = FactoryBot.create(:simple_provider)
+    (AuthenticationProvider.available(AuthenticationProvider.account_types[:developer]) + [AuthenticationProvider::Custom]).each do |authentication_provider_class|
+      kind_name = authentication_provider_class.to_s.demodulize
+      authentication_provider = account.authentication_providers.build_kind(kind: kind_name, client_id: 'id', client_secret: 'secret', site: 'http://example.com')
+      assert_equal authentication_provider_class, authentication_provider.class
+      assert_equal kind_name.downcase, authentication_provider.kind
+      assert_equal account, authentication_provider.account
+      authentication_provider.valid? && puts(authentication_provider.errors.full_messages)
+      assert authentication_provider.valid?
     end
+  end
 
-    should 'destroy dependent' do
-      FactoryBot.create(:authentication_provider, account: @account)
-      FactoryBot.create(:self_authentication_provider, account: @account)
-      assert_difference('AuthenticationProvider.count', -2) { @account.destroy! }
+  test 'self_authentication_providers build_kind valid kinds' do
+    account = FactoryBot.create(:simple_provider)
+    AuthenticationProvider.available(AuthenticationProvider.account_types[:provider]).each do |authentication_provider_class|
+      kind_name = authentication_provider_class.to_s.demodulize
+      authentication_provider = account.self_authentication_providers.build_kind(kind: kind_name, client_id: 'id', client_secret: 'secret', site: 'http://example.com')
+      assert_equal authentication_provider_class, authentication_provider.class
+      assert_equal kind_name.downcase, authentication_provider.kind
+      assert_equal account, authentication_provider.account
+      authentication_provider.valid? && puts(authentication_provider.errors.full_messages)
+      assert authentication_provider.valid?
     end
+  end
 
-    should 'authentication_providers build_kind' do
-      (AuthenticationProvider.available(AuthenticationProvider.account_types[:developer]) + [AuthenticationProvider::Custom]).each do |authentication_provider_class|
-        kind_name = authentication_provider_class.to_s.demodulize
-        authentication_provider = @account.authentication_providers.build_kind(kind: kind_name, client_id: 'id', client_secret: 'secret', site: 'http://example.com')
-        assert_equal authentication_provider_class, authentication_provider.class
-        assert_equal kind_name.downcase, authentication_provider.kind
-        assert_equal @account, authentication_provider.account
-        authentication_provider.valid? && puts(authentication_provider.errors.full_messages)
-        assert authentication_provider.valid?
-      end
-    end
-
-    should 'self_authentication_providers build_kind valid kinds' do
-      AuthenticationProvider.available(AuthenticationProvider.account_types[:provider]).each do |authentication_provider_class|
-        kind_name = authentication_provider_class.to_s.demodulize
-        authentication_provider = @account.self_authentication_providers.build_kind(kind: kind_name, client_id: 'id', client_secret: 'secret', site: 'http://example.com')
-        assert_equal authentication_provider_class, authentication_provider.class
-        assert_equal kind_name.downcase, authentication_provider.kind
-        assert_equal @account, authentication_provider.account
-        authentication_provider.valid? && puts(authentication_provider.errors.full_messages)
-        assert authentication_provider.valid?
-      end
-    end
-
-    should 'self_authentication_providers build_kind invalid kinds' do
-      available_only_for_developers = (AuthenticationProvider.available(AuthenticationProvider.account_types[:developer]) - AuthenticationProvider.available(AuthenticationProvider.account_types[:provider])).map { |ap_class| ap_class.to_s.demodulize }
-      available_only_for_developers += ['CustomKind-123456']
-      available_only_for_developers.each do |authentication_provider_class|
-        authentication_provider = @account.self_authentication_providers.build_kind(kind: authentication_provider_class, client_id: 'id', client_secret: 'secret', site: 'http://example.com')
-        assert_equal @account, authentication_provider.account
-        refute authentication_provider.valid?
-      end
+  test 'self_authentication_providers build_kind invalid kinds' do
+    account = FactoryBot.create(:simple_provider)
+    available_only_for_developers = (AuthenticationProvider.available(AuthenticationProvider.account_types[:developer]) - AuthenticationProvider.available(AuthenticationProvider.account_types[:provider])).map { |ap_class| ap_class.to_s.demodulize }
+    available_only_for_developers += ['CustomKind-123456']
+    available_only_for_developers.each do |authentication_provider_class|
+      authentication_provider = account.self_authentication_providers.build_kind(kind: authentication_provider_class, client_id: 'id', client_secret: 'secret', site: 'http://example.com')
+      assert_equal account, authentication_provider.account
+      assert_not authentication_provider.valid?
     end
   end
 
   test '#api_key?' do
     provider = FactoryBot.create(:simple_provider)
-    refute provider.api_key?
+    assert_not provider.api_key?
 
     FactoryBot.create(:cinstance, user_account: provider)
     assert provider.api_key?
@@ -61,12 +60,12 @@ class Account::ProviderTest < ActiveSupport::TestCase
     assert provider.missing_api_key?
 
     FactoryBot.create(:cinstance, user_account: provider)
-    refute provider.missing_api_key?
+    assert_not provider.missing_api_key?
   end
 
-  test 'provider?'do
+  test 'provider?' do
     account = Account.new
-    refute account.partner?
+    assert_not account.partner?
     account.expects(:partner_id).returns(42)
     assert account.partner?
   end
@@ -75,19 +74,19 @@ class Account::ProviderTest < ActiveSupport::TestCase
     provider = FactoryBot.create :provider_account
     assert provider.should_apply_email_engagement_footer?, 'Expected to have a viral footer'
 
-    plan = FactoryBot.create :published_plan, :system_name => 'enterprise', :issuer => master_account.services.first
+    plan = FactoryBot.create :published_plan, :system_name => 'enterprise', issuer: master_account.services.first
 
     provider.force_upgrade_to_provider_plan! plan
-    refute provider.should_apply_email_engagement_footer?, 'Expected to skip the viral footer'
+    assert_not provider.should_apply_email_engagement_footer?, 'Expected to skip the viral footer'
   end
 
   test '#require_billing_information! and #require_billing_information? and validations' do
     account = Account.new
-    refute account.require_billing_information?
+    assert_not account.require_billing_information?
     account.require_billing_information!
     assert account.require_billing_information?
 
-    refute account.valid?
+    assert_not account.valid?
 
     assert account.errors.messages[:org_legaladdress].present?
     assert account.errors.messages[:country].present?
@@ -136,21 +135,18 @@ class Account::ProviderTest < ActiveSupport::TestCase
   should have_one(:billing_strategy)
   should have_many(:buyer_invoices)
   should have_many(:buyer_line_items)
-
   should have_many(:redirects)
-
   should have_many(:templates)
-
   should have_many(:groups)
   should have_many(:provided_sections)
 
-  should '#show_xss_protection_options?' do
+  test '#show_xss_protection_options? should' do
     account = FactoryBot.build_stubbed(:provider_account)
     settings = account.settings
 
     settings.cms_escape_published_html = true
-    settings.cms_escape_draft_html =  true
-    refute account.show_xss_protection_options?
+    settings.cms_escape_draft_html = true
+    assert_not account.show_xss_protection_options?
 
     settings.cms_escape_published_html = true
     settings.cms_escape_draft_html = false
@@ -165,17 +161,20 @@ class Account::ProviderTest < ActiveSupport::TestCase
     assert account.show_xss_protection_options?
   end
 
-  context 'after created' do
+  class AfterCreatedTest < ActiveSupport::TestCase
+    setup do
+      @subject = Account.new(org_name: "prov", provider_account: master_account, subdomain: 'prov', self_subdomain: 'prov-admin')
+    end
 
-    subject { Account.new :org_name => "prov", :provider_account => master_account, :subdomain => 'prov', :self_subdomain => 'prov-admin' }
+    attr_reader :subject
 
-    should 'have an sso_key' do
-      subject.provider= true
+    test 'should have an sso_key' do
+      subject.provider = true
       subject.save!
       assert_not_nil subject.settings.sso_key
     end
 
-    should 'not have a default service anymore' do
+    test 'should not have a default service anymore' do
       prov = subject
       prov.provider = true
       prov.save!
@@ -184,7 +183,7 @@ class Account::ProviderTest < ActiveSupport::TestCase
       assert prov.default_service_id.blank?
     end
 
-    should 'have a s3_prefix' do
+    test 'should have a s3_prefix' do
       prov = subject
       prov.provider = true
       prov.save!
@@ -193,7 +192,7 @@ class Account::ProviderTest < ActiveSupport::TestCase
       assert_equal 'prov', prov.s3_prefix
     end
 
-    should 'have a go_live_state' do
+    test 'should have a go_live_state' do
       prov = subject
       prov.provider = true
       prov.save
@@ -201,95 +200,59 @@ class Account::ProviderTest < ActiveSupport::TestCase
     end
   end
 
-  context "for the provider" do
-
+  class ForTheProviderTest < ActiveSupport::TestCase
     setup do
       @provider =  FactoryBot.create(:provider_account)
-      @acc_plan = FactoryBot.create(:account_plan, :issuer => @provider)
-      @buyers = []
-      @buyers << FactoryBot.create(:simple_buyer, :provider_account => @provider)
-      @buyers << FactoryBot.create(:simple_buyer, :provider_account => @provider)
+      @buyers = FactoryBot.create_list(:simple_buyer, 2, provider_account: @provider)
     end
 
-    context 'Account#from_email' do
-      should 'have default' do
+    class WithoutPlansTest < ForTheProviderTest
+      test 'Account#from_email should have default' do
         assert_equal Rails.configuration.three_scale.noreply_email, @provider.from_email
       end
 
-      should 'return correct if customized' do
+      test 'Account#from_email should return correct if customized' do
         mail = 'foo@example.net'
         @provider.from_email = mail
         assert_equal mail, @provider.from_email
       end
     end
 
-    context 'with provided plans' do
-      setup do
+    class WithPlansTest < ForTheProviderTest
+      def setup
+        super
+        services = FactoryBot.create_list(:simple_service, 2, account: @provider)
+        @service_one, @service_two = services
 
-        @service_one = FactoryBot.create(:simple_service, :account => @provider)
-        @service_two = FactoryBot.create(:simple_service, :account => @provider)
-        @service_three = FactoryBot.create(:simple_service, :account => @provider)
+        service_one_application_plans = FactoryBot.create_list(:simple_application_plan, 2, issuer: @service_one)
+        @service_two_application_plans = FactoryBot.create_list(:simple_application_plan, 2, issuer: @service_two)
 
-        @plans = {
-            :service => [
-              FactoryBot.create(:service_plan, :issuer => @service_one),
-              FactoryBot.create(:service_plan, :issuer => @service_two)
-            ],
-            :application => [
-              FactoryBot.create(:simple_application_plan, :issuer => @service_one),
-              FactoryBot.create(:simple_application_plan, :issuer => @service_one),
+        service_plans = services.map { |service| FactoryBot.create(:service_plan, issuer: service) }
+        service_plans.map { |plan| @buyers.first.buy!(plan) }
 
-              FactoryBot.create(:simple_application_plan, :issuer => @service_two),
-              FactoryBot.create(:simple_application_plan, :issuer => @service_two)
-            ]
-        }
-
-        assert_equal 2, ApplicationPlan.issued_by(@service_one).count
-
-        @contracts = {:service => [], :cinstance => []}
-
-        @contracts[:service] << @buyers.first.buy!(@plans[:service].first)
-        @contracts[:cinstance] << @buyers.first.buy!(@plans[:application].first)
-        @contracts[:cinstance] << @buyers.first.buy!(@plans[:application].second)
-
-
-        @contracts[:service] << @buyers.last.buy!(@plans[:service].last)
-        @contracts[:cinstance] << @buyers.last.buy!(@plans[:application].third)
-        @contracts[:cinstance] << @buyers.last.buy!(@plans[:application].last)
-
-        @provider.reload
-
-        @plans[:account] = @acc_plan
+        @service_one_cinstances = service_one_application_plans.map { |plan| @buyers.first.buy!(plan) }
+        @service_two_application_plans.map { |plan| @buyers.second.buy!(plan) }
       end
 
-
-      context 'Account#account_plans' do
-        should 'have  #default' do
-          assert_not_nil @provider.account_plans.default
-        end
+      test 'Account#account_plans should have #default' do
+        assert_not_nil @provider.account_plans.default
       end
 
-      context 'Account#application_plans' do
-        should 'return all application plans provided by one of the service of the account' do
-          assert_same_elements ApplicationPlan.provided_by(@provider), @provider.application_plans
-        end
-
-        should 'return only issued by issuer if called with issued_by scope' do
-          assert_same_elements @plans[:application][2..3], @provider.application_plans.issued_by(@service_two)
-        end
+      test 'Account#application_plans should return all application plans provided by one of the service of the account' do
+        assert_same_elements ApplicationPlan.provided_by(@provider), @provider.application_plans
       end
 
-      context 'Account#provided_cinstances' do
-        should 'return all provided cinstances' do
-          assert_same_elements Cinstance.provided_by(@provider), @provider.provided_cinstances
-        end
-
-        should 'return only cinstances for issuer if called with issued_by scope' do
-          assert_same_elements @contracts[:cinstance][0..1], @provider.provided_cinstances.by_service(@service_one)
-        end
+      test 'Account#application_plans should return only issued by issuer if called with issued_by scope' do
+        assert_same_elements @service_two_application_plans, @provider.application_plans.issued_by(@service_two)
       end
 
+      test 'Account#provided_cinstances should return all provided cinstances' do
+        assert_same_elements Cinstance.provided_by(@provider), @provider.provided_cinstances
+      end
+
+      test 'Account#provided_cinstances should return only cinstances for issuer if called with issued_by scope' do
+        assert_same_elements @service_one_cinstances, @provider.provided_cinstances.by_service(@service_one)
+      end
     end
-
   end
 end


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/unit/account/buyer_test.rb
* test/unit/account/fields_test.rb
* test/unit/account/gateway_test.rb
* test/unit/account/provider_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)