### PR TITLE
Deleted product or backend is still visible in list

### DIFF
--- a/app/presenters/provider/admin/backend_apis_index_presenter.rb
+++ b/app/presenters/provider/admin/backend_apis_index_presenter.rb
@@ -15,8 +15,7 @@ class Provider::Admin::BackendApisIndexPresenter
   delegate :total_entries, to: :backend_apis
 
   def backend_apis
-    @backend_apis ||= current_account.backend_apis
-                                     .where.not(state: 'deleted')
+    @backend_apis ||= current_account.accessible_backend_apis
                                      .order(sorting_params)
                                      .scope_search(search)
                                      .paginate(pagination_params)

--- a/app/presenters/provider/admin/backend_apis_index_presenter.rb
+++ b/app/presenters/provider/admin/backend_apis_index_presenter.rb
@@ -16,6 +16,7 @@ class Provider::Admin::BackendApisIndexPresenter
 
   def backend_apis
     @backend_apis ||= current_account.backend_apis
+                                     .where.not(state: 'deleted')
                                      .order(sorting_params)
                                      .scope_search(search)
                                      .paginate(pagination_params)

--- a/test/unit/presenters/api/services_index_presenter_test.rb
+++ b/test/unit/presenters/api/services_index_presenter_test.rb
@@ -19,6 +19,23 @@ class Api::ServicesIndexPresenterTest < ActiveSupport::TestCase
     assert_equal 20, presenter.products.size
   end
 
+  test "deleted products should not be shown" do
+    FactoryBot.create_list(:simple_service, 2, account: provider)
+    presenter = Api::ServicesIndexPresenter.new(current_user: user, params: {})
+
+    service = provider.services.first
+
+    assert_includes provider.services, service
+    assert_includes presenter.products, service
+
+    service.mark_as_deleted
+
+    presenter = Api::ServicesIndexPresenter.new(current_user: user, params: {})
+
+    assert_includes provider.services, service
+    assert_not_includes presenter.products, service
+  end
+
   test "filter products by query" do
     ThinkingSphinx::Test.rt_run do
       perform_enqueued_jobs(only: SphinxIndexationWorker) do

--- a/test/unit/presenters/provider/admin/backend_apis_index_presenter_test.rb
+++ b/test/unit/presenters/provider/admin/backend_apis_index_presenter_test.rb
@@ -18,6 +18,22 @@ class Provider::Admin::BackendApisIndexPresenterTest < ActiveSupport::TestCase
     assert_equal 20, presenter.backend_apis.size
   end
 
+  test "deleted backend apis should not be shown" do
+    FactoryBot.create(:backend_api, account: provider)
+    presenter = Provider::Admin::BackendApisIndexPresenter.new(current_account: provider, params: {})
+    backend_api = provider.backend_apis.first
+
+    assert_includes provider.backend_apis, backend_api
+    assert_includes presenter.backend_apis, backend_api
+
+    backend_api.mark_as_deleted
+
+    presenter = Provider::Admin::BackendApisIndexPresenter.new(current_account: provider, params: {})
+
+    assert_includes provider.backend_apis, backend_api
+    assert_not_includes presenter.backend_apis, backend_api
+  end
+
   test "filter backend_apis by query" do
     ThinkingSphinx::Test.rt_run do
       perform_enqueued_jobs(only: SphinxIndexationWorker) do


### PR DESCRIPTION
**Which issue(s) this PR fixes** 

[THREESCALE-8402 Deleted product or backend is still visible in list
](https://issues.redhat.com/browse/THREESCALE-8402?jql=project%20%3D%20THREESCALE%20AND%20resolution%20%3D%20Unresolved%20AND%20assignee%20in%20(currentUser())%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)

**Verification steps** 

1. Go to Backends.
2. Delete a previously created backend. 
3. Confirm that it doesn't appear on Backends list.

4. Go to Products.
5. Delete a previously created product.
6. Confirm that it doesn't appear on Products list
