### PR TITLE
⚡️✅ Fix circleci Timeouts by stopping tests from getting login page uselessly

### DIFF
--- a/test/test_helpers/authentication.rb
+++ b/test/test_helpers/authentication.rb
@@ -55,15 +55,11 @@ ActionDispatch::IntegrationTest.class_eval do
   end
 
   def provider_login_with(username, password)
-    get '/p/login'
-    follow_redirect! while redirect?
     post provider_sessions_path, params: {username: username, password: password}
     follow_redirect! while redirect?
   end
 
   def login_with(username, password)
-    get '/login'
-    follow_redirect! while redirect?
     post '/session', params: {username: username, password: password}
     follow_redirect! while redirect?
   end


### PR DESCRIPTION
Nightly tests in master are failing because they time out. In particular cucumbers-oracle takes almost 2 hours of our circle ci credits every night. They wait forever to compile the assets, assets compilation is launched whenever any test calls login!
 https://github.com/3scale/porta/blob/2cc685d34cad5c4addb033f28258264155c5a71c/test/integration/api/policies_controller_test.rb#L9)

The issue was introduced by this commit:
https://github.com/3scale/porta/commit/a788c5bb5aa02890e98ce90b6ea468a3bffe202d

Example:
```
# before (master)
$ test test/integration/api/policies_controller_test.rb
Finished tests in 38.853989s, 0.1287 tests/s, 0.4118 assertions/s.

# after this PR
$  test test/integration/api/policies_controller_test.rb
Finished tests in 3.615199s, 1.3830 tests/s, 4.4258 assertions/s.
```