### PR TITLE
⬆️ Node.js 14

### DIFF
--- a/.tool-versions.sample
+++ b/.tool-versions.sample
@@ -1,3 +1,3 @@
 ruby 2.6.10
-nodejs 12.22.2
+nodejs 14.21.3
 python 2.7.18

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/3scale/system-builder:ruby26-nodejs12
+FROM quay.io/3scale/system-builder:ruby26-nodejs14
 
 ARG CUSTOM_DB=mysql
 
@@ -9,7 +9,7 @@ ENV DISABLE_SPRING="true" \
     MASTER_PASSWORD="p" \
     USER_PASSWORD="p" \
     LC_ALL="en_US.UTF-8" \
-    PATH="./node_modules/.bin:/opt/rh/rh-nodejs12/root/usr/bin:$PATH" \
+    PATH="./node_modules/.bin:/opt/rh/rh-nodejs14/root/usr/bin:$PATH" \
     DNSMASQ="#" \
     BUNDLE_FROZEN=1 \
     BUNDLE_JOBS=5 \

--- a/fedora-manual-setup.md
+++ b/fedora-manual-setup.md
@@ -12,7 +12,7 @@ ln -s .tool-versions.sample .tool-versions
 
 ### Ruby and Node.js
 
-The project supports **[ruby 2.6.x](https://www.ruby-lang.org/en/downloads/)** and **[Node.js 12](https://nodejs.org/en/download/)**.
+The project supports **[ruby 2.6.x](https://www.ruby-lang.org/en/downloads/)** and **[Node.js 16](https://nodejs.org/download/release/v14.21.3/)**.
 The recommended way to install them is with `asdf`:
 
 ```
@@ -24,7 +24,7 @@ asdf install
 
 > Alternatively, Node.js can be installed as a [Module](https://developer.fedoraproject.org/tech/languages/nodejs/nodejs.html):
 > ```
-> dnf module install nodejs:12
+> dnf module install nodejs:14
 > ```
 
 ### Dependencies

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -12,7 +12,7 @@ ENV TZ=:/etc/localtime \
     BUNDLE_GEMFILE=Gemfile \
     BUNDLE_WITHOUT=development:test \
     VARNISH_SCL=rh-varnish5 \
-    NODEJS_SCL=rh-nodejs12 \
+    NODEJS_SCL=rh-nodejs14 \
     RUBY_SCL="rh-ruby${RUBY_SCL_NAME_VERSION}" \
     GIT_SCL=rh-git227
 

--- a/osx-manual-setup.md
+++ b/osx-manual-setup.md
@@ -26,7 +26,7 @@ ln -s .tool-versions.sample .tool-versions
 
 ### Ruby and Node.js
 
-The project supports **[ruby 2.6.x](https://www.ruby-lang.org/en/downloads/)** and **[Node.js 12](https://nodejs.org/en/download/)**. To install them with `asdf` run:
+The project supports **[ruby 2.6.x](https://www.ruby-lang.org/en/downloads/)** and **[Node.js 16](https://nodejs.org/download/release/v14.21.3/)**. To install them with `asdf` run:
 
 ```
 asdf plugin add ruby
@@ -34,12 +34,6 @@ asdf plugin add nodejs
 
 asdf install
 ```
-
-* **Macs with M1** require installing and running node through Rosetta 2:
-
-  ```
-  arch -x86_64 asdf install nodejs 12.22.2
-  ```
 
 ### Python (only macs with M1)
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "ci:lint": "eslint --ext .js,.jsx,.ts,.tsx . --quiet"
   },
+  "engines": {
+    "node": "14"
+  },
   "devDependencies": {
     "@babel/core": "^7.15.0",
     "@babel/preset-env": "^7.14.7",


### PR DESCRIPTION
This belongs a series of upgrades towards [shakapacker](https://github.com/shakacode/shakapacker) (AKA webpacker 6)

It also add `engines` to the package.json, this will render an error when node doesn't meet the specified version.

[THREESCALE-7331: Upgrade to NodeJS 14 for ubi8](https://issues.redhat.com/browse/THREESCALE-7331)

TODO:

- [x] node-sass and re-run yarn
- [ ] Docker stuff
- [ ] Update system-builder image

**Verification**:
Update your `.tool-versions` with the new version and/or install the new version, then run `yarn`.