### PR TITLE
THREESCALE-6851: Stripe webhook: Acknowledge reception even for payments we don't care about

### DIFF
--- a/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
+++ b/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
@@ -24,7 +24,15 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::
     service = begin
       Finance::StripePaymentIntentUpdateService.new(current_account, stripe_event)
     rescue ActiveRecord::RecordNotFound
-      # Returning 204 to acknowledge reception even for payments we don't care about
+      # Returning 204 to acknowledge reception even for payments we don't care about.
+      #
+      # There are some clients who are using their Stripe account not only for 3Scale,
+      # but also for other services they provide. When they receive any payment, Stripe
+      # will call all webhooks, no matter where the payment comes from, and we'll
+      # receive a call for a payment not managed by us. Stripe expects us to return 204
+      # in this situation, since they will remove the webhook if it returns error codes
+      # too often.
+      #
       # https://issues.redhat.com/browse/THREESCALE-6851
       nil
     end

--- a/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
+++ b/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
@@ -26,7 +26,6 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::
     rescue ActiveRecord::RecordNotFound
       # Returning 204 to acknowledge reception even for payments we don't care about
       # https://issues.redhat.com/browse/THREESCALE-6851
-      Rails.logger.info("Acknowledging reception: '#{stripe_event.id}'")
       return head(:no_content)
     end
 

--- a/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
+++ b/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
@@ -21,15 +21,15 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::
 
   # Undocumented endpoint used for update callbacks of async-authorized payment transactions (mostly due to SCA regulations)
   def create
-    begin
-      service = Finance::StripePaymentIntentUpdateService.new(current_account, stripe_event)
+    service = begin
+      Finance::StripePaymentIntentUpdateService.new(current_account, stripe_event)
     rescue ActiveRecord::RecordNotFound
       # Returning 204 to acknowledge reception even for payments we don't care about
       # https://issues.redhat.com/browse/THREESCALE-6851
-      return head(:no_content)
+      nil
     end
 
-    return head(:no_content) if service.call
+    return head(:no_content) if service.blank? || service.call
 
     exception = StripeCallbackError.new('Cannot update Stripe payment intent')
     report_error(exception, event: stripe_event, payment_intent: service.payment_intent)

--- a/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
+++ b/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
@@ -26,7 +26,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::
     rescue ActiveRecord::RecordNotFound
       # Returning 204 to acknowledge reception even for payments we don't care about.
       #
-      # There are some clients who are using their Stripe account not only for 3Scale,
+      # There are some clients who are using their Stripe account not only for 3scale,
       # but also for other services they provide. When they receive any payment, Stripe
       # will call all webhooks, no matter where the payment comes from, and we'll
       # receive a call for a payment not managed by us. Stripe expects us to return 204

--- a/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
+++ b/app/controllers/finance/api/payment_callbacks/stripe_callbacks_controller.rb
@@ -21,7 +21,14 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksController < Finance::Api::
 
   # Undocumented endpoint used for update callbacks of async-authorized payment transactions (mostly due to SCA regulations)
   def create
-    service = Finance::StripePaymentIntentUpdateService.new(current_account, stripe_event)
+    begin
+      service = Finance::StripePaymentIntentUpdateService.new(current_account, stripe_event)
+    rescue ActiveRecord::RecordNotFound
+      # Returning 204 to acknowledge reception even for payments we don't care about
+      # https://issues.redhat.com/browse/THREESCALE-6851
+      Rails.logger.info("Acknowledging reception: '#{stripe_event.id}'")
+      return head(:no_content)
+    end
 
     return head(:no_content) if service.call
 

--- a/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
+++ b/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
@@ -61,11 +61,11 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
     end
 
     test 'cannot find payment intent' do
-      stripe_event = self.stripe_event(type: 'payment_intent.requires_action', payment_intent_data: { id: 'non-existent-payment-intent-id' })
+      stripe_event = self.stripe_event(type: 'payment_intent.succeeded', payment_intent_data: { id: 'non-existent-payment-intent-id' })
       Stripe::Webhook.expects(:construct_event).returns(stripe_event)
 
       post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
-      assert_response :not_found
+      assert_response :no_content
     end
 
     test 'fails to update payment intent' do


### PR DESCRIPTION
**What this PR does / why we need it**:

When a client is using Stripe to accept payments from other applications besides 3scale, all payment events are sent through all webhooks, so we receive them even when we don't care. So far, we were returning a 404 in that situation as the payment intent was not in our DB, but that's causing problems to clients since Stripe disables a webhook if it returns 404 too many times. This PR makes it return a 204 to acknowledge the reception in order to prevent Stripe to disable the webhook.

**Which issue(s) this PR fixes** 

[THREESCALE-6851](https://issues.redhat.com/browse/THREESCALE-6851)

**Verification steps** 

The easiest way to generate a stripe payment out of 3scale is to use the [stripe  cli](https://stripe.com/docs/stripe-cli) tool.

1. Log into the Stripe dashboard
2. Add a [Local listener](https://dashboard.stripe.com/test/webhooks/create?endpoint_location=local):
```
stripe listen --events payment_intent.succeeded --forward-to http://provider-admin.3scale.localhost:3000/api/payment_callbacks/stripe_callbacks?access_token=ACCESS_TOKEN
```
4. From another terminal, send a `payment_intent.succeeded` event:
```
stripe trigger payment_intent.succeeded
```
6. A `[204]` code should be returned
