### PR TITLE
🦋 Implement provider footer with PF4

### DIFF
--- a/app/assets/stylesheets/error.scss
+++ b/app/assets/stylesheets/error.scss
@@ -30,16 +30,16 @@ body {
   margin-top: line-height-times(2);
   border-top: $border-width solid $border-color;
 
-  ul {
-    list-style: none;
+  .last {
+    float: right;
+  }
 
-    .last {
-      float: right;
-    }
+  a {
+    display: block;
+  }
 
-    a {
-      display: block;
-    }
+  .powered-by-3scale {
+    padding-top: 16px;
   }
 }
 

--- a/app/assets/stylesheets/provider/_colors.scss
+++ b/app/assets/stylesheets/provider/_colors.scss
@@ -147,7 +147,3 @@ $codemirror-liquid-markup-delim-color: $highlight-color;
 $codemirror-liquid-string-color: $success-color;
 $codemirror-gutter-color: $border-color;
 $codemirror-gutter-background-color: $codemirror-bg;
-
-$footer-background-color: transparent;
-$footer-link-color: $osloGray;
-$footer-link-hover-color: $link-hover-color;

--- a/app/assets/stylesheets/provider/_footer.scss
+++ b/app/assets/stylesheets/provider/_footer.scss
@@ -1,35 +1,14 @@
-#footer {
-  color: $label-color;
-  background-color: $footer-background-color;
-  float: left;
-  width: 100%;
-  white-space: nowrap;
-  margin: line-height-times(4) 0 line-height-times(0) 0;
-  // HACK: import PF4 styles instead of use hardcoded value. In the future it will be included in PF class.
-  padding: 25px !important;
-  border-top: $border-width solid $border-color;
-  font-size: $font-size-sm;
+footer {
+  a {
+    color: $footer-link-color;
 
-  ul {
-      @include horizontal-list(line-height-times(1/2));
-      width: 100%;
-      overflow: visible;
-
-      li {
-        white-space: nowrap;
-
-        a {
-          color: $footer-link-color;
-          &:hover { color: $footer-link-hover-color; }
-
-        }
-
-        &.last { float: right; }
-      }
+    &:hover {
+      color: $footer-link-hover-color;
+    }
   }
-}
 
-.powered-by-3scale {
-  text-decoration: none;
-  color: $footer-link-color;
+  .powered-by-3scale {
+    text-decoration: none;
+    color: $footer-link-color;
+  }
 }

--- a/app/assets/stylesheets/provider/_footer.scss
+++ b/app/assets/stylesheets/provider/_footer.scss
@@ -1,3 +1,6 @@
+$footer-link-color: $osloGray;
+$footer-link-hover-color: $link-hover-color;
+
 footer {
   a {
     color: $footer-link-color;

--- a/app/assets/stylesheets/provider/_print.scss
+++ b/app/assets/stylesheets/provider/_print.scss
@@ -7,7 +7,7 @@
   .action,
   .ExportLink,
   tr.search,
-  #footer {
+  footer {
     display: none;
   }
 

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -25,9 +25,7 @@
 
       <% if admin_domain || master_domain %>
         <div id='footer'>
-          <ul>
-            <%= render 'provider/footer_powered_by_part' %>
-          </ul>
+          <%= render 'provider/footer_powered_by_part' %>
         </div>
       <% else %>
         <%= render partial: 'shared/footer', locals: { site_account: site_account } %>

--- a/app/views/provider/_footer.html.slim
+++ b/app/views/provider/_footer.html.slim
@@ -1,7 +1,10 @@
-footer#footer
-  ul
+hr.pf-c-divider
+footer.pf-c-page__main-section
+  div.pf-l-flex
     - if ThreeScale.tenant_mode.multitenant?
-      li= link_to 'Privacy', '//www.redhat.com/en/about/privacy-policy', target: '_blank'
-    li= link_to 'Support', "//access.redhat.com/products/red-hat-3scale#support", target: '_blank'
-
-    = render 'provider/footer_powered_by_part'
+      div.pf-l-flex__item
+        = link_to 'Privacy', '//www.redhat.com/en/about/privacy-policy', target: '_blank'
+    div.pf-l-flex__item
+      = link_to 'Support', "//access.redhat.com/products/red-hat-3scale#support", target: '_blank'
+    div.pf-l-flex__item.pf-m-align-right
+      = render 'provider/footer_powered_by_part'

--- a/app/views/provider/_footer_powered_by_part.html.slim
+++ b/app/views/provider/_footer_powered_by_part.html.slim
@@ -1,4 +1,4 @@
-li.powered-by-3scale.last
+.powered-by-3scale.last
   - if (version = System::Deploy.info.release)
     span
       ' Version #{version} -


### PR DESCRIPTION
[THREESCALE-9640: Remove hardcoded styles in footer](https://issues.redhat.com/browse/THREESCALE-9640)

Apply Patternfly structure and classes to footer. It looks closer now now closer to the main section, have in mind that's Patternfly's default.

#### Before
![Screenshot 2023-05-25 at 19 19 09](https://github.com/3scale/porta/assets/11672286/d7f8b9eb-20f9-45f7-804e-5d7805054d9e)

#### After
![Screenshot 2023-05-25 at 19 11 51](https://github.com/3scale/porta/assets/11672286/44458996-3c7c-427a-9c82-ac797472524a)

### Error layout
The error layout does not support Patternfly, therefore its footer is to remain unchanged.

#### Before
![Screenshot 2023-05-25 at 19 03 08](https://github.com/3scale/porta/assets/11672286/df2541a6-0d04-4816-ab2b-2046bad23f2d)

#### After
![Screenshot 2023-05-25 at 19 06 24](https://github.com/3scale/porta/assets/11672286/278bb931-a182-482d-bbd5-b42970874bbf)

