### PR TITLE
THREESCALE-9695: Add index for mail dispatch rules

### DIFF
--- a/db/migrate/20230621090207_change_index_for_mail_dispatch_rules_account_id_first.rb
+++ b/db/migrate/20230621090207_change_index_for_mail_dispatch_rules_account_id_first.rb
@@ -1,0 +1,21 @@
+class ChangeIndexForMailDispatchRulesAccountIdFirst < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction! if System::Database.postgres?
+
+  def up
+    add_index :mail_dispatch_rules, [:account_id, :system_operation_id], index_options
+    remove_index :mail_dispatch_rules, column: [:system_operation_id, :account_id]
+  end
+
+  def down
+    add_index :mail_dispatch_rules, [:system_operation_id, :account_id], index_options
+    remove_index :mail_dispatch_rules, column: [:account_id, :system_operation_id]
+  end
+
+  private
+
+  def index_options
+    index_options = { unique: true }
+    index_options[:algorithm] = :concurrently if System::Database.postgres?
+    index_options
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_14_232715) do
+ActiveRecord::Schema.define(version: 2023_06_21_090207) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id", precision: 38, null: false
@@ -744,7 +744,7 @@ ActiveRecord::Schema.define(version: 2023_06_14_232715) do
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.integer "tenant_id", precision: 38
-    t.index ["system_operation_id", "account_id"], name: "index_mail_dispatch_rules_on_system_operation_id_and_account_id", unique: true
+    t.index ["account_id", "system_operation_id"], name: "index_mail_dispatch_rules_on_account_id_and_system_operation_id", unique: true
   end
 
   create_table "member_permissions", force: :cascade do |t|

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_14_232715) do
+ActiveRecord::Schema.define(version: 2023_06_21_090207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -747,7 +747,7 @@ ActiveRecord::Schema.define(version: 2023_06_14_232715) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.bigint "tenant_id"
-    t.index ["system_operation_id", "account_id"], name: "index_mail_dispatch_rules_on_system_operation_id_and_account_id", unique: true
+    t.index ["account_id", "system_operation_id"], name: "index_mail_dispatch_rules_on_account_id_and_system_operation_id", unique: true
   end
 
   create_table "member_permissions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_14_232715) do
+ActiveRecord::Schema.define(version: 2023_06_21_090207) do
 
   create_table "access_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
     t.bigint "owner_id", null: false
@@ -746,7 +746,7 @@ ActiveRecord::Schema.define(version: 2023_06_14_232715) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.bigint "tenant_id"
-    t.index ["system_operation_id", "account_id"], name: "index_mail_dispatch_rules_on_system_operation_id_and_account_id", unique: true
+    t.index ["account_id", "system_operation_id"], name: "index_mail_dispatch_rules_on_account_id_and_system_operation_id", unique: true
   end
 
   create_table "member_permissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|


### PR DESCRIPTION
**What this PR does / why we need it**:

The deletion process, and some other places in the code query `mail_dispatch_rules` table by `account_id`. There is no index for it, so the DB performs full table scan for this, causing a huge DB load.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-9695

**Verification steps** 


**Special notes for your reviewer**:

`algorithm: :concurrently` is for Postgres, the migration was otherwise blocked by `strong_migrations`