### PR TITLE
Add webrick explicitly for Yabeda metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'sidekiq-cron', require: %w[sidekiq/cron sidekiq/cron/web]
 gem 'sidekiq-throttled', '~> 1.4.0'
 
 # Yabeda metrics
+gem 'webrick', '~> 1.8.2'
 gem 'yabeda-prometheus-mmap'
 gem 'yabeda-sidekiq'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1112,6 +1112,7 @@ DEPENDENCIES
   unicorn
   unicorn-rails
   webmock (~> 3.24.0)
+  webrick (~> 1.8.2)
   will_paginate (~> 3.3)
   with_env
   xpath (~> 3.2.0)


### PR DESCRIPTION
**What this PR does / why we need it**:

Since Ruby 3.0 `webrick` is not a default gem: https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

>The following libraries are no longer bundled gems or standard libraries. Install the corresponding gems to use these features.
>- sdbm
>- webrick
>- net-telnet
>- xmlrpc

It is a dependency for Yabeda prometheus exporter: https://github.com/yabeda-rb/yabeda-prometheus?tab=readme-ov-file#usage

> WEBrick will be launched in separate thread and will serve metrics on `/metrics` path.


**Which issue(s) this PR fixes** 

not reported

**Verification steps** 

Check that Sidekiq starts successfully, and this error is not observed:
```
#<Thread:0x00007f533d636ef0 /opt/system/vendor/bundle/ruby/3.1.0/gems/yabeda-prometheus-mmap-0.1.1/lib/yabeda/prometheus/mmap/exporter.rb:24 run> terminated with exception (report_on_exception is true):
/opt/system/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require': cannot load such file -- webrick (LoadError)
	from /opt/system/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /opt/system/vendor/bundle/ruby/3.1.0/gems/rack-2.2.9/lib/rack/handler/webrick.rb:3:in `<top (required)>'
	from /opt/system/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /opt/system/vendor/bundle/ruby/3.1.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /opt/system/vendor/bundle/ruby/3.1.0/gems/yabeda-prometheus-mmap-0.1.1/lib/yabeda/prometheus/mmap/exporter.rb:26:in `block in start_metrics_server!'
```

**Special notes for your reviewer**:
