### PR TITLE
🧶 Fix `http-proxy-middleware` to `2.0.7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "yaml-loader": "^0.6.0"
   },
   "resolutions": {
+    "http-proxy-middleware": "2.0.7",
     "jquery-ui/jquery": "3.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6547,7 +6547,7 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@^2.0.3:
+http-proxy-middleware@2.0.7, http-proxy-middleware@^2.0.3:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz#915f236d92ae98ef48278a95dedf17e991936ec6"
   integrity sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==


### PR DESCRIPTION
[THREESCALE-11549: CVE-2024-21536 3scale-amp-system-container: Denial of Service [3amp-2.14]](https://issues.redhat.com/browse/THREESCALE-11549)

By specifying "resolutions" we force yarn to install that fixed version for 3rd party dependencies, even though in this case webpack has a loose dependency: `^2.0.3`.