### PR TITLE
Do not add Link header for preloading assets

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -71,6 +71,11 @@ module System
 
     # Make `form_with` generate non-remote forms. Defaults true in Rails 5.1 to 6.0
     config.action_view.form_with_generates_remote_forms = false
+
+    # Disable generating Link header with URLs from javascript_include_tag and stylesheet_link_tag
+    # Reconsider whether to enable again after upgrading to Rails 7.1, where the size of the header is limited to 1KB
+    config.action_view.preload_links_header = false
+
     # Make Ruby preserve the timezone of the receiver when calling `to_time`.
     config.active_support.to_time_preserves_timezone = false
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The upgrade from Rails 6.0 to 6.1 introduced a new `Link` header that is added to the response, with the full list of all assets:
https://guides.rubyonrails.org/6_1_release_notes.html#action-view-notable-changes

The `javascript_include_tag` and `stylesheet_link_tag` asset helpers generate a link header that gives hints to modern browsers about preloading assets. This can be disabled by setting `config.action_view.preload_links_header` to `false`.

On some pages this header becomes huge, making the total headers size > 4KB, and this may cause an issue with some proxies.

While this header might be used by browsers for optimizing the assets pre-loading, I think we can happily live without it.

Rails 7.1 and higher includes a fix that stops adding links to the `Link` header if it reaches 1KB, see https://github.com/rails/rails/pull/48405/commits/facc260fbb8a414dd66851bf3d0ce83ea35119b8

When we upgrade, we may consider enabling this feature again.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11417

**Verification steps** 

Load any page and verify that there is no `Link` header.

**Special notes for your reviewer**:
