### PR TITLE
Refactor custom User and Application key forms

### DIFF
--- a/app/controllers/provider/admin/keys_controller.rb
+++ b/app/controllers/provider/admin/keys_controller.rb
@@ -6,27 +6,28 @@ class Provider::Admin::KeysController < Provider::Admin::BaseController
 
   layout false
 
+  # Show a modal window for adding a custom Application Key
   def new
   end
 
+  # Show a modal window for setting a custom User Key
   def edit
   end
 
+  # Set a custom User Key
   def update
     user_key = params[:cinstance][:user_key]
     if user_key.blank?
-      @error = t('activerecord.errors.models.cinstance.attributes.user_key.blank')
+      @cinstance.errors.add(:user_key, :blank)
     else
       @cinstance.user_key = user_key
-      if @cinstance.save
-        @notice = t('.update.success')
-      else
-        @error = @cinstance.errors.messages[:user_key].first
-      end
+      @notice = t('.update.success') if @cinstance.save
     end
+    @error = @cinstance.errors.full_messages_for(:user_key).presence
     respond_to(:js)
   end
 
+  # Create a custom Application Key
   def create
     @key = @cinstance.application_keys.add(params[:key])
 
@@ -34,8 +35,7 @@ class Provider::Admin::KeysController < Provider::Admin::BaseController
       @keys = @cinstance.application_keys.pluck_values
       @notice = t('.create.success')
     else
-      error_type = @key.errors.details[:value].first[:error]
-      @error = t(errot_type, scope: 'activerecord.errors.models.cinstance.keys')
+      @error = @key.errors.full_messages.presence
     end
 
     respond_to(:js)

--- a/app/views/provider/admin/keys/create.js.erb
+++ b/app/views/provider/admin/keys/create.js.erb
@@ -15,7 +15,8 @@
       <%# HACK: Remove helperText and add it again, since replacing the text also removes the icon. %>
       input.closest('.pf-c-form__group-control').children[1].remove()
 
