### PR TITLE
THREESCALE-11383: Ignore errors on payment gateway initialization when destroying buyer

### DIFF
--- a/app/models/account/credit_card.rb
+++ b/app/models/account/credit_card.rb
@@ -96,8 +96,12 @@ module Account::CreditCard # rubocop:disable Metrics/ModuleLength(RuboCop)
   end
 
   def unstore_credit_card!
-    response = provider_payment_gateway.try!(:threescale_unstore, credit_card_auth_code)
-    log_gateway_response(response, "unstore [auth: #{credit_card_auth_code}]")
+    begin
+      response = provider_payment_gateway.try!(:threescale_unstore, credit_card_auth_code)
+      log_gateway_response(response, "unstore [auth: #{credit_card_auth_code}]")
+    rescue Account::Gateway::InvalidSettingsError => error
+      Rails.logger.warn("Couldn't unstore credit card details from the payment gateway: #{error.message}")
+    end
 
     return if payment_detail.destroyed?
 

--- a/app/models/account/gateway.rb
+++ b/app/models/account/gateway.rb
@@ -1,6 +1,8 @@
 module Account::Gateway
   extend ActiveSupport::Concern
 
+  class InvalidSettingsError < StandardError; end
+
   included do
     has_many :payment_transactions
     has_one :payment_gateway_setting, dependent: :destroy, inverse_of: :account
@@ -18,6 +20,8 @@ module Account::Gateway
     return if payment_gateway_type.blank?
 
     PaymentGateway.implementation(payment_gateway_type, **options).new(payment_gateway_options || {})
+  rescue ArgumentError => exception
+    raise InvalidSettingsError, exception.message
   end
 
   def payment_gateway_configured?


### PR DESCRIPTION
**What this PR does / why we need it**:

If payment gateway configuration is invalid on a provider account, their buyers cannot be deleted because the `unstore_credit_card!` method is called as `before_destroy` callback.

Specifically, if the payment gateway type is `:stripe`, but the gateway settings stored in the database miss the `login` field, the payment gateway instance cannot be initialized, and the whole operation fails.

This PR catches the error, raises a more specific `Account::Gateway::InvalidSettingsError` error and "swallows" it the `unstore_credit_card!`, thus allowing for the destroy to complete successfully.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11383

**Verification steps** 

Steps to reproduce or to confirm that that issue is not reproducible in the branch:

```
pgs = PaymentGatewaySetting.new(gateway_type: :stripe, gateway_settings: { test: 1, private_key: "foo", merchant_id: "bar", public_key: "foobar" })

provider = FactoryBot.create(:provider_account, payment_gateway_setting: pgs)

buyer = FactoryBot.create(:buyer_account, provider_account: provider)

buyer.smart_destroy
```

The destroy operation should succeed and not throw errors.

**Special notes for your reviewer**:
