### PR TITLE
[params] Settings controller

### DIFF
--- a/app/controllers/finance/provider/settings_controller.rb
+++ b/app/controllers/finance/provider/settings_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Finance::Provider::SettingsController < Finance::Provider::BaseController
 
   before_action :set_strategy
@@ -13,15 +15,15 @@ class Finance::Provider::SettingsController < Finance::Provider::BaseController
   end
 
   def update
-    if params['finance_billing_strategy']['currency'].blank?
-      params['finance_billing_strategy']['currency'] = nil
+    if finance_billing_strategy_params['currency'].blank?
+      finance_billing_strategy_params['currency'] = nil
     end
 
-    if @billing_strategy.numbering_period != params['finance_billing_strategy']['numbering_period']
+    if @billing_strategy.numbering_period != finance_billing_strategy_params['numbering_period']
       ok_message = "Already existent invoices won't change their id."
     end
 
-    if @billing_strategy.update_attributes(params['finance_billing_strategy'])
+    if @billing_strategy.update_attributes(finance_billing_strategy_params.to_h)
       flash[:message] = 'Finance settings updated.' << ok_message.to_s
       redirect_to :action => 'show'
     else
@@ -36,4 +38,7 @@ class Finance::Provider::SettingsController < Finance::Provider::BaseController
     @billing_strategy = current_user.account.billing_strategy
   end
 
+  def finance_billing_strategy_params
+    params.require(:finance_billing_strategy).permit(:charging_enabled, :currency, :numbering_period, account_attributes: %i[invoice_footnote vat_zero_text id])
+  end
 end

--- a/app/controllers/finance/provider/settings_controller.rb
+++ b/app/controllers/finance/provider/settings_controller.rb
@@ -24,7 +24,7 @@ class Finance::Provider::SettingsController < Finance::Provider::BaseController
     end
 
     if @billing_strategy.update_attributes(finance_billing_strategy_params.to_h)
-      flash[:message] = "Finance settings updated. #{ok_message}"
+      flash[:message] = "Finance settings updated" << ok_message.to_s
       redirect_to :action => 'show'
     else
       flash[:message] = 'Invalid finance settings'

--- a/app/controllers/finance/provider/settings_controller.rb
+++ b/app/controllers/finance/provider/settings_controller.rb
@@ -24,7 +24,7 @@ class Finance::Provider::SettingsController < Finance::Provider::BaseController
     end
 
     if @billing_strategy.update_attributes(finance_billing_strategy_params)
-      flash[:message] = "Finance settings updated" << ok_message.to_s
+      flash[:message] = "Finance settings updated. #{ok_message}"
       redirect_to :action => 'show'
     else
       flash[:message] = 'Invalid finance settings'

--- a/app/controllers/finance/provider/settings_controller.rb
+++ b/app/controllers/finance/provider/settings_controller.rb
@@ -39,6 +39,6 @@ class Finance::Provider::SettingsController < Finance::Provider::BaseController
   end
 
   def finance_billing_strategy_params
-    params.require(:finance_billing_strategy).permit(:charging_enabled, :currency, :numbering_period, account_attributes: %i[invoice_footnote vat_zero_text id])
+    @finance_billing_strategy_params ||= params.require(:finance_billing_strategy).permit(:charging_enabled, :currency, :numbering_period, account_attributes: %i[invoice_footnote vat_zero_text id])
   end
 end

--- a/app/controllers/finance/provider/settings_controller.rb
+++ b/app/controllers/finance/provider/settings_controller.rb
@@ -23,7 +23,7 @@ class Finance::Provider::SettingsController < Finance::Provider::BaseController
       ok_message = "Already existent invoices won't change their id."
     end
 
-    if @billing_strategy.update_attributes(finance_billing_strategy_params.to_h)
+    if @billing_strategy.update_attributes(finance_billing_strategy_params)
       flash[:message] = "Finance settings updated" << ok_message.to_s
       redirect_to :action => 'show'
     else

--- a/app/controllers/finance/provider/settings_controller.rb
+++ b/app/controllers/finance/provider/settings_controller.rb
@@ -24,7 +24,7 @@ class Finance::Provider::SettingsController < Finance::Provider::BaseController
     end
 
     if @billing_strategy.update_attributes(finance_billing_strategy_params.to_h)
-      flash[:message] = 'Finance settings updated.' << ok_message.to_s
+      flash[:message] = "Finance settings updated. #{ok_message}"
       redirect_to :action => 'show'
     else
       flash[:message] = 'Invalid finance settings'

--- a/features/old/finance/settings/provider.feature
+++ b/features/old/finance/settings/provider.feature
@@ -27,3 +27,12 @@ Scenario: Setting a currency
    And an invoice of buyer "zoidberg" for February, 1984
    And I go to the invoices by months page
   Then I should see "USD"
+
+Scenario: Already existent invoices won't change their id
+  Given provider "foo.3scale.localhost" has "finance" switch allowed
+  When I go to the finance settings page
+  And I check "Charging enabled"
+  And I select "yearly" from "Billing periods for invoice ids"
+  And I press "Save"
+  Then I should see "Finance settings updated. Already existent invoices won't change their id."
+  And the "Charging enabled" checkbox should be checked


### PR DESCRIPTION
**Description**
~Unlike Hash, Params doesn't have `with_indiferent_access` so it has to be parsed when passed to `update_attribute`. However, since params are not permitted, `to_h` will fail.~
We need to upgrade `protected_attributes_continued` https://github.com/3scale/porta/pull/2870

**Steps to reproduce**
Go to Audience > Billing > Charging & Gateway and change charging settings

**Before**
![Screenshot 2022-01-04 at 09 55 56](https://user-images.githubusercontent.com/11672286/148035504-088c9f9a-5285-47f6-950d-e1eefcb5f0d6.png)

**After**
![Screenshot 2022-01-04 at 09 56 15](https://user-images.githubusercontent.com/11672286/148035523-9b6b2cc2-b234-4715-a00c-af226d9674e2.png)
