### PR TITLE
add more auditing

### DIFF
--- a/app/lib/policies_config.rb
+++ b/app/lib/policies_config.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# TODO: this is needed because of overriding ::name in Proxy::PoliciesConfig
+#       we may want later to fix it properly
+PoliciesConfig = Proxy::PoliciesConfig

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -10,6 +10,8 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include GatewaySettings::ProxyExtension
   include ProxyConfigAffectingChanges::ModelExtension
 
+  audited :allow_mass_assignment => true
+
   define_proxy_config_affecting_attributes except: %i[api_test_path api_test_success lock_version]
 
   self.background_deletion = [:proxy_rules, [:proxy_configs, { action: :delete }], [:oidc_configuration, { action: :delete, has_many: false }]]
@@ -684,3 +686,5 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
 end
+
+PoliciesConfig = Proxy::PoliciesConfig

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -557,6 +557,7 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
       @policies_config = policies_config
     end
 
+    # TODO: avoid overriding name because it later confuses serialization of PoliciesConfig, see at the bottom
     def self.name
       'PoliciesConfig'
     end
@@ -684,7 +685,7 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def generate_port(proxy_attribute)
     PortGenerator.new(self).call(proxy_attribute)
   end
-
 end
 
+# TODO: this is needed because of overriding ::name above
 PoliciesConfig = Proxy::PoliciesConfig

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -688,6 +688,3 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
     PortGenerator.new(self).call(proxy_attribute)
   end
 end
-
-# TODO: this is needed because of overriding ::name above
-PoliciesConfig = Proxy::PoliciesConfig

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -478,7 +478,7 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     attr_accessor :name, :version, :configuration, :enabled
 
-    delegate :to_json, :as_json, to: :to_h
+    delegate :to_json, :to_yaml, to: :as_json
 
     validates :name, :version, presence: true
     validate :configuration_is_object
@@ -512,11 +512,12 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
       to_h.slice('name', 'version', 'configuration')
     end
 
-    def to_h
+    def to_h(options = nil)
       %i[name version configuration enabled].each_with_object({}) do |key, obj|
         obj[key] = public_send key
-      end.compact.as_json
+      end.compact.as_json(options)
     end
+    alias as_json to_h
 
     def ==(other)
       %i[name version configuration enabled].all? { |key| public_send(key) == other.public_send(key) }
@@ -542,6 +543,7 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
     MAX_LENGTH = 2.megabytes
 
     delegate :each, :to_json, :as_json, to: :policies_config
+    delegate :to_yaml, to: :as_json
     alias to_s to_json
     attr_reader :policies_config
     protected :policies_config

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -10,7 +10,7 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include GatewaySettings::ProxyExtension
   include ProxyConfigAffectingChanges::ModelExtension
 
-  audited :allow_mass_assignment => true
+  audited
 
   define_proxy_config_affecting_attributes except: %i[api_test_path api_test_success lock_version]
 

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -512,12 +512,12 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
       to_h.slice('name', 'version', 'configuration')
     end
 
-    def to_h(options = nil)
+    def as_json(options = nil)
       %i[name version configuration enabled].each_with_object({}) do |key, obj|
         obj[key] = public_send key
       end.compact.as_json(options)
     end
-    alias as_json to_h
+    alias to_h as_json
 
     def ==(other)
       %i[name version configuration enabled].all? { |key| public_send(key) == other.public_send(key) }

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,9 +43,10 @@ module System
     # Applying the patch for CVE-2022-32224 broke YAML deserialization because some classes are disallowed in the serialized YAML
     # NOTE: Symbol was later added to enabled classes by default, see https://github.com/rails/rails/pull/45584,
     # it was added to Rails 6.0.6, 6.1.7, 7.0.4
