### PR TITLE
THREESCALE-8778[UI Strings] Description in Application plan introduction on the application plan list is incorrect

### DIFF
--- a/app/views/api/application_plans/index.html.slim
+++ b/app/views/api/application_plans/index.html.slim
@@ -1,9 +1,9 @@
 h1 Application Plans
 p
-  | Application Plans establish the rules (limits, pricing, features) for 
+  | Application plans establish the rules (limits, pricing, features) for 
   | using your API; every developer's application accessing your API 
   | will be accessing it within the constraints of an application plan. 
-  | From a business perspective, Application Plans allow you to target different 
+  | From a business perspective, application plans allow you to target different 
   | audiences by using multiple plans, that is, basic, pro, premium, 
   | with different sets of rules.
 

--- a/app/views/api/application_plans/index.html.slim
+++ b/app/views/api/application_plans/index.html.slim
@@ -1,9 +1,11 @@
 h1 Application plans
 p
-  | Application plans establish rules like limits, pricing, and features for 
-  | using your API. A developer's application accesses your API 
-  | following the rules of the application plan. Configure application plans 
-  | for specific target audiences with different sets of rules.
+  | Application plans establish the rules (limits, pricing, features) for 
+  | using your API; every developer's application accessing your API 
+  | will be accessing it within the constraints of an application plan. 
+  | From a business perspective, Application Plans allow you to target different 
+  | audiences by using multiple plans, that is, basic, pro, premium, 
+  | with different sets of rules.
 
 - if can_create_plan? ApplicationPlan
   = pf_button_in_title 'Create application plan', new_polymorphic_path([:admin, @service, ApplicationPlan])

--- a/app/views/api/application_plans/index.html.slim
+++ b/app/views/api/application_plans/index.html.slim
@@ -1,6 +1,6 @@
-h1 Application plans
+h1 Application Plans
 p
-  | Application plans establish the rules (limits, pricing, features) for 
+  | Application Plans establish the rules (limits, pricing, features) for 
   | using your API; every developer's application accessing your API 
   | will be accessing it within the constraints of an application plan. 
   | From a business perspective, Application Plans allow you to target different 


### PR DESCRIPTION
**What this PR does / why we need it**:
**Which issue(s) this PR fixes** 

[THREESCALE-8778[UI Strings] Description in Application plan introduction on the application plan list is incorrect](https://issues.redhat.com/browse/THREESCALE-8778)

**Verification steps** 

1. Go to Applications > Applications Plans
2. Confirm the microcopy matches the strings. 

Snapshot: 

![Captura de pantalla 2023-01-31 a las 16 30 41](https://user-images.githubusercontent.com/72191439/215803858-0b49e53f-ba66-475d-b32b-b5ad035ed8ed.png)

**Special notes for your reviewer**: