### PR TITLE
THREESCALE-9162: Fix missing logo on invoices in SaaS

### DIFF
--- a/app/lib/pdf/finance/invoice_report_data.rb
+++ b/app/lib/pdf/finance/invoice_report_data.rb
@@ -140,7 +140,7 @@ class Pdf::Finance::InvoiceReportData
       # read as binary file 'b'
       File.open(logo.path(LOGO_ATTACHMENT_STYLE), 'rb')
     when :s3
-      URI.open(logo.url(LOGO_ATTACHMENT_STYLE))
+      URI.parse(logo.url(LOGO_ATTACHMENT_STYLE)).open
     else
       raise "Invalid attachment type #{storage}"
     end


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix an issue with missing logo on invoices in **SaaS**.

**Which issue(s) this PR fixes** 

Fixes https://issues.redhat.com/browse/THREESCALE-9162

**Verification steps** 

1. Add a Logo in Audience > Developer portal > Logo
2. Create an invoice for an account
3. Generate a PDF invoice
4. Check that the logo appears on the invoice PDF

**Special notes for your reviewer**:

This is a regression caused by https://github.com/3scale/porta/pull/3067 that fixed invoice logo when using file system for paperclip.

This only happens in SaaS, because it's an issue specific to Ruby 2.4.

The `URI.open` call fails with the following error:

```
Failed to retrieve logo: private method `open' called for URI:Module
```

The reason is that in Ruby 2.4 this method is not public, it was only added in later Ruby versions (see [this commit](https://github.com/ruby/ruby/commit/bf287424fd00c0304c836525bb52d89fc1f4a84a)).

`Kernel#open` was used originally, but RuboCop reports a security issue with `Kernel#open`, and actually `URI.open` that was added in https://github.com/3scale/porta/pull/3067 reports it as well :grimacing: This PR changes this to `URI.parse#open` that passes the RuboCop check, and also is compatible with both Ruby 2.4 and 2.6. 