### PR TITLE
Unable to change product authentication method

### DIFF
--- a/app/views/api/services/forms/_integration_settings.html.slim
+++ b/app/views/api/services/forms/_integration_settings.html.slim
@@ -16,13 +16,12 @@
 
   = form.inputs 'Authentication', id: 'auth-wrapper' do
     = form.input :proxy_authentication_method,
-            name: 'service[backend_version]',
             as: :radio,
             required: false,
             collection: BackendVersion.visible_versions(service: service),
             value_as_class: true,
             label: false,
-            input_html: {class: 'auth-method'}
+            input_html: { class: 'auth-method', name: 'service[backend_version]' }
 
     = form.semantic_fields_for :proxy do |f|
       = render 'api/services/forms/authentication_settings', f: f, oauth_hint: 'apicast_oauth'

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -90,6 +90,35 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert hosted_option.attribute('checked').present?
     end
 
+    test 'shows authentication options' do
+      # Default value
+      service.stubs(:backend_version).returns(nil)
+      get settings_admin_service_path(service)
+
+      page = Nokogiri::HTML::Document.parse(response.body)
+      default = page.at_css('#service_proxy_authentication_method_1')
+      assert default.attribute('checked').present?
+      service.unstub(:backend_version)
+
+      # API Key (user_key)
+      service.update!(backend_version: '1')
+      get settings_admin_service_path(service)
+
+      page = Nokogiri::HTML::Document.parse(response.body)
+      api_key_option = page.at_css('#service_proxy_authentication_method_1')
+      assert api_key_option.attribute('checked').present?
+      service.unstub(:backend_version)
+
+      # App_ID and App_Key Pair
+      service.update!(backend_version: '2')
+      get settings_admin_service_path(service)
+
+      page = Nokogiri::HTML::Document.parse(response.body)
+      app_id_app_key_option = page.at_css('#service_proxy_authentication_method_2')
+      assert app_id_app_key_option.attribute('checked').present?
+      service.unstub(:backend_version)
+    end
+
     test 'update the settings' do
       Account.any_instance.stubs(:provider_can_use?).returns(true)
       service.update!(deployment_option: 'self_managed')
@@ -176,6 +205,19 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'Product information updated.', flash[:notice]
       assert_equal 'http://api.example.com:8080', proxy.endpoint
       assert_equal 'http://api.staging.example.com:8080', proxy.sandbox_endpoint
+    end
+
+    test 'update authentication option' do
+      get settings_admin_service_path(service)
+
+      backend_version = service.backend_version
+      assert_equal '1', backend_version
+
+      backend_version = '2'
+
+      put admin_service_path(service), params: update_params
+      assert_equal 'Product information updated.', flash[:notice]
+      assert_equal '2', backend_version
     end
 
     test 'update settings' do

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -92,7 +92,7 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
 
     test 'shows authentication options' do
       # Default value
-      service.stubs(:backend_version).returns(nil)
+      service.stubs(:backend_version)
       get settings_admin_service_path(service)
 
       page = Nokogiri::HTML::Document.parse(response.body)


### PR DESCRIPTION
**Which issue(s) this PR fixes** 

[THREESCALE-8570 Unable to change product authentication method](https://issues.redhat.com/browse/THREESCALE-8570)

**Verification steps** 

1. Navigate to Product setting page (/apiconfig/services/{product_id}/settings).
2. Change authentication method.
3. Click Update Product button at the bottom of the page.
4. You get 'Product information updated' message but authentication method won't change.