### PR TITLE
🔥🧹 Remove unnecessary srcdoc polyfill

### DIFF
--- a/app/assets/javascripts/srcdoc-polyfill.min.js
+++ b/app/assets/javascripts/srcdoc-polyfill.min.js
@@ -1,4 +1,0 @@
-/*! srcdoc-polyfill - v0.1.1 - 2013-03-01
-* http://github.com/jugglinmike/srcdoc-polyfill/
-* Copyright (c) 2013 Mike Pennisi; Licensed MIT */
-(function(t,e){var c,n,o=t.srcDoc,r=!!("srcdoc"in e.createElement("iframe")),i={compliant:function(t,e){e&&t.setAttribute("srcdoc",e)},legacy:function(t,e){var c;t&&t.getAttribute&&(e?t.setAttribute("srcdoc",e):e=t.getAttribute("srcdoc"),e&&(c="javascript: window.frameElement.getAttribute('srcdoc');",t.setAttribute("src",c),t.contentWindow&&(t.contentWindow.location=c)))}},s=t.srcDoc={set:i.compliant,noConflict:function(){return t.srcDoc=o,s}};if(!r)for(s.set=i.legacy,n=e.getElementsByTagName("iframe"),c=n.length;c--;)s.set(n[c])})(this,this.document);

--- a/lib/developer_portal/app/views/shared/cms/_toolbar.html.slim
+++ b/lib/developer_portal/app/views/shared/cms/_toolbar.html.slim
@@ -77,9 +77,6 @@ div id="cms-toolbar"
               style: "border: 0; height: 100%; border-collapse: collapse") do
                 Your browser does not support iframes which is needed to use the 3scale CMS toolbar.
 
-
-= javascript_include_tag 'srcdoc-polyfill.min.js'
-
 - if site_account.cms_toolbar_intro_visible?
   javascript:
     (function(){


### PR DESCRIPTION
This is a pollyfill for the HTML5 attribute `srcdoc`, which is supported by all major browsers since a long time ago. It was probably used at first for IE compatibility.

See https://github.com/jugglinmike/srcdoc-polyfill/