### PR TITLE
🐛 Remove `buyer/1/analytics` from list of Dev Portal available scripts

### DIFF
--- a/lib/developer_portal/lib/liquid/filters/rails_helpers.rb
+++ b/lib/developer_portal/lib/liquid/filters/rails_helpers.rb
@@ -10,7 +10,7 @@ module Liquid
       include Liquid::Filters::Base
 
       THREESCALE_STYLESHEETS = %w[legacy/stats plans_widget.css active-docs/application.css stats.css].freeze
-      THREESCALE_JAVASCRIPTS = %w[buyer/1/analytics plans_widget.js plans_widget_v2.js active-docs/application.js stats.js].freeze
+      THREESCALE_JAVASCRIPTS = %w[plans_widget.js plans_widget_v2.js active-docs/application.js stats.js].freeze
       THREESCALE_WEBPACK_PACKS = %w[stats.js active_docs.js load_stripe.js validateSignup.js].freeze
       THREESCALE_IMAGES      = %w[spinner.gif tick.png cross.png].freeze
       ACTIVE_DOCS_JS = %w[active-docs/application.js active_docs.js].freeze

--- a/test/integration/liquid/legacy_tags_test.rb
+++ b/test/integration/liquid/legacy_tags_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Liquid::LegacyTagsTest < ActionDispatch::IntegrationTest
@@ -25,6 +27,20 @@ class Liquid::LegacyTagsTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_match /No new messages/, response.body
+  end
+
+  # Bug in production https://app.bugsnag.com/3scale-networks-sl/system/errors/622f614862800a00091a1f9b
+  test 'buyer/1/analytics.js' do
+    override_dashboard_with %(
+      {% content_for javascripts %}
+        {{ 'buyer/1/analytics' | javascript_include_tag }}
+      {% endcontent_for %}
+      All is good
+    )
+
+    get '/admin'
+    assert_response :success
+    assert_match /All is good/, response.body
   end
 
   private


### PR DESCRIPTION
### What this PR does / why we need it

There used to be a script `buyer/1/analytics.js` included in some Dev portal templates, I think these two only:

- https://github.com/3scale/system/blob/bbfaa59f2b70d065d432c5771796787732071850/lib/developer_portal/app/views/developer_portal/stats/index.html.liquid#L1-L3
- At some point in `applications/show`

Sometime before the open-sourcing step, the package `highcharts` was removed [with this](https://github.com/3scale/system/pull/9368/files?show-deleted-files=true&show-viewed-files=true&file-filters%5B%5D=#diff-62adc7322d21216fc0dca38d01c1b388f6390f681ff2a0ece2abadf28216cb68) and other scripts. This one however was left inside `THREESCALE_JAVASCRIPTS`, meaning the script would still be available as an importable asset.

Therefore, there is a customer with an old versions of either of those templates who is causing this error in production. There is no need to update those templates, only to remove it from the available assets.

### Which issue(s) this PR fixes
https://app.bugsnag.com/3scale-networks-sl/system/errors/622f614862800a00091a1f9b?event_id=623034f00092fb6506e70000&i=sk&m=fq

### Verification steps

Including this script in a Dev portal template won't make the page crash (there is a test now for this anyway).
```liquid
    {{ 'buyer/1/analytics' | javascript_include_tag }}
```
