### PR TITLE
THREESCALE-1752: Fix messages counter on the dashboard

### DIFF
--- a/app/views/provider/admin/dashboards/_developers_navigation.html.slim
+++ b/app/views/provider/admin/dashboards/_developers_navigation.html.slim
@@ -53,13 +53,13 @@ nav.DashboardNavigation
     // Messages
     li.DashboardNavigation-list-item
       = dashboard_collection_link 'Message',
-                                  current_account.messages.where(sender: !current_account),
+                                  current_account.received_messages.not_system,
                                   provider_admin_messages_root_path,
                                   icon_name: 'envelope'
 
-        - if unread_messages_presenter.show_counter?
-          '
-          | (
-          span.u-notice
-            = unread_messages_presenter.unread_messages_size
-          | )
+      - if unread_messages_presenter.show_counter?
+        '
+        | (
+        span.u-notice
+          = unread_messages_presenter.unread_messages_size
+        | )

--- a/features/old/menu/dashboard.feature
+++ b/features/old/menu/dashboard.feature
@@ -20,3 +20,9 @@ Feature: Dashboard
     Given the provider is charging its buyers
     And I go to the provider dashboard
     Then I should see the link "BILLING" in the audience dashboard widget
+
+  Scenario: Messages link shows correct count
+    And a buyer "john" signed up to provider "foo.3scale.localhost"
+    And 5 messages sent from buyer "john" to the provider with subject "any" and body "any"
+    And I go to the provider dashboard
+    And I should see the link "5 MESSAGES" in the audience dashboard widget


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the messages counter on the dashboard.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-1752

**Verification steps** 

- Send some messages from the developer portal
- Make sure that the correct count is shown in admin portal dashboard. It should correspond to the number of messages in provider's Inbox. The number in parenthesis should indicate the number of unread messages (if any).

**Special notes for your reviewer**:
