### PR TITLE
THREESCALE-4185: Support TLS protection for external DBs

### DIFF
--- a/config/examples/database.yml
+++ b/config/examples/database.yml
@@ -47,6 +47,7 @@ base: &default
   encoding: utf8
   pool: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   collation: utf8_bin
+  ssl_mode: <%= ENV.fetch('DATABASE_SSL_MODE', ENV.fetch('DATABASE_SSL_CA', nil) ? 'verify_identity' : 'disabled') %>
   sslca: <%= ENV['DATABASE_SSL_CA'] %>
   sslcert: <%= ENV['DATABASE_SSL_CERT'] %>
   sslkey: <%= ENV['DATABASE_SSL_KEY'] %>

--- a/config/examples/database.yml
+++ b/config/examples/database.yml
@@ -43,6 +43,9 @@ base: &default
   encoding: utf8
   pool: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   collation: utf8_bin
+  sslca: <%= ENV['DATABASE_SSL_CA'] %>
+  sslcert: <%= ENV['DATABASE_SSL_CERT'] %>
+  sslkey: <%= ENV['DATABASE_SSL_KEY'] %>
 
 development:
   <<: *default

--- a/config/examples/database.yml
+++ b/config/examples/database.yml
@@ -25,7 +25,7 @@ base: &default
   pool: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   variables:
     timezone: 'UTC'
-  sslmode: <%= ENV.fetch('DATABASE_SSL_CA', nil) ? 'verify-full' : 'disable' %>
+  sslmode: <%= ENV.fetch('DATABASE_SSL_MODE', ENV.fetch('DATABASE_SSL_CA', nil) ? 'verify-full' : 'disable') %>
   sslrootcert: <%= ENV['DATABASE_SSL_CA'] %>
   sslcert: <%= ENV['DATABASE_SSL_CERT'] %>
   sslkey: <%= ENV['DATABASE_SSL_KEY'] %>

--- a/config/examples/database.yml
+++ b/config/examples/database.yml
@@ -25,6 +25,10 @@ base: &default
   pool: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
   variables:
     timezone: 'UTC'
+  sslmode: <%= ENV.fetch('DATABASE_SSL_CA', nil) ? 'verify-full' : 'disable' %>
+  sslrootcert: <%= ENV['DATABASE_SSL_CA'] %>
+  sslcert: <%= ENV['DATABASE_SSL_CERT'] %>
+  sslkey: <%= ENV['DATABASE_SSL_KEY'] %>
 
 development:
   <<: *default


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support to connect to TLS protected MySQL and Postgres.

Our current versions of `pg` and `mysql2` gems already support TLS connections, so the only thing we need is a few environment variables for the user to provide the certs and keys.

These variables will be set by the operator, as specified in this jira issue: https://issues.redhat.com/browse/THREESCALE-11156

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-4185

**Verification steps** 

Here is the `podman-compose.yml` I used to launch TLS protected Postgres and MySQL locally:

```yml
version: '3.8'

services:
  mysql:
    image: mysql:8.0
    container_name: mysql-compose-ssl
    ports:
      - "23306:3306"
    environment:
      - MYSQL_ALLOW_EMPTY_PASSWORD=true
    healthcheck:
      test: "mysql --user=root --execute 'SHOW DATABASES;'"
      timeout: 20s
      retries: 10
    volumes:
      - mysql-data-ssl:/var/lib/mysql
      - /home/jlledom/redhat/redis/redis.crt:/etc/certs/server.crt:z
      - /home/jlledom/redhat/redis/redis.key:/etc/certs/server.key:z
      - /home/jlledom/redhat/redis/ca-root-cert.pem:/etc/certs/ca-root-cert.pem:z
    command: [ "mysqld",
               "--require_secure_transport=ON",
               "--ssl-ca=/etc/certs/ca-root-cert.pem",
               "--ssl-cert=/etc/certs/server.crt",
               "--ssl-key=/etc/certs/server.key" ]

  postgresql:
    image: postgres:14
    container_name: postgres-compose-ssl
    ports:
      - "25432:5432"
    environment:
      - POSTGRES_PASSWORD=
      - POSTGRES_HOST_AUTH_METHOD=trust
    volumes:
      - pgdata-ssl:/var/lib/postgresql/data
      - /home/jlledom/redhat/redis/redis.crt:/etc/certs/server.crt:z
      - /home/jlledom/redhat/redis/redis.key:/etc/certs/server.key:z
      - /home/jlledom/redhat/redis/ca-root-cert.pem:/etc/certs/ca-root-cert.pem:z
    command: [ "postgres",
               "-c", "ssl=on",
               "-c", "ssl_cert_file=/etc/certs/server.crt",
               "-c", "ssl_key_file=/etc/certs/server.key",
               "-c", "ssl_ca_file=/etc/certs/ca-root-cert.pem" ]

volumes:
  mysql-data-ssl:
  pgdata-ssl:

```

1. Launch the pods locally.
2. Set the variables:
```
DATABASE_URL=mysql2://root:@127.0.0.1:23306/3scale_system_development
DATABASE_SSL_CA=/home/jlledom/redhat/redis/ca-root-cert.pem
DATABASE_SSL_CERT=/home/jlledom/redhat/redis/porta.crt
DATABASE_SSL_KEY=/home/jlledom/redhat/redis/porta.key
```
3. `bundle exec rails db:reset`
4. Launch porta, sidekiq, sphinx, zync and all porta deps.
5. It all should work with no issues.

**Oracle support**:

I gave up trying to configure a TLS protected Oracle locally. These are theoretically the steps you should follow:

1. Create a wallet with a self-signed cert in the server
2. Edit `*.ora` files on the server to make it use the `TCPS` protocol and link to that wallet
3. Export server certificate and copy it to the client
4. Create a wallet on the client side and add server cert as trusted
5. Edit `*.ora` files on the client to make it use the `TCPS` protocol and link to the wallet
6. Use `sqlplus` to connect to server

The external wallet mechanism and the need to modify files makes it very cumbersome to make it work inside a container. Besides, the client also needs a wallet so you would need to install some oracle utilities in your system. Also some utilities like `orapki` are really hard to install in fedora without installing a complete oracle server in the system. And even if you have everything, the utilities don't give you an error mesage or a clue when the connection fails, so it's really hard to understand what's the problem.

Anyway, the need of an external wallet also makes it difficult for a gem like `oracle-enhanced` to support TLS conections. I checked the [repo](https://github.com/rsim/oracle-enhanced) and I haven't found any mention to TLS or SSL. So I assume it's not supported.

I don't think it's worth trying to support Oracle with TLS at this point.