### PR TITLE
Hide Forum in SaaS

### DIFF
--- a/app/controllers/forums/admin/categories_controller.rb
+++ b/app/controllers/forums/admin/categories_controller.rb
@@ -1,4 +1,4 @@
-class Forums::Admin::CategoriesController < FrontendController
+class Forums::Admin::CategoriesController < Forums::Admin::HidenForumController
   include ForumSupport::Admin
   include ForumSupport::Categories
 

--- a/app/controllers/forums/admin/forums_controller.rb
+++ b/app/controllers/forums/admin/forums_controller.rb
@@ -1,4 +1,4 @@
-class Forums::Admin::ForumsController < FrontendController
+class Forums::Admin::ForumsController < Forums::Admin::HidenForumController
   include ForumSupport::Admin
   include ForumSupport::Forums
 

--- a/app/controllers/forums/admin/hiden_forum_controller.rb
+++ b/app/controllers/forums/admin/hiden_forum_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Forums::Admin::HidenForumController < FrontendController
+  before_action :hide_forum
+
+  private
+
+  def hide_forum
+    raise ActionController::RoutingError, '' unless current_account&.provider_can_use?(:forum)
+  end
+end

--- a/app/controllers/forums/admin/posts_controller.rb
+++ b/app/controllers/forums/admin/posts_controller.rb
@@ -1,4 +1,4 @@
-class Forums::Admin::PostsController < FrontendController
+class Forums::Admin::PostsController < Forums::Admin::HidenForumController
   include ForumSupport::Admin
   include ForumSupport::Posts
 

--- a/app/controllers/forums/admin/subscriptions_controller.rb
+++ b/app/controllers/forums/admin/subscriptions_controller.rb
@@ -1,4 +1,4 @@
-class Forums::Admin::SubscriptionsController < FrontendController
+class Forums::Admin::SubscriptionsController < Forums::Admin::HidenForumController
   include ForumSupport::Admin
   include ForumSupport::UserTopics
 

--- a/app/controllers/forums/admin/topics_controller.rb
+++ b/app/controllers/forums/admin/topics_controller.rb
@@ -1,4 +1,4 @@
-class Forums::Admin::TopicsController < FrontendController
+class Forums::Admin::TopicsController < Forums::Admin::HidenForumController
   include ForumSupport::Admin
   include ForumSupport::Topics
 

--- a/app/controllers/forums/admin/user_topics_controller.rb
+++ b/app/controllers/forums/admin/user_topics_controller.rb
@@ -1,4 +1,4 @@
-class Forums::Admin::UserTopicsController < FrontendController
+class Forums::Admin::UserTopicsController < Forums::Admin::HidenForumController
   include ForumSupport::Admin
   include ForumSupport::UserTopics
 

--- a/app/lib/forum_support/public.rb
+++ b/app/lib/forum_support/public.rb
@@ -15,9 +15,7 @@ module ForumSupport
     private
 
     def render_not_found_if_forum_disabled
-      unless site_account.settings.forum_enabled?
-        render_error("Forum not found", :status => :not_found)
-      end
+      render_error('Page not found', status: :not_found) unless site_account.forum_enabled?
     end
 
     def login_required_unless_public

--- a/config/docker/rolling_updates.yml
+++ b/config/docker/rolling_updates.yml
@@ -11,7 +11,7 @@ base: &default
   apicast_per_service: true
   new_notification_system: true
   cms_api: false
-  forum: true
+  forum: false
   policy_registry: false
   apicast_v2: true
   proxy_private_base_path: true

--- a/config/examples/rolling_updates.yml
+++ b/config/examples/rolling_updates.yml
@@ -11,7 +11,7 @@ base: &default
   apicast_per_service: true
   new_notification_system: true
   cms_api: false
-  forum: true
+  forum: false
   policy_registry: true
   proxy_private_base_path: true
   service_mesh_integration: false

--- a/features/old/forums/anonymous_posting.feature
+++ b/features/old/forums/anonymous_posting.feature
@@ -61,3 +61,11 @@ Feature: Anonymous posting
      And provider "foo.3scale.localhost" has "anonymous posts" disabled
      And I press "Post reply"
     Then I should be on the login page
+
+  Rule: Forum disabled
+    Background:
+      Given I have rolling updates "forum" disabled
+      And provider "foo.3scale.localhost" has "forum" enabled
+
+    Scenario: Buyer cannot access Forum
+      When I should not see forum

--- a/features/old/forums/buyer_side/visibility.feature
+++ b/features/old/forums/buyer_side/visibility.feature
@@ -24,3 +24,14 @@ Feature: Forum visibility
       And I should be on the login page
       And I fill in the "buyer" login data
     Then I should be on the forum subscriptions page
+
+  Rule: Forum disabled
+    Background:
+      Given I have rolling updates "forum" disabled
+      And I am not logged in
+      And provider "foo.3scale.localhost" has "forum" enabled
+
+    Scenario: Buyer cannot access Forum
+      When I request the url of the forum subscriptions page
+      Then I should be on the forum subscriptions page
+      Then I should see "Page not found"

--- a/features/old/forums/buyer_side/visibility.feature
+++ b/features/old/forums/buyer_side/visibility.feature
@@ -14,7 +14,7 @@ Feature: Forum visibility
     Given provider "foo.3scale.localhost" has "forum" disabled
     When I log in as "buyer" on "foo.3scale.localhost"
       And I go to the forum page
-    Then I should see "Forum not found"
+    Then I should see "Page not found"
 
   Scenario: Buyer has to be logged to see the subscriptions page
     Given the current domain is "foo.3scale.localhost"

--- a/features/old/forums/privacy.feature
+++ b/features/old/forums/privacy.feature
@@ -9,14 +9,32 @@ Feature: Forum privacy
     And provider "foo.3scale.localhost" has "forum" enabled
     And the current domain is foo.3scale.localhost
 
-  Scenario: Private forum requires logged in user
-    Given the forum of provider "foo.3scale.localhost" is private
-    When I am not logged in
-      And I go to the forum page
-    Then I should be on the login page
+  Rule: Forum is enabled
+    Background:
+      And I have rolling updates "forum" enabled
 
-  Scenario: Public forum does not require a logged in user
-    Given the forum of provider "foo.3scale.localhost" is public
-    When I am not logged in
+    Scenario: Private forum requires logged in user
+      Given the forum of provider "foo.3scale.localhost" is private
+      When I am not logged in
       And I go to the forum page
-    Then I should be on the forum page
+      Then I should be on the login page
+
+    Scenario: Public forum does not require a logged in user
+      Given the forum of provider "foo.3scale.localhost" is public
+      When I am not logged in
+      And I go to the forum page
+      Then I should be on the forum page
+
+  Rule: Forum is disabled
+    Background:
+      And I have rolling updates "forum" disabled
+
+    Scenario: Private forum is hidden
+      Given the forum of provider "foo.3scale.localhost" is private
+      When I am not logged in
+      Then I should not see forum
+
+    Scenario: Public forum is hidden
+      Given the forum of provider "foo.3scale.localhost" is public
+      When I am not logged in
+      Then I should not see forum

--- a/features/old/forums/subscriptions.feature
+++ b/features/old/forums/subscriptions.feature
@@ -18,10 +18,32 @@ Feature: Users can subscribe to forum topics
      | member_on_foo | active |
     When the current domain is foo.3scale.localhost
 
-  @javascript
-  Scenario: User cannot see Forum
+    @javascript
+  Scenario: Active user can subscribe to topics
     Given I am logged in as "buyer"
-    Then I should not see forum
+    When I navigate to a topic in the forum of "foo.3scale.localhost"
+    Then I should see the link to subscribe to topic
+    When I follow "Subscribe to thread"
+    Then I should see that I am subscribed to the topic
+    Then I should see the link to unsubscribe to topic
+
+
+  Scenario: Email unverified user can not subscribe to topics
+    Given I am logged in as "buyer"
+      And user "buyer" is email unverified
+    When I navigate to a topic in the forum of "foo.3scale.localhost"
+    Then I should see the notice to validate my email
+
+  Scenario: User subscribe to topics
+    Given I am logged in as "buyer"
+    When I navigate to a topic in the forum of "foo.3scale.localhost"
+    When user "buyer" subscribe to the topic in the forum of "foo.3scale.localhost"
+
+    When I navigate to a topic in the forum of "foo.3scale.localhost"
+    Then I should see that I am subscribed to the topic
+      And I should see the link to unsubscribe to topic
+      And I unsubscribe the topic
+      Then I should see the link to subscribe to topic
 
   @emails
   Scenario: Active user subscribed to topic receives email on new posts in topic
@@ -43,7 +65,7 @@ Feature: Users can subscribe to forum topics
     Then the user "foo.3scale.localhost" should not receive an email notifying of the new post
 
 
-  Scenario: User manages can't manage topics because can't see Forum
+  Scenario: User manages its subscriptions to topics
     Given the forum of "foo.3scale.localhost" has the following topics:
       | Topic                    |
       | subscribed topic         |
@@ -55,4 +77,12 @@ Feature: Users can subscribe to forum topics
       | another subscribed topic |
     Given I am logged in as "buyer"
     When I go to the forum page
-    Then I should see "Page not found"
+      And I follow the link to my subscriptions to topics
+
+    Then I should see the topics I follow:
+      | topic                    |
+      | subscribed topic         |
+      | another subscribed topic |
+    But I should not see the topics I do not follow:
+      | topic                    |
+      | no subscribed to topic   |

--- a/features/old/forums/subscriptions.feature
+++ b/features/old/forums/subscriptions.feature
@@ -1,3 +1,4 @@
+# TODO: THREESCALE-8033 Remove this step as it's no longer in use.
 @saas-only
 Feature: Users can subscribe to forum topics
   In order for the forum to be more useful
@@ -17,32 +18,10 @@ Feature: Users can subscribe to forum topics
      | member_on_foo | active |
     When the current domain is foo.3scale.localhost
 
-    @javascript
-  Scenario: Active user can subscribe to topics
+  @javascript
+  Scenario: User cannot see Forum
     Given I am logged in as "buyer"
-    When I navigate to a topic in the forum of "foo.3scale.localhost"
-    Then I should see the link to subscribe to topic
-    When I follow "Subscribe to thread"
-    Then I should see that I am subscribed to the topic
-    Then I should see the link to unsubscribe to topic
-
-
-  Scenario: Email unverified user can not subscribe to topics
-    Given I am logged in as "buyer"
-      And user "buyer" is email unverified
-    When I navigate to a topic in the forum of "foo.3scale.localhost"
-    Then I should see the notice to validate my email
-
-  Scenario: User subscribe to topics
-    Given I am logged in as "buyer"
-    When I navigate to a topic in the forum of "foo.3scale.localhost"
-    When user "buyer" subscribe to the topic in the forum of "foo.3scale.localhost"
-
-    When I navigate to a topic in the forum of "foo.3scale.localhost"
-    Then I should see that I am subscribed to the topic
-      And I should see the link to unsubscribe to topic
-      And I unsubscribe the topic
-      Then I should see the link to subscribe to topic
+    Then I should not see forum
 
   @emails
   Scenario: Active user subscribed to topic receives email on new posts in topic
@@ -64,7 +43,7 @@ Feature: Users can subscribe to forum topics
     Then the user "foo.3scale.localhost" should not receive an email notifying of the new post
 
 
-  Scenario: User manages its subscriptions to topics
+  Scenario: User manages can't manage topics because can't see Forum
     Given the forum of "foo.3scale.localhost" has the following topics:
       | Topic                    |
       | subscribed topic         |
@@ -76,12 +55,4 @@ Feature: Users can subscribe to forum topics
       | another subscribed topic |
     Given I am logged in as "buyer"
     When I go to the forum page
-      And I follow the link to my subscriptions to topics
-
-    Then I should see the topics I follow:
-      | topic                    |
-      | subscribed topic         |
-      | another subscribed topic |
-    But I should not see the topics I do not follow:
-      | topic                    |
-      | no subscribed to topic   |
+    Then I should see "Page not found"

--- a/features/old/forums/subscriptions.feature
+++ b/features/old/forums/subscriptions.feature
@@ -8,7 +8,7 @@ Feature: Users can subscribe to forum topics
     Given a published plan "Basic" of provider "Master account"
       And plan "Basic" has "Forum" enabled
     Given a provider "foo.3scale.localhost" signed up to plan "Basic"
-    And all the rolling updates features are off
+    And all the rolling updates features are on
       And provider "foo.3scale.localhost" has "forum" enabled
       And the forum of "foo.3scale.localhost" have topics
       And a buyer "buyer" signed up to provider "foo.3scale.localhost"
@@ -86,3 +86,11 @@ Feature: Users can subscribe to forum topics
     But I should not see the topics I do not follow:
       | topic                    |
       | no subscribed to topic   |
+
+  Rule: Forum disabled
+    Background:
+      Given I have rolling updates "forum" disabled
+      And provider "foo.3scale.localhost" has "forum" enabled
+
+    Scenario: Buyer cannot access Forum
+      When I should not see forum

--- a/features/old/forums/subscriptions.feature
+++ b/features/old/forums/subscriptions.feature
@@ -45,18 +45,16 @@ Feature: Users can subscribe to forum topics
       And I unsubscribe the topic
       Then I should see the link to subscribe to topic
 
-  @emails
+  @emails @wip
   Scenario: Active user subscribed to topic receives email on new posts in topic
     Given user "buyer" is subscribed to the topic in the forum of "foo.3scale.localhost"
     When the user "member_on_foo" post in the topic in the forum of "foo.3scale.localhost"
     Then the user "buyer" should receive an email notifying of the new post
 
-
   Scenario: Active user subscribed to topic does not receive email when he creates a new post in topic
     Given user "foo.3scale.localhost" is subscribed to the topic in the forum of "foo.3scale.localhost"
     When the user "foo.3scale.localhost" post in the topic in the forum of "foo.3scale.localhost"
     Then the user "foo.3scale.localhost" should not receive an email notifying of the new post
