### PR TITLE
Use redis-client instead of redis globally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'rails', '~> 6.0'
 # Also, upgrading makes this test fail: SendUserInvitationWorkerTest#test_handles_errors
 gem 'mail', '~> 2.7.1'
 
-gem "activejob-uniqueness"
+gem 'activejob-uniqueness', '~> 0.3.0'
 # Needed for XML serialization of ActiveRecord::Base
 gem 'activemodel-serializers-xml'
 
@@ -87,7 +87,7 @@ gem 'faraday_middleware', '~> 0.13.1'
 gem 'mimemagic', '~> 0.3.10'
 gem 'nokogiri', '~> 1.13.10'
 gem 'secure_headers', '~> 6.3.0'
-gem 'redlock'
+gem 'redlock', '~> 2.0.4'
 
 gem 'acts-as-taggable-on', '~> 8.0'
 gem 'baby_squeel', '~> 1.4.3'
@@ -106,7 +106,6 @@ gem 'ratelimit'
 gem 'recaptcha', '4.13.1', require: 'recaptcha/rails'
 gem 'redcarpet', '~>3.5.1', require: false
 gem 'RedCloth', '~>4.3', require: false
-gem 'redis', require: ['redis']
 gem 'rest-client', '~> 2.0.2'
 gem 'rubyzip', '~>1.3.0', require: false
 gem 'svg-graph', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ gem 'faraday_middleware', '~> 0.13.1'
 gem 'mimemagic', '~> 0.3.10'
 gem 'nokogiri', '~> 1.13.10'
 gem 'secure_headers', '~> 6.3.0'
-gem 'redlock', '~> 2.0.4'
+gem 'redlock', '~> 2.0'
 
 gem 'acts-as-taggable-on', '~> 8.0'
 gem 'baby_squeel', '~> 1.4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1027,7 +1027,7 @@ DEPENDENCIES
   recaptcha (= 4.13.1)
   record_tag_helper (~> 1.0)
   redcarpet (~> 3.5.1)
-  redlock (~> 2.0.4)
+  redlock (~> 2.0)
   reek (= 6.01)
   reform (~> 2.0.3)
   rest-client (~> 2.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,9 +119,9 @@ GEM
     activejob (6.0.6.1)
       activesupport (= 6.0.6.1)
       globalid (>= 0.3.6)
-    activejob-uniqueness (0.2.5)
-      activejob (>= 4.2, < 7.1)
-      redlock (>= 1.2, < 2)
+    activejob-uniqueness (0.3.0)
+      activejob (>= 4.2, < 7.2)
+      redlock (>= 2.0, < 3)
     activemerchant (1.107.4)
       activesupport (>= 4.2)
       builder (>= 2.1.2, < 4.0.0)
@@ -649,15 +649,15 @@ GEM
       actionview (>= 5)
     recursive-open-struct (1.1.3)
     redcarpet (3.5.1)
-    redis (5.0.7)
-      redis-client (>= 0.9.0)
+    redis (5.0.8)
+      redis-client (>= 0.17.0)
     redis-client (0.17.0)
       connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
     redis-prescription (2.6.0)
-    redlock (1.3.2)
-      redis (>= 3.0.0, < 6.0)
+    redlock (2.0.4)
+      redis-client (>= 0.14.1, < 1.0.0)
     reek (6.1.0)
       kwalify (~> 0.7.0)
       parser (~> 3.1.0)
@@ -920,7 +920,7 @@ DEPENDENCIES
   3scale_time_range (= 0.0.6)
   RedCloth (~> 4.3)
   active-docs!
-  activejob-uniqueness
+  activejob-uniqueness (~> 0.3.0)
   activemerchant (~> 1.107.4)
   activemodel-serializers-xml
   activerecord-oracle_enhanced-adapter (~> 6.0)
@@ -1027,8 +1027,7 @@ DEPENDENCIES
   recaptcha (= 4.13.1)
   record_tag_helper (~> 1.0)
   redcarpet (~> 3.5.1)
-  redis
-  redlock
+  redlock (~> 2.0.4)
   reek (= 6.01)
   reform (~> 2.0.3)
   rest-client (~> 2.0.2)

--- a/app/lib/stats/storage.rb
+++ b/app/lib/stats/storage.rb
@@ -45,6 +45,7 @@ module Stats
       value_key_without_period = value_key.match(/(.*)\/.*/)[1]
 
       begin
+        # REDIS CLIENT MIGRATION BLOCKER: SORT arguments need to be processed before passing to redis
         sorted = sort(source_key, :by => value_key,
                          :order => options[:order] && options[:order].to_s.upcase,
                          :limit => options[:limit] && [0, options[:limit]],

--- a/app/lib/system/redis_pool.rb
+++ b/app/lib/system/redis_pool.rb
@@ -17,9 +17,12 @@ module System
 
     # This class only respond to public methods of redis-client
     def respond_to_missing?(method_sym, _include_private = false)
-      @pool.with do |conn|
-        conn.respond_to?(method_sym, false)
-      end
+      @pool.respond_to?(method_sym, false)
+    end
+
+    # This is used by some libraries, for example, Redlock
+    def with(...)
+      @pool.with(...)
     end
 
     def method_missing(...)

--- a/app/lib/three_scale/filter_arguments.rb
+++ b/app/lib/three_scale/filter_arguments.rb
@@ -15,7 +15,7 @@ module ThreeScale
         case argument
         when Struct
           FILTER.filter(argument.to_h)
-        when Enumerable
+        when Hash
           FILTER.filter(argument)
         else
           argument

--- a/app/services/action_limiter.rb
+++ b/app/services/action_limiter.rb
@@ -23,6 +23,7 @@ class ActionLimiter
     subject = object.to_gid_param
     @threshold = threshold
     @timespan = timespan
+    # REDIS CLIENT MIGRATION BLOCKER: `ratelimit` gem relies on `redis` and doesn't support `redis-client` or `connection_pool`
     @limiter = ::Ratelimit.new(subject, bucket_span: timespan, bucket_interval: interval, redis: System.redis)
   end
 

--- a/features/step_definitions/stats/provider_response_codes.rb
+++ b/features/step_definitions/stats/provider_response_codes.rb
@@ -10,9 +10,9 @@ Given(/^the provider has response codes stats data$/) do
   now = Time.now.utc
   service = @provider.first_service!
 
-  keys = RESPONSE_CODES.flat_map do |code|
-    [["stats/{service:#{service.id}}/response_code:#{code}/hour:#{now.at_beginning_of_day.to_s(:compact)}", RESPONSE_CODE_VALUE]]
-  end.to_h
+  keys_and_values = RESPONSE_CODES.flat_map do |code|
+    ["stats/{service:#{service.id}}/response_code:#{code}/hour:#{now.at_beginning_of_day.to_s(:compact)}", RESPONSE_CODE_VALUE]
+  end
 
-  storage.mapped_mset(keys)
+  storage.mset(keys_and_values)
 end

--- a/test/unit/backend/storage_test.rb
+++ b/test/unit/backend/storage_test.rb
@@ -24,6 +24,7 @@ test:
 }
     given_redis_config(yaml) do
       mock = mock(id: 'redis://localhost:6389/1')
+      # REDIS CLIENT MIGRATION: failing test
       Redis.expects(:new).with(host: 'example.com', port: 1337, db: 2).returns(mock)
 
       storage = Backend::Storage.clone.instance

--- a/test/unit/system/redis_pool_test.rb
+++ b/test/unit/system/redis_pool_test.rb
@@ -12,6 +12,7 @@ class System::RedisPoolTest < ActiveSupport::TestCase
 
   test 'delegation' do
     redis = mock
+    # REDIS CLIENT MIGRATION: failing test
     redis.expects(:ping).returns('PONG')
     Redis.expects(:new).returns(redis)
 


### PR DESCRIPTION
This was a POC to understand how hard it would be to switch to `redis-client` globally, without the need for `redis` gem (that provides Ruby API for Redis commands).

Of course it turns out that it is not as easy as I was hoping it would be :sweat_smile: Some blockers:
- we are using [ratelimit](https://github.com/ejfinneran/ratelimit) gem (not sure whether actually in use, but it's there), that only supports `redis` gem, not `redis-client`.
- some commands (in stats module) rely on `redis`'s logic, the arguments would need to be decomposed to be digested by `redis-client`

The `redis` gem version that we are using now (v5, upgraded in https://github.com/3scale/porta/pull/3576) uses `redis-client` under the hood anyway, so the effort is not really worth it.
I have left some comments prefixed by `REDIS CLIENT MIGRATION` so it's easier to identify where some of the problems lie, in case we want to revisit this in future. But for now, I'm closing this PR.
