### PR TITLE
Fix deprecations for uniqueness validator (case-sensitivity)

### DIFF
--- a/app/lib/system_name.rb
+++ b/app/lib/system_name.rb
@@ -16,7 +16,7 @@ module SystemName
 
       return unless opts[:uniqueness_scope]
 
-      validates :system_name, uniqueness: opts[:uniqueness_scope] == true ? true : { scope: opts[:uniqueness_scope] }
+      validates :system_name, uniqueness: opts[:uniqueness_scope] == true ? { case_sensitive: true } : { case_sensitive: true, scope: opts[:uniqueness_scope] }
     end
 
     def has_system_name(opts = {})

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -88,7 +88,7 @@ class AccessToken < ApplicationRecord
   end
 
   validates :owner, :value, :name, :permission, presence: true
-  validates :value, uniqueness: { scope: [:owner_id] }, length: { maximum: 255 }
+  validates :value, uniqueness: { scope: [:owner_id], case_sensitive: true }, length: { maximum: 255 }
   validates :permission, inclusion: { in: PERMISSIONS.values }, length: { maximum: 255 }
   validates :scopes, length: { minimum: 1, maximum: 65535 }
   validate :validate_scope_exists

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -19,7 +19,7 @@ class Alert < ApplicationRecord
 
   validates :account, :timestamp, :state, presence: true
   validates :utilization, :level, :alert_id, :cinstance, presence: true
-  validates :alert_id, uniqueness: { :scope => :account_id }
+  validates :alert_id, uniqueness: { scope: :account_id, case_sensitive: true }
   validates :level, inclusion: { :in => ALERT_LEVELS }
   validates :level, numericality: { :only_integer => true }
   validates :utilization, numericality: true

--- a/app/models/authentication_provider.rb
+++ b/app/models/authentication_provider.rb
@@ -13,7 +13,7 @@ class AuthenticationProvider < ApplicationRecord
   enum account_type: {developer: 'developer', provider: 'provider'}
 
   has_system_name uniqueness_scope: [:account_id]
-  validates :kind, uniqueness: { scope: %i[account_id account_type] }, if: :developer?
+  validates :kind, uniqueness: { scope: %i[account_id account_type], case_sensitive: true }, if: :developer?
   validate  :verify_valid_kind_for_account_type
   validates :name, presence: true, length: { maximum: 255 }
   validates :identifier_key, presence: true, length: { maximum: 255 }

--- a/app/models/backend_api_config.rb
+++ b/app/models/backend_api_config.rb
@@ -17,7 +17,7 @@ class BackendApiConfig < ApplicationRecord
   has_many :backend_api_metrics, through: :backend_api, source: :metrics
 
   validates :service_id, :backend_api_id, presence: true
-  validates :backend_api_id, uniqueness: { scope: :service_id }
+  validates :backend_api_id, uniqueness: { scope: :service_id, case_sensitive: true }
   validates :path, uniqueness: { scope: :service_id, case_sensitive: false, message: "This path is already taken. Specify a different path." }
   validates :path, length: { in: 1..255, allow_nil: false }, path: true
 

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -101,11 +101,11 @@ class Cinstance < Contract
 
   validate :plan_is_unique, if: :validate_plan_is_unique?
   validate :application_id_is_unique, if: :validate_application_id_is_unique?
-  validates :application_id, uniqueness: { scope: [:service_id] }, unless: :validate_application_id_is_unique?
+  validates :application_id, uniqueness: { scope: [:service_id], case_sensitive: true }, unless: :validate_application_id_is_unique?
 
   validate :user_key_is_unique, unless: :provider_can_duplicate_user_key?
 
-  validates :user_key, uniqueness: { scope: [:service_id] }, if: :provider_can_duplicate_user_key?
+  validates :user_key, uniqueness: { scope: [:service_id], case_sensitive: true }, if: :provider_can_duplicate_user_key?
 
   validate :same_service, on: :update, if: :plan_id_changed?
 

--- a/app/models/cms/builtin/legal_term.rb
+++ b/app/models/cms/builtin/legal_term.rb
@@ -5,7 +5,7 @@ class CMS::Builtin::LegalTerm < CMS::Builtin::Partial
   NEW_APPLICATION_SYSTEM_NAME = 'new_application_licence'
   
   validates :published, presence: true
-  validates :title, uniqueness: { :scope => [:provider_id] }
+  validates :title, uniqueness: { :scope => [:provider_id], case_sensitive: true }
 
   def title
     I18n.t("builtin_legal_terms.#{system_name}.title")

--- a/app/models/cms/email_template.rb
+++ b/app/models/cms/email_template.rb
@@ -4,7 +4,7 @@ class CMS::EmailTemplate < CMS::Template
 
   validates :system_name, presence: true
   validates :current, presence: true
-  validates :system_name, uniqueness: { scope: %i[provider_id], allow_blank: true }
+  validates :system_name, uniqueness: { scope: %i[provider_id], allow_blank: true, case_sensitive: true }
   validate :headers_formats
 
   class_attribute :templates_path

--- a/app/models/cms/file.rb
+++ b/app/models/cms/file.rb
@@ -29,7 +29,7 @@ class CMS::File < ApplicationRecord
   validates_attachment :attachment, presence: true
   do_not_validate_attachment_file_type :attachment
 
-  validates :path, uniqueness: { :scope => :provider_id }, length: { maximum: 255 }
+  validates :path, uniqueness: { scope: :provider_id, case_sensitive: true }, length: { maximum: 255 }
   validates :attachment_content_type, :attachment_file_name, :random_secret, :name,
             length: { maximum: 255 }
 

--- a/app/models/cms/group.rb
+++ b/app/models/cms/group.rb
@@ -8,7 +8,7 @@ class CMS::Group < ApplicationRecord
   belongs_to :provider, :class_name => "Account"
 
   validates :name, :provider, presence: true, length: { maximum: 255 }
-  validates :name, uniqueness: { scope: [:provider_id] }
+  validates :name, uniqueness: { scope: [:provider_id], case_sensitive: true }
 
   has_many :group_sections, :class_name => 'CMS::GroupSection'
   has_many :sections, :class_name => 'CMS::Section', :through => :group_sections

--- a/app/models/cms/redirect.rb
+++ b/app/models/cms/redirect.rb
@@ -4,7 +4,7 @@ class CMS::Redirect < ApplicationRecord
   belongs_to :provider, :class_name => 'Account'
 
   validates :source, :target, :provider, presence: true
-  validates :source, uniqueness: { scope: [:provider_id] }, length: { maximum: 255 }
+  validates :source, uniqueness: { scope: [:provider_id], case_sensitive: true }, length: { maximum: 255 }
   validates :target, length: { maximum: 255 }
 
   attr_accessible :source, :target

--- a/app/models/cms/section.rb
+++ b/app/models/cms/section.rb
@@ -28,8 +28,8 @@ class CMS::Section < ApplicationRecord
   validates :title, :system_name, :provider, presence: true
   validates :parent_id, presence: { :unless => :root? }
 
-  validates :title, uniqueness: { :scope => [:provider_id, :parent_id] }
-  validates :system_name, uniqueness: { :scope => [:provider_id] }, length: { maximum: 255 }
+  validates :title, uniqueness: { scope: [:provider_id, :parent_id], case_sensitive: true }
+  validates :system_name, uniqueness: { scope: [:provider_id], case_sensitive: true }, length: { maximum: 255 }
   validates :partial_path, :title, :type, length: { maximum: 255 }
 
   before_validation :set_system_name , on: %i[create update]

--- a/app/models/cms/template.rb
+++ b/app/models/cms/template.rb
@@ -22,7 +22,7 @@ class CMS::Template < ApplicationRecord
   has_many :versions, as: :template
 
   validates :provider, presence: true
-  validates :system_name, uniqueness: { :scope => [:provider_id, :type], :allow_blank => true },
+  validates :system_name, uniqueness: { scope: [:provider_id, :type], allow_blank: true, case_sensitive: true },
             format: { :with => /\A\w[\w\-\/_]+\z/, :allow_blank => true }, length: { maximum: 255 }
   validates :handler, inclusion: { in: CMS::Handler.available, allow_blank: false, allow_nil: true },
             length: { maximum: 255 }

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,6 +1,6 @@
 class Country < ApplicationRecord
   validates :name, :code, presence: true
-  validates :code, uniqueness: true
+  validates :code, uniqueness: { case_sensitive: true }
   validates :name, :code, :currency, length: {maximum: 255}
 
   # Cuba, Iran, North Korea, Sudan, Syria

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -25,7 +25,7 @@ class Feature < ApplicationRecord
 
   attr_protected :featurable_id, :featurable_type, :tenant_id, :audit_ids
 
-  validates :system_name, uniqueness: { :scope => [:featurable_id, :featurable_type] }
+  validates :system_name, uniqueness: { scope: [:featurable_id, :featurable_type], case_sensitive: true }
   validates :system_name, :name, length: { maximum: 255 }
 
   def hide!

--- a/app/models/fields_definition.rb
+++ b/app/models/fields_definition.rb
@@ -33,7 +33,7 @@ class FieldsDefinition < ApplicationRecord
 
   validates :label, :target, :name, presence: true, length: { maximum: 255 }
   validates :name, format: { :with =>/\A[A-Za-z][A-Za-z\d_-]*\z/, :message => "Name should start with letters, and can contain numbers, - and _" }
-  validates :name, uniqueness: { :scope => [:account_id, :target] }
+  validates :name, uniqueness: { scope: [:account_id, :target], case_sensitive: true }
   validates :name, :exclusion => Fields::ExtraField::InputField.excludes
   validates :choices, :hint, length: { maximum: 65535 }
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -6,7 +6,7 @@ class Invitation < ApplicationRecord
   validates :account, presence: true
   validates :email, presence: true
   validate :email_is_not_taken
-  validates :email, uniqueness: { :scope => :account_id, :message => "This invitation has already been sent." } # Do you want to resend it?"
+  validates :email, uniqueness: { scope: :account_id, case_sensitive: true, message: "This invitation has already been sent." } # Do you want to resend it?"
 
   #OPTIMIZE: use the same format validations in user, account and invitation, add TESTS!
   validates :email, length: { :within => 6..100, :allow_blank => true } #r@a.wk

--- a/app/models/member_permission.rb
+++ b/app/models/member_permission.rb
@@ -2,7 +2,7 @@ class MemberPermission < ApplicationRecord
   include Symbolize
   belongs_to :user, touch: true
   validates :admin_section, inclusion: { :in => ->(_record) { AdminSection.sections } }
-  validates :admin_section , uniqueness: { :scope => :user_id, if: Proc.new { |mp| mp.user_id } }
+  validates :admin_section , uniqueness: { scope: :user_id, case_sensitive: true, if: Proc.new { |mp| mp.user_id } }
   serialize :service_ids, JSON
 
   symbolize :admin_section

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -28,7 +28,7 @@ class Metric < ApplicationRecord
 
   attr_protected :service_id, :parent_id, :tenant_id, :audit_ids
   validates :unit, presence: true, unless: :child?
-  validates :friendly_name, uniqueness: {scope: %i[owner_type owner_id]}, presence: true
+  validates :friendly_name, uniqueness: { scope: %i[owner_type owner_id], case_sensitive: true }, presence: true
   validates :system_name, :unit, :friendly_name, :owner_type, length: { maximum: 255 }
   validates :owner, presence: true
 

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -7,7 +7,7 @@ class PaymentIntent < ApplicationRecord
 
   validates :invoice, :reference, :state, presence: true
   validates :reference, :state, length: { maximum: 255 }
-  validates :reference, uniqueness: true
+  validates :reference, uniqueness: { case_sensitive: true }
 
   scope :latest, ->(count = 1) { reorder(created_at: :desc, id: :desc).limit(count) }
   scope :pending, ->() { where.not(state: SUCCEEDED_STATES) }

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -5,7 +5,7 @@ class Policy < ApplicationRecord
 
   belongs_to :account, inverse_of: :policies
 
-  validates :version, uniqueness: { scope: %i[account_id name] }
+  validates :version, uniqueness: { scope: %i[account_id name], case_sensitive: true }
   validates :name, :version, :account_id, :schema, presence: true
   validate :belongs_to_a_tenant
   validate :validate_schema_specification
@@ -26,7 +26,7 @@ class Policy < ApplicationRecord
   end
 
   before_validation :set_identifier
-  validates :identifier, uniqueness: { scope: :account_id }
+  validates :identifier, uniqueness: { scope: :account_id, case_sensitive: true }
   validates :name, :version, length: { maximum: 255 }
 
   def self.find_by_id_or_name_version(id_or_name_version)

--- a/app/models/referrer_filter.rb
+++ b/app/models/referrer_filter.rb
@@ -7,7 +7,7 @@ class ReferrerFilter < ApplicationRecord
 
   validates :application, presence: true
   validates :value, presence: true
