### PR TITLE
🐛 Fix change plan widget in account overview

### DIFF
--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -19,7 +19,7 @@ div class="pf-l-grid pf-m-gutter pf-m-all-6-col"
             = render partial: 'account_details', locals: { account: @account }
 
       - if can?(:update, :provider_plans) && can?(:update, @account.bought_cinstance.service)
-        div class="pf-l-flex__item"
+        div class="pf-l-flex__item" id="provider-change-plan"
           = render 'master/providers/plans/widget', provider: @account
 
       - if can?(:manage, :finance)

--- a/app/views/master/providers/plans/_widget.html.slim
+++ b/app/views/master/providers/plans/_widget.html.slim
@@ -1,35 +1,35 @@
 div class="pf-c-card"
   div class="pf-c-card__body"
-    div id="provider-change-plan"
-      - app = provider.bought_cinstance
-      - plans = app.available_application_plans
+    - app = provider.bought_cinstance
+    - plans = app.available_application_plans
 
-      p #{provider.name} is currently on plan <b>#{ app.plan.name  }</b> with these settings:
+    p #{provider.name} is currently on plan <b>#{ app.plan.name  }</b> with these settings:
 
-      table.list
-        - provider.available_switches.each do |switch|
-          tr
-            td
-              b => t(:name, scope: [:switches, switch.name])
+    table.list
+      - provider.available_switches.each do |switch|
+        tr
+          td
+            b => t(:name, scope: [:switches, switch.name])
 
-              - if (description = t(:internal, scope: [:switches, switch.name], default: '').presence)
-                | (#{description})
+            - if (description = t(:internal, scope: [:switches, switch.name], default: '').presence)
+              | (#{description})
 
-            td
-              => switch.status.capitalize
-            td
-              - if switch.denied?
-                = fancy_button_to 'enable', master_provider_switch_path(provider, switch.name), method: :put, data: { confirm: 'Really?', disable_with: true }
+          td
+            => switch.status.capitalize
+          td
+            - if switch.denied?
+              = fancy_button_to 'enable', master_provider_switch_path(provider, switch.name), method: :put, data: { confirm: 'Really?', disable_with: true }
   div class="pf-c-card__body"
     = form_for app, builder: Fields::PatternflyFormBuilder,
                     url: edit_master_provider_plan_path(provider),
                     remote: true,
                     method: :get,
-                    html: { class: 'pf-c-form' } do |form|
+                    html: { class: 'pf-c-form colorbox' } do |form|
       = form.input :plan, as: :patternfly_select,
                           collection: options_from_collection_for_select(plans, :id, :name),
+                          input_html: { id: 'plan_id', name: 'plan_id', required: true },
                           label: 'Change plan',
                           required: false,
-                          include_blank: false
+                          include_blank: true
       = form.actions do
         = form.commit_button 'Change plan'

--- a/features/step_definitions/buyers/accounts/account_overview_steps.rb
+++ b/features/step_definitions/buyers/accounts/account_overview_steps.rb
@@ -108,7 +108,7 @@ def billing_status_card_selector
 end
 
 def within_plan_settings_card(&block)
-  within '.pf-c-card #provider-change-plan' do
+  within '#provider-change-plan .pf-c-card' do
     yield block
   end
 end


### PR DESCRIPTION
Functionality is broken due to missing class `colorbox` and wrong input's `id` and `name`.

![Screenshot 2024-04-04 at 11 46 13](https://github.com/3scale/porta/assets/11672286/d97e6adb-f8f9-4666-99ad-b95545f46042)
