### PR TITLE
Report deprecation warnings to Bugsnag

### DIFF
--- a/app/lib/system/error_reporting.rb
+++ b/app/lib/system/error_reporting.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class DeprecationWarning < StandardError
-  def initialize(msg = nil, deprecation_horizon = nil)
+  def initialize(msg = nil, gem_name = nil, deprecation_horizon = nil)
     super(msg)
     @message = msg
+    @gem_name = gem_name
     @deprecation_horizon = deprecation_horizon
   end
 
-  attr_accessor :message, :deprecation_horizon
+  attr_accessor :message, :gem_name, :deprecation_horizon
 end
 
 module System
@@ -23,12 +24,15 @@ module System
     end
 
     def report_deprecation_warning(payload)
-      exception = DeprecationWarning.new(payload[:message], payload[:deprecation_horizon])
+      exception = DeprecationWarning.new(payload[:message], payload[:gem_name], payload[:deprecation_horizon])
 
       ::Bugsnag.notify(exception) do |report|
         report.severity = 'warning'
         report.grouping_hash = exception.message
-        report.add_tab 'deprecation_horizon', { value: exception.deprecation_horizon }
+        report.add_tab 'deprecation_info', {
+          gem_name: exception.gem_name,
+          deprecation_horizon: exception.deprecation_horizon
+        }
       end
     end
 

--- a/app/lib/system/error_reporting.rb
+++ b/app/lib/system/error_reporting.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+class DeprecationWarning < StandardError
+  def initialize(msg = nil, deprecation_horizon = nil)
+    super(msg)
+    @message = msg
+    @deprecation_horizon = deprecation_horizon
+  end
+
+  attr_accessor :message, :deprecation_horizon
+end
+
 module System
   module ErrorReporting
     module_function
@@ -13,13 +23,12 @@ module System
     end
 
     def report_deprecation_warning(payload)
-      message = payload[:message]
-      deprecation_horizon = payload[:deprecation_horizon]
+      exception = DeprecationWarning.new(payload[:message], payload[:deprecation_horizon])
 
-      ::Bugsnag.notify(message) do |report|
+      ::Bugsnag.notify(exception) do |report|
         report.severity = 'warning'
-        report.grouping_hash = message
-        report.add_tab 'deprecation_horizon', { description: "Rails version that won't have this feature available", value: deprecation_horizon }
+        report.grouping_hash = exception.message
+        report.add_tab 'deprecation_horizon', { value: exception.deprecation_horizon }
       end
     end
 

--- a/app/lib/system/error_reporting.rb
+++ b/app/lib/system/error_reporting.rb
@@ -12,6 +12,17 @@ module System
       end
     end
 
+    def report_deprecation_warning(payload)
+      message = payload[:message]
+      deprecation_horizon = payload[:deprecation_horizon]
+
+      ::Bugsnag.notify(message) do |report|
+        report.severity = 'warning'
+        report.grouping_hash = message
+        report.add_tab 'deprecation_horizon', { description: "Rails version that won't have this feature available", value: deprecation_horizon }
+      end
+    end
+
     class LogFormatter < ActiveSupport::Logger::SimpleFormatter
 
       def initialize

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
     end
 
   # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = :notify
+  config.active_support.deprecation = :log
 
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
     end
 
   # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = :log
+  config.active_support.deprecation = :notify
 
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load

--- a/config/initializers/deprecation.rb
+++ b/config/initializers/deprecation.rb
@@ -3,3 +3,9 @@
 # Silence our custom deprecator in test, production and preview
 # Stop to spam
 ThreeScale::Deprecation.silenced = %w[test production preview].include?(Rails.env)
+
+# Send deprecation warnings to Bugsnag
+ActiveSupport::Notifications.subscribe 'deprecation.rails' do |*args|
+  System::ErrorReporting.report_deprecation_warning(args.extract_options!)
+end
+


### PR DESCRIPTION
The title is self-explanatory.

I added a new tab to store which rails version will stop supporting the deprecated feature. This is how it looks at Bugsnag:

![image](https://github.com/3scale/porta/assets/17052241/7f5d9cba-64ba-484f-9869-436394a0f0e6)

The idea was to have something to filter for, so when we want to upgrade to e.g. rails 6.1, we can filter errors by `deprecation_horizon = 6.1` and get the list quickly. But it seems our plan doesn't allow that kind of custom filters (Sad face).
