### PR TITLE
THREESCALE-11276: New field definition: Fix dropdown content

### DIFF
--- a/app/controllers/admin/fields_definitions_controller.rb
+++ b/app/controllers/admin/fields_definitions_controller.rb
@@ -42,7 +42,7 @@ class Admin::FieldsDefinitionsController < Sites::BaseController
 
     elsif @fields_definition.errors[:target].empty?
       @optional_fields = @fields_definition.target.classify.constantize.builtin_fields -
-          current_account.fields_definitions.by_target(@fields_definition.target).map(&:name)
+          current_account.reload.fields_definitions.by_target(@fields_definition.target).map(&:name)
       @required_fields = @fields_definition.target_class.required_fields
       @optional_fields.unshift "[new field]"
     end


### PR DESCRIPTION
**What this PR does / why we need it**:

Accounts/Settings/Fields Definitions/New: When the form is sent but it's invalid, the sent data stays in the in-memory object. When `fieldname` is in memory, the value it's excluded from the dropdown. This just reloads the object to ensure all in-memory data is discarded. 

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11276

**Verification steps** 

Follow the steps in the ticket description
