### PR TITLE
Upgrade database cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -224,7 +224,7 @@ group :test do
   gem 'mocha', '~> 1.1.0', require: 'mocha/setup'
 
   # proxy tests
-  gem 'database_cleaner', '~> 1.7', require: false
+  gem 'database_cleaner', require: false
   gem 'thin', require: false
 
   # performance tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,7 +312,12 @@ GEM
       cucumber-messages (~> 17.0, >= 17.0.1)
     daemons (1.3.1)
     dalli (3.2.4)
-    database_cleaner (1.7.0)
+    database_cleaner (2.0.2)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.1.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     diffy (3.2.1)
@@ -944,7 +949,7 @@ DEPENDENCIES
   cucumber (~> 7.0)
   cucumber-rails (~> 2.4.0)
   dalli
-  database_cleaner (~> 1.7)
+  database_cleaner
   developer_portal!
   diff-lcs (~> 1.2)
   dotenv-rails (~> 2.7)

--- a/test/test_helpers/transactional_fixtures.rb
+++ b/test/test_helpers/transactional_fixtures.rb
@@ -7,7 +7,7 @@ module TestHelpers
     included do
       class_attribute :database_cleaner_strategy
       class_attribute :database_cleaner_clean_with_strategy
-      self.database_cleaner_clean_with_strategy = self.database_cleaner_strategy = DatabaseCleaner::NullStrategy
+      self.database_cleaner_clean_with_strategy = self.database_cleaner_strategy = DatabaseCleaner::NullStrategy.new
     end
 
     class_methods do
@@ -19,11 +19,10 @@ module TestHelpers
     end
 
     def before_setup
-      case database_cleaner_clean_with_strategy
-      when Class
-        database_cleaner_clean_with_strategy.clean
-      when Symbol
+      if database_cleaner_clean_with_strategy.is_a? Symbol
         DatabaseCleaner.clean_with(database_cleaner_clean_with_strategy)
+      else
+        database_cleaner_clean_with_strategy.clean
       end
 
       DatabaseCleaner.strategy = database_cleaner_strategy


### PR DESCRIPTION
**What this PR does / why we need it**:

I saw this annoying log all the time when running cucumbers locally:

```
Code:
  * features/support/env.rb
Removing :environment prerequisite from db:create
rails aborted!
ActiveRecord::NoEnvironmentInSchemaError: 

Environment data not found in the schema. To resolve this issue, run: 

        rails db:environment:set RAILS_ENV=test

bin/rails:4:in `<main>'
Tasks: TOP => db:test:load => db:test:purge => db:check_protected_environments
(See full trace by running task with --trace)
```

And found this: https://stackoverflow.com/questions/58923245/environment-data-not-found-in-the-schema-with-database-cleaner-when-calling-c

It says that this issue is happening in the version of `database_cleaner` that we were using.

I decided to risk it and upgrade to the latest version. There are some breaking changes when jumping to the next major version, but let's see if it still works.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 


**Special notes for your reviewer**:
