### PR TITLE
THREESCALE-10725: Move metrics from /yabeda-metrics to /metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,8 +56,6 @@ gem 'sidekiq-batch'
 gem 'sidekiq-cron', require: %w[sidekiq/cron sidekiq/cron/web]
 gem 'sidekiq-throttled'
 
-gem 'sidekiq-prometheus-exporter'
-
 # Yabeda metrics
 gem 'yabeda-prometheus-mmap'
 gem 'yabeda-sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -758,9 +758,6 @@ GEM
     sidekiq-cron (1.9.1)
       fugit (~> 1.8)
       sidekiq (>= 4.2.1)
-    sidekiq-prometheus-exporter (0.2.0)
-      rack (>= 1.6.0)
-      sidekiq (>= 4.1.0)
     sidekiq-throttled (0.15.0)
       concurrent-ruby
       redis-prescription
@@ -1039,7 +1036,6 @@ DEPENDENCIES
   sidekiq (~> 6.4.0)
   sidekiq-batch
   sidekiq-cron
-  sidekiq-prometheus-exporter
   sidekiq-throttled
   simplecov (~> 0.21.2)
   slim-rails (~> 3.2)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,9 @@ require 'prometheus_exporter_port'
 Rails.application.routes.draw do
 
   constraints PortConstraint.new(PrometheusExporterPort.call) do
-    require 'sidekiq/prometheus/exporter'
     require 'yabeda/prometheus/mmap'
 
-    mount Sidekiq::Prometheus::Exporter, at: '/metrics'
-    # DEPRECATED: this endpoint will be removed in future versions and Yabeda metrics will be at `/metrics`
-    mount Yabeda::Prometheus::Exporter, at: '/yabeda-metrics'
+    mount Yabeda::Prometheus::Exporter, at: '/metrics'
     mount ::System::Deploy, at: 'deploy'
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Move metrics from /yabeda-metrics to /metrics, and drop sidekiq-prometheus-exporter ones.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10725

**Verification steps** 

Call `http://localhost:9394/metrics` for rails server, it should show all the Rails-related metrics:
```
# HELP rails_request_duration_seconds Multiprocess metric
# TYPE rails_request_duration_seconds histogram
rails_request_duration_seconds_bucket{controller="buyers/accounts",le="+Inf"} 1
...
# HELP rails_requests_total Multiprocess metric
# TYPE rails_requests_total counter
rails_requests_total{controller="buyers/accounts",status="2xx"} 1
rails_requests_total{controller="finance/provider/dashboards",status="2xx"} 1
rails_requests_total{controller="provider/admin/applications",status="2xx"} 2
rails_requests_total{controller="provider/admin/messages/inbox",status="2xx"} 2
rails_requests_total{controller="stats/api/applications",status="2xx"} 12
```

Call `http://localhost:{port}/metrics` for Sidekiq (whatever port you specify in `PROMETHEUS_EXPORTER_PORT`), it should show the Sidekiq metrics (by https://github.com/yabeda-rb/yabeda-sidekiq/tree/master)

Calling `/yabeda-metrics` should now return 404.

The metrics that were previously available at `/metrics`, provided by https://github.com/Strech/sidekiq-prometheus-exporter are not available anymore.


**Special notes for your reviewer**:
