### PR TITLE
Fixing some invalid values for invoice period

### DIFF
--- a/app/lib/month.rb
+++ b/app/lib/month.rb
@@ -67,10 +67,7 @@ class Month < Range
     return month if month.is_a?(Month)
 
     match = /^(\d{4})-(\d{2})(?:-\d{2})?$/.match(month)
-
-    raise ArgumentError unless match
-
-    Month.new(*match.captures)
+    Month.new(*match.captures) if match
   rescue ArgumentError, NoMethodError, RangeError
     nil
   end

--- a/app/lib/month.rb
+++ b/app/lib/month.rb
@@ -67,7 +67,10 @@ class Month < Range
     return month if month.is_a?(Month)
 
     match = /^(\d{4})-(\d{2})(?:-\d{2})?$/.match(month)
-    Month.new(*match.captures) if match
+
+    raise ArgumentError unless match
+
+    Month.new(*match.captures)
   rescue ArgumentError, NoMethodError, RangeError
     nil
   end

--- a/app/lib/month.rb
+++ b/app/lib/month.rb
@@ -66,12 +66,12 @@ class Month < Range
   def self.parse_month(month)
     return month if month.is_a?(Month)
 
-    match = /^(\d{4})-(\d{2})(?:-\d{2})?$/.match(month)
+    match = /^(\d{4})-(\d{2})$/.match(month)
 
     raise ArgumentError unless match
 
     Month.new(*match.captures)
-  rescue ArgumentError, NoMethodError, RangeError
+  rescue StandardError
     nil
   end
 

--- a/app/lib/month.rb
+++ b/app/lib/month.rb
@@ -66,10 +66,11 @@ class Month < Range
   def self.parse_month(month)
     return month if month.is_a?(Month)
 
-    raise ArgumentError unless /^\d{4}-\d{2}$/.match?(month)
+    match = /^(\d{4})-(\d{2})(?:-\d{2})?$/.match(month)
 
-    month_params = month.split('-').first(2)
-    Month.new(*month_params)
+    raise ArgumentError unless match
+
+    Month.new(*match.captures)
   rescue ArgumentError, NoMethodError, RangeError
     nil
   end

--- a/app/lib/month.rb
+++ b/app/lib/month.rb
@@ -66,9 +66,11 @@ class Month < Range
   def self.parse_month(month)
     return month if month.is_a?(Month)
 
+    raise ArgumentError unless /^\d{4}-\d{2}$/.match?(month)
+
     month_params = month.split('-').first(2)
     Month.new(*month_params)
-  rescue ArgumentError, NoMethodError
+  rescue ArgumentError, NoMethodError, RangeError
     nil
   end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -68,7 +68,7 @@ class Invoice < ApplicationRecord
   scope :due_on_or_before, ->(date) { where('due_on <= ?', date ) }
   scope :finalized_before, ->(date) { where("state='finalized' AND finalized_at <= ?", date) }
 
-  # The month should be a YYYY-MM formated string.
+  # The month should be a YYYY-MM formatted string.
   scope :by_month, ->(month) { where(:period => ::Month.parse_month(month)) }
   scope :by_year, ->(year) {  where.has { sift(:year, period) ==  year } }
   scope :by_month_number, ->(month) {  where.has { sift(:month_number, period) == month } }
@@ -532,18 +532,6 @@ class Invoice < ApplicationRecord
     opened.by_provider(buyer.provider_account)
            .where(['invoices.buyer_account_id = ?', buyer.id ])
            .reorder('period DESC, created_at DESC').first
-  end
-
-  # TODO: are those needed without provider/buyer scope?
-  # The month should be a YYYY-MM formated string.
-  def self.find_by_month(month)
-    by_month(month).first
-  end
-
-  # TODO: are those needed without provider/buyer scope?
-  def self.find_by_month!(month)
-    find_by_month(month) ||
-      raise(ActiveRecord::RecordNotFound, "Couldn't find #{name} by month=#{month}")
   end
 
   # TODO: investigate this ... should not be happening on-demand

--- a/test/unit/invoice_test.rb
+++ b/test/unit/invoice_test.rb
@@ -119,10 +119,12 @@ class InvoiceTest < ActiveSupport::TestCase
   end
 
   test 'validates presence of valid period' do
-    @invoice.update(period: 'invalid')
+    %w[invalid 2023abc-01 2023-05xxx 2023-05123456789].each do |value|
+      @invoice.update(period: value)
 
-    assert_not @invoice.valid?
-    assert_includes @invoice.errors[:period], 'Billing period format should be YYYY-MM'
+      assert_not @invoice.valid?
+      assert_includes @invoice.errors[:period], 'Billing period format should be YYYY-MM'
+    end
   end
 
   test 'validates invoice year - invalid if earlier than buyer creation date' do

--- a/test/unit/invoice_test.rb
+++ b/test/unit/invoice_test.rb
@@ -118,8 +118,8 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_equal '1984-00000008', invoice.friendly_id
   end
 
-  test 'validates presence of valid period' do
-    %w[invalid 2023abc-01 2023-05xxx 2023-05123456789].each do |value|
+  %w[invalid 2023abc-01 2022-14].each do |value|
+    test "validation error for invalid value '#{value}'" do
       @invoice.update(period: value)
 
       assert_not @invoice.valid?
@@ -145,9 +145,11 @@ class InvoiceTest < ActiveSupport::TestCase
     end
   end
 
-  test 'validates invoice invalid month' do
-    assert_raises ArgumentError do
-      @invoice.update(period: Month.new(Time.zone.local(2022, 13, 1)))
+  [123, nil, Date].each do |value|
+    test "#period= raises an error if argument of invalid type #{value.class} is passed" do
+      assert_raises ArgumentError do
+        @invoice.update(period: value)
+      end
     end
   end
 
@@ -387,12 +389,6 @@ class InvoiceTest < ActiveSupport::TestCase
   test 'find only "old ones" with #before scope' do
     setup_1984_and_2009_invoices
     assert_equal 0, Invoice.before(Time.utc(1964, 10, 2)).count
-  end
-
-  test 'find_by_month' do
-    setup_1984_and_2009_invoices
-    assert_equal @invoice_one, Invoice.find_by_month('2009-06')
-    assert_equal @invoice_two, Invoice.find_by_month('1984-10')
   end
 
   test 'opened_by_buyer' do

--- a/test/unit/month_test.rb
+++ b/test/unit/month_test.rb
@@ -30,18 +30,18 @@ class MonthTest < ActiveSupport::TestCase
     assert_equal 2001, m.begin.year
   end
 
-  test 'parse not exactly right string' do
-    assert_equal Month.new(2011, 1), Month.parse_month('2011-01-05')
-  end
-
   test 'parse robustly' do
     assert_nil Month.parse_month nil
   end
 
   test 'return nil when parsing invalid date' do
     assert_nil Month.parse_month 'not-a-date'
-    assert_nil Month.parse_month 'giberish'
+    assert_nil Month.parse_month 'gibberish'
     assert_nil Month.parse_month '2020-14'
+    assert_nil Month.parse_month '2011-01-05'
+    assert_nil Month.parse_month '2023abc-01'
+    assert_nil Month.parse_month '2023-05xxx'
+    assert_nil Month.parse_month '2023-05123456789'
   end
 
   test 'raise with wrong params' do


### PR DESCRIPTION
Follow-up for https://github.com/3scale/porta/pull/3073

QE detected some values that were not rejected by the validation:

1. Values such as `2023-05xxx` or `2023abc-05` were accepted and applied successfully, setting the period to May 2023.
This is because `Time.zone.local` allows this:
```
[201] pry(main)> Time.zone.local('2023', '05xxx')
=> Mon, 01 May 2023 00:00:00 UTC +00:00
[202] pry(main)> Time.zone.local('2023abc', '05')
=> Mon, 01 May 2023 00:00:00 UTC +00:00
```
I guess this is because how strings are transformed into integers under the hood.
```
[208] pry(main)> ['2023abc', '05xxx'].map(&:to_i)
=> [2023, 5]
```

The PR adds a regex match for `/^(\d{4})-(\d{2})(?:-\d{2})?$/` to avoid this.

The last non-capturing group is for the optional day, e.g. `2023-04-01`. This is to avoid breaking the existing Month behavior (there was a test allowing this).

2. In case the month was numeric but too long to fit into integer, there was a RangeError thrown - an unhandled exception that would result in the user seeing the Internal Error screen. This actually happens in production right now.

A value to reproduce would be `2023-05123456789`:
```
[209] pry(main)> Month.parse_month('2023-05123456789')
RangeError: integer 5123456789 too big to convert to `int'
```

The PR adds catching the RangeError, however with the regex match I think it's not really needed, not sure whether to keep it.
