### PR TITLE
THREESCALE-7327: Fix missing pagination links on mapping rules search results

### DIFF
--- a/app/concerns/searchable.rb
+++ b/app/concerns/searchable.rb
@@ -12,7 +12,7 @@ module Searchable
 
     scope :by_query, ->(query) do
       options = { ids_only: true, star: true, ignore_scopes: true, with: { },
-                  per_page: ThreeScale::Search::Helpers::MAX_SEARCH_PAGE_SIZE }
+                  per_page: ThreeScale::Search::Helpers::SPHINX_PAGE_SIZE_INFINITE }
       where(id: unscoped.search(ThinkingSphinx::Query.escape(query), options))
     end
 

--- a/app/concerns/searchable.rb
+++ b/app/concerns/searchable.rb
@@ -11,7 +11,8 @@ module Searchable
     self.allowed_search_scopes = %i[query]
 
     scope :by_query, ->(query) do
-      options = {ids_only: true, per_page: 1_000_000, star: true, ignore_scopes: true, with: { }}
+      options = { ids_only: true, star: true, ignore_scopes: true, with: { },
+                  per_page: ThreeScale::Search::Helpers::MAX_SEARCH_PAGE_SIZE }
       where(id: unscoped.search(ThinkingSphinx::Query.escape(query), options))
     end
 

--- a/app/controllers/proxy_rule_shared_controller.rb
+++ b/app/controllers/proxy_rule_shared_controller.rb
@@ -14,7 +14,7 @@ module ProxyRuleSharedController
   def index
     @search = ThreeScale::Search.new(params[:search])
     query = ProxyRuleQuery.new(owner_type: params[:owner_type], owner_id: owner_id,
-                                 direction: params[:direction], sort: params[:sort])
+                               direction: params[:direction], sort: params[:sort])
     @proxy_rules = query.search_for(@search['query'], proxy_rules.includes(:metric))
                         .paginate(pagination_params)
   end

--- a/app/controllers/proxy_rule_shared_controller.rb
+++ b/app/controllers/proxy_rule_shared_controller.rb
@@ -13,7 +13,7 @@ module ProxyRuleSharedController
 
   def index
     @search = ThreeScale::Search.new(params[:search])
-    query   = ProxyRuleQuery.new(owner_type: params[:owner_type], owner_id: owner_id,
+    query = ProxyRuleQuery.new(owner_type: params[:owner_type], owner_id: owner_id,
                                  direction: params[:direction], sort: params[:sort])
     @proxy_rules = query.search_for(@search['query'], proxy_rules.includes(:metric))
                         .paginate(pagination_params)
@@ -22,7 +22,7 @@ module ProxyRuleSharedController
   def new
     last_position = proxy_rules.maximum(:position) || 0
     next_position = last_position + 1
-    @proxy_rule   = proxy_rules.build(position: next_position, delta: 1)
+    @proxy_rule = proxy_rules.build(position: next_position, delta: 1)
   end
 
   private

--- a/app/controllers/proxy_rule_shared_controller.rb
+++ b/app/controllers/proxy_rule_shared_controller.rb
@@ -14,7 +14,7 @@ module ProxyRuleSharedController
   def index
     @search = ThreeScale::Search.new(params[:search])
     query   = ProxyRuleQuery.new(owner_type: params[:owner_type], owner_id: owner_id,
-                                 direction: params[:direction], sort: params[:sort], per_page: per_page)
+                                 direction: params[:direction], sort: params[:sort])
     @proxy_rules = query.search_for(@search['query'], proxy_rules.includes(:metric))
                         .paginate(pagination_params)
   end

--- a/app/lib/three_scale/search.rb
+++ b/app/lib/three_scale/search.rb
@@ -189,7 +189,8 @@ class ThreeScale::Search < ActiveSupport::HashWithIndifferentAccess
 
     # By default sphinx paginates search results, and the default page size is 20.
     # Setting to a high value "disables" sphinx-based pagination to use will_paginate instead
-    MAX_SEARCH_PAGE_SIZE = 1_000_000
+    # See https://freelancing-gods.com/thinking-sphinx/v5/searching.html#pagination
+    SPHINX_PAGE_SIZE_INFINITE = 1_000_000
 
     def self.included(controller)
       controller.class_eval do

--- a/app/lib/three_scale/search.rb
+++ b/app/lib/three_scale/search.rb
@@ -184,7 +184,12 @@ class ThreeScale::Search < ActiveSupport::HashWithIndifferentAccess
 
   module Helpers
 
+    # Maximum page size for search results
     MAX_PER_PAGE = 20
+
+    # By default sphinx paginates search results, and the default page size is 20.
+    # Setting to a high value "disables" sphinx-based pagination to use will_paginate instead
+    MAX_SEARCH_PAGE_SIZE = 1_000_000
 
     def self.included(controller)
       controller.class_eval do

--- a/app/lib/three_scale/search.rb
+++ b/app/lib/three_scale/search.rb
@@ -184,7 +184,7 @@ class ThreeScale::Search < ActiveSupport::HashWithIndifferentAccess
 
   module Helpers
 
-    # Maximum page size for search results
+    # Default maximum page size for search results
     MAX_PER_PAGE = 20
 
     # By default sphinx paginates search results, and the default page size is 20.

--- a/app/models/account/search.rb
+++ b/app/models/account/search.rb
@@ -57,7 +57,7 @@ class Account
 
         options = options
                   .reverse_merge(ids_only: true, star: true,
-                                 per_page: ThreeScale::Search::Helpers::MAX_SEARCH_PAGE_SIZE,
+                                 per_page: ThreeScale::Search::Helpers::SPHINX_PAGE_SIZE_INFINITE,
                                  ignore_scopes: true, with: { })
 
         if (tenant_id = User.tenant_id)

--- a/app/models/account/search.rb
+++ b/app/models/account/search.rb
@@ -56,7 +56,8 @@ class Account
         return [] if query.blank?
 
         options = options
