### PR TITLE
Remove deprecation warning for ReportTrafficWorker

### DIFF
--- a/app/workers/report_traffic_worker.rb
+++ b/app/workers/report_traffic_worker.rb
@@ -73,14 +73,14 @@ class ReportTrafficWorker
     application_id = master_application_id(account_id)
     return unless application_id && master_service_metric?(metric_system_name.to_s)
 
-    transactions = {
+    transactions = [{
       app_id: application_id,
       usage:  { metric_system_name => 1 },
       log:    report_traffic_log(request, response),
       timestamp: time.utc.to_s
-    }
+    }]
 
-    client.report(transactions)
+    client.report(transactions: transactions, service_id: master_service.id, service_token: master_service.service_token)
   rescue ThreeScale::ServerError => exception
     raise ReportTrafficError, exception.response
   end
@@ -88,8 +88,7 @@ class ReportTrafficWorker
   private
 
   def client
-    @client ||= ThreeScale::Client.new(BackendClient.threescale_client_config.merge(
-                                        provider_key: master_service.account.api_key))
+    @client ||= ThreeScale::Client.new(BackendClient.threescale_client_config.merge(service_tokens: true))
   end
 
   def master_service

--- a/test/workers/report_traffic_worker_test.rb
+++ b/test/workers/report_traffic_worker_test.rb
@@ -68,7 +68,7 @@ class ReportTrafficWorkerTest < ActiveSupport::TestCase
         remote_ip: @request.remote_ip,
         headers:   { "HTTP_FOO" => "bar" },
       }
-      transactions = {
+      transactions = [{
         app_id: @cinstance.application_id,
         usage:  { @metric => 1 },
         log: {
@@ -77,10 +77,11 @@ class ReportTrafficWorkerTest < ActiveSupport::TestCase
           code: 200,
         },
         timestamp: Time.now.utc.to_s
-      }
+      }]
 
+      master_service = @master.default_service
       ThreeScale::Client.any_instance.expects(:report)
-        .with(transactions).returns(true)
+        .with(transactions: transactions, service_id: master_service.id, service_token: master_service.service_token).returns(true)
 
       assert ReportTrafficWorker.new.perform(@account.id, @metric, request_attrs, response_attrs)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Use non-deprecated interface for reporting traffic (porta's API traffic) to backend - in order to stop spamming logging infra.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-9170

**Verification steps** 

Example call:

```
ReportTrafficWorker.new.perform(2, 'hits', {}, { code: 200 })
```

Make sure deprecation warning is not shown.

**Special notes for your reviewer**:

Not actually related to the PR itself, but I hit this issue when trying to reproduce the behavior with the previous code.

In a local setup the requests to the backend (when using the provider key) were failing with the following error 
```
=> #<ThreeScale::Response:0x000000000caf8d48 @error_code="provider_key_invalid_or_service_missing", @error_message="provider key \"xxx\" invalid and/or service ID missing">
```

I realised that htis is because the Master's service (against which the traffic is reported by this worker) is not marked as default for the master account, so with just the provider key the backend couldn't figure out, which service to report to. In order to fix this, I had to set `default_service_id` attribute to the master account (with the ID of the master service) and resync with backend (`bundle exec rake backend:storage:enqueue_rewrite`).

This error does not occur when using the new interface, as the service ID (and service token for authentication) is provided explicitly.