### PR TITLE
THREESCALE-11609: Fix whitespaces in keycloak realm

### DIFF
--- a/app/lib/three_scale/oauth2/client.rb
+++ b/app/lib/three_scale/oauth2/client.rb
@@ -72,7 +72,7 @@ module ThreeScale
       # @return [::ThreeScale::OAuth::Client::Options]
       def build_authentication_options(authentication_provider)
         Options.new(
-          authentication_provider.site.presence,
+          authentication_provider.site.presence&.strip,
           authentication_provider.token_url.presence,
           authentication_provider.authorize_url.presence,
           { ssl: { verify_mode: authentication_provider.ssl_verify_mode } })

--- a/app/models/authentication_provider.rb
+++ b/app/models/authentication_provider.rb
@@ -31,7 +31,7 @@ class AuthenticationProvider < ApplicationRecord
 
   validates :client_id, :client_secret, presence: true, if: :oauth_config_required?
 
-  with_options format: { with: URI.regexp(%w(http https)), allow_blank: true, message: :invalid_url } do |ops|
+  with_options format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), allow_blank: true, message: :invalid_url } do |ops|
     ops.validates :site
     ops.validates :token_url
     ops.validates :authorize_url

--- a/app/models/authentication_provider/auth0.rb
+++ b/app/models/authentication_provider/auth0.rb
@@ -3,6 +3,6 @@ class AuthenticationProvider::Auth0 < AuthenticationProvider
   self.oauth_config_required = true
 
   validates :site, presence: true
-  validates :site, format: { without: /\s/ }
+  validates :site, format: { without: /\s/, message: :contains_whitespace }
 
 end

--- a/app/models/authentication_provider/keycloak.rb
+++ b/app/models/authentication_provider/keycloak.rb
@@ -2,7 +2,7 @@ class AuthenticationProvider::Keycloak < AuthenticationProvider
   self.authorization_scope = :iam_tools
   self.oauth_config_required = true
 
-  validates :realm, presence: true
-  validates :realm, format: { with: URI.regexp(%w(http https)), message: :invalid_url }
+  validates :site, presence: true
+  validates :site, format: { without: /\s/, message: :contains_whitespace }
   alias_attribute :realm, :site
 end

--- a/app/models/proxy_rule.rb
+++ b/app/models/proxy_rule.rb
@@ -89,7 +89,7 @@ class ProxyRule < ApplicationRecord
   validates :http_method, inclusion: { in: ALLOWED_HTTP_METHODS }
   validate :non_repeated_parameters
   validate :no_vars_in_keys
-  validates :redirect_url, format: URI.regexp(%w[http https]), allow_blank: true, length: { maximum: 10000 }
+  validates :redirect_url, format: URI::DEFAULT_PARSER.make_regexp(%w[http https]), allow_blank: true, length: { maximum: 10000 }
 
   def parameters
     Addressable::Template.new(path_pattern).variables

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -6,7 +6,7 @@ class WebHook < ApplicationRecord
   attr_protected :account_id, :tenant_id
 
   validates :account_id, presence: true
-  validates :url, format: { :with => URI.regexp(['http', 'https']), :if => :active }, length: { maximum: 255 }
+  validates :url, format: { :with => URI::DEFAULT_PARSER.make_regexp(%w[http https]), :if => :active }, length: { maximum: 255 }
 
   #TODO: limit association only to providers?
   #TODO validate url as url?

--- a/app/views/provider/admin/account/authentication_providers/_keycloak.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/_keycloak.html.slim
@@ -3,7 +3,7 @@ dt.u-dl-term
 dd.u-dl-definition
   = @presenter.authentication_provider.realm
 dt.u-dl-term
-  | Skip SSL Certificate Verification
+  | Skip SSL certificate verification
 dd.u-dl-definition
   => check_box_tag 'check', 'yes', @presenter.authentication_provider.skip_ssl_certificate_verification, disabled: true
 

--- a/app/views/provider/admin/account/authentication_providers/form/_auth0.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/form/_auth0.html.slim
@@ -1,1 +1,1 @@
-= f.input :site, as: :patternfly_input, required: true, hint: 'e.g. https://XXXXX.auth0.com'
+= f.input :site, as: :patternfly_input, required: true, hint: Formtastic::I18n.t('authentication_provider/auth0.site', scope: :hints)

--- a/app/views/provider/admin/account/authentication_providers/form/_auth0.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/form/_auth0.html.slim
@@ -1,1 +1,1 @@
-= f.input :site, as: :patternfly_input, required: true, hint: 'Ex: https://XXXXX.auth0.com'
+= f.input :site, as: :patternfly_input, required: true, hint: 'e.g. https://XXXXX.auth0.com'

--- a/app/views/provider/admin/account/authentication_providers/form/_form.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/form/_form.html.slim
@@ -1,2 +1,2 @@
-= f.input :client_id, as: :patternfly_input, required: true, label: 'Client'
-= f.input :client_secret,  as: :patternfly_input, input_html: { type: 'password' }, required: true, label: 'Client Secret'
+= f.input :client_id, as: :patternfly_input, required: true
+= f.input :client_secret,  as: :patternfly_input, input_html: { type: 'password' }, required: true

--- a/app/views/provider/admin/account/authentication_providers/form/_form.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/form/_form.html.slim
@@ -1,2 +1,2 @@
-      = f.input :client_id, as: :patternfly_input, required: true, label: 'Client'
-      = f.input :client_secret,  as: :patternfly_input, input_html: { type: 'password' }, required: true, label: 'Client Secret'
+= f.input :client_id, as: :patternfly_input, required: true, label: 'Client'
+= f.input :client_secret,  as: :patternfly_input, input_html: { type: 'password' }, required: true, label: 'Client Secret'

--- a/app/views/provider/admin/account/authentication_providers/form/_keycloak.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/form/_keycloak.html.slim
@@ -1,2 +1,2 @@
-= f.input :realm, as: :patternfly_input, required: true, hint: 'Ex: https://rh-sso.example.com/auth/realms/demo'
+= f.input :site, as: :patternfly_input, required: true, hint: 'Ex: https://rh-sso.example.com/auth/realms/demo'
 = f.input :skip_ssl_certificate_verification, as: :patternfly_checkbox

--- a/app/views/provider/admin/account/authentication_providers/form/_keycloak.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/form/_keycloak.html.slim
@@ -1,2 +1,2 @@
-= f.input :site, as: :patternfly_input, required: true, hint: 'Ex: https://rh-sso.example.com/auth/realms/demo'
+= f.input :site, as: :patternfly_input, required: true, label: 'Realm', hint: 'e.g. https://rh-sso.example.com/auth/realms/demo'
 = f.input :skip_ssl_certificate_verification, as: :patternfly_checkbox

--- a/app/views/provider/admin/account/authentication_providers/form/_keycloak.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/form/_keycloak.html.slim
@@ -1,2 +1,4 @@
-= f.input :site, as: :patternfly_input, required: true, label: 'Realm', hint: 'e.g. https://rh-sso.example.com/auth/realms/demo'
+= f.input :site, as: :patternfly_input, required: true, label: Formtastic::I18n.t('authentication_provider/keycloak.site', scope: :labels),
+                                                        hint: Formtastic::I18n.t('authentication_provider/keycloak.site', scope: :hints)
+
 = f.input :skip_ssl_certificate_verification, as: :patternfly_checkbox

--- a/app/views/provider/admin/account/authentication_providers/new.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/new.html.slim
@@ -18,10 +18,13 @@ div class="pf-c-card"
 
       = render partial: 'provider/admin/account/authentication_providers/form/form', locals: {f: f}
 
-      = f.input :site, as: :patternfly_input, required: true, label: 'Realm or Site', hint: 'e.g. https://rh-sso.example.com/auth/realms/demo'
+      = f.input :site, as: :patternfly_input, required: true, label: 'Realm or Site', hint: Formtastic::I18n.t('authentication_provider/keycloak.site', scope: :hints)
 
       = f.actions do
         = f.commit_button I18n.t('provider.admin.authentication_providers.new.submit_button_label')
+
+p id="keycloak_hint_text" style="display:none" = Formtastic::I18n.t('authentication_provider/keycloak.site', scope: :hints)
+p id="auth0_hint_text" style="display:none" = Formtastic::I18n.t('authentication_provider/auth0.site', scope: :hints)
 
 javascript:
   document.addEventListener('DOMContentLoaded', () => {
@@ -29,10 +32,7 @@ javascript:
     const realmOrSiteHint = document.querySelector('.pf-c-form__helper-text')
 
     ssoSelector.addEventListener('change', (e) => {
-      let hintText = 'e.g. https://rh-sso.example.com/auth/realms/demo'
-      if (e.target.value === 'auth0') {
-        hintText = 'e.g. https://XXXXX.auth0.com'
-      }
-      realmOrSiteHint.textContent = hintText
+      const type = e.target.value
+      realmOrSiteHint.textContent = document.querySelector(`#${type}_hint_text`).textContent
     })
   })

--- a/app/views/provider/admin/account/authentication_providers/new.html.slim
+++ b/app/views/provider/admin/account/authentication_providers/new.html.slim
@@ -18,7 +18,7 @@ div class="pf-c-card"
 
       = render partial: 'provider/admin/account/authentication_providers/form/form', locals: {f: f}
 
-      = f.input :site, as: :patternfly_input, required: true, label: 'Realm or Site', hint: 'Ex: https://rh-sso.example.com/auth/realms/demo'
+      = f.input :site, as: :patternfly_input, required: true, label: 'Realm or Site', hint: 'e.g. https://rh-sso.example.com/auth/realms/demo'
 
       = f.actions do
         = f.commit_button I18n.t('provider.admin.authentication_providers.new.submit_button_label')
@@ -29,9 +29,9 @@ javascript:
     const realmOrSiteHint = document.querySelector('.pf-c-form__helper-text')
 
     ssoSelector.addEventListener('change', (e) => {
-      let hintText = 'Ex: https://rh-sso.example.com/auth/realms/demo'
+      let hintText = 'e.g. https://rh-sso.example.com/auth/realms/demo'
       if (e.target.value === 'auth0') {
-        hintText = 'Ex: https://XXXXX.auth0.com'
+        hintText = 'e.g. https://XXXXX.auth0.com'
       }
       realmOrSiteHint.textContent = hintText
     })

--- a/app/views/provider/admin/authentication_providers/_auth0.html.slim
+++ b/app/views/provider/admin/authentication_providers/_auth0.html.slim
@@ -1,1 +1,1 @@
-= f.input :site, as: :patternfly_input, required: true, hint: 'e.g. https://XXXXX.auth0.com'
+= f.input :site, as: :patternfly_input, required: true, hint: Formtastic::I18n.t('authentication_provider/auth0.site', scope: :hints)

--- a/app/views/provider/admin/authentication_providers/_auth0.html.slim
+++ b/app/views/provider/admin/authentication_providers/_auth0.html.slim
@@ -1,1 +1,1 @@
-= f.input :site, as: :patternfly_input, required: true, hint: 'Ex: https://XXXXX.auth0.com'
+= f.input :site, as: :patternfly_input, required: true, hint: 'e.g. https://XXXXX.auth0.com'

--- a/app/views/provider/admin/authentication_providers/_keycloak.html.slim
+++ b/app/views/provider/admin/authentication_providers/_keycloak.html.slim
@@ -1,2 +1,2 @@
-= f.input :realm, as: :patternfly_input, required: true, hint: 'e.g.: https://rh-sso.example.com/auth/realms/demo'
+= f.input :site, as: :patternfly_input, required: true, label: 'Realm', hint: 'e.g. https://rh-sso.example.com/auth/realms/demo'
 = f.input :skip_ssl_certificate_verification, as: :patternfly_checkbox

--- a/app/views/provider/admin/authentication_providers/_keycloak.html.slim
+++ b/app/views/provider/admin/authentication_providers/_keycloak.html.slim
@@ -1,2 +1,3 @@
-= f.input :site, as: :patternfly_input, required: true, label: 'Realm', hint: 'e.g. https://rh-sso.example.com/auth/realms/demo'
+= f.input :site, as: :patternfly_input, required: true, label: Formtastic::I18n.t('authentication_provider/keycloak.site', scope: :labels),
+                                                        hint: Formtastic::I18n.t('authentication_provider/keycloak.site', scope: :hints)
 = f.input :skip_ssl_certificate_verification, as: :patternfly_checkbox

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1656,13 +1656,9 @@ en:
         client_secret: Client Secret
         automatically_approve_accounts: 'Always approve accounts that sign up through this SSO Integration'
         published_admin_portal: Display this SSO Integration on the sign-in page of the admin portal.
-      authentication_provider/github:
-        <<: *authentication_provider
-      authentication_provider/auth0:
-        <<: *authentication_provider
+        skip_ssl_certificate_verification: Skip SSL certificate verification
       authentication_provider/keycloak:
-        <<: *authentication_provider
-        skip_ssl_certificate_verification: Do not verify SSL certificate
+        site: Realm
 
       settings:
         account_approval_required: Account approval required

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1140,9 +1140,7 @@ en:
         authentication_provider:
           attributes:
             site:
-              invalid: "Please, remove any white space."
-            realm:
-              invalid: "Please, remove any white space."
+              contains_whitespace: "can't contain whitespaces"
             kind:
               not_found: "unavailable for this account type"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1494,6 +1494,10 @@ en:
       rest: 'REST API'
   formtastic:
     hints:
+      authentication_provider/keycloak:
+        site: e.g. https://rh-sso.example.com/auth/realms/demo
+      authentication_provider/auth0:
+        site: e.g. https://XXXXX.auth0.com
       backend_api:
         system_name: Only ASCII letters, numbers, dashes and underscores are allowed.
         private_endpoint_html:
@@ -1658,6 +1662,7 @@ en:
         published_admin_portal: Display this SSO Integration on the sign-in page of the admin portal.
         skip_ssl_certificate_verification: Skip SSL certificate verification
       authentication_provider/keycloak:
+        <<: *authentication_provider
         site: Realm
 
       settings:

--- a/features/provider/admin/account/authentication_providers/edit.feature
+++ b/features/provider/admin/account/authentication_providers/edit.feature
@@ -19,7 +19,7 @@ Feature: Account Settings > Users > SSO Integrations > Edit
       | Client                            | Rose Tyler                                     |
       | Client Secret                     | outdated-tardis                                |
       | Realm                             | https://rh-sso.rose-tyler.com/auth/realms/demo |
-      | Skip ssl certificate verification | Yes                                           |
+      | Skip SSL certificate verification | Yes                                           |
     Then they should see the flash message "SSO integration updated"
 
   Scenario: Missing field

--- a/features/provider/admin/account/authentication_providers/new.feature
+++ b/features/provider/admin/account/authentication_providers/new.feature
@@ -45,9 +45,9 @@ Feature: Account Settings > Users > SSO Integrations > New
   Scenario: Realm or Site hint is accurate
     Given they go to the new sso integration page
     When they select "Red Hat Single Sign-On" from "SSO Provider"
-    Then they should see "Ex: https://rh-sso.example.com/auth/realms/demo"
+    Then they should see "e.g. https://rh-sso.example.com/auth/realms/demo"
     When they select "Auth0" from "SSO Provider"
-    Then they should see "Ex: https://XXXXX.auth0.com"
+    Then they should see "e.g. https://XXXXX.auth0.com"
 
   Scenario: Client Secret is required
     Given they go to the new sso integration page

--- a/features/provider/admin/authentication_providers/edit.feature
+++ b/features/provider/admin/authentication_providers/edit.feature
@@ -21,7 +21,7 @@ Feature: Audience > Developer Portal > Settings > SSO Integrations > Edit
       | Client ID                         | Rose Tyler                                     |
       | Client Secret                     | outdated-tardis                                |
       | Realm                             | https://rh-sso.rose-tyler.com/auth/realms/demo |
-      | Skip ssl certificate verification | Yes                                            |
+      | Skip SSL certificate verification | Yes                                            |
     Then they should see the flash message "Authentication provider updated"
 
   Scenario: Missing field

--- a/test/factories/authentication_provider.rb
+++ b/test/factories/authentication_provider.rb
@@ -28,6 +28,11 @@ FactoryBot.define do
     account_type { AuthenticationProvider.account_types[:provider] }
   end
 
+  factory(:keycloak_self_authentication_provider,
+          parent: :keycloak_authentication_provider) do
+    account_type { AuthenticationProvider.account_types[:provider] }
+  end
+
   factory(:auth0_authentication_provider,
                     parent: :authentication_provider,
                     class: AuthenticationProvider::Auth0)

--- a/test/integration/admin/api/account/authentication_providers_controller_test.rb
+++ b/test/integration/admin/api/account/authentication_providers_controller_test.rb
@@ -56,7 +56,7 @@ class Admin::Api::Account::AuthenticationProvidersControllerTest < ActionDispatc
     end
   end
 
-  test '#create keycloak without blank or invalid site returns the right error' do
+  test '#create keycloak with blank or invalid site returns the right error' do
     post admin_api_account_authentication_providers_path(authentication_provider_params(different_attributes: {kind: 'keycloak', site: ''}))
     assert_equal ["can't be blank"], JSON.parse(response.body).dig('errors', 'site')
 

--- a/test/integration/provider/admin/account/authentication_providers_controller_test.rb
+++ b/test/integration/provider/admin/account/authentication_providers_controller_test.rb
@@ -68,6 +68,17 @@ class Provider::Admin::Account::AuthenticationProvidersControllerTest < ActionDi
     assert authentication_provider.reload.skip_ssl_certificate_verification
   end
 
+  test 'PATCH update invalid URL' do
+    authentication_provider = FactoryBot.create(:keycloak_self_authentication_provider, account: @provider)
+
+    patch provider_admin_account_authentication_provider_path(authentication_provider), params: { authentication_provider: { site: '  http://example.com  ' } }
+
+    assert_response :success
+    assert_template :edit
+    assert_match 'SSO integration could not be updated', flash[:error]
+    assert_match "contain whitespaces", response.body
+  end
+
   test 'DELETE destroy' do
     authentication_provider = FactoryBot.create(:self_authentication_provider, account: @provider)
 

--- a/test/integration/provider/admin/account/authentication_providers_controller_test.rb
+++ b/test/integration/provider/admin/account/authentication_providers_controller_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Admin Portal SSO integration
+class Provider::Admin::Account::AuthenticationProvidersControllerTest < ActionDispatch::IntegrationTest
+
+  setup do
+    @provider = FactoryBot.create(:provider_account)
+    FactoryBot.create(:admin, account: @provider)
+    login_provider @provider
+  end
+
+  test 'GET index' do
+    get provider_admin_authentication_providers_path
+    assert_response :success
+    assert_template :index
+  end
+
+  test 'POST create success' do
+    %w[keycloak auth0].each do |kind|
+      attrs = { client_id: 'client', client_secret: 'secret', site: 'http://example.com', kind: kind }
+      assert_not @provider.self_authentication_providers.find_by(kind: kind, client_id: attrs[:client_id])
+      post provider_admin_account_authentication_providers_path, params: { authentication_provider: attrs }
+
+      authentication_provider = @provider.self_authentication_providers.find_by! kind: kind, client_id: attrs[:client_id]
+      assert_equal attrs[:site].strip, authentication_provider.site
+      assert_redirected_to provider_admin_account_authentication_provider_path(authentication_provider)
+      follow_redirect!
+      assert_response :success
+      assert_match 'SSO integration created', flash[:notice]
+    end
+  end
+
+  test 'POST create with site with whitespaces' do
+    %w[keycloak auth0].each do |kind|
+      attrs = { client_id: 'client', client_secret: 'secret', site: '  http://example.com  ', kind: kind }
+      post provider_admin_account_authentication_providers_path, params: { authentication_provider: attrs }
+
+      assert_nil @provider.self_authentication_providers.find_by kind: kind, client_id: attrs[:client_id]
+      assert_response :success
+      assert_template :new
+      assert_match 'SSO integration could not be created', flash[:error]
+      assert_match "contain whitespaces", response.body
+    end
+  end
+
+  test 'GET show' do
+    authentication_provider = FactoryBot.create(:self_authentication_provider, account: @provider)
+    get provider_admin_account_authentication_provider_path(authentication_provider)
+    assert_response :success
+    assert_template :show
+  end
+
+  test 'GET edit' do
+    authentication_provider = FactoryBot.create(:self_authentication_provider, account: @provider)
+    get edit_provider_admin_account_authentication_provider_path(authentication_provider)
+    assert_response :success
+    assert_template :edit
+  end
+
+  test 'PATCH update params' do
+    authentication_provider = FactoryBot.create(:self_authentication_provider, account: @provider)
+    assert_not authentication_provider.skip_ssl_certificate_verification
+    patch provider_admin_account_authentication_provider_path(authentication_provider), params: { authentication_provider: { skip_ssl_certificate_verification: '1' } }
+
+    assert_redirected_to provider_admin_account_authentication_provider_path(authentication_provider)
+    assert authentication_provider.reload.skip_ssl_certificate_verification
+  end
+
+  test 'DELETE destroy' do
+    authentication_provider = FactoryBot.create(:self_authentication_provider, account: @provider)
+
+    delete provider_admin_account_authentication_provider_path(authentication_provider)
+
+    assert_redirected_to provider_admin_account_authentication_providers_path
+
+    assert_raise ActiveRecord::RecordNotFound do
+      authentication_provider.reload
+    end
+  end
+end

--- a/test/unit/presenters/oauth_flow_presenter_test.rb
+++ b/test/unit/presenters/oauth_flow_presenter_test.rb
@@ -28,6 +28,16 @@ class OAuthFlowPresenterTest < ActiveSupport::TestCase
         presenter.sso_integration_callback_url
   end
 
+  # this is to prevent Internal Server Error for any potential
+  # existing SSO integrations with whitespaces in site/realm param
+  test 'ignore whitespaces in site param' do
+    auth_provider = FactoryBot.build_stubbed(:keycloak_authentication_provider, kind: 'keycloak')
+    auth_provider.site = '  http://whitespace-test.com  '
+
+    presenter = OAuthFlowPresenter.new(auth_provider, @request)
+    assert presenter.authorize_url.start_with?('http://whitespace-test.com')
+  end
+
   test 'callback_endpoint' do
     expected_url = "http://#{@provider.external_domain}/auth/#{@authentication_provider.system_name}/callback?plan_id=42"
     assert_equal expected_url, @presenter.callback_url


### PR DESCRIPTION
**What this PR does / why we need it**:

When creating an SSO integration for the admin portal (`/p/admin/account/authentication_providers/new`), if the realm/site URL has leading/trailing spaces, the creation, and later viewing this integration throws an Internal Error (status code 500).

In dev mode the error is:
```
bad URI(is not URI?): "https://rh-sso.example.com/auth/realms/demo " 
  def build_client
    @client = ThreeScale::OAuth2::Client.build(authentication_provider).tap do |new_client|
      new_client.client.connection.ssl.verify = authentication_provider.ssl_verify_mode
    end
  rescue ::ThreeScale::OAuth2::KeycloakClient::MissingRealmError
    @client = NullClient.new
```

Find more details below.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11609

**Verification steps** 

Before the fix:
- try creating a new SSO integration (Keycloak) for admin portal, specifying a URL with a leading or trailing whitespace(s). It is created, but the `show` template where the user is redirected after creation fails.
- when trying to create a new SSO integration with an empty or non-URL value for Realm, the creation fails, but the inline error is not shown (and the field is not highlighted)

After the fix:
- SSO integration creation with the same data now fails, and the corresponding message is shown ("can't contain whitespaces").
- When updating an existing SSO integration, the same error appears if the URL is invalid.
- The invalid SSO integrations, that were previously created with whitespaces, can now be viewed - but when trying to update them the validation error will prevent (unless the value is fixed)
- creating an SSO integration with an empty or non-URL value now shows proper highlighting and error message

**Special notes for your reviewer**:
