### PR TITLE
Remove `context` and `should` and from yet another bunch of tests

### DIFF
--- a/test/unit/liquid/drops/application_drop_test.rb
+++ b/test/unit/liquid/drops/application_drop_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Liquid::Drops::ApplicationDropTest < ActiveSupport::TestCase
@@ -6,6 +8,17 @@ class Liquid::Drops::ApplicationDropTest < ActiveSupport::TestCase
   def setup
     @app = FactoryBot.create(:cinstance, :name => 'some instance')
     @buyer = @app.user_account
+
+    [{ :target => "Cinstance", :name => "visible_extra", :label => "visible_extra" },
+     { :target => "Cinstance", :name => "hidden_extra",  :label => "hidden_extra", :hidden => true }]
+      .each do |field|
+      FactoryBot.create :fields_definition, field.merge({:account_id => @buyer.provider_account.id})
+    end
+
+    @app.reload
+    @app.extra_fields = {"visible_extra" => "visible extra value", "hidden_extra" => "hidden extra value" }
+    @app.save!
+
     @drop = Drops::Application.new(@app)
   end
 
@@ -28,51 +41,34 @@ class Liquid::Drops::ApplicationDropTest < ActiveSupport::TestCase
     assert_same_elements Drops::Collection.for_drop(Drops::Alert).new(expected_alerts), @drop.alerts
   end
 
-  context "field definitions" do
-    setup do
-      [{ :target => "Cinstance", :name => "visible_extra", :label => "visible_extra" },
-       { :target => "Cinstance", :name => "hidden_extra",  :label => "hidden_extra", :hidden => true }]
-       .each do |field|
-         FactoryBot.create :fields_definition, field.merge({:account_id => @buyer.provider_account.id})
-      end
+  test 'builtin_fields should be Fields' do
+    builtins = @drop.builtin_fields
+    assert_instance_of Drops::Fields, builtins
+    assert_instance_of Drops::Field, builtins.first
+  end
 
-      @app.reload
-      @app.extra_fields = {"visible_extra" => "visible extra value", "hidden_extra" => "hidden extra value" }
-      @app.save!
+  test 'bultin fields have visible fields' do
+    assert_equal @app.name, @drop.builtin_fields["name"]
+  end
 
-      @drop = Drops::Application.new(@app)
-    end
+  test 'builtin_fields does not include extra fields' do
+    assert_nil @drop.builtin_fields["visible_extra"]
+  end
 
+  test '#extra_fields are Fields' do
+    extras = @drop.extra_fields
+    assert_instance_of Drops::Fields, extras
+    assert_instance_of Drops::Field, extras.first
+  end
 
-    should 'builtin_fields should be Fields' do
-      builtins = @drop.builtin_fields
-      assert_instance_of Drops::Fields, builtins
-      assert_instance_of Drops::Field, builtins.first
-    end
+  test '#extra_fields have both visible and hidden ones' do
+    extras = @drop.extra_fields
+    assert_equal "visible extra value", extras["visible_extra"]
+    assert_not_nil extras["hidden_extra"]
+  end
 
-    should 'bultin fields have visible fields' do
-      assert_equal @app.name, @drop.builtin_fields["name"]
-    end
-
-    should 'builtin_fields does not include extra fields' do
-      assert_nil @drop.builtin_fields["visible_extra"]
-    end
-
-    should '#extra_fields are Fields' do
-      extras = @drop.extra_fields
-      assert_instance_of Drops::Fields, extras
-      assert_instance_of Drops::Field, extras.first
-    end
-
-    should '#extra_fields have both visible and hidden ones' do
-      extras = @drop.extra_fields
-      assert_equal "visible extra value", extras["visible_extra"]
-      assert_not_nil extras["hidden_extra"]
-    end
-
-    should '#extra_fields does not return builtin fields' do
-      extras = @drop.extra_fields
-      assert_nil extras["name"]
-    end
-  end # field definitions
+  test '#extra_fields does not return builtin fields' do
+    extras = @drop.extra_fields
+    assert_nil extras["name"]
+  end
 end

