### PR TITLE
THREESCALE-11114: Usage rules missing translation

### DIFF
--- a/app/views/sites/usage_rules/_settings_check.html.slim
+++ b/app/views/sites/usage_rules/_settings_check.html.slim
@@ -1,6 +1,6 @@
 - disabled = local_assigns[:disabled]
 - label = local_assigns[:label] || t("formtastic.labels.settings.#{setting}")
-- hint = local_assigns[:hint] || t("formtastic.hints.settings.#{setting}")
+- hint = local_assigns[:hint] || t("formtastic.hints.settings.#{setting}", default: '')
 
 div class="pf-c-check"
   input type="hidden" name="settings[#{setting}]" value="0"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1445,7 +1445,6 @@ en:
         approval_required_referer: "Set per account plan from %{link}."
         account_approval_required: "Approval is required by you before developer accounts are activated."
         useraccountarea_enabled: 'Only disable this if you provide another way to manage this information (e.g. via the User Management API).'
-        signups_enabled: ''
         strong_passwords_enabled: "Require strong passwords from your users: %{strong_password_definition} Existing passwords will still work."
         public_search: >
           Allow anyone to search on your Developer Portal.

--- a/features/master/settings.feature
+++ b/features/master/settings.feature
@@ -1,0 +1,16 @@
+@javascript
+Feature: Settings management
+  In order to control the settings
+  As a master
+  I want to be able to manage the settings
+
+  Background:
+    Given master admin is logged in
+
+  Scenario: Settings page loads properly
+    When they go to the usage rules settings page
+    Then they should see "Usage Rules"
+
+  Scenario: Hide services is visible
+    When they go to the usage rules settings page
+    Then they should see "Hide services"


### PR DESCRIPTION
**What this PR does / why we need it**:
In the master portal, when following Audience > Accounts > Settings > Usage rules it fails due to a missing translation at the edit template. 

As suggested by @mayorova, adding a empty default option fixes the problem. 

**Which issue(s) this PR fixes** 
[THREESCALE-11114](https://issues.redhat.com/browse/THREESCALE-11114)

**Verification steps** 
In the master portal, go to Audience > Accounts > Settings > Usage rules and confirm the page is shown.
