### PR TITLE
Sidekiq task: remove `index` param

### DIFF
--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -17,7 +17,6 @@ namespace :sidekiq do
     envs['RAILS_MAX_THREADS'] = ENV.fetch('RAILS_MAX_THREADS', '1')
 
     args = []
-    args.push(['--index', ENV.fetch('INDEX', '0')])
     args.push(%w[backend_sync billing critical default deletion events low mailers priority web_hooks zync].flat_map { |queue| ['--queue', queue] })
 
     exec(envs, 'sidekiq', *args.flatten)

--- a/test/unit/tasks/sidekiq_test.rb
+++ b/test/unit/tasks/sidekiq_test.rb
@@ -8,7 +8,7 @@ module Tasks
       queues = %w[backend_sync billing critical default deletion events low mailers priority web_hooks zync]
                  .flat_map { |queue| ['--queue', queue] }
 
-      Object.any_instance.expects(:exec).with({ 'RAILS_MAX_THREADS' => '1' }, 'sidekiq', '--index', '0', *queues)
+      Object.any_instance.expects(:exec).with({ 'RAILS_MAX_THREADS' => '1' }, 'sidekiq', *queues)
       execute_rake_task 'sidekiq.rake', 'sidekiq:worker'
     end
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

After upgrading to Sidekiq 6, the rake task to launch Sidekiq started to fail. The problem was found by the RHOAM team.

This PR fixes the problem by removing the `--index` parameter, which was used in very old Sidekiq releases but it's irrelevant since long ago. Check the commit where they removed it:

https://github.com/sidekiq/sidekiq/commit/5987a8c352a220a94e1850c79186d82c35050d85#diff-6cb1e9c2f07f71eba03ed54d2157cd999b8b3212009c92338d630f7e215ceed7L322-L327

**Verification steps** 

Just run `bundle exec rails sidekiq` and check Sidekiq starts without issues.
