### PR TITLE
Fix deprecation warning: Class level methods will no longer inherit scoping

### DIFF
--- a/app/models/deleted_object.rb
+++ b/app/models/deleted_object.rb
@@ -22,7 +22,7 @@ class DeletedObject < ApplicationRecord
 
   scope :stale, -> do
     where.has do
-      ((id.in DeletedObject.deleted_owner.select(:id)) | (object_type == Contract.name)) \
+      ((id.in DeletedObject.unscoped.deleted_owner.select(:id)) | (object_type == Contract.name)) \
       & (created_at <= 1.week.ago)
     end
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a Deprecation warning catched by [Bugsnag](https://app.bugsnag.com/3scale-networks-sl/system/errors/64d96e8ed4b5da00086171cb?filters[event.since]=30d&filters[error.status]=open&filters[search][]=Class&filters[search][]=level&filters[search][]=methods).

**Which issue(s) this PR fixes** 

[THREESCALE-10138](https://issues.redhat.com/browse/THREESCALE-10138)

**Verification steps** 

Just open a Rails console and type:

```
DeletedObject.stale
```

You should see the warning in master but not in this branch. The resulting query should be exactly the same.

