### PR TITLE
Test capybara timeout

### DIFF
--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -28,7 +28,7 @@ Capybara.configure do |config|
   config.raise_server_errors = true
   config.match = :prefer_exact
   config.always_include_port = true
-  config.default_max_wait_time = 2
+  config.default_max_wait_time = 10
 end
 
 # Needed because cucumber-rails requires capybara/cucumber


### PR DESCRIPTION
**What this PR does / why we need it**:

Some random Oracle tests always fail in rails 6, the error is always the same:  Capybara not finding an element in the page. I suspect this is because of the Oracle slowness we discussed a few weeks ago, probably the screen takes too much time to load and Capybara times out.

In this PR I increase the timeout for Capybara on the Rails 6 branch. Let's see if that fixes the tests.

**Which issue(s) this PR fixes** 

No issue.

**Verification steps** 

All tests should pass for Oracle.


