### PR TITLE
Display percentage at Current utilization

### DIFF
--- a/app/views/provider/admin/applications/_utilization.html.erb
+++ b/app/views/provider/admin/applications/_utilization.html.erb
@@ -42,7 +42,7 @@
               <%= content_tag(:span, utilization, class: utilization_type) %>
             </td>
             <td role="cell" data-label="%" class="utilization">
-              <%= content_tag(:span, utilization, class: utilization_type) %>
+              <%= content_tag(:span, percentage, class: utilization_type) %>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
[THREESCALE-10133](https://issues.redhat.com/browse/THREESCALE-10133): Display percentage at Current utilization

**What this PR does / why we need it**:

This PR fixes an error at Current utilization, where it was duplicating the value metrics instead of displaying value and percentage. 

**Verification steps** 

**Before**
![Captura de pantalla 2023-09-04 a las 14 10 14](https://github.com/3scale/porta/assets/72191439/7e24bf8c-0076-4557-8d83-f92627accc11)

**After**
![Captura de pantalla 2023-09-04 a las 14 10 34](https://github.com/3scale/porta/assets/72191439/1f340855-9111-425b-a840-be99a9d78723)

from @mayorova:

Just for reference, the bug was introduced here: https://github.com/3scale/porta/commit/ee6afab4bc84146c6327f16e09a88bf2eb906cab#diff-c03110c10f92df9dcba83b75e405de05ac811ef040b854a1692ad71c6479cdecR45
