### PR TITLE
🔧 Use proper jest preset and TS moduleResolution

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -94,7 +94,7 @@ module.exports = {
   // notifyMode: "failure-change",
 
   // A preset that is used as a base for Jest's configuration
-  preset: 'ts-jest/presets/js-with-babel',
+  preset: 'ts-jest/presets/js-with-babel-esm',
 
   // Run tests from one or more projects
   // projects: null,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     // Modules
     "baseUrl": "./app/javascript/src",
     "module": "ES6",
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "typeRoots": ["app/javascript/src/Types", "./node_modules/@types"],
 
     // Emit


### PR DESCRIPTION
There are inconsistencies between TS and Jest config files. `tsconfig` targets module `ES6` which is meant for web (whereas CommonJS is how node works`.

However, the preset we're using for jest actually transforms `ts` and `tsx` files to CommonJS, hence the following error:
```
    ReferenceError: Cannot access 'enzyme_1' before initialization

      4 | import $ from 'jquery'
      5 | (global as any).jQuery = $
    > 6 |
        | ^
      7 | Enzyme.configure({ adapter: new Adapter() })
      8 |

      at Object.<anonymous> (spec/javascripts/setupTests.ts:6:1)
      at async TestScheduler.scheduleTests (node_modules/@jest/core/build/TestScheduler.js:333:13)
      at async runJest (node_modules/@jest/core/build/runJest.js:404:19)
      at async _run10000 (node_modules/@jest/core/build/cli/index.js:320:7)
      at async runCLI (node_modules/@jest/core/build/cli/index.js:173:3)
```

This is fixed by setting the same module resolution in both. Since we don't run a node application but a web, we use ES modules.

**NOTE**:
For some reason this is not happening in Circleci, even if it should.

**MORE INFO**
https://www.typescriptlang.org/tsconfig#module
https://kulshekhar.github.io/ts-jest/docs/getting-started/presets/