### PR TITLE
Remove `context` and `should` from a bunch of tests

### DIFF
--- a/test/factories/other.rb
+++ b/test/factories/other.rb
@@ -6,6 +6,21 @@ FactoryBot.define do
   factory(:forum) do
     name { 'Forum' }
     account {|a| a.association(:provider_account)}
+
+    trait :public do
+      after :create do |forum|
+        forum.account.settings.update(forum_public: true)
+      end
+    end
+
+    trait :private do
+      after :create do |forum|
+        forum.account.settings.update(forum_public: false)
+      end
+    end
+
+    factory :public_forum, traits: [:public]
+    factory :private_forum, traits: [:private]
   end
 
   factory(:topic_category) do

--- a/test/unit/abilities/forums_test.rb
+++ b/test/unit/abilities/forums_test.rb
@@ -1,312 +1,239 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module Abilities
   class ForumsTest < ActiveSupport::TestCase
     def setup
       @provider = FactoryBot.create(:provider_account)
+      @admin_user = @provider.admins.first
+      # admin = FactoryBot.create(:admin, account: @provider)
+      @provider_user = FactoryBot.create(:user, account: @provider)
+
       @forum = @provider.forum
+      @topic = FactoryBot.create(:topic, forum: @forum)
+
+      @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+      @buyer_user = FactoryBot.create(:user, account: @buyer)
     end
 
     def test_posts
-      assert_equal [], @forum.posts.to_a
-      assert_equal 0, @forum.posts.size
+      forum = FactoryBot.create(:provider_account).forum
+      assert_equal [], forum.posts.to_a
+      assert_equal 0, forum.posts.size
     end
 
     test 'anyone can read topic when forum is public' do
-      @forum.account.settings.update_attribute(:forum_public, true)
-      user  = FactoryBot.create(:user, :account => @provider)
-      topic = FactoryBot.create(:topic, :forum => @forum)
+      @forum.account.settings.update(forum_public: true)
 
-      ability = Ability.new(user)
-      assert ability.can?(:read, topic)
-
-      ability = Ability.new(nil)
-      assert ability.can?(:read, topic)
+      assert Ability.new(@provider_user).can?(:read, @topic)
+      assert Ability.new(nil).can?(:read, @topic)
     end
 
     test 'just logged in users can read topic when forum is not public' do
-      @forum.account.settings.update_attribute(:forum_public, false)
-      provider_user  = FactoryBot.create(:user, :account => @provider)
-      buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
-      buyer_user = FactoryBot.create(:user, :account => buyer)
-      topic = FactoryBot.create(:topic, :forum => @forum)
+      @forum.account.settings.update(forum_public: false)
 
-      ability = Ability.new(provider_user)
-      assert ability.can?(:read, topic)
-
-      ability = Ability.new(buyer_user)
-      assert ability.can?(:read, topic)
-
-      ability = Ability.new(nil)
-      assert !ability.can?(:read, topic)
+      assert Ability.new(@provider_user).can?(:read, @topic)
+      assert Ability.new(@buyer_user).can?(:read, @topic)
+      assert_not Ability.new(nil).can?(:read, @topic)
     end
 
     test "topic owner can update and destroy topic if it is less than one day old" do
-      topic = FactoryBot.create(:topic)
-      user  = topic.user
+      owner = Ability.new(@topic.user)
 
-      ability = Ability.new(user)
-
-      assert ability.can?(:update, topic)
-      assert ability.can?(:destroy, topic)
+      assert owner.can?(:update, @topic)
+      assert owner.can?(:destroy, @topic)
     end
 
     test "topic owner can't update nor destroy topic if it is more than one day old" do
-      topic = FactoryBot.create(:topic)
-      user  = topic.user
-
-      ability = Ability.new(user)
+      owner = Ability.new(@topic.user)
 
       Timecop.travel(2.days.from_now) do
-        assert !ability.can?(:update, topic)
-        assert !ability.can?(:destroy, topic)
+        assert_not owner.can?(:update, @topic)
+        assert_not owner.can?(:destroy, @topic)
       end
     end
 
     test "user can't update not destroy topic of other user" do
-      user_one = FactoryBot.create(:user_with_account)
-      user_two = FactoryBot.create(:user_with_account)
-      topic = FactoryBot.create(:topic, :user => user_one)
+      another_user_topic = FactoryBot.create(:topic, user: FactoryBot.create(:user_with_account))
 
-      ability = Ability.new(user_two)
-      assert !ability.can?(:update, topic)
-      assert !ability.can?(:destroy, topic)
+      user = Ability.new(FactoryBot.create(:user_with_account))
+      assert_not user.can?(:update, another_user_topic)
+      assert_not user.can?(:destroy, another_user_topic)
     end
 
     test "admin can manage any topic of his forum" do
-      admin = @provider.admins.first
-      user  = FactoryBot.create(:user, :account => @provider)
+      admin = Ability.new(@admin_user)
 
-      ability = Ability.new(admin)
+      topic_one = FactoryBot.create(:topic, forum: @forum, user: @admin_user)
+      assert admin.can?(:manage, topic_one)
 
-      topic_one = FactoryBot.create(:topic, :forum => @forum, :user => admin)
-      assert ability.can?(:manage, topic_one)
+      topic_two = FactoryBot.create(:topic, forum: @forum, user: @provider_user)
+      assert admin.can?(:manage, topic_two)
 
-      topic_two = FactoryBot.create(:topic, :forum => @forum, :user => user)
-      assert ability.can?(:manage, topic_two)
-
-      topic_three = FactoryBot.create(:topic, :forum => @forum, :user => user)
+      topic_three = FactoryBot.create(:topic, forum: @forum, user: @provider_user)
       Timecop.travel(2.days.from_now) do
-        assert ability.can?(:manage, topic_three)
+        assert admin.can?(:manage, topic_three)
       end
     end
 
     test "admin can stick a topic" do
-      topic = FactoryBot.create(:topic, :forum => @forum)
-
-      ability = Ability.new(@provider.admins.first)
-      assert ability.can?(:stick, topic)
+      assert Ability.new(@admin_user).can?(:stick, @topic)
     end
 
     test "user can't stick a topic" do
-      topic = FactoryBot.create(:topic, :forum => @forum)
-      user  = FactoryBot.create(:user, :account => @provider)
-
-      ability = Ability.new(user)
-      assert !ability.can?(:stick, topic)
+      assert_not Ability.new(@provider_user).can?(:stick, @topic)
     end
 
     test "post author can update and destroy post if it is less than one day old" do
       post = FactoryBot.create(:post)
-      user = post.user
 
-      ability = Ability.new(user)
+      post_author = Ability.new(post.user)
 
-      assert ability.can?(:update, post)
-      assert ability.can?(:destroy, post)
+      assert post_author.can?(:update, post)
+      assert post_author.can?(:destroy, post)
     end
 
     test "post author can't update nor destroy post if it is more than one day old" do
       post = FactoryBot.create(:post)
-      user = post.user
 
-      ability = Ability.new(user)
+      post_author = Ability.new(post.user)
 
       Timecop.travel(2.days.from_now) do
-        assert !ability.can?(:update, post)
-        assert !ability.can?(:destroy, post)
+        assert_not post_author.can?(:update, post)
+        assert_not post_author.can?(:destroy, post)
       end
     end
 
     test "user can't update not destroy post of other user" do
-      user_one = FactoryBot.create(:user_with_account)
-      user_two = FactoryBot.create(:user_with_account)
-      post = FactoryBot.create(:post, :user => user_one)
+      another_user_post = FactoryBot.create(:post, user: FactoryBot.create(:user_with_account))
 
-      ability = Ability.new(user_two)
-
-      assert !ability.can?(:update, post)
-      assert !ability.can?(:destroy, post)
+      user = Ability.new(FactoryBot.create(:user_with_account))
+      assert_not user.can?(:update, another_user_post)
+      assert_not user.can?(:destroy, another_user_post)
     end
 
     test "user can't destroy a post if it is the last one in the topic" do
       topic = FactoryBot.create(:topic)
-      topic.posts[1..-1].each(&:destroy) # Just in case
+      assert_equal 1, topic.posts.length
 
-      ability = Ability.new(topic.user)
-      assert !ability.can?(:destroy, topic.posts.first)
+      owner = topic.user
+      ability = Ability.new(owner)
+      assert_not ability.can?(:destroy, topic.posts.first)
+
+      FactoryBot.create(:post, topic: topic, user: owner)
+      assert_equal 2, topic.reload.posts.length
+      assert ability.can?(:destroy, topic.posts.first)
     end
 
     test "admin can manage any post of his forum" do
-      topic = FactoryBot.create(:topic, :forum => @forum)
-      admin = @provider.admins.first
-      user  = FactoryBot.create(:user, :account => @provider)
+      admin = Ability.new(@admin_user)
 
-      ability = Ability.new(admin)
+      post_one = FactoryBot.create(:post, topic: @topic, user: @admin_user)
+      assert admin.can?(:manage, post_one)
 
-      post_one = FactoryBot.create(:post, :topic => topic, :user => admin)
-      assert ability.can?(:manage, post_one)
+      post_two = FactoryBot.create(:post, topic: @topic, user: @provider_user)
+      assert admin.can?(:manage, post_two)
 
-      post_two = FactoryBot.create(:post, :topic => topic, :user => user)
-      assert ability.can?(:manage, post_two)
-
-      post_three = FactoryBot.create(:post, :topic => topic, :user => user)
+      post_three = FactoryBot.create(:post, topic: @topic, user: @provider_user)
       Timecop.travel(2.days.from_now) do
-        assert ability.can?(:manage, post_three)
+        assert admin.can?(:manage, post_three)
       end
     end
 
     test 'anyone can read category in public forum' do
-      @forum.account.settings.update_attribute(:forum_public, true)
-      category = @forum.categories.create!(:name => 'Junk')
+      @forum.account.settings.update(forum_public: true)
+      category = @forum.categories.create!(name: 'Junk')
 
-      buyer    = FactoryBot.create(:buyer_account)
-      buyer_user = FactoryBot.create(:user, :account => buyer)
-      provider_user = FactoryBot.create(:user, :account => @provider)
-
-      ability = Ability.new(buyer_user)
-      assert ability.can?(:read, category)
-
-      ability = Ability.new(provider_user)
-      assert ability.can?(:read, category)
-
-      ability = Ability.new(nil)
-      assert ability.can?(:read, category)
+      assert Ability.new(@buyer_user).can?(:read, category)
+      assert Ability.new(@provider_user).can?(:read, category)
+      assert Ability.new(nil).can?(:read, category)
     end
 
-    test 'buyer user can read category in private forum' do
-      @forum.account.settings.update_attribute(:forum_public, false)
+    test 'buyer and provider user can read category in private forum' do
+      @forum.account.settings.update(forum_public: false)
+      category = @forum.categories.create!(name: 'Junk')
 
-      account = FactoryBot.create(:buyer_account, :provider_account => @provider)
-      user = FactoryBot.create(:user, :account => account)
-      category = @forum.categories.create!(:name => 'Junk')
-
-      ability = Ability.new(user)
-      assert ability.can?(:read, category)
-    end
-
-    test 'provider user can read category in private forum' do
-      @forum.account.settings.update_attribute(:forum_public, false)
-
-      user = FactoryBot.create(:user, :account => @provider)
-      category = @forum.categories.create!(:name => 'Junk')
-
-      ability = Ability.new(user)
-      assert ability.can?(:read, category)
+      assert Ability.new(@buyer_user).can?(:read, category)
+      assert Ability.new(@provider_user).can?(:read, category)
     end
 
     test "user can't manage category" do
-      category = @forum.categories.create!(:name => 'Stuff')
-      user = FactoryBot.create(:user, :account => @provider)
+      category = @forum.categories.create!(name: 'Stuff')
 
-      ability = Ability.new(user)
-
-      assert !ability.can?(:create,  TopicCategory)
-      assert !ability.can?(:update,  category)
-      assert !ability.can?(:destroy, category)
+      user = Ability.new(@provider_user)
+      assert_not user.can?(:create, TopicCategory)
+      assert_not user.can?(:update, category)
+      assert_not user.can?(:destroy, category)
     end
 
     test "buyer admin can't manage category" do
-      category = @forum.categories.create!(:name => 'Stuff')
-      buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
+      category = @forum.categories.create!(name: 'Stuff')
 
-      ability = Ability.new(buyer.admins.first)
-
-      assert !ability.can?(:create,  TopicCategory)
-      assert !ability.can?(:update,  category)
-      assert !ability.can?(:destroy, category)
+      admin = Ability.new(@buyer.admins.first)
+      assert_not admin.can?(:create, TopicCategory)
+      assert_not admin.can?(:update, category)
+      assert_not admin.can?(:destroy, category)
     end
 
     test "admin can manage category of his forum" do
-      category = @forum.categories.create!(:name => 'Stuff')
+      category = @forum.categories.create!(name: 'Stuff')
 
-      ability = Ability.new(@provider.admins.first)
+      ability = Ability.new(@admin_user)
 
-      assert ability.can?(:create,  TopicCategory)
-      assert ability.can?(:update,  category)
+      assert ability.can?(:create, TopicCategory)
+      assert ability.can?(:update, category)
       assert ability.can?(:destroy, category)
     end
 
     test "user can create anonymous post if anonymous posting is enabled" do
-      @forum.account.settings.update_attribute(:anonymous_posts_enabled, true)
-      user  = FactoryBot.create(:user, :account => @provider)
-      topic = FactoryBot.create(:topic, :forum => @forum)
-      post  = topic.posts.build
+      @forum.account.settings.update(anonymous_posts_enabled: true)
+      post = @topic.posts.build
 
-      # logged in user
-      ability = Ability.new(user)
-      assert ability.can?(:reply, topic)
-      assert ability.can?(:reply, post)
+      logged_in_user = Ability.new(@provider_user)
+      assert logged_in_user.can?(:reply, @topic)
+      assert logged_in_user.can?(:reply, post)
 
-      # anon user
-      ability = Ability.new(nil)
-      assert ability.can?(:reply, topic)
-      assert ability.can?(:reply, post)
+      anonymous_user = Ability.new(nil)
+      assert anonymous_user.can?(:reply, @topic)
+      assert anonymous_user.can?(:reply, post)
     end
 
     test "user can't create anonymous post if anonymous posting is disabled" do
-      @forum.account.settings.update_attribute(:anonymous_posts_enabled, false)
-      user  = FactoryBot.create(:user, :account => @provider)
-      topic = FactoryBot.create(:topic, :forum => @forum)
-      post  = topic.posts.build
+      @forum.account.settings.update(anonymous_posts_enabled: false)
+      post = @topic.posts.build
 
-      # logged in users
-      ability = Ability.new(user)
-      assert ability.can?(:reply, topic)
-      assert ability.can?(:reply, post)
+      logged_in_user = Ability.new(@provider_user)
+      assert logged_in_user.can?(:reply, @topic)
+      assert logged_in_user.can?(:reply, post)
 
-      # anon users
-      ability = Ability.new(nil)
-      assert !ability.can?(:reply, topic)
-      assert !ability.can?(:reply, post)
+      anonymous_user = Ability.new(nil)
+      assert_not anonymous_user.can?(:reply, @topic)
+      assert_not anonymous_user.can?(:reply, post)
     end
 
+    test "Topic with category should can reply" do
+      @forum.account.settings.update(anonymous_posts_enabled: false)
+      category = FactoryBot.create(:topic_category, forum: @forum)
+      topic = category.topics.build
 
-    context "Topic with category" do
-      should "can reply" do
-        @forum.account.settings.update_attribute(:anonymous_posts_enabled, false)
+      assert Ability.new(@provider_user).can?(:reply, topic)
+      assert Ability.new(@buyer_user).can?(:reply, topic)
 
-        category = FactoryBot.create(:topic_category, :forum => @forum)
-        topic = category.topics.build
+      anonymous_user = Ability.new(nil)
+      assert_not anonymous_user.can?(:reply, topic)
 
-        user  = FactoryBot.create(:user, :account => @provider)
-        # logged in provider
-        ability = Ability.new(user)
-        assert ability.can?(:reply, topic)
+      @forum.account.settings.update(anonymous_posts_enabled: true)
+      topic = category.reload.topics.build
+      assert anonymous_user.can?(:reply, topic)
+    end
 
-        buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
-        buyer_user = FactoryBot.create(:user, :account => buyer)
-        # logged in buyer
-        ability = Ability.new(user)
-        assert ability.can?(:reply, topic)
+    test "Topic with category should be manageable by admin" do
+      category = FactoryBot.create(:topic_category, forum: @forum)
 
-        # anon user
-        ability = Ability.new(nil)
-        assert !ability.can?(:reply, topic)
-
-        @forum.account.settings.update_attribute(:anonymous_posts_enabled, true)
-        topic = category.reload.topics.build
-        assert ability.can?(:reply, topic)
-      end
-
-      should "be manageable by admin" do
-        category = FactoryBot.create(:topic_category, :forum => @forum)
-        admin    = FactoryBot.create(:admin, :account => @provider)
-
-        ability = Ability.new(admin)
-        assert ability.can?(:manage, category.topics.build)
-        assert ability.can?(:manage, @forum.topics.build)
-      end
+      admin = Ability.new(@admin_user)
+      assert admin.can?(:manage, category.topics.build)
+      assert admin.can?(:manage, @forum.topics.build)
     end
   end
 end

--- a/test/unit/array_test.rb
+++ b/test/unit/array_test.rb
@@ -1,38 +1,20 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ArrayTest < ActiveSupport::TestCase
-  context '#to_xml method' do
-    setup do
-      @version = Gem::Version.new(RUBY_VERSION)
-      @ruby_24 = Gem::Version.new('2.4.0')
-    end
+  test '#to_xml not add the attr params as default' do
+    xml = Nokogiri::XML::Document.parse([1,2].to_xml)
+    assert xml.xpath("//integers[@type]").empty?
+  end
 
-    should 'not add the attr params as default' do
-      xml = Nokogiri::XML::Document.parse([1,2].to_xml)
+  test '#to_xml not add the attr params if skip_types => true is passed' do
+    xml = Nokogiri::XML::Document.parse([1,2].to_xml(skip_types: true))
+    assert xml.xpath("//integers[@type]").empty?
+  end
 
-      if @version < @ruby_24
-        assert xml.xpath("//fixnums[@type]").empty?
-      else
-        assert xml.xpath("//integers[@type]").empty?
-      end
-    end
-
-    should 'not add the attr params if skip_types => true is passed' do
-      xml = Nokogiri::XML::Document.parse([1,2].to_xml(:skip_types => true))
-      if @version < @ruby_24
-        assert xml.xpath("//fixnums[@type]").empty?
-      else
-        assert xml.xpath("//integers[@type]").empty?
-      end
-    end
-
-    should 'add the attr params if skip_types => false is passed' do
-      xml = Nokogiri::XML::Document.parse([1,2].to_xml(:skip_types => false))
-      if @version < @ruby_24
-        assert !xml.xpath("//fixnums[@type]").empty?
-      else
-        assert !xml.xpath("//integers[@type]").empty?
-      end
-    end
+  test '#to_xml add the attr params if skip_types => false is passed' do
+    xml = Nokogiri::XML::Document.parse([1,2].to_xml(skip_types: false))
+    assert_not xml.xpath("//integers[@type]").empty?
   end
 end

--- a/test/unit/cinstance/trial_test.rb
+++ b/test/unit/cinstance/trial_test.rb
@@ -1,20 +1,18 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Cinstance::TrialTest < ActiveSupport::TestCase
-
-  def test_notify_about_expired_trial_periods
+  test 'notify about expired trial periods' do
     plan = nil
 
     Timecop.freeze(2010, 1, 1) do
-      provider  = FactoryBot.create(:provider_account,
-                    payment_gateway_options: { test: false })
-      plan      = FactoryBot.create(:application_plan,
-                    issuer: provider.default_service,
-                    trial_period_days: 20, cost_per_month: 10)
+      provider = FactoryBot.create(:provider_account, payment_gateway_options: { test: false })
+      plan = FactoryBot.create(:application_plan, issuer: provider.default_service, trial_period_days: 20, cost_per_month: 10)
 
       FactoryBot.create(:cinstance, plan: plan)
     end
-    
+
     Timecop.freeze(2010, 1, 5) do
       Cinstances::CinstanceExpiredTrialEvent.expects(:create).never
       Cinstance.notify_about_expired_trial_periods
@@ -27,77 +25,73 @@ class Cinstance::TrialTest < ActiveSupport::TestCase
     end
 
     # the plan does not have a trial period
-    plan.update_attributes(trial_period_days: 0)
+    plan.update(trial_period_days: 0)
     Timecop.freeze(2010, 1, 21) do
       Cinstances::CinstanceExpiredTrialEvent.expects(:create).never
       Cinstance.notify_about_expired_trial_periods
     end
   end
 
-  context 'with 30 days trial period plan' do
+  class TrialPeriodPlanTest < ActiveSupport::TestCase
     setup do
-      @plan = FactoryBot.create(:application_plan, :trial_period_days => 30)
+      @plan = FactoryBot.create(:application_plan, trial_period_days: 30)
     end
 
-    should 'compute correct expiration date' do
+    test 'should compute correct expiration date' do
       Timecop.freeze(2009,11,4) do
-        cinstance = FactoryBot.create(:cinstance, :plan => @plan)
-        expected = (cinstance.created_at  + 30.days).to_date
+        cinstance = FactoryBot.create(:cinstance, plan: @plan)
+        expected = (cinstance.created_at + 30.days).to_date
         assert_equal expected, cinstance.trial_period_expires_at.to_date
       end
     end
 
-    should 'expire the trial after 31 days' do
+    test 'should expire the trial after 31 days' do
       Timecop.freeze
-      cinstance = FactoryBot.create(:cinstance, :plan => @plan)
-      Timecop.travel(31.days.from_now) { assert !cinstance.trial? }
+      cinstance = FactoryBot.create(:cinstance, plan: @plan)
+      Timecop.travel(31.days.from_now) { assert_not cinstance.trial? }
+    end
+  end
+
+  class NoTrialPeriodPlanTest < ActiveSupport::TestCase
+    setup do
+      @plan = FactoryBot.create(:application_plan, trial_period_days: nil)
     end
 
-    context 'with no trial' do
-      setup do
-        @plan = FactoryBot.create(:application_plan, :trial_period_days => nil)
-      end
+    test 'should find those expired yesterday' do
+      Timecop.travel(3.days.from_now) { @cinstance = FactoryBot.create(:cinstance, plan: @plan) }
 
-      should 'find those expired yesterday' do
-        Timecop.travel(3.days.from_now) { @cinstance = FactoryBot.create(:cinstance, :plan => @plan) }
-
-        Timecop.travel(4.days.from_now) do
-          found = Cinstance.with_trial_period_expired(Time.zone.now - 1.day)
-          assert_equal 1, found.size
-          assert_equal @cinstance.id, found.first.id
-        end
+      Timecop.travel(4.days.from_now) do
+        found = Cinstance.with_trial_period_expired(Time.zone.now - 1.day)
+        assert_equal 1, found.size
+        assert_equal @cinstance.id, found.first.id
       end
     end
   end
 
