### PR TITLE
prevent stale search data

### DIFF
--- a/features/support/sphinx.rb
+++ b/features/support/sphinx.rb
@@ -7,6 +7,7 @@ end
 
 Before('@search') do
   Sidekiq::Worker.clear_all
+  ::ThinkingSphinx::Test.clear
   ::ThinkingSphinx::Test.init
   ::ThinkingSphinx::Test.stop
   ::ThinkingSphinx::Test.autostop


### PR DESCRIPTION
Hopefully prevent issues like:
```
failed No pages match the search
Scenario: No pages match the search

Given I log in as "bob"

Message:Record IDs found by Sphinx but not by ActiveRecord : 10, 11, 12
https://freelancing-gods.com/thinking-sphinx/v5/common_issues.html#record-ids (ThinkingSphinx::Search::StaleIdsException)
/opt/app-root/src/project/vendor/bundle/ruby/2.6.0/gems/thinking-sphinx-5.5.1/lib/thinking_sphinx/middlewares/stale_id_checker.rb:38:in `raise_exception'
...
```