### PR TITLE
Allow removing Redis client ID added by Sidekiq

### DIFF
--- a/app/lib/three_scale/redis_config.rb
+++ b/app/lib/three_scale/redis_config.rb
@@ -5,10 +5,14 @@ module ThreeScale
     def initialize(redis_config = {})
       raw_config = (redis_config || {}).symbolize_keys
       sentinels = raw_config.delete(:sentinels).presence
+      disable_client_id = raw_config.delete(:disable_client_id).presence
       raw_config.delete_if { |key, value| value.blank? }
 
       @config = ActiveSupport::OrderedOptions.new.merge(raw_config)
       config.sentinels = parse_sentinels(sentinels) if sentinels
+
+      # Disable CLIENT SETNAME, for Redis instances that don't support CLIENT command
+      config.id = nil if disable_client_id
     end
 
     attr_reader :config

--- a/config/examples/redis.yml
+++ b/config/examples/redis.yml
@@ -5,6 +5,7 @@ base: &base
   namespace: "<%= ENV['REDIS_NAMESPACE'] %>"
   sentinels: "<%= ENV['REDIS_SENTINEL_HOSTS'] %>"
   role: <%= ENV['REDIS_SENTINEL_ROLE'] %>
+  disable_client_id: <%= ENV.fetch('REDIS_DISABLE_CLIENT_ID', '0') == '1' %>
 
 production:
   <<: *base

--- a/openshift/system/config/redis.yml
+++ b/openshift/system/config/redis.yml
@@ -5,6 +5,7 @@ base: &base
   namespace: "<%= ENV['REDIS_NAMESPACE'] %>"
   sentinels: "<%= ENV['REDIS_SENTINEL_HOSTS'] %>"
   role: <%= ENV['REDIS_SENTINEL_ROLE'] %>
+  disable_client_id: <%= ENV.fetch('REDIS_DISABLE_CLIENT_ID', '0') == '1' %>
 
 production:
   <<: *base


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows disabling setting Redis client ID by Sidekiq, as this is not supported by some cloud providers, e.g. GCP.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/MGDAPI-5164

**Verification steps** 

TBD

**Special notes for your reviewer**:

TBD
