### PR TITLE
[THREESCALE-11399] presigned invoice PDF downloads

### DIFF
--- a/app/controllers/finance/api/invoices_controller.rb
+++ b/app/controllers/finance/api/invoices_controller.rb
@@ -21,7 +21,7 @@ class Finance::Api::InvoicesController < Finance::Api::BaseController
   # GET /api/invoices/{id}.xml
   def show
     respond_with(invoice) do |format|
-      format.pdf { redirect_to invoice.pdf.url }
+      format.pdf { redirect_to invoice.pdf.expiring_url }
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -270,11 +270,13 @@ module System
 
     require 'three_scale/deprecation'
     require 'three_scale/domain_substitution'
+    require 'three_scale/middleware/presigned_downloads'
     require 'three_scale/middleware/multitenant'
     require 'three_scale/middleware/cors'
     require 'three_scale/patterns/service'
 
     config.middleware.use ThreeScale::Middleware::Multitenant, :tenant_id unless ENV["DEBUG_DISABLE_TENANT_CHECK"] == "1"
+    config.middleware.insert_before ActionDispatch::Static, ThreeScale::Middleware::PresignedDownloads
     config.middleware.insert_before Rack::Runtime, Rack::UTF8Sanitizer
     config.middleware.insert_before(Rack::Runtime, Rack::XServedBy) if ENV["DEBUG_X_SERVED_BY"] == "1"
     config.middleware.insert_before 0, ThreeScale::Middleware::Cors if config.three_scale.cors.enabled

--- a/lib/three_scale/middleware/presigned_downloads.rb
+++ b/lib/three_scale/middleware/presigned_downloads.rb
@@ -16,7 +16,7 @@ module ThreeScale
         def requires_signing?(path)
           # for the used separator see https://github.com/rack/rack/pull/2257
           # question mark on first separator is paranoia of getting a relative path somehow
-          invoices_re = %r{#{RE_SEPARATOR}?system#{RE_SEPARATOR}.*#{RE_SEPARATOR}invoices#{RE_SEPARATOR}}
+          invoices_re = /#{RE_SEPARATOR}?system#{RE_SEPARATOR}.*#{RE_SEPARATOR}invoices#{RE_SEPARATOR}/
           path.start_with? invoices_re
         end
 

--- a/lib/three_scale/middleware/presigned_downloads.rb
+++ b/lib/three_scale/middleware/presigned_downloads.rb
@@ -4,6 +4,7 @@ module ThreeScale
   module Middleware
     class PresignedDownloads
       RE_SEPARATOR = ::File::SEPARATOR == "/" ? "/" : "[#{Regexp.escape(::File::SEPARATOR)}/]"
+      TIMESTAMP_FORMAT = "%Y%m%dT%H%M%S%Z"
 
       delegate *%i[requires_signing? good_signature? signature_at to_time], to: :class, private: true
 
@@ -28,7 +29,7 @@ module ThreeScale
         end
 
         def sign_at(path, expires_at)
-          expires_timestamp = to_timestamp(expires_at)
+          expires_timestamp = expires_at.strftime(TIMESTAMP_FORMAT)
           signature = signature_at(path, expires_at)
           params = { "3scale-Expires" => expires_timestamp, "3scale-Signature" => signature }.to_param
 
@@ -40,12 +41,8 @@ module ThreeScale
           verifier.generate(path.b, **signing_options).split("--").last
         end
 
-        def to_timestamp(time)
-          time.iso8601.gsub(/[-:]/, "")
-        end
-
         def to_time(timestamp)
-          Time.strptime(timestamp, "%Y%m%dT%H%M%S%Z") rescue Time.new(1970)
+          Time.strptime(timestamp, TIMESTAMP_FORMAT) rescue Time.new(1970)
         end
       end
 

--- a/lib/three_scale/middleware/presigned_downloads.rb
+++ b/lib/three_scale/middleware/presigned_downloads.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module ThreeScale
+  module Middleware
+    class PresignedDownloads
+      RE_SEPARATOR = ::File::SEPARATOR == "/" ? "/" : "[#{Regexp.escape(::File::SEPARATOR)}/]"
+
+      delegate *%i[requires_signing? good_signature? signature_at to_time], to: :class, private: true
+
+      class << self
+        def verifier
+          Rails.application.message_verifier("file downloads")
+        end
+
+        def requires_signing?(path)
+          # for the used separator see https://github.com/rack/rack/pull/2257
+          # question mark on first separator is paranoia of getting a relative path somehow
+          invoices_re = %r{#{RE_SEPARATOR}?system#{RE_SEPARATOR}.*#{RE_SEPARATOR}invoices#{RE_SEPARATOR}}
+          path.start_with? invoices_re
+        end
+
+        def sign_path_if_needed(path, expires_in = 3600)
+          requires_signing?(path) ? sign(path, expires_in) : path
+        end
+
+        def sign(path, expires_in = 3600)
+          sign_at(path, Time.now.utc.round + expires_in)
+        end
+
+        def sign_at(path, expires_at)
+          expires_timestamp = to_timestamp(expires_at)
+          signature = signature_at(path, expires_at)
+          params = { "3scale-Expires" => expires_timestamp, "3scale-Signature" => signature }.to_param
+
+          "#{path}?#{params}"
+        end
+
+        def signature_at(path, expires_at)
+          signing_options = { purpose: :download, expires_at: }
+          verifier.generate(path.b, **signing_options).split("--").last
+        end
+
+        def to_timestamp(time)
+          time.iso8601.gsub(/[-:]/, "")
+        end
+
+        def to_time(timestamp)
+          Time.strptime(timestamp, "%Y%m%dT%H%M%S%Z") rescue Time.new(1970)
+        end
+      end
+
+      def initialize(app)
+        @app = app
+        @file_handler = find_file_handler(app)
+      end
+
+      def call(env)
+        path = @file_handler.send(:clean_path, env["PATH_INFO"])
+
+        return [403, {}, ["Forbidden"]] if path && requires_signing?(path) && !good_signature?(env)
+
+        @app.call(env)
+      end
+
+      private
+
+      def good_signature?(env)
+        params = Rack::Utils.parse_query(env["QUERY_STRING"])
+        return false if params["3scale-Expires"].blank? || params["3scale-Signature"].blank?
+
+        expires_at = to_time(params["3scale-Expires"])
+        return false if expires_at < Time.now
+
+        params["3scale-Signature"] == signature_at(env["PATH_INFO"], expires_at)
+      end
+
+      def find_static_middleware(app)
+        raise "cannot find ActionDispatch::Static middleware in the chain" unless app
+        app.is_a?(ActionDispatch::Static) ? app : find_static_middleware(app.instance_variable_get("@app"))
+      end
+
+      def find_file_handler(app)
+        find_static_middleware(app).instance_variable_get("@file_handler") || \
+          raise("cannot find file handler")
+      end
+    end
+  end
+end

--- a/lib/three_scale/middleware/presigned_downloads.rb
+++ b/lib/three_scale/middleware/presigned_downloads.rb
@@ -5,6 +5,9 @@ module ThreeScale
     class PresignedDownloads
       RE_SEPARATOR = ::File::SEPARATOR == "/" ? "/" : "[#{Regexp.escape(::File::SEPARATOR)}/]"
       TIMESTAMP_FORMAT = "%Y%m%dT%H%M%S%Z"
+      PAST_TIME = Time.new(1970)
+
+      private_constant :PAST_TIME
 
       delegate *%i[requires_signing? good_signature? signature_at to_time], to: :class, private: true
 
@@ -42,7 +45,7 @@ module ThreeScale
         end
 
         def to_time(timestamp)
-          Time.strptime(timestamp, TIMESTAMP_FORMAT) rescue Time.new(1970)
+          Time.strptime(timestamp, TIMESTAMP_FORMAT) rescue PAST_TIME
         end
       end
 

--- a/test/integration/finance/api/invoices_test.rb
+++ b/test/integration/finance/api/invoices_test.rb
@@ -144,7 +144,7 @@ module Finance::Api
 
         assert_includes redirect_url, "/system/#{@provider.name}/invoices/#{@invoice.id}/pdfs/original/invoice-"
 
-        uri = URI.parse(response.header["Location"])
+        uri = URI.parse(redirect_url)
         get "#{uri.path}?#{uri.query}"
 
         assert_response :ok

--- a/test/integration/finance/api/invoices_test.rb
+++ b/test/integration/finance/api/invoices_test.rb
@@ -136,8 +136,19 @@ module Finance::Api
       end
 
       test 'redirect when asked for PDF' do
+        @invoice.generate_pdf!
         get "/api/#{@context}invoices/#{@invoice.id}.pdf?provider_key=#{@key}"
         assert_response :found
+
+        redirect_url = response.header["Location"]
+
+        assert_includes redirect_url, "/system/#{@provider.name}/invoices/#{@invoice.id}/pdfs/original/invoice-"
+
+        uri = URI.parse(response.header["Location"])
+        get "#{uri.path}?#{uri.query}"
+
+        assert_response :ok
+        assert_equal @invoice.pdf.size, response.body.size
       end
 
       test 'filter by month' do

--- a/test/integration/finance/invoice_download_test.rb
+++ b/test/integration/finance/invoice_download_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Finance::InvoiceDownloadTest < ActionDispatch::IntegrationTest
+  setup do
+    @invoice = FactoryBot.create(:invoice, state: :finalized)
+  end
+
+  teardown do
+    @invoice.pdf.clear
+    @invoice.save
+  end
+
+  test "can download only with the signed path" do
+    path, query = @invoice.pdf.expiring_url.split("?", 2)
+    invoice2 = FactoryBot.create(:invoice, state: :finalized)
+    wrong_path = invoice2.pdf.expiring_url.split("?", 2).first
+
+    get "#{wrong_path}?#{query}"
+    assert_response :forbidden
+
+    get "#{path}?#{query}"
+    assert_response :ok
+  ensure
+    invoice2&.pdf&.clear
+    invoice2&.save
+  end
+
+  test "can download only with correct signing parameters" do
+    get @invoice.pdf.url
+    assert_response :forbidden
+
+    path, query = @invoice.pdf.expiring_url.split("?", 2)
+    params = Rack::Utils.parse_query(query)
+
+    params_without_expiration = params.reject { _1 == "3scale-Expires" }
+    get "#{path}?#{params_without_expiration.to_param}"
+    assert_response :forbidden
+
+    params_without_signature = params.reject { _1 == "3scale-Signature" }
+    get "#{path}?#{params_without_signature.to_param}"
+    assert_response :forbidden
+
+    year_now = Time.now.utc.year
+    params_with_altered_time = params.dup
+    params_with_altered_time["3scale-Expires"] = params["3scale-Expires"].sub(year_now.to_s, (year_now + 1).to_s)
+    get "#{path}?#{params_with_altered_time.to_param}"
+    assert_response :forbidden
+
+    params_with_altered_time["3scale-Expires"] = "invalidtimestamp"
+    get "#{path}?#{params_with_altered_time.to_param}"
+    assert_response :forbidden
+
+    params_with_altered_sig = params.dup
+    params_with_altered_sig["3scale-Signature"] = params["3scale-Signature"].sub(/[^a]/, "a")
+    get "#{path}?#{params_with_altered_sig.to_param}"
+    assert_response :forbidden
+
+    params_with_altered_sig["3scale-Signature"][2] = "-" # invalid base64
+    get "#{path}?#{params_with_altered_sig.to_param}"
+    assert_response :forbidden
+
+    get "#{path}?#{params.to_param}"
+    assert_response :ok
+    assert_equal @invoice.pdf.size, response.body.size
+
+    travel_to(Time.now + 3602) do
+      get "#{path}?#{params.to_param}"
+      assert_response :forbidden
+    end
+  end
+
+  test "no cheating with path parsing" do
+    path, query = @invoice.pdf.expiring_url.split("?", 2)
+
+    # dunno how to test backslashes, null char and missing leading slash in path, use telnet
+    # telnet provider-admin.3scale.localhost 3000
+    # GET /system/provider-name/invoices/1/pdfs/original/invoice-october-2024.pdf HTTP/1.0
+    # Host: provider-admin.3scale.localhost:3000
+    evil_paths = %w[/./system/ /system/x/../ /../system/ /system%2f /system%2fx/..%2f /system/x/%2e%2e/]
+
+    evil_paths.all? do |replacement|
+      evil_path = path.sub %r{/system/}, replacement
+      get "#{evil_path}?#{query}"
+      assert_response :forbidden
+    end
+
+    other_evils = %w[/system%5c /syst%00em/]
+    other_evils.each do |replacement|
+      evil_path = path.sub %r{/system/}, "/system%5c"
+      assert_raise(ActionController::RoutingError) do
+        get "#{evil_path}?#{query}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
The middleware is installed before the `ActionDispatch::Static` middleware which actually serves the `public` folder.

It tries to use the same PATH_INFO pre-processing as `ActionDispatch::Static` so that we match against the same path it will be using later to serve files, thus avoiding path traversal issues. So we find the actual middleware instance.

If path is under the invoices directory, we require a valid signature. For that we use `Rails.application.message_verifier` to get a secure verifier for us.

To make the pre-signed URLs more user friendly, we put a human readable timestamp as `3scale-Expires` parameter. And since all signed information is just the timestamp and the path, we only pass the signature in the `3scale-Signature` query parameter, not the whole signed message. This makes the parameter vastly shorter.

To validate the signature, we regenerate the message based on the request path and query parameters and see if we get the same signature or a different one. If signature matches, then we are fine. Of course we also check whether the timestamp is in the future (i.e. URL has not expired).