### PR TITLE
some database inscructions and convenience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ clean:
 oracle-db-setup: ## Creates databases in Oracle
 oracle-db-setup: oracle-database
 	MASTER_PASSWORD=p USER_PASSWORD=p ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" bundle exec rake db:drop db:create db:setup
+	MASTER_PASSWORD=p USER_PASSWORD=p ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" RAILS_ENV=test bundle exec rake db:drop db:create db:setup
 
 schema: ## Runs db schema migrations. Run this when you have changes to your database schema that you have added as new migrations.
 schema: POSTGRES_DATABASE_URL ?= "postgresql://postgres:@localhost:5432/3scale_system_development"

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ clean:
 
 oracle-db-setup: ## Creates databases in Oracle
 oracle-db-setup: oracle-database
-	MASTER_PASSWORD=p USER_PASSWORD=p ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" bundle exec rake db:drop db:create db:setup
+	MASTER_PASSWORD=p USER_PASSWORD=p ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" ORACLE_DO_NOT_EXPIRE_SYSTEM=1 bundle exec rake db:drop db:create db:setup
 	MASTER_PASSWORD=p USER_PASSWORD=p ORACLE_SYSTEM_PASSWORD=threescalepass NLS_LANG='AMERICAN_AMERICA.UTF8' DATABASE_URL="oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb" RAILS_ENV=test bundle exec rake db:drop db:create db:setup
 
 schema: ## Runs db schema migrations. Run this when you have changes to your database schema that you have added as new migrations.
@@ -104,8 +104,8 @@ schema:
 
 oracle-database: ## Starts Oracle database container
 oracle-database:
-	[ "$(shell docker inspect -f '{{.State.Running}}' oracle-database 2>/dev/null)" = "true" ] || docker start oracle-database &>/dev/null || docker run \
-	    -d \
+	if [ "$(shell docker inspect -f '{{.State.Running}}' oracle-database 2>/dev/null)" != "true" ]; then \
+	  docker start oracle-database &>/dev/null || docker run -d \
 		--shm-size=6gb \
 		-p 1521:1521 -p 5500:5500 \
 		--name oracle-database \
@@ -113,7 +113,9 @@ oracle-database:
 		-e ORACLE_SID=threescale \
 		-e ORACLE_PWD=threescalepass \
 		-e ORACLE_CHARACTERSET=AL32UTF8 \
-		$(ORACLE_DB_IMAGE)
+		$(ORACLE_DB_IMAGE) && \
+	  docker logs --tail=1 -f oracle-database | grep -m 1 "DATABASE IS READY TO USE"; \
+	fi
 
 # Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help: ## Print this help

--- a/SETUP_ORACLE.md
+++ b/SETUP_ORACLE.md
@@ -12,6 +12,8 @@ If you wish, you can also install SQLPLus client from same location as well.
 
 ### Setup Podman with user namespaces
 
+On recent Fedora versions, new users already have that setup.
+
 ```sh
 dnf install -y podman-docker
 sudoedit /etc/subuid # add line: myusername:10000:54321
@@ -20,7 +22,7 @@ sudoedit /etc/subgid # add line: myusername:10000:54330
 
 ## Prerequisites on other Linux and probably MAC
 
-### Install Oracle dependencies using the script
+### Install Oracle Instant Client using the script
 
 1. Run the script with sudo
 ```shell
@@ -34,13 +36,15 @@ LD_LIBRARY_PATH="/opt/oracle/instantclient/:$LD_LIBRARY_PATH"
 ORACLE_HOME=/opt/oracle/instantclient/
 ```
 
-### Install Oracle Instant Client
+### Install Oracle Instant Client via RPM
 
 1. Go to [the official Oracle Instant Client Downloads site](https://www.oracle.com/database/technologies/instant-client/downloads.html) and download the following **.rpm** packages for your operative system:
 
   - Basic
   - SQL Plus
   - SDK
+
+On Fedora or a Red Hat based distro, you can just install the RPMs. Instructions for Debian based systems follow.
 
 2. Create a folder in `/opt/oracle` if it does not exist yet (with `mkdir -p /opt/oracle`) and save these packages there.
 
@@ -60,7 +64,7 @@ export OCI_LIB_DIR=$ORACLE_HOME/lib
 export OCI_INC_DIR=/usr/include/oracle/X/client64
 ```
 
-### Setup Docker
+### Setup Docker (but preferably use podman)
 
 You need to have Docker installed and running. You also need to be able to [run containers as a non-root user](https://docs.docker.com/install/linux/linux-postinstall/).
 
@@ -95,10 +99,15 @@ You need to have Docker installed and running. You also need to be able to [run 
 
 ### ORA-12637: Packet receive failed
 
-Add `DISABLE_OOB=ON` to `sqlnet.ora` ([github issue](https://github.com/oracle/docker-images/issues/1352)).
+Add `DISABLE_OOB=ON` to `sqlnet.ora` ([github issue](https://github.com/oracle/docker-images/issues/1352)). For installation from archive that would be
 
 ```shell
 echo "DISABLE_OOB=ON" >> /opt/oracle/instantclient/network/admin/sqlnet.ora
+```
+
+For RPM installation (update version `21` with whatever you installed locally).
+```shell
+echo "DISABLE_OOB=ON" >> /usr/lib/oracle/21/client64/lib/network/admin/sqlnet.ora
 ```
 
 For IntelliJ/RubyMine, go to Database -> Database Source properties -> Drivers -> Oracle -> Advanced -> oracle.net.disableOob -> true

--- a/config/examples/database.yml
+++ b/config/examples/database.yml
@@ -35,7 +35,7 @@ development:
 
 test:
   <<: *default
-  url: <%= "#{ENV['DATABASE_URL']}#{ENV['TEST_ENV_NUMBER']}" %>
+  url: <%= "#{ENV['DATABASE_URL'].delete_suffix("_development")}test#{ENV['TEST_ENV_NUMBER']}" %>
 
 production:
   <<: *default

--- a/lib/system/database.rb
+++ b/lib/system/database.rb
@@ -160,6 +160,11 @@ ActiveSupport.on_load(:active_record) do
           if ENV['ORACLE_SYSTEM_PASSWORD'].present?
             Logger.new($stderr).warn("Oracle's SYSTEM user will create/update a non-SYSTEM user and grant it permissions")
             super
+
+            if ["1", "true"].include?(ENV["ORACLE_DO_NOT_EXPIRE_SYSTEM"])
+              profile = connection.execute("select profile from DBA_USERS where username = 'SYSTEM'").fetch.first
+              connection.execute "alter profile #{profile} limit password_life_time UNLIMITED"
+            end
           else
             # Will raise ActiveRecord::NoDatabaseError if the database doesn't exist
             establish_connection(@config)


### PR DESCRIPTION
wrt postgres change in configuration file
    
    To run with Postgres locally is a little harder because when
    DATABASE_URL is set, it remains the same for all environments.
    
    To differentiate from the development database one can set
    TEST_ENV_NUMBER but that makes database name like
    `3scale_system_development_test` instead of simpler `3scale_system_test`
    as on MySQL/MariaDB and more importantly this is somehow ugly to see.
    
    With this change one can just set DATABASE_URL for development and URL
    for the `test` environment will be adjusted automatically.
    
    This is also similar to how oracle works where `test` is appended to
    `systempdb` automatically.
    
  oracle instructions are self-explanatory