### PR TITLE
Threescale 8748 update product overview header

### DIFF
--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -196,7 +196,7 @@ module VerticalNavHelper
     sections = []
     return sections unless @service
 
-    sections << {id: :overview,      title: 'Overview',      path: admin_service_path(@service)} if can? :manage, :plans
+    sections << {id: :overview,      title: 'Product Overview',      path: admin_service_path(@service)} if can? :manage, :plans
     sections << {id: :monitoring,    title: 'Analytics',     items: service_analytics}           if can? :manage, :monitoring
     sections << {id: :applications,  title: 'Applications',  items: service_applications}        if (can? :manage, :plans) || (can? :manage, :applications)
     sections << {id: :subscriptions, title: 'Subscriptions', items: service_subscriptions}       if can?(:manage, :service_plans) && current_account.settings.service_plans_ui_visible?
@@ -254,7 +254,7 @@ module VerticalNavHelper
     sections = []
     return sections unless @backend_api&.persisted?
 
-    sections << {id: :overview,         title: 'Overview',             path: provider_admin_backend_api_path(@backend_api)}
+    sections << {id: :overview,         title: 'Backend Overview',             path: provider_admin_backend_api_path(@backend_api)}
     sections << {id: :monitoring,       title: 'Analytics',            path: provider_admin_backend_api_stats_usage_path(@backend_api)} if can? :manage, :monitoring
     sections << {id: :methods_metrics,  title: 'Methods and Metrics',  path: provider_admin_backend_api_metrics_path(@backend_api)}
     sections << {id: :mapping_rules,    title: 'Mapping Rules',        path: provider_admin_backend_api_mapping_rules_path(@backend_api)}

--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_header_title, 'Overview'
+- content_for :page_header_title, 'Product Overview'
 
 section.Section
   .SettingsBox

--- a/app/views/provider/admin/backend_apis/show.html.slim
+++ b/app/views/provider/admin/backend_apis/show.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_header_title, 'Backend overview'
+- content_for :page_header_title, 'Backend Overview'
 
 section.Section
   .SettingsBox

--- a/features/old/menu/api_menu.feature
+++ b/features/old/menu/api_menu.feature
@@ -15,7 +15,7 @@ Feature: API menu
 
   Scenario: API menu structure
     Then I should see menu sections
-      | Overview     |
+      | Product Overview     |
       | Analytics    |
       | Applications |
       | ActiveDocs   |
@@ -38,7 +38,7 @@ Feature: API menu
       | Usage Rules       |
 
   Scenario: Integration sub menu structure
-    When I follow "Overview"
+    When I follow "Product Overview"
     Then I should see menu items under "Integration"
       | Configuration       |
       | Methods and Metrics |
@@ -51,7 +51,7 @@ Feature: API menu
     When provider "foo.3scale.localhost" has "service_plans" switch allowed
     When I go to the API dashboard page
     Then I should see menu sections
-      | Overview      |
+      | Product Overview      |
       | Analytics     |
       | Applications  |
       | Subscriptions |

--- a/features/old/services/multiservice.feature
+++ b/features/old/services/multiservice.feature
@@ -76,7 +76,7 @@ Feature: Multiservice feature
     And I uncheck "Developers can manage applications"
     And I press "Update Product"
     And I go to the overview page of product "Less fancy API"
-    And I follow "Overview"
+    And I follow "Product Overview"
     Then I should see "Less fancy API"
 
   Scenario: Delete Service

--- a/features/provider/admin/backend_apis/show.feature
+++ b/features/provider/admin/backend_apis/show.feature
@@ -9,7 +9,7 @@ Feature: Backend API overview page
     When an admin is in the backend overview page
     Then the name of the backend can be seen on top of the menu
     And I should see menu sections
-      | Overview            |
+      | Backend Overview            |
       | Analytics           |
       | Methods and Metrics |
       | Mapping Rules       |

--- a/test/helpers/vertical_nav_helper_test.rb
+++ b/test/helpers/vertical_nav_helper_test.rb
@@ -22,11 +22,11 @@ class VerticalNavHelperTest < ActionView::TestCase
       @backend_api = FactoryBot.create(:backend_api)
 
       # if permitted
-      assert_equal(["Overview", "Analytics", "Methods and Metrics", "Mapping Rules"], backend_api_nav_sections.pluck(:title))
+      assert_equal(["Backend Overview", "Analytics", "Methods and Metrics", "Mapping Rules"], backend_api_nav_sections.pluck(:title))
 
       # if not permitted
       stubs(can?: false)
-      assert_equal(["Overview", "Methods and Metrics", "Mapping Rules"], backend_api_nav_sections.pluck(:title))
+      assert_equal(["Backend Overview", "Methods and Metrics", "Mapping Rules"], backend_api_nav_sections.pluck(:title))
 
       # When backend_api is not persisted
       @backend_api = BackendApi.new

--- a/test/helpers/vertical_nav_helper_test.rb
+++ b/test/helpers/vertical_nav_helper_test.rb
@@ -37,6 +37,28 @@ class VerticalNavHelperTest < ActionView::TestCase
       assert_equal([], backend_api_nav_sections.pluck(:title))
     end
 
+    test '#service_nav_sections' do
+      plan = FactoryBot.create(:application_plan)
+      @service= FactoryBot.create(:service)
+
+      # if permitted
+      VerticalNavHelperTest::ProviderTest.any_instance.stubs(:has_out_of_date_configuration?).returns(false)
+      assert_equal(["Product Overview", "Analytics", "Applications", "ActiveDocs", "Integration"], service_nav_sections.pluck(:title))
+
+      # if not permitted
+      stubs(can?: false)
+      assert_equal([], service_nav_sections.pluck(:title))
+
+     # When service is not persisted
+      @service = Service.new
+      assert_equal([], service_nav_sections.pluck(:title))
+
+
+      # When service is nil
+      @service = nil
+      assert_equal([], service_nav_sections.pluck(:title))
+    end
+
     test 'Email configurations' do
       Features::EmailConfigurationConfig.stubs(enabled?: true)
       assert_not_includes account_nav_sections.pluck(:id), :email_configurations


### PR DESCRIPTION
**What this PR does / why we need it:**
Currently the [Product_name] in the side menu is not clickable, user needs to click the dropdown menu on the header, select products>x product to jump to the [Product_overview page

All comments of the JIRA clears the need of this issue

**Which issue(s) this PR fixes**
https://issues.redhat.com/browse/THREESCALE-8748

its already done on Backend so updated Product

![image](https://github.com/3scale/porta/assets/84672731/5653f93b-9cab-4d82-a52f-1cb8b975075d)

![image](https://github.com/3scale/porta/assets/84672731/7f1e35e9-2bef-464c-8ebc-4d1d02b00b31)

