### PR TITLE
🦋 Upgrade Patternfly Quickstarts

### DIFF
--- a/app/javascript/packs/provider.scss
+++ b/app/javascript/packs/provider.scss
@@ -18,3 +18,6 @@
 @import '~@patternfly/patternfly/components/EmptyState/empty-state.css';
 @import '~@patternfly/patternfly/components/OverflowMenu/overflow-menu.css';
 @import '~@patternfly/patternfly/components/Table/table.css';
+
+// Patternfly QuickStarts
+@import '~@patternfly/quickstarts/dist/quickstarts.min.css';

--- a/app/javascript/src/QuickStarts/components/QuickStartContainer.scss
+++ b/app/javascript/src/QuickStarts/components/QuickStartContainer.scss
@@ -1,7 +1,3 @@
-@import '~@patternfly/quickstarts/dist/patternfly-global.css';
-@import '~@patternfly/quickstarts/dist/patternfly-nested.css';
-@import '~@patternfly/quickstarts/dist/quickstarts-standalone.css';
-
 // HACK: removes Main 1.5 rem padding
 #quick-start-catalog-page-wrapper {
   margin: -1.5rem;

--- a/app/javascript/src/QuickStarts/components/QuickStartContainer.tsx
+++ b/app/javascript/src/QuickStarts/components/QuickStartContainer.tsx
@@ -1,13 +1,18 @@
-import {
-  QuickStartContainer as PF4QuickStartContainer,
-  QuickStartCatalogPage,
-  useLocalStorage
-} from '@patternfly/quickstarts/dist/quickstarts-full.es'
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+// import {
+//   QuickStartContainer as PF4QuickStartContainer,
+//   QuickStartCatalogPage,
+//   useLocalStorage
+// } from '@patternfly/quickstarts/dist/quickstarts-full.es'
+
+import { QuickStartContainer as PF4QuickStartContainer, QuickStartCatalogPage, useLocalStorage } from '@patternfly/quickstarts'
 import { PageSection } from '@patternfly/react-core'
 
 import quickStarts from 'QuickStarts/templates'
 import replaceLinksExtension from 'QuickStarts/utils/replaceLinksExtension'
 import { createReactWrapper } from 'utilities/createReactWrapper'
+
+import type { QuickStart } from '@patternfly/quickstarts'
 
 import './QuickStartContainer.scss'
 
