### PR TITLE
THREESCALE-8530: Fix a N+1 problem in Buyers::AccountsIndexPresenter

### DIFF
--- a/app/presenters/buyers/accounts_index_presenter.rb
+++ b/app/presenters/buyers/accounts_index_presenter.rb
@@ -14,6 +14,7 @@ class Buyers::AccountsIndexPresenter
 
   def buyers
     @buyers ||= provider.buyer_accounts
+                        .includes([:admin_user])
                         .not_master
                         .scope_search(search)
                         .order_by(*sorting_params)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

There's a N+1 problem in Buyers::AccountsIndexPresenter

**Which issue(s) this PR fixes** 

 [THREESCALE-8530](https://issues.redhat.com/browse/THREESCALE-8530)

**Verification steps** 

1. Go to `/buyers/accounts`
2. Verify that bullet is not warning about the n+1 anymore
3. Also, in the rails console, a new query is executed to retrieve all users in one single query
`  ↳ app/views/buyers/accounts/_search_results.html.slim:43
  User Load (0.5ms)  SELECT users.* FROM users WHERE users.role = 'admin' AND (username <> '3scaleadmin') AND users.account_id IN (5, 4, 3)`
