### PR TITLE
🦋 Remove ugly borders in forms

### DIFF
--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -1,7 +1,7 @@
-$fieldset-margin-bottom: line-height-times(1.5);
+$fieldset-margin-bottom: 32px; // --pf-c-form__group--m-action--MarginTop
 
 form.formtastic:not(.pf-c-form) ol, form.formtastic:not(.pf-c-form) ul {
-  list-style: none;
+    list-style: none;
 }
 
 input[type='text']:not(.pf-c-form-control, .pf-c-text-input-group__text-input),
@@ -150,8 +150,7 @@ form.formtastic:not(.pf-c-form) fieldset.inputs > ol > li.select select {
   border-radius: $border-radius;
 }
 
-form.formtastic:not(.pf-c-form) fieldset.actions {
-  border-top: $border-width solid $border-color;
+.button-bar fieldset.actions {
   text-align: right;
 
   li {
@@ -159,13 +158,10 @@ form.formtastic:not(.pf-c-form) fieldset.actions {
   }
 
   &-inline {
-    border-top: 0;
     margin: line-height-times(1/2) 0;
   }
-}
 
-.button-bar fieldset.actions {
-  border-top: 0 !important;
+  border-top: 0;
 
   .delete {
     margin-top: 0 !important;
@@ -245,7 +241,6 @@ Load this stylesheet after formtastic.css in your layouts to override the CSS to
 
 form.formtastic:not(.pf-c-form) {
   @include white-box-shadow;
-  margin: line-height-times(1) 0;
   min-width: line-height-times(20);
   padding: line-height-times(1);
   text-align: left; /* overriding legacy_theme text-align: center*/
@@ -320,11 +315,7 @@ form.formtastic:not(.pf-c-form) {
   fieldset.inputs,
   :not(.form-group) > fieldset {
     &:not(.policies-fieldset) {
-      border: 0;
       position: relative;
-      padding: line-height-times(1) 0 0 0;
-      border-top: $border-width solid $border-color;
-      margin-bottom: $fieldset-margin-bottom;
       -moz-appearance: none;
       -webkit-appearance: none;
       appearance: none;
@@ -341,17 +332,22 @@ form.formtastic:not(.pf-c-form) {
     }
   }
 
+  fieldset.inputs > legend {
+    margin-bottom: 12px;
+  }
+
+  div.pf-c-form__group.pf-m-action {
+    margin-top: $fieldset-margin-bottom;
+  }
+
   fieldset {
     border: 0;
   }
 
   legend:not(.label) {
-    padding: 0 line-height-times(1/2) 0 0;
-    font-size: $font-size-base;
-    text-transform: uppercase;
-    color: $label-color;
-    position: relative;
-    white-space: nowrap;
+    color: rgb(21, 21, 21); // --pf-c-content--Color
+    font-size: 18px; // --pf-c-form__section-title--FontSize
+    font-weight: 700; // --pf-c-form__section-title--FontWeight
   }
 }
 
@@ -563,14 +559,8 @@ li.hidden {
 
   form.formtastic:not(.pf-c-form) {
     box-shadow: none;
-    margin: 0;
-
-    fieldset {
-      margin-bottom: 0;
-    }
   }
 }
-
 
 .dashboard_card form.formtastic:not(.pf-c-form) {
   box-shadow: none;

--- a/app/assets/stylesheets/provider/_forms.scss
+++ b/app/assets/stylesheets/provider/_forms.scss
@@ -1,7 +1,9 @@
 $fieldset-margin-bottom: 32px; // --pf-c-form__group--m-action--MarginTop
 
-form.formtastic:not(.pf-c-form) ol, form.formtastic:not(.pf-c-form) ul {
+form.formtastic:not(.pf-c-form) {
+  ol, ul, li {
     list-style: none;
+  }
 }
 
 input[type='text']:not(.pf-c-form-control, .pf-c-text-input-group__text-input),

--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -79,7 +79,7 @@ module AccountHelper
     alert = t('buyers.accounts.edit.delete.admin_restricted', admin: current_account.first_admin.try(:email))
 
     url = can?(:destroy, account) ? admin_buyers_account_path(account) : javascript_alert_url(alert)
-    delete_link_for(url, confirm: msg)
+    delete_link_for(url, confirm: msg, class: 'pf-c-button pf-m-danger')
   end
 
   def master_on_premises?

--- a/app/helpers/api/services_helper.rb
+++ b/app/helpers/api/services_helper.rb
@@ -47,7 +47,7 @@ module Api::ServicesHelper
 
   def delete_service_link(service, options = {})
     msg = t('api.services.forms.definition_settings.delete_confirmation', name: j(service.name))
-    delete_link_for(admin_service_path(service), {data: { confirm: msg }, method: :delete}.merge(options) )
+    delete_link_for(admin_service_path(service), {data: { confirm: msg }, class: 'pf-c-button pf-m-danger', method: :delete}.merge(options) )
   end
 
   def refresh_service_link(service, options = {})

--- a/app/helpers/cinstances_helper.rb
+++ b/app/helpers/cinstances_helper.rb
@@ -38,6 +38,6 @@ Are you sure?}
 
   def delete_application_link(application)
     msg = t('api.applications.edit.delete_confirmation', name: j(application.name))
-    delete_link_for(provider_admin_application_path(application), confirm: msg, title: 'Delete Application')
+    delete_link_for(provider_admin_application_path(application), confirm: msg, title: 'Delete Application', class: 'pf-c-button pf-m-danger')
   end
 end

--- a/app/javascript/src/NewService/components/FormElements/FormWrapper.tsx
+++ b/app/javascript/src/NewService/components/FormElements/FormWrapper.tsx
@@ -27,16 +27,18 @@ const FormWrapper: FunctionComponent<Props> = ({
       <legend><span>Product</span></legend>
       <ol>{children}</ol>
     </fieldset>
-    <fieldset className="buttons">
-      <Button
-        className="create"
-        data-testid="newProductCreateProduct-buttonSubmit"
-        name="commit"
-        type="submit"
-      >
-        {submitText}
-      </Button>
-    </fieldset>
+    <div className="pf-c-form__group pf-m-action">
+      <div className="pf-c-form__actions">
+        <Button
+          className="create"
+          data-testid="newProductCreateProduct-buttonSubmit"
+          name="commit"
+          type="submit"
+        >
+          {submitText}
+        </Button>
+      </div>
+    </div>
   </form>
 )
 

--- a/app/lib/cms/semantic_form_builder.rb
+++ b/app/lib/cms/semantic_form_builder.rb
@@ -59,5 +59,10 @@ module CMS
 
       template.content_tag(:button, 'Hide', button_html)
     end
+
+    def actions(*args, &block)
+      # HACK: CMS design is too far away from the rest of the app so skip SemanticFormBuilder implementation
+      ::Formtastic::FormBuilder.instance_method(:actions).bind(self).call(*args, &block)
+    end
   end
 end

--- a/app/lib/three_scale/semantic_form_builder.rb
+++ b/app/lib/three_scale/semantic_form_builder.rb
@@ -2,6 +2,8 @@ module ThreeScale
   class SemanticFormBuilder < ::Formtastic::FormBuilder
     include ThreeScale::SpamProtection::Integration::FormBuilder
 
+    delegate :tag, to: :template
+
     # Allow specify how to display errors for the input
     #
     # Ex:
@@ -93,6 +95,14 @@ module ThreeScale
         input :system_name, :hint => "Only ASCII letters, numbers, dashes and underscores are allowed."
       else
         input :system_name, :input_html => { :disabled => true }
+      end
+    end
+
+    def actions(*args, &block)
+      return super unless args.empty?
+
+      tag.div(class: 'pf-c-form__group pf-m-action') do
+        tag.div(class: 'pf-c-form__actions', &block)
       end
     end
   end

--- a/app/views/admin/fields_definitions/edit.html.erb
+++ b/app/views/admin/fields_definitions/edit.html.erb
@@ -12,12 +12,12 @@
     <%= render :partial => 'form', :locals => { :f => f } %>
   <% end %>
 
-  <%= f.actions do %>
-    <%= f.commit_button 'Update field' %>
-    <li>
-      <%= delete_link_for(admin_fields_definition_path(@fields_definition), :confirm => 'Are you sure?') unless @fields_definition.required_field_on_target? %>
-    </li>
-  <% end %>
+  <div class="pf-c-form"><%# TODO: remove div and move class to form element %>
+    <%= f.actions do %>
+      <button class="pf-c-button pf-m-primary" type="submit">Update field</button>
+      <%= delete_link_for(admin_fields_definition_path(@fields_definition), confirm: 'Are you sure?', class: 'pf-c-button pf-m-danger') unless @fields_definition.required_field_on_target? %>
+    <% end %>
+  </div>
 <% end %>
 
 

--- a/app/views/api/policies/edit.html.slim
+++ b/app/views/api/policies/edit.html.slim
@@ -17,7 +17,6 @@
     fieldset class="inputs policies-fieldset"
       div#policies data-service-id=@service.id data-registry=@registry_policies.to_json data-chain=@proxy.policies_config.to_json
 
-    div class="pf-c-form__group pf-m-action"
-      div class="pf-c-form__actions"
-        button class="pf-c-button pf-m-primary" type="submit" id="policies-button-sav" disabled=true
-          = t('formtastic.actions.policies.update')
+    = f.actions do
+      button class="pf-c-button pf-m-primary" type="submit" id="policies-button-sav" disabled=true
+        = t('formtastic.actions.policies.update')

--- a/app/views/buyers/accounts/edit.html.slim
+++ b/app/views/buyers/accounts/edit.html.slim
@@ -10,7 +10,8 @@ div
     = form.inputs name: 'Contact Details', class: 'inputs' do
       = form.user_defined_form
 
-    = form.actions do
-      = form.commit_button 'Update Account'
-      li
+    / TODO: remove div and move class to form element
+    div class='pf-c-form'
+      = form.actions do
+        button class="pf-c-button pf-m-primary" type="submit" Update Account
         = delete_buyer_link(@account)

--- a/app/views/buyers/users/edit.html.erb
+++ b/app/views/buyers/users/edit.html.erb
@@ -26,12 +26,14 @@
     <% end %>
   <% end %>
 
-  <%= form.actions do %>
-    <%= form.commit_button %>
-    <% if @user.can_be_destroyed? -%>
-      <%= delete_link_for admin_buyers_account_user_path(account_id: @user.account_id, id: @user.id), data: {confirm: "Are you sure you want to destroy user #{@user.username}?" } %>
-    <% end -%>
-  <% end %>
+  <div class="pf-c-form"><%# TODO: remove div and move class to form element %>
+    <%= form.actions do %>
+      <button class="pf-c-button pf-m-primary" type="submit">Update User</button>
+      <% if @user.can_be_destroyed? %>
+        <%= delete_link_for admin_buyers_account_user_path(account_id: @user.account_id, id: @user.id), data: {confirm: "Are you sure you want to destroy user #{@user.username}?" }, class: 'pf-c-button pf-m-danger' %>
+      <% end -%>
+    <% end %>
+  </div>
 
   <style type="text/css">
     <%# the 'Role' radio button is unclickable without this style (see #1994)%>

--- a/app/views/finance/provider/settings/show.html.slim
+++ b/app/views/finance/provider/settings/show.html.slim
@@ -19,10 +19,9 @@ div class="pf-l-flex pf-m-column"
 
           - new_mode = @billing_strategy.is_a?(Finance::PostpaidBillingStrategy) ? 'prepaid' : 'postpaid'
           = hidden_field_tag 'type', new_mode
-          div class="pf-c-form__group pf-m-action"
-            div class="pf-c-form__actions"
-              button class="pf-c-button pf-m-danger" type="submit" data={ confirm: t('.switch_confirm', mode: new_mode) }
-                = t('.switch_button', mode: new_mode.upcase)
+          = form.actions do
+            button class="pf-c-button pf-m-danger" type="submit" data={ confirm: t('.switch_confirm', mode: new_mode) }
+              = t('.switch_button', mode: new_mode.upcase)
 
   div class="pf-l-flex__item"
     div class="pf-c-card"
@@ -44,9 +43,8 @@ div class="pf-l-flex pf-m-column"
                                           collection: [['Monthly (YYYY-MM-XXXXXXXX)', 'monthly'], ['Yearly (YYYY-XXXXXXXX)', 'yearly']],
                                           include_blank: false
 
-          div class="pf-c-form__group pf-m-action"
-            div class="pf-c-form__actions"
-              button class="pf-c-button pf-m-primary" type="submit" Save
+          = form.actions do
+            button class="pf-c-button pf-m-primary" type="submit" Save
 
   - if can?(:manage, :finance) && @account.billing_strategy.try(:needs_credit_card?)
     div class="pf-l-flex__item"
@@ -77,9 +75,8 @@ div class="pf-l-flex pf-m-column"
                   - if payment_gateway.deprecated
                     = pf_inline_alert t('.deprecation_warning', gateway: payment_gateway.type.capitalize), variant: :warning
 
-          div class="pf-c-form__group pf-m-action"
-            div class="pf-c-form__actions"
-              button class="pf-c-button pf-m-primary" type="submit" Save
+          = form.actions do
+            button class="pf-c-button pf-m-primary" type="submit" Save
 
     javascript:
       document.addEventListener('DOMContentLoaded', () => {

--- a/app/views/provider/admin/account/data_exports/new.html.erb
+++ b/app/views/provider/admin/account/data_exports/new.html.erb
@@ -3,26 +3,24 @@
   <div class="wide_dashboard_card round left">
     <table width="100%">
       <tbody>
-	<tr>
-	  <th>Data:</th>
-	  <td><%= select_tag(:data, options_for_select(@targets)) %></td>
-	</tr>
-	<tr>
-	  <th>Period:</th>
-	  <td><%= select_tag(:period, options_for_select(@periods)) %></td>
-	</tr>
-	<tr><td colspan="2"><hr/></td></tr>
-	<tr>
-	  <td>
-	  </td>
-	  <td width="80%">
-	    <%= submit_tag 'Export CSV', {:onClick => "javascript:jQuery('#progress_notice').fadeIn(); setTimeout(function() {$('#progress_notice').hide();}, 10000);"} %>
-	    <span id="progress_notice" style="font-size:10px;margin:5px;display:none;">
-	      Exporting may take a few minutes, please be patient...
-	    </span>
-	  </td>
-	</tr>
+        <tr>
+          <th>Data:</th>
+          <td><%= select_tag(:data, options_for_select(@targets)) %></td>
+        </tr>
+        <tr>
+          <th>Period:</th>
+          <td><%= select_tag(:period, options_for_select(@periods)) %></td>
+        </tr>
       </tbody>
     </table>
+    <div class="pf-c-form"><%# TODO: remove div and move class to form element %>
+      <div class="pf-c-form__group pf-m-action">
+        <div class="pf-c-form__actions">
+          <button class="pf-c-button pf-m-primary" type="submit" data-disable-with="Exporting CSV...">
+            Export CSV
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/app/views/provider/admin/applications/edit.html.slim
+++ b/app/views/provider/admin/applications/edit.html.slim
@@ -8,7 +8,8 @@
   = form.inputs do
     = form.user_defined_form
 
-  = form.actions do
-    = form.commit_button
-    li
+  / TODO: remove div and move class to form element
+  div class='pf-c-form'
+    = form.actions do
+      button class="pf-c-button pf-m-primary" type="submit" Update Application
       = delete_application_link(@cinstance)

--- a/app/views/provider/admin/backend_apis/forms/_delete.html.slim
+++ b/app/views/provider/admin/backend_apis/forms/_delete.html.slim
@@ -27,5 +27,5 @@
     - else
       p
         - msg = t('api.backend_apis.edit.delete_confirmation', name: j(backend_api.name))
-        - delete_options = { data: { confirm: msg }, method: :delete, label: "I understand the consequences, proceed to delete '#{j(backend_api.name)}' backend" }
+        - delete_options = { data: { confirm: msg }, method: :delete, class: 'pf-c-button pf-m-danger', label: "I understand the consequences, proceed to delete '#{j(backend_api.name)}' backend" }
         = delete_link_for(provider_admin_backend_api_path(backend_api), delete_options)

--- a/app/views/provider/admin/keys/edit.html.erb
+++ b/app/views/provider/admin/keys/edit.html.erb
@@ -10,11 +10,9 @@
                               required: true,
                               input_html: { size: 100, value: nil, required: true, autocomplete: 'off' } %>
 
-    <div class="pf-c-form__group pf-m-action">
-      <div class="pf-c-form__actions">
-        <button class="pf-c-button pf-m-primary" type="submit" data-disable-with="Saving...">Save</button>
-        <button class="pf-c-button pf-m-link fancybox-close" type="submit">Cancel</button>
-      </div>
-    </div>
+    <%= form.actions do %>
+      <button class="pf-c-button pf-m-primary" type="submit" data-disable-with="Saving...">Save</button>
+      <button class="pf-c-button pf-m-link fancybox-close" type="submit">Cancel</button>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/provider/admin/messages/outbox/new.html.slim
+++ b/app/views/provider/admin/messages/outbox/new.html.slim
@@ -24,10 +24,9 @@ div class="pf-c-card"
       - if params[:to]
         = hidden_field_tag :to, params[:to]
 
-      div class="pf-c-form__group pf-m-action"
-        div class="pf-c-form__actions"
-          button class="pf-c-button pf-m-primary" type="submit" Send message
-          = link_to 'Cancel', provider_admin_messages_root_path, class: "pf-c-button pf-m-link #{is_modal ? 'fancybox-close' : ''}"
+      = form.actions do
+        button class="pf-c-button pf-m-primary" type="submit" Send message
+        = link_to 'Cancel', provider_admin_messages_root_path, class: "pf-c-button pf-m-link #{is_modal ? 'fancybox-close' : ''}"
 
 css:
   div#cboxLoadedContent {

--- a/app/views/sites/settings/edit.html.slim
+++ b/app/views/sites/settings/edit.html.slim
@@ -8,6 +8,5 @@ div class="pf-c-card"
       = form.input :cc_privacy_path, as: :patternfly_input, label: 'Path to Privacy page', input_html: { type: 'text' }
       = form.input :cc_refunds_path, as: :patternfly_input, label: 'Path to Refund page', input_html: { type: 'text' }
 
-      div class="pf-c-form__group pf-m-action"
-        div class="pf-c-form__actions"
-          button class="pf-c-button pf-m-primary" type="submit" Save
+      = form.actions do
+        button class="pf-c-button pf-m-primary" type="submit" Save

--- a/app/views/sites/usage_rules/edit.html.slim
+++ b/app/views/sites/usage_rules/edit.html.slim
@@ -82,9 +82,8 @@ div class="pf-c-card"
                   = t('sites.usage_rules.edit.plans_label')
             = render 'shared/plan_change_settings', permission: 'change_service_plan_permission', settings: settings
 
-      div class="pf-c-form__group pf-m-action"
-        div class="pf-c-form__actions"
-          button class="pf-c-button pf-m-primary" type="submit" Update Settings
+      = form.actions do
+        button class="pf-c-button pf-m-primary" type="submit" Update Settings
 
 javascript:
   document.addEventListener('DOMContentLoaded', () => {

--- a/features/step_definitions/providers/csv_steps.rb
+++ b/features/step_definitions/providers/csv_steps.rb
@@ -1,4 +1,4 @@
 Then /^I should see the form to export data to csv$/ do
   assert has_css?('h1', :text => "Export")
-  assert has_xpath?('//input[@value="Export CSV"]')
+  assert has_button?('Export CSV')
 end


### PR DESCRIPTION
[THREESCALE-10250: Remove ugly separators in formtastic forms](https://issues.redhat.com/browse/THREESCALE-10250)

* Apply PF4 to all actions fieldset.
* Remove top border from inputs fieldsets.
* Apply PF4 Form section styles to fieldset legends.

Some examples:

* After:
![Screenshot 2023-10-24 at 09 19 18](https://github.com/3scale/porta/assets/11672286/ede803ac-c20b-44cc-afae-347c6abca820)
![Screenshot 2023-10-24 at 09 16 21](https://github.com/3scale/porta/assets/11672286/55d12d2d-83df-4a00-b880-04b9c3eaa028)
![Screenshot 2023-10-24 at 09 15 22](https://github.com/3scale/porta/assets/11672286/646e0a7d-250e-42f7-9bf4-3fc27c343908)
![Screenshot 2023-10-24 at 09 14 17](https://github.com/3scale/porta/assets/11672286/25fa2bb5-eb48-4a0d-ae4b-b1fb38587ee4)
![Screenshot 2023-10-24 at 09 14 00](https://github.com/3scale/porta/assets/11672286/0c5293d4-b0a6-494c-91e0-cd100e057c6f)
![Screenshot 2023-10-24 at 09 13 49](https://github.com/3scale/porta/assets/11672286/b938c81c-48a9-4fb4-94de-e33e7dc5abfc)