### PR TITLE
CMS API: Return complete data in queries for single resource

### DIFF
--- a/app/controllers/admin/api/cms/files_controller.rb
+++ b/app/controllers/admin/api/cms/files_controller.rb
@@ -36,7 +36,7 @@ class Admin::Api::CMS::FilesController < Admin::Api::CMS::BaseController
       current_account.files
     end).paginate(page: params[:page] || 1, per_page: per_page)
 
-    respond_with files
+    respond_with(files, short: true)
   end
 
   ##~ op            = e.operations.add

--- a/app/controllers/admin/api/cms/sections_controller.rb
+++ b/app/controllers/admin/api/cms/sections_controller.rb
@@ -23,7 +23,7 @@ class Admin::Api::CMS::SectionsController < Admin::Api::CMS::BaseController
   ##~ op.parameters.add @parameter_per_page
   def index
     @sections = current_account.sections.page(params[:page] || 1).per_page(per_page)
-    respond_with @sections
+    respond_with(@sections, short: true)
   end
 
   ##~ op            = e.operations.add

--- a/app/models/cms/base_page.rb
+++ b/app/models/cms/base_page.rb
@@ -23,4 +23,40 @@ class CMS::BasePage < CMS::Template
     sections.reverse
   end
 
+  def hidden?
+    published.nil?
+  end
+
+  def to_xml(options = {})
+    xml = options[:builder] || Nokogiri::XML::Builder.new
+
+    xml.__send__(options.fetch(:root, :page)) do |x|
+      unless new_record?
+        x.id id
+        x.created_at created_at.xmlschema
+        x.updated_at updated_at.xmlschema
+      end
+
+      x.title title
+      section.to_xml(builder: x, root: 'section', short: true) unless options[:short]
+      x.path(path) if respond_to?(:path)
+      if options[:short]
+        x.layout_name layout_name
+      else
+        layout&.to_xml(builder: x, short: true) || x.layout
+      end
+      x.system_name system_name
+      x.content_type content_type
+      x.liquid_enabled !liquid_enabled.nil?
+      x.handler handler
+      x.hidden hidden?
+
+      unless options[:short]
+        x.draft { |node| node.cdata draft }
+        x.published { |node| node.cdata published }
+      end
+    end
+
+    xml.to_xml
+  end
 end

--- a/app/models/cms/base_page.rb
+++ b/app/models/cms/base_page.rb
@@ -47,7 +47,7 @@ class CMS::BasePage < CMS::Template
       end
       x.system_name system_name
       x.content_type content_type
-      x.liquid_enabled !liquid_enabled.nil?
+      x.liquid_enabled liquid_enabled?
       x.handler handler
       x.hidden hidden?
 

--- a/app/models/cms/builtin.rb
+++ b/app/models/cms/builtin.rb
@@ -133,26 +133,7 @@ class CMS::Builtin < CMS::BasePage
   # CMS::Builtin::Page
   class Page < CMS::Builtin
     def to_xml(options = {})
-      xml = options[:builder] || Nokogiri::XML::Builder.new
-
-      xml.builtin_page do |x|
-        unless new_record?
-          xml.id id
-          xml.created_at created_at.xmlschema
-          xml.updated_at updated_at.xmlschema
-        end
-
-        # x.title title
-        x.system_name system_name
-        x.liquid_enabled liquid_enabled
-
-        unless options[:short]
-          x.draft draft
-          x.published published
-        end
-      end
-
-      xml.to_xml
+      super options.merge(root: :builtin_page)
     end
 
     def content_type

--- a/app/models/cms/builtin.rb
+++ b/app/models/cms/builtin.rb
@@ -122,7 +122,7 @@ class CMS::Builtin < CMS::BasePage
         end
 
         x.system_name system_name
-        x.liquid_enabled liquid_enabled
+        x.liquid_enabled liquid_enabled?
         x.layout layout_name
       end
 
@@ -171,11 +171,6 @@ class CMS::Builtin < CMS::BasePage
     private :destroy
     attr_readonly :system_name
     attr_protected :liquid_enabled
-
-    # TODO: this is a quick fix: we should set the liquid enabled attribute to true when creating builtin templates
-    def liquid_enabled?
-      true
-    end
 
     def self.filesystem_templates
       paths = ORIGINAL_PATHS

--- a/app/models/cms/file.rb
+++ b/app/models/cms/file.rb
@@ -57,10 +57,14 @@ class CMS::File < ApplicationRecord
         xml.created_at created_at.xmlschema
         xml.updated_at updated_at.xmlschema
       end
-      x.section_id section_id
+      if options[:short]
+        x.section_id section_id
+      else
+        section.to_xml(builder:x, root: 'section', short: true)
+      end
       x.path path
+      x.downloadable !downloadable.nil?
       x.url url.to_s
-      x.tag_list tag_list
       x.title title
     end
 

--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -28,11 +28,10 @@ class CMS::Layout < CMS::Template
         xml.updated_at updated_at.xmlschema
       end
 
-      x.system_name system_name
-      x.content_type content_type
-      x.handler handler
-      x.liquid_enabled liquid_enabled
       x.title title
+      x.system_name system_name
+      x.liquid_enabled liquid_enabled
+      x.content_type content_type
 
       unless options[:short]
         x.draft draft

--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -34,8 +34,8 @@ class CMS::Layout < CMS::Template
       x.content_type content_type
 
       unless options[:short]
-        x.draft draft
-        x.published published
+        x.draft { |node| node.cdata draft }
+        x.published { |node| node.cdata published }
       end
     end
 

--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -30,7 +30,7 @@ class CMS::Layout < CMS::Template
 
       x.title title
       x.system_name system_name
-      x.liquid_enabled liquid_enabled
+      x.liquid_enabled liquid_enabled?
       x.content_type content_type
 
       unless options[:short]

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -99,17 +99,22 @@ class CMS::Page < CMS::BasePage
       end
 
       x.title title
-      x.system_name system_name
+      section.to_xml(builder: x, root: 'section', short: true) unless options[:short]
       x.path(path) if respond_to?(:path)
-      x.hidden hidden?
-      x.layout layout_name
+      if options[:short]
+        x.layout_name layout_name
+      else
+        layout&.to_xml(builder: x, short: true) || x.layout
+      end
+      x.system_name system_name
       x.content_type content_type
+      x.liquid_enabled !liquid_enabled.nil?
       x.handler handler
-      x.liquid_enabled liquid_enabled
+      x.hidden hidden?
 
       unless options[:short]
-        x.draft draft
-        x.published published
+        x.draft { |node| node.cdata draft }
+        x.published { |node| node.cdata published }
       end
     end
 

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -54,10 +54,6 @@ class CMS::Page < CMS::BasePage
 
   delegate :public?, :protected?, :to => :section, :allow_nil => true
 
-  def hidden?
-    published.nil?
-  end
-
   def visible?
     not hidden?
   end
@@ -86,39 +82,6 @@ class CMS::Page < CMS::BasePage
   # Returns parsed Mime::Type or default ('text/html')
   def mime_type
     super || Mime::Type.lookup(DEFAULT_CONTENT_TYPE)
-  end
-
-  def to_xml(options = {})
-    xml = options[:builder] || Nokogiri::XML::Builder.new
-
-    xml.page do |x|
-      unless new_record?
-        x.id id
-        x.created_at created_at.xmlschema
-        x.updated_at updated_at.xmlschema
-      end
-
-      x.title title
-      section.to_xml(builder: x, root: 'section', short: true) unless options[:short]
-      x.path(path) if respond_to?(:path)
-      if options[:short]
-        x.layout_name layout_name
-      else
-        layout&.to_xml(builder: x, short: true) || x.layout
-      end
-      x.system_name system_name
-      x.content_type content_type
-      x.liquid_enabled !liquid_enabled.nil?
-      x.handler handler
-      x.hidden hidden?
-
-      unless options[:short]
-        x.draft { |node| node.cdata draft }
-        x.published { |node| node.cdata published }
-      end
-    end
-
-    xml.to_xml
   end
 
   private

--- a/app/models/cms/partial.rb
+++ b/app/models/cms/partial.rb
@@ -30,8 +30,8 @@ class CMS::Partial < CMS::Template
       x.content_type content_type
 
       unless options[:short]
-        x.draft draft
-        x.published published
+        x.draft { |node| node.cdata draft }
+        x.published { |node| node.cdata published }
       end
     end
 

--- a/app/models/cms/partial.rb
+++ b/app/models/cms/partial.rb
@@ -16,6 +16,11 @@ class CMS::Partial < CMS::Template
     super.merge string: "#{system_name}"
   end
 
+  # TODO: this is a quick fix: we should set the liquid enabled attribute to true when creating builtin templates
+  def liquid_enabled?
+    true
+  end
+
   def to_xml(options = {})
     xml = options[:builder] || Nokogiri::XML::Builder.new
 
@@ -28,6 +33,7 @@ class CMS::Partial < CMS::Template
 
       x.system_name system_name
       x.content_type content_type
+      x.liquid_enabled liquid_enabled?
 
       unless options[:short]
         x.draft { |node| node.cdata draft }

--- a/app/models/cms/partial.rb
+++ b/app/models/cms/partial.rb
@@ -28,8 +28,6 @@ class CMS::Partial < CMS::Template
 
       x.system_name system_name
       x.content_type content_type
-      x.handler handler
-      x.liquid_enabled liquid_enabled
 
       unless options[:short]
         x.draft draft

--- a/app/models/cms/section.rb
+++ b/app/models/cms/section.rb
@@ -49,11 +49,26 @@ class CMS::Section < ApplicationRecord
         xml.created_at created_at.xmlschema
         xml.updated_at updated_at.xmlschema
       end
-      x.partial_path partial_path
-      x.public public
       x.title title
-      x.parent_id parent_id
       x.system_name system_name
+      x.public !public.nil?
+      if options[:short]
+        x.parent_id parent_id
+      else
+        x.parent_ do |p|
+          p.id parent.id
+          p.title parent.title
+        end
+      end
+      x.partial_path partial_path
+      unless options[:short]
+        x.contents do |c|
+          pages.to_xml(builder: c, root: 'pages', short: true)
+          files.to_xml(builder: c, root: 'files', short: true)
+          builtins.to_xml(builder: c, root: 'builtins', short: true)
+          children.to_xml(builder: c, root: 'sections', short: true)
+        end
+      end
     end
 
     xml.to_xml

--- a/app/models/cms/section.rb
+++ b/app/models/cms/section.rb
@@ -43,7 +43,7 @@ class CMS::Section < ApplicationRecord
   def to_xml(options = {})
     xml = options[:builder] || Nokogiri::XML::Builder.new
 
-    xml.section do |x|
+    xml.__send__(options.fetch(:root, :section)) do |x|
       unless new_record?
         xml.id id
         xml.created_at created_at.xmlschema
@@ -55,10 +55,7 @@ class CMS::Section < ApplicationRecord
       if options[:short]
         x.parent_id parent_id
       else
-        x.parent_ do |p|
-          p.id parent.id
-          p.title parent.title
-        end
+        parent&.to_xml(builder: x, root: 'parent_', short: true) || x.parent_
       end
       x.partial_path partial_path
       unless options[:short]

--- a/spec/acceptance/api/cms_file_spec.rb
+++ b/spec/acceptance/api/cms_file_spec.rb
@@ -10,6 +10,7 @@ resource 'CMS::File' do
 
     get '/admin/api/cms/files.:format', action: :index do
       let(:collection) { provider.files }
+      let(:serialized) { representer.send(serialization_format, short: true) }
     end
 
     get '/admin/api/cms/files/:id.:format', action: :show

--- a/spec/acceptance/api/cms_file_spec.rb
+++ b/spec/acceptance/api/cms_file_spec.rb
@@ -10,7 +10,7 @@ resource 'CMS::File' do
 
     get '/admin/api/cms/files.:format', action: :index do
       let(:collection) { provider.files }
-      let(:serialized) { representer.send(serialization_format, short: true) }
+      let(:serialized) { representer.public_send(serialization_format, short: true) }
     end
 
     get '/admin/api/cms/files/:id.:format', action: :show

--- a/spec/acceptance/api/cms_section_spec.rb
+++ b/spec/acceptance/api/cms_section_spec.rb
@@ -8,6 +8,7 @@ resource 'CMS::Section' do
 
     get '/admin/api/cms/sections.:format', action: :index do
       let(:collection) { provider.sections.order(:id) }
+      let(:serialized) { representer.send(serialization_format, short: true) }
     end
 
     get '/admin/api/cms/sections/:id.:format', action: :show

--- a/spec/acceptance/api/cms_section_spec.rb
+++ b/spec/acceptance/api/cms_section_spec.rb
@@ -8,7 +8,7 @@ resource 'CMS::Section' do
 
     get '/admin/api/cms/sections.:format', action: :index do
       let(:collection) { provider.sections.order(:id) }
-      let(:serialized) { representer.send(serialization_format, short: true) }
+      let(:serialized) { representer.public_send(serialization_format, short: true) }
     end
 
     get '/admin/api/cms/sections/:id.:format', action: :show

--- a/test/integration/cms/api/files_test.rb
+++ b/test/integration/cms/api/files_test.rb
@@ -116,7 +116,7 @@ module CMS
         assert_response :success
 
         doc = Nokogiri::XML(@response.body)
-        id = doc.xpath('//id').text
+        id = doc.xpath('/file/id').text
         file = @provider.files.find(id.to_i)
         assert_equal 'wide.jpg', file.title
       end

--- a/test/integration/cms/api/sections_test.rb
+++ b/test/integration/cms/api/sections_test.rb
@@ -70,7 +70,7 @@ module CMS
         assert_equal section.id.to_s, doc.xpath('/section/id').text
         assert_equal section.created_at.xmlschema, doc.xpath('/section/created_at').text
         assert_equal section.updated_at.xmlschema, doc.xpath('/section/updated_at').text
-        assert_equal section.parent_id.to_s, doc.xpath('/section/parent_id').text
+        assert_equal section.parent_id.to_s, doc.xpath('/section/parent/id').text
         assert_equal section.system_name, doc.xpath('/section/system_name').text
         assert_equal section.title, doc.xpath('/section/title').text
       end
@@ -102,7 +102,7 @@ module CMS
         assert_response :success
 
         doc = Nokogiri::XML::Document.parse(@response.body)
-        id = doc.xpath('//id').text
+        id = doc.xpath('/section/id').text
         section = @provider.sections.find(id.to_i)
 
         assert_equal 'Foo Bar Lol', section.title

--- a/test/integration/cms/api/templates_test.rb
+++ b/test/integration/cms/api/templates_test.rb
@@ -218,7 +218,7 @@ module CMS
         assert_response :success
 
         doc = Nokogiri::XML::Document.parse(@response.body)
-        id = doc.xpath('//id').text
+        id = doc.xpath('/page/id').text
         page = @provider.pages.find(id.to_i)
 
         assert_equal 'Rake 5000', page.title


### PR DESCRIPTION
**What this PR does / why we need it**:

When requesting a list of resources, the API returns a list of summaries, that's OK; but when requesting a single resource it should return more complete information about it. This PR also reorder the fields in the answer to match the order in the UI, and deletes some fields that are not being used AFAIK.

**Which issue(s) this PR fixes** 

[THREESCALE-8992](https://issues.redhat.com/browse/THREESCALE-8992)

**Verification steps** 

Just send GET queries for single resources like pages, sections, files... etc.
```
curl --request GET \
  --url 'http://provider-admin.3scale.localhost:3000//admin/api/cms/sections/[ID]?access_token=secret'
```
```
curl --request GET \
  --url 'http://provider-admin.3scale.localhost:3000//admin/api/cms/files/[ID]?access_token=secret'
```
```
curl --request GET \
  --url 'http://provider-admin.3scale.localhost:3000//admin/api/cms/templates/[ID]?access_token=secret'
```

