### PR TITLE
THREESCALE-10883: Fix OAS document order

### DIFF
--- a/app/controllers/api_docs/services_controller.rb
+++ b/app/controllers/api_docs/services_controller.rb
@@ -42,6 +42,7 @@ class ApiDocs::ServicesController < FrontendController
     def json
       parsed_content = JSON.parse(file_content)
       parsed_content['servers'] = [{ 'url' => backend_base_host }] if backend_api?
+      parsed_content['components'] = parsed_content.delete('components') if parsed_content.key?('components')
 
       parsed_content
     end


### PR DESCRIPTION
When the "components" section of a Swagger document is placed before the "paths", the rendering of schemas with $ref fails to display.

This patch just make sure to move "components" to latest element in hash if they exist, fixing the issue.

fixes #THREESCALE-10883