### PR TITLE
Prevent `update_current_user_after_login` from being called 3 times in Dashboard

### DIFF
--- a/app/controllers/provider/admin/dashboard/widget_controller.rb
+++ b/app/controllers/provider/admin/dashboard/widget_controller.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 class Provider::Admin::Dashboard::WidgetController < Provider::Admin::BaseController
   helper_method :widget, :current_range, :previous_range
   before_action :load_widget
+
+  skip_after_action :update_current_user_after_login # Called already by Provider::Admin::DashboardsController
 
   respond_to :js, :html, :json
 

--- a/app/lib/authenticated_system.rb
+++ b/app/lib/authenticated_system.rb
@@ -30,7 +30,6 @@ module AuthenticatedSystem
     authenticated_request.reset!
   end
 
-  # Feel freee to add skip_after_action for this method in controllers for stats or api transactions
   def update_current_user_after_login
     handle_remember_cookie!(params[:remember_me] == "1")
     user_session.access(request) if user_session

--- a/app/lib/authenticated_system.rb
+++ b/app/lib/authenticated_system.rb
@@ -30,6 +30,7 @@ module AuthenticatedSystem
     authenticated_request.reset!
   end
 
+  # Feel freee to add skip_after_action for this method in controllers for stats or api transactions
   def update_current_user_after_login
     handle_remember_cookie!(params[:remember_me] == "1")
     user_session.access(request) if user_session

--- a/test/integration/provider/admin/dashboards_controller_test.rb
+++ b/test/integration/provider/admin/dashboards_controller_test.rb
@@ -4,6 +4,11 @@ require 'test_helper'
 
 class Provider::Admin::DashboardsControllerTest < ActionDispatch::IntegrationTest
   setup do
+    # FIXME: why are these wrong?
+    Provider::Admin::DashboardsController.any_instance.expects(:update_current_user_after_login).once
+    Provider::Admin::Dashboard::PotentialUpgradesController.any_instance.expects(:update_current_user_after_login).never
+    Provider::Admin::Dashboard::NewAccountsController.any_instance.expects(:update_current_user_after_login).never
+
     @provider = FactoryBot.create(:provider_account, org_name: 'Company')
     user = FactoryBot.create(:admin, account: provider)
     user.activate!


### PR DESCRIPTION
This is called 3 times in the dashboard:
```
  SQL (0.8ms)  UPDATE `users` SET `users`.`remember_token_expires_at` = NULL, `users`.`remember_token` = NULL WHERE `users`.`id` = 2
   (0.2ms)  BEGIN
  SQL (0.4ms)  UPDATE `user_sessions` SET `accessed_at` = '2022-03-28 11:59:18', `updated_at` = '2022-03-28 11:59:18' WHERE `user_sessions`.`id` = 7
   (0.4ms)  COMMIT
```