-    config.active_record.yaml_column_permitted_classes += %w[Symbol Time Date BigDecimal OpenStruct
+    config.active_record.yaml_column_permitted_classes = %w[Symbol Time Date BigDecimal OpenStruct
                                                             Proxy::PolicyConfig PoliciesConfig
                                                             ActionController::Parameters
+                                                            ActiveModel::Errors
                                                             ActiveSupport::TimeWithZone
                                                             ActiveSupport::TimeZone
                                                             ActiveSupport::HashWithIndifferentAccess]

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,9 @@ module System
     # Applying the patch for CVE-2022-32224 broke YAML deserialization because some classes are disallowed in the serialized YAML
     # NOTE: Symbol was later added to enabled classes by default, see https://github.com/rails/rails/pull/45584,
     # it was added to Rails 6.0.6, 6.1.7, 7.0.4
+    #
+    # TODO: many of these are needed for audited as its serialization is suboptimal and should better be changed when
+    #       possible. See also app/lib/policies_config.rb
     config.active_record.yaml_column_permitted_classes = %w[Symbol Time Date BigDecimal OpenStruct
                                                             Proxy::PolicyConfig PoliciesConfig
                                                             ActionController::Parameters

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,11 +43,12 @@ module System
     # Applying the patch for CVE-2022-32224 broke YAML deserialization because some classes are disallowed in the serialized YAML
     # NOTE: Symbol was later added to enabled classes by default, see https://github.com/rails/rails/pull/45584,
     # it was added to Rails 6.0.6, 6.1.7, 7.0.4
-    config.active_record.yaml_column_permitted_classes = [Symbol, Time, Date, BigDecimal, OpenStruct,
-                                                          ActionController::Parameters,
-                                                          ActiveSupport::TimeWithZone,
-                                                          ActiveSupport::TimeZone,
-                                                          ActiveSupport::HashWithIndifferentAccess]
+    config.active_record.yaml_column_permitted_classes += %w[Symbol Time Date BigDecimal OpenStruct
+                                                            Proxy::PolicyConfig PoliciesConfig
+                                                            ActionController::Parameters
+                                                            ActiveSupport::TimeWithZone
+                                                            ActiveSupport::TimeZone
+                                                            ActiveSupport::HashWithIndifferentAccess]
 
     config.action_view.form_with_generates_remote_forms = false
 

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -844,10 +844,13 @@ class ProxyTest < ActiveSupport::TestCase
 
     test 'update policies config with audit check' do
       proxy = FactoryBot.create :proxy
+      long_string = "a" * 62 * 1024
+      # long_string = "foo"
+      # TODO serialization ends up with `ActiveModel::Errors` in there for some reason
+      proxy.update(policies_config: [{name: 'cors2', version: '0.0.2', configuration: {foo: long_string}}])
 
       Proxy.with_synchronous_auditing do
-        proxy.policies_config = [{name: 'cors2', version: '0.0.2', configuration: {foo: 'fofo'}}]
-        proxy.save
+        proxy.update(policies_config: [{name: 'cors2', version: '0.0.3', configuration: {foo: long_string}}])
 
         audit = proxy.audits.last
         assert_equal 'update', audit.action

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -845,8 +845,8 @@ class ProxyTest < ActiveSupport::TestCase
     test 'update policies config with audit check' do
       proxy = FactoryBot.create :proxy
       long_string = "a" * 62 * 1024
-      # long_string = "foo"
-      # TODO serialization ends up with `ActiveModel::Errors` in there for some reason
+      # TODO: audited serialization results in `ActiveModel::Errors` and other class marshaling which is undesirable
+      #       maybe https://github.com/collectiveidea/audited/pull/664 can help in the long run
       proxy.update(policies_config: [{name: 'cors2', version: '0.0.2', configuration: {foo: long_string}}])
 
       Proxy.with_synchronous_auditing do

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -842,15 +842,15 @@ class ProxyTest < ActiveSupport::TestCase
       end
     end
 
-    test 'update policies config with audit check' do
+    test 'update large policies config with auditing' do
       proxy = FactoryBot.create :proxy
-      long_string = "a" * 62 * 1024
+      long_string = "a" * 100 * 1024
       # TODO: audited serialization results in `ActiveModel::Errors` and other class marshaling which is undesirable
       #       maybe https://github.com/collectiveidea/audited/pull/664 can help in the long run
-      proxy.update(policies_config: [{name: 'cors2', version: '0.0.2', configuration: {foo: long_string}}])
+      proxy.update(policies_config: [{name: 'cors2', version: '0.0.2', configuration: {foo: long_string[0..-2]}}])
 
       Proxy.with_synchronous_auditing do
-        proxy.update(policies_config: [{name: 'cors2', version: '0.0.3', configuration: {foo: long_string}}])
+        proxy.update(policies_config: [{name: 'cors2', version: '0.0.3', configuration: {foo: long_string[1..-1]}}])
 
         audit = proxy.audits.last
         assert_equal 'update', audit.action

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -841,6 +841,18 @@ class ProxyTest < ActiveSupport::TestCase
         proxy.destroy
       end
     end
+
+    test 'update policies config with audit check' do
+      proxy = FactoryBot.create :proxy
+
+      Proxy.with_synchronous_auditing do
+        proxy.policies_config = [{name: 'cors2', version: '0.0.2', configuration: {foo: 'fofo'}}]
+        proxy.save
+
+        audit = proxy.audits.last
+        assert_equal 'update', audit.action
+      end
+    end
   end
 
   class StaleObjectErrorTest < ActiveSupport::TestCase


### PR DESCRIPTION
Supersedes #3226 and a follow-up to #3355

before merging, we need to ensure that storing  big audit like for example a big PoliciesConfig or the description of a BackendApi will not result in failures.

Failures can result both - from size limit of Redis as well the db fields used by MySQL.

Audited uses `t.text "audited_changes"` which is the 64kb TEXT type.
Accodring to [docs](https://redis.io/docs/data-types/strings/), by default, a single Redis string can be a maximum of 512 MB, so this should be fine.

See https://issues.redhat.com/browse/THREESCALE-6853, remains to:

- fix issue with auditing long policies_config as described above (upstream https://github.com/collectiveidea/audited/issues/674)
- currently audited `YAMLIfTextColumnType::dump` which uses `ActiveRecord::Coders::YAMLColumn.new(Object).dump(obj)` and this causes policies config to be serialized ugly (not using the defined `#to_yaml` method). Would be better if we can store values as serialized for the database instead, which may also involve audited upstream changes. Upstream reference where ability to use a json column was added collectiveidea/audited#304 as an alternative, but it might be inappropriate for us to change audited column type.