### PR TITLE
➖ Remove `null-loader`

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "jest-environment-jsdom": "^29.5.0",
     "jest-transform-stub": "^2.0.0",
     "mockdate": "^3.0.5",
-    "null-loader": "^3.0.0",
     "raf": "^3.4.1",
     "redux-immutable-state-invariant": "^2.1.0",
     "regenerator-runtime": "^0.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9170,14 +9170,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
-  integrity sha512-hf5sNLl8xdRho4UPBOOeoIwT3WhjYcMUQm0zj44EhD6UscMAz72o2udpoDFBgykucdEDGIcd6SXbc/G6zssbzw==
-  dependencies:
-    loader-utils "^1.2.3"
-    schema-utils "^1.0.0"
-
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"


### PR DESCRIPTION
After upgrading patternfly, this is no longer used by webpack.