### PR TITLE
stricter link following in cucumbers

### DIFF
--- a/app/views/sites/dns/show.html.erb
+++ b/app/views/sites/dns/show.html.erb
@@ -30,7 +30,7 @@
         <% if readonly_dns_domains? %>
           <%= form.label :domain_type_subdomain, 'Developer Portal Site' %>
           <%= form.text_field :subdomain, :value => current_account.external_domain , :disabled => 'disabled' %>
-          <%= switch_link "Change", contact_3scale_admin_site_dns_path, :switch => :branding, :upgrade_notice => true, :class => "fancybox" %>
+          <%= switch_link "Change", contact_3scale_admin_site_dns_path, :switch => :branding, :upgrade_notice => true, :class => "fancybox", :title => "Change account subdomain" %>
           <p class="inline-hints">You can change the domain of your
   	Developer Portal to your own domain, for instance
 	https://developer.example.com. You can also change the

--- a/features/api/backend_usages/index.feature
+++ b/features/api/backend_usages/index.feature
@@ -46,8 +46,8 @@ Feature: Product > Integration > Backends
 
     Scenario: Editing a backend config
       When they go to the backends of product "My API"
-      And follow "Edit config with Backend 1"
-      Then the current page is the edit usage config page between "My API" and "Backend 1"
+      And follow "Edit config with Backend 2"
+      Then the current page is the edit usage config page between "My API" and "Backend 2"
 
     Scenario: Deleting a backend config
       When they go to the backends of product "My API"

--- a/features/old/buyers/users.feature
+++ b/features/old/buyers/users.feature
@@ -28,7 +28,7 @@ Feature: Buyer users management
     When I go to the buyer users page for "SpaceWidgets"
     Then I should see buyer user "SpaceWidgets"
     And I should see link to the buyer user edit page for "SpaceWidgets"
-    When I follow "Edit"
+    When I follow "Edit" for user "SpaceWidgets"
     Then I should not see "Delete"
 
   Scenario: User details

--- a/features/old/providers/fields_definitions.feature
+++ b/features/old/providers/fields_definitions.feature
@@ -15,12 +15,12 @@ Feature: Fields Definitions
   # TODO: Test CRUD for real, this is just making sure the page displays ok
   Scenario: Create a new field definition
     When I go to the fields definitions index page
-    And I follow "Create"
+    And I follow any "Create"
     Then I should see "New Field"
 
   Scenario: Edit a field definition
     When I go to the fields definitions index page
-    And I follow "Edit"
+    And I follow any "Edit"
     Then I should see "Editing field"
 
   Scenario: Show all buyer fields being a provider

--- a/features/old/switches/branding.feature
+++ b/features/old/switches/branding.feature
@@ -10,11 +10,11 @@ Feature: Branding switch
   Scenario: Dns link invites to upgrade
     Given provider "foo.3scale.localhost" has "branding" switch denied
     And I go to the dns settings page
-    And I follow "Change"
+    And I follow "Change account subdomain"
     Then I should see the invitation to upgrade my plan
 
   Scenario: Dns link works if enabled
     Given provider "foo.3scale.localhost" has "branding" switch allowed
     And I go to the dns settings page
-    And I follow "Change"
+    And I follow "Change account subdomain"
     Then I should see "This operation can't be completed automatically"

--- a/features/provider/admin/applications/keys.feature
+++ b/features/provider/admin/applications/keys.feature
@@ -85,7 +85,7 @@ Feature: Applications details
     Scenario: Deleting a key
       Given the application has 2 keys
       And they are reviewing the buyer's application details
-      When follow "Delete" within the API Credentials card
+      When follow any "Delete" within the API Credentials card
       Then the application shows 1 key
 
     Scenario: Deleting last key when not mandatory

--- a/features/provider/admin/messages/inbox.feature
+++ b/features/provider/admin/messages/inbox.feature
@@ -32,7 +32,7 @@ Feature: Audience > Messages > Inbox
     Scenario: Reading an unread message
       Given they go to the provider inbox page
       And they should see unread message from "Alice" with subject "Oh, no!"
-      When follow "Oh, no!"
+      When follow any "Oh, no!"
       And should see "Send reply"
       And follow "Inbox"
       Then they should see read message from "Alice" with subject "Oh, no!"

--- a/features/step_definitions/user_management/common_steps.rb
+++ b/features/step_definitions/user_management/common_steps.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 When "I follow {string} for {user}" do |link_text, user|
-  # specifying class because table contains a second edit link on the username
-  step %(I follow "#{link_text}" within "#user_#{user.id} .pf-c-table__action")
+  find("tr#user_#{user.id} .pf-c-table__action").click_link(link_text)
 end
 
 When "I press {string} for {user}" do |button_text, user|

--- a/features/step_definitions/user_management/common_steps.rb
+++ b/features/step_definitions/user_management/common_steps.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 When "I follow {string} for {user}" do |link_text, user|
-  step %(I follow "#{link_text}" within "#user_#{user.id}")
+  # specifying class because table contains a second edit link on the username
+  step %(I follow "#{link_text}" within "#user_#{user.id} .pf-c-table__action")
 end
 
 When "I press {string} for {user}" do |button_text, user|

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -30,12 +30,12 @@ When /^(?:|I |they )press( invisible)? "([^"]*)"(?: within "([^"]*)")?$/ do |inv
   end
 end
 
-When /^(?:|I |they |the buyer )follow( invisible)? "([^"]*)"(?: within "([^"]*)")?$/ do |invisible, link, selector|
+When /^(?:|I |they |the buyer )follow( any)?( invisible)? "([^"]*)"(?: within "([^"]*)")?$/ do |any, invisible, link, selector|
   with_scope(selector) do
     # there must be a capybara bug because assert_link fails with
     # Unused parameters passed to Capybara::Queries::SelectorQuery : [:link, "..."]
-    # assert_link(link, exact: true, visible: !invisible, count: 1)
-    assert_selector(:link, link, exact: true, visible: !invisible, count: 1)
+    # assert_link(link, exact: true, visible: !invisible, count: 1) unless any
+    assert_selector(:link, link, exact: true, visible: !invisible, count: 1) unless any
     click_link(link, exact: true, visible: !invisible)
   end
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -32,6 +32,10 @@ end
 
 When /^(?:|I |they |the buyer )follow( invisible)? "([^"]*)"(?: within "([^"]*)")?$/ do |invisible, link, selector|
   with_scope(selector) do
+    # there must be a capybara bug because assert_link fails with
+    # Unused parameters passed to Capybara::Queries::SelectorQuery : [:link, "..."]
+    # assert_link(link, exact: true, visible: !invisible, count: 1)
+    assert_selector(:link, link, exact: true, visible: !invisible, count: 1)
     click_link(link, exact: true, visible: !invisible)
   end
 end


### PR DESCRIPTION
This is needed in an effort to understand some intermittent failures but also is a good idea in general to be more strict about which link is being clicked.

Commits are self-contained so can be reviewed individually.