### PR TITLE
♻️ Combine all packs loaded in layout provider

### DIFF
--- a/app/javascript/packs/navigation.scss
+++ b/app/javascript/packs/navigation.scss
@@ -1,3 +1,0 @@
-// import 'patternflyStyles/header'
-@import '~@patternfly/patternfly/components/Avatar/avatar.css';
-@import '~@patternfly/patternfly/components/Brand/brand.css';

--- a/app/javascript/packs/provider.ts
+++ b/app/javascript/packs/provider.ts
@@ -1,1 +1,11 @@
-// TODO: move here header and vertical_nav packs
+import { renderContextSelector } from 'Navigation/renderContextSelector'
+import { renderVerticalNav } from 'Navigation/renderVerticalNav'
+import { setupHeaderTools } from 'Navigation/setupHeaderTools'
+import { renderQuickStarts } from 'QuickStarts/renderQuickStarts'
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupHeaderTools()
+  renderVerticalNav()
+  renderContextSelector()
+  renderQuickStarts()
+})

--- a/app/javascript/src/Navigation/renderContextSelector.ts
+++ b/app/javascript/src/Navigation/renderContextSelector.ts
@@ -2,14 +2,11 @@ import { ContextSelectorWrapper } from 'Navigation/components/ContextSelector'
 
 import type { Menu } from 'Types/NavigationTypes'
 
-const containerId = 'api_selector'
+const renderContextSelector = (): void => {
+  const containerId = 'api_selector'
 
-document.addEventListener('DOMContentLoaded', function () {
-  const apiSelector = document.getElementById(containerId)
-
-  if (!apiSelector) {
-    throw new Error('The target ID was not found: ' + containerId)
-  }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Always present in header
+  const apiSelector = document.getElementById(containerId)!
 
   const { activeMenu, audienceLink, settingsLink = '', productsLink = '', backendsLink = '' } = apiSelector.dataset
 
@@ -20,4 +17,6 @@ document.addEventListener('DOMContentLoaded', function () {
     productsLink,
     backendsLink
   }, containerId)
-})
+}
+
+export { renderContextSelector }

--- a/app/javascript/src/Navigation/renderVerticalNav.ts
+++ b/app/javascript/src/Navigation/renderVerticalNav.ts
@@ -1,12 +1,13 @@
 import { VerticalNavWrapper as VerticalNav } from 'Navigation/components/VerticalNav'
 import { safeFromJsonString } from 'utilities/json-utils'
 
-document.addEventListener('DOMContentLoaded', () => {
+const renderVerticalNav = (): void => {
   const containerId = 'vertical-nav-wrapper'
   const container = document.getElementById(containerId)
 
+  // Some pages don't feature the vertical nav
   if (!container) {
-    throw new Error('The target ID was not found: ' + containerId)
+    return
   }
 
   const { activeItem, activeSection, currentApi, sections } = container.dataset
@@ -17,4 +18,6 @@ document.addEventListener('DOMContentLoaded', () => {
     activeItem,
     currentApi: safeFromJsonString(currentApi)
   }, containerId)
-})
+}
+
+export { renderVerticalNav }

--- a/app/javascript/src/Navigation/setupHeaderTools.ts
+++ b/app/javascript/src/Navigation/setupHeaderTools.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion -- Safe to assume everything is there */
 
-document.addEventListener('DOMContentLoaded', () => {
+const setupHeaderTools = (): void => {
   const docs = document.querySelector<HTMLAnchorElement>('.PopNavigation--docs a')!
   const docsMenu = document.querySelector<HTMLUListElement>('.PopNavigation--docs ul')!
   const session = document.querySelector<HTMLAnchorElement>('.PopNavigation--session a')!
@@ -35,4 +35,6 @@ document.addEventListener('DOMContentLoaded', () => {
       classList.remove(expandedClass)
     })
   })
-})
+}
+
+export { setupHeaderTools }

--- a/app/javascript/src/QuickStarts/renderQuickStarts.ts
+++ b/app/javascript/src/QuickStarts/renderQuickStarts.ts
@@ -2,12 +2,13 @@ import { QuickStartContainerWrapper as QuickStartContainer } from 'QuickStarts/c
 import { getActiveQuickstart } from 'QuickStarts/utils/progressTracker'
 import { safeFromJsonString } from 'utilities/json-utils'
 
-document.addEventListener('DOMContentLoaded', () => {
+const renderQuickStarts = (): void => {
   const containerId = 'quick-start-container'
   const container = document.getElementById(containerId)
 
+  // QuickStarts are hidden behind config QuickstartsConfig
   if (!container) {
-    throw new Error(`Container not found: #${containerId}`)
+    return
   }
 
   const { links, renderCatalog } = container.dataset
@@ -30,4 +31,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (quickStartsContainer && wrapperContainer) {
     quickStartsContainer.after(wrapperContainer)
   }
-})
+}
+
+export { renderQuickStarts }

--- a/app/views/layouts/provider.html.slim
+++ b/app/views/layouts/provider.html.slim
@@ -11,7 +11,6 @@ html[lang="en" class="pf-m-redhat-font"]
     = render 'provider/theme'
     = render 'provider/analytics'
     = javascript_include_tag 'provider/layout/provider'
-    = javascript_pack_tag 'provider'
     = yield :javascripts
 
   body

--- a/app/views/layouts/provider.html.slim
+++ b/app/views/layouts/provider.html.slim
@@ -11,6 +11,7 @@ html[lang="en" class="pf-m-redhat-font"]
     = render 'provider/theme'
     = render 'provider/analytics'
     = javascript_include_tag 'provider/layout/provider'
+    = javascript_pack_tag 'provider'
     = yield :javascripts
 
   body

--- a/app/views/shared/_api_selector.html.slim
+++ b/app/views/shared/_api_selector.html.slim
@@ -1,5 +1,3 @@
-= javascript_pack_tag 'api_selector'
-
 #api_selector data={ 'active-menu': active_menu,
                      'audience-link': audience_link,
                      'settings-link': settings_link,

--- a/app/views/shared/provider/_header.html.slim
+++ b/app/views/shared/provider/_header.html.slim
@@ -1,5 +1,3 @@
-= javascript_pack_tag 'navigation'
-
 header.pf-c-page__header id="user_widget" class='Header' class=('Header--master' if current_account.master?) role='banner'
 
   = link_to provider_admin_dashboard_path, class: 'pf-c-page__header-brand Header-link', title: 'Dashboard' do

--- a/app/views/shared/provider/_quickstarts_container.html.slim
+++ b/app/views/shared/provider/_quickstarts_container.html.slim
@@ -1,2 +1,1 @@
 #quick-start-container data-render-catalog=(active_menu == :quickstarts).to_s data-links=quickstarts_presenter.links
-  = javascript_pack_tag 'quickstarts'

--- a/app/views/shared/provider/navigation/_vertical_nav.html.slim
+++ b/app/views/shared/provider/navigation/_vertical_nav.html.slim
@@ -1,5 +1,3 @@
-= javascript_pack_tag 'vertical_nav'
-
 - sections = vertical_nav_sections || []
 
 #vertical-nav-wrapper class='pf-c-page__sidebar pf-m-dark' data=vertical_nav_data()


### PR DESCRIPTION
The idea is to reduce the amount of entry points. The layout "provider" renders the header, sidebar and quickstarts container so their individual packs can be combined into one. Results:

Before:
```
Asset                                     Size          Chunks
js/api_selector-e9b9632898d3b33b014c.js   592 KiB       3   [emitted] [immutable]  [big]  api_selector
js/provider-d03ab4a73e9061267dd4.js       828 KiB       32  [emitted] [immutable]  [big]  provider
js/quickstarts-f5e48672621375ee7345.js    4.83 MiB      34  [emitted] [immutable]  [big]  quickstarts
js/navigation-6abd334a13fe068b1a26.js     53.8 KiB      21  [emitted] [immutable]         navigation
js/vertical_nav-1c05e2b641ba4d1c1f28.js   953 KiB       43  [emitted] [immutable]  [big]  vertical_nav

~ 7.26 MiB
```

After:
```
js/provider-f9df42c26a1ee4b447d0.js       6 MiB      31  [emitted] [immutable]  [big]  provider

~ 6 MiB
```

Nothing looks broken in the UI:
![Screenshot 2023-04-13 at 09 22 42](https://user-images.githubusercontent.com/11672286/231684933-77b0792c-fb16-4346-a3fc-8badb4730c3b.png)


![Screenshot 2023-04-13 at 09 22 56](https://user-images.githubusercontent.com/11672286/231684721-636c44e2-4eb3-4a14-9bb2-886d4a45e4eb.png)

![Screenshot 2023-04-13 at 09 23 06](https://user-images.githubusercontent.com/11672286/231684697-fbb49f63-9d5a-4417-ae89-9cc384cc39d4.png)
