### PR TITLE
THREESCALE-8184  Use assert_nil if expecting nil

### DIFF
--- a/test/events/service_contracts/service_contract_cancellation_event_test.rb
+++ b/test/events/service_contracts/service_contract_cancellation_event_test.rb
@@ -10,7 +10,7 @@ class ServiceContracts::ServiceContractCancellationEventTest < ActiveSupport::Te
     assert event
     assert_equal event.plan_name, plan.name
     assert_equal event.service_name, service.name
-    assert_equal event.provider, contract.provider_account
+    assert_equal nil, contract.provider_account
     assert_equal event.service, contract.issuer
     assert_equal event.account_id, contract.buyer_account.id
     assert_equal event.account_name, contract.buyer_account.name

--- a/test/events/service_contracts/service_contract_cancellation_event_test.rb
+++ b/test/events/service_contracts/service_contract_cancellation_event_test.rb
@@ -10,7 +10,8 @@ class ServiceContracts::ServiceContractCancellationEventTest < ActiveSupport::Te
     assert event
     assert_equal event.plan_name, plan.name
     assert_equal event.service_name, service.name
-    assert_equal nil, contract.provider_account
+    assert_nil contract.provider_account
+    assert_nil event.provider
     assert_equal event.service, contract.issuer
     assert_equal event.account_id, contract.buyer_account.id
     assert_equal event.account_name, contract.buyer_account.name

--- a/test/unit/liquid/drops/account_drop_test.rb
+++ b/test/unit/liquid/drops/account_drop_test.rb
@@ -21,9 +21,16 @@ class Liquid::Drops::AccountDropTest < ActiveSupport::TestCase
     assert_equal @drop.id, @buyer.id
   end
 
-  test 'returns vat_rate' do
-    assert_nil(nil, @buyer.vat_rate)
+  test 'returns nil vat_rate for drop if buyer vate rate is nil' do
+    assert_nil @drop.vat_rate
   end
+
+  test 'returns vat_rate' do
+    @buyer.update(vat_rate: '123.4')
+    @drop_account = Drops::Account.new(@buyer)
+    assert_equal(@drop_account.vat_rate, @buyer.vat_rate)
+  end
+
 
   test "returns buyer's applications" do
     assert @drop.applications.is_a?(Array)

--- a/test/unit/liquid/drops/account_drop_test.rb
+++ b/test/unit/liquid/drops/account_drop_test.rb
@@ -28,7 +28,7 @@ class Liquid::Drops::AccountDropTest < ActiveSupport::TestCase
   test 'returns vat_rate' do
     @buyer.update(vat_rate: '123.4')
     @drop_account = Drops::Account.new(@buyer)
-    assert_equal(@drop_account.vat_rate, @buyer.vat_rate)
+    assert_equal @buyer.vat_rate, @drop_account.vat_rate
   end
 
 

--- a/test/unit/liquid/drops/account_drop_test.rb
+++ b/test/unit/liquid/drops/account_drop_test.rb
@@ -22,7 +22,7 @@ class Liquid::Drops::AccountDropTest < ActiveSupport::TestCase
   end
 
   test 'returns vat_rate' do
-    assert_equal(@drop.vat_rate, @buyer.vat_rate)
+    assert_nil(nil, @buyer.vat_rate)
   end
 
   test "returns buyer's applications" do


### PR DESCRIPTION
**What this PR does / why we need it:**

When sending emails from the bulk operations emails can be sent if body and subject is empty
make those field required

**DEPRECATED**: Use assert_nil if expecting nil

**Which issue(s) this PR fixes**
 https://issues.redhat.com/browse/THREESCALE-8184