### PR TITLE
better backend defaults

### DIFF
--- a/config/examples/core.yml
+++ b/config/examples/core.yml
@@ -1,6 +1,8 @@
 base: &default
   url: <%= ENV.fetch('THREESCALE_CORE_INTERNAL_API', 'http://localhost:3001/internal/') %>
-  fake_server: 'http://localhost:3000/internal/'
+  # fake server is useful when you don't run a real backend apisonator
+  # fake_server: 'http://localhost:3000/internal/'
+  fake_server: false
   username: <%= ENV.fetch('CONFIG_INTERNAL_API_USER', nil) %>
   password: <%= ENV.fetch('CONFIG_INTERNAL_API_PASSWORD', nil) %>
 
@@ -9,7 +11,6 @@ development:
 
 test:
   <<: *default
-  fake_server: false
 
 preview:
   <<: *default

--- a/config/examples/sandbox_proxy.yml
+++ b/config/examples/sandbox_proxy.yml
@@ -3,19 +3,16 @@ base: &default
     - echo-api.3scale.net
     - hello-world-api.3scale.net
   ignore_test_failures: []
-  hosts:
-    - localhost:8091
-  backend_host: backend:3000
-  shared_secret: dev
-  backend_scheme: http
-  nginx_port: 8080
+  # Backend endpoint as visible by apicast (host.containers.internal in podman)
+  backend_endpoint: http://host.docker.internal:3001
   verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>
   debug: true
   override: 'http://localhost:8091'
   sandbox_endpoint: 'https://%{system_name}-%{account_id}.staging.%{env}apicast.io:%{port}'
   hosted_proxy_endpoint: 'https://%{system_name}-%{account_id}.%{env}apicast.io:%{port}'
-  apicast_staging_endpoint: 'http://%{system_name}-%{account_id}.staging.%{env}apicast.dev:8080'
-  apicast_production_endpoint: 'http://%{system_name}-%{account_id}.%{env}apicast.dev:8080'
+  # APIcast endpoints as visible from the client
+  apicast_staging_endpoint: 'http://%{system_name}-%{account_id}.staging.%{env}apicast.dev.localhost:8080'
+  apicast_production_endpoint: 'http://%{system_name}-%{account_id}.%{env}apicast.dev.localhost:8000'
   skip_deploy: false
   apicast_registry_url: <%= ENV['APICAST_REGISTRY_URL'] %>
   self_managed_apicast_registry_url: <%= ENV['APICAST_REGISTRY_URL'] %>
@@ -32,8 +29,6 @@ test:
   test_api_hosts:
     - echo-api.3scale.net
     - hello-world-api.3scale.net
-  hosts:
-    - 'test.proxy'
   backend_host: '127.0.0.1:4001'
   backend_scheme: 'http'
   shared_secret: 'TEST'


### PR DESCRIPTION
I think we mostly run a real backend when developing. So disable `fake_server`.

and because probably `*.localhost` already resolves to localhost in our
setups, much better to have endpoints use that instead of a domain
that doesn't resolve to what we need.