### PR TITLE
THREESCALE-9571: Prevent writing immutable fields.

### DIFF
--- a/app/controllers/admin/api/cms/base_controller.rb
+++ b/app/controllers/admin/api/cms/base_controller.rb
@@ -3,7 +3,7 @@
 class Admin::Api::CMS::BaseController < Admin::Api::BaseController
   include ApiSupport::ForbidParams
 
-  forbid_extra_params :reject, whitelist: %i[id page per_page]
+  forbid_extra_params :reject, whitelist: %i[id page per_page created_at updated_at]
 
   before_action :ensure_json_request
   before_action :deny_on_premises_for_master

--- a/app/controllers/admin/api/cms/files_controller.rb
+++ b/app/controllers/admin/api/cms/files_controller.rb
@@ -17,6 +17,8 @@ class Admin::Api::CMS::FilesController < Admin::Api::CMS::BaseController
 
   wrap_parameters :file, include: ALLOWED_PARAMS
 
+  forbid_extra_params :reject, whitelist: %i[id page per_page created_at updated_at url title content_type]
+
   representer :entity => ::CMS::FileRepresenter, :collection => ::CMS::FilesRepresenter
 
   ##~ e = sapi.apis.add

--- a/app/controllers/admin/api/cms/templates_controller.rb
+++ b/app/controllers/admin/api/cms/templates_controller.rb
@@ -14,7 +14,8 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
   wrap_parameters :template, include: AVAILABLE_PARAMS,
                              format: %i[json multipart_form url_encoded_form]
 
-  forbid_extra_params :reject, whitelist: %i[id page per_page type layout_name section_name]
+  forbid_extra_params :reject,
+                      whitelist: %i[id page per_page type layout_name section_name created_at updated_at hidden published]
 
   before_action :find_template, except: %i[index create]
 

--- a/app/lib/api_support/forbid_params.rb
+++ b/app/lib/api_support/forbid_params.rb
@@ -22,6 +22,12 @@ module ApiSupport
     end
 
     class_methods do
+      # What to do when the client sends additional parameters not permitted by Strong Parameters
+      # === action:
+      #   * <tt>:log</tt> -   Writes a warning on the logs, containing the list of unpermitted parameters.
+      #   * <tt>:raise</tt> - Raises an +UnpermittedParametersError+ error.
+      # === options:
+      #   * <tt>:whitelist</tt> - List of parameters to be ignored. These parameters won't trigger the action but they are still unpermitted and  won't reach the database.
       def forbid_extra_params(action, options = {})
         before_action :_unpermitted_parameters_check
         self._forbid_params_action = action

--- a/test/integration/cms/api/files_test.rb
+++ b/test/integration/cms/api/files_test.rb
@@ -97,6 +97,31 @@ module CMS
         assert_response :success
       end
 
+      test 'update ignores immutable fields' do
+        file = create_file
+        created_at = file.created_at
+        updated_at = file.updated_at
+        url = file.url
+        title = file.title
+        content_type = file.attachment.content_type
+        params = { provider_key: @provider.provider_key,
+                   created_at: Time.current + 1000, updated_at: Time.current + 1000,
+                   url: '/file', title: 'title',
+                   content_type: 'image/test',
+                   section_id: file.section.id
+        }
+
+        put admin_api_cms_file_path(file, format: :json), params: params
+        file.reload
+
+        assert_response :success
+        assert_equal created_at, file.created_at
+        assert_equal updated_at, file.updated_at
+        assert_equal url, file.url
+        assert_equal title, file.title
+        assert_equal content_type, file.attachment.content_type
+      end
+
       test 'create' do
         post admin_api_cms_files_path, params: { provider_key: @provider.provider_key, format: :json, path: "/foo.bar", attachment: attachment_for_upload, section_id: @provider.sections.root.id }
         assert_response :success

--- a/test/integration/cms/api/files_test.rb
+++ b/test/integration/cms/api/files_test.rb
@@ -115,8 +115,8 @@ module CMS
         file.reload
 
         assert_response :success
-        assert_equal created_at, file.created_at
-        assert_equal updated_at, file.updated_at
+        assert_equal created_at.to_s, file.created_at.to_s
+        assert_equal updated_at.to_s, file.updated_at.to_s
         assert_equal url, file.url
         assert_equal title, file.title
         assert_equal content_type, file.attachment.content_type

--- a/test/integration/cms/api/sections_test.rb
+++ b/test/integration/cms/api/sections_test.rb
@@ -121,8 +121,8 @@ module CMS
         put admin_api_cms_section_path(section), params: params
         section.reload
 
-        assert_equal created_at, section.created_at
-        assert_equal updated_at, section.updated_at
+        assert_equal created_at.to_s, section.created_at.to_s
+        assert_equal updated_at.to_s, section.updated_at.to_s
         assert_equal 'foo', section.title
       end
 

--- a/test/integration/cms/api/sections_test.rb
+++ b/test/integration/cms/api/sections_test.rb
@@ -106,6 +106,27 @@ module CMS
         assert_equal 'foo', section.title
       end
 
+      test 'update ignores immutable fields' do
+        section = create_section
+        created_at = section.created_at
+        updated_at = section.updated_at
+        params = {
+          provider_key: @provider.provider_key,
+          format: :json,
+          created_at: Time.current + 1000,
+          updated_at: Time.current + 1000,
+          title: 'foo'
+        }
+
+        put admin_api_cms_section_path(section), params: params
+        section.reload
+
+        assert_equal created_at, section.created_at
+        assert_equal updated_at, section.updated_at
+        assert_equal 'foo', section.title
+      end
+
+
       test 'create' do
         post admin_api_cms_sections_path, params: {
           provider_key: @provider.provider_key,

--- a/test/integration/cms/api/templates_test.rb
+++ b/test/integration/cms/api/templates_test.rb
@@ -227,6 +227,31 @@ module CMS
         assert_equal new_layout, page.reload.layout
       end
 
+      test 'update ignores immutable fields' do
+        page   = FactoryBot.create(:cms_page, provider: @provider)
+        created_at = page.created_at
+        updated_at = page.updated_at
+        hidden = page.hidden?
+        published = page.published.present?
+        params = {
+          provider_key: @provider.provider_key,
+          title:        'Alaska',
+          created_at:   Time.current + 1000,
+          updated_at:   Time.current + 1000,
+          hidden:       true,
+          published:     true
+        }
+
+        put admin_api_cms_template_path(page), params: params
+        page.reload
+
+        assert_response :success
+        assert_equal created_at, page.created_at
+        assert_equal updated_at, page.updated_at
+        assert_equal hidden, page.hidden?
+        assert_equal published, page.published.present?
+      end
+
       test 'create with missing or invalid type fails' do
         post admin_api_cms_templates_path, params: { provider_key: @provider.provider_key, format: :json,
                                                      type: 'INVALID', title: 'test template' }

--- a/test/integration/cms/api/templates_test.rb
+++ b/test/integration/cms/api/templates_test.rb
@@ -246,8 +246,8 @@ module CMS
         page.reload
 
         assert_response :success
-        assert_equal created_at, page.created_at
-        assert_equal updated_at, page.updated_at
+        assert_equal created_at.to_s, page.created_at.to_s
+        assert_equal updated_at.to_s, page.updated_at.to_s
         assert_equal hidden, page.hidden?
         assert_equal published, page.published.present?
       end


### PR DESCRIPTION
**What this PR does / why we need it**:

To update one resource you can:

1. GET the resource.
2. Update some fields on the received JSON.
3. Copy and paste the modified JSON on a new PUT request.

This fails because the endpoints reject parameters not permitted or whitelisted.
This PR adds some params to the white list. In particular:

File PUT autogenerated attributes: `created_at`, `updated_at`, `url`, `title`, `content_type`
Section PUT autogenerated attributes: `created_at`, `updated_at`
Partial PUT autogenerated attributes: `created_at`, `updated_at`, `published`
Page PUT autogenerated attributes: `created_at`, `updated_at`, `hidden`, `published`
Layout PUT autogenerated attributes: `created_at`, `updated_at`, `published`

**Which issue(s) this PR fixes** 

[THREESCALE-9571](https://issues.redhat.com/browse/THREESCALE-9571)

**Verification steps** 

1. GET the resource.
2. Update some fields on the received JSON.
3. Copy and paste the modified JSON on a new PUT request.
4. Check that immutable fields are ignored.