### PR TITLE
THREESCALE-10688: Fix Rapidast warnings

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,17 +4,13 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self
+  policy.font_src    :self, Rails.configuration.asset_host.to_s.strip
+  policy.img_src     :self, Rails.configuration.asset_host.to_s.strip, :data
+  policy.script_src  :self, Rails.configuration.asset_host.to_s.strip, :unsafe_inline, :unsafe_eval
+  policy.style_src   :self, Rails.configuration.asset_host.to_s.strip, :unsafe_inline
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }

--- a/doc/active_docs/billing_api.json
+++ b/doc/active_docs/billing_api.json
@@ -232,13 +232,6 @@
                 "required": [
                   "access_token"
                 ]
-              },
-              "encoding": {
-                "field_definitions": {
-                  "contentType": "application/x-www-form-urlencoded",
-                  "style": "deepObject",
-                  "explode": true
-                }
               }
             }
           }
@@ -326,13 +319,6 @@
                 "required": [
                   "access_token"
                 ]
-              },
-              "encoding": {
-                "field_definitions": {
-                  "contentType": "application/x-www-form-urlencoded",
-                  "style": "deepObject",
-                  "explode": true
-                }
               }
             }
           }
@@ -391,13 +377,6 @@
                   "access_token",
                   "state"
                 ]
-              },
-              "encoding": {
-                "field_definitions": {
-                  "contentType": "application/x-www-form-urlencoded",
-                  "style": "deepObject",
-                  "explode": true
-                }
               }
             }
           }
@@ -443,13 +422,6 @@
                 "required": [
                   "access_token"
                 ]
-              },
-              "encoding": {
-                "field_definitions": {
-                  "contentType": "application/x-www-form-urlencoded",
-                  "style": "deepObject",
-                  "explode": true
-                }
               }
             }
           }
@@ -593,13 +565,6 @@
                 "required": [
                   "access_token"
                 ]
-              },
-              "encoding": {
-                "field_definitions": {
-                  "contentType": "application/x-www-form-urlencoded",
-                  "style": "deepObject",
-                  "explode": true
-                }
               }
             }
           }


### PR DESCRIPTION
**What this PR does / why we need it**:

Running Rapidast against porta reveals two errors:

Billing API:

```
Job openapi target: https://3scale-admin.DOMAIN/ error: attribute paths.'/api/invoices/{id}.xml'(put).requestBody.content.'application/x-www-form-urlencoded'.encoding.field_definitions is unexpected
```

All APIs and UI:
```
Content Security Policy (CSP) Header Not Set
```

This PR fixes both warnings.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10688

**Verification steps** 

Run Rapidast an ensure the warnings are gone.

**Special notes for your reviewer**:

https://github.com/3scale/porta/commit/31e4f510fe4ee034ad2a0c16d0629eaf2fac104c:
The Billing API warning is only a validation error, because `content.encoding` must mention a property in `content.schema`, and `field_definitions` is not. Check the [reference](https://swagger.io/specification/#media-type-object).

https://github.com/3scale/porta/commit/4d4d88413fde89ef0cdd393d5eb0ecfd32655a2d:
The CSP error is legit, we don't have CSP enabled for porta. Fortunately, Rails provides a feature to enable it easily. Read the [docs](https://guides.rubyonrails.org/security.html#content-security-policy-header) and the [code](https://github.com/rails/rails/blob/v6.1.7.8/actionpack/lib/action_dispatch/http/content_security_policy.rb).

Some useful links about CSP:
- https://content-security-policy.com/
- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources