### PR TITLE
free the Sphinx 1/2

### DIFF
--- a/config/docker/thinking_sphinx.yml
+++ b/config/docker/thinking_sphinx.yml
@@ -9,6 +9,7 @@ production:
   big_document_ids: true
 
   configuration_file: <%= ENV.fetch('THINKING_SPHINX_CONFIGURATION_FILE') { Rails.root.join("config/#{Rails.env}.sphinx.conf")} %>
+  indices_location: <%= ENV.fetch('THINKING_SPHINX_INDICES_LOCATION', Rails.root.join("db/sphinx/#{Rails.env}")) %>
 
   # Batch size for real-time index processing (via the `ts:index` and `ts:rebuild` tasks), the default is 1000
   batch_size: <%= ENV.fetch('THINKING_SPHINX_BATCH_SIZE', 1000) %>

--- a/lib/tasks/openshift.rake
+++ b/lib/tasks/openshift.rake
@@ -47,6 +47,11 @@ ERROR_MESSAGE
       daemon.start
     end
 
+    desc 'Generate configuration file for Thinking Sphinx engine'
+    task configure: %i[environment] do
+      ThinkingSphinx::RakeInterface.new(nodetach: true).configure
+    end
+
     desc 'Cleanup pid and lock files from unclean shutdown'
     task cleanup: %i[environment] do
       indices_location = ThinkingSphinx::Configuration.instance.indices_location

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos7/ruby-26-centos7
+FROM quay.io/centos7/ruby-26-centos7 AS porta-base
 
 USER root
 
@@ -91,11 +91,31 @@ RUN export ${BUNDLER_ENV} >/dev/null \
     && rm log/*.log \
     && chmod g+w /opt/system/config
 
-USER 1001
 ADD openshift/system/entrypoint.sh /opt/system/entrypoint.sh
+USER 1001
 EXPOSE 3000 9306
 # TODO: dumb-init!
 ENTRYPOINT ["/opt/system/entrypoint.sh"]
 CMD ["unicorn", "-c", "config/unicorn.rb", "-E", "${RAILS_ENV}", "config.ru"]
 
-# vim: set ft=dockerfile:
+
+FROM porta-base AS porta-sphinx-config
+ENV THINKING_SPHINX_ADDRESS=0.0.0.0 \
+    THINKING_SPHINX_PID_FILE=/var/run/sphinx/searchd.pid \
+    THINKING_SPHINX_INDICES_LOCATION=/var/lib/sphinx \
+    THINKING_SPHINX_CONFIGURATION_FILE=/opt/system/config/standalone.sphinx.conf \
+    RAILS_ENV=production \
+    SECRET_KEY_BASE=dummy \
+    DATABASE_URL='mysql2://root:@localhost/porta'
+USER 0
+RUN yum install -y mariadb-server \
+    && setpriv --reuid 27 --regid 27 --clear-groups mysql_install_db \
+    && (mysqld_safe &) \
+    && cp -v config/docker/thinking_sphinx.yml config/ \
+    && ./entrypoint.sh bundle exec rake db:create db:schema:load openshift:thinking_sphinx:configure \
+    && grep -q "rt_field = account_id" "$THINKING_SPHINX_CONFIGURATION_FILE" \
+    && kill $(</var/run/mariadb/mariadb.pid)
+
+
+FROM porta-base AS porta-prod
+COPY --from=porta-sphinx-config /opt/system/config/standalone.sphinx.conf /opt/system/config/


### PR DESCRIPTION
To allow decoupling of Sphinx and porta container requirements, stop bundling Sphinx with Porta.

But also generate Sphinx configuration file to be easily available when building the searchd standalone image.

part of THREESCALE-8729