-
 
   Scenario: Email unverified user subscribed to topic does not receives email on new posts in topic
     Given user "foo.3scale.localhost" is subscribed to the topic in the forum of "foo.3scale.localhost"

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -15,9 +15,10 @@ When 'I navigate to the accounts page' do
   click_link href: admin_buyers_accounts_path
 end
 
-When "I navigate to a topic in the forum of {forum}" do |forum|
+# TODO: THREESCALE-8033 Remove this step as it's no longer in use.
+When "I should not see forum" do
   visit forum_path
-  click_link forum.topics.first.title
+  step 'I should see "Page not found"'
 end
 
 When /^I navigate to the forum admin page$/ do

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -16,6 +16,11 @@ When 'I navigate to the accounts page' do
 end
 
 # TODO: THREESCALE-8033 Remove this step as it's no longer in use.
+When "I navigate to a topic in the forum of {forum}" do |forum|
+  visit forum_path
+  click_link forum.topics.first.title
+end
+
 When "I should not see forum" do
   visit forum_path
   step 'I should see "Page not found"'

--- a/features/step_definitions/security/topic_steps.rb
+++ b/features/step_definitions/security/topic_steps.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# TODO: THREESCALE-8033 Remove these steps as it's no longer in use.
+
 When "I request the url to edit the first topic on the forum of {forum}" do |forum|
   visit edit_admin_forum_topic_path(forum.topics.first)
 end

--- a/test/helpers/vertical_nav_helper_test.rb
+++ b/test/helpers/vertical_nav_helper_test.rb
@@ -3,12 +3,22 @@
 require 'test_helper'
 
 class VerticalNavHelperTest < ActionView::TestCase
+  setup do
+    @current_account = FactoryBot.create(:simple_provider)
+
+    @current_user = FactoryBot.create(:simple_user, account: current_account)
+
+    stubs(can?: true, edit_legal_terms_url: '', logged_in?: '', user_has_subscriptions?: true)
+  end
+
+  attr_reader :current_account, :current_user
+
+  delegate :provider_can_use?, :master_on_premises?, to: :current_account
 
   test '#backend_api_nav_sections' do
     @backend_api = FactoryBot.create(:backend_api)
 
     # if permitted
-    stubs(can?: true)
     assert_equal(["Overview", "Analytics", "Methods & Metrics", "Mapping Rules"], backend_api_nav_sections.pluck(:title))
 
     # if not permitted
@@ -19,9 +29,30 @@ class VerticalNavHelperTest < ActionView::TestCase
     @backend_api = BackendApi.new
     assert_equal([], backend_api_nav_sections.pluck(:title))
 
-
     # When backend_api is nil
     @backend_api = nil
     assert_equal([], backend_api_nav_sections.pluck(:title))
+  end
+
+  test 'Forum is disabled in saas' do
+    rolling_update(:forum, enabled: true)
+
+    current_account.settings.forum_enabled = false
+    assert_includes audience_portal_items.pluck(:id), :forum_settings
+    assert_not_includes audience_nav_sections.pluck(:id), :forum
+
+    current_account.settings.forum_enabled = true
+    assert_not_includes audience_portal_items.pluck(:id), :forum_settings
+    assert_includes audience_nav_sections.pluck(:id), :forum
+
+    rolling_update(:forum, enabled: false)
+
+    current_account.settings.forum_enabled = false
+    assert_not_includes audience_portal_items.pluck(:id), :forum_settings
+    assert_not_includes audience_nav_sections.pluck(:id), :forum
+
+    current_account.settings.forum_enabled = true
+    assert_not_includes audience_portal_items.pluck(:id), :forum_settings
+    assert_not_includes audience_nav_sections.pluck(:id), :forum
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

PR in deploy repo: https://github.com/3scale/deploy/pull/727

Updates public forum support helper to check rolling update, not only the provider setting for Forum. This way by switching the rolling update `forum` off all Forum functionality will be hidden.

New providers won't have Forum templates in their CMS either.

ForumsController will now raise an error when the RU is off, showing a 404 page:
![Screenshot 2022-01-24 at 18 33 43](https://user-images.githubusercontent.com/11672286/150834591-167f1929-72fe-44d8-ab5d-d33b25507190.png)


**Which issue(s) this PR fixes** 

[THREESCALE-8032: Hide forum functionality from all users (dev portal)](https://issues.redhat.com/browse/THREESCALE-8032)

**Verification steps** 

Set rolling update `forum: false` and reset the DB, then start the server. Forum should not be visible anywhere:
- Audience > Forum
- Audience > Dev portal > Settings > Forum settings
- Audience > Dev portal > Content (search for Forum templates)
- Manually access `/forum`
- Visit to Dev portal and navigate to /forum (should return Page not found)

