### PR TITLE
Refactor pf_inline_alert

### DIFF
--- a/app/helpers/patternfly_components_helper.rb
+++ b/app/helpers/patternfly_components_helper.rb
@@ -23,21 +23,20 @@ module PatternflyComponentsHelper
     end
   end
 
-  def body_tag(body)
+  def description_tag(description)
+    return unless description
+
     tag.div class: 'pf-c-alert__description' do
-      tag.p body
+      tag.p description
     end
   end
 
-  def pf_inline_alert(title, body, variant: nil)
-    tag.div class: "pf-c-alert pf-m-#{variant} pf-m-inline" do
-      icon_tag(variant) + title_tag(title) + body_tag(body)
-    end
-  end
-
-  def pf_inline_alert_plain(title, variant: nil)
-    tag.div class: "pf-c-alert pf-m-#{variant} pf-m-inline pf-m-plain" do
-      icon_tag(variant) + title_tag(title)
+  def pf_inline_alert(title, variant: nil, description: nil, plain: false)
+    plain_class = plain ? 'pf-m-plain' : ''
+    variant_class = variant ? "pf-m-#{variant}" : ''
+    classes = "pf-c-alert pf-m-inline #{plain_class} #{variant_class}"
+    tag.div class: classes do
+      icon_tag(variant) + title_tag(title) + description_tag(description)
     end
   end
 end

--- a/app/views/shared/_annotations.html.slim
+++ b/app/views/shared/_annotations.html.slim
@@ -1,7 +1,7 @@
 - if resource.respond_to?(:managed_by) && resource.managed_by.present?
   - var = defined?(variant) ? variant : :info
   - if defined?(plain)
-    = pf_inline_alert_plain t('.managed_title', value: resource.managed_by), variant: var
+    = pf_inline_alert t('.managed_title', value: resource.managed_by), variant: var, plain: true
   - else
-    - body = (defined?(description) && description) ? t('.managed_description') : nil
-    = pf_inline_alert t('.managed_title', value: resource.managed_by), body, variant: var
+    - description = (defined?(description) && description) ? t('.managed_description') : nil
+    = pf_inline_alert t('.managed_title', value: resource.managed_by), description: description, variant: var


### PR DESCRIPTION
The changes introduced in are not compatible with Ruby 3.1, the error is:

```
Message:wrong number of arguments (given 1, expected 2) (ActionView::Template::Error)
/opt/ci/project/app/helpers/patternfly_components_helper.rb:32:in `pf_inline_alert'
/opt/ci/project/app/views/finance/provider/settings/show.html.slim:7:in `block in _app_views_finance_provider_settings_show_html_slim__2337285527868729147_165440'
```

To fix it I decided to refactor it a bit more - see comments inline.

