### PR TITLE
Fix random failure... hopefully

### DIFF
--- a/app/controllers/api/application_plans_controller.rb
+++ b/app/controllers/api/application_plans_controller.rb
@@ -24,7 +24,7 @@ class Api::ApplicationPlansController < Api::PlansBaseController
   # rubocop:enable Lint/UselessMethodDefinition
 
   def masterize
-    super(@service, :default_application_plan)
+    super(service, :default_application_plan)
   end
 
   protected
@@ -34,7 +34,7 @@ class Api::ApplicationPlansController < Api::PlansBaseController
   end
 
   def scope
-    @service || current_account
+    service || current_account
   end
 
   def collection
@@ -42,6 +42,6 @@ class Api::ApplicationPlansController < Api::PlansBaseController
   end
 
   def presenter
-    @presenter ||= Api::ApplicationPlansPresenter.new(service: @service, collection: collection, params: params)
+    @presenter ||= Api::ApplicationPlansPresenter.new(service: service, params: params)
   end
 end

--- a/app/controllers/api/service_plans_controller.rb
+++ b/app/controllers/api/service_plans_controller.rb
@@ -26,7 +26,7 @@ class Api::ServicePlansController < Api::PlansBaseController
   # rubocop:enable Lint/UselessMethodDefinition
 
   def masterize
-    super(@service, :default_service_plan)
+    super(service, :default_service_plan)
   end
 
   protected
@@ -49,6 +49,7 @@ class Api::ServicePlansController < Api::PlansBaseController
   end
 
   def presenter
-    @presenter ||= Api::ServicePlansPresenter.new(service: @service, collection: collection, params: params)
+    @presenter ||= Api::ServicePlansPresenter.new(service: service, params: params)
   end
+
 end

--- a/app/presenters/api/application_plans_presenter.rb
+++ b/app/presenters/api/application_plans_presenter.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Api::ApplicationPlansPresenter < PlansBasePresenter
-  def initialize(service:, collection:, params: {})
-    super(service: service, collection: collection, params: params)
+  def initialize(service:, params: {})
+    super(collection: service.application_plans, params: params)
+    @service = service
   end
 
   private
+
+  attr_reader :service
 
   def current_plan
     service.default_application_plan&.to_json(root: false, only: %i[id name]) || nil.to_json

--- a/app/presenters/api/service_plans_presenter.rb
+++ b/app/presenters/api/service_plans_presenter.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Api::ServicePlansPresenter < PlansBasePresenter
-  def initialize(service:, collection:, params: {})
-    super(service: service, collection: collection, params: params)
+  def initialize(service:, params: {})
+    super(collection: service.provider.service_plans, params: params)
+    @service = service
   end
 
   private
+
+  attr_reader :service
 
   def current_plan
     service.default_service_plan&.to_json(root: false, only: %i[id name]) || nil.to_json

--- a/app/presenters/buyers/account_plans_presenter.rb
+++ b/app/presenters/buyers/account_plans_presenter.rb
@@ -2,9 +2,10 @@
 
 class Buyers::AccountPlansPresenter < PlansBasePresenter
   def initialize(collection:, params: {})
-    super(service: nil, collection: collection, params: params)
+    super(collection: collection, params: params)
   end
 
+  # This smells of :reek:NilCheck because it is nil check.
   def no_available_plans
     plans.default.nil? && plans.published.empty?
   end

--- a/app/presenters/plans_base_presenter.rb
+++ b/app/presenters/plans_base_presenter.rb
@@ -3,15 +3,15 @@
 class PlansBasePresenter
   include System::UrlHelpers.system_url_helpers
 
-  def initialize(service:, collection:, params: {})
-    @service = service
+  # This smells of :reek:FeatureEnvy but we don't care
+  def initialize(collection:, params:)
     @collection = collection
     @pagination_params = { page: params[:page] || 1, per_page: params[:per_page] || 20 }
     @search = ThreeScale::Search.new(params[:search])
     @sorting_params = "plans.#{params[:sort].presence || 'name'} #{params[:direction].presence || 'asc'}"
   end
 
-  attr_reader :service, :collection, :pagination_params, :search, :sorting_params
+  attr_reader :collection, :pagination_params, :search, :sorting_params
 
   def paginated_table_plans
     @paginated_table_plans ||= plans.scope_search(search)
@@ -21,9 +21,9 @@ class PlansBasePresenter
 
   def default_plan_select_data
     {
-      'plans': plans.reorder(name: :asc).to_json(root: false, only: %i[id name]),
+      plans: plans.reorder(name: :asc).to_json(root: false, only: %i[id name]),
       'current-plan': current_plan,
-      'path': masterize_path
+      path: masterize_path
     }
   end
 

--- a/test/unit/presenters/plan_presenters_test.rb
+++ b/test/unit/presenters/plan_presenters_test.rb
@@ -3,8 +3,6 @@
 require 'test_helper'
 
 class PlanPresentersTest < ActiveSupport::TestCase
-  attr_reader :service, :plans
-
   test '#paginated_table_plans can be ordered' do
     assert_equal plans.reorder(name: :desc), presenter({ sort: 'name', direction: 'desc' }).paginated_table_plans
     assert_equal plans.reorder(name: :asc), presenter({ sort: 'name', direction: 'asc' }).paginated_table_plans
@@ -40,7 +38,7 @@ class PlanPresentersTest < ActiveSupport::TestCase
       FactoryBot.create_list(:application_plan, 5, issuer: service)
 
       @plans = @service.application_plans
-                       .order(name: :asc)
+                       .reorder(name: :asc)
     end
 
     test '#paginated_table_plans can search' do
@@ -97,7 +95,7 @@ class PlanPresentersTest < ActiveSupport::TestCase
       FactoryBot.create_list(:account_plan, 5, provider: provider)
 
       @plans = provider.account_plans
-                        .order(name: :asc)
+                        .reorder(name: :asc)
     end
 
     test '#paginated_table_plans can search' do
@@ -121,4 +119,8 @@ class PlanPresentersTest < ActiveSupport::TestCase
   def self.runnable_methods
     PlanPresentersTest == self ? [] : super
   end
+
+  private
+
+  attr_reader :service, :plans
 end

--- a/test/unit/presenters/plan_presenters_test.rb
+++ b/test/unit/presenters/plan_presenters_test.rb
@@ -25,11 +25,11 @@ class PlanPresentersTest < ActiveSupport::TestCase
   end
 
   test '#default_plan_select_data' do
-    assert_equal [:plans, :"current-plan", :path], presenter.default_plan_select_data.keys # rubocop:disable Style/SymbolArray
+    assert_equal [:plans, :'current-plan', :path], presenter.default_plan_select_data.keys # rubocop:disable Style/SymbolArray
   end
 
   test '#plans_table_data' do
-    assert_equal [:columns, :plans, :count, :"search-href"], presenter.plans_table_data.keys # rubocop:disable Style/SymbolArray
+    assert_equal [:columns, :plans, :count, :'search-href'], presenter.plans_table_data.keys # rubocop:disable Style/SymbolArray
   end
 
   class Api::ApplicationPlansPresenterTest < PlanPresentersTest
@@ -55,7 +55,7 @@ class PlanPresentersTest < ActiveSupport::TestCase
     end
 
     def presenter(params = {})
-      Api::ApplicationPlansPresenter.new(service: service, collection: plans, params: params)
+      Api::ApplicationPlansPresenter.new(service: service, params: params)
     end
   end
 
@@ -83,7 +83,7 @@ class PlanPresentersTest < ActiveSupport::TestCase
     end
 
     def presenter(params = {})
-      Api::ServicePlansPresenter.new(service: service, collection: plans, params: params)
+      Api::ServicePlansPresenter.new(service: service, params: params)
     end
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

From time to time `test/unit/presenters/plan_presenters_test.rb:26` fails with the following error:
```
--- expected
+++ actual
@@ -1 +1 @@
-[#<ApplicationPlan id: 55, issuer_id: 20, name: "plan100", rights: nil, full_legal: nil, cost_per_month: 0.0, trial_period_days: nil, created_at: "2023-01-30 11:19:48", updated_at: "2023-01-30 11:19:48", position: 4, state: "hidden", cancellation_period: 0, cost_aggregation_rule: "sum", setup_fee: 0.0, master: false, original_id: 0, type: "ApplicationPlan", issuer_type: "Service", description: nil, approval_required: false, tenant_id: 15, system_name: "plan191", partner_id: nil, contracts_count: 0>, #<ApplicationPlan id: 56, issuer_id: 20, name: "plan101", rights: nil, full_legal: nil, cost_per_month: 0.0, trial_period_days: nil, created_at: "2023-01-30 11:19:48", updated_at: "2023-01-30 11:19:48", position: 5, state: "hidden", cancellation_period: 0, cost_aggregation_rule: "sum", setup_fee: 0.0, master: false, original_id: 0, type: "ApplicationPlan", issuer_type: "Service", description: nil, approval_required: false, tenant_id: 15, system_name: "plan192", partner_id: nil, contracts_count: 0>]
+#<ActiveRecord::AssociationRelation [#<ApplicationPlan id: 57, issuer_id: 20, name: "plan102", rights: nil, full_legal: nil, cost_per_month: 0.0, trial_period_days: nil, created_at: "2023-01-30 11:19:48", updated_at: "2023-01-30 11:19:48", position: 6, state: "hidden", cancellation_period: 0, cost_aggregation_rule: "sum", setup_fee: 0.0, master: false, original_id: 0, type: "ApplicationPlan", issuer_type: "Service", description: nil, approval_required: false, tenant_id: 15, system_name: "plan193", partner_id: nil, contracts_count: 0>, #<ApplicationPlan id: 53, issuer_id: 20, name: "plan98", rights: nil, full_legal: nil, cost_per_month: 0.0, trial_period_days: nil, created_at: "2023-01-30 11:19:48", updated_at: "2023-01-30 11:19:48", position: 2, state: "hidden", cancellation_period: 0, cost_aggregation_rule: "sum", setup_fee: 0.0, master: false, original_id: 0, type: "ApplicationPlan", issuer_type: "Service", description: nil, approval_required: false, tenant_id: 15, system_name: "plan189", partner_id: nil, contracts_count: 0>]>

test/unit/presenters/plan_presenters_test.rb:26:in `block in <class:PlanPresentersTest>'
```
(See error in circleci: https://app.circleci.com/pipelines/github/3scale/porta/22770/workflows/c0aa5366-9bdc-44d3-bd95-b3009992bf09/jobs/258590/tests#failed-test-0)

After taking a quick look, I think the problem is that the `attr_reader` from test and presenter are mixing up, and `@plans` is not what we expect. Renaming `plans` to `test_plans` should do the trick.

Moreover, some linter warnings have also been addressed.