### PR TITLE
Fix some missing icons

### DIFF
--- a/app/assets/javascripts/provider/cms/sidebar.js.coffee
+++ b/app/assets/javascripts/provider/cms/sidebar.js.coffee
@@ -24,7 +24,7 @@ jQuery.expr[':'].like = (el, i, selector) ->
 
 ## Sidebar class
 class Sidebar
-  FOLDER_ICONS = ['fa-folder-o', 'fa-folder-open-o']
+  FOLDER_ICONS = ['fa-folder', 'fa-folder-open']
   ICON_SETS = [FOLDER_ICONS]
   HIGHLIGHT_CLASS = 'current'
   TOGGLE_SELECTOR = '[data-behavior~=toggle]'
@@ -84,7 +84,7 @@ class Sidebar
 
   update_expand_collapse_button: (all_packed = @all_items_packed()) ->
     @expand_collapse_all_button().
-      html(Sidebar.icon(if all_packed then 'plus-square-o' else 'minus-square-o'))
+      html(Sidebar.icon(if all_packed then 'plus-square' else 'minus-square'))
 
   fire_ajax: ->
     @ajax.abort() if @ajax
@@ -402,7 +402,7 @@ class SidebarTemplates
           <ul id="cms-sidebar-section-<%= section.id %>">
             <% _.each(pages, function(page) { %>
               <li class="cms-page" data-id="<%= page.id %>" data-behavior="drag search" data-param="cms_page" <%= search(page) %>>
-                <%= icon_link_to('file-o', page.title, page.edit_path, [ page.path, '(' + page.title + ')' ]) %>
+                <%= icon_link_to('file', page.title, page.edit_path, [ page.path, '(' + page.title + ')' ]) %>
               </li>
             <% }); %>
 
@@ -420,7 +420,7 @@ class SidebarTemplates
 
             <% _.each(sections, function(section){ %>
               <li class="cms-section"  data-id="<%= section.id %>" data-behavior="toggle drag search" data-param="cms_section" <%= search(section) %>>
-                <%= icon('folder-open-o fa-fw') %>
+                <%= icon('folder-open fa-fw') %>
                 <%= link_to(section.title, section.edit_path) %>
                 <%= render(section) %>
               </li>

--- a/app/assets/stylesheets/provider/admin/cms/_sidebar.scss
+++ b/app/assets/stylesheets/provider/admin/cms/_sidebar.scss
@@ -54,11 +54,11 @@
     }
   }
 
-  .fa-folder-open-o:hover:before {
+  .fa-folder-open:hover:before {
     content: '\f07c';
   }
 
-  .fa-folder-o:hover:before {
+  .fa-folder:hover:before {
     content: '\f07b';
   }
 
@@ -74,8 +74,8 @@
     }
   }
 
-  .fa-folder-o,
-  .fa-folder-open-o {
+  .fa-folder,
+  .fa-folder-open {
     color: $brand-blue;
 
     &:hover {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -188,9 +188,9 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
 
   def boolean_status_img(enabled, opts = {})
     if enabled
-      '<i class="included fa fa-check-circle-o" title="Enabled"></i>'.html_safe
+      '<i class="included fas fa-check-circle" title="Enabled"></i>'.html_safe
     else
-      '<i class="excluded fa fa-times-circle-o" title="Disabled"></i>'.html_safe
+      '<i class="excluded fas fa-times-circle" title="Disabled"></i>'.html_safe
     end
   end
 

--- a/app/javascript/src/Common/components/SystemNamePopover.tsx
+++ b/app/javascript/src/Common/components/SystemNamePopover.tsx
@@ -1,5 +1,6 @@
 import { render } from 'react-dom'
 import { Popover } from '@patternfly/react-core'
+import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon'
 
 const SystemNamePopover: React.FunctionComponent = () => (
   <Popover
@@ -11,7 +12,7 @@ const SystemNamePopover: React.FunctionComponent = () => (
     )}
     maxWidth="420px"
   >
-    <i className="fa fa-question-circle-o" />
+    <OutlinedQuestionCircleIcon />
   </Popover>
 )
 

--- a/app/views/api/features/_feature.html.erb
+++ b/app/views/api/features/_feature.html.erb
@@ -9,14 +9,14 @@
           :method => :delete,
           remote: true,
           :class => 'action' do -%>
-            <i class="included fa fa-check-circle-o" title="Feature is enabled for this plan"></i>
+            <i class="included fas fa-check-circle" title="Feature is enabled for this plan"></i>
         <% end %>
       <% else %>
         <%= link_to admin_plan_featurings_path(@plan, :type => @plan.class.name.underscore, id: feature.id),
           method: :post,
           remote: true,
           :class => 'action' do -%>
-          <i class="excluded fa fa-times-circle-o" title="Metric is disabled for this plan"></i>
+          <i class="excluded fas fa-times-circle" title="Metric is disabled for this plan"></i>
         <% end %>
       <% end %>
     </td>

--- a/app/views/api/metrics/_metric.html.erb
+++ b/app/views/api/metrics/_metric.html.erb
@@ -26,9 +26,9 @@
                 title: "#{@plan.metric_enabled?(metric) ? 'Disable' : 'Enable'} metric #{metric.friendly_name}",
                 class: 'action' do -%>
       <% if @plan.metric_enabled?(metric) %>
-        <i class="included fa fa-check-circle-o" title="Metric is enabled for this plan"></i>
+        <i class="included fas fa-check-circle" title="Metric is enabled for this plan"></i>
       <% else %>
-        <i class="excluded fa fa-times-circle-o" title="Metric is disabled for this plan"></i>
+        <i class="excluded fas fa-times-circle" title="Metric is disabled for this plan"></i>
       <% end %>
     <% end %>
   </span>
@@ -41,9 +41,9 @@
                       title: "Make metric #{metric.friendly_name} #{@plan.metric_visible?(metric) ? 'invisible' : 'visible'}",
                       class: 'action' do -%>
       <% if @plan.metric_visible?(metric) %>
-        <i class="included fa fa-check-circle-o" title="Metric is visible for this plan"></i>
+        <i class="included fas fa-check-circle" title="Metric is visible for this plan"></i>
       <% else %>
-        <i class="excluded fa fa-times-circle-o" title="Metric is hidden for this plan"></i>
+        <i class="excluded fas fa-times-circle" title="Metric is hidden for this plan"></i>
       <% end %>
     <% end %>
   </span>
@@ -55,9 +55,9 @@
                       :remote => true,
                       class: 'action' do -%>
       <% if @plan.limits_only_text?(metric) %>
-        <i class="included fa fa-check-circle-o" title="Metric limits are shown with icons and text for this plan"></i>
+        <i class="included fas fa-check-circle" title="Metric limits are shown with icons and text for this plan"></i>
       <% else %>
-        <i class="excluded fa fa-times-circle-o" title="Metri limits are text-only for this plan"></i>
+        <i class="excluded fas fa-times-circle" title="Metri limits are text-only for this plan"></i>
       <% end %>
     <% end %>
   </span>

--- a/app/views/buyers/users/show.html.erb
+++ b/app/views/buyers/users/show.html.erb
@@ -35,9 +35,9 @@
     <th>State</th>
     <td>
       <% if @user.active? %>
-        <i class="included fa fa-check-circle-o" title="Feature is enabled for this plan"></i>
+        <i class="included fas fa-check-circle" title="Feature is enabled for this plan"></i>
       <% else %>
-        <i class="excluded fa fa-times-circle-o" title="Feature is disabled for this plan"></i>
+        <i class="excluded fas fa-times-circle" title="Feature is disabled for this plan"></i>
       <% end %>
       <%= h @user.state %>
       <span class="operations">

--- a/app/views/layouts/_cms.html.erb
+++ b/app/views/layouts/_cms.html.erb
@@ -13,7 +13,7 @@
     <li data-filter-type="file" title="Files"><%= icon('paperclip') %></li>
     <li data-filter-type="partial" title="Partials"><%= icon('puzzle-piece') %></li>
     <li data-filter-type="layout" title="Layouts"><%= icon('code') %></li>
-    <li data-filter-type="section" title="Sections"><%= icon('folder-o') %></li>
+    <li data-filter-type="section" title="Sections"><%= icon('folder') %></li>
     <li data-filter-type="portlet" title="Portlets"><%= icon('rocket') %></li>
   </ul>
 

--- a/app/views/plans/_widget.html.erb
+++ b/app/views/plans/_widget.html.erb
@@ -17,9 +17,9 @@
         <th colspan="2"><%= h feature.name %></th>
         <td>
           <% if enabled %>
-            <i class="included fa fa-check-circle-o" title="Feature is enabled for this plan"></i>
+            <i class="included fas fa-check-circle" title="Feature is enabled for this plan"></i>
           <% else %>
-            <i class="excluded fa fa-times-circle-o" title="Feature is disabled for this plan"></i>
+            <i class="excluded fas fa-times-circle" title="Feature is disabled for this plan"></i>
           <% end %>
         </td>
       </tr>
@@ -57,7 +57,7 @@
       	<% if metric.visible_in_plan?(plan) %>
           <tr class="feature unlimited_metric" id="<%= dom_id(metric) %>_unlimited">
             <th rowspan="1"> <%= display_metric_name(metric) %></th>
-            <td colspan="2"><i class="included fa fa-check-circle-o"></i></td>
+            <td colspan="2"><i class="included fas fa-check-circle"></i></td>
           </tr>
         <% end %>
       <% end %>

--- a/app/views/provider/admin/account/change_plans/widget/_features.html.erb
+++ b/app/views/provider/admin/account/change_plans/widget/_features.html.erb
@@ -2,13 +2,13 @@
   <h3>Features</h3>
   <dl class="u-dl">
     <% plan.features.each do |feature| %>
-      <dt class="u-dl-term u-dl-term--check" ><i class="included fa fa-check-circle-o"></i></dt>
+      <dt class="u-dl-term u-dl-term--check" ><i class="included fas fa-check-circle"></i></dt>
       <dd class="u-dl-definition u-dl-definition--check"><%= h(feature.name) %></dd>
     <% end %>
 
     <%  plan.issuer.features.visible.each do |feature| %>
     <% next if plan.feature_enabled?(feature.system_name) %>
-      <dt class="u-dl-term u-dl-term--check" ><i class="excluded fa fa-times-circle-o"></i></dt>
+      <dt class="u-dl-term u-dl-term--check" ><i class="excluded fas fa-times-circle"></i></dt>
       <dd class="u-dl-definition u-dl-definition--check"><%= h(feature.name) %></dd>
     <% end %>
   </dl>

--- a/app/views/provider/admin/account/change_plans/widget/_limits.html.erb
+++ b/app/views/provider/admin/account/change_plans/widget/_limits.html.erb
@@ -20,7 +20,7 @@
         <% plan.metrics_without_limits.each do |metric| %>
           <% if metric.visible_in_plan?(plan) %>
             <dt class="u-dl-term"> <%= display_metric_name(metric) %> </dt>
-            <dd class="u-dl-definition"><i class="included fa fa-check-circle-o"></i></dd>
+            <dd class="u-dl-definition"><i class="included fas fa-check-circle"></i></dd>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/provider/admin/accounts/show.html.slim
+++ b/app/views/provider/admin/accounts/show.html.slim
@@ -44,7 +44,7 @@ div id="account-column-wrapper"
         h2 Red Hat Account Connect Status
         - if @presenter.red_hat_verified?
           p
-            i> class="included check fa fa-check-circle-o"
+            i> class="included check fas fa-check-circle"
             ' Red Hat account
             => @presenter.red_hat_account_number
             | is connected to this 3scale account.
@@ -80,10 +80,10 @@ div id="account-column-wrapper"
             tr
               th = feature.name
               td
-                i class="included fa fa-check-circle-o"
+                i class="included fas fa-check-circle"
 
           - @presenter.absent_visible_features.each do |feature|
             tr
               th = feature.name
               td
-                i class="excluded fa fa-times-circle-o"
+                i class="excluded fas fa-times-circle"


### PR DESCRIPTION
These and other icons have disappeared... who knows when! This PR replace such icons with "updated" ones, according to cms-toolbar-menu-right. Note that they now look flat whereas before they were outlined.

Before:
<img width="1728" alt="Screenshot 2023-07-05 at 14 58 33" src="https://github.com/3scale/porta/assets/11672286/89a6620b-9e79-406b-8452-793a5f80cabb">

After:
<img width="1728" alt="Screenshot 2023-07-05 at 14 55 03" src="https://github.com/3scale/porta/assets/11672286/cb9ce42a-d53b-4180-b2bf-04ad9dd47c41">

