### PR TITLE
THREESCALE-7540 fix master admin tenant name issue

### DIFF
--- a/app/lib/signup/domains_builder.rb
+++ b/app/lib/signup/domains_builder.rb
@@ -15,7 +15,7 @@ module Signup
     end
 
     def generate_subdomain
-      result = org_name.tr("_", "-").to_s.parameterize
+      result = org_name.to_s.tr('_', '-').parameterize
 
       while result.present? && invalid_subdomain_condition.call(subdomain: result)
         base, sequence = result.match(/\A(.*?)(?:\-(\d+))?\z/).to_a[1, 2]

--- a/app/lib/signup/domains_builder.rb
+++ b/app/lib/signup/domains_builder.rb
@@ -15,7 +15,7 @@ module Signup
     end
 
     def generate_subdomain
-      result = org_name.to_s.parameterize
+      result = org_name.gsub("_", "-").to_s.parameterize
 
       while result.present? && invalid_subdomain_condition.call(subdomain: result)
         base, sequence = result.match(/\A(.*?)(?:\-(\d+))?\z/).to_a[1, 2]

--- a/app/lib/signup/domains_builder.rb
+++ b/app/lib/signup/domains_builder.rb
@@ -15,7 +15,7 @@ module Signup
     end
 
     def generate_subdomain
-      result = org_name.gsub("_", "-").to_s.parameterize
+      result = org_name.tr("_", "-").to_s.parameterize
 
       while result.present? && invalid_subdomain_condition.call(subdomain: result)
         base, sequence = result.match(/\A(.*?)(?:\-(\d+))?\z/).to_a[1, 2]

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -260,8 +260,9 @@ class Account < ApplicationRecord
 
   # TODO: multitenant. enable it?
   # validates_uniqueness_of :s3_prefix
-  validates :org_name, format: { with: /\A.*[a-zA-Z0-9]+.*\z/, message: :invalid_format },
-                       presence: true, length: { maximum: 255 }
+  validates :org_name, presence: true, length: { maximum: 255 },
+                       format: { with: /\A.*[a-zA-Z0-9]+.*\z/, message: :invalid_format }
+
 
   validates :org_legaladdress, :domain, :telephone_number, :site_access_code,
             :billing_address_name, :billing_address_address1, :billing_address_address2, :billing_address_city,

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -167,7 +167,7 @@ class Account < ApplicationRecord
   has_many :sso_authorizations, through: :users
   has_many :user_sessions, through: :users
 
-  validates_format_of :org_name, with: /\A.*[a-zA-Z0-9]+.*\z/
+  validates :org_name, format: /\A.*[a-zA-Z0-9]+.*\z/
 
   alias_attribute :name, :org_name
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -167,7 +167,7 @@ class Account < ApplicationRecord
   has_many :sso_authorizations, through: :users
   has_many :user_sessions, through: :users
 
-  validates :org_name, format: /\A.*[a-zA-Z0-9]+.*\z/
+  validates :org_name, format: { with: /\A.*[a-zA-Z0-9]+.*\z/, message: :invalid_format }
 
   alias_attribute :name, :org_name
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -167,8 +167,6 @@ class Account < ApplicationRecord
   has_many :sso_authorizations, through: :users
   has_many :user_sessions, through: :users
 
-  validates :org_name, format: { with: /\A.*[a-zA-Z0-9]+.*\z/, message: :invalid_format }
-
   alias_attribute :name, :org_name
 
   has_one :onboarding
@@ -262,7 +260,8 @@ class Account < ApplicationRecord
 
   # TODO: multitenant. enable it?
   # validates_uniqueness_of :s3_prefix
-  validates :org_name, presence: true, length: { maximum: 255 }
+  validates :org_name, format: { with: /\A.*[a-zA-Z0-9]+.*\z/, message: :invalid_format },
+                       presence: true, length: { maximum: 255 }
 
   validates :org_legaladdress, :domain, :telephone_number, :site_access_code,
             :billing_address_name, :billing_address_address1, :billing_address_address2, :billing_address_city,

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -167,6 +167,8 @@ class Account < ApplicationRecord
   has_many :sso_authorizations, through: :users
   has_many :user_sessions, through: :users
 
+  validates_format_of :org_name, with: /\A.*[a-zA-Z0-9]+.*\z/
+
   alias_attribute :name, :org_name
 
   has_one :onboarding

--- a/app/views/provider/admin/accounts/new.html.slim
+++ b/app/views/provider/admin/accounts/new.html.slim
@@ -1,6 +1,11 @@
 h2 Create new Account
 = semantic_form_for @provider, builder: Fields::FormBuilder, url: provider_admin_accounts_path do |form|
 
+  - if @provider.errors.any?
+    ul style = "color: red"
+      - @provider.errors.full_messages.each do |message|
+        li= h message
+
   = form.inputs name: 'User Information', for: [:user, @user] do |user|
     = user.user_defined_form
     = user.input :password, required: true

--- a/app/views/provider/admin/accounts/new.html.slim
+++ b/app/views/provider/admin/accounts/new.html.slim
@@ -1,11 +1,5 @@
 h2 Create new Account
 = semantic_form_for @provider, builder: Fields::FormBuilder, url: provider_admin_accounts_path do |form|
-
-  - if @provider.errors.any?
-    ul style = "color: red"
-      - @provider.errors.full_messages.each do |message|
-        li= h message
-
   = form.inputs name: 'User Information', for: [:user, @user] do |user|
     = user.user_defined_form
     = user.input :password, required: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -915,7 +915,7 @@ en:
             org_name:
               blank: "can't be blank"
               taken: "already taken"
-              invalid_format: "should contain at least one alphanumeric character"
+              invalid_format: "must contain at least one alphanumeric character"
 
             subdomain:
               blank: "can't be blank"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -915,6 +915,8 @@ en:
             org_name:
               blank: "can't be blank"
               taken: "already taken"
+              invalid_format: "should contain at least one alphanumeric character"
+
             subdomain:
               blank: "can't be blank"
               same: "can't be the same"

--- a/test/unit/account/provider_domains_test.rb
+++ b/test/unit/account/provider_domains_test.rb
@@ -180,4 +180,13 @@ class Account::ProviderDomainsTest < ActiveSupport::TestCase
     assert_equal 'customer-name', provider.subdomain
   end
 
+  test 'subdomain should start and end with a alphanumeric character' do
+    provider = Account.new(name: '$-test-2__') do |account|
+      account.provider = true
+    end
+    provider.generate_domains
+
+    assert provider.valid?
+    assert_equal 'test-2', provider.subdomain
+  end
 end

--- a/test/unit/account/provider_domains_test.rb
+++ b/test/unit/account/provider_domains_test.rb
@@ -161,4 +161,13 @@ class Account::ProviderDomainsTest < ActiveSupport::TestCase
     provider.domain = 'new.example.com'
     provider.save
   end
+
+  test 'special characters are replaced with hyphens in subdomain' do
+    provider = Account.new(name: 'test_2@s n#me') do |account|
+      account.provider = true
+    end
+    provider.generate_domains
+
+    assert_equal 'test-2-s-n-me', provider.subdomain
+  end
 end

--- a/test/unit/account/provider_domains_test.rb
+++ b/test/unit/account/provider_domains_test.rb
@@ -170,4 +170,14 @@ class Account::ProviderDomainsTest < ActiveSupport::TestCase
 
     assert_equal 'test-2-s-n-me', provider.subdomain
   end
+
+  test 'all characters are set to lowercase in subdomain' do
+    provider = Account.new(name: 'Customer Name') do |account|
+      account.provider = true
+    end
+    provider.generate_domains
+
+    assert_equal 'customer-name', provider.subdomain
+  end
+
 end

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -755,6 +755,7 @@ class AccountTest < ActiveSupport::TestCase
   test "there should be at least one alphanum character anywhere in the org_name" do
     account = FactoryBot.build(:simple_account, org_name: '.?+@')
     assert_not account.valid?
+    assert_includes account.errors.messages[:org_name], "should contain at least one alphanumeric character"
   end
 end
 

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -755,7 +755,7 @@ class AccountTest < ActiveSupport::TestCase
   test "there should be at least one alphanum character anywhere in the org_name" do
     account = FactoryBot.build(:simple_account, org_name: '.?+@')
     assert_not account.valid?
-    assert_includes account.errors.messages[:org_name], "should contain at least one alphanumeric character"
+    assert_includes account.errors.messages[:org_name], "must contain at least one alphanumeric character"
   end
 end
 

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -746,6 +746,16 @@ class AccountTest < ActiveSupport::TestCase
     service1.update(state: Service::DELETE_STATE)
     assert_same_elements [c2], account.accessible_proxy_configs.current_versions
   end
+
+  test "allow underscore in org_name" do
+    account = FactoryBot.build(:simple_account, org_name: 'name@._+1')
+    assert account.valid?
+  end
+
+  test "there should be at least one alphanum character anywhere in the org_name" do
+    account = FactoryBot.build(:simple_account, org_name: '.?+@')
+    assert_not account.valid?
+  end
 end
 
 #TODO: test scopes chained, and with nil params

--- a/test/unit/signup/result_test.rb
+++ b/test/unit/signup/result_test.rb
@@ -99,7 +99,7 @@ module Signup
       assert_includes signup_result.errors[:user], 'Username is too short (minimum is 3 characters)'
     end
 
