### PR TITLE
THREESCALE-8371 fixed warning of protected attribute

### DIFF
--- a/app/lib/logic/cms.rb
+++ b/app/lib/logic/cms.rb
@@ -60,7 +60,7 @@ module Logic
       end
 
       def create_cms_assets
-        self.builtin_sections.create!(title: 'Root', system_name: 'root', parent_id: nil)
+        self.builtin_sections.create!(title: 'Root', system_name: 'root')
         # TODO: add SimpleLayout logic here
       end
     end


### PR DESCRIPTION
What this PR does / why we need it:

WARNING: Can't mass-assign protected attributes for CMS::Builtin::Section: parent_id

Which issue(s) this PR fixes

https://issues.redhat.com/browse/THREESCALE-8371