### PR TITLE
Bugfix: datepicker doesn't close

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "codemirror": "^5.43.0",
     "core-js": "^2.6.9",
     "jquery": "^3.5.0",
-    "jquery-ui": "^1.13.0",
+    "jquery-ui": "1.12.1",
     "lodash.escaperegexp": "^4.1.2",
     "moment": "^2.24.0",
     "moment-range": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7204,14 +7204,12 @@ jest@^24.9.0:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
-jquery-ui@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.0.tgz#ab5ac65f37ca093c51b3478c4097f55bbc008f36"
-  integrity sha512-Osf7ECXNTYHtKBkn9xzbIf9kifNrBhfywFEKxOeB/OVctVmLlouV9mfc2qXCp6uyO4Pn72PXKOnj09qXetopCw==
-  dependencies:
-    jquery ">=1.8.0 <4.0.0"
+jquery-ui@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
+  integrity sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=
 
-"jquery@>=1.8.0 <4.0.0", jquery@^3.5.0:
+jquery@^3.5.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

PR https://github.com/3scale/porta/pull/2675 upgraded jquery-ui to 1.13, but it's breaking the datepicker.
To deploy a quickfix we should r**evert the change and block version to 1.12**

Later, in order to upgrade jquery-ui, we should:

- Make sure to use jQuery 1.8+ (we have 3.5 installed, but we are not using it in Admin portal)
- Check jQuery UI 1.13 [release notes](https://blog.jqueryui.com/2021/10/jquery-ui-1-13-0-released/) and [upgrade guide](https://jqueryui.com/upgrade-guide/1.13/) 
- Update code where needed
- Since we have a lot of conflicts with jquery versions, this may take a lot of time, then better to create a new task and not block this one (issue is happening on SAAS and needs a quick fix)
- See https://issues.redhat.com/browse/THREESCALE-7954

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7947

**Verification steps** 

In Admin Portal:

- Select a Product navigating to {Product} > Analytics > Traffic
- Select a time-range using the data-time-picker
- Selecting any "from" or "until"
- Datepicker shoud close

