### PR TITLE
Use h1 for page titles

### DIFF
--- a/app/views/admin/fields_definitions/edit.html.erb
+++ b/app/views/admin/fields_definitions/edit.html.erb
@@ -1,4 +1,4 @@
-<h2>Editing field '<%= @fields_definition.name %>' for <%= @fields_definition.target.constantize.model_name.human %></h2>
+<h1>Editing field '<%= @fields_definition.name %>' for <%= @fields_definition.target.constantize.model_name.human %></h1>
 
 <p>
   Here you can add a field to store information about your partners and make it Hidden, Read Only, Required, or provide a different label. The label is the text your partners will see when viewing or entering their data.

--- a/app/views/admin/fields_definitions/new.html.erb
+++ b/app/views/admin/fields_definitions/new.html.erb
@@ -1,4 +1,4 @@
-<h2>New Field definition for <%= @fields_definition.target.constantize.model_name.human %></h2>
+<h1>New Field definition for <%= @fields_definition.target.constantize.model_name.human %></h1>
 
 <p>
 Add a field to store information about your developers on signup or at any other time. Make the fields Hidden, Read Only, Required.

--- a/app/views/api/alerts/index.html.erb
+++ b/app/views/api/alerts/index.html.erb
@@ -3,13 +3,13 @@
 <% end %>
 
 
-<h2>
+<h1>
   <% if @service %>
     <% content_for :sublayout_title, "Alerts" %>
   <% else %>
     Alerts for all services
   <% end %>
-</h2>
+</h1>
 
 <div id="limit_alerts_container">
     <table class="data" id="limit_alerts">

--- a/app/views/api/applications/index.html.slim
+++ b/app/views/api/applications/index.html.slim
@@ -1,4 +1,4 @@
-h2 = "Applications on #{@service.name}"
+h1 = "Applications on #{@service.name}"
 
 = pf_button_in_title 'Create application', new_admin_service_application_path(@service)
 

--- a/app/views/buyers/account_plans/edit.html.erb
+++ b/app/views/buyers/account_plans/edit.html.erb
@@ -1,4 +1,4 @@
-<h2>Edit Account Plan '<%= h @plan.name %>'</h2>
+<h1>Edit Account Plan '<%= h @plan.name %>'</h1>
 
 <% if @plan.customized? %>
   <%= render :partial => 'api/plans/menu' %>

--- a/app/views/buyers/accounts/index.html.erb
+++ b/app/views/buyers/accounts/index.html.erb
@@ -1,4 +1,4 @@
-<h2>Accounts</h2>
+<h1>Accounts</h1>
 
 <div id="bulk-operations" style="display: none;">
   <h3>Bulk operations</h3>

--- a/app/views/buyers/accounts/new.html.erb
+++ b/app/views/buyers/accounts/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Create new Account</h2>
+<h1>Create new Account</h1>
 
 <%= semantic_form_for @buyer,
                      :builder => Fields::FormBuilder,

--- a/app/views/buyers/applications/index.html.slim
+++ b/app/views/buyers/applications/index.html.slim
@@ -1,6 +1,6 @@
 = render '/buyers/accounts/menu'
 
-h2 = "Applications for #{@account.name}"
+h1 = "Applications for #{@account.name}"
 
 = pf_button_in_title 'Create application', create_application_link_href(@account)
 

--- a/app/views/buyers/service_contracts/index.html.slim
+++ b/app/views/buyers/service_contracts/index.html.slim
@@ -1,10 +1,10 @@
 - if @account
   = render 'buyers/accounts/menu'
-  h2
+  h1
     ' Service subscriptions of
     = @account.org_name
 - else
-  h2
+  h1
     | Service Subscriptions
 
 div id="bulk-operations" style="display: none;"

--- a/app/views/buyers/users/index.html.erb
+++ b/app/views/buyers/users/index.html.erb
@@ -1,6 +1,6 @@
 <%= render 'buyers/accounts/menu' %>
 
-<h2>Users of <%= h @account.org_name %></h2>
+<h1>Users of <%= h @account.org_name %></h1>
 
 <table class="data" id="buyer_users">
   <thead>

--- a/app/views/finance/provider/invoices/index.html.erb
+++ b/app/views/finance/provider/invoices/index.html.erb
@@ -1,8 +1,8 @@
-<h2>Invoices
+<h1>Invoices
   <%- if @buyer.present? -%>
     for account: <%= h @buyer.org_name %>
   <%- end -%>
-</h2>
+</h1>
 
 <table class="data">
   <thead>

--- a/app/views/provider/admin/account/users/index.html.slim
+++ b/app/views/provider/admin/account/users/index.html.slim
@@ -1,4 +1,4 @@
-h2 Users
+h1 Users
 
 table class="data" id="users"
   thead

--- a/app/views/provider/admin/accounts/edit.html.erb
+++ b/app/views/provider/admin/accounts/edit.html.erb
@@ -1,4 +1,4 @@
-<h2>Edit Account Details</h2>
+<h1>Edit Account Details</h1>
 
 <%= semantic_form_for @account,
                      :builder => Fields::FormBuilder,

--- a/app/views/provider/admin/applications/index.html.slim
+++ b/app/views/provider/admin/applications/index.html.slim
@@ -1,4 +1,4 @@
-h2 Applications
+h1 Applications
 
 = pf_button_in_title 'Create application', new_provider_admin_application_path
 

--- a/app/views/provider/admin/cms/builtin_legal_terms/new.html.erb
+++ b/app/views/provider/admin/cms/builtin_legal_terms/new.html.erb
@@ -2,7 +2,7 @@
   Legal Terms for <%= @page.title %>
 <% end %>
 
-<h2>Legal Terms for <%= @page.title %></h2>
+<h1>Legal Terms for <%= @page.title %></h1>
 
 <%= render 'info' %>
 <%= cms_form_for(@page) do |f| %>

--- a/app/views/provider/admin/cms/switches/index.html.erb
+++ b/app/views/provider/admin/cms/switches/index.html.erb
@@ -1,4 +1,4 @@
-<h2>Feature Visibility</h2>
+<h1>Feature Visibility</h1>
 
 <p>Some <b>advanced features</b> of the 3scale platform are by default not
   visible for your developers. In other words, HTML fragments of its controls

--- a/app/views/provider/admin/messages/inbox/index.html.slim
+++ b/app/views/provider/admin/messages/inbox/index.html.slim
@@ -1,6 +1,6 @@
 = render 'provider/admin/messages/menu'
 
-h2 Inbox
+h1 Inbox
 
 = render 'provider/admin/messages/bulk_operations', scope: :received_messages, messages: @messages
 

--- a/app/views/provider/admin/messages/outbox/index.html.slim
+++ b/app/views/provider/admin/messages/outbox/index.html.slim
@@ -1,5 +1,5 @@
 = render 'provider/admin/messages/menu'
-h2 Sent Messages
+h1 Sent Messages
 
 
 - if @messages.blank?

--- a/app/views/provider/admin/messages/trash/index.html.slim
+++ b/app/views/provider/admin/messages/trash/index.html.slim
@@ -1,6 +1,6 @@
 = render 'provider/admin/messages/menu'
 
-h2 Trash
+h1 Trash
 
 - if @messages.blank?
   p The trash is empty.


### PR DESCRIPTION
The use of `h1` and `h2` elements for page titles is not consistent, while IMO it should be.