### PR TITLE
Fix link on Top Applications table

### DIFF
--- a/app/javascript/src/Stats/lib/application_details.jsx
+++ b/app/javascript/src/Stats/lib/application_details.jsx
@@ -1,20 +1,15 @@
 export const applicationDetails = function (data) {
-  function details (data, type) {
+  function details (data) {
     return {
       id: data.id,
       name: data.name,
-      link: createLink(data, type)
+      link: data.link
     }
   }
 
-  function createLink (data, type) {
-    const id = data.id
-    return (type === 'account') ? `/buyers/accounts/${id}` : `/p/admin/applications/${id}`
-  }
-
   return {
-    account: details(data.application.account, 'account'),
-    application: details(data.application, 'application'),
+    account: details(data.application.account),
+    application: details(data.application),
     total: data.total
   }
 }

--- a/app/javascript/src/Stats/lib/application_details.jsx
+++ b/app/javascript/src/Stats/lib/application_details.jsx
@@ -9,7 +9,7 @@ export const applicationDetails = function (data) {
 
   function createLink (data, type) {
     const id = data.id
-    return (type === 'account') ? `/buyers/accounts/${id}` : `/apiconfig/services/${data.service.id}/applications/${id}`
+    return (type === 'account') ? `/buyers/accounts/${id}` : `/p/admin/applications/${id}`
   }
 
   return {

--- a/app/lib/stats/views/usage.rb
+++ b/app/lib/stats/views/usage.rb
@@ -35,20 +35,23 @@ module Stats
               }
 
         unless @cinstance.nil?
+          application_id = @cinstance.id
+          account_id = @cinstance.user_account.id
+
           result[:application] = {
-            :id    => @cinstance.id,
+            :id    => application_id,
             :name  => @cinstance.name,
             :state => @cinstance.state,
-            :link => provider_admin_application_path(@cinstance.id),
+            :link => provider_admin_application_path(application_id),
             :description => @cinstance.description,
             :plan => {
               :id   => @cinstance.plan.id,
               :name => @cinstance.plan.name
             },
             :account => {
-              :id    => @cinstance.user_account.id,
+              :id    => account_id,
               :name  => @cinstance.user_account.org_name,
-              :link => admin_buyers_account_path(@cinstance.user_account.id)
+              :link => admin_buyers_account_path(account_id)
             },
             service: {
               id: @cinstance.service_id

--- a/app/lib/stats/views/usage.rb
+++ b/app/lib/stats/views/usage.rb
@@ -2,6 +2,11 @@
 module Stats
   module Views
     module Usage
+      extend ActiveSupport::Concern
+
+      included do
+        include System::UrlHelpers.system_url_helpers
+      end
 
       GRANULARITIES = {:year  => :month,
                        :month => :day,
@@ -34,6 +39,7 @@ module Stats
             :id    => @cinstance.id,
             :name  => @cinstance.name,
             :state => @cinstance.state,
+            :link => provider_admin_application_path(@cinstance.id),
             :description => @cinstance.description,
             :plan => {
               :id   => @cinstance.plan.id,
@@ -41,7 +47,8 @@ module Stats
             },
             :account => {
               :id    => @cinstance.user_account.id,
-              :name  => @cinstance.user_account.org_name
+              :name  => @cinstance.user_account.org_name,
+              :link => admin_buyers_account_path(@cinstance.user_account.id)
             },
             service: {
               id: @cinstance.service_id

--- a/spec/javascripts/Stats/lib/application_details.spec.ts
+++ b/spec/javascripts/Stats/lib/application_details.spec.ts
@@ -25,7 +25,7 @@ it('should return a weird object', () => {
       },
       "application": Object {
         "id": 11,
-        "link": "/apiconfig/services/22/applications/11",
+        "link": "/p/admin/applications/11",
         "name": "My Application",
       },
       "total": 100,

--- a/spec/javascripts/Stats/lib/application_details.spec.ts
+++ b/spec/javascripts/Stats/lib/application_details.spec.ts
@@ -6,12 +6,14 @@ it('should return a weird object', () => {
     application: {
       id: 11,
       name: 'My Application',
+      link: '/p/admin/applications/11',
       service: {
         id: 22
       },
       account: {
         id: 33,
-        name: 'My Account'
+        name: 'My Account',
+        link: '/buyers/accounts/33'
       }
     }
   })

--- a/spec/javascripts/Stats/lib/applications_table.spec.ts
+++ b/spec/javascripts/Stats/lib/applications_table.spec.ts
@@ -18,7 +18,7 @@ describe('StatsApplicationsTable', () => {
         application: {
           id: '13',
           name: 'Xiam',
-          link: '/apiconfig/services/5/application/13'
+          link: '/p/admin/applications/13'
         },
         total: 42
       }
@@ -32,7 +32,7 @@ describe('StatsApplicationsTable', () => {
     // let total = table.querySelectorAll('.StatsApplicationsTable-total').[0]
     const total = table.querySelectorAll('.StatsApplicationsTable-total')[0]
 
-    expect(application.href).toBe(`${window.location.origin}/apiconfig/services/5/application/13`)
+    expect(application.href).toBe(`${window.location.origin}/p/admin/applications/13`)
     expect(application.innerHTML).toBe('Xiam')
     expect(account.href).toBe(`${window.location.origin}/buyers/account/7`)
     expect(account.innerHTML).toBe('Chino')

--- a/test/integration/stats/clients_test.rb
+++ b/test/integration/stats/clients_test.rb
@@ -47,11 +47,12 @@ class Stats::ClientsTest < ActionDispatch::IntegrationTest
      "total"=>3,
      "application"=>
       {"name"=>@cinstance.name,
-       "plan"=>{"name"=>@cinstance.plan.name, "id"=>@cinstance.plan.id},
-       "id"=>@cinstance.id,
-       "account"=>{"name"=>@cinstance.user_account.org_name, "id"=>@cinstance.user_account.id},
-       "description"=>@cinstance.description,
-       "state"=>@cinstance.state,
+        "plan"=>{"name"=>@cinstance.plan.name, "id"=>@cinstance.plan.id},
+        "id"=>@cinstance.id,
+        "account"=>{"name"=>@cinstance.user_account.org_name, "link"=>"/buyers/accounts/#{@cinstance.user_account.id}", "id"=>@cinstance.user_account.id},
+        "description"=>@cinstance.description,
+        "state"=>@cinstance.state,
+        "link"=>"/p/admin/applications/#{@cinstance.id}",
        "service"=>{"id"=>@cinstance.service_id}},
      "values"=> [0] * 21 + [2] + [0] * 7 + [1, 0],
      "previous_total" => 1,
@@ -90,9 +91,10 @@ class Stats::ClientsTest < ActionDispatch::IntegrationTest
       {"name"=>@cinstance.name,
        "plan"=>{"name"=>@cinstance.plan.name, "id"=>@cinstance.plan.id},
        "id"=>@cinstance.id,
-       "account"=>{"name"=>@cinstance.user_account.org_name, "id"=>@cinstance.user_account.id},
+       "account"=>{"name"=>@cinstance.user_account.org_name, "link"=>"/buyers/accounts/#{@cinstance.user_account.id}", "id"=>@cinstance.user_account.id},
        "description"=>@cinstance.description,
        "state"=>@cinstance.state,
+       "link"=>"/p/admin/applications/#{@cinstance.id}",
        "service"=>{"id"=>@cinstance.service_id}},
      "values"=> [0] * 21 + [2] + [0] * 7 + [1, 0]
 
@@ -112,9 +114,10 @@ class Stats::ClientsTest < ActionDispatch::IntegrationTest
       {"name"=>@cinstance.name,
        "plan"=>{"name"=>@cinstance.plan.name, "id"=>@cinstance.plan.id},
        "id"=>@cinstance.id,
-       "account"=>{"name"=>@cinstance.user_account.org_name, "id"=>@cinstance.user_account.id},
+       "account"=>{"name"=>@cinstance.user_account.org_name, "link"=>"/buyers/accounts/#{@cinstance.user_account.id}", "id"=>@cinstance.user_account.id},
        "description"=>@cinstance.description,
        "state"=>@cinstance.state,
+       "link"=>"/p/admin/applications/#{@cinstance.id}",
        "service"=>{"id"=>@cinstance.service_id}},
      "values"=> [0] * 29 + [1, 0]
   end

--- a/test/unit/stats/views/usage_test.rb
+++ b/test/unit/stats/views/usage_test.rb
@@ -81,7 +81,7 @@ class Stats::Views::UsageTest < ActiveSupport::TestCase
   test '#usage returns nil if application data does not exist' do
     @dummy.instance_variable_set(:@cinstance, nil)
 
-    assert_equal(@dummy.usage(@options)[:application], nil)
+    assert_nil(@dummy.usage(@options)[:application])
   end
 
   test '#usage returns application data if it exists' do
@@ -101,7 +101,6 @@ class Stats::Views::UsageTest < ActiveSupport::TestCase
     @dummy.instance_variable_set(:@cinstance, cinstance)
 
     assert_equal(
-      @dummy.usage(@options)[:application],
       {
         id: 1,
         name: 'Application',
@@ -120,7 +119,8 @@ class Stats::Views::UsageTest < ActiveSupport::TestCase
         service: {
           id: 1
         }
-      }
+      },
+      @dummy.usage(@options)[:application]
     )
   end
 end

--- a/test/unit/stats/views/usage_test.rb
+++ b/test/unit/stats/views/usage_test.rb
@@ -77,4 +77,50 @@ class Stats::Views::UsageTest < ActiveSupport::TestCase
     @dummy.expects(:usage_values_in_range).twice.returns([0])
     @dummy.usage(@options.merge(skip_change: false))
   end
+
+  test '#usage returns nil if application data does not exist' do
+    @dummy.instance_variable_set(:@cinstance, nil)
+
+    assert_equal(@dummy.usage(@options)[:application], nil)
+  end
+
+  test '#usage returns application data if it exists' do
+    application_plan = FactoryBot.build_stubbed(:application_plan, id: 1, name: 'Application Plan')
+    account = FactoryBot.build_stubbed(:account, id: 1, name: 'Account')
+    service = FactoryBot.build_stubbed(:service, id: 1)
+    cinstance = FactoryBot.build_stubbed(
+      :cinstance,
+      id: 1,
+      name: 'Application',
+      state: 'live',
+      plan: application_plan,
+      user_account: account,
+      service: service
+    )
+
+    @dummy.instance_variable_set(:@cinstance, cinstance)
+
+    assert_equal(
+      @dummy.usage(@options)[:application],
+      {
+        id: 1,
+        name: 'Application',
+        state: 'live',
+        link: '/p/admin/applications/1',
+        description: nil,
+        plan: {
+          id: 1,
+          name: 'Application Plan'
+        },
+        account: {
+          id: 1,
+          name: 'Account',
+          link: '/buyers/accounts/1'
+        },
+        service: {
+          id: 1
+        }
+      }
+    )
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a broken link to Applications listed on the "Top Applications" table. This table may be found in `/services/:service_id/stats/usage/top_applications` or by navigating to `Products > Analytics > Top Applications`.
The old broken link "/apiconfig/services/:service_id/applications/:application_id" was replaced by "/p/admin/applications/:application_id".

<img width="712" alt="Screenshot 2023-01-16 at 17 58 23" src="https://user-images.githubusercontent.com/1305223/212731418-e4f08237-81d3-497c-a517-9d82dee4fce8.png">

**Which issue(s) this PR fixes** 

[THREESCALE-8100](https://issues.redhat.com/browse/THREESCALE-8100)

**Verification steps** 

Navigate to the Top Application view;
Check that the URL to Applications works correctly;

**Special notes for your reviewer**:

About testing:
1. The "Top Applications" table only appears if there are at least 2 Applications to be shown;
2. Setting the chart to display "per month" instead of the default "per day" will display today's usage;

About development:
This PR started with 2 commits: 
- a7c9520c91daf7aff7925cd2db1109d75ed9c095, which has the minimum amount of code to fix this issue;
- e0b0b57595a197b34d23e840ec8a1e730a8ef99a, to get the urls directly from the Rails application (where the routes are defined) instead of inferring routes on the JS Component;