### PR TITLE
THREESCALE-7112: Prevent deletion of metrics used in latest config

### DIFF
--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -49,7 +49,7 @@ class Api::MetricsController < Api::BaseController
     if @metric.destroy
       flash[:notice] = "The #{method_or_metric} was deleted"
     else
-      flash[:error] = 'The Hits metric cannot be deleted'
+      flash[:error] = @metric.errors.full_messages.to_sentence
     end
 
     redirect_to admin_service_metrics_path(@service, tab: "#{method_or_metric}s")

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -147,7 +147,7 @@ class Metric < ApplicationRecord
       xml.name          name # As of February 2014 this is deprecated and should be removed
       xml.system_name   name
       xml.friendly_name friendly_name
-      xml.service_id    (backend_api_metric? ? nil : owner_id)
+      xml.service_id    service_owner&.id
       xml.description   description
       if method_metric?
         xml.metric_id parent_id

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -134,7 +134,7 @@ class Metric < ApplicationRecord
   end
 
   def type
-    method_metric? ? 'method' : 'metric'
+    @type ||= method_metric? ? :method : :metric
   end
 
   alias method_metric? child?
@@ -225,7 +225,7 @@ class Metric < ApplicationRecord
   def destroyable?
     return true if destroyed_by_association
 
-    errors.add :base, :cannot_delete_in_use, type: type.capitalize if belongs_to_latest_config?
+    errors.add :base, :cannot_delete_in_use, type: type.to_s.capitalize if belongs_to_latest_config?
     errors.add :base, :cannot_delete_hits if system_name == 'hits'
 
     errors.empty?

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -118,6 +118,10 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
     super + %w[api_backend] + GatewayConfiguration::ATTRIBUTES
   end
 
+  def metric_in_latest_configs?(metric_id)
+    ProxyConfig::ENVIRONMENTS.map { |env| proxy_configs.by_environment(env).newest_first.first.contains_metric?(metric_id) }.any?
+  end
+
   # This smells of :reek:NilCheck
   def authentication_method
     super.presence || service&.read_attribute(:backend_version)

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -119,7 +119,7 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def metric_in_latest_configs?(metric_id)
-    ProxyConfig::ENVIRONMENTS.map { |env| proxy_configs.by_environment(env).newest_first.first.contains_metric?(metric_id) }.any?
+    ProxyConfig::ENVIRONMENTS.map { |env| proxy_configs.by_environment(env).newest_first.first&.contains_metric?(metric_id) }.any?
   end
 
   # This smells of :reek:NilCheck

--- a/app/models/proxy_config.rb
+++ b/app/models/proxy_config.rb
@@ -121,6 +121,10 @@ class ProxyConfig < ApplicationRecord
     JSON.parse(content).deep_symbolize_keys
   end
 
+  def contains_metric?(metric_id)
+    parsed_content[:proxy][:proxy_rules].pluck(:metric_id).include? metric_id
+  end
+
   private
 
   delegate :service_mesh_integration?, to: :proxy, allow_nil: true

--- a/app/views/api/metrics/edit.html.erb
+++ b/app/views/api/metrics/edit.html.erb
@@ -1,9 +1,8 @@
-<% method_or_metric = @metric.child? ? "method" : "metric" %>
-<% content_for :page_header_title, "Edit #{method_or_metric.capitalize}" %>
+<% content_for :page_header_title, "Edit #{@metric.type.capitalize}" %>
 
 <%= semantic_form_for @metric, :url => admin_service_metric_path(@service, @metric) do |form| %>
   <%= render 'form', :form => form %>
 <% end %>
 <% unless @metric.default?(:hits) %>
-  <%= delete_button_for admin_service_metric_path(@service, @metric), data: {:confirm => "Removing this #{method_or_metric} will affect all plans that contain this #{method_or_metric}, all associated mapping rules will be deleted too. Are you sure? "} %>
+  <%= delete_button_for admin_service_metric_path(@service, @metric), data: { confirm: t('api.metrics.edit.delete_confirmation', type: j(@metric.type)) } %>
 <% end %>

--- a/app/views/api/metrics/edit.html.erb
+++ b/app/views/api/metrics/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header_title, "Edit #{@metric.type.capitalize}" %>
+<% content_for :page_header_title, "Edit #{@metric.type.to_s.capitalize}" %>
 
 <%= semantic_form_for @metric, :url => admin_service_metric_path(@service, @metric) do |form| %>
   <%= render 'form', :form => form %>

--- a/app/views/provider/admin/backend_apis/metrics/edit.html.erb
+++ b/app/views/provider/admin/backend_apis/metrics/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header_title, "Edit #{@metric.type.capitalize}" %>
+<% content_for :page_header_title, "Edit #{@metric.type.to_s.capitalize}" %>
 
 <%= semantic_form_for @metric, :url => provider_admin_backend_api_metric_path(@backend_api, @metric) do |form| %>
   <%= render 'form_edit', form: form, backend_api: @backend_api, metric: @metric %>

--- a/app/views/provider/admin/backend_apis/metrics/edit.html.erb
+++ b/app/views/provider/admin/backend_apis/metrics/edit.html.erb
@@ -1,10 +1,8 @@
-
-<% method_or_metric = @metric.child? ? "method" : "metric" %>
-<% content_for :page_header_title, "Edit #{method_or_metric.capitalize}" %>
+<% content_for :page_header_title, "Edit #{@metric.type.capitalize}" %>
 
 <%= semantic_form_for @metric, :url => provider_admin_backend_api_metric_path(@backend_api, @metric) do |form| %>
   <%= render 'form_edit', form: form, backend_api: @backend_api, metric: @metric %>
 <% end %>
 <% unless @metric.default?(:hits) %>
-  <%= delete_button_for provider_admin_backend_api_metric_path(@backend_api, @metric), data: {:confirm => "Removing this #{method_or_metric} will affect all plans that contain this #{method_or_metric}, all associated mapping rules will be deleted too. Are you sure? "} %>
+  <%= delete_button_for provider_admin_backend_api_metric_path(@backend_api, @metric), data: { confirm: t('api.metrics.edit.delete_confirmation', type: j(@metric.type)) } %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -840,6 +840,8 @@ en:
           attributes:
             base:
               all_periods_used: "Metric cannot be disabled. Please contact support."
+              cannot_delete_in_use: "%{type} is used by the latest gateway configuration and cannot be deleted"
+              cannot_delete_hits: 'The Hits metric cannot be deleted'
         policy:
           attributes:
             base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -555,6 +555,9 @@ en:
             Start by creating an application plan.
           no_application:
             In order to send a valid test request, please create an application that subscribes to an application plan of this service.
+    metrics:
+      edit:
+        delete_confirmation: "Removing this %{type} will affect all plans that contain this %{type}, all associated mapping rules will be deleted too. Are you sure?"
 
   deployment_options:
     missing: |

--- a/features/api/metrics/delete.feature
+++ b/features/api/metrics/delete.feature
@@ -30,3 +30,12 @@ Feature: Product > Integration > Metrics > Edit
     Given I change to tab "Metrics"
     When I follow "Hits"
     Then I should not see "Delete"
+
+  Scenario: Cannot delete a metric used in the latest gateway configuration
+    Given metric "Pasta" is mapped
+    And the gateway configuration is promoted to staging
+    When I change to tab "Metrics"
+    And I follow "Pasta"
+    And I press "Delete" and I confirm dialog box
+    Then I should see the flash message "Metric is used by the latest gateway configuration and cannot be deleted"
+    And I should see "Pasta" on the metrics tab

--- a/features/api/metrics/delete.feature
+++ b/features/api/metrics/delete.feature
@@ -38,4 +38,6 @@ Feature: Product > Integration > Metrics > Edit
     And I follow "Pasta"
     And I press "Delete" and I confirm dialog box
     Then I should see the flash message "Metric is used by the latest gateway configuration and cannot be deleted"
-    And I should see "Pasta" on the metrics tab
+    And I should see the following metrics:
+      | Hits  |
+      | Pasta |

--- a/features/step_definitions/api/metrics_steps.rb
+++ b/features/step_definitions/api/metrics_steps.rb
@@ -59,18 +59,6 @@ Then('I should see {string} (already )mapped') do |name|
   assert_equal '', find_mapped_cell_in_table(name).text
 end
 
-Then /^I should (not )?see "([^"]*)" on the (metrics|methods) tab$/ do |negate, metric_name, tab_name|
-  step("I change to tab \"#{tab_name.capitalize}\"")
-  table = tab_name == 'metrics' ? metrics_table : methods_table
-
-  assertion = method(negate ? :refute_includes : :assert_includes)
-
-  with_scope table do
-    table_metrics = find_all('.pf-c-table tbody tr td:first-child').map(&:text)
-    assertion.call table_metrics, metric_name
-  end
-end
-
 def find_mapped_cell_in_table(text)
   find('.pf-c-table tbody tr', text: text).find('[data-label="Mapped"]')
 end

--- a/features/step_definitions/api/metrics_steps.rb
+++ b/features/step_definitions/api/metrics_steps.rb
@@ -63,9 +63,11 @@ Then /^I should (not )?see "([^"]*)" on the (metrics|methods) tab$/ do |negate, 
   step("I change to tab \"#{tab_name.capitalize}\"")
   table = tab_name == 'metrics' ? metrics_table : methods_table
 
+  assertion = method(negate ? :refute_includes : :assert_includes)
+
   with_scope table do
     table_metrics = find_all('.pf-c-table tbody tr td:first-child').map(&:text)
-    assert_includes table_metrics, metric_name
+    assertion.call table_metrics, metric_name
   end
 end
 

--- a/features/step_definitions/api/metrics_steps.rb
+++ b/features/step_definitions/api/metrics_steps.rb
@@ -59,6 +59,16 @@ Then('I should see {string} (already )mapped') do |name|
   assert_equal '', find_mapped_cell_in_table(name).text
 end
 
+Then /^I should (not )?see "([^"]*)" on the (metrics|methods) tab$/ do |negate, metric_name, tab_name|
+  step("I change to tab \"#{tab_name.capitalize}\"")
+  table = tab_name == 'metrics' ? metrics_table : methods_table
+
+  with_scope table do
+    table_metrics = find_all('.pf-c-table tbody tr td:first-child').map(&:text)
+    assert_includes table_metrics, metric_name
+  end
+end
+
 def find_mapped_cell_in_table(text)
   find('.pf-c-table tbody tr', text: text).find('[data-label="Mapped"]')
 end

--- a/features/step_definitions/apicast_steps.rb
+++ b/features/step_definitions/apicast_steps.rb
@@ -15,3 +15,8 @@ Given(/^the default proxy does not use apicast configuration driven$/) do
   proxy = @provider.default_service.proxy
   proxy.update!(apicast_configuration_driven: false, sandbox_endpoint: 'https://api-2.staging.apicast.io:4443', endpoint: 'https://api-2.staging.io:4443')
 end
+
+Given /^the gateway configuration is promoted to (staging|production)$/ do |environment|
+  proxy = @provider.default_service.proxy
+  ProxyDeploymentService.call(proxy, environment: environment.to_sym)
+end

--- a/test/factories/proxy.rb
+++ b/test/factories/proxy.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory (:proxy) do
+  factory(:proxy) do
     association :service
     api_backend { 'http://api.example.net:80' }
     secret_token { "123" }

--- a/test/unit/proxy_config_test.rb
+++ b/test/unit/proxy_config_test.rb
@@ -294,7 +294,7 @@ class ProxyConfigTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassL
     assert_same_elements expected_configs, ProxyConfig.by_version(1).by_host('example.com').by_environment('sandbox')
   end
 
-  test '#by_version returns the latest version of each proxy for a particular environtment and host' do
+  test '#by_version returns the latest version of each proxy for a particular environment and host' do
     proxy1 = FactoryBot.create(:proxy)
     proxy2 = FactoryBot.create(:proxy)
     proxy3 = FactoryBot.create(:proxy)
@@ -368,6 +368,20 @@ class ProxyConfigTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassL
 
     refute proxy_config.valid?
     assert_contains proxy_config.errors[:content], proxy_config.errors.generate_message(:content, :too_long, count: ProxyConfig::MAX_CONTENT_LENGTH)
+  end
+
+  test '#contains_metric?' do
+    metric = FactoryBot.create(:metric)
+    service = metric.owner
+    proxy = FactoryBot.create(:proxy, service: service)
+
+    proxy_config = ApicastV2DeploymentService.new(proxy).call(environment: :sandbox)
+    assert_not proxy_config.contains_metric? metric.id
+
+    FactoryBot.create(:proxy_rule, proxy: proxy, metric: metric)
+
+    proxy_config = ApicastV2DeploymentService.new(proxy.reload).call(environment: :sandbox)
+    assert proxy_config.contains_metric? metric.id
   end
 
   private


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevents deletion of metrics that are used in the current gateway configuration (staging or production).

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7112

**Verification steps** 

1. Create a metric or method
2. Create a mapping rule using this metric
3. Promote the configuration to staging
4. Try deleting the metric and verify that it's not deleted, and an error message (flash) is shown
5. Remove the mapping rule using the metric
6. Promote the configuration
7. Try deleting the metric again and verify that it is successfully deleted

This should work for both staging and production environments.

This should work for both product-level and backend-level metrics.

**Special notes for your reviewer**:

What I am not sure about is - do we need to provide more information to the user to figure out where exactly the metric/method is used?
On one hand, it would be handy, especially for backend metrics (as the same metric can be used by multiple products).
But on the other hand - probably the flash message is not a good place to provide such detailed info, and the user should be able to know what they are doing... 
As mentioned in the JIRA comments, this is not a very common scenario anyway, and users should probably be able to find this on their own.
