### PR TITLE
Fix Context selector items

### DIFF
--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -129,11 +129,11 @@ module MenuHelper # rubocop:disable Metrics/ModuleLength
     {
       toggle: { title: title, icon: icon },
       menuItems: [
-        { title: 'Dashboard',        href: provider_admin_dashboard_path,    icon: :home,     disabled: %i[dashboard].include?(active_menu) },
-        { title: 'Audience',         href: audience_link,                    icon: :bullseye, disabled: %i[buyers finance cms site].include?(active_menu) },
-        { title: 'Products',         href: admin_services_path,              icon: :cubes,    disabled: %i[serviceadmin monitoring products].include?(active_menu) },
-        { title: 'Backends',         href: provider_admin_backend_apis_path, icon: :cube,     disabled: %i[backend_api backend_apis].include?(active_menu) },
-        { title: 'Account Settings', href: settings_link,                    icon: :cog,      disabled: %i[account personal active_docs].include?(active_menu) }
+        { title: 'Dashboard',        href: provider_admin_dashboard_path,    icon: :home,     disabled: active_menu == :dashboard },
+        { title: 'Audience',         href: audience_link,                    icon: :bullseye, disabled: false },
+        { title: 'Products',         href: admin_services_path,              icon: :cubes,    disabled: active_menu == :products },
+        { title: 'Backends',         href: provider_admin_backend_apis_path, icon: :cube,     disabled: active_menu == :backend_apis },
+        { title: 'Account Settings', href: settings_link,                    icon: :cog,      disabled: false }
       ],
     }
   end

--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -129,10 +129,10 @@ module MenuHelper # rubocop:disable Metrics/ModuleLength
     {
       toggle: { title: title, icon: icon },
       menuItems: [
-        { title: 'Dashboard',        href: provider_admin_dashboard_path,    icon: :home,     disabled: active_menu == :dashboard },
+        { title: 'Dashboard',        href: provider_admin_dashboard_path,    icon: :home,     disabled: false }, #active_menu == :dashboard },
         { title: 'Audience',         href: audience_link,                    icon: :bullseye, disabled: false },
-        { title: 'Products',         href: admin_services_path,              icon: :cubes,    disabled: active_menu == :products },
-        { title: 'Backends',         href: provider_admin_backend_apis_path, icon: :cube,     disabled: active_menu == :backend_apis },
+        { title: 'Products',         href: admin_services_path,              icon: :cubes,    disabled: false }, #active_menu == :products },
+        { title: 'Backends',         href: provider_admin_backend_apis_path, icon: :cube,     disabled: false }, #active_menu == :backend_apis },
         { title: 'Account Settings', href: settings_link,                    icon: :cog,      disabled: false }
       ],
     }

--- a/app/javascript/src/Navigation/components/ContextSelector.scss
+++ b/app/javascript/src/Navigation/components/ContextSelector.scss
@@ -10,11 +10,6 @@
   --pf-c-context-selector--Width: initial;
 }
 
-.header-context-selector__toggle-text-icon {
-  margin-right: var(--pf-global--spacer--sm);
-  color: var(--pf-global--active-color--100);
-}
-
 .pf-c-context-selector__menu-list {
   overflow-y: auto;
 }

--- a/app/javascript/src/Navigation/components/InlineIcon.scss
+++ b/app/javascript/src/Navigation/components/InlineIcon.scss
@@ -1,3 +1,8 @@
-.header-context-selector__item-icon {
+.pf-c-icon__inline-icon {
   margin-right: var(--pf-global--spacer--sm);
+}
+
+.pf-c-icon__toggle-inline-icon {
+  margin-right: var(--pf-global--spacer--sm);
+  color: var(--pf-global--active-color--100);
 }

--- a/app/javascript/src/Navigation/components/InlineIcon.tsx
+++ b/app/javascript/src/Navigation/components/InlineIcon.tsx
@@ -1,17 +1,6 @@
 import { Icon } from '@patternfly/react-core'
-import BookIcon from '@patternfly/react-icons/dist/js/icons/book-icon'
-import BullseyeIcon from '@patternfly/react-icons/dist/js/icons/bullseye-icon'
-import CodeIcon from '@patternfly/react-icons/dist/js/icons/code-icon'
-import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon'
-import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon'
-import CubesIcon from '@patternfly/react-icons/dist/js/icons/cubes-icon'
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon'
-import HomeIcon from '@patternfly/react-icons/dist/js/icons/home-icon'
-import LeafIcon from '@patternfly/react-icons/dist/js/icons/leaf-icon'
-import PuzzlePieceIcon from '@patternfly/react-icons/dist/js/icons/puzzle-piece-icon'
-import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon'
 
-import type { FunctionComponent, ReactNode } from 'react'
+import type { FunctionComponent } from 'react'
 
 import './InlineIcon.scss'
 
@@ -20,73 +9,12 @@ interface Props {
   toggle?: boolean;
 }
 
-/**
- * HACK: FIXME: Instead of importing and rendering components in a hacky switch block, ideally it could
- * return the HTML version of Patternfly's Icon:
- *   (icon) => (
- *     <span class="pf-c-icon">
- *       <span class="pf-c-icon__content">
- *         <i class={`fas fa-${icon}`} aria-hidden="true"></i>
- *       </span>
- *     </span>
- *   )
- */
-
 const InlineIcon: FunctionComponent<Props> = ({ icon, toggle }) => {
-  let iconComponent: ReactNode = null
-
-  switch (icon) {
-
-    case 'book':
-      iconComponent = <BookIcon />
-      break
-
-    case 'bullseye':
-      iconComponent = <BullseyeIcon />
-      break
-
-    case 'code':
-      iconComponent = <CodeIcon />
-      break
-
-    case 'cog':
-      iconComponent = <CogIcon />
-      break
-
-    case 'cube':
-      iconComponent = <CubeIcon />
-      break
-
-    case 'cubes':
-      iconComponent = <CubesIcon />
-      break
-
-    case 'external-link':
-      iconComponent = <ExternalLinkAltIcon />
-      break
-
-    case 'home':
-      iconComponent = <HomeIcon />
-      break
-
-    case 'leaf':
-      iconComponent = <LeafIcon />
-      break
-
-    case 'puzzle-piece':
-      iconComponent = <PuzzlePieceIcon />
-      break
-
-    case 'times':
-      iconComponent = <TimesIcon />
-      break
-  }
-
-  const className = `header-context-selector__item-icon${toggle ? ' header-context-selector__toggle-text-icon' : ''}`
+  const className = toggle ? 'pf-c-icon__toggle-inline-icon' : 'pf-c-icon__inline-icon'
 
   return (
     <Icon isInline className={className}>
-      {iconComponent}
+      <i aria-hidden="true" className={`fa fa-${icon}`} />
     </Icon>
   )
 }

--- a/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.tsx.snap
+++ b/spec/javascripts/Navigation/__snapshots__/ContextSelector.spec.tsx.snap
@@ -240,24 +240,15 @@ exports[`should render itself 1`] = `
                       class="pf-c-context-selector__toggle-text"
                     >
                       <span
-                        class="pf-c-icon pf-m-inline header-context-selector__item-icon header-context-selector__toggle-text-icon"
+                        class="pf-c-icon pf-m-inline pf-c-icon__toggle-inline-icon"
                       >
                         <span
                           class="pf-c-icon__content"
                         >
-                          <svg
+                          <i
                             aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 576 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z"
-                            />
-                          </svg>
+                            class="fa fa-home"
+                          />
                         </span>
                       </span>
                       Dashboard
@@ -300,24 +291,15 @@ exports[`should render itself 1`] = `
                       tabindex="-1"
                     >
                       <span
-                        class="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                        class="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                       >
                         <span
                           class="pf-c-icon__content"
                         >
-                          <svg
+                          <i
                             aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 576 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z"
-                            />
-                          </svg>
+                            class="fa fa-home"
+                          />
                         </span>
                       </span>
                       Dashboard
@@ -337,24 +319,15 @@ exports[`should render itself 1`] = `
                       tabindex="-1"
                     >
                       <span
-                        class="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                        class="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                       >
                         <span
                           class="pf-c-icon__content"
                         >
-                          <svg
+                          <i
                             aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 496 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M248 8C111.03 8 0 119.03 0 256s111.03 248 248 248 248-111.03 248-248S384.97 8 248 8zm0 432c-101.69 0-184-82.29-184-184 0-101.69 82.29-184 184-184 101.69 0 184 82.29 184 184 0 101.69-82.29 184-184 184zm0-312c-70.69 0-128 57.31-128 128s57.31 128 128 128 128-57.31 128-128-57.31-128-128-128zm0 192c-35.29 0-64-28.71-64-64s28.71-64 64-64 64 28.71 64 64-28.71 64-64 64z"
-                            />
-                          </svg>
+                            class="fa fa-bullseye"
+                          />
                         </span>
                       </span>
                       Audience
@@ -374,24 +347,15 @@ exports[`should render itself 1`] = `
                       tabindex="-1"
                     >
                       <span
-                        class="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                        class="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                       >
                         <span
                           class="pf-c-icon__content"
                         >
-                          <svg
+                          <i
                             aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 512 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M488.6 250.2L392 214V105.5c0-15-9.3-28.4-23.4-33.7l-100-37.5c-8.1-3.1-17.1-3.1-25.3 0l-100 37.5c-14.1 5.3-23.4 18.7-23.4 33.7V214l-96.6 36.2C9.3 255.5 0 268.9 0 283.9V394c0 13.6 7.7 26.1 19.9 32.2l100 50c10.1 5.1 22.1 5.1 32.2 0l103.9-52 103.9 52c10.1 5.1 22.1 5.1 32.2 0l100-50c12.2-6.1 19.9-18.6 19.9-32.2V283.9c0-15-9.3-28.4-23.4-33.7zM358 214.8l-85 31.9v-68.2l85-37v73.3zM154 104.1l102-38.2 102 38.2v.6l-102 41.4-102-41.4v-.6zm84 291.1l-85 42.5v-79.1l85-38.8v75.4zm0-112l-102 41.4-102-41.4v-.6l102-38.2 102 38.2v.6zm240 112l-85 42.5v-79.1l85-38.8v75.4zm0-112l-102 41.4-102-41.4v-.6l102-38.2 102 38.2v.6z"
-                            />
-                          </svg>
+                            class="fa fa-cubes"
+                          />
                         </span>
                       </span>
                       Products
@@ -411,24 +375,15 @@ exports[`should render itself 1`] = `
                       tabindex="-1"
                     >
                       <span
-                        class="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                        class="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                       >
                         <span
                           class="pf-c-icon__content"
                         >
-                          <svg
+                          <i
                             aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 512 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M239.1 6.3l-208 78c-18.7 7-31.1 25-31.1 45v225.1c0 18.2 10.3 34.8 26.5 42.9l208 104c13.5 6.8 29.4 6.8 42.9 0l208-104c16.3-8.1 26.5-24.8 26.5-42.9V129.3c0-20-12.4-37.9-31.1-44.9l-208-78C262 2.2 250 2.2 239.1 6.3zM256 68.4l192 72v1.1l-192 78-192-78v-1.1l192-72zm32 356V275.5l160-65v133.9l-160 80z"
-                            />
-                          </svg>
+                            class="fa fa-cube"
+                          />
                         </span>
                       </span>
                       Backends
@@ -448,24 +403,15 @@ exports[`should render itself 1`] = `
                       tabindex="-1"
                     >
                       <span
-                        class="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                        class="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                       >
                         <span
                           class="pf-c-icon__content"
                         >
-                          <svg
+                          <i
                             aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 512 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M487.4 315.7l-42.6-24.6c4.3-23.2 4.3-47 0-70.2l42.6-24.6c4.9-2.8 7.1-8.6 5.5-14-11.1-35.6-30-67.8-54.7-94.6-3.8-4.1-10-5.1-14.8-2.3L380.8 110c-17.9-15.4-38.5-27.3-60.8-35.1V25.8c0-5.6-3.9-10.5-9.4-11.7-36.7-8.2-74.3-7.8-109.2 0-5.5 1.2-9.4 6.1-9.4 11.7V75c-22.2 7.9-42.8 19.8-60.8 35.1L88.7 85.5c-4.9-2.8-11-1.9-14.8 2.3-24.7 26.7-43.6 58.9-54.7 94.6-1.7 5.4.6 11.2 5.5 14L67.3 221c-4.3 23.2-4.3 47 0 70.2l-42.6 24.6c-4.9 2.8-7.1 8.6-5.5 14 11.1 35.6 30 67.8 54.7 94.6 3.8 4.1 10 5.1 14.8 2.3l42.6-24.6c17.9 15.4 38.5 27.3 60.8 35.1v49.2c0 5.6 3.9 10.5 9.4 11.7 36.7 8.2 74.3 7.8 109.2 0 5.5-1.2 9.4-6.1 9.4-11.7v-49.2c22.2-7.9 42.8-19.8 60.8-35.1l42.6 24.6c4.9 2.8 11 1.9 14.8-2.3 24.7-26.7 43.6-58.9 54.7-94.6 1.5-5.5-.7-11.3-5.6-14.1zM256 336c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z"
-                            />
-                          </svg>
+                            class="fa fa-cog"
+                          />
                         </span>
                       </span>
                       Account Settings
@@ -522,24 +468,15 @@ exports[`should render itself 1`] = `
                         class="pf-c-context-selector__toggle-text"
                       >
                         <span
-                          class="pf-c-icon pf-m-inline header-context-selector__item-icon header-context-selector__toggle-text-icon"
+                          class="pf-c-icon pf-m-inline pf-c-icon__toggle-inline-icon"
                         >
                           <span
                             class="pf-c-icon__content"
                           >
-                            <svg
+                            <i
                               aria-hidden="true"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 576 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z"
-                              />
-                            </svg>
+                              class="fa fa-home"
+                            />
                           </span>
                         </span>
                         Dashboard
@@ -582,24 +519,15 @@ exports[`should render itself 1`] = `
                         tabindex="-1"
                       >
                         <span
-                          class="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                          class="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                         >
                           <span
                             class="pf-c-icon__content"
                           >
-                            <svg
+                            <i
                               aria-hidden="true"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 576 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z"
-                              />
-                            </svg>
+                              class="fa fa-home"
+                            />
                           </span>
                         </span>
                         Dashboard
@@ -619,24 +547,15 @@ exports[`should render itself 1`] = `
                         tabindex="-1"
                       >
                         <span
-                          class="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                          class="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                         >
                           <span
                             class="pf-c-icon__content"
                           >
-                            <svg
+                            <i
                               aria-hidden="true"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 496 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M248 8C111.03 8 0 119.03 0 256s111.03 248 248 248 248-111.03 248-248S384.97 8 248 8zm0 432c-101.69 0-184-82.29-184-184 0-101.69 82.29-184 184-184 101.69 0 184 82.29 184 184 0 101.69-82.29 184-184 184zm0-312c-70.69 0-128 57.31-128 128s57.31 128 128 128 128-57.31 128-128-57.31-128-128-128zm0 192c-35.29 0-64-28.71-64-64s28.71-64 64-64 64 28.71 64 64-28.71 64-64 64z"
-                              />
-                            </svg>
+                              class="fa fa-bullseye"
+                            />
                           </span>
                         </span>
                         Audience
@@ -656,24 +575,15 @@ exports[`should render itself 1`] = `
                         tabindex="-1"
                       >
                         <span
-                          class="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                          class="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                         >
                           <span
                             class="pf-c-icon__content"
                           >
-                            <svg
+                            <i
                               aria-hidden="true"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 512 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M488.6 250.2L392 214V105.5c0-15-9.3-28.4-23.4-33.7l-100-37.5c-8.1-3.1-17.1-3.1-25.3 0l-100 37.5c-14.1 5.3-23.4 18.7-23.4 33.7V214l-96.6 36.2C9.3 255.5 0 268.9 0 283.9V394c0 13.6 7.7 26.1 19.9 32.2l100 50c10.1 5.1 22.1 5.1 32.2 0l103.9-52 103.9 52c10.1 5.1 22.1 5.1 32.2 0l100-50c12.2-6.1 19.9-18.6 19.9-32.2V283.9c0-15-9.3-28.4-23.4-33.7zM358 214.8l-85 31.9v-68.2l85-37v73.3zM154 104.1l102-38.2 102 38.2v.6l-102 41.4-102-41.4v-.6zm84 291.1l-85 42.5v-79.1l85-38.8v75.4zm0-112l-102 41.4-102-41.4v-.6l102-38.2 102 38.2v.6zm240 112l-85 42.5v-79.1l85-38.8v75.4zm0-112l-102 41.4-102-41.4v-.6l102-38.2 102 38.2v.6z"
-                              />
-                            </svg>
+                              class="fa fa-cubes"
+                            />
                           </span>
                         </span>
                         Products
@@ -693,24 +603,15 @@ exports[`should render itself 1`] = `
                         tabindex="-1"
                       >
                         <span
-                          class="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                          class="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                         >
                           <span
                             class="pf-c-icon__content"
                           >
-                            <svg
+                            <i
                               aria-hidden="true"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 512 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M239.1 6.3l-208 78c-18.7 7-31.1 25-31.1 45v225.1c0 18.2 10.3 34.8 26.5 42.9l208 104c13.5 6.8 29.4 6.8 42.9 0l208-104c16.3-8.1 26.5-24.8 26.5-42.9V129.3c0-20-12.4-37.9-31.1-44.9l-208-78C262 2.2 250 2.2 239.1 6.3zM256 68.4l192 72v1.1l-192 78-192-78v-1.1l192-72zm32 356V275.5l160-65v133.9l-160 80z"
-                              />
-                            </svg>
+                              class="fa fa-cube"
+                            />
                           </span>
                         </span>
                         Backends
@@ -730,24 +631,15 @@ exports[`should render itself 1`] = `
                         tabindex="-1"
                       >
                         <span
-                          class="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                          class="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                         >
                           <span
                             class="pf-c-icon__content"
                           >
-                            <svg
+                            <i
                               aria-hidden="true"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 512 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M487.4 315.7l-42.6-24.6c4.3-23.2 4.3-47 0-70.2l42.6-24.6c4.9-2.8 7.1-8.6 5.5-14-11.1-35.6-30-67.8-54.7-94.6-3.8-4.1-10-5.1-14.8-2.3L380.8 110c-17.9-15.4-38.5-27.3-60.8-35.1V25.8c0-5.6-3.9-10.5-9.4-11.7-36.7-8.2-74.3-7.8-109.2 0-5.5 1.2-9.4 6.1-9.4 11.7V75c-22.2 7.9-42.8 19.8-60.8 35.1L88.7 85.5c-4.9-2.8-11-1.9-14.8 2.3-24.7 26.7-43.6 58.9-54.7 94.6-1.7 5.4.6 11.2 5.5 14L67.3 221c-4.3 23.2-4.3 47 0 70.2l-42.6 24.6c-4.9 2.8-7.1 8.6-5.5 14 11.1 35.6 30 67.8 54.7 94.6 3.8 4.1 10 5.1 14.8 2.3l42.6-24.6c17.9 15.4 38.5 27.3 60.8 35.1v49.2c0 5.6 3.9 10.5 9.4 11.7 36.7 8.2 74.3 7.8 109.2 0 5.5-1.2 9.4-6.1 9.4-11.7v-49.2c22.2-7.9 42.8-19.8 60.8-35.1l42.6 24.6c4.9 2.8 11 1.9 14.8-2.3 24.7-26.7 43.6-58.9 54.7-94.6 1.5-5.5-.7-11.3-5.6-14.1zM256 336c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z"
-                              />
-                            </svg>
+                              class="fa fa-cog"
+                            />
                           </span>
                         </span>
                         Account Settings
@@ -784,39 +676,19 @@ exports[`should render itself 1`] = `
                     toggle={true}
                   >
                     <Icon
-                      className="header-context-selector__item-icon header-context-selector__toggle-text-icon"
+                      className="pf-c-icon__toggle-inline-icon"
                       isInline={true}
                     >
                       <span
-                        className="pf-c-icon pf-m-inline header-context-selector__item-icon header-context-selector__toggle-text-icon"
+                        className="pf-c-icon pf-m-inline pf-c-icon__toggle-inline-icon"
                       >
                         <span
                           className="pf-c-icon__content"
                         >
-                          <HomeIcon
-                            color="currentColor"
-                            noVerticalAlign={false}
-                            size="sm"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              aria-labelledby={null}
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style={
-                                {
-                                  "verticalAlign": "-0.125em",
-                                }
-                              }
-                              viewBox="0 0 576 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z"
-                              />
-                            </svg>
-                          </HomeIcon>
+                          <i
+                            aria-hidden="true"
+                            className="fa fa-home"
+                          />
                         </span>
                       </span>
                     </Icon>
@@ -932,39 +804,19 @@ exports[`should render itself 1`] = `
                       icon="home"
                     >
                       <Icon
-                        className="header-context-selector__item-icon"
+                        className="pf-c-icon__inline-icon"
                         isInline={true}
                       >
                         <span
-                          className="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                          className="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                         >
                           <span
                             className="pf-c-icon__content"
                           >
-                            <HomeIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
-                                  {
-                                    "verticalAlign": "-0.125em",
-                                  }
-                                }
-                                viewBox="0 0 576 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z"
-                                />
-                              </svg>
-                            </HomeIcon>
+                            <i
+                              aria-hidden="true"
+                              className="fa fa-home"
+                            />
                           </span>
                         </span>
                       </Icon>
@@ -1031,39 +883,19 @@ exports[`should render itself 1`] = `
                       icon="bullseye"
                     >
                       <Icon
-                        className="header-context-selector__item-icon"
+                        className="pf-c-icon__inline-icon"
                         isInline={true}
                       >
                         <span
-                          className="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                          className="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                         >
                           <span
                             className="pf-c-icon__content"
                           >
-                            <BullseyeIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
-                                  {
-                                    "verticalAlign": "-0.125em",
-                                  }
-                                }
-                                viewBox="0 0 496 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M248 8C111.03 8 0 119.03 0 256s111.03 248 248 248 248-111.03 248-248S384.97 8 248 8zm0 432c-101.69 0-184-82.29-184-184 0-101.69 82.29-184 184-184 101.69 0 184 82.29 184 184 0 101.69-82.29 184-184 184zm0-312c-70.69 0-128 57.31-128 128s57.31 128 128 128 128-57.31 128-128-57.31-128-128-128zm0 192c-35.29 0-64-28.71-64-64s28.71-64 64-64 64 28.71 64 64-28.71 64-64 64z"
-                                />
-                              </svg>
-                            </BullseyeIcon>
+                            <i
+                              aria-hidden="true"
+                              className="fa fa-bullseye"
+                            />
                           </span>
                         </span>
                       </Icon>
@@ -1130,39 +962,19 @@ exports[`should render itself 1`] = `
                       icon="cubes"
                     >
                       <Icon
-                        className="header-context-selector__item-icon"
+                        className="pf-c-icon__inline-icon"
                         isInline={true}
                       >
                         <span
-                          className="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                          className="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                         >
                           <span
                             className="pf-c-icon__content"
                           >
-                            <CubesIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
-                                  {
-                                    "verticalAlign": "-0.125em",
-                                  }
-                                }
-                                viewBox="0 0 512 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M488.6 250.2L392 214V105.5c0-15-9.3-28.4-23.4-33.7l-100-37.5c-8.1-3.1-17.1-3.1-25.3 0l-100 37.5c-14.1 5.3-23.4 18.7-23.4 33.7V214l-96.6 36.2C9.3 255.5 0 268.9 0 283.9V394c0 13.6 7.7 26.1 19.9 32.2l100 50c10.1 5.1 22.1 5.1 32.2 0l103.9-52 103.9 52c10.1 5.1 22.1 5.1 32.2 0l100-50c12.2-6.1 19.9-18.6 19.9-32.2V283.9c0-15-9.3-28.4-23.4-33.7zM358 214.8l-85 31.9v-68.2l85-37v73.3zM154 104.1l102-38.2 102 38.2v.6l-102 41.4-102-41.4v-.6zm84 291.1l-85 42.5v-79.1l85-38.8v75.4zm0-112l-102 41.4-102-41.4v-.6l102-38.2 102 38.2v.6zm240 112l-85 42.5v-79.1l85-38.8v75.4zm0-112l-102 41.4-102-41.4v-.6l102-38.2 102 38.2v.6z"
-                                />
-                              </svg>
-                            </CubesIcon>
+                            <i
+                              aria-hidden="true"
+                              className="fa fa-cubes"
+                            />
                           </span>
                         </span>
                       </Icon>
@@ -1229,39 +1041,19 @@ exports[`should render itself 1`] = `
                       icon="cube"
                     >
                       <Icon
-                        className="header-context-selector__item-icon"
+                        className="pf-c-icon__inline-icon"
                         isInline={true}
                       >
                         <span
-                          className="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                          className="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                         >
                           <span
                             className="pf-c-icon__content"
                           >
-                            <CubeIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
-                                  {
-                                    "verticalAlign": "-0.125em",
-                                  }
-                                }
-                                viewBox="0 0 512 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M239.1 6.3l-208 78c-18.7 7-31.1 25-31.1 45v225.1c0 18.2 10.3 34.8 26.5 42.9l208 104c13.5 6.8 29.4 6.8 42.9 0l208-104c16.3-8.1 26.5-24.8 26.5-42.9V129.3c0-20-12.4-37.9-31.1-44.9l-208-78C262 2.2 250 2.2 239.1 6.3zM256 68.4l192 72v1.1l-192 78-192-78v-1.1l192-72zm32 356V275.5l160-65v133.9l-160 80z"
-                                />
-                              </svg>
-                            </CubeIcon>
+                            <i
+                              aria-hidden="true"
+                              className="fa fa-cube"
+                            />
                           </span>
                         </span>
                       </Icon>
@@ -1328,39 +1120,19 @@ exports[`should render itself 1`] = `
                       icon="cog"
                     >
                       <Icon
-                        className="header-context-selector__item-icon"
+                        className="pf-c-icon__inline-icon"
                         isInline={true}
                       >
                         <span
-                          className="pf-c-icon pf-m-inline header-context-selector__item-icon"
+                          className="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
                         >
                           <span
                             className="pf-c-icon__content"
                           >
-                            <CogIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
-                                  {
-                                    "verticalAlign": "-0.125em",
-                                  }
-                                }
-                                viewBox="0 0 512 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M487.4 315.7l-42.6-24.6c4.3-23.2 4.3-47 0-70.2l42.6-24.6c4.9-2.8 7.1-8.6 5.5-14-11.1-35.6-30-67.8-54.7-94.6-3.8-4.1-10-5.1-14.8-2.3L380.8 110c-17.9-15.4-38.5-27.3-60.8-35.1V25.8c0-5.6-3.9-10.5-9.4-11.7-36.7-8.2-74.3-7.8-109.2 0-5.5 1.2-9.4 6.1-9.4 11.7V75c-22.2 7.9-42.8 19.8-60.8 35.1L88.7 85.5c-4.9-2.8-11-1.9-14.8 2.3-24.7 26.7-43.6 58.9-54.7 94.6-1.7 5.4.6 11.2 5.5 14L67.3 221c-4.3 23.2-4.3 47 0 70.2l-42.6 24.6c-4.9 2.8-7.1 8.6-5.5 14 11.1 35.6 30 67.8 54.7 94.6 3.8 4.1 10 5.1 14.8 2.3l42.6-24.6c17.9 15.4 38.5 27.3 60.8 35.1v49.2c0 5.6 3.9 10.5 9.4 11.7 36.7 8.2 74.3 7.8 109.2 0 5.5-1.2 9.4-6.1 9.4-11.7v-49.2c22.2-7.9 42.8-19.8 60.8-35.1l42.6 24.6c4.9 2.8 11 1.9 14.8-2.3 24.7-26.7 43.6-58.9 54.7-94.6 1.5-5.5-.7-11.3-5.6-14.1zM256 336c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z"
-                                />
-                              </svg>
-                            </CogIcon>
+                            <i
+                              aria-hidden="true"
+                              className="fa fa-cog"
+                            />
                           </span>
                         </span>
                       </Icon>

--- a/spec/javascripts/Navigation/components/__snapshots__/Masthead.spec.tsx.snap
+++ b/spec/javascripts/Navigation/components/__snapshots__/Masthead.spec.tsx.snap
@@ -33,39 +33,19 @@ exports[`Session menu should describe who is currently signed in 1`] = `
       icon="times"
     >
       <Icon
-        className="header-context-selector__item-icon"
+        className="pf-c-icon__inline-icon"
         isInline={true}
       >
         <span
-          className="pf-c-icon pf-m-inline header-context-selector__item-icon"
+          className="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
         >
           <span
             className="pf-c-icon__content"
           >
-            <TimesIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 352 512"
-                width="1em"
-              >
-                <path
-                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                />
-              </svg>
-            </TimesIcon>
+            <i
+              aria-hidden="true"
+              className="fa fa-times"
+            />
           </span>
         </span>
       </Icon>
@@ -130,39 +110,19 @@ exports[`Session menu should describe who is currently signed in 2`] = `
       icon="times"
     >
       <Icon
-        className="header-context-selector__item-icon"
+        className="pf-c-icon__inline-icon"
         isInline={true}
       >
         <span
-          className="pf-c-icon pf-m-inline header-context-selector__item-icon"
+          className="pf-c-icon pf-m-inline pf-c-icon__inline-icon"
         >
           <span
             className="pf-c-icon__content"
           >
-            <TimesIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 352 512"
-                width="1em"
-              >
-                <path
-                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                />
-              </svg>
-            </TimesIcon>
+            <i
+              aria-hidden="true"
+              className="fa fa-times"
+            />
           </span>
         </span>
       </Icon>


### PR DESCRIPTION
[THREESCALE-9674: Cannot select context Products from other pages](https://issues.redhat.com/browse/THREESCALE-9674)

The "disability" policy in Context selector is too restrictive at the moment. Any page under the Product context would disable the "Products" option from the Context selector. Only the following options should be disabled:
* Dashboard when in dashboard
* Products when in products index
* Backend APIs when in backends index

But, **⚠️ no items will be disabled to maintain the same behaviour.**

![Screenshot 2023-05-31 at 17 37 32](https://github.com/3scale/porta/assets/11672286/db6270d8-a243-42a0-adaf-fa08b4918cf4)

![Screenshot 2023-05-31 at 17 37 23](https://github.com/3scale/porta/assets/11672286/a92ed68f-78da-4189-8aa7-86123361fd9e)
