### PR TITLE
THREESCALE-10245: Expirable access tokens

### DIFF
--- a/app/controllers/admin/api/access_tokens_controller.rb
+++ b/app/controllers/admin/api/access_tokens_controller.rb
@@ -22,7 +22,7 @@ class Admin::Api::AccessTokensController < Admin::Api::BaseController
   protected
 
   def access_token_params
-    params.require(:token).permit(:name, :permission, scopes: [])
+    params.require(:token).permit(:name, :permission, :expires_at, scopes: [])
   end
 
   def authorize_access_tokens

--- a/app/controllers/admin/api/personal/access_tokens_controller.rb
+++ b/app/controllers/admin/api/personal/access_tokens_controller.rb
@@ -39,6 +39,6 @@ class Admin::Api::Personal::AccessTokensController < Admin::Api::Personal::BaseC
   end
 
   def access_token_params
-    params.require(:token).permit(:name, :permission, scopes: [])
+    params.require(:token).permit(:name, :permission, :expires_at, scopes: [])
   end
 end

--- a/app/lib/api_authentication/by_access_token.rb
+++ b/app/lib/api_authentication/by_access_token.rb
@@ -105,7 +105,15 @@ module ApiAuthentication
     def authenticated_token
       return @authenticated_token if instance_variable_defined?(:@authenticated_token)
 
-      @authenticated_token = domain_account.access_tokens.find_from_value(access_token) if access_token
+      given_token = access_token
+
+      return if given_token.blank?
+
+      token = domain_account.access_tokens.find_from_value(given_token)
+
+      return if token.blank? || token.expired?
+
+      @authenticated_token = token
     end
 
     def enforce_access_token_permission(&block)

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -159,4 +159,8 @@ class AccessToken < ApplicationRecord
   def self.random_id
     SecureRandom.hex(32)
   end
+
+  def expired?
+    expires_at.present? && expires_at < Time.now.utc
+  end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -100,7 +100,7 @@ class AccessToken < ApplicationRecord
 
   after_initialize :generate_value
 
-  attr_accessible :owner, :name, :scopes, :permission
+  attr_accessible :owner, :name, :scopes, :permission, :expires_at
 
   attr_readonly :value
 

--- a/app/representers/access_token_representer.rb
+++ b/app/representers/access_token_representer.rb
@@ -11,5 +11,6 @@ class AccessTokenRepresenter < ThreeScale::Representer
   property :name
   property :scopes
   property :permission
+  property :expires_at
   property :value, if: :show_value?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -516,7 +516,7 @@ without fake Core server your after commit callbacks will crash and you might ge
       get 'objects/status' => 'objects#status', as: :objects_status, controller: :objects, defaults: { format: :json }
 
       namespace :personal, defaults: { format: :json } do
-        resources :access_tokens, except: %i[new edit]
+        resources :access_tokens, except: %i[new edit update]
       end
 
       # /admin/api/provider

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -3006,6 +3006,12 @@
                         "policy_registry"
                       ]
                     }
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Expiration time of the access token. In ISO 8601 format",
+                    "example": "2030-01-01T12:00:00Z"
                   }
                 },
                 "required": [
@@ -7149,6 +7155,12 @@
                         "policy_registry"
                       ]
                     }
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Expiration time of the access token. In ISO 8601 format",
+                    "example": "2030-01-01T12:00:00Z"
                   }
                 },
                 "required": [

--- a/test/integration/api/access_tokens_test.rb
+++ b/test/integration/api/access_tokens_test.rb
@@ -50,6 +50,18 @@ class Admin::Api::AccessTokensTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'create accepts an expiration time' do
+    access_token = FactoryBot.create(:access_token, owner: @admin, scopes: %w[account_management])
+
+    user_id = @admin.id
+    expires_at = 1.day.from_now.utc.iso8601
+    assert_difference(AccessToken.method(:count), 1) do
+      post_request(user_id, {access_token: access_token.value}, { expires_at: })
+      assert_response :created, "Not created with response body #{response.body}"
+    end
+    assert_equal expires_at, AccessToken.last!.expires_at.iso8601
+  end
+
   test 'create with provider_key can create for any user of that account' do
     FactoryBot.create(:cinstance, service: master_account.default_service, user_account: @provider)
 

--- a/test/integration/api/personal/access_tokens_test.rb
+++ b/test/integration/api/personal/access_tokens_test.rb
@@ -95,6 +95,15 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
       end
     end
 
+    test 'POST accepts an expiration time' do
+      expires_at = 1.day.from_now.utc.iso8601
+      assert_difference @admin.access_tokens.method(:count) do
+        create_access_token(access_token: admin_access_token.value, params: access_token_params({ expires_at: }))
+        assert_response :created
+        assert_equal expires_at, JSON.parse(response.body).dig('access_token', 'expires_at')
+      end
+    end
+
     def assert_it_worked(_access_token = nil)
       assert_response :created
       created_token = AccessToken.last

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -175,6 +175,42 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert_equal expected_audited_changes, audit.audited_changes
   end
 
+  test 'expiration time is not mandatory' do
+    access_token = FactoryBot.build(:access_token)
+
+    assert access_token.valid?
+  end
+
+  test "expiration time can be blank" do
+    access_token = FactoryBot.build(:access_token, expires_at: '')
+
+    assert access_token.valid?
+  end
+
+  test "expiration time can be nil" do
+    access_token = FactoryBot.build(:access_token, expires_at: nil)
+
+    assert access_token.valid?
+  end
+
+  test "expiration time can't be invalid" do
+    access_token = FactoryBot.build(:access_token, expires_at: 'invalid')
+
+    assert_not access_token.valid?
+  end
+
+  test "expiration time can't be in the past" do
+    access_token = FactoryBot.build(:access_token, expires_at: 1.day.ago.utc.iso8601)
+
+    assert_not access_token.valid?
+  end
+
+  test "expiration time accepts a valid ISO 8601 datetime" do
+    access_token = FactoryBot.build(:access_token, expires_at: 1.year.from_now.utc.iso8601)
+
+    assert access_token.valid?
+  end
+
   private
 
   def assert_access_token_audit_all_data(access_token, audit)

--- a/test/unit/api_authentication/by_authentication_token_test.rb
+++ b/test/unit/api_authentication/by_authentication_token_test.rb
@@ -22,7 +22,7 @@ class ApiAuthentication::ByAuthenticationTokenTest < SimpleMiniTest
 
   def mock_token(attributes = {})
     @params = { access_token: 'some-token' }
-    token = mock('access-token', attributes)
+    token = mock('access-token', attributes.merge(expired?: false))
     @access_tokens.expects(:find_from_value).with('some-token').returns(token)
     token
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the backend to add an expiration date to access tokens.

The PR doesn't include the UI, I plan to do that in another PR.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10245

**Verification steps** 

Since there's no UI, you need to update the DB column manually to verify the behavior:

Query examples (MySQL):

```sql
update access_tokens set expires_at = NOW() where id = 3 

update access_tokens set expires_at = DATE_ADD(NOW(), INTERVAL 10 SECOND) where id = 3

update access_tokens set expires_at = DATE_ADD(NOW(), INTERVAL 2 HOUR) where id = 3

update access_tokens set expires_at = NULL  where id = 3 
```
