### PR TITLE
Restore controller label on rails_request_duration_seconds_* metrics

### DIFF
--- a/lib/three_scale/metrics/yabeda.rb
+++ b/lib/three_scale/metrics/yabeda.rb
@@ -32,10 +32,10 @@ module ThreeScale
               labels = {
                 controller: event.payload[:params]["controller"],
                 status: ThreeScale::Metrics::Yabeda.event_status_code_class(event),
-              }.merge!(event.payload.slice(*::Yabeda.default_tags.keys))
+              }
 
               rails_requests_total.increment(labels)
-              rails_request_duration.measure({}, ThreeScale::Metrics::Yabeda.ms2s(event.duration))
+              rails_request_duration.measure(labels.slice(:controller), ThreeScale::Metrics::Yabeda.ms2s(event.duration))
             end
           end
         end


### PR DESCRIPTION
**What this PR does / why we need it**:

Restoring `controller` label on `rails_request_duration_seconds_*` metrics that was previously deleted in https://github.com/3scale/porta/pull/3648

After speaking with @slopezz we thought it might be useful, and we will need to see how bad will the memory consumption of Prometheus be affected.

Example:
```
# HELP rails_request_duration_seconds Multiprocess metric
# TYPE rails_request_duration_seconds histogram
rails_request_duration_seconds_bucket{controller="api/services",le="+Inf"} 1
rails_request_duration_seconds_bucket{controller="api/services",le="0.01"} 0
rails_request_duration_seconds_bucket{controller="api/services",le="0.025"} 0
rails_request_duration_seconds_bucket{controller="api/services",le="0.05"} 0

rails_request_duration_seconds_sum{controller="api/services"} 0.415
rails_request_duration_seconds_sum{controller="api_docs/services"} 0.36199999999999993
rails_request_duration_seconds_sum{controller="buyers/accounts"} 0.903
rails_request_duration_seconds_sum{controller="buyers/groups"} 1.05
rails_request_duration_seconds_sum{controller="buyers/invoices"} 2.8049999999999997
```

**Which issue(s) this PR fixes** 

-

**Verification steps** 

Call http://localhost:9394/yabeda-metrics and verify that the controller is there.

**Special notes for your reviewer**:
