### PR TITLE
Improve performance of SQL proxy_configs query

### DIFF
--- a/app/controllers/admin/api/services/proxy/configs_controller.rb
+++ b/app/controllers/admin/api/services/proxy/configs_controller.rb
@@ -33,7 +33,6 @@ class Admin::Api::Services::Proxy::ConfigsController < Admin::Api::Services::Bas
     respond_with(service_proxy_configs)
   end
 
-  # TODO: THREESCALE-8208 deprecate
   def index_by_host
     respond_with(host_proxy_configs)
   end
@@ -110,7 +109,6 @@ class Admin::Api::Services::Proxy::ConfigsController < Admin::Api::Services::Bas
     service.proxy.proxy_configs.by_environment(environment)
   end
 
-  # TODO: THREESCALE-8208 deprecate
   def host_proxy_configs
     current_account.accessible_proxy_configs
       .by_environment(environment).by_host(host).current_versions

--- a/app/controllers/admin/api/services/proxy/configs_controller.rb
+++ b/app/controllers/admin/api/services/proxy/configs_controller.rb
@@ -33,6 +33,7 @@ class Admin::Api::Services::Proxy::ConfigsController < Admin::Api::Services::Bas
     respond_with(service_proxy_configs)
   end
 
+  # TODO: THREESCALE-8208 deprecate
   def index_by_host
     respond_with(host_proxy_configs)
   end
@@ -109,6 +110,7 @@ class Admin::Api::Services::Proxy::ConfigsController < Admin::Api::Services::Bas
     service.proxy.proxy_configs.by_environment(environment)
   end
 
+  # TODO: THREESCALE-8208 deprecate
   def host_proxy_configs
     current_account.accessible_proxy_configs
       .by_environment(environment).by_host(host).current_versions

--- a/app/lib/apicast/curl_command_builder.rb
+++ b/app/lib/apicast/curl_command_builder.rb
@@ -134,7 +134,7 @@ module Apicast
     end
 
     def proxy_from_config
-      proxy_config = proxy.proxy_configs.by_environment(environment.to_s).current_versions.order(:id).first
+      proxy_config = proxy.proxy_configs.by_environment(environment.to_s).newest_first.first
       ProxyFromConfig.new(proxy_config.parsed_content) if proxy_config
     end
   end

--- a/app/models/proxy_config.rb
+++ b/app/models/proxy_config.rb
@@ -39,12 +39,12 @@ class ProxyConfig < ApplicationRecord
   scope :by_host,        ->(host) { where.has { hosts =~ "%|#{host}|%" } if host }
 
   scope :current_versions, -> do
-    table = BabySqueel[:proxy_configs].alias(:versions)
-    scope = joining { table.on((table.proxy_id == proxy_id) & (table.environment == environment)) }
-      .when_having { max(table.version) == version }
-      .group(:id)
-
-    System::Database.mysql? ? scope : where(id: scope.group(:version).select(:id))
+    where %(NOT EXISTS (
+      SELECT 1 FROM proxy_configs pc
+      WHERE proxy_configs.environment = environment
+        AND proxy_configs.proxy_id = proxy_id
+        AND proxy_configs.version < version
+      ))
   end
 
   scope :by_version, ->(version) do

--- a/test/integration/master/api/proxy/configs_controller_test.rb
+++ b/test/integration/master/api/proxy/configs_controller_test.rb
@@ -11,16 +11,17 @@ class Master::Api::Proxy::ConfigsControllerTest < ActionDispatch::IntegrationTes
   end
 
   test '#index get all latest proxy_configs' do
+    production_current_versions = []
     proxies = FactoryBot.create_list(:proxy, 3)
     proxies.each do |proxy|
       FactoryBot.create_list(:proxy_config, 5, proxy: proxy, environment: 'sandbox')
-      FactoryBot.create_list(:proxy_config, 3, proxy: proxy, environment: 'production')
+      production_current_versions << FactoryBot.create_list(:proxy_config, 3, proxy: proxy, environment: 'production').last
     end
 
     get master_api_proxy_configs_path(environment: 'production'), params: {access_token: @token.value}
     assert_response :success
 
-    assert_same_elements ProxyConfig.current_versions.by_environment('production').select(:id, :version).map(&:id),
+    assert_same_elements production_current_versions.map(&:id),
                          proxy_config_ids(response.body)
   end
 
@@ -59,6 +60,5 @@ class Master::Api::Proxy::ConfigsControllerTest < ActionDispatch::IntegrationTes
   def proxy_config_ids(json)
     JSON.parse(json).fetch('proxy_configs').map { |h| h.dig('proxy_config', 'id') }
   end
-
 
 end

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -725,6 +725,27 @@ class AccountTest < ActiveSupport::TestCase
     assert master_account.reload
     assert_not master_account.reload.scheduled_for_deletion?
   end
+
+  test "#current_versions for an account's services" do
+    account = FactoryBot.create(:account)
+
+    service1 = FactoryBot.create(:service, account: account)
+    service2 = FactoryBot.create(:service, account: account)
+
+    proxy1 = FactoryBot.create(:proxy, service: service1)
+    proxy2 = FactoryBot.create(:proxy, service: service2)
+
+    c1 = FactoryBot.create_list(:proxy_config, 3, proxy: proxy1).last
+    c2 = FactoryBot.create_list(:proxy_config, 3, proxy: proxy2).last
+    c3 = FactoryBot.create(:proxy_config)
+
+    assert_same_elements [c1, c2, c3], ProxyConfig.current_versions
+
+    assert_same_elements [c1, c2], account.accessible_proxy_configs.current_versions
+
+    service1.update(state: 'deleted')
+    assert_same_elements [c2], account.accessible_proxy_configs.current_versions
+  end
 end
 
 #TODO: test scopes chained, and with nil params

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -743,7 +743,7 @@ class AccountTest < ActiveSupport::TestCase
 
     assert_same_elements [c1, c2], account.accessible_proxy_configs.current_versions
 
-    service1.update(state: 'deleted')
+    service1.update(state: Service::DELETE_STATE)
     assert_same_elements [c2], account.accessible_proxy_configs.current_versions
   end
 end

--- a/test/unit/proxy_config_test.rb
+++ b/test/unit/proxy_config_test.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
-class ProxyConfigTest < ActiveSupport::TestCase
+class ProxyConfigTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
 
   def test_clone_to
     ProxyConfig::ENVIRONMENTS.each do |environment|
@@ -40,13 +42,17 @@ class ProxyConfigTest < ActiveSupport::TestCase
   end
 
   def test_by_host
-    FactoryBot.create(:proxy_config, content: json_content(hosts: ['example.com']))
-    assert ProxyConfig.by_host('example.com').present?
-    refute ProxyConfig.by_host('example.org').present?
+    c1 = FactoryBot.create(:proxy_config, content: json_content(hosts: ['example.com']))
+    assert_same_elements [c1], ProxyConfig.by_host('example.com')
+    assert_empty ProxyConfig.by_host('example')
+    assert_empty ProxyConfig.by_host('.com')
 
-    FactoryBot.create(:proxy_config, content: json_content(hosts: %w[example.com example.org]))
-    assert ProxyConfig.by_host('example.com').present?
-    assert ProxyConfig.by_host('example.org').present?
+    c2 = FactoryBot.create(:proxy_config, content: json_content(hosts: ['example.com', 'example.org']))
+    assert_same_elements [c1, c2], ProxyConfig.by_host('example.com')
+    assert_same_elements [c2], ProxyConfig.by_host('example.org')
+
+    assert_empty ProxyConfig.by_host('')
+    assert_same_elements [c1, c2], ProxyConfig.by_host(nil)
   end
 
   def test_hosts
@@ -58,15 +64,126 @@ class ProxyConfigTest < ActiveSupport::TestCase
     assert_equal [], config.hosts
   end
 
-  def test_current_versions
+  test '#current_versions: a service deploys to a new host' do
     proxy = FactoryBot.create(:proxy)
-    FactoryBot.create(:proxy_config, version: 1, proxy: proxy)
-    assert_equal [1], ProxyConfig.current_versions.pluck(:version)
 
-    FactoryBot.create(:proxy_config, version: 2, proxy: proxy)
-    assert_equal [2], ProxyConfig.current_versions.pluck(:version)
+    old_config = FactoryBot.create(:proxy_config, proxy: proxy, content: json_content(hosts: ['v1.example.com']), environment: 'production')
+    new_config = FactoryBot.create(:proxy_config, proxy: proxy, content: json_content(hosts: ['v2.example.com']), environment: 'production')
 
-    assert ProxyConfig.current_versions.to_a
+    assert_same_elements [new_config], ProxyConfig.current_versions
+  end
+
+  test '#current_versions: a service deploys to a different env' do
+    proxy = FactoryBot.create(:proxy)
+
+    sand_config = FactoryBot.create(:proxy_config, proxy: proxy, content: json_content(hosts: ['staging.example.com']), environment: 'sandbox')
+    prod_config = FactoryBot.create(:proxy_config, proxy: proxy, content: json_content(hosts: ['prod.example.com']), environment: 'production')
+
+    assert_same_elements [sand_config, prod_config], ProxyConfig.current_versions
+  end
+
+  test '#current_versions returns 1 config per proxy and per environment' do
+    proxy1 = FactoryBot.create(:proxy)
+    proxy2 = FactoryBot.create(:proxy)
+
+    current_versions = [
+      create_proxy_configs(3, proxy1, 'sandbox').last,
+      create_proxy_configs(4, proxy1, 'production').last,
+      create_proxy_configs(2, proxy2, 'sandbox').last,
+      create_proxy_configs(6, proxy2, 'production').last,
+    ]
+
+    assert_same_elements current_versions, ProxyConfig.current_versions
+  end
+
+  test '#current_versions returns 1 config per proxy for a single environment' do
+    proxy1 = FactoryBot.create(:proxy)
+    proxy2 = FactoryBot.create(:proxy)
+
+    sandbox_current_versions = [
+      create_proxy_configs(3, proxy1, 'sandbox').last,
+      create_proxy_configs(2, proxy2, 'sandbox').last,
+    ]
+
+    production_current_versions = [
+      create_proxy_configs(4, proxy1, 'production').last,
+      create_proxy_configs(6, proxy2, 'production').last,
+    ]
+
+    assert_same_elements sandbox_current_versions, ProxyConfig.by_environment('sandbox').current_versions
+    assert_same_elements production_current_versions, ProxyConfig.by_environment('production').current_versions
+  end
+
+  test '#current_versions returns 1 config per proxy and per host, when it is latest' do
+    proxy1 = FactoryBot.create(:proxy)
+    proxy2 = FactoryBot.create(:proxy)
+
+    c1 = FactoryBot.create(:proxy_config, proxy: proxy1, content: json_content(hosts: ['old.example.com']))
+    c2 = FactoryBot.create(:proxy_config, proxy: proxy1, content: json_content(hosts: ['new.example.com']))
+    c3 = FactoryBot.create(:proxy_config, proxy: proxy1, content: json_content(hosts: ['new.example.com']))
+
+    c4 = FactoryBot.create(:proxy_config, proxy: proxy2, content: json_content(hosts: ['old.example.com']))
+    c5 = FactoryBot.create(:proxy_config, proxy: proxy2, content: json_content(hosts: ['new.example.com']))
+    c6 = FactoryBot.create(:proxy_config, proxy: proxy2, content: json_content(hosts: ['new.example.com']))
+
+    assert_empty ProxyConfig.by_host('old.example.com').current_versions
+    assert_same_elements [c3, c6], ProxyConfig.by_host('new.example.com').current_versions
+  end
+
+  test '#current_versions returns 1 config per proxy for a single environment and host' do
+    proxy1 = FactoryBot.create(:proxy)
+    proxy2 = FactoryBot.create(:proxy)
+    proxy3 = FactoryBot.create(:proxy)
+
+    c1 = FactoryBot.create_list(:proxy_config, 2, proxy: proxy1, content: json_content(hosts: ['example.com']), environment: 'sandbox').last
+    c2 = FactoryBot.create_list(:proxy_config, 2, proxy: proxy1, content: json_content(hosts: ['example.com']), environment: 'production').last
+
+    c3 = FactoryBot.create_list(:proxy_config, 2, proxy: proxy2, content: json_content(hosts: ['example.com']), environment: 'sandbox').last
+    c4 = FactoryBot.create_list(:proxy_config, 2, proxy: proxy2, content: json_content(hosts: ['example.com']), environment: 'production').last
+
+    c5 = FactoryBot.create_list(:proxy_config, 2, proxy: proxy3, content: json_content(hosts: ['other.example.com']), environment: 'sandbox').last
+    c6 = FactoryBot.create_list(:proxy_config, 2, proxy: proxy3, content: json_content(hosts: ['other.example.com']), environment: 'production').last
+
+    assert_equal [],  ProxyConfig.sandbox.by_host('unknown').current_versions # assert_empty raises an error in mysql
+    assert_same_elements [c1, c3], ProxyConfig.sandbox.by_host('example.com').current_versions
+    assert_same_elements [c2, c4], ProxyConfig.production.by_host('example.com').current_versions
+  end
+
+  test '#current_versions do not ignore configs for unavailable services' do
+    service = FactoryBot.create(:service)
+    proxy1 = FactoryBot.create(:proxy, service: service)
+    proxy2 = FactoryBot.create(:proxy)
+
+    c1 = FactoryBot.create(:proxy_config, proxy: proxy1)
+    c2 = FactoryBot.create(:proxy_config, proxy: proxy2)
+
+    assert_same_elements [c1, c2], ProxyConfig.current_versions
+
+    service.update(state: 'deleted')
+    assert_same_elements [c1, c2], ProxyConfig.current_versions
+  end
+
+  test '#current_versions for available services only' do
+    account = FactoryBot.create(:account)
+
+    service1 = FactoryBot.create(:service, account: account)
+    service2 = FactoryBot.create(:service, account: account)
+
+    proxy1 = FactoryBot.create(:proxy, service: service1)
+    proxy2 = FactoryBot.create(:proxy, service: service2)
+
+    c1 = FactoryBot.create_list(:proxy_config, 3, proxy: proxy1).last
+    c2 = FactoryBot.create_list(:proxy_config, 3, proxy: proxy2).last
+    c3 = FactoryBot.create(:proxy_config)
+
+    assert_same_elements [c1, c2, c3], ProxyConfig.current_versions
+
+    # TODO: THREESCALE-8208: remove next line
+    assert_same_elements [c1, c2], account.accessible_proxy_configs.current_versions
+
+    service1.update(state: 'deleted')
+    # TODO: THREESCALE-8208: remove next line
+    assert_same_elements [c2], account.accessible_proxy_configs.current_versions
   end
 
   def test_filename
@@ -87,6 +204,146 @@ class ProxyConfigTest < ActiveSupport::TestCase
     assert_raises ProxyConfig::InvalidEnvironmentError do
       ProxyConfig.by_environment('foobar')
     end
+  end
+
+  test '#by_version returns all configs with given version' do
+    configs_v2 = []
+    proxies = FactoryBot.create_list(:proxy, 3)
+    proxies.each do |p|
+      FactoryBot.create(:proxy_config, version: 1, proxy: p)
+      configs_v2 << FactoryBot.create(:proxy_config, version: 2, proxy: p)
+      FactoryBot.create(:proxy_config, version: 3, proxy: p)
+    end
+
+    assert_same_elements configs_v2, ProxyConfig.by_version(2)
+    assert_empty ProxyConfig.by_version(5)
+  end
+
+  test '#by_version returns the latest version of each proxy' do
+    latest_versions = []
+    proxies = FactoryBot.create_list(:proxy, 3)
+    proxies.each { |p| latest_versions << FactoryBot.create_list(:proxy_config, 3, proxy: p).last }
+
+    assert_same_elements latest_versions, ProxyConfig.by_version('latest')
+  end
+
+  test '#by_version returns all configs with given version for a particular environment' do
+    proxy1 = FactoryBot.create(:proxy)
+    proxy2 = FactoryBot.create(:proxy)
+    proxy3 = FactoryBot.create(:proxy)
+
+    sandbox_v2 = [
+      FactoryBot.create(:proxy_config, version: 2, proxy: proxy1, environment: 'sandbox'),
+      FactoryBot.create(:proxy_config, version: 2, proxy: proxy2, environment: 'sandbox'),
+    ]
+
+    production_v2 = [
+      FactoryBot.create(:proxy_config, version: 2, proxy: proxy1, environment: 'production'),
+      FactoryBot.create(:proxy_config, version: 2, proxy: proxy2, environment: 'production'),
+    ]
+
+    FactoryBot.create(:proxy_config, version: 3, proxy: proxy3, environment: 'production')
+    FactoryBot.create(:proxy_config, version: 3, proxy: proxy3, environment: 'sandbox')
+
+    assert_same_elements sandbox_v2, ProxyConfig.by_version(2).by_environment('sandbox')
+    assert_same_elements production_v2, ProxyConfig.by_version(2).by_environment('production')
+  end
+
+  test '#by_version returns the latest version of each proxy for a particular environment' do
+    proxy1 = FactoryBot.create(:proxy)
+    proxy2 = FactoryBot.create(:proxy)
+
+    sandbox_latest = [
+      FactoryBot.create_list(:proxy_config, 2, proxy: proxy1, environment: 'sandbox').last,
+      FactoryBot.create_list(:proxy_config, 4, proxy: proxy2, environment: 'sandbox').last,
+    ]
+
+    production_latest = [
+      FactoryBot.create_list(:proxy_config, 4, proxy: proxy1, environment: 'production').last,
+      FactoryBot.create_list(:proxy_config, 2, proxy: proxy2, environment: 'production').last,
+    ]
+
+    assert_same_elements sandbox_latest, ProxyConfig.by_version('latest').by_environment('sandbox')
+    assert_same_elements production_latest, ProxyConfig.by_version('latest').by_environment('production')
+  end
+
+  test '#by_version returns all configs with given version for a particular host' do
+    proxy1 = FactoryBot.create(:proxy)
+    proxy2 = FactoryBot.create(:proxy)
+
+    example_v2 = FactoryBot.create(:proxy_config, version: 2, proxy: proxy1, environment: 'production', content: json_content(hosts: ['foo.example.com']))
+    FactoryBot.create(:proxy_config, version: 3, proxy: proxy1, environment: 'production', content: json_content(hosts: ['foo.example.com']))
+    FactoryBot.create(:proxy_config, version: 2, proxy: proxy2, environment: 'production', content: json_content(hosts: ['new.example.com']))
+
+    assert_same_elements [example_v2], ProxyConfig.by_version(2).by_host('foo.example.com')
+    assert_empty ProxyConfig.by_version(2).by_host('example.com')
+  end
+
+  test '#by_version returns the latest version of each proxy for a particular host' do
+    proxy1 = FactoryBot.create(:proxy)
+    proxy2 = FactoryBot.create(:proxy)
+
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy1, environment: 'production', content: json_content(hosts: ['example.com']))
+    latest_p1 = FactoryBot.create(:proxy_config, version: 2, proxy: proxy1, environment: 'production', content: json_content(hosts: ['example.com']))
+
+    FactoryBot.create(:proxy_config, version: 3, proxy: proxy2, environment: 'production', content: json_content(hosts: ['example.com']))
+    latest_p2 = FactoryBot.create(:proxy_config, version: 4, proxy: proxy2, environment: 'production', content: json_content(hosts: ['new.example.com']))
+
+    assert_same_elements [latest_p1], ProxyConfig.by_version('latest').by_host('example.com')
+    assert_same_elements [latest_p2], ProxyConfig.by_version('latest').by_host('new.example.com')
+  end
+
+  test '#by_version returns all configs with given version for a particular environtment and host' do
+    expected_configs = []
+    proxy1 = FactoryBot.create(:proxy)
+    proxy2 = FactoryBot.create(:proxy)
+    proxy3 = FactoryBot.create(:proxy)
+
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy1, environment: 'production', content: json_content(hosts: ['example.com']))
+    expected_configs << FactoryBot.create(:proxy_config, version: 1, proxy: proxy1, environment: 'sandbox', content: json_content(hosts: ['example.com']))
+    FactoryBot.create(:proxy_config, version: 2, proxy: proxy1, environment: 'production', content: json_content(hosts: ['example.com']))
+    FactoryBot.create(:proxy_config, version: 2, proxy: proxy1, environment: 'sandbox', content: json_content(hosts: ['example.com']))
+
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy2, environment: 'production', content: json_content(hosts: ['example.com']))
+    expected_configs << FactoryBot.create(:proxy_config, version: 1, proxy: proxy2, environment: 'sandbox', content: json_content(hosts: ['example.com']))
+    FactoryBot.create(:proxy_config, version: 2, proxy: proxy2, environment: 'production', content: json_content(hosts: ['example.com']))
+    FactoryBot.create(:proxy_config, version: 2, proxy: proxy2, environment: 'sandbox', content: json_content(hosts: ['example.com']))
+
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy3, environment: 'production', content: json_content(hosts: ['v3.example.com']))
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy3, environment: 'sandbox', content: json_content(hosts: ['v3.example.com']))
+    FactoryBot.create(:proxy_config, version: 2, proxy: proxy3, environment: 'production', content: json_content(hosts: ['v3.example.com']))
+    FactoryBot.create(:proxy_config, version: 2, proxy: proxy3, environment: 'sandbox', content: json_content(hosts: ['v3.example.com']))
+
+    assert_same_elements expected_configs, ProxyConfig.by_version(1).by_host('example.com').by_environment('sandbox')
+  end
+
+  test '#by_version returns the latest version of each proxy for a particular environtment and host' do
+    proxy1 = FactoryBot.create(:proxy)
+    proxy2 = FactoryBot.create(:proxy)
+    proxy3 = FactoryBot.create(:proxy)
+
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy1, environment: 'production', content: json_content(hosts: ['example.com']))
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy1, environment: 'sandbox', content: json_content(hosts: ['example.com']))
+    FactoryBot.create(:proxy_config, version: 2, proxy: proxy1, environment: 'production', content: json_content(hosts: ['example.com']))
+    res1 = FactoryBot.create(:proxy_config, version: 2, proxy: proxy1, environment: 'sandbox', content: json_content(hosts: ['example.com']))
+    res3 = FactoryBot.create(:proxy_config, version: 3, proxy: proxy1, environment: 'production', content: json_content(hosts: ['new.example.com']))
+
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy2, environment: 'production', content: json_content(hosts: ['example.com']))
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy2, environment: 'sandbox', content: json_content(hosts: ['example.com']))
+    res2 = FactoryBot.create(:proxy_config, version: 2, proxy: proxy2, environment: 'production', content: json_content(hosts: ['example.com']))
+    FactoryBot.create(:proxy_config, version: 2, proxy: proxy2, environment: 'sandbox', content: json_content(hosts: ['example.com']))
+    res4 = FactoryBot.create(:proxy_config, version: 3, proxy: proxy2, environment: 'sandbox', content: json_content(hosts: ['new.example.com']))
+
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy3, environment: 'production', content: json_content(hosts: ['v3.example.com']))
+    FactoryBot.create(:proxy_config, version: 1, proxy: proxy3, environment: 'sandbox', content: json_content(hosts: ['v3.example.com']))
+    FactoryBot.create(:proxy_config, version: 2, proxy: proxy3, environment: 'production', content: json_content(hosts: ['v3.example.com']))
+    res5 = FactoryBot.create(:proxy_config, version: 2, proxy: proxy3, environment: 'sandbox', content: json_content(hosts: ['v3.example.com']))
+
+    assert_same_elements [res1], ProxyConfig.by_version('latest').by_host('example.com').by_environment('sandbox')
+    assert_same_elements [res2], ProxyConfig.by_version('latest').by_host('example.com').by_environment('production')
+    assert_same_elements [res3], ProxyConfig.by_version('latest').by_host('new.example.com').by_environment('production')
+    assert_same_elements [res4], ProxyConfig.by_version('latest').by_host('new.example.com').by_environment('sandbox')
+    assert_same_elements [res5], ProxyConfig.by_version('latest').by_host('v3.example.com').by_environment('sandbox')
   end
 
   def test_create_without_service_token
