### PR TITLE
graceful unicorn termination in container

### DIFF
--- a/config/docker/unicorn.rb
+++ b/config/docker/unicorn.rb
@@ -60,6 +60,14 @@ before_fork do |server, _worker|
       # someone else did our job for us
     end
   end
+
+  # Allow graceful shutdown when running in a container with SIGTERM.
+  # It is mostly safe that we revert SIGQUIT to DEFAULT for short
+  # because there are still no workers spawned at this point.
+  # If you want quick shutdown, send SIGINT
+  quit_handler = trap(:QUIT, "DEFAULT")
+  trap(:QUIT, quit_handler)
+  trap(:TERM, quit_handler)
 end
 
 after_fork do |_server, _worker|

--- a/config/unicorn/development.rb
+++ b/config/unicorn/development.rb
@@ -54,6 +54,14 @@ before_fork do |server, worker|
       $stdout.puts "Process already killed..."
     end
   end
+
+  # Allow graceful shutdown when running in a container with SIGTERM.
+  # It is mostly safe that we revert SIGQUIT to DEFAULT for short
+  # because there are still no workers spawned at this point.
+  # If you want quick shutdown, send SIGINT
+  quit_handler = trap(:QUIT, "DEFAULT")
+  trap(:QUIT, quit_handler)
+  trap(:TERM, quit_handler)
 end
 
 


### PR DESCRIPTION
k8s/Openshift sends SIGTERM to containers when terminating them.

This installs same handler for SIGTERM as it is set for SIGQUIT to
make unicorn terminate gracefully instead of killing workers with
active connections.