### PR TITLE
🧪 🥒 Make some cucumbers more robust

### DIFF
--- a/features/step_definitions/applications/applications_steps.rb
+++ b/features/step_definitions/applications/applications_steps.rb
@@ -175,7 +175,7 @@ And(/^has an application$/) do
   step %{an application plan "#{plan_name}" of provider "#{@provider.internal_domain}"}
   step %{a buyer "#{buyer_name}" signed up to application plan "#{plan_name}"}
 
-  @application = Account.find_by_org_name!(buyer_name).bought_cinstance
+  @application = @provider.buyer_accounts.find_by!(org_name: buyer_name).bought_cinstance
 end
 
 Given(/^I'm on that application page$/) do

--- a/features/step_definitions/buyer_steps.rb
+++ b/features/step_definitions/buyer_steps.rb
@@ -62,7 +62,7 @@ end
 
 Given(/^a buyer signed up to the provider$/) do
   step %(an approved buyer "John" signed up to provider "#{@provider.internal_domain}")
-  @buyer = Account.find_by_org_name!('John')
+  @buyer = @provider.buyer_accounts.find_by!(org_name: 'John')
   step 'buyer "John" has application "TimeMachine"'
   @application = @buyer.application_contracts.find_by_name!('TimeMachine')
 end
@@ -77,17 +77,17 @@ Given "a pending buyer {string} signed up to {provider}" do |account_name, provi
   assert buyer.pending?
 end
 
-Given /^an approved buyer "([^\"]*)" signed up to provider "([^\"]*)"$/ do |account_name, provider_account_name|
-  step %(a pending buyer "#{account_name}" signed up to provider "#{provider_account_name}")
+Given "an approved buyer {string} signed up to {provider}" do |account_name, provider|
+  step %(a pending buyer "#{account_name}" signed up to provider "#{provider.org_name}")
 
-  @buyer = Account.find_by_org_name!(account_name)
+  @buyer = provider.buyer_accounts.find_by!(org_name: account_name)
   @buyer.approve! unless @buyer.approved?
 end
 
-Given /^a rejected buyer "([^\"]*)" signed up to provider "([^\"]*)"$/ do |account_name, provider_account_name|
-  step %(a pending buyer "#{account_name}" signed up to provider "#{provider_account_name}")
+Given "a rejected buyer {string} signed up to {provider}" do |account_name, provider|
+  step %(a pending buyer "#{account_name}" signed up to provider "#{provider.org_name}")
 
-  account = Account.find_by_org_name!(account_name)
+  account = provider.buyer_accounts.find_by!(org_name: account_name)
   account.reject!
 end
 
@@ -97,7 +97,7 @@ Given /^a buyer "([^"]*)" signed up to plan "([^"]*)" without providing descript
   # The description is blank already, this is here just to protect us from the future's
   # changes.
 
-  account = Account.find_by_org_name!(account_name)
+  account = ApplicationPlan.find_by!(name: plan_name).provider_account.buyer_accounts.find_by!(org_name: account_name)
   assert account.bought_cinstance.description.blank?
 end
 
@@ -229,7 +229,7 @@ And(/^has a buyer with (application|service) plan/) do |plan|
     step 'a application plan "Metal" of provider "foo.3scale.localhost"'
     step 'a buyer "Alexander" signed up to application plan "Metal"'
   end
-  @buyer = Account.find_by!(org_name: 'Alexander')
+  @buyer = @provider.buyer_accounts.find_by!(org_name: 'Alexander')
 end
 
 When(/^a buyer signs up/) do

--- a/features/step_definitions/buyer_steps.rb
+++ b/features/step_definitions/buyer_steps.rb
@@ -67,21 +67,14 @@ Given(/^a buyer signed up to the provider$/) do
   @application = @buyer.application_contracts.find_by_name!('TimeMachine')
 end
 
-Given "a freshly created buyer {string} signed up to {provider}" do |account_name, provider|
+Given "a pending buyer {string} signed up to {provider}" do |account_name, provider|
   buyer = FactoryBot.create(:buyer_account, :provider_account => provider,
-                  #buyer = FactoryBot.create(:account, :provider_account => provider,
                   :org_name => account_name,
                   :buyer => true)
   buyer.buy! provider.account_plans.default
-end
 
-Given /^a pending buyer "([^\"]*)" signed up to provider "([^\"]*)"$/ do |account_name, provider_account_name|
-  step %(a freshly created buyer "#{account_name}" signed up to provider "#{provider_account_name}")
-
-  account = Account.find_by_org_name!(account_name)
-
-  account.make_pending!
-  assert account.pending?
+  buyer.make_pending!
+  assert buyer.pending?
 end
 
 Given /^an approved buyer "([^\"]*)" signed up to provider "([^\"]*)"$/ do |account_name, provider_account_name|

--- a/features/step_definitions/buyers_management/account_steps.rb
+++ b/features/step_definitions/buyers_management/account_steps.rb
@@ -19,7 +19,7 @@ end
 Given "{provider} has the following buyers with users:" do |provider, buyers|
   buyers = transform_table(buyers)
   buyers.hashes.each do | hash |
-    buyer = Account.find_by_org_name(hash['Account Name'])
+    buyer = provider.buyer_accounts.find_by(org_name: hash['Account Name'])
     unless buyer
       provider_account = Account.find_or_create_by(org_name: provider) do |acc|
         acc.org_name = hash['Account Name']

--- a/features/step_definitions/developer_portal/admin/account/payment_details_steps.rb
+++ b/features/step_definitions/developer_portal/admin/account/payment_details_steps.rb
@@ -22,13 +22,13 @@ When "the buyer is reviewing their account settings" do
 end
 
 When "the buyer is reviewing their credit card details" do
-  stub_stripe_intent_setup if @buyer.provider_account.payment_gateway_type == :stripe # Only stripe need to be stubbed
+  stub_stripe_intent_setup if @buyer.reload.provider_account.payment_gateway_type == :stripe # Only stripe need to be stubbed
   visit admin_account_path
   credit_card_details_tab.click
 end
 
 When "the buyer enters the generic credit card details URL manually" do
-  stub_stripe_intent_setup if @buyer.provider_account.payment_gateway_type == :stripe # Only stripe need to be stubbed
+  stub_stripe_intent_setup if @buyer.reload.provider_account.payment_gateway_type == :stripe # Only stripe need to be stubbed
   visit admin_account_payment_details_path
 end
 
@@ -71,7 +71,7 @@ Given "the buyer {has} added their credit card details" do |has_address|
 end
 
 Then "the buyer can see their billing information" do
-  stub_stripe_intent_setup if @buyer.provider_account.payment_gateway_type == :stripe # Only stripe need to be stubbed
+  stub_stripe_intent_setup if @buyer.reload.provider_account.payment_gateway_type == :stripe # Only stripe need to be stubbed
 
   credit_card_details_tab.click
   assert_buyer_billing_address_details


### PR DESCRIPTION
By removing an unused step definition, I noticed 2 scenarios failed but I could not figure out why. It turns out these particular scenarios rely on 2 buyers created for 2 providers, but the way our steps find those buyers is by `Account.find_by_org_name` so for any X buyers with the same name, only one of them will be found, regardless of the provider they belong too.

This is precisely what happens in commit 30b0c970ad813f9a81e77a7a9f74456d91a478fd, the 2nd buyer is supposed to be approved but it isn't. Instead, the first `buyer_one` is approved twice, making the sign in fail.

The second commit makes sure all buyers are fetched from the provider they belong to.