### PR TITLE
Refactor docs path and fix broken docs links for RHOAM

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -337,21 +337,11 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   end
 
   def saas?
-    ThreeScale.tenant_mode.multitenant?
-  end
-
-  def major_and_minor_version_path
-    info = System::Deploy.info
-
-    if saas?
-      "red_hat_3scale/#{info.major_version}-saas"
-    else
-      "red_hat_3scale_api_management/#{info.major_version}.#{info.minor_version}"
-    end
+    !ThreeScale.config.onpremises
   end
 
   def docs_base_url
-    I18n.t('docs.base_url', major_and_minor_version_path: major_and_minor_version_path)
+    I18n.t('docs.base_url', docs_version: System::Deploy.info.docs_version)
   end
 
   def call_to_action?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -336,10 +336,6 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     current_user.impersonation_admin? && !current_account.master?
   end
 
-  def saas?
-    !ThreeScale.config.onpremises
-  end
-
   def docs_base_url
     I18n.t('docs.base_url', docs_version: System::Deploy.info.docs_version)
   end

--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -163,7 +163,7 @@ module MenuHelper # rubocop:disable Metrics/ModuleLength
       { title: 'Liquid Reference', href: provider_admin_liquid_docs_path, icon: :code }
     ]
 
-    if saas?
+    if ThreeScale.saas?
       items.push(
         { title: "What's new?", href: '//access.redhat.com/articles/3107441#newfeaturesenhancements', icon: :leaf, target: '_blank' }
       )

--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -13,9 +13,9 @@ module System
     #   - deployed_at: timestamp of the deployment
     #   - docs_version: product name and the version that are used as prefix for product documentation path in the
     #                   Red Hat Customer Portal
-    # The data is taken from the `.deploy_info2` file in the root directory, but for SaaS the release
+    # The data is taken from the `.deploy_info` file in the root directory, but for SaaS the release
     # is overridden with DEFAULT_VERSION.
-    # `.deploy_info2` file is injected to the container during container build process in CPaaS (the content is set in Dockerfile)
+    # `.deploy_info` file is injected to the container during container build process in CPaaS (the content is set in Dockerfile)
     # The information is exposed via {MASTER_PORTAL}/deploy endpoint for logged-in users.
     class Info
       DEFAULT_VERSION = '2.x'

--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -26,6 +26,11 @@ module System
         @error = info.fetch(:error) if info.key?(:error)
       end
 
+      def docs_version
+        # minor version is nil for RHOAM (release = 'RHOAM')
+        @docs_version ||= minor_version.nil? || release == VERSION ? 'red_hat_3scale/2-saas' : "red_hat_3scale_api_management/#{release}"
+      end
+
       private
 
       class VersionParser

--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -28,17 +28,13 @@ module System
 
       def initialize(info)
         @revision = info.fetch('revision') { `git rev-parse HEAD 2> /dev/null`.strip }
-        @release = saas? ? DEFAULT_VERSION : info.fetch('release', DEFAULT_VERSION)
+        @release = ThreeScale.saas? ? DEFAULT_VERSION : info.fetch('release', DEFAULT_VERSION)
         @deployed_at = info.fetch('deployed_at') { Time.now }
         @error = info.fetch(:error) if info.key?(:error)
       end
 
       def docs_version
-        @docs_version ||= saas? || rhoam? ? 'red_hat_3scale/2-saas' : "red_hat_3scale_api_management/#{major_version}.#{minor_version}"
-      end
-
-      def saas?
-        !ThreeScale.config.onpremises
+        @docs_version ||= ThreeScale.saas? || rhoam? ? 'red_hat_3scale/2-saas' : "red_hat_3scale_api_management/#{major_version}.#{minor_version}"
       end
 
       # RHOAM version has only one segment (release = 'RHOAM')

--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -27,8 +27,8 @@ module System
       end
 
       def docs_version
-        # minor version is nil for RHOAM (release = 'RHOAM')
-        @docs_version ||= minor_version.nil? || release == DEFAULT_VERSION ? 'red_hat_3scale/2-saas' : "red_hat_3scale_api_management/#{release}"
+        # RHOAM version has only one segment (release = 'RHOAM')
+        @docs_version ||= release == DEFAULT_VERSION || version.segments.count < 2 ? 'red_hat_3scale/2-saas' : "red_hat_3scale_api_management/#{major_version}.#{minor_version}"
       end
 
       private

--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -12,8 +12,8 @@ module System
     # is overridden with VERSION.
     # The information is exposed via {MASTER_PORTAL}/deploy endpoint for logged-in users.
     class Info
-      VERSION = '2.x'
-      private_constant :VERSION
+      DEFAULT_VERSION = '2.x'
+      private_constant :DEFAULT_VERSION
 
       attr_reader :revision, :deployed_at, :release
 
@@ -21,14 +21,14 @@ module System
 
       def initialize(info)
         @revision = info.fetch('revision') { `git rev-parse HEAD 2> /dev/null`.strip }
