### PR TITLE
Fixes/unit postgres

### DIFF
--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -353,10 +353,10 @@ class ServiceTest < ActiveSupport::TestCase
       service = FactoryBot.create(:simple_service)
       service.stubs(destroyed_by_association: true)
       service_id = service.id
-      assert_difference(RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceDeletedEvent).method(:count)) do
+      assert_difference(RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceDeletedEvent.to_s).method(:count)) do
         service.destroy!
       end
-      event = RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceDeletedEvent).last!
+      event = RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceDeletedEvent.to_s).last!
       assert_equal service_id, event.data['service_id']
     end
   end
@@ -366,7 +366,7 @@ class ServiceTest < ActiveSupport::TestCase
 
     test 'creating service creates a related event' do
       User.stubs(current: FactoryBot.create(:simple_user))
-      assert_difference(RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceCreatedEvent).method(:count)) do
+      assert_difference(RailsEventStoreActiveRecord::Event.where(event_type: Services::ServiceCreatedEvent.to_s).method(:count)) do
         FactoryBot.create(:simple_service)
       end
     end
@@ -380,8 +380,8 @@ class ServiceTest < ActiveSupport::TestCase
       service = FactoryBot.create(:simple_service, account: account)
       FactoryBot.create(:simple_service, account: account) # To be able to destroy the other service
 
-      assert_difference(DeletedObject.where(object_type: Service).method(:count), +1) { service.destroy! }
-      deleted_object_entry = DeletedObject.where(object_type: Service).last!
+      assert_difference(DeletedObject.where(object_type: Service.to_s).method(:count), +1) { service.destroy! }
+      deleted_object_entry = DeletedObject.where(object_type: Service.to_s).last!
       assert_equal service.id, deleted_object_entry.object_id
       assert_equal 'Service', deleted_object_entry.object_type
       assert_equal account.id, deleted_object_entry.owner_id

--- a/test/unit/signup/account_manager_test.rb
+++ b/test/unit/signup/account_manager_test.rb
@@ -67,7 +67,7 @@ module Signup
         refute signup_result.account_approved?
 
         # publish account created event
-        check_events_validity!(type: Accounts::AccountCreatedEvent, count: 1)
+        check_events_validity!(type: Accounts::AccountCreatedEvent.to_s, count: 1)
       end
 
       test 'enqueues signup job' do
@@ -219,9 +219,9 @@ module Signup
         #   This needs to be tested because the AccountCreatedEvent is done by calling to AccountManager#publish_related_event,
         #   but the other 2 are done by observers when the contract_plan is done, and for that these needs to be done after saving the user,
         #   otherwise this will not work because MessageObserver#after_create will receive a contract with an empty user
-        check_events_validity!(type: Accounts::AccountCreatedEvent, count: 1)
-        check_events_validity!(type: Applications::ApplicationCreatedEvent, count: 1, opts: {provider_id: manager_account.id})
-        check_events_validity!(type: ServiceContracts::ServiceContractCreatedEvent, count: 1, opts: {provider_id: manager_account.id})
+        check_events_validity!(type: Accounts::AccountCreatedEvent.to_s, count: 1)
+        check_events_validity!(type: Applications::ApplicationCreatedEvent.to_s, count: 1, opts: {provider_id: manager_account.id})
+        check_events_validity!(type: ServiceContracts::ServiceContractCreatedEvent.to_s, count: 1, opts: {provider_id: manager_account.id})
       end
 
       test 'create developer without account plan approval required and minimal signup' do

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -20,8 +20,7 @@ module Tasks
       default_service.reload
 
       ThreeScale::Core::Service.expects(:make_default).with(another_service.backend_id)
-
-      assert_difference(EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent).method(:count)) do
+      assert_difference(EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent.to_s).method(:count)) do
         perform_enqueued_jobs(except: SphinxIndexationWorker) do
           execute_rake_task 'services.rake', 'services:destroy_service', account.id, default_service.id
         end
@@ -30,7 +29,7 @@ module Tasks
       refute Service.where(id: default_service.id).exists?
       assert_equal another_service.id, account.reload.default_service_id
 
-      event = EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent).last!
+      event = EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent.to_s).last!
       assert_equal event.data[:service_id], default_service.id
     end
 
@@ -69,7 +68,7 @@ module Tasks
       ThreeScale::Core::Service.expects(:make_default).never
       ThreeScale::Core::Service.expects(:save!).never
 
-      assert_difference(EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent).method(:count)) do
+      assert_difference(EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent.to_s).method(:count)) do
         perform_enqueued_jobs(except: SphinxIndexationWorker) do
           execute_rake_task 'services.rake', 'services:destroy_service', account.id, non_default_service.id
         end
@@ -78,7 +77,7 @@ module Tasks
       refute Service.where(id: non_default_service.id).exists?
       assert_equal default_service.id, account.reload.default_service_id
 
-      event = EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent).last!
+      event = EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent.to_s).last!
       assert_equal event.data[:service_id], non_default_service.id
     end
   end


### PR DESCRIPTION
What this PR does / why we need it:
This PR is need to fix the failing unit postgres tests.

https://app.circleci.com/pipelines/github/3scale/porta/19316/workflows/08beaec3-12d5-427b-8995-f476fbb6e475/jobs/230051/tests

Which issue(s) this PR fixes

TypeError: can't cast Class

Fix: Converted passed attribute to string as data type was string