### PR TITLE
Increase Capybara timeout for Oracle tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,7 @@ build-envs:
     environment:
       DB: oracle
       DATABASE_URL: oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb
+      CAPYBARA_MAX_WAIT_TIME: 20
 
 ##################################### CIRCLECI COMMANDS ############################################
 

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -10,7 +10,7 @@ Capybara.configure do |config|
   config.match = :prefer_exact
   config.javascript_driver = :headless_chrome
   config.always_include_port = true
-  config.default_max_wait_time = 10
+  config.default_max_wait_time = ENV.fetch('CAPYBARA_MAX_WAIT_TIME', 10).to_i
   config.server = :webrick # default is `:default` (which uses puma)
 end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Oracle tests are slower, so sometimes the default 10 seconds is not enough to find for the desired HTML elements in Cucumber tests.
This PR increases the default wait timeout only for Oracle.

**Which issue(s) this PR fixes** 

-

**Verification steps** 

-

**Special notes for your reviewer**:
