### PR TITLE
CMS: Unify system names

### DIFF
--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -14,6 +14,7 @@ class CMS::Page < CMS::BasePage
 
   belongs_to :section, class_name: 'CMS::Section', touch: true
 
+  before_validation :set_system_name , on: %i[create update]
   before_validation :strip_trailing_slashes
   verify_path_format :path
 
@@ -94,6 +95,10 @@ class CMS::Page < CMS::BasePage
     unless persisted?
       self.content_type ||= DEFAULT_CONTENT_TYPE
     end
+  end
+
+  def set_system_name
+    self.system_name = title.parameterize if title.present? && system_name.blank?
   end
 
   def strip_trailing_slashes

--- a/app/models/cms/section.rb
+++ b/app/models/cms/section.rb
@@ -55,7 +55,7 @@ class CMS::Section < ApplicationRecord
     end
 
     def find_or_create!(name, path, options = {})
-      system_name = name.downcase
+      system_name = name.parameterize
 
       if section = find_by_system_name(system_name)
         section

--- a/app/models/cms/section.rb
+++ b/app/models/cms/section.rb
@@ -26,7 +26,7 @@ class CMS::Section < ApplicationRecord
   validates :system_name, uniqueness: { :scope => [:provider_id] }, length: { maximum: 255 }
   validates :partial_path, :title, :type, length: { maximum: 255 }
 
-  before_validation :set_system_name , :on => :create
+  before_validation :set_system_name , on: %i[create update]
   before_validation :set_partial_path, :on => :create
   verify_path_format :partial_path
   before_validation :set_provider, :on => :create
@@ -154,7 +154,7 @@ class CMS::Section < ApplicationRecord
   protected
 
   def set_system_name
-    self.system_name = self.title if self.title && self.system_name.blank?
+    self.system_name = title.parameterize if title.present? && system_name.blank?
   end
 
   def set_partial_path

--- a/test/integration/cms/api/sections_test.rb
+++ b/test/integration/cms/api/sections_test.rb
@@ -129,7 +129,7 @@ module CMS
 
       test 'create with title but without system_name' do
         expected_title = 'New Section'
-        expected_sysname = 'New Section'
+        expected_sysname = 'new-section'
 
         post admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, format: :xml, title: expected_title}
 
@@ -144,7 +144,7 @@ module CMS
 
       test 'create with title and system_name' do
         expected_title = 'New Section'
-        expected_sysname = 'new_section'
+        expected_sysname = 'section-1'
 
         post admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, format: :xml,
                                                     title: expected_title, system_name: expected_sysname }

--- a/test/unit/cms/page_test.rb
+++ b/test/unit/cms/page_test.rb
@@ -97,4 +97,48 @@ class PageTest < ActiveSupport::TestCase
     page.expects(:tag_list).returns([]).once
     page.as_json(include: [:tag_list])
   end
+
+  test 'generates a system_name with proper format from title when creating' do
+    page = CMS::Page.new.tap do |p|
+      p.title = 'New Page'
+      p.provider = @provider
+      p.section = @provider.sections.root
+      p.path = '/new-page'
+    end
+
+    page.save!
+
+    assert_equal 'new-page', page.reload.system_name
+  end
+
+  test 'generates a system_name with proper format from title when updating' do
+    page = CMS::Page.new.tap do |p|
+      p.title = 'New Page'
+      p.system_name = 'sysname-1'
+      p.provider = @provider
+      p.section = @provider.sections.root
+      p.path = '/new-page'
+    end
+    page.save!
+
+    page.system_name = ''
+    page.save!
+
+    assert_equal 'new-page', page.reload.system_name
+  end
+
+  test "doesn't generate a system_name when one is given" do
+    sysname = 'sysname-1'
+    page = CMS::Page.new.tap do |p|
+      p.title = 'New Page'
+      p.system_name = sysname
+      p.provider = @provider
+      p.section = @provider.sections.root
+      p.path = '/new-page'
+    end
+
+    page.save!
+
+    assert_equal sysname, page.reload.system_name
+  end
 end

--- a/test/unit/cms/page_test.rb
+++ b/test/unit/cms/page_test.rb
@@ -141,4 +141,16 @@ class PageTest < ActiveSupport::TestCase
 
     assert_equal sysname, page.reload.system_name
   end
+
+  test "raises an error when an invalid system_name is given" do
+    page = CMS::Page.new.tap do |p|
+      p.title = 'New Page'
+      p.system_name = 'sysname 1'
+      p.provider = @provider
+      p.section = @provider.sections.root
+      p.path = '/new-page'
+    end
+
+    assert_raise(ActiveRecord::RecordInvalid) { page.save! }
+  end
 end

--- a/test/unit/cms/section_test.rb
+++ b/test/unit/cms/section_test.rb
@@ -106,4 +106,45 @@ class CMS::SectionTest < ActiveSupport::TestCase
     assert_nil CMS::Section.find_by_provider_id(@provider.id)
     assert_not_nil CMS::Section.find_by_provider_id(@provider2.id)
   end
+
+  test 'generates a system_name with proper format from title when creating' do
+    section = CMS::Section.new.tap do |s|
+      s.title = 'New Section'
+      s.provider = @provider
+      s.parent = @root
+    end
+
+    section.save!
+
+    assert_equal 'new-section', section.reload.system_name
+  end
+
+  test 'generates a system_name with proper format from title when updating' do
+    section = CMS::Section.new.tap do |s|
+      s.title = 'New Section'
+      s.system_name = 'sysname-1'
+      s.provider = @provider
+      s.parent = @root
+    end
+    section.save!
+
+    section.system_name = ''
+    section.save!
+
+    assert_equal 'new-section', section.reload.system_name
+  end
+
+  test "doesn't generate a system_name when one is given" do
+    sysname = 'sysname-1'
+    section = CMS::Section.new.tap do |s|
+      s.title = 'New Section'
+      s.system_name = sysname
+      s.provider = @provider
+      s.parent = @root
+    end
+
+    section.save!
+
+    assert_equal sysname, section.reload.system_name
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a simpler approach to https://github.com/3scale/porta/pull/3163.

In that PR I added validations to all CMS models so `system_name`:

1. Is always present.
2. Meets the format `%r{\A\w[\w\-/_]+\z}`.

The problem is that there are some sections and pages in the DB that doesn't meet the format, so adding validations would require a backfill migration to fix those two tables.

In this PR, I applied the minimal changes possible to ensure those two conditions above are meet **for all new records**, but it doesn't add the validations, so the existing records not meeting the conditions are allowed in order to avoid breaking anything.

**Which issue(s) this PR fixes** 

Part of [THREESCALE-8991](https://issues.redhat.com/browse/THREESCALE-8991)

**Verification steps** 

- Creating a new section which title contains spaces should generate a system name without spaces.
- Creating a Pages without a system name should generate one automatically, with the proper format.
- Creating a new tenant should generate valid system names for all the default Developer Portal resources.

**Special notes for your reviewer**:

There are changes only in `CMS::Page` and `CMS::Section`, all other models were already fixed, this tables summarizes the state of system names before this PR.

|Type|Required|Format enforced|Value|
|--|--|--|--|
|Section|Yes|No|Generated from `title` parameter|
|Page|No|Yes|From `system_name` parameter|
|Builtin Page|Yes|Yes|From `system_name` parameter|
|Layout|Yes|Yes|From `system_name` parameter|
|Partial|Yes|Yes|From `system_name` parameter|
|Builtin Partial|Yes|Yes|From `system_name` parameter|
|File|No|No|There's no  `system_name`  column in the table|

As the table shows, `system_name` is not applicable for **Files**; while **Builtin Page**, **Page**, **Layout**, **Partial** and **Builtin Partial** already meet the two conditions. So only changes in **Page** and **Section** are required.
