### PR TITLE
THREESCALE-10452: Set a predefined directory for multi-process Prometheus metrics

### DIFF
--- a/openshift/system/Dockerfile
+++ b/openshift/system/Dockerfile
@@ -50,7 +50,8 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     ENV=/opt/app-root/etc/scl_enable \
     PROMPT_COMMAND=". /opt/app-root/etc/scl_enable" \
     RAILS_ENV=production \
-    SAFETY_ASSURED=1
+    SAFETY_ASSURED=1 \
+    prometheus_multiproc_dir=/opt/system/tmp/prometheus-client-mmap-dir
 
 RUN source /opt/app-root/etc/scl_enable \
     && gem install bundler --version 2.2.25 \
@@ -67,7 +68,7 @@ ADD openshift/system/config/* ./config/
 
 RUN source /opt/app-root/etc/scl_enable \
     && bundle exec rake tmp:create \
-    && mkdir -p public/assets db/sphinx \
+    && mkdir -p public/assets db/sphinx tmp/prometheus-client-mmap-dir \
     && chmod g+w -vfR log tmp public/assets db/sphinx \
     && umask 0002 \
     && cd /opt/system \


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an env var with the directory path so that all Prometheus metrics across Unicorn workers are aggregated properly.

**Which issue(s) this PR fixes** 

[THREESCALE-10452](https://issues.redhat.com/browse/THREESCALE-10452)

**Verification steps** 

- Start the server with multiple Unicorn workers
- Make some request
- Call `:9394/yabeda-metrics` and ensure that all the metrics show consistent values

**Special notes for your reviewer**:
