### PR TITLE
Fix checkbox input margin

### DIFF
--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -136,8 +136,8 @@ select {
   float: right;
 }
 
-input[type='checkbox']:not(.pf-c-check__input, #root_*),
-input[type='checkbox']:not(.pf-c-check__input, #root_*):active,
+input[type='checkbox']:not(.pf-c-check__input),
+input[type='checkbox']:not(.pf-c-check__input):active,
 form.formtastic:not(.pf-c-form) fieldset > ol > li.boolean label input,
 form.formtastic:not(.pf-c-form) fieldset > ol > li.radio fieldset ol li label input[type='radio'],
 form.formtastic:not(.pf-c-form) fieldset.inputs input[type='checkbox'],


### PR DESCRIPTION
I thought this selector made the Policy edit modal look good but it doesn't...? Instead it removes the input's right margin... no idea why either 😆 

**Note for reviewers**: please take an thorough look at possible CSS glitches.. this was added for a reason and something else could be broken.

Before:
![Screenshot 2023-09-20 at 09 20 45](https://github.com/3scale/porta/assets/11672286/6785f071-54ec-49f3-b0cf-2b3deb0f48a7)


After:
![Screenshot 2023-09-20 at 09 18 32](https://github.com/3scale/porta/assets/11672286/2c907f1e-86d6-4fbc-bf16-4efcea0683cc)