### PR TITLE
Fix typo in ZYNC_AUTHENTICATION_TOKEN env var

### DIFF
--- a/config/docker/settings.yml
+++ b/config/docker/settings.yml
@@ -39,7 +39,7 @@ base: &default
   onpremises: true
   janitor_worker_enabled: true
   apicast_staging_url: <%= ENV.fetch('APICAST_STAGING_URL', 'apicast-staging:8090') %>
-  zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATON_TOKEN', '') %>
+  zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATION_TOKEN', '') %>
 
   # deprecated: use payments.yaml to configure payments instead
   active_merchant_logging: <%= ENV.fetch('ACTIVE_MERCHANT_LOGGING', false) %>

--- a/config/examples/settings.yml
+++ b/config/examples/settings.yml
@@ -39,7 +39,7 @@ base: &default
   onpremises: false
   error_reporting_stages: <%= ENV.fetch('ERROR_REPORTING_STAGES', 'production') %>
   apicast_staging_url: <%= ENV.fetch('APICAST_STAGING_URL', 'apicast-staging:8090') %>
-  zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATON_TOKEN', '') %>
+  zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATION_TOKEN', '') %>
   access_code: <%= ENV.fetch('ACCESS_CODE', '') %>
 
   # deprecated: use payments.yaml to configure payments instead

--- a/openshift/system/config/settings.yml
+++ b/openshift/system/config/settings.yml
@@ -34,7 +34,7 @@ base: &default
   db_secret:
 
   assets_cdn_host: <%= ENV.fetch('ASSETS_CDN_HOST', '') %>
-  zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATON_TOKEN', '') %>
+  zync_authentication_token: <%= ENV.fetch('ZYNC_AUTHENTICATION_TOKEN', '') %>
 
   email_sanitizer:
     enabled: <%= ENV.fetch('EMAIL_SANITIZER_ENABLED', Rails.env.preview?) %>


### PR DESCRIPTION
Spelled as `ZYNC_AUTHENTICATON_TOKEN` by mistake (I guess).

The 3scale operator uses the correct spelling `ZYNC_AUTHENTICATION_TOKEN`.

There is also `zync.yml` file where it is spelled correctly.