### PR TITLE
Remove confusing log about /yabeda-metrics

### DIFF
--- a/config/unicorn/development.rb
+++ b/config/unicorn/development.rb
@@ -21,7 +21,6 @@ listen ENV.fetch('PORT', 3000).to_i
 
 prometheus_port = PrometheusExporterPort.call
 $stdout.puts "=> Unicorn Prometheus endpoint http://localhost:#{prometheus_port}/metrics"
-$stdout.puts "=> Unicorn Prometheus endpoint http://localhost:#{prometheus_port}/yabeda-metrics"
 listen prometheus_port
 
 pid app_dir.join('tmp/pids/unicorn.pid').to_s


### PR DESCRIPTION
**What this PR does / why we need it**:

We removed the `/yabeda-metrics` endpoint in https://github.com/3scale/porta/pull/3680, so remove the log line that says that it's available.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

Log is not shown when starting dev server.

**Special notes for your reviewer**:
