### PR TITLE
metrics delete race simplification

### DIFF
--- a/app/lib/backend/model_extensions/metric.rb
+++ b/app/lib/backend/model_extensions/metric.rb
@@ -11,6 +11,7 @@ module Backend
           # - 2 threads are trying to destroy a metric – T1 and T2
           # - T1 succeeds and T2 gets `persisted? => false` inside `ActiveRecord::Persistence#destroy` due to https://apidock.com/rails/v4.2.7/ActiveRecord/Core/sync_with_transaction_state, thus making `@_trigger_destroy_callback = true`
           # - Because of `m.destroyed? == true`, both T1 and T2 will invoke the callback
+          # TODO: this condition seems to do nothing, maybe delete it
           after_commit :sync_backend, if: ->(m) { (m.persisted? || m.destroyed?) && !m.changed? }
         end
       end


### PR DESCRIPTION
The test is doing nothing because essentially we don't protect against a race so callback executes twice. We do not need it to execute twice so there is no point to test that. If it executed only once, that would be better but then this is not the case.