### PR TITLE
🦋 Remove buttons from page headers

### DIFF
--- a/app/controllers/api/proxy_rules_controller.rb
+++ b/app/controllers/api/proxy_rules_controller.rb
@@ -10,6 +10,10 @@ class Api::ProxyRulesController < Api::BaseController
 
   sublayout 'api/service'
 
+  def index
+    @presenter = Api::ProxyRulesIndexPresenter.new(service: service, params: params)
+  end
+
   def create
     @proxy_rule = proxy_rules.build(proxy_rule_params)
     if @proxy_rule.save

--- a/app/controllers/provider/admin/backend_apis/mapping_rules_controller.rb
+++ b/app/controllers/provider/admin/backend_apis/mapping_rules_controller.rb
@@ -8,6 +8,10 @@ class Provider::Admin::BackendApis::MappingRulesController < Provider::Admin::Ba
 
   delegate :proxy_rules, to: :@backend_api
 
+  def index
+    @presenter = Provider::Admin::BackendApis::MappingRulesIndexPresenter.new(backend_api: @backend_api, params: params)
+  end
+
   def create
     @proxy_rule = proxy_rules.build(proxy_rule_params)
     if @proxy_rule.save
@@ -35,11 +39,5 @@ class Provider::Admin::BackendApis::MappingRulesController < Provider::Admin::Ba
     end
 
     redirect_to provider_admin_backend_api_mapping_rules_path(@backend_api)
-  end
-
-  private
-
-  def proxy
-    @backend_api
   end
 end

--- a/app/controllers/proxy_rule_shared_controller.rb
+++ b/app/controllers/proxy_rule_shared_controller.rb
@@ -11,11 +11,6 @@ module ProxyRuleSharedController
     end
   end
 
-  def index
-    @presenter = Api::ProxyRulesIndexPresenter.new(proxy: proxy,
-                                                   params: params)
-  end
-
   def new
     last_position = proxy_rules.maximum(:position) || 0
     next_position = last_position + 1

--- a/app/javascript/src/BackendApis/components/IndexPage.tsx
+++ b/app/javascript/src/BackendApis/components/IndexPage.tsx
@@ -2,8 +2,6 @@ import { Table, TableBody, TableHeader } from '@patternfly/react-table'
 import {
   Button,
   Divider,
-  Level,
-  LevelItem,
   PageSection,
   PageSectionVariants,
   Text,
@@ -64,16 +62,7 @@ const IndexPage: FunctionComponent<Props> = ({
     <>
       <PageSection variant={PageSectionVariants.light}>
         <TextContent>
-          <Level>
-            <LevelItem>
-              <Text component="h1">Backends</Text>
-            </LevelItem>
-            <LevelItem>
-              <Button component="a" href={newBackendPath} variant="primary">
-                Create Backend
-              </Button>
-            </LevelItem>
-          </Level>
+          <Text component="h1">Backends</Text>
           <Text component="p">Explore and manage all your internal APIs.</Text>
         </TextContent>
       </PageSection>
@@ -83,8 +72,13 @@ const IndexPage: FunctionComponent<Props> = ({
       <PageSection variant={PageSectionVariants.light}>
         <Toolbar id="top-toolbar">
           <ToolbarContent>
-            <ToolbarItem variant="search-filter">
+            <ToolbarItem spacer={{ default: 'spacerMd' }} variant="search-filter">
               <ToolbarSearch placeholder="Find a backend" />
+            </ToolbarItem>
+            <ToolbarItem>
+              <Button component="a" href={newBackendPath} variant="primary">
+                Create a backend
+              </Button>
             </ToolbarItem>
             <ToolbarItem alignment={{ default: 'alignRight' }} variant="pagination">
               <Pagination itemCount={backendsCount} />

--- a/app/javascript/src/Products/components/IndexPage.tsx
+++ b/app/javascript/src/Products/components/IndexPage.tsx
@@ -1,8 +1,6 @@
 import {
   Button,
   Divider,
-  Level,
-  LevelItem,
   PageSection,
   PageSectionVariants,
   Text,
@@ -66,14 +64,7 @@ const IndexPage: React.FunctionComponent<Props> = ({
     <>
       <PageSection variant={PageSectionVariants.light}>
         <TextContent>
-          <Level>
-            <LevelItem><Text component="h1">Products</Text></LevelItem>
-            <LevelItem>
-              <Button component="a" href={newProductPath} variant="primary">
-                Create Product
-              </Button>
-            </LevelItem>
-          </Level>
+          <Text component="h1">Products</Text>
           <Text component="p">Explore and manage all customer-facing APIs that contain one or more of your Backends.</Text>
         </TextContent>
       </PageSection>
@@ -83,8 +74,13 @@ const IndexPage: React.FunctionComponent<Props> = ({
       <PageSection variant={PageSectionVariants.light}>
         <Toolbar id="top-toolbar">
           <ToolbarContent>
-            <ToolbarItem variant="search-filter">
+            <ToolbarItem spacer={{ default: 'spacerMd' }} variant="search-filter">
               <ToolbarSearch placeholder="Find a product" />
+            </ToolbarItem>
+            <ToolbarItem>
+              <Button component="a" href={newProductPath} variant="primary">
+                Create a product
+              </Button>
             </ToolbarItem>
             <ToolbarItem alignment={{ default: 'alignRight' }} variant="pagination">
               <Pagination itemCount={productsCount} />

--- a/app/lib/applications_controller_methods.rb
+++ b/app/lib/applications_controller_methods.rb
@@ -16,7 +16,8 @@ module ApplicationsControllerMethods
                                                 service: @service,
                                                 current_account: current_account,
                                                 accessible_plans: accessible_plans,
-                                                account: @account)
+                                                account: @account,
+                                                user: current_user)
   end
 
   protected

--- a/app/presenters/api/proxy_rules_index_presenter.rb
+++ b/app/presenters/api/proxy_rules_index_presenter.rb
@@ -1,50 +1,14 @@
 # frozen_string_literal: true
 
-class Api::ProxyRulesIndexPresenter
-  include System::UrlHelpers.system_url_helpers
+class Api::ProxyRulesIndexPresenter < ProxyRulesIndexBasePresenter
+  attr_reader :service
 
-  def initialize(proxy:, params: {})
-    @proxy = proxy
-
-    @search = ThreeScale::Search.new(params[:search])
-    @query = ProxyRuleQuery.new(owner_type: params[:owner_type],
-                                owner_id: proxy.id,
-                                direction: params[:direction] || 'desc',
-                                sort: params[:sort] || 'created_at')
-
-    @pagination_params = { page: params[:page] || 1, per_page: params[:per_page] || 20 }
+  def initialize(service:, params:)
+    @service = service
+    super(proxy: service.proxy, params: params)
   end
 
-  attr_reader :proxy, :search, :query, :pagination_params
-
-  def proxy_rules
-    @proxy_rules ||= query.search_for(@search['query'], raw_proxy_rules)
-                          .paginate(pagination_params)
-  end
-
-  def empty_state?
-    raw_proxy_rules.empty?
-  end
-
-  def empty_search_state?
-    proxy_rules.empty?
-  end
-
-  def toolbar_props
-    {
-      totalEntries: proxy_rules.total_entries,
-      actions: [],
-      overflow: nil,
-      search: {
-        placeholder: 'Search for pattern'
-      },
-      filters: []
-    }
-  end
-
-  private
-
-  def raw_proxy_rules
-    @raw_proxy_rules ||= proxy.proxy_rules.includes(:metric)
+  def new_rule_path
+    new_admin_service_proxy_rule_path(service)
   end
 end

--- a/app/presenters/provider/admin/backend_apis/mapping_rules_index_presenter.rb
+++ b/app/presenters/provider/admin/backend_apis/mapping_rules_index_presenter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Provider::Admin::BackendApis::MappingRulesIndexPresenter < ProxyRulesIndexBasePresenter
+  attr_reader :backend_api
+
+  def initialize(backend_api:, params:)
+    @backend_api = backend_api
+    super(proxy: backend_api, params: params)
+  end
+
+  def new_rule_path
+    new_provider_admin_backend_api_mapping_rule_path(backend_api)
+  end
+end

--- a/app/presenters/proxy_rules_index_base_presenter.rb
+++ b/app/presenters/proxy_rules_index_base_presenter.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ProxyRulesIndexBasePresenter
+  include System::UrlHelpers.system_url_helpers
+
+  def initialize(proxy:, params: {})
+    @proxy = proxy
+
+    @search = ThreeScale::Search.new(params[:search])
+    @query = ProxyRuleQuery.new(owner_type: params[:owner_type],
+                                owner_id: proxy.id,
+                                direction: params[:direction] || 'desc',
+                                sort: params[:sort] || 'created_at')
+
+    @pagination_params = { page: params[:page] || 1, per_page: params[:per_page] || 20 }
+  end
+
+  attr_reader :proxy, :search, :query, :pagination_params
+
+  def proxy_rules
+    @proxy_rules ||= query.search_for(@search['query'], raw_proxy_rules)
+                          .paginate(pagination_params)
+  end
+
+  def empty_state?
+    raw_proxy_rules.empty?
+  end
+
+  def empty_search_state?
+    proxy_rules.empty?
+  end
+
+  def toolbar_props
+    {
+      totalEntries: proxy_rules.total_entries,
+      actions: [{
+        label: 'Create a mapping rule',
+        href: new_rule_path,
+        variant: :primary
+      }],
+      overflow: nil,
+      search: {
+        placeholder: 'Search for pattern'
+      },
+      filters: []
+    }
+  end
+
+  private
+
+  def raw_proxy_rules
+    @raw_proxy_rules ||= proxy.proxy_rules.includes(:metric)
+  end
+end

--- a/app/views/api/applications/index.html.slim
+++ b/app/views/api/applications/index.html.slim
@@ -1,6 +1,4 @@
-- content_for :page_header_title_with_button, "Applications on #{@service.name}"
-- content_for :page_header_button_label, 'Create application'
-- content_for :page_header_button_href, new_admin_service_application_path(@service)
+- content_for :page_header_title, "Applications on #{@service.name}"
 
 - if current_user.accessible_services.empty?
   = render 'shared/service_access'

--- a/app/views/api/proxy_rules/index.html.slim
+++ b/app/views/api/proxy_rules/index.html.slim
@@ -1,5 +1,3 @@
-= render 'shared/proxy_rules/header_section', new_rule_path: new_admin_service_proxy_rule_path(@service)
-
 - if @presenter.empty_state?
   = render partial: 'shared/empty_state', locals: { title: t('.empty_state.title'),
                                                     body: t('.empty_state.body', name: @service.name),

--- a/app/views/buyers/applications/index.html.slim
+++ b/app/views/buyers/applications/index.html.slim
@@ -1,9 +1,7 @@
 - content_for :menu do
   = render '/buyers/accounts/menu'
 
-- content_for :page_header_title_with_button, "Applications for #{@account.name}"
-- content_for :page_header_button_label, 'Create application'
-- content_for :page_header_button_href, create_application_link_href(@account)
+- content_for :page_header_title, "Applications for #{@account.name}"
 
 - if current_user.accessible_services.empty?
   = render 'shared/service_access'

--- a/app/views/provider/admin/applications/index.html.slim
+++ b/app/views/provider/admin/applications/index.html.slim
@@ -1,10 +1,7 @@
-- content_for :page_header_title_with_button, 'Applications'
+- content_for :page_header_title, 'Applications'
 - content_for :page_header_body do
   ' Applications are a representation of an API consumer. They include credentials obtained through the API's authentication method,
   ' along with usage metrics and other metadata. The application plan sets the limits for each application.
-
-- content_for :page_header_button_label, 'Create application'
-- content_for :page_header_button_href, new_provider_admin_application_path
 
 - if current_user.accessible_services.empty?
   = render 'shared/service_access'

--- a/app/views/provider/admin/backend_apis/mapping_rules/index.html.slim
+++ b/app/views/provider/admin/backend_apis/mapping_rules/index.html.slim
@@ -1,2 +1,1 @@
-= render 'shared/proxy_rules/header_section', new_rule_path: new_provider_admin_backend_api_mapping_rule_path(@backend_api)
 = render 'shared/proxy_rules/body_section', proxy_rules: @proxy_rules

--- a/app/views/shared/provider/_page_header.html.slim
+++ b/app/views/shared/provider/_page_header.html.slim
@@ -7,20 +7,6 @@
     - if (alert = content_for(:page_header_alert).presence)
       = alert
 
-/ TODO: this will go away once we move all buttons from page hader to a toolbar
-- elsif (title = content_for(:page_header_title_with_button).presence)
-  section class="pf-c-page__main-section pf-m-light"
-    div class="pf-c-content"
-      div class="pf-l-level"
-        div class="pf-l-level__item"
-          h1
-            = title
-        div class="pf-l-level__item"
-          a class="pf-c-button pf-m-primary" href=content_for(:page_header_button_href)
-            = content_for(:page_header_button_label)
-      - if (subtitle = content_for(:page_header_body).presence)
-        p = subtitle
-
 / TODO: this is only a temporary workaround for those page headers not using PF4, all pages should
 / have the same page header
 - elsif content_for(:custom_page_header).present?

--- a/app/views/shared/proxy_rules/_body_section.html.slim
+++ b/app/views/shared/proxy_rules/_body_section.html.slim
@@ -1,5 +1,7 @@
+- content_for :page_header_title, 'Mapping Rules'
+
 - content_for :javascripts do
-    = javascript_packs_with_chunks_tag 'table_toolbar'
+  = javascript_packs_with_chunks_tag 'table_toolbar'
 
 div class="pf-c-card"
   table id="mapping_rules" class="pf-c-table pf-m-grid-lg" role="grid" aria-label="Mapping rules table" data-toolbar-props=@presenter.toolbar_props.to_json

--- a/app/views/shared/proxy_rules/_header_section.html.slim
+++ b/app/views/shared/proxy_rules/_header_section.html.slim
@@ -1,3 +1,0 @@
-- content_for :page_header_title_with_button, 'Mapping Rules'
-- content_for :page_header_button_label, 'Create a mapping rule'
-- content_for :page_header_button_href, new_rule_path

--- a/features/api/services/applications/new.feature
+++ b/features/api/services/applications/new.feature
@@ -16,7 +16,7 @@ Feature: Product > Applications > New
 
   Scenario: Navigation
     Given they go to product "My API" applications page
-    When they follow "Create application"
+    When they follow "Create an application"
     Then the current page is product "My API" new application page
 
   Scenario: Create an application
@@ -101,7 +101,7 @@ Feature: Product > Applications > New
 
     Scenario: Manual navigation
       Given they go to product "My API" applications page
-      When they follow "Create application"
+      When they follow "Create an application"
       When the form is submitted with:
         | Account          | Jane          |
         | Application plan | Basic         |

--- a/features/buyers/accounts/applications/new.feature
+++ b/features/buyers/accounts/applications/new.feature
@@ -16,7 +16,7 @@ Feature: Audience > Accounts > Listing > Account > Applications > New
 
   Scenario: Navigation
     Given they go to buyer "Jane" applications page
-    When they follow "Create application"
+    When they follow "Create an application"
     Then the current page is buyer "Jane" new application page
 
   Scenario: Create an application
@@ -102,7 +102,7 @@ Feature: Audience > Accounts > Listing > Account > Applications > New
 
     Scenario: Manual navigation
       Given they go to buyer "Jane" applications page
-      When they follow "Create application"
+      When they follow "Create an application"
       Then the current page is the upgrade notice for multiple applications
 
     Scenario: Navigation via url

--- a/features/provider/admin/applications/new.feature
+++ b/features/provider/admin/applications/new.feature
@@ -16,7 +16,7 @@ Feature: Audience's new application page
 
   Scenario: Navigation
     Given they go to the admin portal applications page
-    When they follow "Create application"
+    When they follow "Create an application"
     Then the current page is the admin portal new application page
 
   Scenario: Create an application
@@ -110,7 +110,7 @@ Feature: Audience's new application page
 
     Scenario: Manual navigation
       Given they go to the admin portal applications page
-      When they follow "Create application"
+      When they follow "Create an application"
       When the form is submitted with:
         | Account          | Jane           |
         | Product          | My API        |

--- a/features/provider/admin/backend_apis/new.feature
+++ b/features/provider/admin/backend_apis/new.feature
@@ -12,7 +12,7 @@ Feature: Backend API new page
   Scenario: Navigation from context selector
     Given the current page is the provider dashboard
     When they select "Backends" from the context selector
-    And follow "Create Backend"
+    And follow "Create a backend"
     Then the current page is the admin portal new backend api page
 
   Scenario: Create a new Backend API


### PR DESCRIPTION
[THREESCALE-9661: Move buttons in title to the main section](https://issues.redhat.com/browse/THREESCALE-9661)

There are still some legacy tables that are blocking this task. When they are updated, the buttons will be removed.

Before:
![Screenshot 2024-03-22 at 17 19 21](https://github.com/3scale/porta/assets/11672286/2c9e19b7-b8f2-406d-8e83-3e6522a44355)
![Screenshot 2024-03-22 at 17 19 29](https://github.com/3scale/porta/assets/11672286/92e35dda-0ead-4312-be27-8334a248130e)
![Screenshot 2024-03-22 at 17 19 55](https://github.com/3scale/porta/assets/11672286/90e63ed8-1e12-482f-b744-b6c411cd7fb4)

After:
![Screenshot 2024-03-22 at 17 18 39](https://github.com/3scale/porta/assets/11672286/b7ead442-0cea-4320-b583-3cda25092166)
![Screenshot 2024-03-22 at 17 18 47](https://github.com/3scale/porta/assets/11672286/85a3b27b-1ed2-4f74-96e4-a5c088d87747)
![Screenshot 2024-03-22 at 17 18 59](https://github.com/3scale/porta/assets/11672286/fb152800-8d06-4d9e-9792-8a565de77e0c)
