### PR TITLE
Small change

### DIFF
--- a/app/events/oidc/proxy_changed_event.rb
+++ b/app/events/oidc/proxy_changed_event.rb
@@ -21,6 +21,6 @@ class OIDC::ProxyChangedEvent < BaseEventStoreEvent
   def self.valid?(proxy)
     service = proxy.try(:service)
     return unless service
-    service.backend_version.oauth? || service.saved_changes&.include?('oauth')
+    service.backend_version.oauth? || service.saved_change_to_backend_version&.include?('oauth')
   end
 end

--- a/test/events/oidc/proxy_changed_event_test.rb
+++ b/test/events/oidc/proxy_changed_event_test.rb
@@ -34,6 +34,10 @@ class OIDC::ProxyChangedEventTest < ActiveSupport::TestCase
     proxy.service.backend_version = 'oauth'
     assert OIDC::ProxyChangedEvent.valid?(proxy)
 
+    proxy.service.save
+    proxy.service.backend_version = "2"
+    assert OIDC::ProxyChangedEvent.valid?(proxy)
+
     proxy.stubs(service: nil)
     refute OIDC::ProxyChangedEvent.valid?(proxy)
   end


### PR DESCRIPTION
According to the warning, it should be `saved_change_to_backend_version` instead of `saved_changes`.
```
DEPRECATION WARNING: The behavior of `attribute_change` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_change_to_attribute` instead. (called from valid? at (pry):7)
```