### PR TITLE
THREESCALE-10212: Fix account approved email template

### DIFF
--- a/app/views/emails/account_approved.text.liquid
+++ b/app/views/emails/account_approved.text.liquid
@@ -2,7 +2,7 @@ Dear {{ user.display_name }},
 
 {{ provider.name }} has approved your signup for the {{ provider.name }} API.
 
-You may now view and manage your app/API key at https://{{ provider.external_domain }}/admin/
+You may now view and manage your app/API key at https://{{ provider.domain }}/admin/
 
 If you have problems logging into the account please contact {{ provider.support_email }}.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a bug introduced by https://github.com/3scale/porta/pull/3001/files#diff-1c5334d368e3ebaf8349ca1d8407e2e694c6d9b54ff062dd728305c900ea4e1e

We renamed all **internal** invocations of `.domain` because this method had been deprecated. However, in this case it's a Liquid drop, it should never have been changed, but we missed this.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10212

**Verification steps** 

Ensure that when the account is approved, the email is sent correctly.

**Special notes for your reviewer**:
