### PR TITLE
🦋 Add third level navigation

### DIFF
--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -98,7 +98,7 @@ module VerticalNavHelper
     items << {id: :subscriptions, title: 'Subscriptions', path: admin_buyers_service_contracts_path}  if service_plans_management_visible?
 
     if can?(:manage, :settings)
-      items << { title: 'Settings', subitems: [
+      items << { title: 'Settings', subItems: [
         { id: :usage_rules,         title: 'Usage Rules',        path: edit_admin_site_usage_rules_path },
         { id: :fields_definitions,  title: 'Fields Definitions', path: admin_fields_definitions_path }
       ]}
@@ -129,7 +129,7 @@ module VerticalNavHelper
       billing_settings_items << {id: :charging_and_gateway, title: 'Charging & Gateway',   path: admin_finance_settings_path} if can?(:manage, :finance)
       billing_settings_items << {id: :credit_card_policies, title: 'Credit Card Policies', path: edit_admin_site_settings_path}
 
-      items << { title: 'Settings', subitems: billing_settings_items }
+      items << { title: 'Settings', subItems: billing_settings_items }
     end
 
     items
@@ -153,7 +153,7 @@ module VerticalNavHelper
     items << {title: 'Visit Portal', path: access_code_url(host: current_account.external_domain, cms_token: current_account.settings.cms_token!, access_code: current_account.site_access_code).html_safe, target: '_blank'}
 
     if can?(:manage, :portal)
-      items << { title: 'Legal Terms', subitems: [
+      items << { title: 'Legal Terms', subItems: [
         {id: :signup_licence,               title: 'Signup',               path: edit_legal_terms_url(CMS::Builtin::LegalTerm::SIGNUP_SYSTEM_NAME)},
         {id: :service_subscription_licence, title: 'Service Subscription', path: edit_legal_terms_url(CMS::Builtin::LegalTerm::SUBSCRIPTION_SYSTEM_NAME)},
         {id: :new_application_licence,      title: 'New Application',      path: edit_legal_terms_url(CMS::Builtin::LegalTerm::NEW_APPLICATION_SYSTEM_NAME)}
@@ -168,10 +168,10 @@ module VerticalNavHelper
       portal_settings_items << {id: :sso_integrations, title: 'SSO Integrations', path: provider_admin_authentication_providers_path}
       portal_settings_items << {id: :forum_settings,   title: 'Forum Settings',   path: edit_admin_site_forum_path} if !current_account.forum_enabled? && provider_can_use?(:forum)
 
-      items << { title: 'Settings', subitems: portal_settings_items }
+      items << { title: 'Settings', subItems: portal_settings_items }
     end
 
-    items << { title: 'Docs', subitems: [
+    items << { title: 'Docs', subItems: [
       { id: :liquid_reference, title: 'Liquid Reference', path: provider_admin_liquid_docs_path },
     ]}
   end
@@ -183,7 +183,7 @@ module VerticalNavHelper
     items << {id: :trash,         title: 'Trash',         path: provider_admin_messages_trash_index_path}
 
     if can?(:manage, :settings) && !master_on_premises?
-      items << { title: 'Settings', subitems: [
+      items << { title: 'Settings', subItems: [
         { id: :email,     title: 'Support Emails',  path: edit_admin_site_emails_path },
         { id: :templates, title: 'Email Templates', path: provider_admin_cms_email_templates_path }
       ]}
@@ -243,7 +243,7 @@ module VerticalNavHelper
     items << {id: :listing,           title: 'Listing',           path: admin_service_applications_path(@service)}      if can? :manage, :applications
     items << {id: :application_plans, title: 'Application Plans', path: admin_service_application_plans_path(@service)} if can?(:manage, :plans)
     unless master_on_premises?
-      items << { title: 'Settings', subitems: [
+      items << { title: 'Settings', subItems: [
         { id: :usage_rules, title: 'Usage Rules', path: usage_rules_admin_service_path(@service) }
       ]}
     end

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -151,6 +151,7 @@ module VerticalNavHelper
 
     items << {title: ''} # Separator
     items << {title: 'Visit Portal', path: access_code_url(host: current_account.external_domain, cms_token: current_account.settings.cms_token!, access_code: current_account.site_access_code).html_safe, target: '_blank'}
+    items << {title: ''} # Separator
 
     if can?(:manage, :portal)
       items << { title: 'Legal Terms', subItems: [

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ModuleLength
 # frozen_string_literal: true
 
 module VerticalNavHelper
@@ -93,13 +94,14 @@ module VerticalNavHelper
   def audience_accounts_items
     items = []
     items << {id: :listing,       title: 'Listing',       path: admin_buyers_accounts_path}           if can?(:manage, :partners)
-    items << {id: :account_plans,  title: 'Account Plans', path: admin_buyers_account_plans_path}     if account_plans_management_visible?
+    items << {id: :account_plans, title: 'Account Plans', path: admin_buyers_account_plans_path}     if account_plans_management_visible?
     items << {id: :subscriptions, title: 'Subscriptions', path: admin_buyers_service_contracts_path}  if service_plans_management_visible?
 
     if can?(:manage, :settings)
-      items << {                          title: 'Settings'}
-      items << {id: :usage_rules,         title: 'Usage Rules',        path: edit_admin_site_usage_rules_path}
-      items << {id: :fields_definitions,  title: 'Fields Definitions', path: admin_fields_definitions_path}
+      items << { title: 'Settings', subitems: [
+        { id: :usage_rules,         title: 'Usage Rules',        path: edit_admin_site_usage_rules_path },
+        { id: :fields_definitions,  title: 'Fields Definitions', path: admin_fields_definitions_path }
+      ]}
     end
 
     items
@@ -122,16 +124,18 @@ module VerticalNavHelper
     end
 
     if can?(:manage, :settings)
-      items << {                           title: 'Settings'}
+      billing_settings_items = []
       # this setting needs more than just editing auth, as such it's not a setting
-      items << {id: :charging_and_gateway, title: 'Charging & Gateway',   path: admin_finance_settings_path} if can?(:manage, :finance)
-      items << {id: :credit_card_policies, title: 'Credit Card Policies', path: edit_admin_site_settings_path}
+      billing_settings_items << {id: :charging_and_gateway, title: 'Charging & Gateway',   path: admin_finance_settings_path} if can?(:manage, :finance)
+      billing_settings_items << {id: :credit_card_policies, title: 'Credit Card Policies', path: edit_admin_site_settings_path}
+
+      items << { title: 'Settings', subitems: billing_settings_items }
     end
 
     items
   end
 
-  def audience_portal_items
+  def audience_portal_items # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     items = []
 
     if can?(:manage, :portal)
@@ -149,23 +153,27 @@ module VerticalNavHelper
     items << {title: 'Visit Portal', path: access_code_url(host: current_account.external_domain, cms_token: current_account.settings.cms_token!, access_code: current_account.site_access_code).html_safe, target: '_blank'}
 
     if can?(:manage, :portal)
-      items << {                                   title: 'Legal Terms'}
-      items << {id: :signup_licence,               title: 'Signup',               path: edit_legal_terms_url(CMS::Builtin::LegalTerm::SIGNUP_SYSTEM_NAME)}
-      items << {id: :service_subscription_licence, title: 'Service Subscription', path: edit_legal_terms_url(CMS::Builtin::LegalTerm::SUBSCRIPTION_SYSTEM_NAME)}
-      items << {id: :new_application_licence,      title: 'New Application',      path: edit_legal_terms_url(CMS::Builtin::LegalTerm::NEW_APPLICATION_SYSTEM_NAME)}
+      items << { title: 'Legal Terms', subitems: [
+        {id: :signup_licence,               title: 'Signup',               path: edit_legal_terms_url(CMS::Builtin::LegalTerm::SIGNUP_SYSTEM_NAME)},
+        {id: :service_subscription_licence, title: 'Service Subscription', path: edit_legal_terms_url(CMS::Builtin::LegalTerm::SUBSCRIPTION_SYSTEM_NAME)},
+        {id: :new_application_licence,      title: 'New Application',      path: edit_legal_terms_url(CMS::Builtin::LegalTerm::NEW_APPLICATION_SYSTEM_NAME)}
+      ]}
     end
 
     if can?(:manage, :settings)
-      items << {                       title: 'Settings'}
-      items << {id: :admin_site_dns,   title: 'Domains & Access', path: admin_site_dns_path}
-      items << {id: :spam_protection,  title: 'Spam Protection',  path: edit_admin_site_spam_protection_path}
-      items << {id: :xss_protection,   title: 'XSS Protection',   path: edit_admin_site_developer_portal_path} if current_account.show_xss_protection_options?
-      items << {id: :sso_integrations, title: 'SSO Integrations', path: provider_admin_authentication_providers_path}
-      items << {id: :forum_settings,   title: 'Forum Settings',   path: edit_admin_site_forum_path} if !current_account.forum_enabled? && provider_can_use?(:forum)
+      portal_settings_items = []
+      portal_settings_items << {id: :admin_site_dns,   title: 'Domains & Access', path: admin_site_dns_path}
+      portal_settings_items << {id: :spam_protection,  title: 'Spam Protection',  path: edit_admin_site_spam_protection_path}
+      portal_settings_items << {id: :xss_protection,   title: 'XSS Protection',   path: edit_admin_site_developer_portal_path} if current_account.show_xss_protection_options?
+      portal_settings_items << {id: :sso_integrations, title: 'SSO Integrations', path: provider_admin_authentication_providers_path}
+      portal_settings_items << {id: :forum_settings,   title: 'Forum Settings',   path: edit_admin_site_forum_path} if !current_account.forum_enabled? && provider_can_use?(:forum)
+
+      items << { title: 'Settings', subitems: portal_settings_items }
     end
 
-    items << {                       title: 'Docs'}
-    items << {id: :liquid_reference, title: 'Liquid Reference', path: provider_admin_liquid_docs_path}
+    items << { title: 'Docs', subitems: [
+      { id: :liquid_reference, title: 'Liquid Reference', path: provider_admin_liquid_docs_path },
+    ]}
   end
 
   def audience_messages_items
@@ -175,9 +183,10 @@ module VerticalNavHelper
     items << {id: :trash,         title: 'Trash',         path: provider_admin_messages_trash_index_path}
 
     if can?(:manage, :settings) && !master_on_premises?
-      items << {                title: 'Settings'}
-      items << {id: :email,     title: 'Support Emails',  path: edit_admin_site_emails_path}
-      items << {id: :templates, title: 'Email Templates', path: provider_admin_cms_email_templates_path}
+      items << { title: 'Settings', subitems: [
+        { id: :email,     title: 'Support Emails',  path: edit_admin_site_emails_path },
+        { id: :templates, title: 'Email Templates', path: provider_admin_cms_email_templates_path }
+      ]}
     end
 
     items
@@ -234,8 +243,9 @@ module VerticalNavHelper
     items << {id: :listing,           title: 'Listing',           path: admin_service_applications_path(@service)}      if can? :manage, :applications
     items << {id: :application_plans, title: 'Application Plans', path: admin_service_application_plans_path(@service)} if can?(:manage, :plans)
     unless master_on_premises?
-      items << {title: 'Settings'}
-      items << {id: :usage_rules, title: 'Usage Rules', path: usage_rules_admin_service_path(@service)}
+      items << { title: 'Settings', subitems: [
+        { id: :usage_rules, title: 'Usage Rules', path: usage_rules_admin_service_path(@service) }
+      ]}
     end
     items
   end
@@ -275,3 +285,5 @@ module VerticalNavHelper
     sections
   end
 end
+
+# rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ModuleLength

--- a/app/javascript/src/Navigation/components/NavSection.tsx
+++ b/app/javascript/src/Navigation/components/NavSection.tsx
@@ -1,7 +1,6 @@
 import {
   NavExpandable,
   NavItem,
-  NavGroup,
   NavItemSeparator
 } from '@patternfly/react-core'
 
@@ -29,8 +28,26 @@ const NavSection: React.FunctionComponent<Props> = ({
     isExpanded={isSectionActive}
     title={navSectionTitle}
   >
-    {items.map(({ id, title, path, target, itemOutOfDateConfig }) => path
+    {items.map(({ id, title, path, target, itemOutOfDateConfig, subItems }) => (subItems && title)
       ? (
+        <NavExpandable
+          key={title}
+          isActive={isSectionActive && subItems.some(s => s.id === activeItem)}
+          isExpanded={isSectionActive && subItems.some(s => s.id === activeItem)}
+          title={title}
+        >
+          {subItems.map(sub => (
+            <NavItem
+              key={sub.id}
+              isActive={isSectionActive && activeItem === sub.id}
+              target={sub.target}
+              to={sub.path}
+            >
+              {sub.title}
+            </NavItem>
+          ))}
+        </NavExpandable>
+      ) : title ? (
         <NavItem
           key={title}
           className={itemOutOfDateConfig ? 'outdated-config' : ''}
@@ -40,8 +57,7 @@ const NavSection: React.FunctionComponent<Props> = ({
         >
           {title}
         </NavItem>
-      )
-      : title ? <NavGroup key={title} title={title} /> : <NavItemSeparator key="separator" />
+      ) : <NavItemSeparator key="separator" />
     )}
   </NavExpandable>
 )

--- a/app/javascript/src/Navigation/components/VerticalNav.tsx
+++ b/app/javascript/src/Navigation/components/VerticalNav.tsx
@@ -25,7 +25,7 @@ const VerticalNav: React.FunctionComponent<Props> = ({
   activeItem,
   currentApi
 }) => {
-  const navSections = sections.map(({ id, title, path, items, outOfDateConfig }) => items
+  const navSections = sections.map(({ id, title, path, items, outOfDateConfig, target }) => items
     ? (
       <NavSection
         key={title}
@@ -39,6 +39,7 @@ const VerticalNav: React.FunctionComponent<Props> = ({
       <NavItem
         key={title}
         isActive={activeSection === id}
+        target={target}
         to={path}
       >
         {title}

--- a/app/javascript/src/Navigation/types.ts
+++ b/app/javascript/src/Navigation/types.ts
@@ -1,12 +1,16 @@
 export interface Item {
   id: string;
-  title: string;
+  title?: string;
   path?: string;
   target?: string;
   itemOutOfDateConfig?: boolean;
+  subItems?: SubItem[];
 }
 
-export type Section = Item & {
+export type Section = Omit<Item, 'subitems'> & {
+  title: string;
   items?: Item[];
   outOfDateConfig?: boolean;
 }
+
+export type SubItem = Omit<Item, 'subitems'>

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -11,7 +11,7 @@ Then "I should see menu items under {string}" do |section, items|
   button.click if button['aria-expanded'] == 'false'
 
   nav_items = within(button.sibling('.pf-c-nav__subnav')) do
-    find_all('.pf-c-nav__item', visible: :all).map { |i| i.text(:all) }
+    find_all('.pf-c-nav__item:not(.pf-m-expandable)', visible: :all).map { |i| i.text(:all) }
   end
 
   assert_equal items.raw.flatten, nav_items

--- a/spec/javascripts/Navigation/VerticalNav.spec.tsx
+++ b/spec/javascripts/Navigation/VerticalNav.spec.tsx
@@ -1,41 +1,258 @@
-import { mount, render } from 'enzyme'
+import { mount } from 'enzyme'
+import { NavItemSeparator } from '@patternfly/react-core'
 
 import { VerticalNav } from 'Navigation/components/VerticalNav'
 
-const currentApi = {
-  id: 1,
-  name: 'My Product',
-  link: '/foo',
-  type: 'product'
+import type { Item, Section, SubItem } from 'Navigation/types'
+import type { Props } from 'Navigation/components/VerticalNav'
+
+const defaultProps: Props = {
+  sections: [],
+  activeSection: undefined,
+  activeItem: undefined,
+  currentApi: undefined
 }
 
-const sections = [{
-  id: '0',
-  title: 'Section 0',
-  items: [{ id: '0', title: 'Subsection 0' }, { id: '1', title: 'Subsection 1' }],
-  outOfDateConfig: false
-}]
+const mountWrapper = (props: Partial<Props> = {}) => mount(<VerticalNav {...{ ...defaultProps, ...props }} />)
 
-it('should display the current API on top', () => {
-  const wrapper = render(<VerticalNav currentApi={currentApi} sections={sections} />)
-  const sectionTitle = wrapper.find('.pf-c-nav__current-api').first()
+describe('product context', () => {
+  const currentApi = {
+    id: 1,
+    name: 'My Product',
+    link: '/foo',
+    type: 'product'
+  }
 
-  expect(sectionTitle.text()).toBe(currentApi.name)
+  it('should display the current API on top', () => {
+    const wrapper = mountWrapper({ currentApi })
+    const sectionTitle = wrapper.find('.pf-c-page__sidebar-body > .pf-c-nav__current-api')
+
+    expect(sectionTitle.text()).toBe(currentApi.name)
+
+    wrapper.setProps({ currentApi: undefined })
+    expect(wrapper.exists('.pf-c-page__sidebar-body > .pf-c-nav__current-api')).toBe(false)
+  })
 })
 
-it('should display sections', () => {
-  const wrapper = render(<VerticalNav sections={sections} />)
-  const navItems = wrapper.find('.pf-c-nav__item')
+describe('first level items and sections', () => {
+  it('should render external links', () => {
+    const section: Section = {
+      id: 'nav-item-1',
+      title: 'External link',
+      path: '/items/0',
+      target: '_blank'
+    }
 
-  expect(navItems.length).toBe(sections.length)
+    const wrapper = mountWrapper({ sections: [section] })
+
+    const link = wrapper.find('.pf-c-nav__item .pf-c-nav__link')
+    expect(link.props().target).toEqual(section.target)
+    expect(link.props().href).toEqual(section.path)
+    expect(link.text()).toEqual(section.title)
+  })
+
+  it('should render sections', () => {
+    const sections = [
+      { id: 'section-0', title: 'Section 0', items: [] },
+      { id: 'section-1', title: 'Section 1', items: [] }
+    ]
+    const wrapper = mountWrapper({ sections })
+    wrapper.find('.pf-c-nav .pf-c-nav__list .pf-c-nav__item.pf-m-expandable button.pf-c-nav__link').forEach((button, i) => {
+      expect(button.text()).toEqual(sections[i].title)
+    })
+  })
+
+  it('should render all sections closed by default', () => {
+    const sections = [
+      { id: 'section-0', title: 'Section 0', items: [] },
+      { id: 'section-1', title: 'Section 1', items: [] }
+    ]
+    const wrapper = mountWrapper({ sections })
+    expect(wrapper.exists('.pf-m-expanded')).toEqual(false)
+  })
+
+  it('should expand the active section', () => {
+    const sections = [
+      { id: 'section-0', title: 'Section 0', items: [] },
+      { id: 'section-1', title: 'Section 1', items: [] }
+    ]
+    const { id, title } = sections[0]
+    const wrapper = mountWrapper({ sections, activeSection: id })
+
+    expect(wrapper.find('.pf-c-nav__item.pf-m-expandable.pf-m-expanded.pf-m-current').text())
+      .toEqual(title)
+  })
 })
 
-// FIXME: VerticalNav needs to be fixed https://issues.redhat.com/browse/THREESCALE-9646
-it.skip('should display all sections closed by default', () => {
-  const wrapper = mount(<VerticalNav sections={sections} />)
-  expect(wrapper.exists('.pf-m-expanded')).toEqual(false)
+describe('second level items', () => {
+  it('should render external links', () => {
+    const navItem: Item = {
+      id: 'section-0-nav-item-0',
+      title: 'External link',
+      path: '/section/0/items/0',
+      target: '_blank'
+    }
+    const section: Section = {
+      id: 'section-0',
+      title: 'Section 0',
+      items: [navItem]
+    }
 
-  wrapper.setProps({ sections, activeSection: '0', activeItem: '0' })
-  wrapper.update()
-  expect(wrapper.exists('.pf-m-expanded')).toEqual(true)
+    const wrapper = mountWrapper({ sections: [section] })
+
+    const link = wrapper.find('.pf-c-nav__item .pf-c-nav__subnav .pf-c-nav__list a.pf-c-nav__link')
+    expect(link.props().target).toEqual(navItem.target)
+    expect(link.props().href).toEqual(navItem.path)
+    expect(link.text()).toEqual(navItem.title)
+  })
+
+  it('should render grouped items', () => {
+    const items: Item[] = [
+      { id: 'section-0-item-0', title: 'Item 0', path: '/section/0/item/0' },
+      { id: 'section-0-item-1', title: 'Item 1', path: '/section/0/item/1' }
+    ]
+    const section: Section = {
+      id: 'section-0',
+      title: 'Section 0',
+      items
+    }
+
+    const wrapper = mountWrapper({ sections: [section] })
+
+    wrapper.find('.pf-c-nav__item.pf-m-expandable .pf-c-nav__subnav a.pf-c-nav__link').forEach((anchor, i) => {
+      const { target, path, title } = items[i]
+      expect(anchor.props().target).toEqual(target)
+      expect(anchor.props().href).toEqual(path)
+      expect(anchor.text()).toEqual(title)
+    })
+  })
+
+  it('should mark a grouped section as out of date', () => {
+    const navItem: Item = {
+      id: 'section-0-nav-item-0',
+      title: 'Outdated Settings',
+      path: '/section/0/items/0',
+      itemOutOfDateConfig: true
+    }
+    const section: Section = {
+      id: 'section-0',
+      title: 'Outdated Section',
+      outOfDateConfig: true,
+      items: [navItem]
+    }
+
+    const wrapper = mountWrapper({ sections: [section] })
+
+    expect(wrapper.find('.pf-c-nav__item.pf-m-expandable').hasClass('outdated-config')).toBe(true)
+    expect(wrapper.find('.pf-c-nav__item .pf-c-nav__subnav .pf-c-nav__list a.pf-c-nav__link').hasClass('outdated-config')).toBe(true)
+
+    navItem.itemOutOfDateConfig = false
+    section.outOfDateConfig = false
+    wrapper.setProps({ sections: [section] })
+
+    expect(wrapper.find('.pf-c-nav__item.pf-m-expandable').hasClass('outdated-config')).toBe(false)
+    expect(wrapper.find('.pf-c-nav__item .pf-c-nav__subnav .pf-c-nav__list a.pf-c-nav__link').hasClass('outdated-config')).toBe(false)
+  })
+
+  it('should render a separator', () => {
+    const navItem: Item = {
+      id: 'section-0-nav-separator'
+    }
+    const section: Section = {
+      id: 'section-0',
+      title: 'Section 0',
+      items: [navItem]
+    }
+
+    const wrapper = mountWrapper({ sections: [section] })
+    expect(wrapper.find('.pf-c-nav__item .pf-c-nav__subnav').exists(NavItemSeparator)).toEqual(true)
+  })
+
+  it('should highlight the active item', () => {
+    const sections = [
+      { id: 'section-0', title: 'Section 0', items: [{ id: 'section-0-item-0', title: 'Item 0' }] },
+      { id: 'section-1', title: 'Section 1', items: [{ id: 'section-1-item-1', title: 'Item 1' }] }
+    ]
+    const { id: sectionId, items } = sections[0]
+    const { id: itemId, title: itemTitle } = items[0]
+    const wrapper = mountWrapper({ sections, activeSection: sectionId, activeItem: itemId })
+
+    expect(wrapper.find('.pf-m-expandable.pf-m-current .pf-c-nav__link.pf-m-current').text())
+      .toEqual(itemTitle)
+  })
+})
+
+describe('third level items', () => {
+  it('should render external links', () => {
+    const subItem: SubItem = {
+      id: 'section-0-nav-item-0',
+      title: 'External link',
+      path: '/section/0/items/0',
+      target: '_blank'
+    }
+    const section: Section = {
+      id: 'section-0',
+      title: 'Section 0',
+      items: [{
+        id: 'section-0-nav-item-0',
+        title: 'External link',
+        subItems: [subItem]
+      }]
+    }
+
+    const wrapper = mountWrapper({ sections: [section] })
+
+    const link = wrapper.find('.pf-m-expandable .pf-c-nav__subnav .pf-c-nav__subnav a.pf-c-nav__link')
+    expect(link.props().target).toEqual(subItem.target)
+    expect(link.props().href).toEqual(subItem.path)
+    expect(link.text()).toEqual(subItem.title)
+  })
+
+  it('should render grouped items', () => {
+    const subItems: SubItem[] = [
+      { id: 'section-0-nav-item-0-subitem-0', title: 'Subitem 0' },
+      { id: 'section-0-nav-item-0-subitem-1', title: 'Subitem 1' }
+    ]
+    const section: Section = {
+      id: 'section-0',
+      title: 'Section 0',
+      items: [{
+        id: 'section-0-nav-item-0',
+        title: 'External link',
+        subItems
+      }]
+    }
+
+    const wrapper = mountWrapper({ sections: [section] })
+
+    wrapper.find('.pf-m-expandable .pf-c-nav__subnav .pf-c-nav__subnav a.pf-c-nav__link')
+      .forEach((anchor, i) => {
+        const { target, path, title } = subItems[i]
+        expect(anchor.props().target).toEqual(target)
+        expect(anchor.props().href).toEqual(path)
+        expect(anchor.text()).toEqual(title)
+      })
+  })
+
+  it('should highlight the active item', () => {
+    const sections: Section[] = [{
+      id: 'section-0',
+      title: 'Section 0',
+      items: [{
+        id: 'section-0-nav-item-0',
+        title: 'External link',
+        subItems: [
+          { id: 'section-0-nav-item-0-subitem-0', title: 'Subitem 0' },
+          { id: 'section-0-nav-item-0-subitem-1', title: 'Subitem 1' }
+        ]
+      }]
+    }]
+    const { id: sectionId, items } = sections[0]
+    const { subItems } = items![0]
+    const { id: subItemId, title: subItemTitle } = subItems![0]
+    const wrapper = mountWrapper({ sections, activeSection: sectionId, activeItem: subItemId })
+
+    expect(wrapper.find('.pf-m-expandable .pf-c-nav__subnav .pf-c-nav__subnav .pf-m-current').text())
+      .toEqual(subItemTitle)
+  })
 })

--- a/test/helpers/vertical_nav_helper_test.rb
+++ b/test/helpers/vertical_nav_helper_test.rb
@@ -41,21 +41,21 @@ class VerticalNavHelperTest < ActionView::TestCase
       rolling_update(:forum, enabled: true)
 
       current_account.settings.forum_enabled = false
-      assert_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subitems].pluck(:id), :forum_settings
+      assert_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subItems].pluck(:id), :forum_settings
       assert_not_includes audience_nav_sections.pluck(:id), :forum
 
       current_account.settings.forum_enabled = true
-      assert_not_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subitems].pluck(:id), :forum_settings
+      assert_not_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subItems].pluck(:id), :forum_settings
       assert_includes audience_nav_sections.pluck(:id), :forum
 
       rolling_update(:forum, enabled: false)
 
       current_account.settings.forum_enabled = false
-      assert_not_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subitems].pluck(:id), :forum_settings
+      assert_not_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subItems].pluck(:id), :forum_settings
       assert_not_includes audience_nav_sections.pluck(:id), :forum
 
       current_account.settings.forum_enabled = true
-      assert_not_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subitems].pluck(:id), :forum_settings
+      assert_not_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subItems].pluck(:id), :forum_settings
       assert_not_includes audience_nav_sections.pluck(:id), :forum
     end
 

--- a/test/helpers/vertical_nav_helper_test.rb
+++ b/test/helpers/vertical_nav_helper_test.rb
@@ -41,21 +41,21 @@ class VerticalNavHelperTest < ActionView::TestCase
       rolling_update(:forum, enabled: true)
 
       current_account.settings.forum_enabled = false
-      assert_includes audience_portal_items.pluck(:id), :forum_settings
+      assert_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subitems].pluck(:id), :forum_settings
       assert_not_includes audience_nav_sections.pluck(:id), :forum
 
       current_account.settings.forum_enabled = true
-      assert_not_includes audience_portal_items.pluck(:id), :forum_settings
+      assert_not_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subitems].pluck(:id), :forum_settings
       assert_includes audience_nav_sections.pluck(:id), :forum
 
       rolling_update(:forum, enabled: false)
 
       current_account.settings.forum_enabled = false
-      assert_not_includes audience_portal_items.pluck(:id), :forum_settings
+      assert_not_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subitems].pluck(:id), :forum_settings
       assert_not_includes audience_nav_sections.pluck(:id), :forum
 
       current_account.settings.forum_enabled = true
-      assert_not_includes audience_portal_items.pluck(:id), :forum_settings
+      assert_not_includes audience_portal_items.find { |item| item[:title] == 'Settings' }[:subitems].pluck(:id), :forum_settings
       assert_not_includes audience_nav_sections.pluck(:id), :forum
     end
 


### PR DESCRIPTION
[THREESCALE-9646: Fix vertical nav](https://issues.redhat.com/browse/THREESCALE-9646)

Patternfly 4 do not support Expandable + Grouped navigation and  items inside a section look very similar if not identical:
![image](https://github.com/3scale/porta/assets/11672286/76e14c04-8d4d-46fb-810e-5f140cadbff6)

Instead, there is a "third level" expandable navigation.

Third level items will be collapsed by default:
![Screenshot 2023-06-20 at 16 07 10](https://github.com/3scale/porta/assets/11672286/dc723e4f-4771-449a-b03f-7801a8666533)

![Screenshot 2023-06-20 at 16 07 15](https://github.com/3scale/porta/assets/11672286/16f37440-3ea3-4bfa-a02c-f10e9e92f3ac)

When the section is active, they will be expanded and highlighted
![Screenshot 2023-06-20 at 16 07 23](https://github.com/3scale/porta/assets/11672286/32bb4ef9-7b1b-4c42-b99d-b150efdff628)


