### PR TITLE
🐛 [dev-portal] parse brain_tree_controller customer params to hash

### DIFF
--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/braintree_blue_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/braintree_blue_controller.rb
@@ -18,7 +18,7 @@ module DeveloperPortal::Admin::Account
     end
 
     def hosted_success
-      customer_info      = params.require(:customer)
+      customer_info      = params.require(:customer).permit!.to_h
       braintree_response = braintree_blue_crypt.confirm(customer_info, params.require(:braintree).require(:nonce))
       @payment_result    = braintree_response&.success?
       if @payment_result

--- a/test/functional/developer_portal/admin/account/braintree_blue_controller_test.rb
+++ b/test/functional/developer_portal/admin/account/braintree_blue_controller_test.rb
@@ -31,7 +31,9 @@ class DeveloperPortal::Admin::Account::BraintreeBlueControllerTest < DeveloperPo
   end
 
   test '#hosted_success' do
-    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm).returns(successful_result)
+    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm)
+                                                    .with({'credit_card' => {'billing_address' => {'company' => 'Invisible Inc.', 'country_name' => 'US', 'locality' => 'Anytown', 'postal_code' => '12345', 'region' => 'Nowhere', 'street_address' => '123 Main Street'}}, 'first_name' => 'John', 'last_name' => 'Doe', 'phone' => '123456789'}, 'a_nonce')
+                                                    .returns(successful_result)
 
     # Account does not have a credit card auth code
     assert_nil @account.credit_card_auth_code
@@ -47,7 +49,9 @@ class DeveloperPortal::Admin::Account::BraintreeBlueControllerTest < DeveloperPo
   end
 
   test '#hosted_success with plan changes' do
-    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm).returns(successful_result)
+    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm)
+                                                    .with({'credit_card' => {'billing_address' => {'company' => 'Invisible Inc.', 'country_name' => 'US', 'locality' => 'Anytown', 'postal_code' => '12345', 'region' => 'Nowhere', 'street_address' => '123 Main Street'}}, 'first_name' => 'John', 'last_name' => 'Doe', 'phone' => '123456789'}, 'a_nonce')
+                                                    .returns(successful_result)
 
     # Account does not have a credit card auth code
     assert_nil @account.credit_card_auth_code
@@ -65,7 +69,9 @@ class DeveloperPortal::Admin::Account::BraintreeBlueControllerTest < DeveloperPo
   end
 
   test '#hosted_success with errors not storing credit card' do
-    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm).returns(successful_result)
+    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm)
+                                                    .with({'credit_card' => {'billing_address' => {'company' => 'Invisible Inc.', 'country_name' => 'US', 'locality' => 'Anytown', 'postal_code' => '12345', 'region' => 'Nowhere', 'street_address' => '123 Main Street'}}, 'first_name' => 'John', 'last_name' => 'Doe', 'phone' => '123456789'}, 'a_nonce')
+                                                    .returns(successful_result)
     PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:update_user).returns(false)
 
     # Account does not have a credit card auth code
@@ -84,7 +90,9 @@ class DeveloperPortal::Admin::Account::BraintreeBlueControllerTest < DeveloperPo
   end
 
   test '#hosted_success with errors' do
-    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm).returns(failed_result)
+    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm)
+                                                    .with({'credit_card' => {'billing_address' => {'company' => 'Invisible Inc.', 'country_name' => 'US', 'locality' => 'Anytown', 'postal_code' => '12345', 'region' => 'Nowhere', 'street_address' => '123 Main Street'}}, 'first_name' => 'John', 'last_name' => 'Doe', 'phone' => '123456789'}, 'a_nonce')
+                                                    .returns(failed_result)
     PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:update_user).never
 
     # Account does not have a credit card auth code
@@ -103,7 +111,9 @@ class DeveloperPortal::Admin::Account::BraintreeBlueControllerTest < DeveloperPo
   end
 
   test '#hosted_success suspend account when failure count is higher than threshold' do
-    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm).returns(failed_result)
+    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm)
+                                                    .with({'credit_card' => {'billing_address' => {'company' => 'Invisible Inc.', 'country_name' => 'US', 'locality' => 'Anytown', 'postal_code' => '12345', 'region' => 'Nowhere', 'street_address' => '123 Main Street'}}, 'first_name' => 'John', 'last_name' => 'Doe', 'phone' => '123456789'}, 'a_nonce')
+                                                    .returns(failed_result)
     ActionLimiter.any_instance.stubs(:perform!).raises(ActionLimiter::ActionLimitsExceededError)
 
     post :hosted_success, params: form_params
@@ -114,7 +124,9 @@ class DeveloperPortal::Admin::Account::BraintreeBlueControllerTest < DeveloperPo
   end
 
   test '#hosted_success does not suspend account when failure count is below the threshold' do
-    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm).returns(failed_result)
+    PaymentGateways::BrainTreeBlueCrypt.any_instance.expects(:confirm)
+                                                    .with({'credit_card' => {'billing_address' => {'company' => 'Invisible Inc.', 'country_name' => 'US', 'locality' => 'Anytown', 'postal_code' => '12345', 'region' => 'Nowhere', 'street_address' => '123 Main Street'}}, 'first_name' => 'John', 'last_name' => 'Doe', 'phone' => '123456789'}, 'a_nonce')
+                                                    .returns(failed_result)
 
     post :hosted_success, params: form_params
 


### PR DESCRIPTION
Follows up on https://github.com/3scale/porta/pull/2938

**What this PR does / why we need it**:
```
NoMethodErrordeveloper_portal/admin/account/braintree_blue#hosted_success
undefined method `deep_merge' for #<ActionController::Parameters:0x00000010ea575...>
```

It seems that `BrainTreeBlueCrypt#confirm` was relying on a hash as a paremeter, but after upgrading rails `params.require` returns `ActiveController::Parameters` instead.

https://github.com/3scale/porta/blob/7f33217f7b54a01d792574136fe1b1693a895bf2/app/lib/payment_gateways/brain_tree_blue_crypt.rb#L19-L20

**Which issue(s) this PR fixes** 

https://app.bugsnag.com/3scale-networks-sl/system/errors/622f6145c44845000939c6e7?event_id=622f61450092d7af73190000&i=sk&m=nw