### PR TITLE
THREESCALE-9576: Add parameter "full" to endpoint GET templates.json

### DIFF
--- a/app/controllers/admin/api/cms/templates_controller.rb
+++ b/app/controllers/admin/api/cms/templates_controller.rb
@@ -14,7 +14,7 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
   wrap_parameters :template, include: AVAILABLE_PARAMS,
                              format: %i[json multipart_form url_encoded_form]
 
-  forbid_extra_params :reject, whitelist: %i[id page per_page type layout_name section_name]
+  forbid_extra_params :reject, whitelist: %i[id page per_page type layout_name section_name full]
 
   before_action :find_template, except: %i[index create]
 
@@ -35,7 +35,8 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
   ##~ op.parameters.add @parameter_per_page
   def index
     templates = cms_templates.scope_search(search).paginate(pagination_params)
-    respond_with(templates, short: true, representer: CMS::TemplatesRepresenter)
+    short = !full_data
+    respond_with(templates, short: short, representer: CMS::TemplatesRepresenter)
   end
 
   ##~ op            = e.operations.add
@@ -162,5 +163,9 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
 
   def cms_templates
     current_account.templates.but(CMS::EmailTemplate, CMS::Builtin::LegalTerm).order(:id)
+  end
+
+  def full_data
+    params[:full] == "true"
   end
 end

--- a/app/controllers/admin/api/cms/templates_controller.rb
+++ b/app/controllers/admin/api/cms/templates_controller.rb
@@ -14,7 +14,7 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
   wrap_parameters :template, include: AVAILABLE_PARAMS,
                              format: %i[json multipart_form url_encoded_form]
 
-  forbid_extra_params :reject, whitelist: %i[id page per_page type layout_name section_name full]
+  forbid_extra_params :reject, whitelist: %i[id page per_page type layout_name section_name content]
 
   before_action :find_template, except: %i[index create]
 
@@ -35,7 +35,7 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
   ##~ op.parameters.add @parameter_per_page
   def index
     templates = cms_templates.scope_search(search).paginate(pagination_params)
-    short = !full_data
+    short = !content?
     respond_with(templates, short: short, representer: CMS::TemplatesRepresenter)
   end
 
@@ -165,7 +165,7 @@ class Admin::Api::CMS::TemplatesController < Admin::Api::CMS::BaseController
     current_account.templates.but(CMS::EmailTemplate, CMS::Builtin::LegalTerm).order(:id)
   end
 
-  def full_data
-    params[:full] == "true"
+  def content?
+    params[:content] == "true"
   end
 end

--- a/doc/active_docs/cms_api.json
+++ b/doc/active_docs/cms_api.json
@@ -43,6 +43,14 @@
             "schema": {
               "type": "integer"
             }
+          },
+          {
+            "name": "content",
+            "in": "query",
+            "description": "Return the draft and published content",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/test/integration/cms/api/templates_test.rb
+++ b/test/integration/cms/api/templates_test.rb
@@ -116,6 +116,16 @@ module CMS
         assert_equal 2, response.parsed_body['collection'].size
       end
 
+      test 'index returns full data when receiving the :full parameter as true' do
+        FactoryBot.create_list(:cms_page, 2, provider: @provider)
+
+        get admin_api_cms_templates_path, params: { provider_key: @provider.provider_key, full: true}
+
+        assert_response :success
+        assert_equal 2, response.parsed_body['collection'].size
+        assert response.parsed_body['collection'].first.key?('draft')
+      end
+
       # TODO: check XML content
       test 'show partial' do
         partial = FactoryBot.create(:cms_partial, provider: @provider)

--- a/test/integration/cms/api/templates_test.rb
+++ b/test/integration/cms/api/templates_test.rb
@@ -116,10 +116,10 @@ module CMS
         assert_equal 2, response.parsed_body['collection'].size
       end
 
-      test 'index returns full data when receiving the :full parameter as true' do
+      test 'index returns content when receiving the :content parameter as true' do
         FactoryBot.create_list(:cms_page, 2, provider: @provider)
 
-        get admin_api_cms_templates_path, params: { provider_key: @provider.provider_key, full: true}
+        get admin_api_cms_templates_path, params: { provider_key: @provider.provider_key, content: true}
 
         assert_response :success
         assert_equal 2, response.parsed_body['collection'].size


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to enable a way to export all templates in one request, QE asked for a new parameter `:full` to add the `:draft` and `:published` fields to every template in the response.

**Which issue(s) this PR fixes** 

[THREESCALE-9576](https://issues.redhat.com/browse/THREESCALE-9576)

**Verification steps** 

`curl --request GET --url 'http://provider-admin.3scale.localhost:3000//admin/api/cms/templates?access_token=secret&full=true'`