### PR TITLE
Remove psych hardcoded version and use alias explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,9 +20,6 @@ gem "activejob-uniqueness"
 # Needed for XML serialization of ActiveRecord::Base
 gem 'activemodel-serializers-xml'
 
-# Fixing https://github.com/ruby/psych/pull/438, remove after upgrading Ruby
-gem 'psych', '~> 3.2.0'
-
 gem 'protected_attributes_continued', '~> 1.8.2'
 
 gem 'rails-observers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -591,7 +591,6 @@ GEM
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
-    psych (3.2.1)
     public_suffix (4.0.7)
     raabro (1.4.0)
     racc (1.8.1)
@@ -1056,7 +1055,6 @@ DEPENDENCIES
   pry-rails
   pry-shell
   pry-stack_explorer
-  psych (~> 3.2.0)
   rack (~> 2.2.8)
   rack-cors
   rack-no_animations (~> 1.0.3)

--- a/app/lib/backend/storage.rb
+++ b/app/lib/backend/storage.rb
@@ -6,7 +6,7 @@ module Backend
     def self.parse_config
       config = File.read("#{Rails.root}/config/backend_redis.yml")
       config = ERB.new(config).result(binding)
-      config = YAML.load(config)
+      config = YAML.load(config, aliases: true)
       config.fetch(Rails.env).deep_symbolize_keys
     end
 

--- a/test/unit/lib/three_scale/jobs_test.rb
+++ b/test/unit/lib/three_scale/jobs_test.rb
@@ -26,14 +26,14 @@ class ThreeScale::JobsTest < ActiveSupport::TestCase
   end
 
   def test_task_serialize
-    task = ThreeScale::Jobs::Task.new(Account, :new, org_name: 'Company')
-    serialized = YAML.dump([Account, :new, {org_name: 'Company'}])
+    task = ThreeScale::Jobs::Task.new(DestroyAllDeletedObjectsWorker, :perform_later, 'Service')
+    serialized = YAML.dump([DestroyAllDeletedObjectsWorker, :perform_later, 'Service'])
     assert_equal({klass: "ThreeScale::Jobs::Task", init_args: serialized}, task.serialize)
   end
 
   def test_task_deserialize
-    task = ThreeScale::Jobs::Task.new(Account, :new, org_name: 'Company')
-    serialized = YAML.dump([Account, :new, [{org_name: 'Company'}]])
+    task = ThreeScale::Jobs::Task.new(DestroyAllDeletedObjectsWorker, :perform_later, 'Service')
+    serialized = YAML.dump([DestroyAllDeletedObjectsWorker, :perform_later, ['Service']])
     assert_equal(task, ThreeScale::Jobs::Task.deserialize(klass: 'ThreeScale::Jobs::Task', init_args: serialized))
   end
 

--- a/test/unit/three_scale/middleware/cors_test.rb
+++ b/test/unit/three_scale/middleware/cors_test.rb
@@ -76,7 +76,7 @@ class ThreeScale::Middleware::CorsTest < ActiveSupport::TestCase
   end
 
   test 'provider signup path excluded in default configs' do
-    cors_config = YAML.load_file(Rails.root.join("config/cors.yml")).deep_symbolize_keys
+    cors_config = YAML.load_file(Rails.root.join("config/cors.yml"), aliases: true, permitted_classes: [Symbol, Regexp]).deep_symbolize_keys
     rails_envs = %i[development test production]
     rails_envs.each do |rails_env|
       stub_config = cors_config[rails_env]


### PR DESCRIPTION
`psych` gem is the a default gem shipped with Ruby.

In https://github.com/3scale/porta/pull/3714 there was an attempt to fix some issues with YAML serialization by upgrading the version, however for some reason it never worked in the production images (still needs to be figured out why).

With Rails upgrade from 2.7 to 3.1 Psych version was upgraded to 4.0.4.

Apparently, this caused an issue due to an uncompatibility between the versions: https://stackoverflow.com/a/71192990

This was caughed by QE tests, the logs in the system pods were:

```
Completed 500 Internal Server Error in 37ms (ActiveRecord: 14.3ms | Allocations: 12401)
  
Psych::BadAlias (Unknown alias: default):
  
app/lib/backend/storage.rb:9:in `parse_config'
app/lib/backend/storage.rb:14:in `initialize'
app/lib/stats/base.rb:22:in `storage'
app/lib/stats/base.rb:26:in `storage'
app/lib/stats/views/usage.rb:130:in `usage_values_in_range'
app/lib/stats/views/usage.rb:26:in `usage'
app/controllers/stats/api/base_controller.rb:41:in `render_usage'
app/controllers/stats/api/base_controller.rb:14:in `usage'
lib/three_scale/middleware/multitenant.rb:128:in `_call'
lib/three_scale/middleware/multitenant.rb:123:in `call'
lib/three_scale/middleware/cors.rb:21:in `call'
```

Unfortunately, I haven't yet found a way to reproduce this locally or in unit tests, locally the versions specified in `Gemfile.lock` are respected. I don't know why it is not the case in the production (alpha) image, it still needs to be investigated.

It is also not clear whether this is the right fix, or we need to rather still keep version `3.2.x`, because I'm not sure what else might be broken.

Looks like in Rails the fix has been backported to 6.x, but not sure... https://github.com/rails/rails/commit/255b5ff9af57f9b54dee7ec884b12a1ad16f0321#diff-25e2f1a942d1b5d9f1b0c71786329f9e33c0787b28bfbf9cff08ec122fdccb76R22-R27