### PR TITLE
Add using_password? method to User at Drops module

### DIFF
--- a/lib/developer_portal/lib/liquid/drops/user.rb
+++ b/lib/developer_portal/lib/liquid/drops/user.rb
@@ -91,6 +91,11 @@ module Liquid
         Drops::Invitation.new(@user.invitation)
       end
 
+      desc "Returns true if user signed up with password"
+      def using_password?
+        @user.using_password?
+      end
+
       desc %{
         This method will return `true` for users using the built-in
         Developer Portal authentication mechanisms and `false` for


### PR DESCRIPTION
**What this PR does / why we need it**:

Customers will update User > Show template at their Developer Portals from the following weeks until 2nd of October, when we will merge #3201. This PR introduces the method `using_password?`, which allows the template to render correctly.


**Which issue(s) this PR fixes** 

This PR is related to [THREESCALE-6648 Require the current password on the password update form](https://issues.redhat.com/browse/THREESCALE-6648) and to #3201.

**Verification steps** 
1. Go to Audience > Developer Portal > Content
2. At User > Show change the template for [this one](https://github.com/3scale/porta/blob/37c08f0882d0d07d00dae51a007f1db266a14029/lib/developer_portal/app/views/developer_portal/user/show.html.liquid).
3. Sign in at the Developer Portal using password.
4. Go to `admin/account/personal_details`.
5. Confirm fields "Provide your current password" and "Change password" are present.
6. Confirm you can change your password introducing `current password` and also without `current_password`.

