### PR TITLE
THREESCALE-9592 show provide invoice years

### DIFF
--- a/app/controllers/finance/provider/invoices_controller.rb
+++ b/app/controllers/finance/provider/invoices_controller.rb
@@ -12,6 +12,7 @@ class Finance::Provider::InvoicesController < Finance::Provider::BaseController
   def index
     @search = ThreeScale::Search.new(params[:search] || params)
     @invoices = collection.scope_search(@search).order_by(params[:sort], params[:direction]).paginate(paginate_params).decorate
+    @years = Invoice.years_by_provider(current_account.id).presence || [(ActiveSupport::TimeZone.new(current_account.timezone) || Time.zone).now.year]
   end
 
   def create

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -587,9 +587,13 @@ class Invoice < ApplicationRecord
     (buyer_account || provider_account.buyer_accounts.build).field_label(name)
   end
 
-  # Returns years which have invoice
-  def self.years
-    self.connection.select_values(selecting { sift(:year, period).as('year') }.distinct.reorder('year DESC').to_sql).map(&:to_i)
+  # Returns years which have invoice, scoped by provider
+  def self.years_by_provider(provider_id)
+    connection.select_values(
+      selecting { sift(:year, period).as('year') }
+        .where.has { provider_account_id == provider_id }
+        .distinct.reorder('year DESC').to_sql
+    ).map(&:to_i)
   end
 
   protected

--- a/app/views/finance/provider/invoices/index.html.erb
+++ b/app/views/finance/provider/invoices/index.html.erb
@@ -24,8 +24,7 @@
         <td><%= s.text_field :buyer_query, :size => 20, :disabled => @buyer.present? %></td>
         <td>
           <%= select_month @search.month_number.try(:to_i), :prefix => :search, :field_name => :month_number, :include_blank => true %>
-          <%- years = Invoice.years %>
-          <%= select_year @search.year.try(:to_i), :prefix => :search, :field_name => :year, :include_blank => true, :start_year => years.first, :end_year => years.last %>
+          <%= select_year @search.year.try(:to_i), :prefix => :search, :field_name => :year, :include_blank => true, :start_year => @years.first, :end_year => @years.last %>
         <td></td>
         <td><%= s.select :state, Invoice.state_machine.states.keys.collect(&:to_s).sort, :include_blank => true, :selected => @search.state %></td>
         <td><%= s.button 'Search', :name => nil, :class => "pf-c-button pf-m-primary" %></td>

--- a/features/old/finance/invoices/deleted_account.feature
+++ b/features/old/finance/invoices/deleted_account.feature
@@ -18,7 +18,7 @@ Feature: Invoices of deleted account
       | Custom | 42   |
     And I issue the invoice number "2011-01-00000001"
     And account "bob" is deleted
-    And I go to the invoices issued by me
+    And I go to all provider's invoices page
     Then I should see 1 invoice
     When I follow "2011-01-00000001"
     Then I should see "2011-01-00000001"

--- a/features/provider/finance/invoices.feature
+++ b/features/provider/finance/invoices.feature
@@ -1,0 +1,38 @@
+@ignore-backend @javascript
+Feature: Provider's invoices
+  In order to manage invoices
+  As a provider
+  I want to be able to see all invoices issued by me
+
+  Background:
+    Given a provider is logged in on 1st January 2011
+    And the provider is charging its buyers in prepaid mode
+    And a buyer "zoidberg" signed up to provider "foo.3scale.localhost"
+
+  Scenario: Display years of invoices when there are invoices
+    Given an invoice of buyer "zoidberg" for January, 2011
+    And an invoice of buyer "zoidberg" for January, 2014 on 1st January 2014 (without scheduled jobs)
+    When the provider is at all provider's invoices page
+    Then invoices can be filtered by the following years:
+      |      |
+      | 2014 |
+      | 2013 |
+      | 2012 |
+      | 2011 |
+
+  Scenario: Display the current year when there are no invoices
+    When the provider is at all provider's invoices page
+    Then invoices can be filtered by the following years:
+      |      |
+      | 2011 |
+
+  Scenario: Display only years belonging to the current provider
+    Given an invoice of buyer "zoidberg" for January, 2011
+    And a provider "bar.3scale.localhost"
+    And provider "bar.3scale.localhost" is charging its buyers
+    And a buyer "leela" signed up to provider "bar.3scale.localhost"
+    And an invoice of buyer "leela" for January, 2012
+    When the provider is at all provider's invoices page
+    Then invoices can be filtered by the following years:
+      |      |
+      | 2011 |

--- a/features/step_definitions/finance/invoicing_steps.rb
+++ b/features/step_definitions/finance/invoicing_steps.rb
@@ -165,3 +165,9 @@ Then(/there is only one invoice for "([^"]*)"/) do |date|
   nodes = page.find_all(:xpath, ".//tr[contains(@class,'invoice')]/td[contains(text(), '#{date}')]")
   assert_equal 1, nodes.count
 end
+
+Then "invoices can be filtered by the following years:" do |table|
+  actual_years = find('#search_year').find_all('option').map(&:value).map(&:to_s)
+  expected_years = table.raw.flatten.map(&:to_s)
+  assert_same_elements expected_years, actual_years
+end

--- a/features/step_definitions/finance/navigation_steps.rb
+++ b/features/step_definitions/finance/navigation_steps.rb
@@ -23,7 +23,7 @@ end
 
 # TODO: remove this legacy step
 When /^I navigate to invoices issued by me$/ do
-  step %(I go to the invoices issued by me)
+  step %(I go to all provider's invoices page)
 end
 
 When /^I navigate to my (?:earnings|revenue)$/ do

--- a/features/step_definitions/provider_steps.rb
+++ b/features/step_definitions/provider_steps.rb
@@ -284,3 +284,7 @@ Then /^(?:|I |they )should see inline error "([^"]*)" for ([^"]*)$/ do |text, in
   inline_error_selector = "li##{input_name.parameterize.underscore} p.inline-errors"
   assert_selector(inline_error_selector, text: text)
 end
+
+When "the provider is at {}" do |page_name|
+  visit path_to(page_name)
+end

--- a/features/step_definitions/timehelpers_steps.rb
+++ b/features/step_definitions/timehelpers_steps.rb
@@ -41,11 +41,9 @@ When /^(?:the )?time flies to (.*)$/ do |date|
 end
 
 # Suffix 'on 5th July 2009'
-#
-Then /^(.+) on (\d+(?:th|st|nd|rd) \S* \d{4}(?: .*)?)$/ do |original, date|
-  # this ensures billing actions are run
-  step %(time flies to #{date})
-  # and then we freeze the time
+# When '(without scheduled jobs)' is present, scheduled jobs will be skipped when travelling in time
+Then /^(.+) on (\d+(?:th|st|nd|rd) \S* \d{4}(?: [^\(]*)?)( \(without scheduled jobs\))?$/ do |original, date, skip_jobs|
+  step %(time flies to #{date}) unless skip_jobs
   safe_travel_to(Time.zone.parse(date)) do
     step original.strip
   end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -584,7 +584,7 @@ World(Module.new do
       account = Account.find_by!(org_name: $1)
       admin_buyers_account_invoices_path(account)
 
-    when /^the invoices issued by me$/
+    when /^all provider's invoices page$/
       admin_finance_invoices_path
 
     when /^the invoice "(.+?)" page$/


### PR DESCRIPTION
**What this PR does / why we need it**:

Reason mentioned in JIRA

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/THREESCALE-9592

We can remove this method as we are not using it any more 

**Pending** : test are pending if query looks good I can check for test

**Notes**
This is how it will look now, will show only current year if no invoices are present

![image](https://github.com/3scale/porta/assets/84672731/039cc765-eecc-4600-8d73-030c270eda27)

this is how it was looking before

![image](https://github.com/3scale/porta/assets/84672731/7dbf72b0-86b3-407e-aa71-88d69dde29ad)


I don't have data on my local, so if any one have please past the screenshot how it will looks with data for reference but IMO query will work fine


