### PR TITLE
THREESCALE-8009 prevent sending blank bulk emails for buyers account

### DIFF
--- a/app/views/buyers/accounts/bulk/send_emails/new.html.erb
+++ b/app/views/buyers/accounts/bulk/send_emails/new.html.erb
@@ -5,9 +5,9 @@
   } do |form| %>
   <%= form.inputs do %>
     <%= render 'buyers/accounts/bulk/selected_accounts', accounts: accounts %>
-    <%= form.input :to, :as => :string, :input_html => {:disabled => true, :value => "#{accounts.count} selected accounts"} %>
-    <%= form.input :subject, :as => :string %>
-    <%= form.input :body, :as => :text, :input_html => {:rows => 10} %>
+    <%= form.input :to, :as => :string, :input_html => { required: true , :disabled => true, :value => "#{accounts.count} selected accounts"} %>
+    <%= form.input :subject, :as => :string, input_html: { required: true } %>
+    <%= form.input :body, :as => :text, :input_html => { required: true , :rows => 10} %>
     <%= form.buttons do %>
       <%= form.commit_button 'Send', :button_html => {:'data-disable-with' => 'Running bulk action...' } %>
     <% end %>


### PR DESCRIPTION

**What this PR does / why we need it:**

When sending emails from the bulk operations emails can be sent if body and subject is empty
make those field required

This PR is for buyers account
http://provider-admin.3scale.localhost:3000/buyers/accounts

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/THREESCALE-8009