### PR TITLE
THREESCALE-10067: Fix exception when creating app with empty data

### DIFF
--- a/app/controllers/api/plans_base_controller.rb
+++ b/app/controllers/api/plans_base_controller.rb
@@ -70,7 +70,7 @@ class Api::PlansBaseController < Api::BaseController
   # FIXME: this method smells of :reek:TooManyStatements
   def create # rubocop:disable Metrics/AbcSize
     attrs = params.require(plan_type).permit(CREATE_PARAMS)
-    plan = collection.build(attrs)
+    @plan = collection.build(attrs)
 
     if plan.save
       if block_given?

--- a/features/api/application_plans.feature
+++ b/features/api/application_plans.feature
@@ -34,6 +34,11 @@ Feature: Application plans index page
     When an admin is in the application plans page
     Then they can add new application plans
 
+  Scenario: Empty data when creating a plan
+    When an admin is in the application plans page
+    And they create a plan with empty data
+    Then I should see error "can't be blank" for field "Name"
+
   Scenario: Copy an application plan
     When an admin selects the action copy of an application plan
     Then a copy of the plan is added to the list

--- a/features/step_definitions/api/application_plans_steps.rb
+++ b/features/step_definitions/api/application_plans_steps.rb
@@ -56,6 +56,12 @@ Then "they can add new application plans" do
   assert current_path, admin_service_application_plans_path(default_service)
 end
 
+When "they create a plan with empty data" do
+  find("a[href='#{new_admin_service_application_plan_path(default_service)}']", text: 'Create application plan')
+    .click
+  click_on('Create application plan', wait: 5)
+end
+
 When "an admin selects the action copy of an application plan" do
   @plan = FactoryBot.create(:application_plan, issuer: default_service)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When creating an application plan with empty values instead of redirecting to the original form with error messages, an exception was thrown (resulting in Internal Error in production).

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10067

**Verification steps** 

1. Create an application plan with empty values
2. Make sure the page gets redirected to the "new plan" form again and an error "can't be blank" is shown.

**Special notes for your reviewer**:

It was broken by this change: https://github.com/3scale/porta/commit/81580b903449a9df4f0e07c6fd9091acef38a4c2#diff-4fe6f4c55cef3c19ca6dd95d29923df263506790f761f312e8bf618bf463e5f7R73

The `#create` action renders [new](https://github.com/3scale/porta/blob/fix-app-plan-create-with-empty-name/app/controllers/api/plans_base_controller.rb#L91) if the validation of the plan does not pass, and so `@plan` in [this view](https://github.com/3scale/porta/blob/fix-app-plan-create-with-empty-name/app/views/api/application_plans/new.html.erb#L39) is empty.
The PR fixes it and adds a test.