### PR TITLE
Prevent traffic importers `#notify_segment` from rising nullpointer error

### DIFF
--- a/app/lib/events/importers/first_daily_traffic_importer.rb
+++ b/app/lib/events/importers/first_daily_traffic_importer.rb
@@ -1,26 +1,26 @@
+# frozen_string_literal: true
+
 require_dependency 'events/importers/base_importer'
 
 module Events
   module Importers
     class FirstDailyTrafficImporter < BaseImporter
       def save!
-        if cinstance
-          cinstance.update_attribute(:first_daily_traffic_at, object.timestamp)
-          notify_segment
-          true
-        end
+        return unless cinstance
+
+        cinstance.update_attribute(:first_daily_traffic_at, object.timestamp)
+        notify_segment
+        true
       end
 
       def notify_segment
         analytics = user_tracking
         timestamp = cinstance.first_daily_traffic_at
 
-        return unless timestamp
+        return unless timestamp && analytics
 
         analytics.with_segment_options(timestamp: timestamp) do
-          if analytics.track('Traffic Sent'.freeze, date: timestamp.to_date, timestamp: timestamp)
-            LastTraffic.send_traffic_in_day(cinstance, timestamp)
-          end
+          analytics.track('Traffic Sent', date: timestamp.to_date, timestamp: timestamp) if LastTraffic.send_traffic_in_day(cinstance, timestamp)
         end
       end
     end

--- a/app/lib/events/importers/first_traffic_importer.rb
+++ b/app/lib/events/importers/first_traffic_importer.rb
@@ -1,27 +1,28 @@
+# frozen_string_literal: true
+
 require_dependency 'events/importers/base_importer'
 
 module Events
   module Importers
     class FirstTrafficImporter < BaseImporter
       def save!
-        if cinstance
-          cinstance.update_attribute(:first_traffic_at, object.timestamp)
-          notify_segment
-          true
-        end
+        return unless cinstance
+
+        cinstance.update_attribute(:first_traffic_at, object.timestamp)
+        notify_segment
+        true
       end
 
       def notify_segment
         analytics = user_tracking
         timestamp = cinstance.first_traffic_at
 
-        return unless timestamp
+        return unless timestamp && analytics
 
         analytics.with_segment_options(timestamp: timestamp) do
-          analytics.track('Traffic Sent'.freeze, date: timestamp.to_date, timestamp: timestamp)
+          analytics.track('Traffic Sent', date: timestamp.to_date, timestamp: timestamp)
         end
       end
     end
   end
 end
-

--- a/test/unit/events/importers/first_daily_traffic_importer_test.rb
+++ b/test/unit/events/importers/first_daily_traffic_importer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Events::Importers::FirstDailyTrafficImporterTest < ActiveSupport::TestCase
@@ -6,13 +8,13 @@ class Events::Importers::FirstDailyTrafficImporterTest < ActiveSupport::TestCase
     @cinstance = FactoryBot.create(:cinstance)
     @timestamp = 1.day.ago.round
     @object    = OpenStruct.new(
-                   application_id: @cinstance.application_id,
-                   service_id:     @cinstance.service.id,
-                   timestamp:      @timestamp.to_s
+      application_id: @cinstance.application_id,
+      service_id:     @cinstance.service.id,
+      timestamp:      @timestamp.to_s
     )
   end
 
-  def test_save!
+  test '#save!' do
     assert importer.save!
 
     @cinstance.reload
@@ -21,23 +23,30 @@ class Events::Importers::FirstDailyTrafficImporterTest < ActiveSupport::TestCase
 
   test "save importer after destroy the cinstance should not raise error" do
     @cinstance.destroy
-    refute importer.save!
+    assert_not importer.save!
   end
 
-  def test_notify_segment
+  test 'notify_segment' do
     @cinstance.account.update_attribute(:provider, true)
     ThreeScale::Analytics::UserTracking::Segment.expects(:track).with(has_entries(event: 'Traffic Sent',
                                                                                   properties: {
-                                                                                      timestamp: @timestamp,
+                                                                                    timestamp: @timestamp,
                                                                                       date: @timestamp.to_date
                                                                                   })).returns(true)
     LastTraffic.expects(:send_traffic_in_day).with(@cinstance, @timestamp).returns(true)
 
-    refute importer.notify_segment
+    assert_not importer.notify_segment
 
     assert @cinstance.update_attribute(:first_daily_traffic_at, @object.timestamp)
 
     assert importer.notify_segment
+  end
+
+  # Regression: https://app.bugsnag.com/3scale-networks-sl/system/errors/61ba778a71d2ed0008544c1d?event_id=622fc0e90092e226db140000&i=sk&m=fq
+  test 'user_tracking is nil' do
+    Events::Importers::BaseImporter.any_instance.expects(:user_tracking).returns(nil)
+    Cinstance.any_instance.expects(:first_daily_traffic_at).returns(@object.timestamp)
+    assert_not importer.notify_segment
   end
 
   protected


### PR DESCRIPTION
**Which issue(s) this PR fixes** 

https://app.bugsnag.com/3scale-networks-sl/system/errors/61ba778a71d2ed0008544c1d?event_id=622fc0e90092e226db140000&i=sk&m=fq

**Verification steps** 

No idea how to reproduce this but hopefully the new tests are enough.