### PR TITLE
Sphinx index only non-deleted accounts

### DIFF
--- a/app/indices/account_index.rb
+++ b/app/indices/account_index.rb
@@ -61,7 +61,10 @@ module AccountIndex
     protected
 
     def index_account
-      SphinxIndexationWorker.perform_later(self) unless master?
+      return if master?
+
+      SphinxIndexationWorker.perform_later(self)
+      buyers.find_each { |buyer| SphinxIndexationWorker.perform_later(buyer) } if provider? && will_be_deleted?
     end
   end
 

--- a/app/indices/account_index.rb
+++ b/app/indices/account_index.rb
@@ -13,12 +13,12 @@ ThinkingSphinx::Index.define(:account, with: :real_time) do
 
   set_property field_weights: { name: 2 }
   set_property charset_table: "0..9, A..Z->a..z, a..z, U+23, U+25, U+27, U+2A..U+2C, U+2E, U+3A, U+3B, U+3F, U+5F, U+60, U+7B, U+7D"
-  
+
   has :provider_account_id, type: :bigint
   has :tenant_id, type: :bigint
   has :state, type: :string
 
-  scope { Account.not_master.includes(:users, :bought_cinstances) }
+  scope { Account.not_master.without_to_be_deleted.includes(:users, :bought_cinstances) }
 end
 
 module AccountIndex

--- a/app/indices/account_index.rb
+++ b/app/indices/account_index.rb
@@ -61,10 +61,7 @@ module AccountIndex
     protected
 
     def index_account
-      return if master?
-
-      SphinxIndexationWorker.perform_later(self)
-      buyers.find_each { |buyer| SphinxIndexationWorker.perform_later(buyer) } if provider? && will_be_deleted?
+      SphinxAccountIndexationWorker.perform_later(self) unless master?
     end
   end
 
@@ -85,7 +82,7 @@ module AccountIndex
     def index_account
       return unless account_for_sphinx&.persisted?
 
-      SphinxIndexationWorker.perform_later(account_for_sphinx)
+      SphinxAccountIndexationWorker.perform_later(account_for_sphinx)
     end
   end
 end

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -94,6 +94,7 @@ module Account::States
 
     scope :without_suspended, -> { where.not(state: :suspended) }
     scope :without_deleted, ->(without = true) { where.has { state != :scheduled_for_deletion } if without }
+    scope :without_to_be_deleted, ->(without = true) { without_deleted.where.not(provider_account: unscoped.scheduled_for_deletion) if without }
 
     scope :by_state, ->(state) do
       where(:state => state.to_s) if state.to_s != "all"

--- a/app/workers/sphinx_account_indexation_worker.rb
+++ b/app/workers/sphinx_account_indexation_worker.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'sphinx_indexation_worker'
+
+# SphinxAccountIndexationWorker updates sphinx index for the Account model.
+# It is enqueued when:
+# - Account gets created and updated (deletion is handled only when scheduled for deletion)
+# - User gets created, updated, deleted
+# - Cinstance gets created, updated, deleted
+# fixme: destroy doesn't remove indexes due to disabled callbacks in config/initializers/sphinx.rb
+class SphinxAccountIndexationWorker < SphinxIndexationWorker
+  def perform(account)
+    if account.will_be_deleted?
+      to_delete = account.buyers.pluck(:id) << account.id
+      # This is how deletion is performed by ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks#delete_from_sphinx
+      # If callbacks were enabled, we could delete individual records one by one with:
+      # ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks.after_destroy(instance)
+      indices(account).each do |index|
+        ThinkingSphinx::Deletion.perform index, to_delete
+      end
+    else
+      super
+    end
+  end
+end

--- a/config/initializers/sphinx.rb
+++ b/config/initializers/sphinx.rb
@@ -17,19 +17,7 @@ ThinkingSphinx::Configuration::MinimumFields.prepend(Module.new do
   end
 end)
 
-class ThinkingSphinx::Callbacks
-  def self.resume
-    return unless ThinkingSphinx::Callbacks.suspended?
-
-    begin
-      ThinkingSphinx::Callbacks.resume!
-      yield
-    ensure
-      ThinkingSphinx::Callbacks.suspend!
-    end
-  end
-end
-
-# TODO: handle destroy for models we want incrementally deleted
+# TODO: in ts v5.3 it probably shouldn't hurt to allow callbacks so we have
+#       destroy for models automatically, see
 # ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks.after_destroy(model)
 ThinkingSphinx::Callbacks.suspend!

--- a/config/initializers/sphinx.rb
+++ b/config/initializers/sphinx.rb
@@ -17,4 +17,19 @@ ThinkingSphinx::Configuration::MinimumFields.prepend(Module.new do
   end
 end)
 
+class ThinkingSphinx::Callbacks
+  def self.resume
+    return unless ThinkingSphinx::Callbacks.suspended?
+
+    begin
+      ThinkingSphinx::Callbacks.resume!
+      yield
+    ensure
+      ThinkingSphinx::Callbacks.suspend!
+    end
+  end
+end
+
+# TODO: handle destroy for models we want incrementally deleted
+# ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks.after_destroy(model)
 ThinkingSphinx::Callbacks.suspend!

