### PR TITLE
Rename `:size` back to `:pool_size`

### DIFF
--- a/app/lib/system/redis_pool.rb
+++ b/app/lib/system/redis_pool.rb
@@ -8,8 +8,8 @@ module System
 
     def initialize(config = {})
       cfg = config.to_h
-      pool_config = cfg.extract!(:size, :pool_timeout)
-      @pool = ConnectionPool.new(size: pool_config[:size] || 5, timeout: pool_config[:pool_timeout] || 5 ) do
+      pool_config = cfg.extract!(:pool_size, :pool_timeout)
+      @pool = ConnectionPool.new(size: pool_config[:pool_size] || 5, timeout: pool_config[:pool_timeout] || 5 ) do
         Redis.new(cfg)
       end
     end

--- a/app/lib/three_scale/redis_config.rb
+++ b/app/lib/three_scale/redis_config.rb
@@ -6,7 +6,6 @@ module ThreeScale
       raw_config = (redis_config || {}).deep_symbolize_keys
       sentinels = raw_config.delete(:sentinels).presence
       raw_config.delete_if { |key, value| value.blank? }
-      raw_config[:size] ||= raw_config.delete(:pool_size) if raw_config.key?(:pool_size)
       uri = URI.parse(raw_config[:url].to_s)
       raw_config[:db] ||= uri.path[1..]
       raw_config[:name] ||= uri.host if sentinels

--- a/config/application.rb
+++ b/config/application.rb
@@ -281,7 +281,7 @@ module System
 
     initializer :load_configs, before: :load_config_initializers do
       config.backend_client = { max_tries: 5 }.merge(config_for(:backend).symbolize_keys)
-      config.redis = config.sidekiq = config_for(:redis)
+      config.redis = config_for(:redis)
       config.s3 = config_for(:amazon_s3)
       config.three_scale.oauth2 = config_for(:oauth2)
     end

--- a/config/examples/backend_redis.yml
+++ b/config/examples/backend_redis.yml
@@ -1,7 +1,7 @@
 base: &default
   url: "<%= ENV.fetch('BACKEND_REDIS_URL', 'redis://localhost:6379/6') %>"
   timeout: <%= ENV.fetch('BACKEND_REDIS_TIMEOUT', 1) %>
-  size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+  pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
   sentinels: "<%= ENV['BACKEND_REDIS_SENTINEL_HOSTS'] %>"
   sentinel_username: <%= ENV['BACKEND_REDIS_SENTINEL_USERNAME'].to_json %>

--- a/config/examples/redis.yml
+++ b/config/examples/redis.yml
@@ -1,6 +1,6 @@
 base: &default
   url: "<%= ENV.fetch('REDIS_URL', 'redis://localhost:6379/1') %>"
-  size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+  pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
   sentinels: "<%= ENV['REDIS_SENTINEL_HOSTS'] %>"
   sentinel_username: <%= ENV['REDIS_SENTINEL_USERNAME'].to_json %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,13 +3,22 @@
 require 'three_scale/sidekiq_retry_support'
 require 'three_scale/sidekiq_logging_middleware'
 
+REDIS_PARAMS_WHITELIST = %i[username password db id timeout read_timeout write_timeout connect_timeout ssl
+                            custom ssl_params driver protocol client_implementation command_builder inherit_socket
+                            reconnect_attempts middlewares circuit_breaker sentinels sentinel_password
+                            sentinel_username role name url].freeze
+
+def sanitize_redis_config(cfg)
+  cfg.slice(*REDIS_PARAMS_WHITELIST)
+end
+
 Sidekiq::Client.try(:reliable_push!) unless Rails.env.test?
 
 Rails.application.config.to_prepare do
   Sidekiq.configure_server do |config|
     config.try(:reliable!)
 
-    config.redis = ThreeScale::RedisConfig.new(System::Application.config.sidekiq).config
+    config.redis = sanitize_redis_config(ThreeScale::RedisConfig.new(System::Application.config.sidekiq).config)
 
     config.logger.formatter = Sidekiq::Logger::Formatters::Pretty.new
 
@@ -44,7 +53,7 @@ end
 
 Rails.application.config.to_prepare do
   Sidekiq.configure_client do |config|
-    config.redis = ThreeScale::RedisConfig.new(System::Application.config.sidekiq).config
+    config.redis = sanitize_redis_config(ThreeScale::RedisConfig.new(System::Application.config.sidekiq).config)
 
     config.client_middleware do |chain|
       chain.add ThreeScale::SidekiqLoggingMiddleware

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -18,7 +18,7 @@ Rails.application.config.to_prepare do
   Sidekiq.configure_server do |config|
     config.try(:reliable!)
 
-    config.redis = sanitize_redis_config(ThreeScale::RedisConfig.new(System::Application.config.sidekiq).config)
+    config.redis = sanitize_redis_config(ThreeScale::RedisConfig.new(System::Application.config.redis).config)
 
     config.logger.formatter = Sidekiq::Logger::Formatters::Pretty.new
 
@@ -53,7 +53,7 @@ end
 
 Rails.application.config.to_prepare do
   Sidekiq.configure_client do |config|
-    config.redis = sanitize_redis_config(ThreeScale::RedisConfig.new(System::Application.config.sidekiq).config)
+    config.redis = sanitize_redis_config(ThreeScale::RedisConfig.new(System::Application.config.redis).config)
 
     config.client_middleware do |chain|
       chain.add ThreeScale::SidekiqLoggingMiddleware

--- a/openshift/system/config/backend_redis.yml
+++ b/openshift/system/config/backend_redis.yml
@@ -1,7 +1,7 @@
 production:
   url: "<%= ENV.fetch('BACKEND_REDIS_URL', 'redis://backend-redis:6379') %>"
   timeout: <%= ENV.fetch('REDIS_BACKEND_TIMEOUT', 1) %>
-  size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+  pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
   sentinels: "<%= ENV['BACKEND_REDIS_SENTINEL_HOSTS'] %>"
   sentinel_username: <%= ENV['BACKEND_REDIS_SENTINEL_USERNAME'].to_json %>

--- a/openshift/system/config/redis.yml
+++ b/openshift/system/config/redis.yml
@@ -1,6 +1,6 @@
 production:
   url: "<%= ENV.fetch('REDIS_URL', 'redis://system-redis/1') %>"
-  size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+  pool_size: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   pool_timeout: 5 # this is in seconds
   sentinels: "<%= ENV['REDIS_SENTINEL_HOSTS'] %>"
   sentinel_username: <%= ENV['REDIS_SENTINEL_USERNAME'].to_json %>

--- a/test/unit/system/redis_pool_test.rb
+++ b/test/unit/system/redis_pool_test.rb
@@ -5,9 +5,9 @@ require 'test_helper'
 class System::RedisPoolTest < ActiveSupport::TestCase
   test 'config' do
     ConnectionPool.expects(:new).with(timeout: 5, size: 5).at_least_once
-    pool = System::RedisPool.new
+    System::RedisPool.new
     ConnectionPool.expects(:new).with(size: 3, timeout: 7).at_least_once
-    pool = System::RedisPool.new(size: 3, pool_timeout: 7)
+    System::RedisPool.new(pool_size: 3, pool_timeout: 7)
   end
 
   test 'delegation' do

--- a/test/unit/three_scale/redis_config_test.rb
+++ b/test/unit/three_scale/redis_config_test.rb
@@ -53,13 +53,6 @@ module ThreeScale
       assert_not config.key? :name
     end
 
-    test ':pool_size is renamed to :size' do
-      config = RedisConfig.new(pool_size: 5)
-
-      assert config.key? :size
-      assert_equal 5, config[:size]
-    end
-
     test "it takes given ca_file when provided" do
       value = 'any_value'
       raw_config = { url: 'rediss://my-secure-redis/1', ssl_params: {}}


### PR DESCRIPTION
**What this PR does / why we need it**:

QE detected some strange behavior when many tenants are created in a short period of time. @akostadinov thinks this could be due to the new `:size` parameter we are sending to Sidekiq.

I verified that `:size` in fact interferes with Sidekiq internals ([code](https://github.com/sidekiq/sidekiq/blob/e798c23643cd7d3f3b229016a87fec2bfeb7905a/lib/sidekiq/redis_connection.rb#L22-L29)) and after Sidekiq 7, they recommend to let Sidekiq decide the pools size ([docs](https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-API-Migration.md#connection-pools))

We don't know if that's going to fix QE problem or not, but I think this PR is needed anyway, considering the reasons above.

The reason why I renamed `:pool_size` to `:size` initially it's because the Redis client doesn't accept unknown parameters after upgrading to `redis-rb` 5. So we can't just revert the renaming. In this PR I filter the parameters being sent to Sidekiq using a white list.

For the direct Redis connection from porta, `:pool_size` is filtered at `redis_pool.rb`

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11079

**Verification steps** 

Launch Sidekiq and check the logs to verify that Sidekiq is setting the pool sizes itself:

```
INFO: Sidekiq 7.2.4 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>"redis://localhost:6379/1", :db=>"1"}
INFO: Sidekiq 7.2.4 connecting to Redis with options {:size=>1, :pool_name=>"default", :url=>"redis://localhost:6379/1", :db=>"1"}
```

