### PR TITLE
Fix serialization of ZyncWorker arguments

### DIFF
--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -139,7 +139,7 @@ class ZyncWorker
     # The number of retries is usually controlled at the origin of the failure using ThreeScale::SidekiqRetrySupport::Worker#last_attempt?,
     # but in this case we are not really using Sidekiq retries, but rather re-enqueueing the job manually here
     manual_retry_count = options['manual_retry_count'].to_i + 1
-    perform_async(event.event_id, event.data.to_json, manual_retry_count)
+    perform_async(event.event_id, event.data.as_json, manual_retry_count)
   end
 
   delegate :perform_async, to: :class

--- a/test/workers/zync_worker_test.rb
+++ b/test/workers/zync_worker_test.rb
@@ -124,7 +124,7 @@ class ZyncWorkerTest < ActiveSupport::TestCase
     test 'on batch complete' do
       event_id = event.event_id
       klass = worker.class
-      klass.expects(:perform_async).with(event_id, anything, 1)
+      klass.expects(:perform_async).with(event_id, event.data.as_json, 1)
       klass.new.on_complete(1, {'event_id' => event_id, 'manual_retry_count' => 0})
     end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a regression that we introduced here: https://github.com/3scale/porta/pull/3608/commits/60ce61cde319490356feaa10ecc7e60f1a014113

It results in some ZyncWorker jobs failing with 
```
ZyncWorker::InvalidResponseError: Expected successful response. Got 400
```
Because the payload get serialized to JSON twice.

**Which issue(s) this PR fixes** 

-none-


**Verification steps** 

-none-

**Special notes for your reviewer**:
