### PR TITLE
Fix logo s3 public access

### DIFF
--- a/app/lib/cms/s3.rb
+++ b/app/lib/cms/s3.rb
@@ -6,6 +6,8 @@ module CMS
 
     FIPS_FILE_PATH = "/proc/sys/crypto/fips_enabled"
 
+    DEFAULT_EXPIRES_IN = 3600
+
     class NoConfigError < StandardError; end
 
     def enabled?

--- a/app/lib/pdf/finance/invoice_report_data.rb
+++ b/app/lib/pdf/finance/invoice_report_data.rb
@@ -140,7 +140,7 @@ class Pdf::Finance::InvoiceReportData
       # read as binary file 'b'
       File.open(logo.path(LOGO_ATTACHMENT_STYLE), 'rb')
     when :s3
-      URI.parse(logo.url(LOGO_ATTACHMENT_STYLE)).open
+      URI.parse(logo.expiring_url(CMS::S3::DEFAULT_EXPIRES_IN, LOGO_ATTACHMENT_STYLE)).open
     else
       raise "Invalid attachment type #{storage}"
     end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -56,7 +56,6 @@ class Profile < ApplicationRecord
     processors: [:g_d_image_processor],
     styles: LOGO_STYLES,
     :url => ':url_root/:account_id/:class/:attachment/:style/:basename.:extension'.freeze,
-    :s3_permissions => 'public-read'.freeze,
     :default_url => '/assets/3scale-logo.png'.freeze
   validates_attachment_content_type :logo, content_type: %r{^image\/(png|jpeg)}, if: :will_save_change_to_logo?
 

--- a/app/views/provider/admin/account/logos/_logo.html.slim
+++ b/app/views/provider/admin/account/logos/_logo.html.slim
@@ -1,2 +1,2 @@
-= image_tag @profile.logo.url(:medium)
+= image_tag @profile.logo.expiring_url(CMS::S3::DEFAULT_EXPIRES_IN, :medium)
 = delete_link_for provider_admin_account_logo_path

--- a/lib/developer_portal/app/views/shared/_logo.html.slim
+++ b/lib/developer_portal/app/views/shared/_logo.html.slim
@@ -2,4 +2,4 @@ h1 id="logo"
   - logo_account = current_account && current_account.provider? ? current_account : site_account
 
   - if logo = logo_account.try(:profile).try(:logo)
-    = link_to image_tag(logo.url(:large), width: '100%'), '/'
+    = link_to image_tag(logo.expiring_url(CMS::S3::DEFAULT_EXPIRES_IN, :large), width: '100%'), '/'

--- a/lib/developer_portal/lib/liquid/drops/provider.rb
+++ b/lib/developer_portal/lib/liquid/drops/provider.rb
@@ -202,7 +202,7 @@ module Liquid
       )
       def logo_url
         if logo = @model.try(:profile).try(:logo)
-          logo.url(:large)
+          logo.expiring_url(CMS::S3::DEFAULT_EXPIRES_IN, :large)
         end
       end
 

--- a/test/unit/pdf/finance/invoice_report_data_test.rb
+++ b/test/unit/pdf/finance/invoice_report_data_test.rb
@@ -106,7 +106,7 @@ class Pdf::Finance::InvoiceReportDataTest < ActiveSupport::TestCase
     Paperclip::Attachment.stubs(default_options: default_options.merge(storage: :s3))
     @provider.profile.update(logo: Rack::Test::UploadedFile.new(file_fixture('wide.jpg'), 'image/jpeg', true))
 
-    stub_request(:get, %r{\Ahttps.*/profiles/logos/invoice/wide.jpg\z})
+    stub_request(:get, %r{\Ahttps.*/profiles/logos/invoice/wide.jpg?.*X-Amz-Expires=#{CMS::S3::DEFAULT_EXPIRES_IN}.*\z})
         .to_return(status: 200, body: File.open(file_fixture('wide.jpg')))
 
     logo_file = nil

--- a/test/unit/profile_test.rb
+++ b/test/unit/profile_test.rb
@@ -114,7 +114,7 @@ class ProfileTest < ActiveSupport::TestCase
 
       profile.logo = hypnotoad
       profile.logo.s3_interface.client.stub_responses(:put_object, ->(request) {
-        assert_equal 'public-read', request.params[:acl]
+        assert_equal 'private', request.params[:acl]
       })
       profile.save!
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, profile logo uses a public URL, e.g.
https://bucket-name.s3.amazonaws.com/provider/id/profiles/logos/medium/logo-file-name.png

This requires public access to be enabled on the bucket, which is a bad security practice.

This PR changes the URL used for the logo to [presigned URL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html) (through `#expiring_url` from `kt-paperclip`).

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-8932

**Verification steps** 

Create and configure an S3 bucket with no public access and verify that the following works:
- upload a logo at `/p/admin/account/logo/edit` and view it afterwards
- regenerate some invoice PDF and verify the logo is visible on the invoice
- add `<img src="{{ provider.logo_url }}" />` to a CMS template and make sure the logo is visible when rendered
- (optional) there is also a `{% logo %}` Liquid tag, but it's deprecated

**Special notes for your reviewer**:

The `#expiring_url` receives positional arguments: expiration time, and the style, see https://github.com/kreeti/kt-paperclip/blob/v7.2.1/lib/paperclip/storage/s3.rb#L188-L198

To keep the existing behavior, we need to pass the style, but then we need to pass something for the expiration time also. Currently, I've opted for adding a constant `CMS::S3::DEFAULT_EXPIRES_IN = 900` and passing it as the 1st argument. But not sure if it's the best way.

If we just pass `nil` the aws skd will apply `900` as default anyway, but I just wanted to be more explicit, because passing `nil` can be confusing, like expecting that the link will have no expiration or something like that.

The `#expiring_url` method itself sets 3600 as the default value, if no arguments are passed, so we could also set the default to 3600.