### PR TITLE
Fixes can't cast class errors when using rails 5.1 version

### DIFF
--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -5,33 +5,33 @@ And(/^there are no events$/) do
 end
 
 And(/^there should be (\d+) application cancelled event$/) do |n|
-  cancelled = EventStore::Repository.adapter.where(event_type: Cinstances::CinstanceCancellationEvent)
+  cancelled = EventStore::Repository.adapter.where(event_type: Cinstances::CinstanceCancellationEvent.to_s)
 
   assert_equal n.to_i, cancelled.count
 end
 
 And(/^there should be (\d+) valid service contract cancelled event$/) do |count|
-  check_events_validity!(type: ServiceContracts::ServiceContractCancellationEvent, count: count)
+  check_events_validity!(type: ServiceContracts::ServiceContractCancellationEvent.to_s, count: count)
 end
 
 And(/^there should be (\d+) valid service contract created event$/) do |count|
-  check_events_validity!(type: ServiceContracts::ServiceContractCreatedEvent, count: count)
+  check_events_validity!(type: ServiceContracts::ServiceContractCreatedEvent.to_s, count: count)
 end
 
 And(/^there should be (\d+) valid account created event$/) do |count|
-  check_events_validity!(type: Accounts::AccountCreatedEvent, count: count)
+  check_events_validity!(type: Accounts::AccountCreatedEvent.to_s, count: count)
 end
 
 And(/^there should be (\d+) valid account deleted event$/) do |count|
-  check_events_validity!(type: Accounts::AccountDeletedEvent, count: count)
+  check_events_validity!(type: Accounts::AccountDeletedEvent.to_s, count: count)
 end
 
 And(/^there should be (\d+) valid application created event$/) do |count|
-  check_events_validity!(type: Applications::ApplicationCreatedEvent, count: count)
+  check_events_validity!(type: Applications::ApplicationCreatedEvent.to_s, count: count)
 end
 
 And(/^there should be (\d+) valid cinstance cancellation event$/) do |count|
-  check_events_validity!(type: Cinstances::CinstanceCancellationEvent, count: count)
+  check_events_validity!(type: Cinstances::CinstanceCancellationEvent.to_s, count: count)
 end
 
 And(/^all the events should be valid$/) do

--- a/test/functional/master/api/services_controller_test.rb
+++ b/test/functional/master/api/services_controller_test.rb
@@ -21,8 +21,8 @@ class Master::Api::ServicesControllerTest < ActionController::TestCase
     service   = FactoryBot.create(:simple_service, account: provider)
     app_plan  =  FactoryBot.create(:simple_application_plan, cinstances: [cinstance], issuer: service)
 
-    method_service_deleted_event_count = RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceDeletedEvent).method(:count)
-    method_notification_event_count    = RailsEventStoreActiveRecord::Event.where(event_type: NotificationEvent).method(:count)
+    method_service_deleted_event_count = RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceDeletedEvent.to_s).method(:count)
+    method_notification_event_count    = RailsEventStoreActiveRecord::Event.where(event_type: NotificationEvent.to_s).method(:count)
     assert_difference(method_notification_event_count, +1) do
       assert_difference(method_service_deleted_event_count, +1) do
         delete :destroy, params: { id: service.id, provider_id: provider.id, api_key: master_account.provider_key }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Fixes can't cast class errors.