@@ -29,7 +34,7 @@ const QuickStartContainer: React.FunctionComponent<Props> = ({
     // eslint-disable-next-line react/no-multi-comp, react/jsx-no-useless-fragment -- TODO: remove this when bug is fixed
     renderExtension: () => <></>,
     extensions: [replaceLinksExtension(links)]
-  } as const
+  }
 
   return (
     <PF4QuickStartContainer
@@ -39,7 +44,7 @@ const QuickStartContainer: React.FunctionComponent<Props> = ({
       language="en"
       loading={false}
       markdown={markdown}
-      quickStarts={quickStarts}
+      quickStarts={quickStarts as QuickStart[]}
       setActiveQuickStartID={setActiveQuickStartID}
       setAllQuickStartStates={setAllQuickStartStates}
       showCardFooters={false}

--- a/app/javascript/src/QuickStarts/components/QuickStartContainer.tsx
+++ b/app/javascript/src/QuickStarts/components/QuickStartContainer.tsx
@@ -1,9 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-// import {
-//   QuickStartContainer as PF4QuickStartContainer,
-//   QuickStartCatalogPage,
-//   useLocalStorage
-// } from '@patternfly/quickstarts/dist/quickstarts-full.es'
 
 import { QuickStartContainer as PF4QuickStartContainer, QuickStartCatalogPage, useLocalStorage } from '@patternfly/quickstarts'
 import { PageSection } from '@patternfly/react-core'
@@ -56,7 +51,6 @@ const QuickStartContainer: React.FunctionComponent<Props> = ({
         <div id={CATALOG_CONTAINER_ID}>
           <PageSection>
             <QuickStartCatalogPage
-              showFilter
               hint="Learn how to create, import, and run applications with step-by-step instructions and tasks."
               title="Quick starts"
             />

--- a/app/javascript/src/Types/custom.d.ts
+++ b/app/javascript/src/Types/custom.d.ts
@@ -33,26 +33,4 @@ declare module '*.yaml' {
 // We don't care about missing types from this package. Used only in spec/javascripts/PaymentGateways/braintree/BraintreeForm.spec.tsx
 declare module 'braintree-web/hosted-fields';
 
-// TODO: when we use a official release of Quickstarts we can remove this workaround
-declare module '@patternfly/quickstarts/dist/quickstarts-full.es' {
-  export function useLocalStorage (key: string, value: unknown): [unknown, unknown]
-  export function QuickStartContainer (props: React.PropsWithChildren<{
-    useLegacyHeaderColors: unknown;
-    activeQuickStartID: unknown;
-    allQuickStartStates: unknown;
-    language: string;
-    loading: boolean;
-    markdown: unknown;
-    quickStarts: unknown;
-    setActiveQuickStartID: unknown;
-    setAllQuickStartStates: unknown;
-    showCardFooters: boolean;
-  }>): React.ReactElement
-  export function QuickStartCatalogPage (props: {
-    showFilter: boolean;
-    hint: string;
-    title: string;
-  }): React.ReactElement
-}
-
 declare let __webpack_public_path__: string

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "4.224.2",
-    "@patternfly/quickstarts": "^1.4.1-rc.1",
+    "@patternfly/quickstarts": "^2.4.1",
     "@patternfly/react-core": "4.276.8",
     "@patternfly/react-table": "4.113.0",
     "@rails/webpacker": "5.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,37 +1481,31 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@patternfly/patternfly@4.122.2":
-  version "4.122.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.122.2.tgz#3e774d78996c7027b8c528edb2e90990676458a5"
-  integrity sha512-kSoW8mt9eEJcAZX2lX4r/SYvFd44GGb8PUSDjMrpKDZqgn9/9VFh1rSChG4v5kCK6cpS99/gdTapZc3ylf8Rpw==
-
-"@patternfly/patternfly@4.224.2":
+"@patternfly/patternfly@4.224.2", "@patternfly/patternfly@^4.224.2":
   version "4.224.2"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.224.2.tgz#9d1b000c3c43457ae47c3556a334412d164fad90"
   integrity sha512-HGNV26uyHSIECuhjPg/WGn0mXbAotcs6ODfhAOkfYjIgGylddgiwElxUe1rpEHV5mQJJ2rMn4OdeJIIpzRX61g==
 
-"@patternfly/quickstarts@^1.4.1-rc.1":
-  version "1.4.1-rc.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-1.4.1-rc.1.tgz#85cc9e618ba6e6cd786a179cb1d380e660f1fc19"
-  integrity sha512-jg1hJviLLYWvEINnG4Gk5EskwlBE2khKWr25Id2g5FaX3YkL6htNawjWSWGr9Llg7FlWqgd8IxxPAvRJCQdUXg==
+"@patternfly/quickstarts@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-2.4.1.tgz#ecebf3c6bcee5124c73ef7c123918c1ee1087011"
+  integrity sha512-Aa/QFgAIq+uPJUYgW4mjqdeVz28MVZZLyzcLKMl5jSPv8GhyOa/61rmjN4vwBZo/PDq4gBYF/ST8FEOOA2eArQ==
   dependencies:
-    "@patternfly/react-catalog-view-extension" "4.12.15"
+    "@patternfly/react-catalog-view-extension" "^4.93.15"
     dompurify "^2.2.6"
     history "^5.0.0"
     showdown "1.8.6"
 
-"@patternfly/react-catalog-view-extension@4.12.15":
-  version "4.12.15"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.12.15.tgz#edb0d6b97b3adf060129fdd1e0c1edc25c31d22e"
-  integrity sha512-1mp+Ogi7fJfgh5wV9q+PolmplbMj3Tcias8xs0eeD5GCirdzOQxG+wihEM5k6CAGhBAr7jHg5fRSgO8QLTt3UQ==
+"@patternfly/react-catalog-view-extension@^4.93.15":
+  version "4.96.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.96.0.tgz#b3e3e8875b0dc37c204cf71c29ea8a95d0442ad4"
+  integrity sha512-ZMPvaE6KOjbLioCdi1wPtxughsce4+sPq6Us5s4JKu2xgn+e83NcfSD3pAcS5e+M8K3SWwdXd3ycgkD8F+Obvg==
   dependencies:
-    "@patternfly/patternfly" "4.122.2"
-    "@patternfly/react-core" "^4.135.15"
-    "@patternfly/react-styles" "^4.11.4"
-    classnames "^2.2.5"
+    "@patternfly/patternfly" "^4.224.2"
+    "@patternfly/react-core" "^4.276.6"
+    "@patternfly/react-styles" "^4.92.6"
 
-"@patternfly/react-core@4.276.8", "@patternfly/react-core@^4.135.15", "@patternfly/react-core@^4.276.8":
+"@patternfly/react-core@4.276.8", "@patternfly/react-core@^4.276.6", "@patternfly/react-core@^4.276.8":
   version "4.276.8"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.276.8.tgz#7ef52830dcdda954bd5bec40132da6eef49aba6f"
   integrity sha512-dn322rEzBeiVztZEuCZMUUittNb8l1hk30h9ZN31FLZLLVtXGlThFNV9ieqOJYA9zrYxYZrHMkTnOxSWVacMZg==
@@ -1529,7 +1523,7 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.6.tgz#4aff18724afa30157e3ffd6a6414951dbb39dcb3"
   integrity sha512-ZrXegc/81oiuTIeWvoHb3nG/eZODbB4rYmekBEsrbiysyO7m/sUFoi/RLvgFINrRoh6YCJqL5fj06Jg6d7jX1g==
 
-"@patternfly/react-styles@^4.11.4", "@patternfly/react-styles@^4.92.6":
+"@patternfly/react-styles@^4.92.6":
   version "4.92.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.6.tgz#a72c5f0b7896ce1c419d1db79f8e39ba6632057d"
   integrity sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw==
@@ -3949,7 +3943,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5, classnames@^2.2.6, classnames@^2.3.1:
+classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrading Patternfly Quick starts to the PF4 ones (https://www.patternfly.org/v4/extensions/quick-starts).

In order to avoid the Quick starts bug with `showFilter`, the search has been deleted until we upgrade to PF5.

**Which issue(s) this PR fixes** 
[THREESCALE-9638: Upgrade Patternfly Quickstarts](https://issues.redhat.com/browse/THREESCALE-9638)

**Before**
![quickstarts-stg-1](https://github.com/3scale/porta/assets/72191439/8287e1dc-5b84-41af-80c4-d145a0822ae9)
![quickstarts-stg-2](https://github.com/3scale/porta/assets/72191439/bd434335-495e-412a-b629-1e97fc64cab2)

**After**
![new-quickstarts](https://github.com/3scale/porta/assets/72191439/8bec91a6-471b-4d88-8e2d-0bbf553db34c)
