### PR TITLE
Fix regression: boot:redis task

### DIFF
--- a/lib/tasks/boot.rake
+++ b/lib/tasks/boot.rake
@@ -18,12 +18,16 @@ namespace :boot do
   desc 'Tries to connect to Redis'
   task :redis do
     require Rails.root.join('app', 'lib', 'three_scale', 'redis_config')
-    require Rails.root.join('config', 'initializers', 'redis_hacks')
 
-    redis_config = ThreeScale::RedisConfig.new(Rails.application.config_for(:redis))
-    redis = Redis.new(redis_config.config)
-    redis.ping
-    puts "Connected to #{redis.id}"
+    redis_config = ThreeScale::RedisConfig.new(Rails.application.config_for(:redis)).config
+    pool_config = redis_config.extract!(:size, :pool_timeout)
+    pool = ConnectionPool.new(size: pool_config[:size] || 5, timeout: pool_config[:pool_timeout] || 5 ) do
+      Redis.new(redis_config)
+    end
+    pool.with do |redis|
+      redis.ping
+      puts "Connected to #{redis.id}"
+    end
   end
 
   task all: %i[backend database redis]

--- a/lib/tasks/boot.rake
+++ b/lib/tasks/boot.rake
@@ -17,8 +17,8 @@ namespace :boot do
 
   desc 'Tries to connect to Redis'
   task :redis do
-    require Rails.root.join('app', 'lib', 'three_scale', 'redis_config')
-    require Rails.root.join('app', 'lib', 'system', 'redis_pool')
+    require Rails.root.join('app/lib/three_scale/redis_config')
+    require Rails.root.join('app/lib/system/redis_pool')
 
     redis_config = ThreeScale::RedisConfig.new(Rails.application.config_for(:redis)).config
     pool = System::RedisPool.new(redis_config)

--- a/lib/tasks/boot.rake
+++ b/lib/tasks/boot.rake
@@ -18,12 +18,10 @@ namespace :boot do
   desc 'Tries to connect to Redis'
   task :redis do
     require Rails.root.join('app', 'lib', 'three_scale', 'redis_config')
+    require Rails.root.join('app', 'lib', 'system', 'redis_pool')
 
     redis_config = ThreeScale::RedisConfig.new(Rails.application.config_for(:redis)).config
-    pool_config = redis_config.extract!(:size, :pool_timeout)
-    pool = ConnectionPool.new(size: pool_config[:size] || 5, timeout: pool_config[:pool_timeout] || 5 ) do
-      Redis.new(redis_config)
-    end
+    pool = System::RedisPool.new(redis_config)
     pool.with do |redis|
       redis.ping
       puts "Connected to #{redis.id}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to a regression after upgrading to Sidekiq 7, the `boot:redis` rake task was broken.

The new redis gem doesn't accept any unknown parameter, but we include some parameters in our `.yml` which belong to the pool, not Redis. I modified the task to connect to Redis the same way [Porta](https://github.com/3scale/porta/blob/master/app/lib/system/redis_pool.rb#L9-L14) and [Sidekiq](https://github.com/sidekiq/sidekiq/blob/main/lib/sidekiq/redis_connection.rb#L10-L26) do it: through a pool.

**Verification steps** 

Run and verify it works correctly

```
bundle exec rake boot:redis
```

