### PR TITLE
THREESCALE-11440: Reduce impersonation token expiration time to 1 minute

### DIFF
--- a/app/controllers/buyers/impersonations_controller.rb
+++ b/app/controllers/buyers/impersonations_controller.rb
@@ -8,7 +8,7 @@ class Buyers::ImpersonationsController < Buyers::BaseController
 
     user= provider.users.impersonation_admin!
 
-    sso_token = SSOToken.new user_id: user.id
+    sso_token = SSOToken.new user_id: user.id, expires_in: 1.minute
 
     sso_token.protocol     = 'http'                unless request.ssl?
     sso_token.redirect_url = params[:redirect_url] if params[:redirect_url] && params[:redirect_url] != "null"

--- a/app/controllers/buyers/impersonations_controller.rb
+++ b/app/controllers/buyers/impersonations_controller.rb
@@ -14,7 +14,7 @@ class Buyers::ImpersonationsController < Buyers::BaseController
     sso_token.redirect_url = params[:redirect_url] if params[:redirect_url] && params[:redirect_url] != "null"
     sso_token.account      = provider
 
-    sso_url = sso_token.sso_url!(provider.external_admin_domain)
+    sso_url = sso_token.sso_url!(host: provider.external_admin_domain, port: request.port)
 
     respond_to do | format |
       format.json { render json: {url: sso_url}, status: :created }

--- a/app/controllers/partners/sessions_controller.rb
+++ b/app/controllers/partners/sessions_controller.rb
@@ -10,7 +10,7 @@ class Partners::SessionsController < Partners::BaseController
         sso_token = SSOToken.new user_id: @user.id
         sso_token.protocol = 'http' unless request.ssl?
         sso_token.account = @account
-        sso_url = sso_token.sso_url!(@account.external_admin_domain)
+        sso_url = sso_token.sso_url!(host: @account.external_admin_domain, port: request.port)
         sso_url << "&return_to=#{params[:return_to]}" if params[:return_to].present?
         redirect_to sso_url
       end

--- a/app/models/sso_token.rb
+++ b/app/models/sso_token.rb
@@ -59,11 +59,12 @@ class SSOToken
   # however, if the provider is also master, host needs to be the provider's admin domain for which we create the URL
   #
   #
-  def sso_url! host = nil
+  def sso_url!(host: nil, port: nil)
     save if new_record?
 
     params= {
       host: host || account.external_domain,
+      port: port,
       protocol: protocol,
       token: encrypted_token,
       expires_at: expires_at.to_i,

--- a/features/old/buyers/impersonate.feature
+++ b/features/old/buyers/impersonate.feature
@@ -14,7 +14,5 @@ Feature: Impersonate
     And I navigate to the accounts page
     Then I should not see link "Act as" for provider "bar.3scale.localhost"
     When I follow "Act as" for account "foo.3scale.localhost"
-    # FIXME: after enabling javascript, the impersonation redirect does not work
-    # Then I should see "Signed in successfully"
-    # And I should be logged in as "impersonation_admin"
-    # And the current domain should be the admin domain of provider "foo.3scale.localhost"
+    Then the current domain in a new window should be admin.foo.3scale.localhost
+    And I should be logged in as "impersonation_admin"


### PR DESCRIPTION
**What this PR does / why we need it**:

The master portal allows impersonating users. To do this, it generates a token which expires in 10 minutes. This PR reduce the expiration time to 1 minute.

Read the Jira description and comments to get more details about this change.

**Which issue(s) this PR fixes**

[THREESCALE-11440](https://issues.redhat.com/browse/THREESCALE-11440)

**Verification steps**

The impersonation feature should work as usual.
