### PR TITLE
THREESCALE-8903 - Prevent notifications to be sent to non active users

### DIFF
--- a/app/workers/process_notification_event_worker.rb
+++ b/app/workers/process_notification_event_worker.rb
@@ -43,7 +43,7 @@ class ProcessNotificationEventWorker
     end
 
     parallelize do
-      provider.users.but_impersonation_admin.find_each do |user|
+      provider.users.active.but_impersonation_admin.find_each do |user|
         UserNotificationWorker.perform_async(user.id, event.event_id, event.system_name)
       end
     end

--- a/test/workers/process_notification_event_worker_test.rb
+++ b/test/workers/process_notification_event_worker_test.rb
@@ -21,7 +21,7 @@ class ProcessNotificationEventWorkerTest < ActiveSupport::TestCase
     provider     = FactoryBot.create(:simple_provider)
     event        = Invoices::InvoicesToReviewEvent.create_and_publish!(provider)
     notification = NotificationEvent.create_and_publish!(:invoices_to_review, event)
-    user         = FactoryBot.create(:simple_admin, account: provider)
+    user         = FactoryBot.create(:simple_admin, state: :active, account: provider)
 
     user.create_notification_preferences!(preferences: { invoices_to_review: true })
 

--- a/test/workers/process_notification_event_worker_test.rb
+++ b/test/workers/process_notification_event_worker_test.rb
@@ -50,6 +50,29 @@ class ProcessNotificationEventWorkerTest < ActiveSupport::TestCase
     refute @worker.create_notifications(notification)
   end
 
+  def test_only_send_notifications_for_active_users
+    provider = FactoryBot.create(:simple_provider)
+    system_name = 'application_created'
+    notification = NotificationEvent.create(system_name, CustomEvent.new(provider: provider))
+
+    ProcessNotificationEventWorker::UserNotificationWorker.expects(:perform_async).with(
+      FactoryBot.create(:simple_admin, state: :active, account: provider).id,
+      notification.event_id,
+      system_name
+    ).once
+
+    non_notifiable_user_states = User.state_machine.states.map(&:name) - [:active]
+    non_notifiable_user_states.each do |state|
+      ProcessNotificationEventWorker::UserNotificationWorker.expects(:perform_async).with(
+        FactoryBot.create(:user, state: state, account: provider).id,
+        notification.event_id,
+        system_name
+      ).never
+    end
+
+    Sidekiq::Testing.inline! { @worker.create_notifications(notification) }
+  end
+
   def test_rescue_errors
     provider     = FactoryBot.create(:simple_provider)
     event        = Invoices::InvoicesToReviewEvent.create_and_publish!(provider)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:

This PR removes non-active users from the list of possible email receivers.

**Which issue(s) this PR fixes** 

Fixes [THREESCALE-8903](https://issues.redhat.com/browse/THREESCALE-8903).

**Verification steps** 

1. Configure SMTP Settings on 3scale in case it is not configured yet
2. Create a New Temporary Email account (i.e using mailhog)
3. As an already existing Admin (Provider) user - User A - log into the admin portal and invite the new user (Provider) - User B - with the email created in the step above
4. User A should create some new Developer Accounts and Applications
5. User B will receive email notifications triggered by the above events
6. User A should suspend User B by using the Account Management API User Suspend (provider account)
7. User A should create a new Developer Account and a new Application
8. Observe that notifications are still received on the mail box of the Temp Mail account of User B

**Special notes for your reviewer**:

Another way of fixing this would be to go through the application's permissions and figure out why non active users still retain some permissions to receive notifications, for example.
We already have [another ticket](https://issues.redhat.com/browse/THREESCALE-6318) that touches permissions based on Services (products), in which I expect to implement a better solution for this.
Right now, the query we perform to get a list of Users is too broad and it's also done in the last possible moment of the email message workflow, leaving the question to send or not the notification in the hast of Notification#should_deliver?. Maybe there's a way to do this so that we don't need to create more instances of Notification than we currently do.