### PR TITLE
why does swagger response contain this extraneous object?

### DIFF
--- a/app/javascript/packs/OAS3Autocomplete.js
+++ b/app/javascript/packs/OAS3Autocomplete.js
@@ -73,32 +73,16 @@ const injectAutocompleteToResponseBody = (responseBody: ResponseBody | string, a
   return res
 }
 
-const injectServerToResponseBody = (responseBody: ResponseBody | string, serviceEndpoint: string): ResponseBody | string => {
-  if (typeof responseBody === 'string') {
-    return responseBody
-  }
-
-  const originalServers = responseBody.servers || []
-  const servers = serviceEndpoint ? [{ url: serviceEndpoint }] : originalServers
-
-  return {
-    ...responseBody,
-    // $FlowFixMe[incompatible-return] should be safe to assume correct type
-    servers
-  }
-}
-
 export const autocompleteOAS3 = async (response: SwaggerResponse, accountDataUrl: string, serviceEndpoint: string): Promise<SwaggerResponse> => {
-  const bodyWithServer = injectServerToResponseBody(response.body, serviceEndpoint)
   const body = await fetchData(accountDataUrl)
     .then(data => (
       data.results
-        ? injectAutocompleteToResponseBody(bodyWithServer, data.results)
-        : bodyWithServer
+        ? injectAutocompleteToResponseBody(response.body, data.results)
+        : response.body
     ))
     .catch(error => {
       console.error(error)
-      return bodyWithServer
+      return response.body
     })
 
   return {


### PR DESCRIPTION
Hi there,

I'd have created an issue, but I couldn't figure out how to do so. I think issues are disabled on this repo?

I'm not entirely sure why the code I've deleted in this PR (`injectServerToResponseBody`) exists, but, as a side effect? it seems to be modifying the actual response body the user sees in the dev portal UI. 

![image](https://user-images.githubusercontent.com/66472/176877272-e0591ad0-18e4-46f2-b134-887f3a08c465.png)

This is quite clearly surprising and not desired! What would be the best way to fix this?

Thanks!