### PR TITLE
fix NoMethodError: undefined method for nil:NilClass

### DIFF
--- a/test/unit/mailers/post_office_test.rb
+++ b/test/unit/mailers/post_office_test.rb
@@ -19,6 +19,14 @@ class PostOfficeTest < ActionMailer::TestCase
     assert_equal message, GlobalID::Locator.locate_signed(uri)
   end
 
+  test 'message_notification is graceful when recipient account is deleted' do
+    message = Message.create! sender: @provider, to: [@buyer]
+    @buyer.destroy!
+    message.reload
+
+    assert_instance_of ActionMailer::Base::NullMail, PostOffice.message_notification(message, message.recipients.first).message
+  end
+
   test 'message_notification manage viral footer on email messages' do
     subject = generate_message_subject
     message   = Message.create! sender: @provider, to: [@buyer], subject: subject, body: 'W0rmDr1nk'


### PR DESCRIPTION
We observed error from ActionMailer background job

>  NoMethodError · undefined method `buyer?' for nil:NilClass

It seems to appear when account got deleted before delivery happens.

This is just logging the error. But PR is in WIP status because
I try to make sure that we don't try to deliver such messages when
for example an account is deleted. So far I don't see such occasion though.