### PR TITLE
THREESCALE-8902: Remove BUNDLER_ENV

### DIFF
--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -8,9 +8,7 @@ ENV RUBY_MAJOR_VERSION=2 \
 ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}" \
     RUBY_SCL_NAME_VERSION="${RUBY_MAJOR_VERSION}${RUBY_MINOR_VERSION}"
 
-ARG BUNDLER_ENV
-ENV BUNDLER_ENV="${BUNDLER_ENV}" \
-    TZ=:/etc/localtime \
+ENV TZ=:/etc/localtime \
     BUNDLE_GEMFILE=Gemfile \
     BUNDLE_WITHOUT=development:test \
     VARNISH_SCL=rh-varnish5 \
@@ -64,8 +62,7 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     RAILS_ENV=production \
     SAFETY_ASSURED=1
 
-RUN export ${BUNDLER_ENV} >/dev/null\
-    && source /opt/app-root/etc/scl_enable \
+RUN source /opt/app-root/etc/scl_enable \
     && gem install bundler --version 2.2.25 \
     && bundle config build.pg --with-pg-config=/usr/pgsql-13/bin/pg_config \
     && bundle install --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
@@ -78,8 +75,7 @@ ADD package.json ./
 ADD yarn.lock ./
 ADD openshift/system/config/* ./config/
 
-RUN export ${BUNDLER_ENV} >/dev/null \
-    && source /opt/app-root/etc/scl_enable \
+RUN source /opt/app-root/etc/scl_enable \
     && bundle exec rake tmp:create \
     && mkdir -p public/assets db/sphinx \
     && chmod g+w -vfR log tmp public/assets db/sphinx \

--- a/openshift/system/Makefile
+++ b/openshift/system/Makefile
@@ -13,8 +13,6 @@ REMOTE_IMAGE := $(NAMESPACE)/$(LOCAL_IMAGE)
 
 DOCKERFILE := Dockerfile
 
-BUNDLER_ENV += $(foreach env,$(BUNDLER_ENVIRONMENTS),$(env)=$(value $(env)))
-
 all: help
 
 COMPOSE_PROJECT_NAME := openshift-$(PROJECT)
@@ -31,24 +29,21 @@ build: ## Build docker image. Accepts DOCKERFILE parameter. Name will be LOCAL_I
 	# But also mistakenly matches `**/.*` as any file with a dot anywhere.
 	# https://github.com/docker/docker-py/issues/1471
 	# @$(DOCKER_COMPOSE) build --pull system
-	docker build --build-arg BUNDLER_ENV="$(BUNDLER_ENV)" --file "$(DOCKERFILE)" --tag $(LOCAL_IMAGE) --pull ../..
+	docker build --file "$(DOCKERFILE)" --tag $(LOCAL_IMAGE) --pull ../..
 
 run: export LOCAL_IMAGE := $(LOCAL_IMAGE)
 run: export DOCKERFILE := $(DOCKERFILE)
-run: export BUNDLER_ENV := $(BUNDLER_ENV)
 run: $(DOCKER_COMPOSE)
 	$(DOCKER_COMPOSE) run --user=1002 --rm system $(CMD)
 
 up: export LOCAL_IMAGE := $(LOCAL_IMAGE)
 up: export DOCKERFILE := $(DOCKERFILE)
-up: export BUNDLER_ENV := $(BUNDLER_ENV)
 up: $(DOCKER_COMPOSE)
 up: ## Start everything
 	$(DOCKER_COMPOSE) up --abort-on-container-exit system
 
 setup: export LOCAL_IMAGE := $(LOCAL_IMAGE)
 setup: export DOCKERFILE := $(DOCKERFILE)
-setup: export BUNDLER_ENV := $(BUNDLER_ENV)
 setup: ## Run the database setup
 	$(DOCKER_COMPOSE) run --rm -e RAILS_LOG_LEVEL=error system rake db:drop db:setup
 

--- a/openshift/system/docker-compose.yml
+++ b/openshift/system/docker-compose.yml
@@ -12,8 +12,6 @@ services:
     build:
       context: ../..
       dockerfile: openshift/system/${DOCKERFILE:-Dockerfile}
-      args:
-        - BUNDLER_ENV
     env_file:
       .env
     depends_on:

--- a/openshift/system/entrypoint.sh
+++ b/openshift/system/entrypoint.sh
@@ -20,9 +20,6 @@ if [ -d "${EXTRA_CONFIGS_DIR}" ]; then
     done
 fi
 
-# Exporting all bundler environment
-export ${BUNDLER_ENV}
-
 if ldconfig -p | grep jemalloc; then
   LD_PRELOAD="$LD_PRELOAD":$(ldconfig -p | grep jemalloc | head -1 | awk '{ print $1 }')
   export LD_PRELOAD


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes a bunch of `declare -x` statements in the logs when the pods starts.
e.g.
```
declare -x THREESCALE_SANDBOX_PROXY_OPENSSL_VERIFY_MODE="VERIFY_NONE"
declare -x THREESCALE_SUPERDOMAIN="3scale.xxxxxx"
declare -x TZ=":/etc/localtime"
declare -x USER_EMAIL=""
declare -x USER_LOGIN="admin"
```

See the notes below.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-8902

Not sure if it fixes the issue completely, but certainly fixes the issue in [this comment](https://issues.redhat.com/browse/THREESCALE-8902?focusedCommentId=21606681&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21606681)

**Verification steps** 

Build the container image and start the container with the default entrypoint.
See that the environment variables are not printed in the logs.

**Special notes for your reviewer**:

The issue (printing the env vars with values) is caused by the `export ${BUNDLER_ENV}` statement [in the `entrypoint.sh`](https://github.com/3scale/porta/blob/2028c61/openshift/system/entrypoint.sh#L24). `BUNDLER_ENV` doesn't have any value, and `export` command prints out all the env vars.

A simple fix could be to do `export ${BUNDLER_ENV} > /dev/null`.

But I think we don't need this variable in the first place, I couldn't find any place where it would be set to a real value.

At some point it used to be set to something meaningful in the old [system repo](https://github.com/3scale/system/commit/45a21f1e229bd74274aa841115ab545fea11ab3e), but now I can't find where this variable would be set, so I'd say we can get rid of it. 