### PR TITLE
👷 Fixes bundle --deployment deprecation in in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,8 @@ commands: # reusable commands with parameters
           command: |
             echo "Running gems install for database: $DB"
             echo "$(bundle version)"
-            bundle check || bundle install --deployment
+            bundle config set --local deployment 'true'
+            bundle check || bundle install
             bundle clean
             # remove capybara-webkit source, save more than 400 MB
             rm -rf "$BUNDLE_PATH/$(ruby -e 'puts Gem.ruby_engine')/$(ruby -e 'puts Gem.ruby_api_version')"/gems/capybara-webkit-*/src


### PR DESCRIPTION
Fixes the following deprecation warning:
```
[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local deployment 'true'`, and stop using this flag
```