### PR TITLE
Proposal: disable asset compilation in development

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -34,7 +34,7 @@ default: &default
 
 development:
   <<: *default
-  compile: true
+  compile: false
   webpack_compile_output: true
   check_yarn_integrity: false
 


### PR DESCRIPTION
I think nobody in their right mind never ever works with porta without running `webpack-dev-server`. Loading a page takes forever otherwise. However, sometimes one simply doesn't need to recompile assets so it would be nice to be able to open a page without waiting centuries for the server to finish compiling.

By setting `compile: false` we'll have to compile manually `assets:precompile´ or via webpack-dev-server to watch for changes. This is exactly how tests work by the way.