### PR TITLE
THREESCALE-1789: Add "Managed by operator" banner (UI)

### DIFF
--- a/app/helpers/patternfly_components_helper.rb
+++ b/app/helpers/patternfly_components_helper.rb
@@ -1,24 +1,43 @@
 # frozen_string_literal: true
 
 module PatternflyComponentsHelper
-  def pf_inline_alert(text, variant: nil)
-    icon_name = case variant
-                when :info then 'info-circle'
-                when :success then 'check-circled'
-                when :warning, :danger then 'exclamation-triangle'
-                else 'bell'
-    end
 
-    icon = tag.div class: 'pf-c-alert__icon' do
-      tag.i class: "fas fa-fw fa-#{icon_name}", 'aria-hidden': 'true'
+  def icon_name(variant)
+    case variant
+    when :info then 'info-circle'
+    when :success then 'check-circled'
+    when :warning, :danger then 'exclamation-triangle'
+    else 'bell'
     end
+  end
 
-    title = tag.p class: 'pf-c-alert__title' do
-      text
+  def icon_tag(variant)
+    tag.div class: 'pf-c-alert__icon' do
+      tag.i class: "fas fa-fw fa-#{icon_name(variant)}", 'aria-hidden': 'true'
     end
+  end
 
+  def title_tag(title)
+    tag.div class: 'pf-c-alert__title' do
+      tag.p title
+    end
+  end
+
+  def body_tag(body)
+    tag.div class: 'pf-c-alert__description' do
+      tag.p body
+    end
+  end
+
+  def pf_inline_alert(title, body, variant: nil)
     tag.div class: "pf-c-alert pf-m-#{variant} pf-m-inline" do
-      icon + title
+      icon_tag(variant) + title_tag(title) + body_tag(body)
+    end
+  end
+
+  def pf_inline_alert_plain(title, variant: nil)
+    tag.div class: "pf-c-alert pf-m-#{variant} pf-m-inline pf-m-plain" do
+      icon_tag(variant) + title_tag(title)
     end
   end
 end

--- a/app/views/api/services/edit.html.slim
+++ b/app/views/api/services/edit.html.slim
@@ -1,4 +1,6 @@
 - content_for :page_header_title, 'Naming'
+- content_for :page_header_annotation do
+  = render partial: 'shared/annotations', locals: { resource: @service, description: true, variant: :warning }
 
 = semantic_form_for @service, url: admin_service_path(@service) do |form|
   = render partial: 'api/services/forms/naming', locals: { form: form }

--- a/app/views/api/services/show.html.slim
+++ b/app/views/api/services/show.html.slim
@@ -1,4 +1,6 @@
 - content_for :page_header_title, 'Product Overview'
+- content_for :page_header_annotation do
+  = render partial: 'shared/annotations', locals: { resource: @service, plain: true }
 
 section.Section
   .SettingsBox

--- a/app/views/buyers/accounts/edit.html.slim
+++ b/app/views/buyers/accounts/edit.html.slim
@@ -2,6 +2,8 @@
   = render 'menu'
 
 - content_for :page_header_title, "Edit account #{@account.org_name} details"
+- content_for :page_header_annotation do
+  = render partial: 'shared/annotations', locals: { resource: @account, description: true, variant: :warning }
 
 div class="pf-c-card"
   div class="pf-c-card__body"

--- a/app/views/buyers/accounts/show.html.slim
+++ b/app/views/buyers/accounts/show.html.slim
@@ -8,6 +8,7 @@
         ' Account: #{@account.org_name}
         - if can? :update, @account
           = link_to 'Edit', edit_admin_buyers_account_path(@account), class: 'action edit'
+      = render partial: 'shared/annotations', locals: { resource: @account, plain: true }
 
 div class="pf-l-grid pf-m-gutter pf-m-all-6-col"
   / Left column

--- a/app/views/provider/admin/backend_apis/edit.html.slim
+++ b/app/views/provider/admin/backend_apis/edit.html.slim
@@ -1,4 +1,6 @@
 - content_for :page_header_title, 'Edit Backend'
+- content_for :page_header_annotation do
+  = render partial: 'shared/annotations', locals: { resource: @backend_api, description: true, variant: :warning }
 
 div class="pf-l-flex pf-m-column"
   div class="pf-l-flex__item"

--- a/app/views/provider/admin/backend_apis/show.html.slim
+++ b/app/views/provider/admin/backend_apis/show.html.slim
@@ -1,4 +1,6 @@
 - content_for :page_header_title, 'Backend Overview'
+- content_for :page_header_annotation do
+  = render partial: 'shared/annotations', locals: { resource: @backend_api, plain: true }
 
 section.Section
   .SettingsBox

--- a/app/views/shared/_annotations.html.slim
+++ b/app/views/shared/_annotations.html.slim
@@ -1,0 +1,7 @@
+- if resource.respond_to?(:managed_by) && resource.managed_by.present?
+  - var = defined?(variant) ? variant : :info
+  - if defined?(plain)
+    = pf_inline_alert_plain t('.managed_title', value: resource.managed_by), variant: var
+  - else
+    - body = (defined?(description) && description) ? t('.managed_description') : nil
+    = pf_inline_alert t('.managed_title', value: resource.managed_by), body, variant: var

--- a/app/views/shared/provider/_page_header.html.slim
+++ b/app/views/shared/provider/_page_header.html.slim
@@ -4,6 +4,8 @@
       h1 = title
       - if (subtitle = content_for(:page_header_body).presence)
         p = subtitle
+      - if (annotation = content_for(:page_header_annotation).presence)
+        = annotation
     - if (alert = content_for(:page_header_alert).presence)
       = alert
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1672,6 +1672,9 @@ en:
       unknown_format: 'The server does not understand "%{request_format}" request.'
 
   shared:
+    annotations:
+      managed_title: Managed by %{value}
+      managed_description: This resource is managed externally and any modifications may be overwritten.
     empty_search_state:
       title: No results
       body: There are no items matching your search criteria.


### PR DESCRIPTION
**What this PR does / why we need it**:

This replaces https://github.com/3scale/porta/pull/3865. That got closed after merging https://github.com/3scale/porta/pull/3857

The operator can manage porta resources through API. When a resource is managed by operator, we must inform the user about that.

https://github.com/3scale/porta/pull/3857 implements the backend support (annotations). This PR implements the frontend, for now, just a banner in the relevant screens:

- `http://provider-admin.3scale.localhost:3000/buyers/accounts/4`
- `http://provider-admin.3scale.localhost:3000/buyers/accounts/4/edit`
- `http://provider-admin.3scale.localhost:3000/apiconfig/services/2`
- `http://provider-admin.3scale.localhost:3000/apiconfig/services/2/edit`
- `http://provider-admin.3scale.localhost:3000/p/admin/backend_apis/2`
- `http://provider-admin.3scale.localhost:3000/p/admin/backend_apis/2/edit`

Examples:

![image](https://github.com/user-attachments/assets/3c053c24-ae8a-474e-8984-6d0ceca46945)


![image](https://github.com/user-attachments/assets/31f0863e-1bad-4412-b01e-57dfd485dc87)


**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-1786

**Verification steps** 

1. Marks a resource as managed by operator. Check https://github.com/3scale/porta/pull/3857 to know how
2. Visit the resource `#show` or `#edit` screens
3. You should see the banner

