### PR TITLE
THREESCALE-10272: Skip CSRF protection for events webhook

### DIFF
--- a/app/controllers/master/events/imports_controller.rb
+++ b/app/controllers/master/events/imports_controller.rb
@@ -2,6 +2,8 @@ class Master::Events::ImportsController < Master::BaseController
   include SiteAccountSupport
   respond_to :xml
 
+  skip_forgery_protection
+
   before_action :check_shared_secret
 
   def create

--- a/test/integration/master/events/imports_controller_test.rb
+++ b/test/integration/master/events/imports_controller_test.rb
@@ -11,13 +11,6 @@ class Master::Events::ImportsControllerTest < ActionDispatch::IntegrationTest
   def setup
     host! master_account.internal_domain
     ::Events.stubs(shared_secret: 'SECRET')
-    # Enable CSRF protection
-    ActionController::Base.allow_forgery_protection = true
-  end
-
-  def teardown
-    # Disable CSRF protection
-    ActionController::Base.allow_forgery_protection = false
   end
 
   test 'is not accessible on other domains' do
@@ -40,5 +33,12 @@ class Master::Events::ImportsControllerTest < ActionDispatch::IntegrationTest
     Events.expects(:async_fetch_backend_events!)
 
     post master_events_import_path secret: Events.shared_secret, :host => master_account.internal_domain
+  end
+
+  test 'skips forgery protection' do
+    with_forgery_protection do
+      post master_events_import_path secret: Events.shared_secret
+      assert_response :ok
+    end
   end
 end

--- a/test/integration/master/events/imports_controller_test.rb
+++ b/test/integration/master/events/imports_controller_test.rb
@@ -11,6 +11,13 @@ class Master::Events::ImportsControllerTest < ActionDispatch::IntegrationTest
   def setup
     host! master_account.internal_domain
     ::Events.stubs(shared_secret: 'SECRET')
+    # Enable CSRF protection
+    ActionController::Base.allow_forgery_protection = true
+  end
+
+  def teardown
+    # Disable CSRF protection
+    ActionController::Base.allow_forgery_protection = false
   end
 
   test 'is not accessible on other domains' do


### PR DESCRIPTION
**What this PR does / why we need it**:

Events coming from backend are failing due to CSRF forgery protection. This is a regression caused by https://github.com/3scale/porta/pull/3543

**Which issue(s) this PR fixes**

[THREESCALE-10272](https://issues.redhat.com/browse/THREESCALE-10272)

**Verification steps** 

1- Send a query to the endpoint:
```
curl --request POST  --url 'http://master-account.3scale.localhost:3000/master/events/import'
```
2- Check that an `EventsFetchWorker` job is enqueued


