### PR TITLE
🐛 Context selector shows forbidden pages to members

### DIFF
--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -89,15 +89,15 @@ module MenuHelper # rubocop:disable Metrics/ModuleLength
   end
 
   def audience_link
-    if can?(:manage, :partners)
-      admin_buyers_accounts_path
-    elsif can?(:manage, :finance)
-      admin_finance_root_path
-    elsif can?(:manage, :portal)
-      provider_admin_cms_templates_path
-    elsif can?(:manage, :settings)
-      edit_admin_site_usage_rules_path
-    end
+    @audience_link ||= if can?(:manage, :partners)
+                         admin_buyers_accounts_path
+                       elsif can?(:manage, :finance)
+                         admin_finance_root_path
+                       elsif can?(:manage, :portal)
+                         provider_admin_cms_templates_path
+                       elsif can?(:manage, :settings)
+                         edit_admin_site_usage_rules_path
+                       end
   end
 
   def settings_link
@@ -127,15 +127,17 @@ module MenuHelper # rubocop:disable Metrics/ModuleLength
 
   def context_selector_props
     title, icon = active_title_and_icon
+    access_to_service_admin_sections = current_user.access_to_service_admin_sections?
+
+    menu_items = [{ title: 'Dashboard',        href: provider_admin_dashboard_path,    icon: :home,     disabled: false }]
+    menu_items << { title: 'Audience',         href: audience_link,                    icon: :bullseye, disabled: false } if audience_link.present?
+    menu_items << { title: 'Products',         href: admin_services_path,              icon: :cubes,    disabled: false } if access_to_service_admin_sections
+    menu_items << { title: 'Backends',         href: provider_admin_backend_apis_path, icon: :cube,     disabled: false } if access_to_service_admin_sections
+    menu_items << { title: 'Account Settings', href: settings_link,                    icon: :cog,      disabled: false }
+
     {
       toggle: { title: title, icon: icon },
-      menuItems: [
-        { title: 'Dashboard',        href: provider_admin_dashboard_path,    icon: :home,     disabled: false }, #active_menu == :dashboard },
-        { title: 'Audience',         href: audience_link,                    icon: :bullseye, disabled: false },
-        { title: 'Products',         href: admin_services_path,              icon: :cubes,    disabled: false }, #active_menu == :products },
-        { title: 'Backends',         href: provider_admin_backend_apis_path, icon: :cube,     disabled: false }, #active_menu == :backend_apis },
-        { title: 'Account Settings', href: settings_link,                    icon: :cog,      disabled: false }
-      ],
+      menuItems: menu_items
     }
   end
 

--- a/features/menu/context_selector.feature
+++ b/features/menu/context_selector.feature
@@ -1,0 +1,35 @@
+@javascript
+Feature: Context selector
+
+  As a user, I want to be able to switch between the different contexts of 3scale in an easy and
+  quick way
+
+  Background:
+    Given a provider
+
+  Rule: User is an admin
+    Background:
+      Given an admin user "Admin" of the provider
+      And the user logs in
+
+    Scenario: Admin sees all contexts
+      Given the current page is the provider dashboard
+      Then the current context should be "Dashboard"
+      And they should be able to navigate to the following contexts:
+        | Dashboard        |
+        | Audience         |
+        | Products         |
+        | Backends         |
+        | Account Settings |
+
+  Rule: User is a member
+    Background:
+      Given a member user "Member" of the provider
+      And the user logs in
+
+    Scenario: Member can't see Audience, Services and Backends
+      And the current page is the provider dashboard
+      Then the current context should be "Dashboard"
+      And they should be able to navigate to the following contexts:
+        | Dashboard        |
+        | Account Settings |

--- a/features/menu/context_selector.feature
+++ b/features/menu/context_selector.feature
@@ -13,7 +13,7 @@ Feature: Context selector
       And the user logs in
 
     Scenario: Admin sees all contexts
-      Given the current page is the provider dashboard
+      Given they go to the provider dashboard
       Then the current context should be "Dashboard"
       And they should be able to navigate to the following contexts:
         | Dashboard        |
@@ -27,8 +27,76 @@ Feature: Context selector
       Given a member user "Member" of the provider
       And the user logs in
 
