### PR TITLE
`InlineChart` as a Common component

### DIFF
--- a/app/javascript/packs/inline_chart.tsx
+++ b/app/javascript/packs/inline_chart.tsx
@@ -1,6 +1,6 @@
-import { render } from 'react-dom'
+import { InlineChartWrapper as InlineChart } from 'Common/components/InlineChart'
 
-import { InlineChart } from 'Stats/inlinechart'
+import type { Props as InlineChartProps } from 'Common/components/InlineChart'
 
 import './inline_chart.scss'
 
@@ -12,30 +12,18 @@ document.addEventListener('DOMContentLoaded', () => {
     throw new Error('The target ID was not found: ' + containerId)
   }
 
-  function renderChart (chart: HTMLElement) {
-    const currentChart = chart.querySelector<HTMLElement>('.inline-chart-container')
+  const charts = container.querySelectorAll<HTMLDivElement>('.charts.inlinechart')
 
-    if (!currentChart) {
+  charts.forEach(chart => {
+    const chartContainer = chart.querySelector<HTMLElement>('.inline-chart-container')
+
+    if (!chartContainer) {
       throw new Error('Inline chart container not found')
     }
 
-    const { endpoint, metricName, title } = currentChart.dataset
-    const { unitPluralized } = chart.dataset
+    // Props defined in app/views/stats/_inlinechart.html.erb
+    const props = chartContainer.dataset as unknown as InlineChartProps
 
-    if (!endpoint || !metricName || !title || !unitPluralized) {
-      throw new Error('Missing some props')
-    }
-
-    render((
-      <InlineChart
-        endPoint={endpoint}
-        metricName={metricName}
-        title={title}
-        unitPluralized={unitPluralized}
-      />
-    ), currentChart)
-  }
-
-  container.querySelectorAll<HTMLElement>('.charts')
-    .forEach(renderChart)
+    InlineChart(props, chartContainer.id)
+  })
 })

--- a/app/javascript/src/Common/components/InlineChart.tsx
+++ b/app/javascript/src/Common/components/InlineChart.tsx
@@ -4,6 +4,7 @@ import moment from 'moment'
 import numeral from 'numeral'
 
 import { fetchData } from 'utilities/fetchData'
+import { createReactWrapper } from 'utilities/createReactWrapper'
 
 import type { IRecord } from 'Types'
 import type { FunctionComponent } from 'react'
@@ -127,5 +128,8 @@ const InlineChart: FunctionComponent<Props> = ({
   )
 }
 
+// eslint-disable-next-line react/jsx-props-no-spreading
+const InlineChartWrapper = (props: Props, containerId: string): void => { createReactWrapper(<InlineChart {...props} />, containerId) }
+
 export type { Props }
-export { InlineChart }
+export { InlineChart, InlineChartWrapper }

--- a/app/views/stats/_inlinechart.html.erb
+++ b/app/views/stats/_inlinechart.html.erb
@@ -9,15 +9,15 @@
 <div id="mini-charts">
   <% Array.wrap(metrics).each do |metric| %>
     <% endpoint ||= usage_stats_api_services_path(metric.backend_api_metric? ? nil : metric.owner_id) %>
-    <div class="charts inlinechart" id="chart-<%= metric.id %>" data-unit-pluralized="<%= metric.unit.pluralize %>" data-metric="<%= metric.name %>" data-source="<%= endpoint %>">
+    <div class="charts inlinechart" id="chart-<%= metric.id %>">
       <%= content_tag :div,
         class: "inline-chart-container",
         id: "inline-chart-container-#{metric.id}",
         data: {
-          "endpoint": "#{endpoint}",
-          "metric-name": "#{metric.name}",
-          "metric-id": "#{metric.id}",
-          "title": "#{metric.friendly_name}"
+          "unit-pluralized": metric.unit.pluralize,
+          "end-point": endpoint,
+          "metric-name": metric.name,
+          "title": metric.friendly_name
         } do %>
       <% end %>
     </div>

--- a/spec/javascripts/Common/components/InlineChart.spec.tsx
+++ b/spec/javascripts/Common/components/InlineChart.spec.tsx
@@ -1,8 +1,8 @@
 import { mount } from 'enzyme'
-import c3 from 'c3'
+import { generate } from 'c3'
 
+import { InlineChart } from 'Common/components/InlineChart'
 import * as utils from 'utilities/fetchData'
-import { InlineChart } from 'Stats/inlinechart'
 import { waitForPromises } from 'utilities/test-utils'
 
 // Mocking moment.js
@@ -56,7 +56,7 @@ it('should generate chart', async () => {
   const wrapper = mountWrapper()
 
   await waitForPromises(wrapper)
-  expect(c3.generate).toHaveBeenCalledWith(expect.any(Object))
+  expect(generate).toHaveBeenCalledWith(expect.any(Object))
 })
 
 it('should print the correct label depending on the total of data', async () => {


### PR DESCRIPTION
This component is used in Product overview as well as Application overview, therefore is should be considered a Common component.

Moreover, we need to clean up module `Stats` and `InlineChart` is now completely independent of it.