### PR TITLE
Fix warning no published default account plan

### DIFF
--- a/app/javascript/packs/plans_index.ts
+++ b/app/javascript/packs/plans_index.ts
@@ -33,7 +33,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const { dataset } = accountPlansIndexContainer
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const props = safeFromJsonString<AccountPlansIndexPageProps>(dataset.plansIndex)!
-    props.showNotice = true
     AccountPlansIndexPageWrapper({ ...props }, accountPlansIndexContainerId)
   }
 })

--- a/app/javascript/src/Plans/components/AccountPlansIndexPage.tsx
+++ b/app/javascript/src/Plans/components/AccountPlansIndexPage.tsx
@@ -16,11 +16,11 @@ import type { Props as MainSectionProps } from 'Plans/components/IndexPageMainSe
 import type { FunctionComponent } from 'react'
 
 interface Props extends MainSectionProps {
-  showNotice: boolean;
+  showNoDefaultPlanWarning: boolean;
 }
 
 const AccountPlansIndexPage: FunctionComponent<Props> = ({
-  showNotice,
+  showNoDefaultPlanWarning,
   defaultPlanSelectProps,
   plansTableProps
 }) => (
@@ -37,7 +37,7 @@ const AccountPlansIndexPage: FunctionComponent<Props> = ({
             </Text>
           </TextContent>
         </StackItem>
-        {showNotice && (
+        {showNoDefaultPlanWarning && (
           <StackItem>
             <Alert
               isInline

--- a/app/presenters/buyers/account_plans_presenter.rb
+++ b/app/presenters/buyers/account_plans_presenter.rb
@@ -11,7 +11,7 @@ class Buyers::AccountPlansPresenter < PlansBasePresenter
   end
 
   def plans_index_data
-    super.merge({ showNotice: no_available_plans })
+    super.merge({ showNoDefaultPlanWarning: no_available_plans })
   end
 
   private

--- a/spec/javascripts/Plans/components/AccountPlansIndexPage.spec.tsx
+++ b/spec/javascripts/Plans/components/AccountPlansIndexPage.spec.tsx
@@ -5,7 +5,7 @@ import { AccountPlansIndexPage } from 'Plans/components/AccountPlansIndexPage'
 import type { Props } from 'Plans/components/AccountPlansIndexPage'
 
 const defaultProps = {
-  showNotice: true,
+  showNoDefaultPlanWarning: true,
   defaultPlanSelectProps: {
     plans: [],
     initialDefaultPlan: null,
@@ -23,9 +23,9 @@ const defaultProps = {
 const shallowWrapper = (props: Partial<Props> = {}) => shallow(<AccountPlansIndexPage {...{ ...defaultProps, ...props }} />)
 
 it('should show a notice', () => {
-  const wrapper = shallowWrapper({ showNotice: false })
+  const wrapper = shallowWrapper({ showNoDefaultPlanWarning: false })
   expect(wrapper).toMatchSnapshot()
 
-  wrapper.setProps({ showNotice: true })
+  wrapper.setProps({ showNoDefaultPlanWarning: true })
   expect(wrapper).toMatchSnapshot()
 })


### PR DESCRIPTION
Just fixing something that was added [here](https://github.com/3scale/porta/pull/3381/commits/24d29f1036bf4ea8509ec9ba1996747858c98556#diff-a4019d6d64924fc4ab94de3404ce5184957beab4240c32a4b6cc7502e14d676bR36) I guess for testing.

One other thing I noticed @josemigallas that can be potentially improved is toggling this warning on publishing/hiding the plans (but probably not worth it).

Renaming is just a suggestion, but I think it helps understand what this variable is for.