### PR TITLE
Fix Minitest and Mocha deprecation warnings

### DIFF
--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -344,7 +344,7 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
     return false unless saved
 
     success = ProxyDeploymentService.call(self)
-    analytics.track('Sandbox Proxy Deploy', success: success)
+    analytics.track('Sandbox Proxy Deploy', { success: success })
     success
   end
 

--- a/test/decorators/contract_decorator_test.rb
+++ b/test/decorators/contract_decorator_test.rb
@@ -4,11 +4,12 @@ require 'test_helper'
 
 class ContractDecoratorTest < Draper::TestCase
   test '#account_admin_user_display_name' do
-    cinstance = FactoryBot.build(:simple_cinstance)
+    account = FactoryBot.create(:account)
+    cinstance = FactoryBot.build(:simple_cinstance, user_account: account)
     expected_display_name = cinstance.user_account.decorate.admin_user_display_name
     assert_equal expected_display_name, cinstance.decorate.account_admin_user_display_name
 
-    service_contract = FactoryBot.build(:service_contract, plan: FactoryBot.create(:service_plan))
+    service_contract = FactoryBot.build(:service_contract, plan: FactoryBot.create(:service_plan), user_account: account)
     expected_display_name = service_contract.account.decorate.admin_user_display_name
     assert_equal expected_display_name, service_contract.decorate.account_admin_user_display_name
   end

--- a/test/events/accounts/account_created_event_test.rb
+++ b/test/events/accounts/account_created_event_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class Accounts::AccountCreatedEventTest < ActiveSupport::TestCase
 
   def test_create
-    account = FactoryBot.build_stubbed(:simple_buyer, id: 1,
-                                          provider_account_id: 2)
+    provider = FactoryBot.build_stubbed(:simple_provider, id: 2)
+    account = FactoryBot.build_stubbed(:simple_buyer, id: 1, provider_account: provider)
     event   = Accounts::AccountCreatedEvent.create(account, user)
 
     assert event

--- a/test/events/accounts/account_deleted_event_test.rb
+++ b/test/events/accounts/account_deleted_event_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class Accounts::AccountDeletedEventTest < ActiveSupport::TestCase
   def test_create
-    account = FactoryBot.build_stubbed(:simple_buyer, id: 1, provider_account_id: 2)
+    provider = FactoryBot.build(:simple_provider, id: 2)
+    account = FactoryBot.build_stubbed(:simple_buyer, id: 1, provider_account: provider)
     event   = Accounts::AccountDeletedEvent.create(account)
 
     assert event

--- a/test/events/accounts/account_plan_change_requested_event_test.rb
+++ b/test/events/accounts/account_plan_change_requested_event_test.rb
@@ -3,9 +3,10 @@ require 'test_helper'
 class Accounts::AccountPlanChangeRequestedEventTest < ActiveSupport::TestCase
 
   def test_create
+    provider = FactoryBot.build(:simple_provider, id: 1)
     plan    = FactoryBot.build_stubbed(:simple_account_plan, id: 1)
     plan_2  = FactoryBot.build_stubbed(:simple_account_plan, id: 2)
-    account = FactoryBot.build_stubbed(:simple_buyer, id: 3, bought_account_plan: plan_2)
+    account = FactoryBot.build_stubbed(:buyer_account, id: 3, bought_account_plan: plan_2, provider_account: provider)
     user    = FactoryBot.build_stubbed(:simple_user, account: account)
     event   = Accounts::AccountPlanChangeRequestedEvent.create(account, user, plan)
 

--- a/test/events/accounts/account_state_changed_event_test.rb
+++ b/test/events/accounts/account_state_changed_event_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class Accounts::AccountStateChangedEventTest < ActiveSupport::TestCase
 
   def test_create
-    account = FactoryBot.build_stubbed(:simple_buyer, id: 1, state: 'pending',
-                                          provider_account_id: 2)
+    provider = FactoryBot.build(:simple_provider)
+    account = FactoryBot.build_stubbed(:simple_buyer, id: 1, state: 'pending', provider_account: provider)
     event   = Accounts::AccountStateChangedEvent.create(account, 'created')
 
     assert event

--- a/test/events/accounts/expired_credit_card_provider_event_test.rb
+++ b/test/events/accounts/expired_credit_card_provider_event_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class Accounts::ExpiredCreditCardProviderEventTest < ActiveSupport::TestCase
 
   def test_create
-    buyer = FactoryBot.build_stubbed(:buyer_account, id: 1,
-                                        provider_account_id: 2)
+    provider = FactoryBot.build(:simple_provider)
+    buyer = FactoryBot.build_stubbed(:buyer_account, id: 1, provider: provider)
     event = Accounts::ExpiredCreditCardProviderEvent.create(buyer)
 
     assert event

--- a/test/events/cinstances/cinstance_cancellation_event_test.rb
+++ b/test/events/cinstances/cinstance_cancellation_event_test.rb
@@ -5,7 +5,7 @@ class Cinstances::CinstanceCancellationEventTest < ActiveSupport::TestCase
   def test_create
     service   = FactoryBot.build_stubbed(:simple_service, id: 2)
     plan      = FactoryBot.build_stubbed(:simple_application_plan, id: 3, issuer: service)
-    cinstance = FactoryBot.build_stubbed(:simple_cinstance, id: 1, plan: plan)
+    cinstance = FactoryBot.build_stubbed(:simple_cinstance, id: 1, name: 'app', plan: plan)
     event     = Cinstances::CinstanceCancellationEvent.create(cinstance)
 
     assert event

--- a/test/events/invoices/unsuccessfully_charged_invoice_final_provider_event_test.rb
+++ b/test/events/invoices/unsuccessfully_charged_invoice_final_provider_event_test.rb
@@ -3,8 +3,7 @@ require 'test_helper'
 class Invoices::UnsuccessfullyChargedInvoiceFinalProviderEventTest < ActiveSupport::TestCase
 
   def test_create
-    invoice = FactoryBot.build_stubbed(:invoice, id: 1, provider_account_id: 2,
-                                        state: 'created')
+    invoice = FactoryBot.build_stubbed(:invoice, id: 1, state: 'created')
     event   = Invoices::UnsuccessfullyChargedInvoiceFinalProviderEvent.create(invoice)
 
     assert event

--- a/test/events/invoices/unsuccessfully_charged_invoice_provider_event_test.rb
+++ b/test/events/invoices/unsuccessfully_charged_invoice_provider_event_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class Invoices::UnsuccessfullyChargedInvoiceProviderEventTest < ActiveSupport::TestCase
 
   def test_create
-    invoice = FactoryBot.build_stubbed(:invoice, id: 1, provider_account_id: 2,
-                                          state: 'created')
+    provider = FactoryBot.build(:simple_provider, id: 2)
+    invoice = FactoryBot.build_stubbed(:invoice, id: 1, provider_account: provider, state: 'created')
     event   = Invoices::UnsuccessfullyChargedInvoiceProviderEvent.create(invoice)
 
     assert event

--- a/test/events/messages/message_received_event_test.rb
+++ b/test/events/messages/message_received_event_test.rb
@@ -3,8 +3,9 @@ require 'test_helper'
 class Messages::MessageReceivedEventTest < ActiveSupport::TestCase
 
   def test_create
+    provider  = FactoryBot.build(:simple_provider, id: 1)
     message   = FactoryBot.build_stubbed(:message)
-    recipient = FactoryBot.build_stubbed(:received_message, message: message, receiver_id: 1)
+    recipient = FactoryBot.build_stubbed(:received_message, message: message, receiver: provider)
     event     = Messages::MessageReceivedEvent.create(message, recipient)
 
     assert event

--- a/test/events/posts/post_created_event_test.rb
+++ b/test/events/posts/post_created_event_test.rb
@@ -8,12 +8,12 @@ class Posts::PostCreatedEventTest < ActiveSupport::TestCase
     event = Posts::PostCreatedEvent.create(post)
 
     assert event
-    assert_equal event.forum, forum
-    assert_equal event.post, post
-    assert_equal event.provider, forum.account
-    assert_equal event.metadata[:provider_id], forum.account_id
-    assert_equal event.user, post.user
-    assert_equal event.account, post.user.account
+    assert_equal forum, event.forum
+    assert_equal post, event.post
+    assert_equal forum.account, event.provider
+    assert_equal forum.account_id, event.metadata[:provider_id]
+    assert_equal post.user, event.user
+    assert_equal post.user.account, event.account
   end
 
   def test_create_anonymous_user
@@ -22,11 +22,11 @@ class Posts::PostCreatedEventTest < ActiveSupport::TestCase
     event = Posts::PostCreatedEvent.create(post)
 
     assert event
-    assert_equal event.forum, forum
-    assert_equal event.post, post
-    assert_equal event.provider, forum.account
-    assert_equal event.metadata[:provider_id], forum.account_id
-    assert_equal event.try(:user), nil
-    assert_equal event.try(:account), nil
+    assert_equal forum, event.forum
+    assert_equal post, event.post
+    assert_equal forum.account, event.provider
+    assert_equal forum.account_id, event.metadata[:provider_id]
+    assert_nil event.try(:user)
+    assert_nil event.try(:account)
   end
 end

--- a/test/events/service_contracts/service_contract_plan_changed_event_test.rb
+++ b/test/events/service_contracts/service_contract_plan_changed_event_test.rb
@@ -3,8 +3,11 @@ require 'test_helper'
 class ServiceContracts::ServiceContractPlanChangedEventTest < ActiveSupport::TestCase
 
   def test_create
-    account  = FactoryBot.build_stubbed(:simple_buyer)
-    contract = FactoryBot.build_stubbed(:simple_service_contract, id: 1, user_account: account)
+    provider = FactoryBot.build_stubbed(:simple_provider)
+    account  = FactoryBot.build_stubbed(:buyer_account, provider_account: provider)
+    service = FactoryBot.build_stubbed(:simple_service, account: provider)
+    plan = FactoryBot.build_stubbed(:simple_service_plan, service: service, issuer: service)
+    contract = FactoryBot.build_stubbed(:simple_service_contract, id: 1, plan: plan, user_account: account)
     user     = FactoryBot.build_stubbed(:simple_user, account: account)
     contract.stubs(:old_plan).returns(FactoryBot.build_stubbed(:simple_service_plan, id: 2))
     event    = ServiceContracts::ServiceContractPlanChangedEvent.create(contract, user)

--- a/test/models/email_configuration_test.rb
+++ b/test/models/email_configuration_test.rb
@@ -129,6 +129,7 @@ class EmailConfigurationTest < ActiveSupport::TestCase
       enable_starttls_auto: true,
       enable_starttls: false,
       tls: true,
+      openssl_verify_mode: 'peer'
     }.freeze
   end
 

--- a/test/unit/account/credit_card_test.rb
+++ b/test/unit/account/credit_card_test.rb
@@ -121,11 +121,12 @@ class Account::CreditCardTest < ActiveSupport::TestCase
 
       ThreeScale::Analytics.expects(:track_account)
         .with(account,
-              'Credit Card Changed',
-              valid_previously: false,
-              valid_now: true,
-              expired_on: nil,
-              expires_on: Date.new(2017, 11, 1)
+              'Credit Card Changed', {
+                valid_previously: false,
+                valid_now: true,
+                expired_on: nil,
+                expires_on: Date.new(2017, 11, 1)
+              }
         )
 
       assert account.save!
@@ -140,11 +141,12 @@ class Account::CreditCardTest < ActiveSupport::TestCase
 
       ThreeScale::Analytics.expects(:track_account)
         .with(account,
-              'Credit Card Changed',
-              valid_previously: true,
-              valid_now: false,
-              expires_on: nil,
-              expired_on: Date.new(2017, 11, 1)
+              'Credit Card Changed', {
+                valid_previously: true,
+                valid_now: false,
+                expires_on: nil,
+                expired_on: Date.new(2017, 11, 1)
+              }
         )
 
       account.save!

--- a/test/unit/authentication_provider_test.rb
+++ b/test/unit/authentication_provider_test.rb
@@ -55,17 +55,18 @@ class AuthenticationProviderTest < ActiveSupport::TestCase
   end
 
   test 'callback_account' do
-      auth_provider = FactoryBot.build_stubbed(:authentication_provider)
-          .becomes(AuthenticationProvider::GitHub)
-      master = FactoryBot.build_stubbed(:master_account)
+    account = FactoryBot.create(:simple_provider)
+    auth_provider = FactoryBot.build_stubbed(:authentication_provider, account: account)
+                              .becomes(AuthenticationProvider::GitHub)
+    master = FactoryBot.build_stubbed(:master_account)
 
-      auth_provider.branding_state = 'threescale_branded'
-      assert auth_provider.threescale_branded?, 'should be 3scale branded'
-      assert_equal master, auth_provider.callback_account
+    auth_provider.branding_state = 'threescale_branded'
+    assert auth_provider.threescale_branded?, 'should be 3scale branded'
+    assert_equal master, auth_provider.callback_account
 
-      auth_provider.branding_state = 'custom_branded'
-      assert auth_provider.custom_branded?, 'should have custom branding'
-      assert_equal auth_provider.account, auth_provider.callback_account
+    auth_provider.branding_state = 'custom_branded'
+    assert auth_provider.custom_branded?, 'should have custom branding'
+    assert_equal auth_provider.account, auth_provider.callback_account
   end
 
   test 'find_kind' do

--- a/test/unit/backend/storage_rewrite_test.rb
+++ b/test/unit/backend/storage_rewrite_test.rb
@@ -13,13 +13,13 @@ module Backend
 
       test 'passes the class_name and ids to rewriter (used in async processing)' do
         ids = [1,2,3,4,5]
-        StorageRewrite::MetricRewriter.expects(:rewrite).with(ids: ids, log_progress: false)
+        StorageRewrite::MetricRewriter.expects(:rewrite).with({ ids: ids, log_progress: false })
         StorageRewrite::Processor.new.rewrite(class_name: 'Metric', ids: ids)
       end
 
       test 'passes the scope to rewriter (used in sync processing)' do
         provider = FactoryBot.create(:simple_provider)
-        StorageRewrite::ServiceRewriter.expects(:rewrite).with(scope: provider.services, log_progress: false)
+        StorageRewrite::ServiceRewriter.expects(:rewrite).with({ scope: provider.services, log_progress: false })
         StorageRewrite::Processor.new.rewrite(scope: provider.services)
       end
 
@@ -29,7 +29,7 @@ module Backend
 
       test 'enables log progress for rewriter if specified explicitly' do
         ids = [1,2,3,4,5]
-        StorageRewrite::UsageLimitRewriter.expects(:rewrite).with(ids: ids, log_progress: true)
+        StorageRewrite::UsageLimitRewriter.expects(:rewrite).with({ ids: ids, log_progress: true })
         StorageRewrite::Processor.new(log_progress: true).rewrite(class_name: 'UsageLimit', ids: ids)
       end
     end

--- a/test/unit/backend/storage_test.rb
+++ b/test/unit/backend/storage_test.rb
@@ -24,7 +24,7 @@ test:
 }
     given_redis_config(yaml) do
       mock = mock(id: 'redis://localhost:6389/1')
-      Redis::Client.expects(:new).with(host: 'example.com', port: 1337, db: 2, logger: Rails.logger).returns(mock)
+      Redis::Client.expects(:new).with({ host: 'example.com', port: 1337, db: 2, logger: Rails.logger }).returns(mock)
 
       storage = Backend::Storage.clone.instance
       assert_equal 'redis://localhost:6389/1', storage.id

--- a/test/unit/lib/cms/aws_credentials_test.rb
+++ b/test/unit/lib/cms/aws_credentials_test.rb
@@ -56,7 +56,7 @@ class Aws::AwsCredentialsTest < ActiveSupport::TestCase
     use_sts
     File.stubs(:exist?).with(full_params[:web_identity_token_file]).returns(true)
 
-    Aws::AssumeRoleWebIdentityCredentials.expects(:new).with(sts_auth_params).returns(sts_credentials)
+    Aws::AssumeRoleWebIdentityCredentials.expects(:new).with(**sts_auth_params).returns(sts_credentials)
     assert_equal sts_credentials, CMS::AwsCredentials.instance.send(:sts_credentials)
   end
 

--- a/test/unit/liquid/drops/account_drop_test.rb
+++ b/test/unit/liquid/drops/account_drop_test.rb
@@ -26,7 +26,7 @@ class Liquid::Drops::AccountDropTest < ActiveSupport::TestCase
   end
 
   test 'returns vat_rate' do
-    @buyer.update(vat_rate: '123.4')
+    @buyer.vat_rate = 123.4
     @drop_account = Drops::Account.new(@buyer)
     assert_equal @buyer.vat_rate, @drop_account.vat_rate
   end

--- a/test/unit/liquid/drops/alert_drop_test.rb
+++ b/test/unit/liquid/drops/alert_drop_test.rb
@@ -5,7 +5,7 @@ class Liquid::Drops::AlertTest < ActiveSupport::TestCase
   include Liquid
 
   def setup
-    @alert = FactoryBot.build_stubbed(:limit_alert)
+    @alert = FactoryBot.build_stubbed(:limit_alert, message: 'some message')
     @drop = Drops::Alert.new(@alert)
   end
 
@@ -23,10 +23,6 @@ class Liquid::Drops::AlertTest < ActiveSupport::TestCase
 
   test 'returns timestamp' do
     assert_equal @alert.timestamp, @drop.timestamp
-  end
-
-  test 'returns description' do
-    assert_equal @alert.message, @drop.message
   end
 
   test 'returns unread?' do

--- a/test/unit/liquid/drops/invoice_drop_test.rb
+++ b/test/unit/liquid/drops/invoice_drop_test.rb
@@ -67,10 +67,12 @@ class Liquid::Drops::InvoiceDropTest < ActiveSupport::TestCase
   end
 
   should 'return due_on' do
+    @invoice.stubs due_on: Time.now.utc.to_date
     assert_equal @invoice.due_on, @drop.due_on
   end
 
   should 'return paid_on' do
+    @invoice.stubs paid_at: Time.now.utc.to_date
     assert_equal @invoice.paid_at, @drop.paid_on
   end
 

--- a/test/unit/liquid/drops/payment_transaction_test.rb
+++ b/test/unit/liquid/drops/payment_transaction_test.rb
@@ -4,7 +4,7 @@ class Liquid::Drops::PaymentTransactionDropTest < ActiveSupport::TestCase
   include Liquid
 
   def setup
-    @payment_transaction = FactoryBot.build(:payment_transaction)
+    @payment_transaction = FactoryBot.build(:payment_transaction, message: 'message', reference: 'ref', created_at: Time.now.utc)
     @drop = Drops::PaymentTransaction.new(@payment_transaction)
   end
 

--- a/test/unit/liquid/filters/rails_helpers_test.rb
+++ b/test/unit/liquid/filters/rails_helpers_test.rb
@@ -10,7 +10,7 @@ class Liquid::Filters::RailsHelpersTest < ActiveSupport::TestCase
 
   test 'javascript_include_tag' do
     @context.registers[:controller] = ApplicationController.new
-    Webpacker.manifest.stubs(:lookup_pack_with_chunks!).with('stats', {:type => :javascript}).returns('/packs/stats.js')
+    Webpacker.manifest.stubs(:lookup_pack_with_chunks!).with('stats', type: :javascript).returns('/packs/stats.js')
     assert_equal "<script src=\"/packs/stats.js\"></script>", javascript_include_tag('stats.js')
   end
 

--- a/test/unit/liquid/tags/active_docs_test.rb
+++ b/test/unit/liquid/tags/active_docs_test.rb
@@ -14,7 +14,11 @@ class Liquid::Tags::ActiveDocsTest < ActiveSupport::TestCase
       match = params.match Liquid::Tags::ActiveDocs::Syntax
       assert match
       assert_equal match[1], expected[0]
-      assert_equal match[2], expected[1]
+      if expected[1]
+        assert_equal match[2], expected[1]
+      else
+        assert_nil match[2]
+      end
     end
   end
 end

--- a/test/unit/liquid/tags/email_test.rb
+++ b/test/unit/liquid/tags/email_test.rb
@@ -61,7 +61,7 @@ class Liquid::Tags::EmailTest < ActiveSupport::TestCase
     mail.expects(:[]=).with(:cc, ['just@me.com'])
     mail.expects(:[]=).with(:from, 'secret@mail.com')
     mail.expects(:[]=).with(:reply_to, 'over@lord.com')
-    mail.expects(:headers).with('MyHeader' => 'Value')
+    mail.expects(:headers).with({ 'MyHeader' => 'Value' })
 
     context = stub(:registers => registers)
 
@@ -70,7 +70,7 @@ class Liquid::Tags::EmailTest < ActiveSupport::TestCase
 
   test "assign do_not_send header to mailer" do
     mail = subject.parse('email', '', ['{% do_not_send %}', @end], {})
-    mail.expects(:headers).with(::Message::DO_NOT_SEND_HEADER => true)
+    mail.expects(:headers).with({ ::Message::DO_NOT_SEND_HEADER => true })
 
     context = stub(:registers => {mail: mail})
     mail.render(context)

--- a/test/unit/liquid/tags/plan_widget_test.rb
+++ b/test/unit/liquid/tags/plan_widget_test.rb
@@ -42,7 +42,7 @@ class Liquid::Tags::PlanWidgetTest < ActiveSupport::TestCase
     tag = Liquid::Tags::PlanWidget.parse('plan_widget', 'myvar', [], {})
     @context['myvar'] = Liquid::Drops::Application.new('contract')
 
-    tag.expects(:render_erb).with(@context, 'applications/applications/plan_widget', { contract: @context['myvar'], wizard: false }).returns('Hello world')
+    tag.expects(:render_erb).with(@context, 'applications/applications/plan_widget', contract: @context['myvar'], wizard: false).returns('Hello world')
     assert_equal 'Hello world', tag.render(@context)
   end
 

--- a/test/unit/liquid/tags/sort_link_test.rb
+++ b/test/unit/liquid/tags/sort_link_test.rb
@@ -10,7 +10,11 @@ class Liquid::Tags::SortLinkTest < ActiveSupport::TestCase
       match = params.match Liquid::Tags::SortLink::SYNTAX
       assert match
       assert_equal match[1], expected[0]
-      assert_equal match[2], expected[1]
+      if expected[1]
+        assert_equal match[2], expected[1]
+      else
+        assert_nil match[2]
+      end
     end
   end
 

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -137,9 +137,9 @@ class PolicyTest < ActiveSupport::TestCase
     assert policy.idle?
 
     FactoryBot.create(:service, account: policy.account)
-    Proxy.any_instance.expects(:find_policy_config_by).at_least_once.
-                       with({ name: policy.name, version: policy.version }).
-                       returns(policy.schema.slice('name', 'version', 'configuration'))
+    Proxy.any_instance.expects(:find_policy_config_by).at_least_once
+         .with(name: policy.name, version: policy.version)
+         .returns(policy.schema.slice('name', 'version', 'configuration'))
 
     assert policy.reload.in_use?
     refute policy.idle?

--- a/test/unit/service_discovery/cluster_client_test.rb
+++ b/test/unit/service_discovery/cluster_client_test.rb
@@ -65,11 +65,11 @@ module ServiceDiscovery
     end
 
     test 'services in a given namespace' do
-      cluster.expects(:get_services).with(namespace: 'my-namespace').returns([
+      cluster.expects(:get_services).with({ namespace: 'my-namespace' }).returns([
         cluster_service(metadata: { name: 'my-api-staging',    uid: '220151f0-1918-4eca-808a-d4d07cea4b16', namespace: 'my-namespace' }, spec: { ports: [{ protocol: 'TCP', port: 3000, targetPort: 8080 }] }),
         cluster_service(metadata: { name: 'my-api-production', uid: '97a926db-e104-44ac-a5dd-43a0cf5ec686', namespace: 'my-namespace' }, spec: { ports: [{ protocol: 'TCP', port: 3001, targetPort: 8080 }] })
       ])
-      cluster.expects(:get_services).with(namespace: 'other-namespace').returns([
+      cluster.expects(:get_services).with({ namespace: 'other-namespace' }).returns([
         cluster_service(metadata: { name: 'my-other-api',      uid: 'b3ae7f5b-6188-4cc9-8fff-5fd4eff79056', namespace: 'other-namespace' }, spec: { ports: [{ protocol: 'TCP', port: 3000, targetPort: 8080 }] })
       ])
 
@@ -137,11 +137,11 @@ module ServiceDiscovery
         cluster_project(metadata: { name: 'project-2', uid: '9649ec16-5500-4531-9f77-1bb2246cc672' })
       ])
 
-      cluster.expects(:get_services).with(namespace: 'project-1', label_selector: 'discovery.3scale.net=true').returns([
+      cluster.expects(:get_services).with({ namespace: 'project-1', label_selector: 'discovery.3scale.net=true' }).returns([
         cluster_service(metadata: { name: 'non-discoverable-api-1', uid: '220151f0-1918-4eca-808a-d4d07cea4b16', namespace: 'project-1' } )
       ])
 
-      cluster.expects(:get_services).with(namespace: 'project-2', label_selector: 'discovery.3scale.net=true').returns([
+      cluster.expects(:get_services).with({ namespace: 'project-2', label_selector: 'discovery.3scale.net=true' }).returns([
         cluster_service(metadata: { name: 'non-discoverable-api-2', uid: 'a608a921-d715-4192-9171-5306c476260a', namespace: 'project-2' } ),
         cluster_service(
           metadata: {

--- a/test/unit/services/import_countries_service_test.rb
+++ b/test/unit/services/import_countries_service_test.rb
@@ -98,7 +98,7 @@ class ImportCountriesServiceTest < ActiveSupport::TestCase
       Country.expects(:find_by).with(code: 'JP').returns(japan)
 
       country_data.select(&:valid?).reject { |country| country.code == 'JP' }.each { |country| Country.expects(:create!).with(country.attributes) }
-      japan.expects(:update!).with(name: 'Japan', currency: 'JPY', updated_at: now)
+      japan.expects(:update!).with({ name: 'Japan', currency: 'JPY', updated_at: now })
 
       service.call!
     end

--- a/test/unit/services/service_token_service_test.rb
+++ b/test/unit/services/service_token_service_test.rb
@@ -5,7 +5,7 @@ class ServiceTokenServiceTest < ActiveSupport::TestCase
     token = ServiceToken.new(value: 'foo', service_id: 42)
 
     ThreeScale::Core::ServiceToken.expects(:save!)
-      .with({ 'foo' => { service_id: 42 } }).returns(true)
+      .with('foo' => { service_id: 42 }).returns(true)
 
     ServiceTokenService.update_backend(token)
   end

--- a/test/unit/services/support_entitlements_service_test.rb
+++ b/test/unit/services/support_entitlements_service_test.rb
@@ -37,7 +37,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     invoice = FactoryBot.create(:invoice, buyer_account: @provider_account, issued_on: Time.parse('2017-11-05'))
     FactoryBot.create(:line_item_plan_cost, invoice: invoice, contract: @provider_account.bought_cinstance, cinstance_id: @provider_account.bought_cinstance.id)
 
-    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_later: true))
+    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, { effective_since: invoice.issued_on, invoice_id: invoice.id }).returns(mock(deliver_later: true))
     AccountMailer.expects(:support_entitlements_revoked).never
 
     assert SupportEntitlementsService.notify_entitlements(@provider_account)
@@ -56,7 +56,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     @provider_account.buy! @trial_plan
 
     freeze_time do
-      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
+      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, { effective_since: Time.now.utc }).returns(mock(deliver_later: true))
       AccountMailer.expects(:support_entitlements_revoked).never
 
       assert SupportEntitlementsService.notify_entitlements(@provider_account)
@@ -68,7 +68,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
 
     freeze_time do
       AccountMailer.expects(:support_entitlements_assigned).never
-      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
+      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, { effective_since: Time.now.utc }).returns(mock(deliver_later: true))
 
       entitlements_options = { previous_plan: @paid_plan }
       assert SupportEntitlementsService.notify_entitlements(@provider_account, entitlements_options)
@@ -79,7 +79,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     @provider_account.buy! @trial_plan
 
     freeze_time do
-      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
+      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, { effective_since: Time.now.utc }).returns(mock(deliver_later: true))
       AccountMailer.expects(:support_entitlements_revoked).never
 
       entitlements_options = { previous_plan: @free_plan }
@@ -104,7 +104,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
 
     invoice = FactoryBot.create(:invoice, buyer_account: @provider_account, issued_on: Time.parse('2017-11-05'))
 
-    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_later: true))
+    AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, { effective_since: invoice.issued_on, invoice_id: invoice.id }).returns(mock(deliver_later: true))
     AccountMailer.expects(:support_entitlements_revoked).never
 
     entitlements_options = { previous_plan: @free_plan, invoice: invoice }
@@ -116,7 +116,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
 
     freeze_time do
       AccountMailer.expects(:support_entitlements_assigned).never
-      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
+      AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, { effective_since: Time.now.utc }).returns(mock(deliver_later: true))
 
       entitlements_options = { previous_plan: @paid_plan }
       assert SupportEntitlementsService.notify_entitlements(@provider_account, entitlements_options)
@@ -143,7 +143,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     FactoryBot.create(:line_item_plan_cost, invoice: invoice, contract: @provider_account.bought_cinstance, cinstance_id: @provider_account.bought_cinstance.id)
 
     AccountMailer.expects(:support_entitlements_assigned).never
-    AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, effective_since: invoice.issued_on, invoice_id: invoice.id).returns(mock(deliver_later: true))
+    AccountMailer.expects(:support_entitlements_revoked).with(@provider_account, { effective_since: invoice.issued_on, invoice_id: invoice.id }).returns(mock(deliver_later: true))
 
     assert SupportEntitlementsService.notify_entitlements(@provider_account)
   end
@@ -173,7 +173,7 @@ class SupportEntitlementsServiceTest < ActiveSupport::TestCase
     @provider_account.buy! @paid_plan
 
     freeze_time do
-      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, effective_since: Time.now.utc).returns(mock(deliver_later: true))
+      AccountMailer.expects(:support_entitlements_assigned).with(@provider_account, { effective_since: Time.now.utc }).returns(mock(deliver_later: true))
       AccountMailer.expects(:support_entitlements_revoked).never
 
       assert SupportEntitlementsService.notify_entitlements(@provider_account)

--- a/test/workers/backend_delete_application_worker_test.rb
+++ b/test/workers/backend_delete_application_worker_test.rb
@@ -8,8 +8,8 @@ class BackendDeleteApplicationWorkerTest < ActiveSupport::TestCase
     service = application.service
 
     seq = sequence('destroy sequence')
-    ApplicationKeyBackendService.expects(:delete_all).with(application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id).in_sequence(seq)
-    ReferrerFilterBackendService.expects(:delete_all).with(application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id).in_sequence(seq)
+    ApplicationKeyBackendService.expects(:delete_all).with({ application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id }).in_sequence(seq)
+    ReferrerFilterBackendService.expects(:delete_all).with({ application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id }).in_sequence(seq)
     ThreeScale::Core::Application.expects(:delete).with(service.backend_id, application.application_id).in_sequence(seq)
 
     event = Applications::ApplicationDeletedEvent.create_and_publish!(application)

--- a/test/workers/backend_metric_worker_test.rb
+++ b/test/workers/backend_metric_worker_test.rb
@@ -13,7 +13,7 @@ class BackendMetricWorkerTest < ActiveSupport::TestCase
   attr_reader :service, :metric
 
   test '#perform for update metric' do
-    ThreeScale::Core::Metric.expects(:save).with(id: metric.id, service_id: service.backend_id, name: metric.system_name, parent_id: nil)
+    ThreeScale::Core::Metric.expects(:save).with({ id: metric.id, service_id: service.backend_id, name: metric.system_name, parent_id: nil })
 
     perform_enqueued_jobs(only: BackendMetricWorker) do
       BackendMetricWorker.perform_later(service.backend_id, metric.id)

--- a/test/workers/backend_random_data_generator_worker_test.rb
+++ b/test/workers/backend_random_data_generator_worker_test.rb
@@ -11,7 +11,7 @@ class BackendRandomDataGeneratorWorkerTest < ActiveSupport::TestCase
   def test_perform
     worker = BackendRandomDataGeneratorWorker.new
 
-    Backend::RandomDataGenerator.expects(:generate).with(foo: 'bar', since: Time.utc(2016, 9, 1))
+    Backend::RandomDataGenerator.expects(:generate).with({ foo: 'bar', since: Time.utc(2016, 9, 1) })
 
     worker.perform('foo' => 'bar', 'since' => '2016-09-01 00:00:00 UTC')
   end

--- a/test/workers/service_discovery/create_service_worker_test.rb
+++ b/test/workers/service_discovery/create_service_worker_test.rb
@@ -14,7 +14,7 @@ module ServiceDiscovery
       account = FactoryBot.create(:simple_provider)
       ServiceDiscovery::OAuthManager.expects(:new).with(@user).returns(oauth_manager).at_least_once
       import_definition = mock
-      import_definition.expects(:create_service).with(account, cluster_namespace: 'fake-project', cluster_service_name: 'fake-api')
+      import_definition.expects(:create_service).with(account, { cluster_namespace: 'fake-project', cluster_service_name: 'fake-api' })
       ImportClusterDefinitionsService.expects(:new).with(@user).returns(import_definition)
       CreateServiceWorker.new.perform(account.id, 'fake-project', 'fake-api', @user&.id)
     end

--- a/test/workers/web_hook_worker_test.rb
+++ b/test/workers/web_hook_worker_test.rb
@@ -47,7 +47,7 @@ class WebHookWorkerTest < ActiveSupport::TestCase
   end
 
   test 'perform sends the webhook' do
-    @worker.expects(:push).with(url: 'url', xml: 'xml', content_type: 'content_type')
+    @worker.expects(:push).with({ url: 'url', xml: 'xml', content_type: 'content_type' })
     @worker.perform('uuid', { 'provider_id' => 'provider', 'url' => 'url', 'xml' => 'xml', 'content_type' => 'content_type' })
   end
 


### PR DESCRIPTION
There were a bunch of deprecation warnings (about 26) on this kind:

```
DEPRECATED: Use assert_nil if expecting nil from test/whatever_test.rb:10. This will fail in Minitest 6.
```

And also many of this kind:

```
SomeClass#some_method Mocha deprecation warning at /opt/ci/workdir/app/some_class.rb:69:in `block in call!': Expectation defined at /opt/ci/workdir/test/unit/some_class_test.rb:101:in `block (2 levels) in <class:SomeClassTest>' expected keyword arguments (:name => "Japan", :currency => "JPY"), but received positional hash ({:name => "Japan", :currency => "JPY"}). These will stop matching when strict keyword argument matching is enabled. See the documentation for Mocha::Configuration#strict_keyword_argument_matching=.
```