### PR TITLE
THREESCALE-8009 prevent outbox emails from being sent empty

### DIFF
--- a/app/views/provider/admin/messages/outbox/new.html.erb
+++ b/app/views/provider/admin/messages/outbox/new.html.erb
@@ -20,7 +20,8 @@
     </li>
 
     <%= form.input :subject, :as => :string, :label => 'Subject:', input_html: { required: true } %>
-    <%= form.input :body, :input_html => {:rows => 10}, :label => 'Body:', input_html: { required: true } %>
+    <%= form.input :body, :input_html => {:rows => 10, required: true}, :label => 'Body:' %>
+
   <% end %>
   <%= form.buttons do %>
     <% if request.xhr? %>

--- a/app/views/provider/admin/messages/outbox/new.html.erb
+++ b/app/views/provider/admin/messages/outbox/new.html.erb
@@ -3,30 +3,30 @@
   <h2>Compose</h2>
 <% end %>
 
-<%= semantic_form_for @message, :url => provider_admin_messages_outbox_index_path,
-  :html => {:class => if request.xhr? then 'remote' end, :id => "message-form"} do |form| %>
+<%= semantic_form_for @message, url: provider_admin_messages_outbox_index_path,
+  html: { class: if request.xhr? then 'remote' end, id: "message-form" } do |form| %>
 
   <%= form.inputs do %>
     <li>
       <label>To:</label>
       <% if current_account.provider? && params[:to].nil? && @message.to.size == current_account.buyer_accounts.size %>
-        <%= text_field_tag '', "All Users", :readonly => true %>
+        <%= text_field_tag '', "All Users", readonly: true %>
         <p class="inline-hints">
           If you want to send a message to a particular user, go to the <%= link_to 'accounts page', admin_buyers_accounts_path %>, click on the user and then click on the send message icon.
         </p>
       <% else %>
-        <%= text_field_tag 'to', @message.to.map(&:org_name).join(', '), :readonly => true  %>
+        <%= text_field_tag 'to', @message.to.map(&:org_name).join(', '), readonly: true %>
       <% end %>
     </li>
 
-    <%= form.input :subject, :as => :string, :label => 'Subject:', input_html: { required: true } %>
-    <%= form.input :body, :input_html => {:rows => 10, required: true}, :label => 'Body:' %>
+    <%= form.input :subject, as: :string, label: 'Subject:', input_html: { required: true } %>
+    <%= form.input :body, input_html: { rows: 10, required: true }, label: 'Body:' %>
 
   <% end %>
   <%= form.buttons do %>
     <% if request.xhr? %>
       <li class="link">
-        <%= link_to 'Cancel', provider_admin_messages_root_path, :class => 'fancybox-close' %>
+        <%= link_to 'Cancel', provider_admin_messages_root_path, class: 'fancybox-close' %>
       </li>
     <% end %>
     <%= form.button 'Send', button_html: { class: 'pf-c-button pf-m-primary' } %>

--- a/app/views/provider/admin/messages/outbox/new.html.erb
+++ b/app/views/provider/admin/messages/outbox/new.html.erb
@@ -19,8 +19,8 @@
       <% end %>
     </li>
 
-    <%= form.input :subject, :as => :string, :label => 'Subject:' %>
-    <%= form.input :body, :input_html => {:rows => 10}, :label => 'Body:' %>
+    <%= form.input :subject, :as => :string, :label => 'Subject:', input_html: { required: true } %>
+    <%= form.input :body, :input_html => {:rows => 10}, :label => 'Body:', input_html: { required: true } %>
   <% end %>
   <%= form.buttons do %>
     <% if request.xhr? %>

--- a/features/old/applications/providers/bulk_operations/send_emails.feature
+++ b/features/old/applications/providers/bulk_operations/send_emails.feature
@@ -76,4 +76,3 @@ Feature: Mass email bulk operations
     Given the email will fail when sent
     And I press "Send" and I confirm dialog box within colorbox
     Then I should see the bulk action failed with account "jane"
-    

--- a/features/old/applications/providers/bulk_operations/send_emails.feature
+++ b/features/old/applications/providers/bulk_operations/send_emails.feature
@@ -81,7 +81,7 @@ Feature: Mass email bulk operations
     Given I am logged in as provider "foo.3scale.localhost"
     And I am on the outbox compose page
     And a clear email queue
-    And I press "Send"
     And I fill in "Body" with "There is no Subject to this email"
+    And I press "Send"
     Then I should see "Compose"
     And "jane@me.us" should receive no emails

--- a/features/old/applications/providers/bulk_operations/send_emails.feature
+++ b/features/old/applications/providers/bulk_operations/send_emails.feature
@@ -76,12 +76,4 @@ Feature: Mass email bulk operations
     Given the email will fail when sent
     And I press "Send" and I confirm dialog box within colorbox
     Then I should see the bulk action failed with account "jane"
-
-  Scenario: Outbox Message can't be sent without subject/body
-    Given I am logged in as provider "foo.3scale.localhost"
-    And I am on the outbox compose page
-    And a clear email queue
-    And I fill in "Body" with "There is no Subject to this email"
-    And I press "Send"
-    Then I should see "Compose"
-    And "jane@me.us" should receive no emails
+    

--- a/features/old/applications/providers/bulk_operations/send_emails.feature
+++ b/features/old/applications/providers/bulk_operations/send_emails.feature
@@ -76,3 +76,12 @@ Feature: Mass email bulk operations
     Given the email will fail when sent
     And I press "Send" and I confirm dialog box within colorbox
     Then I should see the bulk action failed with account "jane"
+
+  Scenario: Outbox Message can't be sent without subject/body
+    Given I am logged in as provider "foo.3scale.localhost"
+    And I am on the outbox compose page
+    And a clear email queue
+    And I press "Send"
+    And I fill in "Body" with "There is no Subject to this email"
+    Then I should see "Compose"
+    And "jane@me.us" should receive no emails

--- a/features/provider/admin/messages/outbox.feature
+++ b/features/provider/admin/messages/outbox.feature
@@ -5,17 +5,7 @@ Feature: Outbox messages
   I want to have an internal messaging system at my disposal
 
   Background:
-    Given a provider "foo.3scale.localhost"
-    Given a default application plan "Basic" of provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has multiple applications enabled
-
-    Given a following buyers with applications exists:
-      | name | provider        | applications        |
-      | bob  | foo.3scale.localhost | BobApp              |
-      | jane | foo.3scale.localhost | JaneApp, JaneAppTwo |
-
-    Given current domain is the admin domain of provider "foo.3scale.localhost"
-      And I don't care about application keys
+    Given a provider is logged in
 
   Scenario: Outbox Message can't be sent without subject/body
     Given I am logged in as provider "foo.3scale.localhost"

--- a/features/provider/admin/messages/outbox.feature
+++ b/features/provider/admin/messages/outbox.feature
@@ -1,0 +1,27 @@
+@javascript
+Feature: Outbox messages
+  In order to facilitate communication between me and my buyers
+  As a provider
+  I want to have an internal messaging system at my disposal
+
+  Background:
+    Given a provider "foo.3scale.localhost"
+    Given a default application plan "Basic" of provider "foo.3scale.localhost"
+      And provider "foo.3scale.localhost" has multiple applications enabled
+
+    Given a following buyers with applications exists:
+      | name | provider        | applications        |
+      | bob  | foo.3scale.localhost | BobApp              |
+      | jane | foo.3scale.localhost | JaneApp, JaneAppTwo |
+
+    Given current domain is the admin domain of provider "foo.3scale.localhost"
+      And I don't care about application keys
+
+  Scenario: Outbox Message can't be sent without subject/body
+    Given I am logged in as provider "foo.3scale.localhost"
+    And I am on the outbox compose page
+    And a clear email queue
+    And I fill in "Body" with "There is no Subject to this email"
+    And I press "Send"
+    Then I should see "Compose"
+    And "jane@me.us" should receive no emails

--- a/features/provider/admin/messages/outbox.feature
+++ b/features/provider/admin/messages/outbox.feature
@@ -6,10 +6,8 @@ Feature: Outbox messages
   Background:
     Given a provider "foo.3scale.localhost"
     Given current domain is the admin domain of provider "foo.3scale.localhost"
-
     Given these buyers signed up to provider "foo.3scale.localhost"
       | jane | foo.3scale.localhost | JaneApp, JaneAppTwo |
-
     Given I am logged in as provider "foo.3scale.localhost"
       And I am on the outbox compose page
 

--- a/features/provider/admin/messages/outbox.feature
+++ b/features/provider/admin/messages/outbox.feature
@@ -1,17 +1,26 @@
-@javascript
 Feature: Outbox messages
   In order to facilitate communication between me and my buyers
   As a provider
   I want to have an internal messaging system at my disposal
 
   Background:
-    Given a provider is logged in
+    Given a provider "foo.3scale.localhost"
+    Given current domain is the admin domain of provider "foo.3scale.localhost"
 
-  Scenario: Outbox Message can't be sent without subject/body
+    Given these buyers signed up to provider "foo.3scale.localhost"
+      | jane | foo.3scale.localhost | JaneApp, JaneAppTwo |
+
     Given I am logged in as provider "foo.3scale.localhost"
-    And I am on the outbox compose page
-    And a clear email queue
-    And I fill in "Body" with "There is no Subject to this email"
+      And I am on the outbox compose page
+
+  Scenario: Outbox Message can't be sent without subject
+    And I fill in "Body" with "Subject is empty"
     And I press "Send"
-    Then I should see "Compose"
-    And "jane@me.us" should receive no emails
+    And there should be no message from provider "foo.3scale.localhost" to buyer "jane" with body "Subject is empty"
+    And I am on the outbox compose page
+
+  Scenario: Outbox Message can't be sent without body
+    And I fill in "subject" with "Body is empty"
+    And I press "Send"
+    And there should be no message from provider "foo.3scale.localhost" to buyer "jane" with subject "Body is empty"
+    And I am on the outbox compose page

--- a/features/provider/admin/messages/outbox.feature
+++ b/features/provider/admin/messages/outbox.feature
@@ -16,11 +16,11 @@ Feature: Outbox messages
   Scenario: Outbox Message can't be sent without subject
     And I fill in "Body" with "Subject is empty"
     And I press "Send"
-    And there should be no message from provider "foo.3scale.localhost" to buyer "jane" with body "Subject is empty"
+    Then I should see "Compose"
     And I am on the outbox compose page
 
   Scenario: Outbox Message can't be sent without body
-    And I fill in "subject" with "Body is empty"
+    And I fill in "Subject" with "Body is empty"
     And I press "Send"
-    And there should be no message from provider "foo.3scale.localhost" to buyer "jane" with subject "Body is empty"
+    Then I should see "Compose"
     And I am on the outbox compose page

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -81,6 +81,9 @@ World(Module.new do
     when "the compose page"
       new_admin_messages_outbox_path
 
+    when "the outbox compose page"
+      new_provider_admin_messages_outbox_path
+
     when "the inbox page"
       admin_messages_root_path
 


### PR DESCRIPTION
**hat this PR does / why we need it:**

When sending emails from the bulk operations emails can be sent if body and subject is empty
make those field required

In admin portal - /p/admin/messages/outbox/new - page under Audience > Messages > Inbox/Sent messages

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/THREESCALE-8009

https://issues.redhat.com/browse/THREESCALE-8392