--- a/test/unit/liquid/drops/application_plan_drop_test.rb
+++ b/test/unit/liquid/drops/application_plan_drop_test.rb
@@ -1,25 +1,25 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Liquid::Drops::ApplicationPlanDropTest < ActiveSupport::TestCase
-  context 'ApplicationPlanDrop' do
-    setup do
-      @plan = FactoryBot.create(:application_plan)
-      2.times { |u| FactoryBot.create(:usage_limit, :plan => @plan) }
-      @drop = Liquid::Drops::ApplicationPlan.new(@plan)
-    end
+  setup do
+    @plan = FactoryBot.create(:application_plan)
+    FactoryBot.create_list(:usage_limit, 2, plan: @plan)
+    @drop = Liquid::Drops::ApplicationPlan.new(@plan)
+  end
 
-    should 'return id' do
-      assert_equal @drop.id, @plan.id
-    end
+  test 'should return id' do
+    assert_equal @drop.id, @plan.id
+  end
 
-    should 'wrap usage_limits' do
-      assert_equal 2, @drop.usage_limits.size
-      assert @drop.usage_limits.all?  { |d| d.class == Liquid::Drops::UsageLimit }
-    end
+  test 'should wrap usage_limits' do
+    assert_equal 2, @drop.usage_limits.size
+    assert(@drop.usage_limits.all?  { |d| d.instance_of?(Liquid::Drops::UsageLimit) })
+  end
 
-    should 'wrap metrics' do
-      assert_equal 1, @drop.metrics.size
-      assert @drop.metrics.all?  { |d| d.class == Liquid::Drops::Metric }
-    end
+  test 'should wrap metrics' do
+    assert_equal 1, @drop.metrics.size
+    assert(@drop.metrics.all?  { |d| d.instance_of?(Liquid::Drops::Metric) })
   end
 end

--- a/test/unit/messengers/service_contract_messenger_test.rb
+++ b/test/unit/messengers/service_contract_messenger_test.rb
@@ -1,49 +1,44 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ServiceContractMessengerTest < ActiveSupport::TestCase
-
   def setup
     @contract = FactoryBot.create(:service_contract)
     @provider = @contract.provider_account
     @plan = @contract.plan
     @buyer = @contract.user_account
     @service = @contract.service
+
+    ServiceContractMessenger.new_contract(@contract).deliver
+    @message = Message.last
   end
 
-  context 'new contract message' do
-
-    setup do
-      ServiceContractMessenger.new_contract(@contract).deliver
-      @message = Message.last
-    end
-
-    should 'be sent' do
-      assert @message.sent?
-    end
-
-    should 'have the provider as recipient' do
-      assert_equal [@provider], @message.to
-    end
-
-    should 'have meaningful subject' do
-      assert_match /service subscription/i, @message.subject
-    end
-
-    should 'contain service name' do
-      assert_match @service.name, @message.body
-    end
-
-    should 'contain plan name' do
-      assert_match @plan.name, @message.body
-    end
-
-    should 'contain buyer name' do
-      assert_match @buyer.org_name, @message.body
-    end
-
-    should 'contain buyer email' do
-      assert_match @buyer.admins.first.email, @message.body
-    end
+  test 'should be sent' do
+    assert @message.sent?
   end
 
+  test 'should have the provider as recipient' do
+    assert_equal [@provider], @message.to
+  end
+
+  test 'should have meaningful subject' do
+    assert_match /service subscription/i, @message.subject
+  end
+
+  test 'should contain service name' do
+    assert_match @service.name, @message.body
+  end
+
+  test 'should contain plan name' do
+    assert_match @plan.name, @message.body
+  end
+
+  test 'should contain buyer name' do
+    assert_match @buyer.org_name, @message.body
+  end
+
+  test 'should contain buyer email' do
+    assert_match @buyer.admins.first.email, @message.body
+  end
 end

--- a/test/unit/pdf/finance/invoice_generator_test.rb
+++ b/test/unit/pdf/finance/invoice_generator_test.rb
@@ -1,57 +1,44 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Pdf::Finance::InvoiceGeneratorTest < ActiveSupport::TestCase
+  LOGO_PICTURE = Rails.root.join('test/fixtures/wide.jpg').to_s
 
-  LOGO_PICTURE = "#{Rails.root}/test/fixtures/wide.jpg"
+  LONG_ADDRESS = [%w[Name Farnsworth],
+                  ['Address', "AAA\n" * 5],
+                  %w[Country Patagonia]].freeze
 
-  LONG_ADDRESS =     [ [ 'Name',    'Farnsworth' ],
-                       [ 'Address', "AAA\n" * 5],
-                       [ 'Country', 'Patagonia' ] ]
-
-
-  context "Pdf::InvoiceGenerator" do
-    setup do
-      cinstance = FactoryBot.create(:cinstance)
-      @invoice = FactoryBot.create(:invoice, :buyer_account => cinstance.buyer_account )
-      @data = Pdf::Finance::InvoiceReportData.new(@invoice)
-      @generator = Pdf::Finance::InvoiceGenerator.new(@data)
-    end
-
-    # TODO: better to use stubbing
-    # TODO: better to test in InvoiceAttachment
-    should 'generate attachment with correct file name' do
-      @invoice.provider_account.update_attribute(:org_name, 'YOU')
-      @invoice.buyer_account.update_attribute(:org_name, 'ME')
-      @invoice.update_attribute(:created_at, Time.zone.local(1984, 1, 31))
-      attachment = @generator.generate_as_attachment
-
-      assert_equal 'invoice-january-1984.pdf', attachment.original_filename
-      assert_equal 'application/pdf', attachment.content_type
-    end
-
-    context "with logo" do
-      setup do
-        @data.stubs(:logo?).returns(true)
-        @data.stubs(:logo).returns(LOGO_PICTURE)
-        @data.stubs(:provider).returns(LONG_ADDRESS)
-      end
-
-      context "and line items" do
-	setup do
-          items = [ ['Licorice', '5', '222', '' ],
-                    ['Haribo  ', '11', '11', '' ],
-                    ['Chocolatte', ''  , '11' , ''],
-                    ['Sugar', nil  , '11' , ''] ]
-
-          @data.stubs(:line_items).returns(items)
- end
-
-        should 'generate valid PDF content' do
-          content = @generator.generate
-          assert_not_nil content
-        end
-      end
-    end
+  setup do
+    cinstance = FactoryBot.create(:cinstance)
+    @invoice = FactoryBot.create(:invoice, buyer_account: cinstance.buyer_account, created_at: Time.zone.local(1984, 1, 31))
+    @data = Pdf::Finance::InvoiceReportData.new(@invoice)
+    @generator = Pdf::Finance::InvoiceGenerator.new(@data)
   end
 
+  # TODO: better to use stubbing
+  # TODO: better to test in InvoiceAttachment
+  test 'should generate attachment with correct file name' do
+    @invoice.provider_account.update(org_name: 'YOU')
+    @invoice.buyer_account.update(org_name: 'ME')
+    attachment = @generator.generate_as_attachment
+
+    assert_equal 'invoice-january-1984.pdf', attachment.original_filename
+    assert_equal 'application/pdf', attachment.content_type
+  end
+
+  test 'should generate valid PDF content with logo and line items' do
+    @data.stubs(:logo?).returns(true)
+    @data.stubs(:logo).returns(LOGO_PICTURE)
+    @data.stubs(:provider).returns(LONG_ADDRESS)
+    items = [['Licorice', '5', '222', ''],
+             ['Haribo  ', '11', '11', ''],
+             ['Chocolatte', '', '11', ''],
+             ['Sugar', nil, '11', '']]
+
+    @data.stubs(:line_items).returns(items)
+
+    content = @generator.generate
+    assert_not_nil content
+  end
 end

--- a/test/unit/three_scale/spam_protection_test.rb
+++ b/test/unit/three_scale/spam_protection_test.rb
@@ -18,7 +18,7 @@ class ThreeScale::SpamProtectionTest < ActiveSupport::TestCase
     has_spam_protection :timestamp
   end
 
-  class EmptyTest < ActiveSupport::TestCase
+  class EmptyModelTest < ActiveSupport::TestCase
     class Empty
       include ThreeScale::SpamProtection::Integration::Model
     end
@@ -28,7 +28,7 @@ class ThreeScale::SpamProtectionTest < ActiveSupport::TestCase
     end
   end
 
-  class ModelTest < ActiveSupport::TestCase
+  class ModelsTest < ActiveSupport::TestCase
     def subject
       @subject ||= ThreeScale::SpamProtection::Integration::Model
     end
@@ -50,7 +50,7 @@ class ThreeScale::SpamProtectionTest < ActiveSupport::TestCase
     end
   end
 
-  class ControllerTest < ActiveSupport::TestCase
+  class ControllersTest < ActiveSupport::TestCase
     def subject
       @subject ||= ThreeScale::SpamProtection::Integration::Controller
     end
@@ -78,13 +78,13 @@ class ThreeScale::SpamProtectionTest < ActiveSupport::TestCase
     end
   end
 
-  class FakeModelTest < ActiveSupport::TestCase
+  class ModelIntegrationTest < ActiveSupport::TestCase
     class Model
       include ThreeScale::SpamProtection::Integration::Model
       has_spam_protection :honeypot, :timestamp
     end
 
-    class ClassTest < FakeModelTest
+    class ClassTest < ModelIntegrationTest
       test "should have right methods" do
         subject = Model
         assert subject.respond_to?(:spam_protection)
@@ -92,7 +92,7 @@ class ThreeScale::SpamProtectionTest < ActiveSupport::TestCase
       end
     end
 
-    class ConfigurationTest < FakeModelTest
+    class ConfigurationTest < ModelIntegrationTest
       setup do
         @subject = Model.spam_protection
       end
@@ -110,7 +110,7 @@ class ThreeScale::SpamProtectionTest < ActiveSupport::TestCase
       end
     end
 
-    class InstanceTest < FakeModelTest
+    class InstanceTest < ModelIntegrationTest
       setup do
         @subject = Model.new
       end
@@ -128,7 +128,7 @@ class ThreeScale::SpamProtectionTest < ActiveSupport::TestCase
       end
     end
 
-    class TimestampTest < FakeModelTest
+    class TimestampTest < ModelIntegrationTest
       test "validate" do
         subject = Timestamp.new
         subject.timestamp = 1.second.ago
@@ -147,7 +147,7 @@ class ThreeScale::SpamProtectionTest < ActiveSupport::TestCase
       end
     end
 
-    class FormProtectionTest < FakeModelTest
+    class FormProtectionTest < ModelIntegrationTest
       setup do
         # We do not want to skip Recaptcha in these tests
         Recaptcha::Verify.stubs(skip?: false)

--- a/test/unit/three_scale/spam_protection_test.rb
+++ b/test/unit/three_scale/spam_protection_test.rb
@@ -148,11 +148,15 @@ class ThreeScale::SpamProtectionTest < ActiveSupport::TestCase
     end
 
     class FormProtectionTest < ModelIntegrationTest
+      class ModelJS < Model
+        include ThreeScale::SpamProtection::Integration::Model
+        has_spam_protection :honeypot, :timestamp, :javascript
+      end
+
       setup do
         # We do not want to skip Recaptcha in these tests
         Recaptcha::Verify.stubs(skip?: false)
-        Model.spam_protection.enable_checks!(:javascript, :honeypot, :timestamp)
-        @object = Model.new
+        @object = ModelJS.new
         @object.stubs(:errors).returns({})
         @template = ActionView::Base.new
         @template.stubs(:logged_in?).returns(false)

--- a/test/unit/web_hook/event_spec_test.rb
+++ b/test/unit/web_hook/event_spec_test.rb
@@ -45,7 +45,7 @@ describe WebHook::Event do
   before { WebHook.stubs(:sanitized_url).returns('http://127.0.0.1/') }
 
   describe "valid event" do
-    let(:resource) { ResourceModel.new(:id => 16, :created => Time.zone.now) }
+    let(:resource) { ResourceModel.new(:id => 16, :created => Time.now) }
 
     it { event.must_be :valid? }
 
@@ -128,7 +128,7 @@ describe WebHook::Event do
   end
 
   describe "created resource" do
-    let(:now) { Time.zone.now }
+    let(:now) { Time.now }
     let(:resource) { mock_resource(:created_at => now, :updated_at => now) }
 
     it { event.event.must_equal 'created' }

--- a/test/unit/web_hook/event_spec_test.rb
+++ b/test/unit/web_hook/event_spec_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest_helper'
 
 # TODO: one day, partialy load rails and leave this on autoloader
@@ -25,9 +27,7 @@ describe WebHook::Event do
 
     def to_xml(options = {})
       builder = options[:builder]
-      builder.resource do |xml|
-        xml.xml
-      end
+      builder.resource(&:xml)
     end
   end
 
@@ -37,7 +37,7 @@ describe WebHook::Event do
 
   let(:web_hook) { stub_everything('web_hook', :enabled? => true) }
   let(:provider) { stub_everything('provider', :id => 16, :web_hook => web_hook, :provider? => true, :web_hooks_allowed? => true) }
-  let(:options)  { Hash.new }
+  let(:options)  { {} }
 
   let(:event)    { WebHook::Event.new(provider, resource, options) }
   let(:enqueue)  { WebHook::Event.enqueue(provider, resource, options) }
@@ -45,7 +45,7 @@ describe WebHook::Event do
   before { WebHook.stubs(:sanitized_url).returns('http://127.0.0.1/') }
 
   describe "valid event" do
-    let(:resource) { ResourceModel.new(:id => 16, :created => Time.now) }
+    let(:resource) { ResourceModel.new(:id => 16, :created => Time.zone.now) }
 
     it { event.must_be :valid? }
 
@@ -86,27 +86,25 @@ describe WebHook::Event do
       end
     end
 
-    context 'without transaction' do
-      before { WebHookWorker.clear }
-
-      it 'enqueues after commit' do
-        assert_equal 0, WebHookWorker.jobs.size
-        Account.transaction do
-          event.enqueue
-          assert_equal 0, WebHookWorker.jobs.size
-        end
-        assert_equal 1, WebHookWorker.jobs.size
-      end
-
-      it 'not enqueues after rollback' do
-        assert_equal 0, WebHookWorker.jobs.size
-        Account.transaction do
-          event.enqueue
-
-          raise ActiveRecord::Rollback
-        end
+    it 'enqueues after commit' do
+      WebHookWorker.clear
+      assert_equal 0, WebHookWorker.jobs.size
+      Account.transaction do
+        event.enqueue
         assert_equal 0, WebHookWorker.jobs.size
       end
+      assert_equal 1, WebHookWorker.jobs.size
+    end
+
+    it 'not enqueues after rollback' do
+      WebHookWorker.clear
+      assert_equal 0, WebHookWorker.jobs.size
+      Account.transaction do
+        event.enqueue
+
+        raise ActiveRecord::Rollback
+      end
+      assert_equal 0, WebHookWorker.jobs.size
     end
   end
 
@@ -115,9 +113,9 @@ describe WebHook::Event do
 
     it { event.resource_type.must_equal 'resource_model' }
     it { event.wont_be :valid? }
-    it { refute event.push_event? }
+    it { assert_not event.push_event? }
 
-    it { refute enqueue }
+    it { assert_not enqueue }
   end
 
   describe "destroyed resource" do
@@ -130,7 +128,7 @@ describe WebHook::Event do
   end
 
   describe "created resource" do
-    let(:now) { Time.now }
+    let(:now) { Time.zone.now }
     let(:resource) { mock_resource(:created_at => now, :updated_at => now) }
 
     it { event.event.must_equal 'created' }
@@ -141,8 +139,8 @@ describe WebHook::Event do
   describe "nil resource" do
     let(:resource) { nil }
 
-    it { proc{ event }.must_raise(WebHook::Event::MissingResourceError) }
-    it { proc{ enqueue }.must_raise(WebHook::Event::MissingResourceError) }
+    it { proc { event }.must_raise(WebHook::Event::MissingResourceError) }
+    it { proc { enqueue }.must_raise(WebHook::Event::MissingResourceError) }
   end
 
   describe "new resource" do
@@ -150,7 +148,7 @@ describe WebHook::Event do
 
     it { event.event.must_be :nil? }
     it { event.wont_be :valid? }
-    it { refute enqueue }
+    it { assert_not enqueue }
   end
 
   describe "push_user?" do


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* test/unit/liquid/drops/application_drop_test.rb
* test/unit/liquid/drops/application_plan_drop_test.rb
* test/unit/messengers/service_contract_messenger_test.rb
* test/unit/pdf/finance/invoice_generator_test.rb
* test/unit/three_scale/spam_protection_test.rb
* test/unit/user/roles_test.rb
* test/unit/web_hook/event_spec_test.rb

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)