### PR TITLE
Threescale 8747 add description for Acount and  Application

### DIFF
--- a/app/views/buyers/accounts/index.html.slim
+++ b/app/views/buyers/accounts/index.html.slim
@@ -1,33 +1,44 @@
-- content_for :page_header_title, 'Accounts'
+section.pf-c-page__main-section.pf-m-light
+  .pf-c-content
+    .pf-l-level
+      .pf-l-level__item
+        h1 Accounts
+
+    div
+      p(data-ouia-component-type="PF4/Text" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Text-2" data-pf-content="true")  Accounts refer to organizations that own applications consuming the API. These organizations may have one or multiple users who can access application credentials and usage analytics through the developer portal.
+
 
 - account_plans_size = presenter.account_plans_size
 - accounts = presenter.buyers.decorate
 
-= render 'shared/bulk_operations' do
-  p
-    ' You have selected <span class="count"></span> accounts
-    ' and you can make following operations with them:
-  dl class="pf-c-description-list pf-m-horizontal pf-m-fluid"
-    = bulk_action 'Send email', new_admin_buyers_accounts_bulk_send_email_path,
-                                'Send email to selected accounts'
-    - if can?(:see, :account_plans) && account_plans_size > 1
-      = bulk_action 'Change account plan', new_admin_buyers_accounts_bulk_change_plan_path,
-                                           'Transfer these accounts to different account plan'
-    = bulk_action 'Change state', new_admin_buyers_accounts_bulk_change_state_path,
-                                  'Approve, reject or make pending selected accounts'
 
-- if presenter.empty_state?
-  div class="pf-c-empty-state"
-    div class="pf-c-empty-state__content"
-      i class="fas fa-ghost pf-c-empty-state__icon" aria-hidden="true"
-      h1 class="pf-c-title pf-m-lg"
-        = t('.empty_state.title')
-      div class="pf-c-empty-state__body"
-        = t('.empty_state.body')
-      - if can?(:create, Account)
-        = link_to t('.empty_state.primary'), presenter.create_account_path, class: "pf-c-button pf-m-primary"
+section.pf-c-page__main-section
+  .pf-c-content
+  = render 'shared/bulk_operations' do
+    p
+      ' You have selected <span class="count"></span> accounts
+      ' and you can make following operations with them:
+    dl class="pf-c-description-list pf-m-horizontal pf-m-fluid"
+      = bulk_action 'Send email', new_admin_buyers_accounts_bulk_send_email_path,
+                                  'Send email to selected accounts'
+      - if can?(:see, :account_plans) && account_plans_size > 1
+        = bulk_action 'Change account plan', new_admin_buyers_accounts_bulk_change_plan_path,
+                                             'Transfer these accounts to different account plan'
+      = bulk_action 'Change state', new_admin_buyers_accounts_bulk_change_state_path,
+                                    'Approve, reject or make pending selected accounts'
 
-- else
+  - if presenter.empty_state?
+    div class="pf-c-empty-state"
+      div class="pf-c-empty-state__content"
+        i class="fas fa-ghost pf-c-empty-state__icon" aria-hidden="true"
+        h1 class="pf-c-title pf-m-lg"
+          = t('.empty_state.title')
+        div class="pf-c-empty-state__body"
+          = t('.empty_state.body')
+        - if can?(:create, Account)
+          = link_to t('.empty_state.primary'), presenter.create_account_path, class: "pf-c-button pf-m-primary"
+
+  - else
   - content_for :javascripts do
     = javascript_packs_with_chunks_tag 'table_toolbar'
 

--- a/app/views/buyers/accounts/index.html.slim
+++ b/app/views/buyers/accounts/index.html.slim
@@ -1,44 +1,36 @@
-section.pf-c-page__main-section.pf-m-light
-  .pf-c-content
-    .pf-l-level
-      .pf-l-level__item
-        h1 Accounts
-
-    div
-      p(data-ouia-component-type="PF4/Text" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Text-2" data-pf-content="true")  Accounts refer to organizations that own applications consuming the API. These organizations may have one or multiple users who can access application credentials and usage analytics through the developer portal.
-
+- content_for :page_header_title, 'Accounts'
+- content_for :page_header_body do
+  ' Accounts refer to organizations that own applications consuming the API. These organizations may
+  ' have one or multiple users who can access application credentials and usage analytics through the developer portal.
 
 - account_plans_size = presenter.account_plans_size
 - accounts = presenter.buyers.decorate
 
+= render 'shared/bulk_operations' do
+  p
+    ' You have selected <span class="count"></span> accounts
+    ' and you can make following operations with them:
+  dl class="pf-c-description-list pf-m-horizontal pf-m-fluid"
+    = bulk_action 'Send email', new_admin_buyers_accounts_bulk_send_email_path,
+                                'Send email to selected accounts'
+    - if can?(:see, :account_plans) && account_plans_size > 1
+      = bulk_action 'Change account plan', new_admin_buyers_accounts_bulk_change_plan_path,
+                                           'Transfer these accounts to different account plan'
+    = bulk_action 'Change state', new_admin_buyers_accounts_bulk_change_state_path,
+                                  'Approve, reject or make pending selected accounts'
 
-section.pf-c-page__main-section
-  .pf-c-content
-  = render 'shared/bulk_operations' do
-    p
-      ' You have selected <span class="count"></span> accounts
-      ' and you can make following operations with them:
-    dl class="pf-c-description-list pf-m-horizontal pf-m-fluid"
-      = bulk_action 'Send email', new_admin_buyers_accounts_bulk_send_email_path,
-                                  'Send email to selected accounts'
-      - if can?(:see, :account_plans) && account_plans_size > 1
-        = bulk_action 'Change account plan', new_admin_buyers_accounts_bulk_change_plan_path,
-                                             'Transfer these accounts to different account plan'
-      = bulk_action 'Change state', new_admin_buyers_accounts_bulk_change_state_path,
-                                    'Approve, reject or make pending selected accounts'
+- if presenter.empty_state?
+  div class="pf-c-empty-state"
+    div class="pf-c-empty-state__content"
+      i class="fas fa-ghost pf-c-empty-state__icon" aria-hidden="true"
+      h1 class="pf-c-title pf-m-lg"
+        = t('.empty_state.title')
+      div class="pf-c-empty-state__body"
+        = t('.empty_state.body')
+      - if can?(:create, Account)
+        = link_to t('.empty_state.primary'), presenter.create_account_path, class: "pf-c-button pf-m-primary"
 
-  - if presenter.empty_state?
-    div class="pf-c-empty-state"
-      div class="pf-c-empty-state__content"
-        i class="fas fa-ghost pf-c-empty-state__icon" aria-hidden="true"
-        h1 class="pf-c-title pf-m-lg"
-          = t('.empty_state.title')
-        div class="pf-c-empty-state__body"
-          = t('.empty_state.body')
-        - if can?(:create, Account)
-          = link_to t('.empty_state.primary'), presenter.create_account_path, class: "pf-c-button pf-m-primary"
-
-  - else
+- else
   - content_for :javascripts do
     = javascript_packs_with_chunks_tag 'table_toolbar'
 

--- a/app/views/provider/admin/applications/index.html.slim
+++ b/app/views/provider/admin/applications/index.html.slim
@@ -1,14 +1,23 @@
-- content_for :page_header_title_with_button, 'Applications'
-- content_for :page_header_button_label, 'Create application'
-- content_for :page_header_button_href, new_provider_admin_application_path
+section.pf-c-page__main-section.pf-m-light
+  .pf-c-content
+    .pf-l-level
+      .pf-l-level__item
+        h1 Applications
+      .pf-l-level__item
+        a.pf-c-button.pf-m-primary(href="/p/admin/applications/new") Create application
 
-- if current_user.accessible_services.empty?
-  = render 'shared/service_access'
-- else
-  = render 'shared/applications/listing', { applications: @cinstances,
-                                            application_plans: @application_plans,
-                                            plan: @plan,
-                                            account: @account,
-                                            search: @search,
-                                            service: @service,
-                                            states: @states }
+    div
+      p(data-ouia-component-type="PF4/Text" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Text-2" data-pf-content="true")  Applications are a representation of an API consumer. They include credentials obtained through the API's authentication method, along with usage metrics and other metadata. The application plan sets the limits for each application
+
+section.pf-c-page__main-section
+  .pf-c-content
+    - if current_user.accessible_services.empty?
+      = render 'shared/service_access'
+    - else
+      = render 'shared/applications/listing', { applications: @cinstances,
+                                                application_plans: @application_plans,
+                                                plan: @plan,
+                                                account: @account,
+                                                search: @search,
+                                                service: @service,
+                                                states: @states }

--- a/app/views/provider/admin/applications/index.html.slim
+++ b/app/views/provider/admin/applications/index.html.slim
@@ -1,23 +1,18 @@
-section.pf-c-page__main-section.pf-m-light
-  .pf-c-content
-    .pf-l-level
-      .pf-l-level__item
-        h1 Applications
-      .pf-l-level__item
-        a.pf-c-button.pf-m-primary(href="/p/admin/applications/new") Create application
+- content_for :page_header_title_with_button, 'Applications'
+- content_for :page_header_body do
+  ' Applications are a representation of an API consumer. They include credentials obtained through the API's authentication method,
+  ' along with usage metrics and other metadata. The application plan sets the limits for each application.
 
-    div
-      p(data-ouia-component-type="PF4/Text" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Text-2" data-pf-content="true")  Applications are a representation of an API consumer. They include credentials obtained through the API's authentication method, along with usage metrics and other metadata. The application plan sets the limits for each application
+- content_for :page_header_button_label, 'Create application'
+- content_for :page_header_button_href, new_provider_admin_application_path
 
-section.pf-c-page__main-section
-  .pf-c-content
-    - if current_user.accessible_services.empty?
-      = render 'shared/service_access'
-    - else
-      = render 'shared/applications/listing', { applications: @cinstances,
-                                                application_plans: @application_plans,
-                                                plan: @plan,
-                                                account: @account,
-                                                search: @search,
-                                                service: @service,
-                                                states: @states }
+- if current_user.accessible_services.empty?
+  = render 'shared/service_access'
+- else
+  = render 'shared/applications/listing', { applications: @cinstances,
+                                            application_plans: @application_plans,
+                                            plan: @plan,
+                                            account: @account,
+                                            search: @search,
+                                            service: @service,
+                                            states: @states }


### PR DESCRIPTION
What this PR does / why we need it:

No description in [Product_applications_listing] page & [Product_accounts_listing]

Improvement: Add a description for audience/applications and audience/accounts.

Location

    https://red-hat-wat-admin.3scale.net/p/admin/applications
    https://red-hat-wat-admin.3scale.net/buyers/accounts

 Microcopy

    https://docs.google.com/document/d/1igPAmV9g78R3tlm8O3fifgAFNq7hYuitz0_1JpRuj0k/edit#


Which issue(s) this PR fixes
https://issues.redhat.com/browse/THREESCALE-8747

![image](https://github.com/3scale/porta/assets/84672731/55c4f47a-62db-45c9-85e8-30da47d7ef2a)
![image](https://github.com/3scale/porta/assets/84672731/fca14fd7-85d2-4efa-ba38-5b1f16d55880)

