### PR TITLE
Fix (hopefully) deploy info random failures

### DIFF
--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -29,7 +29,7 @@ module System
       def initialize(info)
         @revision = info.fetch('revision') { `git rev-parse HEAD 2> /dev/null`.strip }
         @release = ThreeScale.saas? ? DEFAULT_VERSION : info.fetch('release', DEFAULT_VERSION)
-        @deployed_at = info.fetch('deployed_at') { Time.now }
+        @deployed_at = info.fetch('deployed_at') { Time.now.utc }
         @error = info.fetch(:error) if info.key?(:error)
       end
 
@@ -88,8 +88,8 @@ module System
 
     def self.load_info!(deploy_info = parse_deploy_info)
       self.info = Info.new(deploy_info)
-    rescue StandardError => error
-      self.info = InvalidInfo.new(error)
+    rescue StandardError => exception
+      self.info = InvalidInfo.new(exception)
     end
   end
 end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -22,7 +22,7 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal 'one two three', css_class('one', ['two'], three: true)
   end
 
-  class AssetHostTest < ApplicationHelperTest
+  class AssetHostTest < ActionView::TestCase
     setup do
       @request = ActionDispatch::TestRequest.create
       @asset_host = 'cdn.3scale.test.localhost'
@@ -65,9 +65,15 @@ class ApplicationHelperTest < ActionView::TestCase
 
       assert_equal @full_asset_host, result
     end
+  end
+
+  class DocsBaseUrlTest < ActionView::TestCase
+    setup do
+      ThreeScale.config.stubs(onpremises: false)
+      System::Deploy.load_info!
+    end
 
     test 'docs base url' do
-      ThreeScale.config.stubs(onpremises: false)
       assert_equal 'https://access.redhat.com/documentation/en-us/red_hat_3scale/2-saas/html', docs_base_url
     end
   end

--- a/test/unit/lib/system/deploy_test.rb
+++ b/test/unit/lib/system/deploy_test.rb
@@ -40,10 +40,6 @@ class DeployTest < ActiveSupport::TestCase
       System::Deploy.load_info! ActiveSupport::JSON.decode('{"revision": "2.13-stable", "release": "2.13"}')
     end
 
-    teardown do
-      System::Deploy.info = nil
-    end
-
     test 'onpremises release has a major and minor version' do
       assert_equal '2', System::Deploy.info.major_version
       assert_equal '13', System::Deploy.info.minor_version
@@ -58,10 +54,6 @@ class DeployTest < ActiveSupport::TestCase
     setup do
       ThreeScale.config.stubs(onpremises: false)
       System::Deploy.load_info! ActiveSupport::JSON.decode('{"revision": "alpha", "release": "alpha"}')
-    end
-
-    teardown do
-      System::Deploy.info = nil
     end
 
     test 'custom release from .deploy_info is ignored' do
@@ -80,10 +72,6 @@ class DeployTest < ActiveSupport::TestCase
       System::Deploy.load_info! ActiveSupport::JSON.decode('{"revision": "2.x-mas", "release": "RHOAM"}')
     end
 
-    teardown do
-      System::Deploy.info = nil
-    end
-
     test 'RHOAM release has only one segment' do
       assert_equal 'RHOAM', System::Deploy.info.major_version
       assert_nil System::Deploy.info.minor_version
@@ -97,6 +85,10 @@ class DeployTest < ActiveSupport::TestCase
   class InvalidInfoTest < ActiveSupport::TestCase
     setup do
       System::Deploy.load_info! 'invalid-data'
+    end
+
+    teardown do
+      System::Deploy.load_info!
     end
 
     test 'load invalid info' do


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing random failures like here: https://app.circleci.com/pipelines/github/3scale/porta/25892/workflows/ee6dce4c-7b32-462d-ae92-c09b0f4bd21b/jobs/291266/parallel-runs/1?filterBy=FAILED

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

just run the CI tests and pray

**Special notes for your reviewer**:

I believe the issue was caused by the fact that when some tests were run in parallel, the deploy info was in some tests set to `nil` or invalid info.

So, I removed/changed `teardown` to ensure that outside of the `InvalidInfoTest` the `System::Deploy.info` is always a valid `System::Deploy::Info` class.
