### PR TITLE
Fix role radio button label

### DIFF
--- a/app/helpers/whitelabel/admin/accounts/users_helper.rb
+++ b/app/helpers/whitelabel/admin/accounts/users_helper.rb
@@ -8,7 +8,7 @@ module Whitelabel::Admin::Accounts::UsersHelper
       text << ' (full access)' if role == :admin
       text << ' (limited access, <strong>cannot create new API products  or API backends, cannot access or change account-level settings</strong>)' if role == :member && can?(:create_contributors, current_user.account)
       # text << ' (can update/create content)'     if role == :contributor
-      [text, role]
+      [text.html_safe, role]
     end
   end
 end


### PR DESCRIPTION
This string needs to be marked as html safe.

Before:
<img width="1201" alt="Screenshot 2023-08-02 at 09 13 28" src="https://github.com/3scale/porta/assets/11672286/c23dd481-0fa2-427f-8c8c-c42595896bab">

After:
<img width="1299" alt="Screenshot 2023-08-02 at 11 33 29" src="https://github.com/3scale/porta/assets/11672286/5bd97c5a-9d59-493d-8fc9-52b448e98644">
