### PR TITLE
💄 Fix [yet even more] css, this time missing legacy styles

### DIFF
--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -79,7 +79,7 @@ module AccountHelper
     alert = t('buyers.accounts.edit.delete.admin_restricted', admin: current_account.first_admin.try(:email))
 
     url = can?(:destroy, account) ? admin_buyers_account_path(account) : javascript_alert_url(alert)
-    pf_delete_link_for(url, confirm: msg)
+    delete_link_for(url, confirm: msg)
   end
 
   def master_on_premises?

--- a/app/helpers/api/services_helper.rb
+++ b/app/helpers/api/services_helper.rb
@@ -47,7 +47,7 @@ module Api::ServicesHelper
 
   def delete_service_link(service, options = {})
     msg = t('api.services.forms.definition_settings.delete_confirmation', name: j(service.name))
-    pf_delete_link_for(admin_service_path(service), {data: { confirm: msg }, method: :delete}.merge(options) )
+    delete_link_for(admin_service_path(service), {data: { confirm: msg }, method: :delete}.merge(options) )
   end
 
   def refresh_service_link(service, options = {})

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ButtonsHelper
+module ButtonsHelper # rubocop:disable Metrics/ModuleLength
 
   DATA_ATTRIBUTES = [:confirm, :method, :remote, :'disable-with', :disabled]
   #TODO: refactoring: move buttons helpers to own helper
@@ -156,22 +156,8 @@ module ButtonsHelper
     end
   end
 
-  PATTERNFLY_BUTTON_CLASS = 'pf-c-button'
-  PATTERNFLY_LINK_CLASS = "#{PATTERNFLY_BUTTON_CLASS} pf-m-link"
-
-  %i[link_to action_link_to fancy_button_to fancy_link_to delete_button_for delete_link_for].each do |method_sym|
-    define_method("pf_#{method_sym}") do |*args, options|
-      opts = options.respond_to?(:merge) ?
-        [options.merge(class: join_dom_classes(PATTERNFLY_LINK_CLASS, options[:class]))] :
-        [options, { class: PATTERNFLY_LINK_CLASS }]
-      public_send(method_sym, *args, *opts)
-    end
-  end
-
-  def pf_link_as_button(label, url, options)
-    pf_class = "#{PATTERNFLY_BUTTON_CLASS} pf-m-#{options[:modifier]}"
-    options[:class] = join_dom_classes(pf_class, options[:class])
-    
+  def pf_link_to(label, url, options = {})
+    options[:class] = join_dom_classes('pf-c-button pf-m-link', options[:class])
     link_to label, url, options
   end
 

--- a/app/helpers/cinstances_helper.rb
+++ b/app/helpers/cinstances_helper.rb
@@ -38,6 +38,6 @@ Are you sure?}
 
   def delete_application_link(application)
     msg = t('api.applications.edit.delete_confirmation', name: j(application.name))
-    pf_delete_link_for(provider_admin_application_path(application), confirm: msg, title: 'Delete Application')
+    delete_link_for(provider_admin_application_path(application), confirm: msg, title: 'Delete Application')
   end
 end

--- a/app/helpers/finance/invoices_helper.rb
+++ b/app/helpers/finance/invoices_helper.rb
@@ -52,17 +52,10 @@ module Finance::InvoicesHelper
   end
 
 
-  def invoice_pdf_link(invoice, label = 'Download PDF')
+  def invoice_pdf_link(invoice, options = {})
+    label = options.delete(:label) || 'Download PDF'
     if invoice.pdf.file?
-      link_to(label, invoice.pdf.expiring_url)
-    else
-      content_tag(:em,'not yet generated')
-    end
-  end
-
-  def pf_invoice_pdf_link(invoice, label = 'Download PDF')
-    if invoice.pdf.file?
-      pf_link_as_button(label, invoice.pdf.expiring_url, modifier: 'secondary')
+      link_to(label, invoice.pdf.expiring_url, options)
     else
       content_tag(:em,'not yet generated')
     end

