### PR TITLE
CMS API: Forbid extra params at controller level

### DIFF
--- a/app/controllers/admin/api/base_controller.rb
+++ b/app/controllers/admin/api/base_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Admin::Api::BaseController < ApplicationController
+  include ApiSupport::ForbidParams
+
+  forbid_extra_params :raise, whitelist: %i[id page per_page]
+
   around_action :notification_center
 
   before_action :force_provider_or_master_domain

--- a/app/controllers/admin/api/cms/templates_controller.rb
+++ b/app/controllers/admin/api/cms/templates_controller.rb
@@ -14,6 +14,8 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
   wrap_parameters :template, include: AVAILABLE_PARAMS,
                              format: %i[json multipart_form url_encoded_form]
 
+  forbid_extra_params :raise, whitelist: %i[id page per_page type layout_name section_name]
+
   before_action :find_template, except: %i[index create]
 
   before_action :can_destroy, only: :destroy

--- a/app/lib/api_support/forbid_params.rb
+++ b/app/lib/api_support/forbid_params.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module ApiSupport
+
+  class UnpermittedParameters < StandardError
+    def initialize(unpermitted_keys)
+      msg = "Unpermitted parameters: #{unpermitted_keys}"
+      super msg
+    end
+  end
+
+  module ForbidParams
+    extend ::ActiveSupport::Concern
+    include Params
+
+    included do
+      class_attribute :_forbid_params_action
+      class_attribute :_forbid_params_whitelist, default: []
+
+      rescue_from UnpermittedParameters do |error|
+        render_error error.message, status: :unprocessable_entity
+      end
+    end
+
+    class_methods do
+      def forbid_extra_params(action, options = {})
+        before_action :unpermitted_parameters_check
+        self._forbid_params_action = action
+
+        return unless options[:whitelist]
+
+        self._forbid_params_whitelist = [*options[:whitelist]]
+      end
+    end
+
+    private
+
+    def forbid_params_whitelist
+      self.class._forbid_params_whitelist.map(&:to_s)
+    end
+
+    def wrapped_keys
+      [_wrapper_key, *_wrapper_options[:include]].map(&:to_s)
+    end
+
+    def unpermitted_keys
+      flat_params.keys - wrapped_keys - forbid_params_whitelist
+    end
+
+    def unpermitted_parameters_check
+      return unless _forbid_params_action
+      return if unpermitted_keys.blank?
+
+      case self.class._forbid_params_action
+      when :log
+        Rails.logger.warn("Unpermitted parameters: #{unpermitted_keys}")
+      when :raise
+        raise UnpermittedParameters, unpermitted_keys
+      end
+    end
+  end
+end

--- a/app/lib/api_support/params.rb
+++ b/app/lib/api_support/params.rb
@@ -10,7 +10,7 @@ module ApiSupport::Params
     private
 
     def flat_params
-      params.except(:format, :controller, :action, :provider_key, :api_key)
+      params.except(:format, :controller, :action, :provider_key, :api_key, :access_token)
     end
 
     # This basically checks if the wrapped parameter is passed as a Hash, if not it will go 422

--- a/test/integration/api_support/forbid_params_test.rb
+++ b/test/integration/api_support/forbid_params_test.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApiSupport::ForbidParamsTest < ActionDispatch::IntegrationTest
+
+  class TestController < ApplicationController
+    include ApiSupport::ForbidParams
+    def create
+      params.permit(:permitted)
+    end
+  end
+
+  def with_test_routes
+    Rails.application.routes.draw do
+      post '/test/default' => 'api_support/forbid_params_test/action/default/default#create'
+      post '/test/log' => 'api_support/forbid_params_test/action/log/log#create'
+      post '/test/raise' => 'api_support/forbid_params_test/action/raise/raise#create'
+      post '/test/symbol' => 'api_support/forbid_params_test/whitelist/symbol/symbol#create'
+      post '/test/string' => 'api_support/forbid_params_test/whitelist/string/string#create'
+      post '/test/list' => 'api_support/forbid_params_test/whitelist/list/list#create'
+      post '/test/child' => 'api_support/forbid_params_test/single_callback/child#create'
+    end
+    yield
+  ensure
+    Rails.application.routes_reloader.reload!
+  end
+
+  def capture_log
+    orig_logger = Rails.logger.dup
+    logger_output = StringIO.new
+
+    begin
+      Rails.logger = ActiveSupport::Logger.new(logger_output)
+      yield
+    ensure
+      Rails.logger = orig_logger
+    end
+
+    logger_output.string
+  end
+
+  class Action < ApiSupport::ForbidParamsTest
+    class Default <Action
+      class DefaultController < TestController; end
+
+      def setup
+        ActionController::Parameters.action_on_unpermitted_parameters = :raise
+      end
+
+      def teardown
+        ActionController::Parameters.action_on_unpermitted_parameters = false
+      end
+
+      test 'defaults to global action_on_unpermitted_parameters' do
+        with_test_routes do
+          assert_raises(ActionController::UnpermittedParameters) { post '/test/default', params: { unpermitted: true } }
+        end
+      end
+    end
+
+    class Log <Action
+      class LogController < TestController
+        forbid_extra_params :log
+      end
+
+      test 'writes on the log when controller_action_on_unpermitted_parameters = log' do
+        with_test_routes do
+          log_output = capture_log do
+            post '/test/log', params: { unpermitted: true }
+          end
+
+          assert log_output.include?('Unpermitted parameters: ["unpermitted"]')
+        end
+      end
+    end
+
+    class Raise <Action
+      class RaiseController < TestController
+        forbid_extra_params :raise
+      end
+
+      test 'raises an ActionController::UnpermittedParameters when controller_action_on_unpermitted_parameters = :raise' do
+        with_test_routes do
+          assert_raises(ActionController::UnpermittedParameters) { post '/test/raise', params: { unpermitted: true } }
+        end
+      end
+    end
+  end
+
+  class Whitelist < ApiSupport::ForbidParamsTest
+    class Symbol < Whitelist
+      class SymbolController < TestController
+        forbid_extra_params :raise, whitelist: :extra_permitted
+      end
+
+      test "doesn't raise an error for a whitelisted parameter as symbol" do
+        with_test_routes do
+          post '/test/symbol', params: { extra_permitted: true }
+
+          assert true # No error was raised
+        end
+      end
+    end
+
+    class String < Whitelist
+      class StringController < TestController
+        forbid_extra_params :raise, whitelist: 'extra_permitted'
+      end
+
+      test "doesn't raise an error for a whitelisted parameter as string" do
+        with_test_routes do
+          post '/test/string', params: { extra_permitted: true }
+
+          assert true # No error was raised
+        end
+      end
+    end
+
+    class List < Whitelist
+      class ListController < TestController
+        forbid_extra_params :raise, whitelist: %i[extra_permitted also_permitted]
+      end
+
+      test "doesn't raise an error for a white list of parameters" do
+        with_test_routes do
+          post '/test/list', params: { also_permitted: true }
+
+          assert true # No error was raised
+        end
+      end
+    end
+  end
+
+  class SingleCallback < ApiSupport::ForbidParamsTest
+    class BaseController < TestController
+      forbid_extra_params :log
+    end
+
+    class ChildController < BaseController
+      forbid_extra_params :log
+    end
+
+    test 'the callback is only called once' do
+      with_test_routes do
+        ChildController.any_instance.expects(:unpermitted_parameters_check).times(1)
+        post '/test/child', params: { unpermitted: true }
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this PR, when a client sent a parameter not permitted but also not forbidden, it was ignored. It's a requisite that the API returns an error in this case.

Rails' strong parameters provides a [config option](https://guides.rubyonrails.org/configuring.html#config-action-controller-action-on-unpermitted-parameters) to enable this behavior, the problem is that option acts globally, so if we enable it that would problably break some customers implementation for other APIs.

To avoid that, this PR adds a controller method to do the same, but at controller level:

`forbid_extra_params :raise, whitelist: %i[id page per_page]`

Available actions are `:log` and `:raise`. The `:whitelist` option accepts a list of parameters that will be ignored by the module.

**Which issue(s) this PR fixes** 

[THREESCALE-9172](https://issues.redhat.com/browse/THREESCALE-9172)

**Verification steps** 

Request:

```
curl --request POST \
  --url 'http://provider-admin.3scale.localhost:3000//admin/api/cms/sections?access_token=secret' \
  --header 'Content-Type: application/json' \
  --data '{
	"title": "Test section from API",
	"system_name": "test-section-api",
	"extra_param": "value"
}'
```

Should return:

`{"error":"Unpermitted parameters: [\"extra_param\"]"}`
