### PR TITLE
[BugFix] Tag list: order alphabetically

### DIFF
--- a/app/views/provider/admin/cms/files/_form.html.erb
+++ b/app/views/provider/admin/cms/files/_form.html.erb
@@ -3,5 +3,5 @@
   <%= f.input :path, input_html: {class: 'cms-path-autocomplete'}  %>
   <%= f.input :downloadable, :hint => "Checked sets the content-disposition to 'attachment.'" %>
   <%= f.input :attachment, :as => :file %>
-  <%= f.input :tag_list, :hint => 'List of tags separated with comma (","), example: tag1, tag2, tag3', :input_html => { :value => @file.tag_list.join(", ") } %>
+  <%= f.input :tag_list, :hint => 'List of tags separated with comma (","), example: tag1, tag2, tag3', :input_html => { :value => @file.tag_list.sort.join(", ") } %>
 <% end %>

--- a/app/views/provider/admin/cms/pages/_form.html.erb
+++ b/app/views/provider/admin/cms/pages/_form.html.erb
@@ -24,5 +24,5 @@
   <%= f.input :liquid_enabled, :hint => true %>
   <%= f.input :handler, :as => :handler, :hint => true %>
 
-  <%= f.input :tag_list, :hint => 'List of tags separated with comma (","), example: tag1, tag2, tag3', :input_html => { :value => @page.tag_list.join(", ") } %>
+  <%= f.input :tag_list, :hint => 'List of tags separated with comma (","), example: tag1, tag2, tag3', :input_html => { :value => @page.tag_list.sort.join(", ") } %>
 <% end %>

--- a/features/old/cms/pages.feature
+++ b/features/old/cms/pages.feature
@@ -39,7 +39,7 @@ Feature: CMS Pages
         | Path           | /potato       |
         | Content type   | text/css      |
         | Handler        | markdown      |
-        | Tag list       | potato, salad |
+      Then I should see the tags "potato, salad"
 
        And I press "Publish"
       Then I should see "Page saved and published"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Tag list items are being ordered differently by `pgsql` and `mysql`, making some test fail.
To workaround this issue we can **sort** the tags.

Follow-up of https://github.com/3scale/porta/pull/2798
