### PR TITLE
Fix `bootstrap-sass` warning

### DIFF
--- a/app/javascript/src/Policies/styles/policies.scss
+++ b/app/javascript/src/Policies/styles/policies.scss
@@ -2,7 +2,39 @@
 
 $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 .PolicyConfiguration {
-  @import "~bootstrap-sass/assets/stylesheets/_bootstrap.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/_variables.scss";
+
+  // Utilities
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_opacity.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_tab-focus.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_text-overflow.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_vendor-prefixes.scss";
+
+  // Components
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_buttons.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_forms.scss";
+
+  // Skins
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_background-variant.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_border-radius.scss";
+
+  // Layout
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_clearfix.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_grid-framework.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins/_grid.scss";
+
+  // Reset and dependencies
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/_glyphicons.scss";
+
+  // Core CSS
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/_type.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/_grid.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/_forms.scss";
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/_buttons.scss";
+
+  // Components
+  @import "~bootstrap-sass/assets/stylesheets/bootstrap/_button-groups.scss";
 }
 
 $body-background: #fff;

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@rails/webpacker": "5.4.4",
     "@stripe/react-stripe-js": "1.16.5",
     "@stripe/stripe-js": "1.50.0",
-    "bootstrap-sass": "^3.4.1",
+    "bootstrap-sass": "3.4.3",
     "braintree-web": "3.90.0",
     "c3": "^0.4.11",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3772,10 +3772,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bootstrap-sass@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.4.1.tgz#6843c73b1c258a0ac5cb2cc6f6f5285b664a8e9a"
-  integrity sha512-p5rxsK/IyEDQm2CwiHxxUi0MZZtvVFbhWmyMOt4lLkA4bujDA1TGoKT0i1FKIWiugAdP+kK8T5KMDFIKQCLYIA==
+bootstrap-sass@3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.4.3.tgz#742cc8f4286303ae9fe8e4c95237321eae73766c"
+  integrity sha512-vPgFnGMp1jWZZupOND65WS6mkR8rxhJxndT/AcMbqcq1hHMdkcH4sMPhznLzzoHOHkSCrd6J9F8pWBriPCKP2Q==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Recently the following warning shows up when running webpack:
```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($line-height-computed, 2) or calc($line-height-computed / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div
```
To remove it, upgrade `bootstrap-sass`.

On the other hand, we're importing **the whole** library to style only a couple components in Integration / Policies. Ideally we should remove bootstrap-sass altogether and use PF4 components. In the meantime, the imported scss has been removed to the minimum.
```
master    8.7M      public/packs/js/policies-df14e7c216a288d657bb.js
fix       8.6M      public/packs/js/policies-8007597a59460b826fb8.js
```

**NOTE**
After a relatively thorough inspection, the looks have not changed in a noticeable way. The advantage of using Sass is that whenever a mixin, variable or whatever is missing, it fails compilation.

**Verification**:
1. There is no deprecation warning when `bin/webpack`.
2. Policies' styles are not broken

**Changelog for bootstrap-sass**: https://github.com/twbs/bootstrap-sass/blob/master/CHANGELOG.md#343-non-ruby-only