### PR TITLE
⚛️ Fix prop `isShared`

### DIFF
--- a/app/javascript/src/Common/components/TableToolbar.tsx
+++ b/app/javascript/src/Common/components/TableToolbar.tsx
@@ -123,7 +123,8 @@ const TableToolbar: FunctionComponent<Props> = ({
               <OverflowMenu breakpoint="xl" breakpointReference={toolbarRef}>
                 <OverflowMenuContent>
                   <OverflowMenuGroup groupType="button">
-                    {overflow.filter(i => i.isShared).map(({ label, ...btnProps }) => (
+                    {/* eslint-disable-next-line @typescript-eslint/no-unused-vars -- Remove isShared from button props */}
+                    {overflow.filter(i => i.isShared).map(({ label, isShared, ...btnProps }) => (
                       <OverflowMenuItem key={label}>
                         <Button component="a" {...btnProps}>{label}</Button>
                       </OverflowMenuItem>


### PR DESCRIPTION
[THREESCALE-10506: TableToolbar: Rename isShared param to shared](https://issues.redhat.com/browse/THREESCALE-10506)