### PR TITLE
Fixed Updating customer billing address now correctly reflected to stripe

### DIFF
--- a/app/controllers/provider/admin/account/payment_gateways/braintree_blue_controller.rb
+++ b/app/controllers/provider/admin/account/payment_gateways/braintree_blue_controller.rb
@@ -25,7 +25,6 @@ class Provider::Admin::Account::PaymentGateways::BraintreeBlueController < Provi
   end
 
   def update
-    current_account.updating_payment_detail = true
     if current_account.update params.permit(:account)[:account]
       redirect_to provider_admin_account_braintree_blue_url, notice: 'Credit card details were successfully stored.'
     else

--- a/app/models/account/credit_card.rb
+++ b/app/models/account/credit_card.rb
@@ -5,10 +5,6 @@ module Account::CreditCard # rubocop:disable Metrics/ModuleLength(RuboCop)
   extend ActiveSupport::Concern
 
   included do
-    attr_accessor :updating_payment_detail
-
-    validates :payment_detail_conditions, acceptance: { :if => :should_validate_payment_detail_conditions? }
-
     before_destroy :unstore_credit_card!
 
     scope :expired_credit_card, ->(time) {
@@ -20,10 +16,6 @@ module Account::CreditCard # rubocop:disable Metrics/ModuleLength(RuboCop)
     }
 
     after_commit :notify_credit_card_change
-  end
-
-  def should_validate_payment_detail_conditions?
-    updating_payment_detail and !new_record?
   end
 
   def credit_card

--- a/features/step_definitions/developer_portal/admin/account/payment_details_steps.rb
+++ b/features/step_definitions/developer_portal/admin/account/payment_details_steps.rb
@@ -102,7 +102,7 @@ Then "the buyer can't add an incomplete billing address for stripe" do
   click_on 'Save'
 
   assert_flash 'Failed to update your billing address data. Check the required fields'
-  assert_equal admin_account_payment_details_path, current_path
+  assert_equal admin_account_stripe_path, current_path
   assert_buyer_stripe_form_errors
 end
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/payment_details_base_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/payment_details_base_controller.rb
@@ -75,7 +75,6 @@ class DeveloperPortal::Admin::Account::PaymentDetailsBaseController < DeveloperP
   end
 
   def update_billing_address
-    current_account.updating_payment_detail = true
     current_account.transaction do
       raise ActiveRecord::Rollback unless current_account.update(account_params) && update_address_on_payment_gateway
 
@@ -83,6 +82,7 @@ class DeveloperPortal::Admin::Account::PaymentDetailsBaseController < DeveloperP
     end
   end
 
+  # To be overridden by specific gateway controllers
   def update_address_on_payment_gateway
     true
   end

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/stripe_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/stripe_controller.rb
@@ -11,7 +11,7 @@ module DeveloperPortal::Admin::Account
 
     def hosted_success
       payment_method_id = params.require(:stripe).require(:payment_method_id)
-      @payment_result = stripe_crypt.update!(payment_method_id)
+      @payment_result = stripe_crypt.update_payment_detail(payment_method_id)
 
       if @payment_result
         flash[:success] = 'Credit card details were saved correctly'
@@ -25,6 +25,11 @@ module DeveloperPortal::Admin::Account
 
     def stripe_crypt
       @stripe_crypt ||= ::PaymentGateways::StripeCrypt.new(current_user)
+    end
+
+    def update_address_on_payment_gateway
+      billing_address = account_params['billing_address']
+      stripe_crypt.update_billing_address(billing_address.to_h)
     end
   end
 end

--- a/lib/developer_portal/config/routes.rb
+++ b/lib/developer_portal/config/routes.rb
@@ -45,8 +45,8 @@ DeveloperPortal::Engine.routes.draw do
         end
       end
 
-      resource :authorize_net, :braintree_blue, :stripe, only: [:show, :edit] do
-        match 'hosted_success', via: [:get, :post], on: :member
+      resource :authorize_net, :braintree_blue, :stripe, only: %i[show edit update] do
+        match 'hosted_success', via: %i[get post], on: :member
       end
 
       resources :users, :only => [:index, :edit, :update, :destroy]

--- a/lib/developer_portal/lib/liquid/forms/account.rb
+++ b/lib/developer_portal/lib/liquid/forms/account.rb
@@ -8,7 +8,13 @@ module Liquid
         end
 
         def path
-          admin_account_payment_details_path
+          polymorphic_path([:admin, :account, payment_gateway_type])
+        end
+
+        private
+
+        def payment_gateway_type
+          @payment_gateway_type ||= context.registers[:site_account].payment_gateway_type
         end
       end
 

--- a/test/integration/developer_portal/admin/account/stripe_controller_test.rb
+++ b/test/integration/developer_portal/admin/account/stripe_controller_test.rb
@@ -34,11 +34,71 @@ module DeveloperPortal
     test '#hosted_success' do
       payment_method_id = 'pm_fake_payment_method_id'
 
-      PaymentGateways::StripeCrypt.any_instance.expects(:update!).with(payment_method_id).returns(true)
+      PaymentGateways::StripeCrypt.any_instance.expects(:update_payment_detail).with(payment_method_id).returns(true)
 
       post hosted_success_admin_account_stripe_path, params: {stripe: {payment_method_id: payment_method_id}}
 
       assert_equal 'Credit card details were saved correctly', flash[:success]
+    end
+
+    test '#update updates billing address successfully' do
+      billing_address = {
+        name: 'Some Name',
+        address1: 'Some Address 1',
+        address2: 'Some Address 2',
+        city: 'Some City',
+        country: 'US',
+        state: 'Some State',
+        zip: '123456'
+      }
+      account_params = { account: { billing_address: billing_address } }
+      billing_address_params = ::ActionController::Parameters.new(billing_address).permit!
+
+      PaymentGateways::StripeCrypt.any_instance.expects(:update_billing_address).with(billing_address_params).returns(true)
+
+      put admin_account_stripe_path, params: account_params
+
+      assert_redirected_to admin_account_stripe_url
+      expected_address = ::Account::BillingAddress::Address.new(billing_address)
+      assert_equal expected_address.to_s, buyer.reload.billing_address.to_s
+    end
+
+    test '#update shows an error if billing address is not updated on Stripe' do
+      original_address = buyer.billing_address.to_s
+      billing_address = {
+        name: 'Some Name',
+        address1: 'Some Address 1',
+        address2: 'Some Address 2',
+        city: 'Some City',
+        country: 'US',
+        state: 'Some State',
+        zip: '123456'
+      }
+      account_params = { account: { billing_address: billing_address } }
+
+      PaymentGateways::StripeCrypt.any_instance.expects(:update_billing_address).with(billing_address.stringify_keys).returns(false).at_least_once
+
+      put admin_account_stripe_path, params: account_params
+
+      assert_match 'Failed to update your billing address data. Check the required fields', flash[:notice]
+      assert_template 'accounts/payment_gateways/edit'
+      assert_equal original_address, buyer.reload.billing_address.to_s
+    end
+
+    test '#update shows an error if billing address is not updated on account model' do
+      original_address = buyer.billing_address.to_s
+      billing_address = {
+        address1: "A" * 256
+      }
+      account_params = { account: { billing_address: billing_address } }
+
+      PaymentGateways::StripeCrypt.any_instance.expects(:update_billing_address).with(billing_address.stringify_keys).never
+
+      put admin_account_stripe_path, params: account_params
+
+      assert_match 'Failed to update your billing address data. Check the required fields', flash[:notice]
+      assert_template 'accounts/payment_gateways/edit'
+      assert_equal original_address, buyer.reload.billing_address.to_s
     end
   end
 end

--- a/test/unit/account/credit_card_test.rb
+++ b/test/unit/account/credit_card_test.rb
@@ -85,18 +85,6 @@ class Account::CreditCardTest < ActiveSupport::TestCase
     refute master_account.credit_card_editable?
   end
 
-  test "only validates payment_detail_conditions when updating payment detail" do
-    account = Account.new(:org_name => 'ACME', :payment_detail_conditions => false)
-    assert account.save!, "Account should save when account is new"
-
-    account = Account.create!(:org_name => 'ACME')
-    assert account.update(:org_name => 'New ACME', :payment_detail_conditions => false), "Account should update when not updating credit card details"
-
-    account = Account.create!(:org_name => 'ACME')
-    account.updating_payment_detail = true
-    assert !account.update(:org_name => 'New ACME', :payment_detail_conditions => false), "Account shouldn't update when updating credit card details without accepting conditions"
-  end
-
   test '#credit_card_exires_on_with_default' do
     travel_to(Time.utc(2017,8,30)) do
       account = FactoryBot.create(:simple_provider)

--- a/test/unit/lib/payment_gateways/stripe_crypt_test.rb
+++ b/test/unit/lib/payment_gateways/stripe_crypt_test.rb
@@ -52,7 +52,7 @@ module PaymentGateways
       assert stripe_crypt.create_stripe_setup_intent
     end
 
-    test 'update!' do
+    test 'update_payment_detail' do
       payment_method_id = 'pm_1I5s3n2eZvKYlo2CiO193T69'
 
       card_data = {exp_month: 8, exp_year: 1.year.from_now.year, last4: '4242'}
@@ -60,7 +60,7 @@ module PaymentGateways
       payment_method = Stripe::PaymentMethod.new(id: payment_method_id).tap { |pm| pm.update_attributes(payment_method_data) }
       Stripe::PaymentMethod.expects(:retrieve).with(payment_method_id, api_key).returns(payment_method)
 
-      assert stripe_crypt.update!(payment_method_id)
+      assert stripe_crypt.update_payment_detail(payment_method_id)
 
       payment_detail = buyer_account.payment_detail
       assert_equal(Date.new(card_data[:exp_year], card_data[:exp_month]), payment_detail.credit_card_expires_on)
@@ -78,6 +78,48 @@ module PaymentGateways
       Stripe::Customer.expects(:create).with(create_customer_params, api_key).returns(mock_customer(id: 'new-created-customer-id'))
 
       assert_equal 'new-created-customer-id', stripe_crypt.customer.id
+    end
+
+    test '#update_billing_address - successful' do
+      payment_method_id = 'pm_1I5s3n2eZvKYlo2CiO193T69'
+      payment_method = Stripe::PaymentMethod.new(id: payment_method_id)
+      stripe_crypt.payment_detail.update(payment_method_id: payment_method_id)
+
+      Stripe::PaymentMethod.expects(:retrieve).at_least_once.with(payment_method_id, api_key).returns(payment_method)
+      payment_method.expects(:save).returns(payment_method)
+
+      billing_address = {
+        name: 'some name',
+        address1: 'some address 1',
+        address2: 'some address 2',
+        city: 'some city',
+        state: 'some state',
+        zip: '1234',
+        country: 'US'
+      }
+
+      expected_values = billing_address.values_at(:address1, :address2, :city, :state, :zip, :country)
+
+      assert stripe_crypt.update_billing_address(billing_address)
+      assert_equal expected_values, payment_method.billing_details["address"].to_h.values_at(:line1, :line2, :city, :state, :postal_code, :country)
+    end
+
+    test '#update_billing_address - no payment_method_id' do
+      assert_nil buyer_account.payment_detail.payment_method_id
+
+      Stripe::PaymentMethod.expects(:retrieve).never
+      Stripe::PaymentMethod.any_instance.expects(:save).never
+
+      assert stripe_crypt.update_billing_address({ address1: 'something' })
+    end
+
+    test '#update_billing_address - Stripe error' do
+      payment_method_id = 'pm_1I5s3n2eZvKYlo2CiO193T69'
+      stripe_crypt.payment_detail.update(payment_method_id: payment_method_id)
+      Stripe::PaymentMethod.expects(:retrieve).with(payment_method_id, api_key).raises(Stripe::StripeError, 'some error')
+
+      assert_not stripe_crypt.update_billing_address({ address1: 'something' })
+      assert_equal ['Failed to update billing address on Stripe: some error'], stripe_crypt.errors[:base]
     end
 
     def api_key

--- a/test/unit/liquid/forms_test.rb
+++ b/test/unit/liquid/forms_test.rb
@@ -88,6 +88,24 @@ class Liquid::FormsTest < ActiveSupport::TestCase
     assert_match '/buyer/account_contract', content
   end
 
+  test 'account.billing_address form' do
+    account = FactoryBot.create(:account, payment_gateway_type: :stripe)
+    registers = {
+      site_account: account,
+      controller: controller
+    }
+    context = Liquid::Context.new({}, {}, registers)
+
+    form = Liquid::Forms.find_class_by_name('account.billing_address').new(context, 'object', {})
+
+    assert_equal '/admin/account/stripe', form.path
+
+    account.update(payment_gateway_type: :authorize_net)
+    form = Liquid::Forms.find_class_by_name('account.billing_address').new(context, 'object', {})
+
+    assert_equal '/admin/account/authorize_net', form.path
+  end
+
   private
 
   def get(form, name = 'object', html_attributes={})


### PR DESCRIPTION
**What this PR does / why we need it**:

Changing customer billing address, in the developer portal, is updated to Stripe only when credit card details are changed. Just editing and saving billing address details creates problems, when customer details are not consistent between 3scale and Stripe. This can be forcefully fixed, when the customer updates their credit card information as well. 

Expected behavior:

Editing just billing address details should update customer details on Stripe.

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/THREESCALE-9532

**Verification steps** 
Mentioned in jira with snapshots

