### PR TITLE
flaky cucumbers with oracle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ executors:
       - *redis-container
 
   cucumber-with-oracle-ruby26: &cucumber-with-oracle-ruby26
-    resource_class: large
+    resource_class: xlarge
     docker:
       - *system-builder-ruby26
       - *dnsmasq-container


### PR DESCRIPTION
cucumbers often fail with oracle. Data shows it is mostly because of timing.

Lets try to increase executor performance to see if that helps.