### PR TITLE
Update `headless_chrome` options

### DIFF
--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -90,6 +90,7 @@ end
 Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument('--window-size=1280,2048')
+  options.add_argument('--disable-search-engine-choice-screen')
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
@@ -100,19 +101,23 @@ Capybara.register_driver :headless_chrome do |app|
   options.add_argument('--no-sandbox')
   options.add_argument('--disable-popup-blocking')
   options.add_argument('--window-size=1280,2048')
-  options.add_argument('--host-resolver-rules=MAP * ~NOTFOUND , EXCLUDE *.localhost')
+  options.add_argument('--host-resolver-rules=MAP * ~NOTFOUND , EXCLUDE *localhost*')
+  options.add_argument('--disable-search-engine-choice-screen')
 
   options.add_preference(:browser, set_download_behavior: { behavior: 'allow' })
   options.add_option(:w3c, false)
-  options.add_option(:perfLoggingPrefs, {enableNetwork: true})
+  options.add_option(:perfLoggingPrefs, { enableNetwork: true })
   caps = Selenium::WebDriver::Remote::Capabilities.chrome(
-    loggingPrefs: {performance: 'ALL', browser: 'ALL'}
+    loggingPrefs: { performance: 'ALL', browser: 'ALL' }
   )
 
   client = Selenium::WebDriver::Remote::Http::Default.new
   client.read_timeout = client.open_timeout = 120 # default 60
 
-  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client, desired_capabilities: caps)
+  driver = Capybara::Selenium::Driver.new(app, browser: :chrome,
+                                               options: options,
+                                               http_client: client,
+                                               desired_capabilities: caps)
 
   driver
 end


### PR DESCRIPTION
* Assets from webpack-dev-server (after `bye_bye_webpacker`) can't be found due to host_resolver
* Running cucumbers with tag `@chrome` fail due to chromedriver showing a "choose search engine" dialog. Disabled with `--disable-search-engine-choice-screen`.
* Formatting