### PR TITLE
rails 6 deprecation of case-sensitive uniqueness

### DIFF
--- a/app/models/application_key.rb
+++ b/app/models/application_key.rb
@@ -13,7 +13,7 @@ class ApplicationKey < ApplicationRecord
   # letters, numbers, dash, cannot stat with dash, case insensitive
   validates :value, format: { with: /\A[\x20-\x7E]+\Z/ },
                     length: { within: 5..255 },
-                    uniqueness: { scope: :application_id }
+                    uniqueness: { scope: :application_id, case_sensitive: false }
 
   validate :keys_limit_reached
 

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -21,7 +21,7 @@ class CMS::Page < CMS::BasePage
   validates :title, presence:   true
   validates :path,  presence:   true,
                     format:     { with: /\A\/.*\z/, message: :slash },
-                    uniqueness: { scope: [:provider_id] },
+                    uniqueness: { scope: [:provider_id], case_sensitive: true },
                     exclusion:  { in: RESERVED_PATHS }
 
   validates_associated  :section


### PR DESCRIPTION
follow-up on #3507

What really bothers me is that I can't see deprecation error locally. Although `config.active_support.deprecation` is configured.

**update:** I figured out. In prod database we use `utf8_general_ci` while locally we have `utf8_bin`. But the deprecation message from `/home/user/.asdf/installs/ruby/2.6.7/lib/ruby/gems/2.6.0/gems/activerecord-6.0.6.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb` only applies when column collation is case insensitive. That's why locally it didn't trigger. If locally the `ci` collation is being used, the deprecation message is shown up.