### PR TITLE
THREESCALE-8612: Do not manipulate the response of the API calls made from Active Docs

### DIFF
--- a/app/javascript/packs/active_docs.ts
+++ b/app/javascript/packs/active_docs.ts
@@ -9,7 +9,7 @@ import 'ActiveDocs/swagger-ui-3-patch.scss'
 const accountDataUrl = '/api_docs/account_data.json'
 
 window.SwaggerUI = (args: SwaggerUI.SwaggerUIOptions, serviceEndpoint: string) => {
-  const responseInterceptor = (response: SwaggerUI.Response) => autocompleteInterceptor(response, args.url, accountDataUrl, serviceEndpoint)
+  const responseInterceptor = (response: SwaggerUI.Response) => autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, args.url)
 
   SwaggerUI({
     ...args,

--- a/app/javascript/packs/active_docs.ts
+++ b/app/javascript/packs/active_docs.ts
@@ -2,14 +2,14 @@
 import SwaggerUI from 'swagger-ui'
 import 'swagger-ui/dist/swagger-ui.css'
 
-import { autocompleteOAS3 } from 'ActiveDocs/OAS3Autocomplete'
+import { autocompleteInterceptor } from 'ActiveDocs/OAS3Autocomplete'
 
 import 'ActiveDocs/swagger-ui-3-patch.scss'
 
 const accountDataUrl = '/api_docs/account_data.json'
 
 window.SwaggerUI = (args: SwaggerUI.SwaggerUIOptions, serviceEndpoint: string) => {
-  const responseInterceptor = (response: SwaggerUI.Response) => autocompleteOAS3(response, accountDataUrl, serviceEndpoint)
+  const responseInterceptor = (response: SwaggerUI.Response) => autocompleteInterceptor(response, args.url, accountDataUrl, serviceEndpoint)
 
   SwaggerUI({
     ...args,

--- a/app/javascript/packs/service_active_docs.ts
+++ b/app/javascript/packs/service_active_docs.ts
@@ -1,7 +1,7 @@
 import SwaggerUI from 'swagger-ui'
 import 'swagger-ui/dist/swagger-ui.css'
 
-import { autocompleteOAS3 } from 'ActiveDocs/OAS3Autocomplete'
+import { autocompleteInterceptor } from 'ActiveDocs/OAS3Autocomplete'
 
 document.addEventListener('DOMContentLoaded', () => {
   const containerId = 'swagger-ui-container'
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- FIXME
   const accountDataUrl = `${baseUrl}${DATA_URL}`
 
-  const responseInterceptor: SwaggerUI.SwaggerUIOptions['responseInterceptor'] = (response) => autocompleteOAS3(response, accountDataUrl, serviceEndpoint)
+  const responseInterceptor: SwaggerUI.SwaggerUIOptions['responseInterceptor'] = (response) => autocompleteInterceptor(response, url, accountDataUrl, serviceEndpoint)
 
   SwaggerUI({
     url,

--- a/app/javascript/packs/service_active_docs.ts
+++ b/app/javascript/packs/service_active_docs.ts
@@ -3,6 +3,8 @@ import 'swagger-ui/dist/swagger-ui.css'
 
 import { autocompleteInterceptor } from 'ActiveDocs/OAS3Autocomplete'
 
+import 'ActiveDocs/swagger-ui-3-provider-patch.scss'
+
 document.addEventListener('DOMContentLoaded', () => {
   const containerId = 'swagger-ui-container'
   const DATA_URL = 'p/admin/api_docs/account_data.json'

--- a/app/javascript/packs/service_active_docs.ts
+++ b/app/javascript/packs/service_active_docs.ts
@@ -13,11 +13,10 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!container) {
     throw new Error('The target ID was not found: ' + containerId)
   }
-  const { url, baseUrl, serviceEndpoint = '' } = container.dataset
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- FIXME
+  const { url = '', baseUrl = '', serviceEndpoint = '' } = container.dataset
   const accountDataUrl = `${baseUrl}${DATA_URL}`
 
-  const responseInterceptor: SwaggerUI.SwaggerUIOptions['responseInterceptor'] = (response) => autocompleteInterceptor(response, url, accountDataUrl, serviceEndpoint)
+  const responseInterceptor: SwaggerUI.SwaggerUIOptions['responseInterceptor'] = (response) => autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, url)
 
   SwaggerUI({
     url,

--- a/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts
+++ b/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts
@@ -99,7 +99,7 @@ export interface Response extends SwaggerUIResponse {
   text: string;
 }
 
-export const autocompleteOAS3 = async (response: SwaggerUIResponse, accountDataUrl: string, serviceEndpoint: string): Promise<Response> => {
+const autocompleteOAS3 = async (response: SwaggerUIResponse, accountDataUrl: string, serviceEndpoint: string): Promise<Response> => {
   const bodyWithServer = injectServerToResponseBody(response.body, serviceEndpoint)
   const data = await fetchData<{ results: AccountData }>(accountDataUrl)
 
@@ -119,4 +119,16 @@ export const autocompleteOAS3 = async (response: SwaggerUIResponse, accountDataU
     data: JSON.stringify(body),
     text: JSON.stringify(body)
   }
+}
+export const autocompleteInterceptor = async (response: SwaggerUIResponse, specUrl: string | undefined, accountDataUrl: string, serviceEndpoint: string): Promise<Response> => {
+  // only process the response for Open API spec requests (not the actual API calls responses)
+  let interceptedResponse = response as Response
+  if (specUrl === response.url) {
+    try {
+      interceptedResponse = await autocompleteOAS3(response, accountDataUrl, serviceEndpoint)
+    } catch (error: unknown) {
+      console.error(error)
+    }
+  }
+  return interceptedResponse
 }

--- a/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts
+++ b/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts
@@ -120,15 +120,19 @@ const autocompleteOAS3 = async (response: SwaggerUIResponse, accountDataUrl: str
     text: JSON.stringify(body)
   }
 }
-export const autocompleteInterceptor = async (response: SwaggerUIResponse, specUrl: string | undefined, accountDataUrl: string, serviceEndpoint: string): Promise<Response> => {
-  // only process the response for Open API spec requests (not the actual API calls responses)
-  let interceptedResponse = response as Response
-  if (specUrl === response.url) {
-    try {
-      interceptedResponse = await autocompleteOAS3(response, accountDataUrl, serviceEndpoint)
-    } catch (error: unknown) {
-      console.error(error)
-    }
+
+/**
+ * Intercept and process the response made by Swagger UI
+ * Apply transformations (inject servers list and autocomplete data) to the response for OpenAPI spec requests, and
+ * keep the responses to the actual API calls (made through 'Try it out') untouched
+ * @param response response to the request made through Swagger UI
+ * @param specUrl URL of the OpenAPI specification
+ * @param accountDataUrl URL of the data for autocompletion
+ * @param serviceEndpoint Public Base URL of the gateway, that will replace the  URL in the "servers" object
+ */
+export const autocompleteInterceptor = (response: SwaggerUIResponse, accountDataUrl: string, serviceEndpoint: string, specUrl?: string): Promise<Response> | SwaggerUIResponse => {
+  if (specUrl !== response.url) {
+    return response
   }
-  return interceptedResponse
+  return autocompleteOAS3(response, accountDataUrl, serviceEndpoint)
 }

--- a/app/javascript/src/ActiveDocs/swagger-ui-3-provider-patch.scss
+++ b/app/javascript/src/ActiveDocs/swagger-ui-3-provider-patch.scss
@@ -1,0 +1,24 @@
+// Reset some inherited styles so that Swagger UI looks good in the admin portal
+.swagger-ui {
+  table {
+    all: unset;
+  }
+
+  pre code {
+    all: unset;
+  }
+
+  select {
+    width: unset;
+    height: unset;
+  }
+
+  button {
+    min-width: unset;
+    width: unset;
+  }
+
+  .curl-command .copy-to-clipboard button {
+    padding: 0 0 0 25px;
+  }
+}

--- a/spec/javascripts/.eslintrc
+++ b/spec/javascripts/.eslintrc
@@ -2,7 +2,6 @@
   "plugins": ["jest"],
   "extends": ["plugin:jest/recommended"],
   "rules": {
-    "no-unsafe-member-access": "off",
     "react/jsx-key": "off",
     "react/jsx-props-no-spreading": "off",
     "@typescript-eslint/no-non-null-assertion": "off",

--- a/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
+++ b/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
@@ -63,19 +63,15 @@ const accountData = {
 const fetchDataSpy = jest.spyOn(utils, 'fetchData')
 fetchDataSpy.mockResolvedValue(accountData)
 
-it('should inject servers to OpenAPI spec', () => {
-  return autocompleteInterceptor(specResponse, accountDataUrl, serviceEndpoint, specUrl).then((res: SwaggerUIResponse) => {
+describe('when the request is fetching OpenAPI spec', () => {
+  const response = specResponse
+  it('should inject servers to the spec', async () => {
+    const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
     expect(res.body.servers).toEqual([{ 'url': 'foo/bar/serviceEndpoint' }])
-  }) as Promise<SwaggerUIResponse>
-})
+  })
 
-it('should not inject servers to API calls responses', () => {
-  const res: SwaggerUIResponse = autocompleteInterceptor(apiResponse, accountDataUrl, serviceEndpoint, specUrl)
-  expect(res.body.servers).toBe(undefined)
-})
-
-it('should autocomplete fields of OpenAPI spec with x-data-threescale-name property', () => {
-  return autocompleteInterceptor(specResponse, accountDataUrl, serviceEndpoint, specUrl).then((res: SwaggerUIResponse) => {
+  it('should autocomplete fields of OpenAPI spec with x-data-threescale-name property', async () => {
+    const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
     const examplesFirstParam = res.body.paths['/'].get.parameters[0].examples
     const examplesSecondParam = res.body.paths['/'].get.parameters[1].examples
 
@@ -84,5 +80,13 @@ it('should autocomplete fields of OpenAPI spec with x-data-threescale-name prope
       { summary: 'Some App', value: '12345678' }
     ])
     expect(examplesSecondParam).toBe(undefined)
-  }) as Promise<SwaggerUIResponse>
+  })
+})
+
+describe('when the request is fetching API call response', () => {
+  const response = apiResponse
+  it('should not inject servers to the response', async () => {
+    const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
+    expect(res.body.servers).toBe(undefined)
+  })
 })

--- a/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
+++ b/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
@@ -85,8 +85,8 @@ describe('when the request is fetching OpenAPI spec', () => {
 
 describe('when the request is fetching API call response', () => {
   const response = apiResponse
-  it('should not inject servers to the response', async () => {
-    const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
+  it('should not inject servers to the response', () => {
+    const res: SwaggerUIResponse = autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
     expect(res.body.servers).toBe(undefined)
   })
 })

--- a/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
+++ b/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
@@ -62,19 +62,19 @@ const fetchDataSpy = jest.spyOn(utils, 'fetchData')
 fetchDataSpy.mockResolvedValue(accountData)
 
 it('should inject servers to OpenAPI spec', () => {
-  return autocompleteInterceptor(specResponse, specUrl, accountDataUrl, serviceEndpoint).then(res => {
+  return autocompleteInterceptor(specResponse, accountDataUrl, serviceEndpoint, specUrl).then(res => {
     expect(res.body.servers).toEqual([{ 'url': 'foo/bar/serviceEndpoint' }])
   })
 })
 
 it('should not inject servers to API calls responses', () => {
-  return autocompleteInterceptor(apiResponse, specUrl, accountDataUrl, serviceEndpoint).then(res => {
+  return autocompleteInterceptor(apiResponse, accountDataUrl, serviceEndpoint, specUrl).then(res => {
     expect(res.body.servers).toBe(undefined)
   })
 })
 
 it('should autocomplete fields of OpenAPI spec with x-data-threescale-name property', () => {
-  return autocompleteInterceptor(specResponse, specUrl, accountDataUrl, serviceEndpoint).then(res => {
+  return autocompleteInterceptor(specResponse, accountDataUrl, serviceEndpoint, specUrl).then(res => {
     const examplesFirstParam = res.body.paths['/'].get.parameters[0].examples
     const examplesSecondParam = res.body.paths['/'].get.parameters[1].examples
 

--- a/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
+++ b/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
@@ -1,6 +1,8 @@
 import { autocompleteInterceptor } from 'ActiveDocs/OAS3Autocomplete'
 import * as utils from 'utilities/fetchData'
 
+import type { Response as SwaggerUIResponse } from 'swagger-ui'
+
 const specUrl = 'foo/bar.json'
 const apiUrl = 'foo/bar/api-url'
 const accountDataUrl = 'foo/bar'
@@ -62,19 +64,18 @@ const fetchDataSpy = jest.spyOn(utils, 'fetchData')
 fetchDataSpy.mockResolvedValue(accountData)
 
 it('should inject servers to OpenAPI spec', () => {
-  return autocompleteInterceptor(specResponse, accountDataUrl, serviceEndpoint, specUrl).then(res => {
+  return autocompleteInterceptor(specResponse, accountDataUrl, serviceEndpoint, specUrl).then((res: SwaggerUIResponse) => {
     expect(res.body.servers).toEqual([{ 'url': 'foo/bar/serviceEndpoint' }])
-  })
+  }) as Promise<SwaggerUIResponse>
 })
 
 it('should not inject servers to API calls responses', () => {
-  return autocompleteInterceptor(apiResponse, accountDataUrl, serviceEndpoint, specUrl).then(res => {
-    expect(res.body.servers).toBe(undefined)
-  })
+  const res: SwaggerUIResponse = autocompleteInterceptor(apiResponse, accountDataUrl, serviceEndpoint, specUrl)
+  expect(res.body.servers).toBe(undefined)
 })
 
 it('should autocomplete fields of OpenAPI spec with x-data-threescale-name property', () => {
-  return autocompleteInterceptor(specResponse, accountDataUrl, serviceEndpoint, specUrl).then(res => {
+  return autocompleteInterceptor(specResponse, accountDataUrl, serviceEndpoint, specUrl).then((res: SwaggerUIResponse) => {
     const examplesFirstParam = res.body.paths['/'].get.parameters[0].examples
     const examplesSecondParam = res.body.paths['/'].get.parameters[1].examples
 
@@ -83,5 +84,5 @@ it('should autocomplete fields of OpenAPI spec with x-data-threescale-name prope
       { summary: 'Some App', value: '12345678' }
     ])
     expect(examplesSecondParam).toBe(undefined)
-  })
+  }) as Promise<SwaggerUIResponse>
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the issue where the response body of the API calls made from Active Docs (OpenAPI spec v3).
For JSON responses it was adding `"servers"` object, and for XML responses it was also "transforming" it to JSON, which was actually wrapping the response in quotes `"<element>...</element>"`

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/THREESCALE-8612

**Verification steps** 

- Go to `/admin/api_docs/services` in the admin portal
- Create a new spec from [echo-api-3.0.json](https://raw.githubusercontent.com/3scale/porta/3017562449d3275840cae6afe338a01c1dcca899/public/echo-api-3.0.json) - do **not** link it to any service (product).
- Make a test call with _Try it out_ feature
- Verify that there is in "servers" added in the JSON response, and the XML response is not wrapped in quotes

**Special notes for your reviewer**:

As an "extra" some fixes to the styles were applied, so the Swagger UI v3 looks better in the admin portal. Compare:

**Before**
![Screenshot from 2023-03-07 23-59-19](https://user-images.githubusercontent.com/1270328/223573834-152b6ba0-57ed-4bb7-8202-d7f9554f4a50.png)
![Screenshot from 2023-03-07 23-59-52](https://user-images.githubusercontent.com/1270328/223574271-b28f6335-1aab-4e6c-ab78-d625c8ae029f.png)

**After**
![Screenshot from 2023-03-07 23-58-19](https://user-images.githubusercontent.com/1270328/223573882-e2c849d4-ba6f-42cc-a381-d56a258aec02.png)

![Screenshot from 2023-03-07 23-58-38](https://user-images.githubusercontent.com/1270328/223573890-55750827-58b3-4540-8c42-7aa1b2bfd763.png)

