### PR TITLE
use ThinkingSphinx public API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,7 @@ gem 'rubyzip', '~>1.3.0', require: false
 gem 'svg-graph', require: false
 gem 'swagger-ui_rails', git: 'https://github.com/3scale/swagger-ui_rails.git', branch: 'dev'
 gem 'swagger-ui_rails2', git: 'https://github.com/3scale/swagger-ui_rails.git', branch: 'dev-2.1.3'
-gem 'thinking-sphinx', '~> 5.4.0'
+gem 'thinking-sphinx', '~> 5.5.0'
 gem 'ts-datetime-delta', require: 'thinking_sphinx/deltas/datetime_delta'
 gem 'will_paginate', '~> 3.3'
 gem 'zip-zip', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -378,7 +378,7 @@ GEM
     http-form_data (2.3.0)
     http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.12.0)
       actionpack (>= 5.2, < 6.2)
@@ -388,8 +388,8 @@ GEM
     injectedlogger (0.0.13)
     innertube (1.1.0)
     jmespath (1.6.1)
-    joiner (0.3.4)
-      activerecord (>= 4.1.0)
+    joiner (0.4.2)
+      activerecord (>= 5.2.beta1)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -802,7 +802,7 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thinking-sphinx (5.4.0)
+    thinking-sphinx (5.5.1)
       activerecord (>= 4.2.0)
       builder (>= 2.1.2)
       innertube (>= 1.0.2)
@@ -1048,7 +1048,7 @@ DEPENDENCIES
   swagger-ui_rails!
   swagger-ui_rails2!
   thin
-  thinking-sphinx (~> 5.4.0)
+  thinking-sphinx (~> 5.5.0)
   ts-datetime-delta
   uglifier
   unicorn

--- a/app/indices/account_index.rb
+++ b/app/indices/account_index.rb
@@ -19,5 +19,5 @@ ThinkingSphinx::Index.define(:account, with: :real_time) do
   has tenant_id,           type: :bigint
   has state,               type: :string
 
-  scope { Account.not_master.without_to_be_deleted.includes(:users, :bought_cinstances) }
+  scope { Account.searchable }
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -84,7 +84,9 @@ class Account < ApplicationRecord
 
   scope :not_master, -> { where.has { (master != true) | (master == nil) } }
 
-  audited allow_mass_assignment: true
+  scope :searchable, -> { not_master.without_to_be_deleted.includes(:users, :bought_cinstances) }
+
+  audited
 
   # this is done in a callback because we want to do this AFTER the account is deleted
   # otherwise the before_destroy admin check in the user will stop the deletion

--- a/app/workers/sphinx_indexation_worker.rb
+++ b/app/workers/sphinx_indexation_worker.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 # SphinxIndexationWorker updates sphinx index for the provided model.
 # It is enqueued when:
 # - An indexed model is created, updated or deleted
@@ -12,38 +11,24 @@ class SphinxIndexationWorker < ApplicationJob
   end
 
   def perform(model, id)
-    indices_for_model(model).each do |index|
-      instance = index.scope.find_by(model.primary_key => id)
+    instance = model.find_by(model.primary_key => id)
 
-      if instance
-        reindex(index, instance)
-      else
-        delete_from_index(index, id)
-      end
+    if instance
+      reindex(instance)
+    else
+      delete_from_index(model, id)
     end
   end
 
   protected
 
-  def indices_for_instance(instance)
-    # this is how indexes are filtered by ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks#indices
-    ThinkingSphinx::Configuration.instance.index_set_class.new(
-      :instances => [instance], :classes => [instance.class]
-    ).to_a
+  def reindex(instance)
+    ThinkingSphinx::Processor.new(instance: instance).upsert
   end
 
-  def indices_for_model(model)
-    ThinkingSphinx::Configuration.instance.index_set_class.new(classes: [model])
-  end
-
-  def reindex(index, instance)
-    # some indices are defined on model#base_class (*Plan) some on model itself (CMS::Page)
-    callback = ThinkingSphinx::RealTime.callback_for(index.model.name.underscore)
-    callback&.after_commit instance
-  end
-
-  def delete_from_index(index, *ids)
-    # This is how deletion is performed by ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks#delete_from_sphinx
-    ThinkingSphinx::Deletion.perform index, ids
+  def delete_from_index(model, *ids)
+    ids.each do |id|
+      ThinkingSphinx::Processor.new(model: model, id: id).delete
+    end
   end
 end

--- a/config/initializers/sphinx.rb
+++ b/config/initializers/sphinx.rb
@@ -1,19 +1,10 @@
-SPHINX_DELTA_INTERVAL = 90.minutes
-
-# Patches ThinkingSphinx so `sphinx_internal_class_name` field is avoided
-# for no inheritance indices despite other indices with inheritance defined
-# trying to upstream with https://github.com/pat/thinking-sphinx/pull/1222
+# Patches ThinkingSphinx so `sphinx_internal_class_name` field is enabled
+# for rt indices of Single-table inheritance models
+# upstream https://github.com/pat/thinking-sphinx/pull/1249
 ThinkingSphinx::Configuration::MinimumFields.prepend(Module.new do
   private
 
-  def indices
-    super.reject do |index|
-      model = index.model
-      model.table_exists? && model.column_names.include?(model.inheritance_column)
-    end
-  end
-
-  def no_inheritance_columns?
-    true
+  def indices_of_type(type)
+    super.reject(&method(:inheritance_columns?))
   end
 end)

--- a/features/support/initial_data.rb
+++ b/features/support/initial_data.rb
@@ -12,11 +12,7 @@ Before do |scenario|
 
   ThreeScale.config.stubs(superdomain: '3scale.localhost')
 
-  SphinxIndexationWorker.stubs(:perform_later)
-
   FieldsDefinition.create_defaults! master_account
-
-  SphinxIndexationWorker.unstub(:perform_later) if scenario.source_tag_names.include?('@search')
 
   ThreeScale.config.stubs(onpremises: false)
   ThreeScale.config.sandbox_proxy.stubs(apicast_registry_url: 'http://apicast.alaska/policies')

--- a/features/support/sphinx.rb
+++ b/features/support/sphinx.rb
@@ -1,9 +1,12 @@
 require 'thinking_sphinx'
 require 'thinking_sphinx/test'
 
+Before "not @search" do
+  ::ThinkingSphinx::Test.disable_search_jobs!
+end
+
 Before('@search') do
   Sidekiq::Worker.clear_all
-  raise ::Cucumber::Core::Test::Result::Skipped, 'Sphinx does not support OracleDB' if System::Database.oracle?
   ::ThinkingSphinx::Test.init
   ::ThinkingSphinx::Test.stop
   ::ThinkingSphinx::Test.autostop
@@ -13,4 +16,8 @@ end
 
 After '@search' do
   ::ThinkingSphinx::Test.stop
+end
+
+After "not @search" do
+  ::ThinkingSphinx::Test.enable_search_jobs!
 end

--- a/test/integration/master/api/finance/billing_jobs_controller_test.rb
+++ b/test/integration/master/api/finance/billing_jobs_controller_test.rb
@@ -28,8 +28,6 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
   end
 
   test 'trigger billing to all buyers of a provider' do
-    SphinxIndexationWorker.stubs(:perform_later)
-
     Sidekiq::Testing.inline! do
       FactoryBot.create_list(:buyer_account, 4, provider_account: @provider)
 

--- a/test/integration/provider/admin/backend_apis_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis_controller_test.rb
@@ -66,7 +66,7 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
     backend_api.backend_api_configs.delete_all
     assert_not backend_api.backend_api_configs.any?
 
-    perform_enqueued_jobs(except: SphinxIndexationWorker) do
+    perform_enqueued_jobs do
       delete provider_admin_backend_api_path(backend_api)
       assert_redirected_to provider_admin_dashboard_path
       assert_not BackendApi.exists? backend_api.id
