### PR TITLE
THREESCALE-10797: Enable SSO logout when SSO is enforced

### DIFF
--- a/app/controllers/provider/sessions_controller.rb
+++ b/app/controllers/provider/sessions_controller.rb
@@ -8,7 +8,6 @@ class Provider::SessionsController < FrontendController
   before_action :find_provider
   before_action :instantiate_sessions_presenter, only: [:new, :create]
   before_action :redirect_if_logged_in, only: %i[new]
-  before_action :redirect_to_enforced_sso, only: %i[new]
 
   def new
     @session = Session.new
@@ -106,10 +105,5 @@ class Provider::SessionsController < FrontendController
 
   def instantiate_sessions_presenter
     @presenter = Provider::SessionsPresenter.new(domain_account)
-  end
-
-  def redirect_to_enforced_sso
-    return if !domain_account.settings.enforce_sso? || published_authentication_providers.count != 1
-    redirect_to authorization_provider_bounce_path(published_authentication_providers.first.system_name)
   end
 end

--- a/app/views/provider/sessions/logged_out.html.erb
+++ b/app/views/provider/sessions/logged_out.html.erb
@@ -1,3 +1,0 @@
-<p>You've successfully logged out.</p>
-
-<p><%= link_to 'Go to the homepage', root_path %></p>

--- a/test/integration/provider/sessions_controller_test.rb
+++ b/test/integration/provider/sessions_controller_test.rb
@@ -41,7 +41,7 @@ class Provider::SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to "http://example.net/?provider_id=#{account.id}&user_id=#{account.admin_user.id}"
   end
 
-  test "does not redirect users to SSO" do
+  test "does not redirect users to SSO even with enforce_sso and single provider" do
     @provider.settings.update_column(:enforce_sso, true)
     get new_provider_sessions_path
     assert_response :success

--- a/test/integration/provider/sessions_controller_test.rb
+++ b/test/integration/provider/sessions_controller_test.rb
@@ -41,22 +41,8 @@ class Provider::SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to "http://example.net/?provider_id=#{account.id}&user_id=#{account.admin_user.id}"
   end
 
-  test "redirect users to SSO when there's only one authentication provider and enforce_sso is on" do
+  test "does not redirect users to SSO" do
     @provider.settings.update_column(:enforce_sso, true)
-    get new_provider_sessions_path
-    assert_redirected_to authorization_provider_bounce_path(authentication_provider.system_name)
-  end
-
-  test "redirect users to SSO when there's more than one authentication provider but only one is published " do
-    @provider.settings.update_column(:enforce_sso, true)
-    FactoryBot.create(:self_authentication_provider, account: @provider)
-    get new_provider_sessions_path
-    assert_redirected_to authorization_provider_bounce_path(authentication_provider.system_name)
-  end
-
-  test "does not redirect when there's more than one authentication provider" do
-    @provider.settings.update_column(:enforce_sso, true)
-    FactoryBot.create(:self_authentication_provider, account: @provider, published: true)
     get new_provider_sessions_path
     assert_response :success
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we decided that users shouldn't be able to logout when there's SSO is enforced and there's only one SSO provider published.

See the Jira issue: https://issues.redhat.com/browse/THREESCALE-2795
And the PR: https://github.com/3scale/porta/pull/2155

Note the second scenario in the PR: `when only one SSO integration is configured and enforced`

However, **THREESCALE-2983** complains about this behavior. This PR ensures the user can't skip the login screen even when there's only one published provider and one active session on that provider.

**Which issue(s) this PR fixes** 

[THREESCALE-10797](https://issues.redhat.com/browse/THREESCALE-10797)

**Verification steps** 

1. Configure the admin portal to enable an RH SSO integration
   **Account settings -> Users -> SSO Integrations**. Ask me for credentials.
2. Log out.
3. Instead of returning to the dashboard, you should see the login screen.

**Screencast**:

[Screencast from 2024-02-19 12-16-52.webm](https://github.com/3scale/porta/assets/17052241/e89f9b1c-befd-40eb-871c-f732ef725d45)

