### PR TITLE
Disable X-Served-By header by default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -270,7 +270,7 @@ module System
 
     config.middleware.use ThreeScale::Middleware::Multitenant, :tenant_id unless ENV["DEBUG_DISABLE_TENANT_CHECK"] == "1"
     config.middleware.insert_before Rack::Runtime, Rack::UTF8Sanitizer
-    config.middleware.insert_before Rack::Runtime, Rack::XServedBy # we can pass hashed hostname as parameter
+    config.middleware.insert_before(Rack::Runtime, Rack::XServedBy) if ENV["DEBUG_X_SERVED_BY"] == "1"
     config.middleware.insert_before 0, ThreeScale::Middleware::Cors if config.three_scale.cors.enabled
 
     config.unicorn = ActiveSupport::OrderedOptions[after_fork: []]


### PR DESCRIPTION
**What this PR does / why we need it**:

The `X-Served-By` header was added a long time ago (see https://github.com/3scale/system/pull/4966) for debugging purposes, apparently.
I guess this was never announced as a "feature", so I doubt anybody actually relies on it.

This PR effectively removes the header (actually enabling it only when `DEBUG_X_SERVED_BY=1` is set), so it will not be present anywhere, but we may enable it if we want (e.g. in SaaS).

This header is mostly related to caching servers, so I don't think it's critical that it will go away for most users.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11201

**Verification steps** 

Send any request and make sure that `X-Served-By` is not present.

**Special notes for your reviewer**:
