### PR TITLE
CircleCI: Remove 3scale-ninjabot key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,9 +195,6 @@ commands: # reusable commands with parameters
 
   clone-oracle-libraries:
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "aa:64:17:1e:6c:ab:2f:d2:ad:35:59:99:05:31:3e:87"
       - run:
           name: "Fetch oracle libraries"
           command: |


### PR DESCRIPTION
**What this PR does / why we need it**:

There's a reference to the 3scale-ninjabot key in our CircleCI configuration. The key was compromised so we need to rotate it, but I think it's not actually being used and I'd like to remove it. I'm creating this PR to launch CircleCI jobs and check if something fails.