### PR TITLE
Revert "Bump commonmarker from 0.21.0 to 0.23.6"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,7 +147,7 @@ gem 'state_machines', '~> 0.5.0'
 gem 'state_machines-activerecord', '~> 0.5.0'
 
 # for liquid docs on-fly generation
-gem 'commonmarker'
+gem 'commonmarker', '~> 0.21.0'
 gem 'escape_utils'
 gem 'github-markdown'
 gem 'html-pipeline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorize (0.8.1)
-    commonmarker (0.23.6)
+    commonmarker (0.21.0)
+      ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -697,6 +698,8 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
+    ruby-enum (0.7.2)
+      i18n
     ruby-oci8 (2.2.6.1)
     ruby-openid (2.9.2)
     ruby-plsql (0.8.0)
@@ -911,7 +914,7 @@ DEPENDENCIES
   codemirror-rails (~> 5.6)
   coffee-rails (~> 4.2)
   colorize
-  commonmarker
+  commonmarker (~> 0.21.0)
   compass-rails (~> 3.0.2)
   cucumber (~> 7.0)
   cucumber-rails (~> 2.4.0)


### PR DESCRIPTION
Reverts 3scale/porta#3069

Ruby 2.4 is not supported anymore.