### PR TITLE
THREESCALE-5442: Redact sensitive parameters in logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,8 +3,8 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += %i[activation_code cms_token credit_card credit_card_auth_code
-                                   credit_card_authorize_net_payment_profile_token credit_card_expires_on
-                                   credit_card_partial_number crypted_password janrain_api_key lost_password_token
-                                   password password_digest payment_gateway_options payment_service_reference salt
-                                   site_access_code sso_key user_key access_token invitation_token encoded_token
-                                   encoded_key variation_key]
+                                                 credit_card_authorize_net_payment_profile_token credit_card_expires_on
+                                                 credit_card_partial_number crypted_password janrain_api_key lost_password_token
+                                                 password password_digest payment_gateway_options payment_service_reference salt
+                                                 site_access_code sso_key user_key access_token invitation_token encoded_token
+                                                 encoded_key variation_key]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,5 +6,4 @@ Rails.application.config.filter_parameters += %i[activation_code cms_token credi
                                                  credit_card_authorize_net_payment_profile_token credit_card_expires_on
                                                  credit_card_partial_number crypted_password janrain_api_key lost_password_token
                                                  password password_digest payment_gateway_options payment_service_reference salt
-                                                 site_access_code sso_key user_key access_token invitation_token encoded_token
-                                                 encoded_key variation_key]
+                                                 site_access_code sso_key user_key access_token]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,4 +6,4 @@ Rails.application.config.filter_parameters += %i[activation_code cms_token credi
                                                  credit_card_authorize_net_payment_profile_token credit_card_expires_on
                                                  credit_card_partial_number crypted_password janrain_api_key lost_password_token
                                                  password password_digest payment_gateway_options payment_service_reference salt
-                                                 site_access_code sso_key user_key access_token]
+                                                 site_access_code sso_key user_key access_token service_token provider_key app_key]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,4 +6,5 @@ Rails.application.config.filter_parameters += %i[activation_code cms_token credi
                                    credit_card_authorize_net_payment_profile_token credit_card_expires_on
                                    credit_card_partial_number crypted_password janrain_api_key lost_password_token
                                    password password_digest payment_gateway_options payment_service_reference salt
-                                   site_access_code sso_key user_key]
+                                   site_access_code sso_key user_key access_token invitation_token encoded_token
+                                   encoded_key variation_key]


### PR DESCRIPTION
**What this PR does / why we need it**:

Some sensitive parameters are being dumped to the logs without any masking. This PR adds those parameters to the filtering list.

**Which issue(s) this PR fixes** 

[THREESCALE-5442](https://issues.redhat.com/browse/THREESCALE-5442)

**Verification steps** 

1. Send a request including one of the sensitive parameters:
  `curl http://provider-admin.3scale.localhost:3000//admin/api/accounts.xml?access_token=supersecrettoken`
3. Check how it¡s been traced in the logs
  
![image](https://user-images.githubusercontent.com/17052241/199761842-49138171-fc78-46d4-b4e3-26ec520ba4b2.png)


**Special notes for your reviewer**:

This filters parameters being sent to the app, but the issue also mentions how some environmental variables with sensitive values are being disclosed in the the pods logs. Those logs are generated by the container engine and are out of our scope. The only way I can think of workarounding it is by sending the sensitive values to the pods mapping the secrets to an `.env` file instead of environmental variables. I added a [comment](https://issues.redhat.com/browse/THREESCALE-5442?focusedCommentId=21195261&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21195261) in Jira to explain how to do it.