### PR TITLE
use jemalloc or memkind when present

### DIFF
--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -7,6 +7,7 @@ ENV BUNDLER_ENV="${BUNDLER_ENV}" \
     TZ=:/etc/localtime \
     BUNDLE_GEMFILE=Gemfile \
     BUNDLE_WITHOUT=development:test \
+    VARNISH_SCL=rh-varnish5 \
     NODEJS_SCL=rh-nodejs12
 
 WORKDIR /opt/system
@@ -22,9 +23,12 @@ RUN yum-config-manager --save --setopt=cbs.centos.org_repos_sclo7-rh-ruby26-rh-c
               mysql \
               postgresql10 postgresql10-devel postgresql10-libs \
               file \
-              rh-nodejs12 \
+              $NODEJS_SCL \
+              $VARNISH_SCL-jemalloc \
     && yum install -y epel-release \
-    && yum -y clean all
+    && yum -y clean all \
+    && printf /opt/rh/rh-varnish5/root/lib64 > /etc/ld.so.conf.d/jemalloc.conf \
+    && ldconfig && ldconfig -p | grep jemalloc
 
 # Install sphinx search
 RUN if [ "`uname -m`" == "x86_64" ]; then \

--- a/openshift/system/entrypoint.sh
+++ b/openshift/system/entrypoint.sh
@@ -21,4 +21,15 @@ fi
 # Exporting all bundler environment
 export ${BUNDLER_ENV}
 
+if ldconfig -p | grep jemalloc; then
+  LD_PRELOAD="$LD_PRELOAD":$(ldconfig -p | grep jemalloc | head -1 | awk '{ print $1 }')
+  export LD_PRELOAD
+elif ldconfig -p | grep libautohbw; then
+  # AUTO_HBW_SIZE is just a big number to avoit it ever reached
+  # MEMKIND_HEAP_MANAGER=JEMALLOC is the default anyway but goot for reader
+  # MEMKIND_HBW_NODES=0 just to prevent warning log
+  HBWLIB=$(ldconfig -p | grep libautohbw | head -1 | awk '{ print $1 }')
+  export LD_PRELOAD="$LD_PRELOAD":$HBWLIB AUTO_HBW_SIZE=10T AUTO_HBW_LOG=-2 MEMKIND_HBW_NODES=0 MEMKIND_HEAP_MANAGER=JEMALLOC
+fi
+
 exec bundle exec "$@"


### PR DESCRIPTION
jemalloc has a performance and size advantage when running
Ruby on Rails. So use it when available in the container.

container image `quay.io/3scale/porta:jemalloc-20221021`