### PR TITLE
Remove the need for Oracle's SYSTEM user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,6 @@ system-builder-ruby26: &system-builder-ruby26
     BUNDLE_FROZEN: true
     BUNDLE_PATH: 'vendor/bundle'
     DISABLE_SPRING: "true"
-    ORACLE_SYSTEM_PASSWORD: threescalepass
     NLS_LANG: AMERICAN_AMERICA.UTF8
     TZ: UTC
     MASTER_PASSWORD: p

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM quay.io/3scale/system-builder:ruby26-nodejs12
 ARG CUSTOM_DB=mysql
 
 ENV DISABLE_SPRING="true" \
-    ORACLE_SYSTEM_PASSWORD="threescalepass" \
     NLS_LANG="AMERICAN_AMERICA.UTF8" \
     TZ="UTC" \
     MASTER_PASSWORD="p" \

--- a/Makefile
+++ b/Makefile
@@ -92,13 +92,13 @@ clean:
 
 oracle-db-setup: ## Creates databases in Oracle
 oracle-db-setup: oracle-database
-	MASTER_PASSWORD=p USER_PASSWORD=p ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" bundle exec rake db:drop db:create db:setup
+	MASTER_PASSWORD=p USER_PASSWORD=p NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" bundle exec rake db:drop db:create db:setup
 
 schema: ## Runs db schema migrations. Run this when you have changes to your database schema that you have added as new migrations.
 schema: POSTGRES_DATABASE_URL ?= "postgresql://postgres:@localhost:5432/3scale_system_development"
 schema:
 	bundle exec rake db:migrate db:schema:dump
-	MASTER_PASSWORD=p USER_PASSWORD=p ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" bundle exec rake db:migrate db:schema:dump
+	MASTER_PASSWORD=p USER_PASSWORD=p NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" bundle exec rake db:migrate db:schema:dump
 	DATABASE_URL=$(POSTGRES_DATABASE_URL) bundle exec rake db:migrate
 
 oracle-database: ## Starts Oracle database container

--- a/SETUP_ORACLE.md
+++ b/SETUP_ORACLE.md
@@ -24,7 +24,7 @@ sudoedit /etc/subgid # add line: myusername:10000:54330
 
 1. Run the script with sudo
 ```shell
-$ sudo ./script/oracle/install-instantclient-packages.sh 
+$ sudo ./script/oracle/install-instantclient-packages.sh
 ```
 
 2. Add following ENV variables to your system (`~/.profile` or `~/.zshrc`)
@@ -68,7 +68,25 @@ You need to have Docker installed and running. You also need to be able to [run 
 
 1. From this repository, do `make oracle-database` and wait to see *DATABASE IS READY TO USE!*.
 
-2. Finally initialize the database with some seed data by running: `DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG=AMERICAN_AMERICA.UTF8 USER_PASSWORD=123456 MASTER_PASSWORD=123456 MASTER_ACCESS_TOKEN=token bundle exec rake db:drop db:create db:setup`
+2. Create a user and GRANT it the necessary permissions
+    ```
+    docker exec -it oracle-database sqlplus system/threescalepass@127.0.0.1:1521/systempdb
+    ```
+    ```sql
+    CREATE USER rails IDENTIFIED BY railspass;
+    GRANT unlimited tablespace TO rails;
+    GRANT create session TO rails;
+    GRANT create table TO rails;
+    GRANT create view TO rails;
+    GRANT create sequence TO rails;
+    GRANT create trigger TO rails;
+    GRANT create procedure TO rails;
+    ```
+
+3. Finally initialize the database with some seed data by running
+    ```
+    DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" NLS_LANG=AMERICAN_AMERICA.UTF8 USER_PASSWORD=123456 MASTER_PASSWORD=123456 MASTER_ACCESS_TOKEN=token bundle exec rake db:drop db:create db:setup
+    ```
 
 ## Troubleshooting
 

--- a/lib/system/database.rb
+++ b/lib/system/database.rb
@@ -151,17 +151,9 @@ ActiveSupport.on_load(:active_record) do
 if System::Database.oracle? && defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::DatabaseTasks)
   ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter::DatabaseTasks.class_eval do
     prepend(Module.new do
-
+      # Overwrites OracleEnhancedAdapter's create method to prevent Database manipulation using the SYSTEM user.
       def create
-        super
-        connection.execute "GRANT create trigger TO #{username}"
-        connection.execute "GRANT create procedure TO #{username}"
-      end
-
-      protected
-
-      def username
-        @config['username']
+        establish_connection(@config)
       end
     end)
   end

--- a/script/oracle/install-instantclient-packages.sh
+++ b/script/oracle/install-instantclient-packages.sh
@@ -3,8 +3,8 @@
 set +o pipefail
 
 # Execute this script by a user with read right ability to /opt/oracle and /opt/system/vendor/oracle
-declare oracle_otn=https://download.oracle.com/otn_software/linux/instantclient/19600
-declare oracle_version=linux.x64-19.6.0.0.0dbru
+declare oracle_otn=https://download.oracle.com/otn_software/linux/instantclient/1918000
+declare oracle_version=linux.x64-19.18.0.0.0dbru
 declare -a packages=(instantclient-sdk instantclient-odbc)
 
 function install_pkg {
@@ -42,6 +42,6 @@ fi
 
 # hack for system-builder ENV
 rm -rf /opt/system/vendor/oracle
-ln -sf /opt/oracle/instantclient_19_6/libsqora.so.19.1 /opt/oracle/instantclient_19_6/libsqora.so
-ln -sf /opt/oracle/instantclient_19_6 /opt/oracle/instantclient
+ln -sf /opt/oracle/instantclient_19_18/libsqora.so.19.1 /opt/oracle/instantclient_19_18/libsqora.so
+ln -sf /opt/oracle/instantclient_19_18 /opt/oracle/instantclient
 cp config/oracle/*.ini /etc/


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the need of Oracle's SYSTEM user to be used by 3scale.

The SYSTEM user is currently used in two situations:
1. During the database creation, SYSTEM is used to create/update and grant permissions to a non-SYSTEM user that will be used to perform the regular connection with the Database. This happens through the `activerecord-oracle_enhanced-adapter` GEM [Source](https://github.com/rsim/oracle-enhanced/blob/release17/lib/active_record/connection_adapters/oracle_enhanced/database_tasks.rb#L19-L26);
2. For 3scale to check if the OracleDB is up, running and ready for connections. [Source](https://github.com/3scale/porta/blob/master/lib/system/connection_probe.rb#L13-L14);

For each case, follows the proposed solutions (in order):

1. Prevent the activerecord-oracle_enhanced-adapter` GEM from performing tasks using the SYSTEM user;
   1. This implies that, when installing 3scale with Oracle, users will be responsible for providing a valid database user for 3scale, as it happens with MySQL and Postgres installations;  
3. Update the current query for a simpler `SELECT 1, dummy FROM dual`, which may be executed by a non-SYSTEM user;

This PR also removes all traces of the `ORACLE_SYSTEM_PASSWORD` ENV variable from `porta` and updates some documentation.

**Which issue(s) this PR fixes** 

[THREESCALE-1175](https://issues.redhat.com/browse/THREESCALE-1175)

**Verification steps** 
Short answer: Use this PR's code to install 3scale with Oracle without providing the `ORACLE_SYSTEM_PASSWORD` ENV variable and assert that the deployment works correctly and that nothing breaks in the application.

Long one:

1.  Follow the [3Scale guide](https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.12/html-single/installing_3scale/index#installing-threescale-with-operator-oracle-system-database) to deploy with Oracle;
1. Provision an Oracle database. Can be done by Installing the Oracle Openshift Operator and creating OracleDB pods. [This is a nice source](https://github.com/oracle/docker-images/blob/main/OracleDatabase/SingleInstance/README.md);
    1. During my tests, I ended-up adding an Oracle instance in the Developer Cluster. Might be easier just to use it;
1. Create a non-SYSTEM user and grant it permissions (see down below in the "Special notes for your reviewer");
1. Add the newly created user to the connection string used by 3scale;
1. Create the 3scale APIManager;
1. The deployment should start;

It took me a while (and some never seen errors) to have this work as expected... Usually because I did something wrong. So feel extra free to contact me about testing this PR :v:

**Special notes for your reviewer**:
Before merging this PR, the documentation changes need to be aligned with the Technical Writers team as, for future installations of 3scale with Oracle, users will need an extra step when creating a non-SYSTEM user. For current running installations, these changes should be harmless, as their non-SYSTEM users already have all necessary permissions.
For future reference, the creation of this non-SYSTEM user should be
``` SQL
CREATE USER rails IDENTIFIED BY railspass;
GRANT unlimited tablespace TO rails;
GRANT create session TO rails;
GRANT create table TO rails;
GRANT create view TO rails;
GRANT create sequence TO rails;
GRANT create trigger TO rails;
GRANT create procedure TO rails;
```
(extracted from the current GRANTs performed by 3scale using the SYSTEM user).