### PR TITLE
Activate menu in New Provider page

### DIFF
--- a/app/controllers/provider/admin/accounts_controller.rb
+++ b/app/controllers/provider/admin/accounts_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Provider::Admin::AccountsController < Provider::Admin::Account::BaseController
-  activate_menu! :buyers, :accounts, only: [:new]
   activate_menu :account, :overview
 
   before_action :find_countries, :only => [:edit, :update]
@@ -11,6 +10,8 @@ class Provider::Admin::AccountsController < Provider::Admin::Account::BaseContro
   before_action :disable_client_cache
 
   def new
+    activate_menu :buyers, :accounts, :listing
+
     @provider = current_account.buyers.new
     @user = @provider.admins.new
   end


### PR DESCRIPTION
[THREESCALE-10446: New Account page menu is not activated (master)](https://issues.redhat.com/browse/THREESCALE-10446)

Before:
![Screenshot 2023-11-21 at 13 12 09](https://github.com/3scale/porta/assets/11672286/9febebeb-8474-4efd-8729-635e93681b4d)

After:
![Screenshot 2023-11-21 at 13 17 22](https://github.com/3scale/porta/assets/11672286/76f7421f-3e26-46e7-a972-b9c6f0e42a26)
