### PR TITLE
THREESCALE-9570: Fix service plans scope on index page

### DIFF
--- a/app/controllers/api/service_plans_controller.rb
+++ b/app/controllers/api/service_plans_controller.rb
@@ -49,7 +49,7 @@ class Api::ServicePlansController < Api::PlansBaseController
   end
 
   def presenter
-    @presenter ||= Api::ServicePlansPresenter.new(service: service, params: params, user: current_user)
+    @presenter ||= Api::ServicePlansPresenter.new(service: service, collection: collection, params: params, user: current_user)
   end
 
 end

--- a/app/controllers/api/service_plans_controller.rb
+++ b/app/controllers/api/service_plans_controller.rb
@@ -49,7 +49,7 @@ class Api::ServicePlansController < Api::PlansBaseController
   end
 
   def presenter
-    @presenter ||= Api::ServicePlansPresenter.new(service: service, collection: collection, params: params, user: current_user)
+    @presenter ||= Api::ServicePlansPresenter.new(service: service, params: params, user: current_user)
   end
 
 end

--- a/app/presenters/api/service_plans_presenter.rb
+++ b/app/presenters/api/service_plans_presenter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Api::ServicePlansPresenter < PlansBasePresenter
-  def initialize(service:, user:, params: {})
-    super(collection: service.provider.service_plans, user: user, params: params)
+  def initialize(service:, collection:, user:, params: {})
+    super(collection: collection, user: user, params: params)
     @service = service
   end
 

--- a/app/presenters/api/service_plans_presenter.rb
+++ b/app/presenters/api/service_plans_presenter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Api::ServicePlansPresenter < PlansBasePresenter
-  def initialize(service:, collection:, user:, params: {})
-    super(collection: collection, user: user, params: params)
+  def initialize(service:, user:, params: {})
+    super(collection: service.service_plans, user: user, params: params)
     @service = service
   end
 

--- a/features/api/services/service_plans.feature
+++ b/features/api/services/service_plans.feature
@@ -17,8 +17,10 @@ Feature: Service plans index page
 
     Scenario: Service plans are scoped by service
       Given a product
-      When there are other services with service plans
-      Then only service plans of the current service are listed
+      And there are other services with service plans
+      And the product has multiple service plans
+      When an admin is in the service plans page
+      Then only service plans of the product are listed
 
     Scenario: Set a default service plan
       Given a product

--- a/features/api/services/service_plans.feature
+++ b/features/api/services/service_plans.feature
@@ -19,7 +19,7 @@ Feature: Service plans index page
       Given a product
       And there are other services with service plans
       And the product has multiple service plans
-      When an admin is in the service plans page
+      When an admin is on the service plans page of the product
       Then only service plans of the product are listed
 
     Scenario: Set a default service plan
@@ -37,7 +37,7 @@ Feature: Service plans index page
       Then an admin can't select the plan as default
 
     Scenario: Create a service plan
-      When an admin is in the service plans page
+      When an admin is on the service plans page of the product
       Then they can add new service plans
 
     Scenario: Copy a service plan

--- a/features/api/services/service_plans.feature
+++ b/features/api/services/service_plans.feature
@@ -15,6 +15,11 @@ Feature: Service plans index page
       Given a product
       Then an admin is able to see its service plans
 
+    Scenario: Service plans are scoped by service
+      Given a product
+      When there are other services with service plans
+      Then only service plans of the current service are listed
+
     Scenario: Set a default service plan
       Given a product
       When an admin selects a published service plan as default

--- a/features/old/api/plans/creation.feature
+++ b/features/old/api/plans/creation.feature
@@ -31,7 +31,6 @@ Feature: Plan creation
     Given the provider has "service_plans" switch allowed
     And a service "Pocoyo" of provider "foo.3scale.localhost"
     And a default published service plan "Pocoyo service plan" of service "Pocoyo" of provider "foo.3scale.localhost"
-    When I am on the edit page for service "Pocoyo" of provider "foo.3scale.localhost"
-    When I go to the service plans admin page
+    When an admin is on the service plans page of product "Pocoyo"
     And I follow "Pocoyo service plan"
     Then I should see "Pocoyo"

--- a/features/step_definitions/api/services/service_plans_steps.rb
+++ b/features/step_definitions/api/services/service_plans_steps.rb
@@ -106,3 +106,18 @@ Given "a service plan has been deleted" do
   visit admin_service_service_plans_path(default_service)
   @plan.destroy
 end
