### PR TITLE
[params] Fixes Outbox controller

### DIFF
--- a/app/controllers/provider/admin/messages/outbox_controller.rb
+++ b/app/controllers/provider/admin/messages/outbox_controller.rb
@@ -42,7 +42,7 @@ class Provider::Admin::Messages::OutboxController < FrontendController
 
   private
 
-  PERMITTED_PARAMS = %i[id page to subject body origin].freeze
+  PERMITTED_PARAMS = [:id, :to, :page, { message: %i[subject body origin] }].freeze
 
   def build_message
     @message = current_account.messages.build(message_params)
@@ -71,7 +71,7 @@ class Provider::Admin::Messages::OutboxController < FrontendController
   end
 
   def message_params
-    params.fetch(:message, {}).merge(:origin => "web").permit(PERMITTED_PARAMS)
+    permitted_params.fetch(:message, {}).merge(:origin => "web")
   end
 
   def permitted_params

--- a/app/controllers/provider/admin/messages/outbox_controller.rb
+++ b/app/controllers/provider/admin/messages/outbox_controller.rb
@@ -53,7 +53,7 @@ class Provider::Admin::Messages::OutboxController < FrontendController
     if mass_message?
       current_account.buyer_account_ids
     elsif current_account.provider?
-      current_account.buyer_accounts.find(to_param)
+      current_account.buyer_accounts.find(params.require(:to))
     else
       current_account.provider_account
     end
@@ -68,7 +68,7 @@ class Provider::Admin::Messages::OutboxController < FrontendController
   end
 
   def mass_message?
-    current_account.provider? && to_param.blank?
+    current_account.provider? && params[:to].blank?
   end
 
   def message_params
@@ -81,9 +81,5 @@ class Provider::Admin::Messages::OutboxController < FrontendController
 
   def pagination_params
     { page: params.permit(:page)[:page] }
-  end
-
-  def to_param
-    params.permit(:to).fetch(:to)
   end
 end


### PR DESCRIPTION
Fixes failure:
```
    Scenario: Sending a message

Then the "To" field should be fixed to "bob"

Message:

    unable to convert unpermitted parameters to hash (ActionController::UnfilteredParameters)
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/actionpack-5.1.7/lib/action_controller/metal/strong_parameters.rb:265:in `to_h'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/activerecord-5.1.7/lib/active_record/inheritance.rb:218:in `subclass_from_attributes'
...
/opt/app-root/src/project/app/controllers/provider/admin/messages/outbox_controller.rb:45:in `build_message'
...
features/old/messages/provider_side.feature:27:in `the "To" field should be fixed to "bob"'
```
Link to build: https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-0