### PR TITLE
🥒 Fix Delete plan scenario

### DIFF
--- a/features/api/plans/application_plans.feature
+++ b/features/api/plans/application_plans.feature
@@ -6,9 +6,7 @@ Feature: Application plans index page
   by name, no. of apps and state.
 
   Background:
-    Given a provider "foo.3scale.localhost"
-    And current domain is the admin domain of provider "foo.3scale.localhost"
-    And I am logged in as provider "foo.3scale.localhost"
+    Given a provider is logged in
     And an application plan "Basic" of provider "foo.3scale.localhost"
     And plan "Basic" has applications
     And I go to the application plans admin page
@@ -39,8 +37,7 @@ Feature: Application plans index page
     Given an application plan "Deleteme" of provider "foo.3scale.localhost"
     When I go to the application plans admin page
     And I select option "Delete" from the actions menu for plan "Deleteme" and I confirm dialog box
-    Then I should see "The plan was deleted"
-    And I should not see plan "Deleteme"
+    Then the application plan "Deleteme" should be deleted
 
   Scenario: Delete an Application plan is not allowed if subscribed to any application
     Then I should not see option "Delete" from the actions menu for plan "Basic"

--- a/features/step_definitions/plans/application_plans_steps.rb
+++ b/features/step_definitions/plans/application_plans_steps.rb
@@ -126,3 +126,8 @@ end
 Then /^I should be able to customize the plan$/ do
   should have_link("Convert to a Custom Plan")
 end
+
+Then "the application plan {string} should be deleted" do |name|
+  assert_content "The plan was deleted", wait: 10
+  step(%(I should not see plan "#{name}"))
+end


### PR DESCRIPTION
This Scenario is failing on and on again in circleci (oracle and postgres builds). Presumably because of capybara's waiting time.