### PR TITLE
Replace #update_attributes by #update 

### DIFF
--- a/app/controllers/admin/api/account/authentication_providers_controller.rb
+++ b/app/controllers/admin/api/account/authentication_providers_controller.rb
@@ -21,7 +21,7 @@ class Admin::Api::Account::AuthenticationProvidersController < Admin::Api::BaseC
   # PUT /admin/api/account/authentication_providers/{id}.xml
   def update
     authorize_changes
-    authentication_provider.update_attributes(authentication_provider_update_params)
+    authentication_provider.update(authentication_provider_update_params)
     respond_with authentication_provider_presenter
   end
 

--- a/app/controllers/admin/api/account_features_controller.rb
+++ b/app/controllers/admin/api/account_features_controller.rb
@@ -25,7 +25,7 @@ class Admin::Api::AccountFeaturesController < Admin::Api::BaseController
   # Account Feature Update
   # PUT /admin/api/features/{id}.xml
   def update
-    feature.update_attributes(feature_params)
+    feature.update(feature_params)
 
     respond_with(feature)
   end

--- a/app/controllers/admin/api/account_plans_controller.rb
+++ b/app/controllers/admin/api/account_plans_controller.rb
@@ -28,7 +28,7 @@ class Admin::Api::AccountPlansController < Admin::Api::BaseController
   # Account Plan Update
   # PUT /admin/api/account_plans/{id}.xml
   def update
-    account_plan.update_attributes(account_plan_update_params)
+    account_plan.update(account_plan_update_params)
     respond_with(account_plan)
   end
 

--- a/app/controllers/admin/api/application_plan_metric_limits_controller.rb
+++ b/app/controllers/admin/api/application_plan_metric_limits_controller.rb
@@ -28,7 +28,7 @@ class Admin::Api::ApplicationPlanMetricLimitsController < Admin::Api::BaseContro
   # Limit Update
   # PUT /admin/api/application_plans/{application_plan_id}/metrics/{metric_id}/limits/{id}.xml
   def update
-    usage_limit.update_attributes(usage_limit_params)
+    usage_limit.update(usage_limit_params)
 
     respond_with(usage_limit)
   end

--- a/app/controllers/admin/api/application_plans_controller.rb
+++ b/app/controllers/admin/api/application_plans_controller.rb
@@ -32,7 +32,7 @@ class Admin::Api::ApplicationPlansController < Admin::Api::ServiceBaseController
   # Application Plan Update
   # PUT /admin/api/services/{service_id}/application_plans/{id}.xml
   def update
-    application_plan.update_attributes(application_plan_update_params)
+    application_plan.update(application_plan_update_params)
     respond_with(application_plan)
   end
 

--- a/app/controllers/admin/api/authentication_providers_controller.rb
+++ b/app/controllers/admin/api/authentication_providers_controller.rb
@@ -21,7 +21,7 @@ class Admin::Api::AuthenticationProvidersController < Admin::Api::BaseController
   # Authentication Provider Developer Portal Update
   # PUT /admin/api/authentication_providers/{id}.xml
   def update
-    authentication_provider.update_attributes(authentication_provider_update_params)
+    authentication_provider.update(authentication_provider_update_params)
     respond_with authentication_provider_presenter
   end
 

--- a/app/controllers/admin/api/cms/files_controller.rb
+++ b/app/controllers/admin/api/cms/files_controller.rb
@@ -40,7 +40,7 @@ class Admin::Api::CMS::FilesController < Admin::Api::CMS::BaseController
   # File Update
   # PUT admin/api/cms/files/{id}.json
   def update
-    @file.update_attributes(file_params)
+    @file.update(file_params)
     respond_with @file
   end
 

--- a/app/controllers/admin/api/cms/sections_controller.rb
+++ b/app/controllers/admin/api/cms/sections_controller.rb
@@ -33,7 +33,7 @@ class Admin::Api::CMS::SectionsController < Admin::Api::CMS::BaseController
   # Section Update
   # PUT /admin/api/cms/sections/{id}.json
   def update
-    @section.update_attributes(section_params)
+    @section.update(section_params)
     respond_with @section
   end
 

--- a/app/controllers/admin/api/member_permissions_controller.rb
+++ b/app/controllers/admin/api/member_permissions_controller.rb
@@ -22,7 +22,7 @@ class Admin::Api::MemberPermissionsController < Admin::Api::BaseController
   def update
     authorize! :update_permissions, user
 
-    if user.update_attributes(permission_params)
+    if user.update(permission_params)
       respond_with user.member_permissions, user: user
     else
       # errors are stored in the 'user' model

--- a/app/controllers/admin/api/metric_methods_controller.rb
+++ b/app/controllers/admin/api/metric_methods_controller.rb
@@ -25,7 +25,7 @@ class Admin::Api::MetricMethodsController < Admin::Api::MetricsBaseController
   # Service Method Update
   # PUT /admin/api/services/{service_id}/metrics/{metric_id}/methods/{id}.xml
   def update
-    metric_method.update_attributes(update_params)
+    metric_method.update(update_params)
 
     respond_with(metric_method)
   end

--- a/app/controllers/admin/api/metrics_controller.rb
+++ b/app/controllers/admin/api/metrics_controller.rb
@@ -26,7 +26,7 @@ class Admin::Api::MetricsController < Admin::Api::MetricsBaseController
   # Service Metric Update
   # PUT /admin/api/services/{service_id}/metrics/{id}.xml
   def update
-    metric.update_attributes(update_params)
+    metric.update(update_params)
 
     respond_with(metric)
   end

--- a/app/controllers/admin/api/providers_controller.rb
+++ b/app/controllers/admin/api/providers_controller.rb
@@ -13,7 +13,7 @@ class Admin::Api::ProvidersController < Admin::Api::BaseController
   # Provider Account Update
   # PUT /admin/api/provider.xml
   def update
-    current_account.update_attributes(provider_params, without_protection: true)
+    current_account.update(provider_params, without_protection: true)
     respond_with current_account
   end
 

--- a/app/controllers/admin/api/registry/policies_controller.rb
+++ b/app/controllers/admin/api/registry/policies_controller.rb
@@ -32,7 +32,7 @@ class Admin::Api::Registry::PoliciesController < Admin::Api::BaseController
   # APIcast Policy Registry Update
   # PUT /admin/api/registry/policies/{id}.json
   def update
-    policy.update_attributes(policy_params)
+    policy.update(policy_params)
     respond_with(policy)
   end
 

--- a/app/controllers/admin/api/service_features_controller.rb
+++ b/app/controllers/admin/api/service_features_controller.rb
@@ -26,7 +26,7 @@ class Admin::Api::ServiceFeaturesController < Admin::Api::ServiceBaseController
   # Service Feature Update
   # PUT /admin/api/services/{service_id}/features/{id}.xml
   def update
-    feature.update_attributes(feature_params)
+    feature.update(feature_params)
 
     respond_with(feature)
   end

--- a/app/controllers/admin/api/service_plans_controller.rb
+++ b/app/controllers/admin/api/service_plans_controller.rb
@@ -31,7 +31,7 @@ class Admin::Api::ServicePlansController < Admin::Api::ServiceBaseController
   # Service Plan Update
   # PUT /admin/api/services/{service_id}/service_plans/{id}.xml
   def update
-    service_plan.update_attributes(service_plan_update_params)
+    service_plan.update(service_plan_update_params)
     respond_with(service_plan)
   end
 

--- a/app/controllers/admin/api/services/proxies_controller.rb
+++ b/app/controllers/admin/api/services/proxies_controller.rb
@@ -16,7 +16,7 @@ class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseContro
   # Proxy Update
   # PATCH /admin/api/services/{service_id}/proxy.xml
   def update
-    ProxyDeploymentService.call(proxy) if proxy.update_attributes(proxy_params)
+    ProxyDeploymentService.call(proxy) if proxy.update(proxy_params)
 
     respond_with(proxy)
   end

--- a/app/controllers/admin/api/services/proxy/oidc_configurations_controller.rb
+++ b/app/controllers/admin/api/services/proxy/oidc_configurations_controller.rb
@@ -15,7 +15,7 @@ class Admin::Api::Services::Proxy::OIDCConfigurationsController < Admin::Api::Se
   # OIDC Configuration Update
   # PATCH /admin/api/services/{service_id}/proxy/oidc_configuration.xml
   def update
-    configuration.update_attributes(oidc_configuration_params)
+    configuration.update(oidc_configuration_params)
     respond_with(configuration)
   end
 

--- a/app/controllers/admin/api/services/proxy/policies_controller.rb
+++ b/app/controllers/admin/api/services/proxy/policies_controller.rb
@@ -13,7 +13,7 @@ class Admin::Api::Services::Proxy::PoliciesController < Admin::Api::Services::Ba
   # Proxy Policies Chain Update
   # PUT /admin/api/services/{service_id}/proxy/policies.json
   def update
-    if proxy.update_attributes(proxy_params) && proxy.apicast_configuration_driven
+    if proxy.update(proxy_params) && proxy.apicast_configuration_driven
       ApicastV2DeploymentService.new(@proxy).call(environment: :sandbox)
     end
 

--- a/app/controllers/admin/api/settings_controller.rb
+++ b/app/controllers/admin/api/settings_controller.rb
@@ -23,7 +23,7 @@ class Admin::Api::SettingsController < Admin::Api::BaseController
   # Settings Update
   # PUT /admin/api/settings.json
   def update
-    settings.update_attributes(settings_params)
+    settings.update(settings_params)
     respond_with(settings)
   end
 

--- a/app/controllers/admin/api/web_hooks_controller.rb
+++ b/app/controllers/admin/api/web_hooks_controller.rb
@@ -8,7 +8,7 @@ class Admin::Api::WebHooksController < Admin::Api::BaseController
   # WebHooks Update
   # PUT /admin/api/webhooks.json
   def update
-    webhook.update_attributes(webhook_params)
+    webhook.update(webhook_params)
     respond_with(webhook)
   end
 

--- a/app/controllers/admin/fields_definitions_controller.rb
+++ b/app/controllers/admin/fields_definitions_controller.rb
@@ -52,7 +52,7 @@ class Admin::FieldsDefinitionsController < Sites::BaseController
 
   def update
     @required_fields = []
-    if field_definition.update_attributes(field_definition_params)
+    if field_definition.update(field_definition_params)
       @required_fields = field_definition.target_class.required_fields
     end
 

--- a/app/controllers/api/backend_usages_controller.rb
+++ b/app/controllers/api/backend_usages_controller.rb
@@ -38,7 +38,7 @@ class Api::BackendUsagesController < Api::BaseController
   def edit; end
 
   def update
-    if @backend_api_config.update_attributes(backend_api_config_params.slice(:path))
+    if @backend_api_config.update(backend_api_config_params.slice(:path))
       redirect_to admin_service_backend_usages_path(@service), notice: 'Backend usage was updated.'
     else
       render :edit

--- a/app/controllers/api/contents_controller.rb
+++ b/app/controllers/api/contents_controller.rb
@@ -7,7 +7,7 @@ class Api::ContentsController < FrontendController
   end
 
   def update
-    if @service.update_attributes(params[:service])
+    if @service.update(params[:service])
       flash[:notice] =  'Content updated.'
       redirect_to edit_admin_service_content_path(@service)
     else

--- a/app/controllers/api/features_controller.rb
+++ b/app/controllers/api/features_controller.rb
@@ -39,7 +39,7 @@ class Api::FeaturesController < FrontendController
 
   def update
     respond_to do |format|
-      if @feature.update_attributes(feature_params)
+      if @feature.update(feature_params)
         format.js
       else
         format.js { render :action => 'error' }

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -97,7 +97,7 @@ class Api::IntegrationsController < Api::BaseController
   end
 
   def proxy_pro_update
-    if @proxy.update_attributes(proxy_params)
+    if @proxy.update(proxy_params)
       update_mapping_rules_position
       flash[:notice] = flash_message(:proxy_pro_update_sucess)
       redirect_to :show

--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -37,7 +37,7 @@ class Api::MetricsController < Api::BaseController
   def edit; end
 
   def update
-    if @metric.update_attributes(update_params)
+    if @metric.update(update_params)
       flash[:notice] = "The #{method_or_metric} was updated"
       redirect_to admin_service_metrics_path(@service, tab: "#{method_or_metric}s")
     else

--- a/app/controllers/api/pricing_rules_controller.rb
+++ b/app/controllers/api/pricing_rules_controller.rb
@@ -37,7 +37,7 @@ class Api::PricingRulesController < FrontendController
 
   def update
     respond_to do |format|
-      if @pricing_rule.update_attributes(pricing_rule_params)
+      if @pricing_rule.update(pricing_rule_params)
         format.js
         format.html { redirect_to(edit_admin_application_plan_pricing_rule_path(@plan, @pricing_rule), :notice => 'Pricing rule was successfully updated.')}
       else

--- a/app/controllers/api/proxy_rules_controller.rb
+++ b/app/controllers/api/proxy_rules_controller.rb
@@ -22,7 +22,7 @@ class Api::ProxyRulesController < Api::BaseController
   def edit; end
 
   def update
-    if @proxy_rule.update_attributes(proxy_rule_params)
+    if @proxy_rule.update(proxy_rule_params)
       redirect_to admin_service_proxy_rules_path(@service), notice: 'Mapping rule was updated.'
     else
       render :edit

--- a/app/controllers/api/supports_controller.rb
+++ b/app/controllers/api/supports_controller.rb
@@ -7,7 +7,7 @@ class Api::SupportsController < FrontendController
   end
 
   def update
-    if @edited_service.update_attributes(params[:service])
+    if @edited_service.update(params[:service])
       flash[:notice] =  'Support information was updated.'
       redirect_to edit_admin_service_support_path(@service)
     else

--- a/app/controllers/api/terms_controller.rb
+++ b/app/controllers/api/terms_controller.rb
@@ -12,7 +12,7 @@ class Api::TermsController < FrontendController
   end
 
   def update
-    if @edited_service.update_attributes(params[:edited_service])
+    if @edited_service.update(params[:edited_service])
       flash[:notice] =  'Terms & Conditions updated.'
       redirect_to edit_admin_service_terms_path(@edited_service)
     else

--- a/app/controllers/api/usage_limits_controller.rb
+++ b/app/controllers/api/usage_limits_controller.rb
@@ -41,7 +41,7 @@ class Api::UsageLimitsController < FrontendController
   end
 
   def update
-    if @usage_limit.update_attributes(usage_limit_params)
+    if @usage_limit.update(usage_limit_params)
       respond_to do |format|
         format.js
       end

--- a/app/controllers/buyers/accounts_controller.rb
+++ b/app/controllers/buyers/accounts_controller.rb
@@ -34,7 +34,7 @@ class Buyers::AccountsController < Buyers::BaseController
     vat = account_params[:vat_rate]
     account.vat_rate = vat if vat # vat_rate is protected attribute
 
-    if account.update_attributes(account_params)
+    if account.update(account_params)
       redirect_to admin_buyers_account_path(account)
     else
       render :edit

--- a/app/controllers/buyers/groups_controller.rb
+++ b/app/controllers/buyers/groups_controller.rb
@@ -10,7 +10,7 @@ class Buyers::GroupsController < Buyers::BaseController
   end
 
   def update
-    if @account.update_attributes params[:account]
+    if @account.update params[:account]
       flash[:notice]= "Account updated"
     end
 

--- a/app/controllers/finance/api/invoices_controller.rb
+++ b/app/controllers/finance/api/invoices_controller.rb
@@ -53,7 +53,7 @@ class Finance::Api::InvoicesController < Finance::Api::BaseController
   # Invoice Update
   # PUT /api/invoices/{id}.xml
   def update
-    invoice.update_attributes(invoice_params_update, without_protection: true)
+    invoice.update(invoice_params_update, without_protection: true)
     respond_with(invoice)
   end
 

--- a/app/controllers/finance/provider/invoices_controller.rb
+++ b/app/controllers/finance/provider/invoices_controller.rb
@@ -59,7 +59,7 @@ class Finance::Provider::InvoicesController < Finance::Provider::BaseController
     #  @invoice.due_on = due
     #end
 
-    if @invoice.update_attributes(params[:invoice])
+    if @invoice.update(params[:invoice])
       redirect_to admin_finance_invoice_url(@invoice), notice: 'Invoice was successfully updated.'
     else
       render :edit

--- a/app/controllers/finance/provider/settings_controller.rb
+++ b/app/controllers/finance/provider/settings_controller.rb
@@ -23,7 +23,7 @@ class Finance::Provider::SettingsController < Finance::Provider::BaseController
       ok_message = "Already existent invoices won't change their id."
     end
 
-    if @billing_strategy.update_attributes(finance_billing_strategy_params)
+    if @billing_strategy.update(finance_billing_strategy_params)
       flash[:message] = "Finance settings updated. #{ok_message}"
       redirect_to :action => 'show'
     else

--- a/app/controllers/provider/admin/account/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/account/authentication_providers_controller.rb
@@ -36,7 +36,7 @@ class Provider::Admin::Account::AuthenticationProvidersController < Provider::Ad
   def update
     @authentication_provider = authentication_provider
 
-    if @authentication_provider.update_attributes(authentication_provider_params)
+    if @authentication_provider.update(authentication_provider_params)
       redirect_to provider_admin_account_authentication_provider_path(@authentication_provider), notice: 'SSO integration updated'
     else
       flash.now[:error] = 'SSO integration could not be updated'

--- a/app/controllers/provider/admin/account/enforce_sso_controller.rb
+++ b/app/controllers/provider/admin/account/enforce_sso_controller.rb
@@ -5,7 +5,7 @@ class Provider::Admin::Account::EnforceSSOController < Provider::Admin::Account:
   before_action :enforce_sso_allowed?, only: [:create]
 
   def create
-    if current_account.settings.update_attributes(enforce_sso: true)
+    if current_account.settings.update(enforce_sso: true)
       logout_all_password_users
       redirect_to index_path, notice: 'SSO successfully enforced'
     else
@@ -14,7 +14,7 @@ class Provider::Admin::Account::EnforceSSOController < Provider::Admin::Account:
   end
 
   def destroy
-    if current_account.settings.update_attributes(enforce_sso: false)
+    if current_account.settings.update(enforce_sso: false)
       redirect_to index_path, notice: 'SSO enforcement successfully disabled'
     else
       redirect_to index_path, flash: {error: 'SSO enforcement could not be disabled'}

--- a/app/controllers/provider/admin/account/notifications_controller.rb
+++ b/app/controllers/provider/admin/account/notifications_controller.rb
@@ -8,7 +8,7 @@ class Provider::Admin::Account::NotificationsController < Provider::Admin::Accou
 
   def update
     rule = current_account.mail_dispatch_rules.find(params.require(:id))
-    rule.update_attributes(mail_dispatch_rule_params)
+    rule.update(mail_dispatch_rule_params)
 
     @notice = 'Settings were updated.'
 

--- a/app/controllers/provider/admin/account/payment_gateways/braintree_blue_controller.rb
+++ b/app/controllers/provider/admin/account/payment_gateways/braintree_blue_controller.rb
@@ -26,7 +26,7 @@ class Provider::Admin::Account::PaymentGateways::BraintreeBlueController < Provi
 
   def update
     current_account.updating_payment_detail = true
-    if current_account.update_attributes params.permit(:account)[:account]
+    if current_account.update params.permit(:account)[:account]
       redirect_to provider_admin_account_braintree_blue_url, notice: 'Credit card details were successfully stored.'
     else
       hack_errors

--- a/app/controllers/provider/admin/accounts_controller.rb
+++ b/app/controllers/provider/admin/accounts_controller.rb
@@ -40,7 +40,7 @@ class Provider::Admin::AccountsController < Provider::Admin::Account::BaseContro
   def update
     check_require_billing_information
     respond_to do |format|
-      if @account.update_attributes(account_params)
+      if @account.update(account_params)
         flash[:notice] = 'The account information was updated.'
         format.html do
           redirect_to_success

--- a/app/controllers/provider/admin/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/authentication_providers_controller.rb
@@ -41,7 +41,7 @@ class Provider::Admin::AuthenticationProvidersController < FrontendController
   def publish_or_hide
     authorize_authentication_provider('update')
     published = params.require(:authentication_provider).require(:published)
-    persisted = @authentication_provider.update_attributes({published: published})
+    persisted = @authentication_provider.update({published: published})
     flash[:notice] = persisted ? 'Authentication provider updated' : 'Authentication provider has not been updated'
     @oauth_presenter = OauthFlowPresenter.new(@authentication_provider, request)
     render :show
@@ -49,7 +49,7 @@ class Provider::Admin::AuthenticationProvidersController < FrontendController
 
   def update
     authorize_authentication_provider('edit')
-    persisted = @authentication_provider.update_attributes(update_params)
+    persisted = @authentication_provider.update(update_params)
     if persisted
       flash[:notice] = 'Authentication provider updated'
       @oauth_presenter = OauthFlowPresenter.new(@authentication_provider, request)

--- a/app/controllers/provider/admin/backend_apis/mapping_rules_controller.rb
+++ b/app/controllers/provider/admin/backend_apis/mapping_rules_controller.rb
@@ -20,7 +20,7 @@ class Provider::Admin::BackendApis::MappingRulesController < Provider::Admin::Ba
   def edit; end
 
   def update
-    if @proxy_rule.update_attributes(proxy_rule_params)
+    if @proxy_rule.update(proxy_rule_params)
       redirect_to provider_admin_backend_api_mapping_rules_path(@backend_api), notice: 'Mapping rule was updated.'
     else
       render :edit

--- a/app/controllers/provider/admin/backend_apis/metrics_controller.rb
+++ b/app/controllers/provider/admin/backend_apis/metrics_controller.rb
@@ -35,7 +35,7 @@ class Provider::Admin::BackendApis::MetricsController < Provider::Admin::Backend
   def edit; end
 
   def update
-    if @metric.update_attributes(update_params)
+    if @metric.update(update_params)
       flash[:notice] = "The #{metric_type} was updated"
       redirect_to provider_admin_backend_api_metrics_path(@backend_api, tab: "#{metric_type}s")
     else

--- a/app/controllers/provider/admin/backend_apis_controller.rb
+++ b/app/controllers/provider/admin/backend_apis_controller.rb
@@ -38,7 +38,7 @@ class Provider::Admin::BackendApisController < Provider::Admin::BaseController
   def edit; end
 
   def update
-    if @backend_api.update_attributes(update_params)
+    if @backend_api.update(update_params)
       redirect_to provider_admin_backend_api_path(@backend_api), notice: 'Backend updated'
     else
       flash.now[:error] = 'Backend could not be updated'

--- a/app/controllers/provider/admin/cms/email_templates_controller.rb
+++ b/app/controllers/provider/admin/cms/email_templates_controller.rb
@@ -17,7 +17,7 @@ class Provider::Admin::CMS::EmailTemplatesController < Sites::BaseController
   def update
     @page = templates.find(params[:id])
 
-    if @page.update_attributes(cms_templates_params)
+    if @page.update(cms_templates_params)
       flash[:info] = 'Email Template updated.'
       redirect_to action: :index
     else

--- a/app/controllers/provider/admin/cms/files_controller.rb
+++ b/app/controllers/provider/admin/cms/files_controller.rb
@@ -30,7 +30,7 @@ class Provider::Admin::CMS::FilesController < Provider::Admin::CMS::BaseControll
 
   def update
     @file = file
-    if @file.update_attributes(file_params)
+    if @file.update(file_params)
       redirect_to edit_provider_admin_cms_file_path(@file)
     else
       render :edit

--- a/app/controllers/provider/admin/cms/groups_controller.rb
+++ b/app/controllers/provider/admin/cms/groups_controller.rb
@@ -39,7 +39,7 @@ class Provider::Admin::CMS::GroupsController < Provider::Admin::CMS::BaseControl
   def update
     @group = current_account.provided_groups.find(params[:id])
 
-    if @group.update_attributes(sections_params)
+    if @group.update(sections_params)
       flash[:info] = 'Group saved.'
       redirect_to( :action => :index)
     else

--- a/app/controllers/provider/admin/cms/redirects_controller.rb
+++ b/app/controllers/provider/admin/cms/redirects_controller.rb
@@ -27,7 +27,7 @@ class Provider::Admin::CMS::RedirectsController < Provider::Admin::CMS::BaseCont
   end
 
   def update
-    if redirect.update_attributes(params[:cms_redirect])
+    if redirect.update(params[:cms_redirect])
       redirect_to provider_admin_cms_redirects_path, notice: 'Redirect updated'
     else
       render :edit

--- a/app/controllers/provider/admin/cms/sections_controller.rb
+++ b/app/controllers/provider/admin/cms/sections_controller.rb
@@ -39,7 +39,7 @@ class Provider::Admin::CMS::SectionsController < Provider::Admin::CMS::BaseContr
     @section.add_remove_by_ids( :builtin, params[:cms_section][:cms_builtin_ids])
     @section.save!
 
-    if @section.update_attributes(section_params)
+    if @section.update(section_params)
       flash[:info] = 'section saved successfully.'
       redirect_to( :action => :edit, :id => @section.id)
     else

--- a/app/controllers/provider/admin/redhat/auth_controller.rb
+++ b/app/controllers/provider/admin/redhat/auth_controller.rb
@@ -45,7 +45,7 @@ class Provider::Admin::Redhat::AuthController < Provider::AdminController
       'red_hat_account_number' => username,
       'red_hat_account_verified_by' => current_user.username
     }
-    current_account.update_attributes(extra_fields: extra_fields)
+    current_account.update(extra_fields: extra_fields)
   end
 
   def extract_error_message_from(user_data)

--- a/app/controllers/provider/admin/user/notification_preferences_controller.rb
+++ b/app/controllers/provider/admin/user/notification_preferences_controller.rb
@@ -9,7 +9,7 @@ class Provider::Admin::User::NotificationPreferencesController < Provider::Admin
   end
 
   def update
-    if @preferences_form.update_attributes(notification_preferences_params)
+    if @preferences_form.update(notification_preferences_params)
       flash[:success] = 'Preferences updated'
     end
 

--- a/app/controllers/provider/admin/user/personal_details_controller.rb
+++ b/app/controllers/provider/admin/user/personal_details_controller.rb
@@ -5,7 +5,7 @@ class Provider::Admin::User::PersonalDetailsController < Provider::Admin::User::
   def edit; end
 
   def update
-    if current_user.update_attributes(user_params)
+    if current_user.update(user_params)
       if current_user.just_changed_password?
         current_user.kill_user_sessions(user_session)
       end

--- a/app/controllers/provider/admin/webhooks_controller.rb
+++ b/app/controllers/provider/admin/webhooks_controller.rb
@@ -42,7 +42,7 @@ class Provider::Admin::WebhooksController < Sites::BaseController
   end
 
   def update
-    if @webhook.update_attributes(params[:web_hook])
+    if @webhook.update(params[:web_hook])
       flash[:notice] = 'Webhooks settings were successfully updated.'
       redirect_to :action => :edit
     else

--- a/app/controllers/sites/applications_controller.rb
+++ b/app/controllers/sites/applications_controller.rb
@@ -7,7 +7,7 @@ class Sites::ApplicationsController < Sites::BaseController
   end
 
   def update
-    if @account.update_attributes(params[:account])
+    if @account.update(params[:account])
       flash[:notice] = 'The applications settings were updated.'
       redirect_to admin_site_settings_url
     else

--- a/app/controllers/sites/developer_portals_controller.rb
+++ b/app/controllers/sites/developer_portals_controller.rb
@@ -6,7 +6,7 @@ class Sites::DeveloperPortalsController < Sites::BaseController
   end
 
   def update
-    if settings.update_attributes(settings_params)
+    if settings.update(settings_params)
       flash[:notice] = 'Developer Portal settings updated.'
       redirect_to edit_admin_site_developer_portal_path
     else

--- a/app/controllers/sites/dns_controller.rb
+++ b/app/controllers/sites/dns_controller.rb
@@ -7,7 +7,7 @@ class Sites::DnsController < Sites::BaseController
   end
 
   def update
-    if @account.update_attributes(site_params, without_protection: true)
+    if @account.update(site_params, without_protection: true)
       flash[:notice] = 'The account information was updated.'
       redirect_to(admin_site_dns_url)
     else

--- a/app/controllers/sites/documentations_controller.rb
+++ b/app/controllers/sites/documentations_controller.rb
@@ -13,7 +13,7 @@ class Sites::DocumentationsController < Sites::BaseController
                                      :documentation_enabled,
                                      :documentation_public)
 
-    if @settings.update_attributes(attrs)
+    if @settings.update(attrs)
       flash[:notice] = 'Documentations settings updated.'
       redirect_to edit_admin_site_documentation_url
     else

--- a/app/controllers/sites/emails_controller.rb
+++ b/app/controllers/sites/emails_controller.rb
@@ -12,12 +12,12 @@ class Sites::EmailsController < Sites::BaseController
   end
 
   def update
-    unless @account.update_attributes(params[:account])
+    unless @account.update(params[:account])
       not_saved = true
     end
 
     @services.each do |service|
-      unless service.update_attributes :support_email => params["service_#{service.id}_support_email"]
+      unless service.update :support_email => params["service_#{service.id}_support_email"]
         not_saved = true
       end
     end

--- a/app/controllers/sites/forums_controller.rb
+++ b/app/controllers/sites/forums_controller.rb
@@ -8,7 +8,7 @@ class Sites::ForumsController < Sites::BaseController
   end
 
   def update
-    if @settings.update_attributes(params[:settings])
+    if @settings.update(params[:settings])
       flash[:notice] = 'Forum settings updated.'
       redirect_to edit_admin_site_forum_url
     else

--- a/app/controllers/sites/settings_controller.rb
+++ b/app/controllers/sites/settings_controller.rb
@@ -18,7 +18,7 @@ class Sites::SettingsController < Sites::BaseController
   end
 
   def update
-    if @settings.update_attributes(params[:settings])
+    if @settings.update(params[:settings])
       flash[:notice] = 'Settings updated.'
       redirect_to edit_admin_site_settings_path
     else

--- a/app/controllers/sites/spam_protections_controller.rb
+++ b/app/controllers/sites/spam_protections_controller.rb
@@ -7,7 +7,7 @@ class Sites::SpamProtectionsController < Sites::BaseController
   end
 
   def update
-    if @settings.update_attributes(params[:settings])
+    if @settings.update(params[:settings])
       flash[:notice] = 'Spam protection settings updated.'
       redirect_to edit_admin_site_spam_protection_url
     else

--- a/app/controllers/sites/usage_rules_controller.rb
+++ b/app/controllers/sites/usage_rules_controller.rb
@@ -7,7 +7,7 @@ class Sites::UsageRulesController < Sites::BaseController
   end
 
   def update
-    if @settings.update_attributes(params[:settings])
+    if @settings.update(params[:settings])
       flash[:notice] = 'Settings updated.'
       redirect_back(fallback_location: admin_site_settings_url)
     else

--- a/app/forms/notification_preferences_form.rb
+++ b/app/forms/notification_preferences_form.rb
@@ -4,6 +4,7 @@ class NotificationPreferencesForm < Reform::Form
   attr_reader :current_user, :user_ability
 
   delegate :update_attributes,    to: :model
+  delegate :update,               to: :model
   delegate :has_permission?,      to: :current_user
   delegate :account,              to: :current_user
   delegate :can?,                 to: :user_ability

--- a/app/forms/notification_preferences_form.rb
+++ b/app/forms/notification_preferences_form.rb
@@ -3,7 +3,6 @@ class NotificationPreferencesForm < Reform::Form
 
   attr_reader :current_user, :user_ability
 
-  delegate :update_attributes,    to: :model
   delegate :update,               to: :model
   delegate :has_permission?,      to: :current_user
   delegate :account,              to: :current_user

--- a/app/lib/forum_support/categories.rb
+++ b/app/lib/forum_support/categories.rb
@@ -36,7 +36,7 @@ module ForumSupport
     def edit; end
 
     def update
-      if @category.update_attributes(params[:topic_category])
+      if @category.update(params[:topic_category])
         flash[:notice] = "Category was successfully updated."
         redirect_to forum_categories_url
       else

--- a/app/lib/logic/provider_upgrade.rb
+++ b/app/lib/logic/provider_upgrade.rb
@@ -88,7 +88,7 @@ module Logic
         # so if this method would be called twice,
         # it would try to create second constraints instead of updating the existing
         self.provider_constraints = constraints = provider_constraints
-        constraints.update_attributes(new_limits)
+        constraints.update(new_limits)
       end
 
       private

--- a/app/lib/simple_layout.rb
+++ b/app/lib/simple_layout.rb
@@ -272,7 +272,7 @@ class SimpleLayout
     # some providers have this
     if error_layout.published == "error"
       content = DeveloperPortal::VIEW_PATH.join('layouts/error.html.liquid').read
-      error_layout.update_attributes(draft: content,
+      error_layout.update(draft: content,
                                      title: 'Error layout', liquid_enabled: true)
       error_layout.publish!
     else

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -288,7 +288,7 @@ module Account::ProviderMethods
 
   def create_service(attrs)
     services.build do |service|
-      service.update_attributes(attrs)
+      service.update(attrs)
     end
   end
 

--- a/app/models/account/states.rb
+++ b/app/models/account/states.rb
@@ -57,7 +57,7 @@ module Account::States
       end
 
       after_transition any => any do |account|
-        account.update_attributes(state_changed_at: Time.zone.now)
+        account.update(state_changed_at: Time.zone.now)
       end
 
       event :make_pending do

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -333,7 +333,7 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def save_and_deploy(attrs = {})
-    saved = update_attributes(attrs)
+    saved = update(attrs)
 
     analytics.track('Sandbox Proxy updated', analytics_attributes.merge(success: saved))
 

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -44,7 +44,6 @@ class Settings < ApplicationRecord
 
     super(attributes)
   end
-  alias update_attributes update
 
   def set_forum_enabled
     if account

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -35,7 +35,7 @@ class Settings < ApplicationRecord
     not_custom_account_plans.size > 1 && account_plans_ui_visible?
   end
 
-  def update_attributes(attributes)
+  def update(attributes)
     if approval_required_editable?
       value = attributes.delete(:account_approval_required) || false
       account_plan = provider.account_plans.default || not_custom_account_plans.first!
@@ -44,6 +44,7 @@ class Settings < ApplicationRecord
 
     super(attributes)
   end
+  alias update_attributes update
 
   def set_forum_enabled
     if account

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -167,10 +167,10 @@ class Topic < ApplicationRecord
   end
 
   def update_cached_forum_and_user_counts
-    forum.update_attributes(posts_count: "posts_count - #{posts_count}")
+    forum.update(posts_count: "posts_count - #{posts_count}")
 
     @user_posts.each do |user_id, posts_size|
-      User.find(user_id).update_attributes(posts_count: "posts_count - #{posts_size}")
+      User.find(user_id).update(posts_count: "posts_count - #{posts_size}")
     end
   end
 

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -40,7 +40,7 @@ class UserSession < ApplicationRecord
   def access(request)
     return unless valid?
 
-    update_attributes!(accessed_at: Time.zone.now,
+    update!(accessed_at: Time.zone.now,
                        ip: request.ip,
                        user_agent: request.user_agent)
   rescue => error

--- a/app/services/import_countries_service.rb
+++ b/app/services/import_countries_service.rb
@@ -66,7 +66,7 @@ class ImportCountriesService
       country = Country.find_by(code: country_data.code)
       if country
         info "Updating #{country_data})"
-        country.update_attributes!(country_data.attributes_for_update)
+        country.update!(country_data.attributes_for_update)
       else
         info "Creating #{country_data})"
         Country.create!(country_data.attributes)

--- a/app/services/notifications/new_notification_system_migration.rb
+++ b/app/services/notifications/new_notification_system_migration.rb
@@ -86,7 +86,7 @@ class Notifications::NewNotificationSystemMigration
 
     Account.transaction do
       account.users.find_each do |user|
-        user.notification_preferences.update_attributes!(preferences: preferences)
+        user.notification_preferences.update!(preferences: preferences)
 
         Rails.logger.info("[#{self.class.name}] User #{user.email} has been migrated")
       end

--- a/features/step_definitions/authentication_provider_steps.rb
+++ b/features/step_definitions/authentication_provider_steps.rb
@@ -34,7 +34,7 @@ Given(/^the provider has the authentication provider "([^"]+)" published$/) do |
     authentication_provider = authentication_provider_class.create(options)
   end
   @authentication_provider = authentication_provider
-  @authentication_provider.update_attributes!(published: true)
+  @authentication_provider.update!(published: true)
 end
 
 Given(/^the Oauth2 user has all the required fields$/) do

--- a/features/step_definitions/cms/section_steps.rb
+++ b/features/step_definitions/cms/section_steps.rb
@@ -35,7 +35,7 @@ def add_section_to_provider(provider, protection, name, path = nil)
 end
 
 Given "the {section_of_provider} is access restricted" do |section|
-  section.update_attributes({ :public => false })
+  section.update({ :public => false })
 end
 
 #TODO: use test_helper TestHelpers::SectionsPermissions

--- a/features/step_definitions/liquid_steps.rb
+++ b/features/step_definitions/liquid_steps.rb
@@ -23,12 +23,12 @@ Given /^I'm logged in as a malicious buyer$/ do
 end
 
 When /^provider has xss protection enabled$/ do
-  @provider.settings.update_attributes(cms_escape_draft_html: true,
+  @provider.settings.update(cms_escape_draft_html: true,
                                        cms_escape_published_html: true)
 end
 
 When /^provider has xss protection disabled$/ do
-  @provider.settings.update_attributes(cms_escape_draft_html: false,
+  @provider.settings.update(cms_escape_draft_html: false,
                                        cms_escape_published_html: false)
 end
 

--- a/features/step_definitions/settings_steps.rb
+++ b/features/step_definitions/settings_steps.rb
@@ -12,7 +12,7 @@ Given "{provider} has the following settings:" do |account, table|
   attributes = table.rows_hash
   attributes.map_keys! { |key| underscore_spaces(key) }
 
-  account.settings.update_attributes!(attributes)
+  account.settings.update!(attributes)
 end
 
 Then /^I should see the settings updated$/ do

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -47,7 +47,7 @@ Given /^provider "([^\"]*)" has the following users:$/ do |provider_name, table|
 end
 
 Given "{user} has email {string}" do |user, email|
-  user.update_attributes!(:email => email)
+  user.update!(:email => email)
 end
 
 Given "the admin of {account} has password {string}" do |account, password|

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
@@ -27,7 +27,7 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
   end
 
   def update
-    if password_params[:password].present? && @user.update_attributes(password_params)
+    if password_params[:password].present? && @user.update(password_params)
       @user.expire_password_token
       flash[:notice] = "The password has been changed."
       redirect_to login_url

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/payment_details_base_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/payment_details_base_controller.rb
@@ -27,7 +27,7 @@ class DeveloperPortal::Admin::Account::PaymentDetailsBaseController < DeveloperP
 
   def update
     current_account.updating_payment_detail = true
-    if current_account.update_attributes account_params
+    if current_account.update account_params
       redirect_to payment_details_path, notice: 'Your billing address was successfully stored'
     else
       flash[:notice] = 'Failed to update your billing address data. Check the required fields'

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -63,7 +63,7 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
       application.validate_fields!
     end
 
-    application.update_attributes(application_params)
+    application.update(application_params)
     assign_drops application: application
     # make sure to prevent xss on js rendering if this notice is changed to include e.g. application name
     if application.valid?

--- a/spec/acceptance/api/account_spec.rb
+++ b/spec/acceptance/api/account_spec.rb
@@ -20,7 +20,7 @@ resource "Account" do
     before do
       provider.fields_definitions.create!({ :target => "Account", :name => 'billing_address',
                                              :label => 'Billing Address', :read_only => true })
-      resource.update_attributes(billing_address_address1: 'first line', billing_address_address2: 'second line')
+      resource.update(billing_address_address1: 'first line', billing_address_address2: 'second line')
       provider.reload
       resource.reload
     end
@@ -28,7 +28,7 @@ resource "Account" do
 
   shared_context "with credit card details stored" do
     before do
-      payment_detail.update_attributes(credit_card_partial_number: 1234, credit_card_expires_on: Date.parse('2018-05-08'), credit_card_auth_code: 'anything')
+      payment_detail.update(credit_card_partial_number: 1234, credit_card_expires_on: Date.parse('2018-05-08'), credit_card_auth_code: 'anything')
     end
   end
 

--- a/spec/acceptance/api/application_spec.rb
+++ b/spec/acceptance/api/application_spec.rb
@@ -29,7 +29,7 @@ resource "Cinstance" do
     let (:first_traffic) { Time.zone.parse('2017-11-20 10:00:00 UTC') }
     let (:first_daily_traffic) { Time.zone.parse('2017-11-21 10:00:00 UTC') }
     before do
-      resource.update_attributes(first_traffic_at: first_traffic, first_daily_traffic_at: first_daily_traffic)
+      resource.update(first_traffic_at: first_traffic, first_daily_traffic_at: first_daily_traffic)
     end
   end
 
@@ -240,7 +240,7 @@ resource "Cinstance" do
 
   xml(:resource) do
     before do
-      resource.update_attributes(name: 'app name', description: 'app description')
+      resource.update(name: 'app name', description: 'app description')
     end
 
     it('has root') { should have_tag('application') }

--- a/spec/acceptance/api/signup_result_with_access_token_spec.rb
+++ b/spec/acceptance/api/signup_result_with_access_token_spec.rb
@@ -25,7 +25,7 @@ resource 'Signup::ResultWithAccessToken' do
 
     xit 'renders errors correctly' do
       # TODO: bug in rendering errors from specs
-      resource.user.update_attributes(email: '')
+      resource.user.update(email: '')
       subject.fetch('errors').should include('user' => ['Email should look like an email address'])
     end
   end
@@ -52,7 +52,7 @@ resource 'Signup::ResultWithAccessToken' do
 
     xit 'renders errors correctly' do
       # TODO: bug in rendering errors from specs
-      resource.user.update_attributes(email: '')
+      resource.user.update(email: '')
       subject { xml.root.xpath('./errors') }
       should have_tag('user', :text => ['Email should look like an email address'])
     end

--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -141,7 +141,7 @@ FactoryBot.define do
       account.approve!
 
       account.services.first.update_attribute :mandatory_app_key, false
-      account.settings.update_attributes!(
+      account.settings.update!(
         account_plans_ui_visible: true,
         service_plans_ui_visible: true
       )

--- a/test/functional/developer_portal/login_controller_test.rb
+++ b/test/functional/developer_portal/login_controller_test.rb
@@ -137,7 +137,7 @@ class DeveloperPortal::LoginControllerTest < DeveloperPortal::ActionController::
 
   def create_oauth2_provider_account
     provider_account = FactoryBot.create(:provider_account)
-    provider_account.settings.update_attributes({authentication_strategy: 'oauth2'})
+    provider_account.settings.update({authentication_strategy: 'oauth2'})
     provider_account
   end
 end

--- a/test/functional/provider/admin/messages/inbox_controller_test.rb
+++ b/test/functional/provider/admin/messages/inbox_controller_test.rb
@@ -25,7 +25,7 @@ class Provider::Admin::Messages::InboxControllerTest < ActionController::TestCas
   def test_index_system_message
     login_as(@admin)
 
-    @message.message.update_attributes system_operation_id: 1
+    @message.message.update system_operation_id: 1
 
     get :index
 

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -159,7 +159,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     Account.any_instance.stubs(:provider_can_use?).with(:proxy_pro).returns(true)
 
     Proxy.any_instance.expects(:save_and_deploy).never
-    Proxy.any_instance.expects(:update_attributes).once
+    Proxy.any_instance.expects(:update).once
     ProxyTestService.expects(:new).never
     ProxyTestService.any_instance.expects(:perform).never
     Policies::PoliciesListService.expects(:call!)

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -340,7 +340,7 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'not success update' do
-      Service.any_instance.stubs(update_attributes: false)
+      Service.any_instance.stubs(update: false)
       put admin_service_path(service), params: { service: { name: 'Supetramp' } }
       assert_response :redirect
     end

--- a/test/integration/buyers/service_contracts_controller_test.rb
+++ b/test/integration/buyers/service_contracts_controller_test.rb
@@ -85,7 +85,7 @@ class Buyers::ServiceContractsControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'does not render a prompt if there is a default service plan' do
-      service.update_attributes(default_service_plan: service_plan)
+      service.update(default_service_plan: service_plan)
 
       get new_admin_buyers_account_service_contract_path(account_id: buyer1.id, service_id: service.id)
 

--- a/test/integration/developer_portal/access_code_test.rb
+++ b/test/integration/developer_portal/access_code_test.rb
@@ -18,7 +18,7 @@ class DeveloperPortal::AccessCodeTest < ActionDispatch::IntegrationTest
   end
 
   def test_show_no_access_code
-    @provider.update_attributes(site_access_code: nil)
+    @provider.update(site_access_code: nil)
 
     get '/access_code?access_code=12345'
     assert_response :redirect

--- a/test/integration/developer_portal/admin/account/payment_details_base_controller_test.rb
+++ b/test/integration/developer_portal/admin/account/payment_details_base_controller_test.rb
@@ -29,7 +29,7 @@ class DeveloperPortal::Admin::Account::PaymentDetailsBaseTest < ActionDispatch::
       }
     }.deep_stringify_keys
 
-    Account.any_instance.expects(:update_attributes).with(account_params).returns(true)
+    Account.any_instance.expects(:update).with(account_params).returns(true)
     put admin_account_payment_details_path, params: { account: account_params.deep_merge(billing_address: { injected_param: 'unauthorized' }) }
   end
 end

--- a/test/integration/developer_portal/login_test.rb
+++ b/test/integration/developer_portal/login_test.rb
@@ -78,7 +78,7 @@ class DeveloperPortal::LoginTest < ActionDispatch::IntegrationTest
 
   def test_create_approval_required
     # account approval required is set to TRUE and NO sso integrations have automatically approve accounts feature turned on
-    @provider.settings.update_attributes(account_approval_required: true)
+    @provider.settings.update(account_approval_required: true)
     @provider.authentication_providers.update_all(automatically_approve_accounts: false)
     stub_user_data(uid: 'uid1', email: 'foo@example.com', username: 'foo', org_name: 'company', email_verified: true)
     stub_oauth2_request
@@ -103,7 +103,7 @@ class DeveloperPortal::LoginTest < ActionDispatch::IntegrationTest
     assert user_2.account.approved?
 
     # account approval required is set to FALSE and NO sso integrations have automatically approve accounts feature turned on
-    @provider.settings.update_attributes(account_approval_required: false)
+    @provider.settings.update(account_approval_required: false)
     @provider.authentication_providers.update_all(automatically_approve_accounts: false)
     stub_user_data(uid: 'ud3', email: 'foo3@example.com', username: 'foo3', org_name: 'company3', email_verified: true)
     stub_oauth2_request
@@ -116,7 +116,7 @@ class DeveloperPortal::LoginTest < ActionDispatch::IntegrationTest
   end
 
   def test_create_activation
-    @provider.settings.update_attributes(account_approval_required: true)
+    @provider.settings.update(account_approval_required: true)
     @provider.authentication_providers.update_all(automatically_approve_accounts: true)
     stub_user_data(uid: 'ud2', email: 'foo2@example.com', org_name: 'company', email_verified: true)
     stub_oauth2_request

--- a/test/integration/developer_portal/passwords_controller_test.rb
+++ b/test/integration/developer_portal/passwords_controller_test.rb
@@ -36,7 +36,7 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'captcha is present when spam security enabled' do
-    provider.settings.update_attributes(spam_protection_level: :captcha)
+    provider.settings.update(spam_protection_level: :captcha)
 
     get developer_portal.new_admin_account_password_path
     assert_response :success
@@ -44,7 +44,7 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'captcha is not present when spam security set to auto and it is not a spam object' do
-    provider.settings.update_attributes(spam_protection_level: :auto)
+    provider.settings.update(spam_protection_level: :auto)
     ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: false)
 
     get developer_portal.new_admin_account_password_path
@@ -53,7 +53,7 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'captcha is present when the previous request was considered as spam' do
-    provider.settings.update_attributes(spam_protection_level: :auto)
+    provider.settings.update(spam_protection_level: :auto)
     ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: true)
     Recaptcha::Verify.stubs(skip?: false)
 
@@ -71,7 +71,7 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'captcha is not present when spam security disabled' do
-    provider.settings.update_attributes(spam_protection_level: :none)
+    provider.settings.update(spam_protection_level: :none)
 
     get developer_portal.new_admin_account_password_path
     assert_response :success
@@ -79,7 +79,7 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'create responds with error message when detects spam' do
-    provider.settings.update_attributes(spam_protection_level: :auto)
+    provider.settings.update(spam_protection_level: :auto)
     ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: true)
     Recaptcha::Verify.stubs(skip?: false)
 
@@ -89,7 +89,7 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'create sends the email when captcha passes and finds the email' do
-    provider.settings.update_attributes(spam_protection_level: :auto)
+    provider.settings.update(spam_protection_level: :auto)
     ThreeScale::SpamProtection::Protector.any_instance.stubs(spam?: true)
     Recaptcha::Verify.stubs(skip?: true)
 
@@ -104,7 +104,7 @@ class DeveloperPortal::PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'create renders the right error message when the email is not found' do
-    provider.settings.update_attributes(spam_protection_level: :none)
+    provider.settings.update(spam_protection_level: :none)
     Recaptcha::Verify.stubs(skip?: false)
 
     post developer_portal.admin_account_password_path(email: 'fake@example.com')

--- a/test/integration/developer_portal/signup_test.rb
+++ b/test/integration/developer_portal/signup_test.rb
@@ -42,7 +42,7 @@ class DeveloperPortal::SignupTest < ActionDispatch::IntegrationTest
       end
 
       def test_signup_with_oauth_if_account_requires_approval
-        @provider.settings.update_attributes(account_approval_required: true) # rubocop:disable Rails/ActiveRecordAliases) This method is being overriden
+        @provider.settings.update(account_approval_required: true) # rubocop:disable Rails/ActiveRecordAliases) This method is being overriden
 
         @auth = FactoryBot.create(:authentication_provider, published: true, account: @provider)
         stub_user_data({uid: '12345', email: ACCOUNT_EMAIL, email_verified: true}, stubbed_method: :authenticate!)

--- a/test/integration/provider/admin/account/enforce_sso_test.rb
+++ b/test/integration/provider/admin/account/enforce_sso_test.rb
@@ -26,7 +26,7 @@ class Provider::Admin::Account::EnforceSSOTest < ActionDispatch::IntegrationTest
   end
 
   def test_destroy
-    @provider.settings.update_attributes(enforce_sso: true)
+    @provider.settings.update(enforce_sso: true)
     assert @provider.reload.settings.enforce_sso
     delete provider_admin_account_enforce_sso_path
     refute @provider.reload.settings.enforce_sso

--- a/test/integration/provider/admin/authentication_providers_controller_test.rb
+++ b/test/integration/provider/admin/authentication_providers_controller_test.rb
@@ -83,7 +83,7 @@ class Provider::Admin::AuthenticationProvidersControllerTest < ActionDispatch::I
 
   test 'PUT update renders edit when there are errors' do
     @provider.settings.allow_branding
-    AuthenticationProvider.any_instance.stubs(:update_attributes).returns(false)
+    AuthenticationProvider.any_instance.stubs(:update).returns(false)
     authentication_provider = FactoryBot.create(:authentication_provider, account: @provider, client_id: 'client_id')
     put provider_admin_authentication_provider_path(authentication_provider, authentication_provider: {client_id: 'clientID'})
     assert_template 'provider/admin/authentication_providers/edit'
@@ -101,7 +101,7 @@ class Provider::Admin::AuthenticationProvidersControllerTest < ActionDispatch::I
 
   test 'PUT publish_or_hide renders show when there are errors and there is github branding denied' do
     @provider.settings.deny_branding
-    AuthenticationProvider.any_instance.stubs(:update_attributes).returns(false)
+    AuthenticationProvider.any_instance.stubs(:update).returns(false)
     authentication_provider = FactoryBot.create(:github_authentication_provider, account: @provider, branding_state: 'threescale_branded')
     patch publish_or_hide_provider_admin_authentication_provider_path(authentication_provider, authentication_provider: { published: true })
     assert_template 'provider/admin/authentication_providers/show'

--- a/test/integration/provider/admin/messages/trash_controller_test.rb
+++ b/test/integration/provider/admin/messages/trash_controller_test.rb
@@ -26,7 +26,7 @@ class Provider::Admin::Messages::TrashControllerTest < ActionDispatch::Integrati
   end
 
   test 'index of deleted messages' do
-    provider_received_message.update_attributes deleted_at: DateTime.new(2015, 11, 11)
+    provider_received_message.update deleted_at: DateTime.new(2015, 11, 11)
     get provider_admin_messages_trash_index_path
     assert_response :success
     assert_equal 1, assigns(:messages).count
@@ -41,7 +41,7 @@ class Provider::Admin::Messages::TrashControllerTest < ActionDispatch::Integrati
     get provider_admin_messages_trash_path(buyer_sent_message)
     assert_response :success
 
-    provider_received_message.update_attributes deleted_at: DateTime.new(2015, 11, 11)
+    provider_received_message.update deleted_at: DateTime.new(2015, 11, 11)
     get provider_admin_messages_trash_path(buyer_sent_message)
     assert_response :not_found
   end

--- a/test/unit/account/billing_address_test.rb
+++ b/test/unit/account/billing_address_test.rb
@@ -56,7 +56,7 @@ class Account::BillingAddressTest < ActiveSupport::TestCase
   test 'account org_name is used when billing_address_name is blank' do
     assert_equal 'Tim', @account.billing_address.name
 
-    @account.update_attributes(billing_address_name: '')
+    @account.update(billing_address_name: '')
     @account.reload
 
     assert_equal 'PP', @account.billing_address.name

--- a/test/unit/account/credit_card_test.rb
+++ b/test/unit/account/credit_card_test.rb
@@ -90,11 +90,11 @@ class Account::CreditCardTest < ActiveSupport::TestCase
     assert account.save!, "Account should save when account is new"
 
     account = Account.create!(:org_name => 'ACME')
-    assert account.update_attributes(:org_name => 'New ACME', :payment_detail_conditions => false), "Account should update when not updating credit card details"
+    assert account.update(:org_name => 'New ACME', :payment_detail_conditions => false), "Account should update when not updating credit card details"
 
     account = Account.create!(:org_name => 'ACME')
     account.updating_payment_detail = true
-    assert !account.update_attributes(:org_name => 'New ACME', :payment_detail_conditions => false), "Account shouldn't update when updating credit card details without accepting conditions"
+    assert !account.update(:org_name => 'New ACME', :payment_detail_conditions => false), "Account shouldn't update when updating credit card details without accepting conditions"
   end
 
   test '#credit_card_exires_on_with_default' do

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -131,7 +131,7 @@ class AccountTest < ActiveSupport::TestCase
   end
 
   # regression test: https://github.com/3scale/system/pull/3406
-  test 'update_attributes with nil as param should not raise error' do
+  test 'update with nil as param should not raise error' do
     buyer = FactoryBot.create(:simple_buyer)
     buyer.update(nil)
   end

--- a/test/unit/apicast/curl_command_builder_test.rb
+++ b/test/unit/apicast/curl_command_builder_test.rb
@@ -36,21 +36,21 @@ module Apicast
 
       test 'auth based (with password)' do
         create_proxy_config(proxy: { credentials_location: 'authorization' })
-        proxy.service.update_attributes(backend_version: '2')
+        proxy.service.update(backend_version: '2')
         proxy.reload
         assert_match %r(http://APP_ID:APP_KEY@), command.to_s
       end
 
       test 'auth mode app_id and app_key' do
         create_proxy_config
-        proxy.service.update_attributes(backend_version: '2')
+        proxy.service.update(backend_version: '2')
         assert_match(/&?app_key=APP_KEY/, command.to_s)
         assert_match(/&?app_id=APP_ID/, command.to_s)
       end
 
       test 'app_id and app_key with customized params name' do
         create_proxy_config(proxy: { auth_app_id: 'id', auth_app_key: 'p-a-s-s' })
-        proxy.service.update_attributes(backend_version: '2')
+        proxy.service.update(backend_version: '2')
         assert_match(/id=APP_ID/, command.to_s)
         assert_match(/p-a-s-s=APP_KEY/, command.to_s)
       end
@@ -93,7 +93,7 @@ module Apicast
       def setup
         super
 
-        proxy.update_attributes(api_test_path: '/test')
+        proxy.update(api_test_path: '/test')
         FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/foo', position: 1)
         create_proxy_config(proxy: { api_test_path: '/test', proxy_rules: [{ pattern: '/foo' }] })
       end

--- a/test/unit/backend_version_test.rb
+++ b/test/unit/backend_version_test.rb
@@ -16,11 +16,11 @@ class BackendVersionTest < ActiveSupport::TestCase
     refute versions.values.include?('oidc')
 
     rolling_update(:apicast_oidc, enabled: true)
-    service.proxy.update_attributes(apicast_configuration_driven: false)
+    service.proxy.update(apicast_configuration_driven: false)
     versions = BackendVersion.visible_versions(service: service)
     refute versions.values.include?('oidc')
 
-    service.proxy.update_attributes(apicast_configuration_driven: true)
+    service.proxy.update(apicast_configuration_driven: true)
     versions = BackendVersion.visible_versions(service: service)
     assert versions.values.include?('oidc')
   end

--- a/test/unit/csv/applications_exporter_test.rb
+++ b/test/unit/csv/applications_exporter_test.rb
@@ -44,8 +44,8 @@ class Csv::ApplicationsExporterTest < ActiveSupport::TestCase
             choices: ["Orange", "Apple", "Banana"])
     @provider.reload
     @buyer1 = create_buyer_for(@provider)
-    @buyer1.update_attributes(org_name: "MoltbeCat", telephone_number: "+34 902 311 2131")
-    @buyer1.admins.first.update_attributes(username: 'akira', email: 'akira@moltbe.cat', :first_name => "Akira", :last_name => "Kurosawa")
+    @buyer1.update(org_name: "MoltbeCat", telephone_number: "+34 902 311 2131")
+    @buyer1.admins.first.update(username: 'akira', email: 'akira@moltbe.cat', :first_name => "Akira", :last_name => "Kurosawa")
     create_app_for(@buyer1)
     create_app_for(@buyer1, Time.now.utc)
   end
@@ -53,7 +53,7 @@ class Csv::ApplicationsExporterTest < ActiveSupport::TestCase
   test 'to_csv' do
     travel_to(Time.utc(2011,1,1)) do
       cinstance = @provider.services.order(:id).second.cinstances.first!
-      cinstance.update_attributes(first_daily_traffic_at: '2016-03-03 00:00:00 UTC')
+      cinstance.update(first_daily_traffic_at: '2016-03-03 00:00:00 UTC')
       exporter = Csv::ApplicationsExporter.new(@provider, {data: 'applications'})
       lines = exporter.to_csv.lines.to_a
 

--- a/test/unit/csv/buyers_exporter_test.rb
+++ b/test/unit/csv/buyers_exporter_test.rb
@@ -17,8 +17,8 @@ class Csv::BuyersExporterTest < ActiveSupport::TestCase
   def setup
     @provider = FactoryBot.create(:provider_account, org_name: 'Generalitat', domain: 'generalitat.cat')
     @buyer = create_buyer_for(@provider)
-    @buyer.admins.first.update_attributes(username: 'john_doe', email: 'john@my.company.it')
-    @buyer.update_attributes(org_name: 'Eater')
+    @buyer.admins.first.update(username: 'john_doe', email: 'john@my.company.it')
+    @buyer.update(org_name: 'Eater')
     create_buyer_for(@provider, Time.now.utc)
   end
 

--- a/test/unit/csv/messages_exporter_test.rb
+++ b/test/unit/csv/messages_exporter_test.rb
@@ -24,7 +24,7 @@ class Csv::MessagesExporterTest < ActiveSupport::TestCase
       buyer = FactoryBot.create(:buyer_account,
                              org_name: 'Eater',
                              provider_account: @provider)
-      buyer.admins.first.update_attributes(username: 'john_doe', email: 'john@my.company.it')
+      buyer.admins.first.update(username: 'john_doe', email: 'john@my.company.it')
 
       plan = @provider.account_plans.default
       plan.update_column(:name, 'Plan of the Escape')

--- a/test/unit/lib/payment_gateways/stripe_crypt_test.rb
+++ b/test/unit/lib/payment_gateways/stripe_crypt_test.rb
@@ -57,7 +57,7 @@ module PaymentGateways
 
       card_data = {exp_month: 8, exp_year: 1.year.from_now.year, last4: '4242'}
       payment_method_data = {id: payment_method_id, object: 'payment_method', card: card_data, customer: 'cus_IhGaGqpp6zGwyd', type: 'card'}
-      payment_method = Stripe::PaymentMethod.new(id: payment_method_id).tap { |pm| pm.update_attributes(payment_method_data) }
+      payment_method = Stripe::PaymentMethod.new(id: payment_method_id).tap { |pm| pm.update(payment_method_data) }
       Stripe::PaymentMethod.expects(:retrieve).with(payment_method_id, api_key).returns(payment_method)
 
       assert stripe_crypt.update!(payment_method_id)
@@ -94,7 +94,7 @@ module PaymentGateways
 
     def mock_customer(**attrs)
       id = attrs.delete(:id) || 'new-customer-id'
-      Stripe::Customer.new(id: id).tap { |stripe_customer| stripe_customer.update_attributes(**attrs) }
+      Stripe::Customer.new(id: id).tap { |stripe_customer| stripe_customer.update(**attrs) }
     end
 
     def update_credit_card_auth_code

--- a/test/unit/lib/payment_gateways/stripe_crypt_test.rb
+++ b/test/unit/lib/payment_gateways/stripe_crypt_test.rb
@@ -57,7 +57,7 @@ module PaymentGateways
 
       card_data = {exp_month: 8, exp_year: 1.year.from_now.year, last4: '4242'}
       payment_method_data = {id: payment_method_id, object: 'payment_method', card: card_data, customer: 'cus_IhGaGqpp6zGwyd', type: 'card'}
-      payment_method = Stripe::PaymentMethod.new(id: payment_method_id).tap { |pm| pm.update(payment_method_data) }
+      payment_method = Stripe::PaymentMethod.new(id: payment_method_id).tap { |pm| pm.update_attributes(payment_method_data) }
       Stripe::PaymentMethod.expects(:retrieve).with(payment_method_id, api_key).returns(payment_method)
 
       assert stripe_crypt.update!(payment_method_id)
@@ -94,7 +94,7 @@ module PaymentGateways
 
     def mock_customer(**attrs)
       id = attrs.delete(:id) || 'new-customer-id'
-      Stripe::Customer.new(id: id).tap { |stripe_customer| stripe_customer.update(**attrs) }
+      Stripe::Customer.new(id: id).tap { |stripe_customer| stripe_customer.update_attributes(**attrs) }
     end
 
     def update_credit_card_auth_code

--- a/test/unit/liquid/drops/message_drop_test.rb
+++ b/test/unit/liquid/drops/message_drop_test.rb
@@ -37,7 +37,7 @@ class Liquid::Drops::MessageDropTest < ActiveSupport::TestCase
     @message.update_attribute(:subject, 'SUBJECT')
     assert_equal 'SUBJECT', @drop.subject
 
-    @message.update_attributes(body: 'b' * 20, subject: nil)
+    @message.update(body: 'b' * 20, subject: nil)
     assert_equal "#{'b' * 12}...", @drop.subject
   end
 end

--- a/test/unit/message_recipient_test.rb
+++ b/test/unit/message_recipient_test.rb
@@ -7,8 +7,8 @@ class MessageRecipientTest < ActiveSupport::TestCase
     system_message = FactoryBot.create(:received_message, receiver: account)
     normal_message = FactoryBot.create(:received_message, receiver: account)
 
-    system_message.message.update_attributes system_operation_id: 1
-    normal_message.message.update_attributes system_operation_id: nil
+    system_message.message.update system_operation_id: 1
+    normal_message.message.update system_operation_id: nil
 
     assert_equal 2, account.received_messages.count
     assert_equal [normal_message.id], account.received_messages.not_system.pluck(:id)

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -48,7 +48,7 @@ class MetricTest < ActiveSupport::TestCase
       owner_attributes = { owner: owner }
       metric_one = FactoryBot.create(:metric, **owner_attributes, system_name: 'frags')
       metric_two = FactoryBot.create(:metric, owner_attributes)
-      refute metric_two.update_attributes(system_name: 'frags')
+      refute metric_two.update(system_name: 'frags')
       assert_match /already been taken/, metric_two.errors[:system_name].to_s
     end
   end

--- a/test/unit/payment_gateways/brain_tree_blue_crypt_test.rb
+++ b/test/unit/payment_gateways/brain_tree_blue_crypt_test.rb
@@ -140,7 +140,7 @@ module PaymentGateways
 
     test '#buyer_reference takes into account the last saved customer.id' do
       account = FactoryBot.create(:simple_provider)
-      account.update_attributes(credit_card_auth_code: "#{@braintree.buyer_reference}-3")
+      account.update(credit_card_auth_code: "#{@braintree.buyer_reference}-3")
       @braintree.stubs(:account).returns(account)
       account.credit_card_auth_code = nil
       assert_equal "#{@braintree.buyer_reference}-3", @braintree.buyer_reference_for_update

--- a/test/unit/pricing_rule_test.rb
+++ b/test/unit/pricing_rule_test.rb
@@ -89,7 +89,7 @@ class PricingRuleTest < ActiveSupport::TestCase
 
   should 'allow to be updated' do
     rule = @plan.pricing_rules.create!(:min => 16, :max => 100, :cost_per_unit => 0.2)
-    rule.update_attributes(:min => 12)
+    rule.update(:min => 12)
 
     assert rule.valid?
   end

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ProxyTest < ActiveSupport::TestCase
   def setup
     @proxy = FactoryBot.create(:simple_proxy, api_backend: nil)
-    @proxy.update_attributes!(apicast_configuration_driven: false)
+    @proxy.update!(apicast_configuration_driven: false)
     @service = @proxy.service
     @account = @service.account
   end
@@ -400,7 +400,7 @@ class ProxyTest < ActiveSupport::TestCase
   test 'proxy api backend auto port 80' do
     endpoint = 'http://example.org'
     @proxy.api_backend = endpoint
-    @proxy.update_attributes endpoint: endpoint
+    @proxy.update endpoint: endpoint
     @proxy.secret_token = '123'
     @proxy.valid?
 
@@ -411,7 +411,7 @@ class ProxyTest < ActiveSupport::TestCase
   test 'proxy api backend auto port 443' do
     endpoint = 'https://example.org'
     @proxy.api_backend = endpoint
-    @proxy.update_attributes endpoint: endpoint
+    @proxy.update endpoint: endpoint
     @proxy.secret_token = '123'
     @proxy.valid?
 
@@ -420,7 +420,7 @@ class ProxyTest < ActiveSupport::TestCase
   end
 
   test 'proxy_endpoint is unique' do
-    @proxy.update_attributes(endpoint: 'http://foo:80', api_backend: 'http://A:1', secret_token: 'fdsa')
+    @proxy.update(endpoint: 'http://foo:80', api_backend: 'http://A:1', secret_token: 'fdsa')
     p2 = FactoryBot.create(:proxy, endpoint: 'http://foo:80', service: @service, api_backend: 'http://B:1', secret_token: 'fdsafsda')
   end
 
@@ -477,7 +477,7 @@ class ProxyTest < ActiveSupport::TestCase
   test 'allowed domains' do
     Rails.stubs(:env).returns(ActiveSupport::StringInquirer.new('production'))
     %W(api.example.net).each do |b|
-      @proxy.update_attributes(api_backend: "http://#{b}:80")
+      @proxy.update(api_backend: "http://#{b}:80")
       assert @proxy.errors[:api_backend].blank?
     end
   end
@@ -632,7 +632,7 @@ class ProxyTest < ActiveSupport::TestCase
 
     Domains::ProxyDomainsChangedEvent.expects(:create).with(@proxy).once
 
-    @proxy.update_attributes(staging_endpoint: 'http://example.com')
+    @proxy.update(staging_endpoint: 'http://example.com')
   end
 
   test 'domain changes events on update of self managed proxy' do
@@ -640,7 +640,7 @@ class ProxyTest < ActiveSupport::TestCase
 
     Domains::ProxyDomainsChangedEvent.expects(:create).with(@proxy).once
 
-    @proxy.update_attributes(staging_endpoint: 'http://example.com')
+    @proxy.update(staging_endpoint: 'http://example.com')
   end
 
   test 'domain changes events on destroy of hosted proxy' do
@@ -847,7 +847,7 @@ class ProxyTest < ActiveSupport::TestCase
   class StaleObjectErrorTest < ActiveSupport::TestCase
     test 'proxy does not raise stale object error on concurrent touch' do
       class ProxyWithFiber < ::Proxy
-        def update_attributes(*)
+        def update(*)
           Fiber.yield
           super
         end
@@ -855,7 +855,7 @@ class ProxyTest < ActiveSupport::TestCase
 
       proxy_id = FactoryBot.create(:proxy).id
 
-      fiber_update = Fiber.new { ProxyWithFiber.find(proxy_id).update_attributes(error_auth_failed: 'new auth error msg') }
+      fiber_update = Fiber.new { ProxyWithFiber.find(proxy_id).update(error_auth_failed: 'new auth error msg') }
       fiber_touch = Fiber.new { Proxy.find(proxy_id).touch }
 
       fiber_update.resume

--- a/test/unit/services/apicast_v2_deployment_service_test.rb
+++ b/test/unit/services/apicast_v2_deployment_service_test.rb
@@ -14,7 +14,7 @@ class ApicastV2DeploymentServiceTest < ActiveSupport::TestCase
     ThreeScale.config.stubs(onpremises: true)
     raw_policies = [{name: 'policy', version: '1.0.0', enabled: true, configuration: {data: { request: '1', config: '123' }}}]
     policies = [{name: 'policy', version: '1.0.0', configuration: {data: { request: '1', config: '123' }}}]
-    @proxy.update_attributes(policies_config: raw_policies.to_json)
+    @proxy.update(policies_config: raw_policies.to_json)
     Service.new(@proxy).call(environment: ProxyConfig::ENVIRONMENTS.first)
     assert_match policies.first.to_json, @proxy.proxy_configs.last.content
   end

--- a/test/unit/services/import_countries_service_test.rb
+++ b/test/unit/services/import_countries_service_test.rb
@@ -98,7 +98,7 @@ class ImportCountriesServiceTest < ActiveSupport::TestCase
       Country.expects(:find_by).with(code: 'JP').returns(japan)
 
       country_data.select(&:valid?).reject { |country| country.code == 'JP' }.each { |country| Country.expects(:create!).with(country.attributes) }
-      japan.expects(:update_attributes!).with(name: 'Japan', currency: 'JPY', updated_at: now)
+      japan.expects(:update!).with(name: 'Japan', currency: 'JPY', updated_at: now)
 
       service.call!
     end

--- a/test/unit/services/notifications/new_notification_system_migration_test.rb
+++ b/test/unit/services/notifications/new_notification_system_migration_test.rb
@@ -49,7 +49,7 @@ class Notifications::NewNotificationSystemMigrationTest < ActiveSupport::TestCas
   end
 
   def test_run!
-    @user.notification_preferences.update_attributes!(preferences: {})
+    @user.notification_preferences.update!(preferences: {})
     MailDispatchRule.delete_all
     enabled_dispatch_rules = @account.mail_dispatch_rules.enabled
 
@@ -101,6 +101,6 @@ class Notifications::NewNotificationSystemMigrationTest < ActiveSupport::TestCas
   def set_mail_dispatch_rule!(ref, enabled: true)
     operation = SystemOperation.find_by_ref(ref)
     rule = @account.mail_dispatch_rules.find_or_create_by(system_operation: operation)
-    rule.update_attributes!(dispatch: enabled)
+    rule.update!(dispatch: enabled)
   end
 end

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -65,29 +65,29 @@ class SettingsTest < ActiveSupport::TestCase
     assert @settings.approval_required_disabled?
   end
 
-  def test_update_attributes
+  def test_update
     @settings.expects(:approval_required_editable?).returns(false).once
     @provider.account_plans.default.expects(:update_attribute).never
 
-    @settings.update_attributes({ account_approval_required: true })
+    @settings.update({ account_approval_required: true })
 
     @settings.expects(:approval_required_editable?).returns(true).once
     @provider.account_plans.default.expects(:update_attribute).once
 
-    @settings.update_attributes({ account_approval_required: true })
+    @settings.update({ account_approval_required: true })
   end
 
   test "account_approval_required delegated to default account plan" do
     plan = @provider.account_plans.default
-    plan.update_attributes(approval_required: false)
+    plan.update(approval_required: false)
 
-    @settings.update_attributes(account_approval_required: true)
+    @settings.update(account_approval_required: true)
     assert plan.reload.approval_required
 
-    @settings.update_attributes(welcome_text: :bar)
+    @settings.update(welcome_text: :bar)
     assert_equal false, plan.reload.approval_required
 
-    @settings.update_attributes(account_approval_required: false)
+    @settings.update(account_approval_required: false)
     refute plan.reload.approval_required
   end
 
@@ -99,7 +99,7 @@ class SettingsTest < ActiveSupport::TestCase
     plan.update_attribute(:approval_required, true)
     assert @settings.reload.account_approval_required
 
-    @settings.update_attributes(account_approval_required: false)
+    @settings.update(account_approval_required: false)
     refute @provider.account_plans.first.approval_required
   end
 

--- a/test/unit/validators/authentication_provider_publish_validator_test.rb
+++ b/test/unit/validators/authentication_provider_publish_validator_test.rb
@@ -14,7 +14,7 @@ class AuthenticationProviderPublishValidatorTest < ActiveSupport::TestCase
     validator.valid?
     assert_nil validator.error_message
 
-    account.settings.update_attributes(enforce_sso: true)
+    account.settings.update(enforce_sso: true)
     validator = AuthenticationProviderPublishValidator.new(account, auth_provider)
     validator.valid?
     assert_match 'There needs to be at least 1 published SSO Integration', validator.error_message

--- a/test/unit/validators/enforce_sso_validator_test.rb
+++ b/test/unit/validators/enforce_sso_validator_test.rb
@@ -23,7 +23,7 @@ class EnforceSSOValidatorTest < ActiveSupport::TestCase
     refute service.valid?
     assert_match 'You need to be logged in by SSO', service.error_message
 
-    @user_session.update_attributes(sso_authorization_id: sso_authorization.id)
+    @user_session.update(sso_authorization_id: sso_authorization.id)
     service = EnforceSSOValidator.new(@user_session)
     assert service.valid?
     assert_empty service.error_message

--- a/test/workers/process_domain_events_worker_test.rb
+++ b/test/workers/process_domain_events_worker_test.rb
@@ -11,7 +11,7 @@ class ProcessDomainEventsWorkerTest < ActiveSupport::TestCase
   def test_proxy_domain_changed_event
     provider = FactoryBot.create(:simple_provider)
     proxy = FactoryBot.create(:simple_proxy)
-    proxy.update_attributes!(endpoint: "http://#{provider.external_admin_domain}")
+    proxy.update!(endpoint: "http://#{provider.external_admin_domain}")
     event = Domains::ProxyDomainsChangedEvent.create_and_publish!(proxy)
 
     provider_domains_changed = EventStore::Repository.adapter.where(event_type: 'Domains::ProviderDomainsChangedEvent')
@@ -24,7 +24,7 @@ class ProcessDomainEventsWorkerTest < ActiveSupport::TestCase
   def test_provider_domain_changed_event
     provider = FactoryBot.create(:simple_provider)
     proxy = FactoryBot.create(:simple_proxy)
-    proxy.update_attributes!(endpoint: "http://#{provider.external_admin_domain}")
+    proxy.update!(endpoint: "http://#{provider.external_admin_domain}")
     event = Domains::ProviderDomainsChangedEvent.create_and_publish!(provider)
 
     proxy_domains_changed = EventStore::Repository.adapter.where(event_type: 'Domains::ProxyDomainsChangedEvent')


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of the Rails 6 upgrade (https://github.com/3scale/porta/pull/3339): `#update_attributes` is deprecated in favor of `#update`

**Which issue(s) this PR fixes** 

[THREESCALE-7405](https://issues.redhat.com/browse/THREESCALE-7405)

**Verification steps** 

Trust on the tests to find regressions.
