### PR TITLE
THREESCALE-11205: Read sentinels credentials from the URI

### DIFF
--- a/app/lib/three_scale/redis_config.rb
+++ b/app/lib/three_scale/redis_config.rb
@@ -8,7 +8,7 @@ module ThreeScale
       uri = URI.parse(raw_config[:url].to_s)
       raw_config[:db] ||= uri.path[1..]
       raw_config[:ssl] ||= true if uri.scheme == 'rediss'
-      parse_sentinels(raw_config)
+      apply_sentinels_config!(raw_config)
       raw_config.compact!
 
       @config = ActiveSupport::OrderedOptions.new.merge(raw_config)
@@ -40,7 +40,7 @@ module ThreeScale
 
     DEFAULT_SENTINEL_PORT = 26379
 
-    def parse_sentinels(config)
+    def apply_sentinels_config!(config)
       sentinels = config.delete(:sentinels).presence
       return unless sentinels
 

--- a/app/lib/three_scale/redis_config.rb
+++ b/app/lib/three_scale/redis_config.rb
@@ -4,7 +4,7 @@ module ThreeScale
   class RedisConfig
     def initialize(redis_config = {})
       raw_config = (redis_config || {}).deep_symbolize_keys
-      raw_config.delete_if { |key, value| value.blank? }
+      raw_config.delete_if { |_key, value| value.blank? }
       uri = URI.parse(raw_config[:url].to_s)
       raw_config[:db] ||= uri.path[1..]
       raw_config[:ssl] ||= true if uri.scheme == 'rediss'

--- a/test/unit/three_scale/redis_config_test.rb
+++ b/test/unit/three_scale/redis_config_test.rb
@@ -21,14 +21,18 @@ module ThreeScale
     end
 
     test 'sentinels' do
-      config = RedisConfig.new(url: 'redis://my-redis/1', sentinels: 'redis://:abc@127.0.0.1,localhost,redis://:passwd@external-redis,redis://localhost:1234')
+      username = 'user'
+      password = 'abc'
+      config = RedisConfig.new(url: 'redis://my-redis/1', sentinels: "redis://#{username}:#{password}@127.0.0.1,localhost,redis://external-redis,redis://localhost:1234")
       expected_sentinels = [
-        { host: '127.0.0.1', port: 26379, password: 'abc' },
+        { host: '127.0.0.1', port: 26379},
         { host: 'localhost', port: 26379 },
-        { host: 'external-redis', port: 26379, password: 'passwd' },
+        { host: 'external-redis', port: 26379},
         { host: 'localhost', port: 1234 },
       ]
       assert_equal expected_sentinels, config.sentinels
+      assert_equal username, config.sentinel_username
+      assert_equal password, config.sentinel_password
     end
 
     test 'extracts the Redis logical DB from the URL' do


### PR DESCRIPTION
**What this PR does / why we need it**:

Last changes to support TLS for Redis caused a regression that broke one scenario: reading the sentinels credentials from the URL.

Now providing a sentinel URL like this should be accepted:

```
rediss://user:password@localhost:56380 
```

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11205

**Verification steps** 

1. Don't set `REDIS_SENTINEL_USERNAME` nor `REDIS_SENTINEL_PASSWORD`.
2. Include credentials in `REDIS_SENTINEL_HOSTS`:
```
REDIS_SENTINEL_HOSTS=rediss://username:password@localhost:56380,rediss://localhost:56381,rediss://localhost:56382`
```
3. It all should work fine
