### PR TITLE
Truncate logs for enqueuing Sidekiq jobs

### DIFF
--- a/lib/three_scale/sidekiq_logging_middleware.rb
+++ b/lib/three_scale/sidekiq_logging_middleware.rb
@@ -6,7 +6,7 @@ module ThreeScale
       yield
     ensure
       filtered_args = FilterArguments.new(msg['args']).filter
-      Rails.logger.info "Enqueued #{worker_class}##{msg['jid']} with args: #{filtered_args}"
+      Rails.logger.info "Enqueued #{worker_class}##{msg['jid']} with args: #{filtered_args.to_s.truncate(200)}"
     end
   end
 end

--- a/test/unit/sidekiq_logging_middleware_test.rb
+++ b/test/unit/sidekiq_logging_middleware_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class SidekiqLoggingMiddlewareTest < ActiveSupport::TestCase
@@ -7,13 +9,13 @@ class SidekiqLoggingMiddlewareTest < ActiveSupport::TestCase
       'jid' => 123,
       'args' => [
         {
-          "some_arg": "value",
-          "user_key": "secret_value"
+          "some_arg" => "value",
+          "user_key" => "secret_value"
         }
       ]
     }
 
-    Rails.logger.expects(:info).with('Enqueued DummyWorker#123 with args: [{:some_arg=>"value", :user_key=>"[FILTERED]"}]')
+    Rails.logger.expects(:info).with('Enqueued DummyWorker#123 with args: [{"some_arg"=>"value", "user_key"=>"[FILTERED]"}]')
 
     middleware.call('DummyWorker', msg) { nil }
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

When Sidekiq jobs are enqueued, a log statement is printed with the job name and args. In case the args are too long, too much stuff goes to log.
The proposal is to truncate the arguments, for example up to 200 characters.

This is what would be in the output:

```
Enqueued BackendStorageRewriteWorker#dd720cc2a142a144ad087b09 with args: ["Cinstance", [1234567890123, 1234567890123, 1234567890123, 1234567890123, 1234567890123, 1234567890123, 1234567890123, 1234567890123, 1234567890123, 1234567890123, 1234567890123, 1234567890123, 12...
```
It can be truncated even further if needed.

**Which issue(s) this PR fixes** 


**Verification steps** 


**Special notes for your reviewer**:
