### PR TITLE
Fix httpclient fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem 'ransack', '2.4.1' # we can remove line when stop using ruby 2.4
 gem 'browser', '~> 5.0.0' # we can update to lts when we stop using ruby 2.4
 gem 'diff-lcs', '~> 1.2'
 gem 'hiredis', '~> 0.6.3'
-gem 'httpclient', github: 'mikz/httpclient', branch: 'ssl-env-cert'
+gem 'httpclient', github: '3scale/httpclient', branch: 'ssl-env-cert'
 gem 'json-schema', git: 'https://github.com/3scale/json-schema.git'
 gem 'paperclip', '~> 6.0'
 gem 'prawn-core', git: 'https://github.com/3scale/prawn.git', branch: '0.5.1-3scale'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GIT
     swagger-ui_rails (0.1.7)
 
 GIT
-  remote: https://github.com/mikz/httpclient.git
+  remote: https://github.com/3scale/httpclient.git
   revision: fec23fb32fb899b87a8b2c94e2d2069b6b4c633c
   branch: ssl-env-cert
   specs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GIT
 
 GIT
   remote: https://github.com/3scale/httpclient.git
-  revision: fec23fb32fb899b87a8b2c94e2d2069b6b4c633c
+  revision: 779beabd653afcd03c4468e0a69dc043f3bbb748
   branch: ssl-env-cert
   specs:
     httpclient (2.8.3)


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the fork used for the `httpclient` ruby gem

**Special notes for your reviewer**:

same exact code on both forks - the 3scale one having the benefit that it doesn't depend on an external (nowadays) contributor.
