### PR TITLE
Fix a duplicated header for inbox message

### DIFF
--- a/app/views/provider/admin/messages/inbox/show.html.erb
+++ b/app/views/provider/admin/messages/inbox/show.html.erb
@@ -1,5 +1,3 @@
-<% content_for :page_header_title, 'Message' %>
-
 <%= render 'provider/admin/messages/message', :message => @message %>
 
 <% if @reply %>


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a tiny fix that removes the double title.

**Before:**
![Screenshot from 2024-12-18 15-22-20](https://github.com/user-attachments/assets/01aa91da-4e4f-4817-a77e-c15afd4d45cb)


**After:**

![Screenshot from 2024-12-18 15-24-26](https://github.com/user-attachments/assets/219cba66-fbde-4347-9cce-8ec5626590d7)

**Which issue(s) this PR fixes** 

none

**Verification steps** 



**Special notes for your reviewer**:
