### PR TITLE
Serialize Service Mgmt API's report endpoint body correctly

### DIFF
--- a/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts
+++ b/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts
@@ -114,7 +114,7 @@ export interface Response extends SwaggerUIResponse {
   text: string;
 }
 
-const autocompleteOAS3 = async (response: SwaggerUIResponse, accountDataUrl: string, serviceEndpoint: string): Promise<Response> => {
+export const autocompleteOAS3 = async (response: SwaggerUIResponse, accountDataUrl: string, serviceEndpoint: string): Promise<Response> => {
   const bodyWithServer = injectServerToResponseBody(response.body, serviceEndpoint)
   const data = await fetchData<{ results: AccountData }>(accountDataUrl)
 

--- a/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
+++ b/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
@@ -22,6 +22,27 @@ const appendSwaggerDiv = (container: HTMLElement, id: string): void => {
 }
 
 /**
+ * A recursive function that traverses the tree of the multi-level object `data`
+ * and for every leaf (i.e. value of primitive type) adds the value to `formData` single-level object,
+ * with the key that is the `path` to that leaf, e.g. 'paramName[nestedArray][0][arrayProp]'
+ * @param formData single-level object used as accumulator
+ * @param data current node of the object
+ * @param parentKey part of the formData key inherited from the upper level
+ */
+const buildFormData = (formData: FormData, data: BodyValue, parentKey?: string) => {
+  if (data && typeof data === 'object') {
+    const dataObject = data as BodyValueObject
+    Object.keys(dataObject).forEach((key: string) => {
+      buildFormData(formData, dataObject[key], parentKey ? `${parentKey}[${key}]` : key)
+    })
+  } else {
+    if (parentKey) {
+      formData[parentKey] = data ? data : ''
+    }
+  }
+}
+
+/**
  * Transforms an object into form data representation. Does not URL-encode, because it will be done by
  * swagger-client itself
  * Returns an empty object if the argument is not an object
@@ -45,18 +66,6 @@ const appendSwaggerDiv = (container: HTMLElement, id: string): void => {
 export const objectToFormData = (object: BodyValueObject): FormData => {
   if (typeof object !== 'object' || Array.isArray(object)) {
     return {}
-  }
-  const buildFormData = (formData: FormData, data: BodyValue, parentKey?: string) => {
-    if (data && typeof data === 'object') {
-      const dataObject = data as BodyValueObject
-      Object.keys(dataObject).forEach((key: string) => {
-        buildFormData(formData, dataObject[key], parentKey ? `${parentKey}[${key}]` : key)
-      })
-    } else {
-      if (parentKey) {
-        formData[parentKey] = data ? data : ''
-      }
-    }
   }
   const formData: FormData = {}
   buildFormData(formData, object)

--- a/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
+++ b/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
@@ -42,7 +42,7 @@ const appendSwaggerDiv = (container: HTMLElement, id: string): void => {
  * }
  * @param object
  */
-export const objectToFormData = (object: BodyValue): FormData => {
+export const objectToFormData = (object: BodyValueObject): FormData => {
   if (typeof object !== 'object' || Array.isArray(object)) {
     return {}
   }
@@ -89,7 +89,7 @@ export const transformReportRequestBody = (body: BackendApiReportBody): FormData
       return acc
     }, [])
   }
-  return objectToFormData(body as BodyValue)
+  return objectToFormData(body)
 }
 
 const RequestBodyTransformerPlugin: SwaggerUIPlugin = () => {

--- a/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
+++ b/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
@@ -6,7 +6,8 @@ import { fetchData } from 'utilities/fetchData'
 import { safeFromJsonString } from 'utilities/json-utils'
 import { autocompleteRequestInterceptor } from 'ActiveDocs/OAS3Autocomplete'
 
-import type { ApiDocsServices, BackendApiReportBody, BackendApiTransaction, BodyValue, BodyValueObject, FormData, ExecuteData } from 'Types/SwaggerTypes'
+import type { ApiDocsServices, BackendApiReportBody, BackendApiTransaction, BodyValue, BodyValueObject, FormData } from 'Types/SwaggerTypes'
+import type { ExecuteData } from 'swagger-client/es/execute'
 import type { SwaggerUIPlugin } from 'swagger-ui'
 
 const getApiSpecUrl = (baseUrl: string, specPath: string): string => {
@@ -110,7 +111,7 @@ const RequestBodyTransformerPlugin: SwaggerUIPlugin = () => {
             && req.requestBody) {
           req.requestBody = transformReportRequestBody(req.requestBody as BackendApiReportBody)
         }
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+
         return execute(req)
       }
     }

--- a/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
+++ b/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
@@ -1,9 +1,12 @@
 import SwaggerUI from 'swagger-ui'
+// this is how SwaggerUI imports this function https://github.com/swagger-api/swagger-ui/pull/6208
+import { execute } from 'swagger-client/es/execute'
 
 import { fetchData } from 'utilities/fetchData'
 import { autocompleteRequestInterceptor } from 'ActiveDocs/OAS3Autocomplete'
 
-import type { ApiDocsServices } from 'Types/SwaggerTypes'
+import type { ApiDocsServices, BackendApiReportBody, BackendApiTransaction, ExecuteData } from 'Types/SwaggerTypes'
+import type { SwaggerUIPlugin } from 'swagger-ui'
 
 const getApiSpecUrl = (baseUrl: string, specPath: string): string => {
   return `${baseUrl.replace(/\/$/, '')}${specPath}`
@@ -17,6 +20,96 @@ const appendSwaggerDiv = (container: HTMLElement, id: string): void => {
   container.appendChild(div)
 }
 
+/**
+ * when using Record notation, the following error is thrown:
+ * 'TS2456: Type alias 'BodyValue' circularly references itself.'
+ */
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+type BodyValue = boolean | number | string | { [key: string]: BodyValue }
+
+/**
+ * Transforms an object into form data representation, also URL-encoding the values,
+ * Example:
+ * {
+ *   a_string: 'hello',
+ *   an_array: [
+ *     { first: 1 },
+ *     { second: 1, extra_param: 'with whitespace'}
+ *   ]
+ * }
+ * =>
+ * {
+ *   a_string: 'hello',
+ *   'an_array[0][first]': '1',
+ *   'an_array[1][second]': '1',
+ *   'an_array[1][extra_param]': 'with%20whitespace'
+ * }
+ * @param object
+ */
+export const objectToFormData = (object: BodyValue): Record<string, boolean | number | string> => {
+  const buildFormData = (formData: Record<string, boolean | number | string>, data: BodyValue, parentKey?: string) => {
+    if (data && typeof data === 'object') {
+      Object.keys(data).forEach((key: string) => {
+        buildFormData(formData, data[key], parentKey ? `${parentKey}[${key}]` : key)
+      })
+    } else {
+      if (parentKey) {
+        formData[parentKey] = data ? data : ''
+      }
+    }
+  }
+  const formData = {}
+  buildFormData(formData, object)
+  return formData
+}
+
+/**
+ * Transforms the request body of the Service Management API Report, as
+ * SwaggerUI (or rather swagger-js) does not serialize arrays of objects properly
+ * The hack is to process the request body in two steps:
+ * 1. normalize the 'transactions' array, as its elements may be either an object (if the value is taken
+ *    from the example in the spec), or as a serialized JSON (if the field is changed manually)
+ * 2. "flatten" the objects by transforming them into form-data structure with the entries like
+ *    'transactions[0][app_id]': 'example'
+ *    'transactions[0][usage][hits]': 1
+ * @param body BackendApiReportBody
+ */
+export const transformReportRequestBody = (body: BackendApiReportBody): Record<string, boolean | number | string> => {
+  if (Array.isArray(body.transactions)) {
+    body.transactions = body.transactions.map(transaction => {
+      switch (typeof transaction) {
+        case 'object':
+          return transaction
+        case 'string':
+          try {
+            return JSON.parse(transaction) as BackendApiTransaction
+          } catch (error: unknown) {
+            return null
+          }
+        default:
+          return null
+      }
+    }).filter(element => element != null) as BackendApiTransaction[]
+  }
+  return objectToFormData(body as BodyValue)
+}
+
+const RequestBodyTransformerPlugin: SwaggerUIPlugin = () => {
+  return {
+    fn: {
+      execute: (req: ExecuteData): unknown => {
+        if (req.contextUrl.includes('api_docs/services/service_management_api.json')
+            && req.operationId === 'report'
+            && req.requestBody) {
+          req.requestBody = transformReportRequestBody(req.requestBody as BackendApiReportBody)
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        return execute(req)
+      }
+    }
+  }
+}
+
 export const renderApiDocs = async (container: HTMLElement, apiDocsPath: string, baseUrl: string, apiDocsAccountDataPath: string): Promise<void> => {
   const apiSpecs: ApiDocsServices = await fetchData<ApiDocsServices>(apiDocsPath)
   apiSpecs.apis.forEach( api => {
@@ -28,7 +121,10 @@ export const renderApiDocs = async (container: HTMLElement, apiDocsPath: string,
       // eslint-disable-next-line @typescript-eslint/naming-convention -- Swagger UI
       dom_id: `#${domId}`,
       requestInterceptor: (request) => autocompleteRequestInterceptor(request, apiDocsAccountDataPath, ''),
-      tryItOutEnabled: true
+      tryItOutEnabled: true,
+      plugins: [
+        RequestBodyTransformerPlugin
+      ]
     })
   })
 }

--- a/app/javascript/src/Types/SwaggerTypes.ts
+++ b/app/javascript/src/Types/SwaggerTypes.ts
@@ -39,7 +39,7 @@ export interface ExecuteData {
   spec: unknown;
 }
 
-export interface BackendApiTransaction {
+export interface BackendApiTransaction extends BodyValueObject {
   app_id?: string;
   user_key?: string;
   timestamp?: string;
@@ -51,7 +51,7 @@ export interface BackendApiTransaction {
   };
 }
 
-export interface BackendApiReportBody {
+export interface BackendApiReportBody extends BodyValueObject {
   service_token?: string;
   service_id?: string;
   transactions?: (BackendApiTransaction | string)[];

--- a/app/javascript/src/Types/SwaggerTypes.ts
+++ b/app/javascript/src/Types/SwaggerTypes.ts
@@ -19,16 +19,6 @@ export interface ApiDocsServices {
   apis: ApiDocsService[];
 }
 
-export interface RequestData extends Request {
-  url: string;
-  method: SupportedHTTPMethods;
-  body: string;
-  credentials: string;
-  headers: Record<string, string>;
-  requestInterceptor?: ((request: Request) => Promise<Request> | Request) | undefined;
-  responseInterceptor?: ((response: Response) => Promise<Response> | Response) | undefined;
-}
-
 export interface ExecuteData {
   contextUrl: string;
   fetch: (arg: unknown) => unknown;
@@ -37,7 +27,7 @@ export interface ExecuteData {
   operationId: string;
   parameters: unknown;
   pathName: string;
-  requestBody: unknown;
+  requestBody?: unknown;
   requestContentType: string;
   requestInterceptor?: ((request: Request) => Promise<Request> | Request) | undefined;
   responseContentType: string;
@@ -66,3 +56,12 @@ export interface BackendApiReportBody {
   service_id?: string;
   transactions?: (BackendApiTransaction | string)[];
 }
+
+/**
+ * when using Record notation, the following error is thrown:
+ * 'TS2456: Type alias 'BodyValue' circularly references itself.'
+ */
+export type BodyValue = BodyValue[] | boolean | number | string | { [key: string]: BodyValue } | null | undefined
+export type BodyValueObject = Record<string, BodyValue>
+
+export type FormData = Record<string, boolean | number | string>

--- a/app/javascript/src/Types/SwaggerTypes.ts
+++ b/app/javascript/src/Types/SwaggerTypes.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import type { Request, Response, SupportedHTTPMethods } from 'swagger-ui'
 
 export type AccountData = Record<string, {
   name: string;
@@ -17,26 +16,6 @@ export interface ApiDocsService {
 export interface ApiDocsServices {
   host: string;
   apis: ApiDocsService[];
-}
-
-export interface ExecuteData {
-  contextUrl: string;
-  fetch: (arg: unknown) => unknown;
-  method: SupportedHTTPMethods;
-  operation: unknown;
-  operationId: string;
-  parameters: unknown;
-  pathName: string;
-  requestBody?: unknown;
-  requestContentType: string;
-  requestInterceptor?: ((request: Request) => Promise<Request> | Request) | undefined;
-  responseContentType: string;
-  responseInterceptor?: ((response: Response) => Promise<Response> | Response) | undefined;
-  scheme: string;
-  securities: unknown;
-  server: string;
-  serverVariables: unknown;
-  spec: unknown;
 }
 
 export interface BackendApiTransaction extends BodyValueObject {

--- a/app/javascript/src/Types/SwaggerTypes.ts
+++ b/app/javascript/src/Types/SwaggerTypes.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import type { Request, Response, SupportedHTTPMethods } from 'swagger-ui'
 
 export type AccountData = Record<string, {
   name: string;
@@ -16,4 +17,52 @@ export interface ApiDocsService {
 export interface ApiDocsServices {
   host: string;
   apis: ApiDocsService[];
+}
+
+export interface RequestData extends Request {
+  url: string;
+  method: SupportedHTTPMethods;
+  body: string;
+  credentials: string;
+  headers: Record<string, string>;
+  requestInterceptor?: ((request: Request) => Promise<Request> | Request) | undefined;
+  responseInterceptor?: ((response: Response) => Promise<Response> | Response) | undefined;
+}
+
+export interface ExecuteData {
+  contextUrl: string;
+  fetch: (arg: unknown) => unknown;
+  method: SupportedHTTPMethods;
+  operation: unknown;
+  operationId: string;
+  parameters: unknown;
+  pathName: string;
+  requestBody: unknown;
+  requestContentType: string;
+  requestInterceptor?: ((request: Request) => Promise<Request> | Request) | undefined;
+  responseContentType: string;
+  responseInterceptor?: ((response: Response) => Promise<Response> | Response) | undefined;
+  scheme: string;
+  securities: unknown;
+  server: string;
+  serverVariables: unknown;
+  spec: unknown;
+}
+
+export interface BackendApiTransaction {
+  app_id?: string;
+  user_key?: string;
+  timestamp?: string;
+  usage: Record<string, number>;
+  log?: {
+    request?: string;
+    response?: string;
+    code?: string;
+  };
+}
+
+export interface BackendApiReportBody {
+  service_token?: string;
+  service_id?: string;
+  transactions?: (BackendApiTransaction | string)[];
 }

--- a/app/javascript/src/Types/swagger.d.ts
+++ b/app/javascript/src/Types/swagger.d.ts
@@ -1,3 +1,27 @@
+// There are no official types for swagger-client. These has been inspired by:
+// - https://github.com/swagger-api/swagger-js/blob/master/src/execute/index.js
 declare module 'swagger-client/es/execute' {
-  export function execute (req: unknown): unknown
+  import type { Request, Response, SupportedHTTPMethods } from 'swagger-ui'
+
+  export interface ExecuteData {
+    contextUrl: string;
+    fetch: (arg: unknown) => unknown;
+    method: SupportedHTTPMethods;
+    operation: unknown;
+    operationId: string;
+    parameters: unknown;
+    pathName: string;
+    requestBody?: unknown;
+    requestContentType: string;
+    requestInterceptor?: ((request: Request) => Promise<Request> | Request) | undefined;
+    responseContentType: string;
+    responseInterceptor?: ((response: Response) => Promise<Response> | Response) | undefined;
+    scheme: string;
+    securities: unknown;
+    server: string;
+    serverVariables: unknown;
+    spec: unknown;
+  }
+  function execute (req: ExecuteData): unknown
+  export { execute }
 }

--- a/app/javascript/src/Types/swagger.d.ts
+++ b/app/javascript/src/Types/swagger.d.ts
@@ -1,0 +1,3 @@
+declare module 'swagger-client/es/execute' {
+  export function execute (req: unknown): unknown
+}

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "redux-thunk": "^2.3.0",
     "select2": "^4.0.6-rc.1",
     "swagger-ui": "^3.51.1",
+    "swagger-client": "^3.13.5",
     "validate.js": "^0.13.1",
     "virtual-dom": "^2.1.1"
   }

--- a/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
+++ b/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
@@ -4,7 +4,6 @@ import * as utils from 'utilities/fetchData'
 import type { Request as SwaggerUIRequest, Response as SwaggerUIResponse } from 'swagger-ui'
 
 const specUrl = 'https://provider.3scale.test/foo/bar.json'
-const specRelativeUrl = 'foo/bar.json'
 const apiUrl = 'https://some.api.domain/foo/bar/api-url'
 const accountDataUrl = 'foo/bar'
 const serviceEndpoint = 'foo/bar/serviceEndpoint'
@@ -110,7 +109,7 @@ describe('autocompleteRequestInterceptor', () => {
     })
 
     it('should prevent injecting servers to the response', async () => {
-      const res: SwaggerUIResponse = await request.responseInterceptor(apiResponse, accountDataUrl, serviceEndpoint, specUrl)
+      const res: SwaggerUIResponse = await request.responseInterceptor(apiResponse, accountDataUrl, serviceEndpoint)
       expect(res.body.servers).toBe(undefined)
     })
   })

--- a/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
+++ b/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
@@ -1,7 +1,7 @@
-import { autocompleteInterceptor } from 'ActiveDocs/OAS3Autocomplete'
+import { autocompleteOAS3, autocompleteRequestInterceptor } from 'ActiveDocs/OAS3Autocomplete'
 import * as utils from 'utilities/fetchData'
 
-import type { Response as SwaggerUIResponse } from 'swagger-ui'
+import type { Request as SwaggerUIRequest, Response as SwaggerUIResponse } from 'swagger-ui'
 
 const specUrl = 'https://provider.3scale.test/foo/bar.json'
 const specRelativeUrl = 'foo/bar.json'
@@ -67,25 +67,14 @@ const accountData = {
 const fetchDataSpy = jest.spyOn(utils, 'fetchData')
 fetchDataSpy.mockResolvedValue(accountData)
 
-describe('when the request is fetching OpenAPI spec', () => {
-  const response = specResponse
-
-  describe('when spec url is absolute', () => {
-    it('should inject servers to the spec', async () => {
-      const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
-      expect(res.body.servers).toEqual([{ 'url': serviceEndpoint }])
-    })
-  })
-
-  describe('when spec url is relative', () => {
-    it('should inject servers to the spec', async () => {
-      const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specRelativeUrl)
-      expect(res.body.servers).toEqual([{ 'url': serviceEndpoint }])
-    })
+describe('autocompleteOAS3', () => {
+  it('should inject servers to the spec', async () => {
+    const res: SwaggerUIResponse = await autocompleteOAS3(specResponse, accountDataUrl, serviceEndpoint)
+    expect(res.body.servers).toEqual([{ 'url': 'foo/bar/serviceEndpoint' }])
   })
 
   it('should autocomplete fields of OpenAPI spec with x-data-threescale-name property', async () => {
-    const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
+    const res: SwaggerUIResponse = await autocompleteOAS3(specResponse, accountDataUrl, serviceEndpoint)
     const examplesFirstParam = res.body.paths['/'].get.parameters[0].examples
     const examplesSecondParam = res.body.paths['/'].get.parameters[1].examples
 
@@ -98,10 +87,31 @@ describe('when the request is fetching OpenAPI spec', () => {
   })
 })
 
-describe('when the request is fetching API call response', () => {
-  const response = apiResponse
-  it('should not inject servers to the response', () => {
-    const res: SwaggerUIResponse = autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
-    expect(res.body.servers).toBe(undefined)
+describe('autocompleteRequestInterceptor', () => {
+  describe('when the request is fetching OpenAPI spec', () => {
+    it('should update the response interceptor', async () => {
+      let request: SwaggerUIRequest = { loadSpec: true }
+      request = autocompleteRequestInterceptor(request, accountDataUrl, serviceEndpoint)
+
+      expect(request.responseInterceptor).toBeDefined()
+
+      const res: SwaggerUIResponse = await request.responseInterceptor(specResponse, accountDataUrl, serviceEndpoint)
+      expect(res.body.servers).toEqual([{ 'url': 'foo/bar/serviceEndpoint' }])
+    })
+  })
+
+  describe('when the request is fetching API call response', () => {
+    const originalInterceptor = jest.fn((res: SwaggerUIRequest)=> { return res })
+    let request: SwaggerUIRequest = { responseInterceptor: originalInterceptor }
+    request = autocompleteRequestInterceptor(request, accountDataUrl, serviceEndpoint)
+
+    it('should not update the response interceptor', () => {
+      expect(request.responseInterceptor).toEqual(originalInterceptor)
+    })
+
+    it('should prevent injecting servers to the response', async () => {
+      const res: SwaggerUIResponse = await request.responseInterceptor(apiResponse, accountDataUrl, serviceEndpoint, specUrl)
+      expect(res.body.servers).toBe(undefined)
+    })
   })
 })

--- a/spec/javascripts/ActiveDocs/ThreeScaleApiDocs.spec.ts
+++ b/spec/javascripts/ActiveDocs/ThreeScaleApiDocs.spec.ts
@@ -1,0 +1,61 @@
+import { transformReportRequestBody } from 'ActiveDocs/ThreeScaleApiDocs'
+
+import type { BackendApiReportBody } from 'Types/SwaggerTypes'
+
+const body: BackendApiReportBody = {
+  service_token: 'token',
+  service_id: '123',
+  transactions: [
+    {
+      app_id: 'app-id1',
+      timestamp: '2023-03-29 00:00:00 -01:00',
+      usage: {
+        'hit1-1': 11,
+        'hit1-2': 12
+      },
+      log: {
+        request: 'request1',
+        response: 'response1',
+        code: '200'
+      }
+    },
+    {
+      app_id: 'app-id2',
+      timestamp: '2023-03-29 00:00:00 -02:00',
+      usage: {
+        'hit2-1': 21,
+        'hit2-2': 22
+      },
+      log: {
+        request: 'request2',
+        response: 'response2',
+        code: '200'
+      }
+    }
+  ]
+}
+
+describe('transformReportRequestBody', () => {
+  it('transforms the transactions array when transaction is an object', () => {
+    const result = transformReportRequestBody(body)
+
+    expect(result).toEqual({
+      service_token: 'token',
+      service_id: '123',
+      'transactions[0][app_id]': 'app-id1',
+      'transactions[0][timestamp]': '2023-03-29 00:00:00 -01:00',
+      'transactions[0][usage][hit1-1]': 11,
+      'transactions[0][usage][hit1-2]': 12,
+      'transactions[0][log][request]': 'request1',
+      'transactions[0][log][response]': 'response1',
+      'transactions[0][log][code]': '200',
+      'transactions[1][app_id]': 'app-id2',
+      'transactions[1][timestamp]': '2023-03-29 00:00:00 -02:00',
+      'transactions[1][usage][hit2-1]': 21,
+      'transactions[1][usage][hit2-2]': 22,
+      'transactions[1][log][request]': 'request2',
+      'transactions[1][log][response]': 'response2',
+      'transactions[1][log][code]': '200'
+    })
+  })
+})

--- a/spec/javascripts/ActiveDocs/ThreeScaleApiDocs.spec.ts
+++ b/spec/javascripts/ActiveDocs/ThreeScaleApiDocs.spec.ts
@@ -1,6 +1,6 @@
 import { objectToFormData, transformReportRequestBody } from 'ActiveDocs/ThreeScaleApiDocs'
 
-import type { BackendApiReportBody, BackendApiTransaction, BodyValue } from 'Types/SwaggerTypes'
+import type { BackendApiReportBody, BackendApiTransaction, BodyValue, BodyValueObject } from 'Types/SwaggerTypes'
 
 const transaction1: BackendApiTransaction = {
   app_id: 'app-id1',
@@ -75,12 +75,15 @@ describe('objectToFormData', () => {
   })
 
   it('returns an empty object if argument is not a valid object', () => {
-    expect(objectToFormData('hello')).toEqual({})
-    expect(objectToFormData(true)).toEqual({})
-    expect(objectToFormData(123)).toEqual({})
-    expect(objectToFormData(['q', 'w', 'r'])).toEqual({})
-  })
+    const invalidObjects = [
+      'hello',
+      true,
+      123,
+      ['q', 'w', 'r']
+    ] as unknown as BodyValueObject[]
 
+    invalidObjects.forEach(i => { expect(objectToFormData(i)).toEqual({}) })
+  })
 })
 
 describe('transformReportRequestBody', () => {

--- a/spec/javascripts/ActiveDocs/ThreeScaleApiDocs.spec.ts
+++ b/spec/javascripts/ActiveDocs/ThreeScaleApiDocs.spec.ts
@@ -1,39 +1,87 @@
-import { transformReportRequestBody } from 'ActiveDocs/ThreeScaleApiDocs'
+import { objectToFormData, transformReportRequestBody } from 'ActiveDocs/ThreeScaleApiDocs'
 
-import type { BackendApiReportBody } from 'Types/SwaggerTypes'
+import type { BackendApiReportBody, BackendApiTransaction, BodyValue } from 'Types/SwaggerTypes'
 
+const transaction1: BackendApiTransaction = {
+  app_id: 'app-id1',
+  timestamp: '2023-03-29 00:00:00 -01:00',
+  usage: {
+    'hit1-1': 11,
+    'hit1-2': 12
+  },
+  log: {
+    request: 'request1',
+    response: 'response1',
+    code: '200'
+  }
+}
+const transaction2: BackendApiTransaction = {
+  app_id: 'app-id2',
+  timestamp: '2023-03-29 00:00:00 -02:00',
+  usage: {
+    'hit2-1': 21,
+    'hit2-2': 22
+  },
+  log: {
+    request: 'request2',
+    response: 'response2',
+    code: '200'
+  }
+}
 const body: BackendApiReportBody = {
   service_token: 'token',
   service_id: '123',
   transactions: [
-    {
-      app_id: 'app-id1',
-      timestamp: '2023-03-29 00:00:00 -01:00',
-      usage: {
-        'hit1-1': 11,
-        'hit1-2': 12
-      },
-      log: {
-        request: 'request1',
-        response: 'response1',
-        code: '200'
-      }
-    },
-    {
-      app_id: 'app-id2',
-      timestamp: '2023-03-29 00:00:00 -02:00',
-      usage: {
-        'hit2-1': 21,
-        'hit2-2': 22
-      },
-      log: {
-        request: 'request2',
-        response: 'response2',
-        code: '200'
-      }
-    }
+    transaction1,
+    transaction2
   ]
 }
+
+describe('objectToFormData', () => {
+  it('transforms the object to form data', () => {
+    const object: BodyValue = {
+      number: 1,
+      string: 'string with whitespace',
+      object: {
+        numField: 2,
+        strField: 'str',
+        boolField: true
+      },
+      array: [
+        {
+          foo: 'bar'
+        },
+        {
+          foo: 'baz'
+        }
+      ],
+      nullField: null,
+      undefinedField: undefined,
+      emptyField: ''
+    }
+
+    expect(objectToFormData(object)).toEqual({
+      number: 1,
+      string: 'string with whitespace',
+      'object[numField]': 2,
+      'object[strField]': 'str',
+      'object[boolField]': true,
+      'array[0][foo]': 'bar',
+      'array[1][foo]': 'baz',
+      nullField: '',
+      undefinedField: '',
+      emptyField: ''
+    })
+  })
+
+  it('returns an empty object if argument is not a valid object', () => {
+    expect(objectToFormData('hello')).toEqual({})
+    expect(objectToFormData(true)).toEqual({})
+    expect(objectToFormData(123)).toEqual({})
+    expect(objectToFormData(['q', 'w', 'r'])).toEqual({})
+  })
+
+})
 
 describe('transformReportRequestBody', () => {
   it('transforms the transactions array when transaction is an object', () => {
@@ -57,5 +105,58 @@ describe('transformReportRequestBody', () => {
       'transactions[1][log][response]': 'response2',
       'transactions[1][log][code]': '200'
     })
+  })
+
+  it('transforms the transactions array when a transaction is a serialized JSON', () => {
+    const bodyWithSerializedTransaction = {
+      ...body,
+      transactions: [
+        transaction1,
+        '{\n  "app_id": "app-id2",\n  "timestamp": "2023-03-29 00:00:00 -02:00",\n  "usage": {\n    "hit2-1": 21,\n    "hit2-2": 22\n  },\n  "log": {\n    "request": "request2",\n    "response": "response2",\n    "code": "200"\n  }\n}']
+    }
+    const result = transformReportRequestBody(bodyWithSerializedTransaction)
+
+    expect(result).toEqual({
+      service_token: 'token',
+      service_id: '123',
+      'transactions[0][app_id]': 'app-id1',
+      'transactions[0][timestamp]': '2023-03-29 00:00:00 -01:00',
+      'transactions[0][usage][hit1-1]': 11,
+      'transactions[0][usage][hit1-2]': 12,
+      'transactions[0][log][request]': 'request1',
+      'transactions[0][log][response]': 'response1',
+      'transactions[0][log][code]': '200',
+      'transactions[1][app_id]': 'app-id2',
+      'transactions[1][timestamp]': '2023-03-29 00:00:00 -02:00',
+      'transactions[1][usage][hit2-1]': 21,
+      'transactions[1][usage][hit2-2]': 22,
+      'transactions[1][log][request]': 'request2',
+      'transactions[1][log][response]': 'response2',
+      'transactions[1][log][code]': '200'
+    })
+  })
+
+  it('skips the transactions with invalid format', () => {
+    const bodyWithInvalidTransactions = {
+      ...body,
+      transactions: [transaction1, 'invalid', 'anotherOne']
+    }
+    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation()
+
+    const result = transformReportRequestBody(bodyWithInvalidTransactions)
+    expect(result).toEqual({
+      service_token: 'token',
+      service_id: '123',
+      'transactions[0][app_id]': 'app-id1',
+      'transactions[0][timestamp]': '2023-03-29 00:00:00 -01:00',
+      'transactions[0][usage][hit1-1]': 11,
+      'transactions[0][usage][hit1-2]': 12,
+      'transactions[0][log][request]': 'request1',
+      'transactions[0][log][response]': 'response1',
+      'transactions[0][log][code]': '200'
+    })
+
+    expect(consoleErrorMock).toHaveBeenCalledTimes(2)
+    consoleErrorMock.mockRestore()
   })
 })

--- a/spec/javascripts/__mocks__/swagger-client/es/execute/index.js
+++ b/spec/javascripts/__mocks__/swagger-client/es/execute/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-    execute: jest.fn()
+  execute: jest.fn()
 }

--- a/spec/javascripts/__mocks__/swagger-client/es/execute/index.js
+++ b/spec/javascripts/__mocks__/swagger-client/es/execute/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    execute: jest.fn()
+}

--- a/spec/javascripts/__mocks__/swagger-ui.js
+++ b/spec/javascripts/__mocks__/swagger-ui.js
@@ -1,0 +1,1 @@
+module.exports = jest.fn()


### PR DESCRIPTION
This fixes the serialization issue with the `report` endpoint of the Service Management API, initially reported in this comment: https://github.com/3scale/porta/pull/3103#issuecomment-1413955116 (item 2).

Actually, it serializes differently in different cases:
- just using the single transaction element with the value from example:
  ```
  'service_token=token&service_id=123&transactions[user_key]=example&transactions[usage][hits]=1'
  ```
- the default element plus another element:
  ```
  'service_token=token&service_id=123&transactions[user_key]=example&transactions[usage][hits]=1&transactions=%7B%0A%20%20%22user_key%22%3A%20%22example%22%2C%0A%20%20%22usage%22%3A%20%7B%0A%20%20%20%20%22hits%22%3A%201%0A%20%20%7D%0A%7D'
  ```
- with manual changes in both elements:
  ```
  'service_token=token&service_id=123&transactions=%7B%0A%20%20%22user_key%22%3A%20%22example1%22%2C%0A%20%20%22usage%22%3A%20%7B%0A%20%20%20%20%22hits%22%3A%201%0A%20%20%7D%0A%7D&transactions=%7B%0A%20%20%22user_key%22%3A%20%22example2%22%2C%0A%20%20%22usage%22%3A%20%7B%0A%20%20%20%20%22hits%22%3A%201%0A%20%20%7D%0A%7D'
  ```

In order to fix this I considered several options:
1. Do it in `requestInterceptor`
   This was a bit messy, because at this point the request body is already serialized, and it would be tricky to parse, especially given that sometimes it's serialized as JSON, and other times as form-encoded string, and also could be mixed.

2. I also tried to write a plugin in the following way:
```
const ExecuteRequestPlugin: SwaggerUIPlugin = () => {
  return {
    statePlugins: {
      spec: {
        wrapActions: {
          executeRequest: (oriAction: (req: RequestData) => unknown) => (req: RequestData) => {
            // modify req.requestBody
            return oriAction(req)
          }
        }
      }
    }
  }
}
```
At first it looked promising, as `console.log(req)` was printing out the `requestBody` in the browser console, however I then realized that at this point in the execution `requestBody` is actually **not yet** available, and `console.log` was misleading.

3. So, I went with the approach of overriding the `fn.execute` function of the SwaggerUI, which in its turn is just imported from `swagger-js` library.

It's not ideal and quite "hacky", because it tweaks only the specific endpoint and in a very specific way.
Ideally, we could implement something more generic, that would serialize any object with config `deepObject` and `explode` in a way that we expect. Maybe, this would also potentially allow us to get rid of this hack of adding `[]` to the parameters names, like here:
https://github.com/3scale/porta/blob/eb07699ae413be4d6a408de16eb23c947bfc9c28/doc/active_docs/account_management_api.json#L2524-L2531

But I would leave this task for later, as an improvement.

For now, the serialization works as expected, the same way as in the original Swagger v1, with a slight difference on special characters encoding (e.g. spaces are encoded as `%20` rather than `+`. But I think it applies to all APIs in general, and should be OK.

**Example:**

*Before*
```
curl -v  -X POST \
  "https://su1.3scale.net/transactions.xml" \
  -d 'service_token=token&service_id=123&transactions%5B0%5D%5Buser_key%5D=key1&transactions%5B0%5D%5Btimestamp%5D=2011-12-30+22%3A15%3A31+%2B08%3A00&transactions%5B0%5D%5Busage%5D%5Bmetric1-1%5D=11&transactions%5B0%5D%5Busage%5D%5Bmetric1-2%5D=12&transactions%5B1%5D%5Buser_key%5D=key2&transactions%5B1%5D%5Btimestamp%5D=2011-12-30+22%3A15%3A31+-08%3A00&transactions%5B1%5D%5Busage%5D%5Bmetric2-1%5D=21&transactions%5B1%5D%5Busage%5D%5Bmetric2-2%5D=22'
```
decoded body:
```
'service_token=token&service_id=123&transactions[0][user_key]=key1&transactions[0][timestamp]=2011-12-30+22%3A15%3A31+%2B08%3A00&transactions[0][usage][metric1-1]=11&transactions[0][usage][metric1-2]=12&transactions[1][user_key]=key2&transactions[1][timestamp]=2011-12-30+22%3A15%3A31+-08%3A00&transactions[1][usage][metric2-1]=21&transactions[1][usage][metric2-2]=22'
```

*After*
```
curl -X 'POST' \
  'http://localhost:3001/transactions.xml' \
  -H 'accept: */*' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'service_token=token&service_id=123&transactions%5B0%5D%5Buser_key%5D=key1&transactions%5B0%5D%5Btimestamp%5D=2011-12-30%2022%3A15%3A31%20%2B08%3A00&transactions%5B0%5D%5Busage%5D%5Bmetric1-1%5D=11&transactions%5B0%5D%5Busage%5D%5Bmetric1-2%5D=12&transactions%5B1%5D%5Buser_key%5D=key2&transactions%5B1%5D%5Btimestamp%5D=2011-12-30%2022%3A15%3A31%20-08%3A00&transactions%5B1%5D%5Busage%5D%5Bmetric2-1%5D=21&transactions%5B1%5D%5Busage%5D%5Bmetric2-2%5D=22'
```

decoded body:
```
'service_token=token&service_id=123&transactions[0][user_key]=key1&transactions[0][timestamp]=2011-12-30 22%3A15%3A31 %2B08%3A00&transactions[0][usage][metric1-1]=11&transactions[0][usage][metric1-2]=12&transactions[1][user_key]=key2&transactions[1][timestamp]=2011-12-30 22%3A15%3A31 -08%3A00&transactions[1][usage][metric2-1]=21&transactions[1][usage][metric2-2]=22'
```

Before and after are exactly the same, except for the timestamp value:
```
2011-12-30+22%3A15%3A31+%2B08%3A00
vs
2011-12-30%2022%3A15%3A31%20%2B08%3A00
```

Need to check if the new encoding actually works with apisonator, it should as `%20` is standard.


The above bodies as screenshots in the UI:

**Before**
![transactions-swagger1](https://user-images.githubusercontent.com/1270328/229153900-32984e2a-6f9a-4cc1-aa9e-9c5b665a434c.png)

**After** (it's missing a `,` after the timestamp field, but I don't have time to re-screenshot now)
![transactions-openapi3](https://user-images.githubusercontent.com/1270328/229153934-43e3ad52-ab67-45ce-a998-671e821b128e.png)

----

Docs on SwaggerUI plugins: https://github.com/swagger-api/swagger-ui/blob/master/docs/customization/plugin-api.md