-
-
-
   test 'trial? returns false if plan has no trial period' do
-    plan = FactoryBot.create(:application_plan, :trial_period_days => 0)
-    cinstance = FactoryBot.create(:cinstance, :plan => plan)
+    plan = FactoryBot.create(:application_plan, trial_period_days: 0)
+    cinstance = FactoryBot.create(:cinstance, plan: plan)
 
-    assert !cinstance.trial?
+    assert_not cinstance.trial?
   end
 
   test 'trial? accepts a date as argument' do
-    plan = FactoryBot.create(:application_plan, :trial_period_days => 0)
-    cinstance = FactoryBot.create(:cinstance, :plan => plan)
+    plan = FactoryBot.create(:application_plan, trial_period_days: 0)
+    cinstance = FactoryBot.create(:cinstance, plan: plan)
 
-    expires_at = Time.parse('2017-11-13T08:00:00-09:00') # 17:00:00 UTC
+    expires_at = Time.zone.parse('2017-11-13T08:00:00-09:00') # 17:00:00 UTC
     cinstance.expects(:trial_period_expires_at).at_least_once.returns(expires_at)
 
-    now = Time.parse('2017-11-13T17:00:00+01:00') # 16:00:00 UTC
+    now = Time.zone.parse('2017-11-13T17:00:00+01:00') # 16:00:00 UTC
     assert cinstance.trial?(now)
 
-    now = Time.parse('2017-11-13T19:00:00+01:00') # 18:00:00 UTC
-    refute cinstance.trial?(now)
+    now = Time.zone.parse('2017-11-13T19:00:00+01:00') # 18:00:00 UTC
+    assert_not cinstance.trial?(now)
   end
 
-  should 'remaining_trial_period_days returns remaining days of trial period'
-  # do
-  #     plan = FactoryBot.create(:plan, :trial_period_days => 30)
-  #     cinstance = Cinstance.new(:plan => plan)
+  pending_test 'remaining_trial_period_days returns remaining days of trial period'
+  #     plan = FactoryBot.create(:plan, trial_period_days: 30)
+  #     cinstance = Cinstance.new(plan: plan)
 
   #     assert_equal 30, cinstance.remaining_trial_period_days
 
@@ -111,8 +105,8 @@ class Cinstance::TrialTest < ActiveSupport::TestCase
   #   end
 
   test 'Cinstance#remaining_trial_period_days returns 0 if trial period expired' do
-    plan = FactoryBot.create(:application_plan, :trial_period_days => 30)
-    cinstance = FactoryBot.create(:cinstance, :plan => plan)
+    plan = FactoryBot.create(:application_plan, trial_period_days: 30)
+    cinstance = FactoryBot.create(:cinstance, plan: plan)
 
     Timecop.travel(40.days.from_now) do
       assert_equal 0, cinstance.remaining_trial_period_days

--- a/test/unit/month_test.rb
+++ b/test/unit/month_test.rb
@@ -1,57 +1,56 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MonthTest < ActiveSupport::TestCase
+  def setup
+    @first_of_february_2004 = Time.zone.local(2004, 2, 1).to_date # rubocop:disable Naming/VariableNumber
+  end
 
-  context 'Month' do
-    setup do
-      @first_of_february_2004 = Time.zone.local(2004,2,1).to_date
-    end
+  test 'initialize by first day' do
+    month = Month.new(@first_of_february_2004)
+    assert_equal Time.zone.local(2004, 2, 1).to_date, month.begin
+    assert_equal Time.zone.local(2004, 2, 29).to_date, month.end
+  end
 
-    should 'initialize by first day' do
-      month = Month.new(@first_of_february_2004)
-      assert_equal Time.zone.local(2004, 2, 1).to_date, month.begin
-      assert_equal Time.zone.local(2004, 2, 29).to_date, month.end
-    end
+  test 'initialize by year and day' do
+    month = Month.new(2009,3)
+    assert_equal Time.zone.local(2009, 3, 1).to_date, month.begin
+    assert_equal Time.zone.local(2009, 3, 31).to_date, month.end
+  end
 
-    should 'initialize by year and day' do
-      month = Month.new(2009,3)
-      assert_equal Time.zone.local(2009, 3, 1).to_date, month.begin
-      assert_equal Time.zone.local(2009, 3, 31).to_date, month.end
-    end
+  test 'initialize by first day and date arguments equally' do
+    assert_equal Month.new(@first_of_february_2004), Month.new(2004, 2)
+  end
 
-    should 'initialize by first day and date arguments equally' do
-      assert_equal Month.new(@first_of_february_2004), Month.new(2004,2)
-    end
+  test 'parse string' do
+    m = Month.parse_month '2001-11'
+    assert m.is_a?(Month)
+    assert_equal 11, m.begin.month
+    assert_equal 2001, m.begin.year
+  end
 
-    should 'parse string' do
-      m = Month.parse_month '2001-11'
-      assert m.is_a?(Month)
-      assert_equal m.begin.month, 11
-      assert_equal m.begin.year, 2001
-    end
+  test 'parse not exactly right string' do
+    assert_equal Month.new(2011, 1), Month.parse_month('2011-01-05')
+  end
 
-    should 'parse not exactly right string' do
-      assert_equal Month.new(2011, 01), Month.parse_month('2011-01-05')
-    end
+  test 'parse robustly' do
+    assert_nil Month.parse_month nil
+  end
 
-    should 'parse robustly' do
-      assert_nil Month.parse_month nil
-    end
+  test 'return nil when parsing invalid date' do
+    assert_nil Month.parse_month 'not-a-date'
+    assert_nil Month.parse_month 'giberish'
+  end
 
-    should 'return nil when parsing invalid date' do
-      assert_nil Month.parse_month 'not-a-date'
-      assert_nil Month.parse_month 'giberish'
-    end
+  test 'raise with wrong params' do
+    assert_raises(ArgumentError) { Month.new('abcd') }
+    assert_raises(ArgumentError) { Month.new(2001, 2, 1) }
+  end
 
-    should 'raise with wrong params' do
-      assert_raises(ArgumentError) { Month.new('abcd') }
-      assert_raises(ArgumentError) { Month.new(2001,2,1) }
-    end
-
-    should 'return correct next month' do
-      assert_equal Month.new(2004,6), Month.new(2004,5).next
-      assert_equal Month.new(2002,1), Month.new(2001,12).next
-    end
+  test 'return correct next month' do
+    assert_equal Month.new(2004, 6), Month.new(2004, 5).next
+    assert_equal Month.new(2002, 1), Month.new(2001, 12).next
   end
 
   test '#to_time_range returns a TimeRange' do
@@ -61,15 +60,14 @@ class MonthTest < ActiveSupport::TestCase
     assert_equal Time.zone.local(2010, 11, 30).end_of_day, range.end
   end
 
-
   def test_i18_localize
-    month = Month.new(2015, 06)
+    month = Month.new(2015, 6)
 
-    assert_equal 'June 2015', I18n.localize(month, format: :month)
+    assert_equal 'June 2015', I18n.l(month, format: :month)
   end
 
   test '#to_s' do
-    month = Month.new(2015, 06)
+    month = Month.new(2015, 6)
     assert_equal 'June 01, 2015 - June 30, 2015', month.to_s
     assert_equal '2015-06-01', month.to_s(:db)
   end

--- a/test/unit/referrer_filters_test.rb
+++ b/test/unit/referrer_filters_test.rb
@@ -12,7 +12,7 @@ class ReferrerFiltersTest < ActiveSupport::TestCase
 
   test 'have immutable value' do
     assert_raise(ActiveRecord::ActiveRecordError) do
-      @referrer_filters.update(value: 'another')
+      FactoryBot.create(:referrer_filter).update_attribute(:value, 'another') # rubocop:disable Rails/SkipsModelValidations
     end
   end
 

--- a/test/unit/referrer_filters_test.rb
+++ b/test/unit/referrer_filters_test.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ReferrerFiltersTest < ActiveSupport::TestCase
-
-  subject { @referrer_filter ||= FactoryBot.create(:referrer_filter) }
-
   def setup
     ReferrerFilter.disable_backend!
+
+    @application = FactoryBot.create(:cinstance)
+    @referrer_filters = @application.referrer_filters
   end
 
-  should 'have immutable value' do
+  test 'have immutable value' do
     assert_raise(ActiveRecord::ActiveRecordError) do
-      subject.update_attribute :value, 'another'
+      @referrer_filters.update(value: 'another')
     end
   end
 
@@ -26,80 +28,67 @@ class ReferrerFiltersTest < ActiveSupport::TestCase
     assert_equal referrer_filter.id, DeletedObject.referrer_filters.last!.object_id
   end
 
-  context 'referrer_filters' do
+  test 'add filters' do
+    assert_equal 0, @referrer_filters.size
 
-    setup do
-      @application = FactoryBot.create(:cinstance)
-      @referrer_filters = @application.referrer_filters
+    assert @referrer_filters.add('whatever').persisted?
+    assert_not @referrer_filters.add('whatever').persisted?
+
+    assert_equal 1, @referrer_filters.size
+  end
+
+  test 'validate format of value' do
+    ReferrerFilter.any_instance.stubs(:keys_limit_reached).returns({})
+
+    valid = ['example.net', '73.170.78.2', 'foo-bar.example.net', 'example.*', '*.example.com', 'west-is-123.the.best', 'example.example.org']
+    valid.each do |value|
+      assert @referrer_filters.add(value).persisted?, "'#{value}' is valid"
     end
 
-    should 'add filters' do
-      assert_equal 0, @referrer_filters.size
+    invalid = ['@example.net', 'example.net:80', '+73.170.78.2', ' 73.170.78.2', 'example.net?query=s', 'http://example.org', '73.170.78.2 ']
+    invalid.each do |value|
+      assert_not @referrer_filters.add(value).persisted?, "'#{value}' is invalid"
+    end
+  end
 
-      assert @referrer_filters.add('whatever').persisted?
-      # should validate uniqueness
-      refute @referrer_filters.add('whatever').persisted?
+  test 'return list of values' do
+    assert @referrer_filters.add('some-key')
+    assert_equal ['some-key'], @referrer_filters.pluck_values
+  end
 
-      assert_equal 1, @referrer_filters.size
+  test 'raise when removing unknown value' do
+    assert_raise(ActiveRecord::RecordNotFound) do
+      @referrer_filters.remove('unknown')
+    end
+  end
+
+  test 'remove key' do
+    key = FactoryBot.create(:referrer_filter, application: @application)
+    assert_equal [key], @application.referrer_filters.reload
+    assert @application.referrer_filters.remove(key.value)
+    assert_equal [], @application.referrer_filters
+  end
+
+  test 'limit number of keys' do
+    ReferrerFilter::REFERRER_FILTERS_LIMIT.times do |n|
+      assert @referrer_filters.add("filter-#{n+1}").persisted?
     end
 
-    should 'validate format of value' do
-      ReferrerFilter.any_instance.stubs(:keys_limit_reached).returns({})
+    # REFERRER_FILTERS_LIMIT + 1 is over the limit
+    # TODO: maybe check for raise?
+    referrer_filter = @referrer_filters.add('limit-reached')
+    assert_not referrer_filter.persisted?
 
-      # valid
-      ['example.net', '73.170.78.2', 'foo-bar.example.net', 'example.*',
-       '*.example.com', 'west-is-123.the.best', 'example.example.org'].each do |value|
+    assert_no_match(/translation missing/, referrer_filter.errors[:base].to_sentence)
+  end
 
-        assert @referrer_filters.add(value).persisted?, "'#{value}' is valid"
-      end
+  test 'update backend' do
+    ReferrerFilter.enable_backend!
 
-      # invalid
-      ['@example.net', 'example.net:80', '+73.170.78.2', ' 73.170.78.2',
-       'example.net?query=s', 'http://example.org', '73.170.78.2 '].each do |value|
+    expect_backend_create_referrer_filter(@application, 'some-key')
+    @referrer_filters.add('some-key')
 
-        refute @referrer_filters.add(value).persisted?, "'#{value}' is invalid"
-      end
-    end
-
-    should 'return list of values' do
-      assert @referrer_filters.add('some-key')
-      assert_equal ['some-key'], @referrer_filters.pluck_values
-    end
-
-    should 'raise when removing unknown value' do
-      assert_raise(ActiveRecord::RecordNotFound) do
-        @referrer_filters.remove('unknown')
-      end
-    end
-
-    should 'remove key' do
-      key = FactoryBot.create(:referrer_filter, :application => @application)
-      assert_equal [key], @application.referrer_filters.reload
-      assert @application.referrer_filters.remove(key.value)
-      assert_equal [], @application.referrer_filters
-    end
-
-    should 'limit number of keys' do
-      ReferrerFilter::REFERRER_FILTERS_LIMIT.times do |n|
-        assert @referrer_filters.add("filter-#{n+1}").persisted?
-      end
-
-      # REFERRER_FILTERS_LIMIT + 1 is over the limit
-      # TODO: maybe check for raise?
-      referrer_filter = @referrer_filters.add('limit-reached')
-      refute referrer_filter.persisted?
-
-      refute_match(/translation missing/, referrer_filter.errors[:base].to_sentence)
-    end
-
-    should 'update backend' do
-      ReferrerFilter.enable_backend!
-
-      expect_backend_create_referrer_filter(@application, 'some-key')
-      @referrer_filters.add('some-key')
-
-      expect_backend_delete_referrer_filter(@application, 'some-key')
-      @referrer_filters.remove('some-key')
-    end
+    expect_backend_delete_referrer_filter(@application, 'some-key')
+    @referrer_filters.remove('some-key')
   end
 end


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/unit/array_test.rb
* test/unit/abilities/forums_test.rb
* test/unit/month_test.rb
* test/unit/referrer_filters_test.rb
* test/unit/cinstance/trial_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)