### PR TITLE
THREESCALE-8319: Ignore empty values for account_approval_required instead setting to false

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -114,8 +114,8 @@ class Settings < ApplicationRecord
   end
 
   def update_approval_required(attrs)
-    value = attrs.delete(:account_approval_required).presence || false
-    default_account_plan.update_attribute(:approval_required, value)
+    value = attrs.delete(:account_approval_required)
+    default_account_plan.update_attribute(:approval_required, value) unless value.to_s.empty?
   end
 
   # Remove attributes with empty strings and nil for non-null columns

--- a/test/integration/admin/api/settings_controller_test.rb
+++ b/test/integration/admin/api/settings_controller_test.rb
@@ -62,7 +62,11 @@ class Admin::Api::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert JSON.parse(response.body)['settings']['account_approval_required']
+    assert settings.reload.account_approval_required
 
+    put admin_api_settings_path(format: :json), params: { access_token: token, public_search: true }
+
+    assert_response :success
     assert settings.reload.account_approval_required
   end
 end

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -86,9 +86,6 @@ class SettingsTest < ActiveSupport::TestCase
     @settings.update(account_approval_required: true)
     assert plan.reload.approval_required
 
-    @settings.update(welcome_text: :bar)
-    assert_equal false, plan.reload.approval_required
-
     @settings.update(account_approval_required: false)
     refute plan.reload.approval_required
   end
@@ -105,12 +102,18 @@ class SettingsTest < ActiveSupport::TestCase
     refute @provider.account_plans.first.approval_required
   end
 
-  test "account_approval_required defaults to 'false' on empty values" do
+  test "account_approval_required ignores empty values" do
     settings.update(account_approval_required: true)
     assert settings.account_approval_required
 
     settings.update(account_approval_required: "")
-    assert_not settings.account_approval_required
+    assert settings.account_approval_required
+  end
+
+  test "not including account_approval_required doesn't disable it" do
+    settings.update(account_approval_required: true)
+    settings.update({})
+    assert settings.account_approval_required
   end
 
   def test_service_plans_visible_ui_switch


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the issue reported https://issues.redhat.com/browse/THREESCALE-8319?focusedId=24892835&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24892835

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-8319

**Verification steps** 

1) set `account_approval_required` to `true` via API
2) set only `account_plans_ui_visible` or other attribute to whatever and NOT add `account_approval_required` to the query
3) verify that `account_approval_required` is still `true`

**Special notes for your reviewer**:

This behavior (defaulting to `false` on empty values - `attrs.delete(:account_approval_required).presence || false`) was implemented long time ago in the model, and in https://github.com/3scale/porta/pull/3666 I just delegated updating the value from the controller.

I hope changing the logic on the model will not break anything else :grimacing: 
