### PR TITLE
🦋 Use EmptyState for Policies errors

### DIFF
--- a/app/views/api/integrations/apicast/shared/_policies.html.slim
+++ b/app/views/api/integrations/apicast/shared/_policies.html.slim
@@ -1,9 +1,0 @@
-= f.toggled_inputs 'policies', cookie_name: 'policies-rules', legend: "Policies", id: "policies-container" do
-  - if @error.nil?
-    div#policies data-service-id=@service.id data-registry=@registry_policies.to_json data-chain=@proxy.policies_config.to_json
-    = javascript_packs_with_chunks_tag 'policies'
-  - else
-    div
-      h3 A valid APIcast Policies endpoint must be provided
-      p = @error.message
-

--- a/app/views/api/policies/edit.html.slim
+++ b/app/views/api/policies/edit.html.slim
@@ -1,7 +1,22 @@
 - content_for :page_header_title, 'Policies'
 
-= semantic_form_for @proxy, url: admin_service_policies_path(@service) do |f|
-  = render '/api/integrations/apicast/shared/policies', f: f
-  = f.actions do
-    = f.commit_button t('formtastic.actions.policies.update'), button_html: {class: 'update', name: 'update', value: '1',
-      id: 'policies-button-sav', title: 'Update Policies', disabled: (@error ? true : nil) }
+- if @error.present?
+  div class="pf-c-empty-state pf-m-lg"
+    div class="pf-c-empty-state__content"
+      i class="fas fa-exclamation-circle pf-c-empty-state__icon" aria-hidden="true"
+
+      h1 class="pf-c-title pf-m-lg" A valid APIcast Policies endpoint must be provided
+      div class="pf-c-empty-state__body"
+        = @error.message
+
+- else
+  - content_for :javascripts do
+    = javascript_packs_with_chunks_tag 'policies'
+
+  = semantic_form_for @proxy, url: admin_service_policies_path(@service) do |f|
+    = f.toggled_inputs 'policies', cookie_name: 'policies-rules', legend: "Policies", id: "policies-container" do
+      div#policies data-service-id=@service.id data-registry=@registry_policies.to_json data-chain=@proxy.policies_config.to_json
+
+    = f.actions do
+      = f.commit_button t('formtastic.actions.policies.update'), button_html: {class: 'update', name: 'update', value: '1',
+        id: 'policies-button-sav', title: 'Update Policies', disabled: (@error ? true : nil) }


### PR DESCRIPTION
[THREESCALE-10051: Render Policies errors using an Empty State](https://issues.redhat.com/browse/THREESCALE-10051)

Before:
<img src="https://github.com/3scale/porta/assets/11672286/f95c5b73-f7eb-4450-82d1-f728b66604c8" width="250">

After:
<img src="https://github.com/3scale/porta/assets/11672286/964e3414-57ef-42ef-aac8-c6a4cac06dd5" width="250">

