### PR TITLE
THREESCALE-11498: API plans features

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -93,13 +93,10 @@ class Plan < ApplicationRecord
     plan.has_many :plan_metrics, foreign_key: :plan_id, &Logic::MetricVisibility::OfMetricAssociationProxy
   end
 
-  has_many :features_plans, :as => :plan
-
-  # FIXME: this should be a simple HABTM
-  # No it can't, because it is POLYMORPHIC
-  has_many :features, :through => :features_plans do
-    # returns all features owned by issuer, not only enabled by plan
-    def of_service
+  has_many :features_plans, as: :plan, dependent: :delete_all
+  has_many :features, through: :features_plans do # Only enabled features
+    # returns all features available for this plan, not only enabled ones
+    def all_available
       owner = proxy_association.owner
       owner.issuer.features.with_object_scope(owner)
     end

--- a/app/views/api/plans/_features.html.erb
+++ b/app/views/api/plans/_features.html.erb
@@ -15,13 +15,13 @@
 
     <tbody>
 
-      <tr class="notice" <%= "style=display:none;" unless @plan.features.of_service.empty? -%>>
+      <tr class="notice" <%= "style=display:none;" unless @plan.features.all_available.empty? -%>>
         <td colspan="4">
           <span>This plan has no features yet.</span>
         </td>
       </tr>
 
-      <%= render :partial => 'api/features/feature', :collection => @plan.features.of_service %>
+      <%= render :partial => 'api/features/feature', :collection => @plan.features.all_available %>
     </tbody>
   </table>
 </div>

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -3121,7 +3121,7 @@
     "/admin/api/account_plans/{account_plan_id}/features.xml": {
       "get": {
         "summary": "Account Plan Features List",
-        "description": "Returns the list of the features associated to an account plan.",
+        "description": "Returns the list of the features enabled for an account plan.",
         "tags": [
           "Account Plans"
         ],
@@ -3152,12 +3152,10 @@
             "content": {}
           }
         }
-      }
-    },
-    "/admin/api/account_plans/{account_plan_id}/features/{id}.xml": {
+      },
       "post": {
-        "summary": "Account Plan Features Create",
-        "description": "Associate an account feature to an account plan.",
+        "summary": "Account Plan Feature Enable",
+        "description": "Enables an account feature on an account plan.",
         "tags": [
           "Account Plans"
         ],
@@ -3167,15 +3165,6 @@
             "in": "path",
             "description": "ID of the account plan.",
             "x-data-threescale-name": "account_plan_ids",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of the feature.",
             "required": true,
             "schema": {
               "type": "integer"
@@ -3192,10 +3181,15 @@
                   "access_token": {
                     "type": "string",
                     "description": "A personal Access Token."
+                  },
+                  "feature_id": {
+                    "type": "integer",
+                    "description": "ID of the feature."
                   }
                 },
                 "required": [
-                  "access_token"
+                  "access_token",
+                  "feature_id"
                 ]
               }
             }
@@ -3207,10 +3201,12 @@
             "content": {}
           }
         }
-      },
+      }
+    },
+    "/admin/api/account_plans/{account_plan_id}/features/{id}.xml": {
       "delete": {
-        "summary": "Account Plan Features Delete",
-        "description": "Deletes the association of an account feature to an account plan.",
+        "summary": "Account Plan Feature Disable",
+        "description": "Disables an account feature on an account plan.",
         "tags": [
           "Account Plans"
         ],
@@ -3680,7 +3676,7 @@
     "/admin/api/application_plans/{application_plan_id}/features.xml": {
       "get": {
         "summary": "Application Plan Feature List",
-        "description": "Returns the list of features of the application plan.",
+        "description": "Returns the list of features enabled on the application plan.",
         "tags": [
           "Application Plans"
         ],
@@ -3713,8 +3709,8 @@
         }
       },
       "post": {
-        "summary": "Application Plan Feature Create",
-        "description": "Associates a feature to an application plan.",
+        "summary": "Application Plan Feature Enable",
+        "description": "Enables a feature on an application plan.",
         "tags": [
           "Application Plans"
         ],
@@ -3764,8 +3760,8 @@
     },
     "/admin/api/application_plans/{application_plan_id}/features/{id}.xml": {
       "delete": {
-        "summary": "Application Plan Feature Delete",
-        "description": "Removes the association of a feature to an application plan.",
+        "summary": "Application Plan Feature Disable",
+        "description": "Disable a feature on an application plan.",
         "tags": [
           "Application Plans"
         ],
@@ -7384,7 +7380,7 @@
     "/admin/api/service_plans/{service_plan_id}/features.xml": {
       "get": {
         "summary": "Service Plan Feature List",
-        "description": "Returns the list of features of a service plan.",
+        "description": "Returns the list of features enabled on a service plan.",
         "tags": [
           "Service Plans"
         ],
@@ -7417,8 +7413,8 @@
         }
       },
       "post": {
-        "summary": "Service Plan Feature Add",
-        "description": "Associates an existing feature to a service plan.",
+        "summary": "Service Plan Feature Enable",
+        "description": "Enables an existing feature on a service plan.",
         "tags": [
           "Service Plans"
         ],
@@ -7468,8 +7464,8 @@
     },
     "/admin/api/service_plans/{service_plan_id}/features/{id}.xml": {
       "delete": {
-        "summary": "Service Plan Features Delete",
-        "description": "Removes the association of a feature to a service plan.",
+        "summary": "Service Plan Feature Disable",
+        "description": "Disables a feature on a service plan.",
         "tags": [
           "Service Plans"
         ],

--- a/test/integration/user-management-api/service_features_test.rb
+++ b/test/integration/user-management-api/service_features_test.rb
@@ -39,7 +39,7 @@ class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
 
     xml = Nokogiri::XML::Document.parse(@response.body)
 
-    assert_all_features_of_service xml, service
+    assert_all_features_available xml, service
   end
 
   test 'show' do

--- a/test/test_helpers/xml_assertions.rb
+++ b/test/test_helpers/xml_assertions.rb
@@ -183,7 +183,7 @@ module TestHelpers
       assert xml.xpath('.//plan/cancellation_period').presence
     end
 
-    def assert_all_features_of_service(xml, service)
+    def assert_all_features_available(xml, service)
       assert xml.xpath('.//features/feature/service_id').presence
       assert xml.xpath('.//features/feature/service_id')
         .all? { |service_id| service_id.text == service.id.to_s }


### PR DESCRIPTION
**What this PR does / why we need it**:

The plan features API is a bit messy. For instance, AFAIK there's no endpoints to create or remove features for a plan, they must be created and deleted from the UI. The API only allows enabling or disabling features previously created from the UI. These are the endpoints:


1. GET /admin/api/account_plans/:account_plan_id/features(.:format)
   - Returns the enabled features 
3. POST /admin/api/account_plans/:account_plan_id/features(.:format)
   - Enables a feature
   - It must receive `feature_id` as query param or form data
   - Returns 200 on success
   - Returns 409 when the feature was already enabled
   - Returns 404 when the plan doesn't exist or the plan exists but the feature doesn't exists for that plan
5. DELETE /admin/api/account_plans/:account_plan_id/features/:id(.:format)
   - Disables a feature
   - Takes the feature ID from the path, not in parameters like in the enabling endpoint
   - 200 on success
   - 404 when the endpoint was already disabled
   - 404 when the plan doesn't exists or the feature doesn't exist for the plan

I find this inconsistent and confusing. I guess we need to keep it as it is to avoid breaking changes, but it'd be good if we create a new API for this, at some point... in the future...

In this PR I'm making a few changes:

1. I renamed a scope and rewrote some comments to make clear in the code which association returns all available features and which one only returns the enabled ones: https://github.com/3scale/porta/pull/3949/commits/a5d6b40c08f42f50b2fdfa3a9d30ea9a850ee8a2
2. I fixed the Open API spec for Account Plans Features endpoints. It was wrong and it included a new endpoint which doesn't exist: `POST /admin/api/account_plans/:account_plan_id/features/:id(.:format)`
I modified to be `POST /admin/api/account_plans/:account_plan_id/features` which exists and it's the correct one to enable features. https://github.com/3scale/porta/pull/3949/commits/d1b1d00dacac2be64fdf84c60ac2f1b04806369c
3.  I also renamed the same endpoints for Service and Application plans, to explicitly mention enabling and disabling: https://github.com/3scale/porta/pull/3949/commits/60739a78cc1c4b460e2ee16b1c64759f835d594b

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11498


