### PR TITLE
🦋 Replace `react-sortable-hoc` with Patternfly's `DragDrop`

### DIFF
--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -10,7 +10,8 @@ input[type='number'],
 textarea,
 select,
 form.button-to button:not(.pf-c-button),
-form.formtastic:not(.pf-c-form) button:not(.pf-c-button, .btn-add, .btn-danger),
+form.formtastic:not(.pf-c-form) button:not(.pf-c-button, .btn-add, .btn-danger,
+  .pf-c-data-list__item-draggable-button),
 form.formtastic:not(.pf-c-form) textarea,
 form.formtastic:not(.pf-c-form) fieldset.inputs input[type='text'],
 form.formtastic:not(.pf-c-form) fieldset.inputs input[type='number'],
@@ -62,7 +63,8 @@ textarea {
 }
 
 // TODO: where is this applied and why isn't it wrapper around form?
-button:not(.pf-c-button, .pf-c-nav__link, .pf-c-dropdown__menu-item, .pf-c-select__menu-item) {
+button:not(.pf-c-button, .pf-c-nav__link, .pf-c-dropdown__menu-item, .pf-c-select__menu-item,
+  .pf-c-data-list__item-draggable-button) {
   min-width: line-height-times(2);
   width: auto;
 }

--- a/app/javascript/src/Policies/components/PolicyChain.tsx
+++ b/app/javascript/src/Policies/components/PolicyChain.tsx
@@ -1,15 +1,22 @@
 import {
-  SortableContainer,
-  SortableElement,
-  SortableHandle,
-  arrayMove
-} from 'react-sortable-hoc'
+  DragDrop,
+  Droppable,
+  DataList,
+  Draggable,
+  DataListItem,
+  DataListItemRow,
+  DataListControl,
+  DataListDragButton,
+  DataListItemCells,
+  DataListCell
+} from '@patternfly/react-core'
 
-import { PolicyTile } from 'Policies/components/PolicyTile'
 import { HeaderButton } from 'Policies/components/HeaderButton'
+import { PolicyTile } from 'Policies/components/PolicyTile'
 
-import type { SortEndHandler } from 'react-sortable-hoc'
-import type { ChainPolicy, ThunkAction } from 'Policies/types'
+import type { DraggableItemPosition } from '@patternfly/react-core'
+import type { ChainPolicy } from 'Policies/types/Policies'
+import type { ThunkAction } from 'Policies/types/Actions'
 import type { SortPolicyChainAction } from 'Policies/actions/PolicyChain'
 
 interface Props {
@@ -21,52 +28,29 @@ interface Props {
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention -- This is adhoc componnet
-const DragHandle = SortableHandle(() => <div className="Policy-sortHandle"><i className="fa fa-sort" /></div>)
-
-interface SortableItemProps {
-  value: ChainPolicy;
-  editPolicy: Props['actions']['editPolicy'];
-  index: number;
-}
-
-// eslint-disable-next-line @typescript-eslint/naming-convention -- TODO: remove this extra component.
-const SortableItem = SortableElement<SortableItemProps>(({ value, editPolicy, index }: SortableItemProps) => {
-  const edit = () => editPolicy(value, index)
-  return (
-    <li className={value.enabled ? 'Policy' : 'Policy Policy--disabled'}>
-      <PolicyTile policy={value} title="Edit this Policy" onClick={edit} />
-      <DragHandle />
-    </li>
-  )
-})
-
-interface SortableListProps {
-  items: Props['chain'];
-  editPolicy: Props['actions']['editPolicy'];
-}
-
-// eslint-disable-next-line @typescript-eslint/naming-convention -- TODO: remove this extra component.
-const SortableList = SortableContainer<SortableListProps>(({ items, editPolicy }: SortableListProps) => (
-  <ul className="list-group">
-    {items.map((policy, index) => (
-      <SortableItem
-        key={policy.uuid}
-        editPolicy={editPolicy}
-        index={index}
-        value={policy}
-      />
-    ))}
-  </ul>
-))
-
 const PolicyChain: React.FunctionComponent<Props> = ({
   chain,
   actions
 }) => {
-  const onSortEnd: SortEndHandler = ({ oldIndex, newIndex }) => {
-    const sortedChain = arrayMove(chain, oldIndex, newIndex)
-    actions.sortPolicyChain(sortedChain)
+  const arrayMove = (list: ChainPolicy[], startIndex: number, endIndex: number): ChainPolicy[] => {
+    const result = [...list]
+    const [removed] = result.splice(startIndex, 1)
+    result.splice(endIndex, 0, removed)
+    return result
+  }
+
+  const onDrag = (): boolean => {
+    return true
+  }
+
+  const onDrop = (source: DraggableItemPosition, dest?: DraggableItemPosition): boolean => {
+    if (dest) {
+      const sortedChain = arrayMove(chain, source.index, dest.index)
+      actions.sortPolicyChain(sortedChain)
+      return true
+    } else {
+      return false
+    }
   }
 
   return (
@@ -77,21 +61,38 @@ const PolicyChain: React.FunctionComponent<Props> = ({
           Add policy
         </HeaderButton>
       </header>
-      <SortableList
-        useDragHandle
-        editPolicy={actions.editPolicy}
-        helperClass="Policy--sortable"
-        items={chain}
-        onSortEnd={onSortEnd}
-      />
+      <DragDrop onDrag={onDrag} onDrop={onDrop}>
+        <Droppable hasNoWrapper>
+          <DataList isCompact aria-label="Policies list">
+            {chain.map((policy, index) => (
+              <Draggable key={policy.uuid} hasNoWrapper>
+                <DataListItem>
+                  <DataListItemRow>
+                    <DataListControl>
+                      <DataListDragButton />
+                    </DataListControl>
+
+                    <DataListItemCells
+                      dataListCells={[
+                        <DataListCell key={policy.uuid}>
+                          <PolicyTile
+                            policy={policy}
+                            title="Edit this Policy"
+                            onClick={() => actions.editPolicy(policy, index)}
+                          />
+                        </DataListCell>
+                      ]}
+                    />
+                  </DataListItemRow>
+                </DataListItem>
+              </Draggable>
+            ))}
+          </DataList>
+        </Droppable>
+      </DragDrop>
     </section>
   )
 }
 
 export type { Props }
-export {
-  PolicyChain,
-  SortableList,
-  SortableItem,
-  DragHandle
-}
+export { PolicyChain }

--- a/app/javascript/src/Policies/components/PolicyChain.tsx
+++ b/app/javascript/src/Policies/components/PolicyChain.tsx
@@ -76,6 +76,7 @@ const PolicyChain: React.FunctionComponent<Props> = ({
                       dataListCells={[
                         <DataListCell key={policy.uuid}>
                           <PolicyTile
+                            isDisabled={!policy.enabled}
                             policy={policy}
                             title="Edit this Policy"
                             onClick={() => actions.editPolicy(policy, index)}

--- a/app/javascript/src/Policies/components/PolicyTile.tsx
+++ b/app/javascript/src/Policies/components/PolicyTile.tsx
@@ -1,18 +1,24 @@
 import type { RegistryPolicy, ThunkAction } from 'Policies/types'
 
 interface Props {
+  isDisabled?: boolean;
   policy: RegistryPolicy;
   title?: string;
   onClick: () => ThunkAction;
 }
 
 const PolicyTile: React.FunctionComponent<Props> = ({
+  isDisabled,
   policy,
   onClick,
   title = 'Edit this Policy'
 }) => {
   return (
-    <article className="Policy-article" title={title} onClick={onClick}>
+    <article
+      className={`Policy-article ${isDisabled ? 'Policy--disabled' : ''}`}
+      title={title}
+      onClick={onClick}
+    >
       <h3 className="Policy-name">{policy.humanName}</h3>
       <p className="Policy-version-and-summary">
         <span>

--- a/app/javascript/src/Policies/styles/policies.scss
+++ b/app/javascript/src/Policies/styles/policies.scss
@@ -187,13 +187,6 @@ $error-color: #c00;
   user-select: none;
   text-align: left;
 
-  &.Policy--disabled {
-    .Policy-name {
-      color: $disabledColor;
-      text-decoration: line-through;
-    }
-  }
-
   &-sortHandle {
     order: 4;
     cursor: move;
@@ -277,6 +270,13 @@ $error-color: #c00;
     margin: 1rem 0;
     border-bottom: 1px solid $subtleColor;
     border-top: 1px solid $subtleColor;
+  }
+}
+
+.Policy--disabled {
+  .Policy-name {
+    color: $disabledColor;
+    text-decoration: line-through;
   }
 }
 

--- a/app/javascript/src/Policies/styles/policies.scss
+++ b/app/javascript/src/Policies/styles/policies.scss
@@ -58,7 +58,6 @@ $error-color: #c00;
       align-items: baseline;
       justify-content: flex-start;
       margin-bottom: 1rem;
-      border-bottom: 1px solid $subtleColor;
     }
 
     h2 {
@@ -279,11 +278,6 @@ $error-color: #c00;
     border-bottom: 1px solid $subtleColor;
     border-top: 1px solid $subtleColor;
   }
-}
-
-.Policy--sortable {
-  background-color: $body-background;
-  z-index: 100;
 }
 
 .u-link {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "react-dom": "17.0.2",
     "react-jsonschema-form": "^1.8.0",
     "react-redux": "7.2.9",
-    "react-sortable-hoc": "2.0.0",
     "redux": "^4.0.1",
     "redux-api-middleware": "^3.0.1",
     "redux-thunk": "^2.3.0",

--- a/spec/javascripts/Policies/components/PolicyChain.spec.tsx
+++ b/spec/javascripts/Policies/components/PolicyChain.spec.tsx
@@ -1,93 +1,56 @@
 import { mount } from 'enzyme'
+import { DragDrop } from '@patternfly/react-core'
 
-import { DragHandle, PolicyChain, SortableItem, SortableList } from 'Policies/components/PolicyChain'
+import { PolicyChain } from 'Policies/components/PolicyChain'
 
-import type { ChainPolicy } from 'Policies/types'
+const policy1 = { uuid: '1', removable: true, enabled: true, name: 'cors', humanName: 'CORS', summary: 'CORS', description: ['CORS headers'], version: '1.0.0', configuration: {}, $schema: '{}' }
+const policy2 = { uuid: '2', removable: true, enabled: true, name: 'echo', humanName: 'Echo', summary: 'Echo', description: ['Echoes the request'], version: '1.0.0', configuration: {}, $schema: '{}' }
 
-const policies: ChainPolicy[] = [
-  { uuid: '1', removable: true, enabled: true, name: 'cors', humanName: 'CORS', summary: 'CORS', description: ['CORS headers'], version: '1.0.0', configuration: {}, $schema: '{}' },
-  { uuid: '2', removable: true, enabled: true, name: 'echo', humanName: 'Echo', summary: 'Echo', description: ['Echoes the request'], version: '1.0.0', configuration: {}, $schema: '{}' }
-]
-
-jest.mock('react-sortable-hoc')
-
-describe('PolicyChain', () => {
-  function setup () {
-    const props = {
-      visible: true,
-      chain: policies,
-      actions: {
-        openPolicyRegistry: jest.fn(),
-        editPolicy: jest.fn(),
-        sortPolicyChain: jest.fn()
-      }
-    }
-
-    const chainWrapper = mount(<PolicyChain {...props} />)
-
-    return {
-      policies,
-      props,
-      chainWrapper
-    }
+const defaultProps = {
+  visible: true,
+  chain: [policy1, policy2],
+  actions: {
+    openPolicyRegistry: jest.fn(),
+    editPolicy: jest.fn(),
+    sortPolicyChain: jest.fn()
   }
-  it('should render self', () => {
-    const { chainWrapper } = setup()
-    expect(chainWrapper.find('section').hasClass('PolicyChain')).toEqual(true)
-  })
+}
 
-  it('should render subcomponents', () => {
-    const { chainWrapper } = setup()
-    expect(chainWrapper.exists(SortableList)).toEqual(true)
-    expect(chainWrapper.find(SortableItem).length).toBe(2)
-  })
+beforeEach(() => {
+  jest.clearAllMocks()
 })
 
-describe('SortableList', () => {
-  function setup () {
-    const props = {
-      items: [...policies, {
-        uuid: '3',
-        removable: false,
-        enabled: false,
-        name: 'headers',
-        humanName: 'Headers',
-        summary: 'Headers summary',
-        description: ['Headers description'],
-        version: 'builtin',
-        configuration: {},
-        $schema: '{}'
-      }],
-      visible: true,
-      editPolicy: jest.fn()
-    }
+const mountWrapper = () => mount(<PolicyChain {...defaultProps} />)
 
-    const sortableListWrapper = mount(<SortableList {...props} />)
-    const firstSortableItem = sortableListWrapper.find(SortableItem).first()
+it('should render self', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.exists()).toEqual(true)
+})
 
-    return { sortableListWrapper, firstSortableItem, props }
-  }
+it('should call editPolicy when clicked', () => {
+  const wrapper = mountWrapper()
+  const { editPolicy } = defaultProps.actions
+  expect(editPolicy.mock.calls.length).toBe(0)
 
-  it('should render self correctly and subcomponents', () => {
-    const { sortableListWrapper, firstSortableItem } = setup()
-    expect(sortableListWrapper.find('ul').hasClass('list-group')).toEqual(true)
+  wrapper.find('article').at(0).simulate('click')
+  expect(editPolicy.mock.calls.length).toBe(1)
+})
 
-    expect(firstSortableItem.find('li').hasClass('Policy')).toEqual(true)
-    expect(firstSortableItem.find('.Policy-version-and-summary').text()).toBe('1.0.0 - CORS')
-    expect(firstSortableItem.exists(DragHandle)).toEqual(true)
-  })
+it('should be able to drag and drop any item', () => {
+  const wrapper = mountWrapper()
+  // @ts-expect-error - No need to pass Source
+  expect(wrapper.find(DragDrop).props().onDrag!()).toEqual(true)
+})
 
-  it('should show correctly disabled policies', () => {
-    const { sortableListWrapper } = setup()
-    const lastSortableItem = sortableListWrapper.find(SortableItem).last()
+it('should be able to rearrange the chain by drag and drop', () => {
+  const wrapper = mountWrapper()
 
-    expect(lastSortableItem.find('li').hasClass('Policy--disabled')).toEqual(true)
-  })
+  wrapper.find(DragDrop).props().onDrop!(
+    { index: 0, droppableId: 'foo' }, // source
+    { index: 1, droppableId: 'bar' } // dest
+  )
 
-  it('should call editPolicy when edit button is clicked', () => {
-    const { firstSortableItem, props } = setup()
-    expect(props.editPolicy.mock.calls.length).toBe(0)
-    firstSortableItem.find('article').simulate('click')
-    expect(props.editPolicy.mock.calls.length).toBe(1)
-  })
+  const { sortPolicyChain } = defaultProps.actions
+
+  expect(sortPolicyChain).toHaveBeenCalledWith([policy2, policy1])
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,7 +979,7 @@
     core-js-pure "^3.25.1"
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.15.3", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.15.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
   integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==
@@ -6928,7 +6928,7 @@ interpret@^1.4.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -10417,7 +10417,7 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^4.0.0"
 
-prop-types@15.8.1, prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15.8.1, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10790,15 +10790,6 @@ react-shallow-renderer@^16.13.1:
   dependencies:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
-
-react-sortable-hoc@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz#f6780d8aa4b922a21f3e754af542f032677078b7"
-  integrity sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    invariant "^2.2.4"
-    prop-types "^15.5.7"
 
 react-syntax-highlighter@^15.4.4:
   version "15.5.0"


### PR DESCRIPTION
[THREESCALE-10055: Remove dependency to react-sortable-hoc](https://issues.redhat.com/browse/THREESCALE-10055)

This PR removes a library used for the "drag and drop" functionality: `react-sortable-hoc`. This functionality is already included in Patternfly's `DragDrop` so it's become redundant.

It deleted middle-man components: `SortableList`, `SortableItem` and `DragHandle`.

It also implements Patternfly in the list by means of the component `DataList`.

Before:
<img width="1393" alt="Screenshot 2023-08-16 at 15 02 25" src="https://github.com/3scale/porta/assets/11672286/7a2240dc-7460-41de-98f4-9120d2b20a48">
<img width="1393" alt="Screenshot 2023-08-16 at 15 02 31" src="https://github.com/3scale/porta/assets/11672286/643883d3-dc7e-479b-b7d3-182ebdc9136c">
<img width="1393" alt="Screenshot 2023-08-16 at 15 02 43" src="https://github.com/3scale/porta/assets/11672286/eb71b951-eab3-436b-927a-11eb39ef9527">


After:
<img width="1507" alt="Screenshot 2023-08-17 at 10 17 40" src="https://github.com/3scale/porta/assets/11672286/74802df3-4856-4114-8fc4-54cb8300b57a">
<img width="1393" alt="Screenshot 2023-08-16 at 14 28 22" src="https://github.com/3scale/porta/assets/11672286/41dc6f62-35d4-4548-854f-a4c2a6fb9855">
<img width="1393" alt="Screenshot 2023-08-16 at 14 28 29" src="https://github.com/3scale/porta/assets/11672286/db54a43f-39d7-441e-a661-7ad1ac488e9f">
