### PR TITLE
prawn memory leak workaround

### DIFF
--- a/app/lib/pdf/finance/invoice_generator.rb
+++ b/app/lib/pdf/finance/invoice_generator.rb
@@ -5,6 +5,7 @@ require 'prawn/format'
 require "prawn/measurement_extensions"
 require 'gruff'
 require "open-uri"
+require 'pdf/utils'
 
 module Pdf
   module Finance
@@ -15,6 +16,7 @@ module Pdf
       include ActionView::Helpers::NumberHelper
       include ThreeScale::MoneyHelper
       include ::Finance::InvoicesHelper
+      include Pdf::Utils::Cache
 
       def initialize(invoice_data)
         @data = invoice_data
@@ -52,6 +54,8 @@ module Pdf
         move_down
 
         @pdf.render
+      ensure
+        clear_thread_cache
       end
 
       private

--- a/app/lib/pdf/report.rb
+++ b/app/lib/pdf/report.rb
@@ -6,12 +6,14 @@ require "prawn/measurement_extensions"
 require 'gruff'
 require 'pdf/format'
 require 'pdf/data'
+require 'pdf/utils'
 require 'pdf/styles/colored'
 
 # REFACTOR: extract abstract Report class, and DRY functionality with InvoiceReporter
 module Pdf
   class Report
     include Printer
+    include Pdf::Utils::Cache
 
     attr_accessor :account, :period, :pdf, :service, :report
 
@@ -56,6 +58,8 @@ module Pdf
       @report = @pdf.render_file(pdf_file_path)
 
       self
+    ensure
+      clear_thread_cache
     end
 
     def deliver_notification?(user)

--- a/app/lib/pdf/utils.rb
+++ b/app/lib/pdf/utils.rb
@@ -1,0 +1,16 @@
+module Pdf
+  module Utils
+    module Cache
+      # Prawn suffers a memory leak which was fixed upstream by
+      # https://github.com/prawnpdf/prawn/pull/430
+      # New API will require reimplementing a lot of things though
+      # so fixing up that at places we use for the time being.
+      module_function def clear_thread_cache
+        %i(bold_char_width plain_char_width).each do |key|
+          Thread.current[key] = nil
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
We can't easily upgrade prawn because of API changes that will
require reimplementing of PDF generation code.

Issue was fixed upstream with prawnpdf/prawn#430 and described as:

> It boils down to `text.rb#L147` making use of a thread-local cache for character sizes of the current font. The Font objects don't implement #hash or #eql?, so different instances of the same font will end up creating different keys in the thread-local and thus growing the cache.

In our workaround, we just clear that cache after each PDF creation as that
can be done externally without forking prawn. At some point we need to take
the time and update to the latest prawn version.

fixes THREESCALE-8120