### PR TITLE
⬆️ Bump `stripe-js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@patternfly/react-table": "^4.18.14",
     "@rails/webpacker": "5.4.4",
     "@stripe/react-stripe-js": "1.16.5",
-    "@stripe/stripe-js": "1.37.0",
+    "@stripe/stripe-js": "1.50.0",
     "bootstrap-sass": "^3.4.1",
     "braintree-web": "3.90.0",
     "c3": "^0.4.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2119,10 +2119,10 @@
   dependencies:
     prop-types "^15.7.2"
 
-"@stripe/stripe-js@1.37.0":
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.37.0.tgz#e7dc688122186aedb611810f30fbe89feb50af7a"
-  integrity sha512-khoaEqpvQUwEz/PyeKiiOGfzzhX8i009BJNTXjkkUpT2uCjnemo2JyFPCyHGszViqTSpDbFXeNIGIv+dtvd+9g==
+"@stripe/stripe-js@1.50.0":
+  version "1.50.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.50.0.tgz#1a5040485ee96fecc67b9d58533bb7ea7b23efc9"
+  integrity sha512-7j52eB98l/oJL1ywREs7UJAKEavM1HTtS8LUHt1dso8TJN8kNz561/847Xqbafe0yCReET8WFeIBvMeewug8xQ==
 
 "@tootallnate/once@1":
   version "1.1.2"


### PR DESCRIPTION
Fixes:
```
$ yarn check
...
error "@stripe/react-stripe-js#@stripe/stripe-js@^1.44.1" doesn't satisfy found match of "@stripe/stripe-js@1.37.0"
...
```