### PR TITLE
Update `canuse-lite` node package

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,9 +3052,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001245"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz#45b941bbd833cb0fa53861ff2bae746b3c6ca5d4"
-  integrity sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==
+  version "1.0.30001311"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001311.tgz"
+  integrity sha512-mleTFtFKfykEeW34EyfhGIFjGCqzhh38Y0LhdQ9aWF+HorZTtdgKV/1hEE0NlFkG2ubvisPV6l400tlbPys98A==
 
 canvas@^2.5.0:
   version "2.8.0"


### PR DESCRIPTION
Fixes:
```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
```

Output:
```
Latest version:     1.0.30001311
Installed version:  1.0.30001245
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ yarn add -W caniuse-lite
warning " > eslint-plugin-flowtype@5.8.0" has incorrect peer dependency "eslint@^7.1.0".
warning " > eslint-plugin-promise@5.1.0" has incorrect peer dependency "eslint@^7.0.0".
warning "flow-typed > @octokit/rest > @octokit/plugin-request-log@1.0.4" has unmet peer dependency "@octokit/core@>=3".
Cleaning package.json dependencies from caniuse-lite
$ yarn remove -W caniuse-lite
warning " > eslint-plugin-flowtype@5.8.0" has incorrect peer dependency "eslint@^7.1.0".
warning " > eslint-plugin-promise@5.1.0" has incorrect peer dependency "eslint@^7.0.0".
warning "flow-typed > @octokit/rest > @octokit/plugin-request-log@1.0.4" has unmet peer dependency "@octokit/core@>=3".
caniuse-lite has been successfully updated