### PR TITLE
THREESCALE-6933: Fix paperclip filesystem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -229,6 +229,8 @@ group :test do
   gem "n_plus_one_control"
   gem 'ruby-prof'
   gem 'with_env'
+
+  gem 'pdf-inspector', require: 'pdf/inspector'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,6 +508,8 @@ GEM
       ast (~> 2.4.1)
     pastel (0.8.0)
       tty-color (~> 0.5)
+    pdf-inspector (1.0.2)
+      pdf-reader (>= 0.9.0)
     pdf-reader (0.9.3)
       Ascii85 (>= 0.9)
     pg (0.21.0)
@@ -968,6 +970,7 @@ DEPENDENCIES
   oauth2 (~> 1.4)
   open_id_authentication
   paperclip (~> 6.0)
+  pdf-inspector
   pg (~> 0.21.0)
   pisoni (~> 1.29)
   prawn-core!

--- a/app/lib/pdf/finance/invoice_generator.rb
+++ b/app/lib/pdf/finance/invoice_generator.rb
@@ -79,9 +79,9 @@ module Pdf
 
       def print_address_columns
         # TODO: cleanup the constants
-        two_columns( [0.mm, @pdf.cursor], height: 50.mm) do |column|
-          print_address( @data.provider, 'Issued by') if column == :left
-          print_address( @data.buyer, 'For') if column == :right
+        two_columns([0.mm, @pdf.cursor], height: 50.mm) do |column|
+          print_address(@data.provider, 'Issued by') if column == :left
+          print_address(@data.buyer, 'For') if column == :right
         end
       end
 

--- a/app/lib/pdf/finance/invoice_generator.rb
+++ b/app/lib/pdf/finance/invoice_generator.rb
@@ -60,8 +60,9 @@ module Pdf
         two_columns do |column|
           case column
           when :left
-            @pdf.image(@data.logo, fit: [200,50], position: :left) if @data.logo?
-
+            @data.with_logo do |logo|
+              @pdf.image(logo, fit: [200,50], position: :left) if logo
+            end
           when :right
             print_address(@data.buyer)
           end

--- a/app/lib/pdf/finance/invoice_generator.rb
+++ b/app/lib/pdf/finance/invoice_generator.rb
@@ -58,14 +58,8 @@ module Pdf
 
       def print_header
         two_columns do |column|
-          case column
-          when :left
-            @data.with_logo do |logo|
-              @pdf.image(logo, fit: [200,50], position: :left) if logo
-            end
-          when :right
-            print_address(@data.buyer)
-          end
+          print_logo if column == :left
+          print_address(@data.buyer) if column == :right
         end
 
         move_down(14)
@@ -77,13 +71,17 @@ module Pdf
         move_down(3)
       end
 
+      def print_logo
+        @data.with_logo do |logo|
+          @pdf.image(logo, fit: [200,50], position: :left) if logo
+        end
+      end
+
       def print_address_columns
         # TODO: cleanup the constants
         two_columns( [0.mm, @pdf.cursor], height: 50.mm) do |column|
-          case column
-          when :left then print_address( @data.provider, 'Issued by')
-          when :right then print_address( @data.buyer, 'For')
-          end
+          print_address( @data.provider, 'Issued by') if column == :left
+          print_address( @data.buyer, 'For') if column == :right
         end
       end
 

--- a/app/lib/pdf/finance/invoice_report_data.rb
+++ b/app/lib/pdf/finance/invoice_report_data.rb
@@ -13,7 +13,10 @@ class Pdf::Finance::InvoiceReportData
 
   def initialize(invoice)
     @invoice = invoice
-    @logo = @invoice.provider_account.profile.logo
+  end
+
+  def logo
+    @logo ||= @invoice.provider_account.profile.logo
   end
 
   def buyer
@@ -135,12 +138,12 @@ class Pdf::Finance::InvoiceReportData
   # - retrieve either the full path of the local file, or the URL of the file in S3
   # - read the file differently
   def logo_file
-    case storage = @logo.options[:storage].to_sym
+    case storage = logo.options[:storage].to_sym
     when :filesystem
       # read as binary file 'b'
-      File.open(@logo.path(LOGO_ATTACHMENT_STYLE), 'rb')
+      File.open(logo.path(LOGO_ATTACHMENT_STYLE), 'rb')
     when :s3