@@ -140,5 +397,14 @@ class ProxyConfigTest < ActiveSupport::TestCase
 
   def json_content(hosts: [])
     { proxy: { hosts: hosts }}.to_json
+  end
+
+  def create_proxy_configs(length, proxy, env)
+    content = case env
+      when 'production' then json_content(hosts: ['production.example.com'])
+      when 'sandbox' then json_content(hosts: ['sandbox.example.com'])
+    end
+
+    FactoryBot.create_list(:proxy_config, length, proxy: proxy, content: content, environment: env)
   end
 end


### PR DESCRIPTION
## NEW ⚠️ 
@akostadinov came up with a new query that is also very quick and it can be still a scope, therefore we can keep the `.current_versions` format.

## OLD, don't read 💩 

The query to be fixed is `ProxyConfig#current_versions`. It is a very complex one because it's supposed to check the ProxyConfig with max version for each Proxy and each environment, and be compatible with other scopes such as `by_environment` and `by_host`.

After some investigation and testing, this is **not possible**. The query is just too complex for ActiveRecord to figure out, therefore I've refactored it into a class method that will run a handcrafted query, hopefully maintaining the same behaviour.

Here are the places where `current_versions` is called and a comparison with the old and new queries, using 7000 Proxy configs.

### Case A
This endpoint is not in the doc and it's supposed to be removed at some point (see #2289):
https://github.com/3scale/porta/blob/b9757da19cce1d5ed6c859b9ec6cc3af68d53f2d/app/controllers/admin/api/services/proxy/configs_controller.rb#L112-L115
```sql
-- ProxyConfig Load (753185.4ms)
SELECT proxy_configs.* FROM proxy_configs
INNER JOIN proxies ON proxy_configs.proxy_id = proxies.id
INNER JOIN services ON proxies.service_id = services.id
INNER JOIN proxy_configs versions ON versions.proxy_id = proxy_configs.proxy_id
  AND versions.environment = proxy_configs.environment
WHERE services.account_id = 2
  AND (services.state != 'deleted')
  AND proxy_configs.environment = 'sandbox'
  AND (proxy_config.hosts LIKE '%|pepe.prod.org|%')
GROUP BY proxy_configs.id
HAVING max(versions.version) = proxy_configs.version
```
**New query:**
```ruby
ProxyConfig.current_versions(env: environment, host: host, account: account)
```
```sql
-- ProxyConfig Load (19.4ms)
SELECT * FROM proxy_configs
WHERE (proxy_id, environment, version) IN (
  SELECT proxy_id, environment, MAX(version)
  FROM proxy_configs
  INNER JOIN proxies ON proxies.id = proxy_configs.proxy_id
  INNER JOIN services ON proxies.service_id = services.id
  WHERE services.account_id = "2"
    AND services.state != 'deleted'
    AND proxy_configs.environment = 'sandbox'
  GROUP BY environment, proxy_id
)
AND hosts LIKE '%|pepe.prod.org|%'
```
**Notes**
The new implementation seems to return the same results for this case. The `account_id` and `state != 'deleted'` corresponds to `accessible_services`. In the new query, the host is checked after any maxes are found on purpose: if the host doesn't have the latest version of a service, don't show it.

### Case B
https://github.com/3scale/porta/blob/b9757da19cce1d5ed6c859b9ec6cc3af68d53f2d/app/controllers/master/api/proxy/configs_controller.rb#L21-L23
```sql
-- ProxyConfig Load (764104.5ms)
SELECT proxy_configs.* FROM proxy_configs
INNER JOIN proxy_configs versions ON versions.proxy_id = proxy_configs.proxy_id
  AND versions.environment = proxy_configs.environment
WHERE proxy_configs.environment = 'sandbox'
AND (proxy_config.hosts LIKE '%|pepe.prod.org|%')
GROUP BY proxy_configs.id
HAVING max(versions.version) = proxy_configs.version
```
**New query:**
```ruby
ProxyConfig.current_versions(env: environment, host: host)
```
```sql
-- ProxyConfig Load (24.2ms)
SELECT * FROM proxy_configs
WHERE (proxy_id, environment, version) IN (
  SELECT proxy_id, environment, MAX(version)
  FROM proxy_configs
  WHERE proxy_configs.environment = 'sandbox'
  GROUP BY environment, proxy_id
)
AND hosts LIKE '%|pepe.prod.org|%'
```
**Notes**
...

### Case C
To generate the curl command that's displayed in a Product config page
https://github.com/3scale/porta/blob/b9757da19cce1d5ed6c859b9ec6cc3af68d53f2d/app/lib/apicast/curl_command_builder.rb#L136-L139
```sql
-- ProxyConfig Load (38076.4ms)
SELECT proxy_configs.* FROM proxy_configs
INNER JOIN proxy_configs versions ON versions.proxy_id = proxy_configs.proxy_id
  AND versions.environment = proxy_configs.environment
WHERE proxy_configs.proxy_id = 106
  AND proxy_configs.environment = 'sandbox'
GROUP BY proxy_configs.id
HAVING max(versions.version) = proxy_configs.version
ORDER BY proxy_configs.id ASC
LIMIT 1
```
**New query:**
```ruby
ProxyConfig.current_versions(env: environment, account: proxy.service.account).first
```
```sql
-- ProxyConfig Load (26.4ms)
SELECT * FROM proxy_configs
WHERE (proxy_id, environment, version) IN (
  SELECT proxy_id, environment, MAX(version) FROM proxy_configs
  INNER JOIN proxies ON proxies.id = proxy_configs.proxy_id
  INNER JOIN services ON proxies.service_id = services.id
  WHERE services.account_id = "2"
    AND services.state != 'deleted'
    AND proxy_configs.environment = 'sandbox'
  GROUP BY environment, proxy_id
)
```
**Notes**
The can probably be refactored/simplified instead of using current_versions.


