### PR TITLE
Fix member permissions test for Postgres

### DIFF
--- a/app/representers/member_permissions_representer.rb
+++ b/app/representers/member_permissions_representer.rb
@@ -41,7 +41,7 @@ class MemberPermissionsRepresenter < ThreeScale::Representer
   property :user_id, getter: ->(opts) { opts[:user].id }
   property :role, getter: ->(opts) { opts[:user].role }
 
-  collection :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections&.sort }
+  collection :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections }
   collection :allowed_service_ids, getter: ->(opts) { opts[:user].allowed_service_ids }, render_nil: true
 
   class JSON < MemberPermissionsRepresenter
@@ -57,7 +57,7 @@ class MemberPermissionsRepresenter < ThreeScale::Representer
     include Roar::XML
     wraps_resource :permissions
 
-    collection :allowed_sections, as: :allowed_section, wrap: :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections&.sort }
+    collection :allowed_sections, as: :allowed_section, wrap: :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections }
     collection :allowed_service_ids, as: :allowed_service_id, wrap: :allowed_service_ids, getter: ->(opts) { opts[:user].allowed_service_ids }
   end
 

--- a/app/representers/member_permissions_representer.rb
+++ b/app/representers/member_permissions_representer.rb
@@ -41,6 +41,7 @@ class MemberPermissionsRepresenter < ThreeScale::Representer
   property :user_id, getter: ->(opts) { opts[:user].id }
   property :role, getter: ->(opts) { opts[:user].role }
 
+  # NOTE: The list of allowed sections is sorted to facilitate acceptance testing, this is not part of the API specification
   collection :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections&.sort }
   collection :allowed_service_ids, getter: ->(opts) { opts[:user].allowed_service_ids }, render_nil: true
 
@@ -57,6 +58,7 @@ class MemberPermissionsRepresenter < ThreeScale::Representer
     include Roar::XML
     wraps_resource :permissions
 
+    # NOTE: The list of allowed sections is sorted to facilitate acceptance testing, this is not part of the API specification
     collection :allowed_sections, as: :allowed_section, wrap: :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections&.sort }
     collection :allowed_service_ids, as: :allowed_service_id, wrap: :allowed_service_ids, getter: ->(opts) { opts[:user].allowed_service_ids }
   end

--- a/app/representers/member_permissions_representer.rb
+++ b/app/representers/member_permissions_representer.rb
@@ -41,7 +41,7 @@ class MemberPermissionsRepresenter < ThreeScale::Representer
   property :user_id, getter: ->(opts) { opts[:user].id }
   property :role, getter: ->(opts) { opts[:user].role }
 
-  collection :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections }
+  collection :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections&.sort }
   collection :allowed_service_ids, getter: ->(opts) { opts[:user].allowed_service_ids }, render_nil: true
 
   class JSON < MemberPermissionsRepresenter
@@ -57,8 +57,8 @@ class MemberPermissionsRepresenter < ThreeScale::Representer
     include Roar::XML
     wraps_resource :permissions
 
-    collection :allowed_sections, as: :allowed_section, wrap: :allowed_sections, getter: ->(opts) { opts[:user].member_permission_ids }
-    collection :allowed_service_ids, as: :allowed_service_id, wrap: :allowed_service_ids, getter: ->(opts) { opts[:user].member_permission_service_ids }
+    collection :allowed_sections, as: :allowed_section, wrap: :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections&.sort }
+    collection :allowed_service_ids, as: :allowed_service_id, wrap: :allowed_service_ids, getter: ->(opts) { opts[:user].allowed_service_ids }
   end
 
 end

--- a/app/representers/member_permissions_representer.rb
+++ b/app/representers/member_permissions_representer.rb
@@ -9,8 +9,8 @@
 #   <user_id>10</user_id>
 #   <role>member</role>
 #   <allowed_sections>
-#     <admin_section>portal</admin_section>
 #     <admin_section>monitoring</admin_section>
+#     <admin_section>portal</admin_section>
 #     <admin_section>settings</admin_section>
 #   </allowed_sections>
 #   <allowed_service_ids>
@@ -26,7 +26,7 @@
 #     "user_id": 10,
 #     "role": "member",
 #     "allowed_service_ids": [ 2, 3 ],
-#     "allowed_sections": [ "portal", "monitoring", "settings" ],
+#     "allowed_sections": [ "monitoring", "portal", "settings" ],
 #     "links": [{
 #         "rel": "user",
 #         "href": "http://provider-admin.3scale.net/admin/api/accounts/2/users/10"
@@ -41,7 +41,7 @@ class MemberPermissionsRepresenter < ThreeScale::Representer
   property :user_id, getter: ->(opts) { opts[:user].id }
   property :role, getter: ->(opts) { opts[:user].role }
 
-  collection :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections }
+  collection :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections&.sort }
   collection :allowed_service_ids, getter: ->(opts) { opts[:user].allowed_service_ids }, render_nil: true
 
   class JSON < MemberPermissionsRepresenter
@@ -57,7 +57,7 @@ class MemberPermissionsRepresenter < ThreeScale::Representer
     include Roar::XML
     wraps_resource :permissions
 
-    collection :allowed_sections, as: :allowed_section, wrap: :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections }
+    collection :allowed_sections, as: :allowed_section, wrap: :allowed_sections, getter: ->(opts) { opts[:user].allowed_sections&.sort }
     collection :allowed_service_ids, as: :allowed_service_id, wrap: :allowed_service_ids, getter: ->(opts) { opts[:user].allowed_service_ids }
   end
 

--- a/spec/acceptance/api/member_permissions_spec.rb
+++ b/spec/acceptance/api/member_permissions_spec.rb
@@ -7,7 +7,7 @@ resource "MemberPermission" do
   let(:user) { FactoryBot.create(:user, account: provider) }
   let(:resource) { user.member_permissions }
   let(:serialized) { representer.send(serialization_format, user: user) }
-  let(:updatable_resource){ user }
+  let(:updatable_resource) { user }
 
   before do
     provider.settings.allow_multiple_users!


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/3scale/porta/pull/3420 introduced an index for `member_permissions` column. That broke the API integration tests, only for Postgres, and only for CircleCI - it was not reproducible locally. Probably related to the version, running the same container image as CircleCI (`cimg/postgres:10.20`) made it possible to reproduce locally.

So, it seems that introducing an index changed the order in which the records were returned by the DB.

It's all very confusing, because in theory there is a mechanism that prevents that, in the custom responder there is an ordering done on the `id` field: https://github.com/3scale/porta/blob/379b3dc/app/lib/three_scale/api/responder.rb#L87-L89

However, it turns out that in this case this is not taken into account, because the actual query for the member permissions is coming from the representer that queries users's member permissions again: https://github.com/3scale/porta/blob/379b3dc26189f7dc5c5276de84d70c46ba5ae0b6/app/representers/member_permissions_representer.rb#L44-L45

So, there are multiple places where we can fix the order of the admin sections:
1. in the representer - so only the API responses will be affected
2. in the logic of the Permissions module, somewhere around https://github.com/3scale/porta/blob/379b3dc26189f7dc5c5276de84d70c46ba5ae0b6/app/models/user/permissions.rb#L27-L29
3. in the DB query, https://github.com/3scale/porta/blob/379b3dc26189f7dc5c5276de84d70c46ba5ae0b6/app/models/user/permissions.rb#L7 for example, 
```
has_many :member_permissions, -> { order(admin_section: :asc) }, dependent: :destroy, autosave: true
```

I opted for 1, because we only care about the order in the API responses (where we might want to have a predictable order - for tests or for whatever), we don't really care about the order in other uses.

**Which issue(s) this PR fixes** 

-

**Verification steps** 

Run Postgres tests in CircleCI.

**Special notes for your reviewer**:
