### PR TITLE
🐛 Fix default values in Braintree customer form

### DIFF
--- a/app/javascript/packs/braintree_customer_form.ts
+++ b/app/javascript/packs/braintree_customer_form.ts
@@ -16,14 +16,19 @@ document.addEventListener('DOMContentLoaded', async () => {
     throw new Error('The target ID was not found: ' + CONTAINER_ID)
   }
 
-  const { clientToken, threeDSecureEnabled, formActionPath, countriesList, selectedCountryCode } = container.dataset as Record<string, string>
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- FIXME: too much assumption here
-  const billingAddress = safeFromJsonString<BillingAddressData>(container.dataset.billingAddress)!
-  for (const key in billingAddress) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- FIXME
-    if (billingAddress[key as keyof BillingAddressData] === null) {
-      billingAddress[key as keyof BillingAddressData] = ''
-    }
+  const { clientToken, formActionPath, countriesList, selectedCountryCode, threeDSecureEnabled } = container.dataset as Record<string, string> // FIXME: We should not assume this attributes are present
+  const billingAddress = {
+    address: '',
+    address1: '',
+    address2: '',
+    city: '',
+    company: '',
+    country: '',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    phone_number: '',
+    state: '',
+    zip: '',
+    ...safeFromJsonString<Partial<BillingAddressData>>(container.dataset.billingAddress)
   }
   const braintreeClient = await createBraintreeClient(client, clientToken) as Client
 

--- a/app/views/payment_gateways/_braintree_customer_form.html.erb
+++ b/app/views/payment_gateways/_braintree_customer_form.html.erb
@@ -7,7 +7,7 @@
   data-three-d-secure-enabled="<%= site_account.payment_gateway_options[:three_ds_enabled] %>"
   data-client-token="<%= client_token = j @braintree_authorization %>"
   <% unless billing_address_data == nil %>
-    data-billing-address="<%= billing_address_data.to_json  %>"
+    data-billing-address="<%= billing_address_data.to_hash.compact.to_json  %>"
   <% end %>
   data-countries-list="<%= merchant_countries.to_json %>"
   data-selected-country-code="<%= selected_country_code %>"


### PR DESCRIPTION
**What this PR does / why we need it**:

The first time `billingAddress` is empty. Before migrating to TS it was defined as `{}` by default but this got lost in translation. Now the default is an object with all expected attributes set as empty string so that the Form fields does not complain with `undefined` values. `null` values are also stripped from the original object by calling `.compact` before `to_json`.


**Which issue(s) this PR fixes** 

[THREESCALE-8922: Unable to add/edit credit card details in developer portal](https://issues.redhat.com/browse/THREESCALE-8922)

**Verification steps:**
1. Set Braintree as credit card gateway in the admin portal
2. Sign in with a new user (can't have billing address data) in Developer portal
3. Go to Settings > Credit card details > Add Credit Card Details and Billing Address
4. No errors!

 <img width="1031" alt="Screenshot 2022-11-18 at 13 38 04" src="https://user-images.githubusercontent.com/11672286/202707340-96b53a65-25cc-4bfb-8dcd-44a9df0fbde5.png">

<img width="1031" alt="Screenshot 2022-11-18 at 13 38 58" src="https://user-images.githubusercontent.com/11672286/202707357-aae4d2c9-6e72-417f-8d06-3fcb4670c447.png">