### PR TITLE
⚡ Remove react-icons chunk

### DIFF
--- a/app/javascript/src/ActiveDocs/components/ApiJsonSpecInput.tsx
+++ b/app/javascript/src/ActiveDocs/components/ApiJsonSpecInput.tsx
@@ -1,7 +1,7 @@
 import { FormGroup, TextArea } from '@patternfly/react-core'
 
 import { useCodeMirror } from 'ActiveDocs/useCodeMirror'
-// import { ExclamationCircleIcon } from '@patternfly/react-icons' add the icon when we upgrade to PF4
+// import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon' add the icon when we upgrade to PF4
 
 import type { FunctionComponent } from 'react'
 

--- a/app/javascript/src/ActiveDocs/components/NameInput.tsx
+++ b/app/javascript/src/ActiveDocs/components/NameInput.tsx
@@ -1,5 +1,5 @@
 import { FormGroup, TextInput } from '@patternfly/react-core'
-// import { ExclamationCircleIcon } from '@patternfly/react-icons' add the icon when we upgrade to PF4
+// import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon' add the icon when we upgrade to PF4
 
 import type { FunctionComponent } from 'react'
 
@@ -9,7 +9,7 @@ interface Props {
   setName: (name: string) => void;
 }
 
-const NameInput: FunctionComponent<Props> = ({ errors = [], name, setName }) => {    
+const NameInput: FunctionComponent<Props> = ({ errors = [], name, setName }) => {
   const validated = errors.length ? 'error' : 'default'
 
   return (

--- a/app/javascript/src/BackendApis/components/BackendSelect.tsx
+++ b/app/javascript/src/BackendApis/components/BackendSelect.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@patternfly/react-core'
-import { PlusCircleIcon } from '@patternfly/react-icons'
+import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon'
 
 import { SelectWithModal } from 'Common/components/SelectWithModal'
 

--- a/app/javascript/src/Common/components/CompactListCard.tsx
+++ b/app/javascript/src/Common/components/CompactListCard.tsx
@@ -7,7 +7,7 @@ import {
   TextInput
 } from '@patternfly/react-core'
 import { Table, TableBody } from '@patternfly/react-table'
-import { SearchIcon } from '@patternfly/react-icons'
+import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon'
 
 import { MicroPagination } from 'Common/components/MicroPagination'
 

--- a/app/javascript/src/Common/components/MicroPagination.tsx
+++ b/app/javascript/src/Common/components/MicroPagination.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@patternfly/react-core'
-import { AngleLeftIcon, AngleRightIcon } from '@patternfly/react-icons'
+import AngleLeftIcon from '@patternfly/react-icons/dist/js/icons/angle-left-icon'
+import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon'
 
 import type { FunctionComponent } from 'react'
 

--- a/app/javascript/src/Common/components/NoMatchFound.tsx
+++ b/app/javascript/src/Common/components/NoMatchFound.tsx
@@ -6,7 +6,7 @@ import {
   EmptyStatePrimary,
   Title
 } from '@patternfly/react-core'
-import { SearchIcon } from '@patternfly/react-icons'
+import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon'
 
 import type { FunctionComponent } from 'react'
 

--- a/app/javascript/src/Common/components/TableModal.tsx
+++ b/app/javascript/src/Common/components/TableModal.tsx
@@ -14,7 +14,7 @@ import {
   TableBody,
   TableHeader
 } from '@patternfly/react-table'
-import { SearchIcon } from '@patternfly/react-icons'
+import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon'
 
 import { NoMatchFound } from 'Common/components/NoMatchFound'
 import type { IRecord } from 'utilities/patternfly-utils'

--- a/app/javascript/src/Common/components/ToolbarSearch.tsx
+++ b/app/javascript/src/Common/components/ToolbarSearch.tsx
@@ -7,7 +7,7 @@ import {
   Popover,
   TextInput
 } from '@patternfly/react-core'
-import { SearchIcon } from '@patternfly/react-icons'
+import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon'
 
 import { createReactWrapper } from 'utilities/createReactWrapper'
 

--- a/app/javascript/src/Dashboard/components/BackendsWidget.tsx
+++ b/app/javascript/src/Dashboard/components/BackendsWidget.tsx
@@ -8,7 +8,7 @@ import {
   DataList,
   Title
 } from '@patternfly/react-core'
-import { CubeIcon } from '@patternfly/react-icons'
+import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon'
 
 import { APIDataListItem } from 'Dashboard/components/APIDataListItem'
 import { createReactWrapper } from 'utilities/createReactWrapper'

--- a/app/javascript/src/LoginPage/loginForms/AuthenticationProviders.tsx
+++ b/app/javascript/src/LoginPage/loginForms/AuthenticationProviders.tsx
@@ -1,4 +1,6 @@
-import { GreaterThanIcon, KeyIcon, LessThanIcon } from '@patternfly/react-icons'
+import GreaterThanIcon from '@patternfly/react-icons/dist/js/icons/greater-than-icon'
+import KeyIcon from '@patternfly/react-icons/dist/js/icons/key-icon'
+import LessThanIcon from '@patternfly/react-icons/dist/js/icons/less-than-icon'
 
 import type { FunctionComponent } from 'react'
 

--- a/app/javascript/src/LoginPage/loginForms/FlashMessages.tsx
+++ b/app/javascript/src/LoginPage/loginForms/FlashMessages.tsx
@@ -1,4 +1,4 @@
-import { ExclamationCircleIcon } from '@patternfly/react-icons'
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon'
 
 import type { FunctionComponent } from 'react'
 import type { FlashMessage } from 'Types'

--- a/app/javascript/src/Metrics/components/MetricsTable.tsx
+++ b/app/javascript/src/Metrics/components/MetricsTable.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarItem
 } from '@patternfly/react-core'
 import { Table, TableBody, TableHeader } from '@patternfly/react-table'
-import { CheckIcon } from '@patternfly/react-icons'
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon'
 
 import { Pagination } from 'Common/components/Pagination'
 import { ToolbarSearch } from 'Common/components/ToolbarSearch'

--- a/app/javascript/src/Policies/components/HeaderButton.tsx
+++ b/app/javascript/src/Policies/components/HeaderButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@patternfly/react-core'
-import { PlusIcon, TimesIcon } from '@patternfly/react-icons'
+import PlusIcon from '@patternfly/react-icons/dist/js/icons/plus-icon'
+import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon'
 
 import type { FunctionComponent } from 'react'
 import type { ThunkAction } from 'Policies/types/Actions'

--- a/spec/javascripts/Metrics/components/MetricsTable.spec.tsx
+++ b/spec/javascripts/Metrics/components/MetricsTable.spec.tsx
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme'
-import { CheckIcon } from '@patternfly/react-icons'
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon'
 
 import { MetricsTable } from 'Metrics/components/MetricsTable'
 import { mockLocation } from 'utilities/test-utils'


### PR DESCRIPTION
Import icons individually vs. import the whole module.

Before:
<img width="1376" alt="icons-before" src="https://user-images.githubusercontent.com/11672286/235154174-bcc8c63f-66af-480b-98ea-a50486cedf6e.png">

After:
<img width="1376" alt="icons-after" src="https://user-images.githubusercontent.com/11672286/235154316-5f52ab8f-5d8b-4318-86d2-861a97174293.png">

