### PR TITLE
THREESCALE-10207: Upgrade `sidekiq-batch` to 0.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,10 +55,7 @@ gem 'statsd-ruby', require: false
 
 # Sidekiq
 gem 'sidekiq', '~> 7', require: %w[sidekiq sidekiq/web]
-# Use a forked sidekiq-batch with support for Sidekiq 7
-# The next upstream version will add support Sidekiq 7 as well
-# Remove this fork when they release the new version
-gem 'sidekiq-batch', github: '3scale/sidekiq-batch', branch: 'redis-client'
+gem 'sidekiq-batch', '~> 0.2.0'
 gem 'sidekiq-cron', require: %w[sidekiq/cron sidekiq/cron/web]
 gem 'sidekiq-throttled', '~> 1.4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,14 +29,6 @@ GIT
       rspec (>= 3.0.0.a, < 4)
 
 GIT
-  remote: https://github.com/3scale/sidekiq-batch.git
-  revision: f1c56d0b8445fd3eb337614aedba1752aa19938e
-  branch: redis-client
-  specs:
-    sidekiq-batch (0.1.9)
-      sidekiq (~> 7)
-
-GIT
   remote: https://github.com/3scale/swagger-ui_rails.git
   revision: f88bb8bed4fdb57fcf5be6425f3fc10c638788d1
   branch: dev-2.1.3
@@ -792,6 +784,8 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
+    sidekiq-batch (0.2.0)
+      sidekiq (>= 7, < 8)
     sidekiq-cron (1.9.1)
       fugit (~> 1.8)
       sidekiq (>= 4.2.1)
@@ -1074,7 +1068,7 @@ DEPENDENCIES
   selenium-webdriver (~> 3.142)
   shoulda (~> 4.0)
   sidekiq (~> 7)
-  sidekiq-batch!
+  sidekiq-batch (~> 0.2.0)
   sidekiq-cron
   sidekiq-throttled (~> 1.4.0)
   simplecov (~> 0.21.2)


### PR DESCRIPTION
**What this PR does / why we need it**:

After upgrading to Sidekiq 7, we had to fork `sidekiq-batch` because upstream was outdated and only supported up to Sidekiq 6. They recently released a new version with full support for Sidekiq 7, so we can get rid of the fork.

**Which issue(s) this PR fixes** 

This completes [THREESCALE-10207](https://issues.redhat.com/browse/THREESCALE-10207)

**Verification steps** 

Everything should work as usual, specially the workers using the batches feature, like the billing worker.

