### PR TITLE
💩 Revert braintree fix pre TS

### DIFF
--- a/app/javascript/packs/braintree_customer_form.ts
+++ b/app/javascript/packs/braintree_customer_form.ts
@@ -17,12 +17,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const { clientToken, threeDSecureEnabled, formActionPath, countriesList, selectedCountryCode } = container.dataset as Record<string, string>
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- FIXME: too much assumption here
-  const billingAddress = safeFromJsonString<BillingAddressData>(container.dataset.billingAddress)!
+
+  const billingAddress = safeFromJsonString<BillingAddressData>(container.dataset.billingAddress) ?? {}
   for (const key in billingAddress) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- FIXME
-    if (billingAddress[key as keyof BillingAddressData] === null) {
-      billingAddress[key as keyof BillingAddressData] = ''
+    // @ts-expect-error FIXME
+    if (billingAddress[key] === null) {
+      // @ts-expect-error FIXME
+      billingAddress[key] = ''
     }
   }
   const braintreeClient = await createBraintreeClient(client, clientToken) as Client

--- a/app/javascript/packs/braintree_customer_form.ts
+++ b/app/javascript/packs/braintree_customer_form.ts
@@ -16,19 +16,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     throw new Error('The target ID was not found: ' + CONTAINER_ID)
   }
 
-  const { clientToken, formActionPath, countriesList, selectedCountryCode, threeDSecureEnabled } = container.dataset as Record<string, string> // FIXME: We should not assume this attributes are present
-  const billingAddress = {
-    address: '',
-    address1: '',
-    address2: '',
-    city: '',
-    company: '',
-    country: '',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    phone_number: '',
-    state: '',
-    zip: '',
-    ...safeFromJsonString<Partial<BillingAddressData>>(container.dataset.billingAddress)
+  const { clientToken, threeDSecureEnabled, formActionPath, countriesList, selectedCountryCode } = container.dataset as Record<string, string>
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- FIXME: too much assumption here
+  const billingAddress = safeFromJsonString<BillingAddressData>(container.dataset.billingAddress)!
+  for (const key in billingAddress) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- FIXME
+    if (billingAddress[key as keyof BillingAddressData] === null) {
+      billingAddress[key as keyof BillingAddressData] = ''
+    }
   }
   const braintreeClient = await createBraintreeClient(client, clientToken) as Client
 

--- a/app/javascript/src/PaymentGateways/braintree/BraintreeBillingAddressFields.tsx
+++ b/app/javascript/src/PaymentGateways/braintree/BraintreeBillingAddressFields.tsx
@@ -48,6 +48,7 @@ const BraintreeBillingAddressFields: FunctionComponent<Props> = ({
             required
             id="customer_credit_card_billing_address_company"
             name="customer[credit_card][billing_address][company]"
+            // @ts-expect-error FIXME
             value={billingAddressData.company}
             onChange={(e) => { onChangeBillingAddressData(e.currentTarget.value, 'company') }}
           />
@@ -62,6 +63,7 @@ const BraintreeBillingAddressFields: FunctionComponent<Props> = ({
             required
             id="customer_credit_card_billing_address_street_address"
             name="customer[credit_card][billing_address][street_address]"
+            // @ts-expect-error FIXME
             value={billingAddressData.address1}
             onChange={(e) => { onChangeBillingAddressData(e.currentTarget.value, 'address1') }}
           />
@@ -76,6 +78,7 @@ const BraintreeBillingAddressFields: FunctionComponent<Props> = ({
             required
             id="customer_credit_card_billing_address_postal_code"
             name="customer[credit_card][billing_address][postal_code]"
+            // @ts-expect-error FIXME
             value={billingAddressData.zip}
             onChange={(e) => { onChangeBillingAddressData(e.currentTarget.value, 'zip') }}
           />
@@ -90,6 +93,7 @@ const BraintreeBillingAddressFields: FunctionComponent<Props> = ({
             required
             id="customer_credit_card_billing_address_locality"
             name="customer[credit_card][billing_address][locality]"
+            // @ts-expect-error FIXME
             value={billingAddressData.city}
             onChange={(e) => { onChangeBillingAddressData(e.currentTarget.value, 'city') }}
           />
@@ -102,6 +106,7 @@ const BraintreeBillingAddressFields: FunctionComponent<Props> = ({
           <Input
             id="customer_credit_card_billing_address_region"
             name="customer[credit_card][billing_address][region]"
+            // @ts-expect-error FIXME
             value={billingAddressData.state}
             onChange={(e) => { onChangeBillingAddressData(e.currentTarget.value, 'state') }}
           />

--- a/app/javascript/src/PaymentGateways/braintree/types.ts
+++ b/app/javascript/src/PaymentGateways/braintree/types.ts
@@ -1,14 +1,14 @@
 export interface BillingAddressData {
-  address: string;
-  address1: string;
-  address2: string;
-  city: string;
-  company: string;
-  country: string;
+  address?: string;
+  address1?: string;
+  address2?: string;
+  city?: string;
+  company?: string;
+  country?: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  phone_number: string;
-  state: string;
-  zip: string;
+  phone_number?: string;
+  state?: string;
+  zip?: string;
 }
 
 export interface HostedFieldsOptions {

--- a/app/views/payment_gateways/_braintree_customer_form.html.erb
+++ b/app/views/payment_gateways/_braintree_customer_form.html.erb
@@ -7,7 +7,7 @@
   data-three-d-secure-enabled="<%= site_account.payment_gateway_options[:three_ds_enabled] %>"
   data-client-token="<%= client_token = j @braintree_authorization %>"
   <% unless billing_address_data == nil %>
-    data-billing-address="<%= billing_address_data.to_hash.compact.to_json  %>"
+    data-billing-address="<%= billing_address_data.to_json  %>"
   <% end %>
   data-countries-list="<%= merchant_countries.to_json %>"
   data-selected-country-code="<%= selected_country_code %>"


### PR DESCRIPTION
Reverts and fixes: #3116 

The whole Braintree logic needs and will be refactored shortly. But right now there's a blocker bug in production and the safest way is to revert this pack to its original, pre-ts form.

Reference: https://github.com/3scale/porta/blob/3scale-2.12.1-GA/app/javascript/packs/braintree_customer_form.js

**Which issue(s) this PR fixes** 

[THREESCALE-8922: Unable to add/edit credit card details in developer portal](https://issues.redhat.com/browse/THREESCALE-8922)