--- a/app/views/admin/api_docs/base/_menu.html.erb
+++ b/app/views/admin/api_docs/base/_menu.html.erb
@@ -2,12 +2,12 @@
 
 <div class="operations">
   <%- if @api_docs_service.published? -%>
-    <%= pf_link_to 'Hide', toggle_visible_admin_api_docs_service_path(@api_docs_service), class: 'action eye-slash', method: 'put' -%>
+    <%= link_to 'Hide', toggle_visible_admin_api_docs_service_path(@api_docs_service), class: 'action eye-slash', method: 'put' -%>
   <%- else -%>
-    <%= pf_link_to 'Publish', toggle_visible_admin_api_docs_service_path(@api_docs_service), class: 'action eye', method: 'put' -%>
+    <%= link_to 'Publish', toggle_visible_admin_api_docs_service_path(@api_docs_service), class: 'action eye', method: 'put' -%>
   <%- end -%>
   |
-  <%= pf_link_to 'Edit', edit_admin_api_docs_service_path(@api_docs_service), class: 'action edit' -%>
+  <%= link_to 'Edit', edit_admin_api_docs_service_path(@api_docs_service), class: 'action edit' -%>
   |
-  <%= pf_delete_link_for admin_api_docs_service_path(@api_docs_service), data: {:confirm => 'Are you sure?'} -%>
+  <%= delete_link_for admin_api_docs_service_path(@api_docs_service), data: {:confirm => 'Are you sure?'} -%>
 </div>

--- a/app/views/admin/fields_definitions/index.html.erb
+++ b/app/views/admin/fields_definitions/index.html.erb
@@ -20,7 +20,7 @@
   <h2>
     <%= class_name.constantize.model_name.human %>
   </h2>
-  <%= pf_fancy_link_to "Create", new_admin_fields_definition_path(:fields_definition=> {:target => class_name}),
+  <%= fancy_link_to "Create", new_admin_fields_definition_path(:fields_definition=> {:target => class_name}),
     :title => "Create new field for #{class_name.constantize.model_name.human}", :class => 'new-field-definition new
     action add' %>
 
@@ -35,7 +35,7 @@
 	<span>"<%= h truncate(fields_definition.label, :length => 50) %>"</span>
 	<span class="action-set">
 	  <span class="properties"><%=h retrieve_properties_of fields_definition %></span>
-	  <%= pf_link_to 'Edit', edit_admin_fields_definition_path(fields_definition), :class => 'action edit' %>
+	  <%= link_to 'Edit', edit_admin_fields_definition_path(fields_definition), :class => 'action edit' %>
       </li>
     <% end %>
   </ol>

--- a/app/views/api/services/_delete.html.slim
+++ b/app/views/api/services/_delete.html.slim
@@ -1,12 +1,13 @@
 - if can?(:destroy, service)
-  hr
-  h3
-    ' Product deletion
+  div.pf-c-content
+    hr
+    h3
+      ' Product deletion
 
-  p
-    ' Deleting this product will
-    strong> irreversibly destroy
-    ' all applications, application plans, metrics, pricing rules, features, service plans and subscriptions of this product. Therefore all authorization and reporting calls for this product will no longer be valid.
+    p
+      ' Deleting this product will
+      strong> irreversibly destroy
+      ' all applications, application plans, metrics, pricing rules, features, service plans and subscriptions of this product. Therefore all authorization and reporting calls for this product will no longer be valid.
 
-  p
-    = delete_service_link(service, label: "I understand the consequences, proceed to delete '#{j(service.name)}' product")
+    p
+      = delete_service_link(service, label: "I understand the consequences, proceed to delete '#{j(service.name)}' product")

--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -55,7 +55,7 @@ section class="service-widget"
           h2.flex-item
             '  Published
             => link_to 'Application Plans', admin_service_application_plans_path(service)
-          = pf_action_link_to :new, new_admin_service_application_plan_path(service),
+          = action_link_to :new, new_admin_service_application_plan_path(service),
             label: 'Create application plan', class: 'flex-item'
 
         ul.application-plans[data-hint="published"]
