### PR TITLE
THREESCALE-7676: limit number of jobs for tenant fixes

### DIFF
--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -1,33 +1,40 @@
 # frozen_string_literal: true
 
 class SetTenantIdWorker < ApplicationJob
+  queue_as :low
 
-  def perform(provider)
+  RELATIONS = ["backend_apis", "log_entries", "alerts"].freeze
+
+  def perform(provider, relations)
     provider.update_column(:master, false)
 
-    [:backend_apis, :log_entries, :alerts].each do |relation|
-      provider.public_send(relation).where(tenant_id: nil).find_each do |instance|
-        ModelTenantIdWorker.perform_later(instance, provider.tenant_id)
+    relations.each do |relation|
+      model = provider.public_send(relation)
+      model.select(:id).where(tenant_id: nil).find_in_batches(batch_size: 100) do |instances|
+        ModelTenantIdWorker.perform_later(model, instances.map(&:id), provider.tenant_id)
       end
     end
   end
 
   class BatchEnqueueWorker < ApplicationJob
     unique :until_executed
+    queue_as :low
 
-    def perform(*)
-      Account.providers.where(master: nil).find_each do |provider|
-        SetTenantIdWorker.perform_later(provider)
+    def perform(*relations)
+      raise "you must pass relations to fix" if relations.empty?
+      raise "Only relations #{RELATIONS} are supported" unless (relations - RELATIONS).empty?
+
+      Account.providers.select(:id).where(master: nil).find_each do |provider|
+        SetTenantIdWorker.perform_later(provider, relations)
       end
     end
   end
 
   class ModelTenantIdWorker < ApplicationJob
+    queue_as :low
 
-    def perform(object, tenant_id)
-      object.update_column(:tenant_id, tenant_id)
+    def perform(model, ids, tenant_id)
+      model.where(id: ids).update_all(tenant_id: tenant_id)
     end
-
   end
-
 end

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -305,9 +305,4 @@ namespace :fixes do
     exec_batch.call(:providers, Account.providers, provider_states_transitions)
     exec_batch.call(:developers, Account.buyers, buyer_states_transitions)
   end
-
-  desc 'Fix tenant_id missing in some tables'
-  task :tenant_id => :environment do
-    SetTenantIdWorker::BatchEnqueueWorker.perform_later
-  end
 end


### PR DESCRIPTION
First require user to enter relations that need fixing so that
they can be fixed individually.

Additionally perform updating in batches to reduce overal number of
jobs.

Also set the used queue to "low".

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7676