### PR TITLE
Don't load unused rails components

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,3 @@
-require_relative 'boot'
-
 # frozen_string_literal: true
 
 require_relative 'boot'

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,32 @@
 require_relative 'boot'
 
-require 'rails/all'
+# frozen_string_literal: true
+
+require_relative 'boot'
+
+# We don't want to load any Rails component we don't use
+# See https://github.com/rails/rails/blob/v6.1.7.3/railties/lib/rails/all.rb for the list
+# of what is being included here
+require "rails"
+
+# Omitted Rails components
+#   active_storage/engine
+#   action_cable/engine
+#   action_mailbox/engine
+#   action_text/engine
+
+%w[
+  active_record/railtie
+  action_controller/railtie
+  action_view/railtie
+  action_mailer/railtie
+  active_job/railtie
+  rails/test_unit/railtie
+  sprockets/railtie
+].each do |railtie|
+  require railtie
+rescue LoadError
+end
 
 ActiveSupport.on_load(:active_record) do
   # Some rails tasks like db:create may load database before environment

--- a/test/unit/indices/indexing_test.rb
+++ b/test/unit/indices/indexing_test.rb
@@ -56,7 +56,7 @@ class IndexingTest < ActiveSupport::TestCase
 
   # the idea is to double check #indexed_models lists all models, assuring we cover them all in tests
   test "all models with index methods are indexed" do
-    exclusions = [ActiveStorage::Blob, ActiveStorage::Attachment, ApplicationRecord, Plan, Cinstance, User]
+    exclusions = [ApplicationRecord, Plan, Cinstance, User]
     index_modules = [Searchable, Indices::AccountIndex::ForAccount]
     index_modules << Indices::TopicIndex unless System::Database.oracle?
 

--- a/test/unit/models_test.rb
+++ b/test/unit/models_test.rb
@@ -7,9 +7,6 @@ class ModelsTest < ActiveSupport::TestCase
 
   test 'validate length of strings for all models to do not raise an error reaching DB' do
     exceptions = {
-      'Audited::Audit' => :all, 'RailsEventStoreActiveRecord::Event' => :all,
-      'ActiveStorage::Attachment' => :all, 'ActiveRecord::SchemaMigration' => :all, 'ActiveStorage::Blob' => :all,
-      'System::Database::ConnectionProbe' => :all, 'ActsAsTaggableOn::Tag' => :all, 'ActsAsTaggableOn::Tagging' => :all, 'ApplicationRecord' => :all,
       'FieldsDefinition' => %w[target], 'AuthenticationProvider' => %w[account_type], 'Feature' => %w[featurable_type scope], 'Message' => %w[state],
       'UsageLimit' => %w[period plan_type], 'Policy' => %w[identifier], 'ProxyRule' => %w[metric_system_name], 'ProxyConfig' => %w[hosts],
       'Proxy' => %w[endpoint sandbox_endpoint], 'OIDCConfiguration' => %w[oidc_configurable_type], 'Invitation' => %w[token],
@@ -28,7 +25,7 @@ class ModelsTest < ActiveSupport::TestCase
     }
 
     Rails.application.eager_load!
-    models = ActiveRecord::Base.descendants - [BackendApi, Service, Proxy, Topic, Forum]
+    models = ApplicationRecord.descendants - [BackendApi, Service, Proxy, Topic, Forum]
 
     validate_columns_for = ->(model, options = {}) do
       model_name = model.name


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of the Rails 6 upgrade (https://github.com/3scale/porta/pull/3339)

Only load those rails components we actually use, and remove any reference to others.

**Which issue(s) this PR fixes** 

[THREESCALE-7405](https://issues.redhat.com/browse/THREESCALE-7405)

**Verification steps** 

Everything should work. Tests should pass.
