### PR TITLE
CMS API: Pages: Fix update section

### DIFF
--- a/test/functional/admin/api/cms/templates_controller_test.rb
+++ b/test/functional/admin/api/cms/templates_controller_test.rb
@@ -10,56 +10,175 @@ class Admin::Api::CMS::TemplatesControllerTest < ActionController::TestCase
     @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[cms]).value
   end
 
-  def test_show
-    CMS::Portlet.available.each do |portlet_type|
-      portlet = FactoryBot.create(:cms_portlet, provider: @provider,
-        portlet_type: portlet_type.to_s, type: portlet_type.to_s)
+  class TemplatesControllerMethodsTest < Admin::Api::CMS::TemplatesControllerTest
+    def test_show
+      CMS::Portlet.available.each do |portlet_type|
+        portlet = FactoryBot.create(:cms_portlet, provider: @provider,
+          portlet_type: portlet_type.to_s, type: portlet_type.to_s)
 
-      get :show, params: { id: portlet.id, format: :xml, access_token: @token }
+        get :show, params: { id: portlet.id, format: :xml, access_token: @token }
+
+        assert_response :success
+        assert_equal 0, xml_elements_by_key(@response.body, 'builtin_partial').count
+        assert_equal 1, xml_elements_by_key(@response.body, 'partial').count
+      end
+    end
+
+    def test_show_builtin_partial
+      partial = FactoryBot.create(:cms_builtin_partial, provider: @provider)
+
+      get :show, params: { id: partial.id, format: :xml, access_token: @token }
 
       assert_response :success
-      assert_equal 0, xml_elements_by_key(@response.body, 'builtin_partial').count
-      assert_equal 1, xml_elements_by_key(@response.body, 'partial').count
+      assert_equal 1, xml_elements_by_key(@response.body, 'builtin_partial').count
+      assert_equal 0, xml_elements_by_key(@response.body, 'partial').count
+    end
+
+    def test_create
+      post :create, params: { type: 'page', title: 'About', path: '/about', format: :json, access_token: @token }
+
+      assert_response :success
+    end
+
+    def test_update
+      page = FactoryBot.create(:cms_page, provider: @provider)
+
+      put :update, params: { id: page.id, type: 'page', title: 'About', path: '/about', format: :json, access_token: @token }
+
+      assert_response :success
+    end
+
+    def test_destroy_success
+      page = FactoryBot.create(:cms_page, provider: @provider)
+
+      delete :destroy, params: { id: page.id, format: :json, access_token: @token }
+
+      assert_response :success
+    end
+
+    def test_destroy_locked
+      # builtin pages cannot be destroyed
+      page = FactoryBot.create(:cms_builtin_partial, provider: @provider)
+
+      delete :destroy, params: { id: page.id, format: :json, access_token: @token }
+
+      assert_response :locked
+    end
+
+    private
+
+    def xml_elements_by_key(xml, key)
+      Nokogiri::XML::Document.parse(xml).document.children.xpath("//#{key}")
     end
   end
 
-  def test_show_builtin_partial
-    partial = FactoryBot.create(:cms_builtin_partial, provider: @provider)
+  class TemplatesPageTest < Admin::Api::CMS::TemplatesControllerTest
+    def setup
+      super
+      @section = FactoryBot.create :cms_section, provider: @provider, parent: @provider.sections.root
+      @layout = FactoryBot.create :cms_layout, provider: @provider
+    end
 
-    get :show, params: { id: partial.id, format: :xml, access_token: @token }
+    class Create < TemplatesPageTest
+      def test_create_page_section_nil
+        post :create, params: { type: 'page', title: 'About', path: '/about', format: :json, access_token: @token }
 
-    assert_response :success
-    assert_equal 1, xml_elements_by_key(@response.body, 'builtin_partial').count
-    assert_equal 0, xml_elements_by_key(@response.body, 'partial').count
-  end
+        page = @provider.pages.last
+        assert_equal @provider.sections.root, page.section
+      end
 
-  def test_create
-    post :create, params: { section_name: { '0' => 'foooo' }, template: { type: 'page',
-      title: 'About', path: '/about' }, format: :json, access_token: @token }
+      def test_create_page_section_id
+        post :create, params: { section_id: @section.id, type: 'page',
+                                title: 'About', path: '/about', format: :json, access_token: @token }
 
-    assert_response :success
-  end
+        page = @provider.pages.last
+        assert_equal @section, page.section
+      end
 
-  def test_destroy_success
-    page = FactoryBot.create(:cms_page, provider: @provider)
+      def test_create_page_section_name
+        post :create, params: { section_name: @section.system_name, type: 'page',
+                                title: 'About', path: '/about', format: :json, access_token: @token }
 
-    delete :destroy, params: { id: page.id, format: :json, access_token: @token }
+        page = @provider.pages.last
+        assert_equal @section, page.section
+      end
 
-    assert_response :success
-  end
+      def test_create_page_layout_nil
+        post :create, params: { type: 'page', title: 'About', path: '/about', format: :json, access_token: @token }
 
-  def test_destroy_locked
-    # builtin pages cannot be destroyed
-    page = FactoryBot.create(:cms_builtin_partial, provider: @provider)
+        page = @provider.pages.last
+        assert_nil page.layout
+      end
 
-    delete :destroy, params: { id: page.id, format: :json, access_token: @token }
+      def test_create_page_layout_id
+        post :create, params: { layout_id: @layout.id, type: 'page',
+                                title: 'About', path: '/about', format: :json, access_token: @token }
 
-    assert_response :locked
-  end
+        page = @provider.pages.last
+        assert_equal @layout, page.layout
+      end
 
-  private
+      def test_create_page_layout_name
+        post :create, params: { layout_name: @layout.system_name, type: 'page',
+                                title: 'About', path: '/about', format: :json, access_token: @token }
 
-  def xml_elements_by_key(xml, key)
-    Nokogiri::XML::Document.parse(xml).document.children.xpath("//#{key}")
+        page = @provider.pages.last
+        assert_equal @layout, page.layout
+      end
+    end
+
+    class Update < TemplatesPageTest
+      def test_update_page_section_nil
+        page = FactoryBot.create(:cms_page, provider: @provider, section: @section)
+
+        put :update, params: { id: page.id, type: 'page', title: 'About', path: '/about', format: :json, access_token: @token }
+
+        assert_equal @section, page.section
+      end
+
+      def test_update_page_section_id
+        page = FactoryBot.create(:cms_page, provider: @provider)
+
+        put :update, params: { id: page.id, section_id: @section.id, type: 'page',
+                                title: 'About', path: '/about', format: :json, access_token: @token }
+
+        assert_equal @section, page.reload.section
+      end
+
+      def test_update_page_section_name
+        page = FactoryBot.create(:cms_page, provider: @provider)
+
+        put :update, params: { id: page.id, section_name: @section.system_name, type: 'page',
+                                title: 'About', path: '/about', format: :json, access_token: @token }
+
+        assert_equal @section, page.reload.section
+      end
+
+      def test_update_page_layout_nil
+        page = FactoryBot.create(:cms_page, provider: @provider, layout: @layout)
+
+        put :update, params: { id: page.id, type: 'page', title: 'About', path: '/about', format: :json, access_token: @token }
+
+        assert_equal @layout, page.layout
+      end
+
+      def test_update_page_layout_id
+        page = FactoryBot.create(:cms_page, provider: @provider)
+
+        put :update, params: { id: page.id, layout_id: @layout.id, type: 'page',
+                                title: 'About', path: '/about', format: :json, access_token: @token }
+
+        assert_equal @layout, page.reload.layout
+      end
+
+      def test_update_page_layout_name
+        page = FactoryBot.create(:cms_page, provider: @provider)
+
+        put :update, params: { id: page.id, layout_name: @layout.system_name, type: 'page',
+                                title: 'About', path: '/about', format: :json, access_token: @token }
+
+        assert_equal @layout, page.reload.layout
+      end
+    end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

There's a bug in the CMS templates controller that prevents updating a CMS section for a page using the API.

Besides, I refactored the code a bit to handle the sections and the layouts using the same design, it was a bit confusing for me when I saw the old code the first time.

I also added some tests to ensure all combinations are working fine.

**Which issue(s) this PR fixes** 

This is part of [THREESCALE-8991](https://issues.redhat.com/browse/THREESCALE-8991)

**Verification steps** 

The next request should update the section for the given page:

```
curl --request PUT \
  --url 'http://provider-admin.3scale.localhost:3000/admin/api/cms/templates/$ID?access_token=$TOKEN' \
  --header 'Content-Type: application/json' \
  --data '{
        "type": "page",
        "title": "test API2",
        "path": "/testUI2",
        "section_name": "application aºlerts"
}                                           
'

```  

**Special notes for your reviewer**:

These are the possible parameter combinations and the value they should write in the DB:

**Section:**
|| #create  | #update |
|------| ------------- | ------------- |
|**id**: nil, **name**: nil| root  | previous_value  |
|**id**: nil, **name**: name_value| name_value  | name_value  |
|**id**: id_value, **name**: nil| id_value  | id_value  |
|**id**: id_value, **name**: name_value| id_value  | id_value  |



**Layout:**
|| #create  | #update |
|------| ------------- | ------------- |
|**id**: nil, **name**: nil| nil  | previous_value  |
|**id**: nil, **name**: name_value| name_value  | name_value  |
|**id**: id_value, **name**: nil| id_value  | id_value  |
|**id**: id_value, **name**: name_value| id_value  | id_value  |

