### PR TITLE
Update Common/Select component

### DIFF
--- a/app/javascript/src/Common/components/Select.jsx
+++ b/app/javascript/src/Common/components/Select.jsx
@@ -20,6 +20,7 @@ type Props<T: Record> = {
   items: T[],
   onSelect: (T | null) => void,
   label: React.Node,
+  ariaLabel?: string,
   fieldId: string,
   name: string,
   isClearable?: boolean,
@@ -38,6 +39,7 @@ const Select = <T: Record>({
   items,
   onSelect,
   label,
+  ariaLabel,
   fieldId,
   name,
   isClearable = true,
@@ -86,7 +88,7 @@ const Select = <T: Record>({
         onSelect={handleSelect}
         isExpanded={expanded}
         onClear={handleOnClear}
-        aria-label={label}
+        aria-label={ariaLabel}
         isDisabled={isDisabled}
         // $FlowIssue[incompatible-call] should not complain about plan having id as number, since Record has union "number | string"
         onFilter={handleOnFilter(items)}

--- a/spec/javascripts/Common/components/Select.spec.jsx
+++ b/spec/javascripts/Common/components/Select.spec.jsx
@@ -16,7 +16,8 @@ const defaultProps = {
   item: null,
   items,
   onSelect,
-  label: 'Toys',
+  label: <h1>Toys</h1>,
+  ariaLabel: 'Toys',
   fieldId: 'favorite_toy',
   name: 'toy[favorite]',
   isClearable: undefined,
@@ -74,7 +75,7 @@ it('should filter via typeahead', () => {
 
 it('should be aria-labelled', () => {
   const wrapper = mountWrapper()
-  expect(wrapper.find(`[aria-label="${defaultProps.label}"]`))
+  expect(wrapper.find(`[aria-label="${defaultProps.ariaLabel}"]`).exists()).toBe(true)
 })
 
 it('should show a spinner when loading', () => {


### PR DESCRIPTION
`title` was used for `ariaLabel`, but the former can be a React component which is not valid as aria-label. Therefore, we need a new prop to pass a valid aria-label.