### PR TITLE
THREESCALE-8443 prevent Mesages being sent without a subject or body in reply to message form under Messages > Inbox > Message

### DIFF
--- a/app/controllers/provider/admin/messages/inbox_controller.rb
+++ b/app/controllers/provider/admin/messages/inbox_controller.rb
@@ -30,6 +30,19 @@ class Provider::Admin::Messages::InboxController < FrontendController
     end
   end
 
+  def reply
+    reply = @message.reply
+    reply.attributes = message_params
+
+    if reply.save && reply.deliver
+      flash[:notice] = 'Reply was sent.'
+      redirect_to action: :index
+    else
+      flash[:error] = reply.errors.full_messages.to_sentence
+      redirect_to provider_admin_messages_inbox_path(@message)
+    end
+  end
+
   private
 
   def message_params
@@ -38,13 +51,5 @@ class Provider::Admin::Messages::InboxController < FrontendController
 
   def find_message
     @message = current_account.received_messages.find(params.require(:id)).decorate
-  end
-
-  def send_reply(reply)
-    reply.save
-    reply.deliver
-
-    flash[:notice] = 'Reply was sent.'
-    redirect_to action: :index
   end
 end

--- a/app/controllers/provider/admin/messages/inbox_controller.rb
+++ b/app/controllers/provider/admin/messages/inbox_controller.rb
@@ -22,11 +22,16 @@ class Provider::Admin::Messages::InboxController < FrontendController
     reply = @message.reply
     reply.attributes = message_params
 
-    reply.save!
-    reply.deliver!
+    if reply.valid?
+      reply.save!
+      reply.deliver!
 
-    flash[:notice] = 'Reply was sent.'
-    redirect_to action: :index
+      flash[:notice] = 'Reply was sent.'
+      redirect_to action: :index
+    else
+      flash[:error] = reply.errors.full_messages.to_sentence
+      redirect_to provider_admin_messages_inbox_path(@message)
+    end
   end
 
   private

--- a/app/controllers/provider/admin/messages/inbox_controller.rb
+++ b/app/controllers/provider/admin/messages/inbox_controller.rb
@@ -23,11 +23,7 @@ class Provider::Admin::Messages::InboxController < FrontendController
     reply.attributes = message_params
 
     if reply.valid?
-      reply.save!
-      reply.deliver!
-
-      flash[:notice] = 'Reply was sent.'
-      redirect_to action: :index
+      send_reply(reply)
     else
       flash[:error] = reply.errors.full_messages.to_sentence
       redirect_to provider_admin_messages_inbox_path(@message)
@@ -42,5 +38,13 @@ class Provider::Admin::Messages::InboxController < FrontendController
 
   def find_message
     @message = current_account.received_messages.find(params.require(:id)).decorate
+  end
+
+  def send_reply(reply)
+    reply.save!
+    reply.deliver!
+
+    flash[:notice] = 'Reply was sent.'
+    redirect_to action: :index
   end
 end

--- a/app/controllers/provider/admin/messages/inbox_controller.rb
+++ b/app/controllers/provider/admin/messages/inbox_controller.rb
@@ -41,8 +41,8 @@ class Provider::Admin::Messages::InboxController < FrontendController
   end
 
   def send_reply(reply)
-    reply.save!
-    reply.deliver!
+    reply.save
+    reply.deliver
 
     flash[:notice] = 'Reply was sent.'
     redirect_to action: :index

--- a/app/controllers/provider/admin/messages/inbox_controller.rb
+++ b/app/controllers/provider/admin/messages/inbox_controller.rb
@@ -22,18 +22,6 @@ class Provider::Admin::Messages::InboxController < FrontendController
     reply = @message.reply
     reply.attributes = message_params
 
-    if reply.valid?
-      send_reply(reply)
-    else
-      flash[:error] = reply.errors.full_messages.to_sentence
-      redirect_to provider_admin_messages_inbox_path(@message)
-    end
-  end
-
-  def reply
-    reply = @message.reply
-    reply.attributes = message_params
-
     if reply.save && reply.deliver
       flash[:notice] = 'Reply was sent.'
       redirect_to action: :index

--- a/test/functional/provider/admin/messages/inbox_controller_test.rb
+++ b/test/functional/provider/admin/messages/inbox_controller_test.rb
@@ -55,6 +55,7 @@ class Provider::Admin::Messages::InboxControllerTest < ActionController::TestCas
 
     MessageWorker.drain
     msg = Message.last
+    
     assert_equal flash[:notice], 'Reply was sent.'
     assert 'sent', msg.state
     assert_equal 'message with subject', msg.body
@@ -65,7 +66,7 @@ class Provider::Admin::Messages::InboxControllerTest < ActionController::TestCas
     post :reply, params: { message: { subject: nil, body: 'message with nil subject' }, id: @message.id }
 
     MessageWorker.drain
-    msg = Message.find_by(id: @message.message_id)
+    msg = Message.last
     assert_not_equal 'message with nil subject', msg.body
   end
 end

--- a/test/functional/provider/admin/messages/inbox_controller_test.rb
+++ b/test/functional/provider/admin/messages/inbox_controller_test.rb
@@ -49,23 +49,23 @@ class Provider::Admin::Messages::InboxControllerTest < ActionController::TestCas
     assert_select '#export-to-csv', false, 'Export all Messages'
   end
 
-  test 'Prevent sending reply without subject' do
+  test "creates valid reply" do
     login_as(@admin)
-    reply = @message.reply
-    reply.update_attributes(body: 'Reply Body', subject: nil)
+    post :reply, params: { message: { subject: "Valid Message", :body => "message with subject" }, id: @message.id }
 
     MessageWorker.drain
-    assert msg = Message.last
-    assert_not_equal "Reply Body", msg.body
+    msg = Message.last
+    assert "sent" msg.state
+    assert_equal "message with subject", msg.body
   end
 
-  test 'Allow sending reply with subject' do
+  test "not creates invalid message" do
     login_as(@admin)
-    reply = @message.reply
-    reply.update_attributes(body: 'Reply Body', subject: 'Reply Subject')
+    post :reply, params: { message: { subject: nil, body: "message with nil subject" }, id: @message.id }
 
     MessageWorker.drain
-    assert msg = Message.last
-    assert_equal "Reply Subject", msg.subject
+    msg = Message.last
+    assert_not_equal "message with nil subject", msg.body
   end
+
 end

--- a/test/functional/provider/admin/messages/inbox_controller_test.rb
+++ b/test/functional/provider/admin/messages/inbox_controller_test.rb
@@ -51,7 +51,7 @@ class Provider::Admin::Messages::InboxControllerTest < ActionController::TestCas
 
   test "creates valid reply" do
     login_as(@admin)
-    post :reply, params: { message: { subject: "Valid Message", :body => "message with subject" }, id: @message.id }
+    post :reply, params: { message: { subject: "Valid Message", body: "message with subject" }, id: @message.id }
 
     MessageWorker.drain
     msg = Message.last

--- a/test/functional/provider/admin/messages/inbox_controller_test.rb
+++ b/test/functional/provider/admin/messages/inbox_controller_test.rb
@@ -55,7 +55,7 @@ class Provider::Admin::Messages::InboxControllerTest < ActionController::TestCas
 
     MessageWorker.drain
     msg = Message.last
-    assert "sent" msg.state
+    assert "sent", msg.state
     assert_equal "message with subject", msg.body
   end
 

--- a/test/functional/provider/admin/messages/inbox_controller_test.rb
+++ b/test/functional/provider/admin/messages/inbox_controller_test.rb
@@ -49,23 +49,23 @@ class Provider::Admin::Messages::InboxControllerTest < ActionController::TestCas
     assert_select '#export-to-csv', false, 'Export all Messages'
   end
 
-  test "creates valid reply" do
+  test 'creates valid reply' do
     login_as(@admin)
     post :reply, params: { message: { subject: "Valid Message", body: "message with subject" }, id: @message.id }
 
     MessageWorker.drain
     msg = Message.last
-    assert "sent", msg.state
-    assert_equal "message with subject", msg.body
+    assert_equal flash[:notice], 'Reply was sent.'
+    assert 'sent', msg.state
+    assert_equal 'message with subject', msg.body
   end
 
-  test "not creates invalid message" do
+  test 'not creates invalid message' do
     login_as(@admin)
-    post :reply, params: { message: { subject: nil, body: "message with nil subject" }, id: @message.id }
+    post :reply, params: { message: { subject: nil, body: 'message with nil subject' }, id: @message.id }
 
     MessageWorker.drain
-    msg = Message.last
-    assert_not_equal "message with nil subject", msg.body
+    msg = Message.find_by(id: @message.message_id)
+    assert_not_equal 'message with nil subject', msg.body
   end
-
 end


### PR DESCRIPTION
**What this PR does / why we need it:**

prevent Messages being sent without a subject or body in reply to message form under Messages > Inbox > Message

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/THREESCALE-8443

**Verification steps**
Emails can be sent without a subject or body in reply to message form under Messages > Inbox > Message

e.g. path /p/admin/messages/inbox/{message_id}
try sending message without subject.

