### PR TITLE
Disable 'Send empty value' checkbox by default

### DIFF
--- a/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
+++ b/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
@@ -9,6 +9,8 @@ import { autocompleteRequestInterceptor } from 'ActiveDocs/OAS3Autocomplete'
 import type { AccountDataResponse, ApiDocsServices, BackendApiReportBody, BackendApiTransaction, BodyValue, BodyValueObject, FormData } from 'Types/SwaggerTypes'
 import type { ExecuteData } from 'swagger-client/es/execute'
 import type { SwaggerUIPlugin } from 'swagger-ui'
+import type { Component } from 'react'
+import type { SwaggerUIContext, ParameterIncludeEmptyProperties } from 'swagger-ui-utils'
 
 const getApiSpecUrl = (baseUrl: string, specPath: string): string => {
   return `${baseUrl.replace(/\/$/, '')}${specPath}`
@@ -121,9 +123,10 @@ const RequestBodyTransformerPlugin: SwaggerUIPlugin = () => {
 const UncheckSendEmptyValuePlugin: SwaggerUIPlugin = () => {
   return {
     wrapComponents: {
-      ParameterIncludeEmpty: (Original: any, {React}: any) => (props: { isIncludedOptions: { defaultValue: boolean } }) => {
-        props.isIncludedOptions.defaultValue = false;
-        return React.createElement(Original, props)
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      ParameterIncludeEmpty: (originalComponent: Component, { React }: SwaggerUIContext ) => function ParameterIncludeEmptyWrapped (props: ParameterIncludeEmptyProperties) {
+        props.isIncludedOptions.defaultValue = false
+        return React.createElement(originalComponent, props)
       }
     }
   }

--- a/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
+++ b/app/javascript/src/ActiveDocs/ThreeScaleApiDocs.ts
@@ -118,6 +118,17 @@ const RequestBodyTransformerPlugin: SwaggerUIPlugin = () => {
   }
 }
 
+const UncheckSendEmptyValuePlugin: SwaggerUIPlugin = () => {
+  return {
+    wrapComponents: {
+      ParameterIncludeEmpty: (Original: any, {React}: any) => (props: { isIncludedOptions: { defaultValue: boolean } }) => {
+        props.isIncludedOptions.defaultValue = false;
+        return React.createElement(Original, props)
+      }
+    }
+  }
+}
+
 export const renderSwaggerUI = async (container: HTMLElement, apiDocsPath: string, baseUrl: string, accountDataUrl: string): Promise<void> => {
   const apiSpecs: ApiDocsServices = await fetchData<ApiDocsServices>(apiDocsPath)
 
@@ -134,7 +145,7 @@ export const renderSwaggerUI = async (container: HTMLElement, apiDocsPath: strin
       requestInterceptor: (request) => autocompleteRequestInterceptor(request, accountData, ''),
       tryItOutEnabled: true,
       plugins: [
-        RequestBodyTransformerPlugin
+        RequestBodyTransformerPlugin, UncheckSendEmptyValuePlugin
       ]
     })
   })

--- a/app/javascript/src/Types/swagger.d.ts
+++ b/app/javascript/src/Types/swagger.d.ts
@@ -25,3 +25,22 @@ declare module 'swagger-client/es/execute' {
   function execute (req: ExecuteData): unknown
   export { execute }
 }
+
+declare module 'swagger-ui-utils' {
+  import type { Component } from 'react'
+
+  export interface ReactType {
+    createElement: (Original: Component, props: ParameterIncludeEmptyProperties) => Component;
+  }
+
+  export interface SwaggerUIContext {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    React: ReactType;
+  }
+
+  export interface ParameterIncludeEmptyProperties {
+    isIncludedOptions: {
+      defaultValue: boolean;
+    };
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets the "Send empty value" checkbox on the 3scale API docs to disabled state by default.

**Which issue(s) this PR fixes** 

This was part of the wishlist on https://issues.redhat.com/browse/THREESCALE-9599

**Verification steps** 

Open some request on 3scale API docs, and see that "Send empty value" is unchecked by default.

**Special notes for your reviewer**:

Just taken this from https://github.com/swagger-api/swagger-ui/issues/6505#issuecomment-1206651563 not sure whether it's right, but seems to be doing the trick.
