### PR TITLE
Encapsulate `flash` available in React

### DIFF
--- a/app/javascript/src/Types/globals.d.ts
+++ b/app/javascript/src/Types/globals.d.ts
@@ -25,11 +25,4 @@ declare global {
     };
     renderChartWidget: (widget: string, data: unknown) => void;
   }
-
-  interface JQueryStatic {
-    flash: {
-      notice: (msg: string) => void;
-      error: (msg: string) => void;
-    };
-  }
 }

--- a/app/javascript/src/utilities/flash.ts
+++ b/app/javascript/src/utilities/flash.ts
@@ -1,3 +1,13 @@
-// HACK: our flash handler is injected in the global $ in app/assets/javascripts/flash.js
-export const notice = (msg: string): void => { window.$.flash.notice(msg) }
-export const error = (msg: string): void => { window.$.flash.error(msg) }
+interface InjectedJQuery {
+  flash: {
+    notice: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+
+// @ts-expect-error HACK: flash is a function injected in the global $ (see app/assets/javascripts/flash.js).
+// We use the custom type here, instead of in globals.d.ts, to encapsulate all flash usage within this module.
+const { flash } = window.$ as InjectedJQuery
+
+export const notice = (msg: string): void => { flash.notice(msg) }
+export const error = (msg: string): void => { flash.error(msg) }

--- a/spec/javascripts/utilities/flash.spec.ts
+++ b/spec/javascripts/utilities/flash.spec.ts
@@ -1,7 +1,7 @@
 import { error, notice } from 'utilities/flash'
 
-const noticeSpy = jest.spyOn(global.window.$.flash, 'notice')
-const errorSpy = jest.spyOn(global.window.$.flash, 'error')
+const noticeSpy = jest.spyOn((global.window.$ as any).flash, 'notice')
+const errorSpy = jest.spyOn((global.window.$ as any).flash, 'error')
 
 it('should not fail', () => {
   notice('foo')


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now we have `flash` defined as part as `window.$` but also we export a module from `utilities/`. This PR removes the global type and allow to use flash only from that module. From now on, calling `$.flash` will throw a TS error.