### PR TITLE
Fix a missing Plans column on the applications list

### DIFF
--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -5,8 +5,8 @@ class Api::ApplicationsController < FrontendController
   include ApplicationsControllerMethods
 
   before_action :authorize_partners
-  before_action :find_plans
   before_action :find_service
+  before_action :find_plans
   before_action :find_states, only: :index # rubocop:disable Rails/LexicallyScopedActionFilter
   before_action :find_buyer, only: :create
   before_action :authorize_multiple_applications, only: :create
@@ -42,8 +42,8 @@ class Api::ApplicationsController < FrontendController
     @service = accessible_services.find params[:service_id]
   end
 
-  def accessible_plans
-    super.where(issuer: @service)
+  def find_plans
+    @application_plans = accessible_plans.where(issuer: @service)
   end
 
   def initialize_new_presenter

--- a/app/views/shared/applications/_listing.html.slim
+++ b/app/views/shared/applications/_listing.html.slim
@@ -14,9 +14,7 @@
 - content_for :javascripts do
   = javascript_packs_with_chunks_tag 'table_toolbar'
 
-/ FIXME: The first condition does not make any sense but application_plans used to be accessible_plans, now it's accessible_plans.stock
-/ FIXME 2: application_plans returns [] in services/:id/applications even though there are plans
-- show_application_plans = application_plans.size > 0 && !master_on_premises?
+- show_application_plans = application_plans.size > 1 && !master_on_premises?
 - service_column_visible = service.nil? && current_account.multiservice?
 div class="pf-c-card"
   table class="pf-c-table pf-m-grid-lg" role="grid" aria-label="Applications table" data-toolbar-props=@presenter.toolbar_props.to_json

--- a/features/api/services/applications/index.feature
+++ b/features/api/services/applications/index.feature
@@ -6,8 +6,8 @@ Feature: Product > Applications
 
   Background:
     Given a provider
-    And a product "My API"
-    And another product "Another API"
+    And a product "My API" with no plans
+    And another product "Another API" with no plans
     And the following application plans:
       | Product     | Name      | Cost per month | Setup fee |
       | My API      | Cheap     | 0              | 0         |
@@ -42,13 +42,30 @@ Feature: Product > Applications
     And there should be a link to "Add an application"
 
   Scenario: Only the current service applications are listed
-  When they go to product "My API" applications page
-    Then they should see the following table:
-      | Name            | State | Account | Created on        | Traffic on |
-      | Jane's Full App | live  | Jane    | December 13, 2023 |            |
-      | Jane's Lite App | live  | Jane    | December 12, 2023 |            |
-      | Bob's App       | live  | Bob     | December 11, 2023 |            |
+    When they go to product "My API" applications page
+    Then they should see the following table with exact columns:
+      # Plan column is visible because this service has multiple plans
+      | Name            | State | Account | Plan      | Created on        | Traffic on |
+      | Jane's Full App | live  | Jane    | Expensive | December 13, 2023 |            |
+      | Jane's Lite App | live  | Jane    | Cheap     | December 12, 2023 |            |
+      | Bob's App       | live  | Bob     | Cheap     | December 11, 2023 |            |
     When they go to product "Another API" applications page
-    Then they should see the following table:
+    Then they should see the following table with exact columns:
+      # Plan column is not visible because this service has just one plan
       | Name            | State | Account | Created on        | Traffic on |
       | Another API App | live  | Bob     | December 10, 2023 |            |
+
+  Scenario: Paid? column is shown when finance is enabled
+    When the provider is charging its buyers
+    And they go to product "My API" applications page
+    Then they should see the following table with exact columns:
+      # Plan column is visible because this service has multiple plans
+      | Name            | State | Account | Plan      | Paid? | Created on        | Traffic on |
+      | Jane's Full App | live  | Jane    | Expensive | paid  | December 13, 2023 |            |
+      | Jane's Lite App | live  | Jane    | Cheap     | free  | December 12, 2023 |            |
+      | Bob's App       | live  | Bob     | Cheap     | free  | December 11, 2023 |            |
+    When they go to product "Another API" applications page
+    Then they should see the following table with exact columns:
+      # Plan column is not visible because this service has just one plan
+      | Name            | State | Account | Paid? | Created on        | Traffic on |
+      | Another API App | live  | Bob     | paid  | December 10, 2023 |            |

--- a/features/api/services/applications/index.feature
+++ b/features/api/services/applications/index.feature
@@ -44,28 +44,25 @@ Feature: Product > Applications
   Scenario: Only the current service applications are listed
     When they go to product "My API" applications page
     Then they should see the following table with exact columns:
-      # Plan column is visible because this service has multiple plans
       | Name            | State | Account | Plan      | Created on        | Traffic on |
       | Jane's Full App | live  | Jane    | Expensive | December 13, 2023 |            |
       | Jane's Lite App | live  | Jane    | Cheap     | December 12, 2023 |            |
       | Bob's App       | live  | Bob     | Cheap     | December 11, 2023 |            |
     When they go to product "Another API" applications page
     Then they should see the following table with exact columns:
-      # Plan column is not visible because this service has just one plan
       | Name            | State | Account | Created on        | Traffic on |
       | Another API App | live  | Bob     | December 10, 2023 |            |
 
-  Scenario: Paid? column is shown when finance is enabled
-    When the provider is charging its buyers
-    And they go to product "My API" applications page
-    Then they should see the following table with exact columns:
-      # Plan column is visible because this service has multiple plans
-      | Name            | State | Account | Plan      | Paid? | Created on        | Traffic on |
-      | Jane's Full App | live  | Jane    | Expensive | paid  | December 13, 2023 |            |
-      | Jane's Lite App | live  | Jane    | Cheap     | free  | December 12, 2023 |            |
-      | Bob's App       | live  | Bob     | Cheap     | free  | December 11, 2023 |            |
+  Scenario: Plan column is hidden when the API has a single plan
+    When they go to product "My API" applications page
+    Then the table has a column "Plan"
     When they go to product "Another API" applications page
-    Then they should see the following table with exact columns:
-      # Plan column is not visible because this service has just one plan
-      | Name            | State | Account | Paid? | Created on        | Traffic on |
-      | Another API App | live  | Bob     | paid  | December 10, 2023 |            |
+    Then the table does not have a column "Plan"
+
+  Scenario: Paid? column is shown when finance is enabled
+    When the provider has "finance" denied
+    And they go to product "My API" applications page
+    Then the table does not have a column "Paid?"
+    When the provider has "finance" allowed
+    And they go to product "My API" applications page
+    Then the table has a column "Paid?"

--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -21,7 +21,7 @@ When "(they )select action {string} of (row ){string}" do |action, row|
 end
 
 # TODO: can we use "has_table?" instead of this complex step?
-Then "(I )(they )should see (the )following table(:)" do |expected|
+Then /^(?:I |they )?should see (?:the )?following table( with exact columns)?:?$/ do |exact_columns, expected|
   table = extract_table('table', 'tr:not(.search, .table_title)', 'td:not(.select), th:not(.select)')
 
   # strip html entities and non letter, space or number characters
@@ -40,7 +40,8 @@ Then "(I )(they )should see (the )following table(:)" do |expected|
 
   retries ||= 1
 
-  expected.diff! table
+  options = exact_columns.present? ? { surplus_col: true } : {}
+  expected.diff! table, options
 rescue Cucumber::MultilineArgument::DataTable::Different, IndexError => error
   if retries > 0
     retries -= 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the missing **Plan** column on the application listing.

Before:
![Screenshot from 2025-01-28 15-35-24](https://github.com/user-attachments/assets/93e7e0fd-5688-43f0-8864-d5df62153abf)


After:
![Screenshot from 2025-01-28 15-35-39](https://github.com/user-attachments/assets/449f7fc3-f08d-4278-ac4f-a267ee1e136a)


**Which issue(s) this PR fixes** 

not registered

**Verification steps** 

View a list of applications under a service that has multiple plans, and make sure that there is a **Plans** column.

**Special notes for your reviewer**:

See comments inline