### PR TITLE
Create a new workflow to create a release and tag in the repository

### DIFF
--- a/.github/workflows/tagRelease.yml
+++ b/.github/workflows/tagRelease.yml
@@ -1,0 +1,28 @@
+# This is a basic workflow that is manually triggered to create a tag release in the repo in which it is present.
+# It can be manually triggered by those with permissions, or triggered from the main action which can trigger tag releases for all repos at once.
+
+name: tagRelease
+
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      tag:
+        # Friendly description to be shown in the UI instead of 'tag'
+        description: 'Tag to be created along with release'
+        # Input has to be provided for the workflow to run
+        required: true
+      git_ref: 
+        description: 'Git reference to create tag from, can be a commit hash or branch'
+        required: true
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  createRelease:
+      runs-on: ubuntu-latest
+      name: Create Release
+      steps:
+        - uses: softprops/action-gh-release@v1 #This action will create the release with the params specified.
+          with:
+           tag_name: ${{ inputs.tag }}
+           target_commitish: ${{ inputs.git_ref }}


### PR DESCRIPTION
#### Create a new github actions workflow to create releases and tags in the repo, this is part of ongoing work to migrate the upstream tagging job away from jenkins due to the decommissioning of the instance in the near future.
##### This action will be manually triggerable (to create a tag in this repo alone) but can also by triggered by another action which can create tags in all upstream repos at once, similar to the old jenkins job.