### PR TITLE
Document the limitations of the timestamp field, and add another format

### DIFF
--- a/app/javascript/src/ActiveDocs/swagger-ui-3-provider-patch.scss
+++ b/app/javascript/src/ActiveDocs/swagger-ui-3-provider-patch.scss
@@ -21,4 +21,9 @@
   .curl-command .copy-to-clipboard button {
     padding: 0 0 0 25px;
   }
+
+  ul {
+    padding: revert;
+    list-style: revert;
+  }
 }

--- a/doc/active_docs/service_management_api.json
+++ b/doc/active_docs/service_management_api.json
@@ -475,8 +475,7 @@
           },
           "timestamp": {
             "type": "string",
-            "pattern": "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}( [+-]\\d{2}:\\d{2})?$",
-            "description": "If passed, it should be the time when the transaction took place. Format: YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2022-02-01 22:15:31 -08:00",
+            "description": "If passed, it should be the time when the transaction took place.\nTimestamp must be within the following range: 24 hours before and 1\nhour after the current time. Two formats are supported:\n- `YYYY-MM-DD HH:MM:SS` for UTC, add `-HH:MM` or `+HH:MM` for time offset, e.g. `2022-02-01 22:15:31 -08:00`\n- Unix epoch timestamp in seconds, e.g. `1643750131`",
             "example": "2022-02-01 22:15:31 -08:00"
           },
           "usage": {

--- a/doc/active_docs/service_management_api_on_premises.json
+++ b/doc/active_docs/service_management_api_on_premises.json
@@ -449,8 +449,7 @@
           },
           "timestamp": {
             "type": "string",
-            "pattern": "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}( [+-]\\d{2}:\\d{2})?$",
-            "description": "If passed, it should be the time when the transaction took place. Format: YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2022-02-01 22:15:31 -08:00",
+            "description": "If passed, it should be the time when the transaction took place.\nTimestamp must be within the following range: 24 hours before and 1\nhour after the current time. Two formats are supported:\n- `YYYY-MM-DD HH:MM:SS` for UTC, add `-HH:MM` or `+HH:MM` for time offset, e.g. `2022-02-01 22:15:31 -08:00`\n- Unix epoch timestamp in seconds, e.g. `1643750131`",
             "example": "2022-02-01 22:15:31 -08:00"
           },
           "usage": {


### PR DESCRIPTION
The JIRA `THREESCALE—9667` reports a "bug" in the Service Management API which is not actually a bug, but rather a not documented limitation for the "timestamp" value.

This PR adds the description in the API specification.

Also, while looking into this, I realized that there is an undocumented feature that allows specifying the timestamp in unix epoch, so added this to the spec description too.

![Screenshot from 2023-05-26 15-00-02](https://github.com/3scale/porta/assets/1270328/b38a52d8-b574-49c5-9668-a58d0bc4c585)
