### PR TITLE
THREESCALE-8404: Disable edit form When no reCAPTCHA keys are provided

### DIFF
--- a/app/views/sites/spam_protections/edit.html.erb
+++ b/app/views/sites/spam_protections/edit.html.erb
@@ -11,7 +11,7 @@
                 hint: t(".captcha_hint_#{Recaptcha.captcha_configured?.to_s}"),
                 :as => :radio,
                 :collection => ThreeScale::BotProtection::LEVELS,
-                disabled: !Recaptcha.captcha_configured?  %>
+                input_html: { disabled: !Recaptcha.captcha_configured? } %>
     <% end %>
 
   <%= form.actions do %>


### PR DESCRIPTION
**What this PR does / why we need it**:

When no reCAPTCHA keys are provided, the Bot protection edit form should be disabled.

**Which issue(s) this PR fixes** 

[THREESCALE-10579](https://issues.redhat.com/browse/THREESCALE-10579)

**Verification steps** 

Don't configure any reCAPTCHA key and visit `/site/spam_protection/edit`:

**Before:**
![image](https://github.com/3scale/porta/assets/17052241/c4c28721-c8af-461a-8d0e-5c2098c10b20)

**After:**
![image](https://github.com/3scale/porta/assets/17052241/dae5ed87-4b6a-471b-9779-bec6f078e003)

