### PR TITLE
Update usage of #parameterize for rails 5

### DIFF
--- a/app/helpers/cms/form_helper.rb
+++ b/app/helpers/cms/form_helper.rb
@@ -16,7 +16,7 @@ module CMS
     end
 
     def cms_fields_for(template, options = {}, &block)
-      base_name = template.class.base_class.model_name.to_s.parameterize('_').to_sym
+      base_name = template.class.base_class.model_name.to_s.parameterize(separator: '_').to_sym
 
       options[:builder] ||= CMS::SemanticFormBuilder
       options[:as] ||= base_name

--- a/features/step_definitions/new_cms/partials_steps.rb
+++ b/features/step_definitions/new_cms/partials_steps.rb
@@ -4,7 +4,7 @@ Then "{cms_partial} should have:" do |page, table|
   table = table.transpose
   actual = table.headers.map do |header|
 
-    header = header.parameterize('_').to_sym
+    header = header.parameterize(separator: '_').to_sym
     value = page.send(header)
     value.to_s
   end


### PR DESCRIPTION
`#parameterize` no longer accepts arguments (See [test failure](https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-1)) instead `separator: 'foo'` is passed.

Moreover, it downcases by default unless `preserve_case: true` is passed. Therefore any call to `downcase` is redundant.