### PR TITLE
bigger field for audited_changes

### DIFF
--- a/db/migrate/20230614232715_audited_changes_medium_text.rb
+++ b/db/migrate/20230614232715_audited_changes_medium_text.rb
@@ -1,0 +1,9 @@
+class AuditedChangesMediumText < ActiveRecord::Migration[5.2]
+  def up
+    return unless System::Database.mysql?
+
+    safety_assured do
+      change_column :audits, :audited_changes, :text, limit: 16.megabytes - 1
+    end
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_12_105944) do
+ActiveRecord::Schema.define(version: 2023_06_14_232715) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id", precision: 38, null: false

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_12_105944) do
+ActiveRecord::Schema.define(version: 2023_06_14_232715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_12_105944) do
+ActiveRecord::Schema.define(version: 2023_06_14_232715) do
 
   create_table "access_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
     t.bigint "owner_id", null: false
@@ -160,7 +160,7 @@ ActiveRecord::Schema.define(version: 2023_06_12_105944) do
     t.bigint "tenant_id"
     t.bigint "provider_id"
     t.string "kind"
-    t.text "audited_changes"
+    t.text "audited_changes", limit: 16777215
     t.text "comment"
     t.integer "associated_id"
     t.string "associated_type"


### PR DESCRIPTION
this is needed to enable auditing of larger fields like
`policies_config`, see #3342

```sql
MySQL [3scale_system_development]> show create table audits;
+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table  | Create Table                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| audits | CREATE TABLE `audits` (
  `id` bigint(20) NOT NULL AUTO_INCREMENT,
  `auditable_id` bigint(20) DEFAULT NULL,
  `auditable_type` varchar(255) COLLATE utf8_bin DEFAULT NULL,
  `user_id` bigint(20) DEFAULT NULL,
  `user_type` varchar(255) COLLATE utf8_bin DEFAULT NULL,
  `username` varchar(255) COLLATE utf8_bin DEFAULT NULL,
  `action` varchar(255) COLLATE utf8_bin DEFAULT NULL,
  `version` int(11) DEFAULT '0',
  `created_at` datetime DEFAULT NULL,
  `tenant_id` bigint(20) DEFAULT NULL,
  `provider_id` bigint(20) DEFAULT NULL,
  `kind` varchar(255) COLLATE utf8_bin DEFAULT NULL,
  `audited_changes` mediumtext COLLATE utf8_bin,
  `comment` text COLLATE utf8_bin,
  `associated_id` int(11) DEFAULT NULL,
  `associated_type` varchar(255) COLLATE utf8_bin DEFAULT NULL,
  `remote_address` varchar(255) COLLATE utf8_bin DEFAULT NULL,
  `request_uuid` varchar(255) COLLATE utf8_bin DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `index_audits_on_action` (`action`),
  KEY `associated_index` (`associated_type`,`associated_id`),
  KEY `index_audits_on_auditable_id_and_auditable_type_and_version` (`auditable_id`,`auditable_type`,`version`),
  KEY `auditable_index` (`auditable_type`,`auditable_id`,`version`),
  KEY `index_audits_on_created_at` (`created_at`),
  KEY `index_audits_on_kind` (`kind`),
  KEY `index_audits_on_provider_id` (`provider_id`),
  KEY `index_audits_on_request_uuid` (`request_uuid`),
  KEY `user_index` (`user_id`,`user_type`),
  KEY `index_audits_on_version` (`version`)
) ENGINE=InnoDB AUTO_INCREMENT=88 DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0,001 sec)
```