+
+When "there are other services with service plans" do
+  FactoryBot.create_list(:service, 3, account: @provider).each do |service|
+    assert_equal 1, service.service_plans.count
+  end
+end
+
+Then "only service plans of the current service are listed" do
+  FactoryBot.create(:service_plan, issuer: default_service, name: 'An extra plan')
+  FactoryBot.create(:service_plan, issuer: default_service, name: 'Another extra plan')
+
+  @plans = default_service.service_plans
+  visit admin_service_service_plans_path(default_service)
+  assert_plans_table @plans
+end

--- a/features/step_definitions/api/services/service_plans_steps.rb
+++ b/features/step_definitions/api/services/service_plans_steps.rb
@@ -19,8 +19,8 @@ Then "any new application of that product will be subscribed using this plan" do
   assert_equal @plan, Cinstance.last.buyer_account.bought_service_contracts.last.plan
 end
 
-When "an admin is in the service plans page" do
-  visit admin_service_service_plans_path(default_service)
+When "an admin is on the service plans page of {product}" do |product|
+  visit admin_service_service_plans_path(product)
 end
 
 Then "they can add new service plans" do

--- a/features/step_definitions/api/services/service_plans_steps.rb
+++ b/features/step_definitions/api/services/service_plans_steps.rb
@@ -113,11 +113,11 @@ When "there are other services with service plans" do
   end
 end
 
-Then "only service plans of the current service are listed" do
-  FactoryBot.create(:service_plan, issuer: default_service, name: 'An extra plan')
-  FactoryBot.create(:service_plan, issuer: default_service, name: 'Another extra plan')
+When "the product has multiple service plans" do
+  FactoryBot.create(:service_plan, issuer: @product, name: 'An extra plan')
+  FactoryBot.create(:service_plan, issuer: @product, name: 'Another extra plan')
+end
 
-  @plans = default_service.service_plans
-  visit admin_service_service_plans_path(default_service)
-  assert_plans_table @plans
+Then "only service plans of the product are listed" do
+  assert_plans_table @product.service_plans
 end

--- a/features/support/parameter_types.rb
+++ b/features/support/parameter_types.rb
@@ -125,6 +125,17 @@ ParameterType(
 )
 
 ParameterType(
+  name: 'product',
+  type: Service,
+  regexp: /the product|product "([^"]*)"/,
+  transformer: ->(*args) do
+    return Service.find_by(name: args[0]) if args[0].present?
+
+    @product || @service || @provider.default_service
+  end
+)
+
+ParameterType(
   name: 'buyer',
   type: Account,
   regexp: /buyer "([^"]*)"|the buyer/,

--- a/test/unit/presenters/plan_presenters_test.rb
+++ b/test/unit/presenters/plan_presenters_test.rb
@@ -62,8 +62,10 @@ class PlanPresentersTest < ActiveSupport::TestCase
   end
 
   class Api::ServicePlansPresenterTest < PlanPresentersTest
+    attr_reader :provider
+
     def setup
-      provider = FactoryBot.create(:simple_provider)
+      @provider = FactoryBot.create(:simple_provider)
       @service = FactoryBot.create(:service, account: provider)
       FactoryBot.create_list(:service_plan, 5, service: service)
       @user = FactoryBot.create(:simple_user, account: provider)
@@ -83,6 +85,14 @@ class PlanPresentersTest < ActiveSupport::TestCase
 
       ServicePlan.expects(:scope_search).returns(empty_result).once
       assert_equal empty_result, presenter({ search: 'Foo' }).paginated_table_plans
+    end
+
+    test '#paginated_table_plans only includes plans of the current service' do
+      another_service = FactoryBot.create(:service, account: provider)
+      FactoryBot.create_list(:service_plan, 5, service: another_service)
+
+      plans = presenter.paginated_table_plans
+      assert_same_elements service.service_plans, plans
     end
 
     def presenter(params = {})


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the issue where the index of service plans on a product include the service plans from other products.
Introduced by this change: https://github.com/3scale/porta/pull/3185/commits/99c6cb029f773831d287e4fdf1c9672c2f16d7b9#diff-2066514485e54295d6b177e8f030e3d8e547f73abbe2ae019981bac031e2232bR5

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-9570

**Verification steps** 

1. Create multiple products
2. Enable service plans in Audience > Usage Rules
3. Go to a product > Subscriptions > Service Plans
4. Make sure that only the service plans for the selected service are listed

**Special notes for your reviewer**:
