### PR TITLE
[Cucumber] Fix THREESCALE-10219 - feature failing because of a typo

### DIFF
--- a/features/provider/admin/messages/outbox.feature
+++ b/features/provider/admin/messages/outbox.feature
@@ -43,7 +43,7 @@ Feature: Audience > Messages > Outbox
     Scenario: Reading a message
       Given they go to the provider sent messages page
       When follow "Welcome"
-      Then the current page is the provider page of message with subject "Welcome Alice"
+      Then the current page is the provider page of message with subject "Welcome"
 
     Scenario: Bulk operations
       Given they go to the provider sent messages page

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -82,7 +82,7 @@ World(Module.new do
       provider_admin_messages_outbox_index_path
 
     when /^the provider page of message with subject "([^"]*)"$/
-      message = @provider.sent_messages.find { |m| m.subject = $1 }
+      message = @provider.sent_messages.find_by(subject: Regexp.last_match(1))
       provider_admin_messages_outbox_path(message)
 
     when "the outbox compose page"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes CI failing every day on Postgres and Oracle
The `#find` block was using assignment  `=` instead of comparison `==`

**Which issue(s) this PR fixes** 

Fixes [THREESCALE-10219](https://issues.redhat.com/browse/THREESCALE-10219)

**Verification steps** 

> Replace this with a list of necessary steps to verify the PR meets your expectations.
> e.g. `1. Go to Admin Portal, make sure that ...`

**Special notes for your reviewer**:

Say hello to the team from my part ;)