### PR TITLE
🥒 Fix failing cuke in CI

### DIFF
--- a/features/developer_portal/admin/account/invoices.feature
+++ b/features/developer_portal/admin/account/invoices.feature
@@ -4,17 +4,23 @@ Feature: Dev Portal Buyer Invoices
   I don't want to see any invoices if I my provider does not support it
 
   Background:
-    Given a buyer logged in to a provider
+    Given it's the beginning of the month
+    And a buyer signed up to a provider
+    And no emails have been sent
 
-  Scenario: Provider has charging enabled
-    Given the provider is charging its buyers
+  Scenario: Provider has prepaid monthly charging enabled
+    Given the provider is charging its buyers in prepaid mode
     And the provider has "finance" visible
-    When the buyer is reviewing their account settings
-    Then they should be able to see their invoices
-    And the buyer should receive some emails after a month
+    And 1 month pass
+    When the buyer logs in to the provider
+    And the buyer is reviewing their account settings
+    Then they should be able to see an invoice for last month
+    And the buyer should receive some emails
 
   Scenario: Provider has charging disabled
     Given the provider has "finance" denied
-    When the buyer is reviewing their account settings
+    And 1 month pass
+    When the buyer logs in to the provider
+    And the buyer is reviewing their account settings
     Then they should not be able to see any invoices
-    And the buyer should receive no emails after a month
+    And the buyer should receive no emails

--- a/features/step_definitions/buyer_steps.rb
+++ b/features/step_definitions/buyer_steps.rb
@@ -272,11 +272,17 @@ When "the buyer is reviewing their account details" do
   visit path_to('the account page')
 end
 
-Given "a buyer logged in to a provider" do
+Given "a buyer signed up to a provider" do
   steps %(
     Given a provider exists
     And the provider has a default paid application plan
     And a buyer signed up to the provider
+  )
+end
+
+Given "a buyer logged in to a provider" do
+  steps %(
+    Given a buyer signed up to a provider
     And the buyer logs in to the provider
   )
 end

--- a/features/step_definitions/developer_portal/admin/account/invoices_steps.rb
+++ b/features/step_definitions/developer_portal/admin/account/invoices_steps.rb
@@ -6,20 +6,22 @@ Then "they should not be able to see any invoices" do
   assert_text 'Access Denied'
 end
 
-Then "they should be able to see their invoices" do
+Then "they should be able to see an invoice for last month" do
   invoices_tab.click
   assert admin_account_invoices_path, current_path
+
+  invoices = find_all('tr.invoice')
+
+  assert_equal 1, invoices.length
+  assert invoices.first.has_text?(Time.zone.now.last_month.strftime('%B, %Y'))
 end
 
-Then /^the buyer should receive (no|some) emails after a month$/ do |amount|
-  reset_mailer
-  time_machine(1.send(:month).from_now)
+Then /^the buyer should receive (no|some) emails$/ do |amount|
   email_queue = unread_emails_for(@buyer.emails.first)
 
   case amount
   when 'no' then assert_empty(email_queue)
-  # FIXME: fix the date or something so that it's always 4
-  when 'some' then assert_includes [3, 4], email_queue.size # Invoice notice plus 3 or 4 failed charging attempts depending on date
+  when 'some' then assert_equal 4, email_queue.size # Invoice notice plus 3 failed charging attempts
   end
 end
 

--- a/features/step_definitions/time_steps.rb
+++ b/features/step_definitions/time_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This is a hack used only for debugging.
 When 'I wait a moment' do
   wait_for_requests
@@ -5,4 +7,8 @@ end
 
 When /^I wait (?:for )?(\d+) seconds?$/ do |seconds|
   sleep(seconds.to_i)
+end
+
+Given "it's the beginning of the month" do
+  time_machine(Time.zone.now.at_beginning_of_month)
 end


### PR DESCRIPTION
The mails should not really be tested in this feature but it's better than not test them at all.

2 problems with this scenario:
* Provider mode is `postpaid` and the first month won't be charged, therefore it needs to wait 2 months not 1.
* The emails are not sent right at the start of the month, instead, the billing notice is sent on the 3rd or so day, then every 3 days there will be a charging attempt with its corresponding "charge failed" notification.

Solution:
* Fix the time at beginning of the month
* Fix billing mode as postpaid (even though it is the default) to make it clear 2 months must pass