### PR TITLE
THREESCALE-8383: Clear liquid cache for email templates

### DIFF
--- a/app/models/cms/email_template.rb
+++ b/app/models/cms/email_template.rb
@@ -228,7 +228,8 @@ class CMS::EmailTemplate < CMS::Template
                 def mail(headers, &block)
                   if @provider_account
                     headers[:template_path] ||= 'emails'
-                    prepend_view_path Liquid::Template::Resolver.instance(@provider_account)
+                    resolver = Liquid::Template::Resolver.instance(@provider_account)
+                    prepend_view_path resolver
 
                     headers[::Message::APPLY_ENGAGEMENT_FOOTER]= @provider_account.should_apply_email_engagement_footer?
                   else
@@ -236,6 +237,8 @@ class CMS::EmailTemplate < CMS::Template
                   end
 
                   super(headers, &block)
+                ensure
+                  resolver&.clear_cache
                 end
 
                 def render(options)

--- a/lib/developer_portal/lib/liquid/template/resolver.rb
+++ b/lib/developer_portal/lib/liquid/template/resolver.rb
@@ -4,17 +4,20 @@ module Liquid
       # really nasty way, but how else ?
       attr_accessor :cms
 
-      def self.config
-        Rails.configuration.liquid
-      end
+      @instances = Concurrent::Map.new
 
-      def self.instance(scope)
-        config.resolver_caching ? cached(scope) : new(scope)
-      end
+      class << self
+        def config
+          Rails.configuration.liquid
+        end
 
-      @@cache = {}
-      def self.cached(scope)
-        @@cache[scope.id] ||= new(scope)
+        def instance(scope)
+          config.resolver_caching ? cached(scope) : new(scope)
+        end
+
+        def cached(scope)
+          @instances[scope.id] ||= new(scope)
+        end
       end
 
       def initialize(scope)


### PR DESCRIPTION
#### What this PR does / why we need it

On production, when an email template is updated, the changes don't take effect until the Sidekq pod is restarted.

This happens because liquid templates are stored in a cache on the server, and that cache never gets invalidated, so after the template is cached the first time, the renderer will always fetch the same cached version of the template, and ignore any more recent version of it.

It's important to mention that this cache is not the same cache store configured through `cache_store.yml`, so Memcached is not involved. This is an internal in-memory cache implemented by Rails for optimization and the user is not supposed to deal with it.

The bug only affects liquid templates because they are fetched using a custom template resolver written by us, which doesn't integrate correctly with the Rails internal cache.

##### Let's take a look at the code

When rendering an email template, we inject our custom template resolver in the view paths list:

https://github.com/3scale/porta/blob/edce496fab6003bdee8ca0dfac37ccb799854332/app/models/cms/email_template.rb#L231

As you may see in this snippet, `Liquid::Template::Resolver.instance` will return always the same instance when `Rails.configuration.liquid.resolver_caching` is `true`.

https://github.com/3scale/porta/blob/edce496fab6003bdee8ca0dfac37ccb799854332/lib/developer_portal/lib/liquid/template/resolver.rb#L7-L18

Ignore the `@@cache` class variable here, it's not related to the Rails cache causing the problem.

In production we set `liquid.resolver_caching` to `true`.

https://github.com/3scale/porta/blob/edce496fab6003bdee8ca0dfac37ccb799854332/config/environments/production.rb#L118

`Liquid::Template::Resolver` inherits from `ActionView::Resolver`, which implements the mentioned cache:

https://github.com/rails/rails/blob/28bb76d3efc39b2ef663dfe2346f7c2621343cd6/actionview/lib/action_view/template/resolver.rb#L107-L109

When rendering a template, all resolvers are queried in order to find one which has a template matching the given `prefix` and `name`, e.g:  `signup/show`

https://github.com/rails/rails/blob/28bb76d3efc39b2ef663dfe2346f7c2621343cd6/actionview/lib/action_view/template/resolver.rb#L116-L122

Our resolver overrides the private method `_find_all` to lookup for liquid templates in the `cms_templates` table.

https://github.com/3scale/porta/blob/edce496fab6003bdee8ca0dfac37ccb799854332/lib/developer_portal/lib/liquid/template/resolver.rb#L25-L31

When finding one, it's stored in the resolver cache.

##### Why is it not caching developer portal templates?

This liquid resolver is used to lookup for all liquid templates, not only emails, however, dev. portal templates are always loaded correctly. That's because in this scenario the liquid resolver is injected from another place, when calling the `liquify` method from a controller.

https://github.com/3scale/porta/blob/edce496fab6003bdee8ca0dfac37ccb799854332/app/lib/liquid/template_support.rb#L17-L27

This adds a `before_action` callback that injects the resolver:

https://github.com/3scale/porta/blob/edce496fab6003bdee8ca0dfac37ccb799854332/app/lib/liquid/template_support.rb#L34

And an `after_action` callback that clears the cache.

So the resolver cache is always cleared for each request, that's why the next request never finds an old template cached.

##### How this PR fixes the bug

It just does for email templates the same as for dev. portal templates, clear the cache after every email delivery:

https://github.com/3scale/porta/blob/a4d98165f413baed512ae5558cbb1de74ac08015/app/models/cms/email_template.rb#L240-L241

##### Why not just disable the cache?

We could just set `Rails.configuration.liquid.resolver_caching` to `false`. Then every email template render would get a new resolver object with a clear cache and we shouldn't worry about clearing it manually. However, it's better to keep the cache because the renderer calls the resolver several times during rendering, and thanks to the cache the DB is only hit once per request.

#### Which issue(s) this PR fixes

[THREESCALE-8383](https://issues.redhat.com/browse/THREESCALE-8383)

**Verification steps** 

- In `master`, add `config.liquid.resolver_caching = true` to `config/environments/developer.rb` and check how the bug is reproduced.
- Then, in this branch, check how the bug is fixed also with `config.liquid.resolver_caching = true`.