@@ -78,7 +78,7 @@ class Provider::Admin::BackendApisControllerTest < ActionDispatch::IntegrationTe
     backend_api = @provider.backend_apis.order(:id).first!
     assert backend_api.backend_api_configs.any?
 
-    perform_enqueued_jobs(except: SphinxIndexationWorker) do
+    perform_enqueued_jobs do
       delete provider_admin_backend_api_path(backend_api)
       assert backend_api.reload.published?
       assert_equal 'cannot be deleted because it is used by at least one Product', flash[:error]

--- a/test/integration/service_not_deleted_test.rb
+++ b/test/integration/service_not_deleted_test.rb
@@ -16,7 +16,7 @@ class ServiceNotDeletedTest < ActionDispatch::IntegrationTest
   def test_not_deleted
     @provider.settings.allow_multiple_services!
 
-    perform_enqueued_jobs(except: [SphinxIndexationWorker]) do
+    perform_enqueued_jobs do
       (ENV['BRUTOFORCE'].present? ? 2000 : 1).times do |i|
         service_name = "service foo #{i}"
         post admin_api_services_path, params: { provider_key: @provider.api_key, format: :json, name: service_name }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,10 +67,6 @@ class ActiveSupport::TestCase
   def assert_cannot(ability, *args)
     assert ability.cannot?(*args), "User can #{args.join(' ')} but should not"
   end
-
-  teardown do
-    User.current = nil
-  end
 end
 
 # Load test helpers

--- a/test/test_helpers/sidekiq.rb
+++ b/test/test_helpers/sidekiq.rb
@@ -18,19 +18,13 @@ module TestHelpers
     end
 
     def drain_all_sidekiq_jobs
-      ThinkingSphinx::Test.rt_run do
-        ::Sidekiq::Worker.drain_all
-      end
+      ::Sidekiq::Worker.drain_all
     end
 
     def with_sidekiq
-      ::SphinxIndexationWorker.stubs(:perform_later)
-
       ::Sidekiq::Testing.inline! do
         yield
       end
-    ensure
-      ::SphinxIndexationWorker.unstub(:perform_later)
     end
   end
 end

--- a/test/test_helpers/simple_mini_test.rb
+++ b/test/test_helpers/simple_mini_test.rb
@@ -1,8 +1,3 @@
 # frozen_string_literal: true
 
-class SimpleMiniTest < ActiveSupport::TestCase
-  def teardown
-    super
-    User.current = nil
-  end
-end
+class SimpleMiniTest < ActiveSupport::TestCase; end

--- a/test/test_helpers/sphinx.rb
+++ b/test/test_helpers/sphinx.rb
@@ -8,6 +8,7 @@ module ThinkingSphinx
     class << self
 
       def real_time_run
+        clear
         init
         start index: false
 
@@ -57,6 +58,14 @@ module TestHelpers
 
     delegate :enable_search_jobs!, to: :'ThinkingSphinx::Test'
     delegate :disable_search_jobs!, to: :'ThinkingSphinx::Test'
+
+    def indexed_models
+      ThinkingSphinx::Test.indexed_models
+    end
+
+    def indexed_ids(model)
+      model.search(middleware: ThinkingSphinx::Middlewares::IDS_ONLY)
+    end
   end
 end
 

--- a/test/test_helpers/sphinx.rb
+++ b/test/test_helpers/sphinx.rb
@@ -3,22 +3,24 @@
 module ThinkingSphinx
   class Test
 
+    JOB_CLASSES = [SphinxIndexationWorker, SphinxAccountIndexationWorker].freeze
+
     class << self
 
       def real_time_run
         init
         start index: false
+
+        disabled = Mocha::Mockery.instance.stubba.stubba_methods.any? {|m| m.stubbee == SphinxIndexationWorker && m.method == :perform}
+        enable_search_jobs! if disabled
+
         yield
       ensure
         stop
