### PR TITLE
THREESCALE-10043: Optimize BackendStorageRewriteWorker

### DIFF
--- a/app/lib/backend/storage_rewrite.rb
+++ b/app/lib/backend/storage_rewrite.rb
@@ -1,106 +1,178 @@
+# frozen_string_literal: true
+
+require 'progress_counter'
+
 module Backend
+
   module StorageRewrite
 
+    # Rewriter and its subclasses perform operations that update the objects on 3scale Backend
+    class Rewriter
+      # Rewrite a collection
+      # @param scope [ActiveRecord::Associations::CollectionProxy] ActiveRecord collection with filtered scope
+      # @param ids [Array] Array of IDs belonging to scope or class
+      # @param log_progress [Boolean] specifies whether to print progress to console
+      def self.rewrite(**kwargs)
+        scope = kwargs[:scope] || self::CLASS
+        ids = kwargs[:ids]
+        scope = scope.where(id: ids) if ids.present?
+        log_progress = kwargs[:log_progress] || false
+        progress = log_progress ? ProgressCounter.new(scope.count) : nil
 
-    module_function
-
-    def rewrite_all
-      total_count = Service.count + Cinstance.count + Metric.count + UsageLimit.count
-      progress_each = 100
-      index = 0
-
-      progress = -> do
-        index += 1
-        break unless (index % progress_each) == 0
-        percent = (index / total_count.to_f) * 100.0
-
-        yield percent if block_given?
-      end
-
-      Service.find_each do |service|
-        service.update_backend_service
-        progress.call
-        service.service_tokens.find_each(&ServiceTokenService.method(:update_backend))
-      end
-
-      Cinstance.find_each do |cinstance|
-        cinstance.send(:update_backend_application)
-        cinstance.send(:update_backend_user_key_to_application_id_mapping)
-
-        # to ensure that there is a 'backend_object' - there are
-        # invalid data floating around
-        if cinstance.provider_account
-          cinstance.application_keys.each { |k| k.send(:update_backend_value) }
-          cinstance.referrer_filters.each { |f| f.send(:update_backend_value) }
+        scope.includes(self::INCLUDE).find_each do |model|
+          self::REWRITER.call(model)
+          progress&.call
         end
-
-        progress.call
-      end
-
-      Metric.find_each do |metric|
-        metric.sync_backend!
-        progress.call
-      end
-
-      UsageLimit.find_each do |usage_limit|
-        usage_limit.send(:update_backend_usage_limit)
-        progress.call
       end
     end
 
-    def rewrite_provider(id)
-      provider = Account.providers_with_master.find(id)
-
-      services = provider.services.includes(:account)
-      cinstances = provider.buyer_applications.includes(:plan, :service)
-
-      if (cinstance_id = ENV['CINSTANCE_ID'])
-        cinstances = cinstances.where(id: cinstance_id)
-      end
-
-      bought_cinstances = provider.bought_cinstances
-
-      metrics = Metric.by_provider(provider).includes(:parent)
-      usage_limits = provider.usage_limits.includes(plan: :service)
-
-      total_count = services.size + cinstances.size + metrics.size + usage_limits.size + bought_cinstances.size
-
-      index = 0
-      progress = -> do
-        percent = ((index + 1) / total_count.to_f) * 100.0
-        yield percent if block_given?
-        index += 1
-      end
-
-      services.find_each do |service|
-        service.update_backend_service
-        progress.call
-
-        service.service_tokens.find_each(&ServiceTokenService.method(:update_backend))
-      end
-
-      metrics.find_each do |metric|
-        metric.sync_backend!
-        progress.call
-      end
-
-      usage_limits.find_each do |usage_limit|
-        usage_limit.send(:update_backend_usage_limit)
-        progress.call
-      end
-
-      update_cinstance = ->(cinstance) do
+    class CinstanceRewriter < Rewriter
+      CLASS = Cinstance
+      INCLUDE = %i[plan service].freeze
+      REWRITER = ->(cinstance) do
         cinstance.send(:update_backend_application)
         cinstance.send(:update_backend_user_key_to_application_id_mapping)
+        # to ensure that there is a 'backend_object' - there are
+        # invalid data floating around
         if cinstance.provider_account
-          cinstance.application_keys.each { |k| k.send(:update_backend_value) }
-          cinstance.referrer_filters.each { |f| f.send(:update_backend_value) }
+          cinstance.application_keys.each { |app_key| app_key.send(:update_backend_value) }
+          cinstance.referrer_filters.each { |ref_filter| ref_filter.send(:update_backend_value) }
         end
-        progress.call
+      end
+    end
+
+    class ServiceRewriter < Rewriter
+      CLASS = Service
+      INCLUDE = :account
+      REWRITER = ->(service) do
+        service.update_backend_service
+        service.service_tokens.find_each(&ServiceTokenService.method(:update_backend))
+      end
+    end
+
+    class MetricRewriter < Rewriter
+      CLASS = Metric
+      INCLUDE = :parent
+      REWRITER = ->(metric) { metric.sync_backend! }
+    end
+
+    class UsageLimitRewriter < Rewriter
+      CLASS = UsageLimit
+      INCLUDE = { plan: :service }.freeze
+      REWRITER = ->(usage_limit) { usage_limit.update_backend_usage_limit }
+    end
+
+    # Used for rewriting all objects inline, and also. `#rewrite` is used by async jobs
+    class Processor
+
+      attr_reader :include_inactive, :log_progress, :action
+
+      # @param include_inactive [Boolean] specifies whether to include deleted and suspended providers
+      # @param log_progress [Boolean] specifies whether to print progress to console
+      def initialize(**kwargs)
+        @include_inactive = kwargs[:include_inactive] || false
+        @log_progress = kwargs[:log_progress] || false
+        @action = :rewrite
       end
 
-      cinstances.find_each(&update_cinstance)
-      bought_cinstances.find_each(&update_cinstance)
+      # Execute actual rewriting with Backend, depending on the class.
+      # To be called from the async jobs
+      # @param class_name [String] name of class (used by async jobs)
+      # @param scope [ActiveRecord::Associations::CollectionProxy] ActiveRecord collection with filtered scope (used by sync processor)
+      # @param log_progress [Boolean] specifies whether to print progress to console
+      def rewrite(**kwargs)
+        class_name = kwargs.delete(:class_name)
+        klass = class_name || kwargs[:scope]&.klass&.name
+        raise ArgumentError, ':class_name or :scope arguments must be provided' if klass.blank?
+
+        rewriter = Backend::StorageRewrite.const_get("#{klass}Rewriter")
+        rewriter.rewrite({ **kwargs, log_progress: log_progress})
+      end
+
+      # Schedule all objects for all providers, or execute inline
+      def rewrite_all
+        providers.each do |account|
+          rewrite_provider(account.id)
+        end
+        nil
+      end
+
+      # Schedule a single provider or execute inline
+      def rewrite_provider(id)
+        logger.info "#{action} backend storage for provider #{id}..."
+
+        provider = providers.find_by(id: id)
+        unless provider
+          logger.error("Provider with ID #{id} not found")
+          return
+        end
+
+        logger.info "#{action} services for provider #{id}..."
+        process(provider.services)
+
+        logger.info "#{action} buyer applications for provider #{id}..."
+        process(provider.buyer_applications)
+
+        logger.info "#{action} provider applications for provider #{id}..."
+        process(provider.bought_cinstances)
+
+        logger.info "#{action} metrics for provider #{id}..."
+        process(Metric.by_provider(provider))
+
+        logger.info "#{action} usage limits for provider #{id}..."
+        process(provider.usage_limits)
+      end
+
+      private
+
+      # Rewrite the collection
+      def process(collection)
+        rewrite(scope: collection)
+      end
+
+      # This logger just prints out a message to STDOUT, with new line before and after.
+      # New line before is to make progress log look better
+      def logger
+        @logger ||= begin
+          log = ActiveSupport::Logger.new($stdout)
+          log.formatter = ->(_, _, _, msg) { "\n#{msg.is_a?(String) ? msg : msg.inspect}\n" }
+          log
+        end
+      end
+
+      # All accounts eligible for backend sync
+      # Optionally include inactive (deleted and suspended)
+      def providers
+        @providers ||=
+          begin
+            providers = Account.providers_with_master
+            providers = providers.without_deleted.without_suspended unless include_inactive
+            providers
+          end
+      end
+    end
+
+    # Used for scheduling asynchronous jobs for later processing
+    class AsyncProcessor < Processor
+      BATCH_SIZE = 500
+
+      attr_reader :enqueuer
+
+      def initialize(**kwargs)
+        enq = kwargs.delete(:enqueuer)
+        raise ArgumentError, ':enqueuer must be present and respond to :call' unless enq.respond_to?(:call)
+
+        super(**kwargs)
+        @enqueuer = enq
+        @action = :enqueue
+      end
+
+      # Enqueue for asynchronous processing in batches
+      def process(collection)
+        collection.in_batches(of: BATCH_SIZE) do |batch|
+          enqueuer.call(batch.klass.name, batch.pluck(:id))
+        end
+      end
     end
   end
 end

--- a/app/lib/three_scale/filter_arguments.rb
+++ b/app/lib/three_scale/filter_arguments.rb
@@ -15,7 +15,7 @@ module ThreeScale
         case argument
         when Struct
           FILTER.filter(argument.to_h)
-        when Enumerable
+        when Hash
           FILTER.filter(argument)
         else
           argument

--- a/app/workers/backend_storage_rewrite_worker.rb
+++ b/app/workers/backend_storage_rewrite_worker.rb
@@ -4,21 +4,6 @@ class BackendStorageRewriteWorker
   include Sidekiq::Worker
   sidekiq_options queue: :low
 
-  ENQUEUER = ->(class_name, ids) { BackendStorageRewriteWorker.perform_async(class_name, ids) }
-
-  # Enqueue async processing for all providers
-  def self.enqueue_all
-    Backend::StorageRewrite::AsyncProcessor.new(enqueuer: ENQUEUER).rewrite_all
-  end
-
-  # Enqueue async processing for a single provider
-  def self.enqueue(provider_id)
-    Backend::StorageRewrite::AsyncProcessor.new(enqueuer: ENQUEUER).rewrite_provider(provider_id)
-  end
-
-  # The arguments of the worker are: the class name of the collection, and the array of IDs of objects of this class
-  # It should not exceed the BATCH_SIZE defined in AsyncProcessor
-  # All objects in a batch will belong to the same provider (tenant)
   def perform(class_name, ids)
     Backend::StorageRewrite::Processor.new.rewrite(class_name: class_name, ids: ids)
   end

--- a/lib/tasks/backend.rake
+++ b/lib/tasks/backend.rake
@@ -95,31 +95,31 @@ END
     # FIXME: delete non-existing keys too
     #
 
-    rewrite_progress = ->(percent) do
-      puts "#{percent.round(2)}% completed"
-    end
-
     desc "Rewrite the data needed by the backend."
     task :rewrite => :environment do
       next if Rails.env.test? || System::Application.config.three_scale.core.fake_server
 
       if ENV['PROVIDER_ID']
-         break Rake::Task['backend:storage:rewrite_provider'].invoke
+        Rake::Task['backend:storage:rewrite_provider'].invoke
+      else
+        Backend::StorageRewrite::Processor.new(log_progress: true).rewrite_all
       end
-
-      Backend::StorageRewrite.rewrite_all(&rewrite_progress)
     end
 
     desc "Rewrites all the content of a single provider"
     task :rewrite_provider => :environment do
-      Backend::StorageRewrite.rewrite_provider(ENV['PROVIDER_ID'], &rewrite_progress)
+      provider_id = ENV.fetch('PROVIDER_ID', nil)
+      if provider_id
+        Backend::StorageRewrite::Processor.new(log_progress: true).rewrite_provider(provider_id)
+      else
+        puts 'Provider ID has to be set in PROVIDER_ID environment variable'
+      end
     end
 
     desc 'Enqueue job for every provider to do backend storage rewrite.'
     task :enqueue_rewrite => :environment do
-      accounts = Account.providers_with_master
-      BackendStorageRewriteWorker.enqueue_all(accounts)
-      puts "Enqueued #{accounts.count} accounts for rewrite"
+      BackendStorageRewriteWorker.enqueue_all
+      puts "Enqueued all accounts for rewrite"
     end
 
     desc "Regenerate provider keys."

--- a/lib/tasks/backend.rake
+++ b/lib/tasks/backend.rake
@@ -118,7 +118,7 @@ END
 
     desc 'Enqueue job for every provider to do backend storage rewrite.'
     task :enqueue_rewrite => :environment do
-      BackendStorageRewriteWorker.enqueue_all
+      Backend::StorageRewrite::AsyncProcessor.new.rewrite_all
       puts "Enqueued all accounts for rewrite"
     end
 

--- a/test/unit/backend/storage_rewrite_test.rb
+++ b/test/unit/backend/storage_rewrite_test.rb
@@ -4,15 +4,96 @@ require 'test_helper'
 
 module Backend
   class StorageRewriteTest < ActiveSupport::TestCase
-    test 'rewrite provider resyncs all metrics of the provider' do
-      provider = FactoryBot.create(:simple_provider)
-      service = FactoryBot.create(:simple_service, account: provider)
-      backend_api = FactoryBot.create(:backend_api, account: provider)
-      service.backend_api_configs.create!(backend_api: backend_api, path: '/')
-      [service.metrics.hits, backend_api.metrics.hits].each do |metric|
-        ::BackendMetricWorker.expects(:perform_now).with(service.backend_id, metric.id)
+
+    class ProcessorRewriteTest < ActiveSupport::TestCase
+      test 'calls correct rewriter for :class_name' do
+        StorageRewrite::CinstanceRewriter.expects(:rewrite)
+        StorageRewrite::Processor.new.rewrite(class_name: 'Cinstance')
       end
-      StorageRewrite.rewrite_provider(provider.id)
+
+      test 'passes the class_name and ids to rewriter (used in async processing)' do
+        ids = [1,2,3,4,5]
+        StorageRewrite::MetricRewriter.expects(:rewrite).with(ids: ids, log_progress: false)
+        StorageRewrite::Processor.new.rewrite(class_name: 'Metric', ids: ids)
+      end
+
+      test 'passes the scope to rewriter (used in sync processing)' do
+        provider = FactoryBot.create(:simple_provider)
+        StorageRewrite::ServiceRewriter.expects(:rewrite).with(scope: provider.services, log_progress: false)
+        StorageRewrite::Processor.new.rewrite(scope: provider.services)
+      end
+
+      test 'raises an error when :scope or :class_name are not provided' do
+        assert_raises(ArgumentError) { StorageRewrite::Processor.new.rewrite(ids: [1,2,3]) }
+      end
+
+      test 'enables log progress for rewriter if specified explicitly' do
+        ids = [1,2,3,4,5]
+        StorageRewrite::UsageLimitRewriter.expects(:rewrite).with(ids: ids, log_progress: true)
+        StorageRewrite::Processor.new(log_progress: true).rewrite(class_name: 'UsageLimit', ids: ids)
+      end
+    end
+
+    class ProviderProcessingTest < ActiveSupport::TestCase
+      attr_reader :providers
+
+      setup do
+        FactoryBot.create(:simple_master)
+        @providers = FactoryBot.create_list(:simple_provider, 3)
+        providers.last.schedule_for_deletion!
+      end
+
+      test 'run for master and all active providers by default' do
+        processor = StorageRewrite::Processor.new
+        # 2 active providers and 1 master
+        processor.expects(:rewrite_provider).times(3)
+        processor.rewrite_all
+      end
+
+      test 'run for master and inactive providers if specified explicitly' do
+        processor = StorageRewrite::Processor.new(include_inactive: true)
+        # 3 providers and 1 master
+        processor.expects(:rewrite_provider).times(4)
+        processor.rewrite_all
+      end
+
+      test 'rewrites all collections for a provider' do
+        processor = StorageRewrite::Processor.new
+        # services, provider's apps, buyers' apps, metrics and usage limits
+        processor.expects(:rewrite).times(5)
+        processor.rewrite_provider(providers.first.id)
+      end
+
+      test 'rewrite provider resyncs all metrics of the provider' do
+        provider = providers.first
+        service = FactoryBot.create(:simple_service, account: provider)
+        backend_api = FactoryBot.create(:backend_api, account: provider)
+        service.backend_api_configs.create!(backend_api: backend_api, path: '/')
+        [service.metrics.hits, backend_api.metrics.hits].each do |metric|
+          ::BackendMetricWorker.expects(:perform_now).with(service.backend_id, metric.id)
+        end
+        StorageRewrite::Processor.new.rewrite_provider(provider.id)
+      end
+    end
+
+    class AsyncProcessorTest < ActiveSupport::TestCase
+      test 'calls enqueuer for each collection batch' do
+        # ensure all collections have items
+        master = FactoryBot.create(:simple_master)
+        provider = FactoryBot.create(:simple_provider)
+        # Provider's app on master account
+        FactoryBot.create(:simple_cinstance, plan: master.services.first.application_plans.first, user_account: provider)
+        service = FactoryBot.create(:simple_service, account: provider)
+        provider_app_plan = FactoryBot.create(:simple_application_plan, issuer: service)
+        buyer = FactoryBot.create(:simple_buyer, provider_account: provider)
+        # Buyer's app on provider account
+        FactoryBot.create(:simple_cinstance, plan: provider_app_plan, user_account: buyer)
+        FactoryBot.create(:usage_limit, plan: provider_app_plan)
+
+        enqueuer = mock('enqueuer')
+        enqueuer.expects(:call).times(5).returns(:ok)
+        Backend::StorageRewrite::AsyncProcessor.new(enqueuer: enqueuer).rewrite_provider(provider.id)
+      end
     end
   end
 end

--- a/test/unit/sidekiq_logging_middleware_test.rb
+++ b/test/unit/sidekiq_logging_middleware_test.rb
@@ -17,4 +17,19 @@ class SidekiqLoggingMiddlewareTest < ActiveSupport::TestCase
 
     middleware.call('DummyWorker', msg) { nil }
   end
+
+  test 'do not filter plain arrays arguments' do
+    middleware = ThreeScale::SidekiqLoggingMiddleware.new
+    msg = {
+      'jid' => 123,
+      'args' => [
+        'some_arg',
+        [1, 2, 3, 4, 5]
+      ]
+    }
+
+    Rails.logger.expects(:info).with('Enqueued DummyWorker#123 with args: ["some_arg", [1, 2, 3, 4, 5]]')
+
+    middleware.call('DummyWorker', msg) { nil }
+  end
 end

--- a/test/workers/backend_storage_rewrite_worker_test.rb
+++ b/test/workers/backend_storage_rewrite_worker_test.rb
@@ -7,14 +7,4 @@ class BackendStorageRewriteWorkerTest < ActiveSupport::TestCase
     Backend::StorageRewrite::Processor.any_instance.expects(:rewrite).with(class_name: Cinstance, ids: [1,2,3,4,5])
     BackendStorageRewriteWorker.new.perform(Cinstance, [1,2,3,4,5])
   end
-
-  test 'enqueue all' do
-    Backend::StorageRewrite::AsyncProcessor.any_instance.expects(:rewrite_all)
-    BackendStorageRewriteWorker.enqueue_all
-  end
-
-  test 'enqueue a provider' do
-    Backend::StorageRewrite::AsyncProcessor.any_instance.expects(:rewrite_provider).with(123)
-    BackendStorageRewriteWorker.enqueue(123)
-  end
 end

--- a/test/workers/backend_storage_rewrite_worker_test.rb
+++ b/test/workers/backend_storage_rewrite_worker_test.rb
@@ -3,22 +3,18 @@
 require 'test_helper'
 
 class BackendStorageRewriteWorkerTest < ActiveSupport::TestCase
-  attr_accessor :provider
-
-  def setup
-    @provider = FactoryBot.create(:simple_provider)
+  test 'perform worker' do
+    Backend::StorageRewrite::Processor.any_instance.expects(:rewrite).with(class_name: Cinstance, ids: [1,2,3,4,5])
+    BackendStorageRewriteWorker.new.perform(Cinstance, [1,2,3,4,5])
   end
 
-  test '#enqueue' do
-    BackendStorageRewriteWorker.enqueue(provider.id)
-
-    assert_equal 1, BackendStorageRewriteWorker.jobs.size
+  test 'enqueue all' do
+    Backend::StorageRewrite::AsyncProcessor.any_instance.expects(:rewrite_all)
+    BackendStorageRewriteWorker.enqueue_all
   end
 
-  test '#perform enqueued' do
-    Sidekiq::Testing.inline! do
-      Backend::StorageRewrite.expects(:rewrite_provider).with(provider.id)
-      BackendStorageRewriteWorker.enqueue(provider.id)
-    end
+  test 'enqueue a provider' do
+    Backend::StorageRewrite::AsyncProcessor.any_instance.expects(:rewrite_provider).with(123)
+    BackendStorageRewriteWorker.enqueue(123)
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the backend storate rewriting schedules one Sidekiq job per each provider. For some providers, that have thousands of applications, the jobs take forever.... they get stuck in Sidekiq for excessive times (sometimes more than 30 mins), this way blocking all other processing.
This PR adds some improvements:
1. It skips deleted (scheduled for deletion) and suspended providers, so we don't sync anything for these accounts
2. Instead of executing a single job per provider, it splits all the work into mutliple jobs, grouping the objects in batches (currently max batch size is set to 500).
This should allow the jobs to get executed faster, and also give opportunity to other jobs in the same queue to get processed.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10043

**Verification steps** 

Run the rewriting and make sure that it gets processed and not stuck.

**Special notes for your reviewer**:

-none-
