### PR TITLE
Fix broken Log reference in SaaS version of Service Management API spec

### DIFF
--- a/doc/active_docs/service_management_api.json
+++ b/doc/active_docs/service_management_api.json
@@ -177,13 +177,7 @@
             "in": "query",
             "description": "Request Log allows to log status codes of your API back to 3scale to maintain a log of the latest activity on your API. Request Logs are optional and not available in all 3scale plans.",
             "schema": {
-              "type": "object",
-              "properties": {
-                "code": {
-                  "type": "string",
-                  "example": 200
-                }
-              }
+              "$ref": "#/components/schemas/Log"
             },
             "style": "deepObject",
             "explode": true
@@ -481,12 +475,24 @@
           },
           "usage": {
             "$ref": "#/components/schemas/Usage"
+          },
+          "log": {
+            "$ref": "#/components/schemas/Log"
           }
         },
         "example": {
           "user_key": "example",
           "usage": {
             "hits": 1
+          }
+        }
+      },
+      "Log": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": 200
           }
         }
       }


### PR DESCRIPTION
Just fixing a bug in the spec. There was a reference to `"$ref": "#/components/schemas/Log"` in one place, but no Log schema.

There were two occurrences initially, one was replaced with the inline schema definition (hence the schema removed), but there was one more occurrence left.
This PR fixes it.