### PR TITLE
THREESCALE-11070: Extract the Redis sentinels group name from the URL

### DIFF
--- a/app/lib/three_scale/redis_config.rb
+++ b/app/lib/three_scale/redis_config.rb
@@ -7,7 +7,10 @@ module ThreeScale
       sentinels = raw_config.delete(:sentinels).presence
       raw_config.delete_if { |key, value| value.blank? }
       raw_config[:size] ||= raw_config.delete(:pool_size) if raw_config.key?(:pool_size)
-      raw_config[:db] ||= URI.parse(raw_config[:url].to_s).path[1..]
+      uri = URI.parse(raw_config[:url].to_s)
+      raw_config[:db] ||= uri.path[1..]
+      raw_config[:name] ||= uri.host if sentinels
+      raw_config.compact!
 
       @config = ActiveSupport::OrderedOptions.new.merge(raw_config)
       config.sentinels = parse_sentinels(sentinels) if sentinels

--- a/config/examples/backend_redis.yml
+++ b/config/examples/backend_redis.yml
@@ -6,7 +6,6 @@ base: &default
   sentinels: "<%= ENV['BACKEND_REDIS_SENTINEL_HOSTS'] %>"
   sentinel_username: <%= ENV['BACKEND_REDIS_SENTINEL_USERNAME'].to_json %>
   sentinel_password: <%= ENV['BACKEND_REDIS_SENTINEL_PASSWORD'].to_json %>
-  name: <%= ENV['BACKEND_REDIS_SENTINEL_NAME'] %>
   role: <%= ENV['BACKEND_REDIS_SENTINEL_ROLE'] %>
   # == ACL Params ==
   username: <%= ENV['BACKEND_REDIS_USERNAME'].to_json %>

--- a/config/examples/redis.yml
+++ b/config/examples/redis.yml
@@ -5,7 +5,6 @@ base: &default
   sentinels: "<%= ENV['REDIS_SENTINEL_HOSTS'] %>"
   sentinel_username: <%= ENV['REDIS_SENTINEL_USERNAME'].to_json %>
   sentinel_password: <%= ENV['REDIS_SENTINEL_PASSWORD'].to_json %>
-  name: <%= ENV['REDIS_SENTINEL_NAME'] %>
   role: <%= ENV['REDIS_SENTINEL_ROLE'] %>
   # == ACL Params ==
   username: <%= ENV['REDIS_USERNAME'].to_json %>

--- a/openshift/system/config/backend_redis.yml
+++ b/openshift/system/config/backend_redis.yml
@@ -6,7 +6,6 @@ production:
   sentinels: "<%= ENV['BACKEND_REDIS_SENTINEL_HOSTS'] %>"
   sentinel_username: <%= ENV['BACKEND_REDIS_SENTINEL_USERNAME'].to_json %>
   sentinel_password: <%= ENV['BACKEND_REDIS_SENTINEL_PASSWORD'].to_json %>
-  name: <%= ENV['BACKEND_REDIS_SENTINEL_NAME'] %>
   role: <%= ENV['BACKEND_REDIS_SENTINEL_ROLE'] %>
   # == ACL Params ==
   username: <%= ENV['BACKEND_REDIS_USERNAME'].to_json %>

--- a/openshift/system/config/redis.yml
+++ b/openshift/system/config/redis.yml
@@ -5,7 +5,6 @@ production:
   sentinels: "<%= ENV['REDIS_SENTINEL_HOSTS'] %>"
   sentinel_username: <%= ENV['REDIS_SENTINEL_USERNAME'].to_json %>
   sentinel_password: <%= ENV['REDIS_SENTINEL_PASSWORD'].to_json %>
-  name: <%= ENV['REDIS_SENTINEL_NAME'] %>
   role: <%= ENV['REDIS_SENTINEL_ROLE'] %>
   # == ACL Params ==
   username: <%= ENV['REDIS_USERNAME'].to_json %>

--- a/test/unit/three_scale/redis_config_test.rb
+++ b/test/unit/three_scale/redis_config_test.rb
@@ -39,6 +39,20 @@ module ThreeScale
       assert_equal '6', config.db
     end
 
+    test 'extracts the sentinels group name from the URL' do
+      config = RedisConfig.new({ url: 'redis://redis-master/6', sentinels: 'redis://localhost,redis://localhost:1234' })
+
+      assert config.key? :name
+      assert_equal 'redis-master', config[:name]
+      assert_equal 'redis-master', config.name
+    end
+
+    test "doesn't extract the name when no sentinels are provided" do
+      config = RedisConfig.new(url: 'redis://redis-master/6')
+
+      assert_not config.key? :name
+    end
+
     test ':pool_size is renamed to :size' do
       config = RedisConfig.new(pool_size: 5)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When using Redis sentinels, we need to provide a group name. This was automatic before, but after upgrading to Sidekiq 7 we need to provide it manually. For that reason we added `REDIS_SENTINEL_NAME` and `BACKEND_REDIS_SENTINEL_NAME`. However, in order to maintain backwards compatibility and avoid changes in the operator, it's better to extract the group name from the URL.

This PR also removes the env vars, since they are not needed anymore.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11070

**Verification steps** 

1. Set this config:
   ```
   REDIS_URL=redis://redis-master/1
   REDIS_SENTINEL_HOSTS=redis://localhost:26379,redis://localhost:26380,redis://localhost:26381
   ``` 
2. Launch Sidekiq
3. It should start and work correctly.
4. You should see `:name=>"redis-master"` this in the logs:
   ```
   INFO: Sidekiq 7.2.4 connecting to Redis with options {:size=>1, :pool_name=>"internal", :url=>"redis://redis-master/1", :pool_timeout=>5, :db=>"1", :name=>"redis-master", :sentinels=>[{:host=>"localhost", :port=>26379}, {:host=>"localhost", :port=>26380}, {:host=>"localhost", :port=>26381}]}
   ```