@@ -76,7 +76,7 @@ section class="service-widget"
             h2.flex-item
               '  Published
               => link_to 'Service plans', admin_service_service_plans_path(service)
-            = pf_action_link_to :new,  new_admin_service_service_plan_path(service),
+            = action_link_to :new,  new_admin_service_service_plan_path(service),
               label: 'Create Service Plan', class: 'flex-item'
 
           ul.service-plans[data-hint="published"]

--- a/app/views/buyers/accounts/_account_plan.html.erb
+++ b/app/views/buyers/accounts/_account_plan.html.erb
@@ -6,10 +6,10 @@
   <% if can? :manage, :plans -%>
     <div class="operations">
       <% if plan.customized? %>
-      <%= pf_link_to 'Edit', edit_admin_account_plan_path(plan.id), :class => 'action edit' %>
-          <%= pf_delete_button_for admin_buyers_contract_custom_plan_path(contract, plan), :label=> 'Remove customization' %>
+      <%= link_to 'Edit', edit_admin_account_plan_path(plan.id), :class => 'action edit' %>
+          <%= delete_button_for admin_buyers_contract_custom_plan_path(contract, plan), :label=> 'Remove customization' %>
       <% else %>
-      <%= pf_fancy_link_to 'Convert to a Custom Plan' , admin_buyers_contract_custom_plans_path(contract), :method=> :post,
+      <%= fancy_link_to 'Convert to a Custom Plan' , admin_buyers_contract_custom_plans_path(contract), :method=> :post,
         :class => 'new', :remote => true %>
       <% end %>
     </div>

--- a/app/views/buyers/accounts/_monthly_charging.html.erb
+++ b/app/views/buyers/accounts/_monthly_charging.html.erb
@@ -11,7 +11,7 @@
       Monthly billing is <%= status %>.
     </td>
     <td>
-      <%= pf_fancy_button_to action,
+      <%= fancy_button_to action,
                           toggle_monthly_billing_admin_buyers_account_path(account),
                           :method => :put,
                           id: "#{action.downcase}-monthly-billing",
@@ -37,7 +37,7 @@
         Monthly charging is <%= status %>.
       </td>
       <td>
-          <%= pf_fancy_button_to action, toggle_monthly_charging_admin_buyers_account_path(account),
+          <%= fancy_button_to action, toggle_monthly_charging_admin_buyers_account_path(account),
                          :method => :put,
                          :id => "#{action.downcase}-monthly-charging",
                          :class => "action #{action.downcase}",

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -7,9 +7,7 @@
       h1 data-hook="account-show"
         ' Account: #{@account.org_name}
         - if can? :update, @account
-          = pf_link_to 'Edit',
-              edit_admin_buyers_account_path(@account),
-              class: 'action edit'
+          = link_to 'Edit', edit_admin_buyers_account_path(@account), class: 'action edit'
 #twoCol.equal-width
   .left
     .wide_dashboard_card.round
@@ -22,7 +20,7 @@
               => link_to 'Impersonate',
                          admin_buyers_account_impersonation_path(@account),
                          class: 'action bolt', method: 'post', target: '_blank'
-            => pf_link_to 'Send message',
+            => link_to 'Send message',
                        new_provider_admin_messages_outbox_path(to: @account),
                        class: 'action message fancybox'
         - if current_account.master? && @account.provider?
@@ -68,13 +66,13 @@
                                  method: :post,
                                  class: 'reject action'
             - unless @account.suspended_or_scheduled_for_deletion?
-              = pf_action_link_to 'Suspend',
+              = action_link_to 'Suspend',
                                 suspend_admin_buyers_account_path(@account),
                                 method: :post,
                                 data: { confirm: 'Are you sure?', disable_with: 'suspending…' },
                                 class: 'action suspend'
             - if can?(:resume, @account) && @account.can_resume?
-              = pf_action_link_to 'Resume',
+              = action_link_to 'Resume',
                                resume_admin_buyers_account_path(@account),
                                method: :post,
                                data: { confirm: 'Are you sure?', disable_with: 'resuming…' },

--- a/app/views/buyers/applications/_api_credentials.html.erb
+++ b/app/views/buyers/applications/_api_credentials.html.erb
@@ -42,11 +42,11 @@
     <td>
       <span id="cinstance-user-key"><%= cinstance.user_key %></span>
       <% if cinstance.custom_keys_enabled? %>
-        <%= pf_link_to '', edit_provider_admin_application_key_path(cinstance, cinstance.user_key),
+        <%= link_to '', edit_provider_admin_application_key_path(cinstance, cinstance.user_key),
                     :class => 'fancybox action edit', 'data-autodimensions' => 'true', title: "Set Custom Key" %>
       <% end %>
       <% if defined?(regenerate) && regenerate %>
-        <%= pf_link_to 'Regenerate', change_user_key_provider_admin_application_path(cinstance), method: :put, data: {:confirm => "Are you sure?"}, class: ' action refresh' %>
+        <%= link_to 'Regenerate', change_user_key_provider_admin_application_path(cinstance), method: :put, data: {:confirm => "Are you sure?"}, class: ' action refresh' %>
       <% end %>
     </td>
   </tr>

--- a/app/views/buyers/invoices/index.html.erb
+++ b/app/views/buyers/invoices/index.html.erb
@@ -27,7 +27,7 @@
         <td><%= h invoice.state %></td>
         <td><%= price_tag(invoice.cost) %></td>
         <td colspan="2">
-          <%= invoice_pdf_link(invoice, 'PDF') %>
+          <%= invoice_pdf_link(invoice, label: 'PDF') %>
         </td>
        <% end %>
     <% end %>

--- a/app/views/finance/provider/invoices/index.html.erb
+++ b/app/views/finance/provider/invoices/index.html.erb
@@ -45,7 +45,7 @@
         <td><%= price_tag(invoice.cost) %></td>
         <td><%= h invoice.state %></td>
         <td>
-          <%= invoice_pdf_link(invoice, 'PDF') %>
+          <%= invoice_pdf_link(invoice, label: 'PDF') %>
         </td>
         <% end %>
     <% end %>

--- a/app/views/finance/provider/shared/_invoice_header.html.erb
+++ b/app/views/finance/provider/shared/_invoice_header.html.erb
@@ -4,7 +4,7 @@
   <table class="invoice">
     <caption>
       Details
-      <%= pf_link_to 'Edit', polymorphic_path([:edit, :admin, *edit_link_scope, @invoice]), :class => 'action edit next' if @invoice.editable? && can?(:update, @invoice)  %>
+      <%= link_to 'Edit', polymorphic_path([:edit, :admin, *edit_link_scope, @invoice]), :class => 'action edit next' if @invoice.editable? && can?(:update, @invoice)  %>
     </caption>
     <%= invoice_field(:friendly_id, "#{@invoice.friendly_id} #{' (This invoice id is already in use and should probably be changed)' if @invoice.friendly_id_already_used? && @invoice.editable? }") %>
     <%= invoice_field(:state, @invoice.state.to_s.capitalize) %>
@@ -13,7 +13,7 @@
     <%= invoice_field(:issued_on, invoice_date_format(@invoice.issued_on))  %>
     <%= invoice_field(:due_on, invoice_date_format(@invoice.due_on)) %>
     <%= invoice_field(:paid_on, invoice_date_format(@invoice.paid_at))  %>
-    <%= invoice_field('PDF', pf_invoice_pdf_link(@invoice)) %>
+    <%= invoice_field('PDF', invoice_pdf_link(@invoice, class: 'pf-c-button pf-m-secondary')) %>
 
   </table>
 

--- a/app/views/finance/provider/shared/_line_items.html.erb
+++ b/app/views/finance/provider/shared/_line_items.html.erb
@@ -11,7 +11,7 @@
     <th>Charged</th>
     <th>
       <% if @invoice.editable? && editable %>
-        <%= pf_link_to 'Add', new_admin_finance_account_invoice_line_item_path(@invoice.buyer_account, @invoice),
+        <%= link_to 'Add', new_admin_finance_account_invoice_line_item_path(@invoice.buyer_account, @invoice),
                     :title => 'Add Custom Charge',
                     :class => 'action add fancybox',
                     :'data-autodimensions' => 'true'

--- a/app/views/provider/admin/account/authentication_providers/form/_form.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/form/_form.html.slim
@@ -25,7 +25,7 @@
   = f.actions do
     = f.commit_button I18n.t('provider.admin.authentication_providers.form.submit_button_label')
     - unless authentication_provider.new_record?
-      = pf_link_to 'Delete',
+      = link_to 'Delete',
                 provider_admin_account_authentication_provider_path(@authentication_provider),
                 data: {confirm: 'Are you sure?'}, method: :delete,
                 title: 'Delete authentication provider', class: 'action delete'

--- a/app/views/provider/admin/accounts/show.html.slim
+++ b/app/views/provider/admin/accounts/show.html.slim
@@ -27,7 +27,7 @@ div id="account-column-wrapper"
       ' Account Details
       - if @presenter.show_edit_account_link?
         span class="operations"
-          = pf_link_to 'Edit', edit_provider_admin_account_path, class: 'action edit'
+          = link_to 'Edit', edit_provider_admin_account_path, class: 'action edit'
 
     table class="list"
       tbody

--- a/app/views/provider/admin/applications/_plan.html.erb
+++ b/app/views/provider/admin/applications/_plan.html.erb
@@ -10,7 +10,7 @@
         <%= delete_button_for admin_buyers_contract_custom_application_plan_path(contract, contract.plan),
                               :label => 'Remove customization' %>
       <% else %>
-        <%= pf_fancy_link_to 'Convert to a Custom Plan',
+        <%= fancy_link_to 'Convert to a Custom Plan',
                            admin_buyers_contract_custom_application_plans_path(contract),
                            :method => :post,
                            :class => 'new',

--- a/app/views/provider/admin/applications/_state.html.slim
+++ b/app/views/provider/admin/applications/_state.html.slim
@@ -7,9 +7,9 @@ dl#cinstance_state.u-dl.u-dl--skinny
     - if @cinstance.pending?
       = render :partial => 'accept_reject'
     - elsif @cinstance.live?
-      = pf_fancy_link_to 'Suspend', suspend_provider_admin_application_path(@cinstance), method: :post, remote: true, data: {:confirm => suspend_application_confirmation(@cinstance)}, class: 'action suspend'
+      = fancy_link_to 'Suspend', suspend_provider_admin_application_path(@cinstance), method: :post, remote: true, data: {:confirm => suspend_application_confirmation(@cinstance)}, class: 'action suspend'
     - elsif @cinstance.suspended?
-      = pf_fancy_link_to 'Resume', resume_provider_admin_application_path(@cinstance), method: :post, remote: true, class: 'action resume'
+      = fancy_link_to 'Resume', resume_provider_admin_application_path(@cinstance), method: :post, remote: true, class: 'action resume'
 
   - if @cinstance.trial?
     dt.u-dl-term

--- a/app/views/provider/admin/applications/show.html.slim
+++ b/app/views/provider/admin/applications/show.html.slim
@@ -6,7 +6,7 @@
     div class="pf-c-content"
       h1
         => @cinstance.display_name
-        = pf_link_to 'Edit', edit_provider_admin_application_path(@cinstance),
+        = link_to 'Edit', edit_provider_admin_application_path(@cinstance),
                              class: 'action edit'
 
 div#twoCol.equal-width

--- a/app/views/provider/admin/backend_apis/forms/_delete.html.slim
+++ b/app/views/provider/admin/backend_apis/forms/_delete.html.slim
@@ -1,30 +1,31 @@
 - if can?(:destroy, backend_api)
-  hr
-  h3
-    ' Backend deletion
-
-  p
-    ' Deleting this backend will
-    strong> irreversibly
-    ' destroy all methods and metrics and mapping rules of this backend.
-    ' It will also delete in the the application plans all limits and pricing rules set on methods and metrics of this backend.
-
-  p
-    strong> Important!
-    ' Proxy configurations of products using this backend (staging and production) will not update automatically after deleting the backend.
-    ' You need to perform this action on each product using the backend, manually via UI or 3scale API.
-
-  - if backend_api.backend_api_configs.any?
-    p The following products are using this backend:
-    ul
-      - for service in backend_api.services
-        li = link_to service.name, admin_service_path(service)
+  div.pf-c-content
+    hr
+    h3
+      ' Backend deletion
 
     p
-      ' Before deleting this backend, make sure none of the products above is using it.
+      ' Deleting this backend will
+      strong> irreversibly
+      ' destroy all methods and metrics and mapping rules of this backend.
+      ' It will also delete in the the application plans all limits and pricing rules set on methods and metrics of this backend.
 
-  - else
     p
-      - msg = t('api.backend_apis.edit.delete_confirmation', name: j(backend_api.name))
-      - delete_options = { data: { confirm: msg }, method: :delete, label: "I understand the consequences, proceed to delete '#{j(backend_api.name)}' backend" }
-      = pf_delete_link_for(provider_admin_backend_api_path(backend_api), delete_options)
+      strong> Important!
+      ' Proxy configurations of products using this backend (staging and production) will not update automatically after deleting the backend.
+      ' You need to perform this action on each product using the backend, manually via UI or 3scale API.
+
+    - if backend_api.backend_api_configs.any?
+      p The following products are using this backend:
+      ul
+        - for service in backend_api.services
+          li = link_to service.name, admin_service_path(service)
+
+      p
+        ' Before deleting this backend, make sure none of the products above is using it.
+
+    - else
+      p
+        - msg = t('api.backend_apis.edit.delete_confirmation', name: j(backend_api.name))
+        - delete_options = { data: { confirm: msg }, method: :delete, label: "I understand the consequences, proceed to delete '#{j(backend_api.name)}' backend" }
+        = delete_link_for(provider_admin_backend_api_path(backend_api), delete_options)

--- a/app/views/provider/admin/backend_apis/metrics/edit.html.erb
+++ b/app/views/provider/admin/backend_apis/metrics/edit.html.erb
@@ -6,5 +6,5 @@
   <%= render 'form_edit', form: form, backend_api: @backend_api, metric: @metric %>
 <% end %>
 <% unless @metric.default?(:hits) %>
-  <%= pf_delete_button_for provider_admin_backend_api_metric_path(@backend_api, @metric), data: {:confirm => "Removing this #{method_or_metric} will affect all plans that contain this #{method_or_metric}, all associated mapping rules will be deleted too. Are you sure? "} %>
+  <%= delete_button_for provider_admin_backend_api_metric_path(@backend_api, @metric), data: {:confirm => "Removing this #{method_or_metric} will affect all plans that contain this #{method_or_metric}, all associated mapping rules will be deleted too. Are you sure? "} %>
 <% end %>


### PR DESCRIPTION
### What
In the past, we tried to apply Patternfly by adding classes like `pf-c-button` and `pf-m-link` to all buttons and links. This only helper because Patternfly stylesheet was being loaded before our legacy stylesheet, therefore the latter had priority.

Now that Patternfly is loaded last (so that it overrides legacy styles) some of these components are broken.

[THREESCALE-9734: Broken UI/layout on multiple pages - missing CSS](https://issues.redhat.com/browse/THREESCALE-9734)

### How
This PR removes Patternfly classes from legacy components. It doesn't make sense to add them to components that should not look different, only to those that are updated.

Example Application Overview:
* Buttons and links **with** Patternfly classes:
![Screenshot 2023-06-19 at 15 52 00](https://github.com/3scale/porta/assets/11672286/b0f14234-323e-46dc-9662-1b68da52bcf7)

* Buttons and links **without** them:
![Screenshot 2023-06-19 at 18 23 30](https://github.com/3scale/porta/assets/11672286/8fc55cf3-9f52-4f6d-bc8f-96edd1939478)
