### PR TITLE
Update setup steps (`asdf` as default now)

### DIFF
--- a/.tool-versions.sample
+++ b/.tool-versions.sample
@@ -1,2 +1,3 @@
-ruby 2.6.6
-nodejs 14.15.4
+ruby 2.6.10
+nodejs 12.22.12
+python 3.10.7 2.7.18 # Meant for M1 macs


### PR DESCRIPTION
Updates our installation guide:
* For latest macOS and Silicon chip
* Some fixes to Fedora
* asdf is the recommended version manager now for ruby, Node.js and Python.

[ASDF](https://asdf-vm.com/guide/getting-started.html#global)

Any proper dev environment requires a version manager tool, ruby and node in the case of porta. Throughout the years the team has tried a bunch of them: nvm, rvm, rbenv... and recently the majority seems to favor `asdf` which main advantage is it allows managing both packages.

Moreover, there's been times when a conflict between versions between local and prod has caused us problems.

My proposal is to promote `asdf` as the preferred version manager for our project. This way we're all in the same page and we can mitigate potential configuration issues. It will also help using the versions we're supposed to thanks to `.tool-versions`.