### PR TITLE
restore tenant_id enforcement in modern rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,17 +38,17 @@ GIT
 
 GIT
   remote: https://github.com/3scale/swagger-ui_rails.git
-  revision: 13968af8f2845f448a0b88c4ffe4cf93477c90fa
-  branch: dev
-  specs:
-    swagger-ui_rails (0.1.7)
-
-GIT
-  remote: https://github.com/3scale/swagger-ui_rails.git
   revision: f88bb8bed4fdb57fcf5be6425f3fc10c638788d1
   branch: dev-2.1.3
   specs:
     swagger-ui_rails2 (0.1.7)
+
+GIT
+  remote: https://github.com/3scale/swagger-ui_rails.git
+  revision: 13968af8f2845f448a0b88c4ffe4cf93477c90fa
+  branch: dev
+  specs:
+    swagger-ui_rails (0.1.7)
 
 GIT
   remote: https://github.com/prawnpdf/prawn-table.git
@@ -760,7 +760,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 0.87.0)
     ruby-next-core (0.15.3)
-    ruby-oci8 (2.2.6.1)
+    ruby-oci8 (2.2.12)
     ruby-openid (2.9.2)
     ruby-plsql (0.8.0)
     ruby-prof (0.17.0)

--- a/app/controllers/admin/api/objects_controller.rb
+++ b/app/controllers/admin/api/objects_controller.rb
@@ -11,7 +11,7 @@ class Admin::Api::ObjectsController < Admin::Api::BaseController
   # Object deletion status for objects that are deleted asynchronously
   # GET /admin/api/objects/status.json
   def status
-    status_object = status_object_type.classify.constantize.unscoped.find(status_object_id)
+    status_object = status_object_type.classify.constantize.select(:tenant_id).unscoped.find(status_object_id)
 
     authorize_tenant!(status_object)
 

--- a/app/lib/proxy_config_affecting_changes.rb
+++ b/app/lib/proxy_config_affecting_changes.rb
@@ -73,6 +73,19 @@ module ProxyConfigAffectingChanges
       @tracked_objects.clear
     end
 
+    def reported_clear
+      return if @tracked_objects.empty?
+
+      # This error is normal to appear in integration/e2e tests because thread tracker is never removed
+      #   and AR objects are accessed (thus added to track) outside controller actions.
+      list = @tracked_objects.map(&:object).map { "#{_1.class}:#{_1.send(_1.class.primary_key)}" }.join(" ")
+      Rails.logger.error("Proxy config tracked objects for changes non-empty before action: #{list}")
+    rescue StandardError => exception
+      System::ErrorReporting.report_error(exception)
+    ensure
+      @tracked_objects.clear
+    end
+
     # FIXME: This is only so ProxyConfigs::AffectingObjectChangedEvent does not crash
     def id
       Thread.current.name
@@ -160,7 +173,7 @@ module ProxyConfigAffectingChanges
       protected
 
       def track_proxy_affecting_changes
-        Thread.current[TRACKER_NAME] ||= Tracker.new
+        (Thread.current[TRACKER_NAME] ||= Tracker.new).reported_clear
       end
 
       def flush_proxy_affecting_changes

--- a/db/migrate/20240704135614_events_tenant_id_should_not_be_master.rb
+++ b/db/migrate/20240704135614_events_tenant_id_should_not_be_master.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class EventsTenantIdShouldNotBeMaster < ActiveRecord::Migration[5.0]
+  def up
+    triggers = System::Database.triggers.select { |trigger| trigger.table =~ /\Aevent_store_events\z/ }
+    ActiveRecord::Base.transaction do
+      triggers.each do |trigger|
+        expressions = [trigger.public_send(:recreate)].flatten
+        expressions.each(&ActiveRecord::Base.connection.method(:execute))
+      end
+    end
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_02_090207) do
+ActiveRecord::Schema.define(version: 2024_07_04_135614) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id", precision: 38, null: false

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_02_090207) do
+ActiveRecord::Schema.define(version: 2024_07_04_135614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_02_090207) do
+ActiveRecord::Schema.define(version: 2024_07_04_135614) do
 
   create_table "access_tokens", charset: "utf8mb3", collation: "utf8mb3_bin", force: :cascade do |t|
     t.bigint "owner_id", null: false

--- a/features/old/signup/multitenant.feature
+++ b/features/old/signup/multitenant.feature
@@ -20,7 +20,7 @@ Feature: Sign Up of enterprise buyers
     Given a provider "foo2.3scale.localhost"
     And the following account plan:
       | Issuer               | Name   |
-      | foo.3scale.localhost | Tier-2 |
+      | foo2.3scale.localhost | Tier-2 |
       And a default service of provider "foo2.3scale.localhost" has name "api2"
     And the following service plan:
       | Product | Name    |

--- a/features/step_definitions/applications_steps.rb
+++ b/features/step_definitions/applications_steps.rb
@@ -30,7 +30,7 @@ end
 
 Given "{application} has {amount} key(s)" do |application, amount|
   if amount.positive?
-    application.update!(application_keys: FactoryBot.create_list(:application_key, amount))
+    FactoryBot.create_list(:application_key, amount, application: application)
   else
     application.application_keys.destroy_all
   end

--- a/features/step_definitions/plans_steps.rb
+++ b/features/step_definitions/plans_steps.rb
@@ -9,7 +9,7 @@
 #   | My API  | Premium |                |        10 |                   | Hidden    | True    |
 Given "the following {plan_type} plan(s):" do |plan_type, table|
   transform_plans_table(plan_type, table).hashes.each do |row|
-    FactoryBot.create(plan_type, row)
+    FactoryBot.create(plan_type, **row)
   end
 end
 

--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -471,7 +471,9 @@ System::Database::MySQL.define do
 
   trigger 'event_store_events' do
     <<~SQL
-      SET NEW.tenant_id = NEW.provider_id;
+      IF NEW.provider_id <> master_id THEN
+        SET NEW.tenant_id = NEW.provider_id;
+      END IF;
     SQL
   end
 

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -481,7 +481,9 @@ System::Database::Oracle.define do
 
   trigger 'event_store_events' do
     <<~SQL
-      :new.tenant_id := :new.provider_id;
+      IF :new.provider_id <> master_id THEN
+        :new.tenant_id := :new.provider_id;
+      END IF;
     SQL
   end
 

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -481,7 +481,9 @@ System::Database::Postgres.define do
 
   trigger 'event_store_events' do
     <<~SQL
-      NEW.tenant_id := NEW.provider_id;
+      IF NEW.provider_id <> master_id THEN
+        NEW.tenant_id := NEW.provider_id;
+      END IF;
     SQL
   end
 

--- a/lib/three_scale/middleware/multitenant.rb
+++ b/lib/three_scale/middleware/multitenant.rb
@@ -9,6 +9,12 @@ module ThreeScale
       end
 
       class TenantChecker
+        SKIPPED_CONTROLLERS = {
+          "admin/api/objects".freeze => true, # this checks objects' tenant_id so we have to skip it
+          "provider/domains".freeze => true,
+        }.freeze
+        private_constant :SKIPPED_CONTROLLERS
+
         attr_reader :original, :attribute
 
         class TenantLeak < StandardError
@@ -31,9 +37,7 @@ module ThreeScale
         end
 
         def verify!(object)
-
-          # this controller shouldn't be checked
-          return true if @env["action_dispatch.request.path_parameters"]["controller"] == "provider/domains"
+          return if SKIPPED_CONTROLLERS[@env["action_dispatch.request.path_parameters"][:controller]]
 
           # when the ActiveRecord object doesn't have tenant_id attribute at all
           unless object.respond_to?(attribute)

--- a/lib/three_scale/middleware/multitenant.rb
+++ b/lib/three_scale/middleware/multitenant.rb
@@ -32,66 +32,61 @@ module ThreeScale
 
         def verify!(object)
 
-          # this controller shouldnt be checked
-          return true if @env["action_controller.request.path_parameters"]["controller"] == "provider/domains"
+          # this controller shouldn't be checked
+          return true if @env["action_dispatch.request.path_parameters"]["controller"] == "provider/domains"
 
+          # when the ActiveRecord object doesn't have tenant_id attribute at all
           unless object.respond_to?(attribute)
             # Multitenant.log "#{object} does not respond to: #{attribute}"
             return true
           end
 
-
+          # reload object if it was partially loaded from db without the `tenant_id` attribute
           begin
             current = object.send(attribute)
           rescue ActiveRecord::MissingAttributeError
             # Multitenant.log("#{object} is missing #{attribute}. Reloading and trying again")
-            fresh = object.class.send(:with_exclusive_scope) { object.class.find(object.id, :select => attribute) }
+            fresh = object.class.unscoped.find(object.id, :select => attribute)
             current = fresh.send(attribute)
           end
 
-          return true if current.nil?
+          # this is when tenant_id is not set because of a bug or in older installations the master account has it nil
+          return if current.nil?
 
+          # in newer installations master account has a tenant_id same as its id, like other providers
+          return if object.is_a?(::Account) && object.master
+
+          # once initialized a legitimate AR object with a tenant_id, all others in the request should have the same
           @original ||= current
 
           return if current == original
 
-          # we still need to check if it's master before raising a tenant leak
-          @cookie_store ||= find_cookie_store(@app)
-          @session ||= @cookie_store.send(:load_session, @env)
+          # we still need to check if it wasn't master before raising a tenant leak
+          @master ||= ::Account.unscoped.master
 
-          @master ||= Account.find_by_sql(["SELECT * FROM accounts WHERE master = ?", true]).first
+          # this is supposed to match how we get the user_session in app/lib/authenticated_system/request.rb
+          # on API calls cookies are not present though, so we need to use safe navigation
+          @user_session ||= UserSession.authenticate(@env['action_dispatch.cookies']&.signed&.public_send(:[], :user_session))
+          return if @user_session&.user&.account == @master
 
-          if (user_id = @session.last[:user_id].presence)
-            @users ||= {}
-            @users[user_id] ||= User.find_by_sql(["SELECT * FROM users WHERE id = ? AND account_id = ?", user_id, @master.id]).present?
-            return if @users[user_id]
-          end
+          return if @env["action_dispatch.request.query_parameters"]["provider_key"] == @master.api_key
 
-          return if @env["action_controller.request.query_parameters"]["provider_key"] == @master.api_key
+          # must match how we check access token in app/lib/api_authentication/by_access_token.rb
+          return if @master.access_tokens.find_from_value(@env["action_dispatch.request.query_parameters"]["access_token"])
 
           raise TenantLeak.new(object, attribute, original)
-        end
-
-        private
-
-        # these middlewares have a funny recursion
-        def find_cookie_store(app)
-          if app.is_a? ActionDispatch::Session::CookieStore
-            app
-          else
-            find_cookie_store(app.instance_variable_get('@app'))
-          end
         end
       end
 
       module EnforceTenant
-        # adding after_initialize does not work, it would have to be done for every model
-        def after_initialize
-          enforce_tenant!
-          super if defined?(super)
+        extend ActiveSupport::Concern
+
+        included do
+          after_initialize :enforce_tenant!
         end
 
         private
+
         def enforce_tenant!
           # Multitenant.log "initialized object #{self.class}:#{self.id}"
           Thread.current[:multitenant]&.verify!(self)

--- a/spec/acceptance/api/application_spec.rb
+++ b/spec/acceptance/api/application_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 resource "Cinstance" do
 
   let(:service) { provider.services.default }
-  let(:plan) { FactoryBot.create(:application_plan, service: service) }
+  let(:plan) { FactoryBot.create(:application_plan, issuer: service) }
   let(:buyer) { FactoryBot.create(:buyer_account, provider_account: provider) }
   let(:resource) { FactoryBot.create(:cinstance, user_account: buyer, plan: plan) }
-  let(:other_plan) { FactoryBot.create(:application_plan, service: service) }
+  let(:other_plan) { FactoryBot.create(:application_plan, issuer: service) }
 
   shared_examples "find application" do
     context 'with app id', action: :show do

--- a/spec/acceptance/api/line_item_plan_cost_spec.rb
+++ b/spec/acceptance/api/line_item_plan_cost_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 resource "LineItem", transactions: false do
-  let(:provider) { FactoryBot.create(:simple_provider) }
-  let(:buyer) { FactoryBot.create(:simple_buyer, provider_account: provider) }
-  let(:application) { FactoryBot.create(:simple_cinstance, user_account: buyer) }
+  let(:provider) { FactoryBot.create(:provider_account) }
+  let(:buyer) { FactoryBot.create(:buyer_account, provider_account: provider) }
+  let(:application) { FactoryBot.create(:cinstance, user_account: buyer) }
 
   let(:invoice) { FactoryBot.create(:invoice, buyer_account: buyer, provider_account: provider) }
 

--- a/spec/acceptance/api/line_item_spec.rb
+++ b/spec/acceptance/api/line_item_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 resource "LineItem", transactions: false do
-  let(:provider) { FactoryBot.create(:simple_provider) }
-  let(:buyer) { FactoryBot.create(:simple_buyer, provider_account: provider) }
-  let(:application) { FactoryBot.create(:simple_cinstance, user_account: buyer) }
+  let(:provider) { FactoryBot.create(:provider_account) }
+  let(:buyer) { FactoryBot.create(:buyer_account, provider_account: provider) }
+  let(:application) { FactoryBot.create(:cinstance, user_account: buyer) }
 
   let(:invoice) { FactoryBot.create(:invoice, buyer_account: buyer, provider_account: provider) }
 

--- a/spec/acceptance/api/line_item_variable_cost_spec.rb
+++ b/spec/acceptance/api/line_item_variable_cost_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 resource "LineItem", transactions: false do
-  let(:provider) { FactoryBot.create(:simple_provider) }
-  let(:buyer) { FactoryBot.create(:simple_buyer, provider_account: provider) }
-  let(:application) { FactoryBot.create(:simple_cinstance, user_account: buyer) }
+  let(:provider) { FactoryBot.create(:provider_account) }
+  let(:buyer) { FactoryBot.create(:buyer_account, provider_account: provider) }
+  let(:application) { FactoryBot.create(:cinstance, user_account: buyer) }
 
   let(:invoice) { FactoryBot.create(:invoice, buyer_account: buyer, provider_account: provider) }
 

--- a/spec/acceptance/api/method_spec.rb
+++ b/spec/acceptance/api/method_spec.rb
@@ -8,7 +8,7 @@ resource "Metric" do
   let(:service_id) { service.id }
   let(:metric_id) { service.metrics.hits.id }
 
-  let(:resource) { FactoryBot.build(:metric, service: service, parent: hits, description: 'metric description') }
+  let(:resource) { FactoryBot.build(:metric, owner: service, parent: hits, description: 'metric description') }
 
   let(:resource_representer) { 'MethodRepresenter' }
   let(:collection_representer) { 'MethodsRepresenter' }

--- a/test/decorators/application_plan_decorator_test.rb
+++ b/test/decorators/application_plan_decorator_test.rb
@@ -45,7 +45,7 @@ class ApplicationPlanDecoratorTest < Draper::TestCase
   end
 
   test '#index_table_data' do
-    plan = FactoryBot.create(:application_plan, service: FactoryBot.create(:service))
+    plan = FactoryBot.create(:application_plan, issuer: FactoryBot.create(:service))
     data = plan.decorate.index_table_data
 
     assert data.assert_valid_keys(:id, :name, :editPath, :contracts, :contractsPath, :state, :actions)

--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -141,6 +141,11 @@ FactoryBot.define do
       after(:build) do |account|
         account.buyer_accounts << FactoryBot.build(:buyer_account, provider_account: account)
       end
+      after(:stub) do |account|
+        buyer_accounts = []
+        account.stubs(:buyer_accounts).returns(buyer_accounts)
+        account.buyer_accounts << FactoryBot.build_stubbed(:buyer_account, provider_account: account)
+      end
       # looks nicer but doesn't work well
       # :buyer_account is generated before current factory so extra provider is created and tenant_id doesn't match
       # buyer_accounts { [association(:buyer_account)] }

--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -89,10 +89,6 @@ FactoryBot.define do
     association :provider_account
   end
 
-  factory(:pending_buyer_account_with_provider, :parent => :pending_buyer_account) do
-    buyer { true }
-  end
-
 #TODO: rename this, it is actually buying plans!
   factory(:provider_account_with_pending_users_signed_up_to_no_plan, parent: :account) do
     sequence(:self_domain) { |n| "admin-domain-company#{n}.com" }
@@ -145,6 +141,15 @@ FactoryBot.define do
         account_plans_ui_visible: true,
         service_plans_ui_visible: true
       )
+    end
+
+    trait :with_a_buyer do
+      after(:build) do |account|
+        account.buyer_accounts << FactoryBot.build(:buyer_account, provider_account: account)
+      end
+      # looks nicer but doesn't work well
+      # :buyer_account is generated before current factory so extra provider is created and tenant_id doesn't match
+      # buyer_accounts { [association(:buyer_account)] }
     end
   end
 

--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -73,8 +73,6 @@ FactoryBot.define do
   end
 
   factory(:buyer_account_without_billing_address, :parent => :buyer_account) do
-    association :provider_account
-
     after(:create) do |account|
       account.billing_address_name = nil
       account.billing_address_address1 = nil
@@ -83,10 +81,6 @@ FactoryBot.define do
       account.billing_address_country = nil
       account.save!
     end
-  end
-
-  factory(:buyer_account_with_provider, :parent => :buyer_account) do
-    association :provider_account
   end
 
 #TODO: rename this, it is actually buying plans!

--- a/test/factories/backend_api.rb
+++ b/test/factories/backend_api.rb
@@ -15,9 +15,6 @@ FactoryBot.define do
       opts = { account: @overrides[:backend_api]&.account }.compact
       association :service, **opts
     }
-    backend_api {
-      opts = { account: @overrides[:service]&.account }.compact
-      association :backend_api, **opts
-    }
+    backend_api { association :backend_api, account: service.account }
   end
 end

--- a/test/factories/backend_api.rb
+++ b/test/factories/backend_api.rb
@@ -11,7 +11,13 @@ FactoryBot.define do
 
   factory :backend_api_config do
     sequence(:path) { |n| "/path#{n}" }
-    association :service
-    association :backend_api
+    service {
+      opts = { account: @overrides[:backend_api]&.account }.compact
+      association :service, **opts
+    }
+    backend_api {
+      opts = { account: @overrides[:service]&.account }.compact
+      association :backend_api, **opts
+    }
   end
 end

--- a/test/factories/cinstance.rb
+++ b/test/factories/cinstance.rb
@@ -2,7 +2,9 @@
 
 FactoryBot.define do
   factory(:contract) do
-    association :user_account, :factory => :pending_buyer_account
+    user_account {
+      @overrides[:plan]&.provider_account&.buyer_accounts&.first || association(:buyer_account)
+    }
 
     after(:stub) do |cinstance|
       cinstance.created_at = 2.months.ago

--- a/test/factories/cinstance.rb
+++ b/test/factories/cinstance.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
   end
 
   factory(:cinstance, :aliases => %i[application application_contract], :parent => :contract, :class => Cinstance) do
-    association :plan, :factory => :application_plan
+    plan { association :application_plan, issuer: user_account.provider_account.default_service }
 
     sequence(:name) { |n| "Cinstance #{n + Time.now.to_i}" }
 

--- a/test/factories/event.rb
+++ b/test/factories/event.rb
@@ -16,9 +16,8 @@ FactoryBot.define do
   end
 
   factory(:limit_alert, :class => Alert) do
-    account { @overrides[:cinstance]&.user_account&.provider_account || association(:account, factory: [:provider_account, :with_a_buyer]) }
+    account { @overrides[:cinstance]&.user_account&.provider_account || association( :provider_account, :with_a_buyer) }
     cinstance { association :cinstance, user_account: account.provider? ? account.buyer_accounts.first : account }
-
     state { :unread }
 
     timestamp { Time.now }

--- a/test/factories/event.rb
+++ b/test/factories/event.rb
@@ -16,8 +16,8 @@ FactoryBot.define do
   end
 
   factory(:limit_alert, :class => Alert) do
-    association :account
-    association :cinstance
+    account { @overrides[:cinstance]&.user_account&.provider_account || association(:account, factory: [:provider_account, :with_a_buyer]) }
+    cinstance { association :cinstance, user_account: account.provider? ? account.buyer_accounts.first : account }
 
     state { :unread }
 

--- a/test/factories/event.rb
+++ b/test/factories/event.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
 
   factory(:limit_alert, :class => Alert) do
     account { @overrides[:cinstance]&.user_account&.provider_account || association( :provider_account, :with_a_buyer) }
-    cinstance { association :cinstance, user_account: account.provider? ? account.buyer_accounts.first : account }
+    cinstance { association :cinstance, user_account: (account.buyer_accounts.first || account) }
     state { :unread }
 
     timestamp { Time.now }

--- a/test/factories/proxy.rb
+++ b/test/factories/proxy.rb
@@ -11,8 +11,24 @@ FactoryBot.define do
     delta { 1 }
     sequence(:created_at) { |n| Time.zone.now - n.days }
     sequence(:pattern) { |n| "/foo/bar/#{n}" }
-    association :metric
-    association :proxy
+    metric do
+      metric_opts = {}
+      metric_owner = proxy&.service
+      # as far as I can see, a ProxyRule can be owned by a BackendApi or a Proxy
+      # while a Metric can be owned by a BackendApi or a Service
+      metric_owner ||= owner.is_a?(Proxy) ? owner.service : owner
+      metric_opts[:owner] = metric_owner if metric_owner
+      association :metric, **metric_opts
+    end
+    proxy do
+      if owner
+        owner if owner.is_a?(Proxy)
+      elsif @overrides[:metric]
+        @overrides[:metric].proxy if @overrides[:metric].is_a?(Service)
+      else
+        association :proxy
+      end
+    end
   end
 
   factory(:proxy_config) do

--- a/test/factories/simple.rb
+++ b/test/factories/simple.rb
@@ -81,7 +81,7 @@ FactoryBot.define do
 
     trait :with_default_backend_api do
       after(:create) do |record|
-        backend_api = FactoryBot.create(:backend_api, private_endpoint: 'https://echo-api.3scale.net')
+        backend_api = FactoryBot.create(:backend_api, account: record.account, private_endpoint: 'https://echo-api.3scale.net')
         FactoryBot.create(:backend_api_config, path: '', service: record, backend_api: backend_api)
       end
     end

--- a/test/factories/simple.rb
+++ b/test/factories/simple.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
-# TODO: dry up with account_without_users
+
+  # Note: tenant_id discrepancies when using simple factories, not good for request testing
+
   factory(:simple_account, :class => Account) do
     association(:country)
 

--- a/test/functional/developer_portal/buyer/stats_controller_test.rb
+++ b/test/functional/developer_portal/buyer/stats_controller_test.rb
@@ -77,10 +77,10 @@ class DeveloperPortal::Buyer::StatsControllerTest < DeveloperPortal::ActionContr
         @live_app1 = @buyer.buy! @app_plan
         @hits = @provider.default_service.metrics.first
 
-        disabled_metric = FactoryBot.create(:metric, service: @provider.default_service)
+        disabled_metric = FactoryBot.create(:metric, owner: @provider.default_service)
         disabled_metric.disable_for_plan @app_plan
 
-        hidden_metric = FactoryBot.create(:metric, service: @provider.default_service)
+        hidden_metric = FactoryBot.create(:metric, owner: @provider.default_service)
         hidden_metric.toggle_visible_for_plan(@app_plan)
       end
 

--- a/test/functional/developer_portal/dashboards_controller_test.rb
+++ b/test/functional/developer_portal/dashboards_controller_test.rb
@@ -10,7 +10,7 @@ class DeveloperPortal::DashboardsControllerTest < DeveloperPortal::ActionControl
   end
 
   test 'trial' do
-    @plan = FactoryBot.create(:application_plan, service: @provider.first_service!, trial_period_days: 10)
+    @plan = FactoryBot.create(:application_plan, issuer: @provider.first_service!, trial_period_days: 10)
     @app = FactoryBot.create(:cinstance, plan: @plan, user_account: @buyer)
 
     get :show

--- a/test/functional/stats/usage_controller_test.rb
+++ b/test/functional/stats/usage_controller_test.rb
@@ -24,7 +24,7 @@ class Stats::UsageControllerTest < ActionController::TestCase
   end
 
   test 'top_applications' do
-    metric = FactoryBot.create(:metric, :service => @service,
+    metric = FactoryBot.create(:metric, :owner => @service,
                      :parent_id => @service.metrics.hits.id)
     login_as(@provider.admins.first)
     get :top_applications, params: { service_id: @service.id }
@@ -34,7 +34,7 @@ class Stats::UsageControllerTest < ActionController::TestCase
   end
 
   test 'hours' do
-    metric = FactoryBot.build_stubbed(:metric, :service => @service)
+    metric = FactoryBot.build_stubbed(:metric, :owner => @service)
 
     data = (0..23).inject(ActiveSupport::OrderedHash.new) do |memo, hour|
       memo["#{hour}:00"] = rand(1000)

--- a/test/integration/admin/api/application_plan_metric_pricing_rules_controller_test.rb
+++ b/test/integration/admin/api/application_plan_metric_pricing_rules_controller_test.rb
@@ -4,16 +4,16 @@ require 'test_helper'
 
 class Admin::Api::ApplicationPlanMetricPricingRulesControllerTest < ActionDispatch::IntegrationTest
   def setup
-    provider = FactoryBot.create(:provider_account)
-    service  = FactoryBot.create(:service, account: provider)
+    @provider = FactoryBot.create(:provider_account)
+    service  = FactoryBot.create(:service, account: @provider)
     @plan    = FactoryBot.create(:application_plan, issuer: service)
     @metric  = FactoryBot.create(:metric, owner: service)
-    @access_token_value = FactoryBot.create(:access_token, owner: provider.admin_user, scopes: %w[account_management]).value
+    @access_token_value = FactoryBot.create(:access_token, owner: @provider.admin_user, scopes: %w[account_management]).value
 
     host! provider.external_admin_domain
   end
 
-  attr_reader :plan, :metric, :access_token_value
+  attr_reader :provider, :plan, :metric, :access_token_value
 
   def test_index_json
     index_test(format: :json) do
@@ -28,7 +28,7 @@ class Admin::Api::ApplicationPlanMetricPricingRulesControllerTest < ActionDispat
   end
 
   def test_returns_success_if_backend_is_used_by_the_product
-    backend = FactoryBot.create(:backend_api)
+    backend = FactoryBot.create(:backend_api, account: provider)
     metric.update!(owner: backend)
     FactoryBot.create(:backend_api_config, backend_api: backend, service: plan.service)
 

--- a/test/integration/admin/api/application_plan_metric_pricing_rules_controller_test.rb
+++ b/test/integration/admin/api/application_plan_metric_pricing_rules_controller_test.rb
@@ -6,7 +6,7 @@ class Admin::Api::ApplicationPlanMetricPricingRulesControllerTest < ActionDispat
   def setup
     provider = FactoryBot.create(:provider_account)
     service  = FactoryBot.create(:service, account: provider)
-    @plan    = FactoryBot.create(:application_plan, service: service)
+    @plan    = FactoryBot.create(:application_plan, issuer: service)
     @metric  = FactoryBot.create(:metric, owner: service)
     @access_token_value = FactoryBot.create(:access_token, owner: provider.admin_user, scopes: %w[account_management]).value
 

--- a/test/integration/admin/api/application_plans_controller_test.rb
+++ b/test/integration/admin/api/application_plans_controller_test.rb
@@ -113,7 +113,7 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
     end
 
     def test_destroy_json_saas
-      plan = FactoryBot.create(:application_plan, service: service)
+      plan = FactoryBot.create(:application_plan, issuer: service)
       assert_difference(service.application_plans.method(:count), -1) do
         delete admin_api_service_application_plan_path(plan.id, service_id: service.id, format: :json, access_token: @token)
         assert_response :success
@@ -126,7 +126,7 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
 
     def test_destroy_json_on_premises
       ThreeScale.stubs(master_on_premises?: true)
-      plan = FactoryBot.create(:application_plan, service: service)
+      plan = FactoryBot.create(:application_plan, issuer: service)
       assert_no_difference service.application_plans.method(:count) do
         delete admin_api_service_application_plan_path(plan.id, service_id: service.id, format: :json, access_token: @token)
         assert_response :forbidden
@@ -136,7 +136,7 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
     end
 
     def test_index_json_saas
-      FactoryBot.create_list(:application_plan, 2, service: service)
+      FactoryBot.create_list(:application_plan, 2, issuer: service)
       get admin_api_service_application_plans_path(service_id: service.id, format: :json, access_token: @token)
       assert_response :success
       assert_equal service.application_plans.count, JSON.parse(response.body)['plans'].length

--- a/test/integration/admin/api/application_plans_controller_test.rb
+++ b/test/integration/admin/api/application_plans_controller_test.rb
@@ -34,7 +34,7 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
     end
 
     def test_update_valid_params_json
-      application_plan = FactoryBot.create(:application_plan, name: 'firstname', state: 'hidden', service: service)
+      application_plan = FactoryBot.create(:application_plan, name: 'firstname', state: 'hidden', issuer: service)
       refute_equal 50.0, application_plan.cost_per_month.to_f
       refute_equal 20.0, application_plan.setup_fee.to_f
       refute_equal 30, application_plan.trial_period_days.to_i
@@ -49,7 +49,7 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
     end
 
     def test_update_invalid_params_json
-      original_values = {name: 'firstname', state: 'hidden', service: service}
+      original_values = {name: 'firstname', state: 'hidden', issuer: service}
       application_plan = FactoryBot.create(:application_plan, original_values)
       put admin_api_service_application_plan_path(application_plan, application_plan_params(state_event: 'fakestate'))
       assert_response :unprocessable_entity
@@ -59,7 +59,7 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
     end
 
     def test_destroy_json
-      plan = FactoryBot.create(:application_plan, service: service)
+      plan = FactoryBot.create(:application_plan, issuer: service)
       assert_difference(service.application_plans.method(:count), -1) do
         delete admin_api_service_application_plan_path(plan.id, service_id: service.id, format: :json, access_token: @token)
         assert_response :success
@@ -71,7 +71,7 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
     end
 
     def test_index_json
-      FactoryBot.create_list(:application_plan, 2, service: service)
+      FactoryBot.create_list(:application_plan, 2, issuer: service)
       get admin_api_service_application_plans_path(service_id: service.id, format: :json, access_token: @token)
       assert_response :success
       assert_equal 2, JSON.parse(response.body)['plans'].length

--- a/test/integration/admin/api/backend_apis/metric_methods_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metric_methods_controller_test.rb
@@ -27,7 +27,7 @@ class Admin::Api::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
     test 'index' do
       FactoryBot.create_list(:metric, 2, owner: backend_api, service_id: nil, parent: hits) # two more method metrics of the backend api
       FactoryBot.create(:metric, owner: FactoryBot.create(:backend_api, account: provider), service_id: nil) # other backend api
-      FactoryBot.create(:metric, service: FactoryBot.create(:service, account: provider)) # owned by service, not a backend api
+      FactoryBot.create(:metric, owner: FactoryBot.create(:service, account: provider)) # owned by service, not a backend api
 
       get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
 

--- a/test/integration/admin/api/backend_apis/metrics_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metrics_controller_test.rb
@@ -26,7 +26,7 @@ class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
     test 'index' do
       FactoryBot.create(:metric, owner: backend_api, parent: backend_api.metrics.hits, service_id: nil) # a method metric
       FactoryBot.create(:metric, owner: FactoryBot.create(:backend_api, account: provider), service_id: nil) # other backend api
-      FactoryBot.create(:metric, service: FactoryBot.create(:service, account: provider)) # owned by a service, not a backend api
+      FactoryBot.create(:metric, owner: FactoryBot.create(:service, account: provider)) # owned by a service, not a backend api
 
       get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
 

--- a/test/integration/admin/api/buyers_applications_controller_test.rb
+++ b/test/integration/admin/api/buyers_applications_controller_test.rb
@@ -7,7 +7,7 @@ class Admin::Api::BuyersApplicationsControllerTest < ActionDispatch::Integration
   def setup
     provider = FactoryBot.create(:provider_account)
     @service  = FactoryBot.create(:service, account: provider)
-    @plan    = FactoryBot.create(:application_plan, service: @service)
+    @plan    = FactoryBot.create(:application_plan, issuer: @service)
     @buyer   = FactoryBot.create(:buyer_account, provider_account: provider)
     @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).value
 
@@ -62,7 +62,7 @@ class Admin::Api::BuyersApplicationsControllerTest < ActionDispatch::Integration
       host! @provider.external_admin_domain
 
       @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
-      @plan = FactoryBot.create(:application_plan, service: @provider.default_service)
+      @plan = FactoryBot.create(:application_plan, issuer: @provider.default_service)
       @application = @buyer.buy! @plan
     end
 
@@ -77,7 +77,7 @@ class Admin::Api::BuyersApplicationsControllerTest < ActionDispatch::Integration
 
     test 'cannot change plan to a different service' do
       service = FactoryBot.create(:service, account: @provider)
-      new_plan_other_service = FactoryBot.create(:application_plan, service: service)
+      new_plan_other_service = FactoryBot.create(:application_plan, issuer: service)
       request_plan_change new_plan_other_service
       assert_response :unprocessable_entity
       assert_equal @plan, @application.reload.plan
@@ -115,7 +115,7 @@ class Admin::Api::BuyersApplicationsControllerTest < ActionDispatch::Integration
     end
 
     def create_new_plan_same_service
-      FactoryBot.create(:application_plan, service: @provider.default_service)
+      FactoryBot.create(:application_plan, issuer: @provider.default_service)
     end
   end
 end

--- a/test/integration/admin/api/metric_methods_controller_test.rb
+++ b/test/integration/admin/api/metric_methods_controller_test.rb
@@ -8,7 +8,7 @@ class Admin::Api::MetricMethodsControllerTest < ActionDispatch::IntegrationTest
     provider = FactoryBot.create(:provider_account)
     @service = FactoryBot.create(:service, account: provider)
     @metric  = @service.metrics.first
-    @method_metric  = FactoryBot.create(:metric, service: @service, parent_id: @metric.id, friendly_name: 'my method')
+    @method_metric  = FactoryBot.create(:metric, owner: @service, parent_id: @metric.id, friendly_name: 'my method')
     @access_token_value = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management], permission: 'rw').value
 
     host! provider.external_admin_domain

--- a/test/integration/api/access_tokens_test.rb
+++ b/test/integration/api/access_tokens_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class Admin::Api::AccessTokensTest < ActionDispatch::IntegrationTest
   def setup
-    @provider = FactoryBot.create(:simple_provider, provider_account: master_account)
+    @provider = FactoryBot.create(:simple_provider)
     @admin = FactoryBot.create(:simple_admin, account: @provider)
     @admin.activate!
     @member = FactoryBot.create(:simple_user, account: @provider)

--- a/test/integration/api/application_plans_controller_test.rb
+++ b/test/integration/api/application_plans_controller_test.rb
@@ -180,8 +180,8 @@ class Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'plan cannot be deleted because of customizations' do
-      customization = FactoryBot.create(:application_plan, original_id: plan.id)
-      customization.create_contract_with(FactoryBot.create(:buyer_account))
+      customization = FactoryBot.create(:application_plan, issuer: @service, original_id: plan.id)
+      customization.create_contract_with(FactoryBot.create(:buyer_account, provider_account: current_account))
       delete polymorphic_path([:admin, plan])
       assert_response :redirect
       assert_equal error_message(:customizations_has_contracts), flash[:error]

--- a/test/integration/api/application_plans_controller_test.rb
+++ b/test/integration/api/application_plans_controller_test.rb
@@ -56,7 +56,7 @@ class Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTest
     end
 
     test 'destroy' do
-      plan = FactoryBot.create(:application_plan, service: @service)
+      plan = FactoryBot.create(:application_plan, issuer: @service)
       assert_difference( @service.application_plans.method(:count), -1 ) do
         delete polymorphic_path([:admin, plan], format: :json)
         assert_response :success
@@ -67,7 +67,7 @@ class Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTest
       end
 
       ThreeScale.stubs(master_on_premises?: true)
-      plan = FactoryBot.create(:application_plan, service: @service)
+      plan = FactoryBot.create(:application_plan, issuer: @service)
       assert_no_difference @service.application_plans.method(:count) do
         delete polymorphic_path([:admin, plan])
         assert_response :forbidden

--- a/test/integration/api/applications_controller_test.rb
+++ b/test/integration/api/applications_controller_test.rb
@@ -33,7 +33,7 @@ class Api::ApplicationsControllerTest < ActionDispatch::IntegrationTest
     class Index < TenantLoggedInTest
       setup do
         @service = provider.services.first!
-        plans = FactoryBot.create_list(:application_plan, 2, service: @service)
+        plans = FactoryBot.create_list(:application_plan, 2, issuer: @service)
         buyers = FactoryBot.create_list(:buyer_account, 2, provider_account: provider)
         plans.each_with_index { |plan, index| buyers[index].buy! plan }
       end

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -44,6 +44,17 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     get admin_buyers_accounts_path
   end
 
+  test "proxy config objects tracked for changes are cleared" do
+    provider = FactoryBot.create(:provider_account)
+    login! provider
+
+    ProxyConfigAffectingChanges::Tracker.any_instance.expects(:reported_clear)
+    # make sure #reported_clear is not called by #flush_proxy_affecting_changes
+    ApplicationController.any_instance.expects(:flush_proxy_affecting_changes)
+
+    get admin_buyers_accounts_path
+  end
+
   test "forgery protection will force a 403 and revoke the session when no CSRF token provided" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first

--- a/test/integration/buyers/accounts_controller_test.rb
+++ b/test/integration/buyers/accounts_controller_test.rb
@@ -228,18 +228,20 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
     test 'checks if link under number of applications is correct as member' do
       @provider.settings.allow_multiple_applications!
       service = FactoryBot.create(:service, account: @provider)
-      plan  = FactoryBot.create(:application_plan, issuer: service)
-      plan.publish!
+      plan  = FactoryBot.create(:published_application_plan, issuer: service)
 
       FactoryBot.create_list(:application, 2, user_account: @buyer)
-      FactoryBot.create_list(:application, 3, plan: plan, user_account: @buyer)
+      FactoryBot.create_list(:application, 3, service: service, plan: plan, user_account: @buyer)
 
       # Testing member permissions
       member = FactoryBot.create(:member, account: @provider)
+      member.activate!
+      member.member_permissions.create(admin_section: :partners)
       member.member_permission_service_ids = [service.id]
       member.save!
       login! @provider, user: member
       get admin_buyers_accounts_path
+      assert_response :success
 
       assert_select %(td a[href="#{admin_buyers_account_applications_path(@buyer)}"]), text: '3'
     end

--- a/test/integration/buyers/accounts_controller_test.rb
+++ b/test/integration/buyers/accounts_controller_test.rb
@@ -228,9 +228,11 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
     test 'checks if link under number of applications is correct as member' do
       @provider.settings.allow_multiple_applications!
       service = FactoryBot.create(:service, account: @provider)
+      plan  = FactoryBot.create(:application_plan, issuer: service)
+      plan.publish!
 
       FactoryBot.create_list(:application, 2, user_account: @buyer)
-      FactoryBot.create_list(:application, 3, service: service, user_account: @buyer)
+      FactoryBot.create_list(:application, 3, plan: plan, user_account: @buyer)
 
       # Testing member permissions
       member = FactoryBot.create(:member, account: @provider)

--- a/test/integration/buyers/applications/bulk/change_plans_controller_test.rb
+++ b/test/integration/buyers/applications/bulk/change_plans_controller_test.rb
@@ -11,7 +11,7 @@ class Buyers::Applications::Bulk::ChangePlansControllerTest < ActionDispatch::In
   attr_reader :tenant
 
   test '#new renders with the display_name in the title of the contract' do
-    contracts = FactoryBot.create_list(:cinstance, 2, plan: FactoryBot.create(:application_plan, service: tenant.default_service))
+    contracts = FactoryBot.create_list(:cinstance, 2, plan: FactoryBot.create(:application_plan, issuer: tenant.default_service))
 
     get new_admin_buyers_applications_bulk_change_plan_path, params: { selected: contracts.map(&:id) }
 

--- a/test/integration/buyers/service_contracts/bulk/change_plans_controller_test.rb
+++ b/test/integration/buyers/service_contracts/bulk/change_plans_controller_test.rb
@@ -27,7 +27,9 @@ class Buyers::ServiceContracts::Bulk::ChangePlansControllerTest < ActionDispatch
   end
 
   test '#new renders with the display_name in the title of the contract' do
-    another_service_contract = FactoryBot.create(:service_contract, plan: FactoryBot.create(:simple_service_plan, issuer: tenant.default_service))
+    another_plan = FactoryBot.create(:service_plan, issuer: tenant.default_service)
+    buyer = FactoryBot.create(:buyer_account, provider_account: tenant)
+    another_service_contract = FactoryBot.create(:service_contract, plan: another_plan, user_account: buyer)
     contracts = [service_contract, another_service_contract]
 
     tenant.settings.service_plans_ui_visible = true

--- a/test/integration/change_application_plan_test.rb
+++ b/test/integration/change_application_plan_test.rb
@@ -12,8 +12,8 @@ class ChangeApplicationPlanTest < ActionDispatch::IntegrationTest
 
   def test_change_plan
     service = FactoryBot.create(:service, account: @provider)
-    plan_1  = FactoryBot.create(:application_plan, service: service)
-    plan_2  = FactoryBot.create(:application_plan, service: service)
+    plan_1  = FactoryBot.create(:application_plan, issuer: service)
+    plan_2  = FactoryBot.create(:application_plan, issuer: service)
     app     = FactoryBot.create(:cinstance, service: service, plan: plan_1)
 
     assert_equal plan_1.id, app.plan_id

--- a/test/integration/developer_portal/admin/messages/outbox_controller_integration_test.rb
+++ b/test/integration/developer_portal/admin/messages/outbox_controller_integration_test.rb
@@ -4,8 +4,8 @@ class DeveloperPortal::Admin::Messages::OutboxControllerIntegrationTest < Action
   include System::UrlHelpers.cms_url_helpers
 
   def setup
-    @provider = FactoryBot.create(:simple_provider)
-    @buyer    = FactoryBot.create(:buyer_account, provider_account: @provider)
+    @buyer    = FactoryBot.create(:buyer_account)
+    @provider = @buyer.provider_account
 
     login_buyer @buyer
 

--- a/test/integration/developer_portal/api_docs/account_data_controller_test.rb
+++ b/test/integration/developer_portal/api_docs/account_data_controller_test.rb
@@ -9,7 +9,7 @@ class DeveloperPortal::ApiDocs::AccountDataControllerTest < ActionDispatch::Inte
     @provider = FactoryBot.create(:provider_account)
     @buyer = FactoryBot.create(:buyer_account, provider_account: provider)
     service = provider.default_service
-    @application = FactoryBot.create(:cinstance, user_account: buyer, name: 'MyAppName', plan: FactoryBot.create(:application_plan, service: service, name: 'MyPlanName'))
+    @application = FactoryBot.create(:cinstance, user_account: buyer, name: 'MyAppName', plan: FactoryBot.create(:application_plan, issuer: service, name: 'MyPlanName'))
     service.update!(backend_version: 2)
   end
 

--- a/test/integration/finance/api/line_items_controller_test.rb
+++ b/test/integration/finance/api/line_items_controller_test.rb
@@ -65,7 +65,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test '#index returns contract plan_id' do
-    plan = FactoryBot.create(:simple_application_plan)
+    plan = FactoryBot.create(:application_plan, issuer: @provider.services.first!)
     line_item = @invoice.line_items.first
     contract = @buyer.buy! plan
     line_item.update_attribute(:contract, contract)
@@ -197,7 +197,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'does not accept adding metric_id to line_item' do
-    metric = FactoryBot.create(:metric, service: master_account.services.first!)
+    metric = FactoryBot.create(:metric, owner: master_account.services.first!)
     assert_no_difference '@invoice.line_items.count' do
       post api_invoice_line_items_path(@invoice.id), params: line_item_params.merge(metric_id: metric.id), headers: { accept: Mime[:json] }
       assert_response :not_found

--- a/test/integration/liquid/legacy_tags_test.rb
+++ b/test/integration/liquid/legacy_tags_test.rb
@@ -10,7 +10,7 @@ class Liquid::LegacyTagsTest < ActionDispatch::IntegrationTest
   end
 
   test 'latest_forum_posts' do
-    @provider.forum = FactoryBot.create(:forum)
+    @provider.forum = FactoryBot.create(:forum, account: @provider)
     topic = FactoryBot.create(:topic, forum: @provider.forum)
     FactoryBot.create(:post, forum: @provider.forum, topic: topic)
     override_dashboard_with '{% latest_forum_posts %}'

--- a/test/integration/master/api/providers_controller_integration_test.rb
+++ b/test/integration/master/api/providers_controller_integration_test.rb
@@ -269,7 +269,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     end
 
     test '#plan_upgrade successful upgrade' do
-      new_plan = FactoryBot.create(:application_plan, service: master_account.default_service)
+      new_plan = FactoryBot.create(:application_plan, issuer: master_account.default_service)
 
       put plan_upgrade_master_api_provider_path(provider, access_token: token.value, plan_id: new_plan.id, format: :xml)
 
@@ -289,7 +289,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
 
     test '#plan_upgrade no stock plan' do
       new_plan_name = 'invalid-plan'
-      new_plan = FactoryBot.create(:application_plan_without_rules, service: master_account.default_service, name: new_plan_name)
+      new_plan = FactoryBot.create(:application_plan_without_rules, issuer: master_account.default_service, name: new_plan_name)
       current_plan_id = provider.reload.bought_application_plans.first.id
 
       put plan_upgrade_master_api_provider_path(provider, access_token: token.value, plan_id: new_plan.id, format: :xml)

--- a/test/integration/master/api/providers_controller_integration_test.rb
+++ b/test/integration/master/api/providers_controller_integration_test.rb
@@ -67,7 +67,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
 
   test '#create with published account plan sent (for Saas) as a param that requires approval' do
     ThreeScale.config.stubs(onpremises: false)
-    new_account_plan = FactoryBot.create(:account_plan, approval_required: true, provider: master_account, state: 'published')
+    new_account_plan = FactoryBot.create(:account_plan, approval_required: true, issuer: master_account, state: 'published')
     post master_api_providers_path, params: signup_params({ account_plan_id: new_account_plan.id })
     assert_not user.can_login?
     assert user.pending?
@@ -78,7 +78,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
 
   test '#create with unpublished account plan sent (for Saas) as a param that requires approval' do
     ThreeScale.config.stubs(onpremises: false)
-    new_account_plan = FactoryBot.create(:account_plan, approval_required: true, provider: master_account, state: 'hidden')
+    new_account_plan = FactoryBot.create(:account_plan, approval_required: true, issuer: master_account, state: 'hidden')
     post master_api_providers_path, params: signup_params({ account_plan_id: new_account_plan.id })
     assert_not user.can_login?
     assert user.pending?
@@ -89,7 +89,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
 
   test '#create with account plan send (for on-premises) is ignored' do
     ThreeScale.config.stubs(onpremises: true)
-    new_account_plan = FactoryBot.create(:account_plan, provider: master_account)
+    new_account_plan = FactoryBot.create(:account_plan, issuer: master_account)
     post master_api_providers_path, params: signup_params({ account_plan_id: new_account_plan.id })
     assert_equal account_plan, account.bought_account_plan
   end

--- a/test/integration/master/providers/plans_controller_test.rb
+++ b/test/integration/master/providers/plans_controller_test.rb
@@ -7,7 +7,7 @@ class Master::Providers::PlansControllerTest < ActionDispatch::IntegrationTest
     @master_member = FactoryBot.create(:member, account: master_account, state: 'active')
     @service = master_account.default_service
     @tenant = FactoryBot.create(:simple_provider, provider_account: master_account)
-    @old_plan, @new_plan = FactoryBot.create_list(:application_plan, 2, service: service)
+    @old_plan, @new_plan = FactoryBot.create_list(:application_plan, 2, issuer: service)
     @tenant.buy! old_plan
   end
 

--- a/test/integration/multitenant_enforcement_test.rb
+++ b/test/integration/multitenant_enforcement_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MultitenantEnforcementTest < ActionDispatch::IntegrationTest
+  setup do
+    @provider = FactoryBot.create(:provider_account)
+  end
+
+  test "forbid retrieving objects from multiple tenants" do
+    login! @provider
+    service = @provider.first_service!
+    plan = FactoryBot.create(:application_plan, issuer: service)
+    plan.update_column(:tenant_id, @provider.tenant_id + 1)
+    get admin_service_application_plans_path(service)
+  rescue => exception
+    assert_instance_of ThreeScale::Middleware::Multitenant::TenantChecker::TenantLeak, exception.cause
+  end
+
+  test "forbid retrieving from multiple tenants by token" do
+    host! @provider.external_admin_domain
+    service = @provider.first_service!
+    plan = FactoryBot.create(:application_plan, issuer: service)
+    plan.update_column(:tenant_id, @provider.tenant_id + 1)
+    token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+    assert_raises ThreeScale::Middleware::Multitenant::TenantChecker::TenantLeak do
+      get admin_api_service_application_plans_path(service_id: service.id, format: :json, access_token: token)
+    end
+  end
+
+  test "forbid retrieving from multiple tenants by provider key" do
+    host! @provider.external_admin_domain
+    service = @provider.first_service!
+    plan = FactoryBot.create(:application_plan, issuer: service)
+    plan.update_column(:tenant_id, @provider.tenant_id + 1)
+    assert_raises ThreeScale::Middleware::Multitenant::TenantChecker::TenantLeak do
+      get admin_api_service_application_plans_path(service_id: service.id, format: :json, provider_key: @provider.provider_key)
+    end
+  end
+
+  test "allow retrieving objects with NULL tenant_id" do
+    login! @provider
+    service = @provider.first_service!
+    plan = FactoryBot.create(:application_plan, issuer: service)
+    plan.update_column(:tenant_id, nil)
+    get admin_service_application_plans_path(service)
+    assert_response :success
+  end
+
+  test "multitenant account can retrieve from multiple tenants by token" do
+    host! master_account.external_admin_domain
+    service = master_account.first_service!
+    plan = FactoryBot.create(:application_plan, issuer: service)
+    service.update_column(:tenant_id, @provider.tenant_id)
+    plan.update_column(:tenant_id, @provider.tenant_id + 1)
+    token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[account_management]).value
+    AccessToken.new.value
+    get admin_api_service_application_plans_path(service_id: service.id, format: :json, access_token: token)
+    assert_response :success
+  end
+
+  test "multitenant account can retrieve from multiple tenants by master key" do
+    host! master_account.external_admin_domain
+    service = master_account.first_service!
+    plan = FactoryBot.create(:application_plan, issuer: service)
+    service.update_column(:tenant_id, @provider.tenant_id)
+    plan.update_column(:tenant_id, @provider.tenant_id + 1)
+    get admin_api_service_application_plans_path(service_id: service.id, format: :json, provider_key: master_account.provider_key)
+    assert_response :success
+  end
+
+  test "multitenant account can retrieve from multiple tenants by user" do
+    login! master_account
+    service = master_account.first_service!
+    plan = FactoryBot.create(:application_plan, issuer: service)
+    service.update_column(:tenant_id, @provider.tenant_id)
+    plan.update_column(:tenant_id, @provider.tenant_id + 1)
+    get admin_service_application_plans_path(service)
+    assert_response :success
+  end
+end

--- a/test/integration/provider/admin/api_docs/account_data_controller_test.rb
+++ b/test/integration/provider/admin/api_docs/account_data_controller_test.rb
@@ -11,7 +11,7 @@ class Provider::Admin::ApiDocs::AccountDataControllerTest < ActionDispatch::Inte
     provider.settings.allow_multiple_applications!
     provider.settings.show_multiple_applications!
     @buyer = FactoryBot.create(:buyer_account, provider_account: provider)
-    plan = FactoryBot.create(:application_plan, service: service, name: 'MyPlanName')
+    plan = FactoryBot.create(:application_plan, issuer: service, name: 'MyPlanName')
     @application = FactoryBot.create(:cinstance, user_account: buyer, plan: plan, name: 'MyAppName')
 
     service.update!(backend_version: 1)

--- a/test/integration/provider/admin/applications/applications_controller_test.rb
+++ b/test/integration/provider/admin/applications/applications_controller_test.rb
@@ -47,7 +47,7 @@ class Provider::Admin::ApplicationsTest < ActionDispatch::IntegrationTest
     class Index < ProviderLoggedInTest
       setup do
         @service = provider.services.first!
-        plans = FactoryBot.create_list(:application_plan, 2, service: @service)
+        plans = FactoryBot.create_list(:application_plan, 2, issuer: @service)
         buyers = FactoryBot.create_list(:buyer_account, 2, provider_account: provider)
         plans.each_with_index { |plan, index| buyers[index].buy! plan }
       end

--- a/test/integration/provider/admin/keys_controller_test.rb
+++ b/test/integration/provider/admin/keys_controller_test.rb
@@ -11,16 +11,11 @@ class Provider::Admin::KeysControllerTest < ActionDispatch::IntegrationTest
       issuer: service
     )
 
-    @application = FactoryBot.create(
-      :cinstance,
-      plan: plan,
-      application_keys: FactoryBot.create_list(
-        :application_key,
-        2
-      )
-    )
+    @application = FactoryBot.create(:cinstance, plan: plan)
 
