### PR TITLE
THREESCALE-9752: Set :exception as the default forgery protection strategy

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   _helpers.module_eval { prepend DecoratorAdditions }
 
-  protect_from_forgery with: :exception # See ActionController::RequestForgeryProtection for details
+  protect_from_forgery with: ActionController::RequestForgeryProtection::ExceptionAndResetStrategy
 
   # Disable CSRF protection for requests to REST API.
   skip_before_action :verify_authenticity_token, if: -> do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   _helpers.module_eval { prepend DecoratorAdditions }
 
-  protect_from_forgery with: :reset_session # See ActionController::RequestForgeryProtection for details
+  protect_from_forgery with: :exception # See ActionController::RequestForgeryProtection for details
 
   # Disable CSRF protection for requests to REST API.
   skip_before_action :verify_authenticity_token, if: -> do
@@ -59,6 +59,8 @@ class ApplicationController < ActionController::Base
     render_error translate(:unknown_format, scope: :'action_controller.errors', request_format: request.params[:format]),
                  status: :not_acceptable
   end
+
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_forgery_protection
 
 
   # Returns sublayout or nil - see the class level setter.

--- a/app/lib/action_controller/request_forgery_protection/exception_and_reset_strategy.rb
+++ b/app/lib/action_controller/request_forgery_protection/exception_and_reset_strategy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActionController
+  module RequestForgeryProtection
+    class ExceptionAndResetStrategy
+      def initialize(controller)
+        @controller = controller
+      end
+
+      def handle_unverified_request
+        @controller.reset_session
+        exception.handle_unverified_request
+      end
+
+      private
+
+      def exception
+        @exception || ActionController::RequestForgeryProtection::ProtectionMethods::Exception.new(@controller)
+      end
+    end
+  end
+end

--- a/app/lib/action_controller/request_forgery_protection/exception_and_reset_strategy.rb
+++ b/app/lib/action_controller/request_forgery_protection/exception_and_reset_strategy.rb
@@ -15,7 +15,7 @@ module ActionController
       private
 
       def exception
-        @exception || ActionController::RequestForgeryProtection::ProtectionMethods::Exception.new(@controller)
+        @exception ||= ActionController::RequestForgeryProtection::ProtectionMethods::Exception.new(@controller)
       end
     end
   end

--- a/app/lib/authenticated_system.rb
+++ b/app/lib/authenticated_system.rb
@@ -22,7 +22,7 @@ module AuthenticatedSystem
     clear_current_user
     super
   end
-  public :reset_session # required by protect_from_forgery with: :reset_session
+  public :reset_session # required by ActionController::RequestForgeryProtection::ExceptionAndResetStrategy
 
   # TODO: move this to middleware
   def clear_current_user

--- a/lib/developer_portal/app/controllers/developer_portal/login_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/login_controller.rb
@@ -12,9 +12,6 @@ class DeveloperPortal::LoginController < DeveloperPortal::BaseController
 
   activate_menu :root
 
-  protect_from_forgery with: :exception
-  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_forgery_protection
-
   liquify prefix: 'login'
 
   def new

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -44,7 +44,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     get admin_buyers_accounts_path
   end
 
-  test "allowed forgery protection will return 4XX and revoke the session" do
+  test "allowed forgery protection will return 403 and revoke the session" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
     login! provider, user: user

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -44,7 +44,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     get admin_buyers_accounts_path
   end
 
-  test "allowed forgery protection will cause redirect to login page and revocation of the session" do
+  test "allowed forgery protection will return 4XX and revoke the session" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
     login! provider, user: user
@@ -57,7 +57,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
         }
       }
     end
-    assert_redirected_to '/p/login'
+    assert_response :forbidden
     # Check that user session was revoked (because of token authenticity)
     assert_not_nil user.user_sessions.reload[0][:revoked_at]
   end

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -219,7 +219,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'logout if authentication token is invalid' do
+  test 'return 4XX and logout if authentication token is invalid' do
     host! @provider.external_admin_domain
     user = @provider.admins.first
 
@@ -230,7 +230,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
       with_forgery_protection { put provider_admin_account_path, params: { account: { org_name: 'jose' } } }
     end
 
-    assert_redirected_to provider_login_url
+    assert_response :forbidden
 
     pre_org_name = @provider.org_name
     assert_equal pre_org_name, @provider.reload.org_name

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -219,7 +219,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'return 4XX and logout if authentication token is invalid' do
+  test 'return 403 and logout if authentication token is invalid' do
     host! @provider.external_admin_domain
     user = @provider.admins.first
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Check the description and comments at [THREESCALE-9752](https://issues.redhat.com/browse/THREESCALE-9752)

**Which issue(s) this PR fixes** 

[THREESCALE-9752](https://issues.redhat.com/browse/THREESCALE-9752)

**Verification steps** 

See the issue description to reproduce the bug.

