### PR TITLE
Prevent email from being sent in bulk to Subscriptions without subject/body

### DIFF
--- a/app/views/buyers/service_contracts/bulk/send_emails/new.html.erb
+++ b/app/views/buyers/service_contracts/bulk/send_emails/new.html.erb
@@ -5,9 +5,9 @@
   } do |form| %>
   <%= form.inputs do %>
     <%= render 'buyers/service_contracts/bulk/selected_contracts' %>
-    <%= form.input :to, :as => :string, :input_html => {:disabled => true, :value => "#{service_contracts.size} selected service subscriptions"} %>
-    <%= form.input :subject, :as => :string %>
-    <%= form.input :body, :as => :text, :input_html => {:rows => 10} %>
+    <%= form.input :to, :as => :string, :input_html => { required: true, :disabled => true, :value => "#{service_contracts.size} selected service subscriptions"} %>
+    <%= form.input :subject, :as => :string, :input_html => { required: true } %>
+    <%= form.input :body, :as => :text, :input_html => {required: true, :rows => 10} %>
     <%= form.buttons do %>
       <%= form.commit_button 'Send', :button_html => {:'data-disable-with' => 'Running bulk action...' } %>
     <% end %>

--- a/features/old/services/subscriptions/bulk_operations/send_emails.feature
+++ b/features/old/services/subscriptions/bulk_operations/send_emails.feature
@@ -35,10 +35,7 @@ Feature: Mass email bulk operations
     And I fill in "Body" with ""
     And I press "Send"
     Then I should see "Selected Service Subscriptions"
-      And "jane@me.us" should not receive an email with the following subject:
-      """
-        Nothing to say
-      """
+      And a clear email queue
 
   Scenario: Emails can't be sent without subject
     Given provider "foo.3scale.localhost" has "service_plans" visible
@@ -50,10 +47,7 @@ Feature: Mass email bulk operations
     And I fill in "Body" with "Did I forget to add a subject?"
     And I press "Send"
     Then I should see "Selected Service Subscriptions"
-      And "jane@me.us" should not receive an email with the following body:
-      """
-        Did I forget to add a subject?
-      """
+      And a clear email queue
 
   Scenario: Send mass email to application owners
       And provider "foo.3scale.localhost" has "service_plans" visible

--- a/features/old/services/subscriptions/bulk_operations/send_emails.feature
+++ b/features/old/services/subscriptions/bulk_operations/send_emails.feature
@@ -35,7 +35,7 @@ Feature: Mass email bulk operations
     And I fill in "Body" with ""
     And I press "Send"
     Then I should see "Selected Service Subscriptions"
-      And a clear email queue
+      And "jane@me.us" should receive no emails
 
   Scenario: Emails can't be sent without subject
     Given provider "foo.3scale.localhost" has "service_plans" visible
@@ -47,7 +47,7 @@ Feature: Mass email bulk operations
     And I fill in "Body" with "Did I forget to add a subject?"
     And I press "Send"
     Then I should see "Selected Service Subscriptions"
-      And a clear email queue
+      And "jane@me.us" should receive no emails
 
   Scenario: Send mass email to application owners
       And provider "foo.3scale.localhost" has "service_plans" visible

--- a/features/old/services/subscriptions/bulk_operations/send_emails.feature
+++ b/features/old/services/subscriptions/bulk_operations/send_emails.feature
@@ -35,6 +35,10 @@ Feature: Mass email bulk operations
     And I fill in "Body" with ""
     And I press "Send"
     Then I should see "Selected Service Subscriptions"
+      And "jane@me.us" should not receive an email with the following subject:
+      """
+        Nothing to say
+      """
 
   Scenario: Emails can't be sent without subject
     Given provider "foo.3scale.localhost" has "service_plans" visible
@@ -46,6 +50,10 @@ Feature: Mass email bulk operations
     And I fill in "Body" with "Did I forget to add a subject?"
     And I press "Send"
     Then I should see "Selected Service Subscriptions"
+      And "jane@me.us" should not receive an email with the following body:
+      """
+        Did I forget to add a subject?
+      """
 
   Scenario: Send mass email to application owners
       And provider "foo.3scale.localhost" has "service_plans" visible

--- a/features/old/services/subscriptions/bulk_operations/send_emails.feature
+++ b/features/old/services/subscriptions/bulk_operations/send_emails.feature
@@ -25,7 +25,7 @@ Feature: Mass email bulk operations
     Given current domain is the admin domain of provider "foo.3scale.localhost"
     Given I am logged in as provider "foo.3scale.localhost"
 
-  Scenario: Emails can be sent without body
+  Scenario: Emails can't be sent without body
     Given provider "foo.3scale.localhost" has "service_plans" visible
     And I am on the service contracts admin page
     And a clear email queue
@@ -33,13 +33,10 @@ Feature: Mass email bulk operations
     And I press "Send email"
     And I fill in "Subject" with "Nothing to say"
     And I fill in "Body" with ""
-    And I press "Send" and I confirm dialog box within colorbox
-    Then I should see "Action completed successfully"
-    And "jane@me.us" should receive an email with the following body:
-    """
-    """
+    And I press "Send"
+    Then I should see "Selected Service Subscriptions"
 
-  Scenario: Emails can be sent without subject
+  Scenario: Emails can't be sent without subject
     Given provider "foo.3scale.localhost" has "service_plans" visible
     And I am on the service contracts admin page
     And a clear email queue
@@ -47,12 +44,8 @@ Feature: Mass email bulk operations
     And I press "Send email"
     And I fill in "Subject" with ""
     And I fill in "Body" with "Did I forget to add a subject?"
-    And I press "Send" and I confirm dialog box within colorbox
-    Then I should see "Action completed successfully"
-    And "jane@me.us" should receive an email with the following body:
-    """
-    Did I forget to add a subject?
-    """
+    And I press "Send"
+    Then I should see "Selected Service Subscriptions"
 
   Scenario: Send mass email to application owners
       And provider "foo.3scale.localhost" has "service_plans" visible


### PR DESCRIPTION
**What this PR does / why we need it:**

When sending emails from the bulk operations emails for subscriptions can be sent if body and subject is empty
make those field required

Fixed subtask 

**Which issue(s) this PR fixes**

Main task : https://issues.redhat.com/browse/THREESCALE-8009

SubTask: https://issues.redhat.com/browse/THREESCALE-8145