### PR TITLE
db:seed succeed if backend is unavailable

### DIFF
--- a/app/lib/three_scale/socket.rb
+++ b/app/lib/three_scale/socket.rb
@@ -1,0 +1,13 @@
+module ThreeScale
+  module Socket
+    module ClassMethods
+      def accepts_connections?(host, port)
+        ::Socket.tcp(host, port, connect_timeout: 1) { true }
+      rescue
+        false
+      end
+    end
+
+    extend ClassMethods
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,11 +2,10 @@
 
 require 'dotenv/rails-now'
 
-
 ActiveRecord::Base.transaction do
-  if Rails.env.test? || System::Application.config.three_scale.core.fake_server
+  backend_url = URI::parse ThreeScale::Core.url
+  if Rails.env.test? || System::Application.config.three_scale.core.fake_server || !ThreeScale::Socket.accepts_connections?(backend_url.host, backend_url.port)
     require Rails.root.join('test/test_helpers/backend')
-    TestHelpers::Backend::MockCore.mock_core!
   end
 
   master_name = ENV.fetch('MASTER_NAME', 'Master Account')


### PR DESCRIPTION
When doing db:reset usually backend is down. If local configuration
doesn't use `fake_server`, then operation will fail at `db:seed`.

And since recently our example config does disable `fake_server`.

This change makes sure we mock it regardless of configuration when
we detect that backend is not available. So if anybody has a use case
where backend is indeed available it will work as expected. But not fail
for others.