### PR TITLE
THREESCALE-8875: Fix developer portal groups edit page

### DIFF
--- a/app/views/provider/admin/cms/groups/edit.html.erb
+++ b/app/views/provider/admin/cms/groups/edit.html.erb
@@ -2,5 +2,7 @@
 
 <%= cms_form_for(@group) do |f| %>
   <%= render 'form', :f => f %>
-  <%= f.actions :commit %>
+  <%= f.actions do %>
+    <%= f.commit_button %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
**What this PR does / why we need it**:

Developer Portal > Groups > edit is returning an internal server error, due to this line: 

[/app/views/provider/admin/cms/groups/edit.html.erb#L5](https://github.com/3scale/porta/blob/e415c82a8eb57a65724c84ae71741f101f294d2c/app/views/provider/admin/cms/groups/edit.html.erb#L5)

As far as I know, Formtastic 2.3.1 doesn't allow any actions other than `:submit`, `:reset` and `:cancel`.

[lib/formtastic/helpers/action_helper.rb#L90-L96](https://github.com/formtastic/formtastic/blob/2.3.1/lib/formtastic/helpers/action_helper.rb#L90-L96)

To show the commit button, the method `commit_button` must be called explicitly, and it must be wrapped under `f.actions` in order to get the proper styling. The same way that it's done in the `new` form:

[/app/views/provider/admin/cms/groups/new.html.erb#L5-L7](https://github.com/3scale/porta/blob/master/app/views/provider/admin/cms/groups/new.html.erb#L5-L7)

**Which issue(s) this PR fixes** 

[THREESCALE-8875](https://issues.redhat.com/browse/THREESCALE-8875)

**Verification steps** 

1. Open Developer Portal > Groups > edit
2. It should open correctly
3. Make changes and save
4. Changes should persist
