### PR TITLE
THREESCALE-7183 onboardings tenant_id fix

### DIFF
--- a/db/migrate/20240719174715_onboardings_tenant_id_fix.rb
+++ b/db/migrate/20240719174715_onboardings_tenant_id_fix.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class OnboardingsTenantIdFix < ActiveRecord::Migration[6.1]
+  def up
+    triggers = System::Database.triggers.select { |trigger| trigger.table =~ /\Aonboardings\z/ }
+    ActiveRecord::Base.transaction do
+      triggers.each do |trigger|
+        expressions = [trigger.public_send(:recreate)].flatten
+        expressions.each(&ActiveRecord::Base.connection.method(:execute))
+      end
+    end
+
+    Onboarding.update_all(tenant_id: nil)
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_04_135614) do
+ActiveRecord::Schema.define(version: 2024_07_19_174715) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id", precision: 38, null: false

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_04_135614) do
+ActiveRecord::Schema.define(version: 2024_07_19_174715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_04_135614) do
+ActiveRecord::Schema.define(version: 2024_07_19_174715) do
 
   create_table "access_tokens", charset: "utf8mb3", collation: "utf8mb3_bin", force: :cascade do |t|
     t.bigint "owner_id", null: false

--- a/lib/system/database/definitions/mysql.rb
+++ b/lib/system/database/definitions/mysql.rb
@@ -493,9 +493,7 @@ System::Database::MySQL.define do
 
   trigger 'onboardings' do
     <<~SQL
-      IF NEW.account_id <> master_id THEN
-        SET NEW.tenant_id = NEW.account_id;
-      END IF;
+      SET NEW.tenant_id = (SELECT tenant_id FROM accounts WHERE id = NEW.account_id AND tenant_id <> master_id);
     SQL
   end
 

--- a/lib/system/database/definitions/oracle.rb
+++ b/lib/system/database/definitions/oracle.rb
@@ -509,9 +509,7 @@ System::Database::Oracle.define do
 
   trigger 'onboardings' do
     <<~SQL
-      IF :new.account_id <> master_id THEN
-        :new.tenant_id := :new.account_id;
-      END IF;
+      SELECT tenant_id INTO :new.tenant_id FROM accounts WHERE id = :new.account_id AND tenant_id <> master_id;
     SQL
   end
 

--- a/lib/system/database/definitions/postgres.rb
+++ b/lib/system/database/definitions/postgres.rb
@@ -509,9 +509,7 @@ System::Database::Postgres.define do
 
   trigger 'onboardings' do
     <<~SQL
-      IF NEW.account_id <> master_id THEN
-        NEW.tenant_id := NEW.account_id;
-      END IF;
+      SELECT tenant_id INTO NEW.tenant_id FROM accounts WHERE id = NEW.account_id AND tenant_id <> master_id;
     SQL
   end
 

--- a/test/integration/buyers/users_controller_integration_test.rb
+++ b/test/integration/buyers/users_controller_integration_test.rb
@@ -68,4 +68,15 @@ class Buyers::UsersControllerIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal 'newemail@example.org', user.email
     assert_equal 'Japan', user.field_value('country')
   end
+
+  test "#activate" do
+    user = FactoryBot.create(:pending_user, account: buyer)
+    assert_not user.active?
+
+    post activate_admin_buyers_account_user_path(account_id: buyer.id, id: user.id)
+    follow_redirect!
+
+    assert_response :ok
+    assert user.reload.active?
+  end
 end


### PR DESCRIPTION
onboardings are currently created for buyer accounts as well and
existing trigger created with `tennant_id = account_id` is incorrect.

This PR fixes this. Also existing onboardings are reset to `nil` tenant.

This should avoid failures when checking the tenant_id and they don't contain
critical information so no need to obtain the correct `tenant_id`.

It can be done later if necessary.