### PR TITLE
Fix Quick starts notification problem

### DIFF
--- a/app/controllers/provider/admin/dashboards_controller.rb
+++ b/app/controllers/provider/admin/dashboards_controller.rb
@@ -2,6 +2,7 @@
 
 class Provider::Admin::DashboardsController < FrontendController
   before_action :ensure_provider_domain
+  before_action :quickstarts_flash, only: :show
 
   activate_menu :dashboard
   layout 'provider'
@@ -16,10 +17,6 @@ class Provider::Admin::DashboardsController < FrontendController
     @services           = current_user.accessible_services
     @messages_presenter = current_presenter
     @unread_messages_presenter = unread_messages_presenter
-    first_login = flash.delete(:first_login)
-    return unless first_login
-
-    flash[:quick_starts_notice] = t('provider.admin.dashboards.quick_starts_html', link: provider_admin_quickstarts_path).html_safe
   end
 
   include DashboardTimeRange
@@ -53,5 +50,12 @@ class Provider::Admin::DashboardsController < FrontendController
 
   def products_presenter
     Api::ServicesIndexPresenter.new(current_user: current_user, params: { per_page: 5 })
+  end
+
+  def quickstarts_flash
+    return unless flash[:first_login]
+
+    flash.delete(:first_login)
+    flash[:notice] = t('provider.admin.dashboards.quick_starts_html', link: provider_admin_quickstarts_path).html_safe
   end
 end

--- a/app/controllers/provider/sessions_controller.rb
+++ b/app/controllers/provider/sessions_controller.rb
@@ -22,7 +22,7 @@ class Provider::SessionsController < FrontendController
 
     if @user
       self.current_user = @user
-      flash[:first_login] = current_user.user_sessions.empty?
+      flash[:first_login] = current_user.user_sessions.empty? if current_user.user_sessions.empty?
       create_user_session!(strategy.authentication_provider_id)
       flash[:notice] = 'Signed in successfully'
 

--- a/app/controllers/provider/sessions_controller.rb
+++ b/app/controllers/provider/sessions_controller.rb
@@ -22,7 +22,7 @@ class Provider::SessionsController < FrontendController
 
     if @user
       self.current_user = @user
-      flash[:first_login] = current_user.user_sessions.empty? if current_user.user_sessions.empty?
+      flash[:first_login] = true if current_user.user_sessions.empty?
       create_user_session!(strategy.authentication_provider_id)
       flash[:notice] = 'Signed in successfully'
 

--- a/features/provider/dashboard.feature
+++ b/features/provider/dashboard.feature
@@ -4,13 +4,21 @@ Feature: Dashboard
   Background:
     Given a provider is logged in
 
-  Scenario: On first login provider should see a quick starts info notification
-    Given they should see "You can use quick starts to learn about 3scale features step by step."
+  Scenario: Provider logs in for the first time
+    Given they should see the flash message "You can use quick starts to learn about 3scale features step by step."
     When they follow "Take tour"
     Then the current page is the quick start catalog page
 
-  Scenario: On second login provider should not see a quick starts info notification
-    Then they should not see "You can use quick starts to learn about 3scale features step by step."
+  Scenario: Provider reloads dashboard
+    Given they should see the flash message "You can use quick starts to learn about 3scale features step by step."
+    When they go to the dashboard
+    And they should not see "You can use quick starts to learn about 3scale features step by step."
+
+  Scenario: Provider logs in more than once
+    When they log out
+    And the provider logs in
+    Then they should see the flash message "Signed in successfully"
+    And they should not see "You can use quick starts to learn about 3scale features step by step."
 
   Scenario: Navigation
     When they go to the dashboard

--- a/features/step_definitions/password_steps.rb
+++ b/features/step_definitions/password_steps.rb
@@ -64,7 +64,6 @@ And "{user} is now able to sign in with password {string}" do |user, password|
   fill_in('Password', with: password)
   click_button('Sign in')
 
-  assert_content 'Signed in successfully'
   find(:css, '[aria-label="Session toggle"]').click
   assert_content "Signed in to #{@provider.org_name} as #{user.username}"
 end

--- a/features/support/helpers/session_helpers.rb
+++ b/features/support/helpers/session_helpers.rb
@@ -44,7 +44,7 @@ module SessionHelper
   def assert_current_user(username)
     @user = User.find_by(username: username)
     message = "Expected #{username} to be logged in, but is not"
-    assert has_content?(/Signed (?:in|up) successfully/i), message
+    assert has_content?(/Signed (?:in|up) successfully/i, wait: 0) || has_content?(/You can use quick starts/i, wait: 0), message
   end
 end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a bug introduced at #3726 ([THREESCALE-11006](https://issues.redhat.com/browse/THREESCALE-11006)). The `dashboards_controller` wasn't handling properly the `first_login` flash, making Quick starts notification trigger every time the user went to the Dashboard. This PR fixes that problem and improves its cucumber.

**Verification steps** 

1. Create a new provider.
2. Confirm that on login you receive the Quick starts notification.
3. Confirm that after logout and login again you don't receive the Quick starts notification.
4. Confirm that when reloading the dashboard you don't receive the Quick starts notification.