### PR TITLE
THREESCALE-8377: Support for larger policy chains

### DIFF
--- a/app/controllers/admin/api/services/proxy/policies_controller.rb
+++ b/app/controllers/admin/api/services/proxy/policies_controller.rb
@@ -17,7 +17,7 @@ class Admin::Api::Services::Proxy::PoliciesController < Admin::Api::Services::Ba
       ApicastV2DeploymentService.new(@proxy).call(environment: :sandbox)
     end
 
-    respond_with(proxy.policies_config, represent_on_error: :resource)
+    respond_with(proxy.policies_config, represent_on_error: represent_on_error)
   end
 
   private
@@ -32,5 +32,11 @@ class Admin::Api::Services::Proxy::PoliciesController < Admin::Api::Services::Ba
 
   def proxy
     @proxy ||= service.proxy
+  end
+
+  # Either to show policy-level errors (e.g. one policy lacks a field) or chain-level errors (e.g. chain is too long)
+  # Returns +:resource+ to show policy errors, +nil+ for chain errors.
+  def represent_on_error
+    :resource if proxy.errors.messages[:policies_config] == [I18n.t(:invalid_policy, scope: 'activemodel.errors.models.policies_config.attributes.policies_config')]
   end
 end

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -587,12 +587,7 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
 
     def policies_configs_are_correct
-      # TODO: 5: errors.merge!(policy_config.errors)
-      select(&:invalid?).map(&:errors).each do |policy_errors|
-        policy_errors.each do |attribute, message|
-          errors.add(attribute, errors.full_message(attribute, message).downcase)
-        end
-      end
+      errors.add(:policies_config, :invalid_policy) if any?(&:invalid?)
       errors.add(:policies_config, :missing_apicast) unless detect(&:default?)
       errors.add(:policies_config, :too_long, count: MAX_LENGTH) if Proxy.type_for_attribute('policies_config').serialize(self).size > MAX_LENGTH
     rescue NoMethodError
@@ -603,8 +598,8 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def policies_config_structure
     return if policies_config.valid?
 
-    policies_config.errors.each do |attribute, message|
-      errors.add(:policies_config, errors.full_message(attribute, message))
+    policies_config.errors.each do |_attribute, message|
+      errors.add(:policies_config, message)
     end
   end
 

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -536,6 +536,9 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
     include ActiveModel::Validations
     include Enumerable
 
+    # The policy chain must fit inside +ProxyConfig.content+, which is limited to 2.megabytes
+    MAX_LENGTH = 2.megabytes
+
     delegate :each, :to_json, :as_json, to: :policies_config
     alias to_s to_json
     attr_reader :policies_config
@@ -590,9 +593,10 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
           errors.add(attribute, errors.full_message(attribute, message).downcase)
         end
       end
-      errors.add(:base, :missing_apicast) unless detect(&:default?)
+      errors.add(:policies_config, :missing_apicast) unless detect(&:default?)
+      errors.add(:policies_config, :too_long, count: MAX_LENGTH) if Proxy.type_for_attribute('policies_config').serialize(self).size > MAX_LENGTH
     rescue NoMethodError
-      errors.add(:base, :invalid_format)
+      errors.add(:policies_config, :invalid_format)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -791,6 +791,7 @@ en:
             policies_config:
               invalid_format: "has invalid format. The Correct format is: [{ \"name\": \"apicast\"... }]"
               missing_apicast: "is missing apicast policy"
+              invalid_policy: "contains some invalid policy"
         sso_token:
           cannot_be_generated: SSO Token cannot be generated
           one_of_user_id_or_username_is_required: One of user_id or username is required

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -788,7 +788,7 @@ en:
       models:
         policies_config:
           attributes:
-            base:
+            policies_config:
               invalid_format: "has invalid format. The Correct format is: [{ \"name\": \"apicast\"... }]"
               missing_apicast: "is missing apicast policy"
         sso_token:

--- a/db/migrate/20230704094429_extend_policy_chain_my_sql.rb
+++ b/db/migrate/20230704094429_extend_policy_chain_my_sql.rb
@@ -1,0 +1,6 @@
+class ExtendPolicyChainMySql < ActiveRecord::Migration[5.2]
+  # Oracle and PostgreSQL do not need this as their `policies_config` has unlimited size
+  def up
+    change_column :proxies, :policies_config, :mediumtext if System::Database.mysql?
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_21_090207) do
+ActiveRecord::Schema.define(version: 2023_07_04_094429) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id", precision: 38, null: false

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_21_090207) do
+ActiveRecord::Schema.define(version: 2023_07_04_094429) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_21_090207) do
+ActiveRecord::Schema.define(version: 2023_07_04_094429) do
 
   create_table "access_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
     t.bigint "owner_id", null: false
@@ -1082,7 +1082,7 @@ ActiveRecord::Schema.define(version: 2023_06_21_090207) do
     t.string "oidc_issuer_endpoint"
     t.bigint "lock_version", default: 0, null: false
     t.string "authentication_method"
-    t.text "policies_config"
+    t.text "policies_config", limit: 16777215
     t.string "oidc_issuer_type", default: "keycloak"
     t.string "error_headers_limits_exceeded", default: "text/plain; charset=us-ascii"
     t.integer "error_status_limits_exceeded", default: 429

--- a/test/integration/admin/api/services/proxy/policies_controller_test.rb
+++ b/test/integration/admin/api/services/proxy/policies_controller_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PoliciesControllerTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @provider = FactoryBot.create(:provider_account)
+    @service = @provider.default_service
+    host! @provider.external_admin_domain
+    @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+  end
+
+  class UpdateTest < PoliciesControllerTest
+    test 'prints chain level errors' do
+      valid_config = { name: 'apicast', configuration: {}, version: 'builtin', enabled: true, removable: false }
+
+      Proxy::PoliciesConfig.stub_const(:MAX_LENGTH, 16.bytes) do
+        put admin_api_service_proxy_policies_path(@service, access_token: @access_token, format: :json), params: {
+          proxy: { policies_config: valid_config }
+        }, as: :json
+      end
+      resp_body = JSON.parse(response.body)
+
+      assert_response :unprocessable_entity
+      assert_equal 'is too long (maximum is 16 characters)', resp_body['errors']['policies_config'][0]
+    end
+
+    test 'prints policy level errors' do
+      invalid_config = { name: 'apicast', configuration: {}, enabled: true, removable: false }
+
+      put admin_api_service_proxy_policies_path(@service, access_token: @access_token, format: :json), params: {
+        proxy: { policies_config: invalid_config}
+      }, as: :json
+      resp_body = JSON.parse(response.body)
+
+      assert_response :unprocessable_entity
+      assert_equal "can't be blank", resp_body['policies_config'][0]['errors']['version'][0]
+    end
+
+    test 'policy level errors are promoted to chain errors as well' do
+      invalid_config = { name: 'apicast', configuration: {}, enabled: true, removable: false }
+
+      Proxy::PoliciesConfig.stub_const(:MAX_LENGTH, 16.bytes) do
+        put admin_api_service_proxy_policies_path(@service, access_token: @access_token, format: :json), params: {
+          proxy: { policies_config: invalid_config}
+        }, as: :json
+      end
+      resp_body = JSON.parse(response.body)
+
+      assert_response :unprocessable_entity
+      assert_same_elements ['contains some invalid policy', 'is too long (maximum is 16 characters)'], resp_body['errors']['policies_config']
+    end
+  end
+end

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -21,8 +21,7 @@ class ProxyTest < ActiveSupport::TestCase
 
       proxy.policies_config = [{ name: '1' }]
       refute proxy.valid?
-      assert_match 'version can\'t be blank', proxy.errors.full_messages.to_sentence
-      assert_match 'configuration can\'t be blank', proxy.errors.full_messages.to_sentence
+      assert_match 'Policies config contains some invalid policy', proxy.errors.full_messages.to_sentence
     end
 
     def test_not_valid_json_policies_config


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to increase the size of the `policies_config` column in the `proxies` table in MySQL. This column is now limited to 64kb and some customers are complaining because they use larger policy chains that don't fit in the column.

This affects only MySQL databases, Postgres and Oracle don't set a size limit to this colmn.

This PR includes a migration that raises a Strong Migrations error, because changing a column type on the fly is considered dangerous by the gem authors:

https://github.com/ankane/strong_migrations#changing-the-type-of-a-column

However, the safe approach they suggest would require many PRs and a column name change, which seems even more dangerous to me.

@akostadinov tried modifying the column size in a copy of the staging DB and the operation finished in less than 2 seconds. So it shouldn't cause big issues. We of course should run the migration on staging first to see how it behaves, and have some ops guy available when we run the migration on production.

To bypass the strong migrations error, run the migration with this command:

`SAFETY_ASSURED=1 bundle exec rails db:migrate`

For further info about this change, check [THREESCALE-9652](https://issues.redhat.com/browse/THREESCALE-9652)

**Which issue(s) this PR fixes** 

[THREESCALE-8377](https://issues.redhat.com/browse/THREESCALE-8377)

**Verification steps** 

1. Download the example policies chain file (ask me how if you don't know).
2. Checkout and initialize the [3scale_toolbox](https://github.com/3scale/3scale_toolbox) repo.
3. Add a remote with `bundle exec 3scale add ...`
5. Run `bundle exec 3scale policies import <REMOTE> <SERVICE> -f <POLICIES_FILE>.json`
6. It should finish without errors.
7. Go to `apiconfig/services/<SERVICE ID>/policies/edit` and check the policies are there.
