### PR TITLE
THREESCALE-9990: Fix autocomplete for provider user IDs

### DIFF
--- a/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts
+++ b/app/javascript/src/ActiveDocs/OAS3Autocomplete.ts
@@ -29,6 +29,7 @@ const X_DATA_PARAMS_DESCRIPTIONS = {
   service_ids: 'Service IDs',
   service_tokens: 'Service tokens',
   admin_ids: 'Latest 5 users (admin) from your account',
+  provider_users_ids: 'Latest 5 users of your account',
   service_plan_ids: 'Latest 5 service plans',
   application_plan_ids: 'Latest 5 application plans',
   account_plan_ids: 'Latest 5 account plans',

--- a/app/lib/api_docs/provider_data.rb
+++ b/app/lib/api_docs/provider_data.rb
@@ -17,6 +17,12 @@ module ApiDocs
       end
     end
 
+    def provider_users_ids
+      @account.users.but_impersonation_admin.latest.map do |user|
+        {:name => user.username, :value => user.id}
+      end
+    end
+
     def user_ids
       accounts.map do |account|
         if user = account.admins.first
@@ -102,7 +108,7 @@ module ApiDocs
     end
 
     def data_items
-      %w[app_keys app_ids application_ids user_keys user_ids account_ids metric_names metric_ids backend_api_metric_names service_ids admin_ids service_plan_ids application_plan_ids account_plan_ids client_ids client_secrets]
+      %w[app_keys app_ids application_ids user_keys user_ids account_ids metric_names metric_ids backend_api_metric_names service_ids admin_ids provider_users_ids service_plan_ids application_plan_ids account_plan_ids client_ids client_secrets]
     end
   end
 end

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -2149,7 +2149,7 @@
         "summary": "User List (provider account)",
         "description": "Lists the users of the provider account. You can apply filters by state and/or role.",
         "tags": [
-          "Users"
+          "Provider Users"
         ],
         "parameters": [
           {
@@ -2198,7 +2198,7 @@
         "summary": "User Create (provider account)",
         "description": "Creates a new user in the provider account. Do not forget to activate it, otherwise he/she will not be able to sign-in. After creation the default state is pending and the default role is member. The user object can be extended using Fields Definitions in the Admin Portal where you can add/remove fields, for instance token (string), age (int), third name (string optional), etc. Additional fields have to be defined by name and value (i.e &name=value). Additional fields are the custom fields declared in the Fields Definitions section in your API Admin Portal.",
         "tags": [
-          "Users"
+          "Provider Users"
         ],
         "requestBody": {
           "required": true,
@@ -2330,7 +2330,7 @@
         "summary": "User Activate (provider account)",
         "description": "Changes the state of the user of the provider account to active (after sign-up). You can also perform this operation with a PUT on /admin/api/users/{id}.xml to change the state parameter.",
         "tags": [
-          "Users"
+          "Provider Users"
         ],
         "parameters": [
           {
@@ -2376,7 +2376,7 @@
         "summary": "User Change Role to Admin (provider account)",
         "description": "Changes the role of the provider account to admin (full rights and privileges).",
         "tags": [
-          "Users"
+          "Provider Users"
         ],
         "parameters": [
           {
@@ -2422,7 +2422,7 @@
         "summary": "User Change Role to Member (provider account)",
         "description": "Changes the role of the user of the provider account to member.",
         "tags": [
-          "Users"
+          "Provider Users"
         ],
         "parameters": [
           {
@@ -2468,7 +2468,7 @@
         "summary": "User Permissions Read",
         "description": "Shows the permissions of the user of the provider account.",
         "tags": [
-          "Users"
+          "Provider Users"
         ],
         "parameters": [
           {
@@ -2502,7 +2502,7 @@
         "summary": "User Permissions Update",
         "description": "Updates the permissions of member user of the provider account.",
         "tags": [
-          "Users"
+          "Provider Users"
         ],
         "parameters": [
           {
@@ -2581,7 +2581,7 @@
         "summary": "User Suspend (provider account)",
         "description": "Changes the state of the user of the provider account to suspended, which removes the user's ability to sign-in. You can also perform this operation with a PUT on /admin/api/users/{id}.xml to change the state parameter.",
         "tags": [
-          "Users"
+          "Provider Users"
         ],
         "parameters": [
           {
@@ -2627,7 +2627,7 @@
         "summary": "User Unsuspend (provider account)",
         "description": "Revokes the suspension of a user of the provider account. You can also perform this operation with a PUT on /admin/api/users/{id}.xml to change the state parameter.",
         "tags": [
-          "Users"
+          "Provider Users"
         ],
         "parameters": [
           {

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -2240,7 +2240,7 @@
             "name": "id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "provider_users_ids",
             "required": true,
             "schema": {
               "type": "integer"
@@ -2265,7 +2265,7 @@
             "name": "id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "provider_users_ids",
             "required": true,
             "schema": {
               "type": "string"
@@ -2310,7 +2310,7 @@
             "name": "id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "provider_users_ids",
             "required": true,
             "schema": {
               "type": "integer"
@@ -2337,7 +2337,7 @@
             "name": "id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "provider_users_ids",
             "required": true,
             "schema": {
               "type": "string"
@@ -2383,7 +2383,7 @@
             "name": "id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "provider_users_ids",
             "required": true,
             "schema": {
               "type": "string"
@@ -2391,7 +2391,6 @@
           }
         ],
         "requestBody": {
-          "description": "User Change Role to Admin (provider account)",
           "required": true,
           "content": {
             "application/x-www-form-urlencoded": {
@@ -2430,7 +2429,7 @@
             "name": "id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "provider_users_ids",
             "required": true,
             "schema": {
               "type": "string"
@@ -2485,7 +2484,7 @@
             "name": "id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "provider_users_ids",
             "required": true,
             "schema": {
               "type": "integer"
@@ -2510,7 +2509,7 @@
             "name": "id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "provider_users_ids",
             "required": true,
             "schema": {
               "type": "integer"
@@ -2589,7 +2588,7 @@
             "name": "id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "provider_users_ids",
             "required": true,
             "schema": {
               "type": "integer"
@@ -2635,7 +2634,7 @@
             "name": "id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "provider_users_ids",
             "required": true,
             "schema": {
               "type": "integer"
@@ -2681,7 +2680,7 @@
             "name": "user_id",
             "in": "path",
             "description": "ID of the user.",
-            "x-data-threescale-name": "user_ids",
+            "x-data-threescale-name": "admin_ids",
             "required": true,
             "schema": {
               "type": "integer"

--- a/test/integration/provider/admin/api_docs/account_data_controller_test.rb
+++ b/test/integration/provider/admin/api_docs/account_data_controller_test.rb
@@ -49,6 +49,7 @@ class Provider::Admin::ApiDocs::AccountDataControllerTest < ActionDispatch::Inte
         app_keys: [], app_ids: [], client_ids: [], client_secrets: [],
         user_keys: [{name: "#{application.name} - #{application.service.name}", value: application.user_key }],
         admin_ids: [{name: provider_admin.username, value: provider_admin.id}],
+        provider_users_ids: [{name: provider_admin.username, value: provider_admin.id}],
         metric_names: [service_metric_name, backend_api_metric_name],
         metric_ids: [service_metric_id, backend_api_metric_id],
         backend_api_metric_names: [backend_api_metric_name],

--- a/test/unit/api_docs/provider_data_test.rb
+++ b/test/unit/api_docs/provider_data_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class ApiDocs::ProviderDataTest < ActiveSupport::TestCase
+  def setup
+    @account = FactoryBot.create(:simple_provider)
+
+    FactoryBot.create_list(:simple_user, 3, role: :admin, account: account)
+    FactoryBot.create_list(:simple_user, 3, role: :member, account: account)
+  end
+
+  attr_accessor :account
+
+  def test_provider_users_ids
+    data = ApiDocs::ProviderData.new(account).as_json[:results]
+    assert_equal 5, data[:provider_users_ids].size
+  end
+
+  def test_admin_ds
+    data = ApiDocs::ProviderData.new(account).as_json[:results]
+    assert_equal 3, data[:admin_ids].size
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing auto-complete, replacing the buyers' users' IDs with providers' users' IDs (admin users only).

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-9990

**Verification steps** 

Open the Active Docs and check that IDs that appear belong to the current provider account.

**Special notes for your reviewer**:
