### PR TITLE
THREESCALE-9323: Add stripe payment description

### DIFF
--- a/app/services/finance/stripe_charge_service.rb
+++ b/app/services/finance/stripe_charge_service.rb
@@ -13,7 +13,7 @@ class Finance::StripeChargeService
 
     # As per Indian regulations the Payment intents should have a description,
     # see https://stripe.com/docs/india-accept-international-payments#valid-charges
-    @gateway_options[:description] = charge_description
+    @gateway_options[:description] ||= default_charge_description
   end
 
   attr_reader :gateway, :payment_method_id, :invoice, :gateway_options
@@ -52,7 +52,7 @@ class Finance::StripeChargeService
 
   def confirm_payment_intent(payment_intent)
     # Passing the gateway option `off_session: false` will cause a `requires_action` status on the payment intent in cases where otherwise it would be `requires_payment_method`.
-    # This happens even when the payment intent has been originally created with `off_session: true` - i.e. Stripe allows us to turn an "off_session" payment intent into an "on_session" one.
+    # This happens even when the payment intent has been originally created with `off_session: true` – i.e. Stripe allows us to turn an "off_session" payment intent into an "on_session" one.
     # Along with the `requires_action` status, the param `next_action.use_stripe_sdk.stripe_js` holds the next-step link to get the transaction authenticated
     response = gateway.confirm_intent(payment_intent.reference, payment_method_id, gateway_options)
 
@@ -81,9 +81,9 @@ class Finance::StripeChargeService
     payment_intent_data if payment_intent_data['object'] == Stripe::PaymentIntent::OBJECT_NAME
   end
 
-  def charge_description
+  def default_charge_description
     return PAYMENT_DESCRIPTION if invoice.blank?
 
-    "#{invoice&.from&.name} #{PAYMENT_DESCRIPTION} #{invoice&.friendly_id}".strip
+    "#{invoice.from.name} #{PAYMENT_DESCRIPTION} #{invoice.friendly_id}".strip
   end
 end

--- a/app/services/finance/stripe_charge_service.rb
+++ b/app/services/finance/stripe_charge_service.rb
@@ -3,12 +3,17 @@
 class Finance::StripeChargeService
   PAYMENT_INTENT_SUCCEEDED = 'succeeded'
   PAYMENT_INTENT_REQUIRES_CONFIRMATION = 'requires_confirmation'
+  PAYMENT_DESCRIPTION = 'API services'
 
   def initialize(gateway, payment_method_id:, invoice: nil, gateway_options: {})
     @gateway = gateway
     @payment_method_id = payment_method_id
     @invoice = invoice
     @gateway_options = gateway_options
+
+    # As per Indian regulations the Payment intents should have a description,
+    # see https://stripe.com/docs/india-accept-international-payments#valid-charges
+    @gateway_options[:description] = charge_description
   end
 
   attr_reader :gateway, :payment_method_id, :invoice, :gateway_options
@@ -47,7 +52,7 @@ class Finance::StripeChargeService
 
   def confirm_payment_intent(payment_intent)
     # Passing the gateway option `off_session: false` will cause a `requires_action` status on the payment intent in cases where otherwise it would be `requires_payment_method`.
-    # This happens even when the payment intent has been originally created with `off_session: true` – i.e. Stripe allows us to turn an "off_session" payment intent into an "on_session" one.
+    # This happens even when the payment intent has been originally created with `off_session: true` - i.e. Stripe allows us to turn an "off_session" payment intent into an "on_session" one.
     # Along with the `requires_action` status, the param `next_action.use_stripe_sdk.stripe_js` holds the next-step link to get the transaction authenticated
     response = gateway.confirm_intent(payment_intent.reference, payment_method_id, gateway_options)
 
@@ -74,5 +79,11 @@ class Finance::StripeChargeService
     response_params = response.params
     payment_intent_data = (response.success? ? response_params : response_params.dig('error', Stripe::PaymentIntent::OBJECT_NAME)) || {}
     payment_intent_data if payment_intent_data['object'] == Stripe::PaymentIntent::OBJECT_NAME
+  end
+
+  def charge_description
+    return PAYMENT_DESCRIPTION if invoice.blank?
+
+    "#{invoice&.from&.name} #{PAYMENT_DESCRIPTION} #{invoice&.friendly_id}".strip
   end
 end

--- a/test/unit/services/finance/charging_service_test.rb
+++ b/test/unit/services/finance/charging_service_test.rb
@@ -67,7 +67,7 @@ module Finance
         stripe_gateway = build_payment_gateway(:stripe)
         service = ChargingService.new(stripe_gateway, buyer_reference: buyer_reference, amount: amount, options: common_options)
 
-        expected_options = common_options.merge(customer: buyer_reference)
+        expected_options = common_options.merge(customer: buyer_reference, description: Finance::StripeChargeService::PAYMENT_DESCRIPTION)
         response_params = { 'id' => 'ch_1HxxDgIxGJbGz9puarvnHz6X', 'paid' => true, 'payment_method' => 'card_1HxtiHIxGJbGz9pusM7rTEYS' }
         stripe_gateway.expects(:purchase).with(amount.cents, nil, expected_options).returns(active_merchant_response(response_params))
 
@@ -80,7 +80,7 @@ module Finance
         stripe_gateway = build_payment_gateway(:stripe_payment_intents)
         service = ChargingService.new(stripe_gateway, buyer_reference: buyer_reference, amount: amount, options: common_options.merge(payment_method_id: payment_method_id))
 
-        expected_options = common_options.merge(customer: buyer_reference, off_session: true, execute_threed: true)
+        expected_options = common_options.merge(customer: buyer_reference, off_session: true, execute_threed: true, description: Finance::StripeChargeService::PAYMENT_DESCRIPTION)
         response_params = { 'id' => 'pi_1I1EAnIxGJbGz9puiiI6e10D', 'paid' => true, 'payment_method' => payment_method_id }
         stripe_gateway.expects(:purchase).with(amount.cents, payment_method_id, expected_options).returns(active_merchant_response(response_params))
 
@@ -98,8 +98,7 @@ module Finance
       end
 
       def payment_gateway_options
-        { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx',
-          endpoint_secret: 'some-secret', description: Finance::StripeChargeService::PAYMENT_DESCRIPTION }
+        { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx', endpoint_secret: 'some-secret' }
       end
     end
   end

--- a/test/unit/services/finance/charging_service_test.rb
+++ b/test/unit/services/finance/charging_service_test.rb
@@ -98,7 +98,8 @@ module Finance
       end
 
       def payment_gateway_options
-        { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx', endpoint_secret: 'some-secret' }
+        { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc', publishable_key: 'pk_test_TYooMQauvdEDq54NiTphI7jx',
+          endpoint_secret: 'some-secret', description: Finance::StripeChargeService::PAYMENT_DESCRIPTION }
       end
     end
   end

--- a/test/unit/services/finance/stripe_charge_service_test.rb
+++ b/test/unit/services/finance/stripe_charge_service_test.rb
@@ -106,12 +106,14 @@ class Finance::StripeChargeServiceTest < ActiveSupport::TestCase
     assert_equal 'requires_payment_method', payment_intent.reload.state
   end
 
-  test 'has payment intent description' do
+  test 'has payment intent description when invoice is present' do
     invoice.update({friendly_id: '2022-10-00000001'})
     invoice.issue_and_pay_if_free!
     with_invoice = build_charge_service(invoice: invoice)
     assert_equal "#{invoice.provider.name} API services 2022-10-00000001", with_invoice.send(:charge_description)
+  end
 
+  test 'has payment intent description with no invoice in charging service' do
     without_invoice = build_charge_service
     assert_equal 'API services', without_invoice.send(:charge_description)
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a description of the Payment Intent - this is not visible in the 3scale UI / API, but will be seen in Stripe dashboard.

It is required for Stripe account operating in India to accept international payments according to https://stripe.com/docs/india-accept-international-payments#valid-charges

**Which issue(s) this PR fixes** 

Fixes [THREESCALE-9323: Add description to Payment Intent for transactions via Stripe payment gateway](https://issues.redhat.com/browse/THREESCALE-9323)

**Verification steps** 
With Stripe configured in the admin portal:

- Create an invoice on an account
- Issue and charge the invoice
- Verify that the payment has succeeded
- Verify in Stripe dashboard that the payment intent has a description
