### PR TITLE
THREESCALE-10856: Searchd: Filter Accounts by provider id

### DIFF
--- a/app/models/account/search.rb
+++ b/app/models/account/search.rb
@@ -60,7 +60,9 @@ class Account
                                  per_page: ThreeScale::Search::Helpers::SPHINX_PAGE_SIZE_INFINITE,
                                  ignore_scopes: true, with: { })
 
-        options.deep_merge!(with: { provider_account_id: User.current.account_id })
+        if (account_id = User.account_id)
+          options.deep_merge!(with: { provider_account_id: account_id })
+        end
 
         search(ThinkingSphinx::Query.escape(query), options)
       end

--- a/app/models/account/search.rb
+++ b/app/models/account/search.rb
@@ -60,9 +60,7 @@ class Account
                                  per_page: ThreeScale::Search::Helpers::SPHINX_PAGE_SIZE_INFINITE,
                                  ignore_scopes: true, with: { })
 
-        if (tenant_id = User.tenant_id)
-          options.deep_merge!(with: { tenant_id: tenant_id })
-        end
+        options.deep_merge!(with: { provider_account_id: User.current.account_id })
 
         search(ThinkingSphinx::Query.escape(query), options)
       end

--- a/app/models/account/search.rb
+++ b/app/models/account/search.rb
@@ -60,7 +60,7 @@ class Account
                                  per_page: ThreeScale::Search::Helpers::SPHINX_PAGE_SIZE_INFINITE,
                                  ignore_scopes: true, with: { })
 
-        if (account_id = User.account_id)
+        if (account_id = User.current&.account_id)
           options.deep_merge!(with: { provider_account_id: account_id })
         end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -318,6 +318,10 @@ class User < ApplicationRecord
     current.try!(:tenant_id)
   end
 
+  def self.account_id
+    current.try!(:account_id)
+  end
+
   def self.current=(user)
     Thread.current[:cms_user] = user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -318,10 +318,6 @@ class User < ApplicationRecord
     current.try!(:tenant_id)
   end
 
-  def self.account_id
-    current.try!(:account_id)
-  end
-
   def self.current=(user)
     Thread.current[:cms_user] = user
   end

--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -143,7 +143,7 @@ class Account::SearchTest < ActiveSupport::TestCase
     Account.scope_search(:query => '')
   end
 
-  test 'search from master account only returns providers and not buyers' do
+  test 'search as master user only returns providers and not buyers' do
     ThinkingSphinx::Test.rt_run do
       perform_enqueued_jobs only: SphinxAccountIndexationWorker do
         FactoryBot.create_list(:provider_account, 3, :with_a_buyer)
@@ -154,6 +154,18 @@ class Account::SearchTest < ActiveSupport::TestCase
       results = Account.scope_search({query: 'company'})
 
       assert_equal 3, results.size
+    end
+  end
+
+  test 'search as no user returns providers and buyers' do
+    ThinkingSphinx::Test.rt_run do
+      perform_enqueued_jobs only: SphinxAccountIndexationWorker do
+        FactoryBot.create_list(:provider_account, 3, :with_a_buyer)
+      end
+
+      results = Account.scope_search({query: 'company'})
+
+      assert_equal 6, results.size
     end
   end
 

--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -146,9 +146,9 @@ class Account::SearchTest < ActiveSupport::TestCase
   test 'search from master account only returns providers and not buyers' do
     ThinkingSphinx::Test.rt_run do
       perform_enqueued_jobs only: SphinxAccountIndexationWorker do
-        3.times { FactoryBot.create(:provider_account, :with_a_buyer) }
+        FactoryBot.create_list(:provider_account, 3, :with_a_buyer)
       end
-      user = FactoryBot.build(:user, account_id: Account.master.id)
+      user = Account.master.first_admin!
       User.expects(:current).returns(user)
 
       results = Account.scope_search({query: 'company'})

--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -76,7 +76,8 @@ class Account::SearchTest < ActiveSupport::TestCase
                    with: { }
                  }, Account.buyers.search_ids('foo').options)
 
-    User.expects(:account_id).returns(42)
+    user = FactoryBot.build(:user, account_id: 42)
+    User.expects(:current).returns(user)
 
     assert_equal({
                    ids_only: true, per_page: 1_000_000, star: true,

--- a/test/unit/account/search_test.rb
+++ b/test/unit/account/search_test.rb
@@ -76,12 +76,12 @@ class Account::SearchTest < ActiveSupport::TestCase
                    with: { }
                  }, Account.buyers.search_ids('foo').options)
 
-    User.expects(:tenant_id).returns(42)
+    User.expects(:account_id).returns(42)
 
     assert_equal({
                    ids_only: true, per_page: 1_000_000, star: true,
                    ignore_scopes: true, classes: [Account],
-                   with: { tenant_id: 42 }
+                   with: { provider_account_id: 42 }
                  }, Account.providers.search_ids('foo').options)
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When searching accounts using searchd, results are filtered by current `tenant_id`, but not in the master portal. When searching as master, all accounts are considered, also buyer accounts.

Read the Jira description for further info.

This PR introduces one change:

**Before:**
- Master: Search over all accounts
- Provider: Search over all accounts having `tenant_id` = current provider ID

**After:**
- Master and Provider: Search over all accounts having `provider_account_id` = current provider ID

**New query:**

```sql
SELECT * FROM `account_core` WHERE MATCH('*api*')
  AND `provider_account_id` = 1
  AND `sphinx_deleted` = 0 LIMIT 0, 1000000 OPTION cutoff=0, field_weights=(name=2)
```

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10856

**Verification steps** 

I couldn't verify this works because I couldn't reproduce the bug locally. Ideas welcome.
