### PR TITLE
🦋 Update FancySelect with PF React 4

### DIFF
--- a/app/assets/stylesheets/provider/_dropdowns.scss
+++ b/app/assets/stylesheets/provider/_dropdowns.scss
@@ -104,38 +104,3 @@ $dropdown-bg-color: lighten(black, 85%);
   text-align: left;
   min-width: line-height-times(10);
 }
-
-// For a typeahead select with an option marked as a group name, make the option look like the SelectGroup name should
-.pf-c-select__menu-item.pf-c-select__menu-item--group-name {
-  padding-top: var(--pf-c-select__menu-item--PaddingTop);
-  padding-right: var(--pf-c-select__menu-item--PaddingRight);
-  padding-bottom: var(--pf-c-select__menu-item--PaddingBottom);
-  padding-left: var(--pf-c-select__menu-item--PaddingLeft);
-  font-size: var(--pf-global--FontSize--sm);
-  font-weight: var(--pf-global--FontWeight--semi-bold);
-  color: var(--pf-global--Color--dark-200);
-}
-
-// fix the bottom border of the typeahead select that is being overwritten by a reset
-.pf-c-select__toggle-wrapper > .pf-c-form-control {
-  border-bottom-color: var(--pf-c-select__toggle--BorderBottomColor);
-}
-
-// fix a reset that is breaking the disabled typeahead select
-.pf-c-select__toggle.pf-m-disabled input {
-  background-color: var(--pf-global--disabled-color--300);
-}
-
-// Adds a description to select items. This will be available natively once we upgrade @patternfly/react-core
-.pf-c-select__menu {
-  .pf-c-select__menu-item-description {
-    height: auto;
-
-    &::after {
-      color: var(--pf-global--Color--200); // var(--pf-c-select__menu-item-description--Color);
-      content: "\A"attr(data-description);
-      font-size: .75rem; // var(--pf-c-select__menu-item-description--FontSize);
-      white-space: pre-wrap;
-    }
-  }
-}

--- a/app/javascript/src/Common/components/FancySelect.scss
+++ b/app/javascript/src/Common/components/FancySelect.scss
@@ -1,18 +1,5 @@
-// For a select box with fixed link at the bottom, select the last li to be that sticky link
-.pf-c-select__menu--with-fixed-link li:last-of-type {
-  background-color: var(--pf-global--BackgroundColor--100);
-  bottom: calc(-1 * var(--pf-global--spacer--sm));
-  padding-bottom: var(--pf-global--spacer--sm);
-  padding-top: var(--pf-global--spacer--xs);
+.pf-c-select__menu--with-sticky-footer .pf-c-select__menu-footer {
   position: sticky;
-
-  // Make the sticky link look like a link
-  .pf-c-select__menu-item {
-    color: var(--pf-global--link--Color);
-
-    &:hover {
-      background-color: var(--pf-global--BackgroundColor--100);
-      color: var(--pf-global--link--Color--hover);
-    }
-  }
+  bottom: calc(-1 * var(--pf-global--spacer--sm));
+  background-color: var(--pf-global--BackgroundColor--100);
 }

--- a/app/javascript/src/Common/components/FancySelect.tsx
+++ b/app/javascript/src/Common/components/FancySelect.tsx
@@ -1,11 +1,17 @@
 import { useState } from 'react'
-import { FormGroup, Select, SelectVariant } from '@patternfly/react-core'
+import {
+  Button,
+  FormGroup,
+  Select,
+  SelectGroup,
+  SelectVariant
+} from '@patternfly/react-core'
 
 import { toSelectOption, toSelectOptionObject, handleOnFilter } from 'utilities/patternfly-utils'
-import type { IRecord, SelectOptionObject, ISelectOption } from 'utilities/patternfly-utils'
+import type { IRecord, SelectOptionObject } from 'utilities/patternfly-utils'
 
 import type { ReactElement } from 'react'
-import type { SelectOptionObject as PFSelectOptionObject, SelectOptionProps } from '@patternfly/react-core'
+import type { SelectOptionObject as PFSelectOptionObject } from '@patternfly/react-core'
 
 import './FancySelect.scss'
 
@@ -27,9 +33,6 @@ interface Props<T extends IRecord> {
   };
 }
 
-const emptyItem = { id: -1, name: 'No results found', disabled: true, privateEndpoint: '' } as const
-const FOOTER_ID = 'footer_id'
-
 const FancySelect = <T extends IRecord>({
   item,
   items,
@@ -46,43 +49,22 @@ const FancySelect = <T extends IRecord>({
 }: Props<T>): ReactElement => {
   const [expanded, setExpanded] = useState(false)
 
-  const headerItem = { id: 'header', name: header, disabled: true, className: 'pf-c-select__menu-item--group-name' } as const
-  // TODO: Remove after upgrading @patternfly/react-core, see https://www.patternfly.org/v4/components/select#view-more
-  const footerItem = footer && { id: FOOTER_ID, name: footer.label, className: 'pf-c-select__menu-item--sticky-footer' }
-
   const handleOnSelect = (_e: unknown, _option: PFSelectOptionObject | string) => {
     setExpanded(false)
 
     const option = (_option as SelectOptionObject)
+    const selectedBackend = items.find(b => String(b.id) === option.id)
 
-    if (option.id === FOOTER_ID) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      footer!.onClick()
-    } else {
-      const selectedBackend = items.find(b => String(b.id) === option.id)
-
-      if (selectedBackend) {
-        onSelect(selectedBackend)
-      }
+    if (selectedBackend) {
+      onSelect(selectedBackend)
     }
   }
 
-  // TODO: seems like this function should be moved to patternfly-utils
-  const getSelectOptionsForItems = (forItems: T[]): React.ReactElement<SelectOptionProps>[] => {
-    const selectItems: ISelectOption[] = [headerItem]
-
-    if (forItems.length === 0) {
-      selectItems.push(emptyItem)
-    } else {
-      selectItems.push(...forItems.map(i => ({ ...i, className: 'pf-c-select__menu-item-description' })))
-    }
-
-    if (footerItem) {
-      selectItems.push(footerItem)
-    }
-
-    return selectItems.map(toSelectOption)
-  }
+  const options = [
+    <SelectGroup key={0} label={header}>
+      {items.map(toSelectOption)}
+    </SelectGroup>
+  ]
 
   return (
     <FormGroup
@@ -97,18 +79,22 @@ const FancySelect = <T extends IRecord>({
       <Select
         isGrouped
         aria-labelledby={id}
-        className={footer ? 'pf-c-select__menu--with-fixed-link' : undefined}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...footer && {
+          className: 'pf-c-select__menu--with-sticky-footer',
+          footer: <Button isInline variant="link" onClick={footer.onClick}>{footer.label}</Button>
+        }}
         isDisabled={isDisabled}
         isOpen={expanded}
         placeholderText={placeholderText}
         selections={item && toSelectOptionObject(item)}
         variant={SelectVariant.typeahead}
         onClear={() => { onSelect(null) }}
-        onFilter={handleOnFilter<T>(items, getSelectOptionsForItems)}
+        onFilter={handleOnFilter(items)}
         onSelect={handleOnSelect}
         onToggle={() => { setExpanded(!expanded) }}
       >
-        {getSelectOptionsForItems(items)}
+        {options}
       </Select>
     </FormGroup>
   )

--- a/app/javascript/src/Common/components/SelectWithModal.scss
+++ b/app/javascript/src/Common/components/SelectWithModal.scss
@@ -2,22 +2,3 @@
   max-height: 20em;
   overflow: auto;
 }
-
-// For a select box with fixed link at the bottom, select the last li to be that sticky link
-.pf-c-select__menu--with-fixed-link li:last-of-type {
-  position: sticky;
-  bottom: calc(-1 * var(--pf-global--spacer--sm));
-  padding-top: var(--pf-global--spacer--xs);
-  padding-bottom: var(--pf-global--spacer--sm);
-  background-color: var(--pf-global--BackgroundColor--100);
-}
-
-// Make the sticky link look like a link
-.pf-c-select__menu--with-fixed-link li:last-of-type .pf-c-select__menu-item {
-  color: var(--pf-global--link--Color);
-}
-
-.pf-c-select__menu--with-fixed-link li:last-of-type .pf-c-select__menu-item:hover {
-  background-color: var(--pf-global--BackgroundColor--100);
-  color: var(--pf-global--link--Color--hover);
-}

--- a/app/javascript/src/utilities/patternfly-utils.tsx
+++ b/app/javascript/src/utilities/patternfly-utils.tsx
@@ -38,11 +38,9 @@ export const toSelectOption = ({
   <SelectOption
     key={String(id)}
     className={className}
-    data-description={description}
-    // TODO: when we upgrade PF, use description prop directly
-    // description={record.description}
+    description={description}
     isDisabled={disabled}
-    value={toSelectOptionObject({ id, name, description })}
+    value={toSelectOptionObject({ id, name })}
   />
 )
 

--- a/app/javascript/src/utilities/test-utils.ts
+++ b/app/javascript/src/utilities/test-utils.ts
@@ -19,7 +19,7 @@ function openSelect (wrapper: ReactWrapper<unknown>): void {
 
 function openSelectWithModal (wrapper: ReactWrapper<unknown>): void {
   wrapper.find('.pf-c-select__toggle-button').simulate('click')
-  wrapper.find('.pf-c-select__menu li button.pf-c-select__menu-item--sticky-footer').last().simulate('click')
+  wrapper.find('.pf-c-select__menu .pf-c-select__menu-footer button').last().simulate('click')
 }
 
 function closeSelectWithModal (wrapper: ReactWrapper<unknown>): void {

--- a/spec/javascripts/Common/components/FancySelect.spec.tsx
+++ b/spec/javascripts/Common/components/FancySelect.spec.tsx
@@ -75,25 +75,11 @@ describe('with a sticky footer link', () => {
     const wrapper = mountWrapper({ footer })
     expandSelect(wrapper)
 
-    const footerOption = wrapper.find('button.pf-c-select__menu-item--sticky-footer')
+    const footerOption = wrapper.find('.pf-c-select__menu .pf-c-select__menu-footer button')
     expect(footerOption.exists()).toEqual(true)
     expect(footerOption.text()).toEqual(footer.label)
 
     footerOption.simulate('click')
     expect(onFooterClick).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('with no items', () => {
-  it('should show an empty message that is disabled', () => {
-    const wrapper = mountWrapper({ items: [] })
-    wrapper.find('.pf-c-select__toggle-button').simulate('click')
-
-    const items = wrapper.find('SelectOption')
-    expect(items.length).toEqual(2)
-
-    const emptyItem = items.last()
-    expect(emptyItem.prop('isDisabled')).toEqual(true)
-    expect(emptyItem.text()).toEqual('No results found')
   })
 })

--- a/spec/javascripts/Common/components/SelectWithModal.spec.tsx
+++ b/spec/javascripts/Common/components/SelectWithModal.spec.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme'
 
-import { openSelectWithModal as openModal, waitForPromises } from 'utilities/test-utils'
+import { openSelectWithModal as openModal, openSelect, waitForPromises } from 'utilities/test-utils'
 import { SelectWithModal } from 'Common/components/SelectWithModal'
 import { TableModal } from 'Common/components/TableModal'
 
@@ -56,7 +56,7 @@ it('should be able to select an item', () => {
   const targetItem = items[0]
   const wrapper = mountWrapper()
 
-  wrapper.find('.pf-c-select__toggle-button').simulate('click')
+  openSelect(wrapper)
   wrapper.find('.pf-c-select__menu li button').filterWhere(n => n.text().includes(targetItem.name)).simulate('click')
 
   expect(onSelect).toHaveBeenCalledWith(targetItem)
@@ -69,10 +69,10 @@ describe('with 20 items or less', () => {
     itemsCount: items.length
   }
 
-  it('should display all items and a title, but no sticky footer', () => {
+  it('should display all items', () => {
     const wrapper = mountWrapper(props)
-    wrapper.find('.pf-c-select__toggle-button').simulate('click')
-    expect(wrapper.find('.pf-c-select__menu li').length).toEqual(items.length + 1)
+    openSelect(wrapper)
+    expect(wrapper.find('.pf-c-select__menu li').length).toEqual(items.length)
   })
 
   it('should not be able to show a modal', () => {
@@ -88,10 +88,10 @@ describe('with more than 20 items', () => {
     itemsCount: items.length
   }
 
-  it('should display up to 20 items, a title and a sticky footer', () => {
+  it('should display up to 20 items', () => {
     const wrapper = mountWrapper(props)
-    wrapper.find('.pf-c-select__toggle-button').simulate('click')
-    expect(wrapper.find('.pf-c-select__menu li')).toHaveLength(22)
+    openSelect(wrapper)
+    expect(wrapper.find('.pf-c-select__menu li')).toHaveLength(20)
   })
 
   it('should be able to show a modal', () => {
@@ -168,15 +168,11 @@ describe('with no items', () => {
     itemsCount: 0
   }
 
-  it('should show an empty message that is disabled', () => {
+  it('should show no items', () => {
     const wrapper = mountWrapper(props)
-    wrapper.find('.pf-c-select__toggle-button').simulate('click')
+    openSelect(wrapper)
 
     const items = wrapper.find('SelectOption')
-    expect(items.length).toEqual(2)
-
-    const emptyItem = items.last()
-    expect(emptyItem.prop('isDisabled')).toEqual(true)
-    expect(emptyItem.text()).toEqual('No results found')
+    expect(items.length).toEqual(0)
   })
 })

--- a/spec/javascripts/utilities/patternfly-utils.spec.tsx
+++ b/spec/javascripts/utilities/patternfly-utils.spec.tsx
@@ -18,7 +18,7 @@ it('#toSelectOption should work', () => {
 <SelectOption
   className="banana"
   component="button"
-  data-description="A standard item object"
+  description="A standard item object"
   index={0}
   inputId=""
   isChecked={false}


### PR DESCRIPTION
[THREESCALE-9633: Update FancySelect](https://issues.redhat.com/browse/THREESCALE-9633)

Most features are supported by PF React 4 so this PR our custom implementations and styles. Keypoints:
* The header was a disabled option, now an `OptionGroup`
* The sticky footer was an options with a hijacked `onSelect` callback, now a button with its own callback
* Some styles that do not apply anymore have been removed

### Before (master):

https://github.com/3scale/porta/assets/11672286/b6312c54-36d8-4033-b4f0-5c650b8df685

### After this PR:

https://github.com/3scale/porta/assets/11672286/382e0d95-588c-42ba-a873-ebada3d4a525

