### PR TITLE
Do not "privatize" URL helper in Liquid::Drops::Base

### DIFF
--- a/lib/developer_portal/lib/liquid/drops/base.rb
+++ b/lib/developer_portal/lib/liquid/drops/base.rb
@@ -34,12 +34,6 @@ module Liquid
           end
         end
 
-        def publicize(*defined_methods)
-          defined_methods.each do |method|
-            @base.send(:public, method)
-          end
-        end
-
         def proxy(&block)
           instance_eval(&block)
         end
@@ -97,11 +91,7 @@ module Liquid
         end
       end
 
-      privately_include  do
-        include System::UrlHelpers.cms_url_helpers
-        publicize :_routes
-      end
-
+      include System::UrlHelpers.cms_url_helpers
 
       def url_options
         default_url_options


### PR DESCRIPTION
**What this PR does / why we need it**:

When working with the developer portal in the `development` mode I noticed that going to Settings (`/admin/account`) throws the following error:
![image](https://github.com/3scale/porta/assets/1270328/19ea9444-369d-4db3-beaa-725367a216f3)

This happens at least when the provider has a payment gateway defined and Billing is visible in the dev portal. 

This didn't happen before, and it also not reproducible in production (yay!).

Below I list my findings in order of appearance:
- There was a change in accessing the polymorphic routes implemented in Rails 6.1 (that we recently merged): https://github.com/rails/rails/commit/bb61baa6ef2ffb0d01f6f5a37a4add5934341bc6
- there is a difference in the results of `.public_methods` and `.private_methods` of `Liquid::Drops::Urls` (which is the "recipient" in the code referenced in the Rails commit listed above) - in `development` mode URL helper methods such as `admin_account_braintree_blue_path` appeared within the private methods, while in production they appeared within the public methods (that's why it doesn't fail even after changing `send` to `public_send`)
- the difference between the `production` and `development` modes that causes this is the `eager_load` config which is set to `false` in production. When set to `true` in `development` mode, the issue disappears.
- the main cause of this is our own code in `Liquid::Drops::Base`, namely `privately_include` method that makes all of the methods from the included module **private**. In `production` mode (i.e. when eager loading is enabled), at the moment when the module `include System::UrlHelpers.cms_url_helpers` is included, it has only a subset of methods - the default ones, and not the URL and Path hepler methods generated from the `routes.rb` - so those are "privatized", but all other methods (icluding e.g. `admin_account_braintree_blue_path`) are added to the module later, so they are kept public. In the `development` mode however the module is included when it already has all the "custom" methods defined, so they are made private, thus causing the issue.

So, the solution to this is to include the module "normally", as this "privatization" doesn't work in production mode anyway.

**Which issue(s) this PR fixes** 

not registered in JIRA

**Verification steps** 

Go to Settings in developer portal in `development` mode, and verify that the error is not shown.

**Special notes for your reviewer**:
