### PR TITLE
Do not fail when rolling_updates.yml is missing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -215,7 +215,7 @@ module System
     config.three_scale.redhat_customer_portal.enabled = false
     config.three_scale.redhat_customer_portal.merge!(try_config_for(:redhat_customer_portal) || {})
 
-    config.three_scale.rolling_updates.features = try_config_for(:rolling_updates).deep_merge(try_config_for(:"extra-rolling_updates") || {})
+    config.three_scale.rolling_updates.features = try_config_for(:rolling_updates)&.deep_merge(try_config_for(:"extra-rolling_updates") || {})
 
     config.three_scale.service_discovery = ActiveSupport::OrderedOptions.new
     config.three_scale.service_discovery.enabled = false


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent the following error when `rolling_updates.yml` is not present in `config`:

```
NoMethodError: undefined method `deep_merge' for nil:NilClass

    config.three_scale.rolling_updates.features = try_config_for(:rolling_updates).deep_merge(try_config_for(:"extra-rolling_updates") || {})
                                                                                  ^^^^^^^^^^^
/home/dmayorov/Projects/3scale/porta/config/application.rb:218:in `<class:Application>'

```

**Which issue(s) this PR fixes** 

---

**Verification steps** 


**Special notes for your reviewer**:
