### PR TITLE
THREESCALE-9010: Do not add 'schemes' to OpenAPI v3 spec

### DIFF
--- a/test/unit/three_scale/swagger/specification_test.rb
+++ b/test/unit/three_scale/swagger/specification_test.rb
@@ -53,15 +53,26 @@ class ThreeScale::Swagger::SpecificationTest < ActiveSupport::TestCase
     assert_equal "bar", specification["parameters"]["x-data-threescale-name"]
   end
 
-  test 'add schemes if is not present' do
-    specification = ThreeScale::Swagger::Specification.new({}.to_json).as_json
-    assert_equal ["http"], specification["schemes"]
+  test 'add schemes if is not present for Swagger v1 and v2' do
+    [{ swaggerVersion: '1.2'}, { swagger: '2.0'}].each do |spec|
+      specification = ThreeScale::Swagger::Specification.new(spec.to_json).as_json
+      assert_equal ["http"], specification["schemes"]
 
-    specification = ThreeScale::Swagger::Specification.new({"basePath" => "https://example.net"}.to_json).as_json
-    assert_equal ["https"], specification["schemes"]
+      specification = ThreeScale::Swagger::Specification.new(spec.merge({ basePath: 'https://example.net'}).to_json).as_json
+      assert_equal ["https"], specification["schemes"]
 
-    specification = ThreeScale::Swagger::Specification.new({schemes: ["foo"]}.to_json).as_json
-    assert_equal ["foo"], specification["schemes"]
+      specification = ThreeScale::Swagger::Specification.new(spec.merge({ schemes: ['foo'] }).to_json).as_json
+      assert_equal ["foo"], specification["schemes"]
+    end
+  end
+
+  test 'do not add schemes for OpenAPI v3' do
+    spec = { openapi: '3.0.0' }
+    specification = ThreeScale::Swagger::Specification.new(spec.to_json).as_json
+    assert_nil specification["schemes"]
+
+    specification = ThreeScale::Swagger::Specification.new(spec.merge({ servers: ['https://example.net'] }).to_json).as_json
+    assert_nil specification["schemes"]
   end
 
   private


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not add `schemes` field fo OpenAPI v3 spec.

**Which issue(s) this PR fixes** 

[THREESCALE-9010](https://issues.redhat.com/browse/THREESCALE-9010): When downloading the Active Doc 3scale adds "schemes":["http"]" at the end

**Verification steps** 

- Go to the preview page for an OpenAPI specification (e.g. http://provider-admin.3scale.localhost:3000/apiconfig/services/2/api_docs/1/preview)
- Click on the URL of the spec (e.g. http://provider-admin.3scale.localhost:3000/admin/api_docs/services/1.json)
- Verify that there is no `schemes` field.

**Special notes for your reviewer**:

The feature was initially implemented by https://github.com/3scale/system/pull/5548
But OpenAPI v3 was added later, and this is not relevant for v3, as `schemes` field is invalid there.