### PR TITLE
[WIP]Changes for cachito

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "porta",
+  "version": "0.0.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/script/yarn/package.json
+++ b/script/yarn/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "yarn-dependency",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "devDependencies": {
+      "yarn": "^1.22.19"
+    }
+  }
+  


### PR DESCRIPTION
In order to get Porta to build using sources from Cachito, the following changes need to be merged. 
The `name` and `version` fields in the package.json are necessary to prevent a recurring error we had which asked us to add these fields.

The package.json for yarn is necessary in order to install yarn using cachito during the build process
