### PR TITLE
THREESCALE-10259: URL-encode data in the Download CSV link

### DIFF
--- a/app/javascript/src/Stats/lib/csv_link.js
+++ b/app/javascript/src/Stats/lib/csv_link.js
@@ -26,7 +26,7 @@ export class StatsCSVLink extends StatsUI {
 
   buildCSVString (data) {
     let csvMatrix = this._parseData(data)
-    return csvMatrix.map(cell => cell.join(',')).join('%0A')
+    return csvMatrix.map(row => row.map(cell => encodeURIComponent(cell)).join(',')).join('%0A')
   }
 
   _parseData (data) {

--- a/app/javascript/src/Stats/lib/csv_link.js
+++ b/app/javascript/src/Stats/lib/csv_link.js
@@ -24,9 +24,14 @@ export class StatsCSVLink extends StatsUI {
     this.refresh()
   }
 
+  // Enclose in double quotes values that have commas, line breaks or double quotes (escape the latter as "")
+  escapeCellData(data) {
+    return (typeof data === 'string' && data.match(/[\r\n,"]/)) ? `"${data.replace(/"/g, '""')}"` : data
+  }
+
   buildCSVString (data) {
     let csvMatrix = this._parseData(data)
-    return csvMatrix.map(row => row.map(cell => encodeURIComponent(cell)).join(',')).join('%0A')
+    return csvMatrix.map(row => row.map(cell => encodeURIComponent(this.escapeCellData(cell))).join(',')).join('%0A')
   }
 
   _parseData (data) {

--- a/spec/javascripts/Stats/lib/csv_link.spec.js
+++ b/spec/javascripts/Stats/lib/csv_link.spec.js
@@ -20,13 +20,13 @@ describe('StatsCSVLink', () => {
         '30'
       ],
       [
-        'marvin',
+        'marvin #2',
         '11',
         '31'
       ]
     ]
   }
-  const expectedCsvString = 'datetime,zaphod,marvin%0A11 Mar 1952 07:00:00 GMT,12,11%0A11 May 2001 08:00:00 BST,30,31'
+  const expectedCsvString = 'datetime,zaphod,marvin%20%232%0A11%20Mar%201952%2007%3A00%3A00%20GMT,12,11%0A11%20May%202001%2008%3A00%3A00%20BST,30,31'
 
   beforeEach(() => {
     document.body.innerHTML = '<div id="csv_link"></div>'

--- a/spec/javascripts/Stats/lib/csv_link.spec.js
+++ b/spec/javascripts/Stats/lib/csv_link.spec.js
@@ -15,7 +15,7 @@ describe('StatsCSVLink', () => {
         '2001-05-11T07:00:00+00:00'
       ],
       [
-        'zaphod',
+        'with "quotes"',
         '12',
         '30'
       ],
@@ -23,10 +23,20 @@ describe('StatsCSVLink', () => {
         'marvin #2',
         '11',
         '31'
+      ],
+      [
+        'with, comma',
+        '10',
+        '32'
       ]
     ]
   }
-  const expectedCsvString = 'datetime,zaphod,marvin%20%232%0A11%20Mar%201952%2007%3A00%3A00%20GMT,12,11%0A11%20May%202001%2008%3A00%3A00%20BST,30,31'
+  const cells = [
+    ['datetime', '"with ""quotes"""', 'marvin #2', '"with, comma"'],
+    ['11 Mar 1952 07:00:00 GMT', '12', '11', '10'],
+    ['11 May 2001 08:00:00 BST', '30', '31', '32']
+  ]
+  const expectedCsvString = cells.map(row => row.map(cell => encodeURIComponent(cell)).join(',')).join('%0A')
 
   beforeEach(() => {
     document.body.innerHTML = '<div id="csv_link"></div>'


### PR DESCRIPTION
**What this PR does / why we need it**:

Encode the data that is used for the CSV export of charts.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10259

**Verification steps** 

1. Create an app with a special character, e.g. #, and create some traffic on it
2. Go to Analytics > Top Applications of the product, and click Download CSV
3. Verify that the CSV is generated correctly (no data is truncated)

**Special notes for your reviewer**:
