### PR TITLE
Fix incorrect member permission service

### DIFF
--- a/test/unit/abilities/provider_any_test.rb
+++ b/test/unit/abilities/provider_any_test.rb
@@ -32,6 +32,7 @@ module Abilities
 
     test 'Cinstance/Application events can show if has :partners and access to the service if there is a service' do
       service = FactoryBot.create(:simple_service, account: @account)
+      another_service = FactoryBot.create(:simple_service, account: @account)
       plan = FactoryBot.create(:simple_application_plan, issuer: service)
       cinstance = FactoryBot.create(:cinstance, plan: plan)
       cinstance_events = [
@@ -45,7 +46,7 @@ module Abilities
 
         assert_cannot ability, :show, cinstance_event
 
-        user.member_permission_service_ids = [FactoryBot.create(:cinstance).id]
+        user.member_permission_service_ids = [another_service.id]
 
         assert_cannot ability, :show, cinstance_event
 


### PR DESCRIPTION
Fixing a bug introduced in https://github.com/3scale/porta/pull/3929

The test was randomly failing with:
```
User can show #<Cinstances::CinstancePlanChangedEvent:0x00007fcf9c94d3d8> but should not
/opt/ci/workdir/test/test_helper.rb:68:in `assert_cannot'
/opt/ci/workdir/test/unit/abilities/provider_any_test.rb:50:in `block (2 levels) in <class:ProviderAnyTest>'
```
Because... why would a Cinstance ID be provided to a Services IDs list? :upside_down_face: 

Obviously, the Cinstance ID may coincide with the service ID, causing a wrong behavior.