### PR TITLE
Fix new provider form and UI tests

### DIFF
--- a/app/views/provider/admin/accounts/new.html.slim
+++ b/app/views/provider/admin/accounts/new.html.slim
@@ -1,5 +1,8 @@
 - content_for :page_header_title, 'Create new Account'
 
+- content_for :javascripts do
+  = stylesheet_packs_chunks_tag 'pf_form'
+
 div class="pf-c-card"
   div class="pf-c-card__body"
     = semantic_form_for @provider, builder: Fields::PatternflyFormBuilder,

--- a/features/buyers/accounts/edit.feature
+++ b/features/buyers/accounts/edit.feature
@@ -19,12 +19,6 @@ Feature: Audience > Accounts > Edit
     Then the current page is the buyer account page for "Pepito"
     And should see the flash message "Account successfully updated"
 
-  Scenario: Required fields and validation
-    Given they go to the buyer account edit page for "Pepe"
-    When the form is submitted with:
-      | Organization/Group Name | |
-    Then field "Organization/Group Name" has inline error "can't be blank"
-
   Scenario: Deleting an account
     Given a buyer "Deleteme" of the provider
     When they go to the buyer account edit page for "Deleteme"

--- a/features/buyers/accounts/new.feature
+++ b/features/buyers/accounts/new.feature
@@ -30,12 +30,15 @@ Feature: Audience > Accounts > New
     And user "alice" should be active
     But "alice@web-widgets.com" should receive no emails
 
-  Scenario: Required fields and validation
+  Scenario: Fields validation
     Given they go to the new buyer account page
-    When press "Create"
+    When the form is submitted with:
+      | Username | u        |
+      | Email    | invalid  |
+      | Password | p        |
+      | Organization/Group Name | Org |
     Then field "Username" has inline error "is too short"
     And field "Email" has inline error "should look like an email address"
-    And field "Organization/Group Name" has inline error "can't be blank"
     But field "Password" has no inline error
 
   Scenario: Create account with fields with choices

--- a/features/old/accounts/accounts.feature
+++ b/features/old/accounts/accounts.feature
@@ -69,7 +69,7 @@ Feature: Account management
     When I log in as provider "foo.3scale.localhost"
     And I navigate to the Account Settings
     And I go to the provider personal details page
-    When I fill in "Email" with ""
+    When I fill in "Email" with "invalid"
      And I fill in "Current password" with "supersecret"
     And I press "Update Details"
     Then I should see "should look like an email address"

--- a/features/old/accounts/password_change.feature
+++ b/features/old/accounts/password_change.feature
@@ -8,7 +8,7 @@ Feature: Password change
     Given a provider is logged in
     When I navigate to the Account Settings
     And I go to the provider personal details page
-    And I fill in "Password" with "monkey"
+    And I fill in "New password" with "monkey"
     And I fill in "Current password" with "supersecret"
     And I press "Update Details"
     And I log out

--- a/features/old/accounts/personal_details.feature
+++ b/features/old/accounts/personal_details.feature
@@ -38,7 +38,7 @@ Feature: Personal Details
   Scenario: Edit personal details with invalid data
     When I navigate to the Account Settings
     And I go to the provider personal details page
-    And I fill in "Username" with ""
+    And I fill in "Username" with "u"
     And I fill in "Current password" with "supersecret"
     And I press "Update Details"
     Then field "Username" has inline error "is too short (minimum is 3 characters)"
@@ -83,7 +83,7 @@ Feature: Personal Details
     Given the user was signed up with password
     When I navigate to the Account Settings
     And I go to the provider personal details page
-    And I fill in "New Password" with "hi"
+    And I fill in "New password" with "hi"
     And I fill in "Current password" with "supersecret"
     And I press "Update Details"
-    Then field "New Password" has inline error "is too short (minimum is 6 characters)"
+    Then field "New password" has inline error "is too short (minimum is 6 characters)"

--- a/features/provider/admin/accounts/new.feature
+++ b/features/provider/admin/accounts/new.feature
@@ -28,23 +28,14 @@ Feature: Provider accounts management
     Then they should see the flash message "Tenant account was successfully created."
     And the current page is the overview page of account "The Provider"
 
-  Scenario: Validate missing fields
-    Given they go to the new provider account page
-    When the form is submitted with:
-      | Username                |  |
-      | Email                   |  |
-      | Password                |  |
-      | Password confirmation   |  |
-      | Organization/Group Name |  |
-    Then field "Username" has inline error "is too short (minimum is 3 characters)"
-    And field "Email" has inline error "should look like an email address"
-    And field "Organization/Group Name" has inline error "can't be blank"
-    But field "Password" has no inline error
-
   Scenario: Create a provider account with invalid data
     Given they go to the new provider account page
     When the form is submitted with:
-      | Email    | a@a.e  |
+      | Username | u |
+      | Email    | invalid |
       | Password | 123456 |
-    Then field "Email" has inline error "is too short (minimum is 6 characters)"
+      | Password confirmation | 654321 |
+      | Organization/Group Name | Some Provider |
+    Then field "Username" has inline error "is too short (minimum is 3 characters)"
+    And field "Email" has inline error "should look like an email address"
     And field "Password confirmation" has inline error "doesn't match Password"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing some forms and tests that were apparently broken.

**Before:**
![Screenshot from 2024-10-15 15-45-26](https://github.com/user-attachments/assets/651c77c7-a300-4562-946b-c91b83097cad)

**After:**
![Screenshot from 2024-10-15 15-51-23](https://github.com/user-attachments/assets/80b080ad-e599-4a47-a3b0-dae3702590a7)

As for the tests, I think this change has modified the behavior:
https://github.com/3scale/porta/pull/3919/files#diff-6784bb890636509ec8f3fec49d3b6d3af3b7d777beb990cd4b46e8721e1a99baR15-R17

Now for the fields that are marked required  it is not possible to submit empty values, because the browser prevents it (due to `required` property on the HTML).

So, I removed some tests that are not relevant, and updated other that can still be applied.


**Which issue(s) this PR fixes** 


**Verification steps** 


**Special notes for your reviewer**:
