### PR TITLE
🔧 Remove `TerserPlugin` duplication from production webpack config

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,21 +1,7 @@
-const TerserPlugin = require('terser-webpack-plugin')
 const environment = require('./environment')
 const path = require('path')
 
 // Add Webpack custom configs here
-environment.config.merge({
-  optimization: {
-    minimizer: [
-      new TerserPlugin({
-        parallel: 4
-      })
-    ]
-  },
-  output: {
-    pathinfo: false
-  },
-  devtool: 'cheap-module-eval-source-map'
-})
 
 const tsLoader = environment.loaders.get('ts')
 tsLoader.options.configFile = path.resolve(__dirname, '../../tsconfig.prod.json')


### PR DESCRIPTION
TL;DR:
#### Production js bundle size:
|  | master | remove_terser |
| - | - | - |
| `du -hs public/packs/js` | 141M | 118M |

---

Once upon a time, this commit was merged into master https://github.com/3scale/porta/commit/0e4b3c4bc541e5312eeb691f8f1d37551ae8afd8

To fix failing compilation in Circleci. However, the plugin was added both to production and test, resulting in a duplication in the former:
```js
// console.log(environment.toWebpackConfig().optimization)
{
  minimizer: [
    TerserPlugin {
      options: {
        test: /\.[cm]?js(\?.*)?$/i,
        extractComments: true,
        sourceMap: true,
        cache: true,
        cacheKeys: [Function: cacheKeys],
        parallel: true,
        include: undefined,
        exclude: undefined,
        minify: undefined,
        terserOptions: {
          parse: { ecma: 8 },
          compress: { ecma: 5, warnings: false, comparisons: false },
          mangle: { safari10: true },
          output: { ecma: 5, comments: false, ascii_only: true }
        }
      }
    },
    TerserPlugin {
      options: {
        test: /\.m?js(\?.*)?$/i,
        chunkFilter: [Function: chunkFilter],
        warningsFilter: [Function: warningsFilter],
        extractComments: false,
        sourceMap: false,
        cache: false,
        cacheKeys: [Function: cacheKeys],
        parallel: 4,
        include: undefined,
        exclude: undefined,
        minify: undefined,
        terserOptions: { output: { comments: /^\**!|@preserve|@license|@cc_on/i } }
      }
    }
  ]
}
```
It seems the double minimization is creating a bigger bundle (See table on top) or maybe webpack it's only taking the second instance (ours) and it's less optimal.

**TODO:** we still have to test that the production image is built successfully but the `parallelism: 4` option is supposed to be necessary only for Circleci, other environments will have information about number of CPUs and TerserPlugin will use it automatically.