### PR TITLE
Fix developer portal html escaping

### DIFF
--- a/lib/developer_portal/lib/liquid/xss_protection.rb
+++ b/lib/developer_portal/lib/liquid/xss_protection.rb
@@ -10,27 +10,31 @@ module Liquid::XssProtection
     ERB::Util.html_escape(super.dup)
   end
 
+  module Renderer
+    def render(context)
+      output = super(context)
+      should_escape = context.registers[:escape_html] && !output.html_safe?
+
+      if should_escape && output.respond_to?(:to_str)
+        output = output.dup.extend(Liquid::XssProtection)
+      end
+
+      case output
+      when String
+        output.to_str
+      else
+        output
+      end
+    end
+
+    alias render_with_html_escape render
+  end
+
   def self.enable!
     Liquid::Variable.class_eval do
       next if method_defined?(:render_with_html_escape)
 
-      prepend(Module.new do
-        def render(context)
-          output = super(context)
-          should_escape = context.registers[:escape_html] && !output.html_safe?
-
-          if should_escape && output.respond_to?(:to_str)
-            output = output.dup.extend(Liquid::XssProtection)
-          end
-
-          case output
-          when String
-            output.to_str
-          else
-            output
-          end
-        end
-      end)
+      prepend Renderer
 
     end
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

In our development environments, the developer portal is losing its styling after making some changes in the ruby code.

**Which issue(s) this PR fixes** 

No jira for this

**Verification steps** 

1. Open the developer portal
2. Make some changes in the code
3. Open the developer portal again
4. The portal should keep it's styling

**Special notes for your reviewer**:

The problem is caused because some `style` and `script` tags are being escaped. The piece of code that escapes these tags is [/lib/developer_portal/lib/liquid/xss_protection.rb#L20](https://github.com/3scale/porta/blob/9dc90cba804404c6de9bb727112c0c4bb89017b8/lib/developer_portal/lib/liquid/xss_protection.rb#L20). `context.registers[:escape_html]` seems to be always `true`, but `output.html_safe?` is true when the server is started, but becomes `false` after any change on the ruby code, that's what makes the tags get escaped.

The reason for that change of value is that the [liquid initializer](https://github.com/3scale/porta/blob/9dc90cba804404c6de9bb727112c0c4bb89017b8/lib/developer_portal/config/initializers/liquid.rb#L63) is executed after any change in the code (this is something I didn't know and I find it surprising). As a consequence, the [Module](https://github.com/3scale/porta/blob/9dc90cba804404c6de9bb727112c0c4bb89017b8/lib/developer_portal/lib/liquid/xss_protection.rb#L17) is preprended to `Liquid::Variable` as many times as changes were made to the code, and after the first `prepend`, the [call to super](https://github.com/3scale/porta/blob/9dc90cba804404c6de9bb727112c0c4bb89017b8/lib/developer_portal/lib/liquid/xss_protection.rb#L19) is not returning a `Liquid::Variable` object anymore, but a string (the return value of this very render method), since `String.html_safe?` is false, the string is escaped.

I solved this by adding an alias from `render_with_html_escape` to `render`, so the mechanism to avoid prepend duplication works again (the bug was introduced [here](https://github.com/3scale/porta/commit/5ac60c6a3746f6f5807d3e53568f0112fdac4cd2))
