### PR TITLE
Fix eslint 'react/no-object-type-as-default-prop'

### DIFF
--- a/app/javascript/src/ActiveDocs/components/ApiJsonSpecInput.tsx
+++ b/app/javascript/src/ActiveDocs/components/ApiJsonSpecInput.tsx
@@ -13,9 +13,11 @@ interface Props {
   setApiJsonSpec: (description: string) => void;
 }
 
+const emptyStringArray: string[] = []
+
 const ApiJsonSpecInput: FunctionComponent<Props> = ({
   apiJsonSpec,
-  errors = [],
+  errors = emptyStringArray,
   setApiJsonSpec
 }) => {
   const textAreaId = 'api_docs_service_body'

--- a/app/javascript/src/ActiveDocs/components/DescriptionInput.tsx
+++ b/app/javascript/src/ActiveDocs/components/DescriptionInput.tsx
@@ -8,9 +8,11 @@ interface Props {
   setDescription: (description: string) => void;
 }
 
+const emptyStringArray: string[] = []
+
 const DescriptionInput: FunctionComponent<Props> = ({
   description,
-  errors = [],
+  errors = emptyStringArray,
   setDescription
 }) => {
   

--- a/app/javascript/src/ActiveDocs/components/NameInput.tsx
+++ b/app/javascript/src/ActiveDocs/components/NameInput.tsx
@@ -9,7 +9,9 @@ interface Props {
   setName: (name: string) => void;
 }
 
-const NameInput: FunctionComponent<Props> = ({ errors = [], name, setName }) => {
+const emptyStringArray: string[] = []
+
+const NameInput: FunctionComponent<Props> = ({ errors = emptyStringArray, name, setName }) => {
   const validated = errors.length ? 'error' : 'default'
 
   return (

--- a/app/javascript/src/ActiveDocs/components/SystemNameInput.tsx
+++ b/app/javascript/src/ActiveDocs/components/SystemNameInput.tsx
@@ -13,7 +13,9 @@ interface Props {
   systemName: string;
 }
 
-const SystemNameInput: FunctionComponent<Props> = ({ errors = [], isDisabled = false, setSystemName, systemName }) => {
+const emptyStringArray: string[] = []
+
+const SystemNameInput: FunctionComponent<Props> = ({ errors = emptyStringArray, isDisabled = false, setSystemName, systemName }) => {
   const validated = errors.length ? 'error' : 'default'
 
   return (

--- a/app/javascript/src/BackendApis/components/PrivateEndpointInput.tsx
+++ b/app/javascript/src/BackendApis/components/PrivateEndpointInput.tsx
@@ -8,10 +8,12 @@ interface Props {
   errors?: string[];
 }
 
+const emptyStringArray: string[] = []
+
 const PrivateEndpointInput: FunctionComponent<Props> = ({
   privateEndpoint,
   setPrivateEndpoint,
-  errors = []
+  errors = emptyStringArray
 }) => (
   <FormGroup
     isRequired

--- a/app/javascript/src/ChangePassword/components/ChangePassword.tsx
+++ b/app/javascript/src/ChangePassword/components/ChangePassword.tsx
@@ -17,10 +17,12 @@ interface Props {
   errors?: FlashMessage[];
 }
 
+const emptyFlashMessageArray: FlashMessage[] = []
+
 const ChangePassword: FunctionComponent<Props> = ({
   lostPasswordToken = null,
   url = '',
-  errors = []
+  errors = emptyFlashMessageArray
 }) => {
   const {
     isFormDisabled,

--- a/app/javascript/src/Common/components/TableModal.tsx
+++ b/app/javascript/src/Common/components/TableModal.tsx
@@ -55,13 +55,12 @@ interface Props<T extends IRecord> {
 
 const PER_PAGE_DEFAULT = 5
 
-const emptyArray: <T extends IRecord>() => T[]
-
 const TableModal = <T extends IRecord>({
   title,
   isOpen,
   isLoading = false,
   selectedItem,
+  // eslint-disable-next-line react/no-object-type-as-default-prop -- FIXME: reference a variable instead of the literal value
   pageItems = [],
   itemsCount,
   onSelect,

--- a/app/javascript/src/Common/components/TableModal.tsx
+++ b/app/javascript/src/Common/components/TableModal.tsx
@@ -55,6 +55,8 @@ interface Props<T extends IRecord> {
 
 const PER_PAGE_DEFAULT = 5
 
+const emptyArray: <T extends IRecord>() => T[]
+
 const TableModal = <T extends IRecord>({
   title,
   isOpen,

--- a/app/javascript/src/Common/components/UserDefinedField.tsx
+++ b/app/javascript/src/Common/components/UserDefinedField.tsx
@@ -12,11 +12,13 @@ interface Props {
   validationErrors?: string[];
 }
 
+const emptyStringArray: string[] = []
+
 const UserDefinedField: FunctionComponent<Props> = ({
   fieldDefinition,
   value,
   onChange,
-  validationErrors = []
+  validationErrors = emptyStringArray
 }) => {
   const { id, label, required, name, choices } = fieldDefinition
 

--- a/app/javascript/src/EmailConfigurations/components/EmailConfigurationForm.tsx
+++ b/app/javascript/src/EmailConfigurations/components/EmailConfigurationForm.tsx
@@ -23,11 +23,13 @@ interface Props {
   errors?: FormErrors;
 }
 
+const emptyFormErrors: FormErrors = {}
+
 const EmailConfigurationForm: FunctionComponent<Props> = ({
   url,
   emailConfiguration,
   isUpdate = false,
-  errors = {}
+  errors = emptyFormErrors
 }) => {
   const FORM_ID = 'email-configuration-form'
   const [email, setEmail] = useState<string>(emailConfiguration.email ?? '')

--- a/app/javascript/src/NewApplication/components/NewApplicationForm.tsx
+++ b/app/javascript/src/NewApplication/components/NewApplicationForm.tsx
@@ -41,6 +41,8 @@ interface Props {
   error?: string;
 }
 
+const emptyDefinedFields: FieldDefinition[] = []
+
 const NewApplicationForm: React.FunctionComponent<Props> = ({
   buyer: defaultBuyer,
   buyers,
@@ -55,7 +57,7 @@ const NewApplicationForm: React.FunctionComponent<Props> = ({
   products,
   productsCount = 0,
   productsPath,
-  definedFields = [],
+  definedFields = emptyDefinedFields,
   validationErrors,
   error
 }) => {

--- a/app/javascript/src/Users/components/FeaturesFieldset.tsx
+++ b/app/javascript/src/Users/components/FeaturesFieldset.tsx
@@ -23,9 +23,11 @@ interface Props {
   onAdminSectionSelected: (section: AdminSection) => void;
 }
 
+const emptyAdminSections: AdminSection[] = []
+
 const FeaturesFieldset: React.FunctionComponent<Props> = ({
   features,
-  selectedSections = [],
+  selectedSections = emptyAdminSections,
   areServicesVisible = false,
   onAdminSectionSelected
 }) => {

--- a/app/javascript/src/Users/components/PermissionsForm.tsx
+++ b/app/javascript/src/Users/components/PermissionsForm.tsx
@@ -10,26 +10,30 @@ import type { FunctionComponent } from 'react'
 import type { AdminSection, Feature, Role } from 'Users/types'
 import type { Api } from 'Types'
 
+interface State {
+  role?: Role;
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- Comes from rails like that
+  admin_sections?: AdminSection[];
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- Comes from rails like that
+  member_permission_service_ids?: number[];
+}
+
 interface Props {
-  initialState?: {
-    role?: Role;
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- Comes from rails like that
-    admin_sections?: AdminSection[];
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- Comes from rails like that
-    member_permission_service_ids?: number[];
-  };
+  initialState?: State;
   features: Feature[];
   services: Api[];
 }
 
+const emptyState: State = {}
+
 /**
  * Represents the user's permissions form, also known as Administrative. It handles the user's Role and their access to different Services.
- * @param {InitialState}  initialState  - The values of the user's current settings.
+ * @param {State}  initialState  - The values of the user's current settings.
  * @param {Feature[]}     features      - The set of features or sections the user can have access to.
  * @param {Api[]}         services      - The list of services or APIs the user can have access to.
  */
 const PermissionsForm: FunctionComponent<Props> = ({
-  initialState = {},
+  initialState = emptyState,
   features,
   services
 }) => {

--- a/app/javascript/src/Users/components/ServicesFieldset.tsx
+++ b/app/javascript/src/Users/components/ServicesFieldset.tsx
@@ -15,10 +15,14 @@ interface Props {
   onServiceSelected: (id: number) => void;
 }
 
+const emptyApiArray: Api[] = []
+const emptyAdminSectionArray: AdminSection[] = []
+const emptyNumberArray: number[] = []
+
 const ServicesFieldset: React.FunctionComponent<Props> = ({
-  services = [],
-  selectedSections = [],
-  selectedServicesIds = [],
+  services = emptyApiArray,
+  selectedSections = emptyAdminSectionArray,
+  selectedServicesIds = emptyNumberArray,
   onServiceSelected
 }) => {
   const servicesListClassName = 'ServiceAccessList'


### PR DESCRIPTION

**What this PR does / why we need it**:

Fixing:
```
XXX has a/an array literal as default prop. This could lead to potential infinite render loop in React. Use a variable reference instead of array literal  react/no-object-type-as-default-prop
```

For some reason started appearing in https://github.com/3scale/porta/pull/3363

**Which issue(s) this PR fixes** 

_-none-_

**Verification steps** 

run `yarn ci:lint`

**Special notes for your reviewer**:
