### PR TITLE
THREESCALE-8990: CMS access token scope: make  public

### DIFF
--- a/app/lib/logic/rolling_updates.rb
+++ b/app/lib/logic/rolling_updates.rb
@@ -234,16 +234,6 @@ module Logic
         end
       end
 
-      class CMSApi < Base
-        def enabled?
-          super || master?
-        end
-
-        def missing_config
-          false
-        end
-      end
-
       class ApicastV2 < Base
         def missing_config
           master?

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -47,12 +47,6 @@ class AccessToken < ApplicationRecord
       end
     end
 
-    def visible_for(account)
-      select_and_build do |scope|
-        account.provider_can_use?("#{scope.value}_api")
-      end
-    end
-
     def keys
       scopes.map(&:key)
     end
@@ -155,7 +149,7 @@ class AccessToken < ApplicationRecord
   end
 
   def available_scopes
-    owner.allowed_access_token_scopes.visible_for(owner.account)
+    owner.allowed_access_token_scopes
   end
 
   def human_scopes

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -38,7 +38,7 @@ class AccessToken < ApplicationRecord
     private
 
     def non_public_scopes
-      %w(cms).freeze
+      %w[].freeze
     end
   end
 

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -30,16 +30,6 @@ class AccessToken < ApplicationRecord
       else value.to_s.to_sym
       end
     end
-
-    def public?
-      non_public_scopes.exclude?(value.to_s)
-    end
-
-    private
-
-    def non_public_scopes
-      %w[].freeze
-    end
   end
 
   class Scopes
@@ -59,11 +49,7 @@ class AccessToken < ApplicationRecord
 
     def visible_for(account)
       select_and_build do |scope|
-        if scope.public?
-          true
-        else
-          account.provider_can_use?("#{scope.value}_api")
-        end
+        account.provider_can_use?("#{scope.value}_api")
       end
     end
 

--- a/config/docker/rolling_updates.yml
+++ b/config/docker/rolling_updates.yml
@@ -10,7 +10,6 @@ base: &default
   require_cc_on_signup: false
   apicast_per_service: true
   new_notification_system: true
-  cms_api: false
   forum: false
   policy_registry: false
   apicast_v2: true

--- a/config/examples/rolling_updates.yml
+++ b/config/examples/rolling_updates.yml
@@ -10,7 +10,6 @@ base: &default
   require_cc_on_signup: false
   apicast_per_service: true
   new_notification_system: true
-  cms_api: false
   forum: false
   policy_registry: true
   proxy_private_base_path: true

--- a/openshift/system/config/rolling_updates.yml
+++ b/openshift/system/config/rolling_updates.yml
@@ -11,7 +11,6 @@ base: &default
   require_cc_on_signup: false
   apicast_per_service: true
   new_notification_system: true
-  cms_api: false
   apicast_v2: true
   forum: false
   published_service_plan_signup: true

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -16,19 +16,6 @@ class AccessTokenTest < ActiveSupport::TestCase
     end
   end
 
-  def test_non_public_scopes
-    member.admin_sections = [:monitoring, :portal]
-    member.save!
-    @token.owner = member
-    @token.save!
-
-    Account.any_instance.expects(:provider_can_use?).with('cms_api').returns(false)
-    assert_equal ['stats'], @token.available_scopes.values
-
-    Account.any_instance.expects(:provider_can_use?).with('cms_api').returns(true)
-    assert_equal ['cms', 'stats'], @token.available_scopes.values
-  end
-
   def test_available_permissions
     assert_kind_of Hash, @token.available_permissions
   end

--- a/test/unit/logic/rolling_updates_test.rb
+++ b/test/unit/logic/rolling_updates_test.rb
@@ -27,14 +27,6 @@ class Logic::RollingUpdatesTest < ActiveSupport::TestCase
     refute account.provider_can_use?(:forum)
   end
 
-  def test_cms_api
-    account = FactoryBot.build_stubbed(:simple_account)
-
-    Rails.configuration.three_scale.rolling_updates.stubs(features: { cms_api: [account.id] })
-    assert account.provider_can_use?(:cms_api)
-    assert account.provider_can_use?('cms_api')
-  end
-
   def test_feature
     assert Logic::RollingUpdates.feature(:service_permissions)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes the rolling update for the CMS API and makes it public for everyone. This is one of the tasks required to release the tech preview.

**Which issue(s) this PR fixes** 

[THREESCALE-8990](https://issues.redhat.com/browse/THREESCALE-8990)

**Verification steps** 

In the provider portal:

1. Account Settings -> Personal -> Tokens
2. Create or edit a token
3. The check button for the `Developer portal` scope must appear.
4. When `Developer portal` or `Account` tokens are enabled, the CMS API must accept the requests. It must deny the requests otherwise.

![image](https://user-images.githubusercontent.com/17052241/208412659-104a7250-8154-46a3-ad60-67cc32a2dcb7.png)
