### PR TITLE
Upgrade to Sidekiq 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 # to not use insecure git protocol
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-gem 'rack', '~> 2.2.6'
+gem 'rack', '~> 2.2.8'
 
 gem 'aws-sdk-rails', '~> 3'
 gem 'aws-sdk-s3', '~> 1'
@@ -51,8 +51,8 @@ gem '3scale_time_range', '0.0.6'
 gem 'statsd-ruby', require: false
 
 # Sidekiq
-gem 'sidekiq', '< 6', require: %w[sidekiq sidekiq/web]
-gem 'sidekiq-batch', '~> 0.1.6'
+gem 'sidekiq', '~> 6.4.0', require: %w[sidekiq sidekiq/web]
+gem 'sidekiq-batch'
 gem 'sidekiq-cron', require: %w[sidekiq/cron sidekiq/cron/web]
 gem 'sidekiq-lock'
 gem 'sidekiq-throttled'
@@ -108,7 +108,7 @@ gem 'ratelimit'
 gem 'recaptcha', '4.13.1', require: 'recaptcha/rails'
 gem 'redcarpet', '~>3.5.1', require: false
 gem 'RedCloth', '~>4.3', require: false
-gem 'redis', '~> 4.1.3', require: ['redis', 'redis/connection/hiredis']
+gem 'redis', '~> 4.2.0', require: ['redis', 'redis/connection/hiredis']
 gem 'redis-namespace', '~> 1.7.0'
 gem 'rest-client', '~> 2.0.2'
 gem 'rubyzip', '~>1.3.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
       activesupport (>= 3.0)
     analytics-ruby (2.2.8)
     ansi (1.5.0)
+    anyway_config (2.5.0)
+      ruby-next-core (>= 0.14.0)
     ast (2.4.2)
     audited (5.0.2)
       activerecord (>= 5.0, < 7.1)
@@ -265,7 +267,7 @@ GEM
       sass-rails (< 5.1)
       sprockets (< 4.0)
     concurrent-ruby (1.2.2)
-    connection_pool (2.2.5)
+    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -347,7 +349,7 @@ GEM
       nokogiri (>= 1.4.3)
     erubi (1.12.0)
     escape_utils (1.2.1)
-    et-orbi (1.2.4)
+    et-orbi (1.2.7)
       tzinfo
     eventmachine (1.2.7)
     execjs (2.8.1)
@@ -369,8 +371,8 @@ GEM
       railties (>= 3.2, < 6.1)
     formtastic (4.0.0)
       actionpack (>= 5.2.0)
-    fugit (1.5.0)
-      et-orbi (~> 1.1, >= 1.1.8)
+    fugit (1.8.1)
+      et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
     github-markdown (0.6.9)
     globalid (1.1.0)
@@ -567,15 +569,13 @@ GEM
     public_suffix (4.0.7)
     raabro (1.4.0)
     racc (1.6.2)
-    rack (2.2.7)
+    rack (2.2.8)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-no_animations (1.0.3)
     rack-openid (1.4.2)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
-    rack-protection (2.0.4)
-      rack
     rack-proxy (0.7.4)
       rack
     rack-test (2.1.0)
@@ -644,7 +644,7 @@ GEM
       actionview (>= 5)
     recursive-open-struct (1.1.3)
     redcarpet (3.5.1)
-    redis (4.1.4)
+    redis (4.2.5)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
     redis-prescription (1.0.0)
@@ -727,6 +727,7 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
+    ruby-next-core (0.15.3)
     ruby-oci8 (2.2.6.1)
     ruby-openid (2.9.2)
     ruby-plsql (0.8.0)
@@ -753,22 +754,22 @@ GEM
     shoulda-context (2.0.0)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
-    sidekiq (5.2.9)
-      connection_pool (~> 2.2, >= 2.2.2)
+    sidekiq (6.4.2)
+      connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 4.2)
-    sidekiq-batch (0.1.6)
+      redis (>= 4.2.0)
+    sidekiq-batch (0.1.9)
       sidekiq (>= 3)
-    sidekiq-cron (1.2.0)
-      fugit (~> 1.1)
+    sidekiq-cron (1.9.1)
+      fugit (~> 1.8)
       sidekiq (>= 4.2.1)
-    sidekiq-lock (0.4.0)
+    sidekiq-lock (0.6.0)
       redis (>= 3.0.5)
       sidekiq (>= 2.14.0)
-    sidekiq-prometheus-exporter (0.1.13)
-      sidekiq (>= 3.3.1)
-    sidekiq-throttled (0.11.0)
+    sidekiq-prometheus-exporter (0.2.0)
+      rack (>= 1.6.0)
+      sidekiq (>= 4.1.0)
+    sidekiq-throttled (0.15.0)
       concurrent-ruby
       redis-prescription
       sidekiq
@@ -890,7 +891,8 @@ GEM
       rexml
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yabeda (0.8.0)
+    yabeda (0.12.0)
+      anyway_config (>= 1.0, < 3)
       concurrent-ruby
       dry-initializer
     yabeda-prometheus-mmap (0.1.1)
@@ -899,7 +901,8 @@ GEM
     yabeda-rails (0.6.0)
       rails
       yabeda (~> 0.4)
-    yabeda-sidekiq (0.7.0)
+    yabeda-sidekiq (0.10.0)
+      anyway_config (>= 1.3, < 3)
       sidekiq
       yabeda (~> 0.6)
     yard (0.9.27)
@@ -1010,7 +1013,7 @@ DEPENDENCIES
   pry-rails
   pry-shell
   pry-stack_explorer
-  rack (~> 2.2.6)
+  rack (~> 2.2.8)
   rack-cors
   rack-no_animations (~> 1.0.3)
   rack-utf8_sanitizer
@@ -1023,7 +1026,7 @@ DEPENDENCIES
   recaptcha (= 4.13.1)
   record_tag_helper (~> 1.0)
   redcarpet (~> 3.5.1)
-  redis (~> 4.1.3)
+  redis (~> 4.2.0)
   redis-namespace (~> 1.7.0)
   redlock
   reek (= 6.01)
@@ -1045,8 +1048,8 @@ DEPENDENCIES
   secure_headers (~> 6.3.0)
   selenium-webdriver (~> 3.142)
   shoulda (~> 4.0)
-  sidekiq (< 6)
-  sidekiq-batch (~> 0.1.6)
+  sidekiq (~> 6.4.0)
+  sidekiq-batch
   sidekiq-cron
   sidekiq-lock
   sidekiq-prometheus-exporter

--- a/app/lib/events/importer.rb
+++ b/app/lib/events/importer.rb
@@ -4,7 +4,7 @@ module Events
   module Importer
 
     def self.async_import_event!(event_attrs)
-      EventImportWorker.perform_async(event_attrs)
+      EventImportWorker.perform_async(event_attrs.as_json)
     end
 
     def self.import_event!(event_attrs)

--- a/app/models/web_hook/event.rb
+++ b/app/models/web_hook/event.rb
@@ -66,7 +66,8 @@ class WebHook
 
     def enqueue_now
       logger.info "Pushed WebHook::Event(#{id}) #{event} for #{model}##{resource.id}"
-      WebHookWorker.perform_async(id, provider_id: provider.id, url: url, xml: to_xml, content_type: content_type)
+      args = { provider_id: provider.id, url: url, xml: to_xml, content_type: content_type }
+      WebHookWorker.perform_async(id, args.as_json)
     end
 
     def ignore

--- a/app/services/service_discovery/import_cluster_definitions_service.rb
+++ b/app/services/service_discovery/import_cluster_definitions_service.rb
@@ -9,7 +9,7 @@ module ServiceDiscovery
     end
 
     def self.create_service(account, cluster_namespace:, cluster_service_name:, user: nil)
-      CreateServiceWorker.perform_async(account.id, cluster_namespace, cluster_service_name, user&.id)
+      CreateServiceWorker.perform_async(account.id, cluster_namespace.as_json, cluster_service_name.as_json, user&.id)
       build_service(account, name: cluster_service_name)
     end
 

--- a/app/services/service_discovery/import_cluster_definitions_service.rb
+++ b/app/services/service_discovery/import_cluster_definitions_service.rb
@@ -9,7 +9,7 @@ module ServiceDiscovery
     end
 
     def self.create_service(account, cluster_namespace:, cluster_service_name:, user: nil)
-      CreateServiceWorker.perform_async(account.id, cluster_namespace.as_json, cluster_service_name.as_json, user&.id)
+      CreateServiceWorker.perform_async(account.id, cluster_namespace.to_s, cluster_service_name.to_s, user&.id)
       build_service(account, name: cluster_service_name)
     end
 

--- a/app/subscribers/zync_subscriber.rb
+++ b/app/subscribers/zync_subscriber.rb
@@ -11,6 +11,6 @@ class ZyncSubscriber < AfterCommitSubscriber
 
   # @param [ZyncEvent] event
   def after_commit(event)
-    job.perform_async(event.event_id, event.data)
+    job.perform_async(event.event_id, event.data.as_json)
   end
 end

--- a/app/workers/cms/upgrade_content_worker.rb
+++ b/app/workers/cms/upgrade_content_worker.rb
@@ -12,7 +12,7 @@ class CMS::UpgradeContentWorker
 
       batch.jobs do
         provider.templates.select(:id).find_each do |template|
-          CMS::UpgradeContentWorker.perform_async(template.id, kind)
+          CMS::UpgradeContentWorker.perform_async(template.id, kind.to_s)
         end
       end if valid_within_batch?
     end
@@ -31,7 +31,7 @@ class CMS::UpgradeContentWorker
     batch.description = "Upgrading CMS Content (#{kind}) of #{provider.org_name} (#{provider.id})"
 
     batch.jobs do
-      ExpandWorker.perform_async(provider.id, kind)
+      ExpandWorker.perform_async(provider.id, kind.to_s)
     end
   end
 

--- a/app/workers/pdf_report_worker.rb
+++ b/app/workers/pdf_report_worker.rb
@@ -9,7 +9,7 @@ class PdfReportWorker
   # @param [Account] account
   # @param [SystemOperation] system_operation
   def self.enqueue(service, period, system_operation)
-    perform_async(service.id, service.account_id, period, system_operation.ref)
+    perform_async(service.id, service.account_id, period.to_s, system_operation.ref)
   end
 
   # @param [Integer] service_id

--- a/app/workers/persist_event_worker.rb
+++ b/app/workers/persist_event_worker.rb
@@ -2,7 +2,7 @@ class PersistEventWorker
   include Sidekiq::Worker
 
   def self.enqueue(event_attrs)
-    perform_async(event_attrs)
+    perform_async(event_attrs.as_json)
   end
 
   def perform(event_attrs)

--- a/app/workers/report_traffic_worker.rb
+++ b/app/workers/report_traffic_worker.rb
@@ -35,9 +35,9 @@ class ReportTrafficWorker
 
       args = [
         account.id,
-        metric_system_name,
-        filter_request_attrs(request),
-        filter_response_attrs(response),
+        metric_system_name.to_s,
+        filter_request_attrs(request).as_json,
+        filter_response_attrs(response).as_json,
         Time.now.to_i
       ]
 

--- a/config/initializers/audited_hacks.rb
+++ b/config/initializers/audited_hacks.rb
@@ -65,7 +65,7 @@ module AuditHacks
   end
 
   def enqueue_job
-    AuditedWorker.perform_async(attributes)
+    AuditedWorker.perform_async(attributes.as_json)
   end
 end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,38 +8,40 @@ Sidekiq::Throttled.setup!
 
 Sidekiq::Client.try(:reliable_push!) unless Rails.env.test?
 
-Sidekiq.configure_server do |config|
-  config.try(:reliable!)
+Rails.application.config.to_prepare do
+  Sidekiq.configure_server do |config|
+    config.try(:reliable!)
 
-  config.redis = ThreeScale::RedisConfig.new(System::Application.config.sidekiq).config
-  config.error_handlers << System::ErrorReporting.method(:report_error)
+    config.redis = ThreeScale::RedisConfig.new(System::Application.config.sidekiq).config
+    config.error_handlers << System::ErrorReporting.method(:report_error)
 
-  config.server_middleware do |chain|
-    chain.add ThreeScale::Analytics::SidekiqMiddleware
-    chain.add ThreeScale::SidekiqRetrySupport::Middleware
+    config.server_middleware do |chain|
+      chain.add ThreeScale::Analytics::SidekiqMiddleware
+      chain.add ThreeScale::SidekiqRetrySupport::Middleware
+    end
+
+    faraday = ThreeScale::Core.faraday
+    faraday.options.timeout = 30
+    faraday.options.open_timeout = 10
+
+    schedule_file = Rails.root.join('config', 'sidekiq_schedule.yml')
+
+    if File.exist?(schedule_file) && Sidekiq.server?
+      Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file)
+    end
+    # This will start a webrick server in another thread
+    # where the Sidekiq processes are spawned
+    # So if we have multiple processes, then they should listen to different ports
+    # Use PROMETHEUS_EXPORTER_BIND and PROMETHEUS_EXPORTER_PORT
+    # if no PROMETHEUS_EXPORT_PORT given, it will start the server with default port 9394 + index
+    port = ENV.fetch('PROMETHEUS_EXPORTER_PORT', 9394).to_i
+    port += Sidekiq.options[:index].to_i
+    ENV['PROMETHEUS_EXPORTER_PORT'] ||= port.to_s
+
+    require 'yabeda/prometheus/mmap'
+
+    Yabeda::Prometheus::Exporter.start_metrics_server!
   end
-
-  faraday = ThreeScale::Core.faraday
-  faraday.options.timeout = 30
-  faraday.options.open_timeout = 10
-
-  schedule_file = Rails.root.join('config', 'sidekiq_schedule.yml')
-
-  if File.exist?(schedule_file) && Sidekiq.server?
-    Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file)
-  end
-  # This will start a webrick server in another thread
-  # where the Sidekiq processes are spawned
-  # So if we have multiple processes, then they should listen to different ports
-  # Use PROMETHEUS_EXPORTER_BIND and PROMETHEUS_EXPORTER_PORT
-  # if no PROMETHEUS_EXPORT_PORT given, it will start the server with default port 9394 + index
-  port = ENV.fetch('PROMETHEUS_EXPORTER_PORT', 9394).to_i
-  port += Sidekiq.options[:index].to_i
-  ENV['PROMETHEUS_EXPORTER_PORT'] ||= port.to_s
-
-  require 'yabeda/prometheus/mmap'
-
-  Yabeda::Prometheus::Exporter.start_metrics_server!
 end
 
 Rails.application.config.to_prepare do

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -15,6 +15,8 @@ Rails.application.config.to_prepare do
     config.redis = ThreeScale::RedisConfig.new(System::Application.config.sidekiq).config
     config.error_handlers << System::ErrorReporting.method(:report_error)
 
+    config.logger.formatter = Sidekiq::Logger::Formatters::Pretty.new
+
     config.server_middleware do |chain|
       chain.add ThreeScale::Analytics::SidekiqMiddleware
       chain.add ThreeScale::SidekiqRetrySupport::Middleware

--- a/features/support/sidekiq.rb
+++ b/features/support/sidekiq.rb
@@ -4,7 +4,7 @@ require 'sidekiq/testing'
 require 'sidekiq/batch'
 
 # Turn off Sidekiq logging which pollutes the CI logs
-Sidekiq::Logging.logger = nil
+Sidekiq.logger = Logger.new("/dev/null")
 Sidekiq::Testing.inline!
 
 module Sidekiq

--- a/features/support/sidekiq.rb
+++ b/features/support/sidekiq.rb
@@ -4,7 +4,7 @@ require 'sidekiq/testing'
 require 'sidekiq/batch'
 
 # Turn off Sidekiq logging which pollutes the CI logs
-Sidekiq.logger = Logger.new("/dev/null")
+Sidekiq.logger = Sidekiq::Logger.new(nil, level: Logger::FATAL)
 Sidekiq::Testing.inline!
 
 module Sidekiq

--- a/test/test_helpers/sidekiq.rb
+++ b/test/test_helpers/sidekiq.rb
@@ -4,7 +4,7 @@ require 'sidekiq/testing'
 require 'sidekiq/lock/testing/inline'
 
 # Turn off Sidekiq logging which pollutes the CI logs
-Sidekiq.logger = Logger.new("/dev/null")
+Sidekiq.logger = Sidekiq::Logger.new(nil, level: Logger::FATAL)
 module TestHelpers
   module Sidekiq
     def self.included(base)

--- a/test/test_helpers/sidekiq.rb
+++ b/test/test_helpers/sidekiq.rb
@@ -4,7 +4,7 @@ require 'sidekiq/testing'
 require 'sidekiq/lock/testing/inline'
 
 # Turn off Sidekiq logging which pollutes the CI logs
-Sidekiq::Logging.logger = nil
+Sidekiq.logger = Logger.new("/dev/null")
 module TestHelpers
   module Sidekiq
     def self.included(base)

--- a/test/test_helpers/sidekiq.rb
+++ b/test/test_helpers/sidekiq.rb
@@ -5,6 +5,7 @@ require 'sidekiq/lock/testing/inline'
 
 # Turn off Sidekiq logging which pollutes the CI logs
 Sidekiq.logger = Sidekiq::Logger.new(nil, level: Logger::FATAL)
+Sidekiq.strict_args! # Fail if parameters are not valid JSON
 module TestHelpers
   module Sidekiq
     def self.included(base)

--- a/test/workers/backend_storage_rewrite_worker_test.rb
+++ b/test/workers/backend_storage_rewrite_worker_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class BackendStorageRewriteWorkerTest < ActiveSupport::TestCase
+  attr_accessor :provider
+
+  def setup
+    @provider = FactoryBot.create(:simple_provider)
+  end
+
+  test '#enqueue' do
+    BackendStorageRewriteWorker.enqueue(provider.id)
+
+    assert_equal 1, BackendStorageRewriteWorker.jobs.size
+  end
+
+  test '#perform enqueued' do
+    Sidekiq::Testing.inline! do
+      Backend::StorageRewrite.expects(:rewrite_provider).with(provider.id)
+      BackendStorageRewriteWorker.enqueue(provider.id)
+    end
+  end
+end

--- a/test/workers/billing_worker_test.rb
+++ b/test/workers/billing_worker_test.rb
@@ -55,7 +55,7 @@ class BillingWorkerTest < ActiveSupport::TestCase
       callback_options = { batch_id: batch.bid, account_id: @provider.id, billing_date: time }
       batch.on(:complete, BillingWorker::Callback, callback_options)
       batch.jobs do
-        BillingWorker.perform_async(@buyer.id, @provider.id, time)
+        BillingWorker.perform_async(@buyer.id, @provider.id, time.to_s(:iso8601))
       end
 
       Finance::BillingService.any_instance.expects(:notify_billing_finished).returns(true)

--- a/test/workers/billing_worker_test.rb
+++ b/test/workers/billing_worker_test.rb
@@ -55,7 +55,7 @@ class BillingWorkerTest < ActiveSupport::TestCase
       callback_options = { batch_id: batch.bid, account_id: @provider.id, billing_date: time }
       batch.on(:complete, BillingWorker::Callback, callback_options)
       batch.jobs do
-        BillingWorker.perform_async(@buyer.id, @provider.id, time.to_s(:iso8601))
+        BillingWorker.perform_async(@buyer.id, @provider.id, time.iso8601)
       end
 
       Finance::BillingService.any_instance.expects(:notify_billing_finished).returns(true)

--- a/test/workers/create_service_token_worker_test.rb
+++ b/test/workers/create_service_token_worker_test.rb
@@ -26,9 +26,9 @@ class CreateServiceTokenWorkerTest < ActiveSupport::TestCase
         ServiceTokenService.expects(:update_backend).with(instance_of(ServiceToken)).twice
 
         assert_difference ServiceToken.method(:count), +1 do
-          CreateServiceTokenWorker.perform_async(event)
+          CreateServiceTokenWorker.perform_async(event.event_id)
           # for one event there should be only one service token
-          CreateServiceTokenWorker.perform_async(event)
+          CreateServiceTokenWorker.perform_async(event.event_id)
         end
       end
     end

--- a/test/workers/message_worker_test.rb
+++ b/test/workers/message_worker_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MessageWorkerTest < ActiveSupport::TestCase
+  attr_accessor :recipients, :attributes
+
+  def setup
+    provider = FactoryBot.create(:simple_provider)
+    buyers = FactoryBot.create_list(:buyer_account, 3, provider_account: provider)
+    @recipients =  { to: buyers.map { |b| b.admins.first.id } }
+    @attributes = {
+      subject: "API System: New Application submission",
+      body: "Dear API Administrator,\n\n\n\nA new user john has signed up for your service API on plan Basic.",
+      sender_id: provider.id,
+      origin: 'web'
+    }
+  end
+
+  test '#enqueue' do
+    MessageWorker.enqueue(recipients, attributes)
+
+    assert_equal 1, MessageWorker.jobs.size
+  end
+
+  test '#perform enqueued' do
+    Sidekiq::Testing.inline! do
+      Message.any_instance.expects(:deliver!)
+      MessageWorker.enqueue(recipients, attributes)
+    end
+  end
+end

--- a/test/workers/persist_event_worker_test.rb
+++ b/test/workers/persist_event_worker_test.rb
@@ -8,7 +8,7 @@ class PersistEventWorkerTest < ActiveSupport::TestCase
   end
 
   test "enqueue send correct parameters" do
-    PersistEventWorker.expects(:perform_async).with({a: :b})
+    PersistEventWorker.expects(:perform_async).with({"a" => "b"})
     PersistEventWorker.enqueue({a: :b})
   end
 

--- a/test/workers/zync_worker_test.rb
+++ b/test/workers/zync_worker_test.rb
@@ -117,7 +117,7 @@ class ZyncWorkerTest < ActiveSupport::TestCase
     end
 
     test '#publish_dependency_events enqueues the jobs' do
-      %w[Proxy Service].each { |dependent_type| ZyncWorker.expects(:perform_async).with(anything, has_entry(:type, dependent_type)) }
+      %w[Proxy Service].each { |dependent_type| ZyncWorker.expects(:perform_async).with(anything, has_entry('type', dependent_type)) }
       worker.publish_dependency_events(event.create_dependencies)
     end
 

--- a/test/workers/zync_worker_test.rb
+++ b/test/workers/zync_worker_test.rb
@@ -212,7 +212,7 @@ class ZyncWorkerTest < ActiveSupport::TestCase
 
     zync_event = EventStore::Event.where(event_type: ZyncEvent.to_s).last!
     assert_difference(EventStore::Event.where(event_type: ZyncEvent.to_s).method(:count), +1) do
-      Sidekiq::Testing.inline! { ZyncWorker.perform_async(zync_event.event_id, zync_event.data) }
+      Sidekiq::Testing.inline! { ZyncWorker.perform_async(zync_event.event_id, zync_event.data.as_json) }
     end
 
     stub_request(:put, 'http://example.com/notification').to_return(status: 200)
@@ -220,6 +220,6 @@ class ZyncWorkerTest < ActiveSupport::TestCase
     dependency_event_service = EventStore::Event.where(event_type: ZyncEvent.to_s).last!
     assert_equal 'Service', dependency_event_service.data[:type]
     assert_equal zync_event.data[:service_id], dependency_event_service.data[:id]
-    Sidekiq::Testing.inline! { ZyncWorker.perform_async( dependency_event_service.event_id,  dependency_event_service.data) }
+    Sidekiq::Testing.inline! { ZyncWorker.perform_async( dependency_event_service.event_id,  dependency_event_service.data.as_json) }
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to add TLS and ACL support for Redis. The fastest and safest way to do it is to upgrade the `redis-rb` gem to v5. Unfortunately, this version is not supported by Sidekiq 5 which we are using now, so we need to upgrade Sidekiq to version 6.4.X.

**Which issue(s) this PR fixes** 

[THREESCALE-10027](https://issues.redhat.com/browse/THREESCALE-10027)

**Verification steps** 

All jobs should work successfully.

**Special notes for your reviewer**:

-----------
A couple of useful links about this upgrade:

- https://github.com/sidekiq/sidekiq/blob/main/docs/6.0-Upgrade.md
- https://github.com/sidekiq/sidekiq/wiki/Best-Practices

------------
When running `porta reset`, I saw a couple of deprecation warnings like this:

```
2023-08-01T10:45:09.766Z pid=81840 tid=200t0 WARN: Job arguments to ZyncWorker do not serialize to JSON safely. This will raise an error in Sidekiq 7.0.

See https://github.com /mperham/sidekiq/wiki/Best-Practices or raise an error today by calling `Sidekiq.strict_args!` during Sidekiq initialization.
```

That's because Sidekiq now only accepts calls to `perform_async` with parameters serializable  to JSON. I've looked for all places where `perform_async` is called and I found many calls which seem correct to me, and some others which doesn't. Form the last ones, I fixed `AuditedWorker` and `ZyncWorker` (https://github.com/3scale/porta/commit/7a874b36d23fcead61d9c1a90f18d582362b38a2), but there are some others I think could cause problems:

- https://github.com/3scale/porta/blob/3scale-2.13.2-GA/app/services/service_discovery/import_cluster_definitions_service.rb#L12
  - I don't know which type are `cluster_namespace` and `cluster_service_name`, and I'm not sure I can call `as_json` from them.
- https://github.com/3scale/porta/blob/3scale-2.13.2-GA/app/models/web_hook/event.rb#L69
  - This one contains key arguments and I'm not sure how those are serialized.
- https://github.com/3scale/porta/blob/3scale-2.13.2-GA/app/lib/events/importer.rb#L12
  - I don't know which type is `event_attrs` and whether I can call `as_json` from it.

I would need a way to run those jobs and check what are they actually storing at Redis to figure out the best way to ensure they won't fail.

On the other hand, I only executed and checked the jobs which are created after resetting the DB with `porta reset`, and some Audited and Sphinx jobs that run after editing an `Account`. Those are working fine. Now I would need to find a way to test all other jobs, to verify they don't fail before merging. Any ideas?
