### PR TITLE
CMS API: Remove wrong params for DELETE file

### DIFF
--- a/app/controllers/admin/api/cms/files_controller.rb
+++ b/app/controllers/admin/api/cms/files_controller.rb
@@ -102,11 +102,6 @@ class Admin::Api::CMS::FilesController < Admin::Api::CMS::BaseController
   #
   ##~ op.parameters.add @parameter_access_token
   ##~ op.parameters.add @parameter_file_id
-  ##~ op.parameters.add :name => "path", :description => "URI of the file", :paramType => "query"
-  ##~ op.parameters.add :name => "section_id", :description => "ID of a section (valid only for pages)", :type => "int", :paramType => "query", :default => "root section id"
-  ##~ op.parameters.add :name => "tag_list", :description => "List of the tags", :paramType => "query"
-  ##~ op.parameters.add :name => "attachment", :paramType => "query"
-  ##~ op.parameters.add :name => "downloadable", :description => "Checked sets the content-disposition to attachment", :type => "boolean", :paramType => "query", :default => "false"
   def destroy
     @file.destroy
     respond_with @file, location: admin_api_cms_files_path(@file)

--- a/doc/active_docs/CMS API.json
+++ b/doc/active_docs/CMS API.json
@@ -181,34 +181,6 @@
               "dataType": "int",
               "required": true,
               "paramType": "path"
-            },
-            {
-              "name": "path",
-              "description": "URI of the file",
-              "paramType": "query"
-            },
-            {
-              "name": "section_id",
-              "description": "ID of a section (valid only for pages)",
-              "type": "int",
-              "paramType": "query",
-              "default": "root section id"
-            },
-            {
-              "name": "tag_list",
-              "description": "List of the tags",
-              "paramType": "query"
-            },
-            {
-              "name": "attachment",
-              "paramType": "query"
-            },
-            {
-              "name": "downloadable",
-              "description": "Checked sets the content-disposition to attachment",
-              "type": "boolean",
-              "paramType": "query",
-              "default": "false"
             }
           ]
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

The OpenAPI v1 spec for the CMS API contains some wrong parameters for the DELETE File endpoint

**Which issue(s) this PR fixes** 

This is part of: [THREESCALE-8991](https://issues.redhat.com/browse/THREESCALE-8991)
