### PR TITLE
THREESCALE-7676: limit number of jobs for tenant fixes

### DIFF
--- a/app/workers/set_tenant_id_worker.rb
+++ b/app/workers/set_tenant_id_worker.rb
@@ -1,33 +1,43 @@
 # frozen_string_literal: true
 
 class SetTenantIdWorker < ApplicationJob
+  queue_as :low
 
-  def perform(provider)
-    provider.update_column(:master, false)
+  RELATIONS = ["backend_apis", "log_entries", "alerts"].freeze
 
-    [:backend_apis, :log_entries, :alerts].each do |relation|
-      provider.public_send(relation).where(tenant_id: nil).find_each do |instance|
-        ModelTenantIdWorker.perform_later(instance, provider.tenant_id)
+  def perform(provider, relations)
+    relations.each do |relation|
+      assoc = provider.public_send(relation)
+      assoc.select(:id).where(tenant_id: nil).find_in_batches(batch_size: 100) do |instances|
+        ModelTenantIdWorker.perform_later(assoc.klass, instances.map(&:id), provider.tenant_id)
       end
     end
   end
 
   class BatchEnqueueWorker < ApplicationJob
     unique :until_executed
+    queue_as :low
 
-    def perform(*)
-      Account.providers.where(master: nil).find_each do |provider|
-        SetTenantIdWorker.perform_later(provider)
+    def self.validate_params(*relations)
+      raise "you must pass relations to fix" if relations.empty?
+      raise "Only relations #{RELATIONS} are supported" unless (relations - RELATIONS).empty?
+    end
+    delegate :validate_params, :to => :class
+
+    def perform(*relations)
+      validate_params(*relations)
+
+      Account.tenants.select(:id).find_each do |provider|
+        SetTenantIdWorker.perform_later(provider, relations)
       end
     end
   end
 
   class ModelTenantIdWorker < ApplicationJob
+    queue_as :low
 
-    def perform(object, tenant_id)
-      object.update_column(:tenant_id, tenant_id)
+    def perform(model, ids, tenant_id)
+      model.where(id: ids).update_all(tenant_id: tenant_id)
     end
-
   end
-
 end

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -316,9 +316,4 @@ namespace :fixes do
     exec_batch.call(:providers, Account.providers, provider_states_transitions)
     exec_batch.call(:developers, Account.buyers, buyer_states_transitions)
   end
-
-  desc 'Fix tenant_id missing in some tables'
-  task :tenant_id => :environment do
-    SetTenantIdWorker::BatchEnqueueWorker.perform_later
-  end
 end

--- a/lib/tasks/multitenant/tenants.rake
+++ b/lib/tasks/multitenant/tenants.rake
@@ -21,7 +21,7 @@ namespace :multitenant do
     end
 
     desc 'Fix in the background tenant_id missing in alerts, log entries and backend apis'
-    task :fix_missing_in_background => :environment do |_task, relations|
+    task :fix_missing_tenant_id_async => :environment do |_task, relations|
       list = relations.to_a
       SetTenantIdWorker::BatchEnqueueWorker.validate_params(*list)
       SetTenantIdWorker::BatchEnqueueWorker.perform_later(*list)

--- a/lib/tasks/multitenant/tenants.rake
+++ b/lib/tasks/multitenant/tenants.rake
@@ -20,6 +20,13 @@ namespace :multitenant do
       puts(query.any? ? 'Some of the tenants haven\t been suspended' : 'All the right tenants have been suspended')
     end
 
+    desc 'Fix in the background tenant_id missing in alerts, log entries and backend apis'
+    task :fix_missing_in_background => :environment do |_task, relations|
+      list = relations.to_a
+      SetTenantIdWorker::BatchEnqueueWorker.validate_params(*list)
+      SetTenantIdWorker::BatchEnqueueWorker.perform_later(*list)
+    end
+
     desc 'Fix empty or corrupted tenant_id in accounts'
     task :fix_corrupted_tenant_id_accounts, %i[batch_size sleep_time] => :environment do |_task, args|
       batch_size = (args[:batch_size] || 100).to_i
@@ -48,17 +55,17 @@ namespace :multitenant do
 
     desc 'Fix empty tenant_id in access_tokens'
     task :fix_empty_tenant_id_access_tokens, %i[batch_size sleep_time] => :environment do |_task, args|
-      update_tenant_ids(proc { |object| object.owner.tenant_id }, proc { owner }, proc { tenant_id == nil }, args.to_hash.merge({table_name: 'AccessToken'}))
+      update_tenant_ids(proc { |object| object.owner.tenant_id }, proc { owner }, proc { tenant_id == nil }, args.to_hash.merge({ table_name: 'AccessToken' }))
     end
 
     desc 'Restore existing tenant_id in alerts'
     task :restore_existing_tenant_id_alerts, %i[batch_size sleep_time] => :environment do |_task, args|
-      update_tenant_ids(proc { |object| object.account.tenant_id }, proc { account }, proc { tenant_id != nil }, args.to_hash.merge({table_name: 'Alert'}))
+      update_tenant_ids(proc { |object| object.account.tenant_id }, proc { account }, proc { tenant_id != nil }, args.to_hash.merge({ table_name: 'Alert' }))
     end
 
     desc 'Restore empty tenant_id in alerts'
     task :restore_empty_tenant_id_alerts, %i[batch_size sleep_time] => :environment do |_task, args|
-      update_tenant_ids(proc { |object| object.account.tenant_id }, proc { account }, proc { tenant_id == nil }, args.to_hash.merge({table_name: 'Alert'}))
+      update_tenant_ids(proc { |object| object.account.tenant_id }, proc { account }, proc { tenant_id == nil }, args.to_hash.merge({ table_name: 'Alert' }))
     end
 
     def update_tenant_ids(tenant_id_block, association_block, condition, **args)

--- a/test/workers/set_tenant_id_worker_test.rb
+++ b/test/workers/set_tenant_id_worker_test.rb
@@ -30,5 +30,24 @@ class SetTenantIdWorkerTest < ActiveSupport::TestCase
       assert_equal accounts.last.id, backend_api2.reload.tenant_id
       assert_nil alert.reload.tenant_id
     end
+
+    test "raises on empty params" do
+      assert_raises do
+        SetTenantIdWorker::BatchEnqueueWorker.new.perform
+      end
+    end
+
+    test "raises on unsupported relations" do
+      assert_raises do
+        # unsupported relation that
+        SetTenantIdWorker::BatchEnqueueWorker.new.perform("accounts")
+      end
+    end
+
+    test "raises on non-existing relations" do
+      assert_raises do
+        SetTenantIdWorker::BatchEnqueueWorker.new.perform("non-existing-relation", "alerts")
+      end
+    end
   end
 end

--- a/test/workers/set_tenant_id_worker_test.rb
+++ b/test/workers/set_tenant_id_worker_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SetTenantIdWorkerTest < ActiveSupport::TestCase
+
+  class BatchEnqueueWorkerTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
+    test "perform with a single relation" do
+      accounts = FactoryBot.create_list(:simple_provider, 2)
+      backend_api = FactoryBot.create(:backend_api, account: accounts.first)
+      backend_api2 = FactoryBot.create(:backend_api, account: accounts.last)
+      alert = FactoryBot.create(:limit_alert, account: accounts.first)
+      assert_equal accounts.first.id, backend_api.reload.tenant_id
+
+      backend_api.tenant_id = nil
+      backend_api.save!
+      assert_nil backend_api.reload.tenant_id
+
+      alert.reload.tenant_id = nil
+      alert.save!
+      assert_nil alert.reload.tenant_id
+
+      perform_enqueued_jobs(only: [SetTenantIdWorker, SetTenantIdWorker::ModelTenantIdWorker]) do
+        SetTenantIdWorker::BatchEnqueueWorker.new.perform("backend_apis")
+      end
+
+      assert_equal accounts.first.id, backend_api.reload.tenant_id
+      assert_equal accounts.last.id, backend_api2.reload.tenant_id
+      assert_nil alert.reload.tenant_id
+    end
+  end
+end

--- a/test/workers/sphinx_account_indexation_worker_test.rb
+++ b/test/workers/sphinx_account_indexation_worker_test.rb
@@ -4,7 +4,6 @@ require 'test_helper'
 
 class SphinxAccountIndexationWorkerTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
-  include TestHelpers::Master
 
   test "master account should not be indexed" do
     ThinkingSphinx::Test.rt_run do

--- a/test/workers/sphinx_indexation_worker_test.rb
+++ b/test/workers/sphinx_indexation_worker_test.rb
@@ -3,9 +3,6 @@
 require 'test_helper'
 
 class SphinxIndexationWorkerTest < ActiveSupport::TestCase
-
-  include ActiveJob::TestHelper
-
   test 'it does not raises if id does not exist' do
     enable_search_jobs!
     SphinxIndexationWorker.perform_now(ThinkingSphinx::Test.indexed_models.sample, 42)


### PR DESCRIPTION
Follow-up on #2904
Supersedes #2949

First require user to enter relations that need fixing so that
they can be fixed individually.

Additionally perform updating in batches to reduce overall number of
jobs.

Also set the used queue to "low". Can't really test whether its faster in staging before we merge.
```
bundle exec rake 'multitenant:tenants:fix_missing_in_background[backend_apis,alerts]'
BackendApi.where(tenant_id: nil).count # 46850
Alert.where(tenant_id: nil).count # 1695504
```
Which issue(s) this PR fixes:

https://issues.redhat.com/browse/THREESCALE-7676