### PR TITLE
THREESCALE-9006: Add `policy_registry` scope to the initial token

### DIFF
--- a/app/lib/signup/result_with_access_token.rb
+++ b/app/lib/signup/result_with_access_token.rb
@@ -3,7 +3,7 @@
 module Signup
   class ResultWithAccessToken < Signup::Result
     def local_initialize
-      token_params = { name: 'account management rw', scopes: ['account_management'], 'permission': 'rw' }
+      token_params = { name: 'Administration', scopes: %w[account_management policy_registry], 'permission': 'rw' }
       @access_token = user.access_tokens.new(token_params)
     end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `Policy Registry API` scope to the initial token when creating a new tenant

**Which issue(s) this PR fixes** 

[THREESCALE-9006](https://issues.redhat.com/browse/THREESCALE-9006)

**Verification steps** 

1. Create a new tenant:

```
curl --request POST \
  --url 'http://master-account.3scale.localhost:3000//master/api/providers?access_token=[MASTER_TOKEN]' \
  --header 'Content-Type: application/json' \
  --data '{
	"org_name": "API provider",
	"username": "api-user",
	"password": "p",
	"email": "test-api-user@redhat.com",
	"redirect_url": "http://master-account.3scale.localhost:3000/buyers/accounts"
}'
```
2. The new provider should have an access token called `Administration` with the `Policy Registry API` scope enabled:

```
$ bundle exec rails c
Loading development environment (Rails 7.0.8.6)
[1] pry(main)> Account.providers.last.access_tokens.where name: 'Administration'
=> [#<AccessToken:0x00007f730fb15e98
  id: 15,
  owner_id: 20,
  scopes: ["account_management", "policy_registry"],
  value: "7c509aaae40b2d31a6697b94a4aa8a85f41e0ba491134cb7e712c2e17a475145",
  name: "Administration",
  permission: "rw",
  tenant_id: 14,
  created_at: Thu, 16 Jan 2025 17:28:45.000000000 UTC +00:00,
  updated_at: Thu, 16 Jan 2025 17:28:45.000000000 UTC +00:00,
  expires_at: nil>]
```