### PR TITLE
Add x86_64-linux platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,6 +488,8 @@ GEM
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
+      racc (~> 1.4)
     non-stupid-digest-assets (1.0.9)
       sprockets (>= 2.0)
     ntlm-http (0.1.1)
@@ -893,6 +895,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   3scale_client (~> 2.11)


### PR DESCRIPTION
When trying to build an image upstream, `license_finder report` step (in `licenses-report` stage) fails with the following error:

```
/opt/rh/rh-ruby26/root/usr/local/share/gems/gems/bundler-2.2.25/lib/bundler/definition.rb:496:in `materialize': Could not find nokogiri-1.13.10 in any of the sources (Bundler::GemNotFound)
	from /opt/rh/rh-ruby26/root/usr/local/share/gems/gems/bundler-2.2.25/lib/bundler/definition.rb:234:in `specs_for'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/package_managers/bundler.rb:66:in `gem_details'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/package_managers/bundler.rb:51:in `details'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/package_managers/bundler.rb:16:in `current_packages'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/package_manager.rb:105:in `current_packages_with_relations'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/scanner.rb:42:in `each'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/scanner.rb:42:in `flat_map'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/scanner.rb:42:in `active_packages'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/core.rb:84:in `current_packages'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/core.rb:79:in `decision_applier'
	from /opt/rh/rh-ruby26/root/usr/share/ruby/forwardable.rb:224:in `acknowledged'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:51:in `block in aggregate_packages'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `each'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `flat_map'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:49:in `aggregate_packages'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/license_aggregator.rb:11:in `dependencies'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/lib/license_finder/cli/main.rb:161:in `report'
	from /opt/app-root/src/.gem/ruby/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /opt/app-root/src/.gem/ruby/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/app-root/src/.gem/ruby/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /opt/app-root/src/.gem/ruby/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
	from /opt/app-root/src/.gem/ruby/gems/license_finder-7.1.0/bin/license_finder:6:in `<top (required)>'
	from /opt/app-root/src/bin/license_finder:23:in `load'
	from /opt/app-root/src/bin/license_finder:23:in `<main>'
Error: error building at STEP "RUN source /opt/app-root/etc/scl_enable     && pwd && ls -la /opt/system/vendor/bundle/ruby/2.6.0/gems     && bundle config     && gem install license_finder     && license_finder report --format=xml --save=doc/licenses/licenses.xml --decisions-file=doc/dependency_decisions.yml     && [ -s doc/licenses/licenses.xml ]": error while running runtime: exit status 1
```

The issue seems to be caused by the following: https://github.com/pivotal/LicenseFinder/issues/828#issuecomment-953359134

This PR fixes it, following the suggestion provided in that comment (adding `x86_64-linux` as an extra platform in `Gemfile.lock`).