### PR TITLE
Fix Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,17 +30,17 @@ GIT
 
 GIT
   remote: https://github.com/3scale/swagger-ui_rails.git
-  revision: 13968af8f2845f448a0b88c4ffe4cf93477c90fa
-  branch: dev
-  specs:
-    swagger-ui_rails (0.1.7)
-
-GIT
-  remote: https://github.com/3scale/swagger-ui_rails.git
   revision: f88bb8bed4fdb57fcf5be6425f3fc10c638788d1
   branch: dev-2.1.3
   specs:
     swagger-ui_rails2 (0.1.7)
+
+GIT
+  remote: https://github.com/3scale/swagger-ui_rails.git
+  revision: 13968af8f2845f448a0b88c4ffe4cf93477c90fa
+  branch: dev
+  specs:
+    swagger-ui_rails (0.1.7)
 
 GIT
   remote: https://github.com/prawnpdf/prawn-table.git


### PR DESCRIPTION
Fix the annoying `Gemfile.lock` being updated everytime we run `bundle install`.

It was caused by https://github.com/3scale/porta/pull/3667/files
