### PR TITLE
THREESCALE-7676 fix tenant_id triggers

### DIFF
--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class SetTenantIdWorker < ApplicationJob
+
+  def perform(provider)
+    provider.update_column(:master, false)
+
+    [:backend_apis, :log_entries, :alerts].each do |relation|
+      provider.public_send(relation).where(tenant_id: nil).find_each do |instance|
+        ModelTenantIdWorker.perform_later(instance, provider.tenant_id)
+      end
+    end
+  end
+
+  class BatchEnqueueWorker < ApplicationJob
+    unique :until_executed
+
+    def perform(*)
+      Account.providers.where(master: nil).find_each do |provider|
+        SetTenantIdWorker.perform_later(provider)
+      end
+    end
+  end
+
+  class ModelTenantIdWorker < ApplicationJob
+
+    def perform(object, tenant_id)
+      object.update_column(:tenant_id, tenant_id)
+    end
+
+  end
+
+end

--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -21,7 +21,7 @@ System::Database::MySQL.define do
 
   trigger 'alerts' do
     <<~SQL
-      SET NEW.tenant_id = (SELECT tenant_id FROM accounts WHERE id = NEW.account_id AND NOT master);
+      SET NEW.tenant_id = (SELECT tenant_id FROM accounts WHERE id = NEW.account_id AND (NOT master OR master is NULL));
     SQL
   end
 
@@ -415,7 +415,7 @@ System::Database::MySQL.define do
 
   trigger 'log_entries' do
     <<~SQL
-      SET NEW.tenant_id = (SELECT tenant_id FROM accounts WHERE id = NEW.provider_id AND NOT master);
+      SET NEW.tenant_id = (SELECT tenant_id FROM accounts WHERE id = NEW.provider_id AND (NOT master OR master is NULL));
     SQL
   end
 
@@ -435,7 +435,7 @@ System::Database::MySQL.define do
 
   trigger 'backend_apis' do
     <<~SQL
-      SET NEW.tenant_id = (SELECT tenant_id FROM accounts WHERE id = NEW.account_id AND NOT master);
+      SET NEW.tenant_id = (SELECT tenant_id FROM accounts WHERE id = NEW.account_id AND (NOT master OR master is NULL));
     SQL
   end
 

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -21,7 +21,7 @@ System::Database::Oracle.define do
 
   trigger 'alerts' do
     <<~SQL
-      SELECT tenant_id INTO :new.tenant_id FROM accounts WHERE id = :new.account_id AND master <> 1;
+      SELECT tenant_id INTO :new.tenant_id FROM accounts WHERE id = :new.account_id AND (master <> 1 OR master is NULL);
     SQL
   end
 
@@ -425,7 +425,7 @@ System::Database::Oracle.define do
 
   trigger 'log_entries' do
     <<~SQL
-      SELECT tenant_id INTO :new.tenant_id FROM accounts WHERE id = :new.provider_id AND master <> 1;
+      SELECT tenant_id INTO :new.tenant_id FROM accounts WHERE id = :new.provider_id AND (master <> 1 OR master is NULL);
     SQL
   end
 
@@ -445,7 +445,7 @@ System::Database::Oracle.define do
 
   trigger 'backend_apis' do
     <<~SQL
-      SELECT tenant_id INTO :new.tenant_id FROM accounts WHERE id = :new.account_id AND master <> 1;
+      SELECT tenant_id INTO :new.tenant_id FROM accounts WHERE id = :new.account_id AND (master <> 1 OR master is NULL);
     SQL
   end
 

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -21,7 +21,7 @@ System::Database::Postgres.define do
 
   trigger 'alerts' do
     <<~SQL
-      SELECT tenant_id INTO NEW.tenant_id FROM accounts WHERE id = NEW.account_id AND master <> TRUE;
+      SELECT tenant_id INTO NEW.tenant_id FROM accounts WHERE id = NEW.account_id AND (master <> TRUE OR master is NULL);
     SQL
   end
 
@@ -425,7 +425,7 @@ System::Database::Postgres.define do
 
   trigger 'log_entries' do
     <<~SQL
-      SELECT tenant_id INTO NEW.tenant_id FROM accounts WHERE id = NEW.provider_id AND master <> TRUE;
+      SELECT tenant_id INTO NEW.tenant_id FROM accounts WHERE id = NEW.provider_id AND (master <> TRUE OR master is NULL);
     SQL
   end
 
@@ -445,7 +445,7 @@ System::Database::Postgres.define do
 
   trigger 'backend_apis' do
     <<~SQL
-      SELECT tenant_id INTO NEW.tenant_id FROM accounts WHERE id = NEW.account_id AND master <> TRUE;
+      SELECT tenant_id INTO NEW.tenant_id FROM accounts WHERE id = NEW.account_id AND (master <> TRUE OR master is NULL);
     SQL
   end
 

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -305,4 +305,9 @@ namespace :fixes do
     exec_batch.call(:providers, Account.providers, provider_states_transitions)
     exec_batch.call(:developers, Account.buyers, buyer_states_transitions)
   end
+
+  desc 'Fix tenant_id missing in some tables'
+  task :tenant_id => :environment do
+    SetTenantIdWorker::BatchEnqueueWorker.perform_later
+  end
 end

--- a/test/models/backend_api_test.rb
+++ b/test/models/backend_api_test.rb
@@ -90,6 +90,14 @@ class BackendApiTest < ActiveSupport::TestCase
     refute BackendApi.exists? backend_api.id
   end
 
+  test "tenant_id trigger" do
+    @account.save!
+    @account.tenant_id = @account.id
+    @account.save!
+    backend_api = FactoryBot.create(:backend_api, account: @account)
+    assert_equal @account.id, backend_api.reload.tenant_id
+  end
+
   class ProxyConfigAffectingChangesTest < ActiveSupport::TestCase
     disable_transactional_fixtures!
 

--- a/test/unit/alert_test.rb
+++ b/test/unit/alert_test.rb
@@ -24,6 +24,13 @@ class AlertTest < ActiveSupport::TestCase
     assert_equal :alert, Alert.new(level: 0).kind
   end
 
+  test "tenant_id trigger" do
+    account = FactoryBot.create(:buyer_account)
+    alert = FactoryBot.create(:limit_alert, level: 80, account: account)
+    assert alert.reload.tenant_id
+    assert_equal account.reload.tenant_id, alert.tenant_id
+  end
+
   test 'Alert#kind should return :violation if its violation' do
     assert_equal :violation, Alert.new(level: 100).kind
     assert_equal :violation, Alert.new(level: 300).kind

--- a/test/unit/log_entry_test.rb
+++ b/test/unit/log_entry_test.rb
@@ -19,6 +19,12 @@ class LogEntryTest < ActiveSupport::TestCase
     assert_not_nil entry.buyer
   end
 
+  test "tenant_id trigger" do
+    assert @provider.tenant_id
+    entry = LogEntry.log :info, 'all your base are belong to us', @provider, @buyer
+    assert_equal @provider.id, entry.reload.tenant_id
+  end
+
   test 'filters by buyer shows buyer and globals' do
     @buyer2 = FactoryBot.create(:buyer_account, :provider_account => @provider)
     Account.stubs(:search_ids).returns([@buyer.id])


### PR DESCRIPTION
supersedes #2759 and #2900 

We can't set `Account#master` to `false` because there is a database unique index on that field. It should be `NULL` by design. That's why fix triggers.