### PR TITLE
Some suggestions for access token expiration selector

### DIFF
--- a/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx
+++ b/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx
@@ -32,8 +32,11 @@ interface Props {
 }
 
 const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label }) => {
+  const today: Date = new Date()
+  const tomorrow: Date = new Date(today)
+  tomorrow.setDate(today.getDate() + 1)
   const [selectedItem, setSelectedItem] = useState(collection[0])
-  const [pickedDate, setPickedDate] = useState(new Date())
+  const [pickedDate, setPickedDate] = useState(tomorrow)
   const fieldName = `human_${id}`
   const fieldLabel = label ?? 'Expires in'
 
@@ -42,15 +45,6 @@ const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label }) => {
 
     return new Date(new Date().getTime() + selectedItem.period * dayMs)
   }, [selectedItem])
-
-  const fieldHint = useMemo(() => {
-    if (!fieldDate) return
-
-    const date = new Date(fieldDate)
-    date.setHours(0, 0, 0, 0)
-
-    return `The token will expire on ${date.toLocaleDateString()}`
-  }, [fieldDate])
 
   const dateValue = useMemo(() => {
     let value = ''
@@ -64,6 +58,14 @@ const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label }) => {
     return value
   }, [fieldDate, selectedItem, pickedDate])
 
+  const fieldHint = useMemo(() => {
+    if (!dateValue) return
+
+    const date = new Date(dateValue)
+
+    return `The token will expire on ${date.toString()}`
+  }, [dateValue])
+
   const handleOnChange = (_value: string, event: FormEvent<HTMLSelectElement>) => {
     const value = (event.target as HTMLSelectElement).value
     const selected = collection.find(i => i.id.toString() === value) ?? null
@@ -71,7 +73,11 @@ const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label }) => {
     if (selected === null) return
 
     setSelectedItem(selected)
-    setPickedDate(new Date())
+    setPickedDate(tomorrow)
+  }
+
+  const dateValidator = (date: Date): boolean => {
+    return date >= new Date()
   }
 
   return (
@@ -80,6 +86,7 @@ const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label }) => {
         isRequired
         fieldId={fieldName}
         label={fieldLabel}
+        helperText={fieldHint}
       >
         <FormSelect
           className="pf-c-form-control-expiration"
@@ -97,16 +104,11 @@ const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label }) => {
             )
           })}
         </FormSelect>
-        <span className="pf-c-form-control-expiration-hint">{fieldHint}</span>
       </FormGroup>
       <input id={id} name={id} type="hidden" value={dateValue} />
-      {selectedItem.id === 5 && (
-        <>
-          <br />
-          <CalendarMonth date={pickedDate} onChange={setPickedDate} />
-          <br />
-        </>
-      )}
+      {selectedItem.id === 5 &&
+        <CalendarMonth date={pickedDate} onChange={setPickedDate} validators={[dateValidator]}/>
+      }
       {dateValue === '' && (
         <>
           <br />

--- a/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx
+++ b/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx
@@ -43,7 +43,7 @@ const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label }) => {
   const fieldDate = useMemo(() => {
     if (selectedItem.period === 0) return null
 
-    return new Date(new Date().getTime() + selectedItem.period * dayMs)
+    return new Date(today.getTime() + selectedItem.period * dayMs)
   }, [selectedItem])
 
   const dateValue = useMemo(() => {
@@ -77,7 +77,7 @@ const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label }) => {
   }
 
   const dateValidator = (date: Date): boolean => {
-    return date >= new Date()
+    return date >= today
   }
 
   return (

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -9,7 +9,7 @@ class AccessToken < ApplicationRecord
 
   serialize :scopes, Array
 
-  audited only: %i[owner_id scopes name permission created_at updated_at]
+  audited only: %i[owner_id scopes name permission crfeated_at updated_at]
 
   delegate :provider_id_for_audits, to: :owner
 


### PR DESCRIPTION
While reviewing https://github.com/3scale/porta/pull/3943 I saw some things that I thought could be improved, but I was not sure exactly what would be a better way, so I played around a bit.

Probably not everything should be applied, but can be considered as food for thought.

![Screenshot from 2024-12-03 23-19-04](https://github.com/user-attachments/assets/35361e9f-033b-4095-bded-10ee1543d559)

Mainly the changes are:
- Using helper text (under the select) instead of the custom `span` element to the right (which dos not look very Patternfly-y). The drawback is that when the select is expanded, the value is not seen, but I think it doesn't matter.
- Changing the formatting of the "current value". Not sure it's a nice one (probably too long), but I think it's clear, and it also includes timestamp (but not sure if needed)
- When the date is selected via picker, the selected value is also shown now.
- The default value when using "Custom..." is set to tomorro
- The past dates are not pickable in the date picker.

In addition to the last item, it would probably be nice to add an error message when the expiration is set to some time in the past. With this validator it is probably not that relevant, but if the past dates were esasily pickable, an error message saying that past dates can't be selected would be nice (but not required).