### PR TITLE
THREESCALE-10798: Filter out `authenticity_token` and `access_code`

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,4 +6,5 @@ Rails.application.config.filter_parameters += %i[activation_code cms_token credi
                                                  credit_card_authorize_net_payment_profile_token credit_card_expires_on
                                                  credit_card_partial_number crypted_password janrain_api_key lost_password_token
                                                  password password_digest payment_gateway_options payment_service_reference salt
-                                                 site_access_code sso_key user_key access_token service_token provider_key app_key]
+                                                 site_access_code sso_key user_key access_token service_token provider_key app_key
+                                                 authenticity_token access_code]


### PR DESCRIPTION
**What this PR does / why we need it**:

Just add `authenticity_token` and `access_code` to the list of filtered parameters in logs.

The issue mentions `access_token` as well, but that one was fixed in 2.14: https://github.com/3scale/porta/pull/3099/files

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10798

**Verification steps** 

1. Add an access code to the developer portal
2. Open the developer portal and fill in the access code
3. Check the logs, they should look like

```
Parameters:
{"authenticity_token"=>"[FILTERED]", "access_code"=>"[FILTERED]", "commit"=>"Enter"} 
```

