### PR TITLE
THREESCALE-8920: Support postgres 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ mysql-container: &mysql-container
     MYSQL_DATABASE: circleci
 
 postgres-container: &postgres-container
-  image: cimg/postgres:13.15
+  image: cimg/postgres:14.12
   environment:
     POSTGRES_USER: postgres
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Postgres 13 will be EOL soon, we need to officially support Postgres14.

After a research, I would say we already support it completely, so this PR only updates the CircleCI pipeline. More info below.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-8920

**Special notes for your reviewer**:

This is the list of checks and tests I made:

- Check `pg` gem support
  - We use `1.3.5`. In the [Changelog](https://github.com/ged/ruby-pg/blob/master/History.md) I didn't find in which release they added support for Posgres 14, but there are multiple references to it in older releases, so I assume our version supports it.
- Reset database with `bundle exec rails db:reset`
  - Working fine locally
- Create triggers with `bundle exec rails multitenant:triggers`
  - Works fine locally
- Launch Sidekiq after resetting DB and perform all enqueued jobs
  - No issues locally
- Update postgres image on CircleCI and launch tests
  - A couple of cukes [failed](https://app.circleci.com/pipelines/github/3scale/porta/28603/workflows/e5cf2145-a31e-4a53-b517-ce10fcf2d717/jobs/320436/tests) once, they passed in the next run. Also those cukes pass locally. 
- Check Dockerfiles in upstream and midstream
  - I don't think there's a reason they should be wrong, Our current `pg` gem version already supports Postgres 14, and there's no mention to any particular postgres version in the dockerfiles
- Go through release notes to try to spot any breaking change
  - https://www.postgresql.org/docs/14/release-14.html#id-1.11.6.17.4
  - All changes are low level and should be managed by `rails` and `pg`.
  - The only place where we invoke PostgreSQL code is in trigger creation (AFAIK), and those are created correctly.

Any more ideas?