### PR TITLE
Align header font for leagacy page headers

### DIFF
--- a/app/assets/stylesheets/provider/_commons.scss
+++ b/app/assets/stylesheets/provider/_commons.scss
@@ -13,7 +13,7 @@ main > h1,
 main >  h2,
 #tab-content > h1,
 #tab-content > h2 {
-  font-weight: $font-weight-light;
+  font-weight: $font-weight-normal;
 }
 
 .subsubmenu + h1,
@@ -32,7 +32,8 @@ main >  h2:first-child,
 
 h1 {
   font-size: $main-title-font-size;
-  font-weight: $font-weight-light;
+  font-weight: $font-weight-normal;
+  font-family: $font-family-base;
   padding-top: line-height-times(1/3);
   margin-bottom: line-height-times(2/3);
 

--- a/app/assets/stylesheets/provider/_typography.scss
+++ b/app/assets/stylesheets/provider/_typography.scss
@@ -38,7 +38,7 @@ $font-family-base:          RedHatDisplay, Overpass, overpass, helvetica, arial,
 $fontSize:                   1rem;
 
 $hero-title-font-size:       3 * $fontSize;
-$main-title-font-size:       2 * $fontSize;
+$main-title-font-size:       24px; // --pf-global--FontSize--2xl
 $secondary-title-font-size:  (3/2) * $fontSize;
 $sub-title-font-size:        (5/4) * $fontSize;
 $caption-font-size:          (7/8) * $fontSize;


### PR DESCRIPTION
Makes the `h1` title on the legacy (non-react) pages look like Patternfly headers.