### PR TITLE
Remove `context` and `should` from message_test

### DIFF
--- a/test/unit/message_test.rb
+++ b/test/unit/message_test.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MessageTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
-  def test_not_system_for_provider
+  test '#not_system_for_provider' do
     provider = FactoryBot.create(:simple_provider)
     buyer = FactoryBot.create(:simple_buyer, provider_account: provider)
     assert_equal 0, provider.messages.reload.not_system_for_provider.count
@@ -18,7 +20,7 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal 2, provider.messages.reload.not_system_for_provider.count
   end
 
-  def test_send_notifications
+  test 'send notifications' do
     provider = FactoryBot.create(:simple_provider)
     buyer = FactoryBot.create(:simple_buyer, provider_account: provider)
 
@@ -43,8 +45,8 @@ class MessageTest < ActiveSupport::TestCase
 
     ActionMailer::Base.deliveries = []
 
-    message = Message.create!(:sender => sender, :to => recipients,
-                              :subject => 'hello', :body => "what's up?")
+    message = Message.create!(sender: sender, to: recipients,
+                              subject: 'hello', body: "what's up?")
     perform_enqueued_jobs(only: ActionMailer::DeliveryJob) { message.deliver! }
 
     assert delivery = ActionMailer::Base.deliveries.first
@@ -60,12 +62,7 @@ class MessageTest < ActiveSupport::TestCase
   end
 
   test 'keeps subject' do
-    message = FactoryBot.create(:message)
-
-    message.update_column(:subject, 'foobar')
-
-    message.reload
-
+    message = FactoryBot.create(:message, subject: 'foobar')
     assert_equal 'foobar', message.subject
   end
 
@@ -83,21 +80,15 @@ class MessageTest < ActiveSupport::TestCase
 
     sender = FactoryBot.create(:provider_account, from_email: 'fake_email@example.com')
 
-    recipients = [FactoryBot.create(:simple_buyer, provider_account: sender),
-                  FactoryBot.create(:simple_buyer, provider_account: sender)]
-
-    recipients.each do |account|
-      FactoryBot.create(:simple_admin, account: account)
-    end
+    recipients = FactoryBot.create_list(:simple_buyer, 2, provider_account: sender)
+    recipients.each { |account| FactoryBot.create(:simple_admin, account: account) }
 
     ActionMailer::Base.deliveries = []
 
-    message = Message.create!(sender: sender, to: recipients,
-                              subject: 'hello', body: "what's up?")
+    message = Message.create!(sender: sender, to: recipients, subject: 'hello', body: "what's up?")
     perform_enqueued_jobs(only: ActionMailer::DeliveryJob) { message.deliver! }
 
     assert delivery = ActionMailer::Base.deliveries.first
-
     assert_equal delivery['from'].value, sender.from_email
   end
 
@@ -107,7 +98,7 @@ class MessageTest < ActiveSupport::TestCase
     Rails.env.stubs(:test?).returns(false)
 
     message = FactoryBot.create(:message)
-    acc1, acc2 = FactoryBot.create(:simple_account), FactoryBot.create(:simple_account)
+    acc1, acc2 = FactoryBot.create_list(:simple_account, 2)
 
     message.to = acc1
     message.bcc = acc2
@@ -118,409 +109,385 @@ class MessageTest < ActiveSupport::TestCase
     message.deliver!
   end
 
-  context 'by default' do
-    setup do
-      @message = Message.new
-    end
-
-    should 'not have a sender' do
-      assert_nil @message.sender
-    end
-
-    should 'not have a subject' do
-      assert @message.subject.blank?
-    end
-
-    should 'not have a body' do
-      assert @message.body.blank?
-    end
-
-    should 'be in unsent state' do
-      assert @message.unsent?
-    end
-
-    should 'not be hidden' do
-      assert_nil @message.hidden_at
-      assert_not @message.hidden?
-    end
+  test 'not have a sender by default' do
+    assert_nil Message.new.sender
   end
 
-  context 'A message' do
-    setup do
-      @account = FactoryBot.create(:simple_account)
-    end
-
-    should 'be valid with a set of valid attributes' do
-      message = FactoryBot.build(:message, sender: @account)
-      assert message.valid?
-    end
-
-    should 'require a sender_id' do
-      message = FactoryBot.build(:message, sender: nil)
-      assert_not message.valid?
-      assert_equal 1, message.errors[:sender_id].size
-    end
-
-    should 'not require a subject' do
-      message = FactoryBot.build(:message, subject: nil, sender: @account)
-      assert message.valid?
-    end
-
-    should 'not require a body' do
-      message = FactoryBot.build(:message, :body => nil, :sender => @account)
-      assert message.valid?
-    end
+  test 'not have a subject by default' do
+    assert Message.new.subject.blank?
   end
 
-  context 'message before being created' do
-    setup do
-      @sender = FactoryBot.create(:simple_provider)
-      @receiver = FactoryBot.create(:simple_buyer, provider_account: @sender)
-
-      @message = FactoryBot.build(:message, sender: @sender)
-    end
-
-    should 'be enqueueable to background job queue' do
-      @message.enqueue! :to => [@receiver.id]
-
-      assert_equal 1, MessageWorker.jobs.size
-
-      assert job = MessageWorker.jobs.first
-
-      receivers, attributes = job['args']
-
-      assert_equal({ 'to' => [@receiver.id] }, receivers)
-      assert_equal @message.attributes, attributes
-    end
-
-    should 'not have any recipients' do
-      assert @message.recipients.empty?
-    end
-
-    should 'not have any to receivers' do
-      assert @message.to.empty?
-    end
-
-    should 'allow to receivers to be built' do
-      @message.to(@receiver)
-      assert_equal [@receiver], @message.to
-    end
-
-    should 'not_have_any_cc_receivers' do
-      assert @message.cc.empty?
-    end
-
-    should 'allow_cc_receivers_to_be_built' do
-      @message.cc(@receiver)
-      assert_equal [@receiver], @message.cc
-    end
-
-    should 'not_have_any_bcc_receivers' do
-      assert @message.bcc.empty?
-    end
-
-    should 'allow_bcc_receivers_to_be_built' do
-      @message.bcc(@receiver)
-      assert_equal [@receiver], @message.bcc
-    end
+  test 'not have a body by default' do
+    assert Message.new.body.blank?
   end
 
-  context 'message after being created' do
-    setup do
-      @sender = FactoryBot.create(:simple_account)
-      @receiver = FactoryBot.create(:simple_account)
-
-      @message = FactoryBot.create(:message, sender: @sender)
-    end
-
-    should "not be enqued to background job queue" do
-      @message.enqueue! :to => @receiver.id
-      assert_equal 0, MessageWorker.jobs.size
-    end
-
-    should 'record when it was created' do
-      assert_not_nil @message.created_at
-    end
-
-    should 'record when it was updated' do
-      assert_not_nil @message.updated_at
-    end
-
-    should 'not have any recipients' do
-      assert @message.recipients.empty?
-    end
-
-    should 'not have any to receivers' do
-      assert @message.to.empty?
-    end
-
-    should 'allow to receivers to be built' do
-      @message.to(@receiver)
-      assert_equal [@receiver], @message.to
-    end
-
-    should 'not have any cc receivers' do
-      assert @message.cc.empty?
-    end
-
-    should 'allow cc receivers to be built' do
-      @message.cc(@receiver)
-      assert_equal [@receiver], @message.cc
-    end
-
-    should 'not have any bcc receivers' do
-      assert @message.bcc.empty?
-    end
-
-    should 'allow bcc receivers to be built' do
-      @message.bcc(@receiver)
-      assert_equal [@receiver], @message.bcc
-    end
+  test 'be in unsent state by default' do
+    assert Message.new.unsent?
   end
 
