### PR TITLE
THREESCALE-11062: Add env variables to select Redis logical DBs

### DIFF
--- a/config/examples/backend_redis.yml
+++ b/config/examples/backend_redis.yml
@@ -1,5 +1,6 @@
 base: &default
   url: "<%= ENV.fetch('BACKEND_REDIS_URL', 'redis://localhost:6379/6') %>"
+  db: <%= ENV['BACKEND_REDIS_DB'] %>
   timeout: <%= ENV.fetch('BACKEND_REDIS_TIMEOUT', 1) %>
   size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds

--- a/config/examples/redis.yml
+++ b/config/examples/redis.yml
@@ -1,5 +1,6 @@
 base: &default
   url: "<%= ENV.fetch('REDIS_URL', 'redis://localhost:6379/1') %>"
+  db: <%= ENV['REDIS_DB'] %>
   size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
   sentinels: "<%= ENV['REDIS_SENTINEL_HOSTS'] %>"

--- a/openshift/system/config/backend_redis.yml
+++ b/openshift/system/config/backend_redis.yml
@@ -1,5 +1,6 @@
 production:
   url: "<%= ENV.fetch('BACKEND_REDIS_URL', 'redis://backend-redis:6379') %>"
+  db: <%= ENV['BACKEND_REDIS_DB'] %>
   timeout: <%= ENV.fetch('REDIS_BACKEND_TIMEOUT', 1) %>
   size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds

--- a/openshift/system/config/redis.yml
+++ b/openshift/system/config/redis.yml
@@ -1,5 +1,6 @@
 production:
   url: "<%= ENV.fetch('REDIS_URL', 'redis://system-redis/1') %>"
+  db: <%= ENV['REDIS_DB'] %>
   size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
   sentinels: "<%= ENV['REDIS_SENTINEL_HOSTS'] %>"


### PR DESCRIPTION
**What this PR does / why we need it**:

Our Redis client for porta is able to select the given logical database from the url.

e.g. `redis://localhost:6379/6` will connect to `localhost:6379` and select the DB `6`.

When using sentinels, a URL like `redis://redis-master/6` should be used to extract the group name `redis-master` and the DB `6`. This works fine for porta, but not for Sidekiq after we upgraded to version 7. Now Sidekiq expects these two parameters to be provided explicitly through the `:name` and `:db` options.

This PR adds a couple of new environment variables to provide the `:db` parameter.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11062

**Verification steps** 

Set/unset the `REDIS_DB` variable and run `bundle exec rake boot:redis`

**Special notes for your reviewer**:

Sidekiq only uses the configs from the `redis.yml` config file, but I also added a variable for `backend_redis.yml` for consistency, though it's not really needed.
