### PR TITLE
Upgrade BugSnag gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'stripe', '~> 5.28.0' # we need the stripe gem because activemerchant can no
 
 gem 'acts_as_list', '~> 0.9.17'
 gem 'braintree', '~> 2.93'
-gem 'bugsnag', '~> 6.11'
+gem 'bugsnag', '~> 6.26'
 gem 'cancancan', '~> 3.0.0'
 gem 'formtastic', '~> 4.0'
 gem 'htmlentities', '~>4.3', '>= 4.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
     braintree (2.104.1)
       builder (>= 2.0.0)
     browser (5.3.1)
-    bugsnag (6.11.1)
+    bugsnag (6.26.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     bullet (6.1.5)
@@ -937,7 +937,7 @@ DEPENDENCIES
   bootsnap (~> 1.16)
   braintree (~> 2.93)
   browser
-  bugsnag (~> 6.11)
+  bugsnag (~> 6.26)
   bullet (~> 6.1.5)
   cancancan (~> 3.0.0)
   capybara (~> 3.35.3)!

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -81,11 +81,11 @@ module ErrorHandling
 
       # Add some app-specific data which will be displayed on a custom
       # "Provider" tab on each error page on bugsnag.com
-      notification.add_tab(:provider, {
-                             name: site_account.try(:org_name),
-          admin_domain: site_account.try(:self_domain),
-          domain: site_account.try(:domain)
-                           })
+      notification.add_metadata(:provider, {
+                                  name: site_account.try(:org_name),
+                                  admin_domain: site_account.try(:self_domain),
+                                  domain: site_account.try(:domain)
+                                })
     end
 
     def handle_provider_side(status, exception, title)

--- a/app/lib/system/error_reporting.rb
+++ b/app/lib/system/error_reporting.rb
@@ -19,7 +19,7 @@ module System
       logger.error('Exception') { {exception: {class: exception.class, message: (exception.try(:message) || exception.to_s), backtrace: (exception.try(:backtrace) || [])[0..3]}, parameters: parameters} }
 
       ::Bugsnag.notify(exception) do |report|
-        report.add_tab 'parameter', {parameters: parameters}
+        report.add_metadata 'parameter', { parameters: parameters }
       end
     end
 
@@ -29,7 +29,7 @@ module System
       ::Bugsnag.notify(exception) do |report|
         report.severity = 'warning'
         report.grouping_hash = exception.message
-        report.add_tab 'deprecation_info', {
+        report.add_metadata 'deprecation_info', {
           gem_name: exception.gem_name,
           deprecation_horizon: exception.deprecation_horizon
         }

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -5,9 +5,7 @@ Rails.application.config.to_prepare do
     config.api_key = Rails.configuration.three_scale.bugsnag_api_key
     config.app_version = System::Deploy.info.revision
     stages = Rails.configuration.three_scale.error_reporting_stages
-    # TODO: after upgrading Bugsnag replace `notify_release_stages` (deprecated in v6.23) with `enabled_release_stages`
-    # see https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.23.0
-    config.notify_release_stages = stages.present? ? stages : %w[staging production]
+    config.enabled_release_stages = stages.present? ? stages : %w[staging production]
     config.release_stage = Rails.configuration.three_scale.bugsnag_release_stage || Rails.env
 
     ignore_error_names = ActionDispatch::ExceptionWrapper.rescue_responses.keys + ['WebHookWorker::ClientError']


### PR DESCRIPTION
**What this PR does / why we need it**:

The motivation for this upgrade was removing this warning in the development server logs:
```
[Bugsnag] -- Breadcrumb Read cache meta_data super_operation:Symbol has been dropped for having an invalid data type
```
This is [fixed](https://github.com/bugsnag/bugsnag-ruby/pull/563) in [v6.12](https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.12.0)

Another useful fix is [Ruby 2.7 deprecation warnings](https://github.com/bugsnag/bugsnag-ruby/pull/582), which is released in [v6.13.1](https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.13.0).

But as we're upgrading, I decided to upgrade to the latest available version. And it included some deprecations, e.g. in release [v6.23.0](https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.23.0)


**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

-none-

**Special notes for your reviewer**:

-none-
