### PR TITLE
sphinx index only published cms pages

### DIFF
--- a/app/indices/cms_page_index.rb
+++ b/app/indices/cms_page_index.rb
@@ -8,5 +8,5 @@ ThinkingSphinx::Index.define('cms/page'.to_sym, with: :real_time) do
   has tenant_id, type: :bigint
 
   indexes :published
-  scope { CMS::Page.where(searchable: true) }
+  scope { CMS::Page.where(searchable: true).where.not(published: nil) }
 end

--- a/app/presenters/search_presenters.rb
+++ b/app/presenters/search_presenters.rb
@@ -124,7 +124,7 @@ module SearchPresenters
     end
 
     def options
-      super.merge(:classes => [CMS::Page])
+      super.merge(classes: [CMS::Page])
     end
 
     def search

--- a/app/presenters/search_presenters.rb
+++ b/app/presenters/search_presenters.rb
@@ -124,10 +124,12 @@ module SearchPresenters
     end
 
     def options
-      super.merge(:classes => [Topic, CMS::Page])
+      super.merge(:classes => [CMS::Page])
     end
 
     def search
+      return @search if @search
+
       super
 
       # We do not want to display pages not accessible by the user

--- a/app/workers/sphinx_account_indexation_worker.rb
+++ b/app/workers/sphinx_account_indexation_worker.rb
@@ -18,4 +18,16 @@ class SphinxAccountIndexationWorker < SphinxIndexationWorker
       delete_from_index(Account, id, *buyers)
     end
   end
+
+  protected
+
+  def reindex(instance)
+    ThinkingSphinx::Processor.new(instance: instance).upsert
+  end
+
+  def delete_from_index(model, *ids)
+    ids.each do |id|
+      ThinkingSphinx::Processor.new(model: model, id: id).delete
+    end
+  end
 end

--- a/app/workers/sphinx_indexation_worker.rb
+++ b/app/workers/sphinx_indexation_worker.rb
@@ -19,24 +19,6 @@ class SphinxIndexationWorker < ApplicationJob
   end
 
   def perform(model, id)
-    instance = model.find_by(model.primary_key => id)
-
-    if instance
-      reindex(instance)
-    else
-      delete_from_index(model, id)
-    end
-  end
-
-  protected
-
-  def reindex(instance)
-    ThinkingSphinx::Processor.new(instance: instance).upsert
-  end
-
-  def delete_from_index(model, *ids)
-    ids.each do |id|
-      ThinkingSphinx::Processor.new(model: model, id: id).delete
-    end
+    ThinkingSphinx::Processor.new(model: model, id: id).stage
   end
 end

--- a/test/factories/cms.rb
+++ b/test/factories/cms.rb
@@ -51,13 +51,15 @@ FactoryBot.define do
   end
 
   factory(:cms_page, :parent => :cms_template, :class => CMS::Page) do
-    # association is copied to child factory because we reference provider
-    # and it is not yet created, but copying association to this factory fixes it
-    association :provider, :factory => :provider_account
     sequence(:title) { |n| "page-#{n}" }
     sequence(:path) { |n| "/page-#{n}" }
     content_type { 'text/html' }
+    draft { "Some random draft page text. Guaranteed random, I promise!" }
     section { |p| p.provider && p.provider.builtin_sections.root }
+  end
+
+  factory(:cms_published_page, :parent => :cms_page, :class => CMS::Page) do
+    published { "Some random published page text. Guaranteed random, I promise!" }
   end
 
   factory(:cms_builtin_page, :parent => :cms_template, :class => CMS::Builtin::Page) do

--- a/test/unit/indices/indexing_test.rb
+++ b/test/unit/indices/indexing_test.rb
@@ -89,6 +89,7 @@ class IndexingTest < ActiveSupport::TestCase
   def factory_for(model)
     overrides = {
       account: :simple_provider,
+      cms_page: :cms_published_page,
     }
 
     factory = model.name.gsub(/:+/, "_").underscore.to_sym

--- a/test/unit/tasks/searchd_tasks_test.rb
+++ b/test/unit/tasks/searchd_tasks_test.rb
@@ -29,6 +29,7 @@ class SearchdTasksTest < ActiveSupport::TestCase
     overrides = {
       account: :simple_provider,
       plan: :application_plan,
+      cms_page: :cms_published_page,
     }
 
     factory = model.name.gsub(/:+/, "_").underscore.to_sym


### PR DESCRIPTION
We filter out unpublished pages in `SearchPresenter` anyway. So better not index them to begin with.

Also don't index anything out of sphinx/manticore index scope globally.