### PR TITLE
Add support for slash for application IDs and keys

### DIFF
--- a/app/models/application_key.rb
+++ b/app/models/application_key.rb
@@ -12,9 +12,9 @@ class ApplicationKey < ApplicationRecord
   validates :application, presence: true
 
   # The following characters are accepted:
-  # A-Z a-z 0-9 ! " # $ % & ' ( ) * + , - . : ; < = > ? @ [ \ ] ^ _ ` { | } ~
-  # Spaces and / are not allowed
-  validates :value, format: { with: /\A[\x21-\x2E\x30-\x7E]+\Z/ },
+  # A-Z a-z 0-9 ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~
+  # Spaces are not allowed
+  validates :value, format: { with: /\A[\x21-\x7E]+\Z/ },
                     length: { within: 5..255 },
                     uniqueness: { scope: :application_id, case_sensitive: false }
 

--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -120,9 +120,9 @@ class Cinstance < Contract
   USER_KEY_FORMAT = /(([\w\-.]+)|([A-Za-z0-9+]{4})*([A-Za-z0-9+]{4}|[A-Za-z0-9+]{3}=|[A-Za-z0-9+]{2}==))/.freeze
 
   # The following characters are accepted:
-  # A-Z a-z 0-9 ! " # $ % & ' ( ) * + , - . : ; < = > ? @ [ \ ] ^ _ ` { | } ~
-  # Spaces and / are not allowed
-  validates :application_id, format: { with: /\A[\x21-\x2E\x30-\x7E]+\Z/ }, length: { in: 4..255 }
+  # A-Z a-z 0-9 ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~
+  # Spaces are not allowed
+  validates :application_id, format: { with: /\A[\x21-\x7E]+\Z/ }, length: { in: 4..255 }
 
   validates :user_key, format: { with: /\A#{USER_KEY_FORMAT}\Z/ }, length: { maximum: 256 }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1431,7 +1431,7 @@ en:
       cinstance:
         intentions: "Please describe briefly your intentions of use of this service"
         user_key: "Allowed characters: [A-Z a-z 0-9 - _ .], or Base64 format without forward slash (/), no spaces and up to 256 characters."
-        key: "Allowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . : ; < = > ? @ [ \ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
+        key: "Allowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
 
       cms:
         page:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -287,7 +287,7 @@ without fake Core server your after commit callbacks will crash and you might ge
       end
 
       scope 'applications/:application_id', :as => :application do
-        resources :keys, constraints: { id: %r{[^/]+} }, only: %i[new create edit update destroy] do
+        resources :keys, constraints: { id: /.+/ }, only: %i[new create edit update destroy] do
           member do
             put :regenerate
           end

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -902,7 +902,7 @@
                   },
                   "key": {
                     "type": "string",
-                    "description": "app_key to be added.\n\nAllowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
+                    "description": "app_key to be added.\n\nAllowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
                   }
                 },
                 "required": [
@@ -9752,10 +9752,10 @@
           },
           "application_id": {
             "type": "string",
-            "description": "App ID or Client ID (for OAuth and OpenID Connect authentication modes) of the application to be created.\n\nAllowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
+            "description": "App ID or Client ID (for OAuth and OpenID Connect authentication modes) of the application to be created.\n\nAllowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
           },
           "application_key": {
-            "description": "App Key or Client Secret (for OAuth and OpenID Connect authentication modes) of the application to be created.\n\nAllowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters.",
+            "description": "App Key or Client Secret (for OAuth and OpenID Connect authentication modes) of the application to be created.\n\nAllowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters.",
             "type": "string"
           },
           "redirect_url": {

--- a/test/unit/application_keys_test.rb
+++ b/test/unit/application_keys_test.rb
@@ -192,21 +192,19 @@ class ApplicationKeysTest < ActiveSupport::TestCase
   end
 
   test 'value can include special characters as defined in the RFC 6749' do
-    # generate random key with all chars of RFC 6749 except / and spaces
-    random_key = -> { [*"\x21".."\x2E", *"\x30".."\x7E"].shuffle.join }
+    # generate random key with all chars of RFC 6749 except space
+    random_key = -> { [*"\x21".."\x7E"].shuffle.join }
     app_key = FactoryBot.build(:application_key, value: (value = random_key.call))
 
     assert app_key.save
     assert value, app_key.reload.value
   end
 
-  test 'value cannot include slash or spaces' do
-    ['app_id with space', 'app_id-with-/-slash'].each do |key|
-      app_key = FactoryBot.build(:application_key, value: key)
+  test 'value cannot include spaces' do
+    app_key = FactoryBot.build(:application_key, value: 'app key with space')
 
-      assert app_key.invalid?
-      assert app_key.errors[:value].present?
-    end
+    assert app_key.invalid?
+    assert app_key.errors[:value].present?
   end
 
   test 'is audited' do

--- a/test/unit/cinstance_test.rb
+++ b/test/unit/cinstance_test.rb
@@ -599,23 +599,18 @@ class CinstanceTest < ActiveSupport::TestCase
   end
 
   test 'App ID can include special characters as defined in the RFC 6749' do
-    # generate random key with all chars of RFC 6749 except / and spaces
-    random_key = -> { [*"\x21".."\x2E", *"\x30".."\x7E"].shuffle.join }
+    # generate random key with all chars of RFC 6749 except space
+    random_key = -> { [*"\x21".."\x7E"].shuffle.join }
     cinstance = FactoryBot.build(:cinstance, application_id: (app_id = random_key.call))
 
     assert cinstance.save
     assert app_id, cinstance.reload.application_id
   end
 
-  test 'App ID cannot include slash or spaces' do
-    cinstance = FactoryBot.build(:cinstance)
-
-    ['app_id with space', 'app_id-with-/-slash'].each do |key|
-      cinstance.application_id = key
-
-      assert cinstance.invalid?
-      assert cinstance.errors[:application_id].present?
-    end
+  test 'App ID cannot include spaces' do
+    cinstance = FactoryBot.build(:cinstance, application_id: 'app_id with space')
+    assert cinstance.invalid?
+    assert cinstance.errors[:application_id].present?
   end
 
   test 'App ID length is validated to be between 4 and 255 characters' do


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support to `/` and `\` (the latter was previously in the list of allowed characters, but in fact was not working, see [this JIRA comment](https://issues.redhat.com/browse/THREESCALE-9033?focusedId=24165695&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24165695))

This would only work however with apisonator that has this feature: https://github.com/3scale/apisonator/pull/366

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-9033

**Verification steps** 

**Special notes for your reviewer**:

**NOTE:** In theory, according to [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749/#appendix-A) we are supposed to support the whole `x20-7E` range, but we excluded spaces previously. But now I'm not sure that's the right thing to do. On one hand, spaces are error-prone, especially if they are leading or trailing (they would not be visible to the user). On the other hand, if we ensure spaces are properly encoded, they should work OK, as any other character (except we are currently having an issue in apicast with special characters encoding, see JIRA 10762)
