### PR TITLE
Add BUGSNAG_RELEASE_STAGE and use it in Bugsnag initializer

### DIFF
--- a/config/examples/settings.yml
+++ b/config/examples/settings.yml
@@ -11,6 +11,8 @@ base: &default
   daily_weekly_reports_pref: <%= ENV.fetch('ENABLE_DAILY_WEEKLY_REPORTS_PREF', '1') == '1' %>
   readonly_custom_domains_settings: <%= ENV.fetch('READONLY_CUSTOM_DOMAINS_SETTINGS', '1') == '1' %>
   bugsnag_api_key: <%= ENV['BUGSNAG_API_KEY'] %>
+  bugsnag_release_stage: <%= ENV.fetch('BUGSNAG_RELEASE_STAGE', Rails.env) %>
+  error_reporting_stages: <%= ENV.fetch('ERROR_REPORTING_STAGES', 'production') %>
   events_shared_secret: <%= ENV['EVENTS_SHARED_SECRET'] %>
   recaptcha_public_key: <%= ENV.fetch('RECAPTCHA_PUBLIC_KEY', 'YOUR_RECAPTCHA_PUBLIC_KEY') %>
   recaptcha_private_key: <%= ENV['RECAPTCHA_PRIVATE_KEY'] %>
@@ -37,7 +39,6 @@ base: &default
     enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %>
     to: <%= ENV.fetch('EMAIL_SANITIZER_TO', 'saniziter@example.com') %>
   onpremises: false
-  error_reporting_stages: <%= ENV.fetch('ERROR_REPORTING_STAGES', 'production') %>
   apicast_staging_url: <%= ENV.fetch('APICAST_STAGING_URL', 'apicast-staging:8090') %>
   zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATON_TOKEN', '') %>
   access_code: <%= ENV.fetch('ACCESS_CODE', '') %>

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -3,9 +3,9 @@
 Bugsnag.configure do |config|
   config.api_key = Rails.configuration.three_scale.bugsnag_api_key
   config.app_version = System::Deploy.info.revision
-  config.notify_release_stages = %w[production]
   stages = Rails.configuration.three_scale.error_reporting_stages
-  config.notify_release_stages = stages if stages.present?
+  config.notify_release_stages = stages.present? ? stages : %w[production]
+  config.release_stage = Rails.configuration.three_scale.bugsnag_release_stage || Rails.env
 
   ignore_error_names = ActionDispatch::ExceptionWrapper.rescue_responses.keys + ['WebHookWorker::ClientError']
 

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -4,7 +4,9 @@ Bugsnag.configure do |config|
   config.api_key = Rails.configuration.three_scale.bugsnag_api_key
   config.app_version = System::Deploy.info.revision
   stages = Rails.configuration.three_scale.error_reporting_stages
-  config.notify_release_stages = stages.present? ? stages : %w[production]
+  # TODO: after upgrading Bugsnag replace `notify_release_stages` (deprecated in v6.23) with `enabled_release_stages`
+  # see https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.23.0
+  config.notify_release_stages = stages.present? ? stages : %w[staging production]
   config.release_stage = Rails.configuration.three_scale.bugsnag_release_stage || Rails.env
 
   ignore_error_names = ActionDispatch::ExceptionWrapper.rescue_responses.keys + ['WebHookWorker::ClientError']


### PR DESCRIPTION
This is a way to set a different `releaseStage` metadata on Bugsnag (e.g. `staging`), while still using `RAILS_ENV=production`)

**NOTE:** In order to use a different environment `Rails.configuration.three_scale.error_reporting_stages` (in `settings.yml`) must be changed to include the new environment.

This env var as added as default one in Bugsnag Ruby in 6.16, see [the PR](https://github.com/bugsnag/bugsnag-ruby/pull/613) and the [release notes](https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.16.0).