-    Scenario: Member can't see Audience, Services and Backends
-      And the current page is the provider dashboard
+    Scenario: Member with no permissions can't see Audience, Services and Backends
+      Given the user has no permissions
+      When they go to the provider dashboard
+      Then the current context should be "Dashboard"
+      And they should be able to navigate to the following contexts:
+        | Dashboard        |
+        | Account Settings |
+
+    Scenario: Member with portal permission can see Audience
+      Given the user has portal permission
+      When they go to the provider dashboard
+      Then the current context should be "Dashboard"
+      And they should be able to navigate to the following contexts:
+        | Dashboard        |
+        | Audience         |
+        | Account Settings |
+
+    @wip
+    Scenario: Member with finance permission can see Audience
+      Given the user has finance permission
+      When they go to the provider dashboard
+      Then the current context should be "Dashboard"
+      And they should be able to navigate to the following contexts:
+        | Dashboard        |
+        | Audience         |
+        | Account Settings |
+
+    Scenario: Member with settings permission can see Audience
+      Given the user has settings permission
+      When they go to the provider dashboard
+      Then the current context should be "Dashboard"
+      And they should be able to navigate to the following contexts:
+        | Dashboard        |
+        | Audience         |
+        | Account Settings |
+
+    Scenario: Member with partners permission can see everything
+      Given the user has partners permission
+      When they go to the provider dashboard
+      Then the current context should be "Dashboard"
+      And they should be able to navigate to the following contexts:
+        | Dashboard        |
+        | Audience         |
+        | Products         |
+        | Backends         |
+        | Account Settings |
+
+    Scenario: Member with monitoring permission can see Products and Backends
+      Given the user has monitoring permission
+      When they go to the provider dashboard
+      Then the current context should be "Dashboard"
+      And they should be able to navigate to the following contexts:
+        | Dashboard        |
+        | Products         |
+        | Backends         |
+        | Account Settings |
+
+    Scenario: Member with plans permission can see Products and Backends
+      Given the user has plans permission
+      When they go to the provider dashboard
+      Then the current context should be "Dashboard"
+      And they should be able to navigate to the following contexts:
+        | Dashboard        |
+        | Products         |
+        | Backends         |
+        | Account Settings |
+
+    Scenario: Member with policy registry permission can see Products and Backends
+      Given the user has policy_registry permission
+      When they go to the provider dashboard
       Then the current context should be "Dashboard"
       And they should be able to navigate to the following contexts:
         | Dashboard        |

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -45,7 +45,19 @@ When "they select {string} from the context selector" do |context|
   select_context context
 end
 
-private
+Then "they should be able to navigate to the following contexts:" do |list|
+  context_selector.click
+  within(context_selector) do
+    items = find_all('.pf-c-dropdown__menu-item').map(&:text)
+    assert_same_elements(list.raw.flatten, items)
+  end
+end
+
+Then "the current context {should} be {string}" do |should, context|
+  within context_selector do
+    assert_equal should, has_css?('.pf-c-dropdown__toggle', text: context, wait: 0)
+  end
+end
 
 def context_selector
   @context_selector ||= find('[data-ouia-component-id="context-selector"]')

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+Given "an admin user {string} of {provider}" do |username, provider|
+  @user = FactoryBot.create(:active_user, account: provider,
+                                          username: username,
+                                          role: :admin)
+end
+
+Given "a member user {string} of {provider}" do |username, provider|
+  @user = FactoryBot.create(:active_user, account: provider,
+                                          username: username,
+                                          role: :member)
+end
+
 Given "an user {string} of {account}" do |username, account|
   FactoryBot.create(:user, :account => account, :username => username)
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -12,6 +12,12 @@ Given "a member user {string} of {provider}" do |username, provider|
                                           role: :member)
 end
 
+Given "{user} has {word} permission(s)" do |user, permission|
+  user.admin_sections = permission == 'no' ? [] : [permission]
+
+  user.save!(validate: false)
+end
+
 Given "an user {string} of {account}" do |username, account|
   FactoryBot.create(:user, :account => account, :username => username)
 end

--- a/features/support/helpers/session_helpers.rb
+++ b/features/support/helpers/session_helpers.rb
@@ -37,6 +37,8 @@ module SessionHelper
   end
 
   def log_out
+    return unless logged_in?
+
     find(:css, '[aria-label="Session toggle"]').click
     click_link 'Sign Out'
   end
@@ -45,6 +47,12 @@ module SessionHelper
     @user = User.find_by(username: username)
     message = "Expected #{username} to be logged in, but is not"
     assert has_content?(/Signed (?:in|up) successfully/i), message
+  end
+
+  private
+
+  def logged_in?
+    has_css?('[aria-label="Session toggle"]', wait: 0)
   end
 end
 

--- a/test/helpers/menu_helper_test.rb
+++ b/test/helpers/menu_helper_test.rb
@@ -73,6 +73,7 @@ class MenuHelperTest < ActionView::TestCase
 
   test '#context_selector_props' do
     expects(:active_menu).returns(:dashboard).at_least_once
+    expects(:current_user).returns(FactoryBot.create(:simple_user))
     data = context_selector_props.as_json
 
     # Assert app/javascript/src/Navigation/components/ContextSelector.tsx#Props

--- a/test/integration/stats/applications_test.rb
+++ b/test/integration/stats/applications_test.rb
@@ -30,6 +30,7 @@ class Stats::ApplicationsTest < ActionDispatch::IntegrationTest
 
   test '#show needs member permission' do
     User.any_instance.expects(:has_access_to_all_services?).returns(false)
+    User.any_instance.expects(:access_to_service_admin_sections?).returns(false)
     User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
     get admin_buyers_stats_application_path(id: @application.id)
     assert_response :success


### PR DESCRIPTION
A member can't see either Audience, Products or Backends but the context selector shows these options. This PR removes the aforementioned items as long as the current user hasn't got permission to access them.

For a standard member, this is how it looks after this PR:
![Screenshot 2024-05-27 at 14 06 33](https://github.com/3scale/porta/assets/11672286/eb675e11-382c-4a67-ba53-37f76e6ecf82)
