### PR TITLE
more options to build images + buildah

### DIFF
--- a/.github/workflows/container-image-buildah.yml
+++ b/.github/workflows/container-image-buildah.yml
@@ -1,0 +1,88 @@
+name: Build porta oci container image
+
+on:
+  workflow_call:
+    inputs:
+      platforms:
+        description: comma-separated list of platforms to build for, e.g. linux/amd64,linux/s390x,linux/ppc64le
+        default: linux/amd64
+        type: string
+      custom_tag:
+        description: optional custom tag on remote repo you want image to be tagged with
+        required: false
+        default: ''
+        type: string
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: quay.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  buildah:
+    runs-on: ubuntu-latest
+    steps:
+      # Allow multi-target builds
+      # - name: Set up QEMU
+      #  uses: docker/setup-qemu-action@v2
+      #  with:
+      #    platforms: ${{ inputs.platforms }}
+
+      - name: Log in to Red Hat Registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USER_NAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch,enable=${{ github.ref_name != 'master' && inputs.custom_tag == '' }}
+            type=raw,value=latest,enable=${{ github.ref_name == 'master' }}
+            type=raw,value=nightly,enable=${{ github.ref_name == 'master' }}
+            ${{ inputs.custom_tag }}
+            type=ref,event=tag
+            type=ref,event=pr
+
+      - uses: actions/checkout@v3
+
+      - name: Build image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          tags: ${{ steps.meta.outputs.tags }}
+          # enable platforms once base image has them
+          # platforms: ${{ inputs.platforms }}
+          labels: ${{ steps.meta.outputs.labels }}
+          layers: false
+          oci: true
+          tls-verify: true
+          extra-args: |
+            --squash
+          containerfiles: |
+            openshift/system/Dockerfile
+
+      - name: Echo Outputs
+        run: |
+          echo "Image: ${{ steps.build-image.outputs.image }}"
+          echo "Tags: ${{ steps.build-image.outputs.tags }}"
+          echo "Tagged Image: ${{ steps.build-image.outputs.image-with-tag }}"
+
+      - name: Check images created
+        run: buildah images
+
+      - name: Push To quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        if: github.event_name != 'pull_request'
+        with:
+          tags: ${{ steps.build-image.outputs.tags }}
+
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/container-image-buildah.yml
+++ b/.github/workflows/container-image-buildah.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: ''
         type: string
+    secrets:
+      QUAY_USER_NAME:
+        required: false
+      QUAY_PASSWORD:
+        required: false
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/container-image-buildx.yml
+++ b/.github/workflows/container-image-buildx.yml
@@ -1,0 +1,50 @@
+name: Build porta container image - reusable buildx
+on:
+  workflow_call:
+    inputs:
+      platforms:
+        description: comma-separated list of platforms to build for
+        default: linux/amd64,linux/s390x,linux/ppc64le
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      # Allow multi-target builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ inputs.platforms }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: openshift/system/Dockerfile

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,51 +1,24 @@
-name: Build porta container image
+name: Container
 on:
-  # push:
-  #   branches:
-  #   - master
-  workflow_dispatch: {}
-  # pull_request:
-  # branches: [ master ]
-
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+  push:
+    branches:
+      - master
+      - managed-services
+      - 3scale-[0-9]+-stable
+    tags:
+      - 3scale-[0-9]+-GA
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: comma-separated list of platforms to build for, downstream supported are linux/amd64,linux/s390x,linux/ppc64le
+        default: linux/amd64
+      custom_tag:
+        description: a custom tag on remote repo you want image to be tagged with
+        default: scratch
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      # Allow multi-target builds
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v4
-        with:
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/s390x,linux/ppc64le
-          labels: ${{ steps.meta.outputs.labels }}
-          file: openshift/system/Dockerfile
+  call-build:
+    uses: ./.github/workflows/container-image-buildah.yml
+    with:
+      platforms: ${{ inputs.platforms }}
+      custom_tag: ${{ inputs.custom_tag }}

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -22,3 +22,6 @@ jobs:
     with:
       platforms: ${{ inputs.platforms }}
       custom_tag: ${{ inputs.custom_tag }}
+    secrets: # inherit doesn't work for some reason
+      QUAY_USER_NAME: ${{ secrets.QUAY_USER_NAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -4,9 +4,9 @@ on:
     branches:
       - master
       - managed-services
-      - 3scale-[0-9]+-stable
+      - 3scale-[0-9]+.[0-9]+-stable
     tags:
-      - 3scale-[0-9]+-GA
+      - 3scale-[0-9]+.[0-9]+.[0-9]+-GA
   workflow_dispatch:
     inputs:
       platforms:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![CircleCI](https://circleci.com/gh/3scale/porta.svg?style=svg)](https://circleci.com/gh/3scale/porta) [![Maintainability](https://api.codeclimate.com/v1/badges/1fe7e330e8507ea893be/maintainability)](https://codeclimate.com/github/3scale/porta/maintainability) [![codecov](https://codecov.io/gh/3scale/porta/branch/master/graph/badge.svg)](https://codecov.io/gh/3scale/porta) [![Container Repository on Quay](https://quay.io/repository/3scale/porta/status "Container Repository on Quay")](https://quay.io/repository/3scale/porta)
+[![CircleCI](https://circleci.com/gh/3scale/porta.svg?style=svg)](https://circleci.com/gh/3scale/porta)
+[![Maintainability](https://api.codeclimate.com/v1/badges/1fe7e330e8507ea893be/maintainability)](https://codeclimate.com/github/3scale/porta/maintainability)
+[![codecov](https://codecov.io/gh/3scale/porta/branch/master/graph/badge.svg)](https://codecov.io/gh/3scale/porta)
+[![container-image](https://github.com/3scale/porta/actions/workflows/container-image.yml/badge.svg)](https://quay.io/repository/3scale/porta)
+
 # 3scale "Porta" Component
 
 The 3scale `Porta` component is part of the 3Scale API Management solution and is responsible for serving the:


### PR DESCRIPTION
A workflow to replace Quay as builder of our images, still push to Quay. Keeping the `buildx` workflow for debugging purposes in case of troubles with buildah.

This works, tested with
https://github.com/3scale/porta/actions/runs/4745576359/jobs/8428089503

because it needed the licenses report fix