-    test '#save does not save and #errors return the errors when the account is blank' do
+    test '#save does not save and #errors return the errors when the org name is blank' do
       @account = FactoryBot.build(:account, org_name: nil)
       signup_result.save
       refute user.persisted?
@@ -107,12 +107,20 @@ module Signup
       assert_includes signup_result.errors[:account], "Organization/Group Name can't be blank"
     end
 
-    test '#save does not save and #errors return the errors when the account is invalid' do
+    test '#save does not save and #errors return the errors when the org name is invalid' do
       @account = FactoryBot.build(:account, org_name: '?-!_$')
       signup_result.save
       refute user.persisted?
       refute account.persisted?
       assert_includes signup_result.errors[:account], "Organization/Group Name must contain at least one alphanumeric character"
+    end
+
+    test '#save does not save and #errors return the errors when the org name is too long' do
+      @account = FactoryBot.build(:account, org_name: 'a' * 256)
+      signup_result.save
+      refute user.persisted?
+      refute account.persisted?
+      assert_includes signup_result.errors[:account], "Organization/Group Name is too long (maximum is 255 characters)"
     end
 
     test '#save does not save and #errors return the error when @errors has errors' do

--- a/test/unit/signup/result_test.rb
+++ b/test/unit/signup/result_test.rb
@@ -99,12 +99,20 @@ module Signup
       assert_includes signup_result.errors[:user], 'Username is too short (minimum is 3 characters)'
     end
 
-    test '#save does not save and #errors return the errors when the account is invalid/blank' do
+    test '#save does not save and #errors return the errors when the account is blank' do
       @account = FactoryBot.build(:account, org_name: nil)
       signup_result.save
       refute user.persisted?
       refute account.persisted?
-      assert_equal 2, signup_result.errors.full_messages.length
+      assert_includes signup_result.errors[:account], "Organization/Group Name can't be blank"
+    end
+
+    test '#save does not save and #errors return the errors when the account is invalid' do
+      @account = FactoryBot.build(:account, org_name: '?-!_$')
+      signup_result.save
+      refute user.persisted?
+      refute account.persisted?
+      assert_includes signup_result.errors[:account], "Organization/Group Name should contain at least one alphanumeric character"
     end
 
     test '#save does not save and #errors return the error when @errors has errors' do

--- a/test/unit/signup/result_test.rb
+++ b/test/unit/signup/result_test.rb
@@ -112,7 +112,7 @@ module Signup
       signup_result.save
       refute user.persisted?
       refute account.persisted?
-      assert_includes signup_result.errors[:account], "Organization/Group Name should contain at least one alphanumeric character"
+      assert_includes signup_result.errors[:account], "Organization/Group Name must contain at least one alphanumeric character"
     end
 
     test '#save does not save and #errors return the error when @errors has errors' do

--- a/test/unit/signup/result_test.rb
+++ b/test/unit/signup/result_test.rb
@@ -105,7 +105,8 @@ module Signup
       refute user.persisted?
       refute account.persisted?
       assert_includes signup_result.errors[:account], 'Organization/Group Name can\'t be blank'
-      assert_equal 1, signup_result.errors.full_messages.length
+      assert_includes signup_result.errors[:account], 'Organization/Group Name invalid'
+      assert_equal 2, signup_result.errors.full_messages.length
     end
 
     test '#save does not save and #errors return the error when @errors has errors' do

--- a/test/unit/signup/result_test.rb
+++ b/test/unit/signup/result_test.rb
@@ -99,13 +99,11 @@ module Signup
       assert_includes signup_result.errors[:user], 'Username is too short (minimum is 3 characters)'
     end
 
-    test '#save does not save and #errors return the error when the account is invalid' do
+    test '#save does not save and #errors return the errors when the account is invalid/blank' do
       @account = FactoryBot.build(:account, org_name: nil)
       signup_result.save
       refute user.persisted?
       refute account.persisted?
-      assert_includes signup_result.errors[:account], 'Organization/Group Name can\'t be blank'
-      assert_includes signup_result.errors[:account], 'Organization/Group Name invalid'
       assert_equal 2, signup_result.errors.full_messages.length
     end
 


### PR DESCRIPTION

**What this PR does / why we need it**:

 This issue is for tenant (account in master portal) and not for account in admin portal. Because tenant URL is created from tenant name hence those special characters are forbidden.


**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7540

**Verification steps** 

mentioned in Jira

Note for reviewer:
Validation was already there but error message is not shown so I have added. 
![image](https://user-images.githubusercontent.com/84672731/190448590-887c596c-653f-4e18-ac8b-3a1508ad48a1.png)

