### PR TITLE
Add required Git SCL

### DIFF
--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -2,12 +2,20 @@ FROM quay.io/centos7/ruby-26-centos7
 
 USER root
 
+ENV RUBY_MAJOR_VERSION=2 \
+    RUBY_MINOR_VERSION=6
+
+ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}" \
+    RUBY_SCL_NAME_VERSION="${RUBY_MAJOR_VERSION}${RUBY_MINOR_VERSION}"
+
 ARG BUNDLER_ENV
 ENV BUNDLER_ENV="${BUNDLER_ENV}" \
     TZ=:/etc/localtime \
     BUNDLE_GEMFILE=Gemfile \
     BUNDLE_WITHOUT=development:test \
-    NODEJS_SCL=rh-nodejs12
+    NODEJS_SCL=rh-nodejs12 \
+    RUBY_SCL="rh-ruby${RUBY_SCL_NAME_VERSION}" \
+    GIT_SCL=rh-git227
 
 WORKDIR /opt/system
 
@@ -22,7 +30,8 @@ RUN yum-config-manager --save --setopt=cbs.centos.org_repos_sclo7-rh-ruby26-rh-c
               mysql \
               postgresql10 postgresql10-devel postgresql10-libs \
               file \
-              rh-nodejs12 \
+              $NODEJS_SCL \
+              $GIT_SCL \
     && yum install -y epel-release \
     && yum -y clean all
 

--- a/openshift/system/contrib/scl_enable
+++ b/openshift/system/contrib/scl_enable
@@ -1,4 +1,6 @@
-# This file contains automatic SCL enablement.
+# IMPORTANT: Do not add more content to this file unless you know what you are
+#            doing. This file is sourced everytime the shell session is opened.
+#
+# This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-ruby26
-source scl_source enable $NODEJS_SCL
+source scl_source enable $NODEJS_SCL $RUBY_SCL $GIT_SCL


### PR DESCRIPTION
Applying https://github.com/3scale/porta/pull/3130 to 2.13 stable.

Doing this instead of cherry-picking as it's less error-prone. Otherwise, we'd need to cherry-pick also https://github.com/3scale/porta/commit/363fa0621ee2516d66f76f5a69f196d61f4bc34a but it adds other changes that we are not interested in.
Although `openshift/system/Dockerfile` is not used for downstream builds, but in order to avoid confusion we are not applying any changes to it (like jemalloc library) even for upstream.