### PR TITLE
Stringify the name of the class for the by_type query for CMS::Template

### DIFF
--- a/app/models/cms/template.rb
+++ b/app/models/cms/template.rb
@@ -13,7 +13,7 @@ class CMS::Template < ApplicationRecord
 
   self.allowed_search_scopes = %i[type section_id]
 
-  scope :by_type, ->(type) { where(type: CMS::TypeMap.cms_class(type)) }
+  scope :by_type, ->(type) { where(type: CMS::TypeMap.cms_class(type).name) }
   scope :by_section_id, ->(section_id) { where(section_id: section_id) }
 
   self.table_name = :cms_templates


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix `by_type` filter for CMS::Template that was broken in PostgreSQL.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

Make sure the test passes.

**Special notes for your reviewer**:

This was caught by tests in CircleCI:

```
Error:
CMS::Api::TemplatesTest#test_index_filters_by_type:
TypeError: can't cast Class
    app/lib/three_scale/api/responder.rb:80:in `serializable'
    app/lib/three_scale/api/responder.rb:6:in `api_behavior'
    app/controllers/admin/api/cms/templates_controller.rb:38:in `index'
    app/lib/api_authentication/by_access_token.rb:162:in `enforce'
    app/lib/api_authentication/by_access_token.rb:112:in `enforce_access_token_permission'
    app/controllers/admin/api/base_controller.rb:42:in `block in notification_center'
    lib/notification_center.rb:30:in `silent_about'
    app/controllers/application_controller.rb:140:in `silent_about'
    app/controllers/admin/api/base_controller.rb:41:in `notification_center'
    lib/three_scale/middleware/multitenant.rb:113:in `_call'
    lib/three_scale/middleware/multitenant.rb:108:in `call'
    lib/gitlab/testing/request_inspector_middleware.rb:61:in `call'
    lib/gitlab/testing/request_blocker_middleware.rb:73:in `call'
    test/integration/cms/api/templates_test.rb:102:in `block in <class:TemplatesTest>'
```

But it affects not only the test, but the actual controller functionality.
