### PR TITLE
Upgrade Rmagick to 4.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'cancancan', '~> 2.3.0'
 gem 'formtastic', '~> 2.3.1'
 gem 'gruff', '~>0.3', require: false
 gem 'htmlentities', '~>4.3', '>= 4.3.4'
-gem 'rmagick', '~> 2.15.3', require: false
+gem 'rmagick', '~> 4.1', require: false
 # TODO: Not actively maintained https://github.com/activeadmin/inherited_resources#notice replace with respond_with and fix things the rails way
 gem 'inherited_resources', '~> 1.12.0'
 gem 'has_scope', '~> 0.7.2' # remove line after we stop supporting Ruby 2.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,8 +364,9 @@ GEM
     github-markdown (0.6.9)
     globalid (1.0.1)
       activesupport (>= 5.0)
-    gruff (0.7.0)
-      rmagick (~> 2.13, >= 2.13.4)
+    gruff (0.19.0)
+      histogram
+      rmagick (>= 4.2)
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
@@ -373,6 +374,7 @@ GEM
     hashery (2.1.2)
     hashie (3.6.0)
     hiredis (0.6.3)
+    histogram (0.2.4.1)
     html-pipeline (2.12.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
@@ -654,7 +656,7 @@ GEM
       netrc (~> 0.8)
     rexml (3.2.5)
     riddle (2.4.3)
-    rmagick (2.15.4)
+    rmagick (4.3.0)
     roar (1.0.4)
       representable (>= 2.0.1, < 2.4.0)
     roar-rails (1.0.2)
@@ -1015,7 +1017,7 @@ DEPENDENCIES
   reek (= 6.01)
   reform (~> 2.0.3)
   rest-client (~> 2.0.2)
-  rmagick (~> 2.15.3)
+  rmagick (~> 4.1)
   roar-rails
   rspec-html-matchers!
   rspec-rails (~> 4.1)
@@ -1067,4 +1069,4 @@ DEPENDENCIES
   zip-zip
 
 BUNDLED WITH
-   2.2.25
+   2.2.26


### PR DESCRIPTION
**What this PR does / why we need it**:

I upgraded to Fedora 38 and I found I can't run porta anymore. The cause is we are using rmagick 2.15.4 which requires ImageMagick 6 and doesn't support ImageMagick 7. But Fedora 38 only provides ImageMagick 7, version 6 is not available.

I had to upgrade rmagick to > 4.1 where support for ImageMagick 7 was added. In my tests, this doesn't seem to cause any issue. Why were we stuck on rmagick 2.x?

I need this to get merged because otherwise I'll have to manually update the Gemfile in all my branches but never commit it, and that's very inconvenient.

This upgrade shouldn't affect others because Rmagick 4 still supports ImageMagick 6. But I'd like you to test this and verify it works fine on Mac and older Fedora releases.



