### PR TITLE
Log Sidekiq worker arguments

### DIFF
--- a/test/unit/sidekiq_initializer_test.rb
+++ b/test/unit/sidekiq_initializer_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'sidekiq/manager'
+
+class SidekiqInitializerTest < ActiveSupport::TestCase
+
+  test 'log job arguments' do
+    options = {:queues => ['default']}
+
+    logger = Sidekiq.logger = Sidekiq::Logging.initialize_logger
+
+    mgr = Sidekiq::Manager.new(options)
+    processor = ::Sidekiq::Processor.new(mgr)
+
+    invoice = FactoryBot.create(:invoice)
+
+    msg = Sidekiq.dump_json({ 'class' => InvoiceFriendlyIdWorker.to_s, 'args' => [invoice.id] })
+    job = Sidekiq::BasicFetch::UnitOfWork.new('queue:default', msg)
+    processor.send(:process, job)
+
+    # Sidekiq.logger.expects(:info) #.with { |message| message.match("ARGS-[#{invoice.id}]") }
+
+    logger.expects(:info)
+  end
+end


### PR DESCRIPTION
Adds more logging to Sidekiq, printing the arguments passed to the worker's `perform` method.

Compare before:
```
2023-05-25T21:05:48.076Z 3819931 TID-155ikb BillingWorker JID-d1c638b3fc271bed152893d8 BID-sXf1y0rExpEe2A INFO: start
2023-05-25T21:05:52.773Z 3819931 TID-155ikb BillingWorker JID-d1c638b3fc271bed152893d8 BID-sXf1y0rExpEe2A INFO: done: 4.697 sec

```
and after:
```
2023-05-25T21:36:29.556Z 3827198 TID-u08li BillingWorker JID-9423272bd99e4d7d3562869c BID-Qrr4OiSp2F2e9Q ARGS-[2445566778899, 2445599887766, "2023-05-25T00:00:00Z"] INFO: start
2023-05-25T21:36:34.364Z 3827198 TID-u08li BillingWorker JID-9423272bd99e4d7d3562869c BID-Qrr4OiSp2F2e9Q ARGS-[2445566778877, 2445599887766, "2023-05-25T00:00:00Z"] INFO: done: 4.808 sec
```