### PR TITLE
🧑‍💻 Ignore `typescript` errors from tests during development

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -12,4 +12,10 @@ environment.loaders.append('eslint', {
   }
 })
 
+// HACK: this removes transpilation errors in tests during development. tsconfig includes them so
+// that VS Code can work with imports. Ideally we should have a specific config for VS Code but
+// the plugin automatically picks `tsconfig.json` and doesn't support a custom filename.
+const tsLoader = environment.loaders.get('ts')
+tsLoader.options.reportFiles = [/!(spec\/javascripts)/]
+
 module.exports = environment.toWebpackConfig()


### PR DESCRIPTION
I will do this small change to React and the browser will refresh automatically...

![Screenshot 2023-02-23 at 15 41 55](https://user-images.githubusercontent.com/11672286/220939644-c78a9fc9-654f-4ae8-94cb-378ba21c01e8.png)


<img width="750" alt="Screenshot 2023-02-23 at 14 39 24" src="https://user-images.githubusercontent.com/11672286/220936364-39e45b91-b0e1-4a9a-832a-2afcff6f6c3f.png">

But after this PR:
![Screenshot 2023-02-23 at 15 44 59](https://user-images.githubusercontent.com/11672286/220940020-d1fd6074-b7d1-470a-b030-d4f32270ef8e.png)
