### PR TITLE
disable search by default in cucumbers and enable with @search annotation

### DIFF
--- a/features/support/sphinx.rb
+++ b/features/support/sphinx.rb
@@ -1,10 +1,6 @@
 require 'thinking_sphinx'
 require 'thinking_sphinx/test'
 
-Before "not @search" do
-  ::ThinkingSphinx::Test.disable_search_jobs!
-end
-
 Before('@search') do
   Sidekiq::Job.clear_all
   ::ThinkingSphinx::Test.stop
@@ -12,12 +8,13 @@ Before('@search') do
   ::ThinkingSphinx::Test.init
   $searchd_autostop_installed ||= ::ThinkingSphinx::Test.autostop
   ::ThinkingSphinx::Test.wait_start
+
+  ::ThinkingSphinx::Test.enable_search_jobs!
 end
 
 After '@search' do
+  ::ThinkingSphinx::Test.disable_search_jobs!
   ::ThinkingSphinx::Test.stop
 end
 
-After "not @search" do
-  ::ThinkingSphinx::Test.enable_search_jobs!
-end
+::ThinkingSphinx::Test.disable_search_jobs!

--- a/features/support/sphinx.rb
+++ b/features/support/sphinx.rb
@@ -1,7 +1,11 @@
 require 'thinking_sphinx'
 require 'thinking_sphinx/test'
 
-Before('@search') do
+BeforeAll do
+  ::ThinkingSphinx::Test.disable_search_jobs!
+end
+
+Before '@search' do
   Sidekiq::Job.clear_all
   ::ThinkingSphinx::Test.stop
   ::ThinkingSphinx::Test.clear
@@ -16,5 +20,3 @@ After '@search' do
   ::ThinkingSphinx::Test.disable_search_jobs!
   ::ThinkingSphinx::Test.stop
 end
-
-::ThinkingSphinx::Test.disable_search_jobs!


### PR DESCRIPTION
I think previously it was possible for some `After` hooks
to trigger indexing jobs for `not @search` scenarios as well after
`@search` scenarios but after searchd was already stopped.

Thus lets disable indexing jobs at the very begining and only enable it
within scenarios that actually need that.