### PR TITLE
CMS Layout: remove strict mass assignment protection

### DIFF
--- a/app/controllers/provider/admin/cms/templates_controller.rb
+++ b/app/controllers/provider/admin/cms/templates_controller.rb
@@ -45,9 +45,7 @@ class Provider::Admin::CMS::TemplatesController < Provider::Admin::CMS::BaseCont
       end
     else
       respond_to do |format|
-        format.html do
-          render :edit
-        end
+        format.html { render :edit }
 
         format.js { render template: '/provider/admin/cms/templates/update' }
       end

--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -2,8 +2,6 @@ class CMS::Layout < CMS::Template
   self.search_type = 'layout'
   attr_accessible :system_name, :draft, :title
 
-  self.mass_assignment_sanitizer = :strict
-
   has_many :pages, :class_name => 'CMS::Page'
   validates :system_name, presence: true
   validate :yield_content_presence, :if => :is_main_layout?

--- a/test/integration/provider/admin/cms/layouts_test.rb
+++ b/test/integration/provider/admin/cms/layouts_test.rb
@@ -19,9 +19,5 @@ class Provider::Admin::CMS::LayoutsTest < ActionDispatch::IntegrationTest
       assert_response :redirect
       assert_equal "<abc>#{i}</abc>", layout.reload.draft
     end
-
-    params[:cms_template][:not_existing] = 'alaska'
-    System::ErrorReporting.expects(:report_error).never
-    put provider_admin_cms_layout_path(params)
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Mass assignment sanitizer was set to `:strict`, only for CMS Layouts in all the project, which is strange. This produces an exception when somebody try to mass-assign parameters that are not explicitly white listed by `attr_accessible` ([app/models/cms/layout.rb](https://github.com/3scale/porta/blob/b3b774b16bb3be0c3f87cb456227df3aa1c5db2b/app/models/cms/layout.rb#L3))

This was introduced in this [commit](https://github.com/3scale/system/commit/4be79c1382fee617308a3f37987bacb1ae81c0e9), and I'm not sure what is it for. AIUI, that commit ensures the content of the layout draft is not lost when somebody tries to send a parameter which is not in the white list. Buy why would the controller receive such parameter? and anyway, why not just ignore and save the layout? It must be a fix for a particular problem happening back then and I don't think it's relevant anymore, specially after this [commit](https://github.com/3scale/system/commit/adff489c9ecaf019b6cc628a3c4109996e263c34#diff-0c42d065b2f6897046bcaf07b95b84732b5b487c44dcab2de97dbe437b202410R26) altered the test that ensures the draft is saved to ensure the opposite... ` ¯\_(ツ)_/¯`.

The problem with this, is that when sending an unpermitted parameter through the API, the exception is raised, instead of just ignore the parameter and save the layout, which is what all other APIs and endpoints do.

This PR basically reverts all that business logic for coherence with all other APIs and because that logic is probably dead code now, since there's a test to ensure it doesn't work.

**Which issue(s) this PR fixes** 

This is part of [THREESCALE-8991](https://issues.redhat.com/browse/THREESCALE-8991)

**Verification steps** 

This request should create the layout successfully:

```
curl --request POST   --url 'http://provider-admin.3scale.localhost:3000/admin/api/cms/templates?access_token=secret'   --header 'Content-Type: application/json'   --data '{
        "type": "layout",
        "title": "test API",
        "system_name": "test_api",
        "section_id": 3
}                      
'
```
