### PR TITLE
Fix Message Liquid drop that broke replies

### DIFF
--- a/features/old/messages/buyer_side.feature
+++ b/features/old/messages/buyer_side.feature
@@ -36,7 +36,7 @@ Feature: Buyer side messages
     When I follow "Inbox"
     Then I should see read message from "foo.3scale.localhost" with subject "How are you doing?"
 
-  Scenario: Repling to a message
+  Scenario: Replying to a message
     Given a message sent from provider "foo.3scale.localhost" to buyer "bob" with subject "Wassup?" and body "Everything OK?"
 
     When I go to the dashboard

--- a/features/step_definitions/messages_steps.rb
+++ b/features/step_definitions/messages_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Given "a message(s) sent from {provider_or_buyer} to {provider_or_buyer} with subject {string} and body {string}" do |sender, receiver, subject, body|
+Given "a message sent from {provider_or_buyer} to {provider_or_buyer} with subject {string} and body {string}" do |sender, receiver, subject, body|
   message = sender.messages.create!(:to => receiver, :subject => subject, :body => body)
   message.deliver!
 end

--- a/lib/developer_portal/app/controllers/developer_portal/admin/messages/outbox_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/messages/outbox_controller.rb
@@ -16,7 +16,7 @@ class DeveloperPortal::Admin::Messages::OutboxController < DeveloperPortal::Base
 
   def show
     message = current_account.messages.find(message_params[:id])
-    assign_drops message: Liquid::Drops:: Message.new(message)
+    assign_drops message: Liquid::Drops::Message.new(message)
   end
 
   def new

--- a/lib/developer_portal/lib/liquid/drops/message.rb
+++ b/lib/developer_portal/lib/liquid/drops/message.rb
@@ -7,7 +7,7 @@ module Liquid
 
       desc "Returns the ID of the message."
       def id
-        message.id
+        @model.id
       end
 
       desc "If subject is not present then either a truncated body or `(no subject)` string is returned."
@@ -31,7 +31,8 @@ module Liquid
       desc "URL of the message detail, points either to inbox or outbox."
       def url
         if @model.hidden_at.present?
-          admin_messages_trash_path(id)
+          # URLs in Trash always use Message (not MessageRecipient) ID
+          admin_messages_trash_path(message.id)
         else
           if @model.is_a?(MessageRecipient)
             admin_messages_inbox_path(@model.id)

--- a/lib/developer_portal/lib/liquid/drops/message.rb
+++ b/lib/developer_portal/lib/liquid/drops/message.rb
@@ -5,7 +5,7 @@ module Liquid
 
       allowed_name :message, :messages, :reply
 
-      desc "Returns the ID of the message."
+      desc "Returns the ID of the model (depending on controller that is message or message recipient)."
       def id
         @model.id
       end

--- a/test/integration/developer_portal/admin/messages/outbox_controller_integration_test.rb
+++ b/test/integration/developer_portal/admin/messages/outbox_controller_integration_test.rb
@@ -30,4 +30,11 @@ class DeveloperPortal::Admin::Messages::OutboxControllerIntegrationTest < Action
     get admin_messages_outbox_index_path
     assert_not_equal [], assigns['_assigned_drops']['messages']
   end
+
+  def test_show
+    sent_message = FactoryBot.create(:message, sender: @buyer)
+    get admin_messages_outbox_path(sent_message)
+
+    assert_equal sent_message.id, assigns(:_assigned_drops)['message'].id
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

@akostadinov noticed that the following test was failing randomly:

```
No message from bob to foo.3scale.localhost with subject "Re: Wassup?" and body "Yep, all good." was sent.

features/old/messages/buyer_side.feature:48:in `a message should be sent from buyer "bob" to provider "foo.3scale.localhost" with subject "Re: Wassup?" and body "Yep, all good."'

Failing Scenarios:
cucumber -p ci features/old/messages/buyer_side.feature:39 # Scenario: Repling to a message
```

https://app.circleci.com/pipelines/github/3scale/porta/27058/workflows/80e72514-a5cc-40c1-a0ca-8cff2c3c5572/jobs/303600/parallel-runs/5?filterBy=FAILED

This was caused by https://github.com/3scale/porta/pull/3588, specifically [this change](https://github.com/3scale/porta/pull/3588/files#diff-721fd6dcf79b38e89f2022a2bc9d8f9398710acfdbf2110a75f41085f110f8daR10).

This is reproduced also the app in production, giving 404 Not Found when trying to reply to a message in the developer portal. See more info below.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

-none-

**Special notes for your reviewer**:

See [this thread](https://github.com/3scale/porta/pull/3588/files#r1395508807) for more info on the change - basically it was required because in Trash we show URLs with ID of Message, not MessageRecipient.

And the issue happens [here](https://github.com/3scale/porta/blob/0fa79bb375a780436b64acbd0b2393a085437403/lib/developer_portal/app/views/developer_portal/messages/inbox/show.html.liquid#L30), in the Inbox page we started showing Message ID instead of MessageRecipient ID in `reply_to` param, but that ID is then used to find MessageRecipient [here](https://github.com/3scale/porta/blob/0fa79bb375a780436b64acbd0b2393a085437403/lib/developer_portal/app/controllers/developer_portal/admin/messages/inbox_controller.rb#L39).

And the only reason why the tests failed only sometimes, is that in most occasions it happened so that the Message and MessageRecipient's IDs were accidentally the same.