### PR TITLE
🔒️ Set cache headers to no-cache

### DIFF
--- a/app/controllers/admin/api_docs/account_api_docs_controller.rb
+++ b/app/controllers/admin/api_docs/account_api_docs_controller.rb
@@ -4,6 +4,8 @@ class Admin::ApiDocs::AccountApiDocsController < Admin::ApiDocs::BaseController
   activate_menu :audience, :cms, :ActiveDocs
   sublayout 'api/service'
 
+  before_action :disable_client_cache, only: %i[preview]
+
   class NotImplementedServiceScopeError < RuntimeError; end
   rescue_from(NotImplementedServiceScopeError) do |exception|
     System::ErrorReporting.report_error(exception)

--- a/app/controllers/admin/api_docs/service_api_docs_controller.rb
+++ b/app/controllers/admin/api_docs/service_api_docs_controller.rb
@@ -6,6 +6,8 @@ class Admin::ApiDocs::ServiceApiDocsController < Admin::ApiDocs::BaseController
   activate_menu :serviceadmin, :ActiveDocs
   sublayout 'api/service'
 
+  before_action :disable_client_cache, only: :preview
+
   private
 
   def current_scope

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -7,7 +7,6 @@ class Api::IntegrationsController < Api::BaseController
   before_action :find_registry_policies, only: :update
   before_action :disable_client_cache
 
-
   activate_menu :serviceadmin, :integration, :configuration
   sublayout 'api/service'
 

--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -5,6 +5,8 @@ class Api::IntegrationsController < Api::BaseController
   before_action :find_proxy
   before_action :authorize
   before_action :find_registry_policies, only: :update
+  before_action :disable_client_cache
+
 
   activate_menu :serviceadmin, :integration, :configuration
   sublayout 'api/service'

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -10,6 +10,8 @@ class Api::ServicesController < Api::BaseController
   before_action :deny_on_premises_for_master
   before_action :authorize_section
   before_action :authorize_action, only: %i[new create]
+  before_action :disable_client_cache, only: :settings
+
   load_and_authorize_resource :service, through: :current_user, through_association: :accessible_services, except: [:create]
 
   helper_method :presenter

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,9 +18,9 @@ class ApplicationController < ActionController::Base
   skip_forgery_protection if: -> { api_controller? }
 
   before_action :set_timezone
-
   before_action :enable_analytics
   before_action :check_browser
+  before_action :set_cache_headers
 
   def status
     begin
@@ -229,5 +229,13 @@ class ApplicationController < ActionController::Base
   def other_modern_browsers?(browser)
     (browser.firefox? && browser.device.tablet? && browser.platform.android?('>= 14')) ||
       (!browser.compatibility_view? && (browser.ie?('>= 9') || browser.edge?))
+  end
+
+  def set_cache_headers
+    response.headers.merge!(
+      'Cache-Control' => 'no-cache, no-store',
+      'Pragma' => 'no-cache',
+      'Expires' => 'Mon, 01 Jan 1990 00:00:00 GMT'
+    )
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,6 +79,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def disable_client_cache
+    response.headers.merge!(
+      'Cache-Control' => 'no-cache, no-store',
+      'Pragma' => 'no-cache',
+      'Expires' => 'Mon, 01 Jan 1990 00:00:00 GMT'
+    )
+  end
+
   protected
 
   def check_browser
@@ -228,13 +236,5 @@ class ApplicationController < ActionController::Base
   def other_modern_browsers?(browser)
     (browser.firefox? && browser.device.tablet? && browser.platform.android?('>= 14')) ||
       (!browser.compatibility_view? && (browser.ie?('>= 9') || browser.edge?))
-  end
-
-  def disable_client_cache
-    response.headers.merge!(
-      'Cache-Control' => 'no-cache, no-store',
-      'Pragma' => 'no-cache',
-      'Expires' => 'Mon, 01 Jan 1990 00:00:00 GMT'
-    )
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,6 @@ class ApplicationController < ActionController::Base
   before_action :set_timezone
   before_action :enable_analytics
   before_action :check_browser
-  before_action :set_cache_headers
 
   def status
     begin
@@ -231,7 +230,7 @@ class ApplicationController < ActionController::Base
       (!browser.compatibility_view? && (browser.ie?('>= 9') || browser.edge?))
   end
 
-  def set_cache_headers
+  def disable_client_cache
     response.headers.merge!(
       'Cache-Control' => 'no-cache, no-store',
       'Pragma' => 'no-cache',

--- a/app/controllers/finance/provider/settings_controller.rb
+++ b/app/controllers/finance/provider/settings_controller.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 class Finance::Provider::SettingsController < Finance::Provider::BaseController
-
   before_action :set_strategy
   before_action :disable_client_cache
-  layout 'provider'
 
+  layout 'provider'
 
   def show
     activate_menu :audience, :finance, :charging_and_gateway

--- a/app/controllers/finance/provider/settings_controller.rb
+++ b/app/controllers/finance/provider/settings_controller.rb
@@ -3,6 +3,7 @@
 class Finance::Provider::SettingsController < Finance::Provider::BaseController
 
   before_action :set_strategy
+  before_action :disable_client_cache
   layout 'provider'
 
 

--- a/app/controllers/provider/admin/account/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/account/authentication_providers_controller.rb
@@ -3,6 +3,8 @@ class Provider::Admin::Account::AuthenticationProvidersController < Provider::Ad
   before_action :authorize_changes, only: [:edit, :update, :destroy]
   activate_menu :account, :users, :sso_integrations
 
+  before_action :disable_client_cache
+
   def index
     @presenter = Provider::Admin::Account::AuthenticationProvidersIndexPresenter.new(
       current_user, self_authentication_providers, user_session)

--- a/app/controllers/provider/admin/accounts_controller.rb
+++ b/app/controllers/provider/admin/accounts_controller.rb
@@ -9,7 +9,6 @@ class Provider::Admin::AccountsController < Provider::Admin::Account::BaseContro
   before_action :deny_unless_can_update, :only => [:update, :edit]
   before_action :check_provider_signup_possible, :only => %i[new create]
   before_action :disable_client_cache
-  # before_action :disable_client_cache, :only => [:show]
 
   def new
     @provider = current_account.buyers.new

--- a/app/controllers/provider/admin/accounts_controller.rb
+++ b/app/controllers/provider/admin/accounts_controller.rb
@@ -8,6 +8,8 @@ class Provider::Admin::AccountsController < Provider::Admin::Account::BaseContro
   before_action :find_account
   before_action :deny_unless_can_update, :only => [:update, :edit]
   before_action :check_provider_signup_possible, :only => %i[new create]
+  before_action :disable_client_cache
+  # before_action :disable_client_cache, :only => [:show]
 
   def new
     @provider = current_account.buyers.new

--- a/app/controllers/provider/admin/api_docs/account_data_controller.rb
+++ b/app/controllers/provider/admin/api_docs/account_data_controller.rb
@@ -1,4 +1,8 @@
+# frozen_string_literal: true
+
 class Provider::Admin::ApiDocs::AccountDataController < Provider::Admin::BaseController
+  before_action :disable_client_cache
+
   def show
     @data = ::ApiDocs::ProviderUserData.new(current_user)
 

--- a/app/controllers/provider/admin/api_docs_controller.rb
+++ b/app/controllers/provider/admin/api_docs_controller.rb
@@ -1,5 +1,7 @@
 class Provider::Admin::ApiDocsController < Provider::Admin::BaseController
   activate_menu :account, :integrate, :apidocs
 
+  before_action :disable_client_cache
+
   layout 'provider'
 end

--- a/app/controllers/provider/admin/applications_controller.rb
+++ b/app/controllers/provider/admin/applications_controller.rb
@@ -15,6 +15,7 @@ class Provider::Admin::ApplicationsController < FrontendController
   before_action :find_service_plan, only: :create
   before_action :find_cinstance, except: %i[index new create]
   before_action :initialize_cinstance, only: :create
+  before_action :disable_client_cache
 
   activate_menu :audience, :applications, :listing
 

--- a/app/controllers/provider/admin/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/authentication_providers_controller.rb
@@ -2,13 +2,11 @@
 
 class Provider::Admin::AuthenticationProvidersController < FrontendController
   before_action :authorize_settings
-
-  activate_menu :audience, :cms, :sso_integrations
-
   before_action :find_authentication_provider, only: %i[show edit update publish_or_hide destroy]
   before_action :authorize_authentication_provider, only: %i[show edit destroy]
   before_action :disable_client_cache, except: :index
 
+  activate_menu :audience, :cms, :sso_integrations
 
   def index
     @authentication_providers = current_account.authentication_provider_kinds

--- a/app/controllers/provider/admin/authentication_providers_controller.rb
+++ b/app/controllers/provider/admin/authentication_providers_controller.rb
@@ -7,6 +7,8 @@ class Provider::Admin::AuthenticationProvidersController < FrontendController
 
   before_action :find_authentication_provider, only: %i[show edit update publish_or_hide destroy]
   before_action :authorize_authentication_provider, only: %i[show edit destroy]
+  before_action :disable_client_cache, except: :index
+
 
   def index
     @authentication_providers = current_account.authentication_provider_kinds

--- a/app/controllers/provider/admin/user/access_tokens_controller.rb
+++ b/app/controllers/provider/admin/user/access_tokens_controller.rb
@@ -6,7 +6,8 @@ class Provider::Admin::User::AccessTokensController < Provider::Admin::User::Bas
   authorize_resource
   activate_menu :account, :personal, :tokens
   before_action :authorize_access_tokens
-
+  before_action :disable_client_cache
+  
   def create
     create! do |success, _failure|
       success.html do

--- a/app/controllers/provider/admin/user/access_tokens_controller.rb
+++ b/app/controllers/provider/admin/user/access_tokens_controller.rb
@@ -7,7 +7,7 @@ class Provider::Admin::User::AccessTokensController < Provider::Admin::User::Bas
   activate_menu :account, :personal, :tokens
   before_action :authorize_access_tokens
   before_action :disable_client_cache
-  
+
   def create
     create! do |success, _failure|
       success.html do

--- a/app/controllers/provider/admin/webhooks_controller.rb
+++ b/app/controllers/provider/admin/webhooks_controller.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 class Provider::Admin::WebhooksController < Sites::BaseController
 
   before_action :find_webhook
   before_action :authorize_web_hooks
+  before_action :disable_client_cache
 
   activate_menu! :account, :integrate, :webhooks
 

--- a/app/controllers/sites/dns_controller.rb
+++ b/app/controllers/sites/dns_controller.rb
@@ -2,6 +2,7 @@ class Sites::DnsController < Sites::BaseController
   activate_menu :audience, :cms, :admin_site_dns
 
   before_action :find_account
+  before_action :disable_client_cache
 
   def show
   end

--- a/doc/liquid/tags.md
+++ b/doc/liquid/tags.md
@@ -63,6 +63,18 @@ We recommend __to remove this tag__ from public templates.
 ```liquid
 {% debug:help %}
 ```
+# Tag 'disable_client_cache'
+
+Adds HTTP headers to disable the browser cache for the current screen.
+
+__Example:__ Disable browser cache for this screen
+```liquid
+<html>
+  <head>
+    {% disable_client_cache %}
+  </head>
+</html>
+```
 # Tag 'email'
 
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -10,7 +10,6 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
   before_action :authorize_new_app, :only => [:new]
   before_action :authorize_create_app, :only => [:create]
   before_action :authorize_update_app,  :only => [:edit, :update]
-  before_action :disable_client_cache
 
   activate_menu :dashboard, :applications
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -10,6 +10,7 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
   before_action :authorize_new_app, :only => [:new]
   before_action :authorize_create_app, :only => [:create]
   before_action :authorize_update_app,  :only => [:edit, :update]
+  before_action :disable_client_cache
 
   activate_menu :dashboard, :applications
 

--- a/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
@@ -2,7 +2,6 @@ class DeveloperPortal::CMS::NewContentController < DeveloperPortal::BaseControll
 
   skip_before_action :login_required
 
-  before_action :disable_client_cache
   before_action :ensure_can_view_content, :if => :check_permissions?
   append_before_action :ensure_buyer_domain, only: [:show]
 

--- a/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/cms/new_content_controller.rb
@@ -2,6 +2,7 @@ class DeveloperPortal::CMS::NewContentController < DeveloperPortal::BaseControll
 
   skip_before_action :login_required
 
+  before_action :disable_client_cache
   before_action :ensure_can_view_content, :if => :check_permissions?
   append_before_action :ensure_buyer_domain, only: [:show]
 

--- a/lib/developer_portal/app/views/developer_portal/accounts/payment_gateways/edit.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/accounts/payment_gateways/edit.html.liquid
@@ -1,3 +1,5 @@
+{% disable_client_cache %}
+
 <div class="row">
   <div class="col-md-9">
     {% include 'users_menu' %}

--- a/lib/developer_portal/app/views/developer_portal/accounts/payment_gateways/show.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/accounts/payment_gateways/show.html.liquid
@@ -1,3 +1,5 @@
+{% disable_client_cache %}
+
 <div class="row">
   <div class="col-md-9">
     {% include 'users_menu' %}

--- a/lib/developer_portal/app/views/developer_portal/applications/index.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/applications/index.html.liquid
@@ -1,3 +1,5 @@
+{% disable_client_cache %}
+
 <div class="row">
   <div class="col-md-9">
     <table class="table panel panel-default" id="applications">

--- a/lib/developer_portal/app/views/developer_portal/applications/show.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/applications/show.html.liquid
@@ -1,3 +1,5 @@
+{% disable_client_cache %}
+
 <div class="row">
   <div class="col-md-9">
     <div class="panel panel-default">

--- a/lib/developer_portal/app/views/developer_portal/docs.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/docs.html.liquid
@@ -1,3 +1,5 @@
+{% disable_client_cache %}
+
 {% content_for javascripts %}
     {{ 'active_docs.js' | javascript_include_tag }}
 {% endcontent_for %}

--- a/lib/developer_portal/app/views/developer_portal/index.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/index.html.liquid
@@ -1,3 +1,5 @@
+{% disable_client_cache %}
+
 <header class="jumbotron page-header">
   <div class="container">
     <div class="row">

--- a/lib/developer_portal/config/initializers/liquid.rb
+++ b/lib/developer_portal/config/initializers/liquid.rb
@@ -56,6 +56,7 @@ Rails.application.config.to_prepare do
     Liquid::Tags::ContentFor,
     Liquid::Tags::SortLink,
     Liquid::Tags::CdnAsset,
+    Liquid::Tags::DisableClientCache,
   ].each do |tag_class|
     ::Liquid::Template.register_tag(tag_class.tag, tag_class)
   end

--- a/lib/developer_portal/lib/liquid/tags/disable_client_cache.rb
+++ b/lib/developer_portal/lib/liquid/tags/disable_client_cache.rb
@@ -12,8 +12,7 @@ module Liquid
 
       desc "Adds HTTP headers to disable the browser cache for the current screen."
       def render(context)
-        controller = context.registers[:controller].dup
-        controller.disable_client_cache
+        context.registers[:controller].disable_client_cache
         nil
       end
     end

--- a/lib/developer_portal/lib/liquid/tags/disable_client_cache.rb
+++ b/lib/developer_portal/lib/liquid/tags/disable_client_cache.rb
@@ -1,0 +1,21 @@
+module Liquid
+  module Tags
+
+    class DisableClientCache < Liquid::Tags::Base
+      example "Disable browser cache for this screen", %{
+        <html>
+          <head>
+            {% disable_client_cache %}
+          </head>
+        </html>
+      }
+
+      desc "Adds HTTP headers to disable the browser cache for the current screen."
+      def render(context)
+        controller = context.registers[:controller].dup
+        controller.disable_client_cache
+        nil
+      end
+    end
+  end
+end

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -10,7 +10,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
 
   attr_reader :application_controller
 
-  def test_check_browser
+  test 'check browser' do
     provider = FactoryBot.create(:provider_account)
     login! provider
 
