### PR TITLE
💄 Improve Braintree edit page's UX 🧠 🌴

### DIFF
--- a/app/views/provider/admin/account/payment_gateways/braintree_blue/edit.html.slim
+++ b/app/views/provider/admin/account/payment_gateways/braintree_blue/edit.html.slim
@@ -16,28 +16,29 @@ css:
   }
 
   .form-control {
-    display: block;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    font-size: 1rem;
+    border: 1px solid #d1d1d1;
+    color: #393f44;
+    background-color: #fff;
     width: 100%;
-    height: 34px;
-    padding: 6px 12px;
-    font-size: 14px;
-    line-height: 1.428571429;
-    color: #555555;
-    vertical-align: middle;
-    background-color: #ffffff;
-    border: 1px solid #cccccc;
-    border-radius: 4px;
-    - webkit - box - shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-    -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+    padding: 0.375rem;
+    height: 2.25rem;
+    border-radius: 0.1875rem;
+    line-height: 1.5;
   }
 
-  .form-control:focus {
-    border-color: #66afe9;
-    outline: 0;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(102, 175, 233, 0.6);
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(102, 175, 233, 0.6);
+  .form-control.braintree-hosted-fields-focused {
+    outline: none !important;
+    border-color: #0088ce;
+    box-shadow: 0;
+    color: #0088ce;
+  }
+
+  fieldset#hosted-fields.braintree-hosted-fields-focused {
+    display: none;
   }
 
 h2
@@ -64,7 +65,12 @@ p
     = form.input :last_name, required: true
     = form.input :phone, required: true
 
-  = form.inputs "Credit Card Details" do
+  = form.inputs 'Credit Card Details', id: 'fake-fields' do
+    = form.input 'foo', label: 'Number', input_html: { disabled: true }
+    = form.input 'foo', label: 'Expiration Date (MM/YY)', input_html: { disabled: true }
+    = form.input 'foo', label: 'CVV', input_html: { disabled: true }
+
+  = form.inputs "Credit Card Details", id: 'hosted-fields', class: 'braintree-hosted-fields-hidden' do
     ol
       li.string.required#customer_credit_card_number_input
         label for="customer_credit_card_number" Number
@@ -92,7 +98,7 @@ p
 
   = render partial: '/shared/legal_terms_for_cc_details'
   = form.actions do
-    = form.commit_button 'Save credit card'
+    = form.commit_button 'Save credit card', button_html: { disabled: true }
 
 / TODO: All is duplicated. Move this into a pack and use braintree from node_modules
 script src="https://js.braintreegateway.com/web/3.69.0/js/client.min.js"
@@ -100,10 +106,18 @@ script src="https://js.braintreegateway.com/web/3.69.0/js/hosted-fields.min.js"
 javascript:
   const form = document.querySelector('form#new_customer');
   const submit = document.querySelector('button[type="submit"]');
+  const hostedFieldset = document.querySelector('fieldset#hosted-fields')
+  const fakeFieldset = document.querySelector('fieldset#fake-fields')
 
-  if (typeof braintree !== 'undefined') {
+  if (!(form && submit && hostedFieldset && fakeFieldset)) {
+    throw new Error('Required elements not found')
+  }
+
+  const authorization = '#{@braintree_authorization}'
+
+  if (typeof braintree !== 'undefined' && authorization) {
     braintree.client.create({
-      authorization: '#{j @braintree_authorization}'
+      authorization
     }, function(clientErr, clientInstance) {
       if (clientErr) {
         console.error(clientErr);
@@ -147,7 +161,9 @@ javascript:
           return;
         }
 
-        submit.removeAttribute('disabled');
+        fakeFieldset.remove()
+        hostedFieldset.classList.remove('braintree-hosted-fields-focused')
+        submit.removeAttribute('disabled')
         form.addEventListener('submit', function(event) {
           event.preventDefault();
           event.stopPropagation();

--- a/features/old/providers/wizard_upgrade_plan.feature
+++ b/features/old/providers/wizard_upgrade_plan.feature
@@ -19,6 +19,7 @@ Feature: Wizard Billing information
       | zip               |         | ZIP Code       | false    | false     | false  |
       | vat               |         | VAT Code       | false    | false     | false  |
 
+  @javascript
   Scenario: Steps of the wizard
     When I go to the billing information wizard page
     And I fill in the following:
@@ -31,16 +32,7 @@ Feature: Wizard Billing information
     And I select "Spain" from "Country"
     And I press "Save and continue with payment details"
     And I should be on the provider braintree edit credit card details page
-    When I fill in the following:
-      | First name                | Pepe                    |
-      | Last name                 | Ventura                 |
-      | Company                   | comp                    |
-      | Street address            | Calle Simpecado         |
-      | City                      | Sevilla                 |
-      | ZIP / Postal Code         | 4242                    |
-      | Phone                     | +2342342342             |
-    And I fill in the braintree credit card iframe
-    And I select "Spain" from "Country"
+    And I fill in the braintree credit card form
     And I press "Save credit card"
    Then the current domain should be admin.foo.3scale.localhost
    And I should be on the provider account page


### PR DESCRIPTION
**What this PR does / why we need it**:
* It updates the styles used for hosted fields with actual formtastic styles, so that all fields in the form look the same.
* It also disables the credit card fields if Braintree fails (the fields won't be editable anyway).
* And finally disables the submit button until all required fields are filled.

### Wrong authorization token scenario (hosted fields don't instantiate):
Before:
![](https://user-images.githubusercontent.com/11672286/215464976-05f82879-e2f8-4526-9918-ffe139167fe5.mov)

After:
![](https://user-images.githubusercontent.com/11672286/215465022-24e3e3c1-85b8-4a86-b09f-e7160262a4b3.mov)

### Good authorization token scenario (hosted fields instantiate):
Before:
![](https://user-images.githubusercontent.com/11672286/215465081-b3deec7f-9d4c-4539-88de-6ed54145db05.mov)

After:
![](https://user-images.githubusercontent.com/11672286/215465100-0b6d317a-23c5-473c-99ce-85c2a92e5b71.mov)