-  validates :value, uniqueness: { scope: [:application_id] }
+  validates :value, uniqueness: { scope: [:application_id], case_sensitive: true }
   validates :value, format: { with: /\A[a-zA-Z0-9*.-]+\z/ }, length: { maximum: 255 }
 
   validate :keys_limit_reached

--- a/app/models/sso_authorization.rb
+++ b/app/models/sso_authorization.rb
@@ -6,7 +6,7 @@ class SSOAuthorization < ApplicationRecord
   has_many :user_sessions, dependent: :destroy
 
   validates :uid, :authentication_provider, :user, presence: true
-  validates :uid, uniqueness: { scope: :authentication_provider_id }
+  validates :uid, uniqueness: { scope: :authentication_provider_id, case_sensitive: true }
   validates :uid, length: { maximum: 255 }
 
   scope :newest, -> { order(updated_at: :desc).first }

--- a/app/models/system_operation.rb
+++ b/app/models/system_operation.rb
@@ -2,7 +2,7 @@ class SystemOperation < ApplicationRecord
   has_many :messages
   has_many :mail_dispatch_rules, :dependent => :destroy
 
-  validates :ref, uniqueness: true
+  validates :ref, uniqueness: { case_sensitive: true }
   validates :ref, :name, length: {maximum: 255}
 
   DEFAULTS = {'user_signup'            => 'New user signup',

--- a/app/models/topic_category.rb
+++ b/app/models/topic_category.rb
@@ -6,7 +6,7 @@ class TopicCategory < ApplicationRecord
   attr_protected :forum_id, :tenant_id
 
   validates :name, presence: true, length: {maximum: 255}
-  validates :name, uniqueness: { :scope => :forum_id }
+  validates :name, uniqueness: { scope: :forum_id, case_sensitive: true }
 
   default_scope -> { order('name ASC') }
   #scope :with_topics, :include => :topics, :conditions => 'topics.id IS NOT NULL'

--- a/app/models/usage_limit.rb
+++ b/app/models/usage_limit.rb
@@ -29,7 +29,7 @@ class UsageLimit < ApplicationRecord
   validates :metric, presence: true #, :plan #plan.customize method hinders this validation
   validates :plan, presence: true
 
-  validates :period, uniqueness: {scope: [:metric_id, :plan_id]}
+  validates :period, uniqueness: { scope: %i[metric_id plan_id], case_sensitive: true}
 
   before_save :set_value_default_value
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,7 +117,7 @@ class User < ApplicationRecord
 
   validate :email_is_unique
   validate :username_is_unique
-  validates :open_id, uniqueness: true, allow_nil: true
+  validates :open_id, uniqueness: { case_sensitive: true }, allow_nil: true
 
   attr_accessible :title, :username, :email, :first_name, :last_name, :password,
                   :password_confirmation, :conditions, :cas_identifier, :open_id,

--- a/app/models/user_topic.rb
+++ b/app/models/user_topic.rb
@@ -8,5 +8,5 @@ class UserTopic < ApplicationRecord
   validates :user, presence: true
   validates :topic, presence: true
 
-  validates :user_id, uniqueness: { :scope => :topic_id }
+  validates :user_id, uniqueness: { scope: :topic_id, case_sensitive: true }
 end

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -10,7 +10,7 @@ class WebHook < ApplicationRecord
 
   #TODO: limit association only to providers?
   #TODO validate url as url?
-  validates :account_id, uniqueness: true
+  validates :account_id, uniqueness: { case_sensitive: true }
 
   class << self
     delegate :perform_deliveries, :sanitized_url, :to => :configuration

--- a/config/initializers/tags.rb
+++ b/config/initializers/tags.rb
@@ -9,7 +9,7 @@ ActiveSupport.on_load(:active_record) do
     clear_validators!
 
     validates :account_id, presence: true
-    validates :name, presence: true, uniqueness: { scope: :account_id }, length: { maximum: 255 }
+    validates :name, presence: true, uniqueness: { scope: :account_id, case_sensitive: true }, length: { maximum: 255 }
 
     belongs_to :account
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since upgrading to Rails 6 (in Staging so far), we've been seeing deprecation warning with the following text:

```
DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :attribute_name attribute in ModelClass model, pass `case_sensitive: true` option explicitly to the uniqueness validator.
```

This is only observed on SaaS database, because its tables use case-insensitive collation. In on-premises (or locally) the warning is not shown, because there is no mismatch between the table collation and the validator behavior.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

Make sure you don't see the deprecation warnings in the logs or in BugSnag after deployment

**Special notes for your reviewer**:
