### PR TITLE
Fix Braintree form

### DIFF
--- a/app/views/provider/admin/account/payment_gateways/braintree_blue/edit.html.slim
+++ b/app/views/provider/admin/account/payment_gateways/braintree_blue/edit.html.slim
@@ -94,11 +94,12 @@ p
   = form.actions do
     = form.commit_button 'Save credit card'
 
+/ TODO: All is duplicated. Move this into a pack and use braintree from node_modules
 script src="https://js.braintreegateway.com/web/3.69.0/js/client.min.js"
 script src="https://js.braintreegateway.com/web/3.69.0/js/hosted-fields.min.js"
 javascript:
-  var $form = $('#new_customer');
-  var submit = document.querySelector('input[type="submit"]');
+  const form = document.querySelector('form#new_customer');
+  const submit = document.querySelector('button[type="submit"]');
 
   if (typeof braintree !== 'undefined') {
     braintree.client.create({
@@ -147,17 +148,16 @@ javascript:
         }
 
         submit.removeAttribute('disabled');
-
-        $form.on('submit', function(event) {
+        form.addEventListener('submit', function(event) {
           event.preventDefault();
+          event.stopPropagation();
           hostedFieldsInstance.tokenize(function(tokenizeErr, payload) {
             if (tokenizeErr) {
               console.error(tokenizeErr);
               return;
             }
-
-            $('#braintree_nonce').val(payload['nonce']);
-            $form.get(0).submit();
+            document.querySelector('input#braintree_nonce').setAttribute('value', payload.nonce);
+            form.submit();
           });
         });
       });


### PR DESCRIPTION
Crappy solution. We leave the "good one" for when we have time.
 
> **What this PR does / why we need it**:
> 
> The JS at Braintree edit form is faulty, probably due to inconsistent jQuery version or unexpected upgrade.
> 
> The Braintree js SDK is also being downloaded via CDN, even though it's already included as a NPM package. For that reason the JS has been moved into a pack (to be handled by webpack and have access to NPM modules).
> 
> Moreover, this form is already implemented by React and used in the Dev portal but this this bug is a blocker we're not gonna spend time refactoring the whole page.
> 
> **Which issue(s) this PR fixes** 
> 
> [THREESCALE-8808: SaaS customers not able to add/edit Payment details](https://issues.redhat.com/browse/THREESCALE-8808)
> 
> **Special notes for your reviewer**:
> Braintree test data in Bitwarden.
> 
> https://user-images.githubusercontent.com/11672286/196646555-c0184fce-67bb-42e0-b615-6ceb48281107.mp4
> 
> 