### PR TITLE
Fix styles on the Backend API metric Edit form

### DIFF
--- a/app/views/api/metrics/_form.html.slim
+++ b/app/views/api/metrics/_form.html.slim
@@ -24,7 +24,7 @@ div class="pf-c-card"
       = form.actions do
         button type="submit" class="pf-c-button pf-m-primary" = t("api.metrics.#{scope}.submit", type: type)
         - if deleteable
-          = link_to 'Delete', admin_service_metric_path(service_id: metric.owner_id, id: metric.id),
+          = link_to 'Delete', url,
                               class: 'pf-c-button pf-m-danger',
                               data: { confirm: t('api.metrics.edit.delete_confirmation', type: metric.type) },
                               method: :delete

--- a/app/views/provider/admin/backend_apis/metrics/_form_edit.html.slim
+++ b/app/views/provider/admin/backend_apis/metrics/_form_edit.html.slim
@@ -1,8 +1,0 @@
-= form.inputs do
-  = form.input :friendly_name, hint: @metric.child? ? 'e.g. Create new user' : 'e.g. Transfer Out', input_html: { autofocus: true }
-  = form.input :system_name, hint: ( @metric.child? ? 'e.g. users/create or create_user' : 'e.g. transfer_out' ) + '. Spaces are not permitted.', input_html: { disabled: @metric.persisted? }
-  = form.input :unit unless @metric.child?
-  = form.input :description, input_html: { rows: 3 }
-
-= form.actions do
-  = form.commit_button "#{@metric.new_record? ? 'Create' : 'Update'} #{@metric.child? ? 'Method' : 'Metric'}"

--- a/app/views/provider/admin/backend_apis/metrics/edit.html.erb
+++ b/app/views/provider/admin/backend_apis/metrics/edit.html.erb
@@ -1,8 +1,0 @@
-<% content_for :page_header_title, "Edit #{@metric.type.to_s.capitalize}" %>
-
-<%= semantic_form_for @metric, :url => provider_admin_backend_api_metric_path(@backend_api, @metric) do |form| %>
-  <%= render 'form_edit', form: form, backend_api: @backend_api, metric: @metric %>
-<% end %>
-<% unless @metric.default?(:hits) %>
-  <%= delete_button_for provider_admin_backend_api_metric_path(@backend_api, @metric), data: { confirm: t('api.metrics.edit.delete_confirmation', type: j(@metric.type)) } %>
-<% end %>

--- a/app/views/provider/admin/backend_apis/metrics/edit.html.slim
+++ b/app/views/provider/admin/backend_apis/metrics/edit.html.slim
@@ -1,0 +1,3 @@
+- url = provider_admin_backend_api_metric_path(@backend_api, @metric)
+
+= render partial: 'api/metrics/form', locals: { url: url, metric: @metric, scope: :edit }

--- a/features/provider/admin/backend_apis/metrics/delete.feature
+++ b/features/provider/admin/backend_apis/metrics/delete.feature
@@ -15,14 +15,14 @@ Feature: BackendApi > Metrics index > Metric
   Scenario: Delete a method
     When I change to tab 'Methods'
     And I follow "Margherita"
-    And I press "Delete"
+    And I follow "Delete"
     And confirm the dialog
     Then I should not see metric "Margherita"
 
   Scenario: Delete a metric
     When I change to tab 'Metrics'
     And I follow "Pizza"
-    And I press "Delete"
+    And I follow "Delete"
     And confirm the dialog
     Then I should not see metric "Pizza"
 

--- a/test/integration/provider/admin/backend_apis/metrics_controller_test.rb
+++ b/test/integration/provider/admin/backend_apis/metrics_controller_test.rb
@@ -74,7 +74,7 @@ class Provider::Admin::BackendApis::MetricsControllerTest < ActionDispatch::Inte
 
     put provider_admin_backend_api_metric_path(backend_api, ads), params: { metric: { friendly_name: '' } }
     assert_equal 'Metric could not be updated', flash[:error]
-    assert_select '#metric_friendly_name_input.required.error'
+    assert_select '#metric_friendly_name[aria-invalid="true"]'
   end
 
   test 'cannot update system_name' do


### PR DESCRIPTION
**What this PR does / why we need it**:

It started as a desire to fix the Delete button style, but ended up applying PF4 styles by reusing an existing form.

Before:
![Screenshot from 2025-01-30 10-52-04](https://github.com/user-attachments/assets/8cbb2b95-ebd8-4e85-abdb-f4271e3fb539)

After:
![Screenshot from 2025-01-30 11-55-03](https://github.com/user-attachments/assets/75f7ea2a-a375-4194-9660-f45828640e14)


**Which issue(s) this PR fixes** 

- none -

**Verification steps** 



**Special notes for your reviewer**:
