### PR TITLE
Fix httpclient fork in managed-services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem 'ransack', '2.4.1' # we can remove line when stop using ruby 2.4
 gem 'browser', '~> 5.0.0' # we can update to lts when we stop using ruby 2.4
 gem 'diff-lcs', '~> 1.2'
 gem 'hiredis', '~> 0.6.3'
-gem 'httpclient', github: 'mikz/httpclient', branch: 'ssl-env-cert'
+gem 'httpclient', github: '3scale/httpclient', branch: 'ssl-env-cert'
 gem 'json-schema', git: 'https://github.com/3scale/json-schema.git'
 gem 'paperclip', '~> 6.0'
 gem 'prawn-core', git: 'https://github.com/3scale/prawn.git', branch: '0.5.1-3scale'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,8 +61,8 @@ GIT
     swagger-ui_rails (0.1.7)
 
 GIT
-  remote: https://github.com/mikz/httpclient.git
-  revision: fec23fb32fb899b87a8b2c94e2d2069b6b4c633c
+  remote: https://github.com/3scale/httpclient.git
+  revision: 779beabd653afcd03c4468e0a69dc043f3bbb748
   branch: ssl-env-cert
   specs:
     httpclient (2.8.3)


### PR DESCRIPTION
**What this PR does / why we need it**:

* Updates the fork used for the `httpclient` ruby gem

same exact code on both forks - the 3scale one having the benefit that it doesn't depend on an external (nowadays) contributor.

* Fixes version of httpclient

the `require_relative` change is necessary for bundler to be able to correctly resolve the dependencies provided by Cachito

(cherry picked from commit f916a10ef03068a119f84f394730e098e24ba6f7)
> Replace this with a quick explanation of what's included here. 

**Special notes for your reviewer**:

I would like to promote this fix to `managed-services` stream, so that continuous product builds are functional again. (they'll be broken until this is ported over). 

Perhaps merging all commits from `master` to `managed-services` is preferred, but in case it isn't, we can use this PR in the meantime. 