### PR TITLE
Update gems to remove deprecation warnings for ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'sidekiq-prometheus-exporter'
 gem 'yabeda-prometheus-mmap'
 gem 'yabeda-rails'
 gem 'yabeda-sidekiq'
+gem 'prometheus-client-mmap', '~> 0.16.2'
 
 gem 'activemerchant', '~> 1.107.4'
 gem 'audited', '~> 5.0.2'
@@ -128,7 +129,7 @@ gem 'roar-rails'
 gem 'reform', '~> 2.0.3', require: false
 
 # sanitize params passed to rack
-gem 'rack-utf8_sanitizer'
+gem 'rack-utf8_sanitizer', '~> 1.7.0'
 
 gem 'jwt', '~> 1.5.2', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1485,8 +1485,6 @@ GEM
     injectedlogger (0.0.13)
     innertube (1.1.0)
     jmespath (1.6.1)
-    join_dependency (0.1.4)
-      activerecord (>= 4.2.0)
     joiner (0.3.4)
       activerecord (>= 4.1.0)
     jquery-rails (4.3.5)
@@ -1608,7 +1606,7 @@ GEM
     prawn-format (0.2.1)
       prawn-core
     prawn-layout (0.2.1)
-    prometheus-client-mmap (0.11.0)
+    prometheus-client-mmap (0.16.2)
     protected_attributes_continued (1.8.2)
       activemodel (>= 5.0)
     pry (0.13.1)
@@ -1644,7 +1642,7 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rack-utf8_sanitizer (1.6.0)
+    rack-utf8_sanitizer (1.7.0)
       rack (>= 1.0, < 3.0)
     rack-x_served_by (0.1.1)
     rails (5.2.8)
@@ -2062,6 +2060,7 @@ DEPENDENCIES
   prawn-core!
   prawn-format (= 0.2.1)
   prawn-layout (= 0.2.1)
+  prometheus-client-mmap (~> 0.16.2)
   protected_attributes_continued (~> 1.8.2)
   pry-byebug (>= 3.7.0)
   pry-doc (>= 0.8)
@@ -2071,7 +2070,7 @@ DEPENDENCIES
   rack (~> 2.1.4)
   rack-cors
   rack-no_animations (~> 1.0.3)
-  rack-utf8_sanitizer
+  rack-utf8_sanitizer (~> 1.7.0)
   rack-x_served_by (~> 0.1.1)
   rails (~> 5.2.7)
   rails-controller-testing


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes deprecation messages when upgrading to ruby 2.7

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-8509

**Verification steps** 

Run porta with Ruby 2.7.

**Special notes for your reviewer**:

Fixes the following warnings:

1. URI.escape
```
rack-utf8_sanitizer-1.6.0/lib/rack/utf8_sanitizer.rb:234: warning: URI.escape is obsolete
```
Fixed in version 1.7.0 of `rack-utf8_sanitizer`: https://github.com/whitequark/rack-utf8_sanitizer/pull/53


2. rb_safe_level and rb_secure
```
prometheus-client-mmap-0.11.0/lib/prometheus/client/helper/mmaped_file.rb:21: warning: rb_safe_level will be removed in Ruby 3.0
prometheus-client-mmap-0.11.0/lib/prometheus/client/helper/mmaped_file.rb:21: warning: rb_secure will be removed in Ruby 3.0
```
Fixed in version 0.12.0 of `prometheus-client-mmap`: https://gitlab.com/gitlab-org/prometheus-client-mmap/-/blob/master/CHANGELOG.md#v0120

Upgrading to the latest version to fix other ruby 3.0 warnings for the future.