@@ -128,12 +128,36 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
-  test "page should not cache" do
-    provider = FactoryBot.create(:provider_account)
-    host! provider.external_admin_domain
-    get provider_login_path
-    assert_equal 'no-cache, no-store', response.headers['Cache-Control']
-    assert_equal 'no-cache', response.headers['Pragma']
-    assert_equal 'Mon, 01 Jan 1990 00:00:00 GMT', response.headers['Expires']
+  class ClientCaching < ActionDispatch::IntegrationTest
+    def setup
+      @provider = FactoryBot.create(:provider_account)
+      @user = @provider.admins.first
+      login! @provider, user: @user
+    end
+
+    class ClientCachingController < ApplicationController
+      before_action :disable_client_cache
+
+      def show; end
+    end
+
+    def with_test_routes
+      Rails.application.routes.draw do
+        get '/client_caching' => 'application_controller_test/client_caching/client_caching#show'
+      end
+      yield
+    ensure
+      Rails.application.routes_reloader.reload!
+    end
+
+    test "page should not cache" do
+      with_test_routes do
+        get '/client_caching'
+      end
+
+      assert_equal 'no-cache, no-store', response.headers['Cache-Control']
+      assert_equal 'no-cache', response.headers['Pragma']
+      assert_equal 'Mon, 01 Jan 1990 00:00:00 GMT', response.headers['Expires']
+    end
   end
 end

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -127,4 +127,13 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :created
   end
+
+  test "page should not cache" do
+    provider = FactoryBot.create(:provider_account)
+    host! provider.external_admin_domain
+    get provider_login_path
+    assert_equal 'no-cache, no-store', response.headers['Cache-Control']
+    assert_equal 'no-cache', response.headers['Pragma']
+    assert_equal 'Mon, 01 Jan 1990 00:00:00 GMT', response.headers['Expires']
+  end
 end

--- a/test/unit/liquid/tags/disable_client_cache_test.rb
+++ b/test/unit/liquid/tags/disable_client_cache_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Liquid::Tags::DisableClientCacheTest < ActiveSupport::TestCase
+  def setup
+    @context = Liquid::Context.new
+    @context.registers[:controller] = ApplicationController.new
+    @context.registers[:controller].response = ActionDispatch::Response.new
+    @disable_client_cache = Liquid::Tags::DisableClientCache.parse 'disable_client_cache', '', [], {}
+  end
+
+  test "page should not cache" do
+    @disable_client_cache.render(@context)
+    response = @context.registers[:controller].response
+
+    assert_equal 'no-cache, no-store', response.headers['Cache-Control']
+    assert_equal 'no-cache', response.headers['Pragma']
+    assert_equal 'Mon, 01 Jan 1990 00:00:00 GMT', response.headers['Expires']
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

[THREESCALE-10076: Content caching not set for personal tokens page. Allows page retrieval when logged out.
](https://issues.redhat.com/browse/THREESCALE-10076)

**Which issue(s) this PR fixes** 

When logging out and clicking back button on the browser page is rendered from the browser cache.

**Verification steps** 

Though the PR says it's in the personal tokens page, it happens anywhere so it could be verified there and also wherever in the application. Just log out and confirm that when clicking back you won't be redirected to the previous page.

**Update**

As @jlledom proposed, finally we'll be applying this to the following screens: 

Admin portal:
- [x] /p/admin/api_docs
- [x] /p/admin/account
- [x] /p/admin/user/access_tokens
- [x] /p/admin/account/authentication_providers <- Maybe? not sure about this one
- [x] /p/admin/webhooks/ <- Could include tokens in the URL as paremeters
- [x] /apiconfig/services/<ID>/settings
- [x] /apiconfig/services/<ID>/integration
- [x] /apiconfig/services/<ID>/api_docs/<ID>/preview
- [x] /p/admin/applications/<ID>
- [x] /site/dns
- [x] /p/admin/authentication_providers (applied everywhere except index)
- [x] /p/admin/api_docs/account_data // Couldn't test it but the method is there
- [x] /finance/settings

Developer portal:
- [x] /
- [x] /admin/applications/<ID>
- [x] /docs

