### PR TITLE
Prevent alerts to be sent to users who don't have access to the related service

### DIFF
--- a/config/abilities/provider_any.rb
+++ b/config/abilities/provider_any.rb
@@ -41,8 +41,11 @@ Ability.define do |user|
     end
 
     if user.has_permission?(:monitoring)
-      can [:show], AlertRelatedEvent
+      can [:show], AlertRelatedEvent do |event|
+        user.has_access_to_service?(event.try(:service))
+      end
     end
+
     can [:show], Reports::CsvDataExportEvent do |event|
       user.admin? && event.recipient.try!(:id) == user.id
     end

--- a/test/unit/abilities/provider_any_test.rb
+++ b/test/unit/abilities/provider_any_test.rb
@@ -69,6 +69,49 @@ module Abilities
       assert_cannot ability, :show, Accounts::AccountCreatedEvent.create(account, user)
     end
 
+    class ShowAlertRelatedEventTest < ProviderAnyTest
+      setup do
+        user.stubs(:has_permission?)
+
+        cinstance = FactoryBot.build_stubbed(:simple_cinstance)
+        alert = FactoryBot.build_stubbed(:limit_violation, cinstance: cinstance)
+        @limit_violation_reached_provider_event = Alerts::LimitViolationReachedProviderEvent.create(alert)
+      end
+
+      attr_reader :limit_violation_reached_provider_event
+
+      test 'cannot show AlertRelatedEvent when user does not have :monitoring' do
+        user.expects(:has_permission?).with(:monitoring).returns(false)
+
+        assert_cannot ability, :show, limit_violation_reached_provider_event
+      end
+
+      # This is related to the :service_permissions rolling update. Users created before it do not have the :services
+      # section included in their member permissions, which grants them access to all services.
+      test 'can show AlertRelatedEvent when user has :monitoring and the user has access to all services through the old permission system' do
+        user.expects(:has_permission?).with(:monitoring).returns(true)
+
+        assert_can ability, :show, limit_violation_reached_provider_event
+      end
+
+      test 'cannot show AlertRelatedEvent when user has :monitoring and does not have access to the service' do
+        user.stubs(:has_permission?).with(:monitoring).returns(true)
+        user.member_permissions.build(admin_section: :services, service_ids: [])
+
+        assert_cannot ability, :show, limit_violation_reached_provider_event
+      end
+
+      test 'can show AlertRelatedEvent when user has :monitoring and has access to the service' do
+        user.stubs(:has_permission?).with(:monitoring).returns(true)
+        user.member_permissions.build(
+          admin_section: :services,
+          service_ids: [limit_violation_reached_provider_event.service.id]
+        )
+
+        assert_can ability, :show, limit_violation_reached_provider_event
+      end
+    end
+
     private
 
     def ability


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates how we grant the permission to `:show AlertRelatedEvent`s. Right now, any provider on an account has this permission, even though they might not have permissions for a service the alert refers to. With this PR, we're adding a check on service level to prevent the issue reported on the linked ticket. 

**Which issue(s) this PR fixes** 

fixes [THREESCALE-6318](https://issues.redhat.com/browse/THREESCALE-6318)

**Verification steps** 

Verification steps copied from the linked ticket:
1) As Admin user, create a Product i.e. Test API, an application and application plan. Set a limit of 2 requests per minute.
2) Create a member i.e “Tom” user with the following rights:
```
    Accounts – Applications
    Analytics
    Integration & Application Plans
    Disable “All current and future APIs” and check 1 APi, i.e. Test API. 
```
3) Sing in at the admin portal as Tom user and enable the following:
    - Go to the Gear icon - Settings > Notification Preferences > Usage Alerts. Check both “Alert usage warning” and “Alert usage violation”. Then Click Update Notificaton Preferences. See screenshot Notification_preferences.png.
    - Go to Product Cars > Applications > Settings - Usage Rules > Alerts, check both “Show Web Alerts to Admins of this Account” and “Send Email Alerts to Admins of this Account”, from 50% to 100%, see screenshot Alerts.png. Both alerts are necessary due to this issue [THREESCALE-1870](https://issues.redhat.com/browse/THREESCALE-1870).
4) Repeat the same steps 2 & 3 for another user, i.e. Marta, however don't allow access to Test API but to another API. See screenshot Marta.png.
5) Make a request to Test API until hit the limit. Check the emails and you’ll see that Marta has received an alert email regarding Test Api which hasn’t access.

**Special notes for your reviewer**:

To test this, I ended-up having to run `Events.async_fetch_backend_events!` on a Rails console to force System to fetch the alert event from Apisonator. This might be happening due to a misconfiguration on my local environment but, just for the sake of sharing, I wanted to add this note to the PR.