### PR TITLE
test representation of all usage limit type

### DIFF
--- a/app/lib/backend/model_extensions/metric.rb
+++ b/app/lib/backend/model_extensions/metric.rb
@@ -42,6 +42,7 @@ module Backend
       end
 
       def execute_per_service(&block)
+        # TODO: stop referring to obsolete `service` attribute (5592fc2f407b7)
         services = [*owner.try(:services), service].compact
         services.each(&block)
       end

--- a/test/factories/other.rb
+++ b/test/factories/other.rb
@@ -55,9 +55,12 @@ FactoryBot.define do
   end
 
   factory(:metric) do
-    association :service
+    association :owner, factory: :service
     sequence(:friendly_name) { |n| "Metric #{n}" }
     sequence(:unit) { |m| "metric_#{m}" }
+
+    # TODO: stop referring to obsolete `service` attribute (5592fc2f407b7)
+    service { owner if Service === owner }
 
     # TODO: use this factory throughout the codebase
     factory(:method) do

--- a/test/integration/admin/api/application_plan_limits_controller_test.rb
+++ b/test/integration/admin/api/application_plan_limits_controller_test.rb
@@ -3,30 +3,51 @@
 require 'test_helper'
 
 class Admin::Api::ApplicationPlanLimitsControllerTest < ActionDispatch::IntegrationTest
+  attr_reader :service, :app_plan, :provider
 
-  def setup
+  setup do
     @provider = FactoryBot.create(:provider_account)
     @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
     host! @provider.admin_domain
+    @service = FactoryBot.create(:simple_service, account: @provider)
+    @app_plan = FactoryBot.create(:simple_application_plan, issuer: service)
   end
 
-  def test_index
-    service = FactoryBot.create(:simple_service, account: @provider)
-    app_plan = FactoryBot.create(:simple_application_plan, issuer: service)
-    metric = FactoryBot.create(:metric, service: service)
-    metric.usage_limits.create(period: :week, value: 1, plan: app_plan)
-    metric.usage_limits.create(period: :month, value: 1, plan: app_plan)
+  test "index pagination" do
+    populate
 
     get admin_api_application_plan_limits_path(app_plan, format: :json, access_token: @token)
     assert_response :success
-    assert_equal 2, JSON.parse(response.body)['limits'].length
+    assert_equal 4, JSON.parse(response.body)['limits'].length
 
     get admin_api_application_plan_limits_path(app_plan, per_page: 1, format: :json, access_token: @token)
     assert_response :success
     assert_equal 1, JSON.parse(response.body)['limits'].length
 
-    get admin_api_application_plan_limits_path(app_plan, per_page: 2, page: 2, format: :json, access_token: @token)
+    get admin_api_application_plan_limits_path(app_plan, per_page: 2, page: 3, format: :json, access_token: @token)
     assert_response :success
     assert_equal 0, JSON.parse(response.body)['limits'].length
+  end
+
+  test "index works with any kind of metrics and methods" do
+    populate(owner: service)
+    populate(owner: FactoryBot.create(:backend_api, account: provider))
+
+    get admin_api_application_plan_limits_path(app_plan, format: :json, access_token: @token)
+    assert_response :success
+    assert_not_empty JSON.parse(response.body)['limits']
+  end
+
+  private
+
+  def populate(times = 1, owner: service)
+    metrics = FactoryBot.create_list(:metric, times, owner: owner)
+    methods = FactoryBot.create_list(:method, times, owner: owner)
+    metrics.zip(methods).each do |metric, method|
+      metric.usage_limits.create(period: :week, value: 1, plan: app_plan)
+      metric.usage_limits.create(period: :month, value: 1, plan: app_plan)
+      method.usage_limits.create(period: :week, value: 1, plan: app_plan)
+      method.usage_limits.create(period: :month, value: 1, plan: app_plan)
+    end
   end
 end

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -56,8 +56,8 @@ class MetricTest < ActiveSupport::TestCase
   test 'system_name is not case sensitive' do
     service = FactoryBot.create(:simple_service)
 
-    metric_one = FactoryBot.create(:metric, service: service, system_name: 'frags')
-    metric_two = FactoryBot.create(:metric, service: service)
+    FactoryBot.create(:metric, owner: service, system_name: 'frags')
+    metric_two = FactoryBot.create(:metric, owner: service)
 
     assert metric_two.update_column(:system_name, 'Frags')
   end
@@ -67,13 +67,13 @@ class MetricTest < ActiveSupport::TestCase
     service_one = FactoryBot.create(:service)
     service_two = FactoryBot.create(:service)
 
-    FactoryBot.create(:metric, :service => service_one, :system_name => 'frags')
+    FactoryBot.create(:metric, owner: service_one, system_name: 'frags')
 
-    metric_two = FactoryBot.build(:metric, :service => service_one, :system_name => 'frags')
+    metric_two = FactoryBot.build(:metric, owner: service_one, system_name: 'frags')
     refute metric_two.valid?
     assert_not_nil metric_two.errors[:system_name].presence
 
-    metric_three = FactoryBot.build(:metric, :service => service_two, :system_name => 'frags')
+    metric_three = FactoryBot.build(:metric, owner: service_two, system_name: 'frags')
     assert metric_three.valid?
   end
 
@@ -88,9 +88,9 @@ class MetricTest < ActiveSupport::TestCase
 
   test 'fill owner' do
     service = FactoryBot.create(:simple_service)
-    service_metric = FactoryBot.build(:metric, service: service)
+    service_metric = service.metrics.build(system_name: "meth1")
     refute service_metric.owner
-    assert service_metric.valid?
+    service_metric.valid?
     assert_equal service, service_metric.owner
 
     backend_api = FactoryBot.create(:backend_api, name: 'API', system_name: 'api', account: service.provider)


### PR DESCRIPTION
additionally `service` attribute of Metric is obsolete so stop using it
see bbd7051d92

One issue here is that still production code expects `service` attribute to be set when the owner is a service. So we can't fix all tests to stop referring to `#service`. One option is to fix the production code. But maybe better for now to still set `service` attribute in the factory.

At the same we shouldn't leave production code to rely on the `service` because we don't validate and database does not enforce that attribute. So this is just a step to removing reliance on it.