### PR TITLE
Fix licenses report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -242,7 +242,6 @@ group :development, :test do
   gem 'bootsnap', '~> 1.4'
   gem 'colorize'
   gem 'factory_bot_rails', '~> 6.2'
-  gem 'license_finder', '~> 7.1.0'
 
   gem 'pry-byebug', '>= 3.7.0'
   gem 'pry-doc', '>= 0.8', require: false
@@ -253,6 +252,10 @@ group :development, :test do
   # for `rake doc:liquid:generate` and similar
   gem 'source2swagger', git: 'https://github.com/3scale/source2swagger'
   gem 'unicorn-rails'
+end
+
+group :licenses do
+  gem 'license_finder', '~> 7.1.0'
 end
 
 gem 'webpacker', '5.4.4'

--- a/lib/tasks/licenses.rake
+++ b/lib/tasks/licenses.rake
@@ -4,7 +4,7 @@ namespace :licenses do  # rubocop:disable Metrics/BlockLength
   report_path = Rails.root.join('doc/licenses/licenses.xml').freeze
 
   desc 'Generates a report with the dependencies and their licenses'
-  task :report do
+  task report: :license_finder_gem do
     warn 'Generating report...'
     license_finder_report(report_path)
 
@@ -12,7 +12,7 @@ namespace :licenses do  # rubocop:disable Metrics/BlockLength
   end
 
   desc 'Check license compliance of dependencies'
-  task :compliance do
+  task compliance: :license_finder_gem do
     warn 'Checking action items...'
     LicenseFinder::CLI::Main.new.action_items # Aborts if there are pending action items
 
@@ -31,6 +31,10 @@ namespace :licenses do  # rubocop:disable Metrics/BlockLength
     end
 
     warn 'License report up to date.'
+  end
+
+  task :license_finder_gem do
+    Bundler.require(:licenses)
   end
 
   private

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -10,7 +10,6 @@ ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}" \
 
 ENV TZ=:/etc/localtime \
     BUNDLE_GEMFILE=Gemfile \
-    BUNDLE_WITHOUT=development:test \
     VARNISH_SCL=rh-varnish5 \
     NODEJS_SCL=rh-nodejs14 \
     RUBY_SCL="rh-ruby${RUBY_SCL_NAME_VERSION}" \
@@ -65,6 +64,7 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
 RUN source /opt/app-root/etc/scl_enable \
     && gem install bundler --version 2.2.25 \
     && bundle config build.pg --with-pg-config=/usr/pgsql-13/bin/pg_config \
+    && bundle config set --local without development:test:licenses \
     && bundle install --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
 
 RUN chgrp root /opt/system/
@@ -112,8 +112,9 @@ RUN yum install -y mariadb-server \
 
 FROM porta-base AS licenses-report
 RUN source /opt/app-root/etc/scl_enable \
-    && gem install license_finder \
-    && license_finder report --format=xml --save=doc/licenses/licenses.xml --decisions-file=doc/dependency_decisions.yml \
+    && sed -i -e 's/:licenses//' .bundle/config \
+    && bundle install \
+    && bundle exec rake licenses:report \
     && [ -s doc/licenses/licenses.xml ]
 
 FROM porta-base AS porta-prod

--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -110,13 +110,5 @@ RUN yum install -y mariadb-server \
     && grep -q "rt_field = account_id" "$THINKING_SPHINX_CONFIGURATION_FILE" \
     && kill $(</var/run/mariadb/mariadb.pid)
 
-FROM porta-base AS licenses-report
-RUN source /opt/app-root/etc/scl_enable \
-    && sed -i -e 's/:licenses//' .bundle/config \
-    && bundle install \
-    && bundle exec rake licenses:report \
-    && [ -s doc/licenses/licenses.xml ]
-
 FROM porta-base AS porta-prod
 COPY --from=porta-sphinx-config /opt/system/config/standalone.sphinx.conf /opt/system/config/
-COPY --from=licenses-report /opt/system/doc/licenses/licenses.xml /opt/system/doc/licenses/


### PR DESCRIPTION
license_finder fails due to https://github.com/rubygems/rubygems/issues/6626

So easiest solution is to disable it. As it doesn't appear useful anyway. If issue is fixed upstream, then we may re-enable or may not.

The Gemfile change is to enable using bundler and the rake task in production builds where things work due to the different way of distributing gems.