### PR TITLE
Silence deprecation warnings in Sass

### DIFF
--- a/config/webpack/rules.js
+++ b/config/webpack/rules.js
@@ -44,6 +44,12 @@ module.exports = () => [
         options: {
           sassOptions: {
             includePaths: additionalPaths,
+            silenceDeprecations: [
+                'legacy-js-api',
+                'import',
+                'global-builtin',
+                'color-functions',
+            ],
           },
         },
       },


### PR DESCRIPTION
**What this PR does / why we need it**:

When Sass was upgraded by Snyk in https://github.com/3scale/porta/pull/3977 a bunch of deprecation warnings appeared when running `bundle exec rake webpack:dev`

This PR silences them until (if) we address them.

**Which issue(s) this PR fixes** 


**Verification steps** 


**Special notes for your reviewer**:
