### PR TITLE
THREESCALE-7491: Fix permissions errors for member user with Analytics permissions

### DIFF
--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -256,8 +256,9 @@ module VerticalNavHelper
 
     sections << {id: :overview,         title: 'Backend Overview',             path: provider_admin_backend_api_path(@backend_api)}
     sections << {id: :monitoring,       title: 'Analytics',            path: provider_admin_backend_api_stats_usage_path(@backend_api)} if can? :manage, :monitoring
-    sections << {id: :methods_metrics,  title: 'Methods and Metrics',  path: provider_admin_backend_api_metrics_path(@backend_api)}
-    sections << {id: :mapping_rules,    title: 'Mapping Rules',        path: provider_admin_backend_api_mapping_rules_path(@backend_api)}
+    sections << {id: :methods_metrics,  title: 'Methods and Metrics',  path: provider_admin_backend_api_metrics_path(@backend_api)} if can? :edit, BackendApi
+    sections << {id: :mapping_rules,    title: 'Mapping Rules',        path: provider_admin_backend_api_mapping_rules_path(@backend_api)} if can? :edit, BackendApi
+    sections
   end
 
   # Others

--- a/config/abilities/provider_member.rb
+++ b/config/abilities/provider_member.rb
@@ -47,6 +47,7 @@ Ability.define do |user|
   if user.has_permission?('monitoring')
     can :manage, :monitoring
     can :manage, :analytics
+    can %i[index show], BackendApi
   end
 
   if user.has_permission?('portal')

--- a/test/helpers/vertical_nav_helper_test.rb
+++ b/test/helpers/vertical_nav_helper_test.rb
@@ -15,7 +15,7 @@ class VerticalNavHelperTest < ActionView::TestCase
     def setup
       super
       @current_account = FactoryBot.create(:simple_provider)
-      @current_user = FactoryBot.create(:simple_user, account: current_account)
+      @current_user = FactoryBot.create(:simple_admin, account: current_account)
     end
 
     test '#backend_api_nav_sections' do
@@ -26,7 +26,7 @@ class VerticalNavHelperTest < ActionView::TestCase
 
       # if not permitted
       stubs(can?: false)
-      assert_equal(["Backend Overview", "Methods and Metrics", "Mapping Rules"], backend_api_nav_sections.pluck(:title))
+      assert_equal(["Backend Overview"], backend_api_nav_sections.pluck(:title))
 
       # When backend_api is not persisted
       @backend_api = BackendApi.new

--- a/test/integration/provider/admin/backend_apis/stats/usage_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/stats/usage_controller_test.rb
@@ -20,12 +20,23 @@ class Provider::Admin::BackendApis::Stats::UsageControllerTest < ActionDispatch:
     assert_equal @backend_api.metrics, assigns(:metrics)
   end
 
-  test 'user permissions' do
+  test 'user permissions: forbidden to member users' do
     member_user = FactoryBot.create(:member, account: provider)
     member_user.activate!
     login_provider @provider, user: member_user
 
     get provider_admin_backend_api_stats_usage_path(backend_api_id: @backend_api.id)
     assert_response :forbidden
+  end
+
+  test 'user permissions: allowed to member users with Analytics permissions' do
+    member_user = FactoryBot.create(:member, account: provider)
+    member_user.activate!
+    member_user.update(allowed_sections: [:monitoring])
+    login_provider @provider, user: member_user
+
+    get provider_admin_backend_api_stats_usage_path(backend_api_id: @backend_api.id)
+    assert_response :success
+    assert_template 'stats/usage/index'
   end
 end

--- a/test/integration/stats/data/backend_apis_controller_test.rb
+++ b/test/integration/stats/data/backend_apis_controller_test.rb
@@ -37,13 +37,14 @@ class Stats::Data::BackendApisControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test 'user permissions' do
+  test 'user permissions: usage allowed for members with Analytics permissions' do
     member_user = FactoryBot.create(:member, account: provider)
     member_access_token  = FactoryBot.create(:access_token, owner: member_user, scopes: ['stats'])
     get usage_stats_data_backend_apis_path(backend_api, format: :json, access_token: member_access_token.value), params: stats_params
     assert_response :forbidden
 
-    get usage_stats_data_backend_apis_path(backend_api, format: :json, access_token: access_token.value), params: stats_params
+    member_user.update(allowed_sections: [:monitoring])
+    get usage_stats_data_backend_apis_path(backend_api, format: :json, access_token: member_access_token.value), params: stats_params
     assert_response :success
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes "Access Denied" to a member admin user that tries to access the Backend API's analytics screen.

Also fixed a similar access issue when trying to access the backend API usage via Analytics API.

There is no fine-grained permission system for API backends, but the UI says "all API backends", so when this permission is enabled, I guess it should allow the user to view all backends.

![image](https://github.com/3scale/porta/assets/1270328/a4a0f51e-2e07-4880-920c-eac98d44ac17)

I also allowed viewing the Backend API index, because without it the user can't navigate to a specific backend (in a very likely case that it doesn't appear on the Dashboard).

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-7491

**Verification steps** 

- Create a member user in the admin portal and grant "Access & query analytics of:" permissions.
- Log in as the created member user


**a) UI**
- From the dashboard, go to the list of Backends, navigate to a desired backend, and view Analytics
- Access Denied screen should not be visible

**b) API**
- Create an access token - only Analytics API scope would be available
- Go to the API docs, fill in and call the Backend Analytics endpoint
- Make sure the call is successful and no permission error is shown

**Special notes for your reviewer**:
