### PR TITLE
Remove unused sidekiq-lock gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,6 @@ gem 'statsd-ruby', require: false
 gem 'sidekiq', '~> 7', require: %w[sidekiq sidekiq/web]
 gem 'sidekiq-batch', github: '3scale/sidekiq-batch', branch: 'redis-client'
 gem 'sidekiq-cron', require: %w[sidekiq/cron sidekiq/cron/web]
-gem 'sidekiq-lock'
 gem 'sidekiq-throttled', '~> 1.0.0.alpha.1'
 
 gem 'sidekiq-prometheus-exporter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -771,9 +771,6 @@ GEM
       fugit (~> 1.8)
       globalid (>= 1.0.1)
       sidekiq (>= 6)
-    sidekiq-lock (0.6.0)
-      redis (>= 3.0.5)
-      sidekiq (>= 2.14.0)
     sidekiq-prometheus-exporter (0.2.0)
       rack (>= 1.6.0)
       sidekiq (>= 4.1.0)
@@ -1054,7 +1051,6 @@ DEPENDENCIES
   sidekiq (~> 7)
   sidekiq-batch!
   sidekiq-cron
-  sidekiq-lock
   sidekiq-prometheus-exporter
   sidekiq-throttled (~> 1.0.0.alpha.1)
   simplecov (~> 0.21.2)

--- a/test/test_helpers/sidekiq.rb
+++ b/test/test_helpers/sidekiq.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'sidekiq/testing'
-require 'sidekiq/lock/testing/inline'
 
 # Turn off Sidekiq logging which pollutes the CI logs
 Sidekiq.configure_client do |config|

--- a/test/workers/backend_delete_service_token_worker_test.rb
+++ b/test/workers/backend_delete_service_token_worker_test.rb
@@ -3,11 +3,6 @@
 require 'test_helper'
 
 class BackendDeleteServiceTokenWorkerTest < ActiveSupport::TestCase
-
-  def teardown
-    clear_sidekiq_lock
-  end
-
   test 'destroy service token' do
     service_token = FactoryBot.create(:service_token)
     event = ServiceTokenDeletedEvent.create_and_publish!(service_token)


### PR DESCRIPTION
**What this PR does / why we need it**:

Removing `sidekiq-lock` dependency, as it is not used.
It was initially added here:
https://github.com/3scale/system/commit/bd63ac2ecaccb4d51e1854c24e109ae4f4770506
But locking was replaced by `sidekiq-throttled` here:
https://github.com/3scale/porta/commit/9ff8f6abf8a4c1f3b0aa402a6e04a1f997edbac4

No other workers use this.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

**Special notes for your reviewer**:
