### PR TITLE
Fix api docs endpoints in the developer portal

### DIFF
--- a/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts
+++ b/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts
@@ -132,7 +132,7 @@ const autocompleteOAS3 = async (response: SwaggerUIResponse, accountDataUrl: str
  * @param serviceEndpoint Public Base URL of the gateway, that will replace the  URL in the "servers" object
  */
 export const autocompleteInterceptor = (response: SwaggerUIResponse, accountDataUrl: string, serviceEndpoint: string, specUrl?: string): Promise<Response> | SwaggerUIResponse => {
-  if (specUrl !== response.url) {
+  if (!response.url.includes(specUrl)) {
     return response
   }
   return autocompleteOAS3(response, accountDataUrl, serviceEndpoint)

--- a/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
+++ b/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
@@ -46,10 +46,6 @@ const specResponse = {
   },
   obj: {}
 }
-const specRelativeResponse = {
-  ...specResponse,
-  url: specRelativeUrl
-}
 const apiResponse = {
   ...specResponse,
   url: apiUrl,
@@ -70,9 +66,19 @@ fetchDataSpy.mockResolvedValue(accountData)
 
 describe('when the request is fetching OpenAPI spec', () => {
   const response = specResponse
-  it('should inject servers to the spec', async () => {
-    const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
-    expect(res.body.servers).toEqual([{ 'url': serviceEndpoint }])
+
+  describe('when spec url is absolute', () => {
+    it('should inject servers to the spec', async () => {
+      const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
+      expect(res.body.servers).toEqual([{'url': serviceEndpoint}])
+    })
+  })
+
+  describe('when spec url is relative', () => {
+    it('should inject servers to the spec', async () => {
+      const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specRelativeUrl)
+      expect(res.body.servers).toEqual([{'url': serviceEndpoint}])
+    })
   })
 
   it('should autocomplete fields of OpenAPI spec with x-data-threescale-name property', async () => {
@@ -87,15 +93,6 @@ describe('when the request is fetching OpenAPI spec', () => {
     expect(examplesSecondParam).toBe(undefined)
   })
 })
-
-describe('when the request is fetching OpenAPI spec by relative path', () => {
-  const response = specRelativeResponse
-  it('should inject servers to the spec', async () => {
-    const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specRelativeUrl)
-    expect(res.body.servers).toEqual([{ 'url': serviceEndpoint }])
-  })
-})
-
 describe('when the request is fetching API call response', () => {
   const response = apiResponse
   it('should not inject servers to the response', () => {

--- a/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
+++ b/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
@@ -70,14 +70,14 @@ describe('when the request is fetching OpenAPI spec', () => {
   describe('when spec url is absolute', () => {
     it('should inject servers to the spec', async () => {
       const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
-      expect(res.body.servers).toEqual([{'url': serviceEndpoint}])
+      expect(res.body.servers).toEqual([{ 'url': serviceEndpoint }])
     })
   })
 
   describe('when spec url is relative', () => {
     it('should inject servers to the spec', async () => {
       const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specRelativeUrl)
-      expect(res.body.servers).toEqual([{'url': serviceEndpoint}])
+      expect(res.body.servers).toEqual([{ 'url': serviceEndpoint }])
     })
   })
 

--- a/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
+++ b/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
@@ -93,6 +93,7 @@ describe('when the request is fetching OpenAPI spec', () => {
     expect(examplesSecondParam).toBe(undefined)
   })
 })
+
 describe('when the request is fetching API call response', () => {
   const response = apiResponse
   it('should not inject servers to the response', () => {

--- a/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
+++ b/spec/javascripts/ActiveDocs/OAS3Autocomplete.spec.ts
@@ -3,8 +3,9 @@ import * as utils from 'utilities/fetchData'
 
 import type { Response as SwaggerUIResponse } from 'swagger-ui'
 
-const specUrl = 'foo/bar.json'
-const apiUrl = 'foo/bar/api-url'
+const specUrl = 'https://provider.3scale.test/foo/bar.json'
+const specRelativeUrl = 'foo/bar.json'
+const apiUrl = 'https://some.api.domain/foo/bar/api-url'
 const accountDataUrl = 'foo/bar'
 const serviceEndpoint = 'foo/bar/serviceEndpoint'
 const specResponse = {
@@ -45,6 +46,10 @@ const specResponse = {
   },
   obj: {}
 }
+const specRelativeResponse = {
+  ...specResponse,
+  url: specRelativeUrl
+}
 const apiResponse = {
   ...specResponse,
   url: apiUrl,
@@ -67,7 +72,7 @@ describe('when the request is fetching OpenAPI spec', () => {
   const response = specResponse
   it('should inject servers to the spec', async () => {
     const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specUrl)
-    expect(res.body.servers).toEqual([{ 'url': 'foo/bar/serviceEndpoint' }])
+    expect(res.body.servers).toEqual([{ 'url': serviceEndpoint }])
   })
 
   it('should autocomplete fields of OpenAPI spec with x-data-threescale-name property', async () => {
@@ -80,6 +85,14 @@ describe('when the request is fetching OpenAPI spec', () => {
       { summary: 'Some App', value: '12345678' }
     ])
     expect(examplesSecondParam).toBe(undefined)
+  })
+})
+
+describe('when the request is fetching OpenAPI spec by relative path', () => {
+  const response = specRelativeResponse
+  it('should inject servers to the spec', async () => {
+    const res: SwaggerUIResponse = await autocompleteInterceptor(response, accountDataUrl, serviceEndpoint, specRelativeUrl)
+    expect(res.body.servers).toEqual([{ 'url': serviceEndpoint }])
   })
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The endpoint urls in the Developer portal docs were not being processed, due to a regression caused by https://github.com/3scale/porta/pull/3246. This fixes it.

**Which issue(s) this PR fixes** 

[THREESCALE-9498](https://issues.redhat.com/browse/THREESCALE-9498)

**Verification steps** 

Just open http://provider.3scale.localhost:3000/docs and check the "Servers" dropdown is set to apicast.

**Notes for the reviewer**

The problem is at:

 https://github.com/3scale/porta/blob/81f9b67687d137206436f5c6dba1a149528ffd19/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts#L135-L137

Here, `specUrl` comes as a relative path but `response.url` is absolute, so it's a false negative and `autocompleteOAS3` doesn't get called when it should. The value ultimately comes from:

https://github.com/3scale/porta/blob/81f9b67687d137206436f5c6dba1a149528ffd19/lib/developer_portal/lib/liquid/drops/api_spec.rb#L10-L12

which calls a `*_path` helper. In my opinion, this issue could be better solved if we could call a `*_url` helper instead, which would return a full url and therefore the check at `OAS3Autocomplete.ts` would work. The problem is we can't call `*_url` helpers as far as I know, they return an error in my local because the host is not set, and seems logical, provided we handle a different domain for each tenant.

This is a workaround that will be definitely fixed when we merge https://github.com/3scale/porta/pull/3103. See the [diff](https://github.com/3scale/porta/pull/3103/files#diff-4f8bdb6882899231dfd4039aec865573cb6a79e61de460f4425e45b5aa966439R148-R150)