### PR TITLE
Update codecov uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,8 @@
 version: 2.1
+orbs:
+  codecov: codecov/codecov@3.3.0
 
 ##################################### YAML ANCHORS  ############################################
-
-upload-coverage: &upload-coverage
-  run:
-    name: Upload test coverage to Codecov
-    command: bash <(curl --retry 10 --retry-delay 5 --retry-max-time 60 -s https://codecov.io/bash) -Z || echo "Codecov is not working again..."
 
 persist-vendored-dependencies-to-workspace: &persist-vendored-dependencies-to-workspace
   persist_to_workspace:
@@ -357,7 +354,7 @@ commands: # reusable commands with parameters
       - *store-junit-test-results
       - *store-test-artifacts
       - *store-log-artifacts
-      - *upload-coverage
+      - codecov/upload
 
 ##################################### CIRCLECI EXECUTORS ############################################
 
@@ -569,7 +566,7 @@ jobs:
       - run:
           name: Jest specs
           command: yarn jest --maxWorkers=3
-      - *upload-coverage
+      - codecov/upload
       - notify_failure
 
   unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -565,7 +565,7 @@ jobs:
       - *attach-to-workspace
       - run:
           name: Jest specs
-          command: yarn jest --maxWorkers=3
+          command: yarn jest --maxWorkers=3 --coverage
       - codecov/upload
       - notify_failure
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The Codecov bash uploader is deprecated, and (related or not) it was not working consistently lately. 

Te documentation and the migration path are documented here: https://docs.codecov.com/docs/deprecated-uploader-migration-guide

For this PR I've chosen the CircleCI Orb: https://circleci.com/developer/orbs/orb/codecov/codecov

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

Run the full CircleCI pipeline and ensure that the results are uploaded.

**Special notes for your reviewer**:

The latest version of the codecov CircleCI orb is 4.2.0. However, it fails with the following error:
```
[PYI-364:ERROR] Failed to load Python shared library '/tmp/_MEI0P0UrX/libpython3.11.so.1.0': dlopen: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by /tmp/_MEI0P0UrX/libpython3.11.so.1.0)
```

Looks like version `3.3.0` works on our builder image. Maybe after we upgrade to RHEL9, it will work. Also, not sure if `3.3.0` is the right way, because of what the release notes say: https://github.com/codecov/codecov-circleci-orb/releases/tag/v4.0.0

> Version 4.0.0 of the CircleCI orb represents a move to using the new [Codecov CLI](https://docs.codecov.com/docs/the-codecov-cli) over the [Codecov uploader](https://docs.codecov.com/docs/codecov-uploader).

I am not quite sure whether it actually uses CLI or the bash uploader... but looking at the diff between the versions, I'd say it's CLI already.

But anyway, it seems to be working, so it's an improvement.