### PR TITLE
THREESCALE-10579 : Bot protectin on the login screen

### DIFF
--- a/app/controllers/sites/spam_protections_controller.rb
+++ b/app/controllers/sites/spam_protections_controller.rb
@@ -8,7 +8,7 @@ class Sites::SpamProtectionsController < Sites::BaseController
 
   def update
     if @settings.update(params[:settings])
-      flash[:notice] = 'Spam protection settings updated.'
+      flash[:notice] = 'Bot protection settings updated.'
       redirect_to edit_admin_site_spam_protection_url
     else
       flash[:error] = 'There were problems saving the settings.'

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -163,7 +163,7 @@ module VerticalNavHelper
     if can?(:manage, :settings)
       portal_settings_items = []
       portal_settings_items << {id: :admin_site_dns,   title: 'Domains & Access', path: admin_site_dns_path}
-      portal_settings_items << {id: :spam_protection,  title: 'Spam Protection',  path: edit_admin_site_spam_protection_path}
+      portal_settings_items << {id: :spam_protection,  title: 'Bot Protection',  path: edit_admin_site_spam_protection_path}
       portal_settings_items << {id: :xss_protection,   title: 'XSS Protection',   path: edit_admin_site_developer_portal_path} if current_account.show_xss_protection_options?
       portal_settings_items << {id: :sso_integrations, title: 'SSO Integrations', path: provider_admin_authentication_providers_path}
 

--- a/app/lib/three_scale/semantic_form_builder.rb
+++ b/app/lib/three_scale/semantic_form_builder.rb
@@ -106,7 +106,7 @@ module ThreeScale
       end
     end
 
-    # Just adds fields from spam protection module
+    # Just adds fields from bot protection module
     def bot_protection
       bot_protection_inputs
     end

--- a/app/views/sites/spam_protections/edit.html.erb
+++ b/app/views/sites/spam_protections/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:title) do %>
-  Spam Protection
+  Bot Protection
 <% end %>
 
-<% content_for :page_header_title, 'Spam Protection' %>
+<% content_for :page_header_title, 'Bot Protection' %>
 
 <%= semantic_form_for @settings, :url => admin_site_spam_protection_path, :html => {:id => 'spam-protection-settings' } do |form| %>
-  <%= form.inputs 'Spam protection against users that are not signed in' do %>
+  <%= form.inputs 'Protection against bots' do %>
     <%= form.input  :spam_protection_level,
                 :label => false,
                 hint: t(".captcha_hint_#{Recaptcha.captcha_configured?.to_s}"),

--- a/doc/liquid/tags.html
+++ b/doc/liquid/tags.html
@@ -303,7 +303,7 @@ of the form. The supported forms are:</p>
    <tr>
      <th>Form</th>
      <th>Allowed Field Names</th>
-     <th>Spam Protection</th>
+     <th>Bot Protection</th>
      <th>Notes</th>
    </tr>
    <tr>

--- a/doc/liquid/tags.md
+++ b/doc/liquid/tags.md
@@ -154,7 +154,7 @@ of the form. The supported forms are:
    <tr>
      <th>Form</th>
      <th>Allowed Field Names</th>
-     <th>Spam Protection</th>
+     <th>Bot Protection</th>
      <th>Notes</th>
    </tr>
    <tr>

--- a/features/developer_portal/login.feature
+++ b/features/developer_portal/login.feature
@@ -13,3 +13,15 @@ Feature: Login feature
     When I go to the login page
      And I fill in the "bob" login data
     Then I should be logged in the Development Portal
+
+  @recaptcha
+  Scenario: Captcha is disabled
+    Given the provider has bot protection disabled
+     When the buyer wants to log in
+     Then the captcha is not present
+
+  @recaptcha
+  Scenario: Captcha is enabled
+    Given the provider has bot protection enabled
+     When the buyer wants to log in
+     Then the captcha is present

--- a/features/old/accounts/service_contracts.feature
+++ b/features/old/accounts/service_contracts.feature
@@ -30,7 +30,7 @@ Feature: Account service plans management
       | Service Subscription |
       | New Application      |
       | Domains & Access     |
-      | Spam Protection      |
+      | Bot Protection      |
       | SSO Integrations     |
       | Liquid Reference     |
 

--- a/features/old/authorization/provider_settings.feature
+++ b/features/old/authorization/provider_settings.feature
@@ -29,7 +29,7 @@ Feature: Provider settings authorization
       | 0 Messages           | emails settings          |
       | 0 Messages           | email templates          |
       | Developer Portal     | dns settings             |
-      | Developer Portal     | spam protection          |
+      | Developer Portal     | bot protection          |
       | Developer Portal     | xss protection           |
       | Developer Portal     | authentication providers |
 
@@ -55,7 +55,7 @@ Feature: Provider settings authorization
       | 0 Messages           | email templates          |
       | Developer Portal     | site settings            |
       | Developer Portal     | dns settings             |
-      | Developer Portal     | spam protection          |
+      | Developer Portal     | bot protection          |
       | Developer Portal     | xss protection           |
       | Developer Portal     | authentication providers |
 
@@ -83,6 +83,6 @@ Feature: Provider settings authorization
       | Developer Portal     | site settings            |
       | Developer Portal     | feature visibility       |
       | Developer Portal     | dns settings             |
-      | Developer Portal     | spam protection          |
+      | Developer Portal     | bot protection          |
       | Developer Portal     | xss protection           |
       | Developer Portal     | authentication providers |

--- a/features/old/menu/audience_menu.feature
+++ b/features/old/menu/audience_menu.feature
@@ -36,7 +36,7 @@ Feature: Audience menu
       | Service Subscription |
       | New Application      |
       | Domains & Access     |
-      | Spam Protection      |
+      | Bot Protection      |
       | SSO Integrations     |
       | Liquid Reference     |
 
@@ -82,6 +82,6 @@ Feature: Audience menu
       | Service Subscription |
       | New Application      |
       | Domains & Access     |
-      | Spam Protection      |
+      | Bot Protection      |
       | SSO Integrations     |
       | Liquid Reference     |

--- a/features/step_definitions/buyer_steps.rb
+++ b/features/step_definitions/buyer_steps.rb
@@ -166,6 +166,11 @@ Given "a buyer logged in to a provider using SSO" do
   )
 end
 
+When "the buyer wants to log in" do
+  step 'the current domain is foo.3scale.localhost'
+  step 'I go to the login page'
+end
+
 When "the buyer wants to sign up" do
   step 'the current domain is foo.3scale.localhost'
   step 'I go to the sign up page'

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -491,7 +491,7 @@ World(Module.new do
     when 'the dns settings page'
       admin_site_dns_path
 
-    when 'the spam protection page'
+    when 'the bot protection page'
       edit_admin_site_spam_protection_path
 
     when 'the xss protection page'

--- a/lib/developer_portal/app/controllers/developer_portal/login_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/login_controller.rb
@@ -25,7 +25,7 @@ class DeveloperPortal::LoginController < DeveloperPortal::BaseController
   def create
     logout_keeping_session!
 
-    return render_bot_error unless bot_check
+    return render_login_error unless bot_check
 
     if (@user = @strategy.authenticate(params.merge(request: request)))
       self.current_user = @user
@@ -36,7 +36,7 @@ class DeveloperPortal::LoginController < DeveloperPortal::BaseController
       @strategy.on_signup(session)
       redirect_to @strategy.signup_path(params), notice: 'Successfully authenticated, please complete the signup form'
     else
-      render_creation_error
+      render_login_error(@strategy.error_message)
     end
   end
 
@@ -49,15 +49,9 @@ class DeveloperPortal::LoginController < DeveloperPortal::BaseController
 
   private
 
-  def render_bot_error
+  def render_login_error(error_message = nil)
     @session = Session.new
-    assign_drops add_authentication_drops
-    render action: :new
-  end
-
-  def render_creation_error
-    @session = Session.new
-    flash.now[:error] = @strategy.error_message
+    flash.now[:error] = error_message if error_message
     assign_drops add_authentication_drops
     render action: :new
   end

--- a/lib/developer_portal/lib/liquid/forms/login.rb
+++ b/lib/developer_portal/lib/liquid/forms/login.rb
@@ -1,6 +1,6 @@
 module Liquid
   module Forms
-    class Login < Forms::Create
+    class Login < Forms::BotProtected
 
       def html_class_name
         'formtastic session'

--- a/lib/developer_portal/lib/liquid/tags/form.rb
+++ b/lib/developer_portal/lib/liquid/tags/form.rb
@@ -19,7 +19,7 @@ module Liquid
           <tr>
             <th>Form</th>
             <th>Allowed Field Names</th>
-            <th>Spam Protection</th>
+            <th>Bot Protection</th>
             <th>Notes</th>
           </tr>
           <tr>


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds bot protection to the login screen in the developer poral.

It also renames "Spam protection" to "Bot protection" in the UI.

**Which issue(s) this PR fixes** 

[THREESCALE-10579](https://issues.redhat.com/browse/THREESCALE-10579)

**Verification steps** 

1. Enable or disable reCAPTCHA on the bot protection settings screen (`/site/spam_protection/edit`)
2. Check the reCAPTCHA badge appears or disappears accordingly on the login screen
3. With reCAPTCHA enabled, and `RECAPTCHA_MIN_BOT_SCORE=0.5`, the login screen behaves as usual. But with `RECAPTCHA_MIN_BOT_SCORE=0.99`, the bot protection prevents the user to log in, even when sending the correct credentials.
