### PR TITLE
Upgrade PostgreSQL on CircleCI from 10 to 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ mysql-container: &mysql-container
     MYSQL_DATABASE: circleci
 
 postgres-container: &postgres-container
-  image: cimg/postgres:10.20
+  image: cimg/postgres:13.15
   environment:
     POSTGRES_USER: postgres
     POSTGRES_DB: systemdb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ postgres-container: &postgres-container
   image: cimg/postgres:13.15
   environment:
     POSTGRES_USER: postgres
-    POSTGRES_DB: systemdb
 
 oracle-db-container: &oracle-db-container
   image: quay.io/3scale/oracle:19.3.0-ee-ci-prebuilt


### PR DESCRIPTION
**What this PR does / why we need it**:

We say we [support](https://access.redhat.com/articles/2798521) PostgreSQL 13, so we'd rather test it. On the other hand, the built-in Postgres is version 10 still. See JIRA #8545

There is also JIRA #8920 to support the latest version.

And even though built-in Postgres is 10, I think we need to test 13 anyway, because we recommend using an external DB in production environment (and that should be version 13).
 
**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

-none-

**Special notes for your reviewer**:
