### PR TITLE
[params] Service contracts controller

### DIFF
--- a/app/controllers/buyers/service_contracts_controller.rb
+++ b/app/controllers/buyers/service_contracts_controller.rb
@@ -113,7 +113,8 @@ class Buyers::ServiceContractsController < Buyers::BaseController
   end
 
   def service_contract_params
-    params.fetch(:service_contract).merge(plan: service_plan)
+    params.permit(service_contract: [:plan_id])
+          .fetch(:service_contract).merge(plan: service_plan)
   end
 
   def find_service_contract

--- a/app/controllers/buyers/service_contracts_controller.rb
+++ b/app/controllers/buyers/service_contracts_controller.rb
@@ -68,7 +68,7 @@ class Buyers::ServiceContractsController < Buyers::BaseController
 
   def update
     service = @service_contract.issuer
-    new_plan = service.service_plans.find(params[:service_contract][:plan_id])
+    new_plan = service.service_plans.find(service_contract_plan_id)
 
     if @service_contract.change_plan!(new_plan)
       flash[:success] = "Plan of the contract was changed."
@@ -137,8 +137,12 @@ class Buyers::ServiceContractsController < Buyers::BaseController
     @service ||= accessible_services.find(params[:service_id])
   end
 
-  def service_plan(plan_id = params[:service_contract][:plan_id])
+  def service_plan(plan_id = service_contract_plan_id)
     @service_plan ||= service.service_plans.find_by(id: plan_id)
+  end
+
+  def service_contract_plan_id
+    params[:service_contract][:plan_id]
   end
 
   def accessible_services


### PR DESCRIPTION
Fixes scenario:
```
    Scenario: Subscribe to service with selected service plan

AfterStep hook at features/support/hooks.rb:59

Message:

    unable to convert unpermitted parameters to hash (ActionController::UnfilteredParameters)
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/actionpack-5.1.7/lib/action_controller/metal/strong_parameters.rb:265:in `to_h'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/activerecord-5.1.7/lib/active_record/inheritance.rb:218:in `subclass_from_attributes'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/activerecord-5.1.7/lib/active_record/inheritance.rb:56:in `new'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/protected_attributes_continued-1.3.0/lib/active_record/mass_assignment_security/reflection.rb:8:in `build_association'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/protected_attributes_continued-1.3.0/lib/active_record/mass_assignment_security/associations.rb:7:in `build_record'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/protected_attributes_continued-1.3.0/lib/active_record/mass_assignment_security/associations.rb:48:in `block in create_record'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/activerecord-5.1.7/lib/active_record/associations/collection_association.rb:129:in `block in transaction'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/database_statements.rb:235:in `block in transaction'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/transaction.rb:194:in `block in within_new_transaction'
/opt/rh/rh-ruby26/root/usr/share/ruby/monitor.rb:235:in `mon_synchronize'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/transaction.rb:191:in `within_new_transaction'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/database_statements.rb:235:in `transaction'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/activerecord-5.1.7/lib/active_record/transactions.rb:210:in `transaction'
/opt/app-root/src/project/lib/deadlock_retry.rb:52:in `transaction'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/activerecord-5.1.7/lib/active_record/associations/collection_association.rb:128:in `transaction'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/protected_attributes_continued-1.3.0/lib/active_record/mass_assignment_security/associations.rb:47:in `create_record'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/protected_attributes_continued-1.3.0/lib/active_record/mass_assignment_security/associations.rb:32:in `create'
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/protected_attributes_continued-1.3.0/lib/active_record/mass_assignment_security/associations.rb:69:in `create'
/opt/app-root/src/project/app/controllers/buyers/service_contracts_controller.rb:53:in `create'
```

At `features/old/accounts/service_contracts.feature`.