### PR TITLE
THREESCALE-9694: Add index to member_permissions on user_id

### DIFF
--- a/db/migrate/20230612105944_add_index_to_member_permissions_user_id.rb
+++ b/db/migrate/20230612105944_add_index_to_member_permissions_user_id.rb
@@ -1,0 +1,8 @@
+class AddIndexToMemberPermissionsUserId < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction! if System::Database.postgres?
+
+  def change
+    index_options = System::Database.postgres? ? { algorithm: :concurrently } : {}
+    add_index :member_permissions, :user_id, index_options
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_08_155529) do
+ActiveRecord::Schema.define(version: 2023_06_12_105944) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id", precision: 38, null: false
@@ -754,6 +754,7 @@ ActiveRecord::Schema.define(version: 2023_03_08_155529) do
     t.datetime "updated_at", precision: 6
     t.integer "tenant_id", precision: 38
     t.binary "service_ids"
+    t.index ["user_id"], name: "index_member_permissions_on_user_id"
   end
 
   create_table "message_recipients", force: :cascade do |t|

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_08_155529) do
+ActiveRecord::Schema.define(version: 2023_06_12_105944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -757,6 +757,7 @@ ActiveRecord::Schema.define(version: 2023_03_08_155529) do
     t.datetime "updated_at"
     t.bigint "tenant_id"
     t.binary "service_ids"
+    t.index ["user_id"], name: "index_member_permissions_on_user_id"
   end
 
   create_table "message_recipients", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_08_155529) do
+ActiveRecord::Schema.define(version: 2023_06_12_105944) do
 
   create_table "access_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
     t.bigint "owner_id", null: false
@@ -756,6 +756,7 @@ ActiveRecord::Schema.define(version: 2023_03_08_155529) do
     t.datetime "updated_at"
     t.bigint "tenant_id"
     t.binary "service_ids"
+    t.index ["user_id"], name: "index_member_permissions_on_user_id"
   end
 
   create_table "message_recipients", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|


### PR DESCRIPTION
**What this PR does / why we need it**:

Querying member permissions for a user is a very commonly used operation, and not having an index results in the DB having to perform full table scan, causing a huge DB load.

**Which issue(s) this PR fixes** 

[> Replace this comment with references to related issues. This will ensure the issue(s) are closed automatically when the PR gets merged.
> e.g. `fixes #<issue number>(, fixes #<issue_number>, ...)`
](https://issues.redhat.com/browse/THREESCALE-9694)

**Verification steps** 

**Special notes for your reviewer**:
