### PR TITLE
MySQL account query optimization

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -85,7 +85,7 @@ class Account < ApplicationRecord
   # scope :buyers, :conditions => {:provider => false, :master => false}
   scope :buyers, -> { where(provider: false, buyer: true) }
 
-  scope :not_master, -> { where(master: [false, nil]) }
+  scope :not_master, -> { where.has { (master != true) | (master == nil) } }
 
   audited allow_mass_assignment: true
 

--- a/test/test_helpers/sphinx.rb
+++ b/test/test_helpers/sphinx.rb
@@ -23,6 +23,10 @@ module ThinkingSphinx
       def indexed_models
         ThinkingSphinx::Configuration.instance.index_set_class.new.map(&:model).map { |m| m.descendants.presence || m }.flatten
       end
+
+      def index_for(model)
+        ThinkingSphinx::Configuration.instance.index_set_class.new(classes: [model]).first
+      end
     end
   end
 end


### PR DESCRIPTION
MySQL 5.7 used incorrect index when accounts were
queried for sphinx indexation in batches.

This made `rake sphinx:enqueue[Account]` very slow.

Altering the `not_master` scope a little seems to
help optimizer make the right choice so that
getting each batch takes less than 200ms instead
of 3 to 8 seconds.

fixes THREESCALE-8586