### PR TITLE
use #saved_changes in place of #previous_changes

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -165,7 +165,7 @@ class AccessToken < ApplicationRecord
   end
 
   def show_value?(*)
-    previous_changes.include?(:value)
+    saved_changes.include?(:value)
   end
 
   def available_scopes

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -405,7 +405,7 @@ class Cinstance < Contract
   private
 
   def only_traffic_updated?
-    (previous_changes.keys - %w[first_traffic_at first_daily_traffic_at updated_at]).empty?
+    (saved_changes.keys - %w[first_traffic_at first_daily_traffic_at updated_at]).empty?
   end
 
   # It calls to `create_key_after_create` to check if it's possible to add

--- a/app/models/web_hook/event.rb
+++ b/app/models/web_hook/event.rb
@@ -144,7 +144,7 @@ class WebHook
     # :reek:NilCheck
     # That is fine as we want really to check for nil value in the changes
     def guess_event
-      resource_changes = @resource.previous_changes # TODO: use saved_changes instead?
+      resource_changes = @resource.saved_changes
       case
       when @resource.destroyed?
         'deleted'


### PR DESCRIPTION
In these case both methods are equivalent and in Rails 5.2+ they will be equivalent in all conditions. But updating to `#saved_changes` to prevent deprecation warnings as well because this is method with more clear intentions and behavior. At least I don't have to think how to write `previous` properly anymore.

Namely in Rails 5.1, `#saved_changes` and `#previous_changes` differ in behavior only in `after_save` callback where `#previous_changes` returns nothing. In 5.2 `#previous_changes` will behave exactly as `#saved_changes`.