### PR TITLE
fix: Allow tenant_id to be propagated from account

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -99,7 +99,7 @@ class Account < ApplicationRecord
 
   before_validation(on: :create, if: :provider?) { generate_s3_prefix }
   before_validation(on: :create, if: :provider?) { generate_domains }
-  before_create :generate_site_access_code
+  before_create :generate_site_access_code, :set_default_master
 
   attr_protected :master, :provider, :buyer, :from_email, :vat_rate, :sample_data, :default_service_id, :s3_prefix,
                  :provider_account_id, :paid_at, :paid, :signs_legal_terms, :tenant_id, :default_account_plan_id,
@@ -578,6 +578,12 @@ class Account < ApplicationRecord
 
   def generate_site_access_code
     self.site_access_code ||= SecureRandom.hex(5) if provider?
+  end
+
+  def set_default_master
+    # prevent null values that confuse some SQL hooks
+    self.master = provider? && master?
+    true
   end
 
   def destroy_all_users

--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class SetTenantIdWorker < ApplicationJob
+
+  def perform(provider)
+    provider.update_column(:master, false)
+
+    [:backend_apis, :log_entries, :alerts].each do |relation|
+      provider.public_send(relation).where(tenant_id: nil).find_each do |instance|
+        ModelTenantIdWorker.perform_later(instance, provider.tenant_id)
+      end
+    end
+  end
+
+  class BatchEnqueueWorker < ApplicationJob
+    unique :until_executed
+
+    def perform(*)
+      Account.providers.where(master: nil).find_each do |provider|
+        SetTenantIdWorker.perform_later(provider)
+      end
+    end
+  end
+
+  class ModelTenantIdWorker < ApplicationJob
+
+    def perform(object, tenant_id)
+      object.update_column(:tenant_id, tenant_id)
+    end
+
+  end
+
+end

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -305,4 +305,9 @@ namespace :fixes do
     exec_batch.call(:providers, Account.providers, provider_states_transitions)
     exec_batch.call(:developers, Account.buyers, buyer_states_transitions)
   end
+
+  desc 'Fix tenant_id missing in some tables'
+  task :tenant_id => :environment do
+    SetTenantIdWorker::BatchEnqueueWorker.perform_later
+  end
 end


### PR DESCRIPTION
supersedes #2759

fixes THREESCALE-7676