### PR TITLE
🐛 Fix sidebar console error

### DIFF
--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -149,9 +149,9 @@ module VerticalNavHelper
       items << {id: :ActiveDocs,         title: 'ActiveDocs',         path: admin_api_docs_services_path}          if can?(:manage, :plans)
     end
 
-    items << {title: ''} # Separator
+    items << {id: 'separator 0'} # Separator
     items << {title: 'Visit Portal', path: access_code_url(host: current_account.external_domain, cms_token: current_account.settings.cms_token!, access_code: current_account.site_access_code).html_safe, target: '_blank'}
-    items << {title: ''} # Separator
+    items << {id: 'separator 1'} # Separator
 
     if can?(:manage, :portal)
       items << { title: 'Legal Terms', subItems: [

--- a/app/javascript/src/Navigation/components/NavSection.tsx
+++ b/app/javascript/src/Navigation/components/NavSection.tsx
@@ -57,7 +57,7 @@ const NavSection: React.FunctionComponent<Props> = ({
         >
           {title}
         </NavItem>
-      ) : <NavItemSeparator key="separator" />
+      ) : <NavItemSeparator key={id} />
     )}
   </NavExpandable>
 )


### PR DESCRIPTION
Inside the vertical nav, no 2 items should share the same key. Turns out the separators are.

Error in browser console:
```
Warning: Encountered two children with the same key, `separator`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
    in ul (created by Context.Consumer)
    in section (created by Context.Consumer)
    in li (created by Context.Consumer)
    in NavExpandable (created by NavSection)
    in NavSection (created by VerticalNav)
    in ul (created by Context.Consumer)
    in NavList (created by VerticalNav)
    in nav (created by Nav)
    in Nav (created by VerticalNav)
    in div (created by VerticalNav)
    in VerticalNav
```