### PR TITLE
THREESCALE-11624: Fix keyword argument in Service Discovery import

### DIFF
--- a/app/services/finance/charging_service.rb
+++ b/app/services/finance/charging_service.rb
@@ -36,14 +36,14 @@ module Finance
       payment_profile = payment_profiles.is_a?(Array) ? payment_profiles[-1] : payment_profiles # payment_profiles can be a Hash or an Array of hashes
       payment_profile_id = payment_profile['customer_payment_profile_id']
 
-      gateway.cim_gateway.create_customer_profile_transaction(
-        transaction: {
-          customer_profile_id: buyer_reference,
-          customer_payment_profile_id: payment_profile_id,
-          type: :auth_capture,
-          amount: amount.to_f
-        }
-      )
+      gateway.cim_gateway.create_customer_profile_transaction({
+                                                                transaction: {
+                                                                  customer_profile_id: buyer_reference,
+                                                                  customer_payment_profile_id: payment_profile_id,
+                                                                  type: :auth_capture,
+                                                                  amount: amount.to_f
+                                                                }
+                                                              })
     end
 
     def authorize_net_customer_profile

--- a/app/workers/service_discovery/create_service_worker.rb
+++ b/app/workers/service_discovery/create_service_worker.rb
@@ -12,7 +12,7 @@ module ServiceDiscovery
       return unless oauth_manager.service_usable?
       account = Account.providers.find account_id
       options = { cluster_namespace: cluster_namespace, cluster_service_name: cluster_service_name }
-      ImportClusterDefinitionsService.new(user).create_service(account, options)
+      ImportClusterDefinitionsService.new(user).create_service(account, **options)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,6 +48,14 @@ WebMock.enable!
 
 WebMock.disable_net_connect!
 
+require 'mocha/minitest'
+Mocha.configure do |c|
+  c.strict_keyword_argument_matching = true
+  # TODO: enable the following two configs to improve the tests eventually
+  # c.stubbing_non_existent_method = :prevent
+  # c.stubbing_method_unnecessarily = :prevent
+end
+
 class ActiveSupport::TestCase
   self.use_transactional_tests = true
   self.use_instantiated_fixtures  = false

--- a/test/workers/backend_delete_application_worker_test.rb
+++ b/test/workers/backend_delete_application_worker_test.rb
@@ -8,8 +8,8 @@ class BackendDeleteApplicationWorkerTest < ActiveSupport::TestCase
     service = application.service
 
     seq = sequence('destroy sequence')
-    ApplicationKeyBackendService.expects(:delete_all).with({ application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id }).in_sequence(seq)
-    ReferrerFilterBackendService.expects(:delete_all).with({ application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id }).in_sequence(seq)
+    ApplicationKeyBackendService.expects(:delete_all).with(application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id).in_sequence(seq)
+    ReferrerFilterBackendService.expects(:delete_all).with(application_id: application.id, service_backend_id: service.backend_id, application_backend_id: application.application_id).in_sequence(seq)
     ThreeScale::Core::Application.expects(:delete).with(service.backend_id, application.application_id).in_sequence(seq)
 
     event = Applications::ApplicationDeletedEvent.create_and_publish!(application)

--- a/test/workers/service_discovery/create_service_worker_test.rb
+++ b/test/workers/service_discovery/create_service_worker_test.rb
@@ -5,7 +5,6 @@ require 'test_helper'
 module ServiceDiscovery
   class CreateServiceWorkerTest < ActiveSupport::TestCase
     setup do
-      ThreeScale.config.service_discovery.stubs(enabled: true)
       @user = nil
     end
 
@@ -14,7 +13,7 @@ module ServiceDiscovery
       account = FactoryBot.create(:simple_provider)
       ServiceDiscovery::OAuthManager.expects(:new).with(@user).returns(oauth_manager).at_least_once
       import_definition = mock
-      import_definition.expects(:create_service).with(account, { cluster_namespace: 'fake-project', cluster_service_name: 'fake-api' })
+      import_definition.expects(:create_service).with(account, cluster_namespace: 'fake-project', cluster_service_name: 'fake-api')
       ImportClusterDefinitionsService.expects(:new).with(@user).returns(import_definition)
       CreateServiceWorker.new.perform(account.id, 'fake-project', 'fake-api', @user&.id)
     end

--- a/test/workers/web_hook_worker_test.rb
+++ b/test/workers/web_hook_worker_test.rb
@@ -47,7 +47,7 @@ class WebHookWorkerTest < ActiveSupport::TestCase
   end
 
   test 'perform sends the webhook' do
-    @worker.expects(:push).with({ url: 'url', xml: 'xml', content_type: 'content_type' })
+    @worker.expects(:push).with(url: 'url', xml: 'xml', content_type: 'content_type')
     @worker.perform('uuid', { 'provider_id' => 'provider', 'url' => 'url', 'xml' => 'xml', 'content_type' => 'content_type' })
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In the latest alpha Service discovery feature doesn't work - the service is discovered through annotations, but not imported.

The sidekiq logs show the following error:
```
2025-01-23T05:40:56.608Z pid=7 tid=63sh3 WARN: {"context":"Job raised exception","job":{"retry":true,"queue":"default","args":[2,"tools","go-httpbin",2],"class":"ServiceDiscovery::CreateServiceWorker","jid":"00dd5087d7c2cc369aade997","created_at":1737610803.388993,"enqueued_at":1737610856.6016831,"error_message":"wrong number of arguments (given 2, expected 1; required keywords: cluster_namespace, cluster_service_name)","error_class":"ArgumentError","failed_at":1737610803.3969626,"retry_count":1,"retried_at":1737610826.7337837}}
2025-01-23T05:40:56.608Z pid=7 tid=63sh3 WARN: ArgumentError: wrong number of arguments (given 2, expected 1; required keywords: cluster_namespace, cluster_service_name)
2025-01-23T05:40:56.609Z pid=7 tid=63sh3 WARN: app/services/service_discovery/import_cluster_definitions_service.rb:31:in `create_service'
app/workers/service_discovery/create_service_worker.rb:15:in `perform'
lib/three_scale/sidekiq_retry_support.rb:56:in `call'
app/lib/three_scale/analytics/sidekiq_middleware.rb:5:in `call'
```

This was probably caused by Ruby 3.1 upgrade, where keyword arguments are treated differently from hash positional arguments.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11624

**Verification steps** 

Check that the discovered service is eventually imported.

**Special notes for your reviewer**:
