### PR TITLE
THREESCALE-9798 fix wip for Edit personal details with invalid data

### DIFF
--- a/features/old/accounts/personal_details.feature
+++ b/features/old/accounts/personal_details.feature
@@ -36,13 +36,11 @@ Feature: Personal Details
     Then I should be on the provider users page
 
   Scenario: Edit personal details with invalid data
-    And a buyer "randomdude" signed up to provider "foo.3scale.localhost"
-    When I log in as "randomdude" on foo.3scale.localhost
-    And I go to the personal details page
-    Then I should be on the personal details page
-    And I fill in "Email" with ""
-    And I press "Update Personal Details"
-    Then I should see "should look like an email addres"
+    When I go to the personal details page
+    And I fill in "Username" with ""
+    And I fill in "Current password" with "supersecret"
+    And I press "Update Details"
+    Then I should see "is too short"
 
   Scenario: Provider should see all fields defined for user
     Given master provider has the following fields defined for "User":

--- a/features/old/accounts/personal_details.feature
+++ b/features/old/accounts/personal_details.feature
@@ -41,7 +41,7 @@ Feature: Personal Details
     And I fill in "Username" with ""
     And I fill in "Current password" with "supersecret"
     And I press "Update Details"
-    Then I should see "is too short"  
+    Then I should see "is too short"
 
   Scenario: Provider should see all fields defined for user
     Given master provider has the following fields defined for "User":

--- a/features/old/accounts/personal_details.feature
+++ b/features/old/accounts/personal_details.feature
@@ -41,7 +41,7 @@ Feature: Personal Details
     And I fill in "Username" with ""
     And I fill in "Current password" with "supersecret"
     And I press "Update Details"
-    Then I should see "is too short"
+    Then I should see inline error "is too short (minimum is 3 characters)" for user username input
 
   Scenario: Provider should see all fields defined for user
     Given master provider has the following fields defined for "User":

--- a/features/old/accounts/personal_details.feature
+++ b/features/old/accounts/personal_details.feature
@@ -36,11 +36,12 @@ Feature: Personal Details
     Then I should be on the provider users page
 
   Scenario: Edit personal details with invalid data
-    When I go to the personal details page
+    When I navigate to the Account Settings
+    And I go to the provider personal details page
     And I fill in "Username" with ""
     And I fill in "Current password" with "supersecret"
     And I press "Update Details"
-    Then I should see "is too short"
+    Then I should see "is too short"  
 
   Scenario: Provider should see all fields defined for user
     Given master provider has the following fields defined for "User":

--- a/features/old/accounts/personal_details.feature
+++ b/features/old/accounts/personal_details.feature
@@ -36,10 +36,13 @@ Feature: Personal Details
     Then I should be on the provider users page
 
   Scenario: Edit personal details with invalid data
+    And a buyer "randomdude" signed up to provider "foo.3scale.localhost"
+    When I log in as "randomdude" on foo.3scale.localhost
     And I go to the personal details page
+    Then I should be on the personal details page
     And I fill in "Email" with ""
-    And I press "Update Details"
-    Then I should see "can't be blank" within "#user_email_input"
+    And I press "Update Personal Details"
+    Then I should see "should look like an email addres"
 
   Scenario: Provider should see all fields defined for user
     Given master provider has the following fields defined for "User":

--- a/features/old/accounts/personal_details.feature
+++ b/features/old/accounts/personal_details.feature
@@ -35,7 +35,6 @@ Feature: Personal Details
     And I press "Update Details"
     Then I should be on the provider users page
 
-  @wip
   Scenario: Edit personal details with invalid data
     And I go to the personal details page
     And I fill in "Email" with ""

--- a/features/step_definitions/provider_steps.rb
+++ b/features/step_definitions/provider_steps.rb
@@ -279,3 +279,8 @@ Then(/^new tenant should be not created$/) do
     assert_selector('.inline-errors', :text => error_message[:message])
   end
 end
+
+Then /^(?:|I |they )should see inline error "([^"]*)" for ([^"]*)$/ do |text, input_name|
+  inline_error_selector = "li##{input_name.parameterize.underscore} p.inline-errors"
+  assert_selector(inline_error_selector, text: text)
+end


### PR DESCRIPTION
This PR fix failure of wip feature of file 
porta/features/old/accounts/personal_details.feature

Jira issue
https://issues.redhat.com/browse/THREESCALE-9798

For verification

![image](https://github.com/3scale/porta/assets/84672731/c6992759-4cca-47b7-827b-20d6e940051f)
