### PR TITLE
fixup browser logs

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -119,16 +119,21 @@ After do |scenario| # rubocop:disable Metrics/BlockLength
 
   # Network logs
   if page.driver.browser.respond_to?(:manage)
-    logs = page.driver.browser.manage.logs.get(:performance)
-    array = logs.each_with_object([]) do |entry, messages|
-      message = JSON.parse(entry.message)
-      # next unless message.dig('message', 'params', 'documentURL').to_s.end_with? '/p/login'
-      messages << message
-    end
+    # performance logs may fail if this logging type is not configured or not supported by driver
+    if page.driver.browser.manage.logs.available_types.include? :performance
+      logs = page.driver.browser.manage.logs.get(:performance)
+      array = logs.each_with_object([]) do |entry, messages|
+        message = JSON.parse(entry.message)
+        # next unless message.dig('message', 'params', 'documentURL').to_s.end_with? '/p/login'
+        messages << message
+      end
 
-    file = folder.join("#{line_number}-network.json")
-    file.open('w') do  |f|
-      f.puts JSON.dump(array)
+      file = folder.join("#{line_number}-network.json")
+      file.open('w') do |f|
+        f.puts JSON.dump(array)
+      end
+    else
+      warn "Browser driver not configured to collect performance logs."
     end
 
 
@@ -216,7 +221,7 @@ print_banner = ->(title, step) do
     | #{title}: #{step_name.bold} |
     | #{'=' * (step_name.length + title.length + 2)} |
     #{step.multiline_arg}
-NEXT
+  NEXT
 end
 
 Before do |scenario|


### PR DESCRIPTION
I've hit a problem that the `chrome` driver didn't have this enabled in local runs. So on failure there is an error from this code that hides the actual test error. I think it is not necessary to collect performance metrics in the local browser so rather I made this collection optional.

FIY for `headless_chrome` perf logs are enabled here:
https://github.com/3scale/porta/blob/bd54e7485e144e4b0a933f75b51e2463573cb746/features/support/capybara.rb#L108-L110