### PR TITLE
fix double billing of providers

### DIFF
--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -68,7 +68,7 @@ module Account::ProviderMethods
       end
     end
 
-    has_many :buyer_accounts, ->(this_account) { where.not(id: this_account.id) }, class_name: 'Account', foreign_key: 'provider_account_id', dependent: :destroy, inverse_of: :provider_account do
+    has_many :buyer_accounts, ->(provider) { where.not(id: provider.id) }, class_name: 'Account', foreign_key: 'provider_account_id', dependent: :destroy, inverse_of: :provider_account do
       def latest
         order(created_at: :desc).includes([:admin_users]).limit(5)
       end

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -68,7 +68,7 @@ module Account::ProviderMethods
       end
     end
 
-    has_many :buyer_accounts, class_name: 'Account', foreign_key: 'provider_account_id', dependent: :destroy, inverse_of: :provider_account do
+    has_many :buyer_accounts, -> { where(Account.arel_table[:id].not_eq(Account.arel_table[:provider_account_id])) }, class_name: 'Account', foreign_key: 'provider_account_id', dependent: :destroy, inverse_of: :provider_account do
       def latest
         order(created_at: :desc).includes([:admin_users]).limit(5)
       end

--- a/app/models/account/provider_methods.rb
+++ b/app/models/account/provider_methods.rb
@@ -68,7 +68,7 @@ module Account::ProviderMethods
       end
     end
 
-    has_many :buyer_accounts, -> { where(Account.arel_table[:id].not_eq(Account.arel_table[:provider_account_id])) }, class_name: 'Account', foreign_key: 'provider_account_id', dependent: :destroy, inverse_of: :provider_account do
+    has_many :buyer_accounts, ->(this_account) { where.not(id: this_account.id) }, class_name: 'Account', foreign_key: 'provider_account_id', dependent: :destroy, inverse_of: :provider_account do
       def latest
         order(created_at: :desc).includes([:admin_users]).limit(5)
       end

--- a/app/models/finance/billing_strategy.rb
+++ b/app/models/finance/billing_strategy.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class Finance::BillingStrategy < ApplicationRecord
-  class BillingError < StandardError
-  end
-
   module NonAuditedColumns
     def non_audited_columns
       super - [inheritance_column]
@@ -355,7 +352,7 @@ class Finance::BillingStrategy < ApplicationRecord
     if provider.nil?
 
       message = "WARNING: tried to use billing strategy #{self.id} which has no account"
-      exception = BillingError.new message
+      exception = ::Finance::BillingError.new message
       System::ErrorReporting.report_error(exception, :error_message => message, :error_class => 'InvalidData')
       return
     end

--- a/app/services/finance/billing_error.rb
+++ b/app/services/finance/billing_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Finance
+  class BillingError < StandardError; end
+end

--- a/app/services/finance/billing_service.rb
+++ b/app/services/finance/billing_service.rb
@@ -57,9 +57,9 @@ module Finance
     private
 
     def billing_options
-      options = { only: [provider_account_id], now: now, skip_notifications: skip_notifications }
-      raise SpuriousBillingError, "whole provider will be billed when buyer id is the same: #{account_id}" if provider_account_id == account_id
+      raise SpuriousBillingError, "provider and buyer ids are the same: #{account_id}" if provider_account_id == account_id
 
+      options = { only: [provider_account_id], now: now, skip_notifications: skip_notifications }
       options[:buyer_ids] = [account_id]
       options
     end

--- a/app/services/finance/billing_service.rb
+++ b/app/services/finance/billing_service.rb
@@ -34,7 +34,7 @@ module Finance
     end
 
     def call
-      Finance::BillingStrategy.daily(validate_options(billing_options))
+      Finance::BillingStrategy.daily(billing_options)
     end
 
     def notify_billing_finished(_status, billing_results)
@@ -58,15 +58,10 @@ module Finance
 
     def billing_options
       options = { only: [provider_account_id], now: now, skip_notifications: skip_notifications }
-      options[:buyer_ids] = [account_id] if provider_account_id != account_id
-      options
-    end
+      raise SpuriousBillingError, "whole provider will be billed when buyer id is the same: #{account_id}" if provider_account_id == account_id
 
-    def validate_options(billing_options)
-      unless billing_options[:only].presence&.size == 1 && billing_options[:buyer_ids].presence&.size == 1
-        raise SpuriousBillingError, "Expected to bill individual buyers separately but got providers: #{billing_options[:only].inspect}, buyers: #{billing_options[:buyer_ids].inspect}"
-      end
-      billing_options
+      options[:buyer_ids] = [account_id]
+      options
     end
 
     def with_lock

--- a/app/services/finance/lock_billing_error.rb
+++ b/app/services/finance/lock_billing_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Finance
+  class LockBillingError < BillingError; end
+end

--- a/app/services/finance/spurious_billing_error.rb
+++ b/app/services/finance/spurious_billing_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Finance
+  class SpuriousBillingError < BillingError; end
+end

--- a/app/workers/billing_worker.rb
+++ b/app/workers/billing_worker.rb
@@ -45,6 +45,8 @@ class BillingWorker
   end
 
   def self.enqueue_for_buyer(buyer, billing_date)
+    return if buyer.id == buyer.provider_account_id # this should filter out master and any broken accounts
+
     time = billing_date.to_s(:iso8601)
     perform_async(buyer.id, buyer.provider_account_id, time)
   end

--- a/app/workers/billing_worker.rb
+++ b/app/workers/billing_worker.rb
@@ -45,7 +45,12 @@ class BillingWorker
   end
 
   def self.enqueue_for_buyer(buyer, billing_date)
-    return if buyer.id == buyer.provider_account_id # this should filter out master and any broken accounts
+    if buyer.id == buyer.provider_account_id
+      System::ErrorReporting.report_error(ArgumentError.new("invalid buyer #{buyer.id}, has self as provider"),
+                                          buyer_id: buyer.id,
+                                          billing_date: billing_date)
+      return
+    end
 
     time = billing_date.to_s(:iso8601)
     perform_async(buyer.id, buyer.provider_account_id, time)

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -72,11 +72,9 @@ class AccountTest < ActiveSupport::TestCase
     master = master_account
     buyer = FactoryBot.create(:simple_buyer, provider_account: master)
 
-    assert_includes master.buyer_account_ids, buyer.id
-    assert_includes master.buyer_account_ids, master.id
-
-    assert_includes master.buyer_accounts.not_master.ids, buyer.id
-    assert_not_includes master.buyer_accounts.not_master.ids, master.id
+    assert_includes Account.all.ids, master.id
+    assert_includes Account.all.not_master.ids, buyer.id
+    assert_not_includes Account.all.not_master.ids, master.id
   end
 
   test 'provider but not master' do

--- a/test/unit/finance/billing_strategy_test.rb
+++ b/test/unit/finance/billing_strategy_test.rb
@@ -269,6 +269,15 @@ class Finance::BillingStrategyTest < ActiveSupport::TestCase
     @bs.notify_billing_results(results)
   end
 
+  test 'gracefully reports missing provider account' do
+    @bs.expects(:provider).returns(nil)
+    System::ErrorReporting.expects(:report_error).with do |exception, _parameters|
+      exception.is_a? Finance::BillingError
+    end
+
+    @bs.__send__ :bill_and_charge_each, {}
+  end
+
   class DailyBillingTest < ActiveSupport::TestCase
     setup do
       @providers = FactoryBot.create_list(:provider_with_billing, 3)

--- a/test/unit/provider_test.rb
+++ b/test/unit/provider_test.rb
@@ -11,6 +11,12 @@ class ProviderTest < ActiveSupport::TestCase
     assert_equal master_account, Provider.find(master_account.id)
   end
 
+  test 'should never return self as a buyer account' do
+    assert_equal master_account, master_account.provider_account
+
+    assert_not_includes master_account.buyer_accounts, master_account
+  end
+
   test 'publishes domain events when changed' do
     provider = FactoryBot.create(:simple_provider)
 

--- a/test/unit/services/finance/billing_service_test.rb
+++ b/test/unit/services/finance/billing_service_test.rb
@@ -41,7 +41,7 @@ class Finance::BillingServiceTest < ActionDispatch::IntegrationTest
     now = Time.utc(2018, 1, 16, 8)
     Finance::BillingStrategy.expects(:daily).raises RuntimeError, 'random failure'
     assert_raises RuntimeError do
