### PR TITLE
THREESCALE-8347 fixed warnings Can't mass-assign protected attributes

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -1,6 +1,5 @@
 # TODO: parameter name was deprecated on 21.02.2014 and should be removed at one point.
 class Metric < ApplicationRecord
-  include ActiveModel::MassAssignmentSecurity
   include Backend::ModelExtensions::Metric
   include SystemName
   include BackendApiLogic::MetricExtension
@@ -53,22 +52,17 @@ class Metric < ApplicationRecord
     where.has { ((owner_type == 'Service') & owner_id.in(provider.services.pluck(:id))) | ((owner_type == 'BackendApi') & owner_id.in(provider.backend_apis.pluck(:id))) }
   }
 
-  def assign_attributes(values, options = {})
-    sanitize_for_mass_assignment(values, options[:as]).each do |key, value|
-      send("#{key}=", value)
-    end
-  end
-
   # Create one of the predefined, default metrics.
   #
   # == Arguments
   #
   # +type+:: Which default metric to create. Currently only :hits are supported.
   def self.create_default!(type, attributes = {})
-    metric = Metric.new
-    metric.assign_attributes({:friendly_name => 'Hits', :system_name => 'hits', :unit => 'hit',
-                                :description => 'Number of API hits'})
-    metric.service_id = attributes[:service_id]
+    id = attributes[:service_id]
+    attributes.delete(:service_id)
+    metric = new(attributes.merge(:friendly_name => 'Hits', :system_name => 'hits', :unit => 'hit',
+                                  :description => 'Number of API hits'))
+    metric.service_id = id
     metric.save!
     metric
   end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -54,8 +54,8 @@ class Metric < ApplicationRecord
   }
 
   def assign_attributes(values, options = {})
-    sanitize_for_mass_assignment(values, options[:as]).each do |k, v|
-      send("#{k}=", v)
+    sanitize_for_mass_assignment(values, options[:as]).each do |key, value|
+      send("#{key}=", value)
     end
   end
 

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -26,7 +26,9 @@ class Metric < ApplicationRecord
 
   acts_as_tree
 
-  attr_protected :service_id, :parent_id, :tenant_id, :audit_ids
+  attr_protected :parent_id, :tenant_id, :audit_ids
+  attr_accessible :service_id, :friendly_name, :system_name, :unit, :description
+
   validates :unit, presence: true, unless: :child?
   validates :friendly_name, uniqueness: {scope: %i[owner_type owner_id]}, presence: true
   validates :system_name, :unit, :friendly_name, :owner_type, length: { maximum: 255 }

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -58,8 +58,7 @@ class Metric < ApplicationRecord
   #
   # +type+:: Which default metric to create. Currently only :hits are supported.
   def self.create_default!(type, attributes = {})
-    id = attributes[:service_id]
-    attributes.delete(:service_id)
+    service_id = attributes.delete(:service_id)
     metric = new(attributes.merge(:friendly_name => 'Hits', :system_name => 'hits', :unit => 'hit',
                                   :description => 'Number of API hits'))
     metric.service_id = id

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -61,7 +61,7 @@ class Metric < ApplicationRecord
     service_id = attributes.delete(:service_id)
     metric = new(attributes.merge(:friendly_name => 'Hits', :system_name => 'hits', :unit => 'hit',
                                   :description => 'Number of API hits'))
-    metric.service_id = id
+    metric.service_id = service_id
     metric.save!
     metric
   end


### PR DESCRIPTION
What this PR does / why we need it:

WARNING: Can't mass-assign protected attributes 
Added all the attributes which are mass assigned and removed duplicate from protected 

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/THREESCALE-8347