### PR TITLE
⬆️ Upgrade `@patternfly/patternfly` from v2 to v4 (quickstarts dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "yaml-loader": "^0.6.0"
   },
   "dependencies": {
-    "@patternfly/patternfly": "2.40.6",
     "@patternfly/quickstarts": "^1.4.1-rc.1",
     "@patternfly/react-core": "4.276.8",
     "@patternfly/react-icons": "^3.14.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,11 +1486,6 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@patternfly/patternfly@2.40.6":
-  version "2.40.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.40.6.tgz#f1e13069c6c948e194de53bbd00a031bb0ddd051"
-  integrity sha512-YIusipnIPipCJNKN/Lw72MmV1dnsFQvc8Exwo5+IfROF2TnWMpVYaFPC3TvqnuMrysxrxpuGC2HzKJVX5bqbgA==
-
 "@patternfly/patternfly@4.122.2":
   version "4.122.2"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.122.2.tgz#3e774d78996c7027b8c528edb2e90990676458a5"


### PR DESCRIPTION
[THREESCALE-9688: Remove @patternfly/patternfly dependency](https://issues.redhat.com/browse/THREESCALE-9688)

This is a dependency of quickstarts and it should not be listed as a direct dependency in our package.json. In fact quickstarts requires v4 but we list v2:

```
yarn why @patternfly/patternfly
yarn why v1.22.19
[1/4] 🤔  Why do we have the module "@patternfly/patternfly"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "@patternfly/patternfly@2.40.6"
info Has been hoisted to "@patternfly/patternfly"
info This module exists because it's specified in "dependencies".
info Disk size without dependencies: "16.34MB"
info Disk size with unique dependencies: "16.34MB"
info Disk size with transitive dependencies: "16.34MB"
info Number of shared dependencies: 0
=> Found "@patternfly/react-catalog-view-extension#@patternfly/patternfly@4.122.2"
info This module exists because "@patternfly#quickstarts#@patternfly#react-catalog-view-extension" depends on it.
info Disk size without dependencies: "21.53MB"
info Disk size with unique dependencies: "21.53MB"
info Disk size with transitive dependencies: "21.53MB"
info Number of shared dependencies: 0
✨  Done in 0.42s.
```