### PR TITLE
[DO NOT MERGE] Experiment: what would adding a new environment require?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -252,7 +252,7 @@ end
 gem 'webpacker', '~> 4'
 
 gem 'developer_portal', path: 'lib/developer_portal'
-gem 'unicorn', require: false, group: %i[production preview]
+gem 'unicorn', require: false, group: %i[production staging preview]
 
 # NOTE: Use ENV['DB'] only to install oracle dependencies
 oracle = -> { (ENV['ORACLE'] == '1') || ENV.fetch('DATABASE_URL', ENV['DB'])&.start_with?('oracle') }

--- a/app/lib/stats/storage.rb
+++ b/app/lib/stats/storage.rb
@@ -66,7 +66,7 @@ module Stats
 
         rslt
       rescue RuntimeError => e # "no such key" for example
-        System::ErrorReporting.report_error(e) if Rails.env.production?
+        System::ErrorReporting.report_error(e) if Rails.env.production? # TODO: fix this
         ActiveSupport::OrderedHash.new
       end
     end

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -424,8 +424,10 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
     @provider ||= self.service&.account
   end
 
+  # FIXME: This is not right, and needs to be fixed and managed at the configuration level
   PROXY_ENV = {
     preview: 'pre.',
+    staging: '',
     production: ''
   }.freeze
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ ActiveSupport.on_load(:active_record) do
 end
 
 # If you precompile assets before deploying to production, use this line
-Bundler.require(*Rails.groups(:assets => %w[development production preview test]))
+Bundler.require(*Rails.groups(:assets => %w[development production preview staging test]))
 # If you want your assets lazily compiled in production, use this line
 # Bundler.require(:default, :assets, Rails.env)
 
@@ -223,7 +223,7 @@ module System
     config.three_scale.payments.enabled = false
     config.three_scale.payments.merge!(payment_settings)
     config.three_scale.payments.merge!(try_config_for(:payments) || {})
-    config.three_scale.payments.active_merchant_mode ||= Rails.env.production? ? :production : :test
+    config.three_scale.payments.active_merchant_mode ||= Rails.env.production? ? :production : :test # TODO: fix this
 
     email_sanitizer_configs = (three_scale.delete(:email_sanitizer) || {}).symbolize_keys
     config.three_scale.email_sanitizer.merge!(email_sanitizer_configs)

--- a/config/docker/settings.yml
+++ b/config/docker/settings.yml
@@ -34,7 +34,7 @@ base: &default
   onpremises_api_docs_version: true
   assets_cdn_host: <%= ENV.fetch('ASSETS_CDN_HOST', '') %>
   email_sanitizer:
-    enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %>
+    enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %> # potentially add staging
     to: <%= ENV.fetch('EMAIL_SANITIZER_TO', 'sanitizer@example.com') %>
   onpremises: true
   janitor_worker_enabled: true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,11 +31,6 @@ Rails.application.configure do
   config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
-
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 
@@ -53,13 +48,6 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
-
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -95,6 +83,9 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info').downcase.to_sym
 
 
@@ -102,6 +93,7 @@ Rails.application.configure do
   config.action_dispatch.ip_spoofing_check = false
 
   # we precompile in production
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
   config.assets.compress = true
   config.assets.digest = ENV.fetch('DISABLE_DIGEST', '0') != '1'
@@ -119,7 +111,10 @@ Rails.application.configure do
       asset_host
     end
   end
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
+
+  # Prepend all log lines with the following tags.
   # do not change the tags withotu updating logstash rules
   # https://github.com/3scale/puppet/blob/ac161671aee2019eefa87b51b150cb78fcb417e9/modules/logstash/templates/config/system-mt/filter.erb
   config.log_tags = [ :uuid, :host, :remote_ip ]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,130 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
+  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  # config.require_master_key = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = {
+    'Cache-Control' => "public, max-age=#{(config.assets.digest ? 1.year : 1.minute).to_i}",
+  }
+
+  # Compress JavaScripts and CSS.
+  # TODO: switch to ruby-terser: https://github.com/lautis/uglifier/commit/902cc160d3f8f405a35a8f16da227489366a3ad6
+  config.assets.js_compressor = Uglifier.new(harmony: true)
+  # config.assets.css_compressor = :sass
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Store uploaded files on the local file system (see config/storage.yml for options)
+  # config.active_storage.service = :local
+
+  # Mount Action Cable outside main process or domain
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = 'wss://example.com/cable'
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "system_#{Rails.env}"
+  config.action_mailer.perform_caching = false
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info').downcase.to_sym
+
+
+  # ip spoofing checks are pointless and might mess up proxies
+  config.action_dispatch.ip_spoofing_check = false
+
+  # we precompile in production
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+  config.assets.compress = true
+  config.assets.digest = ENV.fetch('DISABLE_DIGEST', '0') != '1'
+
+  if config.assets.digest
+    asset_host = config.three_scale.asset_host.presence
+
+    config.asset_host = ->(source) do
+      # does it exist in /public/assets ?
+      full_path = File.join(Rails.public_path, source)
+      precompiled = File.exist?(full_path)
+
+      break unless precompiled
+
+      asset_host
+    end
+  end
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+
+  # Prepend all log lines with the following tags.
+  # do not change the tags withotu updating logstash rules
+  # https://github.com/3scale/puppet/blob/ac161671aee2019eefa87b51b150cb78fcb417e9/modules/logstash/templates/config/system-mt/filter.erb
+  config.log_tags = [ :uuid, :host, :remote_ip ]
+
+  config.middleware.insert_before ActionDispatch::Static, Rack::Deflater
+
+  config.liquid.resolver_caching = true
+
+  config.three_scale.payments.enabled = true
+
+  config.three_scale.rolling_updates.raise_error_unknown_features = false
+  config.three_scale.rolling_updates.enabled = ENV.fetch('THREESCALE_ROLLING_UPDATES', '0') == '0'
+end

--- a/config/examples/settings.yml
+++ b/config/examples/settings.yml
@@ -34,10 +34,10 @@ base: &default
   onpremises_api_docs_version: false
   assets_cdn_host: <%= ENV.fetch('ASSETS_CDN_HOST', '') %>
   email_sanitizer:
-    enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %>
+    enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %> # potentially add staging
     to: <%= ENV.fetch('EMAIL_SANITIZER_TO', 'saniziter@example.com') %>
   onpremises: false
-  error_reporting_stages: <%= ENV.fetch('ERROR_REPORTING_STAGES', 'production') %>
+  error_reporting_stages: <%= ENV.fetch('ERROR_REPORTING_STAGES', 'staging,production') %>
   apicast_staging_url: <%= ENV.fetch('APICAST_STAGING_URL', 'apicast-staging:8090') %>
   zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATON_TOKEN', '') %>
   access_code: <%= ENV.fetch('ACCESS_CODE', '') %>

--- a/config/initializers/captchas.rb
+++ b/config/initializers/captchas.rb
@@ -9,6 +9,6 @@ end
 
 module Recaptcha
   def self.captcha_configured?
-    !Recaptcha::Verify.skip?(Rails.env)
+    !Recaptcha::Verify.skip?(Rails.env) # Verify how Rails.env affects the behavior
   end
 end

--- a/config/initializers/deprecation.rb
+++ b/config/initializers/deprecation.rb
@@ -2,4 +2,4 @@
 
 # Silence our custom deprecator in test, production and preview
 # Stop to spam
-ThreeScale::Deprecation.silenced = %w[test production preview].include?(Rails.env)
+ThreeScale::Deprecation.silenced = %w[test production staging preview].include?(Rails.env)

--- a/config/initializers/tags.rb
+++ b/config/initializers/tags.rb
@@ -19,7 +19,7 @@ ActiveSupport.on_load(:active_record) do
       if User.current && !tenant_id
         exception = MissingTenantIdError.new(User.current)
 
-        if Rails.env.production?
+        if Rails.env.production? # TODO: fix this
           System::ErrorReporting.report_error(exception)
         elsif Thread.current[:multitenant]
           raise(exception)

--- a/lib/developer_portal/lib/liquid/drops/deprecated.rb
+++ b/lib/developer_portal/lib/liquid/drops/deprecated.rb
@@ -73,7 +73,7 @@ module Liquid
 
       def notify?
         env = Rails.env
-        env.enterprise? or env.production? or env.preview?
+        env.enterprise? or env.production? or env.preview? or env.staging? # FIXME
       end
 
       class << self

--- a/lib/tasks/db/data.rake
+++ b/lib/tasks/db/data.rake
@@ -68,7 +68,7 @@ namespace :db do
     end
 
     def confirm_production_kill
-      if Rails.env.production? && ENV['FORCE'].blank?
+      if Rails.env.production? && ENV['FORCE'].blank? # This is probably OK
         abort "Are you sure you want to kill your PRODUCTION DATABASE? " +
               "If yes, run this task with parameter FORCE=true."
       end

--- a/openshift/system/config/settings.yml
+++ b/openshift/system/config/settings.yml
@@ -37,7 +37,7 @@ base: &default
   zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATON_TOKEN', '') %>
 
   email_sanitizer:
-    enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %>
+    enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %> # potentially add staging
     to: <%= ENV.fetch('EMAIL_SANITIZER_TO', 'sanitizer@example.com') %>
 
   janitor_worker_enabled: true

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ ENV['RAILS_ENV'] ||= 'test'
 
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort("The Rails environment is running in production mode!") if Rails.env.production? # ?
 require 'rspec/rails'
 require 'rspec-html-matchers'
 


### PR DESCRIPTION
This is **not meant to be merged**.

This is just a quick exercise to investigate what changes would be required in the porta code if we wanted to add a `staging` environment (`RAILS_ENV`), that would act the same as `production`.

As we can see, there are quite a few places in the code where the fact of environment being `production` is checked, and the logic depends on that. Some of the changes that would need to be made in case we wanted to have another environment are quite obvious, while others are not and would require some refactoring.

IMO, refactoring is needed anyway, it's not good to have the application logic so bound to `RAILS_ENV`.

Also, this list might not be exhaustive, this is just to show that we can't just add `staging` and expect all features to work. So, for now we discard this option.

In case it is considered in future, a deeper analysis of the potential changes would be required.

