### PR TITLE
Reduce times `by_cookie_token` query is executed

### DIFF
--- a/app/lib/authentication/by_cookie_token.rb
+++ b/app/lib/authentication/by_cookie_token.rb
@@ -51,11 +51,10 @@ module Authentication
       # always be deleted together.
       #
       def forget_me
-        self.remember_token_expires_at = nil
-        self.remember_token            = nil
-        self.class.where(id: id).update_all(:remember_token_expires_at => nil, :remember_token => nil) # TODO: replace by update_columns
-      end
+        return if remember_token_expires_at.nil? && remember_token.nil?
 
+        update_columns(remember_token_expires_at: nil, remember_token: nil) # rubocop:disable Rails/SkipsModelValidations
+      end
     end # instance methods
   end
 

--- a/test/unit/lib/authentication/by_cookie_token_test.rb
+++ b/test/unit/lib/authentication/by_cookie_token_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Authentication
+  class ByCookieTokenTest < ActiveSupport::TestCase
+    test '#forget_me' do
+      user = FactoryBot.create(:user, remember_token_expires_at: Time.current, remember_token: 123)
+
+      user.forget_me
+      assert_nil user.remember_token_expires_at
+      assert_nil user.remember_token
+
+      user.reload
+      assert_nil user.remember_token_expires_at
+      assert_nil user.remember_token
+    end
+  end
+end


### PR DESCRIPTION
It seems like this method it being called many times even tho the updated values are already `nil`.