### PR TITLE
Upgrades bullet gem to 6.1.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -161,7 +161,7 @@ gem 'slim-rails', '~> 3.2'
 gem 'draper', '~> 3.0'
 
 group :development do
-  gem 'bullet', '~> 5.6'
+  gem 'bullet', '~> 6.1.5'
   gem 'listen'
 
   gem 'letter_opener', require: ENV.fetch('LETTER_OPENER', '0') == '1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1303,9 +1303,9 @@ GEM
     bugsnag (6.11.1)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
-    bullet (5.6.1)
+    bullet (6.1.5)
       activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.10.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     cancancan (2.3.0)
     capybara (3.35.3)
@@ -1926,7 +1926,7 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
-    uniform_notifier (1.10.0)
+    uniform_notifier (1.14.2)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -1990,7 +1990,7 @@ DEPENDENCIES
   braintree (~> 2.93)
   browser (~> 5.0.0)
   bugsnag (~> 6.11)
-  bullet (~> 5.6)
+  bullet (~> 6.1.5)
   cancancan (~> 2.3.0)
   capybara (~> 3.35.3)!
   childprocess


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Upgrades bullet gem to a newer version. The old version is incompatible with rails 5.1.7. It results in errors like: `Wrong number of arguments (given 1, expected 2)`. 
The issue in the bullet Github: https://github.com/flyerhzm/bullet/issues/389