### PR TITLE
THREESCALE-10245: access tokens expiration UI

### DIFF
--- a/app/controllers/provider/admin/user/access_tokens_controller.rb
+++ b/app/controllers/provider/admin/user/access_tokens_controller.rb
@@ -1,44 +1,57 @@
-class Provider::Admin::User::AccessTokensController < Provider::Admin::User::BaseController
-  inherit_resources
-  defaults route_prefix: 'provider_admin_user', resource_class: AccessToken
-  actions :index, :new, :create, :edit, :update, :destroy
+# frozen_string_literal: true
 
-  authorize_resource
-  activate_menu :account, :personal, :tokens
-  before_action :authorize_access_tokens
-  before_action :disable_client_cache
+module Provider
+  module Admin
+    module User
+      class AccessTokensController < BaseController
+        inherit_resources
+        defaults route_prefix: 'provider_admin_user', resource_class: AccessToken
+        actions :index, :new, :create, :edit, :update, :destroy
 
-  def create
-    create! do |success, _failure|
-      success.html do
-        flash[:token] = @access_token.id
-        flash[:notice] = 'Access Token was successfully created.'
-        redirect_to(collection_url)
+        authorize_resource
+        activate_menu :account, :personal, :tokens
+        before_action :authorize_access_tokens
+        before_action :disable_client_cache
+
+        def new
+          @presenter = AccessTokensNewPresenter.new(current_account)
+        end
+
+        def create
+          @presenter = AccessTokensNewPresenter.new(current_account)
+          create! do |success, _failure|
+            success.html do
+              flash[:token] = @access_token.id
+              flash[:notice] = 'Access Token was successfully created.'
+              redirect_to(collection_url)
+            end
+          end
+        end
+
+        def index
+          index!
+          @last_access_key = flash[:token]
+        end
+
+        def update
+          update! do |success, _failure|
+            success.html do
+              flash[:notice] = 'Access Token was successfully updated.'
+              redirect_to(collection_url)
+            end
+          end
+        end
+
+        private
+
+        def authorize_access_tokens
+          authorize! :manage, :access_tokens, current_user
+        end
+
+        def begin_of_association_chain
+          current_user
+        end
       end
     end
-  end
-
-  def index
-    index!
-    @last_access_key = flash[:token]
-  end
-
-  def update
-    update! do |success, _failure|
-      success.html do
-        flash[:notice] = 'Access Token was successfully updated.'
-        redirect_to(collection_url)
-      end
-    end
-  end
-
-  private
-
-  def authorize_access_tokens
-    authorize! :manage, :access_tokens, current_user
-  end
-
-  def begin_of_association_chain
-    current_user
   end
 end

--- a/app/javascript/packs/expiration_date_picker.ts
+++ b/app/javascript/packs/expiration_date_picker.ts
@@ -1,0 +1,21 @@
+import { ExpirationDatePickerWrapper } from 'AccessTokens/components/ExpirationDatePicker'
+import { safeFromJsonString } from 'utilities/json-utils'
+
+import type { Props } from 'AccessTokens/components/ExpirationDatePicker'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const containerId = 'expiration-date-picker-container'
+  const container = document.getElementById(containerId)
+
+  if (!container) {
+    throw new Error(`Missing container with id "${containerId}"`)
+  }
+
+  const props = safeFromJsonString<Props>(container.dataset.props)
+
+  if (!props) {
+    throw new Error('Missing props')
+  }
+
+  ExpirationDatePickerWrapper(props, containerId)
+})

--- a/app/javascript/src/AccessTokens/components/ExpirationDatePicker.scss
+++ b/app/javascript/src/AccessTokens/components/ExpirationDatePicker.scss
@@ -1,0 +1,15 @@
+@import '~@patternfly/patternfly/patternfly-addons.css';
+
+.pf-c-calendar-month,
+.pf-c-form-control-expiration {
+  width: 50%;
+}
+
+.pf-c-form-control-expiration {
+  margin-right: 1em;
+}
+
+button.pf-c-form__group-label-help {
+  min-width: auto;
+  width: auto;
+}

