### PR TITLE
[Params] Fixing sudo controllers when using symbolize keys

### DIFF
--- a/app/controllers/provider/admin/sudo_controller.rb
+++ b/app/controllers/provider/admin/sudo_controller.rb
@@ -2,8 +2,7 @@ class Provider::Admin::SudoController < FrontendController
 
   helper_method :sudo
 
-  def show
-  end
+  def show; end
 
   def create
     if sudo.correct_password?(current_password)
@@ -30,7 +29,7 @@ class Provider::Admin::SudoController < FrontendController
   end
 
   def sudo
-    @_sudo ||= ::Sudo.new(sudo_params.symbolize_keys)
+    @sudo ||= ::Sudo.new(sudo_params.to_h.symbolize_keys)
   end
 
 end


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Fixes the sudo controllers usage when using rails 5.1 version. 
We need to convert the params to hash before calling `symbolize_keys`