### PR TITLE
THREESCALE-9752: Fix Basic auth method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
 
   # Disable CSRF protection for requests to REST API.
   skip_before_action :verify_authenticity_token, if: -> do
-    api_controller? && (params.key?(:provider_key) || params.key?(:access_token))
+    api_controller? && logged_in?
   end
 
   before_action :set_timezone

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: ActionController::RequestForgeryProtection::ExceptionAndResetStrategy
 
   # Disable CSRF protection for requests to REST API.
-  skip_forgery_protection if: -> { api_controller? && logged_in? }
+  skip_forgery_protection if: -> { api_controller? }
 
   before_action :set_timezone
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   _helpers.module_eval { prepend DecoratorAdditions }
 
-  protect_from_forgery with: :exception # See ActionController::RequestForgeryProtection for details
+  protect_from_forgery with: ActionController::RequestForgeryProtection::ExceptionAndResetStrategy
 
   # Disable CSRF protection for requests to REST API.
   skip_before_action :verify_authenticity_token, if: -> do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,9 +15,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: ActionController::RequestForgeryProtection::ExceptionAndResetStrategy
 
   # Disable CSRF protection for requests to REST API.
-  skip_before_action :verify_authenticity_token, if: -> do
-    api_controller? && logged_in?
-  end
+  skip_forgery_protection if: -> { api_controller? && logged_in? }
 
   before_action :set_timezone
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   _helpers.module_eval { prepend DecoratorAdditions }
 
-  protect_from_forgery with: :reset_session # See ActionController::RequestForgeryProtection for details
+  protect_from_forgery with: :exception # See ActionController::RequestForgeryProtection for details
 
   # Disable CSRF protection for requests to REST API.
   skip_before_action :verify_authenticity_token, if: -> do
@@ -59,6 +59,8 @@ class ApplicationController < ActionController::Base
     render_error translate(:unknown_format, scope: :'action_controller.errors', request_format: request.params[:format]),
                  status: :not_acceptable
   end
+
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_forgery_protection
 
 
   # Returns sublayout or nil - see the class level setter.

--- a/app/lib/action_controller/request_forgery_protection/exception_and_reset_strategy.rb
+++ b/app/lib/action_controller/request_forgery_protection/exception_and_reset_strategy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActionController
+  module RequestForgeryProtection
+    class ExceptionAndResetStrategy
+      def initialize(controller)
+        @controller = controller
+      end
+
+      def handle_unverified_request
+        @controller.reset_session
+        exception.handle_unverified_request
+      end
+
+      private
+
+      def exception
+        @exception || ActionController::RequestForgeryProtection::ProtectionMethods::Exception.new(@controller)
+      end
+    end
+  end
+end

--- a/app/lib/action_controller/request_forgery_protection/exception_and_reset_strategy.rb
+++ b/app/lib/action_controller/request_forgery_protection/exception_and_reset_strategy.rb
@@ -15,7 +15,7 @@ module ActionController
       private
 
       def exception
-        @exception || ActionController::RequestForgeryProtection::ProtectionMethods::Exception.new(@controller)
+        @exception ||= ActionController::RequestForgeryProtection::ProtectionMethods::Exception.new(@controller)
       end
     end
   end

--- a/app/lib/authenticated_system.rb
+++ b/app/lib/authenticated_system.rb
@@ -22,7 +22,7 @@ module AuthenticatedSystem
     clear_current_user
     super
   end
-  public :reset_session # required by protect_from_forgery with: :reset_session
+  public :reset_session # required by ActionController::RequestForgeryProtection::ExceptionAndResetStrategy
 
   # TODO: move this to middleware
   def clear_current_user

--- a/lib/developer_portal/app/controllers/developer_portal/login_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/login_controller.rb
@@ -12,9 +12,6 @@ class DeveloperPortal::LoginController < DeveloperPortal::BaseController
 
   activate_menu :root
 
-  protect_from_forgery with: :exception
-  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_forgery_protection
-
   liquify prefix: 'login'
 
   def new

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -44,7 +44,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     get admin_buyers_accounts_path
   end
 
-  test "allowed forgery protection will return 4XX and revoke the session" do
+  test "allowed forgery protection will return 403 and revoke the session" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
     login! provider, user: user

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -98,7 +98,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
-  test "forgery protection is skipped for API requests with using basic auth and provider key" do
+  test "forgery protection is skipped for API requests with basic auth and provider key" do
     provider = FactoryBot.create(:provider_account)
     token = provider.api_key
     host! provider.external_admin_domain

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -62,7 +62,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil user.user_sessions.reload[0][:revoked_at]
   end
 
-  test "allowed forgery protection won't destroy session when using API controller" do
+  test "forgery protection returns 200 for API requests with a valid access token" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw').value
@@ -73,6 +73,70 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
       post admin_api_signup_path(format: :json), params: {
         access_token: token, org_name: 'Alaska',
         username: 'hello', email: 'foo@example.com', password: '123456'
+      }
+    end
+    assert_response :created
+  end
+
+  test "forgery protection returns 403 for API requests with an invalid access token" do
+    provider = FactoryBot.create(:provider_account)
+    token = 'invalid'
+
+    host! provider.external_admin_domain
+
+    with_forgery_protection do
+      post admin_api_signup_path(format: :json), params: {
+        access_token: token, org_name: 'Alaska',
+        username: 'hello', email: 'foo@example.com', password: '123456'
+      }
+    end
+    assert_response :forbidden
+  end
+
+  test "forgery protection returns 200 for API requests with basic auth and access token" do
+    provider = FactoryBot.create(:provider_account)
+    user = provider.admins.first
+    token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw').value
+
+    host! provider.external_admin_domain
+
+    with_forgery_protection do
+      post admin_api_signup_path(format: :json), headers: {
+        Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(token, '')
+      }, params: {
+        org_name: 'Alaska', username: 'hello', email: 'foo@example.com', password: '123456'
+      }
+    end
+    assert_response :created
+  end
+
+  test "forgery protection returns 403 for API requests with basic auth and an invalid access token" do
+    provider = FactoryBot.create(:provider_account)
+    token = 'invalid'
+
+    host! provider.external_admin_domain
+
+    with_forgery_protection do
+      post admin_api_signup_path(format: :json), headers: {
+        Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(token, '')
+      }, params: {
+        org_name: 'Alaska', username: 'hello', email: 'foo@example.com', password: '123456'
+      }
+    end
+    assert_response :forbidden
+  end
+
+  test "forgery protection returns 200 for API requests with using basic auth and provider key" do
+    provider = FactoryBot.create(:provider_account)
+    token = provider.api_key
+
+    host! provider.external_admin_domain
+
+    with_forgery_protection do
+      post admin_api_signup_path(format: :json), headers: {
+        Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(token, '')
+      }, params: {
+        org_name: 'Alaska', username: 'hello', email: 'foo@example.com', password: '123456'
       }
     end
     assert_response :created

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -62,6 +62,20 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil user.user_sessions.reload[0][:revoked_at]
   end
 
+  test "forgery protection is skipped for API requests without authentication" do
+    provider = FactoryBot.create(:provider_account)
+    host! provider.external_admin_domain
+
+    ApplicationController.any_instance.expects(:verify_authenticity_token).never
+
+    with_forgery_protection do
+      post admin_api_signup_path(format: :json), params: {
+        org_name: 'Alaska', username: 'hello', email: 'foo@example.com', password: '123456'
+      }
+    end
+    assert_response :forbidden
+  end
+
   test "forgery protection is skipped for API requests with access token" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
@@ -78,7 +92,6 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :created
   end
-
 
   test "forgery protection is skipped for API requests with basic auth and access token" do
     provider = FactoryBot.create(:provider_account)

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -44,7 +44,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     get admin_buyers_accounts_path
   end
 
-  test "allowed forgery protection will cause redirect to login page and revocation of the session" do
+  test "allowed forgery protection will return 4XX and revoke the session" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
     login! provider, user: user
@@ -57,7 +57,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
         }
       }
     end
-    assert_redirected_to '/p/login'
+    assert_response :forbidden
     # Check that user session was revoked (because of token authenticity)
     assert_not_nil user.user_sessions.reload[0][:revoked_at]
   end

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -62,7 +62,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil user.user_sessions.reload[0][:revoked_at]
   end
 
-  test "forgery protection is skipped for API requests with a valid access token" do
+  test "forgery protection is skipped for API requests with access token" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw').value
@@ -79,21 +79,6 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
-  test "forgery protection is enforced for API requests with an invalid access token" do
-    provider = FactoryBot.create(:provider_account)
-    token = 'invalid'
-    host! provider.external_admin_domain
-
-    ApplicationController.any_instance.expects(:verify_authenticity_token).once
-
-    with_forgery_protection do
-      post admin_api_signup_path(format: :json), params: {
-        access_token: token, org_name: 'Alaska',
-        username: 'hello', email: 'foo@example.com', password: '123456'
-      }
-    end
-    assert_response :forbidden
-  end
 
   test "forgery protection is skipped for API requests with basic auth and access token" do
     provider = FactoryBot.create(:provider_account)
@@ -111,23 +96,6 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
       }
     end
     assert_response :created
-  end
-
-  test "forgery protection is enforced for API requests with basic auth and an invalid access token" do
-    provider = FactoryBot.create(:provider_account)
-    token = 'invalid'
-    host! provider.external_admin_domain
-
-    ApplicationController.any_instance.expects(:verify_authenticity_token).once
-
-    with_forgery_protection do
-      post admin_api_signup_path(format: :json), headers: {
-        Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(token, '')
-      }, params: {
-        org_name: 'Alaska', username: 'hello', email: 'foo@example.com', password: '123456'
-      }
-    end
-    assert_response :forbidden
   end
 
   test "forgery protection is skipped for API requests with using basic auth and provider key" do

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -44,7 +44,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     get admin_buyers_accounts_path
   end
 
-  test "allowed forgery protection will return 403 and revoke the session" do
+  test "forgery protection will force a 403 and revoke the session when no CSRF token provided" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
     login! provider, user: user
@@ -62,12 +62,13 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil user.user_sessions.reload[0][:revoked_at]
   end
 
-  test "forgery protection returns 200 for API requests with a valid access token" do
+  test "forgery protection is skipped for API requests with a valid access token" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw').value
-
     host! provider.external_admin_domain
+
+    ApplicationController.any_instance.expects(:verify_authenticity_token).never
 
     with_forgery_protection do
       post admin_api_signup_path(format: :json), params: {
@@ -78,11 +79,12 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
-  test "forgery protection returns 403 for API requests with an invalid access token" do
+  test "forgery protection is enforced for API requests with an invalid access token" do
     provider = FactoryBot.create(:provider_account)
     token = 'invalid'
-
     host! provider.external_admin_domain
+
+    ApplicationController.any_instance.expects(:verify_authenticity_token).once
 
     with_forgery_protection do
       post admin_api_signup_path(format: :json), params: {
@@ -93,12 +95,13 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
-  test "forgery protection returns 200 for API requests with basic auth and access token" do
+  test "forgery protection is skipped for API requests with basic auth and access token" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw').value
-
     host! provider.external_admin_domain
+
+    ApplicationController.any_instance.expects(:verify_authenticity_token).never
 
     with_forgery_protection do
       post admin_api_signup_path(format: :json), headers: {
@@ -110,11 +113,12 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
-  test "forgery protection returns 403 for API requests with basic auth and an invalid access token" do
+  test "forgery protection is enforced for API requests with basic auth and an invalid access token" do
     provider = FactoryBot.create(:provider_account)
     token = 'invalid'
-
     host! provider.external_admin_domain
+
+    ApplicationController.any_instance.expects(:verify_authenticity_token).once
 
     with_forgery_protection do
       post admin_api_signup_path(format: :json), headers: {
@@ -126,11 +130,12 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
-  test "forgery protection returns 200 for API requests with using basic auth and provider key" do
+  test "forgery protection is skipped for API requests with using basic auth and provider key" do
     provider = FactoryBot.create(:provider_account)
     token = provider.api_key
-
     host! provider.external_admin_domain
+
+    ApplicationController.any_instance.expects(:verify_authenticity_token).never
 
     with_forgery_protection do
       post admin_api_signup_path(format: :json), headers: {

--- a/test/integration/request_forgery_protection/exception_and_reset_strategy_test.rb
+++ b/test/integration/request_forgery_protection/exception_and_reset_strategy_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module RequestForgeryProtection
+  class ExceptionAndResetStrategyTest < ActionDispatch::IntegrationTest
+    def with_test_routes
+      Rails.application.routes.draw do
+        post '/signed' => 'request_forgery_protection/exception_and_reset_strategy_test/signed/signed#create'
+        post '/unsigned' => 'request_forgery_protection/exception_and_reset_strategy_test/unsigned/unsigned#create'
+      end
+      yield
+    ensure
+      Rails.application.routes_reloader.reload!
+    end
+
+    class BaseProtectedController < ActionController::Base
+      protect_from_forgery with: ActionController::RequestForgeryProtection::ExceptionAndResetStrategy
+
+      def create; end
+    end
+
+    class Signed < ExceptionAndResetStrategyTest
+
+      setup do
+        @provider = FactoryBot.create(:provider_account)
+        @user = @provider.admins.first
+        login! @provider, user: @user
+        SignedController.any_instance.stubs(:current_user).returns(@user)
+      end
+
+      class SignedController < BaseProtectedController
+        include AuthenticatedSystem
+        before_action :login_required
+      end
+
+      test 'should allow access when including a valid CSRF token' do
+        SignedController.any_instance.stubs(:verified_request?).returns(true)
+
+        with_forgery_protection do
+          with_test_routes do
+            post '/signed', params: { authenticity_token: 'valid' }
+          end
+        end
+
+        assert_response :success
+      end
+
+      test 'should raise InvalidAuthenticityToken error when including an invalid CSRF token' do
+        with_forgery_protection do
+          with_test_routes do
+            assert_raise ActionController::InvalidAuthenticityToken do
+              post '/signed', params: { authenticity_token: 'invalid' }
+            end
+          end
+        end
+      end
+
+      test 'should reset session when including an invalid a CSRF token' do
+        with_forgery_protection do
+          with_test_routes do
+            suppress ActionController::InvalidAuthenticityToken do
+              post '/signed', params: { authenticity_token: 'invalid' }
+            end
+          end
+        end
+        assert_not_nil @user.user_sessions.reload[0][:revoked_at]
+      end
+    end
+
+    class Unsigned < ExceptionAndResetStrategyTest
+      class UnsignedController < BaseProtectedController; end
+
+      test 'should allow access when including a valid CSRF token' do
+        UnsignedController.any_instance.stubs(:verified_request?).returns(true)
+
+        with_forgery_protection do
+          with_test_routes do
+            post '/unsigned', params: { authenticity_token: 'valid' }
+          end
+        end
+
+        assert_response :success
+      end
+
+      test 'should raise InvalidAuthenticityToken error when including an invalid CSRF token' do
+        with_forgery_protection do
+          with_test_routes do
+            assert_raise ActionController::InvalidAuthenticityToken do
+              post '/unsigned', params: { authenticity_token: 'invalid' }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -219,7 +219,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'logout if authentication token is invalid' do
+  test 'return 4XX and logout if authentication token is invalid' do
     host! @provider.external_admin_domain
     user = @provider.admins.first
 
@@ -230,7 +230,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
       with_forgery_protection { put provider_admin_account_path, params: { account: { org_name: 'jose' } } }
     end
 
-    assert_redirected_to provider_login_url
+    assert_response :forbidden
 
     pre_org_name = @provider.org_name
     assert_equal pre_org_name, @provider.reload.org_name

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -219,7 +219,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'return 4XX and logout if authentication token is invalid' do
+  test 'return 403 and logout if authentication token is invalid' do
     host! @provider.external_admin_domain
     user = @provider.admins.first
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We had to revert (https://github.com/3scale/porta/pull/3536) the CSRF fix (https://github.com/3scale/porta/pull/3528) because it broke the `basic` auth method.

This PR fixes the regression and also adds some tests:
- For the `basic` auth method
- For our new request forgery protection strategy

**Which issue(s) this PR fixes**

[THREESCALE-9752](https://issues.redhat.com/browse/THREESCALE-9752)

**Verification steps** 

This both requests should work now

```
curl -X POST \
  'http://master-account.3scale.localhost:3000/master/api/providers.xml?email=admin%40example.com&org_name=examplepp&password=password&username=adminp&access_token=0ed4092e4ce8edd23afb2b68d8216482237da6a990e988616cf2613e8e9e2631' \
  -H 'accept: application/xml' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/x-www-form-urlencoded'
```

```
curl -X POST \
  --basic -u :0ed4092e4ce8edd23afb2b68d8216482237da6a990e988616cf2613e8e9e2631 \
  'http://master-account.3scale.localhost:3000/master/api/providers.xml?email=admin%40example.com&org_name=examplepp&password=password&username=adminp' \
  -H 'accept: application/xml' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/x-www-form-urlencoded'
```

**Notes for reviewers**

These are the changes from (https://github.com/3scale/porta/pull/3528):

https://github.com/3scale/porta/pull/3543/files/60ee379bf1263ab0621deb26e130766784a146da..75a4ca53b3c898ddde11ee99f386a7cb914dc1d8#diff-ffe91beb10984c70928bc271d33d3235b27830610b76c17f7ad2449c246d0ee9