-        @release = ThreeScale.config.onpremises ? info.fetch('release', VERSION) : VERSION
+        @release = ThreeScale.config.onpremises ? info.fetch('release', DEFAULT_VERSION) : DEFAULT_VERSION
         @deployed_at = info.fetch('deployed_at') { Time.now }
         @error = info.fetch(:error) if info.key?(:error)
       end
 
       def docs_version
         # minor version is nil for RHOAM (release = 'RHOAM')
-        @docs_version ||= minor_version.nil? || release == VERSION ? 'red_hat_3scale/2-saas' : "red_hat_3scale_api_management/#{release}"
+        @docs_version ||= minor_version.nil? || release == DEFAULT_VERSION ? 'red_hat_3scale/2-saas' : "red_hat_3scale_api_management/#{release}"
       end
 
       private

--- a/app/lib/three_scale.rb
+++ b/app/lib/three_scale.rb
@@ -31,5 +31,9 @@ module ThreeScale
     !ThreeScale.config.onpremises
   end
 
+  def saas?
+    !config.onpremises
+  end
+
   extend PrivateModule
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@
 en:
   # start documentation links
   docs:
-    base_url: 'https://access.redhat.com/documentation/en-us/%{major_and_minor_version_path}/html'
+    base_url: 'https://access.redhat.com/documentation/en-us/%{docs_version}/html'
     hero_api_portal: '%{docs_base_url}/creating_the_developer_portal/index'
     developer_portal:
       email_configuration: '%{docs_base_url}/creating-developer-portal/email-configuration'

--- a/test/helpers/menu_helper_test.rb
+++ b/test/helpers/menu_helper_test.rb
@@ -81,19 +81,19 @@ class MenuHelperTest < ActionView::TestCase
   end
 
   test '#documentation_items' do
-    expects(:saas?).returns(false)
+    ThreeScale.stubs(:saas?).returns(false)
     Features::QuickstartsConfig.stubs(enabled?: false)
     assert_equal documentation_items.length, 3
 
-    expects(:saas?).returns(true)
+    ThreeScale.stubs(:saas?).returns(true)
     Features::QuickstartsConfig.stubs(enabled?: false)
     assert_equal documentation_items.length, 4
 
-    expects(:saas?).returns(false)
+    ThreeScale.stubs(:saas?).returns(false)
     Features::QuickstartsConfig.stubs(enabled?: true)
     assert_equal documentation_items.length, 4
 
-    expects(:saas?).returns(true)
+    ThreeScale.stubs(:saas?).returns(true)
     Features::QuickstartsConfig.stubs(enabled?: true)
     assert_equal documentation_items.length, 5
   end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -65,6 +65,11 @@ class ApplicationHelperTest < ActionView::TestCase
 
       assert_equal @full_asset_host, result
     end
+
+    test 'docs base url' do
+      ThreeScale.config.stubs(onpremises: false)
+      assert_equal 'https://access.redhat.com/documentation/en-us/red_hat_3scale/2-saas/html', docs_base_url
+    end
   end
 
   private

--- a/test/unit/lib/system/deploy_test.rb
+++ b/test/unit/lib/system/deploy_test.rb
@@ -15,31 +15,84 @@ class DeployTest < ActiveSupport::TestCase
     assert_equal 'x', System::Deploy.info.minor_version
   end
 
-  class OnpremisesDeployTest < DeployTest
+  test 'parse deploy info' do
+    File.open('.deploy_info_test', 'w') do |file|
+      file << '{"revision": "rev", "release": "rel"}'
+      file.flush
+
+      deploy_info = System::Deploy.parse_deploy_info(file.path)
+      assert_equal 'rev', deploy_info['revision']
+      assert_equal 'rel', deploy_info['release']
+    end
+  end
+
+  test 'call' do
+    System::Deploy.load_info!
+    response = System::Deploy.call(nil)
+    assert_equal 200, response[0]
+    assert_equal 'application/json', response[1]['Content-Type']
+    assert_equal '2.x', JSON.parse(response[2].first)['release']
+  end
+
+  class OnpremisesDeployTest < ActiveSupport::TestCase
+    setup do
+      ThreeScale.config.stubs(onpremises: true)
+      System::Deploy.load_info! ActiveSupport::JSON.decode('{"revision": "2.13-stable", "release": "2.13"}')
+    end
+
+    test 'onpremises release has a major and minor version' do
+      assert_equal '2', System::Deploy.info.major_version
+      assert_equal '13', System::Deploy.info.minor_version
+    end
+
+    test 'docs url point to onpremises product docs' do
+      assert_equal 'red_hat_3scale_api_management/2.13', System::Deploy.info.docs_version
+    end
+  end
+
+  class SaasDeployTest < ActiveSupport::TestCase
+    setup do
+      ThreeScale.config.stubs(onpremises: false)
+      System::Deploy.load_info! ActiveSupport::JSON.decode('{"revision": "alpha", "release": "alpha"}')
+    end
+
+    test 'custom release from .deploy_info2 is ignored' do
+      assert_equal '2', System::Deploy.info.major_version
+      assert_equal 'x', System::Deploy.info.minor_version
+    end
+
+    test 'docs url point to SaaS product docs' do
+      assert_equal 'red_hat_3scale/2-saas', System::Deploy.info.docs_version
+    end
+  end
+
+  class RhoamDeployTest < ActiveSupport::TestCase
     setup do
       ThreeScale.config.stubs(onpremises: true)
     end
 
-    test 'custom release' do
-      path = Rails.root.join('test', 'fixtures', 'deploy_info').expand_path
-      System::Deploy.load_info! ActiveSupport::JSON.decode(path.read)
+    test 'RHOAM release has only one segment' do
+      System::Deploy.load_info! ActiveSupport::JSON.decode('{"revision": "2.x-mas", "release": "RHOAM"}')
 
-      assert_equal '4', System::Deploy.info.major_version
-      assert_equal '5', System::Deploy.info.minor_version
+      assert_equal 'RHOAM', System::Deploy.info.major_version
+      assert_nil System::Deploy.info.minor_version
+    end
+
+    test 'docs url point to SaaS product docs' do
+      assert_equal 'red_hat_3scale/2-saas', System::Deploy.info.docs_version
     end
   end
 
-  class SaasDeployTest < DeployTest
+  class InvalidInfoTest < ActiveSupport::TestCase
     setup do
-      ThreeScale.config.stubs(onpremises: false)
+      System::Deploy.load_info! 'invalid-data'
     end
 
-    test 'custom release from .deploy_info is ignored' do
-      path = Rails.root.join('test', 'fixtures', 'deploy_info').expand_path
-      System::Deploy.load_info! ActiveSupport::JSON.decode(path.read)
+    test 'load invalid info' do
+      info = System::Deploy.info
 
-      assert_equal '2', System::Deploy.info.major_version
-      assert_equal 'x', System::Deploy.info.minor_version
+      assert info.is_a? System::Deploy::InvalidInfo
+      assert_nil info.release
     end
   end
 

--- a/test/unit/lib/system/deploy_test.rb
+++ b/test/unit/lib/system/deploy_test.rb
@@ -40,6 +40,10 @@ class DeployTest < ActiveSupport::TestCase
       System::Deploy.load_info! ActiveSupport::JSON.decode('{"revision": "2.13-stable", "release": "2.13"}')
     end
 
+    teardown do
+      System::Deploy.info = nil
+    end
+
     test 'onpremises release has a major and minor version' do
       assert_equal '2', System::Deploy.info.major_version
       assert_equal '13', System::Deploy.info.minor_version
@@ -56,7 +60,11 @@ class DeployTest < ActiveSupport::TestCase
       System::Deploy.load_info! ActiveSupport::JSON.decode('{"revision": "alpha", "release": "alpha"}')
     end
 
-    test 'custom release from .deploy_info2 is ignored' do
+    teardown do
+      System::Deploy.info = nil
+    end
+
+    test 'custom release from .deploy_info is ignored' do
       assert_equal '2', System::Deploy.info.major_version
       assert_equal 'x', System::Deploy.info.minor_version
     end
@@ -69,11 +77,14 @@ class DeployTest < ActiveSupport::TestCase
   class RhoamDeployTest < ActiveSupport::TestCase
     setup do
       ThreeScale.config.stubs(onpremises: true)
+      System::Deploy.load_info! ActiveSupport::JSON.decode('{"revision": "2.x-mas", "release": "RHOAM"}')
+    end
+
+    teardown do
+      System::Deploy.info = nil
     end
 
     test 'RHOAM release has only one segment' do
-      System::Deploy.load_info! ActiveSupport::JSON.decode('{"revision": "2.x-mas", "release": "RHOAM"}')
-
       assert_equal 'RHOAM', System::Deploy.info.major_version
       assert_nil System::Deploy.info.minor_version
     end


### PR DESCRIPTION
**What this PR does / why we need it**:

The documentation URLs in RHOAM are broken and point to 404 page.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-1699, specifically the issue reported in [this comment](https://issues.redhat.com/browse/THREESCALE-1699?focusedId=22849777&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22849777)

**Verification steps** 

1. Run porta in RHOAM mode:
a. Set `onpremises: true` in `config/settings.yml`
b. Add `.deploy_info` file with `{"revision": "2.x-mas", "release": "RHOAM"}`

2. Go to `/p/admin/cms` path in the provider admin portal, and check that the [Creating the Developer Portal](https://access.redhat.com/documentation/en-us/red_hat_3scale/2-saas/html/creating_the_developer_portal/index) link points to `red_hat_3scale/2-saas`

**Special notes for your reviewer**:

-none-