### PR TITLE
wait more for manticore if needed

### DIFF
--- a/features/support/sphinx.rb
+++ b/features/support/sphinx.rb
@@ -12,7 +12,9 @@ Before('@search') do
   ::ThinkingSphinx::Test.stop
   ::ThinkingSphinx::Test.autostop
   output = ::ThinkingSphinx::Test.start index: false
-  assert ::ThinkingSphinx::Test.config.controller.running?, "thinking sphinx should be running: #{output.output}"
+
+  3.times { ::ThinkingSphinx::Test.config.controller.running? && break || sleep(1) }
+  raise "thinking sphinx should be running:\n#{output.output}" unless ::ThinkingSphinx::Test.config.controller.running?
 end
 
 After '@search' do


### PR DESCRIPTION
Trying to fix errors like

```
Before hook at features/support/sphinx.rb:8

Message:thinking sphinx should be running: [Sat Apr 13 00:16:30.021 2024] [626] using config file '/opt/ci/project/config/test.sphinx.conf' (5387 chars)...
[Sat Apr 13 00:16:30.022 2024] [626] WARNING: secondary_indexes set but failed to initialize secondary library: (null)
Manticore 6.2.12 dc5144d35@230822
Copyright (c) 2001-2016, Andrew Aksyonoff
Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
...
```

https://app.circleci.com/pipelines/github/3scale/porta/27939/workflows/c19ccf0a-e1e2-408a-98f4-0e978a01a7f8/jobs/312776/tests