### PR TITLE
THREESCALE-10059: Fix scope leak in ApiDocs::Service

### DIFF
--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -129,7 +129,7 @@ class ApiDocs::Service < ApplicationRecord
   end
 
   def new_base_path?
-    self.class.where({:base_path => base_path}).limit(1).empty?
+    self.class.unscoped.where({service_id: self.service_id, base_path: base_path}).limit(1).empty?
   end
 
   def notify_new_base_path

--- a/app/models/api_docs/service.rb
+++ b/app/models/api_docs/service.rb
@@ -129,7 +129,7 @@ class ApiDocs::Service < ApplicationRecord
   end
 
   def new_base_path?
-    self.class.unscoped.where({service_id: self.service_id, base_path: base_path}).limit(1).empty?
+    self.class.unscoped.where({base_path: base_path}).limit(1).empty?
   end
 
   def notify_new_base_path


### PR DESCRIPTION
**What this PR does / why we need it**:

In ActiveRecord <7 some SQL queries generated under particular circumstances include more WHERE clauses they should. We hit this here:

https://github.com/3scale/porta/blob/f9ccd7442d8beb2e20634de64c1caaec252e05ff/app/models/api_docs/service.rb#L131-L133

From this code, one would expect this to be the resulting SQL:

```
SELECT `api_docs_services` .*
FROM `api_docs_services`
WHERE `api_docs_services`.`base_path` = 'http://echo-api.3scale.net/'
LIMIT 1
```

However, the code above is executed as part of the call to `first_or_create!` from here:

https://github.com/3scale/porta/blob/f9ccd7442d8beb2e20634de64c1caaec252e05ff/app/lib/logic/provider_signup.rb#L102-L104

And because of that, the parent scope `default_service.api_docs_services.where(name: 'Echo')` is leaked to the child query, resulting on this:

```
SELECT `api_docs_services` .*
FROM `api_docs_services`
WHERE `api_docs_services`.`service_id` = 3
  AND `api_docs_services`.`name` = 'Echo'
  AND `api_docs_services`.`base_path` = 'http://echo-api.3scale.net/'
LIMIT 1
```
This **only** happens when `new_base_path?` is called as part of the sample data initialization when a new provider is created.

But `new_base_path?` also gets called in other situation: when adding a new OpenAPI spec from  `Product -> ActiveDocs -> Create new spec`. When this happens, the generated query is correct and it doesn't include the leaked scope. So it's the first SQL query above.

Originally, `new_base_path?` was created for the second use case (`Product -> ActiveDocs -> Create new spec`), to notify support when a new `base_path` is added. It sends an email to `SUPPORT_EMAIL` with this text:

```
Hello support team! New Path https://mercuryretrogradeapi.com/ has been added to ActiveDocs (8)
for provider provider.3scale.localhost (2). If you want to contact the provider, please do
admin@provider.example.com. No action is required, if the basePath looks very fishy (for
instance: no domain name but only ip, pointing to a domain that clearly does not belong to:
api.facebook.com, twitter.com, etc.) please report it to the TechTeam. Your system.
``` 

So I'm sure the scope leak is a bug happening during provider initialization, the correct scope is the entire table, and the first query above is the correct one to be executed from both provider initialization and OpenAPI spec creation.

Rails 7 fixes the scope leak and this same code will generate the first version of the SQL query without the parent scope. Which is correct for us. But anyway this PR modifies `new_base_path?` to manually call the correct scope and not raise the deprecation warning.

**Which issue(s) this PR fixes** 

[THREESCALE-10059](https://issues.redhat.com/browse/THREESCALE-10059)

**Verification steps** 

Run `porta reset`, or send the next request with all `porta deps` and `sidekiq` running:
```
curl --request POST \
  --url 'http://master-account.3scale.localhost:3000//master/api/providers?access_token=TOKEN' \
  --header 'Content-Type: application/json' \
  --data '{
	"org_name": "API provider",
	"username": "api-user",
	"password": "p",
	"email": "api-user@redhat.com",
	"redirect_url": "http://master-account.3scale.localhost:3000/buyers/accounts"
}'
```

Then look for the deprecation warning in the logs and verify it's not present:

```shell
log$ grep -ir "Class level methods" .
``` 

