### PR TITLE
Fix time zone problem affecting cucumbers

### DIFF
--- a/features/step_definitions/timehelpers_steps.rb
+++ b/features/step_definitions/timehelpers_steps.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 After do
+  Time.zone = Rails.application.config.time_zone
   travel_back
 end
 

--- a/features/step_definitions/timehelpers_steps.rb
+++ b/features/step_definitions/timehelpers_steps.rb
@@ -6,11 +6,14 @@ end
 
 # Wrapper for travel_to but implementing safe nested traveling
 def safe_travel_to(time, &block)
+  time_was_frozen = time_frozen?
   previous_time = Time.zone.now
   travel_back
   travel_to(time, &block)
 ensure
-  travel_to(previous_time) if block_given?
+  if block_given?
+    time_was_frozen ? travel_to(previous_time) : travel_back
+  end
 end
 
 def access_user_sessions

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -173,7 +173,7 @@ After do |scenario| # rubocop:disable Metrics/BlockLength
   print "Saved page body to #{Capybara.save_page(folder.join("#{line_number}.html"))}\n"
 
   begin
-    print "Saved sceeenshot to #{Capybara.save_screenshot(folder.join("#{line_number}.png"))}\n"
+    print "Saved screenshot to #{Capybara.save_screenshot(folder.join("#{line_number}.png"))}\n"
   rescue Capybara::NotSupportedByDriverError
     # and that is fine! rack-test does not support screenshots
   end

--- a/features/support/time_machine_helpers.rb
+++ b/features/support/time_machine_helpers.rb
@@ -48,4 +48,12 @@ module TimeMachineHelpers
       Sidekiq::Testing.drain_batches
     end
   end
+
+  def time_frozen?
+    before = Time.zone.now.to_f
+    sleep 0.0001
+    after = Time.zone.now.to_f
+
+    after == before
+  end
 end


### PR DESCRIPTION
### IT'S HAPPENING!!!

**What this PR does / why we need it**:

We have some cucumbers failing on master for some time now ([CircleCI](https://app.circleci.com/pipelines/github/3scale/porta/25187/workflows/1aad78ed-fabf-4b05-9b8d-c24e7fe28b92/jobs/283477/tests)). This is the error:

`Message:Expected /^EUR\p{Separator}-7.00/ to match "EUR -6.7100". (Minitest::Assertion)`

These tests assert the invoice amount is generated correctly when the plan is changed in the middle of the month. But the time at which the plan is changed was wrong and the computed amount in the invoice didn't match because of that.

I observed locally that it was caused by [this step](https://github.com/3scale/porta/blob/4796fc3dcbfc40d549f7447bb0d33f7024ebe8ae/features/finance/variable_cost.feature#L93) being executed at any moment before the failing tests. The [step definition](https://github.com/3scale/porta/blob/4796fc3dcbfc40d549f7447bb0d33f7024ebe8ae/features/step_definitions/account_steps.rb#L36) only writes in a column, but for some reason I don't know, the value for `Time.zone.name` gets updated to `"Pacific Time (US & Canada)"` as well.

When the cucumber finishes, the DB is rollbacked and the time is reset by [this hook](https://github.com/3scale/porta/blob/4796fc3dcbfc40d549f7447bb0d33f7024ebe8ae/features/step_definitions/timehelpers_steps.rb#L4). But the value for `Time.zone` is kept between tests. Since the failing tests are using a wrong time zone, there is a 7 hours offset in the plan change, which produces the wrong invoice.

To fix this, I just manually reset the time zone in the hook: https://github.com/3scale/porta/commit/ae5793fe4c1d31fb246a496920d42a28c5506a2d.

**Bug in `safe_travel_to`:**

When investigating this, I found a bug in `safe_travel_to`. Not related to tests failing but still I think it's worth fixing. When this method is called without a block, it must leave the time frozen, that's working fine. But when called with a block, it must return to previous time after the block finishes. In this case, two things can happen:

1. If the time was frozen at the moment this method was called, the time should be frozen back to that time after the block
2. If the time wasn't frozen, the time must be restored to real time again. Instead of that, the time was being frozen to the time the method was called in all situations.

When called in real time with a block, the method left the time frozen by mistake. Not a big problem since time is restored back to real time after every test, but still better to fix, I think. It could produce problems in complicated tests in the future.

Fixed in https://github.com/3scale/porta/commit/2c77e141ae81f51dc67095743f02d92743b30db4


**Verification steps** 

The fastest way to reproduce the error locally is to run:
```
bundle exec cucumber $PATH_TO_PORTA/features/finance/variable_cost.feature $PATH_TO_PORTA/features/old/providers/invoices.feature --name '^Variable cost in automated billing is always UTC$' --name '^Invoice price is ok when starting from base$'
```

A RubyMine debugger can be attached to this command following the instructions here:

https://www.jetbrains.com/help/ruby/starting-the-debugger-session.html#debug_with_config

