### PR TITLE
QUICKFIX: Use "-" instead of Array#difference

### DIFF
--- a/app/services/aws/credentials_service.rb
+++ b/app/services/aws/credentials_service.rb
@@ -35,7 +35,7 @@ module Aws
     attr_reader :params
 
     def valid_params_with(credentials, keys)
-      return false if credentials.empty? || keys.difference(credentials.keys).any?
+      return false if credentials.empty? || (keys - credentials.keys).any?
 
       credentials.all? { |_key, value| value.present? }
     end


### PR DESCRIPTION
We started receiving a `undefined method `difference' for [:access_key_id, :secret_access_key]:Array` error on Bugsnag because of [this line](https://github.com/3scale/porta/blob/master/app/services/aws/credentials_service.rb#L38). Turns out SaaS runs on ruby 2.4 still and `Array#difference` was introduced on Ruby 2.6.
This PR removes `Array#difference` in favour of the old `-`.