### PR TITLE
Run prometheus metrics installation just once

### DIFF
--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -2,6 +2,6 @@
 
 require 'three_scale/metrics/yabeda'
 
-Rails.application.config.to_prepare do
+Rails.application.config.after_initialize do
   ThreeScale::Metrics::Yabeda.install!
 end

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -2,6 +2,4 @@
 
 require 'three_scale/metrics/yabeda'
 
-Rails.application.config.after_initialize do
-  ThreeScale::Metrics::Yabeda.install!
-end
+ThreeScale::Metrics::Yabeda.install!

--- a/lib/three_scale/metrics/yabeda.rb
+++ b/lib/three_scale/metrics/yabeda.rb
@@ -15,14 +15,6 @@ module ThreeScale
       ].freeze
 
       class << self
-        def controller_handlers
-          @controller_handlers ||= []
-        end
-
-        def on_controller_action(&block)
-          controller_handlers << block
-        end
-
         def install!
           ::Yabeda.configure do
             group :rails
@@ -45,10 +37,6 @@ module ThreeScale
 
               rails_requests_total.increment(labels)
               rails_request_duration.measure(labels, ThreeScale::Metrics::Yabeda.ms2s(event.duration))
-
-              ThreeScale::Metrics::Yabeda.controller_handlers.each do |handler|
-                handler.call(event, labels)
-              end
             end
           end
         end


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the annoying
```
Prometheus::Client::Registry::AlreadyRegisteredError`
rails_requests_total has already been registered
```
![image](https://github.com/3scale/porta/assets/1270328/d55b821b-7564-435b-a80e-6efd87c14623)

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

-none-

**Special notes for your reviewer**:
