### PR TITLE
Fix deprecations on `ActiveModel::Errors`

### DIFF
--- a/app/controllers/admin/api/signups_controller.rb
+++ b/app/controllers/admin/api/signups_controller.rb
@@ -25,8 +25,8 @@ class Admin::Api::SignupsController < Admin::Api::BaseController
     # and not respond with pathetic error
     raise ActiveRecord::RecordNotFound if @signup_result.errors[:plans].present?
 
-    @signup_result.user.errors.each do |attr, error|
-      @signup_result.account.errors.add(attr, error)
+    @signup_result.user.errors.each do |error|
+      @signup_result.account.errors.add(error.attribute, error.message)
     end
   end
 

--- a/app/lib/active_model/errors_to_xml.rb
+++ b/app/lib/active_model/errors_to_xml.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module ErrorsToXml
+    # This was deprecated with no replacement in rails 6. Because allegedly
+    # nobody uses it. So we have to keep a copy until we completely stop
+    # supporting XMLs in our APIs.
+    # https://github.com/rails/rails/pull/32313
+    #
+    # Returns an xml formatted representation of the Errors hash.
+    #
+    #   person.errors.add(:name, :blank, message: "can't be blank")
+    #   person.errors.add(:name, :not_specified, message: "must be specified")
+    #   person.errors.to_xml
+    #   # =>
+    #   #  <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    #   #  <errors>
+    #   #    <error>name can't be blank</error>
+    #   #    <error>name must be specified</error>
+    #   #  </errors>
+    def to_xml(options = {})
+      to_a.to_xml({ root: "errors", skip_types: true }.merge!(options))
+    end
+  end
+end

--- a/app/lib/three_scale/errors_to_xml.rb
+++ b/app/lib/three_scale/errors_to_xml.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ActiveModel
+module ThreeScale
   module ErrorsToXml
     # This was deprecated with no replacement in rails 6. Because allegedly
     # nobody uses it. So we have to keep a copy until we completely stop

--- a/config/initializers/active_model.rb
+++ b/config/initializers/active_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.config.to_prepare do
-  ActiveModel::Errors.prepend ActiveModel::ErrorsToXml
+  ActiveModel::Errors.prepend ThreeScale::ErrorsToXml
 end

--- a/config/initializers/active_model.rb
+++ b/config/initializers/active_model.rb
@@ -1,0 +1,3 @@
+Rails.application.config.to_prepare do
+  ActiveModel::Errors.prepend ActiveModel::ErrorsToXml
+end


### PR DESCRIPTION
### What this PR does / why we need it:

This PR fixes two deprecation messages reported to Bugsnag:
#### ActiveModel::Errors#to_xml is deprecated and will be removed in Rails 7.0
[Report](https://app.bugsnag.com/3scale-networks-sl/system/errors/667178505397250008adc486?filters[event.since]=30d&filters[app.release_stage]=production)

When calling an API endpoint using XML format, if there are any errors those are returned in XML. To do that, rails ends up calling `ActiveModel::Errors#to_xml`.

For some reason they have deprecated that method because allegedly is not much used. I'm very surprised they think nobody supports XML in their APIs... Anyway. They'll remove the method in Rails 7, so we have to provide our own. I monkey patched `ActiveModel::Errors` to include the original `#to_xml` method but without the warning.

Check: https://github.com/rails/rails/pull/32313

**Commit**: https://github.com/3scale/porta/commit/ce01e7ea4e22336b49d799122b7c8b30b5faf7b9

**How to verify**:

This curl reproduces the warning in `master`:

```
curl --request PUT \
  --url 'http://provider-admin.3scale.localhost:3000//admin/api/services/2.xml?access_token=secret' \
  --header 'Content-Type: application/json' \
  --data '{ "service": { "system_name": "" } }'
```

#### Enumerating ActiveModel::Errors as a hash has been deprecated
[Report](https://app.bugsnag.com/3scale-networks-sl/system/errors/66717839e9c9e700080cccf1?filters[event.since]=30d&filters[app.release_stage]=production&pivot_tab=event)

The `ActiveModel::Errors` API changed in Rails 6.1. We already upgraded to it (https://github.com/3scale/porta/commit/4ebe7e6c063891048b752a4e483be33f11a1bf1b) but apparently we forgot to update the signup controller.

**Commit**: https://github.com/3scale/porta/commit/ff3c94ad930b31af2537c06d3f3e93fdcc210660

**How to verify**:

Run this command:

```
curl --request POST \
  --url 'http://provider-admin.3scale.localhost:3000//admin/api/signup.json?access_token=secret' \
  --header 'Content-Type: application/json' \
  --data '{
	"org_name": "API buyer",
	"username": "",
	"password": "p",
	"email": "test@redhat.com"
	}'
```

### Which issue(s) this PR fixes

No issue