--- a/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx
+++ b/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react'
+import {
+  Alert,
+  CalendarMonth,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Popover
+} from '@patternfly/react-core'
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon'
+
+import { createReactWrapper } from 'utilities/createReactWrapper'
+
+import type { FunctionComponent } from 'react'
+
+import './ExpirationDatePicker.scss'
+
+interface ExpirationItem {
+  id: string;
+  label: string;
+  period: number; // In days
+}
+
+const collection: ExpirationItem[] = [
+  { id: '7', label: '7 days', period: 7 },
+  { id: '30', label: '30 days', period: 30 },
+  { id: '60', label: '60 days', period: 60 },
+  { id: '90', label: '90 days', period: 90 },
+  { id: 'custom', label: 'Custom...', period: 0 },
+  { id: 'no-exp', label: 'No expiration', period: 0 }
+]
+
+const today: Date = new Date()
+const tomorrow: Date = new Date(today)
+tomorrow.setDate(today.getDate() + 1)
+const dayMs = 60 * 60 * 24 * 1000
+
+const computeDropdownDate = (dropdownSelectedItem: ExpirationItem) => {
+  if (dropdownSelectedItem.period === 0) return null
+
+  return new Date(today.getTime() + dropdownSelectedItem.period * dayMs)
+}
+
+const computeSelectedDate = (dropdownDate: Date | null, dropdownSelectedItem: ExpirationItem, calendarPickedDate: Date) => {
+  if (dropdownDate) return dropdownDate
+
+  return dropdownSelectedItem.id === 'custom' ? calendarPickedDate : null
+}
+
+const computeFormattedDateValue = (selectedDate: Date | null) => {
+  if (!selectedDate) return ''
+
+  const formatter = Intl.DateTimeFormat('en-US', {
+    month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric', hour12: false
+  })
+
+  return formatter.format(selectedDate)
+}
+
+const computeFieldHint = (formattedDateValue: string) => {
+  if (!formattedDateValue) return
+
+  return `The token will expire on ${formattedDateValue}`
+}
+
+const computeTzMismatch = (tzOffset: number) => {
+  // Timezone offset in the same format as ActiveSupport
+  const jsTzOffset = new Date().getTimezoneOffset() * -60
+
+  return jsTzOffset !== tzOffset
+}
+
+const computeTzMismatchIcon = (tzMismatch: boolean) => {
+  if (!tzMismatch) return
+
+  return (
+    <Popover
+      bodyContent={(
+        <p>
+            Your local time zone differs from the account settings.
+            The token will expire at the time you selected in your local time zone.
+        </p>
+      )}
+      headerContent={(
+        <span>Time zone mismatch</span>
+      )}
+    >
+      <button
+        aria-describedby="form-group-label-info"
+        aria-label="Time zone mismatch warning"
+        className="pf-c-form__group-label-help"
+        type="button"
+      >
+        <ExclamationTriangleIcon noVerticalAlign />
+      </button>
+    </Popover>
+  )
+}
+
+interface Props {
+  id: string;
+  label: string | null;
+  tzOffset: number;
+}
+
+const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label, tzOffset }) => {
+  const [dropdownSelectedItem, setDropdownSelectedItem] = useState(collection[0])
+  const [calendarPickedDate, setCalendarPickedDate] = useState(tomorrow)
+
+  const dropdownDate = computeDropdownDate(dropdownSelectedItem)
+  const selectedDate = computeSelectedDate(dropdownDate, dropdownSelectedItem, calendarPickedDate)
+  const formattedDateValue = computeFormattedDateValue(selectedDate)
+  const fieldHint = computeFieldHint(formattedDateValue)
+  const tzMismatch = computeTzMismatch(tzOffset)
+  const tzMismatchIcon = computeTzMismatchIcon(tzMismatch)
+  const inputDateValue = selectedDate ? selectedDate.toISOString() : ''
+  const fieldName = `human_${id}`
+  const fieldLabel = label ?? 'Expires in'
+
+  const handleOnChange = (value: string) => {
+    const selected = collection.find(i => i.id === value) ?? null
+
+    if (selected === null) return
+
+    setDropdownSelectedItem(selected)
+    setCalendarPickedDate(tomorrow)
+  }
+
+  const dateValidator = (date: Date): boolean => {
+    return date >= today
+  }
+
+  return (
+    <>
+      <FormGroup
+        isRequired
+        fieldId={fieldName}
+        helperText={fieldHint}
+        label={fieldLabel}
+        labelIcon={tzMismatchIcon}
+      >
+        <FormSelect
+          className="pf-c-form-control-expiration"
+          id={fieldName}
+          value={dropdownSelectedItem.id}
+          onChange={handleOnChange}
+        >
+          {collection.map((item: ExpirationItem) => {
+            return (
+              <FormSelectOption
+                key={item.id}
+                label={item.label}
+                value={item.id}
+              />
+            )
+          })}
+        </FormSelect>
+      </FormGroup>
+      <input id={id} name={id} type="hidden" value={inputDateValue} />
+      {dropdownSelectedItem.id === 'custom' && (
+        <CalendarMonth className="pf-u-mt-md" date={calendarPickedDate} validators={[dateValidator]} onChange={setCalendarPickedDate} />
+      )}
+      {!selectedDate && (
+        <Alert className="pf-u-mt-md" title="Expiration is recommended" variant="warning">
+          It is strongly recommended that you set an expiration date for your token to help keep your information
+          secure
+        </Alert>
+      )}
+    </>
+  )
+}
+
+// eslint-disable-next-line react/jsx-props-no-spreading
+const ExpirationDatePickerWrapper = (props: Props, containerId: string): void => { createReactWrapper(<ExpirationDatePicker {...props} />, containerId) }
+
+export type { ExpirationItem, Props }
+export { ExpirationDatePicker, ExpirationDatePickerWrapper }

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -140,7 +140,7 @@ class AccessToken < ApplicationRecord
   def expires_at=(value)
     return if value.blank?
 
-    DateTime.strptime(value)
+    DateTime.parse(value)
 
     super value
   rescue StandardError

--- a/app/presenters/provider/admin/user/access_tokens_new_presenter.rb
+++ b/app/presenters/provider/admin/user/access_tokens_new_presenter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Provider::Admin::User::AccessTokensNewPresenter
+
+  def initialize(provider)
+    @timezone = ActiveSupport::TimeZone.new(provider.timezone)
+  end
+
+  def provider_timezone_offset
+    @timezone.utc_offset
+  end
+
+  def date_picker_props
+    {
+      id: 'access_token[expires_at]',
+      label: I18n.t('access_token_options.expires_in'),
+      tzOffset: provider_timezone_offset
+    }
+  end
+end

--- a/app/views/provider/admin/user/access_tokens/_form.html.slim
+++ b/app/views/provider/admin/user/access_tokens/_form.html.slim
@@ -2,8 +2,19 @@
                     input_html: { autofocus: true }
 
 = form.input :scopes, as: :patternfly_check_boxes,
-                      collection: @access_token.available_scopes.to_collection_for_check_boxes
+                      collection: access_token.available_scopes.to_collection_for_check_boxes
 
 = form.input :permission, as: :patternfly_select,
-                          collection: @access_token.available_permissions,
+                          collection: access_token.available_permissions,
                           include_blank: false
+
+- if access_token.persisted?
+  .pf-c-form__group
+    .pf-c-form__group-label
+      label.pf-c-form__label
+        span.pf-c-form__label-text
+          = t('access_token_options.expires_at')
+    .pf-c-form__group-control
+      = access_token.expires_at.present? ? l(access_token.expires_at) : t('access_token_options.no_expiration')
+- else
+  div id='expiration-date-picker-container' data-props=date_picker_props.to_json

--- a/app/views/provider/admin/user/access_tokens/edit.html.slim
+++ b/app/views/provider/admin/user/access_tokens/edit.html.slim
@@ -8,7 +8,7 @@ div class="pf-c-card"
     = semantic_form_for @access_token, builder: Fields::PatternflyFormBuilder,
                                        url: [:provider, :admin, :user, @access_token],
                                        html: { class: 'pf-c-form pf-m-limit-width' } do |f|
-      = render 'form', form: f
+      = render partial: 'form', locals: { form: f, access_token: @access_token }
 
       = f.actions do
         = f.commit_button t('.submit_button_label')

--- a/app/views/provider/admin/user/access_tokens/index.html.slim
+++ b/app/views/provider/admin/user/access_tokens/index.html.slim
@@ -34,6 +34,13 @@
         div class="pf-c-description-list__group"
           dt class="pf-c-description-list__term"
             span class="pf-c-description-list__text"
+              | Expires at
+          dd class="pf-c-description-list__description"
+            div class="pf-c-description-list__text"
+              = token.expires_at.present? ? l(token.expires_at) : t('access_token_options.no_expiration')
+        div class="pf-c-description-list__group"
+          dt class="pf-c-description-list__term"
+            span class="pf-c-description-list__text"
               | Token
           dd class="pf-c-description-list__description"
             div class="pf-c-description-list__text"
@@ -58,6 +65,7 @@
         tr role="row"
           th role="columnheader" scope="col" Name
           th role="columnheader" scope="col" Scopes
+          th role="columnheader" scope="col" Expiration
           th role="columnheader" scope="col" Permission
           th role="columnheader" scope="col" class="pf-c-table__action pf-m-fit-content"
             = fancy_link_to 'Add Access Token', new_provider_admin_user_access_token_path, class: 'new' if allowed_scopes.any?
@@ -67,6 +75,7 @@
             tr role="row"
               td role="cell" data-label="Name" = token.name
               td role="cell" data-label="Scopes" = token.human_scopes.to_sentence
+              td role="cell" data-label="Expiration" = token.expires_at.present? ? l(token.expires_at) : t('access_token_options.no_expiration')
               td role="cell" data-label="Permission" = token.human_permission
               td role="cell" class="pf-c-table__action"
                 div class="pf-c-overflow-menu"

--- a/app/views/provider/admin/user/access_tokens/new.html.slim
+++ b/app/views/provider/admin/user/access_tokens/new.html.slim
@@ -1,14 +1,14 @@
 - content_for :page_header_title, t('.page_header_title')
 
 - content_for :javascripts do
-  = javascript_packs_with_chunks_tag 'pf_form'
+  = javascript_packs_with_chunks_tag 'pf_form', 'expiration_date_picker'
 
 div class="pf-c-card"
   div class="pf-c-card__body"
     = semantic_form_for @access_token, builder: Fields::PatternflyFormBuilder,
                                        url: [:provider, :admin, :user, @access_token],
                                        html: { class: 'pf-c-form pf-m-limit-width' } do |f|
-      = render 'form', form: f
+      = render partial: 'form', locals: { form: f, access_token: @access_token, date_picker_props: @presenter.date_picker_props }
 
       = f.actions do
         = f.commit_button t('.submit_button_label')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,9 @@ en:
     cms: 'Developer Portal API'
     ro: 'Read Only'
     rw: 'Read & Write'
+    no_expiration: 'Never expires'
+    expires_at: 'Expires at'
+    expires_in: 'Expires in'
   notification_category_titles:
     account: 'Accounts'
     application: 'Applications'

--- a/features/provider/admin/user/access_tokens.feature
+++ b/features/provider/admin/user/access_tokens.feature
@@ -24,9 +24,9 @@ Feature: Provider Admin Access tokens
 
     Scenario: Tokens are listed in a table
       Then the table should contain the following:
-        | Name   | Scopes        | Permission   |
-        | Potato | Analytics API | Read Only    |
-        | Banana | Billing API   | Read & Write |
+        | Name   | Scopes        | Expiration     | Permission   |
+        | Potato | Analytics API | Never expires  | Read Only    |
+        | Banana | Billing API   | Never expires  | Read & Write |
 
   Rule: New page
     Background:
@@ -42,6 +42,7 @@ Feature: Provider Admin Access tokens
       Then there is a required field "Name"
       And there is a required field "Scopes"
       And there is a required field "Permission"
+      And there is a required field "Expires in"
       And the submit button is enabled
 
     Scenario: Create access tokens without required fields
@@ -49,26 +50,29 @@ Feature: Provider Admin Access tokens
       Then field "Name" has inline error "can't be blank"
       And field "Scopes" has inline error "select at least one scope"
       And field "Permission" has no inline error
+      And field "Expires in" has no inline error
 
     Scenario: Create access token
       When they press "Create Access Token"
       And the form is submitted with:
-        | Name          | LeToken      |
-        | Analytics API | Yes          |
-        | Permission    | Read & Write |
+        | Name          | LeToken       |
+        | Analytics API | Yes           |
+        | Permission    | Read & Write  |
+        | Expires in    | No expiration |
       Then the current page is the personal tokens page
       And they should see the flash message "Access token was successfully created"
       And should see the following details:
-        | Name       | LeToken       |
-        | Scopes     | Analytics API |
-        | Permission | Read & Write  |
+        | Name       | LeToken        |
+        | Scopes     | Analytics API  |
+        | Permission | Read & Write   |
+        | Expires at | Never expires  |
       And there should be a link to "I have copied the token"
 
   Rule: Edit page
     Background:
       Given the provider has the following access tokens:
-        | Name    | Scopes                     | Permission |
-        | LeToken | Billing API, Analytics API | Read Only  |
+        | Name    | Scopes                     | Permission | Expires at            |
+        | LeToken | Billing API, Analytics API | Read Only  | 2030-01-01T00:00:00Z  |
       And they go to the access token's edit page
 
     Scenario: Navigation to edit page

--- a/spec/javascripts/AccessTokens/components/ExpirationDatePicker.spec.tsx
+++ b/spec/javascripts/AccessTokens/components/ExpirationDatePicker.spec.tsx
@@ -1,0 +1,156 @@
+import { mount } from 'enzyme'
+
+import { ExpirationDatePicker } from 'AccessTokens/components/ExpirationDatePicker'
+
+import type { ExpirationItem, Props } from 'AccessTokens/components/ExpirationDatePicker'
+import type { ReactWrapper } from 'enzyme'
+
+const msExp = /\.\d{3}Z$/
+
+const defaultProps: Props = {
+  id: 'expires_at',
+  label: 'Expires in',
+  tzOffset: 0
+}
+
+const mountWrapper = (props: Partial<Props> = {}) => mount(<ExpirationDatePicker {...{ ...defaultProps, ...props }} />)
+
+const selectItem = (wrapper: ReactWrapper<any, Readonly<object>>, item: ExpirationItem) => {
+  wrapper.find('select.pf-c-form-control-expiration option').forEach((op) => {
+    const elem: HTMLOptionElement = op.getDOMNode()
+    elem.selected = elem.value === item.id // Mark option as selected if it's value matches the given one
+  })
+  wrapper.find('select.pf-c-form-control-expiration').simulate('change')
+}
+
+const pickDate = (wrapper: ReactWrapper<any, Readonly<object>>) => {
+  /*
+   * Pick tomorrow, to do so, we get the date selected by default which is today and click the next one.
+   * It could happen that today is the last day in the calendar, in that case we pick the previous day, yesterday.
+   * In any case, we return the picked date to the caller.
+   */
+  const targetDate = new Date()
+  targetDate.setHours(0)
+  targetDate.setMinutes(0)
+  targetDate.setSeconds(0)
+  targetDate.setMilliseconds(0)
+
+  const tomorrowButton = wrapper.find('.pf-m-selected > button')
+
+  tomorrowButton.simulate('click')
+  targetDate.setDate(targetDate.getDate() + 1)
+  return targetDate
+}
+
+const dateFormatter = Intl.DateTimeFormat('en-US', {
+  month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric', hour12: false
+})
+
+it('should render itself', () => {
+  const wrapper = mountWrapper()
+  expect(wrapper.exists()).toEqual(true)
+})
+
+describe('select a period', () => {
+  const targetItem: ExpirationItem = { id: '90', label: '90 days', period: 90 }
+
+  it('should update hint to the correct date', () => {
+    const wrapper = mountWrapper()
+    const targetDate = new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * targetItem.period)
+    const expectedHint = `The token will expire on ${dateFormatter.format(targetDate)}`
+
+    selectItem(wrapper, targetItem)
+    const hint = wrapper.find('.pf-c-form__helper-text').text()
+
+    expect(hint).toBe(expectedHint)
+  })
+
+  it('should update hidden input value to the correct timestamp', () => {
+    const wrapper = mountWrapper()
+    const targetDate = new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * targetItem.period)
+    const expectedValue = targetDate.toISOString().replace(msExp, 'Z')
+
+    selectItem(wrapper, targetItem)
+    const value = (wrapper.find(`input#${defaultProps.id}`).prop('value') as string).replace(msExp, 'Z')
+
+    expect(value).toBe(expectedValue)
+  })
+})
+
+describe('select "Custom"', () => {
+  const targetItem: ExpirationItem = { id: 'custom', label: 'Custom...', period: 0 }
+
+  it('should show a calendar', () => {
+    const wrapper = mountWrapper()
+
+    selectItem(wrapper, targetItem)
+    const calendar = wrapper.find('.pf-c-calendar-month')
+
+    expect(calendar.exists()).toBe(true)
+  })
+
+  describe('pick a date from the calendar', () => {
+    it('should update hint to the correct date', () => {
+      const wrapper = mountWrapper()
+
+      selectItem(wrapper, targetItem)
+      const targetDate = pickDate(wrapper)
+      const expectedHint = `The token will expire on ${dateFormatter.format(targetDate)}`
+      const hint = wrapper.find('.pf-c-form__helper-text').text()
+
+      expect(hint).toBe(expectedHint)
+    })
+
+    it('should update hidden input value to the correct timestamp', () => {
+      const wrapper = mountWrapper()
+
+      selectItem(wrapper, targetItem)
+      const targetDate = pickDate(wrapper)
+      const expectedValue = targetDate.toISOString().replace(msExp, 'Z')
+      const value = (wrapper.find(`input#${defaultProps.id}`).prop('value') as string).replace(msExp, 'Z')
+
+      expect(value).toBe(expectedValue)
+    })
+  })
+})
+
+describe('select "No expiration"', () => {
+  const targetItem: ExpirationItem = { id: 'no-exp', label: 'No expiration', period: 0 }
+
+  it('should show a warning', () => {
+    const wrapper = mountWrapper()
+
+    selectItem(wrapper, targetItem)
+    const warning = wrapper.find('.pf-c-alert.pf-m-warning')
+
+    expect(warning.exists()).toBe(true)
+  })
+
+  it('should update hidden input value to empty', () => {
+    const wrapper = mountWrapper()
+    const expectedValue = ''
+
+    selectItem(wrapper, targetItem)
+    const value = wrapper.find(`input#${defaultProps.id}`).prop('value')
+
+    expect(value).toBe(expectedValue)
+  })
+})
+
+describe('time zone matches', () => {
+  it('should not show a warning', ()=> {
+    jest.spyOn(Date.prototype, 'getTimezoneOffset').mockImplementation(() => (0))
+    const wrapper = mountWrapper()
+
+    expect(wrapper.exists('.pf-c-form__group-label-help')).toEqual(false)
+  })
+})
+
+describe('time zone mismatches', () => {
+  it('should show a warning', ()=> {
+    jest.spyOn(Date.prototype, 'getTimezoneOffset').mockImplementation(() => (-120))
+    const wrapper = mountWrapper()
+
+    expect(wrapper.exists('.pf-c-form__group-label-help')).toEqual(true)
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

After we merged https://github.com/3scale/porta/pull/3939 now we want to update the Access Tokens screens to add a new field for the expiration date. For this, I created a new React component based on what Github does:

- A select input with the next options:
  - Expires in 7 days
  - In 30 days
  - In 60 days
  - In 90 days
  - Custom date
    - A calendar appears to select the desired date
  - No expiration
    - An warn is shown to advise the user to set an expiration date for security reasons

**Which issue(s) this PR fixes** 

[THREESCALE-10245](https://issues.redhat.com/browse/THREESCALE-10245)

**Verification steps** 

Just set the an expiration date when creating a token and verify the data is correctly stored in DB and is properly shown in `#index` and `#edit` screens

**Screenshots**

![image](https://github.com/user-attachments/assets/709abd43-9741-4a7b-b67d-5bfcd9f64443)
----
![image](https://github.com/user-attachments/assets/b230da5d-8a17-4616-8c38-a8cb3e83c29d)
----
![image](https://github.com/user-attachments/assets/358f5f5f-a645-44c7-a59f-7cd5530e4b14)
