### PR TITLE
[params] Update `send_emails_controller`s

### DIFF
--- a/app/controllers/buyers/accounts/bulk/base_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/base_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class Buyers::Accounts::Bulk::BaseController < Buyers::BulkBaseController
-  before_action :find_accounts
+  before_action :accounts, only: :create
+
+  helper_method :accounts
+
+  def create; end
 
   protected
 
@@ -9,12 +13,12 @@ class Buyers::Accounts::Bulk::BaseController < Buyers::BulkBaseController
     :partners
   end
 
-  def find_accounts
-    @accounts = collection.decorate
+  def accounts
+    @accounts ||= collection.decorate
   end
 
   def collection
-    current_account.buyers.where(id: selected_ids_param)
+    @collection ||= current_account.buyers.where(id: selected_ids_param)
   end
 
   def errors_template

--- a/app/controllers/buyers/accounts/bulk/base_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/base_controller.rb
@@ -14,7 +14,7 @@ class Buyers::Accounts::Bulk::BaseController < Buyers::BulkBaseController
   end
 
   def collection
-    current_account.buyers.where(id: permitted_params[:selected])
+    current_account.buyers.where(id: selected_ids_param)
   end
 
   def errors_template

--- a/app/controllers/buyers/accounts/bulk/base_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/base_controller.rb
@@ -1,12 +1,12 @@
-class Buyers::Accounts::Bulk::BaseController < FrontendController
+# frozen_string_literal: true
 
-  before_action :authorize_bulk_operations
+class Buyers::Accounts::Bulk::BaseController < Buyers::BulkBaseController
   before_action :find_accounts
 
   protected
 
-  def authorize_bulk_operations
-    authorize! :manage, :partners
+  def scope
+    :partners
   end
 
   def find_accounts
@@ -14,12 +14,10 @@ class Buyers::Accounts::Bulk::BaseController < FrontendController
   end
 
   def collection
-    current_account.buyers.where(id: params[:selected])
+    current_account.buyers.where(id: permitted_params[:selected])
   end
 
-  def handle_errors
-    if @errors.present?
-      render 'buyers/accounts/bulk/shared/errors', :status => :unprocessable_entity, formats: [:html]
-    end
+  def errors_template
+    'buyers/accounts/bulk/shared/errors'
   end
 end

--- a/app/controllers/buyers/accounts/bulk/change_plans_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/change_plans_controller.rb
@@ -4,20 +4,17 @@ class Buyers::Accounts::Bulk::ChangePlansController < Buyers::Accounts::Bulk::Ba
 
   before_action :authorize_account_plans
 
-  def new
-    @plans = current_account.account_plans.not_custom.alphabetically
-  end
+  helper_method :plans
+
+  def new; end
 
   def create
-    @plan = current_account.account_plans.find_by(id: plan_id_param)
-    return unless @plan
+    return unless (plan = current_account.account_plans.find_by(id: plan_id_param))
 
-    @accounts.each do |account|
+    accounts.each do |account|
       contract = account.bought_account_contract
 
-      unless contract.change_plan(@plan)
-        @errors << account
-      end
+      @errors << account unless contract.change_plan(plan)
     end
 
     handle_errors
@@ -29,7 +26,7 @@ class Buyers::Accounts::Bulk::ChangePlansController < Buyers::Accounts::Bulk::Ba
 
   private
 
-  def plan_id_param
-    params.require(:change_plan).require(:plan_id)
+  def plans
+    @plans ||= current_account.account_plans.not_custom.alphabetically
   end
 end

--- a/app/controllers/buyers/accounts/bulk/change_plans_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/change_plans_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Buyers::Accounts::Bulk::ChangePlansController < Buyers::Accounts::Bulk::BaseController
 
   before_action :authorize_account_plans
@@ -7,10 +9,8 @@ class Buyers::Accounts::Bulk::ChangePlansController < Buyers::Accounts::Bulk::Ba
   end
 
   def create
-    @plan = current_account.account_plans.find_by_id params[:change_plans][:plan_id]
+    @plan = current_account.account_plans.find_by(id: plan_id_param)
     return unless @plan
-
-    @errors = []
 
     @accounts.each do |account|
       contract = account.bought_account_contract
@@ -27,4 +27,9 @@ class Buyers::Accounts::Bulk::ChangePlansController < Buyers::Accounts::Bulk::Ba
     authorize! :manage, :account_plans
   end
 
+  private
+
+  def plan_id_param
+    params.require(:change_plan).require(:plan_id)
+  end
 end

--- a/app/controllers/buyers/accounts/bulk/change_states_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/change_states_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Buyers::Accounts::Bulk::ChangeStatesController < Buyers::Accounts::Bulk::BaseController
   ACTIONS = %w{ approve make_pending reject }
 
@@ -6,10 +8,9 @@ class Buyers::Accounts::Bulk::ChangeStatesController < Buyers::Accounts::Bulk::B
   end
 
   def create
-    @action = ( ACTIONS & [params[:change_states][:action]] ).first
+    @action = ( ACTIONS & [change_state_action_param] ).first
     return unless @action.present?
 
-    @errors = []
     @accounts = @accounts.to_a.reject do |account|
       !account.public_send("can_#{@action}?")
     end
@@ -21,4 +22,9 @@ class Buyers::Accounts::Bulk::ChangeStatesController < Buyers::Accounts::Bulk::B
     handle_errors
   end
 
+  private
+
+  def change_state_action_param
+    params.require(:change_states).require(:action)
+  end
 end

--- a/app/controllers/buyers/accounts/bulk/change_states_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/change_states_controller.rb
@@ -3,28 +3,20 @@
 class Buyers::Accounts::Bulk::ChangeStatesController < Buyers::Accounts::Bulk::BaseController
   ACTIONS = %w{ approve make_pending reject }
 
-  def new
-    @actions = ACTIONS.map {|a| [a.humanize, a] }
-  end
+  before_action :humanized_actions, only: :new
+
+  def new; end
 
   def create
-    @action = ( ACTIONS & [change_state_action_param] ).first
-    return unless @action.present?
-
-    @accounts = @accounts.to_a.reject do |account|
-      !account.public_send("can_#{@action}?")
-    end
-
-    @accounts.each do |account|
-      @errors << account unless account.public_send(@action)
-    end
-
+    change_states
     handle_errors
   end
 
   private
 
-  def change_state_action_param
-    params.require(:change_states).require(:action)
+  alias subjects accounts
+
+  def actions
+    ACTIONS
   end
 end

--- a/app/controllers/buyers/accounts/bulk/deletes_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/deletes_controller.rb
@@ -1,16 +1,8 @@
 # frozen_string_literal: true
 
 class Buyers::Accounts::Bulk::DeletesController < Buyers::Accounts::Bulk::BaseController
-
-  def new
-  end
-
   def create
-    @accounts.each do |account|
-      @errors << account unless account.destroy
-    end
-
+    delete_stuff
     handle_errors
   end
-
 end

--- a/app/controllers/buyers/accounts/bulk/deletes_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/deletes_controller.rb
@@ -1,11 +1,11 @@
+# frozen_string_literal: true
+
 class Buyers::Accounts::Bulk::DeletesController < Buyers::Accounts::Bulk::BaseController
 
   def new
   end
 
   def create
-    @errors = []
-
     @accounts.each do |account|
       @errors << account unless account.destroy
     end

--- a/app/controllers/buyers/accounts/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/send_emails_controller.rb
@@ -2,23 +2,9 @@
 
 class Buyers::Accounts::Bulk::SendEmailsController < Buyers::Accounts::Bulk::BaseController
   def create
-    recipients.each do |recipient|
-      message = current_account.messages.build send_email_params
-      message.to = recipient
-
-      @errors << message unless message.save && message.deliver!
-    end
-
+    send_emails
     handle_errors
   end
 
-  private
-
-  def send_email_params
-    params.require(:send_emails).permit(:subject, :body)
-  end
-
-  def recipients
-    @recipients ||= @accounts
-  end
+  alias recipients accounts
 end

--- a/app/controllers/buyers/accounts/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/send_emails_controller.rb
@@ -1,13 +1,14 @@
+# frozen_string_literal: true
+
 class Buyers::Accounts::Bulk::SendEmailsController < Buyers::Accounts::Bulk::BaseController
 
-  def new
-  end
+  def new; end
 
   def create
     @errors = []
 
     @accounts.each do |recipient|
-      message = current_account.messages.build params[:send_emails]
+      message = current_account.messages.build send_emails_params
       message.to = recipient
       @errors << message unless message.save && message.deliver!
     end
@@ -15,4 +16,9 @@ class Buyers::Accounts::Bulk::SendEmailsController < Buyers::Accounts::Bulk::Bas
     handle_errors
   end
 
+  private
+
+  def send_emails_params
+    params.fetch(:send_emails).permit!
+  end
 end

--- a/app/controllers/buyers/accounts/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/send_emails_controller.rb
@@ -1,7 +1,22 @@
 # frozen_string_literal: true
 
 class Buyers::Accounts::Bulk::SendEmailsController < Buyers::Accounts::Bulk::BaseController
+  def create
+    recipients.each do |recipient|
+      message = current_account.messages.build send_email_params
+      message.to = recipient
+
+      @errors << message unless message.save && message.deliver!
+    end
+
+    handle_errors
+  end
+
   private
+
+  def send_email_params
+    params.require(:send_emails).permit(:subject, :body)
+  end
 
   def recipients
     @recipients ||= @accounts

--- a/app/controllers/buyers/accounts/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/accounts/bulk/send_emails_controller.rb
@@ -1,24 +1,9 @@
 # frozen_string_literal: true
 
 class Buyers::Accounts::Bulk::SendEmailsController < Buyers::Accounts::Bulk::BaseController
-
-  def new; end
-
-  def create
-    @errors = []
-
-    @accounts.each do |recipient|
-      message = current_account.messages.build send_emails_params
-      message.to = recipient
-      @errors << message unless message.save && message.deliver!
-    end
-
-    handle_errors
-  end
-
   private
 
-  def send_emails_params
-    params.fetch(:send_emails).permit!
+  def recipients
+    @recipients ||= @accounts
   end
 end

--- a/app/controllers/buyers/applications/bulk/base_controller.rb
+++ b/app/controllers/buyers/applications/bulk/base_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class Buyers::Applications::Bulk::BaseController < Buyers::BulkBaseController
-  before_action :find_applications
+  before_action :applications, only: :create
+
+  helper_method :applications
+
+  def create; end
 
   protected
 
@@ -9,12 +13,12 @@ class Buyers::Applications::Bulk::BaseController < Buyers::BulkBaseController
     :applications
   end
 
-  def find_applications
-    @applications = collection.decorate
+  def applications
+    @applications ||= collection.decorate
   end
 
   def collection
-    current_account.provided_cinstances.where(id: selected_ids_param).includes(:user_account)
+    @collection ||= current_account.provided_cinstances.where(id: selected_ids_param).includes(:user_account)
   end
 
   def errors_template

--- a/app/controllers/buyers/applications/bulk/base_controller.rb
+++ b/app/controllers/buyers/applications/bulk/base_controller.rb
@@ -1,11 +1,12 @@
-class Buyers::Applications::Bulk::BaseController < FrontendController
-  before_action :authorize_bulk_operations
+# frozen_string_literal: true
+
+class Buyers::Applications::Bulk::BaseController < Buyers::BulkBaseController
   before_action :find_applications
 
   protected
 
-  def authorize_bulk_operations
-    authorize! :manage, :applications
+  def scope
+    :applications
   end
 
   def find_applications
@@ -13,12 +14,10 @@ class Buyers::Applications::Bulk::BaseController < FrontendController
   end
 
   def collection
-    current_account.provided_cinstances.where(id: params[:selected]).includes(:user_account)
+    current_account.provided_cinstances.where(id: permitted_params[:selected]).includes(:user_account)
   end
 
-  def handle_errors
-    if @errors.present?
-      render 'buyers/applications/bulk/shared/errors.html', :status => :unprocessable_entity
-    end
+  def errors_template
+    'buyers/applications/bulk/shared/errors.html'
   end
 end

--- a/app/controllers/buyers/applications/bulk/base_controller.rb
+++ b/app/controllers/buyers/applications/bulk/base_controller.rb
@@ -14,7 +14,7 @@ class Buyers::Applications::Bulk::BaseController < Buyers::BulkBaseController
   end
 
   def collection
-    current_account.provided_cinstances.where(id: permitted_params[:selected]).includes(:user_account)
+    current_account.provided_cinstances.where(id: selected_ids_param).includes(:user_account)
   end
 
   def errors_template

--- a/app/controllers/buyers/applications/bulk/change_plans_controller.rb
+++ b/app/controllers/buyers/applications/bulk/change_plans_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Buyers::Applications::Bulk::ChangePlansController < Buyers::Applications::Bulk::BaseController
 
   before_action :find_services
@@ -8,10 +10,9 @@ class Buyers::Applications::Bulk::ChangePlansController < Buyers::Applications::
 
   def create
     # TODO: really change plan
-    @plan = @service.application_plans.find_by_id params[:change_plans][:plan_id]
+    @plan = @service.application_plans.find_by(id: plan_id_param)
     return unless @plan
 
-    @errors = []
     @applications.each do |application|
       unless application.change_plan(@plan)
         @errors << application
@@ -22,6 +23,10 @@ class Buyers::Applications::Bulk::ChangePlansController < Buyers::Applications::
   end
 
   private
+
+  def plan_id_param
+    params.require(:change_plans).require(:plan_id)
+  end
 
   def find_services
     # probably should preload :service and :user_account

--- a/app/controllers/buyers/applications/bulk/change_states_controller.rb
+++ b/app/controllers/buyers/applications/bulk/change_states_controller.rb
@@ -3,30 +3,14 @@
 class Buyers::Applications::Bulk::ChangeStatesController < Buyers::Applications::Bulk::BaseController
   ACTIONS = %w{ accept suspend resume }
 
-  def new
-    @actions = ACTIONS.map {|a| [a.humanize, a] }
-  end
-
   def create
-    @action = ( ACTIONS & [change_state_action_param] ).first
-
-    return unless @action.present?
-
-    @applications = @applications.to_a.reject do |application|
-      !application.public_send("can_#{@action}?")
-    end
-
-    @applications.each do |application|
-      @errors << application unless application.public_send(@action)
-    end
-
+    change_states
     handle_errors
   end
 
   private
 
-  def change_state_action_param
-    params.require(:change_states).require(:action)
+  def actions
+    ACTIONS
   end
-
 end

--- a/app/controllers/buyers/applications/bulk/change_states_controller.rb
+++ b/app/controllers/buyers/applications/bulk/change_states_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Buyers::Applications::Bulk::ChangeStatesController < Buyers::Applications::Bulk::BaseController
   ACTIONS = %w{ accept suspend resume }
 
@@ -6,11 +8,10 @@ class Buyers::Applications::Bulk::ChangeStatesController < Buyers::Applications:
   end
 
   def create
-    @action = ( ACTIONS & [params[:change_states][:action]] ).first
+    @action = ( ACTIONS & [change_state_action_param] ).first
 
     return unless @action.present?
 
-    @errors = []
     @applications = @applications.to_a.reject do |application|
       !application.public_send("can_#{@action}?")
     end
@@ -20,6 +21,12 @@ class Buyers::Applications::Bulk::ChangeStatesController < Buyers::Applications:
     end
 
     handle_errors
+  end
+
+  private
+
+  def change_state_action_param
+    params.require(:change_states).require(:action)
   end
 
 end

--- a/app/controllers/buyers/applications/bulk/deletes_controller.rb
+++ b/app/controllers/buyers/applications/bulk/deletes_controller.rb
@@ -1,16 +1,8 @@
+# frozen_string_literal: true
+
 class Buyers::Applications::Bulk::DeletesController < Buyers::Applications::Bulk::BaseController
-
-  def new
-
-  end
-
   def create
-
-    @errors = @applications.map do |app|
-      app unless app.destroy
-    end.compact
-
+    delete_stuff
     handle_errors
   end
-
 end

--- a/app/controllers/buyers/applications/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/applications/bulk/send_emails_controller.rb
@@ -1,14 +1,15 @@
+# frozen_string_literal: true
+
 class Buyers::Applications::Bulk::SendEmailsController < Buyers::Applications::Bulk::BaseController
 
-  def new
-  end
+  def new; end
 
   def create
     @recipients = @applications.map(&:user_account)
 
     @errors = []
     @recipients.each do |recipient|
-      message = current_account.messages.build params[:send_emails]
+      message = current_account.messages.build send_emails_params
       message.to = recipient
 
       @errors << message unless message.save && message.deliver!
@@ -17,4 +18,9 @@ class Buyers::Applications::Bulk::SendEmailsController < Buyers::Applications::B
     handle_errors
   end
 
+  private
+
+  def send_emails_params
+    params.fetch(:send_emails).permit!
+  end
 end

--- a/app/controllers/buyers/applications/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/applications/bulk/send_emails_controller.rb
@@ -1,26 +1,9 @@
 # frozen_string_literal: true
 
 class Buyers::Applications::Bulk::SendEmailsController < Buyers::Applications::Bulk::BaseController
-
-  def new; end
-
-  def create
-    @recipients = @applications.map(&:user_account)
-
-    @errors = []
-    @recipients.each do |recipient|
-      message = current_account.messages.build send_emails_params
-      message.to = recipient
-
-      @errors << message unless message.save && message.deliver!
-    end
-
-    handle_errors
-  end
-
   private
 
-  def send_emails_params
-    params.fetch(:send_emails).permit!
+  def recipients
+    @recipients ||= @applications.map(&:user_account)
   end
 end

--- a/app/controllers/buyers/applications/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/applications/bulk/send_emails_controller.rb
@@ -2,23 +2,13 @@
 
 class Buyers::Applications::Bulk::SendEmailsController < Buyers::Applications::Bulk::BaseController
   def create
-    recipients.each do |recipient|
-      message = current_account.messages.build send_email_params
-      message.to = recipient
-
-      @errors << message unless message.save && message.deliver!
-    end
-
+    send_emails
     handle_errors
   end
 
   private
 
-  def send_email_params
-    params.require(:send_emails).permit(:subject, :body)
-  end
-
   def recipients
-    @recipients ||= @applications.map(&:user_account)
+    @recipients ||= collection.map(&:user_account)
   end
 end

--- a/app/controllers/buyers/applications/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/applications/bulk/send_emails_controller.rb
@@ -1,7 +1,22 @@
 # frozen_string_literal: true
 
 class Buyers::Applications::Bulk::SendEmailsController < Buyers::Applications::Bulk::BaseController
+  def create
+    recipients.each do |recipient|
+      message = current_account.messages.build send_email_params
+      message.to = recipient
+
+      @errors << message unless message.save && message.deliver!
+    end
+
+    handle_errors
+  end
+
   private
+
+  def send_email_params
+    params.require(:send_emails).permit(:subject, :body)
+  end
 
   def recipients
     @recipients ||= @applications.map(&:user_account)

--- a/app/controllers/buyers/bulk_base_controller.rb
+++ b/app/controllers/buyers/bulk_base_controller.rb
@@ -2,39 +2,26 @@
 
 class Buyers::BulkBaseController < FrontendController
   before_action :authorize_bulk_operations
-  before_action :initializa_errors, only: :create
+  before_action :initialize_errors, only: :create
 
   def new; end
 
   def create
-    @errors = nil
-
-    recipients.each do |recipient|
-      message = current_account.messages.build send_emails_params
-      message.to = recipient
-
-      @errors << message unless message.save && message.deliver!
-    end
-
-    handle_errors
+    raise NoMethodError, "Please define `#create` method in #{self.class}"
   end
 
   protected
 
-  def initializa_errors
-    @errors = nil
+  def initialize_errors
+    @errors = []
   end
 
   def authorize_bulk_operations
     authorize! :manage, scope
   end
 
-  def permitted_params
-    params.permit(selected: [], send_emails: %i[subject body])
-  end
-
-  def send_emails_params
-    permitted_params.fetch(:send_emails)
+  def selected_ids_param
+    params.require(:selected)
   end
 
   def handle_errors

--- a/app/controllers/buyers/bulk_base_controller.rb
+++ b/app/controllers/buyers/bulk_base_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Buyers::BulkBaseController < FrontendController
+  before_action :authorize_bulk_operations
+
+  protected
+
+  def authorize_bulk_operations
+    authorize! :manage, scope
+  end
+
+  def permitted_params
+    params.premit(:selected)
+  end
+
+  def handle_errors
+    render errors_template, status: :unprocessable_entity, formats: [:html] if @errors.present?
+  end
+
+  def errors_template
+    raise NoMethodError
+  end
+end

--- a/app/controllers/buyers/bulk_base_controller.rb
+++ b/app/controllers/buyers/bulk_base_controller.rb
@@ -16,8 +16,6 @@ class Buyers::BulkBaseController < FrontendController
 
   attr_reader :subjects
 
-  alias action change_state_action_param
-
   def humanized_actions
     @humanized_actions ||= actions.map {|a| [a.humanize, a] }
   end
@@ -65,6 +63,8 @@ class Buyers::BulkBaseController < FrontendController
   def change_state_action_param
     params.require(:change_states).require(:action)
   end
+
+  alias action change_state_action_param
 
   def plan_id_param
     params.require(:change_plans).require(:plan_id)

--- a/app/controllers/buyers/bulk_base_controller.rb
+++ b/app/controllers/buyers/bulk_base_controller.rb
@@ -62,7 +62,7 @@ class Buyers::BulkBaseController < FrontendController
   end
 
   def change_state_action_params
-    params.require(:change_states).permit(:action)
+    params.require(:change_states).require(:action)
   end
 
   def plan_id_param

--- a/app/controllers/buyers/bulk_base_controller.rb
+++ b/app/controllers/buyers/bulk_base_controller.rb
@@ -21,7 +21,6 @@ class Buyers::BulkBaseController < FrontendController
   end
 
   def change_states
-    action = change_state_action_params[:action]
     return unless actions.include?(action)
 
     collection.select { |item| item.public_send("can_#{action}?") }
@@ -64,6 +63,8 @@ class Buyers::BulkBaseController < FrontendController
   def change_state_action_params
     params.require(:change_states).require(:action)
   end
+
+  alias action change_state_action_params
 
   def plan_id_param
     params.require(:change_plans).require(:plan_id)

--- a/app/controllers/buyers/bulk_base_controller.rb
+++ b/app/controllers/buyers/bulk_base_controller.rb
@@ -2,15 +2,39 @@
 
 class Buyers::BulkBaseController < FrontendController
   before_action :authorize_bulk_operations
+  before_action :initializa_errors, only: :create
+
+  def new; end
+
+  def create
+    @errors = nil
+
+    recipients.each do |recipient|
+      message = current_account.messages.build send_emails_params
+      message.to = recipient
+
+      @errors << message unless message.save && message.deliver!
+    end
+
+    handle_errors
+  end
 
   protected
+
+  def initializa_errors
+    @errors = nil
+  end
 
   def authorize_bulk_operations
     authorize! :manage, scope
   end
 
   def permitted_params
-    params.premit(:selected)
+    params.permit(selected: [], send_emails: %i[subject body])
+  end
+
+  def send_emails_params
+    permitted_params.fetch(:send_emails)
   end
 
   def handle_errors
@@ -18,6 +42,6 @@ class Buyers::BulkBaseController < FrontendController
   end
 
   def errors_template
-    raise NoMethodError
+    raise NoMethodError, "Please define `#errors_template` method in #{self.class}"
   end
 end

--- a/app/controllers/buyers/bulk_base_controller.rb
+++ b/app/controllers/buyers/bulk_base_controller.rb
@@ -4,6 +4,8 @@ class Buyers::BulkBaseController < FrontendController
   before_action :authorize_bulk_operations
   before_action :initialize_errors, only: :create
 
+  helper_method :humanized_actions
+
   def new; end
 
   def create
@@ -11,6 +13,38 @@ class Buyers::BulkBaseController < FrontendController
   end
 
   protected
+
+  attr_reader :subjects
+
+  alias action change_state_action_param
+
+  def humanized_actions
+    @humanized_actions ||= actions.map {|a| [a.humanize, a] }
+  end
+
+  def change_states
+    return unless actions.include?(action)
+
+    collection.select { |item| item.public_send("can_#{action}?") }
+              .each do |item|
+                @errors << item unless item.public_send(action)
+              end
+  end
+
+  def send_emails
+    recipients.each do |recipient|
+      message = current_account.messages.build send_email_params
+      message.to = recipient
+
+      @errors << message unless message.save && message.deliver!
+    end
+  end
+
+  def delete_stuff
+    collection.each do |item|
+      @errors << item unless items.destroy
+    end
+  end
 
   def initialize_errors
     @errors = []
@@ -24,11 +58,15 @@ class Buyers::BulkBaseController < FrontendController
     params.require(:selected)
   end
 
-  def handle_errors
-    render errors_template, status: :unprocessable_entity, formats: [:html] if @errors.present?
+  def send_email_params
+    params.require(:send_emails).permit(:subject, :body)
   end
 
-  def errors_template
-    raise NoMethodError, "Please define `#errors_template` method in #{self.class}"
+  def change_state_action_param
+    params.require(:change_states).require(:action)
+  end
+
+  def plan_id_param
+    params.require(:change_plans).require(:plan_id)
   end
 end

--- a/app/controllers/buyers/bulk_base_controller.rb
+++ b/app/controllers/buyers/bulk_base_controller.rb
@@ -21,6 +21,7 @@ class Buyers::BulkBaseController < FrontendController
   end
 
   def change_states
+    action = change_state_action_params[:action]
     return unless actions.include?(action)
 
     collection.select { |item| item.public_send("can_#{action}?") }
@@ -60,13 +61,15 @@ class Buyers::BulkBaseController < FrontendController
     params.require(:send_emails).permit(:subject, :body)
   end
 
-  def change_state_action_param
-    params.require(:change_states).require(:action)
+  def change_state_action_params
+    params.require(:change_states).permit(:action)
   end
-
-  alias action change_state_action_param
 
   def plan_id_param
     params.require(:change_plans).require(:plan_id)
+  end
+
+  def handle_errors
+    render errors_template, status: :unprocessable_entity, formats: [:html] if @errors.present?
   end
 end

--- a/app/controllers/buyers/service_contracts/bulk/base_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/base_controller.rb
@@ -14,7 +14,7 @@ class Buyers::ServiceContracts::Bulk::BaseController < Buyers::BulkBaseControlle
   end
 
   def collection
-    current_account.provided_service_contracts.where(id: permitted_params[:selected])
+    current_account.provided_service_contracts.where(id: selected_ids_param)
   end
 
   def errors_template

--- a/app/controllers/buyers/service_contracts/bulk/base_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/base_controller.rb
@@ -1,11 +1,12 @@
-class Buyers::ServiceContracts::Bulk::BaseController < FrontendController
-  before_action :authorize_bulk_operations
+# frozen_string_literal: true
+
+class Buyers::ServiceContracts::Bulk::BaseController < Buyers::BulkBaseController
   before_action :find_service_contracts
 
   protected
 
-  def authorize_bulk_operations
-    authorize! :manage, :service_contracts
+  def scope
+    :service_contracts
   end
 
   def find_service_contracts
@@ -13,12 +14,10 @@ class Buyers::ServiceContracts::Bulk::BaseController < FrontendController
   end
 
   def collection
-    current_account.provided_service_contracts.where(id: params[:selected])
+    current_account.provided_service_contracts.where(id: permitted_params[:selected])
   end
 
-  def handle_errors
-    if @errors.present?
-      render 'buyers/applications/bulk/shared/errors.html', :status => :unprocessable_entity
-    end
+  def errors_template
+    'buyers/applications/bulk/shared/errors.html'
   end
 end

--- a/app/controllers/buyers/service_contracts/bulk/base_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/base_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class Buyers::ServiceContracts::Bulk::BaseController < Buyers::BulkBaseController
-  before_action :find_service_contracts
+  before_action :service_contracts, only: :create
+
+  helper_method :service_contracts
+
+  def create; end
 
   protected
 
@@ -9,12 +13,12 @@ class Buyers::ServiceContracts::Bulk::BaseController < Buyers::BulkBaseControlle
     :service_contracts
   end
 
-  def find_service_contracts
-    @service_contracts = collection.decorate
+  def service_contracts
+    @service_contracts ||= collection.decorate
   end
 
   def collection
-    current_account.provided_service_contracts.where(id: selected_ids_param)
+    @collection ||= current_account.provided_service_contracts.where(id: selected_ids_param)
   end
 
   def errors_template

--- a/app/controllers/buyers/service_contracts/bulk/change_plans_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/change_plans_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Buyers::ServiceContracts::Bulk::ChangePlansController < Buyers::ServiceContracts::Bulk::BaseController
 
   before_action :find_services
@@ -8,10 +10,9 @@ class Buyers::ServiceContracts::Bulk::ChangePlansController < Buyers::ServiceCon
 
   def create
     # TODO: really change plan
-    @plan = @service.service_plans.find_by_id params[:change_plans][:plan_id]
+    @plan = @service.service_plans.find_by(id: plan_id_param)
     return unless @plan
 
-    @errors = []
     @service_contracts.each do |contract|
       unless contract.change_plan(@plan)
         @errors << contract
@@ -22,6 +23,10 @@ class Buyers::ServiceContracts::Bulk::ChangePlansController < Buyers::ServiceCon
   end
 
   private
+
+  def plan_id_param
+    params.require(:change_plans).require(:plan_id)
+  end
 
   def find_services
     # probably should preload :service and :user_account

--- a/app/controllers/buyers/service_contracts/bulk/change_states_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/change_states_controller.rb
@@ -3,7 +3,6 @@
 class Buyers::ServiceContracts::Bulk::ChangeStatesController < Buyers::ServiceContracts::Bulk::BaseController
   ACTIONS = %w{ accept suspend resume }
 
-
   def create
     change_states
     handle_errors

--- a/app/controllers/buyers/service_contracts/bulk/change_states_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/change_states_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Buyers::ServiceContracts::Bulk::ChangeStatesController < Buyers::ServiceContracts::Bulk::BaseController
   ACTIONS = %w{ accept suspend resume }
 
@@ -6,11 +8,10 @@ class Buyers::ServiceContracts::Bulk::ChangeStatesController < Buyers::ServiceCo
   end
 
   def create
-    @action = ( ACTIONS & [params[:change_states][:action]] ).first
+    @action = ( ACTIONS & [change_state_action_param] ).first
 
     return unless @action.present?
 
-    @errors = []
     @service_contracts = @service_contracts.to_a.reject do |contract|
       !contract.public_send("can_#{@action}?")
     end
@@ -22,4 +23,9 @@ class Buyers::ServiceContracts::Bulk::ChangeStatesController < Buyers::ServiceCo
     handle_errors
   end
 
+  private
+
+  def change_state_action_param
+    params.require(:change_states).require(:action)
+  end
 end

--- a/app/controllers/buyers/service_contracts/bulk/change_states_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/change_states_controller.rb
@@ -3,29 +3,15 @@
 class Buyers::ServiceContracts::Bulk::ChangeStatesController < Buyers::ServiceContracts::Bulk::BaseController
   ACTIONS = %w{ accept suspend resume }
 
-  def new
-    @actions = ACTIONS.map {|a| [a.humanize, a] }
-  end
 
   def create
-    @action = ( ACTIONS & [change_state_action_param] ).first
-
-    return unless @action.present?
-
-    @service_contracts = @service_contracts.to_a.reject do |contract|
-      !contract.public_send("can_#{@action}?")
-    end
-
-    @service_contracts.each do |application|
-      @errors << application unless application.public_send(@action)
-    end
-
+    change_states
     handle_errors
   end
 
   private
 
-  def change_state_action_param
-    params.require(:change_states).require(:action)
+  def actions
+    ACTIONS
   end
 end

--- a/app/controllers/buyers/service_contracts/bulk/deletes_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/deletes_controller.rb
@@ -1,16 +1,8 @@
+# frozen_string_literal: true
+
 class Buyers::ServiceContracts::Bulk::DeletesController < Buyers::ServiceContracts::Bulk::BaseController
-
-  def new
-
-  end
-
   def create
-
-    @errors = @service_contracts.map do |app|
-      app unless app.destroy
-    end.compact
-
+    delete_stuff
     handle_errors
   end
-
 end

