### PR TITLE
Improve logging for billing process - add a consistent prefix

### DIFF
--- a/app/models/finance/billing_strategy.rb
+++ b/app/models/finance/billing_strategy.rb
@@ -69,6 +69,8 @@ class Finance::BillingStrategy < ApplicationRecord
   def self.daily(options = {})
     raise 'Options must be a hash' unless options.is_a?(Hash)
 
+    Rails.logger.info("Finance::BillingStrategy.daily started for options #{options}")
+
     now = options[:now] || Time.now.utc
     skip_notifications = options[:skip_notifications]
 
@@ -104,7 +106,7 @@ class Finance::BillingStrategy < ApplicationRecord
       end
     end
 
-    Rails.logger.info("Billing process finished: #{results.inspect_all_things}")
+    Rails.logger.info("Finance::BillingStrategy.daily finished for options #{options}, with results: #{results.inspect_all_things}")
 
     notify_billing_results(results) unless skip_notifications
 
@@ -229,7 +231,7 @@ class Finance::BillingStrategy < ApplicationRecord
     buyer.billable_contracts_with_trial_period_expired(now - 1.day).find_each(batch_size: 50) do |contract|
       plan_type = contract.plan.class.model_name.human.downcase
 
-      info("Billing account #{buyer.name} for #{plan_type} #{contract.plan.name} (just signed up or trial period expired)", buyer)
+      info("#{log_prefix(buyer)} for #{plan_type} #{contract.plan.id} (#{contract.plan.name}) - just signed up or trial period expired", buyer)
       contract.bill_for(Month.new(now), invoice_for(buyer, now))
     end
   end
@@ -238,8 +240,7 @@ class Finance::BillingStrategy < ApplicationRecord
   # TODO: cover it by unit tests
   #
   def bill_fixed_costs(buyer, now = Time.now.utc)
-    Rails.logger.info "Billing fixed cost of account #{buyer.inspect} at #{now}"
-    info("Billing fixed cost of account #{buyer.org_name}", buyer)
+    info("#{log_prefix(buyer)} billing fixed costs at #{now}", buyer)
     buyer.billable_contracts.find_each(batch_size: 50) do |contract|
       contract.bill_for(Month.new(now), invoice_for(buyer, now))
     end
@@ -250,7 +251,7 @@ class Finance::BillingStrategy < ApplicationRecord
   #
   def finalize_invoices_of(buyer, now = Time.now.utc)
     invoices_to_finalize_of(buyer, now).find_each(:batch_size => 20) do |invoice|
-      info("Finalizing invoice for #{buyer.org_name} for period #{invoice.period}", buyer)
+      info("#{log_prefix(buyer)} finalizing invoices for period #{invoice.period}", buyer)
       invoice.finalize!
     end
   end
@@ -259,7 +260,7 @@ class Finance::BillingStrategy < ApplicationRecord
     to_issue = self.provider.buyer_invoices.by_buyer(buyer).finalized_before(now - 1.day - 22.hours)
 
     to_issue.find_each(batch_size: 100) do |invoice|
-      info("Issuing invoice for #{buyer.org_name} for period #{invoice.period}", buyer)
+      info("#{log_prefix(buyer)} issuing invoice #{invoice.id} for period #{invoice.period}", buyer)
       invoice.issue_and_pay_if_free!
 
       # TODO: extract to overloaded method?
@@ -323,17 +324,21 @@ class Finance::BillingStrategy < ApplicationRecord
       end
 
       buyer.invoices.chargeable(now).find_each(batch_size: 50) do |invoice|
-        Rails.logger.info("Trying to charge invoice #{invoice.id}")
+        Rails.logger.info("#{log_prefix(buyer)} trying to charge invoice #{invoice.id}")
         invoice.charge!
 
       end
     else
-      Rails.logger.info("Charging not enabled for #{account.org_name} - bypassing")
+      Rails.logger.info("#{log_prefix(buyer)} charging not enabled for provider #{account.org_name} - bypassing")
     end
   end
 
   def needs_credit_card?
     charging_enabled?
+  end
+
+  def log_prefix(buyer)
+    "[billing] provider #{buyer.provider_account_id} buyer #{buyer.id}:"
   end
 
   public :needs_credit_card?

--- a/app/models/finance/postpaid_billing_strategy.rb
+++ b/app/models/finance/postpaid_billing_strategy.rb
@@ -6,7 +6,7 @@ class Finance::PostpaidBillingStrategy < Finance::BillingStrategy
   def daily(options = {})
     now = options[:now].presence || Time.now.utc
     bill_and_charge_each(options) do |buyer|
-      Rails.logger.info("Started to bill and charge buyer #{buyer.id} for provider #{buyer.provider_account_id} at #{now}")
+      Rails.logger.info("#{log_prefix(buyer)} started daily billing and charging at #{now} (postpaid)")
       bill_expired_trials(buyer, now)
 
       only_on_days(now, 1) do
@@ -19,7 +19,7 @@ class Finance::PostpaidBillingStrategy < Finance::BillingStrategy
 
       charge_invoices(buyer, now)
 
-      info("Successfully finished billing and charging of #{buyer.name}")
+      info("#{log_prefix(buyer)} successfully finished daily billing and charging (postpaid)")
     end
 
     notify_billing_finished(now) unless options[:skip_notifications] # In Sidekiq, notifications are triggered by the callback of the jobs batch
@@ -51,7 +51,7 @@ class Finance::PostpaidBillingStrategy < Finance::BillingStrategy
   # that is used to bill on: here it is the current month.
   #
   def bill_variable_costs(buyer, now = Time.now.utc)
-    info("Billing variable cost of #{buyer.org_name} at #{now}", buyer)
+    info("#{log_prefix(buyer)} billing variable costs at #{now}", buyer)
     buyer.billable_contracts.find_each(batch_size: 100) do |contract|
       contract.bill_for_variable(Month.new(now), invoice_for(buyer, now))
     end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -442,21 +442,20 @@ class Invoice < ApplicationRecord
     ensure_payable_state!
 
     unless chargeable?
-      logger.info "Not charging invoice ID #{self.id} (#{reason_cannot_charge})"
+      logger.info "Not charging invoice #{id} (buyer #{buyer_account_id}), reason: #{reason_cannot_charge}"
       cancel! unless positive?
       return
     end
 
     if buyer_account.charge!(cost, :invoice => self)
-      provider.billing_strategy.try!(:info , "Charging invoice for #{buyer.name} for period #{period}", buyer)
+      provider.billing_strategy&.info("Invoice #{id} (buyer #{buyer_account_id}) for period #{period} was charged, marking as paid", buyer)
       pay!
     else
-      logger.info("Invoice(#{self.id}) was not charged")
+      logger.info("Invoice #{id} (buyer #{buyer_account_id}) was not charged")
       false
     end
   rescue Finance::Payment::CreditCardError, ActiveMerchant::ActiveMerchantError
-    provider.billing_strategy.try!(:error, "Charging for invoice for #{buyer.name} error", buyer)
-    logger.info("Error charging invoice #{self.id}")
+    provider.billing_strategy&.error("Error when charging invoice #{id} (buyer #{buyer_account_id})", buyer)
 
     if automatic
       self.charging_retries_count += 1
@@ -465,10 +464,10 @@ class Invoice < ApplicationRecord
       # REFACTOR: Move the logic to InvoiceMessenger
       if charging_retries_count < MAX_CHARGE_RETRIES
         if unpaid?
-          logger.info("Retrying #{self.id}, unpaid")
+          logger.info("Invoice #{id} (buyer #{buyer_account_id}) remains unpaid after #{charging_retries_count} attempts, will be retried")
           save!
         else
-          logger.info("Retrying #{self.id}, marking as unpaid")
+          logger.info("Marking invoice #{id} (buyer #{buyer_account_id}) as unpaid, will be retried")
           mark_as_unpaid!
         end
 
@@ -482,7 +481,7 @@ class Invoice < ApplicationRecord
         event = Invoices::UnsuccessfullyChargedInvoiceProviderEvent.create(self)
         Rails.application.config.event_store.publish_event(event)
       else
-        logger.info("Retrying #{self.id} failed (too many retries)")
+        logger.info("Marking invoice #{id} (buyer #{buyer_account_id}) as failed (too many retries)")
         fail!
         # TODO: Decouple the notification to observer and delete the IF
         InvoiceMessenger.unsuccessfully_charged_for_buyer_final(self).deliver
@@ -501,7 +500,7 @@ class Invoice < ApplicationRecord
   def ensure_payable_state!
     return if state_events.include?(:pay)
 
-    logger.info("Invoice(#{self.id}) was not charged because the state events don't include :pay")
+    logger.info("Invoice #{id} (buyer #{buyer_account_id}) was not charged because the state events don't include :pay")
     raise InvalidInvoiceStateException.new("Invoice #{id} is not in chargeable state!")
   end
 

--- a/app/workers/billing_worker.rb
+++ b/app/workers/billing_worker.rb
@@ -61,7 +61,7 @@ class BillingWorker
   # @param [String] time
   def perform(buyer_id, provider_id, time)
     Rails.logger.info("Billing worker invoked for buyer #{buyer_id} of provider #{provider_id} at #{time}")
-    billing_results = Finance::BillingService.call!(buyer_id, provider_account_id: provider_id, now: time, skip_notifications: true)
+    billing_results = Finance::BillingService.call!(buyer_id, { provider_account_id: provider_id, now: time, skip_notifications: true })
     store_summary(buyer_id, billing_results[provider_id]) if billing_results
   end
 

--- a/app/workers/billing_worker.rb
+++ b/app/workers/billing_worker.rb
@@ -60,7 +60,7 @@ class BillingWorker
   # @param [Integer] provider_id
   # @param [String] time
   def perform(buyer_id, provider_id, time)
-    Rails.logger.info("Billing worker invoked for buyer #{buyer_id} of provider #{provider_id} at #{time}")
+    Rails.logger.info("[billing] provider #{provider_id} buyer #{buyer_id}: BillingWorker#perform invoked at #{time}")
     billing_results = Finance::BillingService.call!(buyer_id, { provider_account_id: provider_id, now: time, skip_notifications: true })
     store_summary(buyer_id, billing_results[provider_id]) if billing_results
   end


### PR DESCRIPTION
Just adding a consistent `[billing] provider #{buyer.provider_account_id} buyer #{buyer.id}:` prefix to log statements on all billing staging so we can query by that and reconstruct what happened during the process.

Also, putting the provider in front, so we can also filter out all billings for a single provider.