### PR TITLE
🦋 Hide password field at New Provider account

### DIFF
--- a/app/views/provider/admin/accounts/new.html.slim
+++ b/app/views/provider/admin/accounts/new.html.slim
@@ -10,8 +10,8 @@ div class="pf-c-card"
           ' User Information
         = form.fields_for [:user, @user] do |user|
           = user.user_defined_form
-          = user.input :password, as: :patternfly_input, required: true
-          = user.input :password_confirmation, as: :patternfly_input, required: true
+          = user.input :password, as: :patternfly_input, input_html: { type: 'password' }, required: true
+          = user.input :password_confirmation, as: :patternfly_input, input_html: { type: 'password' }, required: true
 
       section class="pf-c-form__section" role="group" aria-labelledby="form-section-org"
         div class="pf-c-form__section-title" id="form-section-org" aria-hidden="true"


### PR DESCRIPTION
**What this PR does / why we need it**:

When we upgraded this template to PatternFly the password field became an input without type. Adding the type covers that.

<img width="1264" alt="Captura de pantalla 2024-08-27 a las 13 19 36" src="https://github.com/user-attachments/assets/983d5bc9-a204-4249-b7fe-97c53b7f600f">
