### PR TITLE
transient CAS login test failure

### DIFF
--- a/test/functional/developer_portal/login_controller_test.rb
+++ b/test/functional/developer_portal/login_controller_test.rb
@@ -16,7 +16,8 @@ class DeveloperPortal::LoginControllerTest < DeveloperPortal::ActionController::
     get :new
 
     assert_response 200
-    assert !@response.body.include?("CAS")
+    # CAS visible outside a tag to avoid rare authenticity_token match
+    assert_not_match />[^<>]*?CAS/, @response.body
   end
 
   test 'cas is displayed on login page' do
@@ -31,7 +32,7 @@ class DeveloperPortal::LoginControllerTest < DeveloperPortal::ActionController::
     get :new
 
     assert_response 200
-    assert @response.body.include?("CAS")
+    assert_match />[^<>]*?CAS/, @response.body
   end
 
   test 'cas successful auth' do


### PR DESCRIPTION
rarely
`FDeveloperPortal::LoginControllerTest#test_cas_is_not_displayed_on_login_page`
may fail, I suspect because of the random content of `authenticity_token`.

Example failure:
https://app.circleci.com/pipelines/github/3scale/porta/19117/workflows/7f60c74d-94d0-48cc-98df-0de12187f9ea/jobs/228400/parallel-runs/1