### PR TITLE
💎 Update `protected_attributes_continued` to 1.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'rails', '~> 5.0.7'
 gem "activejob-uniqueness", github: "3scale/activejob-uniqueness", branch: "main"
 gem 'activemodel-serializers-xml'
 
-gem 'protected_attributes_continued', '~> 1.3.0'
+gem 'protected_attributes_continued', '~> 1.8.2'
 
 gem 'rails-observers'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1609,8 +1609,8 @@ GEM
       prawn-core
     prawn-layout (0.2.1)
     prometheus-client-mmap (0.11.0)
-    protected_attributes_continued (1.3.0)
-      activemodel (~> 5.0)
+    protected_attributes_continued (1.8.2)
+      activemodel (>= 5.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -2057,7 +2057,7 @@ DEPENDENCIES
   prawn-core!
   prawn-format (= 0.2.1)
   prawn-layout (= 0.2.1)
-  protected_attributes_continued (~> 1.3.0)
+  protected_attributes_continued (~> 1.8.2)
   pry-byebug (>= 3.7.0)
   pry-doc (>= 0.8)
   pry-rails

--- a/test/unit/finance/bill_variable_for_plan_changed_test.rb
+++ b/test/unit/finance/bill_variable_for_plan_changed_test.rb
@@ -6,7 +6,7 @@ class Finance::BillVariableForPlanChangedTest < ActiveSupport::TestCase
   attr_reader :contract, :account, :app_plan
 
   setup do
-    @contract = FactoryBot.build_stubbed(:contract)
+    @contract = FactoryBot.build_stubbed(:application_contract)
     @account  = FactoryBot.build_stubbed(:simple_account)
     @app_plan = FactoryBot.build_stubbed(:application_plan)
 


### PR DESCRIPTION
Needed for the rails upgrade. Fixes scenario:

```
    Scenario: Turning charging on/off

And I press "Save"

Message:

    undefined method `with_indifferent_access' for #<ActionController::Parameters:0x0000000011e2ec10> (NoMethodError)
```