### PR TITLE
Remove whatwg-fetch polyfill

### DIFF
--- a/app/javascript/src/Policies/index.jsx
+++ b/app/javascript/src/Policies/index.jsx
@@ -4,7 +4,6 @@ import 'core-js/modules/es6.set'
 import 'core-js/modules/es6.map'
 import 'core-js/es7/array'
 import 'core-js/es7/object'
-import 'whatwg-fetch'
 
 import React from 'react'
 

--- a/app/javascript/src/Types/libs/libdefs.js
+++ b/app/javascript/src/Types/libs/libdefs.js
@@ -3,26 +3,6 @@
 // Disabling all weak-type checks since this file is a workaround for missing types
 /* eslint-disable flowtype/no-weak-types */
 
-// TODO: remove these module declarations when not failing
-declare module 'whatwg-fetch' {
-  declare type Options = {
-    method?: string,
-    body?: string,
-    headers?: Object,
-    credentials?: 'omit' | 'same-origin' | 'include'
-  }
-  declare type Response = {
-    status: number,
-    statusText: string,
-    ok: boolean,
-    headers: any,
-    url: string,
-    text: () => Promise<string>,
-    json: () => Promise<Object>
-  }
-  declare export function fetch (url: string, options: ?Options): Promise<Response>
-}
-
 declare module 'core-js/fn/symbol' {
 
 }

--- a/app/javascript/src/utilities/fetchData.js
+++ b/app/javascript/src/utilities/fetchData.js
@@ -1,9 +1,7 @@
 // @flow
 
-import {fetch as fetchPolyfill} from 'whatwg-fetch'
-
 export function fetchData<T> (url: string): Promise<T> {
-  return fetchPolyfill(url)
+  return fetch(url)
     .then(response => {
       if (!response.ok) {
         throw new Error(response.statusText)

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "swagger-ui": "^3.51.1",
     "url-polyfill": "^1.1.3",
     "validate.js": "^0.13.1",
-    "virtual-dom": "^2.1.1",
-    "whatwg-fetch": "^3.0.0"
+    "virtual-dom": "^2.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12853,7 +12853,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
+whatwg-fetch@>=0.10.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==


### PR DESCRIPTION
**What this PR does / why we need it**:

`whatwg-fetch` is a polyfill for `fetch` that we no longer need. We have been using `fetch` for a while so it should be safe to remove.

**Verification steps** 

`fetchData` is used in `ActiveDocs v3 autocomplete`, `policies`, `service discovery` and `inline stats`. Everything should be working as usual.
