### PR TITLE
THREESCALE-8141 Prevent emails from being sent without subject and/or body for accounts

### DIFF
--- a/features/old/accounts/bulk_operations/send_email.feature
+++ b/features/old/accounts/bulk_operations/send_email.feature
@@ -28,7 +28,7 @@ Feature: Mass email bulk operations
     And I fill in "Subject" with "Nothing to say"
     And I press "Send"
     Then I should see "Selected Accounts"
-      And "jane@me.us" should receive no emails
+    And "jane@me.us" should receive no emails
 
   Scenario: Emails can't be sent without subject
     And I am on the accounts admin page
@@ -38,7 +38,7 @@ Feature: Mass email bulk operations
     And I fill in "Body" with "There is no Subject to this email"
     And I press "Send"
     Then I should see "Selected Accounts"
-      And "jane@me.us" should receive no emails
+    And "jane@me.us" should receive no emails
 
   Scenario: Send mass email to application owners
       And I am on the accounts admin page

--- a/features/old/accounts/bulk_operations/send_email.feature
+++ b/features/old/accounts/bulk_operations/send_email.feature
@@ -28,6 +28,7 @@ Feature: Mass email bulk operations
     And I fill in "Subject" with "Nothing to say"
     And I press "Send"
     Then I should see "Selected Accounts"
+      And "jane@me.us" should receive no emails
 
   Scenario: Emails can't be sent without subject
     And I am on the accounts admin page
@@ -37,6 +38,7 @@ Feature: Mass email bulk operations
     And I fill in "Body" with "There is no Subject to this email"
     And I press "Send"
     Then I should see "Selected Accounts"
+      And "jane@me.us" should receive no emails
 
   Scenario: Send mass email to application owners
       And I am on the accounts admin page


### PR DESCRIPTION
What this PR does / why we need it:

When sending emails from the bulk operations emails can be sent if body and subject is empty
make those field required

Which issue(s) this PR fixes

Main task : https://issues.redhat.com/browse/THREESCALE-8009

SubTask: https://issues.redhat.com/browse/THREESCALE-8141