### PR TITLE
THREESCALE-11067: Fix onboarding wizard error

### DIFF
--- a/app/views/provider/admin/onboarding/wizard/request/show.html.slim
+++ b/app/views/provider/admin/onboarding/wizard/request/show.html.slim
@@ -30,8 +30,8 @@ ol.explain.fa-ul
 
 = link_to "Cool, what's next?", provider_admin_onboarding_wizard_outro_path, class: "button"
 
-coffee:
-  $(".toggle").live "click", ->
-    target = $(this).attr("href")
-    $(target).toggleClass("is-hidden");
-
+javascript:
+  $(document).on("click", ".toggle", function () {
+    const target = $(this).attr("href");
+    return $(target).toggleClass("is-hidden");
+  });

--- a/app/views/provider/admin/onboarding/wizard/request/show.html.slim
+++ b/app/views/provider/admin/onboarding/wizard/request/show.html.slim
@@ -26,12 +26,14 @@ ol.explain.fa-ul
     i.icon.fa-li.fa.fa-puzzle-piece.icon--success
     .text
       strong> = link_to @request.api_name, edit_provider_admin_onboarding_wizard_api_path
-      ' returned <a class="toggle" href="#response">a response</a> to the customer through the gateway.
+      ' returned <a id="response-toggle" href="#response">a response</a> to the customer through the gateway.
 
 = link_to "Cool, what's next?", provider_admin_onboarding_wizard_outro_path, class: "button"
 
 javascript:
-  $(document).on("click", ".toggle", function () {
-    const target = $(this).attr("href");
-    return $(target).toggleClass("is-hidden");
-  });
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('response-toggle')
+    toggle.addEventListener('click', () => {
+      document.getElementById('response').classList.toggle('is-hidden')
+    })
+  })


### PR DESCRIPTION
**What this PR does / why we need it**:

In production, the last step of the onboarding wizard was responding with the `Internal Error` page and the following logs:

```
[728d8711-352c-4fc0-8773-c753a178b2c6] [provider-admin.3scale.localhost] [127.0.0.1]   Rendering provider/admin/onboarding/wizard/request/show.html.slim within layouts/wizard
[728d8711-352c-4fc0-8773-c753a178b2c6] [provider-admin.3scale.localhost] [127.0.0.1]   Rendered provider/admin/onboarding/wizard/request/show.html.slim within layouts/wizard (Duration: 9.8ms | Allocations: 4095)
[728d8711-352c-4fc0-8773-c753a178b2c6] [provider-admin.3scale.localhost] [127.0.0.1] Completed 500 Internal Server Error in 100ms (ActiveRecord: 14.0ms | Allocations: 40423)
[728d8711-352c-4fc0-8773-c753a178b2c6] [provider-admin.3scale.localhost] [127.0.0.1]   
[728d8711-352c-4fc0-8773-c753a178b2c6] [provider-admin.3scale.localhost] [127.0.0.1] LoadError (cannot load such file -- coffee_script):
```

This PR fixes the issue by removing the embedded `coffee` script from within the relevant Slim template.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11067

**Verification steps** 

- set up porta in production mode
- disable `assets` Gem group by running: `bundle config set --local without assets`
- run porta in production mode
- go to the final step of the onboarding wizard: http://provider-admin.3scale.localhost:3000/p/admin/onboarding/wizard/request?response=dGVzdC1yZXNwb25zZQo=
- make sure that you a successful message
- click on "a response" link several times and make sure that "test-response" is toggled

**Special notes for your reviewer**:

The issue was caused by the fact that the Slim template depended on the `coffee-script` gem, which is a sub-dependency of the `coffee-rails` gem, that is located in the `:assets` group of the Gemfile.

In the production images, starting from RHEL8 upgrade the `:assets` group is removed from the final bundler configuration (together with `:development`, `:test` and `:licenses`), because it's supposed that all assets were previously built during the `assets:precompile` stage. However, this was not the case for this Slim template.

So, first the coffee syntax was removed and replaced with jQuery, and then jQuery was replaced with vanilla JavaScript, because jQuery is not really needed here.

P.S. Special thanks to @lvillen and @akostadinov for help in investigating this.