### PR TITLE
Fix postgres tests

### DIFF
--- a/app/presenters/plans_base_presenter.rb
+++ b/app/presenters/plans_base_presenter.rb
@@ -8,7 +8,8 @@ class PlansBasePresenter
     @collection = collection
     @pagination_params = { page: params[:page] || 1, per_page: params[:per_page] || 20 }
     @search = ThreeScale::Search.new(params[:search])
-    @sorting_params = "plans.#{params[:sort].presence || 'name'} #{params[:direction].presence || 'asc'}"
+    @sorting_params = { "plans.#{params[:sort].presence || 'name'}": "#{params[:direction].presence || 'asc'}" }
+                        .merge({ 'plans.name': 'asc' }) { |_, original, _| original }
   end
 
   attr_reader :collection, :pagination_params, :search, :sorting_params

--- a/features/step_definitions/plans_steps.rb
+++ b/features/step_definitions/plans_steps.rb
@@ -134,16 +134,16 @@ And "they can sort plans by name, no. of contracts and state" do
     assert_plans_table @plans.reorder(name: :desc), sort: true
 
     click_on 'Contracts'
-    assert_plans_table @plans.reorder(contracts_count: :asc), sort: true
+    assert_plans_table @plans.reorder(contracts_count: :asc, name: :asc), sort: true
 
     click_on 'Contracts'
-    assert_plans_table @plans.reorder(contracts_count: :desc), sort: true
+    assert_plans_table @plans.reorder(contracts_count: :desc, name: :asc), sort: true
 
     click_on 'State'
-    assert_plans_table @plans.reorder(state: :asc), sort: true
+    assert_plans_table @plans.reorder(state: :asc, name: :asc), sort: true
 
     click_on 'State'
-    assert_plans_table @plans.reorder(state: :desc), sort: true
+    assert_plans_table @plans.reorder(state: :desc, name: :asc), sort: true
   end
 end
 

--- a/test/unit/presenters/plan_presenters_test.rb
+++ b/test/unit/presenters/plan_presenters_test.rb
@@ -7,11 +7,11 @@ class PlanPresentersTest < ActiveSupport::TestCase
     assert_equal plans.reorder(name: :desc), presenter({ sort: 'name', direction: 'desc' }).paginated_table_plans
     assert_equal plans.reorder(name: :asc), presenter({ sort: 'name', direction: 'asc' }).paginated_table_plans
 
-    assert_equal plans.reorder(contracts_count: :desc), presenter({ sort: 'contracts_count', direction: 'desc' }).paginated_table_plans
-    assert_equal plans.reorder(contracts_count: :asc), presenter({ sort: 'contracts_count', direction: 'asc' }).paginated_table_plans
+    assert_equal plans.reorder(contracts_count: :desc, name: :asc), presenter({ sort: 'contracts_count', direction: 'desc' }).paginated_table_plans
+    assert_equal plans.reorder(contracts_count: :asc, name: :asc), presenter({ sort: 'contracts_count', direction: 'asc' }).paginated_table_plans
 
-    assert_equal plans.reorder(state: :desc), presenter({ sort: 'state', direction: 'desc' }).paginated_table_plans
-    assert_equal plans.reorder(state: :asc), presenter({ sort: 'state', direction: 'asc' }).paginated_table_plans
+    assert_equal plans.reorder(state: :desc, name: :asc), presenter({ sort: 'state', direction: 'desc' }).paginated_table_plans
+    assert_equal plans.reorder(state: :asc, name: :asc), presenter({ sort: 'state', direction: 'asc' }).paginated_table_plans
   end
 
   test 'default plan select plans have a fixed order by name' do

--- a/test/unit/services/finance/stripe_charge_service_test.rb
+++ b/test/unit/services/finance/stripe_charge_service_test.rb
@@ -125,11 +125,13 @@ class Finance::StripeChargeServiceTest < ActiveSupport::TestCase
   end
 
   test 'sends payment intent description to the gateway' do
+    friendly_id = '2022-10-00000001'
     response = build_response(true, 'Transaction Approved', object: 'payment_intent', id: 'new-payment-intent-id', status: 'succeeded')
+    invoice.update({friendly_id: friendly_id})
     invoice.issue_and_pay_if_free!
-    gateway.expects(:purchase).with(15_000, anything, has_entry(:description, "#{invoice.provider.name} API services fix")).returns(response)
-
-    assert service.charge(amount)
+    gateway.expects(:purchase).with(15_000, anything, has_entry(:description, "#{invoice.provider.name} API services #{friendly_id}")).returns(response)
+    charge_service = build_charge_service(invoice: invoice)
+    assert charge_service.charge(amount)
   end
 
   private


### PR DESCRIPTION
**What this PR does / why we need it**:

What the title says

**Which issue(s) this PR fixes** 

-

**Verification steps** 

Run postgres build in CircleCI

**Special notes for your reviewer**:

Fixes two issues:
1. Default `friendly_id` on the invoice is set differently in PostgreSQL and MySQL. This is fixed by https://github.com/3scale/porta/pull/3273/commits/eeddb7db47a55235346663030329c9f0193a8388
For some reason, when using MySQL, [calling the stored procedure](https://github.com/3scale/porta/blob/bd064fd/app/services/invoice_friendly_id_service.rb#L51) that sets the correct friendly ID doesn't have any effect, while when using PostgreSQL it does.

2. Another issue was with the application plans ordering.
The issue was that a specific order was expected from the list of application plans, when sorted by a specific column. However, if there are multiple results with the the same value in that column, their order are not predictable.

This is fixed by https://github.com/3scale/porta/pull/3273/commits/4861f15635fed8c9cc0a9de75276a827b327c2d4 that adds ordering by name as a second sort column, making the order of the output more predictable, and in theory will be the same in all DB engines.
