### PR TITLE
EmailConfigurations CA trust

### DIFF
--- a/app/models/email_configuration.rb
+++ b/app/models/email_configuration.rb
@@ -35,18 +35,8 @@ class EmailConfiguration < ApplicationRecord
     }.compact.merge(tls_settings)
   end
 
-  def tls_settings
-    return {} unless tls
-
-    {
-      enable_starttls_auto: tls == "starttls_auto",
-      enable_starttls: tls == "starttls",
-      tls: tls == "tls",
-    }
-  end
-
   def smtp_settings
-    base_settings = only_auth_changes? ? ActionMailer::Base.smtp_settings : {}
+    base_settings = only_auth_changes? ? ActionMailer::Base.smtp_settings : default_trust
     base_settings.merge local_settings
   end
 
@@ -61,6 +51,20 @@ class EmailConfiguration < ApplicationRecord
   end
 
   private
+
+  def default_trust
+    ActionMailer::Base.smtp_settings.slice(:ca_file, :ca_path)
+  end
+
+  def tls_settings
+    return {} unless tls
+
+    {
+      enable_starttls_auto: tls == "starttls_auto",
+      enable_starttls: tls == "starttls",
+      tls: tls == "tls",
+    }
+  end
 
   def account_is_provider
     errors.add(:account_id, "is not a provider account") unless account.try(:provider?)


### PR DESCRIPTION
CA trust is dependent on runtime environment so we need to set it
from default in all cases.

If we implement in the future a feature to specify trust in another way,
it could be merged only in absense of user configuration for that. For now
having it always merged is the safest option.