### PR TITLE
THREESCALE-10245: Migration: add `expires_at` to `access_tokens`

### DIFF
--- a/db/migrate/20241107134140_add_expires_at_to_access_tokens.rb
+++ b/db/migrate/20241107134140_add_expires_at_to_access_tokens.rb
@@ -1,0 +1,7 @@
+class AddExpiresAtToAccessTokens < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction! if System::Database.postgres?
+
+  def change
+    add_column :access_tokens, :expires_at, :datetime
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_26_111800) do
+ActiveRecord::Schema.define(version: 2024_11_07_134140) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id", precision: 38, null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2024_07_26_111800) do
     t.integer "tenant_id", precision: 38
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.datetime "expires_at", precision: 6
   end
 
   create_table "accounts", force: :cascade do |t|

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_26_111800) do
+ActiveRecord::Schema.define(version: 2024_11_07_134140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2024_07_26_111800) do
     t.bigint "tenant_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "expires_at"
   end
 
   create_table "accounts", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_26_111800) do
+ActiveRecord::Schema.define(version: 2024_11_07_134140) do
 
   create_table "access_tokens", charset: "utf8mb3", collation: "utf8mb3_bin", force: :cascade do |t|
     t.bigint "owner_id", null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2024_07_26_111800) do
     t.bigint "tenant_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "expires_at"
     t.index ["owner_id"], name: "idx_auth_tokens_of_user"
     t.index ["value", "owner_id"], name: "idx_value_auth_tokens_of_user", unique: true
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

Comes from https://github.com/3scale/porta/pull/3939. The migration must be deployed first or we'll have a downtime when we deploy the code that uses this new column.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10245

**Verification steps** 

If tests pass I'd say we are good.
