### PR TITLE
Refactor deprecations in Cucumber tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ build-envs:
     environment:
       DB: oracle
       DATABASE_URL: oracle-enhanced://rails:railspass@127.0.0.1:1521/systempdb
-      CAPYBARA_MAX_WAIT_TIME: 20
+      CAPYBARA_MAX_WAIT_TIME: 30
 
 ##################################### CIRCLECI COMMANDS ############################################
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "features/**/*"
+  - "test/**/*"
+  - "spec/**/*"

--- a/features/api/alerts.feature
+++ b/features/api/alerts.feature
@@ -51,7 +51,8 @@ Feature: Audience > Applications > Alerts
 
   Scenario: Deleting alerts
     Given they go to the alerts page
-    When they press "Delete" in the 1st row and confirm the dialog
+    When they press "Delete" in the 1st row
+    And confirm the dialog
     Then they should see the following table:
       | Account | Application   | Message        | Level   | Time (UTC)               |              |
       | Jane    | Application 1 | foos: 18 of 20 | ≥ 90 %  | 14 Oct 2010 11:11:00 UTC | Delete\nRead |
@@ -60,7 +61,8 @@ Feature: Audience > Applications > Alerts
 
   Scenario: Marking all alerts as read
     Given they go to the alerts page
-    When they select toolbar action "Mark all as read" and confirm the dialog
+    When they select toolbar action "Mark all as read"
+    And confirm the dialog
     Then they should see the following table:
       | Account | Application   | Message        | Level   | Time (UTC)               |        |
       | Jane    | Application 1 | foos: 30 of 20 | ≥ 150 % | 15 Oct 2010 14:14:00 UTC | Delete |
@@ -70,5 +72,6 @@ Feature: Audience > Applications > Alerts
 
   Scenario: Deleting all alerts
     Given they go to the alerts page
-    When they select toolbar action "Delete all" and confirm the dialog
+    When they select toolbar action "Delete all"
+    And confirm the dialog
     Then they should see "All clear"

--- a/features/api/application_plans/metrics_methods_limits_rules.feature
+++ b/features/api/application_plans/metrics_methods_limits_rules.feature
@@ -9,7 +9,6 @@ Feature: Application plan Metrics, Methods, Limits & Pricing Rules
     And the following application plan:
       | Product    | Name | Default |
       | Dice rolls | Free | true    |
-    # And the provider has plans ready for signups
     And the product has the following metrics:
       | Friendly name    |
       | Single rolls     |

--- a/features/api/backend_usages/index.feature
+++ b/features/api/backend_usages/index.feature
@@ -46,7 +46,8 @@ Feature: Product > Integration > Backends
 
     Scenario: Deleting a backend config
       When they go to the backends of product "My API"
-      And follow "Delete config with Backend 1" and confirm the dialog
+      And follow "Delete config with Backend 1"
+      And confirm the dialog
       Then they should see the flash message "The Backend was removed from the Product"
       And should see the following table:
         | Name      | Private base URL          | Public path |

--- a/features/api/metrics/edit.feature
+++ b/features/api/metrics/edit.feature
@@ -25,7 +25,8 @@ Feature: Product > Integration > Metrics > Edit
 
     Scenario: Deleting a method
       Given they go to the edit page of method "Carbonara"
-      When they follow "Delete" and confirm the dialog
+      When they follow "Delete"
+      And confirm the dialog
       Then should see the flash message "The method was deleted"
       And should not see method "Carbonara"
 
@@ -50,7 +51,8 @@ Feature: Product > Integration > Metrics > Edit
 
     Scenario: Deleting a metric
       Given they go to the edit page of metric "Pasta"
-      When they follow "Delete" and confirm the dialog
+      When they follow "Delete"
+      And confirm the dialog
       Then should see the flash message "The metric was deleted"
       And should not see metric "Pasta"
 
@@ -61,6 +63,7 @@ Feature: Product > Integration > Metrics > Edit
     Scenario: Cannot delete a metric used in the latest gateway configuration
       Given metric "Pasta" is used in the latest gateway configuration
       When they go to the edit page of metric "Pasta"
-      And follow "Delete" and confirm the dialog
+      And follow "Delete"
+      And confirm the dialog
       Then should see the flash message "Metric is used by the latest gateway configuration and cannot be deleted"
       And should see metric "Pasta"

--- a/features/api/services/alerts.feature
+++ b/features/api/services/alerts.feature
@@ -56,7 +56,8 @@ Feature: Product > Analytics > Alerts
 
   Scenario: Deleting alerts
     Given they go to the alerts of "My Product"
-    When they press "Delete" in the 1st row and confirm the dialog
+    When they press "Delete" in the 1st row
+    And confirm the dialog
     Then they should see the following table:
       | Account | Application | Message        | Level   | Time (UTC)               |              |
       | Bob     | Bob App     | foos: 18 of 20 | ≥ 90 %  | 14 Oct 2010 11:11:00 UTC | Delete\nRead |
@@ -65,7 +66,8 @@ Feature: Product > Analytics > Alerts
 
   Scenario: Marking all alerts as read
     Given they go to the alerts of "My Product"
-    When they select toolbar action "Mark all as read" and confirm the dialog
+    When they select toolbar action "Mark all as read"
+    And confirm the dialog
     Then they should see the following table:
       | Account | Application | Message        | Level   | Time (UTC)               |        |
       | Bob     | Bob App     | foos: 30 of 20 | ≥ 150 % | 15 Oct 2010 14:14:00 UTC | Delete |
@@ -75,5 +77,6 @@ Feature: Product > Analytics > Alerts
 
   Scenario: Deleting all alerts
     Given they go to the alerts of "My Product"
-    When they select toolbar action "Delete all" and confirm the dialog
+    When they select toolbar action "Delete all"
+    And confirm the dialog
     Then they should see "All clear"

--- a/features/api/services/applications/new.feature
+++ b/features/api/services/applications/new.feature
@@ -3,7 +3,7 @@ Feature: Product > Applications > New
 
   Background:
     Given a provider
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And a product "My API"
     And the following application plan:
       | Product | Name  |
@@ -97,7 +97,7 @@ Feature: Product > Applications > New
 
   Rule: Multiple applications denied
     Background:
-      Given the provider has multiple applications disabled
+      Given the provider has "multiple_applications" denied
 
     Scenario: Manual navigation
       Given they go to product "My API" applications page

--- a/features/buyers/accounts/applications/new.feature
+++ b/features/buyers/accounts/applications/new.feature
@@ -3,7 +3,7 @@ Feature: Audience > Accounts > Listing > Account > Applications > New
 
   Background:
     Given a provider
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And a product "My API"
     And the following application plan:
       | Product | Name  |
@@ -98,7 +98,7 @@ Feature: Audience > Accounts > Listing > Account > Applications > New
 
   Rule: Multiple applications denied
     Background:
-      Given the provider has multiple applications disabled
+      Given the provider has "multiple_applications" denied
 
     Scenario: Manual navigation
       Given they go to buyer "Jane" applications page

--- a/features/buyers/accounts/bulk_operations.feature
+++ b/features/buyers/accounts/bulk_operations.feature
@@ -88,7 +88,8 @@ Feature: Buyer accounts bulk operations
       And select bulk action "Send email"
       And fill in "Subject" with "This is the subject"
       And fill in "Body" with "This is the body"
-      And press "Send" and confirm the dialog
+      And press "Send"
+      And confirm the dialog
       Then I should see "Successfully sent 2 emails."
       Then "alice@example.com" should receive 1 email
       Then "bob@example.com" should receive 1 email
@@ -106,7 +107,8 @@ Feature: Buyer accounts bulk operations
       And item "Bob" is selected
       And select bulk action "Change account plan"
       And select "Awesome" from "Plan"
-      And press "Change plan" and confirm the dialog
+      And press "Change plan"
+      And confirm the dialog
       Then should see "Successfully changed the plan of 2 accounts"
       And the table should contain the following:
         | Group/Org.    | Plan    |
@@ -127,7 +129,8 @@ Feature: Buyer accounts bulk operations
       And item "Bob" is selected
       And select bulk action "Change state"
       And select "Make pending" from "Action"
-      And press "Change state" and confirm the dialog within the modal
+      And press "Change state" within the modal
+      And confirm the dialog
       Then should see "Successfully changed the state of 2 accounts"
       And the table should contain the following:
         | Group/Org.    | State    |
@@ -143,7 +146,8 @@ Feature: Buyer accounts bulk operations
       And select bulk action "Send email"
       And fill in "Subject" with "Error"
       And fill in "Body" with "This will fail"
-      And press "Send" and confirm the dialog
+      And press "Send"
+      And confirm the dialog
       Then the bulk operation has failed for "Alice"
       And "alice@example.com" should receive no emails
 
@@ -154,7 +158,8 @@ Feature: Buyer accounts bulk operations
       When item "Alice" is selected
       And select bulk action "Change account plan"
       And select "Awesome" from "Plan"
-      And press "Change plan" and confirm the dialog
+      And press "Change plan"
+      And confirm the dialog
       Then the bulk operation has failed for "Alice"
 
     Scenario: Changing state throws an error
@@ -163,7 +168,8 @@ Feature: Buyer accounts bulk operations
       And item "Pending buyer" is selected
       And select bulk action "Change state"
       When select "Approve" from "Action"
-      And press "Change state" and confirm the dialog within the modal
+      And press "Change state" within the modal
+      And confirm the dialog
       Then the bulk operation has failed for "Pending buyer"
 
     Scenario: Rejecting buyer accounts in bulk
@@ -180,7 +186,8 @@ Feature: Buyer accounts bulk operations
       And item "Alice" is selected
       And select bulk action "Change state"
       And select "Reject" from "Action"
-      And press "Change state" and confirm the dialog within the modal
+      And press "Change state" within the modal
+      And confirm the dialog
       Then should see "Successfully changed the state of 4 accounts"
       And the table should contain the following:
         | Group/Org.    | State    |

--- a/features/buyers/accounts/edit.feature
+++ b/features/buyers/accounts/edit.feature
@@ -22,7 +22,8 @@ Feature: Audience > Accounts > Edit
   Scenario: Deleting an account
     Given a buyer "Deleteme" of the provider
     When they go to the buyer account edit page for "Deleteme"
-    And follow "Delete" and confirm the dialog
+    And follow "Delete"
+    And confirm the dialog
     Then the current page is the buyer accounts page
     And they should see the flash message "The account was successfully deleted."
     And should see the following table:

--- a/features/buyers/accounts/index.feature
+++ b/features/buyers/accounts/index.feature
@@ -15,23 +15,23 @@ Feature: Audience > Accounts
     When they go to the buyer accounts page
     Then the table does not have a column "Plan"
 
-  Scenario: Provider has multiple applications disabled
+  Scenario: Provider has "multiple_applications" denied
     Given a buyer "Pepe" of the provider
     And the default product of the provider has name "The API"
     And the following application plan:
       | Product | Name | Default |
       | The API | Free | true    |
-    And the provider has multiple applications disabled
+    And the provider has "multiple_applications" denied
     When they go to the buyer accounts page
     Then the table don't have a column "Apps"
 
-  Scenario: Provider has multiple applications enabled
+  Scenario: Provider has "multiple_applications" visible
     Given a buyer "Pepe" of the provider
     And the default product of the provider has name "The API"
     And the following application plan:
       | Product | Name | Default |
       | The API | Free | true    |
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     When they go to the buyer accounts page
     Then should see following table:
       | Group/Org. | Apps |
@@ -242,7 +242,7 @@ Feature: Audience > Accounts
     @security
     Scenario: Buyers from other providers are not listed
       Given a provider "bar.3scale.localhost"
-      And provider "bar.3scale.localhost" has multiple applications enabled
+      And provider "bar.3scale.localhost" has "multiple_applications" visible
       And a buyer "claire" signed up to provider "bar.3scale.localhost"
       When they go to the buyer accounts page
       Then they should not see "claire" in the buyer accounts table

--- a/features/buyers/service_contracts/bulk_operations.feature
+++ b/features/buyers/service_contracts/bulk_operations.feature
@@ -65,7 +65,8 @@ Feature: Audience > Accounts > Service subscriptions bulk operations
     And select bulk action "Send email"
     And fill in "Subject" with "This is the subject"
     And fill in "Body" with "This is the body"
-    And press "Send" and confirm the dialog
+    And press "Send"
+    And confirm the dialog
     Then I should see "Successfully sent 2 emails."
     Then "jane@example.com" should receive 1 email
     Then "bob@example.com" should receive 1 email
@@ -82,7 +83,8 @@ Feature: Audience > Accounts > Service subscriptions bulk operations
     And item "Bob" is selected
     And select bulk action "Change service plan"
     And select "Fancy Plan B" from "Plan"
-    And press "Change plan" and confirm the dialog
+    And press "Change plan"
+    And confirm the dialog
     Then should see "Successfully changed the plan of 2 subscriptions"
     And the table should contain the following:
       | Account | Service     | Plan         |
@@ -109,7 +111,8 @@ Feature: Audience > Accounts > Service subscriptions bulk operations
     And item "Jane" is selected
     And select bulk action "Change state"
     And select "Suspend" from "Action"
-    And press "Change state" and confirm the dialog within the modal
+    And press "Change state" within the modal
+    And confirm the dialog
     Then should see "Successfully changed the state of 2 subscriptions"
     And the table should contain the following:
       | Account | Service     | State     |
@@ -124,7 +127,8 @@ Feature: Audience > Accounts > Service subscriptions bulk operations
     And select bulk action "Send email"
     And fill in "Subject" with "Error"
     And fill in "Body" with "This will fail"
-    And press "Send" and confirm the dialog
+    And press "Send"
+    And confirm the dialog
     Then the bulk operation has failed for "Jane"
     And "jane@example.com" should receive no emails
 
@@ -133,7 +137,8 @@ Feature: Audience > Accounts > Service subscriptions bulk operations
     When item "Jane" is selected
     And select bulk action "Change state"
     When select "Suspend" from "Action"
-    And press "Change state" and confirm the dialog within the modal
+    And press "Change state" within the modal
+    And confirm the dialog
     Then the bulk operation has failed for "Subscription of Jane to service Another API"
     And the table should contain the following:
       | Account | Service     | State |
@@ -148,7 +153,8 @@ Feature: Audience > Accounts > Service subscriptions bulk operations
     And item "Alice" is selected
     And select bulk action "Change service plan"
     And select "Fancy Plan B" from "Plan"
-    And press "Change plan" and confirm the dialog
+    And press "Change plan"
+    And confirm the dialog
     Then the bulk operation has failed for "Subscription of Alice to service Fancy API"
     And the table should contain the following:
       | Account | Service     | Plan         |

--- a/features/developer_portal/admin/applications/credentials.feature
+++ b/features/developer_portal/admin/applications/credentials.feature
@@ -2,7 +2,7 @@ Feature: Developer portal application credentials
 
   Background:
     Given a provider
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And a product "My API"
     And the following application plan:
       | Product | Name |

--- a/features/developer_portal/authentication/sso_token.feature
+++ b/features/developer_portal/authentication/sso_token.feature
@@ -4,7 +4,7 @@ Feature: SSO Token
 
   Background:
     Given a provider "foo.3scale.localhost"
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And a buyer "bob" signed up to provider "foo.3scale.localhost"
     And the current domain is foo.3scale.localhost
 

--- a/features/developer_portal/login.feature
+++ b/features/developer_portal/login.feature
@@ -4,7 +4,7 @@ Feature: Login feature
 
   Background:
     Given a provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has multiple applications enabled
+      And provider "foo.3scale.localhost" has "multiple_applications" visible
       And a buyer "bob" signed up to provider "foo.3scale.localhost"
 
   Scenario: Buyer lands on the homepage when in enterprise mode

--- a/features/developer_portal/payment_details.feature
+++ b/features/developer_portal/payment_details.feature
@@ -19,7 +19,7 @@ Feature: Developer portal payment details
 
     Scenario: Paid plan with prepaid billing
       Given the date is 1st January 2023
-      Given the provider has multiple applications disabled
+      Given the provider has "multiple_applications" denied
       And the provider is charging its buyers in prepaid mode
       And plan "Pro" has a monthly fee of 200
       And they go to the dev portal API access details page
@@ -29,7 +29,7 @@ Feature: Developer portal payment details
 
     Scenario: Paid plan with postpaid billing
       Given the date is 1st January 2023
-      Given the provider has multiple applications disabled
+      Given the provider has "multiple_applications" denied
       And the provider is charging its buyers in postpaid mode
       And plan "Pro" has a monthly fee of 200
       And they go to the dev portal API access details page

--- a/features/master/applications/keys.feature
+++ b/features/master/applications/keys.feature
@@ -12,11 +12,13 @@ Feature: Application Keys management
   @ignore-backend
   Scenario: Regenerate provider key
     Given they are reviewing the provider's application details
-    When follow "Regenerate" and confirm the dialog
+    When follow "Regenerate"
+    And confirm the dialog
     And fill in "Current password" with "supersecret"
     And press "Confirm Password"
     And should see "You are now in super-user mode! Retry the action, please."
-    And follow "Regenerate" and confirm the dialog
+    And follow "Regenerate"
+    And confirm the dialog
     Then should see "The key was successfully changed"
 
   Scenario: Set a custom app key

--- a/features/old/accounts/accounts.feature
+++ b/features/old/accounts/accounts.feature
@@ -76,8 +76,7 @@ Feature: Account management
 
   @regression-test @javascript
   Scenario: Edit account information even with advanced CMS enabled
-    When provider "foo.3scale.localhost" has Browser CMS activated
-    And current domain is the admin domain of provider "foo.3scale.localhost"
+    Given current domain is the admin domain of provider "foo.3scale.localhost"
     When I log in as provider "foo.3scale.localhost"
      And I go to the provider edit account page
     Then I should see "Edit Account Details"

--- a/features/old/accounts/buyers/account_fields.feature
+++ b/features/old/accounts/buyers/account_fields.feature
@@ -6,7 +6,7 @@ Feature: Buyer side, account fields
 
   Background:
     Given a provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has multiple applications enabled
+      And provider "foo.3scale.localhost" has "multiple_applications" visible
     And a buyer "bob" signed up to provider "foo.3scale.localhost"
     Given provider "foo.3scale.localhost" has the following fields defined for accounts:
       | name            | choices | required | read_only | hidden |

--- a/features/old/accounts/buyers/users_fields.feature
+++ b/features/old/accounts/buyers/users_fields.feature
@@ -6,7 +6,7 @@ Feature: Buyer side, user extra fields
 
   Background:
     Given a provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has multiple applications enabled
+      And provider "foo.3scale.localhost" has "multiple_applications" visible
     And a buyer "bob" signed up to provider "foo.3scale.localhost"
     Given provider "foo.3scale.localhost" has the following fields defined for users:
       | name            | choices | required | read_only | hidden |

--- a/features/old/accounts/invitations.feature
+++ b/features/old/accounts/invitations.feature
@@ -6,7 +6,7 @@ Feature: Invitations
 
   Background:
     Given a provider "foo.3scale.localhost"
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" has "multiple_users" switch allowed
 
   Scenario: When switch is denied as buyer

--- a/features/old/accounts/personal_details.feature
+++ b/features/old/accounts/personal_details.feature
@@ -6,7 +6,7 @@ Feature: Personal Details
 
   Background:
     Given a provider is logged in
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
 
   Scenario: Edit personal details as provider
     When I navigate to the Account Settings

--- a/features/old/accounts/users.feature
+++ b/features/old/accounts/users.feature
@@ -67,7 +67,8 @@ Feature: User management
     And current domain is the admin domain of provider "foo.3scale.localhost"
     When I log in as provider "foo.3scale.localhost"
     And I go to the provider users page
-    Then I press "Delete" for user "alice" and confirm the dialog
+    Then I press "Delete" for user "alice"
+    And confirm the dialog
     Then I should see "User was successfully deleted"
     And there should be no user with username "alice" of account "foo.3scale.localhost"
 

--- a/features/old/accounts/users.feature
+++ b/features/old/accounts/users.feature
@@ -6,7 +6,7 @@ Feature: User management
 
   Background:
     Given a provider "foo.3scale.localhost"
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     Given an user "alice" of account "foo.3scale.localhost"
     And an user "bob" of account "foo.3scale.localhost"
 

--- a/features/old/authentication/internal.feature
+++ b/features/old/authentication/internal.feature
@@ -10,7 +10,7 @@ Feature: Internal authentication
   Background:
     Given a provider "foo.3scale.localhost"
     And a default service of provider "foo.3scale.localhost" has name "api"
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" requires cinstances to be approved before use
     And provider "foo.3scale.localhost" requires accounts to be approved
 

--- a/features/old/authorization/provider_accounts.feature
+++ b/features/old/authorization/provider_accounts.feature
@@ -7,7 +7,7 @@ Feature: Provider accounts authorization
   Background:
     Given a provider "foo.3scale.localhost"
     And provider "foo.3scale.localhost" has Browser CMS activated
-    Given provider "foo.3scale.localhost" has multiple applications enabled
+    Given provider "foo.3scale.localhost" has "multiple_applications" visible
     And a buyer "buyer" signed up to provider "foo.3scale.localhost"
 
   Scenario: Provider admin can access accounts

--- a/features/old/authorization/provider_accounts.feature
+++ b/features/old/authorization/provider_accounts.feature
@@ -6,14 +6,13 @@ Feature: Provider accounts authorization
 
   Background:
     Given a provider "foo.3scale.localhost"
-    And provider "foo.3scale.localhost" has Browser CMS activated
-    Given provider "foo.3scale.localhost" has "multiple_applications" visible
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And a buyer "buyer" signed up to provider "foo.3scale.localhost"
 
   Scenario: Provider admin can access accounts
     Given current domain is the admin domain of provider "foo.3scale.localhost"
-    Given provider "foo.3scale.localhost" has "groups" switch allowed
-    Given provider "foo.3scale.localhost" has "multiple_users" switch allowed
+    And provider "foo.3scale.localhost" has "groups" switch allowed
+    And provider "foo.3scale.localhost" has "multiple_users" switch allowed
     When I log in as provider "foo.3scale.localhost"
 
     When I go to the provider dashboard

--- a/features/old/authorization/provider_finance.feature
+++ b/features/old/authorization/provider_finance.feature
@@ -6,7 +6,6 @@ Feature: Provider finance authorization
 
   Background:
     Given a provider "foo.3scale.localhost"
-    And provider "foo.3scale.localhost" has Browser CMS activated
     And provider "foo.3scale.localhost" has "finance" allowed
 
   Scenario: Provider admin can access finance

--- a/features/old/authorization/provider_portal.feature
+++ b/features/old/authorization/provider_portal.feature
@@ -6,8 +6,7 @@ Feature: Provider portal section authorization
 
   Background:
     Given a provider "foo.3scale.localhost"
-    And provider "foo.3scale.localhost" has Browser CMS activated
-    Given current domain is the admin domain of provider "foo.3scale.localhost"
+    And current domain is the admin domain of provider "foo.3scale.localhost"
 
   Scenario: Provider admin can access portal
     When I log in as provider "foo.3scale.localhost"

--- a/features/old/authorization/provider_settings.feature
+++ b/features/old/authorization/provider_settings.feature
@@ -7,7 +7,6 @@ Feature: Provider settings authorization
   Background:
     Given a provider exists
     And the provider is charging its buyers
-    And provider "foo.3scale.localhost" has Browser CMS activated
 
   Scenario: Provider admin can access settings
     Given current domain is the admin domain of provider "foo.3scale.localhost"

--- a/features/old/authorization/provider_stats.feature
+++ b/features/old/authorization/provider_stats.feature
@@ -6,7 +6,6 @@ Feature: Provider stats section authorization
 
   Background:
     Given a provider "foo.3scale.localhost" with default plans
-    And provider "foo.3scale.localhost" has Browser CMS activated
     And all the rolling updates features are off
 
   Scenario: Provider admin can access stats

--- a/features/old/buyers/accounts/approving.feature
+++ b/features/old/buyers/accounts/approving.feature
@@ -6,7 +6,7 @@ Feature: Approving buyer account
 
   Background:
     Given a provider is logged in
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And the provider requires cinstances to be approved before use
     And the provider requires accounts to be approved
 

--- a/features/old/buyers/accounts/deleting.feature
+++ b/features/old/buyers/accounts/deleting.feature
@@ -12,7 +12,8 @@ Feature: Deleting buyer account
   Scenario: Deleting buyer account from the account summary page
     When I go to the buyer account page for "bob"
     And I follow "Edit"
-    And I follow "Delete" and confirm the dialog
+    And I follow "Delete"
+    And confirm the dialog
     Then I should be on the buyer accounts page
     And I should see "The account was successfully deleted."
     And I should not see "bob"
@@ -24,5 +25,6 @@ Feature: Deleting buyer account
       | Custom | 42   |
     When I go to the buyer account page for "bob"
     And I follow "Edit"
-    And I follow "Delete" and confirm the dialog
+    And I follow "Delete"
+    And confirm the dialog
     Then I should see "Invoices need to be settled before"

--- a/features/old/buyers/accounts/deleting.feature
+++ b/features/old/buyers/accounts/deleting.feature
@@ -6,7 +6,7 @@ Feature: Deleting buyer account
 
   Background:
     Given a provider is logged in on 1st January 2011
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And a buyer "bob" signed up to provider "foo.3scale.localhost"
 
   Scenario: Deleting buyer account from the account summary page

--- a/features/old/buyers/accounts/rejecting.feature
+++ b/features/old/buyers/accounts/rejecting.feature
@@ -6,7 +6,7 @@ Feature: Rejecting buyer account
 
   Background:
     Given a provider is logged in
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And the provider requires cinstances to be approved before use
     And the provider requires accounts to be approved
 

--- a/features/old/buyers/invitations/for_admins.feature
+++ b/features/old/buyers/invitations/for_admins.feature
@@ -49,7 +49,8 @@ Feature: Buyer Account Invitations
     When I navigate to the page of the invitations of the partner "lol cats"
     # And select action "Delete" of "alice@example.org"
     # And confirm the dialog
-    And I press "Delete" for an invitation from account "lol cats" for "alice@lolcats.com" and confirm the dialog
+    And I press "Delete" for an invitation from account "lol cats" for "alice@lolcats.com"
+    And confirm the dialog
     Then I should not see invitation for "alice@lolcats.com"
 
   Scenario: Resending invitations

--- a/features/old/buyers/invitations/for_admins.feature
+++ b/features/old/buyers/invitations/for_admins.feature
@@ -9,7 +9,7 @@ Feature: Buyer Account Invitations
       | Product    | Name    |
       | Master API | power1M |
     And a provider is logged in
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And the provider has "multiple_users" switch allowed
     And a buyer "lol cats"
 

--- a/features/old/buyers/invitations/security.feature
+++ b/features/old/buyers/invitations/security.feature
@@ -6,7 +6,7 @@ Feature: Security constraints to invite partners
 
   Background:
     Given a provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has multiple applications enabled
+      And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" has the following buyers:
       | Name     |
       | lol cats |

--- a/features/old/buyers/users.feature
+++ b/features/old/buyers/users.feature
@@ -56,7 +56,8 @@ Feature: Buyer users management
   Scenario: Delete buyer user
     When I go to the buyer user page for "bob"
     And I follow "Edit"
-    Then I follow "Delete" and confirm the dialog
+    Then I follow "Delete"
+    And confirm the dialog
     # TODO: confirm step here
     Then I should be on the buyer users page for "SpaceWidgets"
     And I should not see buyer user "bob"

--- a/features/old/buyers/users.feature
+++ b/features/old/buyers/users.feature
@@ -6,7 +6,7 @@ Feature: Buyer users management
 
   Background:
     Given a provider is logged in
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And the provider has the following fields defined for users:
       | Name            | Choices | Label | Required | Read Only | Hidden |
       | custom_field    |         |       |          |           |        |

--- a/features/old/buyers/users_fields.feature
+++ b/features/old/buyers/users_fields.feature
@@ -6,7 +6,7 @@ Feature: Buyer users fields management
 
   Background:
     Given a provider is logged in
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And a buyer "SpaceWidgets" signed up to provider "foo.3scale.localhost"
     And the provider has the following fields defined for users:
       | name                 | required | read_only | hidden |

--- a/features/old/cms/advanced/groups_and_sections.feature
+++ b/features/old/cms/advanced/groups_and_sections.feature
@@ -5,7 +5,7 @@ Feature: Groups and Sections
   Background:
     Given a provider "foo.3scale.localhost"
       And provider "foo.3scale.localhost" has "groups" switch allowed
-      And provider "foo.3scale.localhost" has multiple applications enabled
+      And provider "foo.3scale.localhost" has "multiple_applications" visible
       And an approved buyer "alice" signed up to provider "foo.3scale.localhost"
 
       And provider "foo.3scale.localhost" has a public section "Docs" with path "/docs"

--- a/features/old/cms/advanced/multi-tenant/authorizations/groups_and_sections.feature
+++ b/features/old/cms/advanced/multi-tenant/authorizations/groups_and_sections.feature
@@ -7,10 +7,10 @@ Feature: Groups and permissions
   Background:
     # Given we have 2 enterprise providers
     Given a provider "one.3scale.localhost"
-      And provider "one.3scale.localhost" has multiple applications enabled
+      And provider "one.3scale.localhost" has "multiple_applications" visible
     #
     Given a provider "two.3scale.localhost"
-      And provider "two.3scale.localhost" has multiple applications enabled
+      And provider "two.3scale.localhost" has "multiple_applications" visible
 
     # Given both providers have a page with path "/docs", but one is restricted, while the other is not
     Given provider "one.3scale.localhost" has a private section "Docs" with path "/docs"

--- a/features/old/cms/advanced/multi-tenant/groups.feature
+++ b/features/old/cms/advanced/multi-tenant/groups.feature
@@ -9,10 +9,10 @@ Feature: Groups
     And provider "withgroups.3scale.localhost" has groups for buyers:
       | name        |
       | BuyerGroup1 |
-    And provider "withgroups.3scale.localhost" has multiple applications enabled
+    And provider "withgroups.3scale.localhost" has "multiple_applications" visible
     And provider "withgroups.3scale.localhost" has "groups" switch allowed
     Given a provider "nogroups.3scale.localhost"
-    And provider "nogroups.3scale.localhost" has multiple applications enabled
+    And provider "nogroups.3scale.localhost" has "multiple_applications" visible
     And an approved buyer "userfornogroups.3scale.localhost" signed up to provider "nogroups.3scale.localhost"
     And provider "nogroups.3scale.localhost" has "groups" switch allowed
 

--- a/features/old/cms/email_templates.feature
+++ b/features/old/cms/email_templates.feature
@@ -6,9 +6,8 @@ Feature: Email templates management
 
   Background:
     Given a provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has Browser CMS activated
-      And provider "foo.3scale.localhost" has "skip_email_engagement_footer" switch visible
-    Given I log in as "foo.3scale.localhost" on the admin domain of provider "foo.3scale.localhost"
+    And provider "foo.3scale.localhost" has "skip_email_engagement_footer" switch visible
+    And I log in as "foo.3scale.localhost" on the admin domain of provider "foo.3scale.localhost"
 
   Scenario: Creating template
     When I go to the email templates page

--- a/features/old/cms/groups.feature
+++ b/features/old/cms/groups.feature
@@ -21,5 +21,6 @@ Feature: CMS groups
     Then I should be on the groups page
     And I should see "le java enterprisers"
     And I should see "nothing-to-see-here"
-    When I follow "Delete" and confirm the dialog
+    When I follow "Delete"
+    And confirm the dialog
     Then I should see "Group deleted"

--- a/features/old/cms/redirects.feature
+++ b/features/old/cms/redirects.feature
@@ -17,5 +17,6 @@ Feature: CMS Redirects
     And I fill in "Source" with "/from/Past"
     And I press "Update Redirect"
     Then I should see "Redirect updated"
-    When I follow "Delete" and confirm the dialog
+    When I follow "Delete"
+    And confirm the dialog
     Then I should see "Redirect deleted"

--- a/features/old/dashboards.feature
+++ b/features/old/dashboards.feature
@@ -17,7 +17,7 @@ Feature: Dashboards
   #FIXME this buyer sees a provider submenu, which is not what happens in the app
   # CHECK THIS OUT!
   Scenario: Buyer dashboard in multiple application mode
-    Given provider "foo.3scale.localhost" has multiple applications enabled
+    Given provider "foo.3scale.localhost" has "multiple_applications" visible
     And a buyer "bob" signed up to provider "foo.3scale.localhost"
     When I log in as "bob" on foo.3scale.localhost
     And I go to the dashboard
@@ -25,7 +25,7 @@ Feature: Dashboards
   # TODO: And I should see stuff
 
   Scenario: '/admin' on buyer domain sees buyer dashboard
-    Given provider "foo.3scale.localhost" has multiple applications enabled
+    Given provider "foo.3scale.localhost" has "multiple_applications" visible
     When the current domain is foo.3scale.localhost
     And a buyer "bob" signed up to provider "foo.3scale.localhost"
     And I log in as "bob" on foo.3scale.localhost

--- a/features/old/emails.feature
+++ b/features/old/emails.feature
@@ -19,7 +19,8 @@ Feature: Emails
       | bob   | other |
     And they go to application "other" admin page
     Then they should see "Live" within the application details
-    When I follow "Suspend" and confirm the dialog
+    When I follow "Suspend"
+    And confirm the dialog
     Then they should see "Suspended" within the application details
     And I act as "bob"
     Then I should receive no email with subject "Application has been suspended"

--- a/features/old/emails.feature
+++ b/features/old/emails.feature
@@ -7,7 +7,7 @@ Feature: Emails
     Given a provider "foo.3scale.localhost" with default plans
 
   Scenario: Disable 'Suspend Application' notification
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" has email template "cinstance_messenger_suspended"
       """
       {% email %}{% do_not_send %}{% endemail %}
@@ -27,7 +27,7 @@ Feature: Emails
 
   Scenario: Disable 'Waiting list confirmation' notification
     And provider "foo.3scale.localhost" requires accounts to be approved
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" has email template "account_confirmed"
       """
       {% email %}{% do_not_send %}{% endemail %}
@@ -46,7 +46,7 @@ Feature: Emails
 
   Scenario: Disable 'Waiting list confirmation' notification with truthy condition
     And provider "foo.3scale.localhost" requires accounts to be approved
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" has email template "account_confirmed"
       """
       {% if true %}{% email %}{% do_not_send %}{% endemail %}{% endif %}
@@ -65,7 +65,7 @@ Feature: Emails
 
   Scenario: Disable 'Waiting list confirmation' notification with falsy condition
     And provider "foo.3scale.localhost" requires accounts to be approved
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" has email template "account_confirmed"
       """
       {% if false %}{% email %}{% do_not_send %}{% endemail %}{% endif %}
@@ -84,7 +84,7 @@ Feature: Emails
 
   Scenario: Custom email subject with truthy condition
     And provider "foo.3scale.localhost" requires accounts to be approved
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" has email template "account_confirmed"
       """
       {% if true %}
@@ -113,7 +113,7 @@ Feature: Emails
 
   Scenario: Custom email subject with falsy condition
     And provider "foo.3scale.localhost" requires accounts to be approved
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" has email template "account_confirmed"
       """
       {% if false %}
@@ -142,7 +142,7 @@ Feature: Emails
 
   Scenario: Do not disable 'Waiting list confirmation' notification due to falsy condition but still change the subject
     And provider "foo.3scale.localhost" requires accounts to be approved
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" has email template "account_confirmed"
       """
       {% if false %}

--- a/features/old/finance/invoices/create_invoice.feature
+++ b/features/old/finance/invoices/create_invoice.feature
@@ -20,6 +20,7 @@ Feature: Create invoice
     And I follow "Create invoice"
     Then I should see "Invoice successfully created"
     And I should see "open"
-    Then I follow "Create invoice" and confirm the dialog "You cannot create a new invoice for 'zoidberg' since it already has one open. Please issue it before creating a new one."
+    Then I follow "Create invoice"
+    And confirm the dialog
     When I follow "2009-01-00000001"
     Then I should see "Invoice for January 2009"

--- a/features/old/liquid/content_access.feature
+++ b/features/old/liquid/content_access.feature
@@ -6,7 +6,6 @@ Feature: Content access in liquid
   Background:
     Given a provider "foo.3scale.localhost"
       And provider "foo.3scale.localhost" has "multiple_applications" visible
-    Given provider "foo.3scale.localhost" has Browser CMS activated
       And the template "main_layout" of provider "foo.3scale.localhost" is
         """
         {% if current_user.sections contains "/protected-section" %}

--- a/features/old/liquid/content_access.feature
+++ b/features/old/liquid/content_access.feature
@@ -5,7 +5,7 @@ Feature: Content access in liquid
 
   Background:
     Given a provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has multiple applications enabled
+      And provider "foo.3scale.localhost" has "multiple_applications" visible
     Given provider "foo.3scale.localhost" has Browser CMS activated
       And the template "main_layout" of provider "foo.3scale.localhost" is
         """

--- a/features/old/liquid/drops.feature
+++ b/features/old/liquid/drops.feature
@@ -4,8 +4,7 @@ Feature: Liquid drops
 
   Background:
     Given a provider "foo.3scale.localhost"
-    Given provider "foo.3scale.localhost" has Browser CMS activated
-      And the current domain is foo.3scale.localhost
+    And the current domain is foo.3scale.localhost
 
   Scenario: MenuDrop
     Given a buyer "bob" of provider "foo.3scale.localhost"

--- a/features/old/liquid/multitenant.feature
+++ b/features/old/liquid/multitenant.feature
@@ -5,9 +5,7 @@ Feature: Multitenanted liquid
 
   Background:
     Given a provider "liquid.3scale.localhost"
-      And provider "liquid.3scale.localhost" has Browser CMS activated
-    Given a provider "another-liquid.3scale.localhost"
-      And provider "another-liquid.3scale.localhost" has Browser CMS activated
+    And a provider "another-liquid.3scale.localhost"
 
   Scenario: Liquid layouts are multitenant
     Given the template "main_layout" of provider "liquid.3scale.localhost" is

--- a/features/old/liquid/tags/page_section.feature
+++ b/features/old/liquid/tags/page_section.feature
@@ -10,8 +10,7 @@ Feature: Liquid tags
 
 
   Scenario: Tag page_section works for simple cms
-    Given provider "foo.3scale.localhost" has Browser CMS deactivated
-    And a liquid template "main_layout" of provider "foo.3scale.localhost" with content
+    Given a liquid template "main_layout" of provider "foo.3scale.localhost" with content
       """
         simple cms page_section {{ page_section }}
       """
@@ -20,8 +19,7 @@ Feature: Liquid tags
 
 
   Scenario: Tag page_section works for browser cms
-    Given provider "foo.3scale.localhost" has Browser CMS activated
-    And a liquid template "main_layout" of provider "foo.3scale.localhost" with content
+    Given a liquid template "main_layout" of provider "foo.3scale.localhost" with content
       """
         bcms page_section {{ page_section }}
       """

--- a/features/old/menu/buyer.feature
+++ b/features/old/menu/buyer.feature
@@ -6,7 +6,7 @@ Feature: Menu of the buyers
 
   Background:
     Given a provider "foo.3scale.localhost"
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And the default product of the provider has name "My API"
     And the following application plan:
       | Product | Name    | State     |

--- a/features/old/messages/buyer_side.feature
+++ b/features/old/messages/buyer_side.feature
@@ -5,7 +5,7 @@ Feature: Buyer side messages
 
   Background:
     Given a provider "foo.3scale.localhost"
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And a buyer "bob" signed up to provider "foo.3scale.localhost"
     When I log in as "bob" on foo.3scale.localhost
 

--- a/features/old/services/multiservice.feature
+++ b/features/old/services/multiservice.feature
@@ -84,5 +84,6 @@ Feature: Multiservice feature
     And provider "foo.3scale.localhost" has "multiple_services" switch allowed
     And a service "Second service" of provider "foo.3scale.localhost"
     And I am on the edit page for service "Second service" of provider "foo.3scale.localhost"
-    When I follow "I understand the consequences, proceed to delete 'Second service' product" and confirm the dialog
+    When I follow "I understand the consequences, proceed to delete 'Second service' product"
+    And confirm the dialog
     Then I should see "Product 'Second service' will be deleted shortly."

--- a/features/old/services/switch.feature
+++ b/features/old/services/switch.feature
@@ -6,7 +6,7 @@ Feature: Services switch
 
   Background:
     Given a provider is logged in
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     Given the default product of provider "master" has name "Master API"
     Given the following application plan:
       | Product    | Name  |

--- a/features/old/signup/account_activation_emails.feature
+++ b/features/old/signup/account_activation_emails.feature
@@ -6,7 +6,7 @@ Feature: Account Activation Emails on Sign Up of enterprise buyers
 
   Background:
     Given a provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has multiple applications enabled
+      And provider "foo.3scale.localhost" has "multiple_applications" visible
       And provider "foo.3scale.localhost" has plans ready for signups
       And provider "foo.3scale.localhost" has "skip_email_engagement_footer" switch denied
 

--- a/features/old/signup/account_activation_emails.feature
+++ b/features/old/signup/account_activation_emails.feature
@@ -7,14 +7,14 @@ Feature: Account Activation Emails on Sign Up of enterprise buyers
   Background:
     Given a provider "foo.3scale.localhost"
       And provider "foo.3scale.localhost" has multiple applications enabled
-      And provider "foo.3scale.localhost" has plans already ready for signups
+      And provider "foo.3scale.localhost" has plans ready for signups
       And provider "foo.3scale.localhost" has "skip_email_engagement_footer" switch denied
 
   Scenario: Default account activation email
     Given the current domain is foo.3scale.localhost
 
       When someone signs up with the email "user@3scale.localhost"
-      Then "user@3scale.localhost" should receive the default account activation email with viral footer applyed
+      Then "user@3scale.localhost" should receive the default account activation email with viral footer applied
 
     Given provider "foo.3scale.localhost" has "skip_email_engagement_footer" switch visible
       When someone signs up with the email "anotheruser@3scale.localhost"

--- a/features/old/signup/buyers.feature
+++ b/features/old/signup/buyers.feature
@@ -24,7 +24,7 @@ Feature: Sign Up of enterprise buyers
     Then I should see "Activation error"
 
    Scenario: (Enterprise, Single App Mode) Plain signup, activate and login
-      And provider "foo.3scale.localhost" has multiple applications disabled
+      And provider "foo.3scale.localhost" has "multiple_applications" denied
 
      When I go to the sign up page
       And I fill in the signup fields as "hugo"
@@ -41,7 +41,7 @@ Feature: Sign Up of enterprise buyers
     And account "hugo's stuff" should be buyer
 
   Scenario: Choose application plan, the rest is default
-    Given provider "foo.3scale.localhost" has multiple applications disabled
+    Given provider "foo.3scale.localhost" has "multiple_applications" denied
     When I go to the sign up page for the "iPhone" plan
     Then I should see "You are signing up to plan iPhone."
      And I fill in the signup fields as "hugo"

--- a/features/old/signup/multiple_cinstances.feature
+++ b/features/old/signup/multiple_cinstances.feature
@@ -6,7 +6,7 @@ Feature: Buyer signup to service allowing multiple applications per buyer
 
   Background:
     Given a provider "foo.3scale.localhost" with default plans
-    And provider "foo.3scale.localhost" has multiple applications enabled
+    And provider "foo.3scale.localhost" has "multiple_applications" visible
     And provider "foo.3scale.localhost" requires cinstances to be approved before use
     And provider "foo.3scale.localhost" requires accounts to be approved
     # TODO: add scenario without default app plan

--- a/features/old/signup/multitenant.feature
+++ b/features/old/signup/multitenant.feature
@@ -5,7 +5,7 @@ Feature: Sign Up of enterprise buyers
 
   Background:
     Given a provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has multiple applications enabled
+      And provider "foo.3scale.localhost" has "multiple_applications" visible
     And the following account plan:
       | Issuer               | Name   |
       | foo.3scale.localhost | Tier-1 |

--- a/features/old/signup/providers.feature
+++ b/features/old/signup/providers.feature
@@ -5,7 +5,7 @@ Feature: Signup
   I want to sign up
 
 Background:
-  Given provider "master" has multiple applications disabled
+  Given provider "master" has "multiple_applications" denied
     And provider "master" has default service and account plan
 
 @ignore-backend @allow-rescue

--- a/features/old/site/settings.feature
+++ b/features/old/site/settings.feature
@@ -8,7 +8,7 @@ Feature: Site settings
 
   @security
   Scenario: Settings is not available for buyers
-    Given provider "foo.3scale.localhost" has multiple applications enabled
+    Given provider "foo.3scale.localhost" has "multiple_applications" visible
       And a buyer "bob" signed up to provider "foo.3scale.localhost"
     When I log in as "bob" on foo.3scale.localhost
     When I request the url of the site settings page then I should see 404

--- a/features/old/stats/buyer_side.feature
+++ b/features/old/stats/buyer_side.feature
@@ -7,7 +7,7 @@ Feature: Buyer stats
 
   Scenario: No access to stats if no app plan subscription
     Given a provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has multiple applications enabled
+      And provider "foo.3scale.localhost" has "multiple_applications" visible
       And a buyer "alice" signed up to provider "foo.3scale.localhost"
     When I log in as "alice" on foo.3scale.localhost
       And I go to the dashboard

--- a/features/old/stats/provider/top_applications.feature
+++ b/features/old/stats/provider/top_applications.feature
@@ -7,7 +7,7 @@ Feature: Top applications stats
   Background:
     Given a provider is logged in
     And the provider uses backend v1 in his default service
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And the default product of the provider has name "My API"
     And the following application plan:
       | Product | Name    | State     | Default |

--- a/features/old/stats/provider_side.feature
+++ b/features/old/stats/provider_side.feature
@@ -8,7 +8,7 @@ Feature: Provider stats
 
   Background:
     Given a provider is logged in
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And all the rolling updates features are off
     And All Dashboard widgets are loaded
 
@@ -32,7 +32,7 @@ Feature: Provider stats
     And I should see a chart called "chart"
 
   Scenario: Top users (single application mode)
-    Given the provider has multiple applications disabled
+    Given the provider has "multiple_applications" denied
     And the following application plan:
       | Product | Name    | Default |
       | API     | Default | true    |
@@ -64,7 +64,7 @@ Feature: Provider stats
 
   @wip
   Scenario: Signups (single application mode)
-    Given provider "foo.3scale.localhost" has multiple applications disabled
+    Given provider "foo.3scale.localhost" has "multiple_applications" denied
     And an application plan "Basic" of provider "foo.3scale.localhost"
     Given these buyers signed up to plan "Basic"
       | Name     | Signed on      |
@@ -88,7 +88,7 @@ Feature: Provider stats
 
   @wip
   Scenario: Signups (multiple application mode)
-    Given provider "foo.3scale.localhost" has multiple applications enabled
+    Given provider "foo.3scale.localhost" has "multiple_applications" visible
     And a default application plan of provider "foo.3scale.localhost"
     And a buyer "alice" signed up to provider "foo.3scale.localhost"
     And buyer "alice" has the following applications:

--- a/features/old/stats/provider_side.feature
+++ b/features/old/stats/provider_side.feature
@@ -89,7 +89,9 @@ Feature: Provider stats
   @wip
   Scenario: Signups (multiple application mode)
     Given provider "foo.3scale.localhost" has "multiple_applications" visible
-    And a default application plan of provider "foo.3scale.localhost"
+    And the following application plan:
+      | Product | Name     | State     | Default |
+      | API     | The Plan | Published | true    |
     And a buyer "alice" signed up to provider "foo.3scale.localhost"
     And buyer "alice" has the following applications:
       | Name            | Created at    |

--- a/features/old/switches/groups.feature
+++ b/features/old/switches/groups.feature
@@ -6,7 +6,6 @@ Feature: Groups switch
   Background:
     Given a provider is logged in
     And the provider has "multiple_applications" visible
-    Given provider "foo.3scale.localhost" has Browser CMS activated
 
   Scenario: Groups not accessible if not enabled
     Given the provider has "groups" switch denied

--- a/features/old/switches/groups.feature
+++ b/features/old/switches/groups.feature
@@ -5,7 +5,7 @@ Feature: Groups switch
 
   Background:
     Given a provider is logged in
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     Given provider "foo.3scale.localhost" has Browser CMS activated
 
   Scenario: Groups not accessible if not enabled

--- a/features/old/users/with_state_email_unverified.feature
+++ b/features/old/users/with_state_email_unverified.feature
@@ -4,7 +4,7 @@ Feature: Users enter email unverified state
 
   Background:
     Given a provider "foo.3scale.localhost"
-      And provider "foo.3scale.localhost" has multiple applications enabled
+      And provider "foo.3scale.localhost" has "multiple_applications" visible
     Given a buyer "alice" signed up to provider "foo.3scale.localhost"
 
 

--- a/features/provider/admin/applications/edit.feature
+++ b/features/provider/admin/applications/edit.feature
@@ -45,7 +45,8 @@ Feature: Application edit page
 
   Scenario: Delete application
     Given they go to the application's admin edit page
-    When follow "Delete" and confirm the dialog
+    When follow "Delete"
+    And confirm the dialog
     Then they should see the flash message "The application was successfully deleted."
     And there should be 1 application cancelled event
     # FIXME: And all the events should be valid

--- a/features/provider/admin/applications/new.feature
+++ b/features/provider/admin/applications/new.feature
@@ -3,7 +3,7 @@ Feature: Audience's new application page
 
   Background:
     Given a provider
-    And the provider has multiple applications enabled
+    And the provider has "multiple_applications" visible
     And a product "My API"
     And the following application plan:
       | Product | Name  |
@@ -106,7 +106,7 @@ Feature: Audience's new application page
 
   Rule: Multiple applications denied
     Background:
-      Given the provider has multiple applications disabled
+      Given the provider has "multiple_applications" denied
 
     Scenario: Manual navigation
       Given they go to the admin portal applications page

--- a/features/provider/admin/applications/show/application_details.feature
+++ b/features/provider/admin/applications/show/application_details.feature
@@ -35,7 +35,8 @@ Feature: Application details card
 
   Scenario: Suspending the application
     Given they go to the application's admin page
-    When they follow "Suspend" and confirm the dialog within the application details
+    When they follow "Suspend" within the application details
+    And confirm the dialog
     Then they should see the flash message "The application has been suspended"
     And should see "Suspended" within the application details
 

--- a/features/provider/admin/backend_apis/metrics/delete.feature
+++ b/features/provider/admin/backend_apis/metrics/delete.feature
@@ -15,13 +15,15 @@ Feature: BackendApi > Metrics index > Metric
   Scenario: Delete a method
     When I change to tab 'Methods'
     And I follow "Margherita"
-    And I press "Delete" and confirm the dialog
+    And I press "Delete"
+    And confirm the dialog
     Then I should not see metric "Margherita"
 
   Scenario: Delete a metric
     When I change to tab 'Metrics'
     And I follow "Pizza"
-    And I press "Delete" and confirm the dialog
+    And I press "Delete"
+    And confirm the dialog
     Then I should not see metric "Pizza"
 
   Scenario: Default metric can't be deleted

--- a/features/step_definitions/buyers_management/account_steps.rb
+++ b/features/step_definitions/buyers_management/account_steps.rb
@@ -18,7 +18,7 @@ Given "{provider} has the following buyers:" do |provider, table|
     next unless (plan_name = hash[:plan])
 
     plan = provider.account_plans.find_by(name: plan_name) ||
-           create_plan(:account, name: plan_name, issuer: provider)
+           FactoryBot.create(:account_plan, name: plan_name, issuer: provider)
     buyer.buy! plan
   end
 end

--- a/features/step_definitions/config_steps.rb
+++ b/features/step_definitions/config_steps.rb
@@ -8,16 +8,6 @@ Given "{provider} has signup {enabled}" do |provider, enabled|
   end
 end
 
-Given "{provider} has multiple applications {enabled}" do |provider, enabled|
-  ActiveSupport::Deprecation.warn '[cucumber] use steps from switches_steps.rb'
-  if enabled
-    provider.settings.allow_multiple_applications!
-    provider.settings.show_multiple_applications!
-  elsif provider.settings.can_deny_multiple_applications?
-    provider.settings.deny_multiple_applications!
-  end
-end
-
 # TODO: remove this nonsense
 Given /^provider "([^"]*)" has Browser CMS (activated|deactivated)$/ do |provider, value|
   if value == 'deactivated'

--- a/features/step_definitions/config_steps.rb
+++ b/features/step_definitions/config_steps.rb
@@ -8,13 +8,6 @@ Given "{provider} has signup {enabled}" do |provider, enabled|
   end
 end
 
-# TODO: remove this nonsense
-Given /^provider "([^"]*)" has Browser CMS (activated|deactivated)$/ do |provider, value|
-  if value == 'deactivated'
-    raise 'BCMS cannot be deactivated!'
-  end
-end
-
 # TODO: too generic. Replace it with "{product} uses backend {backend_version}"
 Given "{provider} uses backend {backend_version} in his default service" do |provider, backend_version|
   service = provider.default_service

--- a/features/step_definitions/plans/default.rb
+++ b/features/step_definitions/plans/default.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-Given "a default {word} plan of {provider}" do |type, provider|
-  create_plan(type, name: 'The Plan', issuer: provider, published: true, default: true)
-end
-
-Given "a default {word} {string} plan of {provider}" do |type, name, provider|
-  create_plan(type, name: name, issuer: provider, published: true, default: true)
+Given "a default application plan of {provider}" do |provider|
+  FactoryBot.create(:published_application_plan, name: 'The Plan',
+                    issuer: provider.first_service!,
+                    default: true)
 end
 
 Given "{provider} has no default application plan" do |provider|

--- a/features/step_definitions/plans/default.rb
+++ b/features/step_definitions/plans/default.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-Given "a default application plan of {provider}" do |provider|
-  FactoryBot.create(:published_application_plan, name: 'The Plan',
-                    issuer: provider.first_service!,
-                    default: true)
-end
-
 Given "{provider} has no default application plan" do |provider|
   provider.services.each do |service|
     service.update_attribute :default_application_plan, nil

--- a/features/step_definitions/signup_notification_emails_steps.rb
+++ b/features/step_definitions/signup_notification_emails_steps.rb
@@ -7,7 +7,7 @@ Then /^"([^\"]*)" should receive the default account activation email$/ do |addr
   current_email.body =~ /Thank you for signing up for access to the .* API/
 end
 
-Then(/^"(.*?)" should receive the default account activation email with viral footer applyed$/) do | address |
+Then(/^"(.*?)" should receive the default account activation email with viral footer applied$/) do | address |
   open_email(address, with_subject: 'foo.3scale.localhost API account confirmation')
   current_email.body =~ /Thank you for signing up for access to the .* API/
   assert_match ThreeScale::EmailEngagementFooter.engagement_footer, current_email.body.to_s

--- a/features/step_definitions/signup_steps.rb
+++ b/features/step_definitions/signup_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-Given "{provider} has plans (already )ready for signups" do |provider|
-  create_plan(:application, name: 'application_plan', issuer: provider, published: true, default: true)
+Given "{provider} has plans ready for signups" do |provider|
+  FactoryBot.create(:published_application_plan, name: 'application_plan', issuer: provider.first_service!, default: true)
 end
 
 When /^I fill in the invitation signup as "([^"]*)"$/ do |username|

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -141,15 +141,6 @@ And "confirm the dialog" do
   accept_confirm
 end
 
-Then /^(.+) and confirm the dialog(?: "(.*)")?$/ do |original, text|
-  ActiveSupport::Deprecation.warn "🥒 Replace with step 'And confirm the dialog'"
-  ensure_javascript
-  accept_confirm(text) do
-    step original
-  end
-  wait_for_requests
-end
-
 Then "(they )should see the following details(:)" do |table|
   table.rows_hash.all? do |key, value|
     dt = find('dl dt', text: key)


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove deprecation warnings in Cucumber tests to reduce noise in the test logs.
Same as https://github.com/3scale/porta/pull/3964, but now using the right base branch :melting_face: 

**Which issue(s) this PR fixes** 

**Verification steps** 


**Special notes for your reviewer**:
