### PR TITLE
Remove `:nothing` deprecated option

### DIFF
--- a/app/controllers/admin/api/web_hooks_failures_controller.rb
+++ b/app/controllers/admin/api/web_hooks_failures_controller.rb
@@ -36,7 +36,7 @@ class Admin::Api::WebHooksFailuresController < Admin::Api::BaseController
       render_error 'invalid time', status: :bad_request
     else
       failures.delete(params[:time])
-      respond_with(failures,  head :ok)
+      respond_with(failures, head: :ok)
     end
   end
 

--- a/app/controllers/admin/api/web_hooks_failures_controller.rb
+++ b/app/controllers/admin/api/web_hooks_failures_controller.rb
@@ -36,7 +36,7 @@ class Admin::Api::WebHooksFailuresController < Admin::Api::BaseController
       render_error 'invalid time', status: :bad_request
     else
       failures.delete(params[:time])
-      respond_with(failures, nothing: true)
+      respond_with(failures,  head :ok)
     end
   end
 


### PR DESCRIPTION
**What this PR does / why we need it:**

**DEPRECATION WARNING**: `:nothing` option is deprecated and will be removed in Rails 5.1. Use `head` method to respond with empty response body.

**Which issue(s) this PR fixes**

Main Task: https://issues.redhat.com/browse/THREESCALE-8009

Subtask: https://issues.redhat.com/browse/THREESCALE-8186