### PR TITLE
upgrade cancancan to a version supporting Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'stripe', '~> 5.28.0' # we need the stripe gem because activemerchant can no
 gem 'acts_as_list', '~> 0.9.17'
 gem 'braintree', '~> 2.93'
 gem 'bugsnag', '~> 6.11'
-gem 'cancancan', '~> 2.3.0'
+gem 'cancancan', '~> 3.0.0'
 gem 'formtastic', '~> 4.0'
 gem 'htmlentities', '~>4.3', '>= 4.3.4'
 # TODO: Not actively maintained https://github.com/activeadmin/inherited_resources#notice replace with respond_with and fix things the rails way

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
-    cancancan (2.3.0)
+    cancancan (3.0.2)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -917,7 +917,7 @@ DEPENDENCIES
   browser (~> 5.0.0)
   bugsnag (~> 6.11)
   bullet (~> 6.1.5)
-  cancancan (~> 2.3.0)
+  cancancan (~> 3.0.0)
   capybara (~> 3.35.3)!
   childprocess
   chronic


### PR DESCRIPTION
prior upgrading to Rails 6, better to upgrade cancancan alone and be easier if we have to fix something

upgrade guides are https://github.com/CanCanCommunity/cancancan/blob/develop/docs/migrating.md#from-2x-to-3x

- For "Defining abilities without a subject is not allowed anymore" - grep returned no such definitions, also I assume rails app initialization would fail if we had such
- For "Eager loading is not automatic", we enabled bullet N+1, etc. reporting so I hope we catch any such issues #3475 
- For "aliases are now merged" - I couldn't grep any instance where we call `merge` on Abilities
- For "Use of distinct" - this is more tricky, tried to go through the definitions to see how queries are defined and couldn't spot anything. Hope we test these anyway. Namely I inspected all blcok definitions for using `group_by` or `order` that I could catch with `rg "^\s*can(not|\\?)? "`

