### PR TITLE
Strip 'iss' query param from the redirect URL for Keycloak auth flow

### DIFF
--- a/app/lib/three_scale/oauth2/keycloak_client.rb
+++ b/app/lib/three_scale/oauth2/keycloak_client.rb
@@ -51,7 +51,7 @@ module ThreeScale
 
       class RedirectUri
 
-        NOT_ALLOWED_PARAMS = %w[code].freeze
+        NOT_ALLOWED_PARAMS = %w[code iss].freeze
 
         def self.call(request)
           new(request).call

--- a/app/lib/three_scale/oauth2/redhat_customer_portal_client.rb
+++ b/app/lib/three_scale/oauth2/redhat_customer_portal_client.rb
@@ -66,7 +66,7 @@ module ThreeScale
 
       class RedirectUri < ThreeScale::OAuth2::ClientBase::CallbackUrl
 
-        PARAMS_NOT_ALLOWED = %i[code action controller].freeze
+        PARAMS_NOT_ALLOWED = %i[code action controller iss].freeze
 
         def self.call(client, request)
           new(client, request).call

--- a/test/unit/three_scale/oauth2/keycloak_client_test.rb
+++ b/test/unit/three_scale/oauth2/keycloak_client_test.rb
@@ -25,13 +25,14 @@ class ThreeScale::OAuth2::KeycloakClientTest < ActiveSupport::TestCase
   end
 
   test '#authenticate_options' do
+    query_string = 'foo=bar&code=123456&iss=http%3A%2F%2Fkeycloak.example.com%2Frealms%2Ftest'
     env = {
       'HTTP_HOST' => 'example.net',
-      'QUERY_STRING' => 'foo=bar&code=123456',
+      'QUERY_STRING' => query_string,
       'PATH_INFO' => '/path'
     }
     request = ActionDispatch::TestRequest.create env
-    request.request_uri = 'http://example.net/path?foo=bar&code=123456'
+    request.request_uri = "http://example.net/path?#{query_string}"
 
     options = @oauth2.authenticate_options(request)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since version 23 Keycloak (RHBK) adds a `iss` query parameter to the authentication response, see https://www.keycloak.org/docs/latest/upgrading/index.html#migrating-to-23-0-0

The result of this is that 3scale client included this `iss` value to the `redirect_uri` when fetching the access token, which in its turn caused an error:
```
{"error":"invalid_grant","error_description":"Incorrect redirect_uri"}
```

This PR only removes the `iss` from the redirect URI when forming the access token request. Ideally, we would need to also verify the value of the `iss` parameter to make sure it is exactly the same as the Realm URL specified in the SSO configuration. See [2.4.  Validating the Issuer Identifier](https://www.rfc-editor.org/rfc/rfc9207.html#name-validating-the-issuer-ident) in RFC 9207.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11200

**Verification steps** 

Set up a client for dev portal authentication in RHBK v24 and configure dev portal SSO.
Test the integration and verify it's successful even when the compatibility mode "Exclude Issuer From Authentication Response" is OFF.

**Special notes for your reviewer**:
