### PR TITLE
Try to fix flaky tests involving multi-dropdown forms

### DIFF
--- a/features/buyers/accounts/applications/new.feature
+++ b/features/buyers/accounts/applications/new.feature
@@ -105,7 +105,7 @@ Feature: Audience > Accounts > Listing > Account > Applications > New
       When they follow "Create an application"
       Then the current page is the upgrade notice for multiple applications
 
-    Scenario: Navigation via url
+    Scenario: Can't create multiple applications
       Given they go to buyer "Jane" new application page
       When the form is submitted with:
         | Product          | My API        |

--- a/features/support/capybara_extensions.rb
+++ b/features/support/capybara_extensions.rb
@@ -27,8 +27,12 @@ module CapybaraExtensions
         if has_css?('select.pf-c-form-control', wait: 0)
           super
         else
-          find('.pf-c-select').click
+          select = find('.pf-c-select')
+          select.click unless select.has_css?('.pf-m-expanded', wait: 0)
           find('.pf-c-select__menu button', text: value).click
+
+          # Wait for the select to close
+          assert select.has_no_css?('.pf-m-expanded', wait: 1)
         end
       end
     else


### PR DESCRIPTION
https://issues.redhat.com/browse/THREESCALE-11585

Reason: Capybara tries to click the second select but the first one is still open somehow (see image below). Rerunning the test will make it pass in Circleci. It doesn't fail locally.
![Screenshot 2025-01-20 at 09 44 44](https://github.com/user-attachments/assets/7de5203f-f4ef-4f30-b63f-4342eb4fd736)

