### PR TITLE
THREESCALE-9751: Ignore read only fields

### DIFF
--- a/app/models/fields_definition.rb
+++ b/app/models/fields_definition.rb
@@ -24,6 +24,7 @@ class FieldsDefinition < ApplicationRecord
   scope :by_target, ->(class_name) { where(['target = ?', class_name])}
   scope :by_name, ->(name) { where(['name = ?', name])}
   scope :required, -> { where({ :required => true })}
+  scope :read_only, ->(read_only = true) { where(read_only: read_only) }
 
   def self.editable_by(user)
     select{ |fd| fd.editable_by?(user) }

--- a/features/developer_portal/admin/applications/extra_fields.feature
+++ b/features/developer_portal/admin/applications/extra_fields.feature
@@ -63,6 +63,28 @@ Feature: Developer portal application extra fields
       | Plate number |
       | Stealth      |
 
+  Scenario: Read-only extra fields are ignored if received
+    Given the following application:
+      | Buyer | Name       | Product |
+      | Jane  | Jane's App | The API |
+    And the application has the following extra fields:
+      | Description | It's a car |
+      | Engine      | 120        |
+      | Wheels      | 4          |
+      | Color       | White      |
+    When the buyer logs in
+    And the provider has the field "plate_number" for applications as editable
+    And they go to application "Jane's App" dev portal edit page
+    And the provider has the field "plate_number" for applications as read only
+    And the form is submitted with:
+      | Description  | It's a car |
+      | Engine       | 120        |
+      | Wheels       | 4          |
+      | Color        | White      |
+      | Plate number | edit me    |
+    Then they should see the flash message "Application was successfully updated"
+    And they should not see "Plate number"
+
   Scenario: Extra fields validation
     When they go to the dev portal new application page
     And the form is submitted with:

--- a/features/old/accounts/buyers/account_fields.feature
+++ b/features/old/accounts/buyers/account_fields.feature
@@ -46,6 +46,18 @@ Feature: Buyer side, account fields
        And I press "Update"
      Then I should see "The account information was updated."
 
+  Scenario: Read-only extra fields are ignored on update
+    Given I log in as "bob" on foo.3scale.localhost
+    And provider "foo.3scale.localhost" has the field "non_editable" for accounts as editable
+    Then I go to the account edit page
+    And provider "foo.3scale.localhost" has the field "non_editable" for accounts as read only
+    And the form is submitted with:
+      | Required field | value  |
+      | False field    |        |
+      | Choices field  |      3 |
+      | Non editable   | edited |
+    Then I should see "The account information was updated."
+    Then I should not see "Non editable"
 
   Scenario: Viewing account with extra fields
     #TODO ugly table change this

--- a/features/step_definitions/provider_steps.rb
+++ b/features/step_definitions/provider_steps.rb
@@ -65,6 +65,12 @@ Given "{provider} has the field {string} for {string} in the position {int}" do 
   a.save!
 end
 
+Given "{provider} has the field {string} for {field_definition_target} as {read_only_status}" do |provider, name, target, read_only|
+  a = provider.fields_definitions.by_target(target).find { |fd| fd.name == name }
+  a.read_only = read_only
+  a.save!
+end
+
 Given "{provider} allows to change account plan {change_plan_permission}" do |provider, plan_permission|
   provider.set_change_account_plan_permission! plan_permission
 end

--- a/features/support/parameter_types.rb
+++ b/features/support/parameter_types.rb
@@ -474,3 +474,14 @@ ParameterType(
   regexp: /(.*)/,
   transformer: ->(selector) { selector_for(selector) }
 )
+
+ParameterType(
+  name: 'read_only_status',
+  regexp: /(editable|read only)/,
+  transformer: ->(value) do
+    {
+      'editable' => false,
+      'read only' => true,
+    }[value]
+  end
+)

--- a/lib/developer_portal/app/controllers/developer_portal/accounts/invitee_signups_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/accounts/invitee_signups_controller.rb
@@ -119,7 +119,7 @@ class DeveloperPortal::Accounts::InviteeSignupsController < DeveloperPortal::Bas
   end
 
   def build_user
-    @user = @invitation.make_user(params[:user] || {})
+    @user = @invitation.make_user(filter_readonly_params(params[:user], User))
   end
 
   def invitation_token

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/personal_details_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/personal_details_controller.rb
@@ -44,7 +44,7 @@ class DeveloperPortal::Admin::Account::PersonalDetailsController < ::DeveloperPo
   end
 
   def user_params
-    params.require(:user).permit([:current_password] +
+    filter_readonly_params(params.require(:user), User).permit([:current_password] +
                                    resource.special_fields +
                                    resource.defined_fields.map(&:name))
   end

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/users_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/users_controller.rb
@@ -53,7 +53,7 @@ class DeveloperPortal::Admin::Account::UsersController < ::DeveloperPortal::Base
 
   def update_resource(user, attributes)
     attributes.each do |attrs|
-      user.attributes = attrs
+      user.attributes = filter_readonly_params(attrs, User)
       user.role = attrs[:role] if can? :update_role, user
     end
     user.save

--- a/lib/developer_portal/app/controllers/developer_portal/admin/accounts_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/accounts_controller.rb
@@ -35,7 +35,7 @@ class DeveloperPortal::Admin::AccountsController < DeveloperPortal::BaseControll
   private
 
   def account_params
-    params.require(:account)
+    filter_readonly_params(params.require(:account), Account)
   end
 
   def find_countries

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -172,11 +172,12 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
     # cinstance[*] naming is present for legacy reasons
     application_attributes = params[:application] || params[:cinstance]
     return {} unless application_attributes
+
     permitted_params = fields_definitions + %i[plan_id redirect_url]
     application_attributes.permit(*permitted_params)
   end
 
   def fields_definitions
-    FieldsDefinition.by_provider(site_account).by_target('Cinstance').pluck(:name)
+    FieldsDefinition.by_provider(site_account).by_target('Cinstance').read_only(false).pluck(:name)
   end
 end

--- a/lib/developer_portal/app/controllers/developer_portal/base_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/base_controller.rb
@@ -25,4 +25,11 @@ class DeveloperPortal::BaseController < DeveloperPortal::ApplicationController
 
     redirect_to edit_payment_details_path
   end
+
+  def filter_readonly_params(params, resource_class)
+    return {} unless params
+
+    read_only_fields = FieldsDefinition.by_provider(site_account).by_target(resource_class.name).read_only.pluck(:name)
+    params.except(*read_only_fields)
+  end
 end

--- a/lib/developer_portal/app/controllers/developer_portal/signup_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/signup_controller.rb
@@ -30,8 +30,8 @@ module DeveloperPortal
     end
 
     def create
-      account_params = (params[:account] || {}) .dup
-      user_params    = account_params.try(:delete, :user) || {}
+      account_params = filter_readonly_params(params[:account], Account)
+      user_params    = filter_readonly_params(account_params.try(:delete, :user), User)
 
       if signup_user!(account_params, user_params)
         if @user.can_login?

--- a/test/integration/developer_portal/base_controller_test.rb
+++ b/test/integration/developer_portal/base_controller_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DeveloperPortal
+  class BaseControllerTest < ActionDispatch::IntegrationTest
+
+    class FilterReadOnlyParamsTest < BaseControllerTest
+      class TestController < DeveloperPortal::BaseController
+        skip_before_action :login_required
+
+        def create
+          render plain: filter_readonly_params(params[:user], User)
+        end
+      end
+
+      test 'filters out read-only fields' do
+        account = FactoryBot.create(:simple_provider)
+        ro_fields = FactoryBot.create_list(:fields_definition, 2, account:, read_only: true)
+        editable_fields = FactoryBot.create_list(:fields_definition, 3, account:)
+
+        ro_params = fields_to_hash(ro_fields)
+        editable_params = fields_to_hash(editable_fields)
+
+        TestController.any_instance.expects(:site_account).at_least_once.returns(account)
+
+        with_test_routes do
+          post '/test/create', params: { user: {**ro_params, **editable_params} }
+
+          assert_response :success
+          assert_equal editable_params.to_s, response.body
+        end
+      end
+    end
+
+    private
+
+    def fields_to_hash(fields)
+      fields.each_with_object({}) { |fd, p| p[fd.name]=SecureRandom.hex }
+    end
+
+    def with_test_routes
+      Rails.application.routes.draw do
+        post '/test/create' => 'developer_portal/base_controller_test/filter_read_only_params_test/test#create'
+      end
+      yield
+    ensure
+      Rails.application.routes_reloader.reload!
+    end
+  end
+end

--- a/test/unit/developer_portal/base_controller_test.rb
+++ b/test/unit/developer_portal/base_controller_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+module DeveloperPortal
+  class BaseControllerTest < ActiveSupport::TestCase
+
+    class TestController < DeveloperPortal::BaseController; end
+
+    class FilterReadOnlyParamsTest < BaseControllerTest
+
+      test 'filters out read-only fields' do
+        account = FactoryBot.create(:simple_provider)
+        ro_fields = FactoryBot.create_list(:fields_definition, 2, account:, read_only: true)
+        FactoryBot.create_list(:fields_definition, 3, account:)
+        params = account.fields_definitions.each_with_object({}) { |fd, p| p[fd.name]=SecureRandom.hex }
+        TestController.any_instance.expects(:site_account).returns(account)
+
+        result = TestController.new.send(:filter_readonly_params, params, User)
+
+        assert_equal 3, result.size
+        assert_not_includes result, ro_fields.map(&:name)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

A provider can create extra fields for `Account`, `User` and `Cinstance`. In the developer portal, these fields are hidden by default, but we can't control what clients do with templates, also a form can be easily tampered using browser dev tools. If the user manages to send read-only fields in a form, porta stores them in the DB.

This is a draft because I'm not 100% convinced this is the proper way to solve the problem. I was looking for a way to have a unified solution in one place but I could only think of approaches requiring ActiveRecord methods overwriting or middledware, so I manually edited all controllers to manually remove all read-only fields from parameters. I don't like it but it's the option I dislike the least. Also please read comments below.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-9751

**Verification steps** 

Follow the instructions from the Jira issue. Instead of sending a curl, forms can also be altered using the browser dev tools. The read-only fields should be ignored
