### PR TITLE
Attributes are now Parameters in user_controller's #update_attributes

### DIFF
--- a/app/controllers/provider/admin/account/users_controller.rb
+++ b/app/controllers/provider/admin/account/users_controller.rb
@@ -36,19 +36,19 @@ class Provider::Admin::Account::UsersController < Provider::Admin::Account::Base
     @users ||= end_of_association_chain.but_impersonation_admin.paginate(page: params[:page]).decorate
   end
 
+  def permitted_params
+    # TODO: this should be handled by cancancan
+    permitted = current_account.provider_can_use?(:service_permissions) ? %i[role member_permission_ids member_permission_service_ids] : %i[role member_permission_ids]
+    params.require(:user).permit(permitted)
+  end
+
   def update_resource(user, attributes)
     # FIXME: in rails 3, we're getting an array
     attributes = attributes.first
 
-    # And in rails 5, it can be ActionController::Parameters or hash
-    attributes = ActionController::Parameters.new(attributes) unless attributes.is_a?(ActionController::Parameters)
-    protected_attributes = attributes.permit(User::Permissions::ATTRIBUTES)
-
-    protected_attributes.extract!(:member_permission_service_ids) unless current_account.provider_can_use?(:service_permissions)
-
     user.class.transaction do
       user.assign_attributes(attributes)
-      user.assign_attributes(protected_attributes, without_protection: can?(:update_role, user))
+      user.assign_attributes(attributes, without_protection: can?(:update_role, user))
 
       user.save
     end

--- a/app/controllers/provider/admin/account/users_controller.rb
+++ b/app/controllers/provider/admin/account/users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Provider::Admin::Account::UsersController < Provider::Admin::Account::BaseController
   inherit_resources
   defaults :route_prefix => 'provider_admin_account'
@@ -38,11 +40,11 @@ class Provider::Admin::Account::UsersController < Provider::Admin::Account::Base
     # FIXME: in rails 3, we're getting an array
     attributes = attributes.first
 
-    protected_attributes = attributes.extract!(*User::Permissions::ATTRIBUTES)
+    # And in rails 5, it can be ActionController::Parameters or hash
+    attributes = ActionController::Parameters.new(attributes) unless attributes.is_a?(ActionController::Parameters)
+    protected_attributes = attributes.permit(User::Permissions::ATTRIBUTES)
 
-    unless current_account.provider_can_use?(:service_permissions)
-      protected_attributes.except!(:member_permission_service_ids)
-    end
+    protected_attributes.extract!(:member_permission_service_ids) unless current_account.provider_can_use?(:service_permissions)
 
     user.class.transaction do
       user.assign_attributes(attributes)

--- a/app/models/user/permissions.rb
+++ b/app/models/user/permissions.rb
@@ -5,6 +5,8 @@ require 'admin_section'
 module User::Permissions
   extend ActiveSupport::Concern
 
+  ATTRIBUTES = %I[ role member_permission_ids member_permission_service_ids ]
+
   included do
     has_many :member_permissions, dependent: :destroy, autosave: true
 

--- a/app/models/user/permissions.rb
+++ b/app/models/user/permissions.rb
@@ -5,8 +5,6 @@ require 'admin_section'
 module User::Permissions
   extend ActiveSupport::Concern
 
-  ATTRIBUTES = [:role, member_permission_ids: [], member_permission_service_ids: []].freeze # rubocop:disable Style/HashAsLastArrayItem
-
   included do
     has_many :member_permissions, dependent: :destroy, autosave: true
 

--- a/app/models/user/permissions.rb
+++ b/app/models/user/permissions.rb
@@ -5,7 +5,7 @@ require 'admin_section'
 module User::Permissions
   extend ActiveSupport::Concern
 
-  ATTRIBUTES = %I[ role member_permission_ids member_permission_service_ids ]
+  ATTRIBUTES = [:role, member_permission_ids: [], member_permission_service_ids: []].freeze # rubocop:disable Style/HashAsLastArrayItem
 
   included do
     has_many :member_permissions, dependent: :destroy, autosave: true

--- a/test/integration/provider/admin/account/users_controller_test.rb
+++ b/test/integration/provider/admin/account/users_controller_test.rb
@@ -112,13 +112,4 @@ class Provider::Admin::Account::UsersControllerTest < ActionDispatch::Integratio
 
     assert user.reload.admin?
   end
-
-  # Regression: https://app.bugsnag.com/3scale-networks-sl/system/errors/623154afea8d6b0008c052c5
-  test 'admin cannot update member service_ids if no service permissions' do
-    rolling_updates_on
-    Account.any_instance.expects(:provider_can_use?).with(:service_permissions).returns(false)
-
-    put provider_admin_account_user_path(@user), params: { user: { member_permission_service_ids: %w[1 2] } }
-    assert_response :redirect
-  end
 end

--- a/test/integration/provider/admin/account/users_controller_test.rb
+++ b/test/integration/provider/admin/account/users_controller_test.rb
@@ -78,7 +78,7 @@ class Provider::Admin::Account::UsersControllerTest < ActionDispatch::Integratio
     assert_equal @default_ids, @user.admin_sections.to_a
 
     put provider_admin_account_user_path(@user)
-    assert_response :bad_request
+    assert_response :redirect
   end
 
   test 'admin deletes another admin' do

--- a/test/integration/provider/admin/account/users_controller_test.rb
+++ b/test/integration/provider/admin/account/users_controller_test.rb
@@ -87,4 +87,13 @@ class Provider::Admin::Account::UsersControllerTest < ActionDispatch::Integratio
 
     assert user.reload.admin?
   end
+
+  # Regression: https://app.bugsnag.com/3scale-networks-sl/system/errors/623154afea8d6b0008c052c5
+  test 'admin cannot update member service_ids if no service permissions' do
+    rolling_updates_on
+    Account.any_instance.expects(:provider_can_use?).with(:service_permissions).returns(false)
+
+    put provider_admin_account_user_path(@user), params: { user: { member_permission_service_ids: %w[1 2] } }
+    assert_response :redirect
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

`attributes` used to be a hash, now it's ActionController::Parameters.. and sometimes it's still a hash 🤷🏻‍♂️ .

**Which issue(s) this PR fixes** 

Error found https://app.bugsnag.com/3scale-networks-sl/system/errors/623154afea8d6b0008c052c5?event_id=623154af0092ebfb070a0000&i=sk&m=nw