### PR TITLE
🥒 Reduce Cucumber build time

### DIFF
--- a/features/api/backend_usages.feature
+++ b/features/api/backend_usages.feature
@@ -12,17 +12,6 @@ Feature: Backend Usages
     And I go to the provider dashboard
     And I go to the service backends admin page of service "API"
 
-  Scenario: Add a backend api that is unused
-    Given I should see "Backends"
-    And I follow "Add Backend"
-    Then I should see "Add a Backend"
-    And I select "my backend" from "Backend"
-    And I fill in "Path" with "/api/v1"
-    And I press "Add to Product"
-    Then I should see "Backend added to Product."
-    Then I follow "Add Backend"
-    And the "Backend" select should not contain "my backend" option
-
   Scenario: Add a backend with wrong path
     Given I follow "Add Backend"
     And I select "my backend" from "Backend"

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -28,7 +28,7 @@ Capybara.configure do |config|
   config.raise_server_errors = true
   config.match = :prefer_exact
   config.always_include_port = true
-  config.default_max_wait_time = 10
+  config.default_max_wait_time = 2
 end
 
 # Needed because cucumber-rails requires capybara/cucumber


### PR DESCRIPTION
Cucumbers are not written well and that is a fact. I don't think nobody has ever understood them very well and one of the workarounds added to force them pass was adding a max waiting time of 10 seconds whereas the default is 2. That means, every time capybara checks something it isn't in the UI it will wait 10 seconds. Thats x5 spent time for elements that are not supposed to be there!

Whenever cucumber fails finding or not finding a selector, it should be addressed locally
- Rethink the Scenario and steps involved (it's supposed to test behavior NOT functionality)
- Add a specific max wait time for that specific instruction (by using `wait: T` option)
- Re write the step to assert the scenario correctly: look for invisible, wait for X to happen, navigate to a route instead of clicking a link, etc.

This choice in the past resulted in a horrible dev experience, because running cucumbers locally is painfully slow AND much more cost in Circleci.

Average time cucumber job takes from `mysql_nightly_build_ruby26` for the last 90 days is `17m 30s` [1]
Rough average it takes in this branch: 6 m 30s [2]

[1] https://app.circleci.com/insights/github/3scale/porta/workflows/mysql_nightly_build_ruby26/jobs?branch=master&reporting-window=last-90-days
[2] https://app.circleci.com/pipelines/github/3scale/porta?branch=reduce_ci_cucumber_time&filter=all