### PR TITLE
THREESCALE-8562: Search products and backend APIs by system name

### DIFF
--- a/app/indices/backend_api_index.rb
+++ b/app/indices/backend_api_index.rb
@@ -3,6 +3,7 @@
 ThinkingSphinx::Index.define(:backend_api, with: :real_time) do
   # Fields
   indexes name
+  indexes system_name
 
   # Attributes
 end

--- a/app/indices/service_index.rb
+++ b/app/indices/service_index.rb
@@ -3,6 +3,7 @@
 ThinkingSphinx::Index.define(:service, with: :real_time) do
   # Fields
   indexes name
+  indexes system_name
 
   # Attributes
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `system_name` to index for Product and Backend API.

**Which issue(s) this PR fixes**

Fixes [THREESCALE-8562: Products and backend can't be found by searching for system name](https://issues.redhat.com/browse/THREESCALE-8562)

**Verification steps** 

- Create a Product with system name which is different from the name.
- Search by the system name.
- Verify that the product appears in search results.

**Special notes for your reviewer**:

Applying this change requires rebuilding the index, so it should only be merged when we're ready to do that.
