### PR TITLE
THREESCALE-918: Optimize service contracts page loading

### DIFF
--- a/app/controllers/buyers/service_contracts_controller.rb
+++ b/app/controllers/buyers/service_contracts_controller.rb
@@ -38,7 +38,7 @@ class Buyers::ServiceContractsController < Buyers::BaseController
 
     @service_contracts = current_user.accessible_service_contracts
               .scope_search(@search).order_by(*sorting_params)
-              .includes({ plan: %i[issuer pricing_rules]}, :user_account)
+              .includes(plan: %i[issuer pricing_rules], user_account: [:admin_user])
               .paginate(pagination_params)
               .decorate
 

--- a/app/controllers/buyers/service_contracts_controller.rb
+++ b/app/controllers/buyers/service_contracts_controller.rb
@@ -38,7 +38,7 @@ class Buyers::ServiceContractsController < Buyers::BaseController
 
     @service_contracts = current_user.accessible_service_contracts
               .scope_search(@search).order_by(*sorting_params)
-              .includes(plan: %i[issuer pricing_rules], user_account: [:admin_user])
+              .includes(plan: %i[pricing_rules], user_account: [:admin_user])
               .paginate(pagination_params)
               .decorate
 

--- a/app/controllers/buyers/service_contracts_controller.rb
+++ b/app/controllers/buyers/service_contracts_controller.rb
@@ -17,6 +17,7 @@ class Buyers::ServiceContractsController < Buyers::BaseController
     @services = accessible_services.includes(:service_plans)
     @search = ThreeScale::Search.new(params[:search] || params)
     @plans = current_account.service_plans
+    @multiservice = current_account.multiservice?
 
     if (service_id = params[:service_id] || @search.service_id)
       @service = @services.find service_id
@@ -37,6 +38,7 @@ class Buyers::ServiceContractsController < Buyers::BaseController
 
     @service_contracts = current_user.accessible_service_contracts
               .scope_search(@search).order_by(*sorting_params)
+              .includes({ plan: %i[issuer pricing_rules]}, :user_account)
               .paginate(pagination_params)
               .decorate
 

--- a/app/helpers/buyers/accounts_helper.rb
+++ b/app/helpers/buyers/accounts_helper.rb
@@ -15,7 +15,7 @@ module Buyers::AccountsHelper
     if buyer
       if can? :manage, :partners
         path = path_method.is_a?(Symbol) ? send( path_method, buyer) : path_method
-        link_to buyer.org_name, path
+        link_to buyer.org_name, path, title: account_title(buyer)
       else
         buyer.org_name
       end

--- a/app/helpers/buyers/accounts_helper.rb
+++ b/app/helpers/buyers/accounts_helper.rb
@@ -15,7 +15,7 @@ module Buyers::AccountsHelper
     if buyer
       if can? :manage, :partners
         path = path_method.is_a?(Symbol) ? send( path_method, buyer) : path_method
-        link_to buyer.org_name, path, :title => account_title(buyer)
+        link_to buyer.org_name, path
       else
         buyer.org_name
       end

--- a/app/models/service_contract.rb
+++ b/app/models/service_contract.rb
@@ -31,6 +31,10 @@ class ServiceContract < Contract
     where(:plans => { :issuer_id => service_id.to_i }).joins(:plan).references(:plan)
   end
 
+  # TODO: unit test this scope
+  def self.provided_by(account)
+    where(plan_id: ServicePlan.provided_by(account).select(:id))
+  end
 
   # HACK: to enable it on-fly just when it comes from controller
   #

--- a/app/models/service_contract.rb
+++ b/app/models/service_contract.rb
@@ -14,6 +14,10 @@ class ServiceContract < Contract
     where(:issuer_type => service.class.model_name.to_s, :issuer_id => service.id)
   end
 
+  scope :provided_by, ->(account) do
+    where(plan_id: ServicePlan.provided_by(account).select(:id))
+  end
+
   alias service issuer
   alias service_plan plan
 
@@ -29,11 +33,6 @@ class ServiceContract < Contract
 
   scope :by_service_id, ->(service_id) do
     where(:plans => { :issuer_id => service_id.to_i }).joins(:plan).references(:plan)
-  end
-
-  # TODO: unit test this scope
-  def self.provided_by(account)
-    where(plan_id: ServicePlan.provided_by(account).select(:id))
   end
 
   # HACK: to enable it on-fly just when it comes from controller

--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -11,7 +11,7 @@ class ServicePlan < Plan
   before_destroy :destroy_contracts
 
   def self.provided_by(account)
-    Plan.by_type(self).issued_by(Service, account.service_ids)
+    Plan.by_type(ServicePlan).issued_by(Service, account.service_ids)
   end
 
   def provider_account

--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -10,6 +10,10 @@ class ServicePlan < Plan
 
   before_destroy :destroy_contracts
 
+  def self.provided_by(account)
+    Plan.by_type(self).issued_by(Service, account.service_ids)
+  end
+
   def provider_account
     service && service.account
   end

--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -8,11 +8,15 @@ class ServicePlan < Plan
 
   belongs_to :service, :foreign_key => :issuer_id, :inverse_of => :service_plans
 
-  before_destroy :destroy_contracts
-
-  def self.provided_by(account)
-    Plan.by_type(ServicePlan).issued_by(Service, account.service_ids)
+  scope :provided_by, ->(provider) do
+    if provider == :all || provider.blank?
+      {}
+    else
+      issued_by(Service, provider.service_ids)
+    end
   end
+
+  before_destroy :destroy_contracts
 
   def provider_account
     service && service.account

--- a/app/views/buyers/service_contracts/index.html.slim
+++ b/app/views/buyers/service_contracts/index.html.slim
@@ -37,7 +37,7 @@ table.data
       - unless @account
         th
           = sortable('accounts.org_name', 'Account')
-      - if current_account.multiservice?
+      - if @multiservice
         th
           label for="search_service_id"
             | Service
@@ -57,7 +57,7 @@ table.data
           th
             = s.text_field :account_query, size: 15
 
-          - if current_account.multiservice?
+          - if @multiservice
             th
               = s.collection_select :service_id, @services, :id, :name,
                                         { include_blank: true },
@@ -85,7 +85,7 @@ table.data
         - unless @account
           td
             = link_to_buyer_or_deleted contract.account
-        - if current_account.multiservice?
+        - if @multiservice
           td
             = link_to service.name, admin_service_path(service)
         td.plan
@@ -115,7 +115,7 @@ table.data
           td colspan="6"
             | No Service Subscriptions
       - else
-        = no_search_results(current_account.multiservice? ? 7 : 6)
+        = no_search_results(@multiservice ? 7 : 6)
 
 = will_paginate @service_contracts
 

--- a/test/integration/buyers/service_contracts_controller_test.rb
+++ b/test/integration/buyers/service_contracts_controller_test.rb
@@ -92,6 +92,19 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
       page = Nokogiri::HTML4::Document.parse(response.body)
       assert page.xpath("//select[@id='service_contract_plan_id']/option").map(&:text).exclude?('Please select')
     end
+
+    test 'no n+1 queries on index' do
+      populate = ->(n) do
+        n.times do
+          buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+          service_contract = FactoryBot.create(:simple_service_contract, plan: service_plan, user_account: buyer)
+        end
+      end
+
+      assert_perform_constant_number_of_queries(populate: populate) do
+        get admin_buyers_service_contracts_path
+      end
+    end
   end
 
   class ProviderMemberTest < self

--- a/test/unit/service_contract_test.rb
+++ b/test/unit/service_contract_test.rb
@@ -30,4 +30,28 @@ class ServiceContractTest < ActiveSupport::TestCase
     service = FactoryBot.create(:simple_service)
     assert ServiceContract.issued_by(service).count
   end
+
+  test '.provided_by scope' do
+    provider1 = FactoryBot.create(:simple_provider)
+    provider2 = FactoryBot.create(:simple_provider)
+    p1_service1 = FactoryBot.create(:simple_service, account: provider1)
+    p1_service2 = FactoryBot.create(:simple_service, account: provider1)
+    p2_service3 = FactoryBot.create(:simple_service, account: provider2)
+
+    # Default service plans are created on service creation, we destroy them for a clean comparison
+    p1_service1.service_plans.destroy_all
+    p1_service2.service_plans.destroy_all
+    p2_service3.service_plans.destroy_all
+
+    p1_s1_plan = FactoryBot.create(:simple_service_plan, issuer: p1_service1)
+    p1_s2_plan = FactoryBot.create(:simple_service_plan, issuer: p1_service2)
+    p2_s3_plan = FactoryBot.create(:simple_service_plan, issuer: p2_service3)
+
+    p1_contracts = FactoryBot.create_list(:simple_service_contract, 2, plan: p1_s1_plan) +
+                   FactoryBot.create_list(:simple_service_contract, 3, plan: p1_s2_plan)
+    p2_contracts = FactoryBot.create_list(:simple_service_contract, 4, plan: p2_s3_plan)
+
+    assert_same_elements p1_contracts, ServiceContract.provided_by(provider1).to_a
+    assert_same_elements p2_contracts, ServiceContract.provided_by(provider2).to_a
+  end
 end

--- a/test/unit/service_plan_test.rb
+++ b/test/unit/service_plan_test.rb
@@ -31,4 +31,24 @@ class ServicePlanTest < ActiveSupport::TestCase
       custom_service_plan.reload
     end
   end
+
+  test '.provided_by scope' do
+    provider1 = FactoryBot.create(:simple_provider)
+    provider2 = FactoryBot.create(:simple_provider)
+    p1_service1 = FactoryBot.create(:simple_service, account: provider1)
+    p1_service2 = FactoryBot.create(:simple_service, account: provider1)
+    p2_service3 = FactoryBot.create(:simple_service, account: provider2)
+
+    # Default service plans are created on service creation, we destroy them for a clean comparison
+    p1_service1.service_plans.destroy_all
+    p1_service2.service_plans.destroy_all
+    p2_service3.service_plans.destroy_all
+
+    p1_plans = FactoryBot.create_list(:simple_service_plan, 3, issuer: p1_service1) +
+               FactoryBot.create_list(:simple_service_plan, 4, issuer: p1_service2)
+    p2_plans = FactoryBot.create_list(:simple_service_plan, 2, issuer: p2_service3)
+
+    assert_same_elements p1_plans, ServicePlan.provided_by(provider1).to_a
+    assert_same_elements p2_plans, ServicePlan.provided_by(provider2).to_a
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

The queries are not very efficient on the page, so it takes a long time to load the Service Subscriptions page - Audience > Accounts > Subscriptions, or `/buyers/service_contracts`.

**Which issue(s) this PR fixes** 

Service Subscriptions page takes too long to load: [THREESCALE-918](https://issues.redhat.com/browse/THREESCALE-918)

**Verification steps** 

Go to `/buyers/service_contracts` in the admin portal, and make sure that the loading times are reasonable (I used the staging database locally).

**Special notes for your reviewer**:

I used the SaaS Staging DB locally, because it is difficult to reproduce on an empty (local) DB, unless you fill the DB with a significant amount of data.

I used my test account, which has roughly 60 service subscriptions (3 pages), and the time of page loading are:

**Before**
```
Completed 200 OK in 28523ms (Views: 2404.0ms | ActiveRecord: 24932.4ms)
Completed 200 OK in 24114ms (Views: 2148.4ms | ActiveRecord: 20899.2ms)
Completed 200 OK in 28202ms (Views: 2305.9ms | ActiveRecord: 25045.8ms)
```

**After**
```
Completed 200 OK in 8785ms (Views: 1756.2ms | ActiveRecord: 6103.2ms)
Completed 200 OK in 3838ms (Views: 397.2ms | ActiveRecord: 3319.6ms)
Completed 200 OK in 8014ms (Views: 1284.7ms | ActiveRecord: 5808.6ms)
```

The query that has been improved significantly is the following, it was using nested queries, some of which were not relevant (querying for account plans and application plans for example, while they were not used).

**Before**
```
ServiceContract Load (15134.9ms)  SELECT  `cinstances`.* FROM `cinstances` WHERE `cinstances`.`type` IN ('ServiceContract') AND `cinstances`.`plan_id` IN (SELECT `plans`.`id` FROM `plans` WHERE (`plans`.`id` IN (SELECT `plans`.`id` FROM `plans` WHERE `plans`.`issuer_type` = 'Account' AND `plans`.`issuer_id` = 2445566778899 ORDER BY `plans`.`position` ASC) OR `plans`.`id` IN (SELECT `plans`.`id` FROM `plans` WHERE `plans`.`issuer_type` = 'Service' AND `plans`.`issuer_id` IN (2550000000001, 2550000000002, 2550000000003, 2550000000004, 2550000000005, 2550000000006, 2550000000007, 2550000000008, 2550000000009, 2550000000010, 2550000000011, 2550000000012, 2550000000013, 2550000000014, 2550000000015, 2550000000016, 2550000000017, 2550000000018, 2550000000019, 2550000000020, 2550000000021, 2550000000022, 2550000000023, 2550000000024, 2550000000025, 2550000000026, 2550000000027, 2550000000028, 2550000000029) ORDER BY `plans`.`position` ASC)) ORDER BY `plans`.`position` ASC) ORDER BY cinstances.created_at DESC LIMIT 20 OFFSET 40
```

**After**
```
ServiceContract Load (101.9ms)  SELECT  `cinstances`.* FROM `cinstances` WHERE `cinstances`.`type` IN ('ServiceContract') AND `cinstances`.`plan_id` IN (SELECT `plans`.`id` FROM `plans` WHERE `plans`.`type` IN ('ServicePlan') AND `plans`.`issuer_type` = 'Service' AND `plans`.`issuer_id` IN (2550000000001, 2550000000002, 2550000000003, 2550000000004, 2550000000005, 2550000000006, 2550000000007, 2550000000008, 2550000000009, 2550000000010, 2550000000011, 2550000000012, 2550000000013, 2550000000014, 2550000000015, 2550000000016, 2550000000017, 2550000000018, 2550000000019, 2550000000020, 2550000000021, 2550000000022, 2550000000023, 2550000000024, 2550000000025, 2550000000026, 2550000000027, 2550000000028, 2550000000029) ORDER BY `plans`.`position` ASC) ORDER BY cinstances.created_at DESC LIMIT 20 OFFSET 40
```