### PR TITLE
THREESCALE-10843: Audit user sessions

### DIFF
--- a/app/controllers/provider/admin/user/personal_details_controller.rb
+++ b/app/controllers/provider/admin/user/personal_details_controller.rb
@@ -34,6 +34,7 @@ class Provider::Admin::User::PersonalDetailsController < Provider::Admin::User::
 
     unless current_user.authenticated?(user_params[:current_password])
       flash.now[:error] = 'Current password is incorrect.'
+      AuditLogService.call("User tried to change password, but failed due to incorrect current password: #{current_user.id}/#{current_user.username}") if user_params[:password].present?
       render(action: :edit)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,8 +32,9 @@ class User < ApplicationRecord
     [:notification_preferences, { action: :delete, class_name: 'NotificationPreferences', has_many: false }]
   ].freeze
 
-  audited except: %i[salt posts_count janrain_identifier cas_identifier password_digest
-                     authentication_id open_id last_login_at last_login_ip crypted_password].freeze
+  audited except: %i[salt posts_count janrain_identifier cas_identifier
+                     authentication_id open_id last_login_at last_login_ip crypted_password].freeze,
+          redacted: %i[password_digest].freeze
 
   before_validation :trim_white_space_from_username
   before_destroy :avoid_destruction

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -18,6 +18,8 @@ class UserSession < ApplicationRecord
 
   delegate :account, to: :user
 
+  audited except: [:accessed_at]
+
   def self.authenticate(key)
     return nil if key.nil?
     self.active.find_by_key(key)

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/personal_details_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/personal_details_controller.rb
@@ -40,9 +40,7 @@ class DeveloperPortal::Admin::Account::PersonalDetailsController < ::DeveloperPo
   end
 
   def deny_unless_can_update
-    unless can?(:update, current_user)
-      render :plain => 'Action disabled', :status => :forbidden
-    end
+    render :plain => 'Action disabled', :status => :forbidden unless can?(:update, current_user)
   end
 
   def user_params
@@ -56,6 +54,7 @@ class DeveloperPortal::Admin::Account::PersonalDetailsController < ::DeveloperPo
     return if current_user.authenticated?(user_params[:current_password])
 
     resource.errors.add(:current_password, t('activerecord.errors.models.user.current_password_incorrect'))
+    AuditLogService.call("User tried to change password, but failed due to incorrect current password: #{resource.id}/#{resource.username}") if user_params[:password].present?
     flash.now[:error] = resource.errors.full_messages.to_sentence
   end
 end

--- a/test/factories/user_session.rb
+++ b/test/factories/user_session.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user_session do
+    association :user, factory: :user_with_account
+  end
+end

--- a/test/functional/developer_portal/admin/account/personal_details_controller_test.rb
+++ b/test/functional/developer_portal/admin/account/personal_details_controller_test.rb
@@ -63,4 +63,24 @@ class DeveloperPortal::Admin::Account::PersonalDetailsControllerTest < Developer
     assert_response :success
     assert_equal flash[:error], 'Current password is incorrect'
   end
+
+  test 'changing password is audited' do
+    user = @buyer.admins.first
+    login_as user
+
+    assert_difference(Audited.audit_class.method(:count)) do
+      User.with_synchronous_auditing do
+        put :update, params: { user: {current_password: 'supersecret', password: 'new_password', password_confirmation: 'new_password'} }
+      end
+    end
+
+    expected = [Audited::Auditor::AuditedInstanceMethods::REDACTED] * 2
+    assert_equal expected,user.audits.last.audited_changes['password_digest']
+  end
+
+  test 'failed password change creates an audit log' do
+    login_as @buyer.admins.first
+    AuditLogService.expects(:call).with { |msg| msg.start_with? "User tried to change password" }
+    put :update, params: { user: {current_password: 'wrong_password', password: 'new_password', password_confirmation: 'new_password'} }
+  end
 end

--- a/test/functional/developer_portal/login_controller_test.rb
+++ b/test/functional/developer_portal/login_controller_test.rb
@@ -122,6 +122,19 @@ class DeveloperPortal::LoginControllerTest < DeveloperPortal::ActionController::
     assert_equal error, flash[:error]
   end
 
+  test 'login fail generates an audit log' do
+    buyer_account = FactoryBot.create :buyer_account
+    buyer_settings = buyer_account.settings
+    buyer_settings.authentication_strategy = 'internal'
+    buyer_settings.save!
+    user = buyer_account.admins.first
+
+    AuditLogService.expects(:call).with { |msg| msg.start_with? "Login attempt failed" }
+
+    host! buyer_account.provider_account.external_domain
+    post :create, params: { username: user.username, password: 'wrong_pass' }
+  end
+
   def user
     @user ||= create_user_and_account
   end

--- a/test/functional/provider/admin/user/personal_details_controller_test.rb
+++ b/test/functional/provider/admin/user/personal_details_controller_test.rb
@@ -27,4 +27,20 @@ class Provider::Admin::User::PersonalDetailsControllerTest < ActionController::T
     assert_template 'edit'
   end
 
+  test 'changing password is audited' do
+    assert_difference(Audited.audit_class.method(:count)) do
+      User.with_synchronous_auditing do
+        put :update, params: { user: {current_password: 'supersecret', password: 'new_password', password_confirmation: 'new_password'} }
+      end
+    end
+
+    expected = [Audited::Auditor::AuditedInstanceMethods::REDACTED] * 2
+    assert_equal expected, @provider.first_admin.audits.last.audited_changes['password_digest']
+  end
+
+  test 'failed password change creates an audit log' do
+    AuditLogService.expects(:call).with { |msg| msg.start_with? "User tried to change password" }
+    put :update, params: { user: {current_password: 'wrong_password', password: 'new_password', password_confirmation: 'new_password'} }
+  end
+
 end

--- a/test/unit/user_session_test.rb
+++ b/test/unit/user_session_test.rb
@@ -83,4 +83,26 @@ class UserSessionTest < ActiveSupport::TestCase
     assert_equal 3.weeks, UserSession.send(:ttl_value, 3.weeks.seconds.to_s)
     assert_raise(ApplicationConfigurationError) { UserSession.send(:ttl_value, "123p") }
   end
+
+  test 'new session is audited' do
+    user = FactoryBot.create :user_with_account
+    session = FactoryBot.build :user_session, user: user
+
+    assert_difference(Audited.audit_class.method(:count)) do
+      UserSession.with_synchronous_auditing do
+        session.save!
+      end
+    end
+  end
+
+  test 'revoke session is audited' do
+    user = FactoryBot.create :user_with_account
+    session = FactoryBot.create :user_session, user: user
+
+    assert_difference(Audited.audit_class.method(:count)) do
+      UserSession.with_synchronous_auditing do
+        session.revoke!
+      end
+    end
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds audits for `UserSession`. In particular fot `:create` and `:revoke` operations

The Jira issue also mentions auditing when a `User` is locked. I'm not sure what **"locked"** means but I assume it means **"suspended"**. If that's the case, then that was already done.

Besides, the issue also asks to add some audit logs for some operations:

- Login
  - success (this was already done)
  - failed
- User account
  - password change success
  - password change failed

In both admin and developer portals.

The PR also adds some tests for the new functionality.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10843

**Verification steps** 

Just perform the operations above and check the audits appear.
