### PR TITLE
THREESCALE-11090: Add description to Applications > Listing on Product side

### DIFF
--- a/app/views/api/applications/index.html.slim
+++ b/app/views/api/applications/index.html.slim
@@ -1,5 +1,7 @@
 - service_name = @service.name
 - content_for :page_header_title, "Applications on #{service_name}"
+- content_for :page_header_body do
+  = t('.description')
 
 - if current_user.accessible_services.empty?
   = render 'shared/service_access'

--- a/app/views/provider/admin/applications/index.html.slim
+++ b/app/views/provider/admin/applications/index.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_header_title, 'Applications'
 - content_for :page_header_body do
-  ' Applications are a representation of an API consumer. They include credentials obtained through the API's authentication method,
-  ' along with usage metrics and other metadata. The application plan sets the limits for each application.
+  = t('api.applications.index.description')
 
 - if current_user.accessible_services.empty?
   = render 'shared/service_access'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -724,6 +724,9 @@ en:
         delete_alert_confirmation: Do you really want to delete this alert?
     applications:
       index:
+        description: |
+          Applications represent pieces of software consuming the API. They contain a set of credentials used to access the API,
+          along with usage metrics and other metadata. The application plan sets the limits for each application.
         empty_state:
           title: No applications yet
           body: There are no applications subscribed to %{name}.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a brief description to the header of Product > Applications > Listing, applying consistency as we already have that description at Audience > Applications > Listing.

**Which issue(s) this PR fixes** 

[THREESCALE-11090](https://issues.redhat.com/browse/THREESCALE-11090)

**Verification steps** 

1. Go to Product > Applications > Listing
2. Confirm there is a description under the header

**Before**
![Captura de pantalla 2024-09-17 a las 14 35 51](https://github.com/user-attachments/assets/d25693e5-6a4d-4d93-bf78-c0f8ce58d9ae)

**After**
![Captura de pantalla 2024-09-17 a las 14 35 23](https://github.com/user-attachments/assets/f2b4138e-4ccb-49d4-9ad4-30d9c93fdfc0)
