### PR TITLE
Fixes errors with sphinx BackendStorageRewriteWorker

### DIFF
--- a/app/workers/backend_storage_rewrite_worker.rb
+++ b/app/workers/backend_storage_rewrite_worker.rb
@@ -20,7 +20,6 @@ class BackendStorageRewriteWorker
   end
 
   def perform(provider_id)
-    provider = Provider.find(provider_id)
-    Backend::StorageRewrite.rewrite_provider(provider)
+    Backend::StorageRewrite.rewrite_provider(provider_id)
   end
 end


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

Fixes this errors that appears in the thinking sphinx logs.

```log
2021-12-14T12:38:36.221Z 132730 TID-1ovjl6 WARN: {"context":"Job raised exception","job":{"class":"BackendStorageRewriteWorker","args":[1],"retry":true,"queue":"low","jid":"34e41e7542db77ef034f3b32","created_at":1639485407.7940912,"bid":"yJVM1slCL5sCAA","enqueued_at":1639485516.1842265,"error_message":"You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.","error_class":"ArgumentError","failed_at":1639485407.819227,"retry_count":2,"retried_at":1639485465.4869988},"jobstr":"{\"class\":\"BackendStorageRewriteWorker\",\"args\":[1],\"retry\":true,\"queue\":\"low\",\"jid\":\"34e41e7542db77ef034f3b32\",\"created_at\":1639485407.7940912,\"bid\":\"yJVM1slCL5sCAA\",\"enqueued_at\":1639485516.1842265,\"error_message\":\"You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.\",\"error_class\":\"ArgumentError\",\"failed_at\":1639485407.819227,\"retry_count\":2,\"retried_at\":1639485465.4869988}"}
2021-12-14T12:38:36.222Z 132730 TID-1ovjl6 WARN: ArgumentError: You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.
2021-12-14T12:38:36.222Z 132730 TID-1ovjl6 WARN: /home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/activerecord-5.1.7/lib/active_record/relation/finder_methods.rb:451:in `find_one'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/activerecord-5.1.7/lib/active_record/relation/finder_methods.rb:440:in `find_with_ids'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/activerecord-5.1.7/lib/active_record/relation/finder_methods.rb:66:in `find'
/home/avalon/ws/repos/porta/app/lib/backend/storage_rewrite.rb:52:in `rewrite_provider'
/home/avalon/ws/repos/porta/app/workers/backend_storage_rewrite_worker.rb:24:in `perform'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:192:in `execute_job'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:165:in `block (2 levels) in process'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:128:in `block in invoke'
/home/avalon/ws/repos/porta/lib/three_scale/sidekiq_retry_support.rb:56:in `call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/home/avalon/ws/repos/porta/app/lib/three_scale/analytics/sidekiq_middleware.rb:5:in `call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-throttled-0.11.0/lib/sidekiq/throttled/middleware.rb:14:in `call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/bugsnag-6.11.1/lib/bugsnag/integrations/sidekiq.rb:24:in `call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/yabeda-sidekiq-0.7.0/lib/yabeda/sidekiq/server_middleware.rb:16:in `block in call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/yabeda-0.8.0/lib/yabeda/dsl/class_methods.rb:69:in `with_tags'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/yabeda-sidekiq-0.7.0/lib/yabeda/sidekiq/server_middleware.rb:15:in `call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-lock-0.4.0/lib/sidekiq/lock/middleware.rb:8:in `call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-batch-0.1.6/lib/sidekiq/batch/middleware.rb:20:in `call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/middleware/chain.rb:133:in `invoke'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:164:in `block in process'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:137:in `block (6 levels) in dispatch'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/job_retry.rb:109:in `local'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:136:in `block (5 levels) in dispatch'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/rails.rb:43:in `block in call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/activesupport-5.1.7/lib/active_support/execution_wrapper.rb:85:in `wrap'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/activesupport-5.1.7/lib/active_support/reloader.rb:68:in `block in wrap'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/activesupport-5.1.7/lib/active_support/execution_wrapper.rb:85:in `wrap'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/activesupport-5.1.7/lib/active_support/reloader.rb:67:in `wrap'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/rails.rb:42:in `call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:132:in `block (4 levels) in dispatch'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:250:in `stats'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:127:in `block (3 levels) in dispatch'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/job_logger.rb:8:in `call'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:126:in `block (2 levels) in dispatch'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/job_retry.rb:74:in `global'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:125:in `block in dispatch'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/logging.rb:48:in `with_context'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/logging.rb:42:in `with_job_hash_context'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:124:in `dispatch'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:163:in `process'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:83:in `process_one'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/processor.rb:71:in `run'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/util.rb:16:in `watchdog'
/home/avalon/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/sidekiq-5.2.9/lib/sidekiq/util.rb:25:in `block in safe_thread'

```