### PR TITLE
🔥🥒 Delete old scenario and selector

### DIFF
--- a/features/old/menu/dashboard.feature
+++ b/features/old/menu/dashboard.feature
@@ -16,9 +16,6 @@ Feature: Dashboard
     And I should see the link "0 DRAFTS" in the audience dashboard widget
     And I should see the link "0 MESSAGES" in the audience dashboard widget
 
-  Scenario: first API widget
-    And I should see "API" in the first api dashboard widget
-
   Scenario: Audience widget with Finance enabled
     Given the provider is charging its buyers
     And I go to the provider dashboard

--- a/features/step_definitions/custom_web_steps.rb
+++ b/features/step_definitions/custom_web_steps.rb
@@ -153,7 +153,6 @@ When /^(.*) within ([^:"]+)$/ do |lstep, scope|
 end
 
 [ 'the audience dashboard widget', 'the apis dashboard widget',
-  'the first api dashboard widget',
   'the main menu' ].each do |scope|
   When /^(.*) in (#{scope})$/ do |lstep, scope|
     within(*selector_for(scope)) do

--- a/features/support/selectors.rb
+++ b/features/support/selectors.rb
@@ -13,9 +13,6 @@ module HtmlSelectorsHelper
       '#audience'
     when 'the apis dashboard widget', :apis_dashboard_widget
       '.DashboardSection--services'
-    # TODO: there is no first api widget anymore, clean this up
-    when 'the first api dashboard widget'
-      '.DashboardSection--services'
     when 'the secondary nav'
       'nav.pf-c-nav.pf-m-horizontal'
     when 'the user widget'


### PR DESCRIPTION
🔥🔥🔥 

Back in the day, there was a widget in the Dashboard showing details about the first API (product). With APIaP it was replaced by the current widgets Products and Backends.

These 2 widgets are tested in `features/provider/dashboard/widgets.feature`.

<img width="1322" alt="Screenshot 2023-08-23 at 13 14 30" src="https://github.com/3scale/porta/assets/11672286/a60421ce-fd1d-4b3f-983a-a47cc7ffbb9e">
