### PR TITLE
THREESCALE-8974: Reword "your account is suspended" page

### DIFF
--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -60,7 +60,7 @@ class FrontendController < ApplicationController
   end
 
   def provider_suspended?
-    current_account.try!(:suspended?) && current_account.try!(:provider?)
+    current_account&.suspended? && current_account&.provider?
   end
 
   def with_password_confirmation!

--- a/app/views/provider/admin/accounts/suspended.html.slim
+++ b/app/views/provider/admin/accounts/suspended.html.slim
@@ -1,22 +1,16 @@
 h1 Hello #{current_user.display_name},
 p
-  | Your 3scale trial has expired and the account is de-activated.
-    To continue using the service, you’ll need to move onto a paid plan.
+  | Your account 
+  strong #{current_account.external_admin_domain} 
+  | is suspended.
 
-p
-  | Please contact
-  =>< mail_to ThreeScale.config.sales_email, nil, subject: %q{I'd like to continue using 3scale}, id: 'continue-using-3scale'
-  | to enable your upgrade or if you have questions.
-
-p = mail_to ThreeScale.config.sales_email, 'Purchase paid plan',
-        subject: %q{I'd like to purchase a paid plan}, class: 'button', id: 'purchase-paid-plan'
-
-javascript:
-  analytics.trackLink(document.getElementById('continue-using-3scale'), 'Suspended account page', {
-    step: 'click help suspended account',
-    path: window.location.pathname
-  })
-  analytics.trackLink(document.getElementById('purchase-paid-plan'), 'Suspended account page', {
-    step: 'click upgrade suspended account',
-    path: window.location.pathname
-  })
+- if ThreeScale.config.saas?
+  p
+    ' Please
+    => link_to 'open a Support Case', 'https://access.redhat.com/support/', target: '_blank'
+    | if you think that your account was suspended by mistake.
+- else
+  p
+    ' Please contact
+    => mail_to ThreeScale.config.support_email
+    | if you think that your account was suspended by mistake.

--- a/features/provider/accounts/suspending_tenants.feature
+++ b/features/provider/accounts/suspending_tenants.feature
@@ -1,0 +1,17 @@
+@javascript
+Feature: Suspending tenants
+  As a master
+  I to want to suspend tenants so that users can't access admin portals
+
+  Background:
+    Given a provider is logged in
+    And the provider is suspended
+
+  @onpremises
+  Scenario: Show Access Denied page on-premises
+    When I go to the provider login page
+    Then I see the support email of the provider
+
+  Scenario: Show "Account suspended" page in SaaS
+    When I go to the provider login page
+    Then I should see "Please open a support case"

--- a/features/step_definitions/provider_steps.rb
+++ b/features/step_definitions/provider_steps.rb
@@ -287,3 +287,11 @@ end
 When "the provider is at {}" do |page_name|
   visit path_to(page_name)
 end
+
+When "{provider} is suspended" do |provider|
+  provider.suspend!
+end
+
+Then "I see the support email of {provider}" do |provider|
+  step %(I should see "#{ThreeScale.config.support_email}")
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -2,6 +2,12 @@
 
 Before '@onpremises' do
   ThreeScale.config.stubs(onpremises: true)
+  ThreeScale.config.stubs(saas?: false)
+end
+
+After '@onpremises' do
+  ThreeScale.config.stubs(onpremises: false)
+  ThreeScale.config.stubs(saas?: true)
 end
 
 Before '@ignore-backend' do

--- a/features/support/initial_data.rb
+++ b/features/support/initial_data.rb
@@ -15,6 +15,7 @@ Before do |scenario|
   FieldsDefinition.create_defaults! master_account
 
   ThreeScale.config.stubs(onpremises: false)
+  ThreeScale.config.stubs(saas?: true)
   ThreeScale.config.sandbox_proxy.stubs(apicast_registry_url: 'http://apicast.alaska/policies')
   ThreeScale.config.sandbox_proxy.stubs(self_managed_apicast_registry_url: 'http://self-managed.apicast.alaska/policies')
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the wording on the suspended page, and ensure it is informative and non-confusing for both SaaS and On-premises.

SaaS (point to https://access.redhat.com/support):
![Screenshot from 2023-11-10 11-31-56](https://github.com/3scale/porta/assets/1270328/3368ccfc-717c-4132-a24b-0ef456795b02)


On-premises (using `SUPPORT_EMAIL` value):

![Screenshot from 2023-11-10 11-32-13](https://github.com/3scale/porta/assets/1270328/15b79337-78b2-4219-bbc6-3b88462d7cd2)


**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-8974

**Verification steps** 

Go to any page on the portal of the suspended tenant.

**Special notes for your reviewer**:
