### PR TITLE
  remove obsolete CSRF options

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,10 +38,6 @@ module System
     config.load_defaults 5.1
     config.active_record.belongs_to_required_by_default = false
     config.active_record.include_root_in_json = true
-    # Enable per-form CSRF tokens. Rails before 5.0 had false.
-    config.action_controller.per_form_csrf_tokens = false
-    # Enable origin-checking CSRF mitigation. Rails before had false.
-    config.action_controller.forgery_protection_origin_check = false
     # Make `form_with` generate non-remote forms. Defaults true in Rails 5.1 to 6.0
     config.action_view.form_with_generates_remote_forms = false
 


### PR DESCRIPTION
In THREESCALE-8905 it became known that these settings n 2.12 did not
take effect. While in 2.13 they did again, it is worth reverting back
to the community standards.

In 2.12 we had these settings in an initializer that was actually not loaded
early enough as evidenced by THREESCALE-8905

Given that we had no issues reported in SaaS and only one 2.12 user that used reverse proxy improperly, I think it is
safe to drop that option and use the Rails recommended default.