### PR TITLE
sphinx clean indices

### DIFF
--- a/config/thinking_sphinx.yml
+++ b/config/thinking_sphinx.yml
@@ -23,6 +23,10 @@ base: &default
   html_index_attrs: "img=alt,title; a=title"
   min_infix_len: 3
 
+  # clean-up orphan records after full reindexing
+  # see https://github.com/pat/thinking-sphinx/pull/1192
+  real_time_tidy: true
+
   # ----------------------------------
   # Data source configuration, see http://sphinxsearch.com/docs/current.html#confgroup-source
   # ----------------------------------

--- a/openshift/system/config/thinking_sphinx.yml
+++ b/openshift/system/config/thinking_sphinx.yml
@@ -24,6 +24,10 @@ production:
   html_index_attrs: "img=alt,title; a=title"
   min_infix_len: 3
 
+  # clean-up orphan records after full reindexing
+  # see https://github.com/pat/thinking-sphinx/pull/1192
+  real_time_tidy: true
+
   # ----------------------------------
   # Data source configuration, see http://sphinxsearch.com/docs/current.html#confgroup-source
   # ----------------------------------


### PR DESCRIPTION
Need more investigation how it works and how exactly to apply it with our custom background jobs indexing (if we keep that to begin with) but the basic idea is described in pat/thinking-sphinx#1192

So basically this is all to make the PR work. The only thing needed is to wipe all indices of sunning sphinx though. Which should happen automatically at present. Except on SaaS.