### PR TITLE
API Docs: Add comments to keys parameters

### DIFF
--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -903,7 +903,7 @@
                   },
                   "key": {
                     "type": "string",
-                    "description": "app_key to be added"
+                    "description": "app_key to be added.\n\n**(Only alphanumeric characters `[0-9, a-z, A-Z]`, hyphen-minus (`-`), between 5 and 256 characters long. No spaces allowed).**"
                   }
                 },
                 "required": [
@@ -9771,15 +9771,15 @@
           },
           "user_key": {
             "type": "string",
-            "description": "User Key (API Key) of the application to be created.",
+            "description": "User Key (API Key) of the application to be created.\n\n**Only alphanumeric characters `[0-9, a-z, A-Z]`, hyphen-minus (`-`), between 5 and 256 characters long. No spaces allowed.**",
             "x-data-threescale-name": "user_keys"
           },
           "application_id": {
             "type": "string",
-            "description": "App ID or Client ID (for OAuth and OpenID Connect authentication modes) of the application to be created."
+            "description": "App ID or Client ID (for OAuth and OpenID Connect authentication modes) of the application to be created.\n\n**Only alphanumeric characters `[0-9, a-z, A-Z]`, hyphen-minus (`-`), between 4 and 256 characters long. No spaces allowed.**"
           },
           "application_key": {
-            "description": "App Key or Client Secret (for OAuth and OpenID Connect authentication modes) of the application to be created.",
+            "description": "App Key or Client Secret (for OAuth and OpenID Connect authentication modes) of the application to be created.\n\n**Only alphanumeric characters `[0-9, a-z, A-Z]`, hyphen-minus (`-`), between 5 and 256 characters long. No spaces allowed.**",
             "type": "string"
           },
           "redirect_url": {


### PR DESCRIPTION
**What this PR does / why we need it**:

Applications `user_key` and `app_id`/`app_key` can be set via API. However, those keys are subject to format validations.

This PR adds some labels to the keys parameters in the API Docs.

Before:
![image](https://github.com/3scale/porta/assets/17052241/1e74a875-66c3-4ccd-8331-3dad56e99933)
![image](https://github.com/3scale/porta/assets/17052241/f20fee2c-8f81-4975-85e9-994423c1566a)

After:
![image](https://github.com/3scale/porta/assets/17052241/781b658b-c835-43a8-a6f8-8d8343edc0fc)
![image](https://github.com/3scale/porta/assets/17052241/96c18347-35a8-402c-9062-b3a15b5154a7)


**Which issue(s) this PR fixes** 

[THREESCALE-9188](https://issues.redhat.com/browse/THREESCALE-9188)

**Verification steps** 

Open the API Docs and verify the format notices are there.

**Special notes for your reviewer**:

Please read the issue comments.
