### PR TITLE
THREESCALE-6412: Fix admin member user permissions for services (also THREESCALE-11202)

### DIFF
--- a/app/controllers/api/plan_copies_controller.rb
+++ b/app/controllers/api/plan_copies_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Api::PlanCopiesController < FrontendController
-  before_action :find_plan
-  before_action :find_service
   before_action :authorize_section, only: %i[new create]
   before_action :authorize_action, only: %i[new create]
+  before_action :find_plan
+  before_action :find_service
 
   def create
     @plan = @original.copy(params[@type] || {})

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -62,15 +62,15 @@ class Contract < ApplicationRecord
     where.has { plan_id.in( scope ) }
   end
 
-  # FIXME: this probably shouldn't return `all`, it's dangerous if it is accidentally
-  # used as a separate scope, and not merged with other scopes that filters by account previously
   scope :permitted_for, ->(user) {
-    permitted_services_status = user.permitted_services_status
-    next none if permitted_services_status == :none
-
-    next all if permitted_services_status == :all
-
-    merge(permitted_services_status == :selected ? where(service_id: user.member_permission_service_ids) : {})
+    case user.permitted_services_status
+    when :none
+      none
+    when :all
+      merge(provided_by(user.account))
+    else
+      merge(where(service_id: user.member_permission_service_ids))
+    end
   }
 
   # Return contracts bought by given account.

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -115,10 +115,14 @@ class Service < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :permitted_for, ->(user = nil) {
     next all unless user
 
+    permitted_services_status = user.permitted_services_status
+
+    next none if permitted_services_status == :none
+
     account = user.account
     account_services = (account.provider? ? account : account.provider_account).services
-    self.merge(
-      account_services.merge(user.forbidden_some_services? ? where(id: user.member_permission_service_ids) : {})
+    merge(
+      account_services.merge(permitted_services_status == :selected ? where(id: user.member_permission_service_ids) : {})
     )
   }
 

--- a/app/models/user/permissions.rb
+++ b/app/models/user/permissions.rb
@@ -5,7 +5,7 @@ require 'admin_section'
 module User::Permissions
   extend ActiveSupport::Concern
 
-  ATTRIBUTES = %I[ role member_permission_ids member_permission_service_ids ]
+  ATTRIBUTES = %I[role member_permission_ids member_permission_service_ids].freeze
 
   included do
     has_many :member_permissions, dependent: :destroy, autosave: true
@@ -16,15 +16,12 @@ module User::Permissions
     alias_attribute :allowed_service_ids, :member_permission_service_ids
   end
 
-  #TODO: this is repeated from bcms_hacks plugins because of some loading problem
   def has_permission?(permission)
-    return true  if account.provider? && admin?
+    return true if account.provider? && admin?
     return false if account.buyer?
 
-    # check = Permission.count(:include => {:groups => :users}, :conditions => ["users.id = ? and permissions.name=?", id, permission]) > 0
-
     admin_sections.include?(permission.to_sym).tap do |check|
-      logger.info "~> #{username} has_permission?(#{permission}) => #{check}"
+      logger.debug "~> #{username} has_permission?(#{permission}) => #{check}"
     end
   end
 
@@ -60,11 +57,12 @@ module User::Permissions
   end
 
   def member_permission_service_ids=(service_ids)
-    if service_ids.present?
-      service_ids = Array(service_ids).compact.map(&:to_i)
+    if service_ids.is_a? Array
+      # remove all non-integer values
+      service_ids = service_ids.map { Integer(_1, exception: false) }.compact_blank
       member_permission = services_member_permission || member_permissions.build(admin_section: :services)
       member_permission.service_ids = service_ids & existing_service_ids
-    else
+    elsif service_ids.blank?
       self.member_permissions = member_permissions - [services_member_permission].compact
     end
   ensure
@@ -80,6 +78,7 @@ module User::Permissions
   # returns [] if no services are enabled, and nil if all (current and future) services are enabled
   def member_permission_service_ids
     return nil if admin? || !services_member_permission
+
     permitted_service_ids = services_member_permission.try(:service_ids) || []
     permitted_service_ids & existing_service_ids
   end
@@ -89,22 +88,34 @@ module User::Permissions
   end
 
   def has_access_to_service?(service)
-    services_permission = services_member_permission
-    services_permission && services_permission.has_service?(service) || has_access_to_all_services?
+    has_access_to_all_services? || services_member_permission&.has_service?(service)
   end
 
-  # Lack of the services section means it is the old permission system where everyone had access
-  # to every service. So to limit the scope only for new users, we start adding this permission.
+  # Returns:
+  #   :none - if no services are allowed
+  #   :all - if all services are allowed for the selected service-related permissions
+  #   :selected - if a subset of services is allowed for the selected service-related permissions
+  def permitted_services_status
+    if admin? || (service_permissions_selected? && member_permission_service_ids.nil?)
+      :all
+    elsif service_permissions_selected? && member_permission_service_ids.present?
+      :selected
+    else
+      :none
+    end
+  end
+
   def has_access_to_all_services?
-    !admin_sections.include?(:services) || admin?
+    permitted_services_status == :all
   end
 
-  def forbidden_some_services?
-    !has_access_to_all_services? && account.provider_can_use?(:service_permissions)
+  # Returns whether the user has access to any service-related permissions (partners, plans or monitoring)
+  def service_permissions_selected?
+    (member_permission_ids & AdminSection::SERVICE_PERMISSIONS).any?
   end
 
   def access_to_service_admin_sections?
-    (member_permission_ids & AdminSection::SERVICE_PERMISSIONS).any? && accessible_services?
+    service_permissions_selected? && accessible_services?
   end
 
   def reload(*)

--- a/config/abilities/provider_any.rb
+++ b/config/abilities/provider_any.rb
@@ -21,7 +21,8 @@ Ability.define do |user| # rubocop:disable Metrics/BlockLength
     cannot %i[destroy update_role], user
 
     # Services
-    can %i[read show edit update], Service, user.accessible_services.where_values_hash
+    user_accessible_services = user.accessible_services
+    can %i[read show edit update], Service, user_accessible_services.where_values_hash unless user_accessible_services.is_a? ActiveRecord::NullRelation
 
     #
     # Events

--- a/config/abilities/provider_member.rb
+++ b/config/abilities/provider_member.rb
@@ -28,10 +28,11 @@ Ability.define do |user|
 
     # Using historical optimized way and leave canonical way (through plan) commented out below
     # The resulting hash presently is something like {"type"=>"Cinstance", "service_id"=>[ids..]}
-    can %i[read show edit update], Cinstance, Cinstance.permitted_for(user).where_values_hash
+    permitted_cinstances = Cinstance.permitted_for(user)
+    can %i[read show edit update], Cinstance, permitted_cinstances.where_values_hash unless permitted_cinstances.is_a? ActiveRecord::NullRelation
     # can %i[read show edit update], Cinstance, user.accessible_cinstances do |cinstance|
     #   cinstance.plan&.issuer_type == "Service" && cinstance.plan.issuer.account == user.account &&
-    #     (!user.forbidden_some_services? || user.member_permission_service_ids.include?(cinstance.plan.issuer.id))
+    #     (user.permitted_services_status == :selected || user.member_permission_service_ids.include?(cinstance.plan.issuer.id))
     # end
 
     # abilities for buyer users

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -2812,7 +2812,7 @@
                   },
                   "allowed_service_ids[]": {
                     "type": "array",
-                    "description": "IDs of the services that need to be enabled, URL-encoded array. To disable all services, set the value to '[]'. To enable all services, add parameter 'allowed_service_ids[]' with no value to the 'curl' command (can't be done in ActiveDocs)",
+                    "description": "IDs of the services that need to be enabled, URL-encoded array. To disable all services, send `allowed_service_ids[]` with an empty value, e.g. `allowed_service_ids%5B%5D=` (can't be done in ActiveDocs). `<allowed_service_ids/>` or `\"allowed_service_ids\":[]` in the response indicate that no services are allowed. To enable all services, send 'allowed_service_ids' with no value to the 'curl' command, e.g. `allowed_service_ids=` (can't be done in ActiveDocs). Missing `<allowed_service_ids>` or `\"allowed_service_ids\":null` indicate that all services are allowed.",
                     "items": {
                       "type": "integer"
                     }

--- a/spec/acceptance/api/member_permissions_spec.rb
+++ b/spec/acceptance/api/member_permissions_spec.rb
@@ -28,7 +28,7 @@ resource "MemberPermission" do
 
   shared_context "all services disabled" do
     before do
-      user.member_permission_service_ids = "[]"
+      user.member_permission_service_ids = []
     end
   end
 

--- a/test/integration/admin/api/member_permissions_controller_test.rb
+++ b/test/integration/admin/api/member_permissions_controller_test.rb
@@ -90,7 +90,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
   test "PUT: enable 'settings', but disable all services" do
     user.update({ allowed_service_ids: [service1_id] })
     # allowed_sections%5B%5D=settings&allowed_service_ids%5B%5D=%5B%5D
-    params = { allowed_sections: ['settings'], allowed_service_ids: ["[]"], access_token: token }
+    params = { allowed_sections: ['settings'], allowed_service_ids: [""], access_token: token }
 
     put admin_api_permissions_path(id: user.id, format: :json), params: params
 
@@ -101,6 +101,21 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     user.member_permissions.reload
     assert_equal [:settings], user.allowed_sections.to_a
     assert_empty user.allowed_service_ids
+  end
+
+  # This way was previously documented in ActiveDocs, so keeping it for backwards compatibility
+  test "PUT: disable all services with `[]` value" do
+    user.update({ allowed_service_ids: [service1_id] })
+    # allowed_service_ids%5B%5D=%5B%5D
+    params = { allowed_service_ids: ["[]"], access_token: token }
+
+    put admin_api_permissions_path(id: user.id, format: :json), params: params
+
+    assert_not_nil(permissions = JSON.parse(response.body)['permissions'])
+    assert_empty permissions['allowed_service_ids']
+
+    user.member_permissions.reload
+    assert_equal [], user.allowed_service_ids
   end
 
   test "updating admin's permissions is not allowed" do

--- a/test/integration/admin/api/service_plans_controller_test.rb
+++ b/test/integration/admin/api/service_plans_controller_test.rb
@@ -78,8 +78,7 @@ class Admin::Api::ServicePlansControllerTest < ActionDispatch::IntegrationTest
       @forbidden_service = FactoryBot.create(:simple_service, account: provider)
       @forbidden_service_plan = FactoryBot.create(:service_plan, name: 'Forbidden Plan', state: 'published', service: forbidden_service)
 
-      @member = FactoryBot.create(:member, account: provider, member_permission_ids: ['partners'])
-      member.member_permission_service_ids = [service.id]
+      @member = FactoryBot.create(:member, account: provider, member_permission_ids: ['partners'], member_permission_service_ids: [service.id])
       member.activate!
 
       login!(provider, user: member)

--- a/test/integration/api/application_plans_controller_test.rb
+++ b/test/integration/api/application_plans_controller_test.rb
@@ -239,13 +239,13 @@ class Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTest
       get new_admin_service_application_plan_path(service)
       assert_response :forbidden
 
-      post admin_service_application_plans_path(service), params: { application_plan:{ name: 'planName' } }
+      post admin_service_application_plans_path(service), params: { application_plan: { name: 'planName' } }
       assert_response :forbidden
 
       get edit_admin_application_plan_path(plan)
       assert_response :forbidden
 
-      put admin_application_plan_path(plan), params: { application_plan:{ name: 'New plan name' } }
+      put admin_application_plan_path(plan), params: { application_plan: { name: 'New plan name' } }
       assert_response :forbidden
 
       post masterize_admin_service_application_plans_path(service)
@@ -274,13 +274,13 @@ class Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTest
       get new_admin_service_application_plan_path(service)
       assert_response :success
 
-      post admin_service_application_plans_path(service), params: { application_plan:{ name: 'planName' } }
+      post admin_service_application_plans_path(service), params: { application_plan: { name: 'planName' } }
       assert_response :redirect
 
       get edit_admin_application_plan_path(plan)
       assert_response :success
 
-      put admin_application_plan_path(plan), params: { application_plan:{ name: 'New plan name' } }
+      put admin_application_plan_path(plan), params: { application_plan: { name: 'New plan name' } }
       assert_response :redirect
 
       post masterize_admin_service_application_plans_path(service)

--- a/test/integration/api/backend_usages_controller_test.rb
+++ b/test/integration/api/backend_usages_controller_test.rb
@@ -106,20 +106,26 @@ class Api::BackendUsagesControllerTest < ActionDispatch::IntegrationTest
     logout!
     login! provider, user: member
 
+    # a specific service allowed
     get admin_service_backend_usages_path(service)
     assert_response :success
 
-    member.member_permission_service_ids = []
-    member.save!
-
-    get admin_service_backend_usages_path(service)
-    assert_response :success
-
-    other_service = FactoryBot.create(:simple_service, account: provider)
-    member.member_permission_service_ids = [other_service.id]
-    member.save!
+    # no services allowed
+    member.update(member_permission_service_ids: [])
 
     get admin_service_backend_usages_path(service)
     assert_response :not_found
+
+    # a different service allowed
+    other_service = FactoryBot.create(:simple_service, account: provider)
+    member.update(member_permission_service_ids: [other_service.id])
+
+    get admin_service_backend_usages_path(service)
+    assert_response :not_found
+
+    # all services allowed
+    member.update(member_permission_service_ids: nil)
+    get admin_service_backend_usages_path(service)
+    assert_response :success
   end
 end

--- a/test/integration/api/integrations_controller_test.rb
+++ b/test/integration/api/integrations_controller_test.rb
@@ -23,7 +23,7 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     login! provider, user: member
 
     get admin_service_integration_path(service_id: service.id)
-    assert_response 403
+    assert_response 404
 
     member.member_permissions.create!(admin_section: 'plans')
     get admin_service_integration_path(service_id: service.id)

--- a/test/integration/api/policies_controller_test.rb
+++ b/test/integration/api/policies_controller_test.rb
@@ -55,4 +55,15 @@ class Api::PoliciesControllerTest < ActionDispatch::IntegrationTest
     get edit_admin_service_policies_path(@service)
     assert_response :service_unavailable
   end
+
+  test 'policies edit for members with no permissions' do
+    Policies::PoliciesListService.unstub(:call!)
+    Policies::PoliciesListService.expects(:call!).never
+    member = FactoryBot.create(:member, account: @provider, state: 'active')
+    logout! && login!(@provider, user: member)
+
+    get edit_admin_service_policies_path(@service)
+
+    assert_response :not_found
+  end
 end

--- a/test/integration/api/proxy_configs_controller_test.rb
+++ b/test/integration/api/proxy_configs_controller_test.rb
@@ -56,4 +56,14 @@ class Api::ProxyConfigsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal '{"foo":"bar"}', response.body
   end
+
+  test 'proxy configs index for members with no permissions' do
+    member = FactoryBot.create(:member, account: @provider, state: 'active')
+    logout! && login!(@provider, user: member)
+
+    get admin_service_proxy_configs_path(service_id: service, environment: 'sandbox')
+
+    # TODO: maybe this should be be a :forbidden
+    assert_response :not_found
+  end
 end

--- a/test/integration/buyers/accounts_controller_test.rb
+++ b/test/integration/buyers/accounts_controller_test.rb
@@ -79,17 +79,17 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
       cinstance = service.cinstances.last
       cinstance.update(name: 'Alaska Application App')
 
-      User.any_instance.expects(:has_access_to_all_services?).returns(true).at_least_once
+      assert_nil user.member_permission_service_ids
       get admin_buyers_account_path(buyer)
       assert_response :success
       assert_match 'Alaska Application App', response.body
 
-      User.any_instance.expects(:has_access_to_all_services?).returns(false).at_least_once
+      user.update(member_permission_service_ids: [])
       get admin_buyers_account_path(buyer)
       assert_response :success
       assert_not_match 'Alaska Application App', response.body
 
-      User.any_instance.expects(:member_permission_service_ids).returns([service.id]).at_least_once
+      user.update(member_permission_service_ids: [service.id])
       get admin_buyers_account_path(buyer)
       assert_response :success
       assert_match 'Alaska Application App', response.body

--- a/test/integration/master/providers/plans_controller_test.rb
+++ b/test/integration/master/providers/plans_controller_test.rb
@@ -52,7 +52,7 @@ class Master::Providers::PlansControllerTest < ActionDispatch::IntegrationTest
   end
 
   test '#update for a member with permission partners but without the service' do
-    master_member.update!({member_permission_ids: ['partners'], member_permission_service_ids: '[]'})
+    master_member.update!({member_permission_ids: ['partners'], member_permission_service_ids: []})
     login! master_account, user: master_member
 
     put master_provider_plan_path(tenant), params: { plan_id: new_plan.id, format: :js }

--- a/test/integration/provider/admin/applications/applications_controller_test.rb
+++ b/test/integration/provider/admin/applications/applications_controller_test.rb
@@ -133,12 +133,14 @@ class Provider::Admin::ApplicationsTest < ActionDispatch::IntegrationTest
       end
 
       test 'show renders application for the permitted services ids when there is no access to all services' do
+        member = FactoryBot.create(:member, account: provider, member_permission_ids: [:partners], member_permission_service_ids: [application.issuer.id])
+        member.activate!
+        logout! && login!(provider, user: member)
+
         second_service = FactoryBot.create(:simple_service, account: provider)
         second_plan = FactoryBot.create(:application_plan, issuer: second_service)
         second_app = FactoryBot.create(:cinstance, plan: second_plan)
 
-        User.any_instance.expects(:has_access_to_all_services?).returns(false).at_least_once
-        User.any_instance.expects(:member_permission_service_ids).returns([application.issuer.id]).at_least_once
         get provider_admin_application_path(application)
         assert_response :success
         get provider_admin_application_path(second_app)

--- a/test/integration/stats/applications_test.rb
+++ b/test/integration/stats/applications_test.rb
@@ -8,37 +8,33 @@ class Stats::ApplicationsTest < ActionDispatch::IntegrationTest
     @service = @provider.default_service
     @plan = FactoryBot.create(:simple_application_plan, issuer: @service)
     @application = FactoryBot.create(:simple_cinstance, plan: @plan)
+    @member = FactoryBot.create(:member, account: @provider, member_permission_ids: %i[partners plans], state: 'active')
 
     host! @provider.external_admin_domain
-    login_provider @provider
+    login_provider @provider, user: @member
   end
 
   test '#show nonexistent application does not check permissions' do
-    User.any_instance.expects(:has_access_to_all_services?).never
     User.any_instance.expects(:member_permission_service_ids).never
 
     get admin_buyers_stats_application_path(id: 'foo')
     assert_response :not_found
   end
 
-  test '#show does not check member permission with access to all services' do
-    User.any_instance.expects(:has_access_to_all_services?).returns(true).at_least_once
-    User.any_instance.expects(:member_permission_service_ids).never
+  test '#show succeeds with access to all services' do
+    assert_nil @member.member_permission_service_ids
     get admin_buyers_stats_application_path(id: @application.id)
     assert_response :success
   end
 
-  test '#show needs member permission' do
-    User.any_instance.expects(:has_access_to_all_services?).returns(false)
-    User.any_instance.expects(:access_to_service_admin_sections?).returns(false)
-    User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
+  test '#show succeeds with permission for a specific service' do
+    @member.update(member_permission_service_ids: [@service.id])
     get admin_buyers_stats_application_path(id: @application.id)
     assert_response :success
   end
 
   test '#show is forbidden without member permission' do
-    User.any_instance.expects(:has_access_to_all_services?).returns(false)
-    User.any_instance.expects(:member_permission_service_ids).returns([]).at_least_once
+    @member.update(member_permission_service_ids: [])
     get admin_buyers_stats_application_path(id: @application.id)
     assert_response :forbidden
   end

--- a/test/integration/stats/data/requests_to_api_test.rb
+++ b/test/integration/stats/data/requests_to_api_test.rb
@@ -35,21 +35,19 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
 
     token.scopes = ['stats']
     token.save!
-    member.admin_sections = []
-    member.save!
+
     # member does not have the right permission
+    member.update(member_permission_ids: [])
     get usage_stats_data_applications_path(@application, format: :json), params: params
     assert_response :forbidden
 
-    member.admin_sections = ['monitoring']
-    member.save!
-    User.any_instance.expects(:has_access_to_all_services?).returns(false).at_least_once
     # the service is not accessible for the member
+    member.update(member_permission_ids: [:monitoring], member_permission_service_ids: [])
     get usage_stats_data_applications_path(@application, format: :json), params: params
     assert_response :forbidden
 
-    User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
     # the service is accessible for the member
+    member.update(member_permission_service_ids: [@service.id])
     get usage_stats_data_applications_path(@application, format: :json), params: params
     assert_response :success
   end

--- a/test/integration/user-management-api/application_plan_limits_test.rb
+++ b/test/integration/user-management-api/application_plan_limits_test.rb
@@ -16,8 +16,8 @@ class Admin::Api::ApplicationPlanLimitsTest < ActionDispatch::IntegrationTest
   class AccessTokenTest < Admin::Api::ApplicationPlanLimitsTest
     def setup
       super
-      user = FactoryBot.create(:member, account: @provider, admin_sections: %w[partners plans])
-      @token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
+      @user = FactoryBot.create(:member, account: @provider, member_permission_ids: %i[partners plans], member_permission_service_ids: [])
+      @token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management')
 
       User.any_instance.stubs(:has_access_to_all_services?).returns(false)
     end
@@ -28,20 +28,18 @@ class Admin::Api::ApplicationPlanLimitsTest < ActionDispatch::IntegrationTest
     end
 
     test 'index with access to no services' do
-      User.any_instance.expects(:member_permission_service_ids).returns([]).at_least_once
       get admin_api_application_plan_limits_path(@app_plan), params: params
       assert_response :not_found
     end
 
     test 'index with access to some service' do
-      User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
+      @user.update(member_permission_service_ids: [@service.id])
       get admin_api_application_plan_limits_path(@app_plan), params: params
       assert_response :success
     end
 
-    test 'index' do
-      User.any_instance.stubs(:has_access_to_all_services?).returns(true)
-      User.any_instance.expects(:member_permission_service_ids).never
+    test 'index with access to all services' do
+      @user.update(member_permission_service_ids: nil)
       get admin_api_application_plan_limits_path(@app_plan), params: params
       assert_response :success
     end

--- a/test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
+++ b/test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
@@ -18,10 +18,8 @@ class Admin::Api::ApplicationPlanMetricPricingRulesTest < ActionDispatch::Integr
   class AccessTokenTest < Admin::Api::ApplicationPlanMetricPricingRulesTest
     def setup
       super
-      user = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
-      @token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
-
-      User.any_instance.stubs(:has_access_to_all_services?).returns(false)
+      @user = FactoryBot.create(:member, account: @provider, member_permission_ids: [:partners], member_permission_service_ids: [])
+      @token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management')
     end
 
     test 'index with no token' do
@@ -30,20 +28,25 @@ class Admin::Api::ApplicationPlanMetricPricingRulesTest < ActionDispatch::Integr
     end
 
     test 'index with access to no services' do
-      User.any_instance.expects(:member_permission_service_ids).returns([]).at_least_once
       get admin_api_application_plan_metric_pricing_rules_path(@app_plan, @metric.id), params: params
       assert_response :not_found
     end
 
     test 'index with access to some service' do
-      User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
+      @user.update(member_permission_service_ids: [@service.id])
       get admin_api_application_plan_metric_pricing_rules_path(@app_plan, @metric.id), params: params
       assert_response :success
+
+      @another_service = FactoryBot.create(:service, account: @provider)
+      @another_plan = FactoryBot.create(:application_plan, issuer: @another_service)
+      @another_metric = FactoryBot.create(:metric, owner: @another_service)
+
+      get admin_api_application_plan_metric_pricing_rules_path(@another_plan, @another_metric.id), params: params
+      assert_response :not_found
     end
 
     test 'index with access to all services' do
-      User.any_instance.stubs(:has_access_to_all_services?).returns(true)
-      User.any_instance.expects(:member_permission_service_ids).never
+      @user.update(member_permission_service_ids: nil)
       get admin_api_application_plan_metric_pricing_rules_path(@app_plan, @metric.id), params: params
       assert_response :success
     end

--- a/test/integration/user-management-api/application_plan_pricing_rules_test.rb
+++ b/test/integration/user-management-api/application_plan_pricing_rules_test.rb
@@ -16,10 +16,8 @@ class Admin::Api::ApplicationPlanPricingRulesTest < ActionDispatch::IntegrationT
   class AccessTokenTest < Admin::Api::ApplicationPlanPricingRulesTest
     def setup
       super
-      user = FactoryBot.create(:member, account: @provider, admin_sections: %w[partners plans])
-      @token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
-
-      User.any_instance.stubs(:has_access_to_all_services?).returns(false)
+      @user = FactoryBot.create(:member, account: @provider, member_permission_ids: %i[partners plans])
+      @token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management')
     end
 
     test 'index with no token' do
@@ -28,20 +26,19 @@ class Admin::Api::ApplicationPlanPricingRulesTest < ActionDispatch::IntegrationT
     end
 
     test 'index with access to no services' do
-      User.any_instance.expects(:member_permission_service_ids).returns([]).at_least_once
+      @user.update(member_permission_service_ids: [])
       get admin_api_application_plan_pricing_rules_path(@app_plan), params: params
       assert_response :not_found
     end
 
     test 'index with access to some service' do
-      User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
+      @user.update(member_permission_service_ids: [@service.id])
       get admin_api_application_plan_pricing_rules_path(@app_plan), params: params
       assert_response :success
     end
 
     test 'index with access to all services' do
-      User.any_instance.stubs(:has_access_to_all_services?).returns(true)
-      User.any_instance.expects(:member_permission_service_ids).never
+      @user.update(member_permission_service_ids: nil)
       get admin_api_application_plan_pricing_rules_path(@app_plan), params: params
       assert_response :success
     end

--- a/test/integration/user-management-api/buyers_application_keys_test.rb
+++ b/test/integration/user-management-api/buyers_application_keys_test.rb
@@ -25,7 +25,7 @@ class Admin::Api::BuyersApplicationKeysTest < ActionDispatch::IntegrationTest
 
   test 'create (access_token)' do
     User.any_instance.stubs(:has_access_to_all_services?).returns(false)
-    user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
+    user  = FactoryBot.create(:member, account: @provider, member_permission_ids: [:partners], member_permission_service_ids: [])
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
     app   = @buyer.bought_cinstances.last
 
@@ -33,7 +33,7 @@ class Admin::Api::BuyersApplicationKeysTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
     post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'), params: { access_token: token.value })
     assert_response :not_found
-    User.any_instance.expects(:member_permission_service_ids).returns([app.issuer.id]).at_least_once
+    user.update(member_permission_service_ids: [app.issuer.id])
     post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'), params: { access_token: token.value })
     assert_response :success
   end

--- a/test/integration/user-management-api/buyers_application_referrer_filters_test.rb
+++ b/test/integration/user-management-api/buyers_application_referrer_filters_test.rb
@@ -22,8 +22,7 @@ class Admin::Api::BuyersApplicationReferrerFiltersTest < ActionDispatch::Integra
   end
 
   test 'index (access_token)' do
-    User.any_instance.stubs(:has_access_to_all_services?).returns(false)
-    user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
+    user = FactoryBot.create(:member, account: @provider, member_permission_ids: [:partners], member_permission_service_ids: [])
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
     app   = @buyer.bought_cinstances.last
 
@@ -31,7 +30,7 @@ class Admin::Api::BuyersApplicationReferrerFiltersTest < ActionDispatch::Integra
     assert_response :forbidden
     get(admin_api_account_application_referrer_filters_path(@buyer, app), params: { access_token: token.value })
     assert_response :not_found
-    User.any_instance.expects(:member_permission_service_ids).returns([app.issuer.id]).at_least_once
+    user.update(member_permission_service_ids: [app.issuer.id])
     get(admin_api_account_application_referrer_filters_path(@buyer, app), params: { access_token: token.value })
     assert_response :success
   end

--- a/test/integration/user-management-api/service_features_test.rb
+++ b/test/integration/user-management-api/service_features_test.rb
@@ -13,16 +13,15 @@ class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
   # Access token
 
   test 'show (access_token)' do
-    User.any_instance.stubs(:has_access_to_all_services?).returns(false)
     feature = FactoryBot.create(:feature, featurable: @service)
-    user    = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
+    user    = FactoryBot.create(:member, account: @provider, member_permission_ids: [:partners], member_permission_service_ids: [])
     token   = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
 
     get admin_api_service_feature_path(@service, feature)
     assert_response :forbidden
     get admin_api_service_feature_path(@service, feature), params: { access_token: token.value }
     assert_response :not_found
-    User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
+    user.update(member_permission_service_ids: [@service.id])
     get admin_api_service_feature_path(@service, feature), params: { access_token: token.value }
     assert_response :success
   end

--- a/test/integration/user-management-api/service_plans_test.rb
+++ b/test/integration/user-management-api/service_plans_test.rb
@@ -18,8 +18,7 @@ class Admin::Api::ServicePlansTest < ActionDispatch::IntegrationTest
   # Access token
 
   test 'show (access_token)' do
-    User.any_instance.stubs(:has_access_to_all_services?).returns(false)
-    user    = FactoryBot.create(:member, account: @provider, admin_sections: %w[partners plans])
+    user    = FactoryBot.create(:member, account: @provider, member_permission_ids: %i[partners plans], member_permission_service_ids: [])
     token   = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
     service = @provider.default_service
     plan    = service.service_plans.first
@@ -28,7 +27,7 @@ class Admin::Api::ServicePlansTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
     get admin_api_service_service_plan_path(service, plan), params: { access_token: token.value }
     assert_response :not_found
-    User.any_instance.expects(:member_permission_service_ids).returns([service.id]).at_least_once
+    user.update(member_permission_service_ids: [service.id])
     get admin_api_service_service_plan_path(service, plan), params: { access_token: token.value }
     assert_response :success
   end

--- a/test/integration/user-management-api/services/mapping_rules_test.rb
+++ b/test/integration/user-management-api/services/mapping_rules_test.rb
@@ -13,8 +13,7 @@ class Admin::Api::Services::MappingRulesTest < ActionDispatch::IntegrationTest
   end
 
   def test_crud_access_token
-    User.any_instance.stubs(:has_access_to_all_services?).returns(false)
-    user  = FactoryBot.create(:member, account: @account, admin_sections: ['partners'])
+    user = FactoryBot.create(:member, account: @account, member_permission_ids: [:partners], member_permission_service_ids: [])
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
 
     # index
@@ -22,7 +21,7 @@ class Admin::Api::Services::MappingRulesTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
     get(admin_api_service_proxy_mapping_rules_path(access_token_params(token.value)))
     assert_response :not_found
-    User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
+    user.update(member_permission_service_ids: [@service.id])
     get(admin_api_service_proxy_mapping_rules_path(access_token_params(token.value)))
     assert_response :success
 

--- a/test/integration/user-management-api/services/proxies_test.rb
+++ b/test/integration/user-management-api/services/proxies_test.rb
@@ -11,8 +11,7 @@ class Admin::Api::Services::ProxiesTest < ActionDispatch::IntegrationTest
   end
 
   def test_crud_access_token
-    User.any_instance.stubs(:has_access_to_all_services?).returns(false)
-    user  = FactoryBot.create(:member, account: @account, admin_sections: ['partners'])
+    user = FactoryBot.create(:member, account: @account, member_permission_ids: [:partners], member_permission_service_ids: [])
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
 
     # show
@@ -20,7 +19,7 @@ class Admin::Api::Services::ProxiesTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
     get(admin_api_service_proxy_path(access_token_params(token.value)))
     assert_response :not_found
-    User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
+    user.update(member_permission_service_ids: [@service.id])
     get(admin_api_service_proxy_path(access_token_params(token.value)))
     assert_response :success
 

--- a/test/integration/user-management-api/services_test.rb
+++ b/test/integration/user-management-api/services_test.rb
@@ -14,14 +14,14 @@ class Admin::Api::ServicesTest < ActionDispatch::IntegrationTest
 
   test 'show (access_token)' do
     User.any_instance.stubs(:has_access_to_all_services?).returns(false)
-    user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
+    user = FactoryBot.create(:member, account: @provider, member_permission_ids: [:partners], member_permission_service_ids: [])
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
 
     get admin_api_service_path(@service)
     assert_response :forbidden
     get admin_api_service_path(@service), params: { access_token: token.value }
     assert_response :not_found
-    User.any_instance.expects(:member_permission_service_ids).returns([@service.id]).at_least_once
+    user.update(member_permission_service_ids: [@service.id])
     get admin_api_service_path(@service), params: { access_token: token.value }
     assert_response :success
   end

--- a/test/unit/abilities/provider_any_test.rb
+++ b/test/unit/abilities/provider_any_test.rb
@@ -5,24 +5,21 @@ require 'test_helper'
 module Abilities
   class ProviderAnyTest < ActiveSupport::TestCase
     setup do
-      @account = Account.new
-      @account.stubs(provider?: true)
+      @account = FactoryBot.create(:simple_provider)
       @account.stubs(:provider_can_use?).with(any_parameters).returns(false)
-      @user = User.new({account: @account}, without_protection: true)
+      @user  = FactoryBot.create(:simple_user, account: @account)
     end
 
     attr_reader :user, :account
 
     def test_policies_allowed
       account.expects(:provider_can_use?).with(:policy_registry).returns(true)
-      account.stubs(tenant?: true)
 
       assert_can ability, :manage, :policy_registry
     end
 
     def test_policies_no_rolling_update
       account.expects(:provider_can_use?).with(:policy_registry).returns(false)
-      account.stubs(tenant?: true)
 
       assert_cannot ability, :manage, :policy_registry
     end
@@ -34,79 +31,75 @@ module Abilities
     end
 
     test 'Cinstance/Application events can show if has :partners and access to the service if there is a service' do
-      cinstance = FactoryBot.create(:cinstance)
-      service = cinstance.service
+      service = FactoryBot.create(:simple_service, account: @account)
+      plan = FactoryBot.create(:simple_application_plan, issuer: service)
+      cinstance = FactoryBot.create(:cinstance, plan: plan)
       cinstance_events = [
         Cinstances::CinstanceExpiredTrialEvent.create(cinstance), Cinstances::CinstanceCancellationEvent.create(cinstance),
         Cinstances::CinstancePlanChangedEvent.create(cinstance, user), Applications::ApplicationCreatedEvent.create(cinstance, user)
       ]
 
-      user.stubs(:has_permission?)
-      user.stubs(:has_access_to_service?)
-
       cinstance_events.each do |cinstance_event|
-        user.expects(:has_permission?).with(:partners).returns(true)
-        user.expects(:has_access_to_service?).with(service.id).returns(false)
+        user.member_permission_ids = [:partners]
+        user.member_permission_service_ids = []
+
         assert_cannot ability, :show, cinstance_event
 
-        user.expects(:has_permission?).with(:partners).returns(false)
-        user.stubs(:has_access_to_service?).returns(true)
+        user.member_permission_service_ids = [FactoryBot.create(:cinstance).id]
+
         assert_cannot ability, :show, cinstance_event
 
-        user.expects(:has_permission?).with(:partners).returns(true)
-        user.expects(:has_access_to_service?).with(service.id).returns(true)
+        user.member_permission_service_ids = [service.id]
+
         assert_can ability, :show, cinstance_event
+
+        user.member_permission_ids = []
+
+        assert_cannot ability, :show, cinstance_event
       end
     end
 
     test 'AccountRelatedEvent can show if has :partners and does not have a service' do
-      user.stubs(:has_permission?)
-
-      user.expects(:has_permission?).with(:partners).returns(true)
-      assert_can ability, :show, Accounts::AccountCreatedEvent.create(account, user)
-
-      user.expects(:has_permission?).with(:partners).returns(false)
       assert_cannot ability, :show, Accounts::AccountCreatedEvent.create(account, user)
+
+      user.member_permission_ids = [:partners]
+      assert_can ability, :show, Accounts::AccountCreatedEvent.create(account, user)
     end
 
     class ShowAlertRelatedEventTest < ProviderAnyTest
       setup do
-        user.stubs(:has_permission?)
-
-        cinstance = FactoryBot.build_stubbed(:simple_cinstance)
-        alert = FactoryBot.build_stubbed(:limit_violation, cinstance: cinstance)
+        service = FactoryBot.create(:simple_service, account: @account)
+        plan = FactoryBot.create(:simple_application_plan, issuer: service)
+        cinstance = FactoryBot.create(:cinstance, plan: plan)
+        alert = FactoryBot.create(:limit_violation, cinstance: cinstance)
         @limit_violation_reached_provider_event = Alerts::LimitViolationReachedProviderEvent.create(alert)
       end
 
       attr_reader :limit_violation_reached_provider_event
 
       test 'cannot show AlertRelatedEvent when user does not have :monitoring' do
-        user.expects(:has_permission?).with(:monitoring).returns(false)
-
+        assert_not user.has_permission? :monitoring
         assert_cannot ability, :show, limit_violation_reached_provider_event
       end
 
-      # This is related to the :service_permissions rolling update. Users created before it do not have the :services
-      # section included in their member permissions, which grants them access to all services.
-      test 'can show AlertRelatedEvent when user has :monitoring and the user has access to all services through the old permission system' do
-        user.expects(:has_permission?).with(:monitoring).returns(true)
+      # If the user has service-related permission, and no :services permission, it means it has access to all services
+      test 'can show AlertRelatedEvent when user has :monitoring and the user has access to all services' do
+        user.member_permission_ids = [:monitoring]
+        assert user.has_permission? :monitoring
 
         assert_can ability, :show, limit_violation_reached_provider_event
       end
 
       test 'cannot show AlertRelatedEvent when user has :monitoring and does not have access to the service' do
-        user.stubs(:has_permission?).with(:monitoring).returns(true)
-        user.member_permissions.build(admin_section: :services, service_ids: [])
+        user.member_permission_ids = [:monitoring]
+        user.member_permission_service_ids = []
 
         assert_cannot ability, :show, limit_violation_reached_provider_event
       end
 
       test 'can show AlertRelatedEvent when user has :monitoring and has access to the service' do
-        user.stubs(:has_permission?).with(:monitoring).returns(true)
-        user.member_permissions.build(
-          admin_section: :services,
-          service_ids: [limit_violation_reached_provider_event.service.id]
-        )
+        user.member_permission_ids = [:monitoring]
+        user.member_permission_service_ids = [limit_violation_reached_provider_event.service.id]
 
         assert_can ability, :show, limit_violation_reached_provider_event
       end

--- a/test/unit/api_docs/provider_user_data_test.rb
+++ b/test/unit/api_docs/provider_user_data_test.rb
@@ -13,8 +13,6 @@ class ApiDocs::ProviderUserDataTest < ActiveSupport::TestCase
   end
 
   def test_service_tokens
-    User.any_instance.stubs(admin_sections: [:services])
-
     data = ApiDocs::ProviderUserData.new(@admin).as_json[:results]
     assert_equal [{ name: "You don't have access to any services, contact an administrator of this account.",
                     value: '' }], data[:service_tokens]
@@ -22,6 +20,8 @@ class ApiDocs::ProviderUserDataTest < ActiveSupport::TestCase
     service = FactoryBot.create(:simple_service, account: @admin.account)
     service_other = FactoryBot.create(:simple_service, account: @admin.account)
     _service_without_token = FactoryBot.create(:simple_service, account: @admin.account)
+    @admin.account.reload # ensure that @admin.account.service_ids returns the updated list of services
+
     # Resets all service_tokens
     ServiceToken.where(service_id: [service, service_other, _service_without_token]).delete_all
     service.service_tokens.create!(value: 'Foo')
@@ -30,9 +30,7 @@ class ApiDocs::ProviderUserDataTest < ActiveSupport::TestCase
     admin_data = ApiDocs::ProviderUserData.new(@admin).as_json[:results]
     assert_same_elements [{ name: service.name, value: 'Foo' }, { name: service_other.name, value: 'Bar' }], admin_data[:service_tokens]
 
-    member = FactoryBot.create(:simple_user, account: @admin.account)
-    member.stubs(member_permission_service_ids: [service.id])
-    member.expects(:has_permission?).with(:plans).returns(true)
+    member = FactoryBot.create(:simple_user, account: @admin.account, member_permission_ids: [:plans], member_permission_service_ids: [service.id])
 
     data1 = ApiDocs::ProviderUserData.new(member).as_json[:results]
     assert_equal [{ name: service.name, value: 'Foo' }], data1[:service_tokens]
@@ -59,8 +57,7 @@ class ApiDocs::ProviderUserDataTest < ActiveSupport::TestCase
     end
 
     test 'member users can only see applications of authorized services' do
-      member = FactoryBot.create(:simple_user, account: @admin.account)
-      FactoryBot.create(:member_permission, user: member, admin_section: :services, service_ids: [@authorized_service.id])
+      member = FactoryBot.create(:simple_user, account: @admin.account, member_permission_ids: [:plans], member_permission_service_ids: [@authorized_service.id])
 
       apps = ApiDocs::ProviderUserData.new(member).apps.to_a
       assert_includes apps, @authorized_cinstance
@@ -73,9 +70,14 @@ class ApiDocs::ProviderUserDataTest < ActiveSupport::TestCase
       assert_empty ApiDocs::ProviderUserData.new(member).apps.to_a
     end
 
-    # Old permission system
-    test 'member users without services admin permission see all applications' do
+    test 'member users with no permissions cannot see applications' do
       member = FactoryBot.create(:simple_user, account: @admin.account)
+      apps = ApiDocs::ProviderUserData.new(member).apps.to_a
+      assert_empty apps
+    end
+
+    test 'member users with access to all services see all applications' do
+      member = FactoryBot.create(:simple_user, account: @admin.account, allowed_sections: ['plans'], allowed_service_ids: nil)
       apps = ApiDocs::ProviderUserData.new(member).apps.to_a
       assert_same_elements [@authorized_cinstance, @unauthorized_cinstance], apps
     end

--- a/test/unit/concerns/new_application_form_test.rb
+++ b/test/unit/concerns/new_application_form_test.rb
@@ -7,7 +7,7 @@ class MyForm
 
   def initialize(provider:, service_plans_management_visible:)
     @provider = provider
-    @user = FactoryBot.create(:simple_user, account: @provider)
+    @user = FactoryBot.create(:simple_user, account: @provider, role: :admin)
     @service_plans_management_visible = service_plans_management_visible
   end
 

--- a/test/unit/contract_test.rb
+++ b/test/unit/contract_test.rb
@@ -103,11 +103,11 @@ class ContractTest < ActiveSupport::TestCase
     cinstances = FactoryBot.create_list(:simple_cinstance, 2)
     user = FactoryBot.build(:member)
 
-    user.stubs(forbidden_some_services?: false)
+    user.stubs(permitted_services_status: :all)
     permitted_contract_ids = Contract.permitted_for(user).pluck(:id)
     cinstances.each { |contract| assert_includes(permitted_contract_ids, contract.id) }
 
-    user.stubs(forbidden_some_services?: true)
+    user.stubs(permitted_services_status: :selected)
     user.stubs(member_permission_service_ids: [cinstances.first.service_id])
     assert_equal [cinstances.first.id], Contract.permitted_for(user).pluck(:id)
   end

--- a/test/unit/presenters/api/services_index_presenter_test.rb
+++ b/test/unit/presenters/api/services_index_presenter_test.rb
@@ -7,7 +7,7 @@ class Api::ServicesIndexPresenterTest < ActiveSupport::TestCase
 
   def setup
     @provider = FactoryBot.create(:simple_provider)
-    @user = FactoryBot.create(:simple_user, account: @provider)
+    @user = FactoryBot.create(:simple_user, account: @provider, role: :admin)
   end
 
   attr_reader :provider, :user

--- a/test/unit/service_test.rb
+++ b/test/unit/service_test.rb
@@ -562,10 +562,10 @@ class ServiceTest < ActiveSupport::TestCase
     member_permission_service_ids = [Service.last.id]
     user.stubs(member_permission_service_ids: member_permission_service_ids)
 
-    user.stubs(forbidden_some_services?: false)
+    user.stubs(permitted_services_status: :all)
     assert_same_elements account.services.pluck(:id), Service.permitted_for(user).pluck(:id)
 
-    user.stubs(forbidden_some_services?: true)
+    user.stubs(permitted_services_status: :selected)
     assert_same_elements member_permission_service_ids, Service.permitted_for(user).pluck(:id)
     assert_same_elements Service.pluck(:id), Service.permitted_for.pluck(:id)
   end

--- a/test/unit/user/permissions_test.rb
+++ b/test/unit/user/permissions_test.rb
@@ -68,19 +68,45 @@ class User::PermissionsTest < ActiveSupport::TestCase
   end
 
   test 'member_permission_service_ids=' do
-    user = FactoryBot.build_stubbed(:simple_user, admin_sections: [:services])
+    user = FactoryBot.create(:simple_user, admin_sections: [:partners])
     user.stubs(:existing_service_ids).returns([42])
 
-    refute user.has_access_to_service?(42)
+    assert user.has_access_to_service?(42)
     assert_equal 1, user.admin_sections.size
 
-    user.member_permission_service_ids = [42]
-    assert user.has_access_to_service?(42)
-    assert_equal Set[:services], user.admin_sections
+    # all values have the same effect
+    [[], [""], ["[]"], ["xyz"]].each do |service_ids_empty_value|
+      user.update(member_permission_service_ids: service_ids_empty_value)
+      assert_not user.has_access_to_service?(42)
+      assert_equal Set[:partners, :services], user.admin_sections
+      assert_equal [], user.member_permission_service_ids
+    end
 
-    user.member_permission_service_ids = nil
-    assert user.has_access_to_service?(42)
-    assert_equal 0, user.admin_sections.size
+    [nil, ""].each do |enable_all_value|
+      user.update(member_permission_service_ids: enable_all_value)
+      assert user.has_access_to_service?(42)
+      assert_equal Set[:partners], user.admin_sections
+    end
+
+    previous_permissions = user.member_permissions
+    ["abc", 123].each do |invalid_value|
+      user.update(member_permission_service_ids: invalid_value)
+      assert_equal previous_permissions, user.reload.member_permissions
+    end
+
+    # when setting numeric values and empty value, empty values are ignored
+    [[42, ''], [42, "[]"]].each do |service_ids|
+      user.update(member_permission_service_ids: service_ids)
+      assert user.has_access_to_service?(42)
+      assert_equal Set[:partners, :services], user.admin_sections
+      assert_equal [42], user.member_permission_service_ids
+    end
+
+    # if 0 is a valid service_id, it can be set as an allowed service
+    user.stubs(:existing_service_ids).returns([0, 42])
+    user.update(member_permission_service_ids: ['0'])
+    assert user.has_access_to_service?(0)
+    assert_equal [0], user.member_permission_service_ids
   end
 
   test 'member_permission_service_ids= filters the services list before saving' do
@@ -118,38 +144,57 @@ class User::PermissionsTest < ActiveSupport::TestCase
 
   test 'has_access_to_all_services?' do
     user = FactoryBot.build_stubbed(:simple_user)
+    assert_not user.has_access_to_all_services?
+
+    user.member_permission_ids = [:portal]
+    assert_not user.has_access_to_all_services?
+
+    user.member_permission_ids = [:plans]
     assert user.has_access_to_all_services?
 
-    user.admin_sections = [:services]
-    refute user.has_access_to_all_services?
+    user.member_permission_service_ids = []
+    assert_not user.has_access_to_all_services?
 
-    # updating admin section doesn't remove service permissions
-    user.admin_sections = [:plans]
-    refute user.has_access_to_all_services?
-
-    user.admin_sections = []
     user.stubs(:admin?).returns(true)
     assert user.has_access_to_all_services?
   end
 
-  test '#forbidden_some_services?' do
-    user = FactoryBot.build(:simple_user)
+  test '#permitted_services_status' do
+    user = FactoryBot.build_stubbed(:simple_user)
+    user.stubs(:existing_service_ids).returns([42])
 
-    user.stubs(has_access_to_all_services?: true)
-    user.account.stubs(provider_can_use?: true)
-    refute user.forbidden_some_services?
+    assert_equal :none, user.permitted_services_status
 
-    user.stubs(has_access_to_all_services?: true)
-    user.account.stubs(provider_can_use?: false)
-    refute user.forbidden_some_services?
+    user.member_permission_ids = [:portal]
+    assert_equal :none, user.permitted_services_status
 
-    user.stubs(has_access_to_all_services?: false)
-    user.account.stubs(provider_can_use?: false)
-    refute user.forbidden_some_services?
+    user.member_permission_ids = [:plans]
+    assert_equal :all, user.permitted_services_status
 
-    user.stubs(has_access_to_all_services?: false)
-    user.account.stubs(provider_can_use?: true)
-    assert user.forbidden_some_services?
+    user.member_permission_service_ids = [24]
+    assert_equal :none, user.permitted_services_status
+
+    user.member_permission_service_ids = [42]
+    assert_equal :selected, user.permitted_services_status
+
+    user.member_permission_service_ids = []
+    assert_equal :none, user.permitted_services_status
+
+    user.stubs(:admin?).returns(true)
+    assert_equal :all, user.permitted_services_status
+  end
+
+  test '#service_permissions_selected?' do
+    user = FactoryBot.build_stubbed(:simple_user)
+    %i[partners plans monitoring].each do |section|
+      user.stubs(:member_permission_ids).returns([section])
+      assert user.service_permissions_selected?
+    end
+
+    %i[portal finance settings policy_registry].each do |section|
+      user.stubs(:member_permission_ids).returns([section])
+      assert_not user.service_permissions_selected?
+    end
   end
 
   test '#access_to_service_admin_sections? when no accessible services' do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -95,39 +95,33 @@ class UserTest < ActiveSupport::TestCase
 
     service.service_tokens.create!(value: 'money-makes-people-cautious')
 
-    member.stubs(:has_access_to_all_services?).returns(true)
-    member.expects(:has_permission?).with(:plans).returns(true)
-    assert_equal 1, member.accessible_service_tokens.count
-
-    member.expects(:has_permission?).with(:plans).returns(false)
     assert_equal 0, member.accessible_service_tokens.count
+
+    member.member_permission_ids = ['plans']
+    assert_equal 1, member.accessible_service_tokens.count
   end
 
   def test_accessible_services
     provider = FactoryBot.create(:simple_provider)
     service = FactoryBot.create(:service, account: provider)
+    another_service = FactoryBot.create(:service, account: provider)
     admin = FactoryBot.build_stubbed(:admin, account: provider)
     member = FactoryBot.build_stubbed(:member, account: provider)
 
-    assert_equal [service.id], admin.accessible_services.map(&:id)
-    assert_equal [service.id], member.accessible_services.map(&:id)
-
-    member.stubs(:has_access_to_all_services?).returns(true)
-
-    assert_equal [service.id], member.accessible_services.map(&:id)
-
-    member.stubs(:has_access_to_all_services?).returns(false)
-    member.stubs(:member_permission_service_ids).returns([service.id])
-
-    assert_equal [service.id], member.accessible_services.map(&:id)
-
-    member.stubs(:member_permission_service_ids).returns([])
-
+    assert_equal [service.id, another_service.id], admin.accessible_services.map(&:id)
     assert_equal [], member.accessible_services.map(&:id)
 
-    member.stubs(:has_access_to_all_services?).returns(true)
-    member.stubs(:member_permission_service_ids).returns(nil)
+    member.member_permission_ids = ['partners']
+
+    assert_equal [service.id, another_service.id], member.accessible_services.map(&:id)
+
+    member.member_permission_service_ids = [service.id]
+
     assert_equal [service.id], member.accessible_services.map(&:id)
+
+    member.member_permission_service_ids = []
+
+    assert_equal [], member.accessible_services.map(&:id)
   end
 
   test '#find_by_username_or_email returns nil for TypeError' do


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue where a member user with NO permissions could see and update some service configuration.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-6412
https://issues.redhat.com/browse/THREESCALE-11202

**Verification steps** 

tbd

**Special notes for your reviewer**:

There is another strange thing regarding policies specifically. There is a special permission for managing the API policy chain, but it doesn't seem to be used for this view.
![Screenshot from 2024-10-17 13-16-51](https://github.com/user-attachments/assets/a4ad8ea8-eb34-44b9-a3cc-57b19a0c17f6)

In fact, it is specifically configured that any user can manage policies, if the feature is enabled in the whole account: 
https://github.com/3scale/porta/blob/f291877f07734754dfa46ec7451ab5c96b1fff0c/config/abilities/provider_any.rb#L14-L15

(also, I couldn't find references to `:policy_registry_ui` anywhere :thinking:)

So, I guess I will not be touching this. So, the user will be able to modify the policy chain (through the direct link), even if they don't have this specific permission set - having any type of access to the service would be enough.
