### PR TITLE
THREESCALE-7570: Allow dots in application key for API

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -607,7 +607,8 @@ without fake Core server your after commit callbacks will crash and you might ge
             put :suspend
             put :resume
           end
-          resources :keys, :controller => 'buyer_application_keys', :only => [:index, :create, :destroy]
+          resources :keys, constraints: { id: %r{([^/]+?)(?=\.json|\.xml|$|/)} }, controller: 'buyer_application_keys', only: %i[index create destroy]
+
           resources :referrer_filters, :controller => 'buyer_application_referrer_filters', :only => [:index, :create, :destroy]
         end
 

--- a/test/integration/user-management-api/buyers_application_keys_test.rb
+++ b/test/integration/user-management-api/buyers_application_keys_test.rb
@@ -70,20 +70,21 @@ class Admin::Api::BuyersApplicationKeysTest < ActionDispatch::IntegrationTest
   end
 
   test 'destroy key' do
-    rm_key = "foo-key"
+    %w[foo-key foo.key].each do |rm_key|
 
-    application = @buyer.bought_cinstances.last
-    expect_backend_create_key(application, rm_key)
-    expect_backend_delete_key(application, rm_key)
+      application = @buyer.bought_cinstances.last
+      expect_backend_create_key(application, rm_key)
+      expect_backend_delete_key(application, rm_key)
 
+      application.application_keys.add(rm_key)
 
-    application.application_keys.add(rm_key)
+      delete(admin_api_account_application_key_path(@buyer.id, application.id, rm_key),
+             params: { provider_key: @provider.api_key,
+                       method: '_destroy',
+                       format: :xml })
 
-    delete(admin_api_account_application_key_path(@buyer.id, application.id, rm_key),
-           params: { provider_key: @provider.api_key,
-           method: "_destroy", format: :xml })
-
-    assert_response :success
+      assert_response :success
+    end
   end
 
   test 'destroy not existing key returns not found' do


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes deleting application key when it has dots, via API.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7570

**Verification steps** 

**Special notes for your reviewer**:

Honestly, I am not sure whether that's the right way, but it seems to be working as expected :upside_down_face: 