--- a/app/controllers/buyers/service_contracts/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/send_emails_controller.rb
@@ -2,23 +2,13 @@
 
 class Buyers::ServiceContracts::Bulk::SendEmailsController < Buyers::ServiceContracts::Bulk::BaseController
   def create
-    recipients.each do |recipient|
-      message = current_account.messages.build send_email_params
-      message.to = recipient
-
-      @errors << message unless message.save && message.deliver!
-    end
-
+    send_emails
     handle_errors
   end
 
   private
 
-  def send_email_params
-    params.require(:send_emails).permit(:subject, :body)
-  end
-
   def recipients
-    @recipients ||= @service_contracts.map(&:user_account)
+    @recipients ||= service_contracts.map(&:user_account)
   end
 end

--- a/app/controllers/buyers/service_contracts/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/send_emails_controller.rb
@@ -1,7 +1,22 @@
 # frozen_string_literal: true
 
 class Buyers::ServiceContracts::Bulk::SendEmailsController < Buyers::ServiceContracts::Bulk::BaseController
+  def create
+    recipients.each do |recipient|
+      message = current_account.messages.build send_email_params
+      message.to = recipient
+
+      @errors << message unless message.save && message.deliver!
+    end
+
+    handle_errors
+  end
+
   private
+
+  def send_email_params
+    params.require(:send_emails).permit(:subject, :body)
+  end
 
   def recipients
     @recipients ||= @service_contracts.map(&:user_account)

--- a/app/controllers/buyers/service_contracts/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/send_emails_controller.rb
@@ -1,14 +1,15 @@
+# frozen_string_literal: true
+
 class Buyers::ServiceContracts::Bulk::SendEmailsController < Buyers::ServiceContracts::Bulk::BaseController
 
-  def new
-  end
+  def new; end
 
   def create
     @recipients = @service_contracts.map(&:user_account)
 
     @errors = []
     @recipients.each do |recipient|
-      message = current_account.messages.build params[:send_emails]
+      message = current_account.messages.build send_emails_params
       message.to = recipient
 
       @errors << message unless message.save && message.deliver!
@@ -17,4 +18,9 @@ class Buyers::ServiceContracts::Bulk::SendEmailsController < Buyers::ServiceCont
     handle_errors
   end
 
+  private
+
+  def send_emails_params
+    params.fetch(:send_emails).permit!
+  end
 end

--- a/app/controllers/buyers/service_contracts/bulk/send_emails_controller.rb
+++ b/app/controllers/buyers/service_contracts/bulk/send_emails_controller.rb
@@ -1,26 +1,9 @@
 # frozen_string_literal: true
 
 class Buyers::ServiceContracts::Bulk::SendEmailsController < Buyers::ServiceContracts::Bulk::BaseController
-
-  def new; end
-
-  def create
-    @recipients = @service_contracts.map(&:user_account)
-
-    @errors = []
-    @recipients.each do |recipient|
-      message = current_account.messages.build send_emails_params
-      message.to = recipient
-
-      @errors << message unless message.save && message.deliver!
-    end
-
-    handle_errors
-  end
-
   private
 
-  def send_emails_params
-    params.fetch(:send_emails).permit!
+  def recipients
+    @recipients ||= @service_contracts.map(&:user_account)
   end
 end

--- a/app/views/buyers/accounts/bulk/_selected_accounts.html.erb
+++ b/app/views/buyers/accounts/bulk/_selected_accounts.html.erb
@@ -1,7 +1,7 @@
 <li>
   <label>Selected Accounts</label>
   <ul class="bulk_operation_items">
-    <% @accounts.each do |account| %>
+    <% accounts.each do |account| %>
       <%= content_tag :li, title: "#{account.org_name} - #{account.admin_user_display_name}" do %>
         <span class="name"><%= account.org_name %></span>
         (<%= h account.admin_user_display_name %>)

--- a/app/views/buyers/accounts/bulk/change_plans/new.html.erb
+++ b/app/views/buyers/accounts/bulk/change_plans/new.html.erb
@@ -2,11 +2,11 @@
   :html => {
     :class => 'bulk_operations',
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to change plan of these #{@accounts.count} accounts?"
+    :'data-confirm' => "Are you sure to change plan of these #{accounts.count} accounts?"
   } do |form| %>
   <%= form.inputs do %>
-    <%= render 'buyers/accounts/bulk/selected_accounts' %>
-    <%= form.input :plan_id, :as => :select, :collection => @plans %>
+    <%= render 'buyers/accounts/bulk/selected_accounts', accounts: accounts %>
+    <%= form.input :plan_id, :as => :select, :collection => plans %>
     <%= form.buttons do %>
       <%= form.commit_button 'Change plan', :button_html => {:'data-disable-with' => 'Running bulk action...' } %>
     <% end %>

--- a/app/views/buyers/accounts/bulk/change_states/new.html.slim
+++ b/app/views/buyers/accounts/bulk/change_states/new.html.slim
@@ -2,11 +2,11 @@
                     url: admin_buyers_accounts_bulk_change_state_path,
                     html: { class: 'bulk_operation',
                             data: { remote: true,
-                                    confirm: "Are you sure to change state of these #{@accounts.count} accounts?" },
+                                    confirm: "Are you sure to change state of these #{accounts.count} accounts?" },
                           } do |form|
   = form.inputs do
-    = render 'buyers/accounts/bulk/selected_accounts'
-    = form.input :action, as: :select, collection: @actions
+    = render 'buyers/accounts/bulk/selected_accounts', accounts: accounts
+    = form.input :action, as: :select, collection: humanized_actions
     p.notice Changing the state of a developer account doesn't change the state of its applications.
     = form.buttons do
       = form.commit_button 'Change state', button_html: {:'data-disable-with' => 'Running bulk action...' }

--- a/app/views/buyers/accounts/bulk/deletes/create.js.erb
+++ b/app/views/buyers/accounts/bulk/deletes/create.js.erb
@@ -1,4 +1,4 @@
-<%- @accounts.each do |account| %>
+<%- accounts.each do |account| %>
   $("#<%=dom_id(account)%>").fadeOut(function(){$(this).remove()});
 <%-end-%>
 $("#bulk-operations").trigger("bulk:success");

--- a/app/views/buyers/accounts/bulk/deletes/new.html.erb
+++ b/app/views/buyers/accounts/bulk/deletes/new.html.erb
@@ -1,10 +1,10 @@
 <% semantic_form_for :delete, :url => admin_buyers_accounts_bulk_delete_path,
   :html => {
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to delete these #{@accounts.count} accounts?"
+    :'data-confirm' => "Are you sure to delete these #{accounts.count} accounts?"
   } do |form| %>
   <%- form.inputs do -%>
-    <%= render 'buyers/accounts/bulk/selected_accounts' %>
+    <%= render 'buyers/accounts/bulk/selected_accounts', accounts: accounts %>
     <%- form.buttons do -%>
       <%= form.commit_button 'Delete accounts', :button_html => {:'data-disable-with' => 'Running bulk action...' } %>
     <%- end -%>

--- a/app/views/buyers/accounts/bulk/send_emails/new.html.erb
+++ b/app/views/buyers/accounts/bulk/send_emails/new.html.erb
@@ -1,11 +1,11 @@
 <%= semantic_form_for :send_emails, :url => admin_buyers_accounts_bulk_send_email_path,
   :html => {
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to send emails to these #{@accounts.count} accounts?"
+    :'data-confirm' => "Are you sure to send emails to these #{accounts.count} accounts?"
   } do |form| %>
   <%= form.inputs do %>
-    <%= render 'buyers/accounts/bulk/selected_accounts' %>
-    <%= form.input :to, :as => :string, :input_html => {:disabled => true, :value => "#{@accounts.count} selected accounts"} %>
+    <%= render 'buyers/accounts/bulk/selected_accounts', accounts: accounts %>
+    <%= form.input :to, :as => :string, :input_html => {:disabled => true, :value => "#{accounts.count} selected accounts"} %>
     <%= form.input :subject, :as => :string %>
     <%= form.input :body, :as => :text, :input_html => {:rows => 10} %>
     <%= form.buttons do %>

--- a/app/views/buyers/applications/bulk/_selected_applications.html.erb
+++ b/app/views/buyers/applications/bulk/_selected_applications.html.erb
@@ -1,7 +1,7 @@
 <li>
   <label>Selected Applications</label>
   <ul class="bulk_operation_items">
-    <% @applications.each do |cinstance| %>
+    <% applications.each do |cinstance| %>
       <%= content_tag :li, title: "#{cinstance.user_account.org_name} - #{cinstance.account_admin_user_display_name}" do %>
         <span class="name"><%= h cinstance.name %></span>
         (<span class="account"><%= h cinstance.user_account.org_name %></span>)

--- a/app/views/buyers/applications/bulk/change_plans/create.js.erb
+++ b/app/views/buyers/applications/bulk/change_plans/create.js.erb
@@ -1,4 +1,4 @@
-<%- @applications.each do |cinstance| %>
+<%- applications.each do |cinstance| %>
   $("#<%=dom_id(cinstance)%>").
     find(".plan").html("<%= escape_javascript link_to_plan_edit(cinstance.plan) %>").end().
     find(".free_or_paid").html("<%= escape_javascript plan_free_or_paid(cinstance.plan) %>");

--- a/app/views/buyers/applications/bulk/change_plans/new.html.erb
+++ b/app/views/buyers/applications/bulk/change_plans/new.html.erb
@@ -2,11 +2,11 @@
   :html => {
     :class => 'bulk_operations',
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to change plan of these #{@applications.count} applications?"
+    :'data-confirm' => "Are you sure to change plan of these #{applications.count} applications?"
   } do |form| %>
   <%= form.inputs do %>
-    <%= render 'buyers/applications/bulk/selected_applications' %>
-    <%= form.input :plan_id, :as => :select, :collection => @plans %>
+    <%= render 'buyers/applications/bulk/selected_applications', applications: applications %>
+    <%= form.input :plan_id, :as => :select, :collection => plans %>
     <%= form.buttons do %>
       <%= form.commit_button 'Change plan', :button_html => {:'data-disable-with' => 'Running bulk action...' } %>
     <% end %>

--- a/app/views/buyers/applications/bulk/change_states/create.js.erb
+++ b/app/views/buyers/applications/bulk/change_states/create.js.erb
@@ -1,4 +1,4 @@
-<%- @applications.each do |application| %>
+<%- applications.each do |application| %>
   $("#<%=dom_id(application)%>").find(".state").text("<%= escape_javascript application.state %>");
 <%-end-%>
 $("#bulk-operations").trigger("bulk:success");

--- a/app/views/buyers/applications/bulk/change_states/new.html.erb
+++ b/app/views/buyers/applications/bulk/change_states/new.html.erb
@@ -1,11 +1,11 @@
 <%= semantic_form_for :change_states, :url => admin_buyers_applications_bulk_change_state_path,
   :html => {
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to change state of these #{@applications.count} applications?"
+    :'data-confirm' => "Are you sure to change state of these #{applications.count} applications?"
   } do |form| %>
   <%= form.inputs do %>
-    <%= render 'buyers/applications/bulk/selected_applications' %>
-    <%= form.input :action, :as => :select, :collection => @actions %>
+    <%= render 'buyers/applications/bulk/selected_applications', applications: applications %>
+    <%= form.input :action, :as => :select, :collection => humanized_actions %>
     <p class="inline-hint">Remember that when you suspend application which is on paid plan, it will be invoiced and/or charged accordingly.</p>
     <%= form.buttons do %>
       <%= form.commit_button 'Change state', :button_html => {:'data-disable-with' => 'Running bulk action...' } %>

--- a/app/views/buyers/applications/bulk/deletes/create.js.erb
+++ b/app/views/buyers/applications/bulk/deletes/create.js.erb
@@ -1,4 +1,4 @@
-<%- @applications.each do |application| %>
+<%- applications.each do |application| %>
   $("#<%=dom_id(application)%>").fadeOut(function(){$(this).remove()});
 <%-end-%>
 $("#bulk-operations").trigger("bulk:success");

--- a/app/views/buyers/applications/bulk/deletes/new.html.erb
+++ b/app/views/buyers/applications/bulk/deletes/new.html.erb
@@ -1,10 +1,10 @@
 <% semantic_form_for :delete, :url => admin_buyers_applications_bulk_delete_path,
   :html => {
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to delete these #{@applications.count} applications?"
+    :'data-confirm' => "Are you sure to delete these #{applications.count} applications?"
   } do |form| %>
   <%- form.inputs do -%>
-    <%= render 'buyers/applications/bulk/selected_applications' %>
+    <%= render 'buyers/applications/bulk/selected_applications', applications: applications %>
     <%- form.buttons do -%>
       <%= form.commit_button 'Delete applications', :button_html => {:'data-disable-with' => 'Running bulk action...' } %>
     <%- end -%>

--- a/app/views/buyers/applications/bulk/send_emails/new.html.erb
+++ b/app/views/buyers/applications/bulk/send_emails/new.html.erb
@@ -1,11 +1,11 @@
 <%= semantic_form_for :send_emails, :url => admin_buyers_applications_bulk_send_email_path,
   :html => {
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to send emails to these #{@applications.count} applications ?"
+    :'data-confirm' => "Are you sure to send emails to these #{applications.count} applications ?"
   } do |form| %>
   <%= form.inputs do %>
-    <%= render 'buyers/applications/bulk/selected_applications' %>
-    <%= form.input :to, :as => :string, :input_html => {:disabled => true, :value => "#{@applications.count} selected applications"} %>
+    <%= render 'buyers/applications/bulk/selected_applications', applications: applications %>
+    <%= form.input :to, :as => :string, :input_html => {:disabled => true, :value => "#{applications.count} selected applications"} %>
     <%= form.input :subject, :as => :string %>
     <%= form.input :body, :as => :text, :input_html => {:rows => 10} %>
     <%= form.buttons do %>

--- a/app/views/buyers/service_contracts/bulk/_selected_contracts.html.erb
+++ b/app/views/buyers/service_contracts/bulk/_selected_contracts.html.erb
@@ -1,7 +1,7 @@
 <li>
   <label>Selected Service Subscriptions</label>
   <ul class="bulk_operation_items">
-    <% @service_contracts.each do |contract| %>
+    <% service_contracts.each do |contract| %>
       <%= content_tag :li, title: "#{contract.account.org_name} - #{contract.account_admin_user_display_name}" do %>
         <span class="account"><%= contract.account.org_name %></span>
         <span class="plan"><%= contract.plan.name %></span>

--- a/app/views/buyers/service_contracts/bulk/change_plans/new.html.erb
+++ b/app/views/buyers/service_contracts/bulk/change_plans/new.html.erb
@@ -2,11 +2,11 @@
   :html => {
     :class => 'bulk_operations',
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to change plan of these #{@service_contracts.count} service subscriptions?"
+    :'data-confirm' => "Are you sure to change plan of these #{service_contracts.count} service subscriptions?"
   } do |form| %>
   <%= form.inputs do %>
     <%= render 'buyers/service_contracts/bulk/selected_contracts' %>
-    <%= form.input :plan_id, :as => :select, :collection => @plans %>
+    <%= form.input :plan_id, :as => :select, :collection => plans %>
     <%= form.buttons do %>
       <%= form.commit_button 'Change plan', :button_html => {:'data-disable-with' => 'Running bulk action...' } %>
     <% end %>

--- a/app/views/buyers/service_contracts/bulk/change_states/create.js.erb
+++ b/app/views/buyers/service_contracts/bulk/change_states/create.js.erb
@@ -1,4 +1,4 @@
-<%- @service_contracts.each do |contract| %>
+<%- service_contracts.each do |contract| %>
   $("#<%=dom_id(contract)%>").find(".state").text("<%= escape_javascript contract.state %>");
 <%-end-%>
 $("#bulk-operations").trigger("bulk:success");

--- a/app/views/buyers/service_contracts/bulk/change_states/new.html.erb
+++ b/app/views/buyers/service_contracts/bulk/change_states/new.html.erb
@@ -1,11 +1,11 @@
 <%= semantic_form_for :change_states, :url => admin_buyers_service_contracts_bulk_change_state_path,
   :html => {
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to change state of these #{@service_contracts.count} service subscriptions?"
+    :'data-confirm' => "Are you sure to change state of these #{service_contracts.count} service subscriptions?"
   } do |form| %>
   <%= form.inputs do %>
     <%= render 'buyers/service_contracts/bulk/selected_contracts' %>
-    <%= form.input :action, :as => :select, :collection => @actions %>
+    <%= form.input :action, :as => :select, :collection => humanized_actions %>
     <p class="inline-hint">Remember that when you suspend service subsription which is on paid plan, it will be invoiced and/or charged accordingly.</p>
     <%= form.buttons do %>
       <%= form.commit_button 'Change state', :button_html => {:'data-disable-with' => 'Running bulk action...' } %>

--- a/app/views/buyers/service_contracts/bulk/deletes/create.js.erb
+++ b/app/views/buyers/service_contracts/bulk/deletes/create.js.erb
@@ -1,4 +1,4 @@
-<%- @service_contracts.each do |contract| %>
+<%- service_contracts.each do |contract| %>
   $("#<%=dom_id(contract)%>").fadeOut(function(){$(this).remove()});
 <%-end-%>
 $("#bulk-operations").trigger("bulk:success");

--- a/app/views/buyers/service_contracts/bulk/deletes/new.html.erb
+++ b/app/views/buyers/service_contracts/bulk/deletes/new.html.erb
@@ -1,7 +1,7 @@
 <% semantic_form_for :delete, :url => admin_buyers_service_contracts_bulk_delete_path,
   :html => {
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to delete these #{@service_contracts.count} service subscriptions?"
+    :'data-confirm' => "Are you sure to delete these #{service_contracts.count} service subscriptions?"
   } do |form| %>
   <%- form.inputs do -%>
     <%= render 'buyers/service_contracts/bulk/selected_contracts' %>

--- a/app/views/buyers/service_contracts/bulk/send_emails/new.html.erb
+++ b/app/views/buyers/service_contracts/bulk/send_emails/new.html.erb
@@ -1,11 +1,11 @@
 <%= semantic_form_for :send_emails, :url => admin_buyers_service_contracts_bulk_send_email_path,
   :html => {
     :'data-remote' => true,
-    :'data-confirm' => "Are you sure to send emails to these #{@service_contracts.size} service subscriptions?"
+    :'data-confirm' => "Are you sure to send emails to these #{service_contracts.size} service subscriptions?"
   } do |form| %>
   <%= form.inputs do %>
     <%= render 'buyers/service_contracts/bulk/selected_contracts' %>
-    <%= form.input :to, :as => :string, :input_html => {:disabled => true, :value => "#{@service_contracts.size} selected service subscriptions"} %>
+    <%= form.input :to, :as => :string, :input_html => {:disabled => true, :value => "#{service_contracts.size} selected service subscriptions"} %>
     <%= form.input :subject, :as => :string %>
     <%= form.input :body, :as => :text, :input_html => {:rows => 10} %>
     <%= form.buttons do %>

--- a/features/old/accounts/bulk_operations/change_plans.feature
+++ b/features/old/accounts/bulk_operations/change_plans.feature
@@ -22,6 +22,14 @@ Feature: Bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
       And I am logged in as provider "foo.3scale.localhost"
 
+  Scenario: No plan is selected
+    Given an application plan "Advanced" of provider "foo.3scale.localhost"
+    And I am on the accounts admin page
+    When I check select for "bob"
+    And I press "Change account plan"
+    And I press "Change plan" and I confirm dialog box
+    Then I should see "Required parameter missing: plan_id"
+
   Scenario: Unable to change plans unless account_plans switch allowed
     Given an application plan "Advanced" of provider "foo.3scale.localhost"
       And provider "foo.3scale.localhost" has "account_plans" switch denied

--- a/features/old/accounts/bulk_operations/change_states.feature
+++ b/features/old/accounts/bulk_operations/change_states.feature
@@ -16,6 +16,14 @@ Feature: Bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
       And I am logged in as provider "foo.3scale.localhost"
 
+  Scenario: Do nothing
+    And I am on the accounts admin page
+    And I check select for "pending" and "rejected"
+    And I press "Change state"
+    Then I should see "Approve, reject or make pending selected accounts"
+    And I press "Change state" and I confirm dialog box within fancybox
+    Then I should see "Action completed successfully"
+
   Scenario: Approve accounts
       And I am on the accounts admin page
     When I follow "Group/Org."

--- a/features/old/accounts/bulk_operations/change_states.feature
+++ b/features/old/accounts/bulk_operations/change_states.feature
@@ -16,13 +16,13 @@ Feature: Bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
       And I am logged in as provider "foo.3scale.localhost"
 
-  Scenario: Do nothing
+  Scenario: No state selected
     And I am on the accounts admin page
     And I check select for "pending" and "rejected"
     And I press "Change state"
     Then I should see "Approve, reject or make pending selected accounts"
     And I press "Change state" and I confirm dialog box within fancybox
-    Then I should see "Action completed successfully"
+    Then I should see "Required parameter missing: action"
 
   Scenario: Approve accounts
       And I am on the accounts admin page

--- a/features/old/accounts/bulk_operations/send_email.feature
+++ b/features/old/accounts/bulk_operations/send_email.feature
@@ -20,6 +20,18 @@ Feature: Mass email bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
       And I am logged in as provider "foo.3scale.localhost"
 
+  Scenario: No subject and no body
+    And I am on the accounts admin page
+    And a clear email queue
+    When I check select for "jane"
+    And I press "Send email"
+    And I press "Send" and I confirm dialog box within colorbox
+    Then I should see "Action completed successfully"
+    And "jane@jane.com" should receive 1 email with subject ""
+    And "jane@jane.com" should receive an email with the following body:
+    """
+    """
+
   Scenario: Send mass email to application owners
       And I am on the accounts admin page
       And a clear email queue

--- a/features/old/accounts/bulk_operations/send_email.feature
+++ b/features/old/accounts/bulk_operations/send_email.feature
@@ -20,16 +20,29 @@ Feature: Mass email bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
       And I am logged in as provider "foo.3scale.localhost"
 
-  Scenario: No subject and no body
+  Scenario: Emails can be sent without body
     And I am on the accounts admin page
     And a clear email queue
     When I check select for "jane"
     And I press "Send email"
+    And I fill in "Subject" with "Nothing to say"
     And I press "Send" and I confirm dialog box within colorbox
     Then I should see "Action completed successfully"
-    And "jane@jane.com" should receive 1 email with subject ""
     And "jane@jane.com" should receive an email with the following body:
     """
+    """
+
+  Scenario: Emails can be sent without subject
+    And I am on the accounts admin page
+    And a clear email queue
+    When I check select for "jane"
+    And I press "Send email"
+    And I fill in "Body" with "Did I forget to add a subject?"
+    And I press "Send" and I confirm dialog box within colorbox
+    Then I should see "Action completed successfully"
+    And "jane@jane.com" should receive an email with the following body:
+    """
+    Did I forget to add a subject?
     """
 
   Scenario: Send mass email to application owners

--- a/features/old/applications/providers/bulk_operations/change_plans.feature
+++ b/features/old/applications/providers/bulk_operations/change_plans.feature
@@ -19,6 +19,15 @@ Feature: Bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
       And I don't care about application keys
 
+  Scenario: No plan is selected
+    Given an application plan "Advanced" of provider "foo.3scale.localhost"
+    And I am logged in as provider "foo.3scale.localhost"
+    And I am on the applications admin page
+    When I check select for "BobApp", "JaneApp"
+    And I press "Change application plan"
+    And I press "Change plan" and I confirm dialog box
+    Then I should see "Required parameter missing: plan_id"
+
   Scenario: Mass change of application plans
     Given an application plan "Advanced" of provider "foo.3scale.localhost"
       And I am logged in as provider "foo.3scale.localhost"

--- a/features/old/applications/providers/bulk_operations/change_states.feature
+++ b/features/old/applications/providers/bulk_operations/change_states.feature
@@ -19,6 +19,15 @@ Feature: Bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
       And I don't care about application keys
 
+  Scenario: Do nothing
+    Given I am logged in as provider "foo.3scale.localhost"
+    And I am on the applications admin page
+    And I check select for "PendingApp" and "SuspendedApp"
+    And I press "Change state"
+    Then I should see "Accept, suspend or resume selected applications"
+    And I press "Change state" and I confirm dialog box within fancybox
+    Then I should see "Action completed successfully"
+
   Scenario: Accept applications
     Given I am logged in as provider "foo.3scale.localhost"
       And I am on the applications admin page

--- a/features/old/applications/providers/bulk_operations/change_states.feature
+++ b/features/old/applications/providers/bulk_operations/change_states.feature
@@ -26,7 +26,7 @@ Feature: Bulk operations
     And I press "Change state"
     Then I should see "Accept, suspend or resume selected applications"
     And I press "Change state" and I confirm dialog box within fancybox
-    Then I should see "Action completed successfully"
+    Then I should see "Required parameter missing: action"
 
   Scenario: Accept applications
     Given I am logged in as provider "foo.3scale.localhost"

--- a/features/old/applications/providers/bulk_operations/send_emails.feature
+++ b/features/old/applications/providers/bulk_operations/send_emails.feature
@@ -22,6 +22,19 @@ Feature: Mass email bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
       And I don't care about application keys
 
+  Scenario: No subject and no body
+    Given I am logged in as provider "foo.3scale.localhost"
+    And I am on the applications admin page
+    And a clear email queue
+    When I check select for "BobApp"
+    And I press "Send email"
+    And I press "Send" and I confirm dialog box within colorbox
+    Then I should see "Action completed successfully"
+    And "jane@me.us" should receive 1 email with subject ""
+    And "jane@me.us" should receive an email with the following body:
+    """
+    """
+
   Scenario: Send mass email to application owners
     Given I am logged in as provider "foo.3scale.localhost"
       And I am on the applications admin page

--- a/features/old/applications/providers/bulk_operations/send_emails.feature
+++ b/features/old/applications/providers/bulk_operations/send_emails.feature
@@ -22,17 +22,31 @@ Feature: Mass email bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
       And I don't care about application keys
 
-  Scenario: No subject and no body
+  Scenario: Emails can be sent without body
     Given I am logged in as provider "foo.3scale.localhost"
     And I am on the applications admin page
     And a clear email queue
     When I check select for "BobApp"
     And I press "Send email"
+    And I fill in "Subject" with "Nothing to say"
     And I press "Send" and I confirm dialog box within colorbox
     Then I should see "Action completed successfully"
-    And "jane@me.us" should receive 1 email with subject ""
-    And "jane@me.us" should receive an email with the following body:
+    And "bob@me.us" should receive an email with the following body:
     """
+    """
+
+  Scenario: Emails can be sent without subject
+    Given I am logged in as provider "foo.3scale.localhost"
+    And I am on the applications admin page
+    And a clear email queue
+    When I check select for "BobApp"
+    And I press "Send email"
+    And I fill in "Body" with "Did I forget to add a subject?"
+    And I press "Send" and I confirm dialog box within colorbox
+    Then I should see "Action completed successfully"
+    And "bob@me.us" should receive an email with the following body:
+    """
+    Did I forget to add a subject?
     """
 
   Scenario: Send mass email to application owners

--- a/features/old/services/subscriptions/bulk_operations/change_plans.feature
+++ b/features/old/services/subscriptions/bulk_operations/change_plans.feature
@@ -21,6 +21,14 @@ Feature: Bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
       And I am logged in as provider "foo.3scale.localhost"
 
+  Scenario: No plan is selected
+    Given a service plan "Awesome" of service "New Service"
+    And I am on the service contracts admin page
+    When I check select for "mike"
+    And I press "Change service plan"
+    And I press "Change plan" and I confirm dialog box
+    Then I should see "Required parameter missing: plan_id"
+
   Scenario: Mass change of service contracts' plans
     Given a service plan "Awesome" of service "New Service"
       And I am on the service contracts admin page

--- a/features/old/services/subscriptions/bulk_operations/change_states.feature
+++ b/features/old/services/subscriptions/bulk_operations/change_states.feature
@@ -20,6 +20,14 @@ Feature: Bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
     Given I am logged in as provider "foo.3scale.localhost"
 
+  Scenario: Do nothing
+    And I am on the service contracts admin page
+    And I check select for "bob" and "mike"
+    And I press "Change state"
+    Then I should see "Accept, suspend or resume selected applications"
+    And I press "Change state" and I confirm dialog box within fancybox
+    Then I should see "Action completed successfully"
+
   Scenario: Accept subscription
       And I am on the service contracts admin page
 

--- a/features/old/services/subscriptions/bulk_operations/change_states.feature
+++ b/features/old/services/subscriptions/bulk_operations/change_states.feature
@@ -26,7 +26,7 @@ Feature: Bulk operations
     And I press "Change state"
     Then I should see "Accept, suspend or resume selected applications"
     And I press "Change state" and I confirm dialog box within fancybox
-    Then I should see "Action completed successfully"
+    Then I should see "Required parameter missing: action"
 
   Scenario: Accept subscription
       And I am on the service contracts admin page

--- a/features/old/services/subscriptions/bulk_operations/change_states.feature
+++ b/features/old/services/subscriptions/bulk_operations/change_states.feature
@@ -22,9 +22,10 @@ Feature: Bulk operations
 
   Scenario: Do nothing
     And I am on the service contracts admin page
+    When I follow "Account" within table
     And I check select for "bob" and "mike"
     And I press "Change state"
-    Then I should see "Accept, suspend or resume selected applications"
+    Then I should see "Accept, suspend or resume selected subscriptions"
     And I press "Change state" and I confirm dialog box within fancybox
     Then I should see "Required parameter missing: action"
 

--- a/features/old/services/subscriptions/bulk_operations/send_emails.feature
+++ b/features/old/services/subscriptions/bulk_operations/send_emails.feature
@@ -25,6 +25,19 @@ Feature: Mass email bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
     Given I am logged in as provider "foo.3scale.localhost"
 
+  Scenario: No subject and no body
+    And provider "foo.3scale.localhost" has "service_plans" visible
+    And I am on the service contracts admin page
+    And a clear email queue
+    When I check select for "jane"
+    And I press "Send email"
+    And I press "Send" and I confirm dialog box within colorbox
+    Then I should see "Action completed successfully"
+    And "jane@me.us" should receive 1 email with subject ""
+    And "jane@me.us" should receive an email with the following body:
+    """
+    """
+
   Scenario: Send mass email to application owners
       And provider "foo.3scale.localhost" has "service_plans" visible
       And I am on the service contracts admin page

--- a/features/old/services/subscriptions/bulk_operations/send_emails.feature
+++ b/features/old/services/subscriptions/bulk_operations/send_emails.feature
@@ -25,17 +25,33 @@ Feature: Mass email bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
     Given I am logged in as provider "foo.3scale.localhost"
 
-  Scenario: No subject and no body
-    And provider "foo.3scale.localhost" has "service_plans" visible
+  Scenario: Emails can be sent without body
+    Given provider "foo.3scale.localhost" has "service_plans" visible
     And I am on the service contracts admin page
     And a clear email queue
     When I check select for "jane"
     And I press "Send email"
+    And I fill in "Subject" with "Nothing to say"
+    And I fill in "Body" with ""
     And I press "Send" and I confirm dialog box within colorbox
     Then I should see "Action completed successfully"
-    And "jane@me.us" should receive 1 email with subject ""
     And "jane@me.us" should receive an email with the following body:
     """
+    """
+
+  Scenario: Emails can be sent without subject
+    Given provider "foo.3scale.localhost" has "service_plans" visible
+    And I am on the service contracts admin page
+    And a clear email queue
+    When I check select for "jane"
+    And I press "Send email"
+    And I fill in "Subject" with ""
+    And I fill in "Body" with "Did I forget to add a subject?"
+    And I press "Send" and I confirm dialog box within colorbox
+    Then I should see "Action completed successfully"
+    And "jane@me.us" should receive an email with the following body:
+    """
+    Did I forget to add a subject?
     """
 
   Scenario: Send mass email to application owners


### PR DESCRIPTION
Fixes _Send mass email to application owners_ tests:
https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-2

https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-5

https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-13

**Note about new scenarios**
The application currently allows sending emails without a subject. This is problematic since the email can't be opened without it (see image below). However wrong this may be, it should be included in the tests. I create a JIRA to address this functionality https://issues.redhat.com/browse/THREESCALE-8009.
![Screenshot 2021-12-23 at 10 19 42](https://user-images.githubusercontent.com/11672286/147218319-4bad272a-b630-4a5d-817f-208124bb3ec1.png)
