### PR TITLE
Add test for getting latest version + pagination

### DIFF
--- a/test/integration/admin/api/account/proxy_configs_controller_test.rb
+++ b/test/integration/admin/api/account/proxy_configs_controller_test.rb
@@ -160,6 +160,22 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
     assert_equal [proxy_config_version_new.id], response_proxy_config_ids
   end
 
+  test '#index for latest with pagination' do
+    service = FactoryBot.create(:simple_service, :with_default_backend_api, account: provider)
+    FactoryBot.create_list(:proxy_config, 2, proxy: service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('foo.example.com'))
+
+    get admin_api_account_proxy_configs_path(
+      environment: ProxyConfig::ENVIRONMENTS.first,
+      access_token: access_token_value(user: provider.admin_user)
+    ), params: {
+      page: 5,
+      host: 'foo.example.com',
+      version: 'latest'
+    }
+
+    assert_equal [], response_proxy_config_ids
+  end
+
   private
 
   def content_hosts(*hosts)

--- a/test/integration/admin/api/account/proxy_configs_controller_test.rb
+++ b/test/integration/admin/api/account/proxy_configs_controller_test.rb
@@ -162,7 +162,19 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
 
   test '#index for latest with pagination' do
     service = FactoryBot.create(:simple_service, :with_default_backend_api, account: provider)
-    FactoryBot.create_list(:proxy_config, 2, proxy: service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('foo.example.com'))
+    expected = FactoryBot.create_list(:proxy_config, 3, proxy: service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('foo.example.com')).last
+
+    get admin_api_account_proxy_configs_path(
+      environment: ProxyConfig::ENVIRONMENTS.first,
+      access_token: access_token_value(user: provider.admin_user)
+    ), params: {
+      per_page: 1,
+      page: 1,
+      host: 'foo.example.com',
+      version: 'latest'
+    }
+
+    assert_same_elements [expected.id], response_proxy_config_ids
 
     get admin_api_account_proxy_configs_path(
       environment: ProxyConfig::ENVIRONMENTS.first,
@@ -173,7 +185,7 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
       version: 'latest'
     }
 
-    assert_equal [], response_proxy_config_ids
+    assert_empty response_proxy_config_ids
   end
 
   private


### PR DESCRIPTION
This used to fail with the old `current_versions`. Now it doesn't and it doesn't make sense to ask for pagination, but since it's possible and it used to fail, here's a test for it.