### PR TITLE
Settings API validations

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -6,8 +6,8 @@ class Settings < ApplicationRecord
 
   attr_protected :account_id, :tenant_id, :product, :audit_ids, :sso_key
 
-  validates :product, inclusion: { in: %w(connect enterprise).freeze }
-  validates :change_account_plan_permission, inclusion: { in: %w(request none credit_card request_credit_card direct).freeze }
+  validates :product, inclusion: { in: %w[connect enterprise].freeze }
+  validates :change_account_plan_permission, :change_service_plan_permission, inclusion: { in: %w[request none credit_card request_credit_card direct].freeze }
   validates :bg_colour, :link_colour, :text_colour, :menu_bg_colour, :link_label, :link_url, :menu_link_colour, :token_api,
             :content_bg_colour, :tracker_code, :favicon, :plans_tab_bg_colour, :plans_bg_colour, :content_border_colour,
             :cc_privacy_path, :cc_terms_path, :cc_refunds_path, :change_service_plan_permission, :spam_protection_level,

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -28,7 +28,7 @@ class Settings < ApplicationRecord
   end
 
   def self.non_null_columns_names
-    columns.select { |column| column.null == false }.map(&:name)
+    columns.select { |column| !column.null }.map(&:name)
   end
 
   def approval_required_editable?
@@ -39,10 +39,14 @@ class Settings < ApplicationRecord
     not_custom_account_plans.size > 1 && account_plans_ui_visible?
   end
 
+  def assign_attributes(attrs, options = {})
+    super(sanitize_attributes(attrs), options)
+  end
+
   def update(attrs)
     update_approval_required(attrs) if approval_required_editable?
 
-    super(sanitize_attributes(attrs))
+    super(attrs)
   end
 
   def set_forum_enabled

--- a/test/integration/admin/api/settings_controller_test.rb
+++ b/test/integration/admin/api/settings_controller_test.rb
@@ -33,7 +33,7 @@ class Admin::Api::SettingsControllerTest < ActionDispatch::IntegrationTest
 
   test 'update' do
     params = { access_token: token, signups_enabled: false, change_account_plan_permission: 'invalid', change_service_plan_permission: 'invalid'}
-    assert 'request', settings.change_account_plan_permission
+    assert_equal 'request', settings.change_account_plan_permission
     assert settings.signups_enabled
 
     put admin_api_settings_path(format: :json), params: params
@@ -50,8 +50,8 @@ class Admin::Api::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     settings.reload
-    assert 'direct', settings.change_account_plan_permission
-    assert 'none', settings.change_service_plan_permission
+    assert_equal 'direct', settings.change_account_plan_permission
+    assert_equal 'none', settings.change_service_plan_permission
     assert_not settings.signups_enabled
   end
 

--- a/test/integration/admin/api/settings_controller_test.rb
+++ b/test/integration/admin/api/settings_controller_test.rb
@@ -32,19 +32,26 @@ class Admin::Api::SettingsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'update' do
-    params = { access_token: token, signups_enabled: false, change_account_plan_permission: 'invalid' }
+    params = { access_token: token, signups_enabled: false, change_account_plan_permission: 'invalid', change_service_plan_permission: 'invalid'}
     assert 'request', settings.change_account_plan_permission
     assert settings.signups_enabled
 
     put admin_api_settings_path(format: :json), params: params
     assert_response 422
 
+    errors = JSON.parse(response.body)['errors']
+    assert_equal ['is not included in the list'], errors['change_account_plan_permission']
+    assert_equal ['is not included in the list'], errors['change_service_plan_permission']
+
     params['change_account_plan_permission'] = 'direct'
+    params['change_service_plan_permission'] = 'none'
 
     put admin_api_settings_path(format: :json), params: params
     assert_response :success
 
-    assert 'direct', settings.reload.change_account_plan_permission
+    settings.reload
+    assert 'direct', settings.change_account_plan_permission
+    assert 'none', settings.change_service_plan_permission
     assert_not settings.signups_enabled
   end
 

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -7,6 +7,8 @@ class SettingsTest < ActiveSupport::TestCase
     @settings = @provider.settings
   end
 
+  attr_reader :settings
+
   def test_hide_basic_switches
     Rails.configuration.three_scale.stubs(:hide_basic_switches).returns(true)
     assert Settings.hide_basic_switches?
@@ -103,6 +105,14 @@ class SettingsTest < ActiveSupport::TestCase
     refute @provider.account_plans.first.approval_required
   end
 
+  test "account_approval_required defaults to 'false' on empty values" do
+    settings.update(account_approval_required: true)
+    assert settings.account_approval_required
+
+    settings.update(account_approval_required: "")
+    assert_not settings.account_approval_required
+  end
+
   def test_service_plans_visible_ui_switch
    assert @settings.has_attribute?(:service_plans_switch)
    assert @settings.has_attribute?(:service_plans_ui_visible)
@@ -167,6 +177,17 @@ class SettingsTest < ActiveSupport::TestCase
     @provider.save!
     settings.reload
     assert settings.monthly_billing_enabled
+  end
+
+  test 'empty values sanitized for non-null columns' do
+    settings.update(public_search: true)
+    assert settings.reload.public_search
+
+    settings.update(public_search: "")
+    assert settings.reload.public_search
+
+    settings.update(public_search: nil)
+    assert settings.reload.public_search
   end
 
   class FinanceDisabledSwitchTest < ActiveSupport::TestCase

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -179,15 +179,21 @@ class SettingsTest < ActiveSupport::TestCase
     assert settings.monthly_billing_enabled
   end
 
-  test 'empty values sanitized for non-null columns' do
+  test 'empty values are skipped for non-null columns' do
     settings.update(public_search: true)
     assert settings.reload.public_search
 
     settings.update(public_search: "")
+    assert_not settings.previous_changes[:public_search]
     assert settings.reload.public_search
 
     settings.update(public_search: nil)
+    assert_not settings.previous_changes[:public_search]
     assert settings.reload.public_search
+
+    settings.update(public_search: "false")
+    assert settings.previous_changes[:public_search]
+    assert_not settings.reload.public_search
   end
 
   test "validate change plan permission values" do

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -190,6 +190,15 @@ class SettingsTest < ActiveSupport::TestCase
     assert settings.reload.public_search
   end
 
+  test "validate change plan permission values" do
+    assert_equal 'request', settings.change_account_plan_permission
+    assert_equal 'request', settings.change_service_plan_permission
+
+    settings.update(change_account_plan_permission: 'invalid', change_service_plan_permission: 'invalid')
+    assert settings.errors.of_kind? :change_account_plan_permission, "is not included in the list"
+    assert settings.errors.of_kind? :change_service_plan_permission, "is not included in the list"
+  end
+
   class FinanceDisabledSwitchTest < ActiveSupport::TestCase
     def setup
       @provider = FactoryBot.build_stubbed(:simple_provider)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds some validations for the settings attributes that were having issues:
- `change_service_plan_permission` could be set to any value, added a validation
- when setting empty values, for some columns the following error was being thrown:
```
ActiveRecord::NotNullViolation: Mysql2::Error: Column 'public_search' cannot be null
```

I've also noticed that setting boolean attributes to any string (e.g. `public_search=whatever`) was flipping the setting to `true`. This is how Rails casting works, it converts any value that is not `"false"`, `"false"` or empty to `true`. So, I guess this is the common behavior across all endpoints. I don't like it, because it is quite confusing, but it is also a bit tricky to fix.
We can't really add a validation because it would run after the value has been already assigned (so e.g. `settings.public_search = "whatever"` will set `public_search` to `true`).

My original thought was to implement it within `sanitize_attributes`, but if we add a validation error there, I think it's discarded later. Or alternatively, we can ignore boolean attributes that have values that are not either `true` or `false`, but that doesn't seem right either.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

**Special notes for your reviewer**:
