### PR TITLE
💄 Fix quick start dashboard button

### DIFF
--- a/app/javascript/packs/dashboard.scss
+++ b/app/javascript/packs/dashboard.scss
@@ -39,12 +39,17 @@
   grid-template-columns: 1fr 1fr;
 }
 
+button.pf-c-button.pf-m-primary.pf-c-button__float-button {
+  display: none;
+}
+
 @media screen and (min-width: 1200px) {
   button.pf-c-button.pf-m-primary.pf-c-button__float-button {
+    display: block;
     background-color: #b1b1e6;
     top: 0;
     color:black;
-    margin: 400px -50px 0 0;
+    margin: 470px -50px 0 0;
     position: absolute;
     right: 0;
     transform: rotate(-90deg);

--- a/features/provider/dashboard.feature
+++ b/features/provider/dashboard.feature
@@ -24,3 +24,8 @@ Feature: Dashboard
     When they go to the dashboard
     And they follow "Quick starts"
     Then the current page is the quick start catalog page
+
+  Scenario: Quick start button is not displayed on narrow screens
+    When they go to the dashboard
+    And they set the screen width to "1190" pixels
+    Then they should not see "Quick starts"

--- a/features/step_definitions/window_steps.rb
+++ b/features/step_definitions/window_steps.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+And "(they )set the screen width to {string} pixels" do |width|
+  height = page.driver.browser.manage.window.size.height
+  page.driver.browser.manage.window.resize_to(width.to_i, height)
+end


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR assures that Quick start button at the dashboard disappears when screen size is smaller than 1200px.  

**Verification steps** 

1. Go to Dashboard
2. Make the screen smaller than 1200px
3. Confirm Quick start button isn't displayed

**Before**
![Captura de pantalla 2024-09-17 a las 14 17 35](https://github.com/user-attachments/assets/68bb885a-7ea9-4967-bfeb-a8f6d1bfd008)

**After**
![Captura de pantalla 2024-09-17 a las 14 11 55](https://github.com/user-attachments/assets/fea4c365-ffcd-48dc-8d4d-888c82cbbf0c)

