### PR TITLE
THREESCALE-8042: Retrieve deploy info from env variable

### DIFF
--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -58,7 +58,20 @@ module System
       end
     end
 
+    def self.deploy_info_env
+      ENV.keys.filter { |key| key.start_with?("DEPLOY_INFO") }.each_with_object({}) do |key, deploy_info|
+        deploy_info[key.delete_prefix("DEPLOY_INFO_").downcase] = ENV[key]
+      end
+    end
+
     def self.parse_deploy_info
+      from_env = deploy_info_env
+      return read_deploy_info if from_env.empty?
+
+      from_env
+    end
+
+    def self.read_deploy_info
       path = Rails.root.join('.deploy_info').expand_path
       return { error: { path: path.to_s, message: 'not found' } } unless path.exist?
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

The deploy info is currently obtained from a `.deploy_info` JSON file. Add the ability to obtain these data from DEPLOY_INFO_` environment variables.

Example:
```
DEPLOY_INFO_RELEASE=2.11
DEPLOY_INFO_REVISION=2.11-stable
```
Will result in the following:
```
{ release => "2.11", revision => "2.11-stable" }
```

If the environment variables aren't set, default on the `.deploy_info` file.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-8042

**Verification steps** 

Open a console with the environment variables and ensure that the deploy info is populated:

```sh
DEPLOY_INFO_RELEASE=2.11 DEPLOY_INFO_REVISION=2.11-stable rails console
```
```ruby
System::Deploy.info
=> #<System::Deploy::Info:0x000000000b556878 @deployed_at=2022-01-17 16:06:44 +0000, @release="2.11", @revision="2.11-stable">

```
