### PR TITLE
Prevent initial re-render in React component

### DIFF
--- a/app/javascript/src/Common/components/SelectWithModal.tsx
+++ b/app/javascript/src/Common/components/SelectWithModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { SortByDirection } from '@patternfly/react-table'
 import escapeRegExp from 'lodash.escaperegexp'
 
@@ -52,11 +52,12 @@ const SelectWithModal = <T extends IRecord>({
   helperTextInvalid,
   fetchItems
 }: Props<T>): React.ReactElement => {
+  let { current: isOnMount } = useRef(true)
+
   const [count, setCount] = useState(itemsCount)
   const [isLoading, setIsLoading] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
   const [page, setPage] = useState(1)
-  const [isOnMount, setIsOnMount] = useState(true)
   const [query, setQuery] = useState('')
   const [pageDictionary, setPageDictionary] = useState(() => paginateCollection(initialItems, PER_PAGE))
 
@@ -106,7 +107,7 @@ const SelectWithModal = <T extends IRecord>({
     }
 
     if (isOnMount) {
-      setIsOnMount(false)
+      isOnMount = false
     } else {
       // perPage 20 to get 4 pages
       fetchItems({ page: 1, perPage: 20, query })


### PR DESCRIPTION
Tiny improvement. Since `onMount` does not really manage anything "UI relevant", the component does not need to render when it changes its value.

By using a ref instead of a state variable the component won't be rendered twice.

Check number of renders in the following images. These are the output of a `console.count` added in the component's body, so every time it is rendered it adds 1.

Before:
<img width="971" alt="Screenshot 2023-01-19 at 17 02 47" src="https://user-images.githubusercontent.com/11672286/213494937-064278fc-aba1-4092-8fbc-ebc2d549c5e9.png">

After:
<img width="971" alt="Screenshot 2023-01-19 at 17 03 25" src="https://user-images.githubusercontent.com/11672286/213494960-5a1d7503-d55e-4034-830b-7ecbfe3912f8.png">