+        disable_search_jobs! if disabled
       end
-      alias_method :rt_run, :real_time_run
 
-      def disable_real_time_callbacks!
-        original_settings = ThinkingSphinx::Configuration.instance.settings
-        new_settings = original_settings.dup.merge({"real_time_callbacks" => false})
-        ThinkingSphinx::Configuration.any_instance.stubs(:settings).returns(new_settings)
-      end
+      alias_method :rt_run, :real_time_run
 
       def indexed_base_models
         ThinkingSphinx::Configuration.instance.index_set_class.new.map(&:model)
@@ -31,6 +33,31 @@ module ThinkingSphinx
       def index_for(model)
         ThinkingSphinx::Configuration.instance.index_set_class.new(classes: [model]).first
       end
+
+      def disable_search_jobs!
+        ThinkingSphinx::Test::JOB_CLASSES.each do |clazz|
+          clazz.any_instance.stubs(:perform)
+        end
+      end
+
+      def enable_search_jobs!
+        ThinkingSphinx::Test::JOB_CLASSES.each do |clazz|
+          clazz.any_instance.unstub(:perform)
+        end
+      end
     end
   end
 end
+
+module TestHelpers
+  module Sphinx
+    def self.included(base)
+      base.setup(:disable_search_jobs!)
+    end
+
+    delegate :enable_search_jobs!, to: :'ThinkingSphinx::Test'
+    delegate :disable_search_jobs!, to: :'ThinkingSphinx::Test'
+  end
+end
+
+ActiveSupport::TestCase.include TestHelpers::Sphinx

--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -161,6 +161,7 @@ class Account::SearchTest < ActiveSupport::TestCase
       ThinkingSphinx::Test.clear
       ThinkingSphinx::Test.init
       ThinkingSphinx::Test.start index: false
+      ThinkingSphinx::Test.enable_search_jobs!
       perform_enqueued_jobs(only: SphinxAccountIndexationWorker) do
         @provider = FactoryBot.create(:simple_provider)
         @buyers = FactoryBot.create_list(:simple_buyer, 2, provider_account: provider)

--- a/test/unit/indices/indexing_test.rb
+++ b/test/unit/indices/indexing_test.rb
@@ -86,14 +86,6 @@ class IndexingTest < ActiveSupport::TestCase
 
   private
 
-  def indexed_models
-    ThinkingSphinx::Test.indexed_models
-  end
-
-  def indexed_ids(model)
-    model.search(middleware: ThinkingSphinx::Middlewares::IDS_ONLY)
-  end
-
   def factory_for(model)
     overrides = {
       account: :simple_provider,

--- a/test/unit/indices/indexing_test.rb
+++ b/test/unit/indices/indexing_test.rb
@@ -7,6 +7,7 @@ class IndexingTest < ActiveSupport::TestCase
     ThinkingSphinx::Test.clear
     ThinkingSphinx::Test.init
     ThinkingSphinx::Test.start index: false
+    ThinkingSphinx::Test.enable_search_jobs!
   end
 
   teardown do

--- a/test/unit/tasks/services_test.rb
+++ b/test/unit/tasks/services_test.rb
@@ -20,7 +20,6 @@ module Tasks
       default_service.reload
 
       ThreeScale::Core::Service.expects(:make_default).with(another_service.backend_id)
-      ThinkingSphinx::Test.disable_real_time_callbacks!
       assert_difference(EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent.to_s).method(:count)) do
         perform_enqueued_jobs do
           execute_rake_task 'services.rake', 'services:destroy_service', account.id, default_service.id
@@ -70,7 +69,7 @@ module Tasks
       ThreeScale::Core::Service.expects(:save!).never
 
       assert_difference(EventStore::Repository.adapter.where(event_type: Services::ServiceDeletedEvent.to_s).method(:count)) do
-        perform_enqueued_jobs(except: SphinxIndexationWorker) do
+        perform_enqueued_jobs do
           execute_rake_task 'services.rake', 'services:destroy_service', account.id, non_default_service.id
         end
       end

--- a/test/workers/delete_account_hierarchy_worker_test.rb
+++ b/test/workers/delete_account_hierarchy_worker_test.rb
@@ -43,19 +43,19 @@ class DeleteAccountHierarchyWorkerTest < ActiveSupport::TestCase
     DeletePaymentSettingHierarchyWorker.expects(:perform_later).with(provider.payment_gateway_setting, anything, 'destroy')
     DeleteObjectHierarchyWorker.expects(:perform_later).with(api_docs_service, anything, 'destroy')
 
-    perform_enqueued_jobs(except: SphinxIndexationWorker) { DeleteAccountHierarchyWorker.perform_now(provider) }
+    perform_enqueued_jobs { DeleteAccountHierarchyWorker.perform_now(provider) }
   end
 
   test 'does not perform if wrong state' do
     provider.update_column(:state, 'approved')
 
-    perform_enqueued_jobs(except: SphinxIndexationWorker) { DeleteAccountHierarchyWorker.perform_now(provider) }
+    perform_enqueued_jobs { DeleteAccountHierarchyWorker.perform_now(provider) }
 
     assert provider.reload
   end
 
   test 'the account ends up destroyed after the hierarchy' do
-    perform_enqueued_jobs(except: SphinxIndexationWorker) { DeleteAccountHierarchyWorker.perform_now(provider) }
+    perform_enqueued_jobs { DeleteAccountHierarchyWorker.perform_now(provider) }
 
     assert_raises(ActiveRecord::RecordNotFound) { provider.reload }
   end

--- a/test/workers/delete_object_hierarchy_worker_test.rb
+++ b/test/workers/delete_object_hierarchy_worker_test.rb
@@ -10,7 +10,6 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
   end
 
   def test_perform
-    ThinkingSphinx::Test.disable_real_time_callbacks!
     perform_enqueued_jobs do
       perform_expectations
 
@@ -49,7 +48,7 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
       features_plan = plan.features_plans.create!(feature: feature)
 
       assert_difference(plan.features_plans.method(:count), -1) do
-        perform_enqueued_jobs(except: SphinxIndexationWorker) { DeleteObjectHierarchyWorker.perform_now(feature) }
+        perform_enqueued_jobs { DeleteObjectHierarchyWorker.perform_now(feature) }
       end
 
       assert_raises(ActiveRecord::RecordNotFound) { feature.reload }
@@ -81,7 +80,7 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
     def test_perform_deserialization_error
       object.destroy!
       Rails.logger.expects(:info).with { |message| message.match(/DeleteObjectHierarchyWorker#perform raised ActiveJob::DeserializationError/) }
-      perform_enqueued_jobs(except: SphinxIndexationWorker) { DeleteObjectHierarchyWorker.perform_later(object) }
+      perform_enqueued_jobs { DeleteObjectHierarchyWorker.perform_later(object) }
     end
 
     def test_success_record_not_found
@@ -174,7 +173,6 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
     attr_reader :member, :member_permission
 
     def test_perform
-      ThinkingSphinx::Test.disable_real_time_callbacks!
       perform_enqueued_jobs { DeleteObjectHierarchyWorker.perform_now(member) }
 
       assert_raises(ActiveRecord::RecordNotFound) { member_permission.reload }

--- a/test/workers/signup_worker_test.rb
+++ b/test/workers/signup_worker_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class SignupWorkerTest < ActiveSupport::TestCase
-
   def test_enqueue
     assert SignupWorker.enqueue(stub('provider', id: 42))
 

--- a/test/workers/sphinx_account_indexation_worker_test.rb
+++ b/test/workers/sphinx_account_indexation_worker_test.rb
@@ -6,20 +6,6 @@ class SphinxAccountIndexationWorkerTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
   include TestHelpers::Master
 
-  test "callback" do
-    account = FactoryBot.create(:simple_account)
-    callback = ThinkingSphinx::RealTime.callback_for(:account)
-    assert callback
-
-    ThinkingSphinx::RealTime.expects(callback_for: callback)
-    callback.expects(:after_commit).with(Equals.new(account))
-    ThinkingSphinx::Test.rt_run do
-      perform_enqueued_jobs only: SphinxAccountIndexationWorker do
-        SphinxAccountIndexationWorker.perform_later(account.class, account.id)
-      end
-    end
-  end
-
   test "master account should not be indexed" do
     ThinkingSphinx::Test.rt_run do
       perform_enqueued_jobs(only: SphinxAccountIndexationWorker) do
@@ -37,9 +23,7 @@ class SphinxAccountIndexationWorkerTest < ActiveSupport::TestCase
       assert_includes master_account.buyers, @provider
 
       worker = SphinxAccountIndexationWorker.new
-      index = worker.send(:indices_for_model, Account).first
-      # ThinkingSphinx::RealTime::Transcriber.new(index).copy(master_account)
-      worker.send :reindex, index, master_account # enforce indexing master which should not hapen in practice
+      worker.send :reindex, master_account # enforce indexing master which should not happen in practice
       assert_includes Account.search(middleware: ThinkingSphinx::Middlewares::IDS_ONLY, limit: 100), master_account.id
 
       worker.perform(Account, master_account.id)

--- a/test/workers/sphinx_account_indexation_worker_test.rb
+++ b/test/workers/sphinx_account_indexation_worker_test.rb
@@ -11,7 +11,7 @@ class SphinxAccountIndexationWorkerTest < ActiveSupport::TestCase
       perform_enqueued_jobs(only: SphinxAccountIndexationWorker) do
         SphinxAccountIndexationWorker.perform_now(Account, master_account.id)
       end
-      assert_not_includes Account.search(middleware: ThinkingSphinx::Middlewares::IDS_ONLY, limit: 100), master_account.id
+      assert_not_includes indexed_ids(Account), master_account.id
     end
   end
 
@@ -24,11 +24,53 @@ class SphinxAccountIndexationWorkerTest < ActiveSupport::TestCase
 
       worker = SphinxAccountIndexationWorker.new
       worker.send :reindex, master_account # enforce indexing master which should not happen in practice
-      assert_includes Account.search(middleware: ThinkingSphinx::Middlewares::IDS_ONLY, limit: 100), master_account.id
+      assert_includes indexed_ids(Account), master_account.id
 
       worker.perform(Account, master_account.id)
-      assert_not_includes Account.search(middleware: ThinkingSphinx::Middlewares::IDS_ONLY, limit: 100), master_account.id
-      assert_includes Account.search(middleware: ThinkingSphinx::Middlewares::IDS_ONLY, limit: 100), @provider.id
+      assert_not_includes indexed_ids(Account), master_account.id
+      assert_includes indexed_ids(Account), @provider.id
+    end
+  end
+
+  test "providers are deleted from index with their buyers" do
+    ThinkingSphinx::Test.rt_run do
+      perform_enqueued_jobs(only: SphinxAccountIndexationWorker) do
+        providers = FactoryBot.create_list(:simple_provider, 2)
+        buyers = []
+        providers.each { |provider| buyers << FactoryBot.create(:simple_buyer, provider_account: provider) }
+
+        assert_equal (providers + buyers).map(&:id), indexed_ids(Account).to_a
+
+        providers.first.schedule_for_deletion
+        providers.first.save!
+        indexed = indexed_ids(Account)
+
+        assert Account.exists?(providers.first.id)
+        assert Account.exists?(buyers.first.id)
+        assert_not_includes indexed, providers.first.id
+        assert_not_includes indexed, buyers.first.id
+        assert_includes indexed, providers.last.id
+        assert_includes indexed, buyers.last.id
+      end
+    end
+  end
+
+  test "buyers are deleted from index without anybody else" do
+    ThinkingSphinx::Test.rt_run do
+      perform_enqueued_jobs(only: SphinxAccountIndexationWorker) do
+        provider = FactoryBot.create(:simple_provider)
+        buyers = FactoryBot.create_list(:simple_buyer, 2, provider_account: provider)
+
+        assert_equal Set.new(buyers.map(&:id) << provider.id), Set.new(indexed_ids(Account).to_a)
+
+        buyers.last.destroy!
+
+        indexed = indexed_ids(Account)
+
+        assert_not_includes indexed, buyers.last.id
+        assert_includes indexed, provider.id
+        assert_includes indexed, buyers.first.id
+      end
     end
   end
 end

--- a/test/workers/sphinx_indexation_worker_test.rb
+++ b/test/workers/sphinx_indexation_worker_test.rb
@@ -6,30 +6,8 @@ class SphinxIndexationWorkerTest < ActiveSupport::TestCase
 
   include ActiveJob::TestHelper
 
-  test "callback" do
-    account = FactoryBot.create(:simple_account)
-    callback = ThinkingSphinx::RealTime.callback_for(:account)
-    assert callback
-
-    ThinkingSphinx::RealTime.expects(callback_for: callback)
-    callback.expects(:after_commit).with(Equals.new(account))
-    ThinkingSphinx::Test.rt_run do
-      perform_enqueued_jobs only: SphinxIndexationWorker do
-        SphinxIndexationWorker.perform_later(account.class, account.id)
-      end
-    end
-  end
-
-  test "only one index found per indexed model" do
-    worker = SphinxIndexationWorker.new
-    indices = ThinkingSphinx::Test.indexed_models.select do |model|
-      assert_match SizeMatcher.new(1), worker.send(:indices_for_model, model).to_a
-    end
-
-    assert_not_empty indices.map(&:name)
-  end
-
   test 'it does not raises if id does not exist' do
+    enable_search_jobs!
     SphinxIndexationWorker.perform_now(ThinkingSphinx::Test.indexed_models.sample, 42)
   end
 end


### PR DESCRIPTION
## How to review

### main change

This is upgrading thinking-sphinx and updating `SphinxIndexationWorker` and `SphinxAccountIndexationWorker`.

In the past we used some internal APIs to call the proper thinking-sphinx callbacks for indexing and deinxing stuff. But  in 5.5.0 the `ThinkingSphinx::Processor` was introduced.

Unfortunately not getting access to the index, we also don't get the index `scope`, that's why `SphinxAccountIndexationWorker` hardcodes the searching scope. And the index `scope` is extracted into a model `scope` for easier access (see `account.rb`).

<del>### the error reporting</del>

<del>Improved error reporting of index worker errors. Switched `ErrorReporting` to use `add_metadata` because `add_tab` is deprecated.</del>

<del>https://www.rubydoc.info/gems/bugsnag/6.24.2/Bugsnag/Report#add_metadata-instance_method</del>


<del>Also tried to avoid double-wrapping of parameters into a hash. Need to test this though.</del>

### monkey patching to use proper fields for indices

This is `config/initializers/sphinx.rb`. You can leave that alone, I tested the config generated is same as previously. Or if you like to dig into it, you'd have to understand how previous monkey patching worked and then the pull requests linked in the comment. We can have a call to drive you though this if so much want.

### test suite changes

The main issue was that we didn't have a global way to turn on/off sphinx (previously we could disable the callback but no such API to turn off `Processor`) and it broke a lot of tests.

So the main part for unit/integration/functional tests is `test/test_helpers/sphinx.rb`. It adds methods to stub and unstub the workers as well automatically doing the right thing inside a `real_time_run/rt_run` blocks. Also it adds a test helper to disable sphinx workers before each test. So that we only enable them when we want.

For cucumbers, the main part is `features/support/sphinx.rb`. There hooks are added to disable indexation workers for all tests but these tagged with `@search`.

Then the rest is about removing redundant calls to disable sphinx indexing workers. Occasionally a call to enable index workers where `rt_run` was not used.