### PR TITLE
Do not hardcode chromedriver versions for test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ attach-to-workspace: &attach-to-workspace
     at: .
 
 system-builder-ruby31: &system-builder-ruby31
-  image: quay.io/3scale/system-builder:stream8-ruby3.1-chrome126
+  image: quay.io/3scale/system-builder:stream8-ruby3.1
   environment:
     BUNDLE_FROZEN: true
     BUNDLE_PATH: 'vendor/bundle'

--- a/Gemfile
+++ b/Gemfile
@@ -182,18 +182,18 @@ group :test do
   gem 'simplecov', '~> 0.22.0', require: false
   gem 'simplecov-cobertura', '~> 2.1'
 
-  gem 'capybara', '~>3.35.3'
+  gem 'capybara', '~>3.40.0'
   gem 'xpath', '~>3.2.0'
 
   gem 'chronic'
   gem 'cucumber', '~> 7.0'
-  gem 'cucumber-rails', '~> 2.4.0', require: false
+  gem 'cucumber-rails', '~> 3.0.0', require: false
   gem 'email_spec', require: false
   gem 'fakefs', require: 'fakefs/safe'
   gem 'launchy'
   gem 'mechanize'
-  gem 'selenium-webdriver', '~> 3.142', require: false
-  gem 'webmock', '~> 3.8.0'
+  gem 'selenium-webdriver', '~> 4.25', require: false
+  gem 'webmock', '~> 3.24.0'
 
   gem 'childprocess'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,7 @@ GEM
       ransack (~> 2.3)
     base64 (0.2.0)
     bcrypt (3.1.13)
+    bigdecimal (3.1.8)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     bootsnap (1.16.0)
@@ -223,10 +224,11 @@ GEM
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
     cancancan (3.6.1)
-    capybara (3.35.3)
+    capybara (3.40.0)
       addressable
+      matrix
       mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
+      nokogiri (~> 1.11)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
@@ -265,7 +267,8 @@ GEM
       sprockets (< 4.0)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
-    crack (0.4.5)
+    crack (1.0.0)
+      bigdecimal
       rexml
     crass (1.0.6)
     css_parser (1.12.0)
@@ -296,14 +299,10 @@ GEM
     cucumber-html-formatter (17.0.0)
       cucumber-messages (~> 17.1, >= 17.1.0)
     cucumber-messages (17.1.1)
-    cucumber-rails (2.4.0)
-      capybara (>= 2.18, < 4)
-      cucumber (>= 3.2, < 8)
-      mime-types (~> 3.3)
-      nokogiri (~> 1.10)
-      railties (>= 5.0, < 7)
-      rexml (~> 3.0)
-      webrick (~> 1.7)
+    cucumber-rails (3.0.0)
+      capybara (>= 3.11, < 4)
+      cucumber (>= 5, < 10)
+      railties (>= 5.2, < 8)
     cucumber-tag-expressions (4.1.0)
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -390,7 +389,7 @@ GEM
     has_scope (0.8.1)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
-    hashdiff (1.0.1)
+    hashdiff (1.1.1)
     hashery (2.1.2)
     hashie (3.6.0)
     hiredis-client (0.22.2)
@@ -781,9 +780,12 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     secure_headers (6.3.0)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.25.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     set (1.1.0)
     shoulda (4.0.0)
       shoulda-context (~> 2.0)
@@ -915,12 +917,13 @@ GEM
       unicorn
     uniform_notifier (1.14.2)
     version_gem (1.1.3)
-    webmock (3.8.3)
-      addressable (>= 2.3.6)
+    webmock (3.24.0)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.2)
     webrobots (0.1.2)
+    websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -976,7 +979,7 @@ DEPENDENCIES
   bugsnag (~> 6.26)
   bullet (~> 6.1.5)
   cancancan (~> 3.6.0)
-  capybara (~> 3.35.3)
+  capybara (~> 3.40.0)
   childprocess
   chronic
   ci_reporter_shell!
@@ -985,7 +988,7 @@ DEPENDENCIES
   commonmarker (~> 0.23.10)
   compass-rails (~> 3.0.2)
   cucumber (~> 7.0)
-  cucumber-rails (~> 2.4.0)
+  cucumber-rails (~> 3.0.0)
   dalli
   database_cleaner
   developer_portal!
@@ -1080,7 +1083,7 @@ DEPENDENCIES
   rubyzip (~> 1.3.0)
   sass-rails (~> 5.0.8)
   secure_headers (~> 6.3.0)
-  selenium-webdriver (~> 3.142)
+  selenium-webdriver (~> 4.25)
   shoulda (~> 4.0)
   sidekiq (~> 7)
   sidekiq-batch (~> 0.2.0)
@@ -1105,7 +1108,7 @@ DEPENDENCIES
   uglifier
   unicorn
   unicorn-rails
-  webmock (~> 3.8.0)
+  webmock (~> 3.24.0)
   will_paginate (~> 3.3)
   with_env
   xpath (~> 3.2.0)

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -95,7 +95,10 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
+  options = Selenium::WebDriver::Options.chrome(
+    logging_prefs: { performance: 'ALL', browser: 'ALL' },
+    perf_logging_prefs: { enableNetwork: true }
+  )
 
   options.add_argument('--headless')
   options.add_argument('--no-sandbox')
@@ -105,19 +108,9 @@ Capybara.register_driver :headless_chrome do |app|
   options.add_argument('--disable-search-engine-choice-screen')
 
   options.add_preference(:browser, set_download_behavior: { behavior: 'allow' })
-  options.add_option(:w3c, false)
-  options.add_option(:perfLoggingPrefs, { enableNetwork: true })
-  caps = Selenium::WebDriver::Remote::Capabilities.chrome(
-    loggingPrefs: { performance: 'ALL', browser: 'ALL' }
-  )
 
-  client = Selenium::WebDriver::Remote::Http::Default.new
-  client.read_timeout = client.open_timeout = 120 # default 60
+  timeout = 120 # default 60
+  client = Selenium::WebDriver::Remote::Http::Default.new(open_timeout: timeout, read_timeout: timeout)
 
-  driver = Capybara::Selenium::Driver.new(app, browser: :chrome,
-                                               options: options,
-                                               http_client: client,
-                                               desired_capabilities: caps)
-
-  driver
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client)
 end

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -100,12 +100,13 @@ Capybara.register_driver :headless_chrome do |app|
     perf_logging_prefs: { enableNetwork: true }
   )
 
-  options.add_argument('--headless')
+  options.add_argument('--headless=new')
   options.add_argument('--no-sandbox')
   options.add_argument('--disable-popup-blocking')
   options.add_argument('--window-size=1280,2048')
   options.add_argument('--host-resolver-rules=MAP * ~NOTFOUND , EXCLUDE *localhost*')
   options.add_argument('--disable-search-engine-choice-screen')
+  options.add_argument('--disable-gpu')
 
   options.add_preference(:browser, set_download_behavior: { behavior: 'allow' })
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -118,11 +118,12 @@ After do |scenario| # rubocop:disable Metrics/BlockLength
   line_number = scenario.location.line.to_s
 
   # Network logs
-  if page.driver.browser.respond_to?(:manage)
+  if page.driver.browser.respond_to?(:logs)
     # performance logs may fail if this logging type is not configured or not supported by driver
-    if page.driver.browser.manage.logs.available_types.include? :performance
-      logs = page.driver.browser.manage.logs.get(:performance)
-      array = logs.each_with_object([]) do |entry, messages|
+    logs = page.driver.browser.logs
+    if logs.available_types.include? :performance
+      perf_logs = logs.get(:performance)
+      array = perf_logs.each_with_object([]) do |entry, messages|
         message = JSON.parse(entry.message)
         # next unless message.dig('message', 'params', 'documentURL').to_s.end_with? '/p/login'
         messages << message
@@ -139,11 +140,11 @@ After do |scenario| # rubocop:disable Metrics/BlockLength
 
     console_log = folder.join("#{line_number}.log")
 
-    if (logs = page.driver.browser.manage.logs.get(:browser)).present?
-      entries = logs.map{ |entry| "[#{entry.level}] #{entry.message}" }
+    if (browser_logs = logs.get(:browser)).present?
+      entries = browser_logs.map { |entry| "[#{entry.level}] #{entry.message}" }
 
       console_log.open('w') do |f|
-        f.puts *entries
+        f.puts(*entries)
       end
 
       print "Saved console log to #{console_log}\n"


### PR DESCRIPTION
For Ruby 3.1 upgrade we built a `system-builder` image with a fixed version of chromedriver, because the latest (127 on that moment) was timing out.

https://github.com/3scale/porta/pull/3896 introduced a configuration change which probably is what was missing for the latest Chrome to work as expected, so hopefully we can now remove this restriction.