### PR TITLE
Report 2.x version for SaaS, despite what's set in .deploy_info

### DIFF
--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -5,14 +5,15 @@ module System
     mattr_accessor :info
 
     class Info
-      attr_reader :revision, :deployed_at
-      attr_reader :release
+      VERSION = '2.x'
+
+      attr_reader :revision, :deployed_at, :release
 
       delegate :minor_version, :major_version, to: :version
 
       def initialize(info)
         @revision = info.fetch('revision') { `git rev-parse HEAD 2> /dev/null`.strip }
-        @release = info.fetch('release') { '2.x' }
+        @release = ThreeScale.config.onpremises ? info.fetch('release', VERSION) : VERSION
         @deployed_at = info.fetch('deployed_at') { Time.now }
         @error = info.fetch(:error) if info.key?(:error)
       end

--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -4,6 +4,13 @@ module System
   module Deploy
     mattr_accessor :info
 
+    # Provides information about the version of the code:
+    #   - revision: low-level version, that is used by BugSnag as app version
+    #   - release: customer-facing version, that is visible in the admin portal footer
+    #   - deployed_at: timestamp of the deployment
+    # The data is taken from the `.deploy_info` file in the root directory, but for SaaS the release
+    # is overridden with VERSION.
+    # The information is exposed via {MASTER_PORTAL}/deploy endpoint for logged-in users.
     class Info
       VERSION = '2.x'
       private_constant :VERSION

--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -6,6 +6,7 @@ module System
 
     class Info
       VERSION = '2.x'
+      private_constant :VERSION
 
       attr_reader :revision, :deployed_at, :release
 

--- a/test/unit/lib/system/deploy_test.rb
+++ b/test/unit/lib/system/deploy_test.rb
@@ -3,6 +3,7 @@
 require 'test_helper'
 
 class DeployTest < ActiveSupport::TestCase
+
   test 'default release is 2.x' do
     System::Deploy.load_info!
     assert_equal '2.x', System::Deploy.info.release
@@ -14,11 +15,32 @@ class DeployTest < ActiveSupport::TestCase
     assert_equal 'x', System::Deploy.info.minor_version
   end
 
-  test 'custom release' do
-    path = Rails.root.join('test', 'fixtures', 'deploy_info').expand_path
-    System::Deploy.load_info! ActiveSupport::JSON.decode(path.read)
+  class OnpremisesDeployTest < DeployTest
+    setup do
+      ThreeScale.config.stubs(onpremises: true)
+    end
 
-    assert_equal '4', System::Deploy.info.major_version
-    assert_equal '5', System::Deploy.info.minor_version
+    test 'custom release' do
+      path = Rails.root.join('test', 'fixtures', 'deploy_info').expand_path
+      System::Deploy.load_info! ActiveSupport::JSON.decode(path.read)
+
+      assert_equal '4', System::Deploy.info.major_version
+      assert_equal '5', System::Deploy.info.minor_version
+    end
   end
+
+  class SaasDeployTest < DeployTest
+    setup do
+      ThreeScale.config.stubs(onpremises: false)
+    end
+
+    test 'custom release from .deploy_info is ignored' do
+      path = Rails.root.join('test', 'fixtures', 'deploy_info').expand_path
+      System::Deploy.load_info! ActiveSupport::JSON.decode(path.read)
+
+      assert_equal '2', System::Deploy.info.major_version
+      assert_equal 'x', System::Deploy.info.minor_version
+    end
+  end
+
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore what's set in the `.deploy_info` for SaaS, as in the container image the version will be set to `alpha`

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

Start porta with `onpremises: false` in `settings.yml`.
Verify that the version that is shown in the admin portal footer is 2.x

![Screenshot from 2023-02-09 14-32-33](https://user-images.githubusercontent.com/1270328/217837992-31c498b5-2fe7-4354-ac89-d0424ca13012.png)


**Special notes for your reviewer**:
