### PR TITLE
Do not additionally deep-symbolize-keys

### DIFF
--- a/app/lib/plan_rule_loader.rb
+++ b/app/lib/plan_rule_loader.rb
@@ -26,7 +26,7 @@ module PlanRuleLoader
   module_function
 
   def load_config
-    config = (ThreeScale.config.plan_rules.deep_symbolize_keys || {}).reverse_merge DEFAULT_RULES
+    config = (ThreeScale.config.plan_rules || {}).reverse_merge DEFAULT_RULES
     sorted_config = sort_by_rank(config)
     convert_to_hash_with_plan_rule_objects sorted_config
   end

--- a/test/unit/plan_rule_loader_test.rb
+++ b/test/unit/plan_rule_loader_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class PlanRuleLoaderTest < ActiveSupport::TestCase
   def given_plan_rules_config(config)
-    ThreeScale.config.stubs(:plan_rules).returns(config)
+    ThreeScale.config.stubs(:plan_rules).returns(HashWithIndifferentAccess.new(config))
   end
 
   class LoadErrorTest < PlanRuleLoaderTest


### PR DESCRIPTION
The tests pass: https://app.circleci.com/pipelines/github/3scale/porta?branch=THREESCALE-7405-rails-6-test

Not saying this is strictly required, but just wanted to clarify this :)

I think that even when the config shows up as having string keys, they are actually converted to `HasWithIndifferentAccess` by Rails' `config_for`, so symbol keys also work. So maybe we can clean up some more `symbolize_keys`, but not in the Rails PR.