### PR TITLE
Fix icon

### DIFF
--- a/app/assets/stylesheets/provider/_authentication_providers.scss
+++ b/app/assets/stylesheets/provider/_authentication_providers.scss
@@ -22,3 +22,11 @@
 #settings_enforce_sso:not(:checked) + label + .AllowPasswordButton {
   display: block !important;
 }
+
+// HACK: Patternfly 4 uses Font Awesome 5. Icons are now separated in sets (regular, solid, brand)
+// and github belongs to brand. As a workaround, force its font-family so that it comes from FA 4.
+// font-awesome-rails (FA 4) can't be updated to font-awesome-sass, it is not compatible with
+// our sass-rails. And recent sass-rails is not compatible with compass-sass, which is EOL.
+i.fa.fa-github.fa-fw {
+  font-family: FontAwesome;
+}

--- a/app/assets/stylesheets/provider/_authentication_providers.scss
+++ b/app/assets/stylesheets/provider/_authentication_providers.scss
@@ -5,6 +5,7 @@
 .fa-keycloak:before {
   content: '❮❯';
   white-space: nowrap;
+  font-size: $font-size-sm;
 }
 
 .EnforceSSOButton {

--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -158,7 +158,7 @@ module MenuHelper # rubocop:disable Metrics/ModuleLength
 
   def documentation_items
     items = [
-      { title: 'Customer Portal', href: '//access.redhat.com/products/red-hat-3scale', icon: :'external-link', target: '_blank'},
+      { title: 'Customer Portal', href: '//access.redhat.com/products/red-hat-3scale', icon: :'external-link-alt', target: '_blank'},
       { title: '3scale API Docs', href: provider_admin_api_docs_path, icon: :'puzzle-piece' },
       { title: 'Liquid Reference', href: provider_admin_liquid_docs_path, icon: :code }
     ]


### PR DESCRIPTION
Fixes [THREESCALE-9938: Missing GitHub icon in the UI](https://issues.redhat.com/browse/THREESCALE-9938)

Before:
<img width="361" alt="Screenshot 2023-08-02 at 16 36 45" src="https://github.com/3scale/porta/assets/11672286/dd2fd765-1355-4b89-8c1e-c30c20b5728e">

After:
<img width="361" alt="Screenshot 2023-08-02 at 16 36 33" src="https://github.com/3scale/porta/assets/11672286/f049386c-0ead-4e37-84e5-3201f220dc72">

BONUS github icon:
<img width="846" alt="Screenshot 2023-08-09 at 11 35 54" src="https://github.com/3scale/porta/assets/11672286/d71dcce1-703b-477f-b651-3be70e5e99d6">

