### PR TITLE
Remove `context` from the last batch of tests

### DIFF
--- a/test/test_helpers/assertions.rb
+++ b/test/test_helpers/assertions.rb
@@ -6,6 +6,7 @@ module TestHelpers
       assert record.valid?, message || record.errors.full_messages.to_sentence
     end
 
+    # TODO: rename to assert_not_valid and replace assert_not *.valid? everywhere
     def refute_valid(record, message = nil)
       refute_predicate record, :valid?, message
     end

--- a/test/test_helpers/pending.rb
+++ b/test/test_helpers/pending.rb
@@ -4,11 +4,6 @@ module TestHelpers
     def pending_test(name, &block)
       test(name) { puts "  * WARNING: Test: <#{self}> is pending." }
     end
-
-    # Use this to temporarily disable whole shoulda context
-    def pending_context(name = nil, &block)
-      puts "  * WARNING: Context <#{name}> in <#{self}> is pending."
-    end
   end
 end
 

--- a/test/unit/cinstance/billing_test.rb
+++ b/test/unit/cinstance/billing_test.rb
@@ -1,106 +1,87 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # REFACTOR: totally remove that and place Cinstance::Billing to some
 # separate class/module
 class Cinstance::BillingTest < ActiveSupport::TestCase
+  setup do
+    @end_of_november = Time.zone.local(2009,11,30)
+    @first_of_december = Time.zone.local(2009,12,1)
+    @november = Month.new(2009,11)
+    @last_of_october = Time.zone.local(2009,9,30)
 
-  context 'Cinstance::Billing' do
-    setup do
-        @end_of_november = Time.zone.local(2009,11,30)
-        @first_of_december = Time.zone.local(2009,12,1)
-        @november = Month.new(2009,11)
-        @last_of_october = Time.zone.local(2009,9,30)
+    @plan = FactoryBot.create(:application_plan, :name => 'FAKE')
+    @plan.stubs(:cost_for_period).returns(42)
 
-        @plan = FactoryBot.create(:application_plan, :name => 'FAKE')
-        @plan.stubs(:cost_for_period).returns(42)
+    @cinstance = FactoryBot.create(:cinstance, :paid_until => nil, :plan => @plan)
+  end
+
+  pending_test '#refund_fixed_cost not bill if nothing is paid'
+  pending_test '#refund_fixed_cost bill if something is paid'
+
+  class NothingToBillTest < Cinstance::BillingTest
+    def setup
+      super
+      @invoice = FactoryBot.create(:invoice)
     end
 
-    # context '#refund_fixed_cost' do
-    #   setup do
-    #     # TODO - remove too much implementation detail
-    #     Finance::BillingOperations::stubs(:invoice_for_cinstance => (@invoice = mock))
-    #   end
+    test 'should not bill [already paid]' do
+      @cinstance.update(paid_until: @end_of_november)
+      @cinstance.bill_for(@november, @invoice)
+      assert_equal 0, @invoice.line_items.count
+    end
 
-    #   should 'not bill if nothing is paid' do
-    #    Finance::Billing.any_instance.expects(:create_line_item!).never
-    #   end
+    test 'should not bill [on trial]' do
+      @cinstance.update(paid_until: nil)
+      @cinstance.stubs(:trial_period_expires_at).returns(@first_of_december)
+      @cinstance.bill_for(@november, @invoice)
+      assert_equal 0, @invoice.line_items.count
+    end
 
-    #   should 'bill if something is paid' do
-    #     Finance::Billing.any_instance.expects(:create_line_item!).once
-    #     cinstance = FactoryBot.create(:cinstance, :paid_until => @end_of_november, :plan => @plan)
-    #     cinstance.refund_fixed_cost(@last_of_october)
-    #   end
-    # end
+    test 'should not bill [zero cost]' do
+      @plan.stubs(:cost_for_period).returns(0)
+      @cinstance.bill_for(@november, @invoice)
+      assert_equal 0, @invoice.line_items.count
+    end
+  end
 
-    context '#bill_for' do
-      setup do
-        @cinstance = FactoryBot.create(:cinstance, :paid_until => nil, :plan => @plan)
+  class StuffToBillTest < Cinstance::BillingTest
+    def setup
+      super
+      Timecop.freeze(2010,1,1)
+      @invoice = FactoryBot.create(:invoice)
+    end
+
+    test 'should bill for setup fee just once' do
+      @cinstance.update_attribute(:trial_period_expires_at, 1.day.ago) # rubocop:disable Rails/SkipsModelValidations
+      @cinstance.update_attribute(:setup_fee, 42) # rubocop:disable Rails/SkipsModelValidations
+      assert_difference @invoice.line_items.method(:count), 1 do
+        2.times { @cinstance.bill_for(@november, @invoice) }
       end
+    end
 
-      context 'with nothing to bill' do
-        setup do
-          @invoice = FactoryBot.create(:invoice)
-        end
+    test 'should bill only unpaid part' do
+      @cinstance.trial_period_expires_at = Time.zone.local(2009,11,9)
+      @cinstance.paid_until = Time.zone.local(2009,11,10)
 
-        should 'not bill [already paid]' do
-          @cinstance.update_attribute( :paid_until, @end_of_november)
-          @cinstance.bill_for(@november, @invoice)
-          assert_equal 0, @invoice.line_items.count
-        end
-
-        should 'not bill [on trial]' do
-          @cinstance.update_attribute( :paid_until, nil)
-          @cinstance.stubs(:trial_period_expires_at).returns(@first_of_december)
-          @cinstance.bill_for(@november, @invoice)
-          assert_equal 0, @invoice.line_items.count
-        end
-
-        should 'not bill [zero cost]' do
-          @plan.stubs(:cost_for_period).returns(0)
-          @cinstance.bill_for(@november, @invoice)
-          assert_equal 0, @invoice.line_items.count
-        end
+      assert_difference @invoice.line_items.method(:count), 1 do
+        @cinstance.bill_for(@november, @invoice)
       end
+      assert_equal @end_of_november.to_date, @cinstance.reload.paid_until.to_date
+    end
 
-      context 'with stuff to bill' do
-        setup do
-          Timecop.freeze(2010,1,1)
-          @invoice = FactoryBot.create(:invoice)
-        end
+    test 'should bill with correct info' do
+      @cinstance.paid_until = nil
+      # TODO: change from stub to attribute update
+      @cinstance.stubs(:trial_period_expires_at => Time.zone.local(2009,1,1))
+      @cinstance.bill_for(@november, @invoice)
 
-        should 'bill for setup fee just once' do
-          @cinstance.update_attribute(:trial_period_expires_at, 1.day.ago)
-          @cinstance.update_attribute(:setup_fee, 42)
-          assert_difference @invoice.line_items.method(:count), 1 do
-            2.times { @cinstance.bill_for(@november, @invoice) }
-          end
-        end
-
-        should 'bill only unpaid part' do
-          @cinstance.trial_period_expires_at = Time.zone.local(2009,11,9)
-          @cinstance.paid_until = Time.zone.local(2009,11,10)
-
-          billed_for = 'November 11, 2009 ( 0:00) - November 30, 2009 (23:59)'
-
-          assert_difference @invoice.line_items.method(:count), 1 do
-            @cinstance.bill_for(@november, @invoice)
-          end
-          assert_equal @end_of_november.to_date, @cinstance.reload.paid_until.to_date
-        end
-
-        should 'bill with correct info' do
-          @cinstance.paid_until = nil
-          # TODO: change from stub to attribute update
-          @cinstance.stubs(:trial_period_expires_at => Time.zone.local(2009,1,1))
-          @cinstance.bill_for(@november, @invoice)
-
-          item = @invoice.line_items.first
-          assert_equal @end_of_november.to_date, @cinstance.reload.paid_until.to_date
-          assert_equal "Fixed fee ('FAKE')", item.name
-          assert_equal 'November  1, 2009 ( 0:00) - November 30, 2009 (23:59)', item.description
-          assert_equal 42, item.cost
-        end
-      end
+      item = @invoice.line_items.first
+      assert_equal @end_of_november.to_date, @cinstance.reload.paid_until.to_date
+      assert_equal "Fixed fee ('FAKE')", item.name
+      assert_equal 'November  1, 2009 ( 0:00) - November 30, 2009 (23:59)', item.description
+      assert_equal 42, item.cost
     end
   end
 end

--- a/test/unit/cinstance/billing_test.rb
+++ b/test/unit/cinstance/billing_test.rb
@@ -21,8 +21,7 @@ class Cinstance::BillingTest < ActiveSupport::TestCase
   pending_test '#refund_fixed_cost bill if something is paid'
 
   class NothingToBillTest < Cinstance::BillingTest
-    def setup
-      super
+    setup do
       @invoice = FactoryBot.create(:invoice)
     end
 
@@ -47,8 +46,7 @@ class Cinstance::BillingTest < ActiveSupport::TestCase
   end
 
   class StuffToBillTest < Cinstance::BillingTest
-    def setup
-      super
+    setup do
       Timecop.freeze(2010,1,1)
       @invoice = FactoryBot.create(:invoice)
     end

--- a/test/unit/cms/email_template_test.rb
+++ b/test/unit/cms/email_template_test.rb
@@ -98,7 +98,7 @@ class EmailTemplateTest < ActiveSupport::TestCase
                                                                                                                         })
     message = AccountMessenger.expired_credit_card_notification_for_buyer(@buyer) && Message.last
 
-    assert_match("more awesome content", message.body)
+    assert_equal("more awesome content", message.body)
     assert_equal({"cc"=>@cc, "bcc"=>@bcc, "custom"=>@custom}, message.headers)
     assert_equal(@subject, message.subject)
   end
@@ -120,7 +120,7 @@ class EmailTemplateTest < ActiveSupport::TestCase
     message = AccountMessenger.expired_credit_card_notification_for_buyer(@buyer) && Message.last
 
     assert_equal("Subject!", message.subject)
-    assert_match("more awesome content", message.body)
+    assert_equal("more awesome content", message.body)
     assert_equal({ "cc"=>@cc,
                    "bcc"=>["alias <bcc@mail.example.com>", "another <alias@mail.example.com>"],
                    "custom"=>@custom,

--- a/test/unit/cms/email_template_test.rb
+++ b/test/unit/cms/email_template_test.rb
@@ -1,27 +1,26 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class EmailTemplateTest < ActiveSupport::TestCase
-
   def setup
     @subject = "subject"
     @bcc = "bcc@mail.example.com"
     @cc = "cc@mail.example.com"
     @custom = "CUSTOM"
-    @tags = %{\
+    @tags = %(\
 {% email %}
   {% subject "Subject!" %}
   {% bcc = "alias <bcc@mail.example.com>" "another <alias@mail.example.com>" %}
   {% header 'X-Custom' = 'X-Value' %}
 {% endemail %}\
-}
+)
   end
 
   test 'save headers' do
-    saved = CMS::EmailTemplate.create! :system_name => 'system_name', :published => 'text',
-                                        :provider => FactoryBot.create(:provider_account),
-                                        :headers => {
-                                          :key => 'value'
-                                        }
+    saved = CMS::EmailTemplate.create!(system_name: 'system_name', published: 'text',
+                                                                   provider: FactoryBot.create(:provider_account),
+                                                                   headers: { key: 'value' })
     loaded = saved.class.find(saved.id)
 
     assert_equal saved.headers, loaded.headers
@@ -30,20 +29,16 @@ class EmailTemplateTest < ActiveSupport::TestCase
 
   test 'serialize headers as Hash' do
     headers = {"subject"=>"Text Analysis API - New key created", "bcc"=>"", "cc"=>"", "reply_to"=>"", "from"=>"AYLIEN"}
-    template = CMS::EmailTemplate.create! system_name: 'system_name', published: 'text',
-      provider: FactoryBot.create(:simple_account)
-    # Testing it does not raise if we do `update_column` with simple Hash
-    template.update_column :options, headers
+    template = CMS::EmailTemplate.create!(system_name: 'system_name', published: 'text', provider: FactoryBot.create(:simple_account))
+    template.update_column :options, headers # rubocop:disable Rails/SkipsModelValidations Testing it does not raise if we do `update_column` with simple Hash
     assert_equal headers, template.options
   end
 
   test 'serialize headers as ActionController::Parameters' do
     headers = {"subject"=>"Text Analysis API - New key created", "bcc"=>"", "cc"=>"", "reply_to"=>"", "from"=>"AYLIEN"}
     params = ActionController::Parameters.new(headers)
-    template = CMS::EmailTemplate.create! system_name: 'system_name', published: 'text',
-      provider: FactoryBot.create(:simple_account)
-    # Testing it does not raise if we `update_column` with unpermitted parameters
-    template.update_column :options, params
+    template = CMS::EmailTemplate.create!(system_name: 'system_name', published: 'text', provider: FactoryBot.create(:simple_account))
+    template.update_column :options, params # rubocop:disable Rails/SkipsModelValidations Testing it does not raise if we `update_column` with unpermitted parameters
     template.reload
     assert_equal headers, template.options
   end
@@ -53,9 +48,8 @@ class EmailTemplateTest < ActiveSupport::TestCase
     params = ActionController::Parameters.new(headers)
     template = CMS::EmailTemplate.create! system_name: 'system_name', published: 'text',
       provider: FactoryBot.create(:simple_account)
-    # Testing it does not raise if we `update_column` with unpermitted parameters
     yaml = YAML.dump(params)
-    template.update_column :options, yaml
+    template.update_column :options, yaml # rubocop:disable Rails/SkipsModelValidations Testing it does not raise if we `update_column` with unpermitted parameters
     template.reload
     assert_equal yaml, template.options_before_type_cast
   end
@@ -63,9 +57,9 @@ class EmailTemplateTest < ActiveSupport::TestCase
   test 'comma separated emails in headers are valid' do
     template = FactoryBot.build(:cms_email_template)
     template.headers = {
-      :bcc => 'email@address.example.com, email@address.example.com',
-      :cc => 'email@address.example.com, email@address.example.com',
-      :reply_to => 'email@address.example.com, email@address.example.com',
+      bcc: 'email@address.example.com, email@address.example.com',
+      cc: 'email@address.example.com, email@address.example.com',
+      reply_to: 'email@address.example.com, email@address.example.com',
     }
 
     assert template.valid?
@@ -74,7 +68,7 @@ class EmailTemplateTest < ActiveSupport::TestCase
   test 'validates email format' do
     template = FactoryBot.build(:cms_email_template)
     template.headers = {
-      :bcc => 'email@address.example.com and some other stuff'
+      bcc: 'email@address.example.com and some other stuff'
     }
     assert template.invalid?
   end
@@ -82,115 +76,104 @@ class EmailTemplateTest < ActiveSupport::TestCase
   test 'validates headers' do
     template = FactoryBot.build(:cms_email_template)
     template.headers = {
-      :bcc => 'bcc',
-      :cc => 'email@address.example.com',
+      bcc: 'bcc',
+      cc: 'email@address.example.com',
     }
 
     assert template.invalid?
     assert template.errors['headers.bcc'].presence
   end
 
-  context "Account Messenger expired_credit_card_notification_for_buyer" do
-    setup do
-      @provider = FactoryBot.create(:provider_account)
-      @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
-      @body = "more awesome content"
-      @template = CMS::EmailTemplate.create! :system_name => 'account_messenger_expired_credit_card_notification_for_buyer', :published => @body,
-                                        :provider => @provider,
-                                        :headers => {
-                                          :bcc => @bcc,
-                                          :cc => @cc,
-                                          :subject => @subject,
-                                          :custom => @custom
-                                        }
-    end
+  test "Account Messenger expired_credit_card_notification_for_buyer should assign headers to messenger" do
+    @provider = FactoryBot.create(:provider_account)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+    @body = "more awesome content"
+    @template = CMS::EmailTemplate.create!(system_name: 'account_messenger_expired_credit_card_notification_for_buyer', published: @body,
+                                                                                                                        provider: @provider,
+                                                                                                                        headers: {
+                                                                                                                          bcc: @bcc,
+                                                                                                                          cc: @cc,
+                                                                                                                          subject: @subject,
+                                                                                                                          custom: @custom
+                                                                                                                        })
+    message = AccountMessenger.expired_credit_card_notification_for_buyer(@buyer) && Message.last
 
-    should "assign headers to messenger" do
-      message = AccountMessenger.expired_credit_card_notification_for_buyer(@buyer) && Message.last
+    assert_match("more awesome content", message.body)
+    assert_equal({"cc"=>@cc, "bcc"=>@bcc, "custom"=>@custom}, message.headers)
+    assert_equal(@subject, message.subject)
+  end
 
-      assert_equal("more awesome content", message.body)
-      assert_equal({"cc"=>@cc, "bcc"=>@bcc, "custom"=>@custom}, message.headers)
-      assert_equal(@subject, message.subject)
-    end
+  test "Account Messenger expired_credit_card_notification_for_buyer with headers should assign headers to messenger" do
+    @provider = FactoryBot.create(:provider_account)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+    @body = "more awesome content"
+    @template = CMS::EmailTemplate.create!(system_name: 'account_messenger_expired_credit_card_notification_for_buyer', published: @body,
+                                                                                                                        provider: @provider,
+                                                                                                                        headers: {
+                                                                                                                          bcc: @bcc,
+                                                                                                                          cc: @cc,
+                                                                                                                          subject: @subject,
+                                                                                                                          custom: @custom
+                                                                                                                        })
+    @template.published = @tags + @template.published
+    @template.save!
+    message = AccountMessenger.expired_credit_card_notification_for_buyer(@buyer) && Message.last
 
-    context "with headers" do
-      setup do
-        @template.published =  @tags + @template.published
-        @template.save!
-      end
-
-      should "assign headers to messenger" do
-        message = AccountMessenger.expired_credit_card_notification_for_buyer(@buyer) && Message.last
-
-        assert_equal("Subject!", message.subject)
-        assert_equal("more awesome content", message.body)
-        assert_equal({
-          "cc"=>@cc,
-          "bcc"=>[ "alias <bcc@mail.example.com>", "another <alias@mail.example.com>"],
-          "custom"=>@custom,
-          'X-Custom' => 'X-Value'
-        }, message.headers)
-      end
-    end
+    assert_equal("Subject!", message.subject)
+    assert_match("more awesome content", message.body)
+    assert_equal({ "cc"=>@cc,
+                   "bcc"=>["alias <bcc@mail.example.com>", "another <alias@mail.example.com>"],
+                   "custom"=>@custom,
+                   'X-Custom' => 'X-Value' }, message.headers)
   end
 
   # this is to check we can override template of message send to provider to buyer
-  context "Account Messenger New Signup template" do
-    setup do
-      @provider = FactoryBot.create(:provider_account)
-      @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
-      @body = "awesome content"
-      @template = CMS::EmailTemplate.create! :system_name => 'account_messenger_new_signup', :published => @body,
-                                        :provider => @provider,
-                                        :headers => {
-                                          :bcc => @bcc,
-                                          :cc => @cc,
-                                          :subject => @subject,
-                                          :custom => @custom
-                                        }
-    end
+  test "Account Messenger New Signup template should assign headers to messenger" do
+    @provider = FactoryBot.create(:provider_account)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+    @body = "awesome content"
+    @template = CMS::EmailTemplate.create!(system_name: 'account_messenger_new_signup', published: @body,
+                                                                                        provider: @provider,
+                                                                                        headers: {
+                                                                                          bcc: @bcc,
+                                                                                          cc: @cc,
+                                                                                          subject: @subject,
+                                                                                          custom: @custom
+                                                                                        })
+    message = AccountMessenger.new_signup(@buyer) && Message.last
 
-    should "assign headers to messenger" do
-      message = AccountMessenger.new_signup(@buyer) && Message.last
-
-      assert_equal("awesome content", message.body)
-    end
+    assert_equal("awesome content", message.body)
   end
 
-  context "Account Approved template" do
-    setup do
-      @provider = FactoryBot.create(:provider_account)
-      @buyer = FactoryBot.create(:buyer_account, :provider_account => @provider)
-      @body = "My content"
-      @template = CMS::EmailTemplate.create! :system_name => 'account_approved', :published => @body,
-                                        :provider => @provider,
-                                        :headers => {
-                                          :bcc => @bcc,
-                                          :cc => @cc,
-                                          :subject => @subject,
-                                          :custom => @custom
-                                        }
-    end
+  test "Account Approved template should assign headers to mailer" do
+    @provider = FactoryBot.create(:provider_account)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+    @body = "My content"
+    @template = CMS::EmailTemplate.create!(system_name: 'account_approved', published: @body,
+                                                                            provider: @provider,
+                                                                            headers: {
+                                                                              bcc: @bcc,
+                                                                              cc: @cc,
+                                                                              subject: @subject,
+                                                                              custom: @custom
+                                                                            })
+    @template.published = @tags + @template.published
+    @template.save!
 
-    should "assign headers to mailer" do
-      @template.published =  @tags + @template.published
-      @template.save!
+    mail = AccountMailer.approved(@buyer)
 
-      mail = AccountMailer.approved(@buyer)
+    assert_equal "Subject!", mail.subject
+    assert_match 'My content', mail.body.to_s
+    assert_equal "alias <bcc@mail.example.com>, another <alias@mail.example.com>", mail.header['bcc'].to_s
+    assert_equal "cc@mail.example.com", mail.header['cc'].to_s
+    assert_equal @custom, mail.header['custom'].to_s
 
-      assert_equal "Subject!", mail.subject
-      assert_equal 'My content', mail.body.to_s
-      assert_equal "alias <bcc@mail.example.com>, another <alias@mail.example.com>", mail.header['bcc'].to_s
-      assert_equal "cc@mail.example.com", mail.header['cc'].to_s
-      assert_equal @custom, mail.header['custom'].to_s
+    mail.deliver_now
 
-      mail.deliver_now
-
-      assert_match /poweredby/, mail.body.to_s
-    end
+    assert_match /poweredby/, mail.body.to_s
   end
 
-  def test_all_new_and_overriden
+  test 'all new and overriden' do
     provider = FactoryBot.create(:provider_account)
 
     assert provider.provider_can_use?(:new_notification_system)

--- a/test/unit/finance/charging_test.rb
+++ b/test/unit/finance/charging_test.rb
@@ -15,8 +15,7 @@ class Finance::ChargingTest < ActiveSupport::TestCase
   end
 
   class BuyerNotPayingMonthlyTest < Finance::ChargingTest
-    def setup
-      super
+    setup do
       @buyer_account.not_paying_monthly!
       @invoice = @provider_account.billing_strategy.create_invoice!(buyer_account: @buyer_account)
       @invoice.line_items << LineItem.new(cost: 100)
@@ -46,8 +45,7 @@ class Finance::ChargingTest < ActiveSupport::TestCase
   end
 
   class BuyerChargedMonthlyTest < Finance::ChargingTest
-    def setup
-      super
+    setup do
       @buyer_account.paying_monthly!
 
       @invoice = Invoice.new(provider_account: @provider_account, buyer_account: @buyer_account,
@@ -108,8 +106,7 @@ class Finance::ChargingTest < ActiveSupport::TestCase
     end
 
     class PaymentGatewayRespondsFailureTest < BuyerChargedMonthlyTest
-      def setup
-        super
+      setup do
         @buyer_account.credit_card_expires_on_year = 2.years.from_now.year
         @buyer_account.credit_card_expires_on_month = 2.years.from_now.month
         @buyer_account.credit_card_auth_code = 'pg responds failure if code ends in 2'
@@ -158,8 +155,7 @@ class Finance::ChargingTest < ActiveSupport::TestCase
     end
 
     class PaymentGatewayRisesExceptionTest < BuyerChargedMonthlyTest
-      def setup
-        super
+      setup do
         @buyer_account.credit_card_expires_on_year = 2.years.from_now.year
         @buyer_account.credit_card_expires_on_month = 2.years.from_now.month
         @buyer_account.credit_card_auth_code = 'pg responds failure if code ends in 3'
@@ -193,8 +189,7 @@ class Finance::ChargingTest < ActiveSupport::TestCase
     end
 
     class PaymentGatewayRespondsSuccessTest < BuyerChargedMonthlyTest
-      def setup
-        super
+      setup do
         @buyer_account.credit_card_expires_on_year = 2.years.from_now.year
         @buyer_account.credit_card_expires_on_month = 2.years.from_now.month
         @buyer_account.credit_card_auth_code = 'pg responds failure if code ends in 1'

--- a/test/unit/finance/charging_test.rb
+++ b/test/unit/finance/charging_test.rb
@@ -1,64 +1,65 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Finance::ChargingTest < ActiveSupport::TestCase
+  setup do
+    Invoice.any_instance.stubs log_entry_created: true
+    @provider_account = FactoryBot.create(:provider_account, billing_strategy: FactoryBot.create(:postpaid_billing))
 
-  context 'Invoice#charge! ... ' do
-    setup do
-      Invoice.any_instance.stubs log_entry_created: true
-      @provider_account = FactoryBot.create(:provider_account,
-                                  :billing_strategy => FactoryBot.create(:postpaid_billing))
+    @provider_account.bought_plan.enable_feature!(:postpaid_billing)
+    @plan = FactoryBot.create(:application_plan, issuer: @provider_account.default_service)
 
-      @provider_account.bought_plan.enable_feature!(:postpaid_billing)
-      @plan = FactoryBot.create(:application_plan, :issuer => @provider_account.default_service)
+    @buyer_account = FactoryBot.create(:buyer_account, provider_account: @provider_account)
+    @cinstance = @buyer_account.buy!(@plan)
+  end
 
-      @buyer_account = FactoryBot.create(:buyer_account, :provider_account => @provider_account)
-      @cinstance = @buyer_account.buy!(@plan)
+  class BuyerNotPayingMonthlyTest < Finance::ChargingTest
+    def setup
+      super
+      @buyer_account.not_paying_monthly!
+      @invoice = @provider_account.billing_strategy.create_invoice!(buyer_account: @buyer_account)
+      @invoice.line_items << LineItem.new(cost: 100)
+      @invoice.save!
+      @invoice.issue_and_pay_if_free!
     end
 
-    context 'buyer is not paying monthly' do
-      setup do
-        @buyer_account.not_paying_monthly!
-        @invoice = @provider_account.billing_strategy.create_invoice!(:buyer_account => @buyer_account)
-        @invoice.line_items << LineItem.new(:cost => 100)
-        @invoice.save!
-        @invoice.issue_and_pay_if_free!
-      end
-
-      should 'leave the invoice as unpaid' do
-        @invoice.charge!
-        refute @invoice.paid?
-      end
-
-      should 'return false' do
-        refute @invoice.charge!
-      end
-
-      should 'not send charge notification email' do
-        InvoiceMessenger.expects(:successfully_charged).never
-        @invoice.charge!
-      end
-
-      should 'not send analytics notification' do
-        # FIXME: this is evergreen
-        UserTrackingHelper.expects(:analytics_track).never
-        @invoice.charge!
-      end
+    test 'should leave the invoice as unpaid' do
+      @invoice.charge!
+      assert_not @invoice.paid?
     end
 
-    context 'buyer is being charged monthly' do
-      setup do
-        @buyer_account.paying_monthly!
+    test 'should return false' do
+      assert_not @invoice.charge!
+    end
 
-        @invoice = Invoice.new(:provider_account => @provider_account,
-                               :buyer_account => @buyer_account,
-                               :friendly_id => '0000-00-00000001',
-                               :period => Month.new(Time.zone.now))
-        @invoice.line_items << LineItem.new(:cost => 100)
-        @invoice.save!
-        @invoice.issue_and_pay_if_free!
-      end
+    test 'should not send charge notification email' do
+      InvoiceMessenger.expects(:successfully_charged).never
+      @invoice.charge!
+    end
 
-      should 'not charge if invoice already paid' do
+    test 'should not send analytics notification' do
+      # FIXME: this is evergreen
+      UserTrackingHelper.expects(:analytics_track).never
+      @invoice.charge!
+    end
+  end
+
+  class BuyerChargedMonthlyTest < Finance::ChargingTest
+    def setup
+      super
+      @buyer_account.paying_monthly!
+
+      @invoice = Invoice.new(provider_account: @provider_account, buyer_account: @buyer_account,
+                                                                  friendly_id: '0000-00-00000001',
+                                                                  period: Month.new(Time.zone.now))
+      @invoice.line_items << LineItem.new(cost: 100)
+      @invoice.save!
+      @invoice.issue_and_pay_if_free!
+    end
+
+    class NotChargedTest < BuyerChargedMonthlyTest
+      test 'should not charge if invoice already paid' do
         @invoice.paid_at = 1.week.ago
         @invoice.save!
 
@@ -66,13 +67,13 @@ class Finance::ChargingTest < ActiveSupport::TestCase
         @invoice.charge!
       end
 
-      should 'not charge if provider does not exists' do
+      test 'should not charge if provider does not exists' do
         @invoice.expects(:provider).returns(nil).at_least_once
         @buyer_account.expects(:charge!).never
         @invoice.charge!
       end
 
-      should 'not charge if credit card is invalid' do
+      test 'should not charge if credit card is invalid' do
         @buyer_account.credit_card_auth_code = nil
 
         @buyer_account.save!
@@ -80,10 +81,12 @@ class Finance::ChargingTest < ActiveSupport::TestCase
         @provider_account.payment_gateway.class.any_instance.expects(:purchase).never
         @invoice.charge!
 
-        refute @invoice.paid?
+        assert_not @invoice.paid?
       end
+    end
 
-      should 'charge if credit card is expired' do
+    class Foo < BuyerChargedMonthlyTest
+      test 'should charge if credit card is expired' do
         @buyer_account.credit_card_expires_on_year = 2.years.ago.year
         @buyer_account.credit_card_expires_on_month = 2.years.ago.month
         @buyer_account.credit_card_auth_code = 'SECRET'
@@ -95,176 +98,173 @@ class Finance::ChargingTest < ActiveSupport::TestCase
           @provider_account.payment_gateway.class.any_instance.expects(:purchase)
           .with(10000, @buyer_account.credit_card_auth_code, has_key(:order_id))
           .returns(stub('response', :success? => false, :authorization => '1234',
-                       :message => 'whatever', :params => {'foo' => 'bar'}, :test => false))
+                        :message => 'whatever', :params => {'foo' => 'bar'}, :test => false))
 
           @invoice.charge!
         end
 
-        refute @invoice.paid?
+        assert_not @invoice.paid?
+      end
+    end
+
+    class PaymentGatewayRespondsFailureTest < BuyerChargedMonthlyTest
+      def setup
+        super
+        @buyer_account.credit_card_expires_on_year = 2.years.from_now.year
+        @buyer_account.credit_card_expires_on_month = 2.years.from_now.month
+        @buyer_account.credit_card_auth_code = 'pg responds failure if code ends in 2'
+
+        @buyer_account.save!
+
+        @provider_account.payment_gateway.class.any_instance.expects(:purchase)
+          .with(10000, @buyer_account.credit_card_auth_code, has_key(:order_id))
+          .returns(stub('response', :success? => false, :authorization => '1234',
+                        :message => 'whatever', :params => {'foo' => 'bar'}, :test => false))
       end
 
-      context 'if the payment gateway responds with failure' do
-        setup do
-          @buyer_account.credit_card_expires_on_year = 2.years.from_now.year
-          @buyer_account.credit_card_expires_on_month = 2.years.from_now.month
-          @buyer_account.credit_card_auth_code = 'pg responds failure if code ends in 2'
-
-          @buyer_account.save!
-
-          @provider_account.payment_gateway.class.any_instance.expects(:purchase)
-            .with(10000, @buyer_account.credit_card_auth_code, has_key(:order_id))
-            .returns(stub('response', :success? => false, :authorization => '1234',
-                         :message => 'whatever', :params => {'foo' => 'bar'}, :test => false))
-        end
-
-        should 'not mark invoice as paid' do
-          @invoice.charge!
-          refute @invoice.paid?
-        end
-
-        should 'record payment transaction' do
-          assert_difference 'PaymentTransaction.count', 1 do
-            @invoice.charge!
-          end
-
-          transaction = PaymentTransaction.last
-          assert_equal @invoice, transaction.invoice
-          refute transaction.success?
-        end
-
-        should 'log_entry error' do
-          @invoice.charge!
-          assert_equal 1, LogEntry.count
-          assert_equal :error, LogEntry.first.level
-        end
-
-        should 'notify buyer and provider accounts about failed first attempt to charge' do
-          message = stub(:deliver => nil)
-
-          Logic::RollingUpdates.stubs(skipped?: true)
-
-          InvoiceMessenger.expects(:unsuccessfully_charged_for_buyer)
-            .with(@invoice).returns(message)
-          InvoiceMessenger.expects(:unsuccessfully_charged_for_provider)
-            .with(@invoice).returns(message)
-
-          @invoice.charge!
-        end
+      test 'should not mark invoice as paid' do
+        @invoice.charge!
+        assert_not @invoice.paid?
       end
 
-      context 'if the payment gateway raises an exception' do
-        setup do
-          @buyer_account.credit_card_expires_on_year = 2.years.from_now.year
-          @buyer_account.credit_card_expires_on_month = 2.years.from_now.month
-          @buyer_account.credit_card_auth_code = 'pg responds failure if code ends in 3'
-
-          @buyer_account.save!
-
-          @provider_account.payment_gateway.class.any_instance.expects(:purchase)
-            .raises(ActiveMerchant::ActiveMerchantError, 'boo')
-        end
-
-        should 'not mark invoice as paid' do
+      test 'should record payment transaction' do
+        assert_difference 'PaymentTransaction.count', 1 do
           @invoice.charge!
-          refute @invoice.paid?
         end
 
-        should 'log_entry error' do
-          @invoice.charge!
-          assert_equal 1, LogEntry.count
-          assert_equal :error, LogEntry.first.level
-        end
-
-        should 'record payment transaction' do
-          assert_difference 'PaymentTransaction.count', 1 do
-            @invoice.charge!
-          end
-
-          transaction = PaymentTransaction.last
-          assert_equal @invoice, transaction.invoice
-          refute transaction.success?
-        end
+        transaction = PaymentTransaction.last
+        assert_equal @invoice, transaction.invoice
+        assert_not transaction.success?
       end
 
-      context 'if the payment gateway responds with success' do
-        setup do
-          @buyer_account.credit_card_expires_on_year = 2.years.from_now.year
-          @buyer_account.credit_card_expires_on_month = 2.years.from_now.month
-          @buyer_account.credit_card_auth_code = 'pg responds failure if code ends in 1'
+      test 'should log_entry error' do
+        @invoice.charge!
+        assert_equal 1, LogEntry.count
+        assert_equal :error, LogEntry.first.level
+      end
 
-          @buyer_account.save!
+      test 'should notify buyer and provider accounts about failed first attempt to charge' do
+        message = stub(:deliver => nil)
 
-          @provider_account.payment_gateway.class.any_instance.expects(:purchase)
-            .with(10000, @buyer_account.credit_card_auth_code, has_key(:order_id))
-            .returns(stub('response', :success? => true, :authorization => '1234',
-                         :message => 'whatever', :params => {'foo' => 'bar'}, :test => false))
-        end
+        Logic::RollingUpdates.stubs(skipped?: true)
 
-        should 'mark the invoice as paid' do
-          @invoice.mark_as_unpaid!
-          @invoice.charge!
-          assert @invoice.paid?
-        end
+        InvoiceMessenger.expects(:unsuccessfully_charged_for_buyer)
+          .with(@invoice).returns(message)
+        InvoiceMessenger.expects(:unsuccessfully_charged_for_provider)
+          .with(@invoice).returns(message)
 
-        class BuyerNotificationWhenPaidTest < ActiveSupport::TestCase
+        @invoice.charge!
+      end
+    end
 
-          setup do
-            @provider_account = FactoryBot.create(:provider_account,
-                                        :billing_strategy => FactoryBot.create(:postpaid_billing))
+    class PaymentGatewayRisesExceptionTest < BuyerChargedMonthlyTest
+      def setup
+        super
+        @buyer_account.credit_card_expires_on_year = 2.years.from_now.year
+        @buyer_account.credit_card_expires_on_month = 2.years.from_now.month
+        @buyer_account.credit_card_auth_code = 'pg responds failure if code ends in 3'
 
-            @provider_account.bought_plan.enable_feature!(:postpaid_billing)
-            @plan = FactoryBot.create(:application_plan, :issuer => @provider_account.default_service)
+        @buyer_account.save!
 
-            @buyer_account = FactoryBot.create(:buyer_account, :provider_account => @provider_account)
-            @cinstance = @buyer_account.buy!(@plan)
+        @provider_account.payment_gateway.class.any_instance.expects(:purchase)
+          .raises(ActiveMerchant::ActiveMerchantError, 'boo')
+      end
 
-            @buyer_account.paying_monthly!
+      test 'should not mark invoice as paid' do
+        @invoice.charge!
+        assert_not @invoice.paid?
+      end
 
-            @invoice = Invoice.new(:provider_account => @provider_account,
-                                   :buyer_account => @buyer_account,
-                                   :friendly_id => '0000-00-00000001',
-                                   :period => Month.new(Time.zone.now))
-            @invoice.line_items << LineItem.new(:cost => 100)
-            @invoice.save!
-            @invoice.issue_and_pay_if_free!
-          end
+      test 'should log_entry error' do
+        @invoice.charge!
+        assert_equal 1, LogEntry.count
+        assert_equal :error, LogEntry.first.level
+      end
 
-          test 'send buyer notification on successful payment' do
-            message = stub(:deliver => nil)
-            Logic::RollingUpdates.stubs(skipped?: true)
-            Account.any_instance.expects(:charge!).returns(true)
-
-            InvoiceMessenger.expects(:successfully_charged)
-              .with(@invoice).returns(message)
-            assert @invoice.charge!
-
-          end
-        end
-
-        should 'not send analytics notification' do
-          # FIXME: this is evergreen
-          UserTrackingHelper.expects(:analytics_track).never
+      test 'should record payment transaction' do
+        assert_difference 'PaymentTransaction.count', 1 do
           @invoice.charge!
         end
 
-        should 'record payment transaction' do
-          assert_difference 'PaymentTransaction.count', 1 do
-            @invoice.charge!
-          end
+        transaction = PaymentTransaction.last
+        assert_equal @invoice, transaction.invoice
+        assert_not transaction.success?
+      end
+    end
 
-          transaction = PaymentTransaction.last
-          assert_equal @invoice, transaction.invoice
-          assert transaction.success?
-        end
+    class PaymentGatewayRespondsSuccessTest < BuyerChargedMonthlyTest
+      def setup
+        super
+        @buyer_account.credit_card_expires_on_year = 2.years.from_now.year
+        @buyer_account.credit_card_expires_on_month = 2.years.from_now.month
+        @buyer_account.credit_card_auth_code = 'pg responds failure if code ends in 1'
 
-        should 'log_entry info' do
+        @buyer_account.save!
+
+        @provider_account.payment_gateway.class.any_instance.expects(:purchase)
+          .with(10000, @buyer_account.credit_card_auth_code, has_key(:order_id))
+          .returns(stub('response', :success? => true, :authorization => '1234',
+                        :message => 'whatever', :params => {'foo' => 'bar'}, :test => false))
+      end
+
+      test 'should mark the invoice as paid' do
+        @invoice.mark_as_unpaid!
+        @invoice.charge!
+        assert @invoice.paid?
+      end
+
+      test 'should not send analytics notification' do
+        # FIXME: this is evergreen
+        UserTrackingHelper.expects(:analytics_track).never
+        @invoice.charge!
+      end
+
+      test 'should record payment transaction' do
+        assert_difference 'PaymentTransaction.count', 1 do
           @invoice.charge!
-          assert_equal 1, LogEntry.count
-          assert_equal :info, LogEntry.first.level
         end
 
+        transaction = PaymentTransaction.last
+        assert_equal @invoice, transaction.invoice
+        assert transaction.success?
+      end
+
+      test 'should log_entry info' do
+        @invoice.charge!
+        assert_equal 1, LogEntry.count
+        assert_equal :info, LogEntry.first.level
       end
     end
   end
+end
 
+class Finance::BuyerNotificationWhenPaidTest < ActiveSupport::TestCase
+  setup do
+    @provider_account = FactoryBot.create(:provider_account, billing_strategy: FactoryBot.create(:postpaid_billing))
+
+    @provider_account.bought_plan.enable_feature!(:postpaid_billing)
+    @plan = FactoryBot.create(:application_plan, issuer: @provider_account.default_service)
+
+    @buyer_account = FactoryBot.create(:buyer_account, provider_account: @provider_account)
+    @cinstance = @buyer_account.buy!(@plan)
+
+    @buyer_account.paying_monthly!
+
+    @invoice = Invoice.new(provider_account: @provider_account, buyer_account: @buyer_account,
+                                                                friendly_id: '0000-00-00000001',
+                                                                period: Month.new(Time.zone.now))
+    @invoice.line_items << LineItem.new(cost: 100)
+    @invoice.save!
+    @invoice.issue_and_pay_if_free!
+  end
+
+  test 'send buyer notification on successful payment' do
+    message = stub(:deliver => nil)
+    Logic::RollingUpdates.stubs(skipped?: true)
+    Account.any_instance.expects(:charge!).returns(true)
+
+    InvoiceMessenger.expects(:successfully_charged)
+      .with(@invoice).returns(message)
+    assert @invoice.charge!
+  end
 end

--- a/test/unit/helpers/messages_helper_test.rb
+++ b/test/unit/helpers/messages_helper_test.rb
@@ -1,93 +1,88 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MessagesHelperTest < ActionView::TestCase
   include Buyers::AccountsHelper
   attr_accessor :current_account
 
+  setup do
+    @buyer_sender = FactoryBot.create(:buyer_account)
+    @buyer_receiver = FactoryBot.create(:buyer_account)
+
+    @provider_sender = FactoryBot.create(:account)
+    @provider_receiver = FactoryBot.create(:account)
+  end
+
   def can?(*)
     true
   end
 
-  context 'message_receiver' do
-    setup do
-      @buyer_receiver = FactoryBot.create(:buyer_account)
-      @provider_receiver = FactoryBot.create(:account)
-    end
-
-    should 'return link to buyer for buyer recipient' do
-      message = FactoryBot.create(:message, to: [@buyer_receiver]).decorate
-      expected_link = link_to(@buyer_receiver.org_name,
-                        admin_buyers_account_path(@buyer_receiver),
-                        title: account_title(@buyer_receiver.decorate))
-      assert_equal expected_link, message_receiver(message)
-    end
-
-    should 'return org name for provider recipient' do
-      message = FactoryBot.create(:message, :to => [@provider_receiver])
-      assert_equal @provider_receiver.org_name,
-                   message_receiver(message)
-    end
-
-    should 'return (deleted) for non existing recipient' do
-      message = FactoryBot.create(:message, :to => [@buyer_receiver])
-      message.recipients.first.receiver = nil
-      assert_equal "<span class=\"deleted\">(deleted)</span>", message_receiver(message)
-      message.recipients = []
-      assert_equal "<span class=\"deleted\">(deleted)</span>", message_receiver(message)
-    end
-
-    should 'not return org names for message with multi recipients' do
-      message = FactoryBot.create(:message, :to => [@buyer_receiver, @provider_receiver])
-      assert_equal "Multiple Recipients", message_receiver(message)
-    end
+  test '#message_receiver should return link to buyer for buyer recipient' do
+    message = FactoryBot.create(:message, to: [@buyer_receiver]).decorate
+    expected_link = link_to(@buyer_receiver.org_name,
+                            admin_buyers_account_path(@buyer_receiver),
+                            title: account_title(@buyer_receiver.decorate))
+    assert_equal expected_link, message_receiver(message)
   end
 
-  context 'message_sender' do
-    setup do
-      @buyer_sender = FactoryBot.create(:buyer_account)
-      @provider_sender = FactoryBot.create(:account)
-    end
+  test '#message_receiver should return org name for provider recipient' do
+    message = FactoryBot.create(:message, to: [@provider_receiver])
+    assert_equal @provider_receiver.org_name,
+                 message_receiver(message)
+  end
 
-    should 'return link to buyer account' do
-      message_from_buyer = FactoryBot.create(:message, sender: @buyer_sender).decorate
-      assert_equal link_to(@buyer_sender.org_name, admin_buyers_account_path(@buyer_sender), title: account_title(@buyer_sender.decorate)),
-                   message_sender(message_from_buyer)
-    end
+  test '#message_receiver should return (deleted) for non existing recipient' do
+    message = FactoryBot.create(:message, to: [@buyer_receiver])
+    message.recipients.first.receiver = nil
+    assert_equal "<span class=\"deleted\">(deleted)</span>", message_receiver(message)
+    message.recipients = []
+    assert_equal "<span class=\"deleted\">(deleted)</span>", message_receiver(message)
+  end
 
-    should 'return org name of provider account' do
-      message_from_provider = FactoryBot.create(:message, :sender => @provider_sender)
-      assert_equal @provider_sender.org_name,
-                   message_sender(message_from_provider)
-    end
+  test '#message_receiver should not return org names for message with multi recipients' do
+    message = FactoryBot.create(:message, to: [@buyer_receiver, @provider_receiver])
+    assert_equal "Multiple Recipients", message_receiver(message)
+  end
 
-    should 'return (deleted) for non existing sender' do
-      message = FactoryBot.create(:message, :to => [@buyer_sender])
-      message.sender = nil
-      assert_equal "<span class=\"deleted\">(deleted)</span>",
-                   message_sender(message)
-    end
+  test '#message_sender should return link to buyer account' do
+    message_from_buyer = FactoryBot.create(:message, sender: @buyer_sender).decorate
+    assert_equal link_to(@buyer_sender.org_name, admin_buyers_account_path(@buyer_sender), title: account_title(@buyer_sender.decorate)),
+                 message_sender(message_from_buyer)
+  end
+
+  test '#message_sender should return org name of provider account' do
+    message_from_provider = FactoryBot.create(:message, sender: @provider_sender)
+    assert_equal @provider_sender.org_name,
+                 message_sender(message_from_provider)
+  end
+
+  test '#message_sender should return (deleted) for non existing sender' do
+    message = FactoryBot.create(:message, to: [@buyer_sender])
+    message.sender = nil
+    assert_equal "<span class=\"deleted\">(deleted)</span>",
+                 message_sender(message)
   end
 
   def test_one
-    assert_equal %q{Some <a href="http://google.com">http://google.com</a> text},
+    assert_equal 'Some <a href="http://google.com">http://google.com</a> text',
                  hyperlink_urls('Some http://google.com text')
   end
 
   def test_text_with_incomplete_link
-    assert_equal %q{sth sth sth <a href="http://duzadupa">http://duzadupa</a> sth sth},
+    assert_equal 'sth sth sth <a href="http://duzadupa">http://duzadupa</a> sth sth',
                  hyperlink_urls('sth sth sth http://duzadupa sth sth')
   end
 
   def test_text_without_links
-    assert_equal %{sth sth sth sth},
+    assert_equal %(sth sth sth sth),
                  hyperlink_urls('sth sth sth sth')
   end
 
   def test_text_with_two_links
-    assert_equal %{Some <a href="http://google.com">http://google.com</a> text <a href="http://3scale.net">http://3scale.net</a> text2},
+    assert_equal %(Some <a href="http://google.com">http://google.com</a> text <a href="http://3scale.net">http://3scale.net</a> text2),
                  hyperlink_urls('Some http://google.com text http://3scale.net text2')
   end
-
 
   def test_replace_links_with_html_escapes_html
     text = hyperlink_urls('<b>text</b>')
@@ -95,10 +90,9 @@ class MessagesHelperTest < ActionView::TestCase
     assert_equal '&lt;b&gt;text&lt;/b&gt;', text
     assert text.html_safe?
   end
-  #
 
   def test_if_removes_dots_from_end_of_links
-    assert_equal %{Some <a href="http://google.com">http://google.com</a>. text},
+    assert_equal %(Some <a href="http://google.com">http://google.com</a>. text),
                  hyperlink_urls('Some http://google.com. text')
   end
 
@@ -108,29 +102,28 @@ class MessagesHelperTest < ActionView::TestCase
   end
 
   def test_if_other_unusual_caracters_around_url_pass
-    assert_equal %{Some <a href="http://google.com">http://google.com</a>]] text},
+    assert_equal %(Some <a href="http://google.com">http://google.com</a>]] text),
                  hyperlink_urls('Some http://google.com]] text')
   end
 
   def test_if_links_staring_with_https_are_highlighted_correctly
-    assert_equal %{Some <a href="https://google.com">https://google.com</a> text},
+    assert_equal %(Some <a href="https://google.com">https://google.com</a> text),
                  hyperlink_urls('Some https://google.com text')
   end
 
   def test_if_links_with_colon_at_the_end_are_shown_properly_with_https_links
-    assert_equal %{Some <a href="https://google.com">https://google.com</a>: text},
+    assert_equal %(Some <a href="https://google.com">https://google.com</a>: text),
                  hyperlink_urls('Some https://google.com: text')
   end
 
   def test_if_links_with_colon_at_the_end_are_shown_properly_with_http_links
-    assert_equal %{Some <a href="http://google.com">http://google.com</a>: text},
+    assert_equal %(Some <a href="http://google.com">http://google.com</a>: text),
                  hyperlink_urls('Some http://google.com: text')
   end
 
   # this is regression test for: https://github.com/3scale/system/issues/4819
   def test_if_random_word_with_colon_at_the_end_is_not_treated_like_link
-    assert_equal %{Some random word:},
-                 %{Some random word:}
+    assert_equal %(Some random word:),
+                 %(Some random word:)
   end
-
 end

--- a/test/unit/liquid/drops/user_drop_test.rb
+++ b/test/unit/liquid/drops/user_drop_test.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
   include Liquid
-
 
   def setup
     @buyer = FactoryBot.create(:buyer_account)
@@ -10,120 +11,111 @@ class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
     @drop = Drops::User.new(@user)
   end
 
-  test '#display_name' do
-    assert_equal @user.decorate.display_name, @drop.display_name
+  class NoCurrentUserTest < Liquid::Drops::UserDropTest
+    test '#display_name' do
+      assert_equal @user.decorate.display_name, @drop.display_name
+    end
+
+    test '#informal_name' do
+      assert_equal @user.decorate.informal_name, @drop.informal_name
+    end
+
+    test '#name' do
+      assert_equal @user.decorate.full_name, @drop.name
+    end
+
+    def test_oauth2
+      @user.signup.expects(:oauth2?).returns(true)
+      assert @drop.oauth2?
+
+      @user.signup.expects(:oauth2?).returns(false)
+      assert_not @drop.oauth2?
+    end
+
+    test 'returns roles_collection' do
+      User.current = @user
+      assert_kind_of Array, @drop.roles_collection
+      assert_kind_of Liquid::Drops::User::Role, @drop.roles_collection[0]
+    end
+
+    test 'returns url' do
+      assert_equal "/admin/account/users/#{@user.id}", @drop.url
+    end
+
+    test 'returns edit_url' do
+      assert_equal "/admin/account/users/#{@user.id}/edit", @drop.edit_url
+    end
+
+    test 'returns the role as string' do
+      assert_equal(@user.role.to_s, @drop.role)
+    end
   end
 
-  test '#informal_name' do
-    assert_equal @user.decorate.informal_name, @drop.informal_name
-  end
-
-  test '#name' do
-    assert_equal @user.decorate.full_name, @drop.name
-  end
-
-  def test_oauth2
-    @user.signup.expects(:oauth2?).returns(true)
-    assert @drop.oauth2?
-
-    @user.signup.expects(:oauth2?).returns(false)
-    refute @drop.oauth2?
-  end
-
-  should 'returns roles_collection' do
-    User.current = @user
-    assert_kind_of Array, @drop.roles_collection
-    assert_kind_of Liquid::Drops::User::Role, @drop.roles_collection[0]
-  end
-
-  should 'returns url' do
-    assert_equal "/admin/account/users/#{@user.id}", @drop.url
-  end
-
-  should 'returns edit_url' do
-    assert_equal "/admin/account/users/#{@user.id}/edit", @drop.edit_url
-  end
-
-  should 'return the role as string' do
-    assert_equal(@user.role.to_s, @drop.role)
-  end
-
-
-  context 'by a buyer' do
-    setup do
+  class BuyerUserTest < Liquid::Drops::UserDropTest
+    def setup
+      super
       ::User.current = @user
 
       @drop2 = Drops::User.new(FactoryBot.create(:user, account: @buyer))
-
     end
 
-    should "can be destroyed" do
+    test "can be destroyed" do
       assert @drop2.can.be_destroyed?
     end
 
-    should "can be managed" do
+    test "can be managed" do
       assert @drop2.can.be_managed?
     end
 
-    should "can be update role" do
+    test "can be update role" do
       assert @drop2.can.be_update_role?
     end
-
   end
 
-  context 'by a normal user' do
-    setup do
+  class NormalUserTest < Liquid::Drops::UserDropTest
+    def setup
+      super
       ::User.current = FactoryBot.create(:user, account: @buyer)
     end
 
-    should "can't be destroyed" do
-      assert !@drop.can.be_destroyed?
+    test "can't be destroyed" do
+      assert_not @drop.can.be_destroyed?
     end
 
-    should "can't be managed" do
-      assert !@drop.can.be_managed?
+    test "can't be managed" do
+      assert_not @drop.can.be_managed?
     end
 
-    should "can't be update role" do
-      assert !@drop.can.be_update_role?
+    test "can't be update role" do
+      assert_not @drop.can.be_update_role?
     end
-
   end
 
-  context '#sections' do
-    context 'users with no sections' do
+  class SectionsTest < Liquid::Drops::UserDropTest
+    test 'users with no sections should be empty' do
+      user_drop = Drops::User.new(@user)
+      assert user_drop.sections.empty?
+    end
 
-      should 'be empty' do
-        user_drop = Drops::User.new(@user)
-        assert user_drop.sections.empty?
-      end
+    test 'users with sections should return sections paths' do
+      @section = FactoryBot.create(:cms_section, public: false,
+                                                 provider: @buyer.provider_account,
+                                                 title: "protected-section",
+                                                 parent: @buyer.provider_account.sections.root)
+      grant_buyer_access_to_section @buyer, @section
+      user_drop = Drops::User.new(@user)
+      assert_equal ["/protected-section"], user_drop.sections
+    end
+  end
 
-    end # users with no sections
-
-    context 'users with sections' do
-      setup do
-        @section = FactoryBot.create(:cms_section, :public => false,
-                           :provider => @buyer.provider_account,
-                           :title => "protected-section",
-                           :parent => @buyer.provider_account.sections.root)
-        grant_buyer_access_to_section @buyer, @section
-      end
-
-      should 'return sections paths' do
-        user_drop = Drops::User.new(@user)
-        assert user_drop.sections == ["/protected-section"]
-      end
-
-    end # users with sections
-  end # sections
-
-  context "field definitions" do
-    setup do
+  class FieldDefinitionsTest < Liquid::Drops::UserDropTest
+    def setup
+      super
       [{ target: "User", name: "first_name",    label: "first_name", hidden: true },
        { target: "User", name: "visible_extra", label: "visible_extra" },
        { target: "User", name: "hidden_extra",  label: "hidden_extra", hidden: true }]
        .each do |field|
-         FactoryBot.create :fields_definition, field.merge({account_id: @buyer.provider_account.id})
+        FactoryBot.create :fields_definition, field.merge({account_id: @buyer.provider_account.id})
       end
 
       @buyer.reload
@@ -134,11 +126,11 @@ class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
       @drop = Drops::User.new(@user)
     end
 
-    should '#fields' do
+    test '#fields' do
       assert @drop.fields.first.is_a?(Drops::Field)
     end
 
-    should '#fields contain both visible and invisible' do
+    test '#fields should contain both visible and invisible' do
       @user.username = 'someone'
       @user.first_name = 'John'
 
@@ -146,25 +138,24 @@ class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
       assert_equal 'John', @drop.fields["first_name"].to_str
     end
 
-    should '#fields include extra fields and builtin fields' do
+    test '#fields should include extra fields and builtin fields' do
       #regression test
       assert_not_nil @drop.fields["visible_extra"]
       assert_not_nil @drop.fields["first_name"]
       assert_not_nil @drop.fields["username"]
     end
 
-    should 'be fields' do
+    test 'should be fields' do
       assert @drop.extra_fields.first.is_a?(Drops::Field)
     end
 
-    should '#extra visible and invisible' do
+    test '#extra visible and invisible' do
       assert_equal "visible extra value", @drop.extra_fields["visible_extra"]
       assert_equal "hidden extra value", @drop.extra_fields["hidden_extra"]
     end
 
-    should 'not return builtin fields' do
+    test 'should not return builtin fields' do
       assert_nil @drop.extra_fields["username"]
     end
-
-  end # field definitions
+  end
 end

--- a/test/unit/liquid/drops/user_drop_test.rb
+++ b/test/unit/liquid/drops/user_drop_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
   include Liquid
 
-  def setup
+  setup do
     @buyer = FactoryBot.create(:buyer_account)
     @user = @buyer.users.first
     @drop = Drops::User.new(@user)
@@ -52,8 +52,7 @@ class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
   end
 
   class BuyerUserTest < Liquid::Drops::UserDropTest
-    def setup
-      super
+    setup do
       ::User.current = @user
 
       @drop2 = Drops::User.new(FactoryBot.create(:user, account: @buyer))
@@ -73,8 +72,7 @@ class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
   end
 
   class NormalUserTest < Liquid::Drops::UserDropTest
-    def setup
-      super
+    setup do
       ::User.current = FactoryBot.create(:user, account: @buyer)
     end
 
@@ -109,8 +107,7 @@ class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
   end
 
   class FieldDefinitionsTest < Liquid::Drops::UserDropTest
-    def setup
-      super
+    setup do
       [{ target: "User", name: "first_name",    label: "first_name", hidden: true },
        { target: "User", name: "visible_extra", label: "visible_extra" },
        { target: "User", name: "hidden_extra",  label: "hidden_extra", hidden: true }]

--- a/test/unit/mailers/user_mailer_test.rb
+++ b/test/unit/mailers/user_mailer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UserMailerTest < ActionMailer::TestCase
@@ -15,38 +17,39 @@ class UserMailerTest < ActionMailer::TestCase
     ActionMailer::Base.deliveries.last
   end
 
-  context "lost_password" do
-
-    setup do
-      @provider_account = FactoryBot.create(:provider_account,
-                                  :domain     => 'api.monkey.com',
-                                  :org_name   => "Monkey",
-                                  :from_email => 'api@monkey.com')
-
+  class AdminTest < UserMailerTest
+    def setup
+      super
+      @provider_account = FactoryBot.create(:provider_account, domain: 'api.monkey.com',
+                                                               org_name: "Monkey",
+                                                               from_email: 'api@monkey.com')
       @user = @provider_account.admins.first
-      @user.lost_password_token = 'abc123'
-      @noreply_email_address = Mail::Address.new(ThreeScale.config.noreply_email).address
     end
 
-    should "have specific header" do
-      email = deliver_lost_password
-
-      assert_match "Lost password recovery", email.subject
-      assert_equal [@user.email], email.to
-      assert_equal [@noreply_email_address], email.from
-    end
-
-    should 'have specific body hello' do
-      with_default_url_options protocol: 'https' do
-        email = deliver_lost_password
-        assert_match "You can reset your password by visiting the following link", email.body.to_s
-        assert_match "https://#{@provider_account.external_admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
+    class LostPasswordTest < AdminTest
+      def setup
+        super
+        @user.lost_password_token = 'abc123'
+        @noreply_email_address = Mail::Address.new(ThreeScale.config.noreply_email).address
       end
-    end
 
-    context "custom template" do
+      test "should have specific header" do
+        email = deliver_lost_password
 
-      setup do
+        assert_match "Lost password recovery", email.subject
+        assert_equal [@user.email], email.to
+        assert_equal [@noreply_email_address], email.from
+      end
+
+      test 'should have specific body hello' do
+        with_default_url_options protocol: 'https' do
+          email = deliver_lost_password
+          assert_match "You can reset your password by visiting the following link", email.body.to_s
+          assert_match "https://#{@provider_account.external_admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
+        end
+      end
+
+      test "custom template should have specific body when provider has custom templates" do
         content = <<-MSG
         Dear {{ user.display_name }},
 
@@ -57,11 +60,7 @@ class UserMailerTest < ActionMailer::TestCase
         The API Team.
         MSG
 
-        @user.account.provider_account.email_templates.create!(:system_name => "lost_password_email", :published => content)
-
-      end
-
-      should "have specific body when provider has custom templates" do
+        @user.account.provider_account.email_templates.create!(system_name: "lost_password_email", published: content)
 
         email = deliver_lost_password
         # assert_match "CUSTOM SUBJECT", email.subject
@@ -70,31 +69,22 @@ class UserMailerTest < ActionMailer::TestCase
         assert_match "CUSTOM MESSAGE", email.body.to_s
         assert_match "http://#{@provider_account.external_admin_domain}/p/password?password_reset_token=abc123", email.body.to_s
         assert_match "The API Team", email.body.to_s
-
       end
-
     end
-
-
   end
 
+  class BuyerTest < UserMailerTest
+    def setup
+      super
+      @provider_account = FactoryBot.create(:provider_account, domain: 'api.monkey.com',
+                                                               org_name: "Monkey",
+                                                               from_email: 'api@monkey.com')
+      @buyer_account = FactoryBot.create(:buyer_account_with_pending_user, provider_account: @provider_account)
+      @user = FactoryBot.create(:admin, account: @buyer_account)
+    end
 
-  context "signup_notification" do
-    context "for buyer" do
-      setup do
-        @provider_account = FactoryBot.create(:provider_account,
-                                    :domain     => 'api.monkey.com',
-                                    :org_name   => "Monkey",
-                                    :from_email => 'api@monkey.com')
-
-        @buyer_account = FactoryBot.create(:buyer_account_with_pending_user,
-                                 :provider_account => @provider_account)
-
-        @user = FactoryBot.create :admin, :account => @buyer_account
-      end
-
-      should "have specific headers" do
-
+    class SignUpNotificationForBuyerTest < BuyerTest
+      test "should have specific headers" do
         email = deliver_signup_notification
 
         assert_equal [@provider_account.from_email], email.from
@@ -103,7 +93,7 @@ class UserMailerTest < ActionMailer::TestCase
         assert_nil email.bcc
       end
 
-      should "have specific body" do
+      test "should have specific body" do
         with_default_url_options protocol: 'https' do
           email = deliver_signup_notification
 
@@ -115,16 +105,15 @@ class UserMailerTest < ActionMailer::TestCase
         end
       end
 
-      should "have specific body when provider has custom templates" do
-        content = <<-MSG
-Customized Template
-{{ user.display_name }}
-{{ url }}
-{{ provider.name }}
+      test "should have specific body when provider has custom templates" do
+        content = <<~MSG
+          Customized Template
+          {{ user.display_name }}
+          {{ url }}
+          {{ provider.name }}
         MSG
 
-        @user.account.provider_account.email_templates.create!(:system_name => "signup_notification_email",
-                                                         :published => content)
+        @user.account.provider_account.email_templates.create!(system_name: "signup_notification_email", published: content)
 
         email = deliver_signup_notification
 
@@ -134,7 +123,7 @@ Customized Template
         assert_match "http://api.monkey.com/activate/#{@user.activation_code}", email.body.to_s
       end
 
-      should "have specific body and subject" do
+      test "should have specific body and subject" do
         UserMailer.signup_notification(@user).deliver_now
         message = ActionMailer::Base.deliveries.last
 
@@ -146,33 +135,32 @@ Customized Template
         assert_nil message.bcc
         assert_match "Thank you for signing up for access to the Monkey API, your account has been created", message.body.to_s
       end
+    end
 
-      context "lost_password" do
+    class LostPasswordTest < BuyerTest
+      def setup
+        super
+        @user.lost_password_token = 'abc123'
+      end
 
-        setup do
-          @user.lost_password_token = 'abc123'
-        end
+      test "should have specific header" do
+        email = deliver_lost_password
 
-        should "have specific header" do
+        assert_match "Lost password recovery", email.subject
+        assert_equal [@user.email], email.to
+        assert_equal ['api@monkey.com'], email.from
+      end
+
+      test 'should have specific body' do
+        with_default_url_options protocol: 'https' do
           email = deliver_lost_password
-
-          assert_match "Lost password recovery", email.subject
-          assert_equal [@user.email], email.to
-          assert_equal ['api@monkey.com'], email.from
+          assert_match "You can reset your password by visiting the following link", email.body.to_s
+          assert_match "https://#{@provider_account.external_domain}/admin/account/password?password_reset_token=abc123", email.body.to_s
         end
+      end
 
-        should 'have specific body' do
-          with_default_url_options protocol: 'https' do
-            email = deliver_lost_password
-            assert_match "You can reset your password by visiting the following link", email.body.to_s
-            assert_match "https://#{@provider_account.external_domain}/admin/account/password?password_reset_token=abc123", email.body.to_s
-          end
-        end
-
-        context "custom template" do
-
-          setup do
-            content = <<-MSG
+      test "custom template should have specific body when provider has custom templates" do
+        content = <<-MSG
         Dear {{ user.display_name }},
 
         CUSTOM MESSAGES
@@ -180,27 +168,17 @@ Customized Template
         {{ url }}
 
         The API Team.
-            MSG
+        MSG
 
-            @user.account.provider_account.email_templates.create!(:system_name => "lost_password_email", :published => content)
+        @user.account.provider_account.email_templates.create!(system_name: "lost_password_email", published: content)
 
-          end
-
-          should "have specific body when provider has custom templates" do
-
-            email = deliver_lost_password
-            # assert_match "CUSTOM SUBJECT", email.subject
-            assert_match "Lost password recovery", email.subject
-            assert_match "Dear #{user_decorator.display_name},", email.body.to_s
-            assert_match "CUSTOM MESSAGE", email.body.to_s
-            assert_match "http://#{@provider_account.external_domain}/admin/account/password?password_reset_token=abc123", email.body.to_s
-            assert_match "The API Team", email.body.to_s
-
-          end
-
-        end
-
-
+        email = deliver_lost_password
+        # assert_match "CUSTOM SUBJECT", email.subject
+        assert_match "Lost password recovery", email.subject
+        assert_match "Dear #{user_decorator.display_name},", email.body.to_s
+        assert_match "CUSTOM MESSAGE", email.body.to_s
+        assert_match "http://#{@provider_account.external_domain}/admin/account/password?password_reset_token=abc123", email.body.to_s
+        assert_match "The API Team", email.body.to_s
       end
     end
   end

--- a/test/unit/mailers/user_mailer_test.rb
+++ b/test/unit/mailers/user_mailer_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class UserMailerTest < ActionMailer::TestCase
-  def setup
+  setup do
     ActionMailer::Base.deliveries = []
   end
 
@@ -18,8 +18,7 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   class AdminTest < UserMailerTest
-    def setup
-      super
+    setup do
       @provider_account = FactoryBot.create(:provider_account, domain: 'api.monkey.com',
                                                                org_name: "Monkey",
                                                                from_email: 'api@monkey.com')
@@ -27,8 +26,7 @@ class UserMailerTest < ActionMailer::TestCase
     end
 
     class LostPasswordTest < AdminTest
-      def setup
-        super
+      setup do
         @user.lost_password_token = 'abc123'
         @noreply_email_address = Mail::Address.new(ThreeScale.config.noreply_email).address
       end
@@ -74,8 +72,7 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   class BuyerTest < UserMailerTest
-    def setup
-      super
+    setup do
       @provider_account = FactoryBot.create(:provider_account, domain: 'api.monkey.com',
                                                                org_name: "Monkey",
                                                                from_email: 'api@monkey.com')
@@ -138,8 +135,7 @@ class UserMailerTest < ActionMailer::TestCase
     end
 
     class LostPasswordTest < BuyerTest
-      def setup
-        super
+      setup do
         @user.lost_password_token = 'abc123'
       end
 

--- a/test/unit/observers/cinstance_observer_test.rb
+++ b/test/unit/observers/cinstance_observer_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class CinstanceObserverTest < ActiveSupport::TestCase
   fixtures :countries
 
-  def setup
+  setup do
     @plan = FactoryBot.create(:application_plan)
     @service = @plan.service
 
@@ -17,8 +17,7 @@ class CinstanceObserverTest < ActiveSupport::TestCase
   end
 
   class NewCinstanceCreatedTest < CinstanceObserverTest
-    def setup
-      super
+    setup do
       @cinstance = @buyer.buy!(@plan)
       @message = Message.last
     end
@@ -58,8 +57,7 @@ class CinstanceObserverTest < ActiveSupport::TestCase
   end
 
   class NewCinstanceApprovalRequired < CinstanceObserverTest
-    def setup
-      super
+    setup do
       @plan.update(approval_required: true)
       @cinstance = @buyer.buy!(@plan)
     end
@@ -71,8 +69,7 @@ class CinstanceObserverTest < ActiveSupport::TestCase
     end
 
     class AcceptedCinstanceTest < NewCinstanceApprovalRequired
-      def setup
-        super
+      setup do
         @cinstance.accept!
         @message = Message.last
       end
@@ -106,8 +103,7 @@ class CinstanceObserverTest < ActiveSupport::TestCase
     end
 
     class RejectedCinstanceTest < NewCinstanceApprovalRequired
-      def setup
-        super
+      setup do
         @cinstance.reject!('any reason')
         @message = Message.last
       end
@@ -120,8 +116,7 @@ class CinstanceObserverTest < ActiveSupport::TestCase
   end
 
   class NewCinstanceApprovalNotRequired < CinstanceObserverTest
-    def setup
-      super
+    setup do
       @plan.update(approval_required: false)
       @cinstance = @buyer.buy!(@plan)
     end
@@ -138,8 +133,7 @@ class CinstanceObserverTest < ActiveSupport::TestCase
   end
 
   class CinstanceCancelledTest < CinstanceObserverTest
-    def setup
-      super
+    setup do
       @cinstance = @buyer.buy!(@plan)
       Message.destroy_all
 
@@ -178,8 +172,7 @@ class CinstanceObserverTest < ActiveSupport::TestCase
   end
 
   class CinstanceChangesPlanTest < CinstanceObserverTest
-    def setup
-      super
+    setup do
       @cinstance = @buyer.buy!(@plan)
       @new_plan = FactoryBot.create( :application_plan, :issuer => @service)
 
@@ -188,8 +181,7 @@ class CinstanceObserverTest < ActiveSupport::TestCase
     end
 
     class MessageToProviderTest < CinstanceChangesPlanTest
-      def setup
-        super
+      setup do
         @message = @buyer.messages.last
       end
 
@@ -218,8 +210,7 @@ class CinstanceObserverTest < ActiveSupport::TestCase
     end
 
     class MessageToBuyerTest < CinstanceChangesPlanTest
-      def setup
-        super
+      setup do
         @message = @provider.messages.last
       end
 

--- a/test/unit/observers/message_observer_test.rb
+++ b/test/unit/observers/message_observer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MessageObserverTest < ActiveSupport::TestCase
@@ -8,58 +10,62 @@ class MessageObserverTest < ActiveSupport::TestCase
     @buyer = FactoryBot.create(:buyer_account)
     @provider = @buyer.provider_account
     @service = @provider.first_service!
-    @plan = FactoryBot.create(:application_plan, :issuer => @service)
+    @plan = FactoryBot.create(:application_plan, issuer: @service)
   end
 
-  def test_after_create_after_destroy
-    app_plan  = FactoryBot.create(:application_plan, issuer: @service)
-    contract  = FactoryBot.build(:service_contract, plan: FactoryBot.create(:service_plan))
-    cinstance = contract(app_plan)
+  class OtherTest < MessageObserverTest
+    test 'after_create after_destroy' do
+      app_plan = FactoryBot.create(:application_plan, issuer: @service)
+      contract = FactoryBot.build(:service_contract, plan: FactoryBot.create(:service_plan))
+      cinstance = contract(app_plan)
 
-    Applications::ApplicationCreatedEvent.expects(:create).once
-    assert cinstance.save!
+      Applications::ApplicationCreatedEvent.expects(:create).once
+      assert cinstance.save!
 
-    ServiceContracts::ServiceContractCreatedEvent.expects(:create).once
-    assert contract.save!
+      ServiceContracts::ServiceContractCreatedEvent.expects(:create).once
+      assert contract.save!
 
-    Cinstances::CinstanceCancellationEvent.expects(:create).once
-    assert cinstance.destroy!
+      Cinstances::CinstanceCancellationEvent.expects(:create).once
+      assert cinstance.destroy!
 
-    ServiceContracts::ServiceContractCancellationEvent.expects(:create).once
-    assert contract.destroy!
+      ServiceContracts::ServiceContractCancellationEvent.expects(:create).once
+      assert contract.destroy!
+    end
+
+    test 'plan changed' do
+      contract = FactoryBot.create(:service_contract)
+
+      ServiceContracts::ServiceContractPlanChangedEvent.expects(:create).once
+      ContractMessenger.expects(:plan_change).never
+
+      contract.change_plan! FactoryBot.create(:simple_service_plan)
+
+      cinstance = FactoryBot.create(:cinstance, service: @service)
+
+      Cinstances::CinstancePlanChangedEvent.expects(:create).once
+      ContractMessenger.expects(:plan_change).never
+
+      ContractMessenger.expects(:plan_change_for_buyer).once.returns(mock(deliver: true))
+
+      cinstance.change_plan! FactoryBot.create(:simple_application_plan, service: @service)
+
+      Logic::RollingUpdates.stubs(skipped?: true)
+
+      Cinstances::CinstancePlanChangedEvent.expects(:create).never
+      ContractMessenger.expects(:plan_change).once.returns(mock(deliver: true))
+
+      ContractMessenger.expects(:plan_change_for_buyer).once.returns(mock(deliver: true))
+
+      cinstance.change_plan! FactoryBot.create(:simple_application_plan, service: @service)
+    end
+
+    pending_test 'after_commit_on_destroy'
   end
 
-  def test_plan_changed
-    contract = FactoryBot.create(:service_contract)
-
-    ServiceContracts::ServiceContractPlanChangedEvent.expects(:create).once
-    ContractMessenger.expects(:plan_change).never
-
-    contract.change_plan! FactoryBot.create(:simple_service_plan)
-
-    cinstance = FactoryBot.create(:cinstance, service: @service)
-
-    Cinstances::CinstancePlanChangedEvent.expects(:create).once
-    ContractMessenger.expects(:plan_change).never
-
-    ContractMessenger.expects(:plan_change_for_buyer).once.returns(mock(deliver: true))
-
-    cinstance.change_plan! FactoryBot.create(:simple_application_plan, service: @service)
-
-    Logic::RollingUpdates.stubs(skipped?: true)
-
-    Cinstances::CinstancePlanChangedEvent.expects(:create).never
-    ContractMessenger.expects(:plan_change).once.returns(mock(deliver: true))
-
-    ContractMessenger.expects(:plan_change_for_buyer).once.returns(mock(deliver: true))
-
-    cinstance.change_plan! FactoryBot.create(:simple_application_plan, service: @service)
-  end
-
-  context "after_commit_on_create" do
-    should "call correct messenger" do
-      @app_plan = FactoryBot.create(:application_plan, :issuer => @service)
-      @service_plan = FactoryBot.create(:service_plan, :issuer => @service)
+  class AfterCommitOnCreateTest < MessageObserverTest
+    test "should call correct messenger" do
+      @app_plan = FactoryBot.create(:application_plan, issuer: @service)
+      @service_plan = FactoryBot.create(:service_plan, issuer: @service)
 
       @cinstance = contract(@app_plan)
       CinstanceMessenger.expects(:new_contract).with(@cinstance).returns(message)
@@ -70,116 +76,75 @@ class MessageObserverTest < ActiveSupport::TestCase
       @service_contract.save!
     end
 
-    should 'call observer' do
+    test 'should call observer' do
       @contract = contract(@plan)
       @observer.expects(:after_commit_on_create).with(@contract)
       @contract.save!
     end
 
-    context "with account" do
-      setup do
-        @contract = contract(@plan)
-      end
-
-      should 'send message' do
-        CinstanceMessenger.expects(:new_contract).with(@contract).returns(message)
-        @contract.save!
-      end
-
-      context 'but without admin users' do
-        setup do
-          @buyer.admins.delete_all
-        end
-
-        should 'not send message' do
-          CinstanceMessenger.expects(:new_contract).with(@cinstance).never
-          @contract.save!
-        end
-      end
-
+    test 'with account it should send message' do
+      @contract = contract(@plan)
+      CinstanceMessenger.expects(:new_contract).with(@contract).returns(message)
+      @contract.save!
     end
 
-    context 'without account' do
-      setup do
-        @cinstance = @plan.contracts.build
-      end
-
-      should 'not send message' do
-        CinstanceMessenger.expects(:new_contract).with(@cinstance).never
-        @cinstance.save!
-      end
+    test 'with account but without admin users it should not send message' do
+      @contract = contract(@plan)
+      @buyer.admins.delete_all
+      CinstanceMessenger.expects(:new_contract).with(@cinstance).never
+      @contract.save!
     end
 
+    test 'without account it should not send message' do
+      @cinstance = @plan.contracts.build
+      CinstanceMessenger.expects(:new_contract).with(@cinstance).never
+      @cinstance.save!
+    end
   end
 
-  context 'after_commit_on_destroy' do
-    # TODO: implement destro tests
+  class PlanRequiresApproval < MessageObserverTest
+    def setup
+      super
+      @plan.update(approval_required: true)
+      @contract = contract(@plan)
+      @contract.save!
+    end
+
+    test '#accept should send message' do
+      Contract.transaction do
+        @contract.accept!
+        CinstanceMessenger.expects(:accept).with(@contract).returns(message)
+      end
+    end
+
+    test '#reject should send message' do
+      Contract.transaction do
+        @contract.reject! 'reason'
+        CinstanceMessenger.expects(:reject).with(@contract).returns(message)
+      end
+    end
   end
 
-  context 'after_approve' do
-
-    context 'when plan requires approval' do
-      setup do
-        @plan.update_attribute :approval_required, true
-        @contract = contract(@plan)
-        @contract.save!
-      end
-
-      should 'send message' do
-        Contract.transaction do
-          @contract.accept!
-          CinstanceMessenger.expects(:accept).with(@contract).returns(message)
-        end
-      end
+  class PlanDoesNotRequireApproval < MessageObserverTest
+    def setup
+      super
+      @plan.update(approval_required: false)
+      @contract = contract(@plan)
     end
 
-    context 'when plan doesnt require approval' do
-      setup do
-        @plan.update_attribute :approval_required, false
-        @contract = contract(@plan)
-      end
-
-      should 'not send message' do
-        CinstanceMessenger.expects(:accept).never
-        @contract.save!
-      end
+    test '#accept should not send message' do
+      CinstanceMessenger.expects(:accept).never
+      @contract.save!
     end
 
+    test '#reject should not send message' do
+      CinstanceMessenger.expects(:accept).never
+      @contract.save! and @contract.reject!('reason')
+    end
   end
-
-  context 'after_reject' do
-
-    context 'when plan requires approval' do
-      setup do
-        @plan.update_attribute :approval_required, true
-        @contract = contract(@plan)
-        @contract.save!
-      end
-
-      should 'send message' do
-        Contract.transaction do
-          @contract.reject! 'reason'
-          CinstanceMessenger.expects(:reject).with(@contract).returns(message)
-        end
-      end
-    end
-
-    context 'when plan doesnt require approval' do
-      setup do
-        @plan.update_attribute :approval_required, false
-        @contract = contract(@plan)
-      end
-
-      should 'not send message' do
-        CinstanceMessenger.expects(:accept).never
-        @contract.save! and @contract.reject!('reason')
-      end
-    end
-
-  end
-
 
   private
+
   def message
     mock 'message' do
       expects(:deliver).returns(true)
@@ -188,6 +153,6 @@ class MessageObserverTest < ActiveSupport::TestCase
 
   def contract(plan)
     # if you try to create from buyers association it will create only Contract and observers wont ran
-    plan.contracts.build :user_account => @buyer
+    plan.contracts.build(user_account: @buyer)
   end
 end

--- a/test/unit/observers/message_observer_test.rb
+++ b/test/unit/observers/message_observer_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class MessageObserverTest < ActiveSupport::TestCase
   fixtures :countries
 
-  def setup
+  setup do
     @observer = MessageObserver.instance
     @buyer = FactoryBot.create(:buyer_account)
     @provider = @buyer.provider_account
@@ -103,8 +103,7 @@ class MessageObserverTest < ActiveSupport::TestCase
   end
 
   class PlanRequiresApproval < MessageObserverTest
-    def setup
-      super
+    setup do
       @plan.update(approval_required: true)
       @contract = contract(@plan)
       @contract.save!
@@ -126,8 +125,7 @@ class MessageObserverTest < ActiveSupport::TestCase
   end
 
   class PlanDoesNotRequireApproval < MessageObserverTest
-    def setup
-      super
+    setup do
       @plan.update(approval_required: false)
       @contract = contract(@plan)
     end

--- a/test/unit/signup/plans_with_defaults_test.rb
+++ b/test/unit/signup/plans_with_defaults_test.rb
@@ -7,13 +7,13 @@ module Signup
     setup do
       @manager_account ||= FactoryBot.create(:provider_account)
       @service = @manager_account.first_service!
-      @manager_account.update_attribute :default_account_plan, nil
-      @service.update_attribute :default_service_plan, nil
-      @service.update_attribute :default_application_plan, nil
+      @manager_account.update(default_account_plan: nil)
+      @service.update(default_service_plan: nil)
+      @service.update(default_application_plan: nil)
     end
 
-    context 'without default plans' do
-      should 'be invalid on account plan without passed plans' do
+    class WithoutDefaultPlanTest < PlansWithDefaultsTest
+      test 'should be invalid on account plan without passed plans' do
         plans.selected = []
 
         assert plans.errors.any?
@@ -21,7 +21,7 @@ module Signup
         assert plans.to_a.empty?
       end
 
-      should 'yield errors to proc' do
+      test 'should yield errors to proc' do
         errors = []
         plans = Signup::PlansWithDefaults.new(@manager_account, nil) { |error| errors << error }
         plans.selected = []
@@ -31,33 +31,35 @@ module Signup
       end
     end
 
-    context 'with default account plan' do
+    class WithDefaultAccountPlanTest < PlansWithDefaultsTest
       setup do
         @account_plan = FactoryBot.create(:account_plan, :issuer => @manager_account)
-        @manager_account.update_attribute :default_account_plan, @account_plan
+        @manager_account.update(default_account_plan: @account_plan)
       end
 
-      should 'select default account plan and nothing else' do
-        plans.selected = []
+      class OnlyAccountPlanTest < WithDefaultAccountPlanTest
+        test 'select default account plan and nothing else' do
+          plans.selected = []
 
-        assert plans.errors.none?
-        assert_equal [@account_plan], plans.to_a
+          assert plans.errors.none?
+          assert_equal [@account_plan], plans.to_a
+        end
       end
 
-      context 'and default service plan' do
+      class AlsoDefaultServicePlanTest < WithDefaultAccountPlanTest
         setup do
           @service_plan = FactoryBot.create(:service_plan, :issuer => @service)
-          @service.update_attribute :default_service_plan, @service_plan
+          @service.update(default_service_plan: @service_plan)
         end
 
-        should 'select default account and service plan' do
+        test 'select default account and service plan' do
           plans.selected = []
 
           assert plans.errors.none?
           assert_equal [@account_plan, @service_plan], plans.to_a
         end
 
-        should 'have error on service plan when tries to subscribe two plans' do
+        test 'have error on service plan when tries to subscribe two plans' do
           service_plans = @service.service_plans
           plans.selected = service_plans
 
@@ -66,35 +68,31 @@ module Signup
           assert_match /subscribe only one plan per service/, plans.errors.to_sentence
         end
 
-        context 'and default application plan' do
-          setup do
-            @application_plan = FactoryBot.create(:application_plan, :issuer => @service)
-            @service.update_attribute :default_application_plan, @application_plan
-          end
+        test 'and also default application plan: select default account, service and application plan' do
+          @application_plan = FactoryBot.create(:application_plan, :issuer => @service)
+          @service.update(default_application_plan: @application_plan)
 
-          should 'select default account, service and application plan' do
-            plans.selected = []
+          plans.selected = []
 
-            assert plans.errors.none?
-            assert_equal [@account_plan, @service_plan, @application_plan], plans.to_a
-          end
+          assert plans.errors.none?
+          assert_equal [@account_plan, @service_plan, @application_plan], plans.to_a
         end
       end
 
-      context 'and default application plan without service plan' do
+      class AlsoDefaultApplicationPlanTest < WithDefaultAccountPlanTest
         setup do
           @application_plan = FactoryBot.create(:application_plan, :issuer => @service)
-          @service.update_attribute :default_application_plan, @application_plan
+          @service.update(default_application_plan: @application_plan)
         end
 
-        should 'select only account plan' do
+        test 'select only account plan' do
           plans.selected = []
 
           assert plans.errors.none?
           assert_equal [@account_plan], plans.to_a
         end
 
-        should 'select all when passed service plan' do
+        test 'select all when passed service plan' do
           service_plan = @service.service_plans.first!
           plans.selected = [service_plan]
 
@@ -103,7 +101,7 @@ module Signup
         end
 
 
-        should 'have error on application plan when explicitly selected' do
+        test 'have error on application plan when explicitly selected' do
           plans.selected = [@application_plan]
 
           assert plans.errors.any?
@@ -111,43 +109,43 @@ module Signup
           assert_match /Couldn't find a Service Plan for/, plans.errors.to_sentence
         end
 
-        should 'work when provider has service plans disabled and default plan' do
+        test 'work when provider has service plans disabled and default plan' do
           service_plan = @service.service_plans.first!
           @manager_account.settings.service_plans_ui_visible = false
 
           plans.selected = []
 
           assert plans.errors.none?
-          assert_equal [ @account_plan, service_plan , @application_plan], plans.to_a
+          assert_equal [@account_plan, service_plan, @application_plan], plans.to_a
         end
 
-        should 'work when provider has service plans disabled' do
+        test 'work when provider has service plans disabled' do
           service_plan = @service.service_plans.first!
           @manager_account.settings.service_plans_ui_visible = false
 
           plans.selected = [@application_plan]
 
           assert plans.errors.none?
-          assert_equal [ @account_plan, service_plan , @application_plan], plans.to_a
+          assert_equal [@account_plan, service_plan, @application_plan], plans.to_a
         end
 
-        should 'have error when rolling update is not active' do
+        test 'have error when rolling update is not active' do
           service_plan = @service.service_plans.first!
-          service_plan.update_columns(state: 'published')
+          service_plan.update(state: 'published')
           @manager_account.settings.service_plans_ui_visible = false
 
           Logic::RollingUpdates.stubs(skipped?: true)
 
           plans.selected = [@application_plan]
 
-          refute plans.errors.none?
-          assert_equal [ @account_plan, @application_plan ], plans.to_a
+          assert_not plans.errors.none?
+          assert_equal [@account_plan, @application_plan], plans.to_a
           assert_match /Couldn't find a Service Plan/, plans.errors.to_sentence
         end
 
-        should 'work without the rolling update' do
+        test 'work without the rolling update' do
           service_plan = @service.service_plans.first!
-          service_plan.update_columns(state: 'published')
+          service_plan.update(state: 'published')
           @manager_account.settings.service_plans_ui_visible = false
 
           Logic::RollingUpdates.stubs(skipped?: true)
@@ -155,18 +153,18 @@ module Signup
           plans.selected = []
 
           assert plans.errors.none?
-          assert_equal [ @account_plan], plans.to_a
+          assert_equal [@account_plan], plans.to_a
         end
 
-        should 'have error with hidden service plan when provider has service plans disabled' do
+        test 'have error with hidden service plan when provider has service plans disabled' do
           service_plan = @service.service_plans.first!
           service_plan.update_columns(state: 'hidden') # default plans used to be hidden
           @manager_account.settings.service_plans_ui_visible = false
 
           plans.selected = [@application_plan]
 
-          refute plans.errors.none?
-          assert_equal [ @account_plan, @application_plan ], plans.to_a
+          assert_not plans.errors.none?
+          assert_equal [@account_plan, @application_plan], plans.to_a
           assert_match /Couldn't find a Service Plan/, plans.errors.to_sentence
         end
       end

--- a/test/unit/three_scale/search_test.rb
+++ b/test/unit/three_scale/search_test.rb
@@ -1,17 +1,18 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ThreeScale::SearchTest < ActiveSupport::TestCase
+  class FakeModelTest < ActiveSupport::TestCase
+    class Model < ApplicationRecord
+      self.table_name = 'accounts'
 
-  class Model < ActiveRecord::Base
-    self.table_name = 'accounts'
+      include ThreeScale::Search::Scopes
 
-    include ThreeScale::Search::Scopes
+      scope :by_fancy_scope, ->(value) { where(id: value == '1') }
+      scope :by_another_scope, -> { where(created_at: :column) }
+    end
 
-    scope :by_fancy_scope, ->(value) { where(id: value == '1') }
-    scope :by_another_scope, -> { where(created_at: :column) }
-  end
-
-  context "fake Model" do
     teardown do
       Model.allowed_sort_columns = []
       Model.allowed_search_scopes = []
@@ -19,153 +20,138 @@ class ThreeScale::SearchTest < ActiveSupport::TestCase
       Model.sort_columns_joins = {}
     end
 
-    should "have right methods" do
+    test "should have right methods" do
       assert Model.respond_to?(:scope_search)
       assert Model.respond_to?(:order_by)
     end
 
-    should "search with non allowed scope" do
+    test "should search with non allowed scope" do
       assert_equal(Model.all, Model.scope_search(:another_scope => "dl"))
     end
 
-    should "search with allowed scope" do
+    test "should search with allowed scope" do
       Model.allowed_search_scopes = ['fancy_scope']
       assert_equal(Model.by_fancy_scope('1'), Model.scope_search(:fancy_scope => "1") )
     end
 
-    should "have default scope" do
+    test "should have default scope" do
       Model.allowed_search_scopes = ['fancy_scope']
-      Model.default_search_scopes = ['fancy_scope', 'another_scope']
+      Model.default_search_scopes = %w[fancy_scope another_scope]
 
       scope = Model.by_another_scope.by_fancy_scope('1')
       assert_equal(scope, Model.scope_search(:fancy_scope => "1"))
     end
 
-    should "order by allowed column with full table name" do
+    test "should order by allowed column with full table name" do
       Model.allowed_sort_columns =  ['created_at']
 
       scope = Model.order('accounts.created_at DESC')
       assert_equal scope, Model.order_by(:created_at, :desc)
     end
 
-    should "order by non allowed column" do
+    test "should order by non allowed column" do
       assert_equal Model.all, Model.order_by(:unknown, :desc)
     end
   end
 
-  context "Search object" do
-    should "reject blank values" do
-      search = ThreeScale::Search.new :blank => '', :present => 'present'
-      assert_nil search.blank
-      assert 'present', search.present
-    end
+  test "Search object should reject blank values" do
+    search = ThreeScale::Search.new :blank => '', :present => 'present'
+    assert_nil search.blank
+    assert 'present', search.present
   end
 
-  context "ServiceContract" do
-    should "can search by service_id and plan_id same time" do
-      FactoryBot.create(:service_plan)
-      service_plan = FactoryBot.create(:service_plan)
-      service = service_plan.service
-      service_contract = FactoryBot.create(:service_contract, :plan => service_plan)
-      query = { "account_query"=>"", "deleted_accounts"=>"0", "service_id"=>service.id, "plan_type"=>"", "plan_id"=>"", "state"=>"" }
-      search = ThreeScale::Search.new(query)
-      assert_equal [service_contract], ServiceContract.scope_search(query).order_by(nil)
-      assert_equal [service_contract], service.account.provided_service_contracts.scope_search(query)
-    end
+  test "can search ServiceContract by service_id and plan_id same time" do
+    FactoryBot.create(:service_plan)
+    service_plan = FactoryBot.create(:service_plan)
+    service = service_plan.service
+    service_contract = FactoryBot.create(:service_contract, :plan => service_plan)
+    query = { "account_query"=>"", "deleted_accounts"=>"0", "service_id"=>service.id, "plan_type"=>"", "plan_id"=>"", "state"=>"" }
+    ThreeScale::Search.new(query)
+    assert_equal [service_contract], ServiceContract.scope_search(query).order_by(nil)
+    assert_equal [service_contract], service.account.provided_service_contracts.scope_search(query)
   end
 
-  context "Alert" do
-    should "sort by timestmap" do
-      alert_one = FactoryBot.create(:limit_alert)
-      alert_two = FactoryBot.create(:limit_alert)
-      assert_equal [alert_one, alert_two], Alert.order_by(:timestamp, :asc)
-    end
-
-    should "sort by timestamp and retain next scope" do
-      assert_equal(Alert.preload(:account).order("alerts.timestamp DESC"), Alert.preload(:account).order_by(:timestamp))
-    end
+  test "Alert should sort by timestmap" do
+    alert_one = FactoryBot.create(:limit_alert)
+    alert_two = FactoryBot.create(:limit_alert)
+    assert_equal [alert_one, alert_two], Alert.order_by(:timestamp, :asc)
   end
 
-  context "Cinstance" do
-    should "retain previous scope on search" do
-      abc = FactoryBot.create(:cinstance, :user_key => "abc")
-      bcd = FactoryBot.create(:cinstance, :user_key => "bcd")
-
-      assert_equal [abc], Cinstance.by_user_key("abc").scope_search(:user_key => 'abc')
-      assert_equal [bcd], Cinstance.by_user_key("bcd").scope_search(:user_key => 'bcd')
-      assert_equal [], Cinstance.by_user_key('abc').scope_search(:user_key => 'bcd')
-    end
-
-    should "order and search" do
-      account = FactoryBot.create(:account)
-
-      abc = FactoryBot.create(:cinstance, :name => "abc", :user_account => account)
-      bcd = FactoryBot.create(:cinstance, :name => "bcd", :user_account => account)
-      cde = FactoryBot.create(:cinstance, :name => "cde", :user_account => account)
-
-      options = {:account => account.id}
-      array = [abc, bcd, cde]
-
-      assert_equal array, Cinstance.order_by(:name, :asc).scope_search(options).to_a
-      assert_equal array.reverse, Cinstance.order_by(:name, :desc).scope_search(options).to_a
-      assert_equal array, Cinstance.scope_search(options).order_by(:name, :asc)
-      assert_equal array.reverse, Cinstance.scope_search(options).order_by(:name, :desc)
-    end
-
-    should "work with all scopes" do
-      app = FactoryBot.create(:cinstance, :name => "test")
-      plan = app.plan
-
-      options = {:account => app.user_account_id, :deleted_accounts => true, :plan_type => "free", :plan_id => plan.id, :type => "Cinstance"}
-
-      assert_equal [app], Cinstance.order_by(:name).scope_search(options)
-    end
+  test "Alert should sort by timestamp and retain next scope" do
+    assert_equal(Alert.preload(:account).order("alerts.timestamp DESC"), Alert.preload(:account).order_by(:timestamp))
   end
 
-  context "ServiceContract" do
+  test "Cinstance should retain previous scope on search" do
+    abc = FactoryBot.create(:cinstance, :user_key => "abc")
+    bcd = FactoryBot.create(:cinstance, :user_key => "bcd")
 
-    should "not depend on parameters order" do
-      sc1 = FactoryBot.create(:service_contract)
-      sc2 = FactoryBot.create(:service_contract)
-
-      plan2 = sc2.plan
-      plan2.update_attribute :setup_fee, 30
-
-      assert plan2.paid?
-
-      assert_equal ServiceContract.scope_search(:plan_id => sc2.plan_id, :plan_type => :paid),
-                   ServiceContract.scope_search(:plan_type => :paid, :plan_id => sc2.plan_id)
-
-      assert_equal ServiceContract.scope_search(:plan_id => sc2.plan_id, :plan_type => :free),
-                   ServiceContract.scope_search(:plan_type => :free, :plan_id => sc2.plan_id)
-    end
+    assert_equal [abc], Cinstance.by_user_key("abc").scope_search(:user_key => 'abc')
+    assert_equal [bcd], Cinstance.by_user_key("bcd").scope_search(:user_key => 'bcd')
+    assert_equal [], Cinstance.by_user_key('abc').scope_search(:user_key => 'bcd')
   end
 
-  context "Account" do
-    should "order by country name" do
-      it = FactoryBot.create(:country, :code => "IT", :name => "Italy")
-      zb = FactoryBot.create(:country, :code => "ZB", :name => "Zimbabwe")
+  test "Cinstance should order and search" do
+    account = FactoryBot.create(:account)
 
-      provider = FactoryBot.create(:provider_account)
+    abc = FactoryBot.create(:cinstance, name: "abc", user_account: account)
+    bcd = FactoryBot.create(:cinstance, name: "bcd", user_account: account)
+    cde = FactoryBot.create(:cinstance, name: "cde", user_account: account)
 
-      buyer_it = FactoryBot.create(:buyer_account, :provider_account => provider, :country => it)
-      buyer_zb = FactoryBot.create(:buyer_account, :provider_account => provider, :country => zb)
+    options = {:account => account.id}
+    array = [abc, bcd, cde]
 
-      assert_equal [buyer_it, buyer_zb], provider.buyer_accounts.order_by('countries.name', :asc)
-    end
+    assert_equal array, Cinstance.order_by(:name, :asc).scope_search(options).to_a
+    assert_equal array.reverse, Cinstance.order_by(:name, :desc).scope_search(options).to_a
+    assert_equal array, Cinstance.scope_search(options).order_by(:name, :asc)
+    assert_equal array.reverse, Cinstance.scope_search(options).order_by(:name, :desc)
   end
 
+  test "Cinstance should work with all scopes" do
+    app = FactoryBot.create(:cinstance, name: "test")
+    plan = app.plan
+
+    options = {:account => app.user_account_id, :deleted_accounts => true, :plan_type => "free", :plan_id => plan.id, :type => "Cinstance"}
+
+    assert_equal [app], Cinstance.order_by(:name).scope_search(options)
+  end
+
+  test "ServiceContract should not depend on parameters order" do
+    FactoryBot.create(:service_contract)
+    sc2 = FactoryBot.create(:service_contract)
+
+    plan2 = sc2.plan
+    plan2.update(setup_fee: 30)
+
+    assert plan2.paid?
+
+    assert_equal ServiceContract.scope_search(:plan_id => sc2.plan_id, :plan_type => :paid),
+                 ServiceContract.scope_search(:plan_type => :paid, :plan_id => sc2.plan_id)
+
+    assert_equal ServiceContract.scope_search(:plan_id => sc2.plan_id, :plan_type => :free),
+                 ServiceContract.scope_search(:plan_type => :free, :plan_id => sc2.plan_id)
+  end
+
+  test "Account should order by country name" do
+    it = FactoryBot.create(:country, code: "IT", name: "Italy")
+    zb = FactoryBot.create(:country, code: "ZB", name: "Zimbabwe")
+
+    provider = FactoryBot.create(:provider_account)
+
+    buyer_it = FactoryBot.create(:buyer_account, provider_account: provider, country: it)
+    buyer_zb = FactoryBot.create(:buyer_account, provider_account: provider, country: zb)
+
+    assert_equal [buyer_it, buyer_zb], provider.buyer_accounts.order_by('countries.name', :asc)
+  end
+
+  class FooClass < ApplicationController
+    include ThreeScale::Search::Helpers
+    def params
+      {per_page: 100}
+    end
+  end
 
   test 'per_page should be minus or equal that MAX_PER_PAGE' do
-     class FooClass < ActionController::Base
-       include ThreeScale::Search::Helpers
-       def params
-         {per_page: 100}
-       end
-     end
-
-     pagination_params = FooClass.new.send(:pagination_params)
-     assert_equal ThreeScale::Search::Helpers::MAX_PER_PAGE, pagination_params[:per_page]
+    pagination_params = FooClass.new.send(:pagination_params)
+    assert_equal ThreeScale::Search::Helpers::MAX_PER_PAGE, pagination_params[:per_page]
   end
-
 end

--- a/test/unit/three_scale/search_test.rb
+++ b/test/unit/three_scale/search_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class ThreeScale::SearchTest < ActiveSupport::TestCase
-  class FakeModelTest < ActiveSupport::TestCase
+  class ScopesTest < ActiveSupport::TestCase
     class Model < ApplicationRecord
       self.table_name = 'accounts'
 
@@ -143,7 +143,7 @@ class ThreeScale::SearchTest < ActiveSupport::TestCase
     assert_equal [buyer_it, buyer_zb], provider.buyer_accounts.order_by('countries.name', :asc)
   end
 
-  class FooClass < ApplicationController
+  class FooClass < ActionController::Base
     include ThreeScale::Search::Helpers
     def params
       {per_page: 100}


### PR DESCRIPTION
### Remove `shoulda-context` (part 1)

First step is removing usage of `context` and `should` in favor of organizing in classes and using `test`.

#### Affected files

* ...
* ...

#### JIRA
[THREESCALE-7907: Remove shoulda-context > THREESCALE-7939: Remove all contexts](https://issues.redhat.com/browse/THREESCALE-7939)