### PR TITLE
🦋 Backend APIs pagination, toolbar and empty state

### DIFF
--- a/app/controllers/api/backend_usages_controller.rb
+++ b/app/controllers/api/backend_usages_controller.rb
@@ -12,6 +12,8 @@ class Api::BackendUsagesController < Api::BaseController
   activate_menu :serviceadmin, :integration, :backend_api_configs
   sublayout 'api/service'
 
+  helper_method :service, :toolbar_props
+
   def index
     @backend_api_configs = service.backend_api_configs.order_by(params[:sort], params[:direction])
                                                       .includes(:backend_api)
@@ -80,5 +82,16 @@ class Api::BackendUsagesController < Api::BaseController
     flash[:error] = "Couldn't add Backend to Product"
     @inline_errors = { backend_api_id: ['Not a valid backend'] }
     render 'new'
+  end
+
+  def toolbar_props
+    {
+      totalEntries: @backend_api_configs.total_entries,
+      rightActions: [{
+        variant: :primary,
+        label: t('.toolbar.primary'),
+        href: new_admin_service_backend_usage_path(@service),
+      }]
+    }
   end
 end

--- a/app/controllers/api/backend_usages_controller.rb
+++ b/app/controllers/api/backend_usages_controller.rb
@@ -87,7 +87,7 @@ class Api::BackendUsagesController < Api::BaseController
   def toolbar_props
     {
       totalEntries: @backend_api_configs.total_entries,
-      rightActions: [{
+      leftActions: [{
         variant: :primary,
         label: t('.toolbar.primary'),
         href: new_admin_service_backend_usage_path(@service),

--- a/app/javascript/packs/toolbar.ts
+++ b/app/javascript/packs/toolbar.ts
@@ -1,0 +1,20 @@
+// TODO: combine with Messages toolbar
+
+import { ToolbarWrapper } from 'Common/components/Toolbar'
+
+import type { Props } from 'Common/components/Toolbar'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const table = document.querySelector<HTMLTableElement>('table[data-toolbar-props]')
+
+  if (!table) {
+    return
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const data = table.dataset.toolbarProps!
+
+  const props = JSON.parse(data) as Props
+
+  ToolbarWrapper(props, table)
+})

--- a/app/javascript/src/Common/components/Toolbar.tsx
+++ b/app/javascript/src/Common/components/Toolbar.tsx
@@ -18,19 +18,19 @@ interface ToolbarAction {
 
 interface Props {
   totalEntries: number;
-  rightActions?: ToolbarAction[];
+  leftActions?: ToolbarAction[];
 }
 
 const TopToolbar: FunctionComponent<Props> = ({
   totalEntries,
-  rightActions
+  leftActions
 }) => {
   return (
     <Toolbar>
       <ToolbarContent>
-        {rightActions && (
-          <ToolbarItem alignment={{ default: 'alignRight' }}>
-            {rightActions.map(({ variant, label, href }) => (
+        {leftActions && (
+          <ToolbarItem alignment={{ default: 'alignLeft' }}>
+            {leftActions.map(({ variant, label, href }) => (
               <Button key={label} component="a" href={href} variant={variant}>{label}</Button>
             ))}
           </ToolbarItem>

--- a/app/javascript/src/Common/components/Toolbar.tsx
+++ b/app/javascript/src/Common/components/Toolbar.tsx
@@ -1,0 +1,70 @@
+import { render } from 'react-dom'
+import {
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  Button
+} from '@patternfly/react-core'
+
+import { Pagination } from 'Common/components/Pagination'
+
+import type { FunctionComponent } from 'react'
+
+interface ToolbarAction {
+  variant: 'primary';
+  label: string;
+  href: string;
+}
+
+interface Props {
+  totalEntries: number;
+  rightActions?: ToolbarAction[];
+}
+
+const TopToolbar: FunctionComponent<Props> = ({
+  totalEntries,
+  rightActions
+}) => {
+  return (
+    <Toolbar>
+      <ToolbarContent>
+        {rightActions && (
+          <ToolbarItem alignment={{ default: 'alignRight' }}>
+            {rightActions.map(({ variant, label, href }) => (
+              <Button key={label} component="a" href={href} variant={variant}>{label}</Button>
+            ))}
+          </ToolbarItem>
+        )}
+        <ToolbarItem alignment={{ default: 'alignRight' }} variant="pagination">
+          <Pagination itemCount={totalEntries} />
+        </ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  )
+}
+
+// eslint-disable-next-line react/no-multi-comp
+const BottomToolbar: FunctionComponent<{ totalEntries: number }> = ({ totalEntries }) => (
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarItem alignment={{ default: 'alignRight' }} variant="pagination">
+        <Pagination itemCount={totalEntries} />
+      </ToolbarItem>
+    </ToolbarContent>
+  </Toolbar>
+)
+
+const ToolbarWrapper = (props: Props, table: HTMLTableElement): void => {
+  const top = document.createElement('div')
+  const bottom = document.createElement('div')
+
+  table.insertAdjacentElement('beforebegin', top)
+  table.insertAdjacentElement('afterend', bottom)
+
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  render(<TopToolbar {...props} />, top)
+  render(<BottomToolbar totalEntries={props.totalEntries} />, bottom)
+}
+
+export type { Props }
+export { ToolbarWrapper }

--- a/app/views/api/backend_usages/index.html.slim
+++ b/app/views/api/backend_usages/index.html.slim
@@ -1,33 +1,43 @@
-- content_for :page_header_title_with_button, 'Backends'
+- content_for :page_header_title, 'Backends'
 - content_for :page_header_body do
   ' For a product to work, it must have at least one backend with a private base URL - your API. If
   ' you add multiple backends to a product, each backend must have a unique public path.
-- content_for :page_header_button_label, 'Add backend'
-- content_for :page_header_button_href, new_admin_service_backend_usage_path(@service)
 
-table class="pf-c-table pf-m-grid-lg" role="grid" aria-label="Backends table"
-  thead
-    tr role="row"
-      = th_sortable('backend_apis.name', 'Name')
-      = th_sortable('backend_apis.private_endpoint', 'Private base URL')
-      = th_sortable('backend_api_configs.path', 'Public path')
-      td
-  tbody role="rowgroup"
-    - @backend_api_configs.each do |config|
+- if @backend_api_configs.empty?
+  div class="pf-c-empty-state"
+    div class="pf-c-empty-state__content"
+      i class="fas fa-cube pf-c-empty-state__icon" aria-hidden="true"
+      h1 class="pf-c-title pf-m-lg"
+        = t('.empty_state.title')
+      div class="pf-c-empty-state__body"
+        = t('.empty_state.body', name: service.name)
+      a class="pf-c-button pf-m-primary" type="button" href=new_admin_service_backend_usage_path(service)
+        = t('.empty_state.primary_action')
+- else
+  - content_for :javascripts do
+    = javascript_packs_with_chunks_tag 'toolbar'
+
+  table class="pf-c-table pf-m-grid-lg" role="grid" aria-label="Backends table" data-toolbar-props=toolbar_props.to_json
+    thead
       tr role="row"
-        td role="cell" data-label="Name"
-          = link_to config.backend_api.name, provider_admin_backend_api_path(config.backend_api)
-        td role="cell" data-label="Private Base URL" class="pattern"
-          = config.backend_api.private_endpoint
-        td role="cell" data-label="Public path" class="position"
-          = config.path
-        td role="cell" class="pf-c-table__action actions"
-          div class="pf-c-overflow-menu"
-            div class="pf-c-overflow-menu__content"
-              div class="pf-c-overflow-menu__group pf-m-button-group"
-                div class="pf-c-overflow-menu__item"
-                  = link_to '', edit_admin_service_backend_usage_path(@service, config), class: 'action edit'
-                div class="pf-c-overflow-menu__item"
-                  = link_to '', admin_service_backend_usage_path(@service, config), class: 'action delete', data: {confirm: 'Are you sure?'}, method: :delete
-
-= will_paginate(@backend_api_configs)
+        = th_sortable('backend_apis.name', 'Name')
+        = th_sortable('backend_apis.private_endpoint', 'Private base URL')
+        = th_sortable('backend_api_configs.path', 'Public path')
+        td
+    tbody role="rowgroup"
+      - @backend_api_configs.each do |config|
+        tr role="row"
+          td role="cell" data-label="Name"
+            = link_to config.backend_api.name, provider_admin_backend_api_path(config.backend_api)
+          td role="cell" data-label="Private Base URL" class="pattern"
+            = config.backend_api.private_endpoint
+          td role="cell" data-label="Public path" class="position"
+            = config.path
+          td role="cell" class="pf-c-table__action actions"
+            div class="pf-c-overflow-menu"
+              div class="pf-c-overflow-menu__content"
+                div class="pf-c-overflow-menu__group pf-m-button-group"
+                  div class="pf-c-overflow-menu__item"
+                    = link_to '', edit_admin_service_backend_usage_path(@service, config), class: 'action edit'
+                  div class="pf-c-overflow-menu__item"
+                    = link_to '', admin_service_backend_usage_path(@service, config), class: 'action delete', data: {confirm: 'Are you sure?'}, method: :delete

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -636,6 +636,14 @@ en:
     backend_apis:
       edit:
         delete_confirmation: "Are you sure you want to delete the backend '%{name}'?"
+    backend_usages:
+      index:
+        empty_state:
+          title: There are no backends yet
+          body: The current product %{name} does not have any backends.
+          primary_action: Add a backend
+        toolbar:
+          primary: Add a backend
     services:
       forms:
         definition_settings:

--- a/features/api/backend_usages.feature
+++ b/features/api/backend_usages.feature
@@ -7,6 +7,12 @@ Feature: Backend Usages
   Background:
     Given a provider is logged in
 
+  Scenario: Empty state
+    Given a product with no backends
+    When an admin goes to the product's backend usages page
+    Then should see "There are no backends yet"
+    And they can create a backend from there
+
   Scenario: Add a backend API
     Given a backend
     And a product

--- a/features/step_definitions/backend_usages_steps.rb
+++ b/features/step_definitions/backend_usages_steps.rb
@@ -9,7 +9,7 @@ When "an admin goes to the product's backend usages page" do
 end
 
 Then 'they can add the backend by filling up the form' do
-  click_on 'Add backend'
+  click_on_add_backend
   pf4_select(@backend.name, from: 'Backend')
   fill_in('Path', with: '/api/v1')
   click_on 'Add to product'
@@ -20,7 +20,7 @@ And 'the product will be using this backend' do
 end
 
 When 'they try to add the backend( again)' do
-  click_on 'Add backend'
+  click_on_add_backend
 end
 
 Then "the backend won't be available" do
@@ -28,11 +28,20 @@ Then "the backend won't be available" do
 end
 
 Then "they can't add the backend with an invalid path" do
-  click_on 'Add backend'
+  click_on_add_backend
   pf4_select(@backend.name, from: 'Backend')
   fill_in('Path', with: '???')
   click_on 'Add to product'
 
   assert_content "Couldn't add Backend to Product"
   assert_not_includes @product.reload.backend_apis, @backend
+end
+
+And "they can create a backend from there" do
+  click_on I18n.t('api.backend_usages.index.empty_state.primary_action')
+  assert_current_path new_admin_service_backend_usage_path(@product)
+end
+
+def click_on_add_backend
+  click_on I18n.t('api.backend_usages.index.toolbar.primary')
 end

--- a/features/step_definitions/service_steps.rb
+++ b/features/step_definitions/service_steps.rb
@@ -4,6 +4,10 @@ Given 'a product' do
   @product = @provider.default_service
 end
 
+Given 'a product with no backends' do
+  @product = FactoryBot.create(:service, account: @provider)
+end
+
 Given "a service {string} of {provider}" do |name, provider|
   @service = provider.services.create! name: name, mandatory_app_key: false
 end


### PR DESCRIPTION
[THREESCALE-9814: Integration > Backend usages table](https://issues.redhat.com/browse/THREESCALE-9814)

Old:
<img width="1728" alt="Screenshot 2023-10-25 at 18 02 27" src="https://github.com/3scale/porta/assets/11672286/e805025e-50c7-401f-9529-642f42adadb2">


Option A: button to the right
<img width="1728" alt="Screenshot 2023-10-25 at 12 52 33" src="https://github.com/3scale/porta/assets/11672286/ab93f0e6-61a5-4b22-bc54-bbb284300ed8">


Option B: button to the left
<img width="1728" alt="Screenshot 2023-10-25 at 12 52 04" src="https://github.com/3scale/porta/assets/11672286/cc63e0ea-9b9b-4a0b-9838-f0c3630ca11e">
