### PR TITLE
Fix fast-forward GitHub action

### DIFF
--- a/.github/workflows/fast-forward-branch.yml
+++ b/.github/workflows/fast-forward-branch.yml
@@ -37,10 +37,6 @@ jobs:
       - name: Print diff log
         run: |
           echo -e "\nISSUES MENTIONED IN THE CHANGELOG:"
-          cat << EOF
-          ${{ steps.git_log.outputs.issues }}
-          EOF
+          echo "${{ steps.git_log.outputs.issues }}"
           echo -e "\nCHANGELOG SUMMARY:"
-          cat << EOF
-          ${{ steps.git_log.outputs.log }}
-          EOF
+          echo "${{ steps.git_log.outputs.log }}"

--- a/.github/workflows/fast-forward-branch.yml
+++ b/.github/workflows/fast-forward-branch.yml
@@ -22,11 +22,11 @@ jobs:
       - id: git_log
         name: Generate diff log
         run: |
-          issues=$(git log origin/${{ inputs.to_branch }}..origin/${{ inputs.ref }} | grep -ioh "THREESCALE-[0-9]\+" | sort -u | sed -e 's/^/https:\/\/issues.redhat.com\/browse\//')
+          issues=$(git log origin/${{ inputs.to_branch }}..${{ inputs.ref }} | grep -ioh "THREESCALE-[0-9]\+" | sort -u | sed -e 's/^/https:\/\/issues.redhat.com\/browse\//')
           echo "issues<<EOF" >> $GITHUB_OUTPUT
           echo "$issues" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          log=$(git log origin/${{ inputs.to_branch }}..origin/${{ inputs.ref }} --pretty=format:'%h - %s (%an)')
+          log=$(git log origin/${{ inputs.to_branch }}..${{ inputs.ref }} --pretty=format:'%h - %s (%an)')
           echo "log<<EOF" >> $GITHUB_OUTPUT
           echo "$log" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes two issues with the fast-forward action:

1. The refs (not branches) couldn't be fast-forwarded, as one of the steps was failing with the following error:
```
Run issues=$(git log origin/managed-services..origin/13022c9ac07a87847d3d3dec00085e3f24dcfbd0 | grep -ioh "THREESCALE-[0-9]\+" | sort -u | sed -e 's/^/https:\/\/issues.redhat.com\/browse\//')
fatal: ambiguous argument 'origin/managed-services..origin/13022c9ac07a87847d3d3dec00085e3f24dcfbd0': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: ambiguous argument 'origin/managed-services..origin/13022c9ac07a87847d3d3dec00085e3f24dcfbd0': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Error: Process completed with exit code [12](https://github.com/3scale/porta/actions/runs/7488125018/job/20381930224#step:3:13)8.
```

Another issue was that the output with the issues and commits diff was not showing in the logs:
![Screenshot from 2024-01-11 11-44-20](https://github.com/3scale/porta/assets/1270328/9c0cc459-571e-4802-b674-3d2cbd333fb4)


**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

Trigger a "Fast forward manually" action with a branch name as target and a ref or branch in source.

**Special notes for your reviewer**:
