### PR TITLE
Fix deprecated usage of `attribute_changed?` in callbacks

### DIFF
--- a/app/lib/permalink_fu.rb
+++ b/app/lib/permalink_fu.rb
@@ -25,7 +25,8 @@ module PermalinkFu
   private
 
   def create_unique_permalink
-    return if permalink.present? && !permalink_changed?
+    return if permalink.present? && !will_save_change_to_permalink?
+
     base_permalink = build_permalink_from_attribute
     count = where_match_permalink_with_conditions(base_permalink).count
     self.permalink = count.positive? ? "#{base_permalink}-#{count + 1}" : base_permalink

--- a/app/models/cms/builtin.rb
+++ b/app/models/cms/builtin.rb
@@ -235,7 +235,7 @@ class CMS::Builtin < CMS::BasePage
         unless self.class.system_name_whitelist.include?(system_name)
           errors.add(:system_name, :not_reserved)
         end
-      elsif system_name_changed? && attribute_was('system_name') != system_name
+      elsif will_save_change_to_system_name? && attribute_was('system_name') != system_name
         errors.add(:system_name, :cannot_be_changed)
       end
     end

--- a/app/models/payment_gateway_setting.rb
+++ b/app/models/payment_gateway_setting.rb
@@ -84,8 +84,6 @@ class PaymentGatewaySetting < ApplicationRecord
   end
 
   def active_gateway_type
-    if gateway_type_changed? && PaymentGateway.find(gateway_type)&.deprecated?
-      errors.add(:gateway_type, :invalid)
-    end
+    errors.add(:gateway_type, :invalid) if will_save_change_to_gateway_type? && PaymentGateway.find(gateway_type)&.deprecated?
   end
 end

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -106,7 +106,7 @@ class Proxy < ApplicationRecord
   after_save :publish_events
   before_destroy :publish_events
 
-  after_save :track_apicast_version_change, if: :apicast_configuration_driven_changed?
+  after_save :track_apicast_version_change, if: :saved_change_to_apicast_configuration_driven?
 
   alias_attribute :production_endpoint, :endpoint
   alias_attribute :staging_endpoint, :sandbox_endpoint
@@ -269,7 +269,8 @@ class Proxy < ApplicationRecord
   end
 
   def set_correct_endpoints?
-    apicast_configuration_driven_changed? || new_record?
+    # Verified
+    will_save_change_to_apicast_configuration_driven? || new_record?
   end
 
   def publish_events

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -269,7 +269,6 @@ class Proxy < ApplicationRecord
   end
 
   def set_correct_endpoints?
-    # Verified
     will_save_change_to_apicast_configuration_driven? || new_record?
   end
 

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -17,3 +17,6 @@ Rails.application.config.action_controller.forgery_protection_origin_check = fal
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
 ActiveSupport.to_time_preserves_timezone = false
+
+# Do not halt callback chains when a callback returns false. Previous versions had true.
+ActiveSupport.halt_callback_chains_on_return_false = true

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 #
 # This file contains migration options to ease your Rails 5.0 upgrade.
@@ -16,6 +17,3 @@ Rails.application.config.action_controller.forgery_protection_origin_check = fal
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
 ActiveSupport.to_time_preserves_timezone = false
-
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
**What this PR does / why we need it**:
Rails changed the behavior of `attribute_changed?` in after and before callbacks. Older versions will throw deprecation warnings indicating which methods to use instead.
```
DEPRECATION WARNING: The behavior of `attribute_changed?` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
```
This PR reviews usages of `attribute_changed?` and replace it with `saved_change_to_attribute?` when necessary.
More info:
* https://rubyinrails.com/2019/04/08/rails-changed-behavior-of-attribute-changed-in-callbacks/
* https://github.com/rails/rails/issues/29035#issuecomment-423085336

**Which issue(s) this PR fixes** 

[THREESCALE-8109: The behavior of `attribute_changed?` will be changing](https://issues.redhat.com/browse/THREESCALE-8109)
