### PR TITLE
CircleCI: Allow manually clearing cache

### DIFF
--- a/.circleci/asset_paths
+++ b/.circleci/asset_paths
@@ -4,7 +4,7 @@ app/javascript
 app/assets
 app/lib/pdf/images
 babel.config.js
-cdn
+public/dev-portal-assets
 config/compass.rb
 config/webpack
 config/webpacker.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ store-log-artifacts: &store-log-artifacts
     destination: log
 
 npm-cache-key: &npm-cache-key porta-{{ .Environment.CACHE_VERSION }}-node-v10-{{ checksum "yarn.lock" }}
-bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ .Environment.DB }}
+bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ $DB }}
 assets-cache-key: &assets-cache-key porta-{{ .Environment.CACHE_VERSION }}-asset-cache-{{ checksum "tmp/assets_related_checksums" }}
 
 restore-npm-cache: &restore-npm-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ store-log-artifacts: &store-log-artifacts
     destination: log
 
 npm-cache-key: &npm-cache-key porta-{{ .Environment.CACHE_VERSION }}-node-modules-{{ checksum "yarn.lock" }}
-bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "/tmp/db" }}
+bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "/tmp/db" }}
 assets-cache-key: &assets-cache-key porta-{{ .Environment.CACHE_VERSION }}-asset-cache-{{ checksum "tmp/assets_related_checksums" }}
 
 restore-npm-cache: &restore-npm-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,9 @@ store-log-artifacts: &store-log-artifacts
     path: log
     destination: log
 
-npm-cache-key: &npm-cache-key node-v10-{{ checksum "yarn.lock" }}-{{ .Environment.CACHE_VERSION }}
-bundle-cache-key: &bundle-cache-key bundler-gems-{{ .Environment.DB }}-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ .Environment.CACHE_VERSION }}
-assets-cache-key: &assets-cache-key asset-cache-{{ checksum "tmp/assets_related_checksums" }}-{{ .Environment.CACHE_VERSION }}
+npm-cache-key: &npm-cache-key porta-{{ .Environment.CACHE_VERSION }}-node-v10-{{ checksum "yarn.lock" }}
+bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ .Environment.DB }}-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+assets-cache-key: &assets-cache-key porta-{{ .Environment.CACHE_VERSION }}-asset-cache-{{ checksum "tmp/assets_related_checksums" }}
 
 restore-npm-cache: &restore-npm-cache
   restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ store-log-artifacts: &store-log-artifacts
     destination: log
 
 npm-cache-key: &npm-cache-key porta-{{ .Environment.CACHE_VERSION }}-node-v10-{{ checksum "yarn.lock" }}
-bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ .Environment.DB }}-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ .Environment.DB }}
 assets-cache-key: &assets-cache-key porta-{{ .Environment.CACHE_VERSION }}-asset-cache-{{ checksum "tmp/assets_related_checksums" }}
 
 restore-npm-cache: &restore-npm-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,6 +350,7 @@ executors:
     docker:
       - *system-builder-ruby26
     environment:
+      DB: << parameters.database >>
     working_directory: /opt/app-root/src/project
 
   builder-with-mysql-ruby26: &builder-with-mysql-ruby26

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ store-log-artifacts: &store-log-artifacts
     path: log
     destination: log
 
-npm-cache-key: &npm-cache-key porta-{{ .Environment.CACHE_VERSION }}-node-v10-{{ checksum "yarn.lock" }}
+npm-cache-key: &npm-cache-key porta-{{ .Environment.CACHE_VERSION }}-node-modules-{{ checksum "yarn.lock" }}
 bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "/tmp/db" }}
 assets-cache-key: &assets-cache-key porta-{{ .Environment.CACHE_VERSION }}-asset-cache-{{ checksum "tmp/assets_related_checksums" }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ store-log-artifacts: &store-log-artifacts
     destination: log
 
 npm-cache-key: &npm-cache-key porta-{{ .Environment.CACHE_VERSION }}-node-v10-{{ checksum "yarn.lock" }}
-bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ $DB }}
+bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ checksum "/tmp/db" }}
 assets-cache-key: &assets-cache-key porta-{{ .Environment.CACHE_VERSION }}-asset-cache-{{ checksum "tmp/assets_related_checksums" }}
 
 restore-npm-cache: &restore-npm-cache
@@ -210,6 +210,9 @@ commands: # reusable commands with parameters
         default: []
     steps:
       - checkout
+      - run:
+          name: Make $DB Available for cache keys
+          command: echo $DB > /tmp/db
       - restore-gem-cache
       - steps: << parameters.extra-deps >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ store-log-artifacts: &store-log-artifacts
     destination: log
 
 npm-cache-key: &npm-cache-key porta-{{ .Environment.CACHE_VERSION }}-node-v10-{{ checksum "yarn.lock" }}
-bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ .Environment.DB }}
 assets-cache-key: &assets-cache-key porta-{{ .Environment.CACHE_VERSION }}-asset-cache-{{ checksum "tmp/assets_related_checksums" }}
