### PR TITLE
THREESCALE-8131 fix misleading error

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -57,7 +57,7 @@ class Api::ServicesController < Api::BaseController
       flash[:notice] = t('flash.services.create.notice')
       redirect_to admin_service_path(@service)
     else
-      flash.now[:error] = I18n.t!('flash.services.create.errors.default')
+      flash.now[:error] = @service.errors.full_messages.to_sentence.presence || I18n.t!('flash.services.create.errors.default')
       activate_menu :dashboard
       render :new
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -896,11 +896,6 @@ en:
         service_plan:
           has_contracts: 'This service plan cannot be deleted! At least one contract depends on it.'
 
-        service:
-          attributes:
-            system_name:
-              invalid: Invalid.
-
         cinstance:
           attributes:
             plan:

--- a/features/old/services/multiservice.feature
+++ b/features/old/services/multiservice.feature
@@ -42,8 +42,8 @@ Feature: Multiservice feature
     And I fill in "Name" with "Less fancy API"
     And I fill in "System name" with "SystemName@123"
     And I press "Create Product"
-    Then I should see "Invalid."
-    Then I should see the flash message "System name Invalid."
+    Then I should see "invalid"
+    And I should see the flash message "System name invalid"
 
   @javascript
   Scenario: Create new product: with already existing System name
@@ -55,6 +55,7 @@ Feature: Multiservice feature
     And I fill in "System name" with "api"
     And I press "Create Product"
     Then I should see "Has already been taken"
+    And I should see the flash message "System name has already been taken"
 
   @wip
   Scenario: Create new backend

--- a/features/old/services/multiservice.feature
+++ b/features/old/services/multiservice.feature
@@ -43,7 +43,7 @@ Feature: Multiservice feature
     And I fill in "System name" with "SystemName@123"
     And I press "Create Product"
     Then I should see "Invalid."
-    Then I should see the flash message "Couldn't create Product. Check your Plan limits"
+    Then I should see the flash message "System name Invalid."
 
   @javascript
   Scenario: Create new product: with already existing System name

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -322,7 +322,7 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'Name can\'t be blank', flash[:error]
 
       post admin_services_path, params: { service: { name: 'example-service', system_name: '###' } }
-      assert_equal 'System name invalid.', flash[:error]
+      assert_equal 'System name Invalid.', flash[:error]
     end
   end
 

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -322,7 +322,7 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'Name can\'t be blank', flash[:error]
 
       post admin_services_path, params: { service: { name: 'example-service', system_name: '###' } }
-      assert_equal 'System name Invalid.', flash[:error]
+      assert_equal 'System name invalid', flash[:error]
     end
   end
 

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -319,10 +319,10 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       @provider.settings.allow_multiple_services!
 
       post admin_services_path, params: { service: { name: '' } }
-      assert_equal 'Couldn\'t create Product. Check your Plan limits', flash[:error]
+      assert_equal 'Name can\'t be blank', flash[:error]
 
       post admin_services_path, params: { service: { name: 'example-service', system_name: '###' } }
-      assert_equal 'Couldn\'t create Product. Check your Plan limits', flash[:error]
+      assert_equal 'System name invalid.', flash[:error]
     end
   end
 


### PR DESCRIPTION
**What this PR does / why we need it:**

Updated Flash errors while creating  new product
updated screenshots is added in JIRA comments


**Steps to reproduce**
Go to Products
Create new product
try creating product with name already used or not in the expected format which is mentioned in the form

Bakend page is a rails page and New prodcut is typescript.

**Which issue(s) this PR fixes**
https://issues.redhat.com/browse/THREESCALE-8131