### PR TITLE
allow /deploy endpoint on prometheus port

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
 
     mount Sidekiq::Prometheus::Exporter, at: '/metrics'
     mount Yabeda::Prometheus::Exporter, at: '/yabeda-metrics'
+    mount ::System::Deploy, at: 'deploy'
   end
 
   mount CdnAssets.new => '/_cdn_assets_' unless Rails.configuration.three_scale.assets_cdn_host


### PR DESCRIPTION
allow operations to check deployment data without need to save a cookie


```shell
curl http://localhost:9394/deploy/status | jq '.revision'
```

Should display the revision of the running code