### PR TITLE
THREESCALE-8009 Prevent emails from being sent without subject and/or…

### DIFF
--- a/app/views/buyers/applications/bulk/send_emails/new.html.erb
+++ b/app/views/buyers/applications/bulk/send_emails/new.html.erb
@@ -5,9 +5,9 @@
   } do |form| %>
   <%= form.inputs do %>
     <%= render 'buyers/applications/bulk/selected_applications', applications: applications %>
-    <%= form.input :to, :as => :string, :input_html => {:disabled => true, :value => "#{applications.count} selected applications"} %>
-    <%= form.input :subject, :as => :string %>
-    <%= form.input :body, :as => :text, :input_html => {:rows => 10} %>
+    <%= form.input :to, :as => :string, input_html: {required: true , :disabled => true, :value => "#{applications.count} selected applications"} %>
+    <%= form.input :subject, :as => :string, input_html: {required: true } %>
+    <%= form.input :body, :as => :text, input_html: {:rows => 10, required: true } %>
     <%= form.buttons do %>
       <%= form.commit_button 'Send', :button_html => {:'data-disable-with' => 'Running bulk action...' } %>
     <% end %>


### PR DESCRIPTION
**What this PR does / why we need it:**

When sending emails from the bulk operations emails can be sent if body and subject is empty
make those field required 

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/THREESCALE-8009