-      URI.open(@logo.url(LOGO_ATTACHMENT_STYLE))
+      URI.open(logo.url(LOGO_ATTACHMENT_STYLE))
     else
       raise StandardError, "Invalid attachment type #{storage}"
     end

--- a/app/lib/pdf/finance/invoice_report_data.rb
+++ b/app/lib/pdf/finance/invoice_report_data.rb
@@ -57,15 +57,10 @@ class Pdf::Finance::InvoiceReportData
   end
 
   def with_logo
-    file = begin
-      logo_file
-    rescue StandardError => exception
-      Rails.logger.error "Failed to retrieve logo: #{exception.message}"
-      nil
-    end
-    yield file if block_given?
+    io = logo_io
+    yield io if block_given?
   ensure
-    file&.close
+    io&.close
   end
 
   def line_items
@@ -137,7 +132,7 @@ class Pdf::Finance::InvoiceReportData
   # Depending on the storage option for the attachment:
   # - retrieve either the full path of the local file, or the URL of the file in S3
   # - read the file differently
-  def logo_file
+  def logo_io
     case storage = logo.options[:storage].to_sym
     when :filesystem
       # read as binary file 'b'
@@ -147,6 +142,8 @@ class Pdf::Finance::InvoiceReportData
     else
       raise StandardError, "Invalid attachment type #{storage}"
     end
+  rescue StandardError => exception
+    Rails.logger.error "Failed to retrieve logo: #{exception.message}"
+    nil
   end
-
 end

--- a/app/lib/pdf/finance/invoice_report_data.rb
+++ b/app/lib/pdf/finance/invoice_report_data.rb
@@ -52,23 +52,22 @@ class Pdf::Finance::InvoiceReportData
   end
 
   def logo
-    @logo_stream ||= URI.open(logo_url(:invoice))
+    @logo_file ||= logo_file(:invoice)
   rescue StandardError => exception
-    # TODO: - uncomment complete exception!
-    # rescue OpenURI::HTTPError => e
     Rails.logger.error "Failed to retrieve logo from: #{exception.message}"
     nil
   end
 
   # Depending on the storage option for the attachment, retrieve either the full path
-  # of the local file, or the URL of the file in S3
-  def logo_url(args)
+  # of the local file, or the URL of the file in S3, and read the file differently
+  def logo_file(style)
     attachment = @invoice.provider_account.profile.logo
     case attachment.options[:storage].to_sym
     when :filesystem
-      attachment.path(args)
+      # read as binary file
+      File.open(attachment.path(style), 'rb')
     when :s3
-      attachment.url(args)
+      URI.open(attachment.url(style))
     else
       raise StandardError, 'Invalid attachment type'
     end

--- a/config/docker/paperclip.yml
+++ b/config/docker/paperclip.yml
@@ -6,6 +6,12 @@ filesystem: &filesystem
 s3: &s3
   storage: 's3'
 
+development:
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'] || 'filesystem' %>
+
+test:
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'] || 'filesystem' %>
+
 preview:
   <<: *<%= ENV['PAPERCLIP_STORAGE'] || 'filesystem' %>
 

--- a/config/docker/paperclip.yml
+++ b/config/docker/paperclip.yml
@@ -13,7 +13,7 @@ test:
   <<: *<%= ENV['FILE_UPLOAD_STORAGE'] || 'filesystem' %>
 
 preview:
-  <<: *<%= ENV['PAPERCLIP_STORAGE'] || 'filesystem' %>
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'] || 'filesystem' %>
 
 production:
-  <<: *<%= ENV['PAPERCLIP_STORAGE'] || 'filesystem' %>
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'] || 'filesystem' %>

--- a/config/examples/amazon_s3.yml
+++ b/config/examples/amazon_s3.yml
@@ -1,18 +1,19 @@
-development:
-  access_key_id:     access_key_id
-  secret_access_key: secret_access_key
-  bucket:            dev-my-s3-bucket
-  region:            "us-east-1"
-  force_path_style:  false
+default: &default {}
 
-test: &test
-  access_key_id: invalid
-  secret_access_key: invalid
-  bucket: test-my-s3-bucket
-  region: "us-east-1"
+s3: &s3
+  access_key_id:     "<%= ENV['AWS_ACCESS_KEY_ID'] %>"
+  secret_access_key: "<%= ENV['AWS_SECRET_ACCESS_KEY'] %>"
+  bucket:            "<%= ENV['AWS_BUCKET'] %>"
+  region:            "<%= ENV['AWS_REGION'] %>"
+  hostname:          "<%= ENV['AWS_HOSTNAME'] %>"
+  protocol:          "<%= ENV['AWS_PROTOCOL'] %>"
+  force_path_style:  <%= ENV['AWS_PATH_STYLE'].presence || false %>
+
+development:
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'].presence || 'default' %>
+
+preview:
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'].presence || 'default' %>
 
 production:
-  access_key_id: invalid
-  secret_access_key: invalid
-  bucket: prod-my-s3-bucket
-  region: "us-east-1"
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'].presence || 'default' %>

--- a/config/examples/amazon_s3.yml
+++ b/config/examples/amazon_s3.yml
@@ -12,6 +12,12 @@ s3: &s3
 development:
   <<: *<%= ENV['FILE_UPLOAD_STORAGE'].presence || 'default' %>
 
+test: &test
+  access_key_id: invalid
+  secret_access_key: invalid
+  bucket: test-my-s3-bucket
+  region: "us-east-1"
+
 preview:
   <<: *<%= ENV['FILE_UPLOAD_STORAGE'].presence || 'default' %>
 

--- a/config/examples/paperclip.yml
+++ b/config/examples/paperclip.yml
@@ -7,7 +7,7 @@ s3: &s3
   storage: 's3'
 
 development:
-  <<: *<%= ENV['PAPERCLIP_STORAGE'] || 'filesystem' %>
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'] || 'filesystem' %>
 
 test:
-  <<: *<%= ENV['PAPERCLIP_STORAGE'] || 'filesystem' %>
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'] || 'filesystem' %>

--- a/openshift/system/.env
+++ b/openshift/system/.env
@@ -82,7 +82,7 @@ THREESCALE_ROLLING_UPDATES=1
 ACTIVE_DOCS_URL=https://support.3scale.net
 
 # Paperclip storage (s3, filesystem)
-# PAPERCLIP_STORAGE=filesystem
+# FILE_UPLOAD_STORAGE=filesystem
 
 # Create Access Token with full RW permissions
 # ADMIN_ACCESS_TOKEN=sometokenvalue

--- a/test/unit/paperclip_test.rb
+++ b/test/unit/paperclip_test.rb
@@ -30,15 +30,15 @@ class PaperclipTest < ActiveSupport::TestCase
     end
 
     test 'force_path_style' do
-      Paperclip::Attachment.default_options.merge!(s3_options: { force_path_style: true })
+      Paperclip::Attachment.default_options[:s3_options] = { force_path_style: true }
       attachment = Paperclip::Attachment.new(:attachment, account, url: ':url_root/:account_id/:class/:attachment/:style/:basename.:extension')
       attachment.stubs(original_filename: 'fake_attachment.png')
 
       assert_equal "https://s3.amazonaws.com/my-bucket/fake-s3-prefix/#{account.id}/accounts/attachments/medium/fake_attachment.png", attachment.url(:medium)
     end
 
-    test 'bucket name contaning a dot' do
-      Paperclip::Attachment.default_options.merge!(bucket: 'test.my-bucket')
+    test 'bucket name containing a dot' do
+      Paperclip::Attachment.default_options[:bucket] = 'test.my-bucket'
       attachment = Paperclip::Attachment.new(:attachment, account, url: ':url_root/:account_id/:class/:attachment/:style/:basename.:extension')
       attachment.stubs(original_filename: 'fake_attachment.png')
 

--- a/test/unit/pdf/finance/invoice_generator_test.rb
+++ b/test/unit/pdf/finance/invoice_generator_test.rb
@@ -28,7 +28,6 @@ class Pdf::Finance::InvoiceGeneratorTest < ActiveSupport::TestCase
 
   test 'should generate valid PDF content with logo and line items' do
     logo_file = File.open(file_fixture('wide.jpg'), 'rb')
-    @data.stubs(:logo?).returns(true)
     @data.expects(:with_logo).yields(logo_file)
     @data.stubs(:provider).returns(LONG_ADDRESS)
     items = [['Licorice', '5', '222', ''],

--- a/test/unit/pdf/finance/invoice_report_data_test.rb
+++ b/test/unit/pdf/finance/invoice_report_data_test.rb
@@ -123,4 +123,10 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
     end
     assert logo_file&.closed?
   end
+
+  test '#with_logo raises an error if no block is passed' do
+    assert_raises ArgumentError, 'Calling #with_logo requires a block' do
+      @data.with_logo
+    end
+  end
 end

--- a/test/unit/pdf/finance/invoice_report_data_test.rb
+++ b/test/unit/pdf/finance/invoice_report_data_test.rb
@@ -95,17 +95,17 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
     @data.with_logo do |logo|
       logo_file = logo
       assert logo.is_a? File
-      assert logo&.binmode?
+      assert logo.binmode?
       assert logo.respond_to?(:read)
     end
-    assert logo_file&.closed?
+    assert logo_file.closed?
   end
 
   test '#with_logo yields nil if logo not set' do
     @provider.profile.update(logo: nil)
 
     @data.with_logo do |logo|
-      assert logo.nil?
+      assert_nil logo
     end
   end
 
@@ -113,7 +113,7 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
     default_options = Paperclip::Attachment.default_options
     Paperclip::Attachment.stubs(default_options: default_options.merge(storage: :s3))
     @provider.profile.update(logo: Rack::Test::UploadedFile.new(file_fixture('wide.jpg'), 'image/jpeg', true))
-    URI.stubs(:open).returns(File.open(file_fixture("wide.jpg")))
+    URI.expects(:open).with(regexp_matches(/\Ahttps.*\/profiles\/logos\/invoice\/wide.png\z/)).returns(File.open(file_fixture('wide.jpg')))
 
     logo_file = nil
     @data.with_logo do |logo|

--- a/test/unit/pdf/finance/invoice_report_data_test.rb
+++ b/test/unit/pdf/finance/invoice_report_data_test.rb
@@ -86,4 +86,18 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
     @provider.update_attribute(:org_name, '<ScRipT>alert("address1")</ScRipT>')
     assert_equal @data.provider[0][1], '&lt;ScRipT&gt;alert(&quot;address1&quot;)&lt;/ScRipT&gt;'
   end
+
+  test '#with_logo should yield to a block with open file and close is after' do
+    @provider.profile.update(logo: Rack::Test::UploadedFile.new(file_fixture('wide.jpg'), 'image/jpeg', true))
+
+    logo_file = nil
+    @data.with_logo do |logo|
+      logo_file = logo
+      assert logo.is_a? File
+      assert logo&.binmode?
+      assert logo.respond_to?(:read)
+    end
+    assert logo_file&.closed?
+  end
+
 end

--- a/test/unit/pdf/finance/invoice_report_data_test.rb
+++ b/test/unit/pdf/finance/invoice_report_data_test.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
-
 
   def setup
     @provider = FactoryBot.create(:provider_with_billing)
@@ -13,8 +14,8 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
   test 'not change total without VAT rate' do
     @invoice.line_items.create :name => 'Junk', :cost => 42
 
-    assert_equal ["Junk"                     , "", 42 , '' ], @data.line_items[0]
-    assert_equal ["Total cost" , "", 42 , 42 ], @data.line_items[1]
+    assert_equal ["Junk", "", 42, ''], @data.line_items[0]
+    assert_equal ["Total cost", "", 42, 42], @data.line_items[1]
   end
 
   test 'respect the defined labels of fields' do
@@ -46,14 +47,14 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
     @invoice.reload
     @invoice.line_items.create :name => 'Junk', :cost => 10000
 
-    assert_equal [ 'Fiscal code', 'chino22' ], @data.buyer[3]
-    assert_equal [ 'VAT Code', 'vat55' ], @data.buyer[4]
-    assert_equal [ 'PO num', 'po123s' ], @data.buyer[5]
+    assert_equal ['Fiscal code', 'chino22'], @data.buyer[3]
+    assert_equal ['VAT Code', 'vat55'], @data.buyer[4]
+    assert_equal ['PO num', 'po123s'], @data.buyer[5]
 
-    assert_equal [ [ "Junk", "", 10000.0 , ''],
-                   [ "Total cost (without Vat rate)",  "", 10000.0, 10000.0 ],
-                   [ "Total Vat rate Amount",  "", 234.0, 234.0 ],
-                   [ "Total cost (Vat rate 2.34% included)", "", '', 10234.0 ] ], @data.line_items
+    assert_equal [["Junk", "", 10000.0, ''],
+                  ["Total cost (without Vat rate)",  "", 10000.0, 10000.0 ],
+                  ["Total Vat rate Amount",  "", 234.0, 234.0 ],
+                  ["Total cost (Vat rate 2.34% included)", "", '', 10234.0 ]], @data.line_items
   end
 
   test 'respect and provide VAT rate and po number if present and modified by provider' do
@@ -69,14 +70,14 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
     @invoice.reload
     @invoice.line_items.create :name => 'Junk', :cost => 10000
 
-    assert_equal [ 'Fiscal code', 'chino22' ], @data.buyer[3]
-    assert_equal [ 'ABN', 'vat55' ], @data.buyer[4]
-    assert_equal [ 'PO num', 'po123s' ], @data.buyer[5]
+    assert_equal ['Fiscal code', 'chino22'], @data.buyer[3]
+    assert_equal ['ABN', 'vat55'], @data.buyer[4]
+    assert_equal ['PO num', 'po123s'], @data.buyer[5]
 
-    assert_equal [ [ "Junk", "", 10000.0 , ''],
-                   [ "Total cost (without GST)",  "", 10000.0, 10000.0 ],
-                   [ "Total GST Amount",  "", 234.0, 234.0 ],
-                   [ "Total cost (GST 2.34% included)", "", '', 10234.0 ] ], @data.line_items
+    assert_equal [["Junk", "", 10000.0, ''],
+                  ["Total cost (without GST)",  "", 10000.0, 10000.0],
+                  ["Total GST Amount",  "", 234.0, 234.0],
+                  ["Total cost (GST 2.34% included)", "", '', 10234.0]], @data.line_items
   end
 
 

--- a/test/unit/pdf/finance/invoice_report_data_test.rb
+++ b/test/unit/pdf/finance/invoice_report_data_test.rb
@@ -85,13 +85,11 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
   #
   test 'not be vulnerable to XSS attack' do
     @provider.update_attribute(:org_name, '<ScRipT>alert("address1")</ScRipT>')
-    @invoice.reload
     assert_equal @data.provider[0][1], '&lt;ScRipT&gt;alert(&quot;address1&quot;)&lt;/ScRipT&gt;'
   end
 
   test '#with_logo yields to a block with open file and close is after' do
     @provider.profile.update(logo: Rack::Test::UploadedFile.new(file_fixture('wide.jpg'), 'image/jpeg', true))
-    @data = Pdf::Finance::InvoiceReportData.new(@invoice.reload)
 
     logo_file = nil
     @data.with_logo do |logo|
@@ -105,7 +103,6 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
 
   test '#with_logo yields nil if logo not set' do
     @provider.profile.update(logo: nil)
-    @data = Pdf::Finance::InvoiceReportData.new(@invoice.reload)
 
     @data.with_logo do |logo|
       assert logo.nil?
@@ -116,7 +113,6 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
     default_options = Paperclip::Attachment.default_options
     Paperclip::Attachment.stubs(default_options: default_options.merge(storage: :s3))
     @provider.profile.update(logo: Rack::Test::UploadedFile.new(file_fixture('wide.jpg'), 'image/jpeg', true))
-    @data = Pdf::Finance::InvoiceReportData.new(@invoice.reload)
     URI.stubs(:open).returns(File.open(file_fixture("wide.jpg")))
 
     logo_file = nil

--- a/test/unit/pdf/finance/invoice_report_data_test.rb
+++ b/test/unit/pdf/finance/invoice_report_data_test.rb
@@ -99,5 +99,4 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
     end
     assert logo_file&.closed?
   end
-
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the issue where the logo image is not added to the invoice PDF.

**Which issue(s) this PR fixes** 

Fixes https://issues.redhat.com/browse/THREESCALE-6933

**Verification steps** 

1. Add a Logo in Audience > Developer portal > Logo
2. Create an invoice for an account
3. Generate a PDF invoice
4. Check that the logo appears on the invoice PDF

**Special notes for your reviewer**:

`PAPERCLIP_STORAGE` was renamed to `FILE_UPLOAD_STORAGE` for consistency.

The root cause of the issue is that the invoice generator was using the `.url` method of paperclip attachment, which for file system storage type returns a **relative** path on the server (which is fine for front-end usage), instead of the actual path in the file system.

Also, it's important to note that the standard `read` on the actual file path reads the image as UTF-8 encoding, while it should read it as a binary file (`ASCII-8BIT`), which is achieved by `File.open('/path', 'rb')