### Case D
Used when filtering by `version = lastest` which is pretty bad, because it's not really compatible with other scopes. `by_version` is used in 1 endpoint only and it's probably better to check for `'later'` manually, outside the scope.
https://github.com/3scale/porta/blob/b9757da19cce1d5ed6c859b9ec6cc3af68d53f2d/app/models/proxy_config.rb#L50-L55
```sql
-- ProxyConfig Load (710401.8ms)
SELECT proxy_configs.* FROM proxy_configs
INNER JOIN proxies ON proxies.id = proxy_configs.proxy_id
INNER JOIN proxy_configs versions ON versions.proxy_id = proxy_configs.proxy_id
  AND versions.environment = proxy_configs.environment
WHERE proxies.service_id IN (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109)
  AND proxy_configs.environment = 'sandbox'
GROUP BY proxy_configs.id
HAVING max(versions.version) = proxy_configs.version
```
**New query:**
```ruby
ProxyConfig.current_versions(env: environment, host: host, account: account)
```
```sql
-- ProxyConfig Load (21.9ms)
SELECT * FROM proxy_configs
WHERE (proxy_id, environment, version) IN (
  SELECT proxy_id, environment, MAX(version) FROM proxy_configs
  INNER JOIN proxies ON proxies.id = proxy_configs.proxy_id
  INNER JOIN services ON proxies.service_id = services.id
  WHERE services.account_id = "2"
    AND services.state != 'deleted'
    AND proxy_configs.environment = 'sandbox'
  GROUP BY environment, proxy_id
)
```
**Notes**
As far as I can tell this query is the same use case as case A above.

**JIRA:**
[THREESCALE-7183: mysql slow queries](https://issues.redhat.com/browse/THREESCALE-7183)