### PR TITLE
Fix CMS::S3.hostname

### DIFF
--- a/app/lib/cms/s3.rb
+++ b/app/lib/cms/s3.rb
@@ -32,11 +32,15 @@ module CMS
       CMS::AwsCredentials.instance.credentials
     end
 
+    def hostname
+      config[:hostname].presence if enabled?
+    end
+
     def protocol
       config[:protocol].presence || 'https' if enabled?
     end
 
-    %i[access_key_id bucket hostname region role_arn role_session_name secret_access_key web_identity_token_file].each do |param|
+    %i[access_key_id bucket region role_arn role_session_name secret_access_key web_identity_token_file].each do |param|
       define_method(param) do
         config[param] if enabled?
       end

--- a/app/lib/cms/s3.rb
+++ b/app/lib/cms/s3.rb
@@ -32,17 +32,13 @@ module CMS
       CMS::AwsCredentials.instance.credentials
     end
 
-    def hostname
-      config[:hostname].presence if enabled?
-    end
-
     def protocol
       config[:protocol].presence || 'https' if enabled?
     end
 
-    %i[access_key_id bucket region role_arn role_session_name secret_access_key web_identity_token_file].each do |param|
+    %i[access_key_id bucket hostname region role_arn role_session_name secret_access_key web_identity_token_file].each do |param|
       define_method(param) do
-        config[param] if enabled?
+        config[param].presence if enabled?
       end
     end
 

--- a/test/unit/cms/s3_test.rb
+++ b/test/unit/cms/s3_test.rb
@@ -65,6 +65,26 @@ class CMS::S3Test < ActiveSupport::TestCase
     assert_not CMS::S3.options[:use_fips_endpoint]
   end
 
+  test "#hostname returns nil when CMS::S3 is not enabled" do
+    CMS::S3.stubs(:enabled?).returns(false)
+
+    assert_nil CMS::S3.hostname
+  end
+
+  test "#hostname returns nil when it's not provided" do
+    CMS::S3.stubs(:config).returns(protocol: "https", hostname: "")
+
+    assert_nil CMS::S3.hostname
+  end
+
+  test "#hostname returns the correct config data when provided" do
+    hostname = "some_hostname"
+
+    CMS::S3.stubs(:config).returns(hostname: hostname)
+
+    assert_equal CMS::S3.hostname, hostname
+  end
+
   test "#credentials returns nil when CMS::S3 is not enabled" do
     CMS::S3.stubs(:enabled?).returns(false)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

QE noticed that, when `ENV['AWS_HOSTNAME']` is not provided, Paperclip is not able to generate the correct path to S3 files.
This happens because we're now returning an empty string (`""`) instead of `nil` in `CMS::S3.hostname` when the ENV variable is not provided. When a hostname is not provided (`nil`) Paperclip tries to get it from the provided credentials and, when not found, defaults to `s3.amazonaws.com` ([reference](https://github.com/thoughtbot/paperclip/blob/c769382c9b7078f3d1620b50ec2a70e91ba62ec4/lib/paperclip/storage/s3.rb#L197-L202)). Since we're sending an empty string, paperclip just returns it as the hostname.
This change was introduced not long ago in https://github.com/3scale/porta/pull/3095.

**Verification steps** 

1. When `ENV['AWS_HOSTNAME']` is not provided, `CMS::S3.hostname` should return `nil` instead of `""`;
2. When `ENV['AWS_HOSTNAME']` is not provided, calls to S3 should have a proper hostname that ends with `amazonaws.com`; This can be tested by calling Paperclip like `CMS::File.last.url`;


**Special notes for your reviewer**:
