### PR TITLE
THREESCALE-3927 remove rspec api documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -203,7 +203,6 @@ group :test do
   gem 'rspec-rails', '~> 4.1', require: false # version 5.x is needed for Rails 6
 
   # Reason to use the fork: https://github.com/kucaahbe/rspec-html-matchers/pull/21
-  gem 'rspec_api_documentation'
   gem 'rspec-html-matchers', github: '3scale/rspec-html-matchers', branch: 'fix/rspec-3-with-xml-document', require: false
 
   gem 'shoulda', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1557,7 +1557,6 @@ GEM
     multi_test (0.1.2)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    mustache (1.1.1)
     mysql2 (0.5.3)
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
@@ -1749,10 +1748,6 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
-    rspec_api_documentation (6.1.0)
-      activesupport (>= 3.0.0)
-      mustache (~> 1.0, >= 0.99.4)
-      rspec (~> 3.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.93.1)
@@ -2072,7 +2067,6 @@ DEPENDENCIES
   roar-rails
   rspec-html-matchers!
   rspec-rails (~> 4.1)
-  rspec_api_documentation
   rspec_junit_formatter
   rubocop (~> 0.92)
   rubocop-performance

--- a/spec/api_helper.rb
+++ b/spec/api_helper.rb
@@ -3,8 +3,6 @@
 # so we can include them by metadata
 #
 # maybe load the environment first?
-require 'rspec_api_documentation'
-require 'rspec_api_documentation/dsl'
 
 module NamingHelper
   def model_name

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -134,15 +134,3 @@ RSpec.configure do |config|
     config.add_formatter RspecJunitFormatter, junit
   end
 end
-
-
-RspecApiDocumentation.configure do |config|
-  config.docs_dir = Rails.root.join('doc', 'api')
-  # html pages with the wURL console
-  config.format = %i[json wurl combined_text]
-  # html pages without the wURL console
-  #config.format = [:json, :html]
-  #config.url_prefix = "/docs"
-  config.curl_host = 'http://localhost:3000'
-  config.api_name = "Example App API"
-end


### PR DESCRIPTION
**What this PR does / why we need it:**

(Update our own docs to OAS 3.0)

removed gem rspec_api_documentation and its support code

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/THREESCALE-3927