### PR TITLE
Final touches for Quickstarts

### DIFF
--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -37,6 +37,8 @@ class FrontendController < ApplicationController
 
   layout :pick_buyer_or_provider_layout
 
+  helper_method :quickstarts_presenter
+
   private
 
   def disable_x_content_type
@@ -167,5 +169,9 @@ class FrontendController < ApplicationController
 
   def set_display_currency
     ThreeScale::MoneyHelper.display_currency = current_account.currency if current_account
+  end
+
+  def quickstarts_presenter
+    @quickstarts_presenter ||= QuickstartsPresenter.new(@backend_api || @service || current_account.default_service)
   end
 end

--- a/app/controllers/provider/admin/quickstarts_controller.rb
+++ b/app/controllers/provider/admin/quickstarts_controller.rb
@@ -1,17 +1,9 @@
 # frozen_string_literal: true
 
 class Provider::Admin::QuickstartsController < FrontendController
-  before_action :hide_quickstarts
-
   activate_menu :quickstarts
 
   layout 'provider'
 
   def show; end
-
-  private
-
-  def hide_quickstarts
-    raise ActionController::RoutingError, '' unless Features::QuickstartsConfig.enabled?
-  end
 end

--- a/app/javascript/packs/quickstarts/container.js
+++ b/app/javascript/packs/quickstarts/container.js
@@ -17,4 +17,12 @@ document.addEventListener('DOMContentLoaded', () => {
     links: safeFromJsonString<Array<[string, string, string]>>(links) || [],
     renderCatalog: safeFromJsonString<boolean>(renderCatalog)
   }, containerId)
+
+  // HACK of the year: We need QuickStartContainer to wrap the whole #wrapper for the Drawer to work properly.
+  const wrapperContainer = document.getElementById('wrapper')
+  const quickStartsContainer = document.querySelector('.pfext-quick-start-drawer__body')
+
+  if (wrapperContainer && quickStartsContainer) {
+    quickStartsContainer.after(wrapperContainer)
+  }
 })

--- a/app/javascript/packs/quickstarts/container.js
+++ b/app/javascript/packs/quickstarts/container.js
@@ -1,9 +1,14 @@
 // @flow
 
 import { QuickStartContainerWrapper as QuickStartContainer } from 'QuickStarts/components/QuickStartContainer'
+import { getActiveQuickstart } from 'QuickStarts/utils/progressTracker'
 import { safeFromJsonString } from 'utilities/json-utils'
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (getActiveQuickstart == null) {
+    return // No need to render Quickstarts
+  }
+
   const containerId = 'quick-start-container'
   const container = document.getElementById(containerId)
 

--- a/app/javascript/src/QuickStarts/utils/progressTracker.js
+++ b/app/javascript/src/QuickStarts/utils/progressTracker.js
@@ -1,0 +1,13 @@
+// @flow
+
+/**
+ * This is a collection of wrappers around localStorage to ease getting information about Quickstarts state
+ */
+
+function getActiveQuickstart (): null | string {
+  const quickstartId: string = JSON.parse(localStorage.getItem('quickstartId') || '')
+
+  return quickstartId.length ? quickstartId : null
+}
+
+export { getActiveQuickstart }

--- a/app/lib/features/quickstarts_config.rb
+++ b/app/lib/features/quickstarts_config.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module Features
-  class QuickstartsConfig < Config; end
-end

--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -296,12 +296,6 @@ module Logic
         end
       end
 
-      class QuickStarts < Base
-        def missing_config
-          false
-        end
-      end
-
       class Unknown < Base
         def missing_config
           false

--- a/app/presenters/quickstarts_presenter.rb
+++ b/app/presenters/quickstarts_presenter.rb
@@ -11,6 +11,7 @@ class QuickstartsPresenter
 
   attr_reader :current_api
 
+  # Consumed by app/javascript/src/QuickStarts/utils/replaceLinksExtension.js
   def links
     [
       ['create-a-product-link', new_admin_service_path, 'Create a product'],

--- a/app/views/layouts/provider.html.slim
+++ b/app/views/layouts/provider.html.slim
@@ -14,7 +14,7 @@ html[lang="en" class="pf-m-redhat-font"]
     = yield :javascripts
 
   body
-    = render partial: 'shared/provider/quickstarts_container' if Features::QuickstartsConfig.enabled?
+    = render partial: 'shared/provider/quickstarts_container'
     #wrapper.pf-c-page
       = render partial: 'shared/provider/header'
       = render partial: 'shared/provider/navigation/vertical_nav' unless vertical_nav_hidden?

--- a/app/views/shared/provider/_header.html.slim
+++ b/app/views/shared/provider/_header.html.slim
@@ -28,9 +28,8 @@ header.pf-c-page__header id="user_widget" class='Header' class=('Header--master'
         - if saas?
           li.PopNavigation-listItem
             = fixed_width_icon_link_to "What's new?", 'leaf', '//access.redhat.com/articles/3107441#newfeaturesenhancements', class: 'PopNavigation-link', target: '_blank'
-        - if Features::QuickstartsConfig.enabled?
-          li.PopNavigation-listItem
-            = fixed_width_icon_link_to 'Quick starts', 'book', provider_admin_quickstarts_path, class: 'PopNavigation-link'
+        li.PopNavigation-listItem
+          = fixed_width_icon_link_to 'Quick starts', 'book', provider_admin_quickstarts_path, class: 'PopNavigation-link'
 
     .PopNavigation.PopNavigation--session
       a.PopNavigation-trigger.u-toggler class=('is-current' if active_menu?(:topmenu, :help)) href="#session-menu" title="Session"

--- a/app/views/shared/provider/_quickstarts_container.html.slim
+++ b/app/views/shared/provider/_quickstarts_container.html.slim
@@ -1,4 +1,4 @@
-#quick-start-container data-render-catalog=(active_menu == :quickstarts).to_s data-links=QuickstartsPresenter.new(current_api).links
+#quick-start-container data-render-catalog=(active_menu == :quickstarts).to_s data-links=quickstarts_presenter.links
   = javascript_pack_tag 'quickstarts/container'
 
 javascript:

--- a/app/views/shared/provider/_quickstarts_container.html.slim
+++ b/app/views/shared/provider/_quickstarts_container.html.slim
@@ -1,11 +1,2 @@
 #quick-start-container data-render-catalog=(active_menu == :quickstarts).to_s data-links=quickstarts_presenter.links
   = javascript_pack_tag 'quickstarts/container'
-
-javascript:
-  document.addEventListener('DOMContentLoaded', () => {
-    // HACK of the year: We need QuickStartContainer to wrap the whole #wrapper for the Drawer to work properly.
-    const wrapperContainer = document.getElementById('wrapper')
-    const quickStartsContainer = document.querySelector('.pfext-quick-start-drawer__body')
-
-    quickStartsContainer.after(wrapperContainer)
-  })

--- a/config/examples/features.yml
+++ b/config/examples/features.yml
@@ -16,8 +16,6 @@ features: &default
     wait_time: 0
   logging:
     audits_to_stdout: true
-  quickstarts:
-    enabled: false
   email_configuration:
     enabled: false
 

--- a/features/provider/admin/quickstarts.feature
+++ b/features/provider/admin/quickstarts.feature
@@ -4,38 +4,22 @@ Feature: Quick Starts
   Background:
     And a provider is logged in
 
-  Rule: Feature is enabled
-    Background:
-      Given quickstarts is enabled
+  Scenario: Header help menu have the option
+    Then I should be able to go to the quick start catalog from the help menu
 
-    Scenario: Header help menu have the option
-      Then I should be able to go to the quick start catalog from the help menu
+  Scenario: Quick Start catalog
+    Given I go to the quick start catalog page
+    Then I should be able to start following a quick start from a gallery
 
-    Scenario: Quick Start catalog
-      Given I go to the quick start catalog page
-      Then I should be able to start following a quick start from a gallery
+  Scenario: Following a Quick Start
+    Given I am following a quick start
+    When I go anywhere else
+    Then I will still be able to see the quick start
 
-    Scenario: Following a Quick Start
-      Given I am following a quick start
-      When I go anywhere else
-      Then I will still be able to see the quick start
+  Scenario: Closing a Quick Start
+    Given I am following a quick start
+    Then I should be able to close it without losing any progress
 
-    Scenario: Closing a Quick Start
-      Given I am following a quick start
-      Then I should be able to close it without losing any progress
-
-    Scenario: Restart a Quick Start
-      Given I have finished a quick start
-      Then I should be able to restart its progress
-
-  Rule: Quickstarts disabled
-    Background:
-      Given quickstarts is disabled
-
-    Scenario: Header help menu does not have the option
-      Then I should not be able to go to the quick start catalog from the help menu
-
-    Scenario: Following a Quick Start does not show it
-      Given I am following a quick start
-      When I go anywhere else
-      Then I won't be able to see the quick start
+  Scenario: Restart a Quick Start
+    Given I have finished a quick start
+    Then I should be able to restart its progress

--- a/features/provider/header.feature
+++ b/features/provider/header.feature
@@ -9,12 +9,4 @@ Feature: Header buttons and menus
       | 3scale API Docs  |
       | Liquid Reference |
       | What's new?      |
-
-  Scenario: Help menu dropdown when Quickstarts enabled
-    Given quickstarts is enabled
-    Then the help menu should have the following items:
-      | Customer Portal  |
-      | 3scale API Docs  |
-      | Liquid Reference |
-      | What's new?      |
       | Quick starts     |

--- a/features/step_definitions/provider/admin/quickstarts_steps.rb
+++ b/features/step_definitions/provider/admin/quickstarts_steps.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-Given "quickstarts is {enabled}" do |enabled|
-  Features::QuickstartsConfig.stubs(enabled?: enabled)
-  visit current_path
-end
-
 Then "I should be able to start following a quick start from a gallery" do
   within '#quick-start-catalog-page-wrapper .pfext-quick-start-catalog__gallery' do
     quickstarts = find_all('.pfext-quick-start-catalog__gallery-item')

--- a/features/step_definitions/provider/admin/quickstarts_steps.rb
+++ b/features/step_definitions/provider/admin/quickstarts_steps.rb
@@ -13,8 +13,8 @@ Then "I should be able to start following a quick start from a gallery" do
 end
 
 Given "I am following a quick start" do
-  page.execute_script "window.localStorage.setItem('quickstartId', '\"#{test_quickstart_id}\"')"
-  page.execute_script "window.localStorage.setItem('quickstarts', '{\"#{test_quickstart_id}\":{\"status\":\"In Progress\",\"taskNumber\":0,\"taskStatus0\":\"Visited\",\"taskStatus1\":\"Initial\"}}')"
+  page.execute_script "window.localStorage.setItem('quickstartId', '\"create-a-backend-quick-start\"')"
+  page.execute_script "window.localStorage.setItem('quickstarts', '{\"create-a-backend-quick-start\":{\"status\":\"In Progress\",\"taskNumber\":0,\"taskStatus0\":\"Visited\",\"taskStatus1\":\"Initial\"}}')"
   Capybara.refresh
 end
 
@@ -51,16 +51,16 @@ end
 
 Given "I have finished a quick start" do
   page.execute_script "window.localStorage.setItem('quickstartId', '\"\"')"
-  page.execute_script "window.localStorage.setItem('quickstarts', '{\"#{test_quickstart_id}\":{\"status\":\"Complete\",\"taskNumber\":2,\"taskStatus0\":\"Review\",\"taskStatus1\":\"Review\"}}')"
+  page.execute_script "window.localStorage.setItem('quickstarts', '{\"creating-a-backend-quick-start\":{\"status\":\"Complete\",\"taskNumber\":2,\"taskStatus0\":\"Review\"}}')"
   Capybara.refresh
 end
 
 Then "I should be able to restart its progress" do
   visit provider_admin_quickstarts_path
 
-  find("[data-test='tile #{test_quickstart_id}']").click
+  find("[data-testid='qs-card-createABackend']").click
 
-  assert_selector "[data-testid='qs-drawer-#{test_quickstart_id.underscore.camelize(:lower)}']"
+  assert_selector "[data-testid='qs-drawer-createABackend']"
   assert_selector('[data-testid="qs-drawer-side-note-action"]', text: 'Restart')
 end
 
@@ -74,11 +74,6 @@ Then "I {should} be able to go to the quick start catalog from the help menu" do
       has_no_link?('Quick starts', visible: :all)
     end
   end
-end
-
-def test_quickstart_id
-  # This depends on the actual quick starts stored in app/javascript/src/QuickStarts/templates
-  'getting-started-with-quick-starts'
 end
 
 def quickstarts_panel

--- a/test/functional/provider/admin/quickstarts_controller_test.rb
+++ b/test/functional/provider/admin/quickstarts_controller_test.rb
@@ -9,24 +9,8 @@ class Provider::Admin::QuickstartsControllerTest < ActionController::TestCase
     login_provider(provider)
   end
 
-  class FeatureOnTest < self
-    setup do
-      Features::QuickstartsConfig.stubs(enabled?: true)
-    end
-
-    test '#show' do
-      get :show
-      assert_response :ok
-    end
-  end
-
-  class FeatureOffTest < self
-    setup do
-      Features::QuickstartsConfig.stubs(enabled?: false)
-    end
-
-    test 'raises not found' do
-      assert_raise(ActionController::RoutingError) { get :show }
-    end
+  test '#show' do
+    get :show
+    assert_response :ok
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Once this PR is merged, we should be able to deploy to master and ship this new feature.

Changes:
- Removes feature config
- Prevent Quickstarts from rendering when not necessary
- Cleanup / Refactor

**Which issue(s) this PR fixes** 
[THREESCALE-8283: Integrate Quick Starts into 3scale](https://issues.redhat.com/browse/THREESCALE-8283)