### PR TITLE
🐛 Restore OgoneForm liquid tag (for backwards compatibility)

### DIFF
--- a/lib/developer_portal/config/initializers/liquid.rb
+++ b/lib/developer_portal/config/initializers/liquid.rb
@@ -25,6 +25,7 @@ Rails.application.config.to_prepare do
     Liquid::Tags::AuthorizeNetForm,
     Liquid::Tags::PaymentExpressForm,
     Liquid::Tags::BraintreeCustomerForm,
+    Liquid::Tags::OgoneForm,
     Liquid::Tags::StripeForm,
     Liquid::Tags::Content,
     Liquid::Tags::Container,

--- a/lib/developer_portal/lib/liquid/tags/ogone_form.rb
+++ b/lib/developer_portal/lib/liquid/tags/ogone_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# This exists to prevent crashing old versions of
+# lib/developer_portal/app/views/developer_portal/accounts/payment_gateways/show.html.liquid
+# It can and should be removed since Ogone was already deprecated and cleaned up.
+module Liquid
+  module Tags
+    class OgoneForm < Liquid::Tags::PaymentGatewayBaseForm
+      def render(context); end
+    end
+  end
+end


### PR DESCRIPTION
![Screenshot 2023-03-21 at 17 29 24](https://user-images.githubusercontent.com/11672286/226676472-44739916-326c-4f55-a32b-76269809c4db.png)

Even though we deprecated Ogone and Authorize.net a while ago, the liquid template where they were rendered weren't updated until now. All developer portals are initialized with a template rendering `ogone_form` but now it's been removed, so they crash in production:

<img width="1118" alt="Screenshot 2023-03-21 at 17 31 01" src="https://user-images.githubusercontent.com/11672286/226676982-8012323d-3d13-4911-989a-79ad08dea1cc.png">

The quick fix is to restore the tag `OgoneForm` even though it's not possible to actually render it, since `payment_gateway` can't be `ogone` anymore.
The not-so-quick-fix is to tell customers to update their templates (bad)
Or to catch this error (in general rather than for this particular case) so that the page does not crash (maybe bad, maybe not so much)