-  context 'message with recipients' do
-    setup do
-      sender = FactoryBot.create(:simple_provider)
-      @erich = FactoryBot.create(:simple_buyer, provider_account: sender)
-      @richard = FactoryBot.create(:simple_buyer, provider_account: sender)
-      @ralph = FactoryBot.create(:simple_buyer, provider_account: sender)
-      @message = FactoryBot.create(:message,
-                                   :to => @erich,
-                                   :cc => @richard,
-                                   :bcc => @ralph,
-                                   :sender => sender
-      )
-    end
-
-    should 'have recipients' do
-      assert_equal 3, @message.recipients.count
-    end
-
-    should 'have to receivers' do
-      assert_equal [@erich], @message.to
-    end
-
-    should 'have cc receivers' do
-      assert_equal [@richard], @message.cc
-    end
-
-    should 'have bcc receivers' do
-      assert_equal [@ralph], @message.bcc
-    end
-
-    should 'be able to deliver' do
-      assert @message.deliver!
-    end
+  test 'not be hidden by default' do
+    assert_nil Message.new.hidden_at
+    assert_not Message.new.hidden?
   end
 
-  context 'message hidden' do
-    setup do
-      @message = FactoryBot.create(:message, :sender => FactoryBot.create(:simple_account))
-      @message.hide!
-    end
-
-    should 'record when it was hidden' do
-      assert_not_nil @message.hidden_at
-    end
-
-    should 'be hidden' do
-      assert @message.hidden?
-    end
+  test 'A message be valid with a set of valid attributes' do
+    message = FactoryBot.build(:message, sender: FactoryBot.create(:simple_account))
+    assert_valid message
   end
 
-  context 'message unhidden' do
-    setup do
-      @message = FactoryBot.create(:message, :sender => FactoryBot.create(:simple_account))
-      @message.hide!
-      @message.unhide!
-    end
-
-    should 'not have the recorded value when it was hidden' do
-      assert_nil @message.hidden_at
-    end
-
-    should 'not be hidden' do
-      refute @message.hidden?
-    end
+  test 'A message require a sender_id' do
+    message = FactoryBot.build(:message, sender: nil)
+    assert_not message.valid?
+    assert_equal 1, message.errors[:sender_id].size
   end
 
-  context 'message forwarded' do
-    setup do
-      @sender = FactoryBot.create(:simple_account)
-      original_message = FactoryBot.create(:message,
-                                           :subject => 'Hello',
-                                           :body => 'How are you?',
-                                           :sender => @sender,
-                                           :to => FactoryBot.create(:simple_account),
-                                           :cc => FactoryBot.create(:simple_account),
-                                           :bcc => FactoryBot.create(:simple_account)
-      )
-
-      @message = original_message.forward
-    end
-
-    should 'be in unsent state' do
-      assert @message.unsent?
-    end
-
-    should 'not be hidden' do
-      refute @message.hidden?
-    end
-
-    should 'have original subject' do
-      assert_equal 'Hello', @message.subject
-    end
-
-    should 'have original body' do
-      assert_equal 'How are you?', @message.body
-    end
-
-    should 'use same sender' do
-      assert_equal @sender, @message.sender
-    end
-
-    should 'not include to recipients' do
-      assert @message.to.empty?
-    end
-
-    should 'not include cc recipients' do
-      assert @message.cc.empty?
-    end
-
-    should 'not include bcc recipients' do
-      assert @message.bcc.empty?
-    end
+  test 'A message not require a subject' do
+    message = FactoryBot.build(:message, subject: nil, sender: FactoryBot.create(:simple_account))
+    assert_valid message
   end
 
-  context 'message replied' do
-    setup do
-      @admin = FactoryBot.create(:simple_account)
-      @erich = FactoryBot.create(:simple_account)
-      @richard = FactoryBot.create(:simple_account)
-      @ralph = FactoryBot.create(:simple_account)
-
-      original_message = FactoryBot.create(:message,
-                                           :subject => 'Hello',
-                                           :body => "This is first line.\n\nThis is second line.",
-                                           :sender => @admin,
-                                           :to => @erich,
-                                           :cc => @richard,
-                                           :bcc => @ralph
-      )
-
-      @message = original_message.reply
-    end
-
-    should 'be in unsent state' do
-      assert @message.unsent?
-    end
-
-    should 'not be hidden' do
-      refute @message.hidden?
-    end
-
-    should 'have original subject prefixed with Re:' do
-      assert_equal 'Re: Hello', @message.subject
-    end
-
-    should 'have original body with quotation tags' do
-      assert_equal "> This is first line.\n> \n> This is second line.", @message.body
-    end
-
-    should 'use same sender' do
-      assert_equal @admin, @message.sender
-    end
-
-    should 'use same to recipients' do
-      assert_equal [@erich], @message.to
-    end
-
-    should 'not include cc recipients' do
-      assert @message.cc.empty?
-    end
-
-    should 'not include bcc recipients' do
-      assert @message.bcc.empty?
-    end
-  end
-
-  context 'message replied to all' do
-    setup do
-      @admin = FactoryBot.create(:simple_account)
-      @erich = FactoryBot.create(:simple_account)
-      @richard = FactoryBot.create(:simple_account)
-      @ralph = FactoryBot.create(:simple_account)
-
-      original_message = FactoryBot.create(:message, subject: 'Hello',
-                                                     body: 'How are you?',
-                                                     sender: @admin,
-                                                     to: @erich,
-                                                     cc: @richard,
-                                                     bcc: @ralph)
-
-      @message = original_message.reply_to_all
-    end
-
-    should 'be in unsent state' do
-      assert @message.unsent?
-    end
-
-    should 'not be hidden' do
-      assert_not @message.hidden?
-    end
-
-    should 'have original subject prefixed with Re:' do
-      assert_equal 'Re: Hello', @message.subject
-    end
-
-    should 'have original body with quotation tags' do
-      assert_equal '> How are you?', @message.body
-    end
-
-    should 'use same sender' do
-      assert_equal @admin, @message.sender
-    end
-
-    should 'use same to recipients' do
-      assert_equal [@erich], @message.to
-    end
-
-    should 'use same cc recipients' do
-      assert_equal [@richard], @message.cc
-    end
-
-    should 'use same bcc recipients' do
-      assert_equal [@ralph], @message.bcc
-    end
-  end
-
-  context 'message as a class' do
-    setup do
-      Message.delete_all
-      @hidden_message = FactoryBot.create(:message, hidden_at: Time.now,
-                                                    sender: FactoryBot.create(:simple_account))
-      @visible_message = FactoryBot.create(:message, sender: FactoryBot.create(:simple_account))
-    end
-
-    should 'include only visible messages in visible scope' do
-      assert_equal [@visible_message], Message.visible
-    end
+  test 'A message not require a body' do
+    message = FactoryBot.build(:message, body: nil, sender: FactoryBot.create(:simple_account))
+    assert_valid message
   end
 
   test 'restore' do
     provider = FactoryBot.create(:simple_account)
     buyer = FactoryBot.create(:buyer_account, provider_account: provider)
     provider_sent_message = FactoryBot.create(:message, sender: provider)
-    buyer_received_message = FactoryBot.create(:received_message, message: provider_sent_message, receiver: buyer)
+    FactoryBot.create(:received_message, message: provider_sent_message, receiver: buyer)
     buyer_sent_message = FactoryBot.create(:message, sender: buyer)
     provider_received_message = FactoryBot.create(:received_message, message: buyer_sent_message, receiver: provider)
 
     [provider_sent_message, provider_received_message].each(&:hide!)
 
     provider_sent_message.restore_for!(provider)
-    refute provider_sent_message.reload.hidden?
+    assert_not provider_sent_message.reload.hidden?
 
     buyer_sent_message.restore_for!(provider)
     assert_not provider_received_message.reload.hidden?
+  end
+end
+
+class MessageBeforeBeingCreatedTest < ActiveSupport::TestCase
+  def setup
+    @sender = FactoryBot.create(:simple_provider)
+    @receiver = FactoryBot.create(:simple_buyer, provider_account: @sender)
+
+    @message = FactoryBot.build(:message, sender: @sender)
+  end
+
+  test 'message before being created be enqueueable to background job queue' do
+    @message.enqueue! to: [@receiver.id]
+
+    assert_equal 1, MessageWorker.jobs.size
+
+    assert job = MessageWorker.jobs.first
+
+    receivers, attributes = job['args']
+
+    assert_equal({ 'to' => [@receiver.id] }, receivers)
+    assert_equal @message.attributes, attributes
+  end
+
+  test 'message before being created not have any recipients' do
+    assert_empty @message.recipients
+  end
+
+  test 'message before being created not have any to receivers' do
+    assert_empty @message.to
+  end
+
+  test 'message before being created allow to receivers to be built' do
+    @message.to(@receiver)
+    assert_equal [@receiver], @message.to
+  end
+
+  test 'message before being created not_have_any_cc_receivers' do
+    assert_empty @message.cc
+  end
+
+  test 'message before being created allow_cc_receivers_to_be_built' do
+    @message.cc(@receiver)
+    assert_equal [@receiver], @message.cc
+  end
+
+  test 'message before being created not_have_any_bcc_receivers' do
+    assert_empty @message.bcc
+  end
+
+  test 'message before being created allow_bcc_receivers_to_be_built' do
+    @message.bcc(@receiver)
+    assert_equal [@receiver], @message.bcc
+  end
+end
+
+class MessageAfterBeingCreatedTest < ActiveSupport::TestCase
+  def setup
+    @sender = FactoryBot.create(:simple_account)
+    @receiver = FactoryBot.create(:simple_account)
+
+    @message = FactoryBot.create(:message, sender: @sender)
+  end
+
+  test "not be enqued to background job queue" do
+    @message.enqueue! to: @receiver.id
+    assert_equal 0, MessageWorker.jobs.size
+  end
+
+  test 'record when it was created' do
+    assert_not_nil @message.created_at
+  end
+
+  test 'record when it was updated' do
+    assert_not_nil @message.updated_at
+  end
+
+  test 'not have any recipients' do
+    assert_empty @message.recipients
+  end
+
+  test 'not have any to receivers' do
+    assert_empty @message.to
+  end
+
+  test 'allow to receivers to be built' do
+    @message.to(@receiver)
+    assert_equal [@receiver], @message.to
+  end
+
+  test 'not have any cc receivers' do
+    assert_empty @message.cc
+  end
+
+  test 'allow cc receivers to be built' do
+    @message.cc(@receiver)
+    assert_equal [@receiver], @message.cc
+  end
+
+  test 'not have any bcc receivers' do
+    assert_empty @message.bcc
+  end
+
+  test 'allow bcc receivers to be built' do
+    @message.bcc(@receiver)
+    assert_equal [@receiver], @message.bcc
+  end
+end
+
+class MessageWithRecipientsTest < ActiveSupport::TestCase
+  def setup
+    sender = FactoryBot.create(:simple_provider)
+    @erich = FactoryBot.create(:simple_buyer, provider_account: sender)
+    @richard = FactoryBot.create(:simple_buyer, provider_account: sender)
+    @ralph = FactoryBot.create(:simple_buyer, provider_account: sender)
+    @message = FactoryBot.create(:message, to: @erich,
+                                           cc: @richard,
+                                           bcc: @ralph,
+                                           sender: sender )
+  end
+
+  test 'have recipients' do
+    assert_equal 3, @message.recipients.count
+  end
+
+  test 'have to receivers' do
+    assert_equal [@erich], @message.to
+  end
+
+  test 'have cc receivers' do
+    assert_equal [@richard], @message.cc
+  end
+
+  test 'have bcc receivers' do
+    assert_equal [@ralph], @message.bcc
+  end
+
+  test 'be able to deliver' do
+    assert @message.deliver!
+  end
+end
+
+class MessageHiddenTest < ActiveSupport::TestCase
+  def setup
+    @message = FactoryBot.create(:message, sender: FactoryBot.create(:simple_account))
+    @message.hide!
+  end
+
+  test 'record when it was hidden' do
+    assert_not_nil @message.hidden_at
+  end
+
+  test 'be hidden' do
+    assert @message.hidden?
+  end
+end
+
+class MessageUnhiddenTest < ActiveSupport::TestCase
+  def setup
+    @message = FactoryBot.create(:message, sender: FactoryBot.create(:simple_account))
+    @message.hide!
+    @message.unhide!
+  end
+
+  test 'not have the recorded value when it was hidden' do
+    assert_nil @message.hidden_at
+  end
+
+  test 'not be hidden' do
+    assert_not @message.hidden?
+  end
+end
+
+class MessageForwardedTest < ActiveSupport::TestCase
+  def setup
+    @sender = FactoryBot.create(:simple_account)
+    original_message = FactoryBot.create(:message, subject: 'Hello',
+                                                   body: 'How are you?',
+                                                   sender: @sender,
+                                                   to: FactoryBot.create(:simple_account),
+                                                   cc: FactoryBot.create(:simple_account),
+                                                   bcc: FactoryBot.create(:simple_account))
+    @message = original_message.forward
+  end
+
+  test 'be in unsent state' do
+    assert @message.unsent?
+  end
+
+  test 'not be hidden' do
+    assert_not @message.hidden?
+  end
+
+  test 'have original subject' do
+    assert_equal 'Hello', @message.subject
+  end
+
+  test 'have original body' do
+    assert_equal 'How are you?', @message.body
+  end
+
+  test 'use same sender' do
+    assert_equal @sender, @message.sender
+  end
+
+  test 'not include to recipients' do
+    assert_empty @message.to
+  end
+
+  test 'not include cc recipients' do
+    assert_empty @message.cc
+  end
+
+  test 'not include bcc recipients' do
+    assert_empty @message.bcc
+  end
+end
+
+class MessageRepliedTest < ActiveSupport::TestCase
+  def setup
+    @admin = FactoryBot.create(:simple_account)
+    @erich = FactoryBot.create(:simple_account)
+    @richard = FactoryBot.create(:simple_account)
+    @ralph = FactoryBot.create(:simple_account)
+    original_message = FactoryBot.create(:message, subject: 'Hello',
+                                                   body: "This is first line.\n\nThis is second line.",
+                                                   sender: @admin,
+                                                   to: @erich,
+                                                   cc: @richard,
+                                                   bcc: @ralph)
+    @message = original_message.reply
+  end
+
+  test 'be in unsent state' do
+    assert @message.unsent?
+  end
+
+  test 'not be hidden' do
+    assert_not @message.hidden?
+  end
+
+  test 'have original subject prefixed with Re:' do
+    assert_equal 'Re: Hello', @message.subject
+  end
+
+  test 'have original body with quotation tags' do
+    assert_equal "> This is first line.\n> \n> This is second line.", @message.body
+  end
+
+  test 'use same sender' do
+    assert_equal @admin, @message.sender
+  end
+
+  test 'use same to recipients' do
+    assert_equal [@erich], @message.to
+  end
+
+  test 'not include cc recipients' do
+    assert_empty @message.cc
+  end
+
+  test 'not include bcc recipients' do
+    assert_empty @message.bcc
+  end
+end
+
+class MessageRepliedToAllTest < ActiveSupport::TestCase
+  def setup
+    @admin = FactoryBot.create(:simple_account)
+    @erich = FactoryBot.create(:simple_account)
+    @richard = FactoryBot.create(:simple_account)
+    @ralph = FactoryBot.create(:simple_account)
+    original_message = FactoryBot.create(:message, subject: 'Hello',
+                                                   body: 'How are you?',
+                                                   sender: @admin,
+                                                   to: @erich,
+                                                   cc: @richard,
+                                                   bcc: @ralph)
+    @message = original_message.reply_to_all
+  end
+
+  test 'be in unsent state' do
+    assert @message.unsent?
+  end
+
+  test 'not be hidden' do
+    assert_not @message.hidden?
+  end
+
+  test 'have original subject prefixed with Re:' do
+    assert_equal 'Re: Hello', @message.subject
+  end
+
+  test 'have original body with quotation tags' do
+    assert_equal '> How are you?', @message.body
+  end
+
+  test 'use same sender' do
+    assert_equal @admin, @message.sender
+  end
+
+  test 'use same to recipients' do
+    assert_equal [@erich], @message.to
+  end
+
+  test 'use same cc recipients' do
+    assert_equal [@richard], @message.cc
+  end
+
+  test 'use same bcc recipients' do
+    assert_equal [@ralph], @message.bcc
+  end
+end
+
+class MessageAsAClassTest < ActiveSupport::TestCase
+  def setup
+    Message.delete_all
+    @hidden_message = FactoryBot.create(:message, hidden_at: Time.zone.now, sender: FactoryBot.create(:simple_account))
+    @visible_message = FactoryBot.create(:message, sender: FactoryBot.create(:simple_account))
+  end
+
+  test 'include only visible messages in visible scope' do
+    assert_equal [@visible_message], Message.visible
   end
 end


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/unit/message_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)