### PR TITLE
fix rake in production environment

### DIFF
--- a/lib/tasks/licenses.rake
+++ b/lib/tasks/licenses.rake
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 namespace :licenses do  # rubocop:disable Metrics/BlockLength
-  require 'license_finder'
-
   report_path = Rails.root.join('doc/licenses/licenses.xml')
 
   desc 'Generates a report with the dependencies and their licenses'
@@ -40,7 +38,10 @@ namespace :licenses do  # rubocop:disable Metrics/BlockLength
   private
 
   def cli
-    @cli ||= LicenseFinder::CLI::Main.new
+    @cli ||= begin
+               require 'license_finder'
+               LicenseFinder::CLI::Main.new
+             end
   end
 
   def license_finder_report(path)


### PR DESCRIPTION
rake fails in production environment (read container images) with the changes from #3093

```
LoadError: cannot load such file -- license_finder
```

Because `license_finder` is a development dependency and these are
not installed in images, the `require` statement should only be
evaluated if one tries to call the dependent tasks.

Otherwise any rake call raises an error to load `license_finder`.

This is consistent with how it worked when we used cli.