### PR TITLE
🐛 Parse customer params to hash in BrainTreeController

### DIFF
--- a/app/controllers/provider/admin/account/payment_gateways/braintree_blue_controller.rb
+++ b/app/controllers/provider/admin/account/payment_gateways/braintree_blue_controller.rb
@@ -35,7 +35,7 @@ class Provider::Admin::Account::PaymentGateways::BraintreeBlueController < Provi
   end
 
   def hosted_success
-    customer_info      = params.require(:customer)
+    customer_info      = params.require(:customer).permit!.to_h
     braintree_response = braintree_blue_crypt.confirm(customer_info, params.require(:braintree).require(:nonce))
     @payment_result    = braintree_response&.success?
 

--- a/test/integration/provider/admin/account/payment_gateways/braintree_blue_controller_test.rb
+++ b/test/integration/provider/admin/account/payment_gateways/braintree_blue_controller_test.rb
@@ -83,10 +83,24 @@ class Provider::Admin::Account::PaymentGateways::BraintreeBlueControllerTest < A
 
   end
 
+  test '#hosted_success' do
+    gateway_options = { public_key: 'Public Key', merchant_id: 'Merchant ID', private_key: 'Private Key' }
+    @provider.provider_account.update(payment_gateway_options: gateway_options)
+
+    ::PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm)
+                                                      .with({'first_name' => 'John', 'last_name' => 'Doe', 'phone' => '123456789', 'credit_card' => {'billing_address' => {'company' => 'Invisible Inc.', 'street_address' => '123 Main Street', 'postal_code' => '12345', 'locality' => 'Anytown', 'region' => 'Nowhere', 'country_name' => 'US'}}}, 'a_nonce')
+                                                      .returns(failed_result)
+
+    post hosted_success_provider_admin_account_braintree_blue_path, params: form_params
+    assert_response :redirect
+  end
+
   test '#hosted_success suspend account when failure count is higher than threshold' do
     gateway_options = { public_key: 'Public Key', merchant_id: 'Merchant ID', private_key: 'Private Key' }
     @provider.provider_account.update(payment_gateway_options: gateway_options)
-    ::PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm).returns(failed_result)
+    ::PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm)
+                                                      .with({'first_name' => 'John', 'last_name' => 'Doe', 'phone' => '123456789', 'credit_card' => {'billing_address' => {'company' => 'Invisible Inc.', 'street_address' => '123 Main Street', 'postal_code' => '12345', 'locality' => 'Anytown', 'region' => 'Nowhere', 'country_name' => 'US'}}}, 'a_nonce')
+                                                      .returns(failed_result)
     ActionLimiter.any_instance.stubs(:perform!).raises(ActionLimiter::ActionLimitsExceededError)
 
     post hosted_success_provider_admin_account_braintree_blue_path, params: form_params
@@ -99,7 +113,9 @@ class Provider::Admin::Account::PaymentGateways::BraintreeBlueControllerTest < A
   test '#hosted_success does not suspend account when failure count is below the threshold' do
     gateway_options = { public_key: 'Public Key', merchant_id: 'Merchant ID', private_key: 'Private Key' }
     @provider.provider_account.update(payment_gateway_options: gateway_options)
-    ::PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm).returns(failed_result)
+    ::PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm)
+                                                      .with({'first_name' => 'John', 'last_name' => 'Doe', 'phone' => '123456789', 'credit_card' => {'billing_address' => {'company' => 'Invisible Inc.', 'street_address' => '123 Main Street', 'postal_code' => '12345', 'locality' => 'Anytown', 'region' => 'Nowhere', 'country_name' => 'US'}}}, 'a_nonce')
+                                                      .returns(failed_result)
 
     post hosted_success_provider_admin_account_braintree_blue_path, params: form_params
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```
NoMethodErrordeveloper_portal/admin/account/braintree_blue#hosted_success
undefined method `deep_merge' for #<ActionController::Parameters:0x00000010ea575...>
```

It seems that `BrainTreeBlueCrypt#confirm` was relying on a hash as a paremeter, but after upgrading rails `params.require` returns `ActiveController::Parameters` instead.

https://github.com/3scale/porta/blob/7f33217f7b54a01d792574136fe1b1693a895bf2/app/lib/payment_gateways/brain_tree_blue_crypt.rb#L19-L20

**Which issue(s) this PR fixes** 

https://app.bugsnag.com/3scale-networks-sl/system/errors/622f6145c44845000939c6e7?event_id=622f61450092d7af73190000&i=sk&m=nw