### PR TITLE
THREESCALE-10056: Fix Deprecation when rendering file

### DIFF
--- a/app/controllers/stats/data/base_controller.rb
+++ b/app/controllers/stats/data/base_controller.rb
@@ -44,7 +44,7 @@ class Stats::Data::BaseController < ApplicationController
 
     respond_to do |format|
       format.json { render :json => @data.to_json }
-      format.xml  { render :layout => false, :file => '/stats/data/usage/usage' }
+      format.xml  { render :layout => false, :template => '/stats/data/usage/usage' }
       format.csv  do
         send_data(*Stats::Views::Csv::Usage.new(@data).to_send_data)
       end


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a deprecation warning:

`DEPRECATION WARNING: render file: should be given the absolute path to a file`

**Which issue(s) this PR fixes** 

[THREESCALE-10056](https://issues.redhat.com/browse/THREESCALE-10056)

**Verification steps** 

Send a `GET` request to:

```
http://provider-admin.3scale.localhost:3000/stats/applications/5/usage.xml?access_token=secret&metric_name=hits&since=2023-08-01&period=month&granularity=month&timezone=UTC
```

Before and after this PR, the deprecation warning should disappear.