-                  .reverse_merge(ids_only: true, per_page: 1_000_000, star: true,
+                  .reverse_merge(ids_only: true, star: true,
+                                 per_page: ThreeScale::Search::Helpers::MAX_SEARCH_PAGE_SIZE,
                                  ignore_scopes: true, with: { })
 
         if (tenant_id = User.tenant_id)

--- a/app/queries/proxy_rule_query.rb
+++ b/app/queries/proxy_rule_query.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ProxyRuleQuery
-  def initialize(owner_type:, owner_id:, sort: nil, direction: nil, per_page: ThreeScale::Search::Helpers::MAX_PER_PAGE)
+  def initialize(owner_type:, owner_id:, sort: nil, direction: nil,
+                 per_page: ThreeScale::Search::Helpers::MAX_SEARCH_PAGE_SIZE)
     @direction  = direction
     @owner_type = owner_type
     @owner_id   = owner_id
@@ -12,6 +13,7 @@ class ProxyRuleQuery
   def search_for(query, scope = ProxyRule.all)
     scope = scope.order_by(@sort, @direction).includes(:metric)
     return scope if query.blank?
+
     options = {
       ids_only: true, star: true, per_page: @per_page, ignore_scopes: true,
       with: { owner_type: @owner_type, owner_id: @owner_id }

--- a/app/queries/proxy_rule_query.rb
+++ b/app/queries/proxy_rule_query.rb
@@ -13,7 +13,7 @@ class ProxyRuleQuery
     return scope if query.blank?
 
     options = {
-      ids_only: true, star: true, per_page: ThreeScale::Search::Helpers::MAX_SEARCH_PAGE_SIZE, ignore_scopes: true,
+      ids_only: true, star: true, per_page: ThreeScale::Search::Helpers::SPHINX_PAGE_SIZE_INFINITE, ignore_scopes: true,
       with: { owner_type: @owner_type, owner_id: @owner_id }
     }
     ids = ProxyRule.search(ThinkingSphinx::Query.escape(query), options)

--- a/app/queries/proxy_rule_query.rb
+++ b/app/queries/proxy_rule_query.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 class ProxyRuleQuery
-  def initialize(owner_type:, owner_id:, sort: nil, direction: nil,
-                 per_page: ThreeScale::Search::Helpers::MAX_SEARCH_PAGE_SIZE)
+  def initialize(owner_type:, owner_id:, sort: nil, direction: nil)
     @direction  = direction
     @owner_type = owner_type
     @owner_id   = owner_id
-    @per_page   = per_page.to_i
     @sort       = sort
   end
 
@@ -15,7 +13,7 @@ class ProxyRuleQuery
     return scope if query.blank?
 
     options = {
-      ids_only: true, star: true, per_page: @per_page, ignore_scopes: true,
+      ids_only: true, star: true, per_page: ThreeScale::Search::Helpers::MAX_SEARCH_PAGE_SIZE, ignore_scopes: true,
       with: { owner_type: @owner_type, owner_id: @owner_id }
     }
     ids = ProxyRule.search(ThinkingSphinx::Query.escape(query), options)

--- a/features/services/mapping_rules.feature
+++ b/features/services/mapping_rules.feature
@@ -1,8 +1,8 @@
 @javascript
 Feature: Product mapping rules
-  In order to integrate with 3scale via a on-premise proxy
+  In order to configure API gateway access control
   As a provider
-  I want to download config files from the inteface
+  I want to be able to manage my mapping rules
 
   Background:
     Given all the rolling updates features are off
@@ -45,3 +45,11 @@ Feature: Product mapping rules
     Given I have proxy_pro feature disabled
     When I go to the create mapping rule page for service "one"
     Then I should not see field "Redirect URL"
+
+  @search
+  Scenario: Pagination when search results are multi-page
+    Given a service "ManyRules"
+    And the service "ManyRules" has 30 mapping rules starting with pattern "/test"
+    When I go to the mapping rules index page for service "ManyRules"
+    And I search mapping rules for pattern "/test"
+    Then I should see 2 pages

--- a/features/step_definitions/proxy_steps.rb
+++ b/features/step_definitions/proxy_steps.rb
@@ -85,3 +85,29 @@ Then(/^the mapping rules should be in the following order:$/) do |table|
     end
   end
 end
+
+Given('the service {string} has {int} mapping rules starting with pattern {string}') do |service_name, rules_size, pattern|
+  service = @provider.services.find_by_name(service_name)
+  hits_metric = service.metrics.first
+  proxy_rules = service.proxy.proxy_rules
+  rules_size.times do |num|
+    proxy_rules.create(http_method: 'GET', pattern: "#{pattern}/num", delta: 1, metric: hits_metric)
+  end
+end
+
+Then(/^the mapping rules of service "([^"]*)" should be in the following order:$/) do |service_name, table|
+  service = @provider.services.find_by_name(service_name)
+  data = service.proxy.proxy_rules.includes(:metric).ordered
+  data.each_with_index do |mapping_rule, index|
+    MAPPING_RULE_ATTR.each do |attr|
+      actual_value = mapping_rule.public_send(attr)
+      actual_value = actual_value.name if attr == 'metric'
+      assert_equal table.hashes[index][attr].to_s, actual_value.to_s
+    end
+  end
+end
+
+When('I search mapping rules for pattern {string}') do |query|
+  fill_in('search_query', :with => query)
+  click_button('Search')
+end

--- a/features/step_definitions/proxy_steps.rb
+++ b/features/step_definitions/proxy_steps.rb
@@ -87,23 +87,11 @@ Then(/^the mapping rules should be in the following order:$/) do |table|
 end
 
 Given('the service {string} has {int} mapping rules starting with pattern {string}') do |service_name, rules_size, pattern|
-  service = @provider.services.find_by_name(service_name)
+  service = @provider.services.find_by(name: service_name)
   hits_metric = service.metrics.first
   proxy_rules = service.proxy.proxy_rules
   rules_size.times do |num|
     proxy_rules.create(http_method: 'GET', pattern: "#{pattern}/num", delta: 1, metric: hits_metric)
-  end
-end
-
-Then(/^the mapping rules of service "([^"]*)" should be in the following order:$/) do |service_name, table|
-  service = @provider.services.find_by_name(service_name)
-  data = service.proxy.proxy_rules.includes(:metric).ordered
-  data.each_with_index do |mapping_rule, index|
-    MAPPING_RULE_ATTR.each do |attr|
-      actual_value = mapping_rule.public_send(attr)
-      actual_value = actual_value.name if attr == 'metric'
-      assert_equal table.hashes[index][attr].to_s, actual_value.to_s
-    end
   end
 end
 

--- a/test/unit/queries/proxy_rule_query_test.rb
+++ b/test/unit/queries/proxy_rule_query_test.rb
@@ -53,4 +53,17 @@ class ProxyRuleTest < ActiveSupport::TestCase
       assert_equal master_account.proxy_rules, query.search_for('')
     end
   end
+
+  test '#search_for queries when there are more results than page size' do
+    ThinkingSphinx::Test.rt_run do
+      backend_api = FactoryBot.build_stubbed(:backend_api)
+      perform_enqueued_jobs(only: SphinxIndexationWorker) do
+        proxy_rules = FactoryBot.create_list(:proxy_rule, 25, owner: backend_api, pattern: '/path/test')
+        query      = ProxyRuleQuery.new(owner_type: proxy_rules.first.owner_type, owner_id: proxy_rules.first.owner_id)
+
+        assert_equal 25, query.search_for('test').size
+      end
+    end
+  end
+
 end

--- a/test/unit/queries/proxy_rule_query_test.rb
+++ b/test/unit/queries/proxy_rule_query_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class ProxyRuleTest < ActiveSupport::TestCase
+class ProxyRuleQueryTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
   test '#search_for uses sphinx if query given' do
@@ -10,7 +10,7 @@ class ProxyRuleTest < ActiveSupport::TestCase
       backend_api = FactoryBot.build_stubbed(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test')
-        query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+        query = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
 
         assert_equal [proxy_rule], query.search_for('test')
       end
@@ -21,10 +21,10 @@ class ProxyRuleTest < ActiveSupport::TestCase
     ThinkingSphinx::Test.rt_run do
       backend_api = FactoryBot.build_stubbed(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
-        proxy_rule   = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test1', position: 1)
-        proxy_rule2  = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test2', position: 2)
-        query        = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
-        scope        = ProxyRule.where(position: 2)
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test1', position: 1)
+        proxy_rule2 = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test2', position: 2)
+        query = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
+        scope = ProxyRule.where(position: 2)
 
         assert_equal [proxy_rule2], query.search_for('test', scope)
       end
@@ -35,9 +35,9 @@ class ProxyRuleTest < ActiveSupport::TestCase
     ThinkingSphinx::Test.rt_run do
       backend_api = FactoryBot.build_stubbed(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
-        proxy_rule   = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test1', position: 1)
-        proxy_rule2  = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test2', position: 2)
-        query        = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id,
+        proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test1', position: 1)
+        proxy_rule2 = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test2', position: 2)
+        query = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id,
                                           sort: :position, direction: :desc)
 
         assert_equal [proxy_rule2, proxy_rule], query.search_for('test')
@@ -59,7 +59,7 @@ class ProxyRuleTest < ActiveSupport::TestCase
       backend_api = FactoryBot.build_stubbed(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rules = FactoryBot.create_list(:proxy_rule, 25, owner: backend_api, pattern: '/path/test')
-        query      = ProxyRuleQuery.new(owner_type: proxy_rules.first.owner_type, owner_id: proxy_rules.first.owner_id)
+        query = ProxyRuleQuery.new(owner_type: proxy_rules.first.owner_type, owner_id: proxy_rules.first.owner_id)
 
         assert_equal 25, query.search_for('test').size
       end


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes missing pagination links on mapping rules search results.

**Which issue(s) this PR fixes** 

Fixes [THREESCALE-7327: Mapping rule search pagination not displayed on search results page](https://issues.redhat.com/browse/THREESCALE-7327)

**Verification steps** 
From the above JIRA:

- Create a new product
- Add more than 25 mapping rules similar to /cust/(RANDOM_PATHs)
- You will notice that the pagination is enabled by default when you load the admin-portal mapping rules page.
- Search the term /cust
- Only 20 results will be displayed and pagination is not shown to view the rest of the results.

**Special notes for your reviewer**:

The root cause of the issue is that the size of the search results returned by Sphinx was always maximum 20, which equals the size of the page for search results, so the pagination links was never visible, as considered "not needed" by `will_paginate`.
The reason of this :grimacing: : https://github.com/3scale/porta/pull/1239#pullrequestreview-294459623 

The test only validates that the original reason is fixed, IMO frontend test is not required, as a standard `will_paginate` is used on the page.

Mapping rules can be batch-created with the following bash loop:

```
for i in {a..z}; do curl -v  -X POST "{ADMIN_URL}/admin/api/services/{SERVICE_ID}/proxy/mapping_rules.xml" -d "access_token={ACCESS_TOKEN}&http_method=GET&pattern=%2Fcust%2F$i&delta=1&metric_id={METRIC_ID}"; done
```
