### PR TITLE
liberation fonts for PDF generation

### DIFF
--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -26,6 +26,7 @@ RUN yum-config-manager --save --setopt=cbs.centos.org_repos_sclo7-$RUBY_SCL-rh-c
               gd-devel \
               unixODBC-devel \
               mysql \
+              liberation-sans-fonts \
               llvm5.0-devel \
               postgresql13 postgresql13-devel postgresql13-libs \
               file \


### PR DESCRIPTION
The community image had liberation fonts missing thus billing acocunts failed when PDF was generated.

```
RuntimeError 
BillingWorker@billing
cannot find location of LiberationSans-Regular.ttf
```