### PR TITLE
Change the Sidekiq Batch default TTL to 6h

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -12,6 +12,12 @@ def sanitize_redis_config(cfg)
   cfg.slice(*REDIS_PARAMS_WHITELIST)
 end
 
+class Sidekiq::Batch
+  # Override the default value of 30 days with 6 hours
+  remove_const(:BID_EXPIRE_TTL) if defined?(BID_EXPIRE_TTL)
+  const_set(:BID_EXPIRE_TTL, 21_600)
+end
+
 Sidekiq::Client.try(:reliable_push!) unless Rails.env.test?
 
 Rails.application.config.to_prepare do


### PR DESCRIPTION
**What this PR does / why we need it**:

**NOTE:** merge https://github.com/3scale/porta/pull/3928 first, run the script in production, and then merge this PR.

Changes the default TTL of Sidekiq Batch keys from 30 days to 6 hours.

This is a temporary measure, because we need a proper way to fix the issue with this keys accumulation (either by fixing our code, or by getting rid of the gem).

In theory, once the batch is finished, the keys should get cleaned up, but they never are, for some reason. And very weird things happen with these batch keys in general :dizzy_face: 

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-8124

**Verification steps** 


**Special notes for your reviewer**:

Need to remove the constant and set it again, because just changing the value causes these warnings:
```
/home/dmayorov/Projects/3scale/porta/config/initializers/sidekiq.rb:16: warning: already initialized constant Sidekiq::Batch::BID_EXPIRE_TTL
/home/dmayorov/.asdf/installs/ruby/3.1.5/lib/ruby/gems/3.1.0/gems/sidekiq-batch-0.2.0/lib/sidekiq/batch.rb:13: warning: previous definition of BID_EXPIRE_TTL was here
```
