### PR TITLE
CMS API:  Drop support for XML requests

### DIFF
--- a/app/controllers/admin/api/cms/base_controller.rb
+++ b/app/controllers/admin/api/cms/base_controller.rb
@@ -1,5 +1,7 @@
-class Admin::Api::CMS::BaseController < Admin::Api::BaseController
+# frozen_string_literal: true
 
+class Admin::Api::CMS::BaseController < Admin::Api::BaseController
+  before_action :ensure_json_request
   before_action :deny_on_premises_for_master
   self.access_token_scopes = %i[cms account_management]
 
@@ -14,6 +16,10 @@ class Admin::Api::CMS::BaseController < Admin::Api::BaseController
     else
       DEFAULT_PER_PAGE
     end
+  end
+
+  def ensure_json_request
+    raise ActionController::UnknownFormat unless request.format.json?
   end
 end
 

--- a/app/controllers/admin/api/cms/files_controller.rb
+++ b/app/controllers/admin/api/cms/files_controller.rb
@@ -20,7 +20,7 @@ class Admin::Api::CMS::FilesController < Admin::Api::CMS::BaseController
   representer :entity => ::CMS::FileRepresenter, :collection => ::CMS::FilesRepresenter
 
   ##~ e = sapi.apis.add
-  ##~ e.path = "/admin/api/cms/files.xml"
+  ##~ e.path = "/admin/api/cms/files.json"
   ##~ e.responseClass = "List[short-file]"
   #
   ##~ op            = e.operations.add
@@ -62,7 +62,7 @@ class Admin::Api::CMS::FilesController < Admin::Api::CMS::BaseController
   end
 
   ##~ e = sapi.apis.add
-  ##~ e.path = "/admin/api/cms/files/{id}.xml"
+  ##~ e.path = "/admin/api/cms/files/{id}.json"
   ##~ e.responseClass = "file"
   #
   ##~ op             = e.operations.add

--- a/app/controllers/admin/api/cms/sections_controller.rb
+++ b/app/controllers/admin/api/cms/sections_controller.rb
@@ -10,7 +10,7 @@ class Admin::Api::CMS::SectionsController < Admin::Api::CMS::BaseController
   representer :entity => ::CMS::SectionRepresenter, :collection => ::CMS::SectionsRepresenter
 
   ##~ e = sapi.apis.add
-  ##~ e.path = "/admin/api/cms/sections.xml"
+  ##~ e.path = "/admin/api/cms/sections.json"
   ##~ e.responseClass = "List[short-section]"
   #
   ##~ op            = e.operations.add
@@ -47,7 +47,7 @@ class Admin::Api::CMS::SectionsController < Admin::Api::CMS::BaseController
   end
 
   ##~ e = sapi.apis.add
-  ##~ e.path = "/admin/api/cms/sections/{id}.xml"
+  ##~ e.path = "/admin/api/cms/sections/{id}.json"
   ##~ e.responseClass = "template"
   #
   ##~ op             = e.operations.add

--- a/app/controllers/admin/api/cms/templates_controller.rb
+++ b/app/controllers/admin/api/cms/templates_controller.rb
@@ -12,7 +12,7 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
   }.freeze
 
   wrap_parameters :template, include: AVAILABLE_PARAMS,
-                             format: %i[json xml multipart_form url_encoded_form]
+                             format: %i[json multipart_form url_encoded_form]
 
   before_action :find_template, except: %i[index create]
 

--- a/app/controllers/admin/api/cms/templates_controller.rb
+++ b/app/controllers/admin/api/cms/templates_controller.rb
@@ -19,7 +19,7 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
   before_action :can_destroy, only: :destroy
 
   ##~ e = sapi.apis.add
-  ##~ e.path = "/admin/api/cms/templates.xml"
+  ##~ e.path = "/admin/api/cms/templates.json"
   ##~ e.responseClass = "List[short-template]"
   #
   ##~ op            = e.operations.add
@@ -62,7 +62,7 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
   end
 
   ##~ e = sapi.apis.add
-  ##~ e.path = "/admin/api/cms/templates/{id}.xml"
+  ##~ e.path = "/admin/api/cms/templates/{id}.json"
   ##~ e.responseClass = "template"
   #
   ##~ op             = e.operations.add
@@ -116,7 +116,7 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
   end
 
   ##~ e = sapi.apis.add
-  ##~ e.path = "/admin/api/cms/templates/{id}/publish.xml"
+  ##~ e.path = "/admin/api/cms/templates/{id}/publish.json"
   ##~ e.responseClass = "template"
   #
   ##~ op             = e.operations.add

--- a/app/models/cms/builtin.rb
+++ b/app/models/cms/builtin.rb
@@ -110,51 +110,12 @@ class CMS::Builtin < CMS::BasePage
     end
 
     has_data_tag :builtin_page
-
-    def to_xml(options = {})
-      xml = options[:builder] || Nokogiri::XML::Builder.new
-
-      xml.__send__(self.class.data_tag) do |x|
-        unless new_record?
-          xml.id id
-          xml.created_at created_at.xmlschema
-          xml.updated_at updated_at.xmlschema
-        end
-
-        x.system_name system_name
-        x.liquid_enabled liquid_enabled
-        x.layout layout_name
-      end
-
-      xml.to_xml
-    end
   end
 
   # CMS::Builtin::Page
   class Page < CMS::Builtin
 
     has_data_tag :builtin_page
-
-    def to_xml(options = {})
-      xml = options[:builder] || Nokogiri::XML::Builder.new
-
-      xml.__send__(self.class.data_tag) do |x|
-        unless new_record?
-          xml.id id
-          xml.created_at created_at.xmlschema
-          xml.updated_at updated_at.xmlschema
-        end
-        x.title title
-        x.system_name system_name
-        x.layout_id layout_id
-        unless options[:short]
-          x.draft { |node| node.cdata(draft) if draft }
-          x.published { |node| node.cdata(published) if published }
-        end
-      end
-
-      xml.to_xml
-    end
 
     def content_type
       'text/html'

--- a/app/models/cms/file.rb
+++ b/app/models/cms/file.rb
@@ -51,26 +51,6 @@ class CMS::File < ApplicationRecord
   alias_attribute :name, :attachment_file_name
   alias_attribute :title, :attachment_file_name
 
-  def to_xml(options = {})
-    xml = options[:builder] || Nokogiri::XML::Builder.new
-
-    xml.__send__(self.class.data_tag) do |x|
-      unless new_record?
-        xml.id id
-        xml.created_at created_at.xmlschema
-        xml.updated_at updated_at.xmlschema
-      end
-      x.section_id section_id
-      x.path path
-      x.downloadable downloadable?
-      x.url url.to_s
-      x.title title
-      x.content_type attachment.content_type
-    end
-
-    xml.to_xml
-  end
-
   def redirect?
     attachment.options[:storage] == :s3
   end

--- a/app/models/cms/layout.rb
+++ b/app/models/cms/layout.rb
@@ -17,27 +17,6 @@ class CMS::Layout < CMS::Template
     self[:content_type] || 'text/html'
   end
 
-  def to_xml(options = {})
-    xml = options[:builder] || Nokogiri::XML::Builder.new
-
-    xml.__send__(self.class.data_tag) do |x|
-      unless new_record?
-        xml.id id
-        xml.created_at created_at.xmlschema
-        xml.updated_at updated_at.xmlschema
-      end
-      x.title title
-      x.system_name system_name
-      x.liquid_enabled liquid_enabled?
-      unless options[:short]
-        x.draft { |node| node.cdata(draft) if draft }
-        x.published { |node| node.cdata(published) if published }
-      end
-    end
-
-    xml.to_xml
-  end
-
   def can_be_destroyed?
     pages.empty?
   end

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -88,33 +88,6 @@ class CMS::Page < CMS::BasePage
     super || Mime::Type.lookup(DEFAULT_CONTENT_TYPE)
   end
 
-  def to_xml(options = {})
-    xml = options[:builder] || Nokogiri::XML::Builder.new
-
-    xml.__send__(self.class.data_tag) do |x|
-      unless new_record?
-        x.id id
-        x.created_at created_at.xmlschema
-        x.updated_at updated_at.xmlschema
-      end
-      x.title title
-      x.system_name system_name
-      x.layout_id layout_id
-      x.section_id section_id
-      x.path path
-      x.content_type content_type
-      x.liquid_enabled liquid_enabled?
-      x.handler handler
-      x.hidden hidden?
-      unless options[:short]
-        x.draft { |node| node.cdata(draft) if draft }
-        x.published { |node| node.cdata(published) if published }
-      end
-    end
-
-    xml.to_xml
-  end
-
   private
 
   def set_default_values

--- a/app/models/cms/partial.rb
+++ b/app/models/cms/partial.rb
@@ -17,25 +17,6 @@ class CMS::Partial < CMS::Template
     super.merge string: "#{system_name}"
   end
 
-  def to_xml(options = {})
-    xml = options[:builder] || Nokogiri::XML::Builder.new
-
-    xml.__send__(self.class.data_tag) do |x|
-      unless new_record?
-        xml.id id
-        xml.created_at created_at.xmlschema
-        xml.updated_at updated_at.xmlschema
-      end
-      x.system_name system_name
-      unless options[:short]
-        x.draft { |node| node.cdata(draft) if draft }
-        x.published { |node| node.cdata(published) if published }
-      end
-    end
-
-    xml.to_xml
-  end
-
   def content_type
     'text/html'
   end

--- a/app/models/cms/section.rb
+++ b/app/models/cms/section.rb
@@ -43,25 +43,6 @@ class CMS::Section < ApplicationRecord
 
   has_data_tag :section
 
-  def to_xml(options = {})
-    xml = options[:builder] || Nokogiri::XML::Builder.new
-
-    xml.__send__(self.class.data_tag) do |x|
-      unless new_record?
-        xml.id id
-        xml.created_at created_at.xmlschema
-        xml.updated_at updated_at.xmlschema
-      end
-      x.title title
-      x.system_name system_name
-      x.public public
-      x.parent_id parent_id
-      x.partial_path partial_path
-    end
-
-    xml.to_xml
-  end
-
   module ProviderAssociationExtension
     def root
       self.find_by_system_name('root')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -550,7 +550,7 @@ without fake Core server your after commit callbacks will crash and you might ge
         resources :proxy_configs, path: 'proxy_configs/:environment', only: %i[index], defaults: { format: :json }
       end
 
-      namespace(:cms) do
+      namespace :cms, defaults: { format: :json } do
         resources :sections do
           resources :files, only: :index
           #resources :templates, only: :index