-      input.insertAdjacentHTML('afterend', '<%= j render partial: "shared/pf_error_helper_text", locals: { error: @error } %>')
+      input.insertAdjacentHTML('afterend', '<%= j render partial: "shared/pf_error_helper_text",
+          locals: { error: [@error.to_sentence, t('formtastic.hints.cinstance.key')].join('. ') } %>')
       input.setAttribute('aria-invalid', 'true')
 
       $.colorbox.resize();

--- a/app/views/provider/admin/keys/new.html.erb
+++ b/app/views/provider/admin/keys/new.html.erb
@@ -4,7 +4,7 @@
 
 <div class="pf-c-card__body">
   <%= form_tag provider_admin_application_keys_path(@cinstance), class: 'pf-c-form pf-m-limit-width',
-                                                                 data: { remote: 'true' } do |form| %>
+                                                                 remote: true do |form| %>
     <div class="pf-c-form__group">
       <div class="pf-c-form__group-label">
         <label class="pf-c-form__label" for="key">

--- a/app/views/provider/admin/keys/update.js.erb
+++ b/app/views/provider/admin/keys/update.js.erb
@@ -8,7 +8,8 @@
     <%# HACK: Remove helperText and add it again, since replacing the text also removes the icon. %>
     input.closest('.pf-c-form__group-control').children[1].remove()
 
-    input.insertAdjacentHTML('afterend', '<%= j render partial: "shared/pf_error_helper_text", locals: { error: @error } %>')
+    input.insertAdjacentHTML('afterend', '<%= j render partial: "shared/pf_error_helper_text",
+        locals: { error: [@error.to_sentence, t('formtastic.hints.cinstance.user_key')].join('. ') } %>')
     input.setAttribute('aria-invalid', 'true')
 
     $.colorbox.resize();

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -924,17 +924,6 @@ en:
           attributes:
             plan:
               not_allowed: "not allowed in this context"
-            keys:
-              invalid: Invalid characters. Use only alphanumeric characters [0-9, a-z, A-Z], hyphen-minus (-), no spaces and between 5 and 255 characters.
-              taken: Key is already taken. Use only alphanumeric characters [0-9, a-z, A-Z], hyphen-minus (-), no spaces and between 5 and 255 characters.
-              too_short: Key is too short. Use only alphanumeric characters [0-9, a-z, A-Z], hyphen-minus (-), no spaces and between 5 and 255 characters.
-              too_long: Key is too long. Use only alphanumeric characters [0-9, a-z, A-Z], hyphen-minus (-), no spaces and between 5 and 255 characters.
-            user_key:
-              blank: Key can't be blank. Use only alphanumeric characters [0-9, a-z, A-Z], hyphen-minus (-), no spaces and up to 256 characters.
-              invalid: Invalid characters. Use only alphanumeric characters [0-9, a-z, A-Z], hyphen-minus (-), no spaces and up to 256 characters.
-              taken: Key is already taken. Use only alphanumeric characters [0-9, a-z, A-Z], hyphen-minus (-), no spaces and up to 256 characters.
-              too_short: Key is too short. Use only alphanumeric characters [0-9, a-z, A-Z], hyphen-minus (-), no spaces and up to 256 characters.
-              too_long: Key is too long. Use only alphanumeric characters [0-9, a-z, A-Z], hyphen-minus (-), no spaces and up to 256 characters.
 
         application_key:
           attributes:

--- a/features/provider/admin/applications/keys.feature
+++ b/features/provider/admin/applications/keys.feature
@@ -34,14 +34,14 @@ Feature: Applications details
       And fill in "User key" with "   "
       And press "Save"
       Then the application's user key has not changed
-      And should see "Key can't be blank."
+      And should see "User key can't be blank."
 
     Scenario: Set custom user key fails
       When follow "Set a custom User Key" within the API Credentials card
       And fill in "User key" with "invalid-Ñ$%"
       And press "Save"
       Then the application's user key has not changed
-      And should see "Invalid characters."
+      And should see "User key invalid"
 
   Rule: Backend v2
     Background:
@@ -54,6 +54,13 @@ Feature: Applications details
       And fill in "Key" with "new-valid-key"
       And press "Save"
       Then should see "new-valid-key" within the API Credentials card
+
+    Scenario: Setting an invalid custom key fails
+      Given they are reviewing the buyer's application details
+      When follow "Add Custom key" within the API Credentials card
+      And fill in "Key" with "invalid-Ñ$%"
+      And press "Save"
+      Then should see "Value invalid."
 
     Scenario: Adding a random key
       Given the application has no keys

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -315,7 +315,7 @@ class CinstanceTest < ActiveSupport::TestCase
     cinstance_two = FactoryBot.build(:cinstance, plan: plan, user_key: 'foo')
 
     assert cinstance_two.invalid?
-    assert_match /Key is already taken./, cinstance_two.errors[:user_key].to_s
+    assert_match /has already been taken/, cinstance_two.errors[:user_key].to_s
 
     cinstance_two.user_key = 'bar'
     assert cinstance_two.valid?


### PR DESCRIPTION
New screenshots:

![Screenshot from 2023-10-02 16-54-59](https://github.com/3scale/porta/assets/1270328/f9f7e86c-f568-40f9-86f8-d06e61db02bf)
![Screenshot from 2023-10-02 16-53-36](https://github.com/3scale/porta/assets/1270328/6565a519-b795-43bd-a963-bbe15783c5b9)
![Screenshot from 2023-10-02 16-52-59](https://github.com/3scale/porta/assets/1270328/ea6b6e61-4847-494a-a49c-d05a610506d7)

It says "value" instead of "key" (because this is the actual name of the attribute), but I think it's perfectly clear and it is not worth to complicate the things to make it read "Application key" in the error messages.