### PR TITLE
Fix missing slash in app key allowed characters hint

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1550,7 +1550,7 @@ en:
       cinstance:
         intentions: "Please describe briefly your intentions of use of this service"
         user_key: "Allowed characters: [A-Z a-z 0-9 - _ .], or Base64 format without forward slash (/), no spaces and up to 256 characters."
-        key: "Allowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
+        key: "Allowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
 
       cms:
         page:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1549,8 +1549,8 @@ en:
 
       cinstance:
         intentions: "Please describe briefly your intentions of use of this service"
-        user_key: "Allowed characters: [A-Z a-z 0-9 - _ .], or Base64 format without forward slash (/), no spaces and up to 256 characters."
-        key: "Allowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
+        user_key: "Allowed characters: A-Z a-z 0-9 - _ . or Base64 format without forward slash (/), no spaces and up to 256 characters."
+        key: "Allowed characters: A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~ , no spaces and between 5 and 255 characters."
 
       cms:
         page:

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -1186,7 +1186,7 @@
                   },
                   "key": {
                     "type": "string",
-                    "description": "app_key to be added.\n\nAllowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
+                    "description": "app_key to be added.\n\nAllowed characters: A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~ , no spaces and between 5 and 255 characters."
                   }
                 },
                 "required": [
@@ -10035,15 +10035,15 @@
           },
           "user_key": {
             "type": "string",
-            "description": "User Key (API Key) of the application to be created.\n\nAllowed characters: [A-Z a-z 0-9 - _ .], or Base64 format without forward slash (/), no spaces and up to 256 characters.",
+            "description": "User Key (API Key) of the application to be created.\n\nAllowed characters: A-Z a-z 0-9 - _ . or Base64 format without forward slash (/), no spaces and up to 256 characters.",
             "x-data-threescale-name": "user_keys"
           },
           "application_id": {
             "type": "string",
-            "description": "App ID or Client ID (for OAuth and OpenID Connect authentication modes) of the application to be created.\n\nAllowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters."
+            "description": "App ID or Client ID (for OAuth and OpenID Connect authentication modes) of the application to be created.\n\nAllowed characters: A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~ , no spaces and between 5 and 255 characters."
           },
           "application_key": {
-            "description": "App Key or Client Secret (for OAuth and OpenID Connect authentication modes) of the application to be created.\n\nAllowed characters: [A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~], no spaces and between 5 and 255 characters.",
+            "description": "App Key or Client Secret (for OAuth and OpenID Connect authentication modes) of the application to be created.\n\nAllowed characters: A-Z a-z 0-9 ! \" # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \\ ] ^ _ ` { | } ~ , no spaces and between 5 and 255 characters.",
             "type": "string"
           },
           "redirect_url": {


### PR DESCRIPTION
**What this PR does / why we need it**:

Making sure that the backslash `\` appears in the list of the valid characters for the application key:

![image](https://github.com/user-attachments/assets/43066dd4-50c7-4e30-8f0d-1829dd77fd96)

That character is supported according to https://github.com/3scale/porta/blob/26743e8b360e4c8c7fcae370a721c3ed5e1f9b00/app/models/application_key.rb#L15-L17

**Which issue(s) this PR fixes** 


**Verification steps** 


**Special notes for your reviewer**:
