### PR TITLE
🚧 🦓 Add new input for Cardholder name

### DIFF
--- a/app/javascript/src/PaymentGateways/stripe/StripeElementsForm.scss
+++ b/app/javascript/src/PaymentGateways/stripe/StripeElementsForm.scss
@@ -30,6 +30,53 @@ $stripe-form-spinner-color: #5469d4;
   .cardErrors {
     margin: 1rem;
   }
+
+  .fakeStripeElement::placeholder {
+    color: rgb(63, 69, 76);
+    font-weight: 300;
+    font-style: normal;
+  }
+
+  .fakeStripeElement {
+    // HACK: The following are styles copy-pasted from the browser
+    writing-mode: horizontal-tb;
+    font-style: -webkit-small-control;
+    font-weight: -webkit-small-control;
+    font-size: -webkit-small-control;
+    font-family: -webkit-small-control;
+    font-variant-caps: -webkit-small-control;
+    letter-spacing: normal;
+    word-spacing: normal;
+    text-transform: none;
+    text-indent: 0px;
+    text-shadow: none;
+    text-align: start;
+    -webkit-rtl-ordering: logical;
+    -webkit-user-select: text;
+    user-select: text;
+    cursor: auto;
+    background-color: transparent;
+    border: none;
+    display: block;
+    height: 1.2em;
+    line-height: 1.2em;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    box-sizing: border-box;
+    appearance: auto;
+    color: black;
+    font-weight: 300;
+    font-family: "Helvetica Neue", Helvetica, sans-serif;
+    font-size: 19px;
+    top: 0;
+    transform: scale(1);
+    transition: opacity .3s cubic-bezier(.25,.46,.45,.94);
+    -webkit-animation: native-autofill-out 1ms;
+    animation: native-autofill-out 1ms;
+
+    margin-bottom: 2rem;
+  }
 }
 
 .stripe-form {

--- a/app/javascript/src/PaymentGateways/stripe/StripeElementsForm.tsx
+++ b/app/javascript/src/PaymentGateways/stripe/StripeElementsForm.tsx
@@ -46,10 +46,13 @@ const StripeElementsForm: FunctionComponent<Props> = ({
   successUrl,
   isCreditCardStored
 }) => {
+  const [cardHolderName, setCardHolderName] = useState('')
   const [cardErrorMessage, setCardErrorMessage] = useState<string>()
   const [isStripeFormVisible, setIsStripeFormVisible] = useState(!isCreditCardStored)
-  const [formComplete, setFormComplete] = useState(false)
+  const [cardElementComplete, setCardElementComplete] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+
+  const formComplete = cardElementComplete && cardHolderName.trim().length > 0
 
   const stripe = useStripe()
   const elements = useElements()
@@ -76,7 +79,7 @@ const StripeElementsForm: FunctionComponent<Props> = ({
         billing_details: {
           address: billingAddressDetails,
           email: '',
-          name: '',
+          name: cardHolderName,
           phone: ''
         }
       }
@@ -94,7 +97,7 @@ const StripeElementsForm: FunctionComponent<Props> = ({
   }
 
   const validateCardElement = (event: StripeCardElementChangeEvent) => {
-    setFormComplete(event.complete)
+    setCardElementComplete(event.complete)
     setCardErrorMessage(event.error?.message)
   }
 
@@ -114,6 +117,14 @@ const StripeElementsForm: FunctionComponent<Props> = ({
       >
         <fieldset>
           <legend>Credit card details</legend>
+          <div className="col-md-12 StripeElement is-empty">
+            <input
+              className="fakeStripeElement col-md-12"
+              placeholder="Cardholder name"
+              value={cardHolderName}
+              onChange={(e) => { setCardHolderName(e.currentTarget.value) }}
+            />
+          </div>
           <CardElement
             className="col-md-12"
             options={CARD_OPTIONS}


### PR DESCRIPTION
This is a proposal for https://issues.redhat.com/browse/THREESCALE-8626, see also https://github.com/3scale/porta/pull/3237

It adds a hacky new input to the Stripe element (this could be supported by `react-stripe-js` but it isn't, so we have to make it up).

The input is only used for registering the credit card, it won't be stored in the DB.

NOTE: the problem is that this "cardholder name" may need to match "Billing address name", legally speaking. If this is not true, then this PR is all right.
If the billing address name is used, then we have to add new fields (first and last name) to the "Billing Address" form, store it in the DB (as we do with Braintree) and then use it when registering the card.

Some visuals:
<img width="1215" alt="Screenshot 2023-03-03 at 18 11 44" src="https://user-images.githubusercontent.com/11672286/222787941-38324bdb-7b03-41eb-8929-fdf8bc27d991.png">

<img width="1215" alt="Screenshot 2023-03-03 at 18 12 21" src="https://user-images.githubusercontent.com/11672286/222787928-f1189a6c-a947-4e50-a4e8-d5579867484a.png">

