### PR TITLE
fixes to PDF rendering

### DIFF
--- a/app/lib/pdf/data.rb
+++ b/app/lib/pdf/data.rb
@@ -36,11 +36,11 @@ module Pdf
         # because account can have multiple cinstances from multiple services, scope them by service and find last one
         cinstance = account.bought_cinstances.by_service(@service).latest.first or next
         [
-          sanitize_text(account.org_name),
+          account.org_name,
           account.created_at,
           account.users.first&.email,
           cinstance.plan.name
-        ].map {|v| "<td>#{h v}</td>"}
+        ]
       end.compact
     end
 

--- a/app/lib/pdf/finance/invoice_generator.rb
+++ b/app/lib/pdf/finance/invoice_generator.rb
@@ -81,7 +81,11 @@ module Pdf
 
       def print_address(person, name = nil)
         subtitle("#{name}") if name
-        table_with_column_header(person, width: TABLE_HALF_WIDTH)
+        table_with_column_header(person, width: TABLE_HALF_WIDTH) do
+          # prevent long addresses from wrapping header words
+          # see https://github.com/prawnpdf/prawn-table/issues/67
+          style(column(0), width: 50)
+        end
       end
 
       def print_details

--- a/test/test_helpers/env.rb
+++ b/test/test_helpers/env.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module TestHelpers
+  module Env
+    private
+
+    def set_env(var_values)
+      original = ENV.to_hash
+      ENV.update var_values
+      yield
+    ensure
+      ENV.replace original
+    end
+  end
+end
+
+ActiveSupport::TestCase.send(:include, TestHelpers::Env)

--- a/test/unit/pdf/data_test.rb
+++ b/test/unit/pdf/data_test.rb
@@ -75,11 +75,11 @@ class Pdf::DataTest < ActiveSupport::TestCase
 
     data = Pdf::Data.new(@provider_account, @service, :period => :day)
 
-    assert_equal ['<td>first</td>', '<td>second</td>', '<td>third</td>' ],
+    assert_equal ['first', 'second', 'third' ],
                  data.latest_users(3).map(&:first)
   end
 
-  test 'sanitize escape sequences' do
+  test 'does not escape special characters' do
     buyer1     = FactoryBot.create(:buyer_account, :org_name => 'fi\rst buye\r', :provider_account => @provider_account, :created_at => 1.day.ago)
     buyer2     = FactoryBot.create(:buyer_account, :org_name => 'seco\nd buyer\r\n', :provider_account => @provider_account, :created_at => 5.days.ago)
     buyer3     = FactoryBot.create(:buyer_account, :org_name => '\nthi\rd buyer', :provider_account => @provider_account, :created_at => 10.days.ago)
@@ -94,7 +94,7 @@ class Pdf::DataTest < ActiveSupport::TestCase
 
     data = Pdf::Data.new(@provider_account, @service, :period => :day)
 
-    assert_equal ['<td>fi\\\rst buye\\\r</td>', '<td>seco\\\nd buyer\\\r\\\n</td>', '<td>\\\nthi\\\rd buyer</td>' ],
+    assert_equal ['fi\rst buye\r', 'seco\nd buyer\r\n', '\nthi\rd buyer' ],
                  data.latest_users(3).map(&:first)
   end
 end

--- a/test/unit/pdf/finance/invoice_generator_test.rb
+++ b/test/unit/pdf/finance/invoice_generator_test.rb
@@ -5,7 +5,8 @@ require 'test_helper'
 class Pdf::Finance::InvoiceGeneratorTest < ActiveSupport::TestCase
 
   LONG_ADDRESS = [%w[Name Farnsworth],
-                  ['Address', "AAA\n" * 5],
+                  ['Address', %{JOHN "GULLIBLE" DOE\nCENTER FOR FINANCIAL ASSISTANCE TO DEPOSED NIGERIAN ROYALTY\n421 E DRACHMAN
+  TUCSON AZ 85705-7598}],
                   %w[Country Patagonia]].freeze
 
   setup do
@@ -43,10 +44,14 @@ class Pdf::Finance::InvoiceGeneratorTest < ActiveSupport::TestCase
     # ensure an image is present in the PDF
     assert_equal 1, content.scan(%r{/Type /XObject}).size
 
-    text = PDF::Inspector::Text.analyze(content)
+    strings = PDF::Inspector::Text.analyze(content).strings
     flat_items = items.flatten.reject(&:blank?).map(&:strip)
-    flat_items.each { |item| assert_includes text.strings, item }
-    assert_includes text.strings, "Chocolatte#{Prawn::Text::NBSP}" # prawn should not strip non-braking-spaces
+    flat_items.each { |item| assert_includes strings, item }
+    assert_includes strings, "Chocolatte#{Prawn::Text::NBSP}" # prawn should not strip non-breaking spaces
+
+    # Address tables should not wrap header words
+    assert_equal 3, strings.count("Address")
+    assert_equal 3, strings.count("Country")
   ensure
     logo_file.close
   end


### PR DESCRIPTION
We had some unnecessary escaping in report PDFs.
![image](https://user-images.githubusercontent.com/1408661/224128029-fa56e6d8-e18a-4b0d-9301-9e26654309d1.png)

Also Invoices with long addresses caused `Address` and `Country` words to wrap (see screenshot vs attached PDF).
![image](https://user-images.githubusercontent.com/1408661/224127657-b61fc7eb-4e4c-4aa9-b565-0c8373bb017b.png)
[fixed invoice.pdf](https://github.com/3scale/porta/files/10935133/fixed.invoice.pdf)

