### PR TITLE
💄 Product name in vert nav

### DIFF
--- a/app/javascript/src/Navigation/components/VerticalNav.scss
+++ b/app/javascript/src/Navigation/components/VerticalNav.scss
@@ -19,7 +19,7 @@
     color: #fff;
     background-color: var(--pf-c-nav__link--BackgroundColor);outline-offset: var(--pf-c-nav__link--OutlineOffset);
 
-    height: 45px;
+    min-height: 45px;
     border-bottom: 1px solid #3c3f42;
   }
 


### PR DESCRIPTION
[THREESCALE-11235: Product or Backend name is not visible if name is too long](https://issues.redhat.com/browse/THREESCALE-11235)

Before:
![Screenshot 2024-09-06 at 12 16 16](https://github.com/user-attachments/assets/5f995dcc-29c8-4190-8877-f81e392f8eb9)

After:
![Screenshot 2024-09-06 at 12 16 21](https://github.com/user-attachments/assets/b8f73089-f7ab-4e34-a568-3c989015938c)