### PR TITLE
🦋 Add missing style for disabled PF checkbox

### DIFF
--- a/app/inputs/patternfly_checkbox_input.rb
+++ b/app/inputs/patternfly_checkbox_input.rb
@@ -24,7 +24,9 @@ class PatternflyCheckboxInput < Formtastic::Inputs::BooleanInput
   end
 
   def label
-    tag.label(label_text, class: 'pf-c-check__label', for: input_html_options[:id])
+    disabled = input_html_options[:disabled]
+    tag.label(label_text, class: "pf-c-check__label#{disabled ? ' pf-m-disabled' : ''}",
+                          for: input_html_options[:id])
   end
 
   def description


### PR DESCRIPTION
There are no disabled checkboxes yet, but the style will be missing when it's used.

Before:
![Screenshot 2024-03-12 at 12 58 10](https://github.com/3scale/porta/assets/11672286/1efaa8a7-65d9-42b4-8d4b-e46f711aa4b2)


After:
![Screenshot 2024-03-12 at 12 58 28](https://github.com/3scale/porta/assets/11672286/b4d5b8ab-68de-4b79-815d-e8425a4f510f)
