### PR TITLE
Update color palette after PF4 upgrade

### DIFF
--- a/app/assets/stylesheets/provider/_colors.scss
+++ b/app/assets/stylesheets/provider/_colors.scss
@@ -5,19 +5,19 @@
 
 // greys
 $alabasterWhite: #fafafa; // pf-black-100
-$altoGray:       #d1d1d1; // pf-black-300
+$altoGray:       #d2d2d2; // pf-black-300
 $black:          #030303; // pf-black
-$osloGray:       #8b8d8f; // pf-black-500
-$outerSpaceGray: #393f44; // pf-black-800
-$gallery:        #ededed; // pf-black-200
+$osloGray:       #8a8d90; // pf-black-500
+$outerSpaceGray: #3c3f42; // pf-black-800
+$gallery:        #f0f0f0; // pf-black-200
 $white:          #fff;
 $whiteBoxShadowColor: rgba(3, 3, 3, .2);
 $whiteBoxShadow: $whiteBoxShadowColor 0 1px 2px 0;
 $wildSandGray:   #f5f5f5; // pf-black-150
 
 // colors
-$curiousBlue:    #39a5dc; // pf-blue-300
-$lochMaraBlue:   #0088ce; //pf-blue-400
+$curiousBlue:    #2b9af3; // pf-blue-300
+$lochMaraBlue:   #0066cc; //pf-blue-400
 $appleGreen:     #3f9c35;
 $guardsmanRed:   #cc0000;
 $tahitiGold:     #ec7a08;


### PR DESCRIPTION
PatternFly color palette is different from the one that was used in PF3.
Compare:
PF3: https://pf3.patternfly.org/v3/styles/color-palette/
PF4: https://www.patternfly.org/v4/guidelines/colors/#color-palette

This PR updates the colors, without changing the names of the variables.

This removes some weird artifacts, like the one observed here (different colors on the background) and introduced in [this PR](https://github.com/3scale/porta/pull/3367):
 
![239496053-e308628a-748f-48e6-ac39-f08fd23bf10f](https://github.com/3scale/porta/assets/1270328/fce44ced-b65c-4f4b-8fd7-d3b1d51dd82f)