--- a/doc/active_docs/Developer Portal API (Tech Preview).json
+++ b/doc/active_docs/Developer Portal API (Tech Preview).json
@@ -5,7 +5,7 @@
   "apiVersion": "1.0",
   "apis": [
     {
-      "path": "/admin/api/cms/files.xml",
+      "path": "/admin/api/cms/files.json",
       "responseClass": "List[short-file]",
       "operations": [
         {
@@ -82,7 +82,7 @@
       ]
     },
     {
-      "path": "/admin/api/cms/files/{id}.xml",
+      "path": "/admin/api/cms/files/{id}.json",
       "responseClass": "file",
       "operations": [
         {
@@ -180,7 +180,7 @@
       ]
     },
     {
-      "path": "/admin/api/cms/sections.xml",
+      "path": "/admin/api/cms/sections.json",
       "responseClass": "List[short-section]",
       "operations": [
         {
@@ -257,7 +257,7 @@
       ]
     },
     {
-      "path": "/admin/api/cms/sections/{id}.xml",
+      "path": "/admin/api/cms/sections/{id}.json",
       "responseClass": "template",
       "operations": [
         {
@@ -356,7 +356,7 @@
       ]
     },
     {
-      "path": "/admin/api/cms/templates.xml",
+      "path": "/admin/api/cms/templates.json",
       "responseClass": "List[short-template]",
       "operations": [
         {
@@ -485,7 +485,7 @@
       ]
     },
     {
-      "path": "/admin/api/cms/templates/{id}.xml",
+      "path": "/admin/api/cms/templates/{id}.json",
       "responseClass": "template",
       "operations": [
         {
@@ -624,7 +624,7 @@
       ]
     },
     {
-      "path": "/admin/api/cms/templates/{id}/publish.xml",
+      "path": "/admin/api/cms/templates/{id}/publish.json",
       "responseClass": "template",
       "operations": [
         {

--- a/spec/acceptance/api/cms_file_spec.rb
+++ b/spec/acceptance/api/cms_file_spec.rb
@@ -7,15 +7,15 @@ resource 'CMS::File' do
 
   let(:resource) { FactoryBot.create(:cms_file, provider: provider, section: provider.sections.root) }
 
-  api 'cms file' do
-    get '/admin/api/cms/files.:format', action: :index do
+  api 'cms file', format: [:json] do
+    get '/admin/api/cms/files', action: :index do
       let(:collection) { provider.files }
       let(:serialized) { representer.public_send(serialization_format, short: true) }
     end
 
-    get '/admin/api/cms/files/:id.:format', action: :show
+    get '/admin/api/cms/files/:id', action: :show
 
-    post '/admin/api/cms/files.:format', action: :create do
+    post '/admin/api/cms/files', action: :create do
       parameter :path, 'The path'
       parameter :section_id, 'Section where this file belongs'
       parameter :attachment, 'The Attachment'
@@ -24,13 +24,13 @@ resource 'CMS::File' do
       let(:attachment) { fixture_file_upload('/wide.jpg',' image/jpeg') }
     end
 
-    put '/admin/api/cms/files/:id.:format', action: :update do
+    put '/admin/api/cms/files/:id', action: :update do
       parameter :downloadable, 'Checked sets the content-disposition to attachment'
 
       let(:downloadable) { true }
     end
 
-    delete '/admin/api/cms/files/:id.:format', action: :destroy
+    delete '/admin/api/cms/files/:id', action: :destroy
   end
 
   describe 'representer' do
@@ -48,12 +48,6 @@ resource 'CMS::File' do
           expect(subject.keys).to eq(expected_attributes)
         end
       end
-
-      xml(:resource) do
-        it 'should have the correct attributes' do
-          expect(subject.root.elements.map(&:name)).to eq(expected_attributes)
-        end
-      end
     end
 
     context 'when requesting a single resource' do
@@ -64,34 +58,22 @@ resource 'CMS::File' do
           expect(subject.keys).to eq(expected_attributes)
         end
       end
-
-      xml(:resource) do
-        it 'should have the correct attributes' do
-          expect(subject.root.elements.map(&:name)).to eq(expected_attributes)
-        end
-      end
     end
 
     context 'when requesting a collection' do
       let(:root) { 'files' }
 
       json(:collection)
-
-      xml(:collection) do
-        it 'should have root' do
-          expect(xml).to have_tag(root)
-        end
-      end
     end
   end
 end
 
 __END__
 
-admin_api_cms_files     GET      /admin/api/cms/files(.:format)          admin/api/cms/files#index {:format=>"xml"}
-                        POST     /admin/api/cms/files(.:format)          admin/api/cms/files#create {:format=>"xml"}
- new_admin_api_cms_file GET      /admin/api/cms/files/new(.:format)      admin/api/cms/files#new {:format=>"xml"}
-edit_admin_api_cms_file GET      /admin/api/cms/files/:id/edit(.:format) admin/api/cms/files#edit {:format=>"xml"}
-     admin_api_cms_file GET      /admin/api/cms/files/:id(.:format)      admin/api/cms/files#show {:format=>"xml"}
-                        PUT      /admin/api/cms/files/:id(.:format)      admin/api/cms/files#update {:format=>"xml"}
-                        DELETE   /admin/api/cms/files/:id(.:format)      admin/api/cms/files#destroy {:format=>"xml"}
+admin_api_cms_files     GET      /admin/api/cms/files(.:format)          admin/api/cms/files#index {:format=>"json"}
+                        POST     /admin/api/cms/files(.:format)          admin/api/cms/files#create {:format=>"json"}
+ new_admin_api_cms_file GET      /admin/api/cms/files/new(.:format)      admin/api/cms/files#new {:format=>"json"}
+edit_admin_api_cms_file GET      /admin/api/cms/files/:id/edit(.:format) admin/api/cms/files#edit {:format=>"json"}
+     admin_api_cms_file GET      /admin/api/cms/files/:id(.:format)      admin/api/cms/files#show {:format=>"json"}
+                        PUT      /admin/api/cms/files/:id(.:format)      admin/api/cms/files#update {:format=>"json"}
+                        DELETE   /admin/api/cms/files/:id(.:format)      admin/api/cms/files#destroy {:format=>"json"}

--- a/spec/acceptance/api/cms_layout_spec.rb
+++ b/spec/acceptance/api/cms_layout_spec.rb
@@ -16,10 +16,6 @@ resource 'CMS::Layout' do
       json(:resource) do
         it { should have_properties(expected_attributes).from(resource) }
       end
-
-      xml(:resource) do
-        it { should have_tags(expected_attributes).from(resource) }
-      end
     end
 
     context 'when requesting the shorten version' do
@@ -28,10 +24,6 @@ resource 'CMS::Layout' do
 
       json(:resource) do
         it { should have_properties(expected_attributes).from(resource) }
-      end
-
-      xml(:resource) do
-        it { should have_tags(expected_attributes).from(resource) }
       end
     end
   end

--- a/spec/acceptance/api/cms_page_spec.rb
+++ b/spec/acceptance/api/cms_page_spec.rb
@@ -43,12 +43,6 @@ resource 'CMS::Page' do
           expect(subject.keys).to eq(expected_attributes)
         end
       end
-
-      xml(:resource) do
-        it 'should have the correct attributes' do
-          expect(subject.root.elements.map(&:name)).to eq(expected_attributes)
-        end
-      end
     end
 
     context 'when requesting the shorten version' do
@@ -74,12 +68,6 @@ resource 'CMS::Page' do
       json(:resource, skip_resource_save: true) do
         it 'should have the correct attributes' do
           expect(subject.keys).to eq(expected_attributes)
-        end
-      end
-
-      xml(:resource) do
-        it 'should have the correct attributes' do
-          expect(subject.root.elements.map(&:name)).to eq(expected_attributes)
         end
       end
     end

--- a/spec/acceptance/api/cms_partial_spec.rb
+++ b/spec/acceptance/api/cms_partial_spec.rb
@@ -23,10 +23,6 @@ resource "CMS::Partial" do
       json(:resource) do
         it { should have_properties(expected_attributes).from(resource) }
       end
-
-      xml(:resource) do
-        it { should have_tags(expected_attributes).from(resource) }
-      end
     end
 
     context 'when requesting the shorten version' do
@@ -35,10 +31,6 @@ resource "CMS::Partial" do
 
       json(:resource) do
         it { should have_properties(expected_attributes).from(resource) }
-      end
-
-      xml(:resource) do
-        it { should have_tags(expected_attributes).from(resource) }
       end
     end
   end

--- a/spec/acceptance/api/cms_section_spec.rb
+++ b/spec/acceptance/api/cms_section_spec.rb
@@ -5,15 +5,15 @@ require 'rails_helper'
 resource 'CMS::Section' do
   let(:resource) { FactoryBot.create(:cms_section, provider: provider, parent: provider.sections.root) }
 
-  api 'cms section' do
-    get '/admin/api/cms/sections.:format', action: :index do
+  api 'cms section', format: [:json] do
+    get '/admin/api/cms/sections', action: :index do
       let(:collection) { provider.sections.order(:id) }
       let(:serialized) { representer.public_send(serialization_format, short: true) }
     end
 
-    get '/admin/api/cms/sections/:id.:format', action: :show
+    get '/admin/api/cms/sections/:id', action: :show
 
-    post '/admin/api/cms/sections.:format', action: :create do
+    post '/admin/api/cms/sections', action: :create do
       parameter :parent_id, 'The Parent Section'
       parameter :title, 'Section Title'
 
@@ -21,12 +21,12 @@ resource 'CMS::Section' do
       let(:parent_id) { resource.parent_id }
     end
 
-    put '/admin/api/cms/sections/:id.:format', action: :update do
+    put '/admin/api/cms/sections/:id', action: :update do
       parameter :title, 'Section Title'
       let(:title) { 'Magic Section' }
     end
 
-    delete '/admin/api/cms/sections/:id.:format', action: :destroy
+    delete '/admin/api/cms/sections/:id', action: :destroy
   end
 
   describe 'representer' do
@@ -42,10 +42,6 @@ resource 'CMS::Section' do
       json(:resource) do
         it { should have_properties(expected_attributes).from(resource) }
       end
-
-      xml(:resource) do
-        it { should have_tags(expected_attributes).from(resource) }
-      end
     end
 
     context 'when requesting a single resource' do
@@ -54,31 +50,21 @@ resource 'CMS::Section' do
       json(:resource) do
         it { should have_properties(expected_attributes).from(resource) }
       end
-
-      xml(:resource) do
-        it { should have_tags(expected_attributes).from(resource) }
-      end
     end
 
     context 'when requesting a collection' do
       let(:root) { 'sections' }
 
       json(:collection)
-
-      xml(:collection) do
-        it 'should have root' do
-          expect(xml).to have_tag(root)
-        end
-      end
     end
   end
 end
 
 __END__
-   admin_api_cms_sections  GET      /admin/api/cms/sections(.:format)          admin/api/cms/sections#index {:format=>'xml'}
-                           POST     /admin/api/cms/sections(.:format)          admin/api/cms/sections#create {:format=>'xml'}
- new_admin_api_cms_section GET      /admin/api/cms/sections/new(.:format)      admin/api/cms/sections#new {:format=>'xml'}
-edit_admin_api_cms_section GET      /admin/api/cms/sections/:id/edit(.:format) admin/api/cms/sections#edit {:format=>'xml'}
-     admin_api_cms_section GET      /admin/api/cms/sections/:id(.:format)      admin/api/cms/sections#show {:format=>'xml'}
-                           PUT      /admin/api/cms/sections/:id(.:format)      admin/api/cms/sections#update {:format=>'xml'}
-                           DELETE   /admin/api/cms/sections/:id(.:format)      admin/api/cms/sections#destroy {:format=>'xml'}
+   admin_api_cms_sections  GET      /admin/api/cms/sections(.:format)          admin/api/cms/sections#index {:format=>'json'}
+                           POST     /admin/api/cms/sections(.:format)          admin/api/cms/sections#create {:format=>'json'}
+ new_admin_api_cms_section GET      /admin/api/cms/sections/new(.:format)      admin/api/cms/sections#new {:format=>'json'}
+edit_admin_api_cms_section GET      /admin/api/cms/sections/:id/edit(.:format) admin/api/cms/sections#edit {:format=>'json'}
+     admin_api_cms_section GET      /admin/api/cms/sections/:id(.:format)      admin/api/cms/sections#show {:format=>'json'}
+                           PUT      /admin/api/cms/sections/:id(.:format)      admin/api/cms/sections#update {:format=>'json'}
+                           DELETE   /admin/api/cms/sections/:id(.:format)      admin/api/cms/sections#destroy {:format=>'json'}

--- a/spec/acceptance/api/cms_template_spec.rb
+++ b/spec/acceptance/api/cms_template_spec.rb
@@ -11,23 +11,23 @@ resource "CMS::Template" do
   let(:collection) { [partial, layout, page] }
 
   shared_examples "cms resource" do
-    post '/admin/api/cms/templates.:format', action: :create do
+    post '/admin/api/cms/templates', action: :create do
       let(:resource) { CMS::Template.last }
       parameter :type, 'Type of the CMS Template'
     end
-    get '/admin/api/cms/templates/:id.:format', action: :show
-    put '/admin/api/cms/templates/:id.:format', action: :update
-    put '/admin/api/cms/templates/:id.:format', action: :publish do
+    get '/admin/api/cms/templates/:id', action: :show
+    put '/admin/api/cms/templates/:id', action: :update
+    put '/admin/api/cms/templates/:id', action: :publish do
       before { resource.should be_dirty }
       after { resource.should_not be_dirty }
     end
-    delete '/admin/api/cms/templates/:id.:format', action: :destroy do
+    delete '/admin/api/cms/templates/:id', action: :destroy do
       after { expect{ resource.reload }.to raise_error(ActiveRecord::RecordNotFound) }
     end
   end
 
-  api 'cms template' do
-    get '/admin/api/cms/templates.:format', action: :index do
+  api 'cms template', format: [:json] do
+    get '/admin/api/cms/templates', action: :index do
       before { collection.each(&:save!).sort_by!(&:id) }
       let(:serialized) { representer.send(serialization_format, short: true) }
     end
@@ -104,8 +104,8 @@ resource "CMS::Template" do
 end
 
 __END__
- publish_admin_api_cms_template PUT    /admin/api/cms/templates/:id/publish(.:format) admin/api/cms/templates#publish {:format=>"xml"}
-        admin_api_cms_templates GET    /admin/api/cms/templates(.:format)             admin/api/cms/templates#index {:format=>"xml"}
-                                POST   /admin/api/cms/templates(.:format)             admin/api/cms/templates#create {:format=>"xml"}
-         admin_api_cms_template GET    /admin/api/cms/templates/:id(.:format)         admin/api/cms/templates#show {:format=>"xml"}
-                                PUT    /admin/api/cms/templates/:id(.:format)         admin/api/cms/templates#update {:format=>"xml"}
+ publish_admin_api_cms_template PUT    /admin/api/cms/templates/:id/publish(.:format) admin/api/cms/templates#publish {:format=>"json"}
+        admin_api_cms_templates GET    /admin/api/cms/templates(.:format)             admin/api/cms/templates#index {:format=>"json"}
+                                POST   /admin/api/cms/templates(.:format)             admin/api/cms/templates#create {:format=>"json"}
+         admin_api_cms_template GET    /admin/api/cms/templates/:id(.:format)         admin/api/cms/templates#show {:format=>"json"}
+                                PUT    /admin/api/cms/templates/:id(.:format)         admin/api/cms/templates#update {:format=>"json"}

--- a/test/functional/admin/api/cms/templates_controller_test.rb
+++ b/test/functional/admin/api/cms/templates_controller_test.rb
@@ -12,26 +12,15 @@ class Admin::Api::CMS::TemplatesControllerTest < ActionController::TestCase
 
   class TemplatesControllerMethodsTest < Admin::Api::CMS::TemplatesControllerTest
     def test_show
-      CMS::Portlet.available.each do |portlet_type|
-        portlet = FactoryBot.create(:cms_portlet, provider: @provider,
-          portlet_type: portlet_type.to_s, type: portlet_type.to_s)
-
-        get :show, params: { id: portlet.id, format: :xml, access_token: @token }
-
-        assert_response :success
-        assert_equal 0, xml_elements_by_key(@response.body, 'builtin_partial').count
-        assert_equal 1, xml_elements_by_key(@response.body, 'partial').count
-      end
-    end
-
-    def test_show_builtin_partial
       partial = FactoryBot.create(:cms_builtin_partial, provider: @provider)
 
-      get :show, params: { id: partial.id, format: :xml, access_token: @token }
+      get :show, params: { id: partial.id, format: :json, access_token: @token }
 
       assert_response :success
-      assert_equal 1, xml_elements_by_key(@response.body, 'builtin_partial').count
-      assert_equal 0, xml_elements_by_key(@response.body, 'partial').count
+      assert_equal(
+        %w[id created_at updated_at system_name draft published],
+        response.parsed_body['builtin_partial'].keys
+      )
     end
 
     def test_create

--- a/test/functional/admin/api/cms/templates_controller_test.rb
+++ b/test/functional/admin/api/cms/templates_controller_test.rb
@@ -19,7 +19,7 @@ class Admin::Api::CMS::TemplatesControllerTest < ActionController::TestCase
       assert_response :success
       assert_equal(
         %w[id created_at updated_at system_name draft published],
-        response.parsed_body['builtin_partial'].keys
+        JSON.parse(response.body)['builtin_partial'].keys
       )
     end
 

--- a/test/integration/cms/api/files_test.rb
+++ b/test/integration/cms/api/files_test.rb
@@ -5,7 +5,6 @@ require 'test_helper'
 module CMS
   module Api
     class FilesTest < ActionDispatch::IntegrationTest
-
       def setup
         @provider = FactoryBot.create(:provider_account)
         host! @provider.external_admin_domain
@@ -21,11 +20,10 @@ module CMS
 
       test 'index' do
         21.times { create_file }
-        get admin_api_cms_files_path, params: { provider_key: @provider.provider_key, format: :xml }
+        get admin_api_cms_files_path, params: { provider_key: @provider.provider_key, format: :json }
         assert_response :success
 
-        doc = Nokogiri::XML::Document.parse(@response.body)
-        assert_equal 20, doc.xpath('/files/*').size
+        assert_equal 20, response.parsed_body['files'].size
       end
 
       test 'index with section' do
@@ -33,7 +31,7 @@ module CMS
         FactoryBot.create :cms_file, provider: @provider, title: 'file-in-root-section'
         FactoryBot.create :cms_file, provider: @provider, section_id: section.id, title: 'a file'
 
-        get admin_api_cms_section_files_path(section, format: :xml), params: { provider_key: @provider.provider_key }
+        get admin_api_cms_section_files_path(section, format: :json), params: { provider_key: @provider.provider_key }
 
         assert_response :success
         assert_not_match 'file-in-root-section', response.body
@@ -41,7 +39,7 @@ module CMS
 
         other_provider = FactoryBot.create :provider_account
         other_section  = FactoryBot.create :cms_section, provider: other_provider, parent: other_provider.sections.root
-        get admin_api_cms_section_files_path(other_section, format: :xml), params: { provider_key: @provider.provider_key }
+        get admin_api_cms_section_files_path(other_section, format: :json), params: { provider_key: @provider.provider_key }
         assert_response :not_found
 
         get admin_api_cms_section_files_path(@provider.sections.root.system_name, format: :json), params: { provider_key: @provider.provider_key }
@@ -56,54 +54,55 @@ module CMS
         21.times { create_file  }
 
         # first page
-        get admin_api_cms_files_path, params: { provider_key: @provider.provider_key, format: :xml }
+        get admin_api_cms_files_path, params: { provider_key: @provider.provider_key, format: :json }
         assert_response :success
-        doc = Nokogiri::XML::Document.parse(@response.body)
 
-        assert_equal '1', doc.xpath('/files/@current_page').text
-        assert_equal '2', doc.xpath('/files/@total_pages').text
-        assert_equal '21', doc.xpath('/files/@total_entries').text
-        assert_equal 20, doc.xpath('/files/*').size
+        assert_equal 20, response.parsed_body['files'].size
+        assert_equal(
+          { per_page: 20, total_entries: 21, total_pages: 2, current_page: 1 },
+          response.parsed_body['metadata'].symbolize_keys
+        )
 
         # second page
-        get admin_api_cms_files_path, params: { provider_key: @provider.provider_key, page: 2, format: :xml }
+        get admin_api_cms_files_path, params: { provider_key: @provider.provider_key, page: 2, format: :json }
         assert_response :success
-        doc = Nokogiri::XML::Document.parse(@response.body)
-        assert_equal 1, doc.xpath('/files/*').size
+
+        assert_equal 1, response.parsed_body['files'].size
+        assert_equal(
+          { per_page: 20, total_entries: 21, total_pages: 2, current_page: 2 },
+          response.parsed_body['metadata'].symbolize_keys
+        )
       end
 
       test 'index with explicit per_page parameter' do
         11.times { create_file  }
 
-        common = { provider_key: @provider.provider_key, format: :xml }
+        common = { provider_key: @provider.provider_key, format: :json }
         get admin_api_cms_files_path, params: common.merge(per_page: 5)
         assert_response :success
-        doc = Nokogiri::XML::Document.parse(@response.body)
 
-        assert_equal '5', doc.xpath('/files/@per_page').text
-        assert_equal '11', doc.xpath('/files/@total_entries').text
-        assert_equal '3', doc.xpath('/files/@total_pages').text
-        assert_equal '1', doc.xpath('/files/@current_page').text
+        assert_equal 5, response.parsed_body['files'].size
+        assert_equal(
+          { per_page: 5, total_entries: 11, total_pages: 3, current_page: 1 },
+          response.parsed_body['metadata'].symbolize_keys
+        )
       end
 
       test 'show file' do
         file = create_file
-        get admin_api_cms_file_path(file), params: { provider_key: @provider.provider_key, format: :xml }
+        get admin_api_cms_file_path(file), params: { provider_key: @provider.provider_key, format: :json }
         assert_response :success
 
-        doc = Nokogiri::XML::Document.parse(@response.body)
-
-        assert_equal file.id.to_s, doc.xpath('/file/id').text
-        assert_equal file.created_at.xmlschema, doc.xpath('/file/created_at').text
-        assert_equal file.updated_at.xmlschema, doc.xpath('/file/updated_at').text
-        assert_equal file.path, doc.xpath('/file/path').text
-        assert_equal file.title, doc.xpath('/file/title').text
+        assert_equal(
+          %w[id created_at updated_at section_id path downloadable url title content_type],
+          response.parsed_body['file'].keys
+        )
       end
 
       test 'update' do
         file = create_file
 
-        put admin_api_cms_file_path(file, format: :xml), params: { provider_key: @provider.provider_key, attachment: attachment_for_upload }
+        put admin_api_cms_file_path(file, format: :json), params: { provider_key: @provider.provider_key, attachment: attachment_for_upload }
 
         file.reload
 
@@ -112,21 +111,23 @@ module CMS
       end
 
       test 'create' do
-        post admin_api_cms_files_path, params: { provider_key: @provider.provider_key, format: :xml, path: "/foo.bar", attachment: attachment_for_upload, section_id: @provider.sections.root.id }
+        post admin_api_cms_files_path, params: { provider_key: @provider.provider_key, format: :json, path: "/foo.bar", attachment: attachment_for_upload, section_id: @provider.sections.root.id }
         assert_response :success
 
-        doc = Nokogiri::XML(@response.body)
-        id = doc.xpath('//id').text
+        id = response.parsed_body['file']['id']
         file = @provider.files.find(id.to_i)
         assert_equal 'wide.jpg', file.title
       end
 
       test 'create with errors' do
-        post admin_api_cms_files_path(format: :xml), params: { provider_key: @provider.provider_key, downloadable: true }
+        post admin_api_cms_files_path(format: :json), params: { provider_key: @provider.provider_key, downloadable: true }
 
         assert_response :unprocessable_entity
 
-        assert_xml_error response.body, "Path can't be blank"
+        assert_equal(
+          { path: ["can't be blank"], attachment: ["can't be blank"] },
+          response.parsed_body['errors'].symbolize_keys
+        )
       end
 
       test 'create without section will put the file in root section' do
@@ -138,10 +139,9 @@ module CMS
 
       test 'delete' do
         file = create_file
-        delete admin_api_cms_file_path(file), params: { provider_key: @provider.provider_key, format: :xml }
+        delete admin_api_cms_file_path(file), params: { provider_key: @provider.provider_key, format: :json }
         assert_nil CMS::File.find_by(id: file.id)
       end
-
     end
   end
 end

--- a/test/integration/cms/api/sections_test.rb
+++ b/test/integration/cms/api/sections_test.rb
@@ -5,7 +5,6 @@ require 'test_helper'
 module CMS
   module Api
     class SectionsTest < ActionDispatch::IntegrationTest
-
       def setup
         @provider = FactoryBot.create(:provider_account)
         host! @provider.external_admin_domain
@@ -18,61 +17,58 @@ module CMS
       test 'index' do
         20.times { create_section }
 
-        get admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, format: :xml }
+        get admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, format: :json }
         assert_response :success
-
-        doc = Nokogiri::XML::Document.parse(@response.body)
-
-        assert_equal 20, doc.xpath('/sections/*').size
+        assert_equal 20, response.parsed_body['sections'].size
       end
 
       test 'index with pagination' do
         20.times { create_section  }
 
         # first page
-        get admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, format: :xml }
+        get admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, format: :json }
         assert_response :success
-        doc = Nokogiri::XML::Document.parse(@response.body)
 
-        assert_equal '1', doc.xpath('/sections/@current_page').text
-        assert_equal '2', doc.xpath('/sections/@total_pages').text
-        assert_equal '21', doc.xpath('/sections/@total_entries').text
-        assert_equal 20, doc.xpath('/sections/*').size
+        assert_equal 20, response.parsed_body['sections'].size
+        assert_equal(
+          { per_page: 20, total_entries: 21, total_pages: 2, current_page: 1 },
+          response.parsed_body['metadata'].symbolize_keys
+        )
 
         # second page
-        get admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, page: 2, format: :xml }
+        get admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, page: 2, format: :json }
         assert_response :success
-        doc = Nokogiri::XML::Document.parse(@response.body)
-        assert_equal 1, doc.xpath('/sections/*').size
+
+        assert_equal 1, response.parsed_body['sections'].size
+        assert_equal(
+          { per_page: 20, total_entries: 21, total_pages: 2, current_page: 2 },
+          response.parsed_body['metadata'].symbolize_keys
+        )
       end
 
       test 'explicit per_page parameter' do
         10.times { create_section  }
 
-        common = { provider_key: @provider.provider_key, format: :xml }
+        common = { provider_key: @provider.provider_key, format: :json }
         get admin_api_cms_sections_path, params: common.merge(per_page: 5)
         assert_response :success
-        doc = Nokogiri::XML::Document.parse(@response.body)
 
-        assert_equal '5', doc.xpath('/sections/@per_page').text
-        assert_equal '11', doc.xpath('/sections/@total_entries').text
-        assert_equal '3', doc.xpath('/sections/@total_pages').text
-        assert_equal '1', doc.xpath('/sections/@current_page').text
+        assert_equal 5, response.parsed_body['sections'].size
+        assert_equal(
+          { per_page: 5, total_entries: 11, total_pages: 3, current_page: 1 },
+          response.parsed_body['metadata'].symbolize_keys
+        )
       end
 
       test 'show section' do
         section = create_section
-        get admin_api_cms_section_path(section), params: { provider_key: @provider.provider_key, format: :xml }
+        get admin_api_cms_section_path(section), params: { provider_key: @provider.provider_key, format: :json }
         assert_response :success
 
-        doc = Nokogiri::XML::Document.parse(@response.body)
-
-        assert_equal section.id.to_s, doc.xpath('/section/id').text
-        assert_equal section.created_at.xmlschema, doc.xpath('/section/created_at').text
-        assert_equal section.updated_at.xmlschema, doc.xpath('/section/updated_at').text
-        assert_equal section.parent_id.to_s, doc.xpath('/section/parent_id').text
-        assert_equal section.system_name, doc.xpath('/section/system_name').text
-        assert_equal section.title, doc.xpath('/section/title').text
+        assert_equal(
+          %w[id created_at updated_at title system_name public parent_id partial_path],
+          response.parsed_body['section'].keys
+        )
       end
 
       test 'find section by system name' do
@@ -88,7 +84,11 @@ module CMS
 
       test 'update' do
         section = create_section
-        put admin_api_cms_section_path(section), params: { provider_key: @provider.provider_key, format: :xml, title: 'foo' }
+        put admin_api_cms_section_path(section), params: {
+          provider_key: @provider.provider_key,
+          format: :json,
+          title: 'foo'
+        }
         assert_response :success
 
         section.reload
@@ -96,18 +96,19 @@ module CMS
       end
 
       test 'create' do
-
-        post admin_api_cms_sections_path, params: { provider_key: @provider.provider_key, format: :xml, title: 'Foo Bar Lol' }
+        post admin_api_cms_sections_path, params: {
+          provider_key: @provider.provider_key,
+          format: :json,
+          title: 'Foo Bar Lol'
+        }
 
         assert_response :success
 
-        doc = Nokogiri::XML::Document.parse(@response.body)
-        id = doc.xpath('//id').text
+        id = response.parsed_body['section']['id']
         section = @provider.sections.find(id.to_i)
 
         assert_equal 'Foo Bar Lol', section.title
       end
     end
-
   end
 end

--- a/test/integration/cms/api/templates_test.rb
+++ b/test/integration/cms/api/templates_test.rb
@@ -24,6 +24,7 @@ module CMS
 
         assert_equal 4, templates.size
         assert_equal 1, templates.find { |templ| templ['partial'] }.values.size
+        assert_nil templates.find { |templ| templ['partial'] }['partial']['draft']
         assert_equal 1, templates.find { |templ| templ['page'] }.values.size
         assert_equal 1, templates.find { |templ| templ['builtin_page'] }.values.size
         assert_equal 1, templates.find { |templ| templ['layout'] }.values.size

--- a/test/integration/cms/api/templates_test.rb
+++ b/test/integration/cms/api/templates_test.rb
@@ -134,18 +134,14 @@ module CMS
         assert_equal '/cool', response.parsed_body['page']['path']
       end
 
-      {
-        HTML: '<html><body><p>This is a test</p></body></html>',
-        CDATA: '<![CDATA[<html><body><p>This is a test</p></body></html>]]>'
-      }.each do |name, published|
-        test "show a page with #{name} inside the content" do
-          page = FactoryBot.create(:cms_page, provider: @provider, path: '/cool', published: published)
-          get admin_api_cms_template_path(page), params: { provider_key: @provider.provider_key, id: page.id, format: :json }
-          assert_response :success
+      test "show a page with HTML inside the content" do
+        html_content = '<html><body><p>This is a test</p></body></html>'
+        page = FactoryBot.create(:cms_page, provider: @provider, path: '/cool', published: html_content)
+        get admin_api_cms_template_path(page), params: { provider_key: @provider.provider_key, id: page.id, format: :json }
+        assert_response :success
 
-          page = response.parsed_body['page']
-          assert_equal published, page['published']
-        end
+        page = response.parsed_body['page']
+        assert_equal html_content, page['published']
       end
 
       test 'publish' do


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes support for `XML` format requests from all CMS endpoints. It also makes `JSON` the standard request format for the CMS API. 

**Which issue(s) this PR fixes** 

[THREESCALE-9433](https://issues.redhat.com/browse/THREESCALE-9433)

**Verification steps** 

The following endpoints should only respond to `JSON` requests. Any other format should return a `406` status.

| Verb | Endpoint | Controller#Action |
| ------- | ------- | ------- |
|GET|/admin/api/cms/sections/:section_id/files|admin/api/cms/files#index|
|GET|/admin/api/cms/sections|admin/api/cms/sections#index|
|POST|/admin/api/cms/sections|admin/api/cms/sections#create|
|GET|/admin/api/cms/sections/new|admin/api/cms/sections#new|
|GET|/admin/api/cms/sections/:id/edit|admin/api/cms/sections#edit|
|GET|/admin/api/cms/sections/:id|admin/api/cms/sections#show|
|PATCH|/admin/api/cms/sections/:id|admin/api/cms/sections#update|
|PUT|/admin/api/cms/sections/:id|admin/api/cms/sections#update|
|DELETE|/admin/api/cms/sections/:id|admin/api/cms/sections#destroy|
|GET|/admin/api/cms/files|admin/api/cms/files#index|
|POST|/admin/api/cms/files|admin/api/cms/files#create|
|GET|/admin/api/cms/files/new|admin/api/cms/files#new|
|GET|/admin/api/cms/files/:id/edit|admin/api/cms/files#edit|
|GET|/admin/api/cms/files/:id|admin/api/cms/files#show|
|PATCH|/admin/api/cms/files/:id|admin/api/cms/files#update|
|PUT|/admin/api/cms/files/:id|admin/api/cms/files#update|
|DELETE|/admin/api/cms/files/:id|admin/api/cms/files#destroy|
|PUT|/admin/api/cms/templates/:id/publish|admin/api/cms/templates#publish|
|GET|/admin/api/cms/templates|admin/api/cms/templates#index|
|POST|/admin/api/cms/templates|admin/api/cms/templates#create|
|GET|/admin/api/cms/templates/:id|admin/api/cms/templates#show|
|PATCH|/admin/api/cms/templates/:id|admin/api/cms/templates#update|
|PUT|/admin/api/cms/templates/:id|admin/api/cms/templates#update|
|DELETE|/admin/api/cms/templates/:id|admin/api/cms/templates#destroy|

**Special notes for your reviewer**:

![](https://media.giphy.com/media/3eKdC7REvgOt2/giphy.gif)