-      Finance::BillingService.call!(@provider.id, now: now, provider_account_id: master_account.id)
+      Finance::BillingService.call!(@provider.id, { now: now, provider_account_id: master_account.id })
     end
     Finance::BillingService.any_instance.expects(:report_error).with { |error| error.is_a? Finance::LockBillingError }
     Finance::BillingService.call!(@provider.id, { now: now, provider_account_id: master_account.id })

--- a/test/unit/services/finance/billing_service_test.rb
+++ b/test/unit/services/finance/billing_service_test.rb
@@ -44,7 +44,7 @@ class Finance::BillingServiceTest < ActionDispatch::IntegrationTest
       Finance::BillingService.call!(@provider.id, now: now, provider_account_id: master_account.id)
     end
     Finance::BillingService.any_instance.expects(:report_error).with { |error| error.is_a? Finance::LockBillingError }
-    Finance::BillingService.call!(@provider.id, now: now, provider_account_id: master_account.id)
+    Finance::BillingService.call!(@provider.id, { now: now, provider_account_id: master_account.id })
   end
 
   # WARNING: flakiness here means a bug

--- a/test/unit/services/finance/billing_service_test.rb
+++ b/test/unit/services/finance/billing_service_test.rb
@@ -162,7 +162,7 @@ class Finance::BillingServiceTest < ActionDispatch::IntegrationTest
   test 'can run without lock' do
     now = '2018-01-16 08:00:00 UTC'
     Finance::BillingStrategy.expects(:daily).returns(mock_billing_success(now, @provider)).twice
-    Finance::BillingService.call(@provider.id, now: now, provider_account_id: master_account.id)
-    Finance::BillingService.call(@provider.id, now: now, provider_account_id: master_account.id)
+    Finance::BillingService.call(@provider.id, { now: now, provider_account_id: master_account.id })
+    Finance::BillingService.call(@provider.id, { now: now, provider_account_id: master_account.id })
   end
 end

--- a/test/unit/services/finance/billing_service_test.rb
+++ b/test/unit/services/finance/billing_service_test.rb
@@ -31,7 +31,6 @@ class Finance::BillingServiceTest < ActionDispatch::IntegrationTest
   test 'does not trigger billing without a buyer' do
     Sidekiq::Testing.inline! do
       now = Time.utc(2018, 1, 16, 8)
-      billing_options = { only: [@provider.id], now: now, skip_notifications: true }
       Finance::BillingStrategy.expects(:daily).never
       Finance::BillingService.call!(@provider.id, now: now, skip_notifications: true)
     end

--- a/test/workers/billing_worker_test.rb
+++ b/test/workers/billing_worker_test.rb
@@ -68,6 +68,7 @@ class BillingWorkerTest < ActiveSupport::TestCase
   test 'does not enqueue master as a buyer' do
     assert_equal master_account.id, master_account.provider_account_id
 
+    System::ErrorReporting.expects(:report_error).with { |*args| args[0].is_a?(ArgumentError) }
     BillingWorker.enqueue_for_buyer(master_account, Time.zone.now)
     assert_empty BillingWorker.jobs
 

--- a/test/workers/billing_worker_test.rb
+++ b/test/workers/billing_worker_test.rb
@@ -75,8 +75,7 @@ class BillingWorkerTest < ActiveSupport::TestCase
     BillingWorker.enqueue(master_account, Time.zone.now)
     assert_equal 1, BillingWorker.jobs.size
 
-    provider_id = BillingWorker.jobs.first["args"][1]
-    buyer_id = BillingWorker.jobs.first["args"][0]
+    buyer_id, provider_id = BillingWorker.jobs.first["args"]
 
     assert_equal master_account.id, provider_id
     assert_equal @provider.id, buyer_id


### PR DESCRIPTION
The main fix is adding a scope to the `buyer_accounts` association that prevents returning self as a buyer. The changes in `BillingWorker::enqueue_for_buyer`, `BillingService` and `BillingStrategy` are extra safety layers.

<del>The main fix is in `BillingWorker::enqueue_for_buyer`. The changes in
`BillingService` and `BillingStrategy` are extra safety layers.</del>

And of course some tests.