### PR TITLE
Revert "Bump nokogiri from 1.10.10 to 1.13.6"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ gem 'dalli', '~> 2.7'
 gem 'faraday', '~> 0.15.3'
 gem 'faraday_middleware', '~> 0.13.1'
 gem 'mimemagic', '~> 0.3.10'
-gem 'nokogiri', '~> 1.13.6'
+gem 'nokogiri', '~> 1.10.10'
 gem 'secure_headers', '~> 6.3.0'
 
 gem 'acts-as-taggable-on', '~> 8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1548,7 +1548,7 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.1)
-    mini_portile2 (2.8.0)
+    mini_portile2 (2.4.0)
     minitest (5.10.3)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
@@ -1572,9 +1572,8 @@ GEM
       connection_pool (~> 2.2)
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.13.6)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
     non-stupid-digest-assets (1.0.9)
       sprockets (>= 2.0)
     ntlm-http (0.1.1)
@@ -1633,7 +1632,6 @@ GEM
       pry (~> 0.13)
     public_suffix (4.0.7)
     raabro (1.4.0)
-    racc (1.6.0)
     rack (2.1.4.1)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
@@ -2047,7 +2045,7 @@ DEPENDENCIES
   minitest-stub-const
   mocha (~> 1.1.0)
   mysql2 (~> 0.5.3)
-  nokogiri (~> 1.13.6)
+  nokogiri (~> 1.10.10)
   non-stupid-digest-assets (~> 1.0)
   oauth2 (~> 1.4)
   open_id_authentication

--- a/app/lib/three_scale/json_representer.rb
+++ b/app/lib/three_scale/json_representer.rb
@@ -22,7 +22,7 @@ module ThreeScale::JSONRepresenter
     doc = options.fetch(:doc)
     xml = to_xml(builder: builder)
 
-    Nokogiri::XML::Node.new('root', doc).add_child(xml)
+    Nokogiri::XML::Node.new('root', doc).replace(xml)
   end
 
   module Format


### PR DESCRIPTION
DEJAVU https://github.com/3scale/porta/pull/2391

Since we're using ruby 2.4 in the production server we can't upgrade Nokogiri just yet.

Reverts 3scale/porta#2988