### PR TITLE
clean compatibility code in SphinxIndexationWorker

### DIFF
--- a/app/workers/sphinx_indexation_worker.rb
+++ b/app/workers/sphinx_indexation_worker.rb
@@ -12,12 +12,6 @@ class SphinxIndexationWorker < ApplicationJob
   end
 
   def perform(model, id=nil)
-    # this is temporary just one version to drain queue from old jobs, please delete this conditional block
-    unless model.is_a? Class
-      id = model.id
-      model = model.class
-    end
-
     indices_for_model(model).each do |index|
       instance = index.scope.find_by(model.primary_key => id)
 

--- a/test/workers/sphinx_indexation_worker_test.rb
+++ b/test/workers/sphinx_indexation_worker_test.rb
@@ -11,13 +11,11 @@ class SphinxIndexationWorkerTest < ActiveSupport::TestCase
     callback = ThinkingSphinx::RealTime.callback_for(:account)
     assert callback
 
-    ThinkingSphinx::RealTime.expects(callback_for: callback).twice
-    callback.expects(:after_commit).twice.with(Equals.new(account))
+    ThinkingSphinx::RealTime.expects(callback_for: callback)
+    callback.expects(:after_commit).with(Equals.new(account))
     ThinkingSphinx::Test.rt_run do
       perform_enqueued_jobs only: SphinxIndexationWorker do
         SphinxIndexationWorker.perform_later(account.class, account.id)
-        # remove this once we remove backward compatibility from SphinxIndexationWorker
-        SphinxIndexationWorker.perform_later(account)
       end
     end
   end


### PR DESCRIPTION
we needed this part when we changed enqueuing from passing an object
to passing a class and id. It was only needed until old jobs were
drained.

So we have this code in 2.12 as well 2.13, it should be fine
to get rid of it in 2.14