### PR TITLE
THREESCALE-9934: Report less metrics to prometheus from Rails app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,6 @@ gem 'sidekiq-prometheus-exporter'
 
 # Yabeda metrics
 gem 'yabeda-prometheus-mmap'
-gem 'yabeda-rails'
 gem 'yabeda-sidekiq'
 
 gem 'activemerchant', '~> 1.107.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -900,9 +900,6 @@ GEM
     yabeda-prometheus-mmap (0.1.1)
       prometheus-client-mmap
       yabeda (~> 0.5)
-    yabeda-rails (0.6.0)
-      rails
-      yabeda (~> 0.4)
     yabeda-sidekiq (0.10.0)
       anyway_config (>= 1.3, < 3)
       sidekiq
@@ -1079,7 +1076,6 @@ DEPENDENCIES
   with_env
   xpath (~> 3.2.0)
   yabeda-prometheus-mmap
-  yabeda-rails
   yabeda-sidekiq
   yard
   zip-zip

--- a/app/lib/three_scale/metrics/yabeda.rb
+++ b/app/lib/three_scale/metrics/yabeda.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Based on https://github.com/yabeda-rb/yabeda-rails/blob/v0.8.1/lib/yabeda/rails.rb
+
+require "yabeda"
+require "active_support"
+require "rails/railtie"
+
+module ThreeScale
+  module Metrics
+    module Yabeda
+      LONG_RUNNING_REQUEST_BUCKETS = [
+        0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, # standard
+        40, # default Unicorn timeout
+      ].freeze
+
+      class << self
+        def controller_handlers
+          @controller_handlers ||= []
+        end
+
+        def on_controller_action(&block)
+          controller_handlers << block
+        end
+
+        def install!
+          ::Yabeda.configure do
+            group :rails
+
+            counter   :requests_total,   comment: "A counter of the total number of HTTP requests rails processed.",
+                      tags: %i[controller action status]
+
+            histogram :request_duration, tags: %i[controller action status],
+                      unit: :seconds,
+                      buckets: LONG_RUNNING_REQUEST_BUCKETS,
+                      comment: "A histogram of the response latency."
+
+            ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
+              event = ActiveSupport::Notifications::Event.new(*args)
+              labels = {
+                controller: event.payload[:params]["controller"],
+                action: event.payload[:params]["action"],
+                status: ThreeScale::Metrics::Yabeda.event_status_code(event),
+              }.merge!(event.payload.slice(*::Yabeda.default_tags.keys))
+
+              rails_requests_total.increment(labels)
+              rails_request_duration.measure(labels, ThreeScale::Metrics::Yabeda.ms2s(event.duration))
+
+              ThreeScale::Metrics::Yabeda.controller_handlers.each do |handler|
+                handler.call(event, labels)
+              end
+            end
+          end
+        end
+
+        def ms2s(milliseconds)
+          (milliseconds / 1000.0).round(3)
+        end
+
+        def event_status_code(event)
+          if event.payload[:status].nil? && event.payload[:exception].present?
+            ActionDispatch::ExceptionWrapper.status_code_for_exception(event.payload[:exception].first)
+          else
+            event.payload[:status]
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'three_scale/metrics/yabeda'
+
+Rails.application.config.to_prepare do
+  ThreeScale::Metrics::Yabeda.install!
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     require 'yabeda/prometheus/mmap'
 
     mount Sidekiq::Prometheus::Exporter, at: '/metrics'
+    # DEPRECATED: this endpoint will be removed in future versions and Yabeda metrics will be at `/metrics`
     mount Yabeda::Prometheus::Exporter, at: '/yabeda-metrics'
     mount ::System::Deploy, at: 'deploy'
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

- report less stuff

The next step (once we are happy with this set of metrics) would be to expose system-app metrics (not sidekiq) at `/metrics` (as opposed to the current `/yabeda-metrics`).

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-9934

**Verification steps** 

```
curl http://localhost:9394/yabeda-metrics
```

Verify that it reports what is expected.

**Special notes for your reviewer**:

The changes are just to try something, it's not necessarily what we want, we may remove some metrics completely, or change them.
