### PR TITLE
Fix RSpecs for Proxy API

### DIFF
--- a/spec/acceptance/api/proxy_spec.rb
+++ b/spec/acceptance/api/proxy_spec.rb
@@ -10,6 +10,9 @@ resource 'Proxy' do
     get '/admin/api/services/:service_id/proxy.:format', action: :show
 
     put '/admin/api/services/:service_id/proxy.:format', action: :update do
+      # stubbing the subscriber to avoid changing the 'updated_at' timestamp on Proxy
+      before { allow_any_instance_of(ProxyConfigEventSubscriber).to receive(:call) }
+
       parameter :credentials_location, 'Credentials Location'
       parameter :api_backend, 'Private endpoint'
       parameter :jwt_claim_with_client_id, 'JWT Claim with ClientID Location'

--- a/test/unit/finance/billing_strategy_test.rb
+++ b/test/unit/finance/billing_strategy_test.rb
@@ -78,7 +78,7 @@ class Finance::BillingStrategyTest < ActiveSupport::TestCase
     canaries = FactoryBot.create_list(:provider_with_billing, 4).map(&:id)
     ThreeScale.config.payments.expects(:billing_canaries).at_least_once.returns(canaries)
 
-    Finance::BillingStrategy.expects(:daily_async).with { |scope| assert_equal canaries, scope.pluck(:account_id) }.returns(true)
+    Finance::BillingStrategy.expects(:daily_async).with { |scope| assert_same_elements canaries, scope.pluck(:account_id) }.returns(true)
     assert Finance::BillingStrategy.daily_canaries
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the RSpec for API update, which has intermittent failures.
I believe this has been broken since https://github.com/3scale/porta/pull/3953/files

The issue is that any API spec test [compares](https://github.com/3scale/porta/blob/c982bdcb0f21444b75c7304680b011c31d355bd5/spec/api_helper.rb#L51) the API response (`response_body`) to the serialized version of the resource (`serialized`). And in this case the resource is Proxy, and the problem is that the `updated_at` in the serialized resource and in the response body do not coincide.

The reason is because the flow is:
1. the resource (proxy) is updated via API and a response is returned. This response has a timestamp, say `15:00:00`.
2. after the response is returned, the `ProxyConfigs::AffectingObjectChangedEvent` triggers another update on the proxy (via `touch`), which updates `updated_at` again, and sets it to, say `15:00:01`
3. When the `serialized` is called, it uses the latest version of the resource (in this case, I think it's also because `resource.reload` is called in the test), so, `15:00:01`, while the `response_body` still has the old `15:00:00` timestamp.

Of course it can happen, that all steps occur within the same second, then the test will pass.

This PR stubs `ProxyConfigEventSubscriber#call` to prevent the event from "touching" the Proxy and hence updating the `updated_at` field.

**Which issue(s) this PR fixes** 

-

**Verification steps** 


**Special notes for your reviewer**:
