### PR TITLE
🦋🐛 Fix PF4 Pagination

### DIFF
--- a/app/javascript/src/Common/components/Pagination.tsx
+++ b/app/javascript/src/Common/components/Pagination.tsx
@@ -1,14 +1,14 @@
 import { Pagination as PFPagination } from '@patternfly/react-core'
 
 import type { PaginationProps, OnPerPageSelect } from '@patternfly/react-core'
-import type { FunctionComponent, ReactElement } from 'react'
+import type { FunctionComponent } from 'react'
 
 type Props = Pick<PaginationProps, 'itemCount' | 'variant'>
 
-const Pagination: FunctionComponent<Props> = ({ variant, itemCount }): ReactElement<PaginationProps> => {
+const Pagination: FunctionComponent<Props> = ({ variant, itemCount }) => {
   const url = new URL(window.location.href)
-  const currentPage = Number(url.searchParams.get('page'))
-  const currentPerPage = Number(url.searchParams.get('per_page')) || 20
+  const currentPage = Number(url.searchParams.get('page') ?? 1)
+  const currentPerPage = Number(url.searchParams.get('per_page') ?? 20)
 
   const onPerPageSelect: OnPerPageSelect = (_event, selectedPerPage) => {
     url.searchParams.set('per_page', String(selectedPerPage))
@@ -26,6 +26,7 @@ const Pagination: FunctionComponent<Props> = ({ variant, itemCount }): ReactElem
       itemCount={itemCount}
       page={currentPage}
       perPage={currentPerPage}
+      perPageComponent="button"
       perPageOptions={[{ title: '10', value: 10 }, { title: '20', value: 20 }]}
       variant={variant}
       widgetId="pagination-options-menu-top"
@@ -38,4 +39,5 @@ const Pagination: FunctionComponent<Props> = ({ variant, itemCount }): ReactElem
   )
 }
 
+export type { Props }
 export { Pagination }

--- a/app/javascript/src/Common/components/Pagination.tsx
+++ b/app/javascript/src/Common/components/Pagination.tsx
@@ -33,6 +33,7 @@ const Pagination: FunctionComponent<Props> = ({ variant, itemCount }) => {
       onFirstClick={goToPage}
       onLastClick={goToPage}
       onNextClick={goToPage}
+      onPageInput={goToPage}
       onPerPageSelect={onPerPageSelect}
       onPreviousClick={goToPage}
     />

--- a/spec/javascripts/BackendApis/components/IndexPage.spec.tsx
+++ b/spec/javascripts/BackendApis/components/IndexPage.spec.tsx
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme'
 
 import { IndexPage } from 'BackendApis/components/IndexPage'
-import { mockLocation } from 'utilities/test-utils'
 
 import type { Props } from 'BackendApis/components/IndexPage'
 import type { Backend } from 'BackendApis/types'
@@ -42,23 +41,6 @@ it('should render a table with backends', () => {
 
 it('should have a paginated table', () => {
   const backendsCount = 10
-  mockLocation('href://foo.bar/metrics?per_page=2&page=2')
   const wrapper = mountWrapper({ backendsCount })
-  const pagination = wrapper.find('.pf-c-pagination').first()
-
-  expect(pagination.find('[aria-label="Current page"]').first().prop('value')).toBe(2)
-
-  pagination.find('button[data-action="first"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=1'))
-
-  pagination.find('button[data-action="previous"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=1'))
-
-  pagination.find('button[data-action="next"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=3'))
-
-  pagination.find('button[data-action="last"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=3'))
-
-  expect(pagination.find('.pf-c-options-menu__toggle-text').text()).toMatch(`3 - 4 of ${backendsCount}`)
+  expect(wrapper.find('.pf-c-pagination').exists()).toEqual(true)
 })

--- a/spec/javascripts/Common/components/Pagination.spec.tsx
+++ b/spec/javascripts/Common/components/Pagination.spec.tsx
@@ -1,0 +1,59 @@
+import { mount } from 'enzyme'
+
+import { Pagination } from 'Common/components/Pagination'
+import { mockLocation } from 'utilities/test-utils'
+
+import type { Props } from 'Common/components/Pagination'
+
+const defaultProps = {
+  itemCount: undefined,
+  variant: undefined
+}
+
+const mountWrapper = (props: Partial<Props> = {}) => mount(<Pagination {...{ ...defaultProps, ...props }} />)
+
+it('should render', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.find('.pf-c-pagination').exists()).toEqual(true)
+})
+
+it('should get page info from URL', () => {
+  const itemCount = 100
+  const page = 2
+  const perPage = 25
+  mockLocation(`http://example.com?page=${page}&per_page=${perPage}`)
+
+  const wrapper = mountWrapper({ itemCount })
+  expect(wrapper.find('.pf-c-options-menu__toggle-text').text()).toEqual('26 - 50 of 100 ')
+  expect(wrapper.find('.pf-c-pagination [aria-label="Current page"]').first().prop('value')).toBe(2)
+})
+
+it('should show 20 items per page by default', () => {
+  const itemCount = 100
+  mockLocation('http://example.com')
+
+  const wrapper = mountWrapper({ itemCount })
+  expect(wrapper.find('.pf-c-options-menu__toggle-text').text()).toEqual('1 - 20 of 100 ')
+})
+
+it('should be able to jump from page to page', () => {
+  const itemCount = 100
+  const page = 2
+  const perPage = 25
+  mockLocation(`http://example.com?page=${page}&per_page=${perPage}`)
+
+  const wrapper = mountWrapper({ itemCount })
+  const pagination = wrapper.find('.pf-c-pagination').first()
+
+  pagination.find('button[data-action="first"]').simulate('click')
+  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=1'))
+
+  pagination.find('button[data-action="previous"]').simulate('click')
+  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=1'))
+
+  pagination.find('button[data-action="next"]').simulate('click')
+  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=3'))
+
+  pagination.find('button[data-action="last"]').simulate('click')
+  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=3'))
+})

--- a/spec/javascripts/Common/components/Pagination.spec.tsx
+++ b/spec/javascripts/Common/components/Pagination.spec.tsx
@@ -57,3 +57,17 @@ it('should be able to jump from page to page', () => {
   pagination.find('button[data-action="last"]').simulate('click')
   expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=3'))
 })
+
+it('should be able to jump to a page', () => {
+  const itemCount = 100
+  mockLocation('http://example.com')
+
+  const wrapper = mountWrapper({ itemCount })
+  const pagination = wrapper.find('.pf-c-pagination').first()
+
+  const nextPage = 2
+  const input = pagination.find('.pf-c-pagination__nav-page-select input')
+  input.simulate('change', { target: { value: nextPage } })
+  input.simulate('keydown', { key: 'Enter' })
+  expect(window.location.replace).toHaveBeenCalledWith(`http://example.com/?page=${nextPage}`)
+})

--- a/spec/javascripts/Common/components/Pagination.spec.tsx
+++ b/spec/javascripts/Common/components/Pagination.spec.tsx
@@ -14,7 +14,7 @@ const mountWrapper = (props: Partial<Props> = {}) => mount(<Pagination {...{ ...
 
 it('should render', () => {
   const wrapper = mountWrapper()
-  expect(wrapper.find('.pf-c-pagination').exists()).toEqual(true)
+  expect(wrapper.exists('.pf-c-pagination')).toEqual(true)
 })
 
 it('should get page info from URL', () => {

--- a/spec/javascripts/Metrics/components/MetricsTable.spec.tsx
+++ b/spec/javascripts/Metrics/components/MetricsTable.spec.tsx
@@ -2,7 +2,6 @@ import { mount } from 'enzyme'
 import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon'
 
 import { MetricsTable } from 'Metrics/components/MetricsTable'
-import { mockLocation } from 'utilities/test-utils'
 
 import type { Props } from 'Metrics/components/MetricsTable'
 
@@ -35,25 +34,10 @@ it('should render itself', () => {
 })
 
 it('should have a paginated table', () => {
-  mockLocation('href://foo.bar/metrics?per_page=2&page=2')
   const wrapper = mountWrapper()
   const pagination = wrapper.find('.pf-c-pagination').first()
 
   expect(pagination.find('[aria-label="Current page"]').first().prop('value')).toBe(2)
-
-  pagination.find('button[data-action="first"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=1'))
-
-  pagination.find('button[data-action="previous"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=1'))
-
-  pagination.find('button[data-action="next"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=3'))
-
-  pagination.find('button[data-action="last"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=3'))
-
-  expect(pagination.find('.pf-c-options-menu__toggle-text').text()).toMatch(`3 - 4 of ${metricsCount}`)
 })
 
 describe('for metrics without mapping rule', () => {

--- a/spec/javascripts/Metrics/components/MetricsTable.spec.tsx
+++ b/spec/javascripts/Metrics/components/MetricsTable.spec.tsx
@@ -35,9 +35,7 @@ it('should render itself', () => {
 
 it('should have a paginated table', () => {
   const wrapper = mountWrapper()
-  const pagination = wrapper.find('.pf-c-pagination').first()
-
-  expect(pagination.find('[aria-label="Current page"]').first().prop('value')).toBe(2)
+  expect(wrapper.exists('.pf-c-pagination')).toEqual(true)
 })
 
 describe('for metrics without mapping rule', () => {

--- a/spec/javascripts/Products/components/IndexPage.spec.tsx
+++ b/spec/javascripts/Products/components/IndexPage.spec.tsx
@@ -43,7 +43,5 @@ it('should render a table with products', () => {
 it('should have a paginated table', () => {
   const productsCount = 10
   const wrapper = mountWrapper({ productsCount })
-  const pagination = wrapper.find('.pf-c-pagination').first()
-
-  expect(pagination.find('[aria-label="Current page"]').first().prop('value')).toBe(2)
+  expect(wrapper.exists('.pf-c-pagination')).toEqual(true)
 })

--- a/spec/javascripts/Products/components/IndexPage.spec.tsx
+++ b/spec/javascripts/Products/components/IndexPage.spec.tsx
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme'
 
 import { IndexPage } from 'Products/components/IndexPage'
-import { mockLocation } from 'utilities/test-utils'
 
 import type { Props } from 'Products/components/IndexPage'
 import type { Product } from 'Products/types'
@@ -43,23 +42,8 @@ it('should render a table with products', () => {
 
 it('should have a paginated table', () => {
   const productsCount = 10
-  mockLocation('href://foo.bar/metrics?per_page=2&page=2')
   const wrapper = mountWrapper({ productsCount })
   const pagination = wrapper.find('.pf-c-pagination').first()
 
   expect(pagination.find('[aria-label="Current page"]').first().prop('value')).toBe(2)
-
-  pagination.find('button[data-action="first"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=1'))
-
-  pagination.find('button[data-action="previous"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=1'))
-
-  pagination.find('button[data-action="next"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=3'))
-
-  pagination.find('button[data-action="last"]').simulate('click')
-  expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining('page=3'))
-
-  expect(pagination.find('.pf-c-options-menu__toggle-text').text()).toMatch(`3 - 4 of ${productsCount}`)
 })


### PR DESCRIPTION
[THREESCALE-9644: Fix PF pagination](https://issues.redhat.com/browse/THREESCALE-9644)

There seems to be a bug in PF's Pagination component. `page` default value is 0 and the math doesn't work, but it does when it's 1 so that's the workaround.

Mind the lack of query param `page` in the URL.

Before:
![Screenshot 2023-05-19 at 10 00 50](https://github.com/3scale/porta/assets/11672286/0210a32b-3d91-4425-805a-d59dbbbfa26b)

After:
![Screenshot 2023-05-19 at 10 01 49](https://github.com/3scale/porta/assets/11672286/d1a0cdc7-3305-4393-a6bd-21fc5fa61c74)
