### PR TITLE
CMS API: Implement API Contract for JSON responses

### DIFF
--- a/app/models/cms/builtin.rb
+++ b/app/models/cms/builtin.rb
@@ -150,8 +150,8 @@ class CMS::Builtin < CMS::BasePage
         x.system_name system_name
         x.layout_id layout_id
         unless options[:short]
-          x.draft { |node| node.cdata draft }
-          x.published { |node| node.cdata published }
+          x.draft { |node| draft.present? ? node.cdata(draft) : nil }
+          x.published { |node| published.present? ? node.cdata(published) : nil }
         end
       end
 

--- a/app/models/cms/builtin.rb
+++ b/app/models/cms/builtin.rb
@@ -150,8 +150,8 @@ class CMS::Builtin < CMS::BasePage
         x.system_name system_name
         x.layout_id layout_id
         unless options[:short]
-          x.draft { |node| draft.present? ? node.cdata(draft) : nil }
-          x.published { |node| published.present? ? node.cdata(published) : nil }
+          x.draft { |node| node.cdata(draft) unless draft.nil? }
+          x.published { |node| node.cdata(published) unless published.nil? }
         end
       end
 

--- a/app/models/cms/builtin.rb
+++ b/app/models/cms/builtin.rb
@@ -150,8 +150,8 @@ class CMS::Builtin < CMS::BasePage
         x.system_name system_name
         x.layout_id layout_id
         unless options[:short]
-          x.draft { |node| node.cdata(draft) unless draft.nil? }
-          x.published { |node| node.cdata(published) unless published.nil? }
+          x.draft { |node| node.cdata(draft) if draft }
+          x.published { |node| node.cdata(published) if published }
         end
       end
 

--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -31,8 +31,8 @@ class CMS::Layout < CMS::Template
       x.system_name system_name
       x.liquid_enabled liquid_enabled
       unless options[:short]
-        x.draft { |node| node.cdata draft }
-        x.published { |node| node.cdata published }
+        x.draft { |node| draft.present? ? node.cdata(draft) : nil }
+        x.published { |node| published.present? ? node.cdata(published) : nil }
       end
     end
 

--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -31,8 +31,8 @@ class CMS::Layout < CMS::Template
       x.system_name system_name
       x.liquid_enabled liquid_enabled
       unless options[:short]
-        x.draft { |node| node.cdata(draft) unless draft.nil? }
-        x.published { |node| node.cdata(published) unless published.nil? }
+        x.draft { |node| node.cdata(draft) if draft }
+        x.published { |node| node.cdata(published) if published }
       end
     end
 

--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -31,8 +31,8 @@ class CMS::Layout < CMS::Template
       x.system_name system_name
       x.liquid_enabled liquid_enabled
       unless options[:short]
-        x.draft { |node| draft.present? ? node.cdata(draft) : nil }
-        x.published { |node| published.present? ? node.cdata(published) : nil }
+        x.draft { |node| node.cdata(draft) unless draft.nil? }
+        x.published { |node| node.cdata(published) unless published.nil? }
       end
     end
 

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -109,8 +109,8 @@ class CMS::Page < CMS::BasePage
       x.handler handler
       x.hidden hidden?
       unless options[:short]
-        x.draft { |node| node.cdata(draft) unless draft.nil? }
-        x.published { |node| node.cdata(published) unless published.nil? }
+        x.draft { |node| node.cdata(draft) if draft }
+        x.published { |node| node.cdata(published) if published }
       end
     end
 

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -100,10 +100,10 @@ class CMS::Page < CMS::BasePage
         x.updated_at updated_at.xmlschema
       end
       x.title title
+      x.system_name system_name
+      x.layout_id layout_id
       x.section_id section_id
       x.path path
-      x.layout_id layout_id
-      x.system_name system_name
       x.content_type content_type
       x.liquid_enabled liquid_enabled?
       x.handler handler

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -109,8 +109,8 @@ class CMS::Page < CMS::BasePage
       x.handler handler
       x.hidden hidden?
       unless options[:short]
-        x.draft { |node| node.cdata draft }
-        x.published { |node| node.cdata published }
+        x.draft { |node| draft.present? ? node.cdata(draft) : nil }
+        x.published { |node| published.present? ? node.cdata(published) : nil }
       end
     end
 

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -109,8 +109,8 @@ class CMS::Page < CMS::BasePage
       x.handler handler
       x.hidden hidden?
       unless options[:short]
-        x.draft { |node| draft.present? ? node.cdata(draft) : nil }
-        x.published { |node| published.present? ? node.cdata(published) : nil }
+        x.draft { |node| node.cdata(draft) unless draft.nil? }
+        x.published { |node| node.cdata(published) unless published.nil? }
       end
     end
 

--- a/app/models/cms/partial.rb
+++ b/app/models/cms/partial.rb
@@ -29,8 +29,8 @@ class CMS::Partial < CMS::Template
       end
       x.system_name system_name
       unless options[:short]
-        x.draft { |node| node.cdata draft }
-        x.published { |node| node.cdata published }
+        x.draft { |node| draft.present? ? node.cdata(draft) : nil }
+        x.published { |node| published.present? ? node.cdata(published) : nil }
       end
     end
 

--- a/app/models/cms/partial.rb
+++ b/app/models/cms/partial.rb
@@ -29,8 +29,8 @@ class CMS::Partial < CMS::Template
       end
       x.system_name system_name
       unless options[:short]
-        x.draft { |node| draft.present? ? node.cdata(draft) : nil }
-        x.published { |node| published.present? ? node.cdata(published) : nil }
+        x.draft { |node| node.cdata(draft) unless draft.nil? }
+        x.published { |node| node.cdata(published) unless published.nil? }
       end
     end
 

--- a/app/models/cms/partial.rb
+++ b/app/models/cms/partial.rb
@@ -29,8 +29,8 @@ class CMS::Partial < CMS::Template
       end
       x.system_name system_name
       unless options[:short]
-        x.draft { |node| node.cdata(draft) unless draft.nil? }
-        x.published { |node| node.cdata(published) unless published.nil? }
+        x.draft { |node| node.cdata(draft) if draft }
+        x.published { |node| node.cdata(published) if published }
       end
     end
 

--- a/app/representers/cms/file_representer.rb
+++ b/app/representers/cms/file_representer.rb
@@ -1,18 +1,22 @@
-module CMS::FileRepresenter
-  include ThreeScale::JSONRepresenter
+# frozen_string_literal: true
 
-  wraps_resource
+module CMS
+  module FileRepresenter
+    include ThreeScale::JSONRepresenter
 
-  property :id
-  property :created_at
-  property :updated_at
-  property :title
-  property :path
-  property :url
-  property :section_id
-  property :tag_list
+    wraps_resource
 
-  link :section do
-    admin_api_cms_section_path section
+    with_options(unless: :new_record?) do
+      property :id
+      property :created_at
+      property :updated_at
+    end
+
+    property :section_id
+    property :path
+    property :downloadable, getter: ->(*) { downloadable? }
+    property :url
+    property :title
+    property :content_type, getter: ->(*) { attachment.content_type }
   end
 end

--- a/app/representers/cms/file_representer.rb
+++ b/app/representers/cms/file_representer.rb
@@ -4,7 +4,7 @@ module CMS
   module FileRepresenter
     include ThreeScale::JSONRepresenter
 
-    wraps_resource
+    wraps_resource ->(*) { self.class.data_tag }
 
     with_options(unless: :new_record?) do
       property :id

--- a/app/representers/cms/layout_representer.rb
+++ b/app/representers/cms/layout_representer.rb
@@ -3,7 +3,7 @@
 module CMS::LayoutRepresenter
   include ThreeScale::JSONRepresenter
 
-  wraps_resource
+  wraps_resource ->(*) { self.class.data_tag }
 
   property :id
   property :created_at

--- a/app/representers/cms/layout_representer.rb
+++ b/app/representers/cms/layout_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CMS::LayoutRepresenter
   include ThreeScale::JSONRepresenter
 
@@ -10,8 +12,8 @@ module CMS::LayoutRepresenter
   property :system_name
   property :liquid_enabled
 
-  with_options(if: ->(options) { !options[:short] }) do |p|
-    p.property :draft, render_nil: true
-    p.property :published, render_nil: true
+  with_options(if: ->(options) { !options[:short] }) do
+    property :draft, render_nil: true
+    property :published, render_nil: true
   end
 end

--- a/app/representers/cms/layout_representer.rb
+++ b/app/representers/cms/layout_representer.rb
@@ -4,17 +4,14 @@ module CMS::LayoutRepresenter
   wraps_resource
 
   property :id
-
-  property :title
-  property :system_name
-  property :content_type
-  property :handler, render_nil: true
-
-  with_options(if: ->(options) { options[:short] == false }) do |p|
-    p.property :published, render_nil: true
-    p.property :draft, render_nil: true
-  end
-
   property :created_at
   property :updated_at
+  property :title
+  property :system_name
+  property :liquid_enabled
+
+  with_options(if: ->(options) { !options[:short] }) do |p|
+    p.property :draft, render_nil: true
+    p.property :published, render_nil: true
+  end
 end

--- a/app/representers/cms/page_representer.rb
+++ b/app/representers/cms/page_representer.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module CMS::PageRepresenter
   include ThreeScale::JSONRepresenter
 
-  wraps_resource -> (*) { self.class.data_tag }
+  wraps_resource ->(*) { self.class.data_tag }
 
   property :id
   property :created_at
@@ -19,8 +21,8 @@ module CMS::PageRepresenter
     p.property :hidden, getter: ->(*) { hidden? }
   end
 
-  with_options(if: ->(options) { !options[:short] }) do |p|
-    p.property :draft, render_nil: true
-    p.property :published, render_nil: true
+  with_options(if: ->(options) { !options[:short] }) do
+    property :draft, render_nil: true
+    property :published, render_nil: true
   end
 end

--- a/app/representers/cms/page_representer.rb
+++ b/app/representers/cms/page_representer.rb
@@ -9,14 +9,14 @@ module CMS::PageRepresenter
   property :created_at
   property :updated_at
   property :title
-  property :system_name
-  property :layout_id
+  property :system_name, render_nil: true
+  property :layout_id, render_nil: true
 
   with_options(if: ->(*) { is_a?(CMS::Page) }) do |p|
     p.property :section_id
     p.property :path, if: ->(*) { respond_to?(:path) }
     p.property :content_type
-    p.property :liquid_enabled
+    p.property :liquid_enabled, getter: ->(*) { liquid_enabled? }
     p.property :handler
     p.property :hidden, getter: ->(*) { hidden? }
   end

--- a/app/representers/cms/page_representer.rb
+++ b/app/representers/cms/page_representer.rb
@@ -1,32 +1,26 @@
 module CMS::PageRepresenter
   include ThreeScale::JSONRepresenter
 
-  wraps_resource
+  wraps_resource -> (*) { self.class.data_tag }
 
   property :id
-
-  with_options(if: ->(options) { options[:short] == false }) do |p|
-    p.property :draft, render_nil: true
-    p.property :published, render_nil: true
-  end
-
-  property :system_name
-  property :liquid_enabled
-
-  with_options(if: ->(*) { is_a?(CMS::Page) }) do |p|
-    # this needs a getter
-    p.property :path, if: ->(*) { respond_to?(:path) }
-    p.property :title
-    p.property :hidden
-    p.property :layout
-    p.property :content_type
-    p.property :handler
-  end
-
   property :created_at
   property :updated_at
+  property :title
+  property :system_name
+  property :layout_id
 
-  def hidden
-    hidden?
+  with_options(if: ->(*) { is_a?(CMS::Page) }) do |p|
+    p.property :section_id
+    p.property :path, if: ->(*) { respond_to?(:path) }
+    p.property :content_type
+    p.property :liquid_enabled
+    p.property :handler
+    p.property :hidden, getter: ->(*) { hidden? }
+  end
+
+  with_options(if: ->(options) { !options[:short] }) do |p|
+    p.property :draft, render_nil: true
+    p.property :published, render_nil: true
   end
 end

--- a/app/representers/cms/partial_representer.rb
+++ b/app/representers/cms/partial_representer.rb
@@ -1,19 +1,15 @@
 module CMS::PartialRepresenter
   include ThreeScale::JSONRepresenter
 
-  wraps_resource
+  wraps_resource -> (*) { self.class.data_tag }
 
   property :id
-  property :system_name
-
-  with_options(if: ->(options) { options[:short] == false }) do |p|
-    p.property :published, render_nil: true
-    p.property :draft, render_nil: true
-  end
-
-  property :handler
-  property :liquid_enabled
-
   property :created_at
   property :updated_at
+  property :system_name
+
+  with_options(if: ->(options) { !options[:short] }) do |p|
+    p.property :draft, render_nil: true
+    p.property :published, render_nil: true
+  end
 end

--- a/app/representers/cms/partial_representer.rb
+++ b/app/representers/cms/partial_representer.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 module CMS::PartialRepresenter
   include ThreeScale::JSONRepresenter
 
-  wraps_resource -> (*) { self.class.data_tag }
+  wraps_resource ->(*) { self.class.data_tag }
 
   property :id
   property :created_at
   property :updated_at
   property :system_name
 
-  with_options(if: ->(options) { !options[:short] }) do |p|
-    p.property :draft, render_nil: true
-    p.property :published, render_nil: true
+  with_options(if: ->(options) { !options[:short] }) do
+    property :draft, render_nil: true
+    property :published, render_nil: true
   end
 end

--- a/app/representers/cms/portlet_representer.rb
+++ b/app/representers/cms/portlet_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CMS::PortletRepresenter
   include ThreeScale::JSONRepresenter
 
@@ -9,13 +11,12 @@ module CMS::PortletRepresenter
   property :portlet_type
   property :name
 
-  with_options(if: ->(options) { options[:short] == false }) do |p|
-    p.property :draft
-    p.property :published
+  with_options(if: ->(options) { !options[:short] }) do
+    property :draft, render_nil: true
+    property :published, render_nil: true
   end
 
   property :liquid_enabled
   property :created_at
   property :updated_at
-
 end

--- a/app/representers/cms/section_representer.rb
+++ b/app/representers/cms/section_representer.rb
@@ -1,15 +1,21 @@
-module CMS::SectionRepresenter
-  include ThreeScale::JSONRepresenter
+# frozen_string_literal: true
 
-  wraps_resource
+module CMS
+  module SectionRepresenter
+    include ThreeScale::JSONRepresenter
 
-  property :id
+    wraps_resource -> (*) { self.class.data_tag }
 
-  property :created_at
-  property :updated_at
-  property :partial_path
-  property :public
-  property :title
-  property :parent_id
-  property :system_name
+    with_options(unless: :new_record?) do
+      property :id
+      property :created_at
+      property :updated_at
+    end
+
+    property :title
+    property :system_name
+    property :public
+    property :parent_id
+    property :partial_path
+  end
 end

--- a/app/representers/cms/section_representer.rb
+++ b/app/representers/cms/section_representer.rb
@@ -12,10 +12,10 @@ module CMS
       property :updated_at
     end
 
-    property :title
+    property :title, render_nil: true
     property :system_name
     property :public
-    property :parent_id
-    property :partial_path
+    property :parent_id, render_nil: true
+    property :partial_path, render_nil: true
   end
 end

--- a/app/representers/cms/section_representer.rb
+++ b/app/representers/cms/section_representer.rb
@@ -4,7 +4,7 @@ module CMS
   module SectionRepresenter
     include ThreeScale::JSONRepresenter
 
-    wraps_resource -> (*) { self.class.data_tag }
+    wraps_resource ->(*) { self.class.data_tag }
 
     with_options(unless: :new_record?) do
       property :id

--- a/spec/acceptance/api/cms_layout_spec.rb
+++ b/spec/acceptance/api/cms_layout_spec.rb
@@ -1,11 +1,38 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-resource "CMS::Layout" do
+resource 'CMS::Layout' do
+  let(:resource) { FactoryBot.create(:cms_layout, body: 'body', draft: 'draft', liquid_enabled: true) }
 
-  let(:resource) { FactoryBot.create(:cms_layout, body: 'body', draft: 'draft') }
-
-  json(:resource) do
+  describe 'representer' do
     let(:root) { 'layout' }
-    it { should have_properties('id', 'content_type', 'handler', 'system_name', 'title').from(resource) }
+
+    context 'when requesting all attributes' do
+      let(:expected_attributes) do
+        %w[id created_at updated_at title system_name liquid_enabled draft published]
+      end
+
+      json(:resource) do
+        it { should have_properties(expected_attributes).from(resource) }
+      end
+
+      xml(:resource) do
+        it { should have_tags(expected_attributes).from(resource) }
+      end
+    end
+
+    context 'when requesting the shorten version' do
+      let(:expected_attributes) { %w[id created_at updated_at title system_name liquid_enabled] }
+      let(:serialized) { representer.public_send(serialization_format, short: true) }
+
+      json(:resource) do
+        it { should have_properties(expected_attributes).from(resource) }
+      end
+
+      xml(:resource) do
+        it { should have_tags(expected_attributes).from(resource) }
+      end
+    end
   end
 end

--- a/spec/acceptance/api/cms_page_spec.rb
+++ b/spec/acceptance/api/cms_page_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+resource 'CMS::Page' do
+  let(:resource) do
+    FactoryBot.create(
+      :cms_page,
+      system_name: 'some-partial',
+      layout_id: 1,
+      handler: 'markdown',
+      body: 'body',
+      draft: 'draft',
+      liquid_enabled: true
+    )
+    end
+
+  describe 'representer' do
+    let(:root) { 'page' }
+
+    context 'when requesting all attributes' do
+      let(:expected_attributes) do
+        %w[
+          id
+          created_at
+          updated_at
+          title
+          system_name
+          layout_id
+          section_id
+          path
+          content_type
+          liquid_enabled
+          handler
+          hidden
+          draft
+          published
+        ]
+      end
+
+      json(:resource, skip_resource_save: true) do
+        it 'should have the correct attributes' do
+          expect(subject.keys).to eq(expected_attributes)
+        end
+      end
+
+      xml(:resource) do
+        it 'should have the correct attributes' do
+          expect(subject.root.elements.map(&:name)).to eq(expected_attributes)
+        end
+      end
+    end
+
+    context 'when requesting the shorten version' do
+      let(:expected_attributes) do
+        %w[
+          id
+          created_at
+          updated_at
+          title
+          system_name
+          layout_id
+          section_id
+          path
+          content_type
+          liquid_enabled
+          handler
+          hidden
+        ]
+      end
+
+      let(:serialized) { representer.public_send(serialization_format, short: true) }
+
+      json(:resource, skip_resource_save: true) do
+        it 'should have the correct attributes' do
+          expect(subject.keys).to eq(expected_attributes)
+        end
+      end
+
+      xml(:resource) do
+        it 'should have the correct attributes' do
+          expect(subject.root.elements.map(&:name)).to eq(expected_attributes)
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/api/cms_partial_spec.rb
+++ b/spec/acceptance/api/cms_partial_spec.rb
@@ -1,14 +1,45 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 resource "CMS::Partial" do
-
   let(:resource) do
-    FactoryBot.create(:cms_partial, body: 'body', draft: 'draft',
-            system_name: 'some-partial', liquid_enabled: false, handler: 'markdown')
+    FactoryBot.create(
+      :cms_partial,
+      body: 'body',
+      draft: 'draft',
+      system_name: 'some-partial',
+      liquid_enabled: false,
+      handler: 'markdown'
+    )
   end
 
-  json(:resource) do
+  describe 'representer' do
     let(:root) { 'partial' }
-    it { should have_properties('id', 'system_name', 'handler', 'liquid_enabled').from(resource) }
+
+    context 'when requesting all attributes' do
+      let(:expected_attributes) { %w[id created_at updated_at system_name draft published] }
+
+      json(:resource) do
+        it { should have_properties(expected_attributes).from(resource) }
+      end
+
+      xml(:resource) do
+        it { should have_tags(expected_attributes).from(resource) }
+      end
+    end
+
+    context 'when requesting the shorten version' do
+      let(:expected_attributes) { %w[id created_at updated_at system_name] }
+      let(:serialized) { representer.public_send(serialization_format, short: true) }
+
+      json(:resource) do
+        it { should have_properties(expected_attributes).from(resource) }
+      end
+
+      xml(:resource) do
+        it { should have_tags(expected_attributes).from(resource) }
+      end
+    end
   end
 end

--- a/spec/api_helper.rb
+++ b/spec/api_helper.rb
@@ -95,23 +95,21 @@ module ApiHelper
     end
   end
 
-  def format_context(format, context, &block)
+  def format_context(format, context, **options, &block)
     previous_definition = block
     new_definition = proc do
-      include_context "api"
-      include_context context.to_s
-      include_context format.to_s
+      ['api', context.to_s, format.to_s].each { |group_name| include_context(group_name, options) }
       class_exec(&previous_definition) if previous_definition
     end
     context("#{format} #{context}", :api, context.to_sym, format.to_sym, serialize: :resource, &new_definition)
   end
 
-  def json(context, &block)
-    format_context(:json, context, &block)
+  def json(context, **options, &block)
+    format_context(:json, context, options, &block)
   end
 
-  def xml(context, &block)
-    format_context(:xml, context, &block)
+  def xml(context, **options, &block)
+    format_context(:xml, context, options, &block)
   end
 end
 

--- a/spec/support/api/context.rb
+++ b/spec/support/api/context.rb
@@ -64,8 +64,8 @@ shared_context "collection", collection: true do
   let(:representer) { collection_representer.constantize.format(format).prepare(serializable) }
 end
 
-shared_context "json", json: true do
-  before { resource.save! if resource.respond_to?(:save!) }
+shared_context "json", json: true do |args|
+  before { resource.save! if resource.respond_to?(:save!) && !args[:skip_resource_save] }
 
   let(:format) { :json }
   let(:json) { JSON.parse(serialized) }

--- a/test/integration/cms/api/sections_test.rb
+++ b/test/integration/cms/api/sections_test.rb
@@ -78,7 +78,7 @@ module CMS
       test 'find section by system name' do
         get admin_api_cms_section_path(id: 'root', format: :json), params: { provider_key: @provider.provider_key }
         assert_response :success
-        assert_equal 'root', JSON.parse(response.body)['section']['system_name']
+        assert_equal 'root', JSON.parse(response.body)['builtin_section']['system_name']
       end
 
       test 'invalid system name or id' do


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the JSON format responses for the CMS API so that they follow the same structure and return the same data as the XML responses, updated recently in https://github.com/3scale/porta/pull/3193.

**Which issue(s) this PR fixes** 

Fixes [THREESCALE-8993](https://issues.redhat.com/browse/THREESCALE-8993).

**Verification steps** 

Call the following endpoints to check they match the responses in [this document](https://docs.google.com/document/d/14Lpu5T-ktDVUNl9SINtd7WRdew1x0f5qDzFngThZyV8/edit):
```
GET /admin/api/cms/sections/:section_id/files.json
GET /admin/api/cms/sections.json
GET /admin/api/cms/sections/:id.json
GET /admin/api/cms/files.json
GET /admin/api/cms/files/:id.json
GET /admin/api/cms/templates.json
GET /admin/api/cms/templates/:id.json
```


**Special notes for your reviewer**:

Be happy
![](https://media.giphy.com/media/4Zo41lhzKt6iZ8xff9/giphy.gif)