### PR TITLE
Fix amazon_s3.yml config for FILE_UPLOAD_STORAGE=filesystem

### DIFF
--- a/config/examples/amazon_s3.yml
+++ b/config/examples/amazon_s3.yml
@@ -13,7 +13,7 @@ s3: &s3
   force_path_style: <%= ENV['AWS_PATH_STYLE'].presence || false %>
 
 development:
-  <<: *<%= ENV['FILE_UPLOAD_STORAGE'].presence || 'default' %>
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'] == 's3' ? 's3' : 'default' %>
 
 test: &test
   access_key_id: invalid
@@ -22,4 +22,4 @@ test: &test
   region: "us-east-1"
 
 production:
-  <<: *<%= ENV['FILE_UPLOAD_STORAGE'].presence || 'default' %>
+  <<: *<%= ENV['FILE_UPLOAD_STORAGE'] == 's3' ? 's3' : 'default' %>


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a confusing behavior when `FILE_UPLOAD_STORAGE` is set to `filesystem` explicitly.
It's not "broken" in the product, because it's assumed that when this env var is empty, `filesystem` is used, and when it's `s3`, then S3 is used for storage.

But when `FILE_UPLOAD_STORAGE=filesystem` is set explicitly, the application isn't loaded, with the error:
```
/home/dmayorov/.asdf/installs/ruby/3.1.5/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:326:in `block in visit_Psych_Nodes_Alias': Unknown alias: filesystem (Psych::BadAlias)
```

because the `amazon_s3.yml` doesn't have a `:filesystem` alias.

There are some references that hint that `filesystem` is a potential valid value for `FILE_UPLOAD_STORAGE`:
- https://github.com/3scale/porta/blob/c0ec8861d5f44a160b13a94317e092e055156c4e/openshift/system/.env#L85
- https://github.com/3scale/porta/blob/c0ec8861d5f44a160b13a94317e092e055156c4e/config/examples/paperclip.yml#L16

so I made some changes in the example config to prevent this config from failing.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

Run the app with `FILE_UPLOAD_STORAGE=filesystem` and make sure no errors are thrown and the storage is set correctly.

**Special notes for your reviewer**:
