### PR TITLE
remove now redundant billing_locks table

### DIFF
--- a/app/models/billing_lock.rb
+++ b/app/models/billing_lock.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class BillingLock < ApplicationRecord
-  self.primary_key = :account_id
-
-  belongs_to :account
-
-  validates :account_id, presence: true, uniqueness: true
-end

--- a/db/migrate/20230927012615_drop_billing_locks.rb
+++ b/db/migrate/20230927012615_drop_billing_locks.rb
@@ -1,0 +1,14 @@
+class DropBillingLocks < ActiveRecord::Migration[5.2]
+  def down
+    table_opts = System::Database.mysql? ? { options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" } : {}
+    datetime_opts = System::Database.oracle? ? { precision: 6 } : {}
+
+    create_table "billing_locks", primary_key: "account_id", force: :cascade, **table_opts do |t|
+      t.datetime "created_at", null: false, **datetime_opts
+    end
+  end
+
+  def up
+    drop_table :billing_locks
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_19_112703) do
+ActiveRecord::Schema.define(version: 2023_09_27_012615) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id", precision: 38, null: false
@@ -235,10 +235,6 @@ ActiveRecord::Schema.define(version: 2023_07_19_112703) do
     t.text "data"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "billing_locks", primary_key: "account_id", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
   end
 
   create_table "billing_strategies", force: :cascade do |t|

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_19_112703) do
+ActiveRecord::Schema.define(version: 2023_09_27_012615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -238,10 +238,6 @@ ActiveRecord::Schema.define(version: 2023_07_19_112703) do
     t.text "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "billing_locks", primary_key: "account_id", force: :cascade do |t|
-    t.datetime "created_at", null: false
   end
 
   create_table "billing_strategies", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_19_112703) do
+ActiveRecord::Schema.define(version: 2023_09_27_012615) do
 
   create_table "access_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
     t.bigint "owner_id", null: false
@@ -237,10 +237,6 @@ ActiveRecord::Schema.define(version: 2023_07_19_112703) do
     t.text "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "billing_locks", primary_key: "account_id", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
-    t.datetime "created_at", null: false
   end
 
   create_table "billing_strategies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|


### PR DESCRIPTION
merge this only once we are confident the new locking strategy (#3403) is superior and actually prevents double execution