-    @key = @application.application_keys.first!
+    FactoryBot.create_list(:application_key, 2, application: @application)
+
+    @key = @application.reload.application_keys.first!
 
     @member_user = FactoryBot.create(
       :member,

--- a/test/integration/rake/remove_dup_usage_limits_test.rb
+++ b/test/integration/rake/remove_dup_usage_limits_test.rb
@@ -6,7 +6,7 @@ class RemoveDupUsageLimitsTest < ActiveSupport::TestCase
     @provider = FactoryBot.create :provider_account
     @service_plan = FactoryBot.create :service_plan, :issuer => @provider.first_service!
     @application_plan = FactoryBot.create :application_plan, :issuer => @provider.first_service!, :service => @provider.first_service!
-    @metric = FactoryBot.create :metric, :service => @application_plan.service
+    @metric = FactoryBot.create :metric, :owner => @application_plan.service
   end
 
   test 'does not remove if there is only one usagelimit' do

--- a/test/integration/user-management-api/application_plan_limits_test.rb
+++ b/test/integration/user-management-api/application_plan_limits_test.rb
@@ -7,7 +7,7 @@ class Admin::Api::ApplicationPlanLimitsTest < ActionDispatch::IntegrationTest
     @provider = FactoryBot.create(:provider_account, domain: 'provider.example.com')
     @service = FactoryBot.create(:service, account: @provider)
     @app_plan = FactoryBot.create(:application_plan, issuer: @service)
-    @metric = FactoryBot.create(:metric, service: @service)
+    @metric = FactoryBot.create(:metric, owner: @service)
     @limit = FactoryBot.create(:usage_limit, plan: @app_plan, metric: @metric)
 
     host! @provider.external_admin_domain

--- a/test/integration/user-management-api/application_plan_pricing_rules_test.rb
+++ b/test/integration/user-management-api/application_plan_pricing_rules_test.rb
@@ -7,7 +7,7 @@ class Admin::Api::ApplicationPlanPricingRulesTest < ActionDispatch::IntegrationT
     @provider = FactoryBot.create(:provider_account, domain: 'provider.example.com')
     @service = FactoryBot.create(:service, account: @provider)
     @app_plan = FactoryBot.create(:application_plan, issuer: @service)
-    @metric = FactoryBot.create(:metric, service: @service)
+    @metric = FactoryBot.create(:metric, owner: @service)
     @pricing_rule = FactoryBot.create(:pricing_rule, plan: @app_plan, metric: @metric)
 
     host! @provider.external_admin_domain

--- a/test/integration/user-management-api/service_metrics_test.rb
+++ b/test/integration/user-management-api/service_metrics_test.rb
@@ -13,7 +13,7 @@ class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
   end
 
   test 'index' do
-    FactoryBot.create(:metric, service: @service)
+    FactoryBot.create(:metric, owner: @service)
 
     get admin_api_service_metrics_path(@service, format: :xml), params: { provider_key: @provider.api_key }
 
@@ -46,7 +46,7 @@ class Admin::Api::MetricsTest < ActionDispatch::IntegrationTest
 
   test 'show with wrong id' do
     # a metric of another service
-    metric = FactoryBot.create(:metric, service: FactoryBot.create(:service, account: @provider))
+    metric = FactoryBot.create(:metric, owner: FactoryBot.create(:service, account: @provider))
 
     get admin_api_service_metric_path(@service, metric, format: :xml), params: { provider_key: @provider.api_key }
 

--- a/test/integration/user-management-api/service_subscriptions_controller_test.rb
+++ b/test/integration/user-management-api/service_subscriptions_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::Api::ServiceSubscriptionsControllerTest < ActionDispatch::Integrati
 
   class ProviderAccountTest < Admin::Api::ServiceSubscriptionsControllerTest
     test 'index' do
-      another_plan = FactoryBot.create(:service_plan)
+      another_plan = FactoryBot.create(:service_plan, issuer: FactoryBot.create(:simple_service, account: current_account))
       another_service_contract = FactoryBot.create(:simple_service_contract, plan: another_plan, user_account: buyer)
       get admin_api_account_service_subscriptions_path(account_id: buyer.id, format: :json, access_token: token)
       assert_response :ok
@@ -112,7 +112,8 @@ class Admin::Api::ServiceSubscriptionsControllerTest < ActionDispatch::Integrati
     end
 
     test 'approve pending subscription' do
-      plan_with_approval = FactoryBot.create(:service_plan, approval_required: true)
+      another_service = FactoryBot.create(:simple_service, account: current_account)
+      plan_with_approval = FactoryBot.create(:service_plan, approval_required: true, issuer: another_service)
       subscription = FactoryBot.create(:simple_service_contract, plan: plan_with_approval, user_account: buyer)
 
       assert 'pending', subscription.state
@@ -125,7 +126,8 @@ class Admin::Api::ServiceSubscriptionsControllerTest < ActionDispatch::Integrati
     end
 
     test 'approval fails if incorrect state' do
-      plan_with_approval = FactoryBot.create(:service_plan, approval_required: true)
+      another_service = FactoryBot.create(:simple_service, account: current_account)
+      plan_with_approval = FactoryBot.create(:service_plan, approval_required: true, issuer: another_service)
       subscription = FactoryBot.create(:simple_service_contract, plan: plan_with_approval, user_account: buyer)
 
       assert 'pending', subscription.state

--- a/test/test_helpers/authentication.rb
+++ b/test/test_helpers/authentication.rb
@@ -57,6 +57,7 @@ ActionDispatch::IntegrationTest.class_eval do
   def provider_login_with(username, password)
     post provider_sessions_path, params: {username: username, password: password}
     follow_redirect! while redirect?
+    assert_response :success
   end
 
   def login_with(username, password)
@@ -65,7 +66,7 @@ ActionDispatch::IntegrationTest.class_eval do
   end
 
   def logout!
-    get '/p/logout'
+    get provider_logout_path
   end
 
   def with_forgery_protection(enabled: true)

--- a/test/test_helpers/backend.rb
+++ b/test/test_helpers/backend.rb
@@ -107,11 +107,11 @@ module TestHelpers
     def create_master_account_metrics
       master_service = ::Account.master.default_service
       hits = master_service.metrics.find_by_name('hits')
-      FactoryBot.create(:metric, :parent => hits, :service => master_service, :name => 'transactions/create_single')
-      FactoryBot.create(:metric, :parent => hits, :service => master_service, :name => 'transactions/create_multiple')
-      FactoryBot.create(:metric, :parent => hits, :service => master_service, :name => 'transactions/confirm')
-      FactoryBot.create(:metric, :parent => hits, :service => master_service, :name => 'transactions/destroy')
-      FactoryBot.create(:metric, :parent => hits, :service => master_service, :name => 'transactions/authorize')
+      FactoryBot.create(:metric, :parent => hits, :owner => master_service, :name => 'transactions/create_single')
+      FactoryBot.create(:metric, :parent => hits, :owner => master_service, :name => 'transactions/create_multiple')
+      FactoryBot.create(:metric, :parent => hits, :owner => master_service, :name => 'transactions/confirm')
+      FactoryBot.create(:metric, :parent => hits, :owner => master_service, :name => 'transactions/destroy')
+      FactoryBot.create(:metric, :parent => hits, :owner => master_service, :name => 'transactions/authorize')
     end
 
     def make_transaction_at(time, options)

--- a/test/unit/account/buyer_test.rb
+++ b/test/unit/account/buyer_test.rb
@@ -118,7 +118,7 @@ class Account::BuyerTest < ActiveSupport::TestCase
   test 'Account#bought_plan' do
     provider_account = FactoryBot.create(:provider_account)
     service = FactoryBot.create(:simple_service, account: provider_account)
-    plan = FactoryBot.create(:application_plan, service: service)
+    plan = FactoryBot.create(:application_plan, issuer: service)
 
     buyer_account = FactoryBot.create(:simple_buyer, provider_account: provider_account)
     buyer_account.buy(plan)

--- a/test/unit/account/buyer_test.rb
+++ b/test/unit/account/buyer_test.rb
@@ -20,7 +20,7 @@ class Account::BuyerTest < ActiveSupport::TestCase
   should have_many(:bought_service_plans).through(:bought_service_contracts)
 
   test '#has_bought_cinstance?' do
-    buyer = FactoryBot.create(:simple_buyer)
+    buyer = FactoryBot.create(:buyer_account)
 
     assert_not buyer.has_bought_cinstance?
 

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -236,7 +236,7 @@ class Account::StatesTest < ActiveSupport::TestCase
     account_without_traffic = FactoryBot.create(:simple_account)
 
     account_with_old_traffic = FactoryBot.create(:buyer_account)
-    FactoryBot.create(:cinstance, user_account: account_with_old_traffic, first_daily_traffic_at: inactive_since_days.ago)
+    FactoryBot.create(:cinstance, user_account: account_with_old_traffic, first_daily_traffic_at: inactive_since_days.ago - 1)
 
     account_with_recent_traffic = FactoryBot.create(:buyer_account)
     FactoryBot.create(:cinstance, user_account: account_with_recent_traffic, first_daily_traffic_at: (inactive_since_days - 1.day).ago)

--- a/test/unit/account/states_test.rb
+++ b/test/unit/account/states_test.rb
@@ -93,21 +93,21 @@ class Account::StatesTest < ActiveSupport::TestCase
   # end
 
   test 'enqueues notification email when account is made pending' do
-    account = FactoryBot.create(:buyer_account_with_provider)
+    account = FactoryBot.create(:buyer_account)
     assert_enqueued_email_with(AccountMailer, :confirmed, args: [account]) do
       account.make_pending!
     end
   end
 
   test 'enqueues notification email when account is rejected' do
-    account = FactoryBot.create(:buyer_account_with_provider)
+    account = FactoryBot.create(:buyer_account)
     assert_enqueued_email_with(AccountMailer, :rejected, args: [account]) do
       account.reject!
     end
   end
 
   test 'enqueues notification email when buyer account is approved' do
-    account = FactoryBot.create(:buyer_account_with_provider)
+    account = FactoryBot.create(:buyer_account)
 
     account.update_attribute(:state, 'pending')
     account.buy! FactoryBot.create(:account_plan, :approval_required => true)
@@ -206,21 +206,21 @@ class Account::StatesTest < ActiveSupport::TestCase
 
   test '.inactive_since' do
     inactive_since_days = 5.days
+    provider = FactoryBot.create(:provider_account)
 
-    old_account_without_traffic = FactoryBot.create(:simple_account)
+    old_account_without_traffic = FactoryBot.create(:buyer_account, provider_account: provider)
     old_account_without_traffic.update_attribute(:created_at, inactive_since_days.ago)
 
-    old_account_with_old_traffic = FactoryBot.create(:simple_account)
+    old_account_with_old_traffic = FactoryBot.create(:buyer_account, provider_account: provider)
     old_account_with_old_traffic.update_attribute(:created_at, inactive_since_days.ago)
-    FactoryBot.create(:cinstance, user_account: old_account_with_old_traffic, first_daily_traffic_at: inactive_since_days.ago)
+    FactoryBot.create(:cinstance, user_account: old_account_with_old_traffic, first_daily_traffic_at: inactive_since_days.ago - 1)
 
-    recent_account_without_traffic = FactoryBot.create(:simple_account)
+    recent_account_without_traffic = FactoryBot.create(:buyer_account, provider_account: provider)
     recent_account_without_traffic.update_attribute(:created_at, (inactive_since_days - 1.day).ago)
-    FactoryBot.create(:cinstance, user_account: recent_account_without_traffic, first_daily_traffic_at: (inactive_since_days - 1.day).ago)
 
-    recent_account_with_recent_traffic = FactoryBot.create(:simple_account)
+    recent_account_with_recent_traffic = FactoryBot.create(:buyer_account, provider_account: provider)
     recent_account_with_recent_traffic.update_attribute(:created_at, inactive_since_days.ago)
-    FactoryBot.create(:cinstance, user_account: recent_account_with_recent_traffic, first_daily_traffic_at: (inactive_since_days - 1.day).ago)
+    FactoryBot.create(:cinstance, user_account: recent_account_with_recent_traffic, first_daily_traffic_at: inactive_since_days.ago)
 
     assert_raise(ArgumentError) { Account.inactive_since.pluck(:id) }
     results = Account.inactive_since(inactive_since_days.ago).pluck(:id)
@@ -235,10 +235,10 @@ class Account::StatesTest < ActiveSupport::TestCase
 
     account_without_traffic = FactoryBot.create(:simple_account)
 
-    account_with_old_traffic = FactoryBot.create(:simple_account)
+    account_with_old_traffic = FactoryBot.create(:buyer_account)
     FactoryBot.create(:cinstance, user_account: account_with_old_traffic, first_daily_traffic_at: inactive_since_days.ago)
 
-    account_with_recent_traffic = FactoryBot.create(:simple_account)
+    account_with_recent_traffic = FactoryBot.create(:buyer_account)
     FactoryBot.create(:cinstance, user_account: account_with_recent_traffic, first_daily_traffic_at: (inactive_since_days - 1.day).ago)
 
     assert_raise(ArgumentError) { Account.without_traffic_since.pluck(:id) }

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -510,7 +510,7 @@ class AccountTest < ActiveSupport::TestCase
 
     account = FactoryBot.create(:provider_account)
     service = account.default_service
-    metric = FactoryBot.create(:metric, service: service)
+    metric = FactoryBot.create(:metric, owner: service)
     feature = FactoryBot.create(:feature, featurable: service)
 
     assert_not account.destroy

--- a/test/unit/application_keys_test.rb
+++ b/test/unit/application_keys_test.rb
@@ -195,8 +195,9 @@ class ApplicationKeysTest < ActiveSupport::TestCase
     # generate random key with all chars of RFC 6749 except space
     random_key = -> { [*"\x21".."\x7E"].shuffle.join }
     app_key = FactoryBot.build(:application_key, value: (value = random_key.call))
+    app_key.application.user_account.save!
 
-    assert app_key.save
+    app_key.save!
     assert value, app_key.reload.value
   end
 
@@ -209,6 +210,7 @@ class ApplicationKeysTest < ActiveSupport::TestCase
 
   test 'is audited' do
     app_key = FactoryBot.build(:application_key)
+    app_key.application.user_account.save!
 
     assert_difference(Audited.audit_class.method(:count)) do
       ApplicationKey.with_synchronous_auditing do

--- a/test/unit/application_plan_test.rb
+++ b/test/unit/application_plan_test.rb
@@ -132,7 +132,7 @@ class ApplicationPlanTest < ActiveSupport::TestCase
     feature = stock.issuer.features.create!(name: "feature enabled", scope: 'ApplicationPlan')
     stock.features_plans.create!(feature: feature)
 
-    metric = FactoryBot.create(:metric, service: stock.service, system_name: 'frags')
+    metric = FactoryBot.create(:metric, owner: stock.service, system_name: 'frags')
     stock.pricing_rules.create!(metric: metric, min: 1, max: 5, cost_per_unit: 1)
     ul1 = stock.usage_limits.new(period: :day, value: 10)
     ul1.metric = metric

--- a/test/unit/application_plan_test.rb
+++ b/test/unit/application_plan_test.rb
@@ -26,7 +26,7 @@ class ApplicationPlanTest < ActiveSupport::TestCase
   test '#contract_count normal behavior' do
     account = FactoryBot.create(:simple_provider)
     service = FactoryBot.create(:service, account: account)
-    plan = FactoryBot.create(:application_plan, service: service)
+    plan = FactoryBot.create(:application_plan, issuer: service)
 
     assert_equal 0, plan.reload.contracts_count
     app = FactoryBot.create(:cinstance, service: service, plan: plan)
@@ -39,7 +39,7 @@ class ApplicationPlanTest < ActiveSupport::TestCase
   test '#contracts_count account being deleted' do
     account = FactoryBot.create(:simple_provider)
     service = FactoryBot.create(:service, account: account)
-    plan = FactoryBot.create(:application_plan, service: service)
+    plan = FactoryBot.create(:application_plan, issuer: service)
 
     assert_equal 0, plan.reload.contracts_count
     app = FactoryBot.create(:cinstance, service: service, plan: plan)
@@ -53,7 +53,7 @@ class ApplicationPlanTest < ActiveSupport::TestCase
   test '#contracts_count service being deleted' do
     account = FactoryBot.create(:simple_provider)
     service = FactoryBot.create(:service, account: account)
-    plan = FactoryBot.create(:application_plan, service: service, issuer: service)
+    plan = FactoryBot.create(:application_plan, issuer: service, issuer: service)
 
     assert_equal 0, plan.reload.contracts_count
     app = FactoryBot.create(:cinstance, service: service, plan: plan)

--- a/test/unit/backend/model_extensions/metric_test.rb
+++ b/test/unit/backend/model_extensions/metric_test.rb
@@ -25,7 +25,7 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
 
   test 'does not sync backend metric when validation fails creating a nested metric (method)' do
     service = FactoryBot.create(:simple_service)
-    metric  = FactoryBot.create(:metric, :service => service, :friendly_name => 'Foos')
+    metric  = FactoryBot.create(:metric, :owner => service, :friendly_name => 'Foos')
 
     Metric.any_instance.expects(:sync_backend).never
     BackendMetricWorker.expects(:perform_later).never
@@ -37,7 +37,7 @@ class Backend::ModelExtensions::MetricTest < ActiveSupport::TestCase
 
   test 'does not sync backend metric data when validation fails' do
     service = FactoryBot.create(:simple_service)
-    metric  = FactoryBot.create(:metric, :service => service, :friendly_name => 'Foos')
+    metric  = FactoryBot.create(:metric, :owner => service, :friendly_name => 'Foos')
 
     BackendMetricWorker.expects(:perform_later).never
 

--- a/test/unit/backend/model_extensions/usage_limit_test.rb
+++ b/test/unit/backend/model_extensions/usage_limit_test.rb
@@ -44,7 +44,7 @@ class Backend::ModelExtensions::UsageLimitTest < ActiveSupport::TestCase
 
   test 'stores usage_limit backend data when usage_limit is created' do
     plan   = FactoryBot.create(:application_plan)
-    metric = FactoryBot.create(:metric, :service => plan.service)
+    metric = FactoryBot.create(:metric, owner: plan.service)
 
     usage_limit = metric.usage_limits.new(:period => :week, :value => 7000)
     usage_limit.plan = plan

--- a/test/unit/backend_client/application/utilization_test.rb
+++ b/test/unit/backend_client/application/utilization_test.rb
@@ -38,7 +38,7 @@ class BackendClient::Application::UtilizationTest < ActiveSupport::TestCase
   end
 
   def test_output_order
-    metrics = FactoryBot.create_list(:metric, 3, service: @application_plan.issuer)
+    metrics = FactoryBot.create_list(:metric, 3, owner: @application_plan.issuer)
 
     utilization_records = ThreeScale::Core::APIClient::Collection.new([
       { period: 'day', metric_name: metrics.first.name, max_value: 5000, current_value: 2500 },
@@ -87,7 +87,7 @@ class BackendClient::Application::UtilizationTest < ActiveSupport::TestCase
   end
 
   test 'metrics not requested should be ignored' do
-    metrics = FactoryBot.create_list(:metric, 3, service: @application_plan.issuer)
+    metrics = FactoryBot.create_list(:metric, 3, owner: @application_plan.issuer)
 
     utilization_records = ThreeScale::Core::APIClient::Collection.new([
       { period: 'day', metric_name: metrics.first.name, max_value: 5000, current_value: 2500 },

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -934,7 +934,8 @@ end
 
 class KeysTest < ActiveSupport::TestCase
   test 'creating keys in backend is fired only when app is created' do
-    app = FactoryBot.build(:cinstance)
+    buyer = FactoryBot.create(:buyer_account)
+    app = FactoryBot.build(:cinstance, user_account: buyer)
 
     app.expects(:create_key_after_create?).returns(true)
 
@@ -945,7 +946,7 @@ class KeysTest < ActiveSupport::TestCase
 
     BackendClient::ToggleBackend.enable_all!
 
-    assert app.save!
+    app.save!
     assert app.application_keys.presence
 
     app.expects(:create_key_after_create?).never

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -421,12 +421,12 @@ class CinstanceTest < ActiveSupport::TestCase
     cinstance = FactoryBot.create(:cinstance)
 
     other_service = FactoryBot.create(:service, account: cinstance.provider_account)
-    other_plan_diff_service = FactoryBot.create(:application_plan, service: other_service, name: "other plan of different service")
+    other_plan_diff_service = FactoryBot.create(:application_plan, issuer: other_service, name: "other plan of different service")
     cinstance.plan = other_plan_diff_service
     assert cinstance.invalid?
     assert_includes cinstance.errors['plan'], 'not allowed in this context'
 
-    other_plan_same_service = FactoryBot.build_stubbed(:application_plan, service: cinstance.service, name: "other plan of same service")
+    other_plan_same_service = FactoryBot.build_stubbed(:application_plan, issuer: cinstance.service, name: "other plan of same service")
     cinstance.plan = other_plan_same_service
     assert cinstance.valid?
   end
@@ -814,7 +814,7 @@ class ChangePlanTest < ActiveSupport::TestCase
 
   test 'cannot change to a plan of different service' do
     other_service = FactoryBot.create(:service, account: @cinstance.provider_account)
-    other_plan = FactoryBot.create(:application_plan, service: other_service, name: "other plan")
+    other_plan = FactoryBot.create(:application_plan, issuer: other_service, name: "other plan")
     assert_not @cinstance.change_plan other_plan
     assert_includes @cinstance.errors['plan'], 'not allowed in this context'
   end

--- a/test/unit/contract_test.rb
+++ b/test/unit/contract_test.rb
@@ -4,11 +4,12 @@ require 'test_helper'
 
 class ContractTest < ActiveSupport::TestCase
   test '#by_account' do
-    accounts = [FactoryBot.create(:simple_buyer), FactoryBot.create(:simple_provider)]
-    accounts.each { |account| FactoryBot.create_list(:application, 2, user_account: account) }
+    buyer = FactoryBot.create(:buyer_account)
+    provider = buyer.provider_account
+    [buyer, provider].each { |account| FactoryBot.create_list(:application, 2, user_account: account) }
 
-    assert_same_elements Contract.where(user_account: accounts[0].id).pluck(:id), Contract.by_account(accounts[0].id).pluck(:id)
-    assert_same_elements Contract.where(user_account: accounts[1].id).pluck(:id), Contract.by_account(accounts[1].id).pluck(:id)
+    assert_same_elements Contract.where(user_account: buyer.id).pluck(:id), Contract.by_account(buyer.id).pluck(:id)
+    assert_same_elements Contract.where(user_account: provider.id).pluck(:id), Contract.by_account(provider.id).pluck(:id)
   end
 
   test '#have_paid_on' do

--- a/test/unit/deleted_object_test.rb
+++ b/test/unit/deleted_object_test.rb
@@ -31,11 +31,11 @@ class DeletedObjectTest < ActiveSupport::TestCase
 
   test 'deleted_owner' do
     service = FactoryBot.create(:simple_service)
-    metric = FactoryBot.create(:metric, service: service)
+    metric = FactoryBot.create(:metric, owner: service)
     deleted_child_but_owner_persisted = DeletedObject.create(object: metric, owner: service).id
 
     service = FactoryBot.create(:simple_service)
-    metric = FactoryBot.create(:metric, service: service)
+    metric = FactoryBot.create(:metric, owner: service)
     deleted_child_and_owner_deleted = DeletedObject.create(object: metric, owner: service).id
     deleted_object_with_deleted_children_but_its_owner_persisted = DeletedObject.create(object: service, owner: service.account).id
 

--- a/test/unit/finance/variable_cost_calculation_test.rb
+++ b/test/unit/finance/variable_cost_calculation_test.rb
@@ -7,7 +7,7 @@ class Finance::VariableCostCalculationTest < ActiveSupport::TestCase
   def setup
     @cinstance  = FactoryBot.create(:cinstance)
     @metric_one = @cinstance.service.metrics.hits
-    @metric_two = FactoryBot.create(:metric, :service => @cinstance.service)
+    @metric_two = FactoryBot.create(:metric, owner: @cinstance.service)
 
     @stats = stub('stats')
     Stats::Client.stubs(:new).with(@cinstance).returns(@stats)

--- a/test/unit/indices/proxy_rules_indices_test.rb
+++ b/test/unit/indices/proxy_rules_indices_test.rb
@@ -5,7 +5,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test 'alphanumeric characters are indexed' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/abc/123')
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -17,7 +17,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test 'character `/` is indexed' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/')
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -29,7 +29,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test 'character `!` is indexed' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/!/')
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -41,7 +41,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test "character `'` is indexed" do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: "/'/")
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -53,7 +53,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test 'characters `()` are indexed' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/()/')
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -65,7 +65,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test 'character `*` is indexed' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/*/')
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -77,7 +77,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test 'character `+` is indexed' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/+/')
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -89,7 +89,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test 'character `,` is indexed' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/,/')
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -101,7 +101,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test 'character `-` is indexed' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/-/')
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -113,7 +113,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test 'character `.` is indexed' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/./')
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -125,7 +125,7 @@ class ProxyRulesIndicesTest < ActiveSupport::TestCase
 
   test 'character `_` is indexed' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/_/')
         query      = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -264,7 +264,7 @@ class MetricTest < ActiveSupport::TestCase
   class PlanVisibilityOptions < ActiveSupport::TestCase
     setup do
       @plan =  FactoryBot.create(:application_plan)
-      @metric = FactoryBot.create(:metric, :service => @plan.service)
+      @metric = FactoryBot.create(:metric, owner: @plan.service)
     end
 
     test 'be visible by default' do
@@ -300,8 +300,8 @@ class MetricTest < ActiveSupport::TestCase
   class PlanAvailability < ActiveSupport::TestCase
     setup do
       @plan =  FactoryBot.create(:application_plan)
-      @metric1 = FactoryBot.create(:metric,  :service => @plan.service)
-      @metric2 = FactoryBot.create(:metric,  :service => @plan.service)
+      @metric1 = FactoryBot.create(:metric,  owner: @plan.service)
+      @metric2 = FactoryBot.create(:metric,  owner: @plan.service)
 
       FactoryBot.create :usage_limit, :plan => @plan, :metric => @metric1, :period => :day, :value => 1
       FactoryBot.create :usage_limit, :plan => @plan, :metric => @metric2, :period => :day, :value => 1

--- a/test/unit/observers/message_observer_test.rb
+++ b/test/unit/observers/message_observer_test.rb
@@ -16,7 +16,7 @@ class MessageObserverTest < ActiveSupport::TestCase
   class OtherTest < MessageObserverTest
     test 'after_create after_destroy' do
       app_plan = FactoryBot.create(:application_plan, issuer: @service)
-      contract = FactoryBot.build(:service_contract, plan: FactoryBot.create(:service_plan))
+      contract = FactoryBot.build(:service_contract, plan: FactoryBot.create(:service_plan, issuer: @service))
       cinstance = contract(app_plan)
 
       Applications::ApplicationCreatedEvent.expects(:create).once

--- a/test/unit/pdf/report_test.rb
+++ b/test/unit/pdf/report_test.rb
@@ -120,7 +120,7 @@ class Pdf::ReportTest < ActiveSupport::TestCase
     buyer = FactoryBot.create(:buyer_account, org_name: company_name)
     provider = buyer.provider_account
     service = provider.services.first
-    plan = FactoryBot.create(:application_plan, service: service, name: plan_name, state: 'published')
+    plan = FactoryBot.create(:application_plan, issuer: service, name: plan_name, state: 'published')
 
     cinstance = FactoryBot.create(:cinstance, user_account: buyer, plan: plan)
     custom_metric = FactoryBot.create(:metric, friendly_name: metric_name, owner: service)

--- a/test/unit/pricing_rule_test.rb
+++ b/test/unit/pricing_rule_test.rb
@@ -76,8 +76,8 @@ class PricingRuleTest < ActiveSupport::TestCase
   end
 
   should 'allow range overlap for pricing rules with different metrics' do
-    metric_one = FactoryBot.create(:metric, :service => @plan.service)
-    metric_two = FactoryBot.create(:metric, :service => @plan.service)
+    metric_one = FactoryBot.create(:metric, owner: @plan.service)
+    metric_two = FactoryBot.create(:metric, owner: @plan.service)
 
     rule_one = @plan.pricing_rules.create!(:metric => metric_one, :min => 1, :max => 10,
                                            :cost_per_unit => 0.2)

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -424,7 +424,7 @@ class ProxyTest < ActiveSupport::TestCase
   end
 
   test 'credentials names should allow good params' do
-    m = FactoryBot.create(:metric, service: @service)
+    m = FactoryBot.create(:metric, owner: @service)
 
     %W[ foo bar-baz bar_baz].each do |w|
       @proxy.auth_app_id = w
@@ -441,7 +441,7 @@ class ProxyTest < ActiveSupport::TestCase
   end
 
   test 'credentials names cannot have strange params' do
-    m = FactoryBot.create(:metric, service: @service)
+    m = FactoryBot.create(:metric, owner: @service)
 
     %W|foo/bar {fdsa} fda [fdsa]|.each do |w|
       @proxy.auth_app_id = w

--- a/test/unit/queries/auto_account_deletion_queries_test.rb
+++ b/test/unit/queries/auto_account_deletion_queries_test.rb
@@ -36,7 +36,7 @@ class AutoAccountDeletionQueriesTest < ActiveSupport::TestCase
       FactoryBot.create(:cinstance, user_account: old_tenant_with_old_traffic_but_paid, first_daily_traffic_at: (account_inactivity + 1).days.ago, paid_until: (contract_unpaid_time - 1).days.ago)
       @accounts[:not_to_suspend] << old_tenant_with_old_traffic_but_paid.id
 
-      old_buyer_with_old_traffic = FactoryBot.create(:simple_buyer)
+      old_buyer_with_old_traffic = FactoryBot.create(:buyer_account)
       old_buyer_with_old_traffic.update_attribute(:created_at, (account_inactivity + 1).days.ago)
       FactoryBot.create(:cinstance, user_account: old_buyer_with_old_traffic, first_daily_traffic_at: (account_inactivity + 1).days.ago)
       @accounts[:not_to_suspend] << old_buyer_with_old_traffic.id

--- a/test/unit/queries/proxy_rule_query_test.rb
+++ b/test/unit/queries/proxy_rule_query_test.rb
@@ -7,7 +7,7 @@ class ProxyRuleQueryTest < ActiveSupport::TestCase
 
   test '#search_for uses sphinx if query given' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test')
         query = ProxyRuleQuery.new(owner_type: proxy_rule.owner_type, owner_id: proxy_rule.owner_id)
@@ -19,7 +19,7 @@ class ProxyRuleQueryTest < ActiveSupport::TestCase
 
   test '#search_for reuses the scope if given' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test1', position: 1)
         proxy_rule2 = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test2', position: 2)
@@ -33,7 +33,7 @@ class ProxyRuleQueryTest < ActiveSupport::TestCase
 
   test '#search_for order result if sort/direction parameters given' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test1', position: 1)
         proxy_rule2 = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/path/test2', position: 2)
@@ -56,7 +56,7 @@ class ProxyRuleQueryTest < ActiveSupport::TestCase
 
   test '#search_for queries when there are more results than page size' do
     ThinkingSphinx::Test.rt_run do
-      backend_api = FactoryBot.build_stubbed(:backend_api)
+      backend_api = FactoryBot.create(:backend_api)
       perform_enqueued_jobs(only: SphinxIndexationWorker) do
         proxy_rules = FactoryBot.create_list(:proxy_rule, 25, owner: backend_api, pattern: '/path/test')
         query = ProxyRuleQuery.new(owner_type: proxy_rules.first.owner_type, owner_id: proxy_rules.first.owner_id)

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -257,7 +257,7 @@ class ServiceTest < ActiveSupport::TestCase
 
     assert_equal 'foos', method1.system_name
 
-    FactoryBot.create(:metric, service: service)
+    FactoryBot.create(:metric, owner: service)
 
     assert_same_elements [method1, method2], service.method_metrics
   end

--- a/test/unit/services/alerts/publish_alert_event_service_test.rb
+++ b/test/unit/services/alerts/publish_alert_event_service_test.rb
@@ -8,7 +8,7 @@ class Alerts::PublishAlertEventServiceTest < ActiveSupport::TestCase
   end
 
   def test_run_alert_for_provider
-    alert = FactoryBot.create(:limit_alert)
+    alert = FactoryBot.create(:limit_alert, account: @account.provider_account, cinstance: @cinstance)
 
     assert_difference(EventStore::Event.where(event_type: 'Alerts::LimitAlertReachedProviderEvent').method(:count)) do
       assert Alerts::PublishAlertEventService.run! alert
@@ -24,7 +24,7 @@ class Alerts::PublishAlertEventServiceTest < ActiveSupport::TestCase
   end
 
   def test_run_violation_for_provider
-    alert = FactoryBot.create(:limit_violation)
+    alert = FactoryBot.create(:limit_violation, account: @account.provider_account, cinstance: @cinstance)
 
     assert_difference(EventStore::Event.where(event_type: 'Alerts::LimitViolationReachedProviderEvent').method(:count)) do
       assert Alerts::PublishAlertEventService.run! alert

--- a/test/unit/stats/storage_test.rb
+++ b/test/unit/stats/storage_test.rb
@@ -9,7 +9,7 @@ class Stats::StorageTest < ActiveSupport::TestCase
     storage.flushdb
 
     service = FactoryBot.create(:service)
-    metric  = FactoryBot.create(:metric, :service => service)
+    metric  = FactoryBot.create(:metric, owner: service)
 
     # some fake data
     storage.set("stats/{service:#{service.backend_id}}/metric:#{metric.id}/day:20091210", 12)

--- a/test/unit/tasks/deleted_objects_test.rb
+++ b/test/unit/tasks/deleted_objects_test.rb
@@ -8,13 +8,13 @@ module Tasks
 
       # Metric Object destroyed with Service owner persisted
       service = FactoryBot.create(:simple_service)
-      metric = FactoryBot.create(:metric, service: service)
+      metric = FactoryBot.create(:metric, owner: service)
       DeletedObject.create!(object: metric, owner: service)
       metric.delete
 
       # Metric Object destroyed with Service owner destroyed (without its own DeletedObject)
       service = FactoryBot.create(:simple_service)
-      metric = FactoryBot.create(:metric, service: service)
+      metric = FactoryBot.create(:metric, owner: service)
       object_with_service_owner_destroyed = DeletedObject.create!(object: metric, owner: service)
       metric.delete
       service.delete
@@ -33,7 +33,7 @@ module Tasks
 
     test 'destroy_objects_with_service_owner_or_service_objects' do
       service = FactoryBot.create(:simple_service)
-      metric = FactoryBot.create(:metric, service: service)
+      metric = FactoryBot.create(:metric, owner: service)
       delete_object_with_service_owner = DeletedObject.create!(object: metric, owner: service)
 
       service = FactoryBot.create(:simple_service)

--- a/test/unit/tasks/multitenant/tenants_test.rb
+++ b/test/unit/tasks/multitenant/tenants_test.rb
@@ -71,7 +71,7 @@ module Tasks
         end
 
         test 'restore_existing_tenant_id_alerts' do
-          account = FactoryBot.create(:simple_provider)
+          account = FactoryBot.create(:provider_account, :with_a_buyer)
           alerts_empty = FactoryBot.create_list(:limit_alert, 2, account: account)
           alerts_with_tenant_id = FactoryBot.create_list(:limit_alert, 2, account: account)
           account.update_column(:tenant_id, account.id)
@@ -85,7 +85,7 @@ module Tasks
         end
 
         test 'restore_empty_tenant_id_alerts' do
-          account = FactoryBot.create(:simple_provider)
+          account = FactoryBot.create(:provider_account, :with_a_buyer)
           alerts_empty = FactoryBot.create_list(:limit_alert, 2, account: account)
           alerts_with_tenant_id = FactoryBot.create_list(:limit_alert, 2, account: account)
           account.update_column(:tenant_id, account.id)
@@ -138,7 +138,7 @@ module Tasks
 
           @tenant_without_any_cinstance = FactoryBot.create(:simple_provider, state: 'scheduled_for_deletion')
 
-          @developer_with_enterprise = FactoryBot.create(:simple_buyer, state: 'scheduled_for_deletion')
+          @developer_with_enterprise = FactoryBot.create(:buyer_account, state: 'scheduled_for_deletion')
           cinstance = FactoryBot.create(:cinstance, user_account: @developer_with_enterprise)
           cinstance.plan.update_column(:system_name, 'enterprise')
         end

--- a/test/unit/three_scale/search_test.rb
+++ b/test/unit/three_scale/search_test.rb
@@ -91,7 +91,7 @@ class ThreeScale::SearchTest < ActiveSupport::TestCase
   end
 
   test "Cinstance should order and search" do
-    account = FactoryBot.create(:account)
+    account = FactoryBot.create(:buyer_account)
 
     abc = FactoryBot.create(:cinstance, name: "abc", user_account: account)
     bcd = FactoryBot.create(:cinstance, name: "bcd", user_account: account)

--- a/test/unit/user/states_test.rb
+++ b/test/unit/user/states_test.rb
@@ -66,7 +66,7 @@ class User::StatesTest < ActiveSupport::TestCase
   end
 
   test 'when user is activated, and his buyer account is created, it becomes pending' do
-    account = FactoryBot.create(:buyer_account_with_provider)
+    account = FactoryBot.create(:buyer_account)
 
     account.update_attribute(:state, 'created')
     account.buy! FactoryBot.create(:account_plan, :approval_required => true)

--- a/test/workers/backend_metric_worker_test.rb
+++ b/test/workers/backend_metric_worker_test.rb
@@ -7,7 +7,7 @@ class BackendMetricWorkerTest < ActiveSupport::TestCase
 
   def setup
     @service = FactoryBot.create(:simple_service)
-    @metric = FactoryBot.create(:metric, service: service, system_name: 'some_system_name')
+    @metric = FactoryBot.create(:metric, owner: service, system_name: 'some_system_name')
   end
 
   attr_reader :service, :metric

--- a/test/workers/publish_enabled_changed_event_for_provider_applications_worker_test.rb
+++ b/test/workers/publish_enabled_changed_event_for_provider_applications_worker_test.rb
@@ -4,7 +4,7 @@ class PublishEnabledChangedEventForProviderApplicationsWorkerTest < ActiveSuppor
     @provider = FactoryBot.create(:provider_account)
     service = provider.services.first!
     service.service_tokens.create!(value: 'token')
-    plan = FactoryBot.create(:application_plan, service: service)
+    plan = FactoryBot.create(:application_plan, issuer: service)
     buyer = FactoryBot.create(:buyer_account, provider_account: provider)
     buyer.buy! plan
     provider.reload

--- a/test/workers/set_tenant_id_worker_test.rb
+++ b/test/workers/set_tenant_id_worker_test.rb
@@ -8,7 +8,7 @@ class SetTenantIdWorkerTest < ActiveSupport::TestCase
     include ActiveJob::TestHelper
 
     test "perform with a single relation" do
-      accounts = FactoryBot.create_list(:simple_provider, 2)
+      accounts = FactoryBot.create_list(:provider_account, 2, :with_a_buyer)
       backend_api = FactoryBot.create(:backend_api, account: accounts.first)
       backend_api2 = FactoryBot.create(:backend_api, account: accounts.last)
       alert = FactoryBot.create(:limit_alert, account: accounts.first)
@@ -32,8 +32,8 @@ class SetTenantIdWorkerTest < ActiveSupport::TestCase
     end
 
     test "account relations are also fixed for buyer accounts" do
-      provider = FactoryBot.create(:simple_provider)
-      buyer = FactoryBot.create(:simple_buyer, provider_account: provider)
+      buyer = FactoryBot.create(:buyer_account)
+      provider = buyer.provider_account
 
       assert_equal provider.id, buyer.reload.tenant_id
 


### PR DESCRIPTION
needs tests before merging and also we should consider whether this is needed at all at this point

fixes THREESCALE-10686