### PR TITLE
Fix a TypeScript error in QuickStarts catalog

### DIFF
--- a/app/javascript/src/QuickStarts/components/CustomCatalog.tsx
+++ b/app/javascript/src/QuickStarts/components/CustomCatalog.tsx
@@ -62,7 +62,7 @@ export const CustomCatalog: React.FC = () => {
                     <QuickStartTile
                       isActive={id === activeQuickStartID}
                       quickStart={quickStart}
-                      status={getQuickStartStatus(allQuickStartStates!, id)}
+                      status={getQuickStartStatus(allQuickStartStates!, id!)}
                     />
                   </GalleryItem>
                 )


### PR DESCRIPTION
**What this PR does / why we need it**:

`assets:precompile` was throwing the following error:

```
ERROR in /home/dmayorov/Projects/3scale/porta/app/javascript/src/QuickStarts/components/CustomCatalog.tsx
[tsl] ERROR in /home/dmayorov/Projects/3scale/porta/app/javascript/src/QuickStarts/components/CustomCatalog.tsx(65,73)
      TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
```

**Which issue(s) this PR fixes** 

-

**Verification steps** 

-

**Special notes for your reviewer**:

-