### PR TITLE
Upgrade psych to fix issues with serializing values with trailing underscore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ gem "activejob-uniqueness"
 # Needed for XML serialization of ActiveRecord::Base
 gem 'activemodel-serializers-xml'
 
+# Fixing https://github.com/ruby/psych/pull/438, remove after upgrading Ruby
+gem 'psych', '~> 3.2.0'
+
 gem 'protected_attributes_continued', '~> 1.8.2'
 
 gem 'rails-observers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -560,6 +560,7 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
+    psych (3.2.1)
     public_suffix (4.0.7)
     raabro (1.4.0)
     racc (1.7.3)
@@ -999,6 +1000,7 @@ DEPENDENCIES
   pry-rails
   pry-shell
   pry-stack_explorer
+  psych (~> 3.2.0)
   rack (~> 2.2.8)
   rack-cors
   rack-no_animations (~> 1.0.3)


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrades `psych` gem - it's normally provided together with Ruby, but as we are using an older version (2.7), we are just upgrading this gem.

The issue is described in the [issue #442](https://github.com/ruby/psych/issues/442), and fixed in the [PR #438](https://github.com/ruby/psych/pull/438).

The first release where it got fixed is [v](https://github.com/ruby/psych/releases/tag/v3.2.0). I am not sure if it makes sense going to the most recent version. I'd say - not worth it, maybe on the next Ruby upgrade we can consider getting rid of adding explicit version for `psych`.

And the reason why this causes an issue in the first place is that we create audit logs for `Cinstance` (among other models), and `audited_changes` column is YAML-serialized.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10763

**Verification steps** 

Create an app with description with trailing `_` and make sure no error is thrown.

**Special notes for your reviewer**:

There is an outstanding issue which is explained [in this comment](https://github.com/ruby/psych/issues/442#issuecomment-866254929), I think it can be considered an edge case, so not sure if it's worth to apply the Monkey-patch. I'd probably avoid it.
