### PR TITLE
[master] Fix unknown key format error

### DIFF
--- a/test/integration/provider/invoices_controller_test.rb
+++ b/test/integration/provider/invoices_controller_test.rb
@@ -76,7 +76,7 @@ class Finance::Provider::InvoicesControllerTest < ActionDispatch::IntegrationTes
       Invoice.any_instance.stubs("transition_allowed?").returns(true)
       Invoice.any_instance.stubs("#{action}!").returns(true)
 
-      put url_for([action, :admin, :finance, @invoice, format: 'js'])
+      put url_for([action, :admin, :finance, @invoice, { format: 'js' }])
       assert_response :success
     end
 
@@ -84,7 +84,7 @@ class Finance::Provider::InvoicesControllerTest < ActionDispatch::IntegrationTes
       Invoice.any_instance.stubs("transition_allowed?").returns(true)
       Invoice.any_instance.stubs("#{action}!").returns(false)
 
-      put url_for([action, :admin, :finance, @invoice, format: 'js'])
+      put url_for([action, :admin, :finance, @invoice, { format: 'js' }])
       assert_response :success
       # TODO: update error messages
     end


### PR DESCRIPTION
Some tests are outdated in the upgrade branch `rails` and are throwing "unknown key format". This is the same change as #2835 but for `master`. 