### PR TITLE
Allow enabling latest git version

### DIFF
--- a/openshift/system/contrib/scl_enable
+++ b/openshift/system/contrib/scl_enable
@@ -3,4 +3,4 @@
 #
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable $NODEJS_SCL $RUBY_SCL
+source scl_source enable $NODEJS_SCL $RUBY_SCL $GIT_SCL


### PR DESCRIPTION
**What this PR does / why we need it**:

This is required because cachito requires `git > 2.7.0` and the git version available in the current RHEL7 parent image is < 2.0

**Which issue(s) this PR fixes** 

**Special notes for your reviewer**:

In case the env var is not set, this shouldn't affect anything