### PR TITLE
Do not expose environment variables at /deploy endpoint

### DIFF
--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -4,14 +4,7 @@ module System
   module Deploy
     mattr_accessor :info
 
-    module BasicInfo
-      def as_json(*)
-        super.merge(rails: Rails::VERSION::STRING, env: ENV.to_hash)
-      end
-    end
-
     class Info
-      include BasicInfo
       attr_reader :revision, :deployed_at
       attr_reader :release
 
@@ -48,7 +41,6 @@ module System
     end
 
     class InvalidInfo
-      include BasicInfo
       attr_reader :release
 
       def initialize(error)

--- a/test/unit/lib/system/deploy_test.rb
+++ b/test/unit/lib/system/deploy_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class BasicInfoTest < ActiveSupport::TestCase
+class DeployTest < ActiveSupport::TestCase
   test 'default release is 2.x' do
     System::Deploy.load_info!
     assert_equal '2.x', System::Deploy.info.release


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the environment variables and the Rails version from the information exposed by the `/deploy` on master account.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

Go to `{MASTER_URL}/deploy` and make sure that the environment variables and the Rails version are not seen. Example response should be:
```
{"revision":"alpha","release":"alpha","deployed_at":"2023-02-09T12:03:44+01:00"}
```

**Special notes for your reviewer**:
