### PR TITLE
THREESCALE-8140 Prevent emails from being sent without subject and/or body for applications

### DIFF
--- a/features/old/applications/providers/bulk_operations/send_emails.feature
+++ b/features/old/applications/providers/bulk_operations/send_emails.feature
@@ -31,7 +31,7 @@ Feature: Mass email bulk operations
     And I fill in "Subject" with "Nothing to say"
     And I press "Send"
     Then I should see "Selected Applications"
-      And "jane@me.us" should receive no emails
+    And "jane@me.us" should receive no emails
 
   Scenario: Emails can't be sent without subject
     Given I am logged in as provider "foo.3scale.localhost"
@@ -42,7 +42,7 @@ Feature: Mass email bulk operations
     And I fill in "Body" with "There is no Subject to this email"
     And I press "Send"
     Then I should see "Selected Applications"
-      And "jane@me.us" should receive no emails
+    And "jane@me.us" should receive no emails
     
   Scenario: Send mass email to application owners
     Given I am logged in as provider "foo.3scale.localhost"

--- a/features/old/applications/providers/bulk_operations/send_emails.feature
+++ b/features/old/applications/providers/bulk_operations/send_emails.feature
@@ -31,6 +31,7 @@ Feature: Mass email bulk operations
     And I fill in "Subject" with "Nothing to say"
     And I press "Send"
     Then I should see "Selected Applications"
+      And "jane@me.us" should receive no emails
 
   Scenario: Emails can't be sent without subject
     Given I am logged in as provider "foo.3scale.localhost"
@@ -41,6 +42,7 @@ Feature: Mass email bulk operations
     And I fill in "Body" with "There is no Subject to this email"
     And I press "Send"
     Then I should see "Selected Applications"
+      And "jane@me.us" should receive no emails
     
   Scenario: Send mass email to application owners
     Given I am logged in as provider "foo.3scale.localhost"


### PR DESCRIPTION
**What this PR does / why we need it:**

When sending emails from the bulk operations emails can be sent if body and subject is empty
make those field required

Which issue(s) this PR fixes

Main task : https://issues.redhat.com/browse/THREESCALE-8009

SubTask: https://issues.redhat.com/browse/THREESCALE-8140