### PR TITLE
Upgrade Ruby version in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,7 +77,7 @@ Metrics/ClassLength:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   UseCache: true
   Exclude:
     - 'db/**/*'


### PR DESCRIPTION
What the title says. We're on Ruby 2.7 now.