### PR TITLE
Add an endpoint for upgrading a tenant in SaaS

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,10 +98,11 @@ without fake Core server your after commit callbacks will crash and you might ge
       end
 
       namespace :api, defaults: {format: 'json'} do
-        # /master/api/provider
+        # /master/api/providers
         resources :providers, except: :index do
           member do
             post :change_partner
+            put :plan_upgrade
           end
           resources :services, only: [:destroy]
         end

--- a/test/factories/plan.rb
+++ b/test/factories/plan.rb
@@ -26,9 +26,11 @@ FactoryBot.define do # rubocop:disable Metrics/BlockLength
     association(:issuer, :factory => :service)
   end
 
-  factory(:application_plan, :parent => :plan, :class => ApplicationPlan) do
-    association(:issuer, :factory => :service)
+  factory(:application_plan_without_rules, parent: :plan, class: ApplicationPlan) do
+    association(:issuer, factory: :service)
+  end
 
+  factory(:application_plan, parent: :application_plan_without_rules) do
     after(:build) do |plan|
       plan_rule = PlanRulesCollection.find_for_plan(plan) || FactoryBot.build(:plan_rule, system_name: plan.system_name.to_sym)
       plan.stubs(:plan_rule).returns(plan_rule)


### PR DESCRIPTION
In SaaS there is a special logic for upgrading tenant accounts (includes not only the application plan change, but also applying switches for the different features).

This is currently only available through the multitenant UI.

This PR adds an endpoint `PUT /master/api/providers/{id}/plan_upgrade.xml` (with `plan_id` body param specifying the ID of the new plan) that allows upgrading the tenant through API.

This will be useful in SaaS staging environment, where a new provider can be created and upgraded to the corresponding plan, in order to enable all features (by default only a limited subset of features is enabled).