### PR TITLE
Fix SSO user creation test

### DIFF
--- a/test/unit/authentication/strategy/provider_oauth2_test.rb
+++ b/test/unit/authentication/strategy/provider_oauth2_test.rb
@@ -168,6 +168,10 @@ class Authentication::Strategy::ProviderOAuth2Test < ActiveSupport::TestCase
 
     include ActiveJob::TestHelper
 
+    teardown do
+      ActionMailer::Base.deliveries.clear
+    end
+
     test 'create an active user through sso' do
       authentication_provider = FactoryBot.create(:self_authentication_provider, account: oauth2_provider, kind: 'base')
       authentication_strategy = Authentication::Strategy.build_provider(oauth2_provider)
@@ -192,6 +196,8 @@ class Authentication::Strategy::ProviderOAuth2Test < ActiveSupport::TestCase
         assert result.active?
         assert authentication_strategy.error_message.blank?
         assert authentication_strategy.new_user_created?
+
+        assert_empty ActionMailer::Base.deliveries
       end
     end
 

--- a/test/unit/authentication/strategy/provider_oauth2_test.rb
+++ b/test/unit/authentication/strategy/provider_oauth2_test.rb
@@ -193,10 +193,6 @@ class Authentication::Strategy::ProviderOAuth2Test < ActiveSupport::TestCase
         assert authentication_strategy.error_message.blank?
         assert authentication_strategy.new_user_created?
       end
-
-      last_email = ActionMailer::Base.deliveries.last
-      assert_match 'Account Activation', last_email.subject
-      assert_match 'activate your account', last_email.body.to_s
     end
 
     test 'create a non active user through sso' do

--- a/test/unit/authentication/strategy/provider_oauth2_test.rb
+++ b/test/unit/authentication/strategy/provider_oauth2_test.rb
@@ -166,11 +166,8 @@ class Authentication::Strategy::ProviderOAuth2Test < ActiveSupport::TestCase
 
   class SsoSignupTest < ActiveSupport::TestCase
 
+    include ActionMailer::TestCase::ClearTestDeliveries
     include ActiveJob::TestHelper
-
-    teardown do
-      ActionMailer::Base.deliveries.clear
-    end
 
     test 'create an active user through sso' do
       authentication_provider = FactoryBot.create(:self_authentication_provider, account: oauth2_provider, kind: 'base')


### PR DESCRIPTION
**What this PR does / why we need it**:

This test started randomly failing when we switched to `:random` test order in https://github.com/3scale/porta/pull/3618

Basically, the test is wrong, and the reason why they used to pass, is that when they were always executed in order, it was like this:
1. `test_create_a_non_active_user_through_sso`
2. `test_create_an_active_user_through_sso`

So, the email was actually sent in test 1, and this was the email asserted in test 2, while test 2 did not actually create any new emails. It is expected, because if the user already has `email_verified: true` coming from SSO, we don't need to verify their email by sending them a message with activation link.


**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

Make sure the tests do not randomly fail.

**Special notes for your reviewer**:
