### PR TITLE
Remove deprecation warnings for Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'rails-observers'
 gem 'strong_migrations', '~> 0.6.8'
 
 group :assets do
-  gem 'coffee-rails', '~> 4.2'
+  gem 'coffee-rails', '~> 5.0'
   gem 'non-stupid-digest-assets', '~> 1.0'
   gem 'sprockets-rails', '3.2.2' # remove version after we stop supporting Ruby 2.4
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,9 +226,9 @@ GEM
     codecov (0.4.3)
       simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
-    coffee-rails (4.2.2)
+    coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
+      railties (>= 5.2.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -332,7 +332,7 @@ GEM
     et-orbi (1.2.4)
       tzinfo
     eventmachine (1.2.7)
-    execjs (2.7.0)
+    execjs (2.8.1)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -426,9 +426,9 @@ GEM
     local-fastimage (3.1.3)
     local-fastimage_resize (3.4.0)
       local-fastimage (~> 3.0)
-    loofah (2.20.0)
+    loofah (2.21.2)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     mail_view (2.0.4)
@@ -809,7 +809,7 @@ GEM
       joiner (>= 0.3.4)
       middleware (>= 0.1.0)
       riddle (~> 2.3)
-    thor (1.2.1)
+    thor (1.2.2)
     thread_safe (0.3.6)
     tilt (2.0.9)
     to_regexp (0.2.1)
@@ -923,7 +923,7 @@ DEPENDENCIES
   chronic
   ci_reporter_shell!
   codecov
-  coffee-rails (~> 4.2)
+  coffee-rails (~> 5.0)
   colorize
   commonmarker (~> 0.23.9)
   compass-rails (~> 3.0.2)

--- a/app/controllers/provider/admin/destroys_controller.rb
+++ b/app/controllers/provider/admin/destroys_controller.rb
@@ -8,7 +8,7 @@ class Provider::Admin::DestroysController < Provider::Admin::BaseController
     @destroy_type = kind
     @kind = ALLOWED_KINDS.fetch(@destroy_type).constantize.model_name
     @destroys = current_account.provider_audits.destroys
-        .order('audits.id desc').where(kind: @kind.to_s).paginate(page: params[:page])
+        .order('audits.id DESC').where(kind: @kind.to_s).paginate(page: params[:page])
   end
 
   private

--- a/app/lib/csv/applications_exporter.rb
+++ b/app/lib/csv/applications_exporter.rb
@@ -10,7 +10,7 @@ class Csv::ApplicationsExporter < ::Csv::Exporter
 
       query = @account.provided_cinstances
                 .includes([ { :user_account => [:users, :country] }, :plan])
-                .order('`cinstances`.`created_at` DESC')
+                .order('cinstances.created_at DESC')
 
       query = query.where(created_at: @range) if @range
       query.find_each do |cinstance|

--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -30,7 +30,7 @@ class Forum < ApplicationRecord
   attr_protected :topics_count, :posts_count, :account_id, :tenant_id
 
   def latest_posts
-    posts.joins(:topic).order('posts.created_at desc')
+    posts.joins(:topic).order('posts.created_at DESC')
   end
 
   def to_param

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -593,7 +593,7 @@ class Invoice < ApplicationRecord
 
   # Returns years which have invoice
   def self.years
-    self.connection.select_values(selecting { sift(:year, period).as('year') }.distinct.reorder('year desc').to_sql).map(&:to_i)
+    self.connection.select_values(selecting { sift(:year, period).as('year') }.distinct.reorder('year DESC').to_sql).map(&:to_i)
   end
 
   protected

--- a/app/presenters/dashboard/notifications_presenter.rb
+++ b/app/presenters/dashboard/notifications_presenter.rb
@@ -2,7 +2,7 @@ class Dashboard::NotificationsPresenter < Dashboard::MessagesPresenter
   IGNORED_NOTIFICATIONS = %w(csv_data_export daily_report weekly_report).freeze
 
   def initialize(notifications)
-    super notifications.where.not(system_name: IGNORED_NOTIFICATIONS, title: nil).order(created_at: :desc)
+    super notifications.where.not(system_name: IGNORED_NOTIFICATIONS).where.not(title: nil).order(created_at: :desc)
   end
 
   def link_tag(notification)

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
-run System::Application
+run Rails.application

--- a/lib/developer_portal/lib/liquid/drops/pagination.rb
+++ b/lib/developer_portal/lib/liquid/drops/pagination.rb
@@ -121,7 +121,7 @@ module Liquid
         def make_parts
           pagination.map do |item|
             case item
-            when Fixnum
+            when Integer
               page_number(item)
             when :previous_page, :next_page
               send(item)

--- a/lib/developer_portal/lib/liquid/tags/debug.rb
+++ b/lib/developer_portal/lib/liquid/tags/debug.rb
@@ -1,7 +1,7 @@
 module Liquid
   module Tags
     class Debug < Base
-      include ActionView::Helpers::ApplicationHelper
+      include ApplicationHelper
       # vars excluded from the help message
       PROTECTED_ASSIGNS = %w{ content_for_layout }
 

--- a/lib/developer_portal/lib/liquid/template/handler.rb
+++ b/lib/developer_portal/lib/liquid/template/handler.rb
@@ -1,8 +1,10 @@
 module Liquid
   class Template
     class Handler
-      def self.call(template)
-        "Liquid::Template::Handler.new(self).render(#{template.source.inspect}, local_assigns)"
+      # DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
+      # now accept two parameters, the view object and the source for the view object.
+      def self.call(template, source = template.source)
+        "Liquid::Template::Handler.new(self).render(#{source.inspect}, local_assigns)"
       end
 
       def initialize(view)

--- a/test/unit/liquid/drops/authentication_strategy_test.rb
+++ b/test/unit/liquid/drops/authentication_strategy_test.rb
@@ -13,7 +13,7 @@ class Liquid::Drops::AuthenticationStrategyTest < ActiveSupport::TestCase
   test 'country#choices' do
     drop = Drops::CountryField.new(@buyer, :country)
     country = drop.choices.first
-    assert country.id.is_a?(Fixnum)
+    assert country.id.is_a?(Integer)
     assert country.label.is_a?(String)
   end
 

--- a/test/unit/liquid/drops/country_field_test.rb
+++ b/test/unit/liquid/drops/country_field_test.rb
@@ -13,7 +13,7 @@ class Liquid::Drops::CountryFieldTest < ActiveSupport::TestCase
   test 'country#choices' do
     drop = Drops::CountryField.new(@buyer, :country)
     country = drop.choices.first
-    assert country.id.is_a?(Fixnum)
+    assert country.id.is_a?(Integer)
     assert country.label.is_a?(String)
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of the Rails 6 upgrade (https://github.com/3scale/porta/pull/3339)

Move to 5.2 all changes that fix deprecation warnings in 6 but are also valid for 5.2

**Which issue(s) this PR fixes** 

[THREESCALE-7405](https://issues.redhat.com/browse/THREESCALE-7405)

**Verification steps** 

Everything should work. The tests should pass.

