### PR TITLE
🦓💣 Remove `load_stripe.js`

### DIFF
--- a/app/javascript/packs/load_stripe.ts
+++ b/app/javascript/packs/load_stripe.ts
@@ -1,2 +1,0 @@
-// TODO: remove this pack
-import '@stripe/stripe-js'

--- a/features/asset_host/asset_host.feature
+++ b/features/asset_host/asset_host.feature
@@ -28,4 +28,5 @@ Feature: Asset host
 
     Scenario: Developer portal with asset host configured
       When the buyer logs in to the provider
+      And follow "Documentation"
       Then javascript assets should be loaded from the asset host

--- a/lib/developer_portal/app/views/developer_portal/main_layout.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/main_layout.html.liquid
@@ -22,9 +22,6 @@
     {{ '/javascripts/vendor/colorbox/jquery.colorbox-patched.js' | javascript_include_tag }}
     {{ '/javascripts/3scale_v2.js' | javascript_include_tag }}
     {{ '/javascripts/excanvas.compiled.js' | javascript_include_tag }}
-    {% if provider.payment_gateway_type == :stripe %}
-      {{ 'load_stripe.js' | javascript_include_tag }}
-    {% endif %}
 
     {{ content_of.stylesheets | html_safe }}
     {{ '/css/default.css' | stylesheet_link_tag }}

--- a/lib/developer_portal/lib/liquid/filters/rails_helpers.rb
+++ b/lib/developer_portal/lib/liquid/filters/rails_helpers.rb
@@ -11,7 +11,7 @@ module Liquid
 
       THREESCALE_STYLESHEETS = %w[legacy/stats plans_widget.css active-docs/application.css stats.css].freeze
       THREESCALE_JAVASCRIPTS = %w[plans_widget.js plans_widget_v2.js active-docs/application.js stats.js].freeze
-      THREESCALE_WEBPACK_PACKS = %w[stats.js active_docs.js load_stripe.js validate_signup.js].freeze
+      THREESCALE_WEBPACK_PACKS = %w[stats.js active_docs.js validate_signup.js].freeze
       THREESCALE_IMAGES      = %w[spinner.gif tick.png cross.png].freeze
       ACTIVE_DOCS_JS = %w[active-docs/application.js active_docs.js].freeze
 


### PR DESCRIPTION
This snippet from dev portal's main layout:
```liquid
    {% if provider.payment_gateway_type == :stripe %}
      {{ 'load_stripe.js' | javascript_include_tag }}
    {% endif %}
```
doesn't do what you think. It always loads stripe, no matter the provider's settings.

Luckily for us we moved the Stripe form into React so now we can import the module directly there and don't need a pack anymore.

This removal has no impact on older dev portals and only shows the following failed request:
![Screenshot 2023-05-03 at 16 15 44](https://user-images.githubusercontent.com/11672286/235944926-e47373f0-8d7f-424c-a079-2146330d735a.png)

[THREESCALE-9590: Don't include Stripe js in Dev portal](https://issues.redhat.com/browse/THREESCALE-9590)