### PR TITLE
THREESCALE-11062: Redis config: extract DB from URL

### DIFF
--- a/app/lib/three_scale/redis_config.rb
+++ b/app/lib/three_scale/redis_config.rb
@@ -7,6 +7,7 @@ module ThreeScale
       sentinels = raw_config.delete(:sentinels).presence
       raw_config.delete_if { |key, value| value.blank? }
       raw_config[:size] ||= raw_config.delete(:pool_size) if raw_config.key?(:pool_size)
+      raw_config[:db] ||= URI.parse(raw_config[:url].to_s).path[1..]
 
       @config = ActiveSupport::OrderedOptions.new.merge(raw_config)
       config.sentinels = parse_sentinels(sentinels) if sentinels
@@ -15,11 +16,7 @@ module ThreeScale
     attr_reader :config
 
     def db
-      value = config.db.presence
-      return value.to_i if value
-      url = config.url.presence
-      return unless url
-      URI.parse(url).path[1..-1].to_s.to_i
+      config.db.to_i
     end
 
     def reverse_merge(other)

--- a/app/lib/three_scale/redis_config.rb
+++ b/app/lib/three_scale/redis_config.rb
@@ -15,10 +15,6 @@ module ThreeScale
 
     attr_reader :config
 
-    def db
-      config.db.to_i
-    end
-
     def reverse_merge(other)
       other.merge(config)
     end

--- a/test/unit/three_scale/redis_config_test.rb
+++ b/test/unit/three_scale/redis_config_test.rb
@@ -4,12 +4,6 @@ require 'test_helper'
 
 module ThreeScale
   class RedisConfigTest < ActiveSupport::TestCase
-    test '#db' do
-      assert_equal 4, RedisConfig.new(db: 4).db
-      assert_equal 3, RedisConfig.new(url: 'redis://my-redis/3').db
-      assert_equal 0, RedisConfig.new(url: 'redis://my-redis').db
-    end
-
     test '#reverse_merge' do
       config_1 = RedisConfig.new(host: 'localhost', db: 1)
       config_2 = RedisConfig.new(db: 2, password: 'passwd')
@@ -42,6 +36,7 @@ module ThreeScale
 
       assert config.key? :db
       assert_equal '6', config[:db]
+      assert_equal '6', config.db
     end
 
     test ':pool_size is renamed to :size' do

--- a/test/unit/three_scale/redis_config_test.rb
+++ b/test/unit/three_scale/redis_config_test.rb
@@ -37,6 +37,13 @@ module ThreeScale
       assert_equal expected_sentinels, config.sentinels
     end
 
+    test 'extracts the Redis logical DB from the URL' do
+      config = RedisConfig.new(url: 'redis://localhost:6379/6')
+
+      assert config.key? :db
+      assert_equal '6', config[:db]
+    end
+
     test ':pool_size is renamed to :size' do
       config = RedisConfig.new(pool_size: 5)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Our Redis client for porta is able to select the given logical database from the url.

e.g. `redis://localhost:6379/6` will connect to `localhost:6379` and select the DB `6`.

When using sentinels, a URL like `redis://redis-master/6` should be used to extract the group name `redis-master` and the DB `6`. This works fine for porta, but not for Sidekiq after we upgraded to version 7. Now Sidekiq expects these two parameters to be provided explicitly through the `:name` and `:db` options.

This PR extracts the `:db` parameter from the URL in case it's not provided. If empty, `:db` will be null, not `0`.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11062

**Verification steps** 

1. Set a config like this:
     ```
    REDIS_URL=redis://redis-master/1
    REDIS_SENTINEL_NAME=redis-master
    REDIS_SENTINEL_HOSTS=redis://localhost:26379,redis://localhost:26380,redis://localhost:26381
     ```
2. Launch Sidekiq
3. Verify it's writing its data in DB `1` and not `0`