### PR TITLE
CMS: Enforce params security for templates

### DIFF
--- a/app/controllers/provider/admin/cms/templates_controller.rb
+++ b/app/controllers/provider/admin/cms/templates_controller.rb
@@ -27,7 +27,7 @@ class Provider::Admin::CMS::TemplatesController < Provider::Admin::CMS::BaseCont
   def update
     @page ||= templates.find(params[:id])
 
-    @page.assign_attributes(template_params, without_protection: true)
+    @page.assign_attributes(template_params)
     @page.build_version if params[:version]
 
     if @page.save

--- a/app/models/cms/base_page.rb
+++ b/app/models/cms/base_page.rb
@@ -2,8 +2,6 @@ class CMS::BasePage < CMS::Template
   self.search_type = 'page'
   self.search_origin = 'own'
 
-  attr_accessible :layout
-
   belongs_to :layout, :class_name => 'CMS::Layout'
   belongs_to :section, :class_name => 'CMS::Section'
 

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -12,7 +12,7 @@ class CMS::Page < CMS::BasePage
 
   include Searchable
 
-  attr_accessible :title, :section, :path, :content_type, :tag_list, :system_name
+  attr_accessible :title, :section, :layout, :path, :content_type, :tag_list, :system_name
 
   belongs_to :section, class_name: 'CMS::Section', touch: true
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In the templates controller for the UI, `assign_attributes` was being called with `without_protection: true` to bypass the strong parameters protection. I removed that option and unified the mass_assignment whitelist in `CMS::Page`.

**Which issue(s) this PR fixes** 

This is part of [THREESCALE-8991](https://issues.redhat.com/browse/THREESCALE-8991)

**Verification steps** 

Nothing should change in the user experience.