+#bundle-cache-key: defined at restore-gem-cache and save-gem-cache because {{ .Environment.DB }} is not available here
 
 restore-npm-cache: &restore-npm-cache
   restore_cache:
@@ -321,7 +321,7 @@ commands: # reusable commands with parameters
   save-gem-cache:
     steps:
       - save_cache:
-          key: *bundle-cache-key
+          key: porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ .Environment.DB }}
           paths:
             - ./vendor/bundle
             - ./.bundle/
@@ -329,8 +329,7 @@ commands: # reusable commands with parameters
   restore-gem-cache:
     steps:
       - restore_cache:
-          keys:
-            - *bundle-cache-key
+          key: porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ .Environment.DB }}
 
   upload-artifacts:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,9 @@ store-log-artifacts: &store-log-artifacts
     path: log
     destination: log
 
-npm-cache-key: &npm-cache-key node-v10-{{ checksum "yarn.lock" }}-5
-bundle-cache-key: &bundle-cache-key v2-bundler-gems-{{ .Environment.DB }}-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-assets-cache-key: &assets-cache-key v1-asset-cache-{{ checksum "tmp/assets_related_checksums" }}
+npm-cache-key: &npm-cache-key node-v10-{{ checksum "yarn.lock" }}-{{ .Environment.CACHE_VERSION }}
+bundle-cache-key: &bundle-cache-key bundler-gems-{{ .Environment.DB }}-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ .Environment.CACHE_VERSION }}
+assets-cache-key: &assets-cache-key asset-cache-{{ checksum "tmp/assets_related_checksums" }}-{{ .Environment.CACHE_VERSION }}
 
 restore-npm-cache: &restore-npm-cache
   restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ commands: # reusable commands with parameters
     steps:
       - restore_cache:
           keys:
-            - v2-bundler-gems-{{ .Environment.DB }}-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - *bundle-cache-key
 
   upload-artifacts:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,14 +152,17 @@ nightly-trigger: &nightly-trigger
 build-envs:
   mysql: &build-envs-mysql
     environment:
+      DB: mysql
       DATABASE_URL: mysql2://root:@127.0.0.1:3306/3scale_system_test
 
   postgresql: &build-envs-postgresql
     environment:
+      DB: postgresql
       DATABASE_URL: postgresql://postgres:@127.0.0.1:5432/systemdb
 
   oracle: &build-envs-oracle
     environment:
+      DB: oracle
       DATABASE_URL: oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb
 
 ##################################### CIRCLECI COMMANDS ############################################
@@ -347,7 +350,6 @@ executors:
     docker:
       - *system-builder-ruby26
     environment:
-      DB: << parameters.database >>
     working_directory: /opt/app-root/src/project
 
   builder-with-mysql-ruby26: &builder-with-mysql-ruby26

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ store-log-artifacts: &store-log-artifacts
     destination: log
 
 npm-cache-key: &npm-cache-key porta-{{ .Environment.CACHE_VERSION }}-node-v10-{{ checksum "yarn.lock" }}
+bundle-cache-key: &bundle-cache-key porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ .Environment.DB }}
 assets-cache-key: &assets-cache-key porta-{{ .Environment.CACHE_VERSION }}-asset-cache-{{ checksum "tmp/assets_related_checksums" }}
-#bundle-cache-key: defined at restore-gem-cache and save-gem-cache because {{ .Environment.DB }} is not available here
 
 restore-npm-cache: &restore-npm-cache
   restore_cache:
@@ -321,7 +321,7 @@ commands: # reusable commands with parameters
   save-gem-cache:
     steps:
       - save_cache:
-          key: porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ .Environment.DB }}
+          key: *bundle-cache-key
           paths:
             - ./vendor/bundle
             - ./.bundle/
@@ -329,7 +329,8 @@ commands: # reusable commands with parameters
   restore-gem-cache:
     steps:
       - restore_cache:
-          key: porta-{{ .Environment.CACHE_VERSION }}-bundler-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}-{{ .Environment.DB }}
+          keys:
+            - *bundle-cache-key
 
   upload-artifacts:
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:

The alpha nightly tests are failing because of two cucumbers:

https://app.circleci.com/pipelines/github/3scale/porta/24483/workflows/5b85ed13-787e-4c08-a25c-923f678b0026/jobs/275299/tests

They started failing overnight, without any change in the code, testing the same commit, etc. I wasn't able to find the cause, so I thought it could be fixed by clearing the cache.

Cache clearing in CircleCI requires changes in the config file and a PR, I think the process is too slow so I implemented this:

https://support.circleci.com/hc/en-us/articles/115015426888-Clear-project-dependency-cache

I created the `CACHE_VERSION` env. variable in CircleCI. Every time we want to clear the cache we only have to update the value for that variable.

The tests seem to be fixed in this branch:

https://app.circleci.com/pipelines/github/3scale/porta/24501/workflows/2dca4d98-6540-45cc-be67-868b208ffd00

Let's merge this and check if this actually fixes the tests on master. If not, at least we gained a nice way to invalidate cache when we want.