--- a/test/monkey_patches/active_job_test_helper.rb
+++ b/test/monkey_patches/active_job_test_helper.rb
@@ -1,7 +1,7 @@
 require 'active_job/test_helper'
 require 'active_job/queue_adapters/test_adapter'
 
-# TODO: Remove this Monkey patch after we move to Rails 5.
+# TODO: Remove this Monkey patch after we move to Rails 5.2
 # This is used to ensure that we run only a specific job in a Test.
 # It was extracted from
 # https://github.com/rails/rails/blob/fc5dd0b85189811062c85520fd70de8389b55aeb/activejob/lib/active_job/test_helper.rb#L368

--- a/test/test_helpers/sphinx.rb
+++ b/test/test_helpers/sphinx.rb
@@ -14,6 +14,11 @@ module ThinkingSphinx
       end
       alias_method :rt_run, :real_time_run
 
+      def disable_real_time_callbacks!
+        original_settings = ThinkingSphinx::Configuration.instance.settings
+        new_settings = original_settings.dup.merge({"real_time_callbacks" => false})
+        ThinkingSphinx::Configuration.any_instance.stubs(:settings).returns(new_settings)
+      end
     end
   end
 end

--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -65,28 +65,6 @@ class Account::SearchTest < ActiveSupport::TestCase
     assert_equal 'fo\/o', Account.search_ids('fo/o').query
   end
 
-  test 'search with query by email' do
-    ThinkingSphinx::Test.rt_run do
-      perform_enqueued_jobs(only: SphinxIndexationWorker) do
-        provider = FactoryBot.create(:simple_provider)
-        buyers = FactoryBot.create_list(:simple_buyer, 2, provider_account: provider)
-        ['foo@bar.co.example.com', 'foo@example.org'].each_with_index do |email, buyer_index|
-          FactoryBot.create(:admin, account: buyers[buyer_index], email: email)
-        end
-
-        buyers = provider.buyer_accounts.scope_search(:query => 'foo@bar.co.example.com')
-        expected_buyer = User.find_by!(email: 'foo@bar.co.example.com').account
-        assert_equal [expected_buyer], buyers
-
-        # incrementally delete accounts from index even if soft-deleted
-        provider.smart_destroy
-        assert Account.exists?(provider.id)
-        assert_equal 2, provider.buyer_accounts.size
-        assert_equal [], provider.buyer_accounts.scope_search(:query => 'foo@bar.co.example.com')
-      end
-    end
-  end
-
   test 'search_ids options' do
     ThinkingSphinx::Test.rt_run do
       assert Account.buyers.search_ids('foo').populate
@@ -137,7 +115,7 @@ class Account::SearchTest < ActiveSupport::TestCase
 
   test 'search user_key without keyword with many records is always indexed and found' do
     ThinkingSphinx::Test.rt_run do
-      perform_enqueued_jobs(only: SphinxIndexationWorker) do
+      perform_enqueued_jobs(only: SphinxAccountIndexationWorker) do
         service = FactoryBot.create(:simple_service)
         buyer = FactoryBot.create(:simple_buyer)
         FactoryBot.create_list(:application_plan, 5, issuer: service).each_with_index do |plan, index|
@@ -172,5 +150,64 @@ class Account::SearchTest < ActiveSupport::TestCase
     buyers.first.update_attribute(:created_at, '2019-02-10'.to_time)
     result = provider.buyers.scope_search(created_within: ['2019-01-01', '2019-01-31'])
     assert_equal 2, result.size
+  end
+
+  class IncrementalIndexingTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
+    attr_reader :provider, :buyers
+
+    setup do
+      ThinkingSphinx::Test.clear
+      ThinkingSphinx::Test.init
+      ThinkingSphinx::Test.start index: false
+      perform_enqueued_jobs(only: SphinxAccountIndexationWorker) do
+        @provider = FactoryBot.create(:simple_provider)
+        @buyers = FactoryBot.create_list(:simple_buyer, 2, provider_account: provider)
+        ['foo@bar.co.example.com', 'foo@example.org'].each_with_index do |email, buyer_index|
+          FactoryBot.create(:admin, account: buyers[buyer_index], email: email)
+        end
+      end
+    end
+
+    teardown do
+      ThinkingSphinx::Test.stop
+    end
+
+    test 'search with query by email' do
+      buyers = provider.buyer_accounts.scope_search(:query => 'foo@bar.co.example.com')
+      expected_buyer = User.find_by!(email: 'foo@bar.co.example.com').account
+      assert_equal [expected_buyer], buyers
+    end
+
+    test 'soft-deleting accounts removed from index' do
+      assert_not_empty Account.search(Riddle.escape('foo@bar.co.example.com'), middleware: ThinkingSphinx::Middlewares::IDS_ONLY).to_a
+
+      perform_enqueued_jobs(only: SphinxAccountIndexationWorker) do
+        FactoryBot.create(:simple_provider) # second provider
+        provider.smart_destroy
+      end
+      indexed_ids = Account.search(middleware: ThinkingSphinx::Middlewares::IDS_ONLY).to_a
+
+      assert Account.exists?(provider.id)
+      assert_equal 2, provider.buyer_accounts.size
+      assert_empty Account.search(Riddle.escape('foo@bar.co.example.com'), middleware: ThinkingSphinx::Middlewares::IDS_ONLY).to_a
+      assert_not_empty indexed_ids
+      assert_not_includes indexed_ids, provider.id
+      provider.buyers.pluck(:id).each { |id| assert_not_includes indexed_ids, id }
+    end
+
+    test 'hard deleting account removes from index' do
+      buyer = User.find_by!(email: 'foo@bar.co.example.com').account
+      perform_enqueued_jobs(only: SphinxAccountIndexationWorker) do
+        buyer.smart_destroy
+      end
+      assert_not Account.exists?(buyer.id)
+
+      # because we suspend callbacks, index stays even after object is destroyed, see config/initializers/sphinx.rb
+      # we need to fix this and remove from index deleted objects
+      # TODO: after we fix, change this to assert_not_includes
+      assert_includes Account.search(middleware: ThinkingSphinx::Middlewares::IDS_ONLY), buyer.id
+    end
   end
 end

--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -77,6 +77,12 @@ class Account::SearchTest < ActiveSupport::TestCase
         buyers = provider.buyer_accounts.scope_search(:query => 'foo@bar.co.example.com')
         expected_buyer = User.find_by!(email: 'foo@bar.co.example.com').account
         assert_equal [expected_buyer], buyers
+
+        # incrementally delete accounts from index even if soft-deleted
+        provider.smart_destroy
+        assert Account.exists?(provider.id)
+        assert_equal 2, provider.buyer_accounts.size
+        assert_equal [], provider.buyer_accounts.scope_search(:query => 'foo@bar.co.example.com')
       end
     end
   end

--- a/test/unit/presenters/buyers/accounts_index_presenter_test.rb
+++ b/test/unit/presenters/buyers/accounts_index_presenter_test.rb
@@ -20,7 +20,7 @@ class Buyers::AccountsIndexPresenterTest < ActiveSupport::TestCase
 
   test "filter buyers by query" do
     ThinkingSphinx::Test.rt_run do
-      perform_enqueued_jobs(only: SphinxIndexationWorker) do
+      perform_enqueued_jobs(only: SphinxAccountIndexationWorker) do
         FactoryBot.create(:simple_buyer, name: 'Pepe Account', provider_account: provider)
         FactoryBot.create(:simple_buyer, name: 'Pepa Account', provider_account: provider)
       end

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -20,8 +20,9 @@ module Tasks
       default_service.reload
 
       ThreeScale::Core::Service.expects(:make_default).with(another_service.backend_id)
+      ThinkingSphinx::Test.disable_real_time_callbacks!
       assert_difference(EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent.to_s).method(:count)) do
-        perform_enqueued_jobs(except: SphinxIndexationWorker) do
+        perform_enqueued_jobs do
           execute_rake_task 'services.rake', 'services:destroy_service', account.id, default_service.id
         end
       end

--- a/test/workers/delete_object_hierarchy_worker_test.rb
+++ b/test/workers/delete_object_hierarchy_worker_test.rb
@@ -10,7 +10,8 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
   end
 
   def test_perform
-    perform_enqueued_jobs(except: SphinxIndexationWorker) do
+    ThinkingSphinx::Test.disable_real_time_callbacks!
+    perform_enqueued_jobs do
       perform_expectations
 
       hierarchy_worker.perform_now(object)
@@ -173,7 +174,8 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
     attr_reader :member, :member_permission
 
     def test_perform
-      perform_enqueued_jobs(except: SphinxIndexationWorker) { DeleteObjectHierarchyWorker.perform_now(member) }
+      ThinkingSphinx::Test.disable_real_time_callbacks!
+      perform_enqueued_jobs { DeleteObjectHierarchyWorker.perform_now(member) }
 
       assert_raises(ActiveRecord::RecordNotFound) { member_permission.reload }
       assert_raises(ActiveRecord::RecordNotFound) { member.reload }

--- a/test/workers/sphinx_account_indexation_worker_test.rb
+++ b/test/workers/sphinx_account_indexation_worker_test.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative 'sphinx_indexation_worker_test'
+
+class SphinxAccountIndexationWorkerTest < SphinxIndexationWorker; end

--- a/test/workers/sphinx_indexation_worker_test.rb
+++ b/test/workers/sphinx_indexation_worker_test.rb
@@ -14,9 +14,14 @@ class SphinxIndexationWorkerTest < ActiveSupport::TestCase
     callback.expects(:after_commit).with(account)
 
     ThinkingSphinx::Test.rt_run do
-      perform_enqueued_jobs only: SphinxIndexationWorker do
-        SphinxIndexationWorker.perform_later(account)
+      perform_enqueued_jobs only: indexation_class do
+        indexation_class.perform_later(account)
       end
     end
+  end
+
+  private
+  def indexation_class
+    Object.const_get(self.class.name.sub(/Test$/, ""))
   end
 end


### PR DESCRIPTION
we may also need to add a callback when state of account changes to `scheduled_for_deletion`. But this probably will quickly reduce index size.