### PR TITLE
Enable Webpack split chunks

### DIFF
--- a/app/views/admin/api_docs/base/_form.html.slim
+++ b/app/views/admin/api_docs/base/_form.html.slim
@@ -1,8 +1,7 @@
 - content_for :javascripts do
-  = javascript_pack_tag 'codemirror'
+  = javascript_packs_with_chunks_tag 'codemirror', 'api_docs_form'
   = javascript_include_tag 'codemirror/modes/liquid'
 
 - content_for :sublayout_title, 'ActiveDocs'
 
 div id="api-docs-container" data-service=api_docs_service_data(@api_docs_service).to_json
-  = javascript_pack_tag 'api_docs_form'

--- a/app/views/admin/api_docs/base/swagger.html.erb
+++ b/app/views/admin/api_docs/base/swagger.html.erb
@@ -26,7 +26,7 @@
 <%# TODO: this is here until we get swagger-ui 2.1 to load swagger spec 1.2 and 2.0 %>
 
 <% if @api_docs_service.specification.openapi_3_0? -%>
- <%= javascript_pack_tag 'service_active_docs'%>
+ <%= javascript_packs_with_chunks_tag 'service_active_docs'%>
 
 <% elsif @api_docs_service.specification.swagger_2_0? -%>
 

--- a/app/views/api/applications/new.html.slim
+++ b/app/views/api/applications/new.html.slim
@@ -1,4 +1,4 @@
 h2 New application
 
 div id="new-application-form" data=presenter.new_application_form_data
-  = javascript_pack_tag 'new_application'
+  = javascript_packs_with_chunks_tag 'new_application'

--- a/app/views/api/backend_usages/new.html.slim
+++ b/app/views/api/backend_usages/new.html.slim
@@ -1,4 +1,4 @@
 h2 Add a backend
 
 div id="add-backend-form" data=add_backend_usage_form_data(@service) data-inline-errors=@inline_errors.to_json data-backend-api-id=@backend_api_config&.backend_api_id
-  = javascript_pack_tag 'add_backend_usage'
+  = javascript_packs_with_chunks_tag 'add_backend_usage'

--- a/app/views/api/integrations/apicast/shared/_policies.html.slim
+++ b/app/views/api/integrations/apicast/shared/_policies.html.slim
@@ -1,7 +1,7 @@
 = f.toggled_inputs 'policies', cookie_name: 'policies-rules', legend: "Policies", id: "policies-container" do
   - if @error.nil?
     div#policies data-service-id=@service.id data-registry=@registry_policies.to_json data-chain=@proxy.policies_config.to_json
-    = javascript_pack_tag 'policies'
+    = javascript_packs_with_chunks_tag 'policies'
   - else
     div
       h3 A valid APIcast Policies endpoint must be provided

--- a/app/views/api/metrics/index.html.slim
+++ b/app/views/api/metrics/index.html.slim
@@ -1,2 +1,2 @@
 div id='product-metrics-index-container' data=presenter.index_data
-  = javascript_pack_tag 'product_metrics_index'
+  = javascript_packs_with_chunks_tag 'product_metrics_index'

--- a/app/views/api/plans/_metrics.html.erb
+++ b/app/views/api/plans/_metrics.html.erb
@@ -68,5 +68,5 @@
       <% end -%>
     </tbody>
   </table>
-  <%= javascript_pack_tag 'plans_metrics' %>
+  <%= javascript_packs_with_chunks_tag 'plans_metrics' %>
 </div>

--- a/app/views/api/services/cards/_backends_table.html.slim
+++ b/app/views/api/services/cards/_backends_table.html.slim
@@ -1,3 +1,3 @@
 h2 Backends used in this product
 div id='backends-used-list-container' data-backends=product.decorate.backends_table_data
-  = javascript_pack_tag 'backends_used_list'
+  = javascript_packs_with_chunks_tag 'backends_used_list'

--- a/app/views/api/services/forms/_integration_settings.html.slim
+++ b/app/views/api/services/forms/_integration_settings.html.slim
@@ -1,4 +1,4 @@
-= javascript_pack_tag 'settings'
+= javascript_packs_with_chunks_tag 'settings'
 
 - service.deployment_option ||= 'hosted'
 #settings

--- a/app/views/api/services/index.html.slim
+++ b/app/views/api/services/index.html.slim
@@ -1,2 +1,2 @@
 div#products data=presenter.data
-  = javascript_pack_tag 'products_index'
+  = javascript_packs_with_chunks_tag 'products_index'

--- a/app/views/api/services/new.html.slim
+++ b/app/views/api/services/new.html.slim
@@ -1,4 +1,4 @@
-= javascript_pack_tag 'new_service'
+= javascript_packs_with_chunks_tag 'new_service'
 
 #new_service_wrapper data-new-service-data={ isServiceDiscoveryAccessible: service_discovery_accessible?,
                                              template: @service.as_json,

--- a/app/views/buyers/applications/new.html.slim
+++ b/app/views/buyers/applications/new.html.slim
@@ -3,4 +3,4 @@
 h2 Create application
 
 div id="new-application-form" data=presenter.new_application_form_data
-  = javascript_pack_tag 'new_application'
+  = javascript_packs_with_chunks_tag 'new_application'

--- a/app/views/layouts/provider.html.slim
+++ b/app/views/layouts/provider.html.slim
@@ -7,7 +7,7 @@ html[lang="en" class="pf-m-redhat-font"]
       |  | Red Hat 3scale API Management
     = csrf_meta_tag
     = rails_asset_url_tag
-    = javascript_pack_tag 'provider'
+    = javascript_packs_with_chunks_tag 'provider'
     = render 'provider/theme'
     = render 'provider/analytics'
     = javascript_include_tag 'provider/layout/provider'

--- a/app/views/layouts/provider/login.html.slim
+++ b/app/views/layouts/provider/login.html.slim
@@ -5,7 +5,7 @@ html[lang="en" class="pf-m-redhat-font"]
     title 3scale Login
     = csrf_meta_tag
     = rails_asset_url_tag
-    = javascript_pack_tag 'login'
+    = javascript_packs_with_chunks_tag 'login'
 
   body class="login-layout"
     = yield

--- a/app/views/payment_gateways/_braintree_customer_form.html.erb
+++ b/app/views/payment_gateways/_braintree_customer_form.html.erb
@@ -1,5 +1,5 @@
 <div id="braintree-form-wrapper" data-braintree-form="<%= braintree_form_data.to_json %>"></div>
-<%= javascript_pack_tag 'braintree_customer_form'%>
+<%= javascript_packs_with_chunks_tag 'braintree_customer_form'%>
 
 <% unless @errors.blank? %>
     <div class="errorExplanation" id="errorExplanation">

--- a/app/views/payment_gateways/_stripe.html.slim
+++ b/app/views/payment_gateways/_stripe.html.slim
@@ -1,2 +1,2 @@
 div#stripe-form-wrapper data-stripe-form=stripe_form_data(@intent).to_json
-  = javascript_pack_tag 'stripe_form'
+  = javascript_packs_with_chunks_tag 'stripe_form'

--- a/app/views/provider/admin/account/email_configurations/edit.html.slim
+++ b/app/views/provider/admin/account/email_configurations/edit.html.slim
@@ -1,2 +1,2 @@
 div id='email-configurations-edit-container' data=presenter.edit_data
-  = javascript_pack_tag 'email_configurations_edit'
+  = javascript_packs_with_chunks_tag 'email_configurations_edit'

--- a/app/views/provider/admin/account/email_configurations/index.html.slim
+++ b/app/views/provider/admin/account/email_configurations/index.html.slim
@@ -1,2 +1,2 @@
 div id='email-configurations-index-container' data=presenter.index_data
-  = javascript_pack_tag 'email_configurations_index'
+  = javascript_packs_with_chunks_tag 'email_configurations_index'

--- a/app/views/provider/admin/account/email_configurations/new.html.slim
+++ b/app/views/provider/admin/account/email_configurations/new.html.slim
@@ -1,2 +1,2 @@
 div id='email-configurations-new-container' data=presenter.new_data
-  = javascript_pack_tag 'email_configurations_new'
+  = javascript_packs_with_chunks_tag 'email_configurations_new'

--- a/app/views/provider/admin/account/payment_gateways/braintree_blue/edit.html.slim
+++ b/app/views/provider/admin/account/payment_gateways/braintree_blue/edit.html.slim
@@ -58,4 +58,4 @@ p
     = form.commit_button 'Save credit card', button_html: { disabled: true }
 
 span#braintree_data data-client-token=braintree_authorization
-  = javascript_pack_tag 'braintree_provider_form'
+  = javascript_packs_with_chunks_tag 'braintree_provider_form'

--- a/app/views/provider/admin/account/users/_form.html.erb
+++ b/app/views/provider/admin/account/users/_form.html.erb
@@ -57,7 +57,7 @@
     </script>
     <%- if current_account.provider_can_use?(:service_permissions) %>
         <% content_for :javascripts do %>
-            <% javascript_pack_tag 'permissions' %>
+            <% javascript_packs_with_chunks_tag 'permissions' %>
         <% end %>
     <%- end -%>
   <% end %>

--- a/app/views/provider/admin/api_docs/show.html.erb
+++ b/app/views/provider/admin/api_docs/show.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_pack_tag 'provider_active_docs' %>
+<%= javascript_packs_with_chunks_tag 'provider_active_docs' %>
 
 <% content_for :title do %>
   3scale API Documentation

--- a/app/views/provider/admin/applications/_change_plan.html.slim
+++ b/app/views/provider/admin/applications/_change_plan.html.slim
@@ -1,2 +1,2 @@
 div id='change_plan_select' data=change_application_plan_data(@cinstance)
-  = javascript_pack_tag 'change_plan_select'
+  = javascript_packs_with_chunks_tag 'change_plan_select'

--- a/app/views/provider/admin/applications/new.html.slim
+++ b/app/views/provider/admin/applications/new.html.slim
@@ -1,4 +1,4 @@
 h2 Create application
 
 div id="new-application-form" data=presenter.new_application_form_data
-  = javascript_pack_tag 'new_application'
+  = javascript_packs_with_chunks_tag 'new_application'

--- a/app/views/provider/admin/backend_apis/cards/_products_used_list.html.slim
+++ b/app/views/provider/admin/backend_apis/cards/_products_used_list.html.slim
@@ -1,3 +1,3 @@
 h2 Products using this backend
 div id='products-used-list-container' data-products=backend_api.decorate.products_table_data
-  = javascript_pack_tag 'products_used_list'
+  = javascript_packs_with_chunks_tag 'products_used_list'

--- a/app/views/provider/admin/backend_apis/index.html.slim
+++ b/app/views/provider/admin/backend_apis/index.html.slim
@@ -1,2 +1,2 @@
 div#backend-apis data=presenter.data
-  = javascript_pack_tag 'backend_apis_index'
+  = javascript_packs_with_chunks_tag 'backend_apis_index'

--- a/app/views/provider/admin/backend_apis/metrics/_form_new.html.slim
+++ b/app/views/provider/admin/backend_apis/metrics/_form_new.html.slim
@@ -7,7 +7,7 @@
       p
         = ".#{backend_api.id}"
       div id='system_name_popover'
-        = javascript_pack_tag('system_name_input_popover')
+        = javascript_packs_with_chunks_tag('system_name_input_popover')
     p class='inline-hints' Only ASCII letters, numbers, dashes and underscores are allowed.
   = form.input :unit unless @metric.child?
   = form.input :description, input_html: { rows: 3 }

--- a/app/views/provider/admin/backend_apis/metrics/index.html.slim
+++ b/app/views/provider/admin/backend_apis/metrics/index.html.slim
@@ -1,2 +1,2 @@
 div id='backend-api-metrics-index-container' data=presenter.index_data
-  = javascript_pack_tag 'backend_api_metrics_index'
+  = javascript_packs_with_chunks_tag 'backend_api_metrics_index'

--- a/app/views/provider/admin/backend_apis/stats/usage/index.html.slim
+++ b/app/views/provider/admin/backend_apis/stats/usage/index.html.slim
@@ -5,7 +5,7 @@
   = stylesheet_link_tag 'jquery-ui/1.11.4/jquery-ui.css'
 
   - content_for :javascripts do
-    = javascript_pack_tag 'provider_stats'
+    = javascript_packs_with_chunks_tag 'provider_stats'
 
 .Stats
   .StatsMenu-container

--- a/app/views/provider/admin/cms/_includes.html.erb
+++ b/app/views/provider/admin/cms/_includes.html.erb
@@ -1,5 +1,5 @@
 <%= javascript_include_tag 'provider/cms' %>
-<%= javascript_pack_tag 'codemirror' %>
+<%= javascript_packs_with_chunks_tag 'codemirror' %>
 <%= javascript_include_tag 'codemirror/modes/liquid' %>
 
 <%= javascript_tag do %>

--- a/app/views/provider/admin/cms/builtin_legal_terms/_form.html.erb
+++ b/app/views/provider/admin/cms/builtin_legal_terms/_form.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_pack_tag 'codemirror' %>
+<%= javascript_packs_with_chunks_tag 'codemirror' %>
 <%= javascript_include_tag 'codemirror/modes/liquid' %>
 
 <%= f.input :system_name, :as => :hidden %>

--- a/app/views/provider/admin/cms/email_templates/_includes.html.erb
+++ b/app/views/provider/admin/cms/email_templates/_includes.html.erb
@@ -1,3 +1,3 @@
 <%= javascript_include_tag 'jqueryui/jquery-ui-1.9.2.custom.min.js' %>
-<%= javascript_pack_tag 'codemirror' %>
+<%= javascript_packs_with_chunks_tag 'codemirror' %>
 <%= javascript_include_tag 'codemirror/modes/liquid' %>

--- a/app/views/provider/admin/dashboards/show.html.slim
+++ b/app/views/provider/admin/dashboards/show.html.slim
@@ -2,7 +2,7 @@
   = stylesheet_link_tag 'vendor/c3'
 
 = content_for :javascripts do
-  = javascript_pack_tag 'dashboard'
+  = javascript_packs_with_chunks_tag 'dashboard'
 
 .Dashboard
   div.Dashboard-widgets

--- a/app/views/provider/admin/onboarding/wizard/backend_api/new.html.slim
+++ b/app/views/provider/admin/onboarding/wizard/backend_api/new.html.slim
@@ -25,4 +25,4 @@ ol.explain.fa-ul
   button type="submit" class="button button--next"
     = 'Add this Backend'
 
-= javascript_pack_tag 'wizard_backend_api'
+= javascript_packs_with_chunks_tag 'wizard_backend_api'

--- a/app/views/provider/invitee_signups/show.html.erb
+++ b/app/views/provider/invitee_signups/show.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_pack_tag 'sign_up_page' %>
+<%= javascript_packs_with_chunks_tag 'sign_up_page' %>
 
 <%= tag("div", :id => "pf-login-page-container", :"data-signup-props" => {:path => provider_invitee_signup_path(@invitation.token),
   :name => @invitation.account.name,

--- a/app/views/provider/passwords/reset.html.slim
+++ b/app/views/provider/passwords/reset.html.slim
@@ -1,4 +1,4 @@
-= javascript_pack_tag 'request_password_page'
+= javascript_packs_with_chunks_tag 'request_password_page'
 - authentication_providers = (@authentication_providers || []).map { |ap| {authorizeURL: ap.authorize_url, humanKind: ap.human_kind} }
 - flash_messages = (flash || []).map { |f| {type: f[0], message: f[1]}}
 

--- a/app/views/provider/passwords/show.html.erb
+++ b/app/views/provider/passwords/show.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_pack_tag 'change_password' %>
+<%= javascript_packs_with_chunks_tag 'change_password' %>
 
 <%= tag :div, id: 'pf-login-page-container',
               data: { change_password_props: @password_presenter.change_password_props_json } %>

--- a/app/views/provider/sessions/new.html.slim
+++ b/app/views/provider/sessions/new.html.slim
@@ -1,4 +1,4 @@
-= javascript_pack_tag 'login_page'
+= javascript_packs_with_chunks_tag 'login_page'
 - authentication_providers = (@authentication_providers || []).map { |ap| {authorizeURL: ap.authorize_url, humanKind: ap.human_kind} }
 - flash_messages = (flash || []).map { |f| {type: f[0], message: f[1]}}
 - is_master_account = domain_account.master?

--- a/app/views/shared/_new_mapping_rules.html.slim
+++ b/app/views/shared/_new_mapping_rules.html.slim
@@ -6,4 +6,4 @@ div{ id="new-mapping-rule-form" data-url=url
                                 data-top-level-metrics=top_level_metrics
                                 data-errors=errors
                                 data-methods=methods}
-  = javascript_pack_tag 'new_mapping_rule'
+  = javascript_packs_with_chunks_tag 'new_mapping_rule'

--- a/app/views/shared/plans/_plans_index_main_section.html.slim
+++ b/app/views/shared/plans/_plans_index_main_section.html.slim
@@ -1,6 +1,5 @@
+= javascript_packs_with_chunks_tag 'default_plan_selector', 'plans_table'
 section class="pf-c-page__main-section pf-m-no-padding"
   div id='default_plan' data=default_plan_select_data
-    = javascript_pack_tag 'default_plan_selector'
 
   div id='plans_table' data=plans_table_data
-    = javascript_pack_tag 'plans_table'

--- a/app/views/stats/_inlinechart.html.erb
+++ b/app/views/stats/_inlinechart.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_pack_tag 'inline_chart' %>
+<%= javascript_packs_with_chunks_tag 'inline_chart' %>
 
 <div id="mini-charts">
   <% Array.wrap(metrics).each do |metric| %>

--- a/app/views/stats/applications/show.html.slim
+++ b/app/views/stats/applications/show.html.slim
@@ -6,7 +6,7 @@ h2 Traffic statistics for #{@cinstance.display_name} /  #{@cinstance.user_accoun
   = stylesheet_link_tag 'jquery-ui/1.11.4/jquery-ui.css'
 
 - content_for :javascripts do
-  = javascript_pack_tag 'provider_stats'
+  = javascript_packs_with_chunks_tag 'provider_stats'
 
 .Stats
   .StatsMenu-container

--- a/app/views/stats/days/index.html.slim
+++ b/app/views/stats/days/index.html.slim
@@ -1,7 +1,7 @@
 - content_for :sublayout_title, 'Daily Averages'
 
 - content_for :javascripts do
-  = javascript_pack_tag 'provider_stats'
+  = javascript_packs_with_chunks_tag 'provider_stats'
 
 .Stats
   .StatsSelector-container

--- a/app/views/stats/response_codes/show.html.slim
+++ b/app/views/stats/response_codes/show.html.slim
@@ -5,7 +5,7 @@
   = stylesheet_link_tag 'jquery-ui/1.11.4/jquery-ui.css'
 
 - content_for :javascripts do
-  = javascript_pack_tag 'provider_stats'
+  = javascript_packs_with_chunks_tag 'provider_stats'
 
 .Stats
   .StatsMenu-container

--- a/app/views/stats/usage/hours.html.slim
+++ b/app/views/stats/usage/hours.html.slim
@@ -1,7 +1,7 @@
 - content_for :sublayout_title, 'Hourly Averages'
 
 - content_for :javascripts do
-  = javascript_pack_tag 'provider_stats'
+  = javascript_packs_with_chunks_tag 'provider_stats'
 
 .Stats
   .StatsSelector-container

--- a/app/views/stats/usage/index.html.slim
+++ b/app/views/stats/usage/index.html.slim
@@ -5,7 +5,7 @@
   = stylesheet_link_tag 'jquery-ui/1.11.4/jquery-ui.css'
 
   - content_for :javascripts do
-    = javascript_pack_tag 'provider_stats'
+    = javascript_packs_with_chunks_tag 'provider_stats'
 
 .Stats
   .StatsMenu-container

--- a/app/views/stats/usage/top_applications.html.slim
+++ b/app/views/stats/usage/top_applications.html.slim
@@ -4,7 +4,7 @@
   = stylesheet_link_tag 'jquery-ui/1.11.4/jquery-ui.css'
 
   - content_for :javascripts do
-    = javascript_pack_tag 'provider_stats'
+    = javascript_packs_with_chunks_tag 'provider_stats'
 
 .Stats
   .StatsMenu-container

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,3 +1,4 @@
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const environment = require('./environment')
 
 // Add Webpack custom configs here
@@ -17,5 +18,9 @@ environment.loaders.append('eslint', {
 // the plugin automatically picks `tsconfig.json` and doesn't support a custom filename.
 const tsLoader = environment.loaders.get('ts')
 tsLoader.options.reportFiles = [/!(spec\/javascripts)/]
+
+environment.plugins.append('BundleAnalyzerPlugin',
+  new BundleAnalyzerPlugin()
+)
 
 module.exports = environment.toWebpackConfig()

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -62,4 +62,12 @@ Object.assign(fileLoader.use[0].options, {
   postTransformPublicPath: (p) => `window.rails_asset_host + ${p}`
 });
 
+environment.config.merge({
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    }
+  }
+})
+
 module.exports = environment

--- a/lib/developer_portal/app/views/developer_portal/admin/account/invoices/payment.html.erb
+++ b/lib/developer_portal/app/views/developer_portal/admin/account/invoices/payment.html.erb
@@ -91,4 +91,4 @@
   </div>
 </div>
 </div>
-<%= javascript_pack_tag 'invoice_payment' %>
+<%= javascript_packs_with_chunks_tag 'invoice_payment' %>

--- a/lib/developer_portal/lib/liquid/filters/rails_helpers.rb
+++ b/lib/developer_portal/lib/liquid/filters/rails_helpers.rb
@@ -2,7 +2,7 @@
 
 module Liquid
   module Filters
-    module RailsHelpers
+    module RailsHelpers # rubocop:disable Metrics/ModuleLength
       extend ActionView::Helpers::TagHelper
       extend ActionView::Helpers::UrlHelper
       extend ActionView::Helpers::AssetTagHelper
@@ -51,7 +51,7 @@ module Liquid
         js = RailsHelpers.replace_googleapis(name)
         case
         when THREESCALE_WEBPACK_PACKS.include?(name) # TODO: This is an intermediate step in order to tackle webpack assets in dev portal. A final solution might be needed easing the update of templates/assets.
-          active_docs_proxy(name) + view.javascript_pack_tag(name, options)
+          active_docs_proxy(name) + view.javascript_packs_with_chunks_tag(name.chomp('.js'), options)
         when js != name || THREESCALE_JAVASCRIPTS.include?(js)
           active_docs_proxy(js) + view.javascript_include_tag(js)
         else

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ts-loader": "8.4.0",
     "typescript": "^4.8.4",
     "webpack": "4.46.0",
+    "webpack-bundle-analyzer": "^4.8.0",
     "webpack-cli": "3.3.12",
     "webpack-dev-server": "3.11.1",
     "yaml-loader": "^0.6.0"

--- a/test/unit/liquid/filters/rails_helpers_test.rb
+++ b/test/unit/liquid/filters/rails_helpers_test.rb
@@ -10,7 +10,7 @@ class Liquid::Filters::RailsHelpersTest < ActiveSupport::TestCase
 
   test 'javascript_include_tag' do
     @context.registers[:controller] = ApplicationController.new
-    Webpacker.manifest.stubs(:lookup).with('stats.js', {:type => :javascript}).returns('/packs/stats.js')
+    Webpacker.manifest.stubs(:lookup_pack_with_chunks!).with('stats', {:type => :javascript}).returns('/packs/stats.js')
     assert_equal "<script src=\"/packs/stats.js\"></script>", javascript_include_tag('stats.js')
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1565,6 +1565,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@discoveryjs/json-ext@0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
+  integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
+
 "@emotion/babel-utils@^0.6.4":
   version "0.6.10"
   resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.6.10.tgz#83dbf3dfa933fae9fc566e54fbb45f14674c6ccc"
@@ -2107,6 +2112,11 @@
   version "4.44.15"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.44.15.tgz#8eca5b3b03d1c8fd88664ab45f7a7238f9b9b218"
   integrity sha512-Xp82baZURMISkvpNaWNu3w4cMfc2NIsDYh9K5QpVMQ94vphQrAd54UoO5NQI574+/QY2IPGKWadfvix8324J0Q==
+
+"@polka/url@^1.0.0-next.20":
+  version "1.0.0-next.21"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
+  integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
 "@rails/webpacker@5.4.4":
   version "5.4.4"
@@ -3383,7 +3393,7 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-walk@^8.0.2:
+acorn-walk@^8.0.0, acorn-walk@^8.0.2:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
@@ -3403,7 +3413,7 @@ acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.1.0, acorn@^8.5.0, acorn@^8.8.1:
+acorn@^8.0.4, acorn@^8.1.0, acorn@^8.5.0, acorn@^8.8.1:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -4795,6 +4805,11 @@ commander@^2.19.0, commander@^2.20.0, commander@^2.5.0, commander@^2.7.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 commander@~2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
@@ -5803,6 +5818,11 @@ duplexer2@^0.1.2:
   integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
   dependencies:
     readable-stream "^2.0.2"
+
+duplexer@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
+  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
@@ -7351,6 +7371,13 @@ graphlib@^2.1.8:
   integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
   dependencies:
     lodash "^4.17.15"
+
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
 
 handle-thing@^2.0.0:
   version "2.0.1"
@@ -9336,7 +9363,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
+lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9779,6 +9806,11 @@ move-concurrently@^1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
+
+mrmime@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
+  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
 
 ms@2.0.0:
   version "2.0.0"
@@ -10295,6 +10327,11 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+opener@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 opn@^5.5.0:
   version "5.5.0"
@@ -12711,6 +12748,15 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+sirv@^1.0.7:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
+  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.20"
+    mrmime "^1.0.0"
+    totalist "^1.0.0"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -13601,6 +13647,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+totalist@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
+  integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
+
 touch@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/touch/-/touch-2.0.2.tgz#ca0b2a3ae3211246a61b16ba9e6cbf1596287164"
@@ -14144,6 +14195,22 @@ webpack-assets-manifest@^3.1.1:
     tapable "^1.0.0"
     webpack-sources "^1.0.0"
 
+webpack-bundle-analyzer@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.8.0.tgz#951b8aaf491f665d2ae325d8b84da229157b1d04"
+  integrity sha512-ZzoSBePshOKhr+hd8u6oCkZVwpVaXgpw23ScGLFpR6SjYI7+7iIWYarjN6OEYOfRt8o7ZyZZQk0DuMizJ+LEIg==
+  dependencies:
+    "@discoveryjs/json-ext" "0.5.7"
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    chalk "^4.1.0"
+    commander "^7.2.0"
+    gzip-size "^6.0.0"
+    lodash "^4.17.20"
+    opener "^1.5.2"
+    sirv "^1.0.7"
+    ws "^7.3.1"
+
 webpack-cli@3.3.12, webpack-cli@^3.3.12:
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.12.tgz#94e9ada081453cd0aa609c99e500012fd3ad2d4a"
@@ -14409,6 +14476,11 @@ ws@^6.2.1:
   integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
   dependencies:
     async-limiter "~1.0.0"
+
+ws@^7.3.1:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 ws@^8.11.0:
   version "8.13.0"


### PR DESCRIPTION
Split chunks is one of those features that make Webpack useful. Why we have it disabled is a mystery to me although it will be enabled by default once we upgrade to webpacker 6 / shakapacker.
In the meantime, it shouldn't hurt enabling it.

> ⚠️ WARNING: in order to prevent duplicated chunks, `javascript_packs_with_chunks_tag` is not to be called repeatedly. That is:
>```
><%= javascript_packs_with_chunks_tag 'calendar', 'map' %>
>```
>Instead of:
>```
><%= javascript_packs_with_chunks_tag 'calendar' %>
><%= javascript_packs_with_chunks_tag 'map' %>
>```

**Before:**
![Screenshot 2023-04-27 at 12 27 01](https://user-images.githubusercontent.com/11672286/234835940-ff81b2f6-70c0-4dfb-8d3a-1f8deda04ae2.png)

Dashboard Network data example:
![Screenshot 2023-04-27 at 12 32 31](https://user-images.githubusercontent.com/11672286/234838416-cae789c9-3c18-44be-b429-0418fba51c7f.png)

**After:**
![Screenshot 2023-04-27 at 12 23 43](https://user-images.githubusercontent.com/11672286/234838298-4aaba256-c5ff-447e-9c0e-0b86e34c0412.png)

Dashboard Network data example:
![Screenshot 2023-04-27 at 12 38 53](https://user-images.githubusercontent.com/11672286/234838538-2f2041fc-2312-418c-b1b6-6824328c0726.png)

