### PR TITLE
✅ Fix unhandled promise in test

### DIFF
--- a/spec/javascripts/Stats/buyer/stats_application.spec.ts
+++ b/spec/javascripts/Stats/buyer/stats_application.spec.ts
@@ -1,14 +1,23 @@
 import { StatsApplicationSourceCollector } from 'Stats/buyer/stats_application'
 import { StatsApplicationMetricsSource } from 'Stats/lib/application_metrics_source'
 
+const metrics = [{ systemName: 'metric-0' }, { systemName: 'metric-1' }, { systemName: 'metric-2' }]
+
 describe('StatsApplicationSourceCollector', () => {
   it('should get the source', () => {
     expect(StatsApplicationSourceCollector.Source).toEqual(StatsApplicationMetricsSource)
   })
 
-  it('should get sources', () => {
-    const sources = new StatsApplicationSourceCollector({ id: 0, metrics: Promise.resolve([]) }).getSources({ selectedApplicationId: 0, selectedMetricName: '' })
-    expect(sources).not.toBeUndefined()
+  it('should get sources', async () => {
+    const collector = new StatsApplicationSourceCollector({
+      id: 0,
+      metrics: Promise.resolve({
+        metrics,
+        methods: []
+      })
+    })
+    const sources = await collector.getSources({ selectedApplicationId: 0, selectedMetricName: 'metric-2' })
+    expect(sources).toHaveLength(1)
   })
 })
 


### PR DESCRIPTION
`spec/javascripts/Stats/buyer/stats_application.spec.ts` throws the following error:
```
(node:59475) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'concat' of undefined
(Use `node --trace-warnings ...` to show where the warning was created)
(node:59475) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:59475) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Also, the test is a false positive.