### PR TITLE
THREESCALE-10145: Add Terms and Conditions link to the admin portal footer

### DIFF
--- a/app/views/provider/_footer.html.slim
+++ b/app/views/provider/_footer.html.slim
@@ -1,10 +1,12 @@
 hr.pf-c-divider
 footer.pf-c-page__main-section
   div.pf-l-flex
-    - if ThreeScale.tenant_mode.multitenant?
-      div.pf-l-flex__item
-        = link_to 'Privacy', '//www.redhat.com/en/about/privacy-policy', target: '_blank'
     div.pf-l-flex__item
       = link_to 'Support', "//access.redhat.com/products/red-hat-3scale#support", target: '_blank'
+    - if ThreeScale.saas?
+      div.pf-l-flex__item
+        = link_to 'Privacy', '//www.redhat.com/en/about/privacy-policy', target: '_blank'
+      div.pf-l-flex__item
+        = link_to 'Terms and Conditions', '//cloud.redhat.com/legal ', target: '_blank'
     div.pf-l-flex__item.pf-m-align-right
       = render 'provider/footer_powered_by_part'


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a link to the admin portal footer.

**Which issue(s) this PR fixes** 

[THREESCALE-10145](https://issues.redhat.com/browse/THREESCALE-10145)

**Verification steps** 

Open any page of the admin portal and see the link in the footer.

**Special notes for your reviewer**:

`ThreeScale.saas?` checks for `onpremises: false` in `settings.yml`, while `ThreeScale.tenant_mode.multitenant?` checks for the tenant mode (which is only multitenant in SaaS). In the current configuration (where on-premises pods use different tenant modes) they are equivalent, and I find `ThreeScale.saas?` less confusing.
