### PR TITLE
🦓 Use billing address name when registering a CC

### DIFF
--- a/app/helpers/payment_details_helper.rb
+++ b/app/helpers/payment_details_helper.rb
@@ -47,9 +47,10 @@ module PaymentDetailsHelper
       stripePublishableKey: site_account.payment_gateway_options[:publishable_key],
       setupIntentSecret: intent.client_secret,
       billingAddress: stripe_billing_address,
+      billingName: current_account[:billing_address_name],
       successUrl: hosted_success_admin_account_stripe_path,
       creditCardStored: current_account.credit_card_stored?
-    }
+    }.compact
   end
 
   # Must match PaymentMethod's address format https://stripe.com/docs/api/payment_methods/object#payment_method_object-billing_details-address

--- a/app/javascript/packs/stripe_form.ts
+++ b/app/javascript/packs/stripe_form.ts
@@ -17,12 +17,13 @@ document.addEventListener('DOMContentLoaded', () => {
     throw new Error('Stripe data was not provided')
   }
 
-  const { stripePublishableKey, setupIntentSecret, billingAddress, successUrl, creditCardStored } = data
+  const { stripePublishableKey, setupIntentSecret, billingAddress, billingName, successUrl, creditCardStored } = data
 
   StripeFormWrapper({
     publishableKey: stripePublishableKey,
     setupIntentSecret,
     billingAddressDetails: billingAddress,
+    billingName,
     successUrl,
     isCreditCardStored: creditCardStored
   }, containerId)

--- a/app/javascript/src/PaymentGateways/stripe/StripeElementsForm.tsx
+++ b/app/javascript/src/PaymentGateways/stripe/StripeElementsForm.tsx
@@ -36,6 +36,7 @@ const CARD_OPTIONS: StripeCardElementOptions = {
 interface Props {
   setupIntentSecret: string;
   billingAddressDetails: BillingAddress;
+  billingName?: string;
   successUrl: string;
   isCreditCardStored: boolean;
 }
@@ -43,6 +44,7 @@ interface Props {
 const StripeElementsForm: FunctionComponent<Props> = ({
   setupIntentSecret,
   billingAddressDetails,
+  billingName = '',
   successUrl,
   isCreditCardStored
 }) => {
@@ -76,7 +78,7 @@ const StripeElementsForm: FunctionComponent<Props> = ({
         billing_details: {
           address: billingAddressDetails,
           email: '',
-          name: '',
+          name: billingName,
           phone: ''
         }
       }

--- a/app/javascript/src/PaymentGateways/stripe/types.ts
+++ b/app/javascript/src/PaymentGateways/stripe/types.ts
@@ -6,6 +6,7 @@ export interface StripeFormDataset {
   stripePublishableKey: string;
   setupIntentSecret: string;
   billingAddress: BillingAddress;
+  billingName: string;
   successUrl: string;
   creditCardStored: boolean;
 }

--- a/spec/javascripts/PaymentGateways/stripe/StripeElementsForm.spec.tsx
+++ b/spec/javascripts/PaymentGateways/stripe/StripeElementsForm.spec.tsx
@@ -14,46 +14,13 @@ const defaultProps: Props = {
     postal_code: '80440',
     country: 'US'
   },
+  billingName: 'Guy Random',
   successUrl: '/Broflovski/Residence',
   isCreditCardStored: false
 }
 
-/**
-* IMPORTANT NOTE:
-* stripe-react is not easy to test, see discussion in https://github.com/stripe/react-stripe-js/issues/59
-* we should update this tests when the issue is updated
-*/
-
-it('should render properly', () => {
+it('should send billing address and name', () => {
   const wrapper = mount(<StripeElementsForm {...defaultProps} />)
-  expect(wrapper.exists('.StripeElementsForm')).toEqual(true)
-  expect(wrapper.exists('#stripe-form')).toEqual(true)
-})
 
-it('should enable submit button when form is complete and valid', () => {
-  const wrapper = mount(<StripeElementsForm {...defaultProps} />)
-  expect(wrapper.find('#stripe-submit').prop('disabled')).toEqual(true)
-
-  // TODO: this should be possible without mocking the whole component
-  // wrapper.find('CardElement').simulate('change', { complete: true })
-  // wrapper.update()
-  // expect(wrapper.find('#stripe-submit').prop('disabled')).toEqual(false)
-})
-
-describe('A credit card is stored', () => {
-  const props = { ...defaultProps, isCreditCardStored: true }
-
-  it('should render properly', () => {
-    const wrapper = mount(<StripeElementsForm {...props} />)
-    expect(wrapper.find('#stripe-form').hasClass('hidden')).toEqual(true)
-  })
-})
-
-describe('No credit card is stored', () => {
-  const props = { ...defaultProps, isCreditCardStored: false }
-
-  it('should render properly', () => {
-    const wrapper = mount(<StripeElementsForm {...props} />)
-    expect(wrapper.find('#stripe-form').hasClass('hidden')).toEqual(false)
-  })
+  wrapper.find('button[type="submit"]').simulate('submit')
 })

--- a/spec/javascripts/PaymentGateways/stripe/StripeElementsForm.spec.tsx
+++ b/spec/javascripts/PaymentGateways/stripe/StripeElementsForm.spec.tsx
@@ -1,7 +1,13 @@
 import { mount } from 'enzyme'
+import { CardElement, useStripe } from '@stripe/react-stripe-js'
+import { act } from 'react-dom/test-utils'
+import * as ReactStripeJS from '@stripe/react-stripe-js'
 
 import { StripeElementsForm } from 'PaymentGateways/stripe/StripeElementsForm'
+import { waitForPromises } from 'utilities/test-utils'
 
+import type { ReactWrapper } from 'enzyme'
+import type { Stripe, StripeCardElementChangeEvent } from '@stripe/stripe-js'
 import type { Props } from 'PaymentGateways/stripe/StripeElementsForm'
 
 const defaultProps: Props = {
@@ -19,8 +25,154 @@ const defaultProps: Props = {
   isCreditCardStored: false
 }
 
-it('should send billing address and name', () => {
-  const wrapper = mount(<StripeElementsForm {...defaultProps} />)
+const mountWrapper = (props: Partial<Props> = {}) => mount(<StripeElementsForm {...{ ...defaultProps, ...props }} />)
 
-  wrapper.find('button[type="submit"]').simulate('submit')
+const addValidCreditCard = (wrapper: ReactWrapper<unknown>) => {
+  act(() => {
+    const event = { complete: true, error: undefined } as StripeCardElementChangeEvent
+    // Ideally, we'd use simulate('change', { complete: true }) but CardElement is mocked.
+    wrapper.find(CardElement).prop('onChange')!(event)
+  })
+}
+
+const isSubmitDisabled = (wrapper: ReactWrapper<unknown>) => {
+  return Boolean(wrapper.find('button[type="submit"]').props().disabled)
+}
+
+describe('when credit card is stored', () => {
+  const props = { ...defaultProps, isCreditCardStored: true }
+
+  it('should hide then card widget', () => {
+    const wrapper = mountWrapper(props)
+
+    const button = wrapper.find('.editCardButton')
+    expect(button.text()).toEqual('Edit Credit Card Details')
+    expect(wrapper.exists('.editCardButton i.fa-pencil')).toEqual(true)
+    expect(wrapper.exists('#stripe-form.hidden')).toEqual(true)
+
+    button.simulate('click')
+    expect(wrapper.find('.editCardButton').text()).toEqual('cancel')
+    expect(wrapper.exists('.editCardButton i.fa-chevron-left')).toEqual(true)
+    expect(wrapper.find('#stripe-form').hasClass('hidden')).toEqual(false)
+  })
+})
+
+describe('when credit card is not stored', () => {
+  const props = { ...defaultProps, isCreditCardStored: false }
+
+  it('should hide then card widget', () => {
+    const wrapper = mountWrapper(props)
+
+    const button = wrapper.find('.editCardButton')
+    expect(button.text()).toEqual('cancel')
+    expect(wrapper.exists('.editCardButton i.fa-chevron-left')).toEqual(true)
+    expect(wrapper.find('#stripe-form').hasClass('hidden')).toEqual(false)
+
+    button.simulate('click')
+    expect(wrapper.find('.editCardButton').text()).toEqual('Edit Credit Card Details')
+    expect(wrapper.exists('.editCardButton i.fa-pencil')).toEqual(true)
+    expect(wrapper.exists('#stripe-form.hidden')).toEqual(true)
+  })
+})
+
+describe('when confirmCardSetup returns an error', () => {
+  beforeAll(() => {
+    jest.spyOn(ReactStripeJS, 'useStripe')
+      .mockImplementation(() => ({
+        confirmCardSetup: () => Promise.resolve({
+          error: { message: 'Something went wrong' },
+          setupIntent: undefined
+        })
+      } as unknown as Stripe))
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render the error', async () => {
+    const wrapper = mountWrapper()
+
+    addValidCreditCard(wrapper)
+    wrapper.find('button[type="submit"]').simulate('submit')
+    await waitForPromises(wrapper)
+
+    expect(wrapper.find('.cardErrors').text()).toEqual('Something went wrong')
+  })
+
+  it('should disable the submit button when form incomplete or submitting', async () => {
+    const wrapper = mountWrapper()
+    expect(isSubmitDisabled(wrapper)).toEqual(true)
+
+    addValidCreditCard(wrapper)
+    expect(isSubmitDisabled(wrapper.update())).toEqual(false)
+
+    wrapper.find('button[type="submit"]').simulate('submit')
+    expect(isSubmitDisabled(wrapper.update())).toEqual(true)
+
+    await waitForPromises(wrapper)
+    expect(isSubmitDisabled(wrapper.update())).toEqual(false)
+  })
+})
+
+describe('when confirmCardSetup is successfull', () => {
+  beforeAll(() => {
+    // Defined separately as a mock fn so that it can be checked later
+    const confirmCardSetup = jest.fn(() => Promise.resolve({
+      error: undefined,
+      setupIntent: { status: 'succeeded' }
+    }))
+
+    jest.spyOn(ReactStripeJS, 'useStripe')
+      .mockImplementation(() => ({ confirmCardSetup } as unknown as Stripe))
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should submit the form', async () => {
+    const submit = jest.spyOn(HTMLFormElement.prototype, 'submit')
+    const wrapper = mountWrapper()
+
+    addValidCreditCard(wrapper)
+
+    wrapper.find('button[type="submit"]').simulate('submit')
+
+    await waitForPromises(wrapper)
+    expect(submit).toHaveBeenCalledTimes(1)
+  })
+
+  it('should confirm card setup with billing address and name', () => {
+    const wrapper = mountWrapper()
+
+    addValidCreditCard(wrapper)
+
+    wrapper.find('button[type="submit"]').simulate('submit')
+
+    // eslint-disable-next-line jest/unbound-method -- Get the mock defined in __mocks__/@stripe/react-stripe-js.js
+    const { confirmCardSetup } = useStripe()!
+    expect(confirmCardSetup).toHaveBeenCalledTimes(1)
+    expect(confirmCardSetup).toHaveBeenCalledWith(defaultProps.setupIntentSecret, {
+      payment_method: expect.objectContaining({
+        billing_details: expect.objectContaining({
+          address: defaultProps.billingAddressDetails,
+          name: defaultProps.billingName
+        })
+      })
+    })
+  })
+
+  it.todo('should set stripe_payment_method_id value')
+})
+
+it('should not render an error by default', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.exists('.cardErrors')).toEqual(false)
+})
+
+it('should submit to the success url', () => {
+  const successUrl = '/foo'
+  const wrapper = mountWrapper({ successUrl })
+  expect(wrapper.find('form#stripe-form').props().action).toEqual(successUrl)
 })

--- a/spec/javascripts/PaymentGateways/stripe/StripeElementsProvider.spec.tsx
+++ b/spec/javascripts/PaymentGateways/stripe/StripeElementsProvider.spec.tsx
@@ -1,8 +1,12 @@
 import { mount } from 'enzyme'
+import { loadStripe } from '@stripe/stripe-js'
 
 import { StripeElementsProvider } from 'PaymentGateways/stripe/StripeElementsProvider'
 
-it('should render', () => {
-  const wrapper = mount(<StripeElementsProvider publishableKey="public-key" />)
-  expect(wrapper.exists()).toEqual(true)
+it('should load stripe with the provided key', () => {
+  const publishableKey = 'public-key'
+  mount(<StripeElementsProvider publishableKey={publishableKey} />)
+
+  expect(loadStripe).toHaveBeenCalledWith(publishableKey)
+  expect(loadStripe).toHaveBeenCalledTimes(1)
 })

--- a/spec/javascripts/PaymentGateways/stripe/StripeFormWrapper.spec.tsx
+++ b/spec/javascripts/PaymentGateways/stripe/StripeFormWrapper.spec.tsx
@@ -1,0 +1,21 @@
+import { StripeFormWrapper } from 'PaymentGateways/stripe/StripeFormWrapper'
+import { createReactWrapper } from 'utilities/createReactWrapper'
+
+import type { BillingAddress } from 'PaymentGateways/stripe/types'
+
+jest.mock('utilities/createReactWrapper', () => ({
+  createReactWrapper: jest.fn()
+}))
+
+it('should create a react wrapper', () => {
+  StripeFormWrapper({
+    publishableKey: '',
+    setupIntentSecret: '',
+    billingAddressDetails: {} as BillingAddress,
+    successUrl: '',
+    isCreditCardStored: false
+  }, 'some-id')
+
+  expect(createReactWrapper).toHaveBeenCalledTimes(1)
+  expect(createReactWrapper).toHaveBeenCalledWith(expect.anything(), 'some-id')
+})

--- a/spec/javascripts/__mocks__/@stripe/react-stripe-js.js
+++ b/spec/javascripts/__mocks__/@stripe/react-stripe-js.js
@@ -1,10 +1,15 @@
-module.exports = {
-  Elements: () => null,
-  CardElement: () => null,
-  useStripe: () => ({
-    confirmCardSetup: jest.fn(),
-  }),
-  useElements: () => ({
-    getElement: jest.fn()
-  })
-}
+const confirmCardSetup = jest.fn()
+
+const Elements = () => null
+
+const CardElement = () => null
+
+const useStripe = () => ({
+  confirmCardSetup
+})
+
+const useElements = () => ({
+  getElement: jest.fn()
+})
+
+export { Elements, CardElement, useStripe, useElements }

--- a/spec/javascripts/__mocks__/@stripe/stripe-js.js
+++ b/spec/javascripts/__mocks__/@stripe/stripe-js.js
@@ -1,3 +1,3 @@
 module.exports = {
-  loadStripe: () => Promise.resolve(null)
+  loadStripe: jest.fn(() => Promise.resolve(null))
 }

--- a/test/helpers/payment_details_helper_test.rb
+++ b/test/helpers/payment_details_helper_test.rb
@@ -66,7 +66,7 @@ class PaymentDetailsHelperTest < DeveloperPortal::ActionView::TestCase
   end
 
   test '#stripe_form_data' do
-    stubs(:current_account).returns(FactoryBot.create(:simple_account))
+    stubs(:current_account).returns(FactoryBot.create(:simple_account, billing_address_name: 'name'))
     stubs(:stripe_billing_address).returns({})
     stubs(:site_account).returns(mock(payment_gateway_options: { :publishable_key => 'publishable_key' }))
     stubs(:hosted_success_admin_account_stripe_path).returns('/ou-yeah')
@@ -76,6 +76,7 @@ class PaymentDetailsHelperTest < DeveloperPortal::ActionView::TestCase
       stripePublishableKey: 'publishable_key',
       setupIntentSecret: 'super-secret',
       billingAddress: {},
+      billingName: 'name',
       successUrl: '/ou-yeah',
       creditCardStored: false
     }


### PR DESCRIPTION
This is a proposal for https://issues.redhat.com/browse/THREESCALE-8626, see also https://github.com/3scale/porta/pull/3236

It uses the existing Billing address' name of the account to register the credit card.

In the Braintree form we already ask for first and last name. In the Stripe for we only ask for "Contact / Company", whatever that means. The fun part is that internally we store it as `billing_address_name`😓. 

So for this proposal to work, we need to replace the existing field with a first and last name ones and then use it when registering the card.

Ideally, we could merge this 2 weird forms (credit card and Billing address) into 1, same as Braintree.

TODO:

- [x] Need tests!!