### PR TITLE
THREESCALE-11439: Sign the CMS token

### DIFF
--- a/app/controllers/provider/admin/cms/visit_portal_controller.rb
+++ b/app/controllers/provider/admin/cms/visit_portal_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Provider::Admin::CMS::VisitPortalController < Provider::Admin::CMS::BaseController
+  # Encrypt the CMS token under a temporary SSO token and redirect to the Developer Portal
+  def with_token
+    cms_token = current_account.settings.cms_token!
+    expires_at = Time.now.utc.round + 1.minute
+    signature = CMS::Signature.generate(cms_token, expires_at)
+
+    redirect_to access_code_url(
+      host: current_account.external_domain,
+      signature:,
+      expires_at: expires_at.to_i,
+      access_code: current_account.site_access_code,
+      return_to:,
+      cms: cms_mode)
+  end
+
+  private
+
+  def return_to
+    params.permit(:return_to)[:return_to]
+  end
+
+  def cms_mode
+    session[:cms]
+  end
+end

--- a/app/helpers/cms/url_helper.rb
+++ b/app/helpers/cms/url_helper.rb
@@ -21,12 +21,8 @@ module CMS
     }.freeze
 
     def cms_uri(page)
-      uri = URI.parse(access_code_url)
-      uri.host = page.provider.external_domain
-      uri.query = { return_to: page.path ? page.path : HARD_WIRED_PATHS[page.system_name],
-                    access_code: current_account.site_access_code,
-                    cms_token: page.provider.settings.cms_token! }.to_query
-      uri.port = request.port if Rails.env.development?
+      uri = URI.parse(provider_admin_cms_visit_portal_path)
+      uri.query = { return_to: page.path ? page.path : HARD_WIRED_PATHS[page.system_name]}.to_query
       uri
     end
 

--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -150,7 +150,7 @@ module VerticalNavHelper
     end
 
     items << {id: 'separator 0'} # Separator
-    items << {title: 'Visit Portal', path: access_code_url(host: current_account.external_domain, cms_token: current_account.settings.cms_token!, access_code: current_account.site_access_code).html_safe, target: '_blank'}
+    items << {title: 'Visit Portal', path: provider_admin_cms_visit_portal_path.html_safe, target: '_blank'}
     items << {id: 'separator 1'} # Separator
 
     if can?(:manage, :portal)

--- a/app/lib/cms/signature.rb
+++ b/app/lib/cms/signature.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CMS
+  class Signature
+    def self.generate(token, expires_at)
+      verifier = Rails.application.message_verifier(:cms_token)
+      signing_options = { purpose: :cms_edit_mode, expires_at: expires_at.utc.floor }
+      verifier.generate(token.b, **signing_options).split("--").last
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -354,6 +354,7 @@ without fake Core server your after commit callbacks will crash and you might ge
           end
 
         end
+        get 'visit_portal' => 'visit_portal#with_token'
       end
 
       namespace :user do

--- a/features/developer_portal/cms_toolbar.feature
+++ b/features/developer_portal/cms_toolbar.feature
@@ -14,7 +14,7 @@ Feature: CMS Toolbar
     And go to the homepage
     Then there should not be a CMS toolbar
 
-  Scenario: Hide the toolbar
+  Scenario: Hide the toolbar when seeing drafts
     When they visit the developer portal in CMS mode
     And follow "Draft"
     And press "Toggle toolbar"
@@ -27,17 +27,22 @@ Feature: CMS Toolbar
     But they press "Toggle toolbar"
     And the cms toolbar should be visible
 
-  Scenario:
+  Scenario: Hide the toolbar when seeing published pages
     When they visit the developer portal in CMS mode
     And follow "Published"
     And follow "Close the CMS toolbar"
     Then there should not be a CMS toolbar
 
+  Scenario: Hide the toolbar when providing an expired signature
+    When they visit the developer portal in CMS mode with an expired signature
+    Then there should not be a CMS toolbar
+    And should see "Invalid or expired signature"
+
   Rule: There is a John Doe admin user
     Background:
       When the admin user is John Doe
 
-    Scenario: An admin visist de dev portal
+    Scenario: An admin visits the dev portal
       When they visit the developer portal in CMS mode
       Then the cms toolbar should be visible
       And should see "Templates used on this page"

--- a/features/step_definitions/developer_portal/cms_toolbar_steps.rb
+++ b/features/step_definitions/developer_portal/cms_toolbar_steps.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
-Given "they visit the developer portal in CMS mode" do
+Given /^they visit the developer portal in CMS mode(\swith an expired signature)?/ do |token_is_expired|
+  cms_token = @provider.settings.cms_token!
+  expires_at = Time.now.utc.round - 30.seconds
+  expires_at += 1.minute unless token_is_expired
+  signature = CMS::Signature.generate(cms_token, expires_at)
+
   visit access_code_url(host: @provider.external_domain,
                         cms: 'draft',
-                        cms_token: @provider.settings.cms_token!,
+                        expires_at: expires_at.to_i,
+                        signature:,
                         access_code: @provider.site_access_code)
 end
 

--- a/lib/developer_portal/app/controllers/developer_portal/access_codes_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/access_codes_controller.rb
@@ -30,7 +30,7 @@ class DeveloperPortal::AccessCodesController < ApplicationController
   private
 
   def cms_params
-    params.permit(:cms_token, :cms)
+    params.permit(:signature, :expires_at, :cms)
   end
 
   def return_url

--- a/lib/developer_portal/app/views/shared/cms/_toolbar.html.slim
+++ b/lib/developer_portal/app/views/shared/cms/_toolbar.html.slim
@@ -34,7 +34,7 @@ div class="pf-c-drawer pf-m-inline #{'pf-m-expanded' unless hidden}"
             div class="pf-c-drawer__actions" id="cms-toolbar-menu-right"
               div class="pf-c-drawer__close"
                 - unless draft
-                  a class="pf-c-button pf-m-plain" type="button" href=url_for(request.query_parameters.merge(cms_token: "")) title="Close the CMS toolbar"
+                  a class="pf-c-button pf-m-plain" type="button" href=url_for(request.query_parameters.merge(signature: "")) title="Close the CMS toolbar"
                     i class="fa fa-times-circle" aria-hidden="true"
 
         div class="pf-c-drawer__body"

--- a/test/integration/cms/toolbar_test.rb
+++ b/test/integration/cms/toolbar_test.rb
@@ -8,9 +8,12 @@ class CMS::ToolbarTest < ActionDispatch::IntegrationTest
   end
 
   test 'CMS toolbar rendering' do
+    cms_token = @provider.settings.cms_token!
+    expires_at = Time.now.utc.round + 1.minute
+    signature = CMS::Signature.generate(cms_token, expires_at)
     host! @provider.internal_domain
 
-    get "/?cms_token=#{@provider.settings.cms_token!}"
+    get "/", params: { expires_at: expires_at.to_i, signature: }
     assert_response :success
 
     get '/api_docs/login'


### PR DESCRIPTION
**What this PR does / why we need it**:

This might replace https://github.com/3scale/porta/pull/3932

To avoid sending the CMS token in the URL, this PR signs it and sends the signature instead. Then it signs the token again when the request is received, if the signature matches, then it enables the CMS edit mode. This way the actual CMS token never leaves the server.

See the Jira description and comments for more info.

**Which issue(s) this PR fixes** 

[THREESCALE-11439](https://issues.redhat.com/browse/THREESCALE-11439)

**Verification steps** 

1. Go to Audiende -> Developer Portal -> Visit Portal
2. The developer portal should load correctly and the CMS toolbar should be visible
3. Copy the URL that includes the token
4. Open a private window and paste the URL
5. The dev. portal should load correctly and the toolbar should be visible
6. Try to modify the signature or the timestamp
7. The dev. portal should load correctly, but you shouldn't see the toolbar.
8. Wait a minute for the token to expire
9. Open a private window and paste the URL
10. The dev. portal should load correctly, but you shouldn't see the toolbar.

**Notes for the reviewer**

The logic works but for some reason the tests fail because the verifier generates a completely different signature when given exactly the same parameters, which is weird. After being blocked for hours on this I decided to give up and ask for help.

For instance, try adding this trace in `lib/developer_portal/lib/cms/toolbar.rb` and `test/integration/cms/toolbar_test.rb`:

```
puts "verifier: #{verifier.inspect} params: {value: #{cms_token}, options: #{signing_options}}, secret_key_base: #{Rails.application.secret_key_base}. Result: #{signature}"
```

The trace shows how the same `verifier`, with the same `@secret`, generated from the same `secret_key_base`, receiving a call to `generate` with exactly the same parameters, leads to different result.

**UDPATE**: Solved, see https://github.com/3scale/porta/pull/3938#issuecomment-2461621231