### PR TITLE
THREESCALE-8913: Fix inline charts - missing unitPluralized value

### DIFF
--- a/app/javascript/packs/inline_chart.tsx
+++ b/app/javascript/packs/inline_chart.tsx
@@ -16,12 +16,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const currentChart = chart.querySelector<HTMLElement>('.inline-chart-container')
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TODO: need to give some default values or something here
     const { endpoint, metricName, title } = currentChart!.dataset
+    const { unitPluralized } = chart.dataset
     render((
       <InlineChart
         endPoint={endpoint as unknown as string}
         metricName={metricName as unknown as string}
         title={title as unknown as string}
-        unitPluralized={chart.dataset.unitPluralized as unknown as string}
+        unitPluralized={unitPluralized as unknown as string}
       />
     ), currentChart)
   }

--- a/app/javascript/packs/inline_chart.tsx
+++ b/app/javascript/packs/inline_chart.tsx
@@ -15,13 +15,13 @@ document.addEventListener('DOMContentLoaded', () => {
   function renderChart (chart: HTMLElement) {
     const currentChart = chart.querySelector<HTMLElement>('.inline-chart-container')
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TODO: need to give some default values or something here
-    const { endpoint, metricName, title, unitPluralized } = currentChart!.dataset
+    const { endpoint, metricName, title } = currentChart!.dataset
     render((
       <InlineChart
         endPoint={endpoint as unknown as string}
         metricName={metricName as unknown as string}
         title={title as unknown as string}
-        unitPluralized={unitPluralized as unknown as string}
+        unitPluralized={chart.dataset.unitPluralized as unknown as string}
       />
     ), currentChart)
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug that was introduced during Flow > Typescript migration.

**Which issue(s) this PR fixes** 

Fixes https://issues.redhat.com/browse/THREESCALE-8913

**Verification steps** 

1. Load any application page
2. Make sure the "Usage in last 30 Days" chart gets loaded (even with empty data), and not shows up with a spinning icon.

**Special notes for your reviewer**:
