### PR TITLE
THREESCALE-2689: Service Subscription API: create, show, change plan, approve

### DIFF
--- a/app/controllers/admin/api/service_contracts_controller.rb
+++ b/app/controllers/admin/api/service_contracts_controller.rb
@@ -7,13 +7,13 @@ class Admin::Api::ServiceContractsController < Admin::Api::ServiceBaseController
   before_action :deny_on_premises_for_master
   before_action :authorize_service_plans!
 
-  # Service Subscription List
+  # [DEPRECATED] Service Subscription List
   # GET /admin/api/accounts/{account_id}/service_contracts.xml
   def index
     respond_with account.bought_service_contracts
   end
 
-  # Service Subscription Delete
+  # [DEPRECATED] Service Subscription Delete
   # DELETE /admin/api/accounts/{account_id}/service_contracts/{id}.xml
   def destroy
     service_subscription = ServiceSubscriptionService.new(account)

--- a/app/controllers/admin/api/service_subscriptions_controller.rb
+++ b/app/controllers/admin/api/service_subscriptions_controller.rb
@@ -40,6 +40,13 @@ class Admin::Api::ServiceSubscriptionsController < Admin::Api::ServiceBaseContro
     respond_with service_subscription
   end
 
+  # Service Subscription Approve
+  # PUT /admin/api/accounts/{account_id}/service_subscriptions/{id}/approve.json
+  def approve
+    service_subscription.accept
+    respond_with service_subscription
+  end
+
   private
 
   def account

--- a/app/controllers/admin/api/service_subscriptions_controller.rb
+++ b/app/controllers/admin/api/service_subscriptions_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class Admin::Api::ServiceSubscriptionsController < Admin::Api::ServiceBaseController
+  wrap_parameters ServiceContract, name: :service_subscription
+  representer entity: ::ServiceSubscriptionRepresenter, collection: ::ServiceSubscriptionsRepresenter
+
+  before_action :deny_on_premises_for_master
+  before_action :authorize_service_plans!
+
+  # Service Subscription Create
+  # POST /admin/api/accounts/:account_id/service_subscriptions.json
+  def create
+    respond_with account.bought_service_contracts.create(plan: service_plan)
+  end
+
+  # Service Subscription List
+  # GET /admin/api/accounts/{account_id}/service_subscriptions.json
+  def index
+    respond_with account.bought_service_contracts
+  end
+
+  # Service Subscription Delete
+  # DELETE /admin/api/accounts/{account_id}/service_subscriptions/{id}.json
+  def destroy
+    service = ServiceSubscriptionService.new(account)
+
+    respond_with(service.unsubscribe(service_subscription))
+  end
+
+  # Service Subscription Change Plan
+  # PUT /admin/api/accounts/{account_id}/service_subscriptions/{id}/change_plan.json
+  def change_plan
+    service_subscription.change_plan(service_plan)
+    respond_with(service_subscription, serialize: service_plan, representer: ServicePlanRepresenter)
+  end
+
+  # Service Subscription Show
+  # GET /admin/api/accounts/:account_id/service_subscriptions/:id.json
+  def show
+    respond_with service_subscription
+  end
+
+  private
+
+  def account
+    @account ||= current_account.buyers.find params.require(:account_id)
+  end
+
+  def service_subscription
+    @service_subscription ||= account.bought_service_contracts.find(params.require(:id))
+  end
+
+  def service_plan
+    @service_plan ||= ServicePlan.provided_by(current_account).find(service_subscription_plan_id)
+  end
+
+  def service_subscription_plan_id
+    @service_subscription_plan_id ||= service_subscription_params[:plan_id]
+  end
+
+  def service_subscription_params
+    @service_subscription_params ||= params.permit(service_subscription: [:plan_id]).fetch(:service_subscription)
+  end
+end

--- a/app/models/service_contract.rb
+++ b/app/models/service_contract.rb
@@ -1,6 +1,8 @@
 class ServiceContract < Contract
   include Logic::Contracting::ServiceContract
 
+  validate :same_service_plan_update, on: :update, if: :plan_id_changed?
+
   before_create :accept_on_create, :unless => :live?
 
   before_create :set_service_id
@@ -57,4 +59,9 @@ class ServiceContract < Contract
     @legal_terms_acceptance
   end
 
+  def same_service_plan_update
+    return if plan.blank?
+
+    errors.add(:plan, :service_conflict) if Plan.find_by(id: plan_id_was)&.issuer_id != plan.issuer_id
+  end
 end

--- a/app/representers/service_subscription_representer.rb
+++ b/app/representers/service_subscription_representer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ServiceSubscriptionRepresenter
+  include ThreeScale::JSONRepresenter
+  wraps_resource :service_subscription
+
+  property :id
+  property :plan_id
+  property :user_account_id
+  property :created_at
+  property :updated_at
+  property :state
+  property :paid_until
+  property :trial_period_expires_at
+  property :setup_fee
+  property :type
+  property :variable_cost_paid_until
+  property :tenant_id
+  property :service_id
+  property :accepted_at
+end

--- a/app/representers/service_subscriptions_representer.rb
+++ b/app/representers/service_subscriptions_representer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ServiceSubscriptionsRepresenter < ThreeScale::CollectionRepresenter
+  include ThreeScale::JSONRepresenter
+  wraps_resource :service_subscriptions
+  items extend: ServiceSubscriptionRepresenter
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1217,6 +1217,9 @@ en:
               unsuspended_applications:
                 one: 'There is 1 unsuspended application subscribed to the service'
                 other: 'There are %{count} unsuspended applications subscribed to the service'
+            plan:
+              service_conflict: 'must belong to the same product'
+
         invoice:
           attributes:
             state:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -614,6 +614,12 @@ without fake Core server your after commit callbacks will crash and you might ge
 
         resources :service_contracts, :only => [:index, :destroy]
 
+        resources :service_subscriptions, constraints: { format: :json }, defaults: { format: :json }, except: %i[new edit update] do
+          member do
+            put :change_plan
+          end
+        end
+
         resources :messages, :only => [:create]
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -617,6 +617,7 @@ without fake Core server your after commit callbacks will crash and you might ge
         resources :service_subscriptions, constraints: { format: :json }, defaults: { format: :json }, except: %i[new edit update] do
           member do
             put :change_plan
+            put :approve
           end
         end
 

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -266,7 +266,7 @@
         }
       }
     },
-    "/admin/api/accounts/{account_id}/service_subscriptions.xml": {
+    "/admin/api/accounts/{account_id}/service_subscriptions.json": {
       "get": {
         "summary": "Service Subscription List",
         "description": "List all the service subscriptions of an account.",
@@ -349,7 +349,7 @@
         }
       }
     },
-    "/admin/api/accounts/{account_id}/service_subscriptions/{id}.xml": {
+    "/admin/api/accounts/{account_id}/service_subscriptions/{id}.json": {
       "get": {
         "summary": "Service Subscription Show",
         "description": "Retrieve details of a specific service subscription.",
@@ -437,7 +437,61 @@
         }
       }
     },
-    "/admin/api/accounts/{account_id}/service_subscriptions/{id}/change_plan.xml": {
+    "/admin/api/accounts/{account_id}/service_subscriptions/{id}/approve.json": {
+      "put": {
+        "summary": "Service Subscription Approve",
+        "description": "Approve a pending service subscription.",
+        "tags": [
+          "Service Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the service subscription.",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "account_id",
+            "in": "path",
+            "description": "ID of the account.",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "access_token": {
+                    "type": "string",
+                    "description": "A personal Access Token."
+                  }
+                },
+                "required": [
+                  "access_token"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "success",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/admin/api/accounts/{account_id}/service_subscriptions/{id}/change_plan.json": {
       "put": {
         "summary": "Service Subscription Change Plan",
         "description": "Update the plan of a service subscription.",

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -266,6 +266,236 @@
         }
       }
     },
+    "/admin/api/accounts/{account_id}/service_subscriptions.xml": {
+      "get": {
+        "summary": "Service Subscription List",
+        "description": "List all the service subscriptions of an account.",
+        "tags": [
+          "Service Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "access_token",
+            "in": "query",
+            "description": "A personal Access Token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account_id",
+            "in": "path",
+            "description": "ID of the account.",
+            "x-data-threescale-name": "account_ids",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "success",
+            "content": {}
+          }
+        }
+      },
+      "post": {
+        "summary": "Service Subscription Create",
+        "description": "Subscribe an account to a service through the specified service plan.",
+        "tags": [
+          "Service Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "description": "ID of the account.",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "access_token": {
+                    "type": "string",
+                    "description": "A personal Access Token."
+                  },
+                  "plan_id": {
+                    "type": "integer",
+                    "description": "ID of the Service plan"
+                  }
+                },
+                "required": [
+                  "access_token",
+                  "plan_id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Success",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/admin/api/accounts/{account_id}/service_subscriptions/{id}.xml": {
+      "get": {
+        "summary": "Service Subscription Show",
+        "description": "Retrieve details of a specific service subscription.",
+        "tags": [
+          "Service Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "access_token",
+            "in": "query",
+            "description": "A personal Access Token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account_id",
+            "in": "path",
+            "description": "ID of the account.",
+            "x-data-threescale-name": "account_ids",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the service contract.",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "success",
+            "content": {}
+          }
+        }
+      },
+      "delete": {
+        "summary": "Service Subscription Delete",
+        "description": "Unsubscribe from a service. This endpoint will delete all the applications under the subscribed service.",
+        "tags": [
+          "Service Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "access_token",
+            "in": "query",
+            "description": "A personal Access Token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account_id",
+            "in": "path",
+            "description": "ID of the account.",
+            "x-data-threescale-name": "account_ids",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the service contract.",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "success",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/admin/api/accounts/{account_id}/service_subscriptions/{id}/change_plan.xml": {
+      "put": {
+        "summary": "Service Subscription Change Plan",
+        "description": "Update the plan of a service subscription.",
+        "tags": [
+          "Service Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the service subscription.",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "account_id",
+            "in": "path",
+            "description": "ID of the account.",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "access_token": {
+                    "type": "string",
+                    "description": "A personal Access Token."
+                  },
+                  "plan_id": {
+                    "type": "integer",
+                    "description": "ID of the target account plan"
+                  }
+                },
+                "required": [
+                  "access_token",
+                  "plan_id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "success",
+            "content": {}
+          }
+        }
+      }
+    },
     "/admin/api/accounts/{account_id}/applications.xml": {
       "get": {
         "summary": "Application List",
@@ -1229,8 +1459,8 @@
     },
     "/admin/api/accounts/{account_id}/service_contracts.xml": {
       "get": {
-        "summary": "Service Subscription List",
-        "description": "List all the service_contracts of an account",
+        "summary": "[DEPRECATED] Service Subscription List",
+        "description": "This endpoint is deprecated, use `GET /admin/api/accounts/{account_id}/service_subscriptions.xml` instead.",
         "tags": [
           "Accounts"
         ],
@@ -1265,8 +1495,8 @@
     },
     "/admin/api/accounts/{account_id}/service_contracts/{id}.xml": {
       "delete": {
-        "summary": "Service Subscription Delete",
-        "description": "Unsubscribe from a service. This endpoint will delete all the applications that are under the subscribed service.",
+        "summary": "[DEPRECATED] Service Subscription Delete",
+        "description": "This endpoint is deprecated, use `DELETE /admin/api/accounts/{account_id}/service_subscriptions/{id}.xml` instead.",
         "tags": [
           "Accounts"
         ],

--- a/test/integration/user-management-api/service_subscriptions_controller_test.rb
+++ b/test/integration/user-management-api/service_subscriptions_controller_test.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Admin::Api::ServiceSubscriptionsControllerTest < ActionDispatch::IntegrationTest
+
+  SERVICE_SUBSCRIPTION_ATTRIBUTES = %w[id plan_id service_id user_account_id created_at updated_at state paid_until trial_period_expires_at setup_fee type variable_cost_paid_until tenant_id].freeze
+
+  def setup
+    @service_plan     = FactoryBot.create(:service_plan, issuer: service)
+    @application_plan = FactoryBot.create(:application_plan, issuer: service)
+
+    @buyer            = FactoryBot.create(:buyer_account, provider_account: current_account)
+    @service_contract = FactoryBot.create(:simple_service_contract, plan: @service_plan, user_account: @buyer)
+
+    @buyer.buy! @application_plan
+
+    @token = FactoryBot.create(:access_token, owner: current_account.admin_users.first!, scopes: 'account_management').value
+    host! current_account.internal_admin_domain
+  end
+
+  attr_reader :buyer, :token, :service_contract
+
+  class ProviderAccountTest < Admin::Api::ServiceSubscriptionsControllerTest
+    test 'index' do
+      another_plan = FactoryBot.create(:service_plan)
+      another_service_contract = FactoryBot.create(:simple_service_contract, plan: another_plan, user_account: buyer)
+      get admin_api_account_service_subscriptions_path(account_id: buyer.id, format: :json, access_token: token)
+      assert_response :ok
+
+      expected_ids = [service_contract.id, another_service_contract.id]
+      json_body = JSON.parse(response.body)
+      assert_equal expected_ids, (json_body['service_subscriptions'].map { |item| item['service_subscription']['id'] })
+    end
+
+    test 'successful unsubscribe' do
+      apps = buyer.bought_cinstances.by_service_id(service_contract.service_id)
+      apps.update_all state: 'suspended'
+
+      delete admin_api_account_service_subscription_path(service_contract.id, account_id: buyer.id, format: :json, access_token: token)
+
+      assert_response :ok
+      assert_raises(ActiveRecord::RecordNotFound) { service_contract.reload }
+    end
+
+    test 'unsubscribe forbidden' do
+      delete admin_api_account_service_subscription_path(service_contract.id, account_id: buyer.id, format: :json, access_token: token)
+      assert_response :forbidden
+    end
+
+    test 'show' do
+      get admin_api_account_service_subscription_path(service_contract.id, account_id: buyer.id, format: :json, access_token: token)
+      assert_response :ok
+
+      json_body = JSON.parse(response.body)
+      assert_equal service_contract.id, json_body.dig('service_subscription', 'id')
+      assert_same_elements SERVICE_SUBSCRIPTION_ATTRIBUTES, json_body['service_subscription'].keys
+    end
+
+    test 'subscribe successfully on another service' do
+      another_service = FactoryBot.create(:service, account: current_account)
+      another_service_plan = FactoryBot.create(:service_plan, issuer: another_service)
+      post admin_api_account_service_subscriptions_path(account_id: buyer.id, format: :json, access_token: token),
+           params: { plan_id: another_service_plan.id }
+      assert_response :created
+
+      json_body = JSON.parse(response.body)
+      assert_equal another_service_plan.id, json_body.dig('service_subscription', 'plan_id')
+    end
+
+    test 'subscription on the same service fails' do
+      another_service_plan = FactoryBot.create(:service_plan, issuer: service)
+      post admin_api_account_service_subscriptions_path(account_id: buyer.id, format: :json, access_token: token),
+           params: { plan_id: another_service_plan.id }
+      assert_response :unprocessable_entity
+
+      json_body = JSON.parse(response.body)
+      assert_equal 'already subscribed to this service', json_body.dig('errors', 'base', 0)
+    end
+
+    test "subscription on other another provider's plan fails" do
+      another_provider = FactoryBot.create(:provider_account, provider_account: master_account)
+      another_service = FactoryBot.create(:service, account: another_provider)
+      another_service_plan = FactoryBot.create(:service_plan, issuer: another_service)
+
+      post admin_api_account_service_subscriptions_path(account_id: buyer.id, format: :json, access_token: token),
+           params: { plan_id: another_service_plan.id }
+      assert_response :not_found
+    end
+
+    test 'plan changed successfully' do
+      another_service_plan = FactoryBot.create(:service_plan, issuer: service)
+
+      put change_plan_admin_api_account_service_subscription_path(service_contract.id, account_id: buyer.id, format: :json, access_token: token),
+          params: { plan_id: another_service_plan.id }
+      assert_response :ok
+
+      json_body = JSON.parse(response.body)
+      assert_equal another_service_plan.id, json_body.dig('service_plan', 'id')
+    end
+
+    test "plan change fails for plan in another service" do
+      another_service = FactoryBot.create(:service, account: current_account)
+      another_service_plan = FactoryBot.create(:service_plan, issuer: another_service)
+
+      put change_plan_admin_api_account_service_subscription_path(service_contract.id, account_id: buyer.id, format: :json, access_token: token),
+          params: { plan_id: another_service_plan.id }
+      assert_response :unprocessable_entity
+
+      json_body = JSON.parse(response.body)
+      assert_equal 'must belong to the same product', json_body.dig('errors', 'plan', 0)
+    end
+
+    private
+
+    def current_account
+      @current_account ||= FactoryBot.create(:provider_account, provider_account: master_account)
+    end
+
+    def service
+      @service ||= FactoryBot.create(:service, account: current_account)
+    end
+  end
+
+  class MasterAccountTest < Admin::Api::ServiceSubscriptionsControllerTest
+    test 'index is not authorized in on-premises' do
+      ThreeScale.stubs(master_on_premises?: true)
+      get admin_api_account_service_subscriptions_path(account_id: buyer.id, format: :json, access_token: token)
+      assert_response :forbidden
+    end
+
+    test 'index works in SaaS' do
+      get admin_api_account_service_subscriptions_path(account_id: buyer.id, format: :json, access_token: token)
+      assert_response :success
+    end
+
+    test 'delete is not authorized on-premises' do
+      ThreeScale.stubs(master_on_premises?: true)
+      apps = buyer.bought_cinstances.by_service_id(service_contract.service_id)
+      apps.update_all state: 'suspended'
+      delete admin_api_account_service_contract_path(service_contract.id, account_id: buyer.id, format: :json, access_token: token)
+      assert_response :forbidden
+    end
+
+    test 'delete works in SaaS' do
+      apps = buyer.bought_cinstances.by_service_id(service_contract.service_id)
+      apps.update_all state: 'suspended'
+      delete admin_api_account_service_contract_path(service_contract.id, account_id: buyer.id, format: :json, access_token: token)
+      assert_response :success
+    end
+
+    private
+
+    def current_account
+      master_account
+    end
+
+    def service
+      @service ||= master_account.first_service!
+    end
+  end
+end

--- a/test/unit/observers/message_observer_test.rb
+++ b/test/unit/observers/message_observer_test.rb
@@ -33,12 +33,12 @@ class MessageObserverTest < ActiveSupport::TestCase
     end
 
     test 'plan changed' do
-      contract = FactoryBot.create(:service_contract)
+      contract = FactoryBot.create(:service_contract, plan: FactoryBot.create(:simple_service_plan, issuer: @service))
 
       ServiceContracts::ServiceContractPlanChangedEvent.expects(:create).once
       ContractMessenger.expects(:plan_change).never
 
-      contract.change_plan! FactoryBot.create(:simple_service_plan)
+      contract.change_plan! FactoryBot.create(:simple_service_plan, issuer: @service)
 
       cinstance = FactoryBot.create(:cinstance, service: @service)
 

--- a/test/unit/observers/plan_observer_test.rb
+++ b/test/unit/observers/plan_observer_test.rb
@@ -3,11 +3,13 @@ require 'test_helper'
 class PlanObserverTest < ActiveSupport::TestCase
 
   def test_plan_downgraded
+    service = FactoryBot.create(:service)
     contract = FactoryBot.create(:service_contract,
-      plan: FactoryBot.create(:service_plan, cost_per_month: 30))
+                                 plan: FactoryBot.create(:service_plan, issuer: service, cost_per_month: 30))
+    another_plan = FactoryBot.create(:service_plan, issuer: service, cost_per_month: 20)
 
     Plans::PlanDowngradedEvent.expects(:create).once
 
-    contract.change_plan! FactoryBot.create(:service_plan, cost_per_month: 20)
+    contract.change_plan! another_plan
   end
 end

--- a/test/unit/service_contract_test.rb
+++ b/test/unit/service_contract_test.rb
@@ -54,4 +54,25 @@ class ServiceContractTest < ActiveSupport::TestCase
     assert_same_elements p1_contracts, ServiceContract.provided_by(provider1).to_a
     assert_same_elements p2_contracts, ServiceContract.provided_by(provider2).to_a
   end
+
+  test 'update plan within the same service' do
+    service = FactoryBot.create(:simple_service)
+    plan1 = FactoryBot.create(:service_plan, issuer: service)
+    plan2 = FactoryBot.create(:service_plan, issuer: service)
+    service_contract = FactoryBot.create(:service_contract, plan: plan1)
+
+    assert service_contract.change_plan(plan2)
+    assert plan2.id, service_contract.reload.plan.id
+  end
+
+  test 'update plan from a different service' do
+    service1 = FactoryBot.create(:simple_service)
+    plan1 = FactoryBot.create(:service_plan, issuer: service1)
+    service2 = FactoryBot.create(:simple_service)
+    plan2 = FactoryBot.create(:service_plan, issuer: service2)
+    service_contract = FactoryBot.create(:service_contract, plan: plan1)
+
+    assert_not service_contract.change_plan(plan2)
+    assert service_contract.errors.of_kind? :plan, :service_conflict
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR comes out of https://github.com/3scale/porta/pull/3750 and replaces https://github.com/3scale/porta/pull/3672 (as it has already diverged from it too much).

It adds the missing service subscription (service contracts) API endpoints, and fixes some bad representation in the existing endpoints - by adding new endpoints under `/admin/api/accounts/{account_id}/service_subscriptions` and deprecating the old `/admin/api/accounts/{account_id}/service_contracts`.

The new endpoints are only available in JSON format, XML is not supported.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-2689

**Verification steps** 


**Special notes for your reviewer**:

