### PR TITLE
[THREESCALE-10375] manticore support

### DIFF
--- a/config/initializers/sphinx.rb
+++ b/config/initializers/sphinx.rb
@@ -8,3 +8,15 @@ ThinkingSphinx::Configuration::MinimumFields.prepend(Module.new do
     super.reject(&method(:inheritance_columns?))
   end
 end)
+
+# workaround unresolved issue with manticore total_pages
+# fixes SearchPresentersTest#test_pagination
+# see https://github.com/pat/thinking-sphinx/pull/1213
+ThinkingSphinx::Masks::PaginationMask.prepend(Module.new do
+  def total_pages
+    return 0 unless search.meta['total_found']
+
+    # 1000 is the default server max_matches value. We should stay at or below the server setting here.
+    @total_pages ||= ([total_entries, 1000].min / search.per_page.to_f).ceil
+  end
+end)

--- a/test/workers/sphinx_account_indexation_worker_test.rb
+++ b/test/workers/sphinx_account_indexation_worker_test.rb
@@ -38,7 +38,7 @@ class SphinxAccountIndexationWorkerTest < ActiveSupport::TestCase
         buyers = []
         providers.each { |provider| buyers << FactoryBot.create(:simple_buyer, provider_account: provider) }
 
-        assert_equal (providers + buyers).map(&:id), indexed_ids(Account).to_a
+        assert_equal (providers + buyers).map(&:id).to_set, indexed_ids(Account).to_set
 
         providers.first.schedule_for_deletion
         providers.first.save!


### PR DESCRIPTION
The purpose of this is to support manticore which doesn't have compatible
behavior for the `found` query metadata.

The pagination in sphinx should work ideally with `found`:
https://sphinxsearch.com/blog/2014/03/28/basics-of-paginating-results/

Since that is not available (see https://github.com/pat/thinking-sphinx/pull/1213 and https://github.com/manticoresoftware/manticoresearch/issues/912) we
monkey patch the method as well limit max results we return to 1000.

That should be plenty for our use cases. And should thus work with both - sphinx and manticore.