### PR TITLE
Update usage of #include in categories.rb

### DIFF
--- a/app/lib/forum_support/categories.rb
+++ b/app/lib/forum_support/categories.rb
@@ -10,7 +10,7 @@ module ForumSupport
     end
 
     def index
-      @categories = @forum.categories :include => :topics
+      @categories = @forum.categories.includes(:topics)
     end
 
     def show


### PR DESCRIPTION
Fixes tests using  `app/lib/forum_support/categories.rb`: 

https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-6

https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-9

https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-10

https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-11

https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-12

https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-15

https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-16

https://app.circleci.com/pipelines/github/3scale/porta/19248/workflows/2546831f-88c2-4728-a620-bf9cd2b9341e/jobs/229561/tests#failed-test-17