### PR TITLE
Add styles for invoice show view

### DIFF
--- a/app/javascript/packs/invoice_show.scss
+++ b/app/javascript/packs/invoice_show.scss
@@ -1,0 +1,3 @@
+@import '~@patternfly/patternfly/layouts/Grid/grid.css';
+@import '~@patternfly/patternfly/components/DescriptionList/description-list.css';
+@import '~@patternfly/patternfly/components/Table/table.css';

--- a/app/views/buyers/invoices/show.html.erb
+++ b/app/views/buyers/invoices/show.html.erb
@@ -10,4 +10,3 @@
   <%= render :partial => '/finance/provider/shared/payment_transactions' %>
   <%= render :partial => '/finance/provider/invoices/actions' %>
 </div>
-

--- a/app/views/finance/provider/invoices/show.html.erb
+++ b/app/views/finance/provider/invoices/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :javascripts do %>
+  <%= javascript_packs_with_chunks_tag 'invoice_show' %>
+<% end %>
+
 <%= render '/finance/provider/shared/invoice_title', invoice: @invoice %>
 
 <div class="pf-l-grid pf-m-gutter">


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes missing styles on the Invoice Show page.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

Create invoice for a buyer and go to the invoice details.

**Special notes for your reviewer**:

**Before:**
![Screenshot from 2024-10-07 13-06-03](https://github.com/user-attachments/assets/27562533-307e-4a0c-a3e0-64fa7eec137f)

**After:**
![Screenshot from 2024-10-07 13-06-52](https://github.com/user-attachments/assets/55d4d83f-30f3-4aeb-89b7-2c0e5fb6b8b7)



