### PR TITLE
Fix copy plan scenarios failing in oracle

### DIFF
--- a/features/step_definitions/api/application_plans_steps.rb
+++ b/features/step_definitions/api/application_plans_steps.rb
@@ -284,10 +284,8 @@ When(/^the provider creates a plan$/) do
 end
 
 Then "a copy of the plan is added to the list" do
-  steps %(
-    Then I should see "Plan copied."
-    And I should see "#{@plan.name} (copy)"
-  )
+  assert_flash "Plan copied."
+  assert_content "#{@plan.name} (copy)"
 end
 
 Then "they can edit its details" do


### PR DESCRIPTION
[THREESCALE-8591: Fix failing scenario "Copy an application plan" in oracle](https://issues.redhat.com/browse/THREESCALE-8591)

[THREESCALE-8593: Fix failing scenario "Copy an account plan" in oracle](https://issues.redhat.com/browse/THREESCALE-8593)