### PR TITLE
THREESCALE-11644: Fix policy registry permission (and THREESCALE-6482)

### DIFF
--- a/app/controllers/admin/api/services/proxy/policies_controller.rb
+++ b/app/controllers/admin/api/services/proxy/policies_controller.rb
@@ -4,6 +4,8 @@ class Admin::Api::Services::Proxy::PoliciesController < Admin::Api::Services::Ba
   wrap_parameters ::Proxy
   representer Proxy::PoliciesConfig
 
+  self.access_token_scopes = %i[policy_registry account_management]
+
   # Proxy Policies Chain Show
   # GET /admin/api/services/{service_id}/proxy/policies.json
   def show

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -8,7 +8,7 @@ class Api::ServicesController < Api::BaseController
   activate_menu :serviceadmin, :overview
 
   before_action :deny_on_premises_for_master
-  before_action :authorize_section
+  before_action :authorize_section, except: :index
   before_action :authorize_action, only: %i[new create]
   before_action :disable_client_cache, only: :settings
 
@@ -155,6 +155,7 @@ class Api::ServicesController < Api::BaseController
 
   def authorize_action
     return if current_user.admin? # We want to postpone for admins so we can use #can_create? and provide better error messages
+
     authorize! action_name.to_sym, Service
   end
 

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -42,6 +42,8 @@ class ServiceDecorator < ApplicationDecorator
       h.admin_service_stats_usage_path(object)
     elsif h.can?(:manage, :partners)
       h.admin_service_applications_path(object)
+    elsif h.can?(:manage, :policy_registry)
+      h.edit_admin_service_policies_path(object)
     end
   end
 

--- a/app/javascript/src/Users/utils/index.tsx
+++ b/app/javascript/src/Users/utils/index.tsx
@@ -32,7 +32,7 @@ export const FEATURE_NAMES_DESCRIPTION_ITEMS: Record<Feature, React.ReactNode[] 
   ]
 }
 
-const FEATURES_GRANTING_SERVICE_ACCESS = ['partners', 'monitoring', 'plans']
+const FEATURES_GRANTING_SERVICE_ACCESS = ['partners', 'monitoring', 'plans', 'policy_registry']
 
 export function getFeatureName (feature: Feature): React.ReactNode {
   if (feature in FEATURE_NAMES) {

--- a/app/models/admin_section.rb
+++ b/app/models/admin_section.rb
@@ -2,7 +2,7 @@
 
 class AdminSection
   PERMISSIONS = %i[portal finance settings partners monitoring plans policy_registry].freeze
-  SERVICE_PERMISSIONS = %i[partners plans monitoring].freeze
+  SERVICE_PERMISSIONS = %i[partners plans monitoring policy_registry].freeze
   NO_SERVICE_PERMISSIONS = PERMISSIONS - SERVICE_PERMISSIONS
   SECTIONS = PERMISSIONS + %i[services]
 

--- a/app/presenters/service_actions_presenter.rb
+++ b/app/presenters/service_actions_presenter.rb
@@ -20,8 +20,12 @@ class ServiceActionsPresenter
       actions << { name: 'Applications', path: admin_service_application_plans_path(product) }
     end
 
-    actions << { name: 'ActiveDocs', path: admin_service_api_docs_path(product) } if can?(:manage, :plans)
-    actions << { name: 'Integration', path: admin_service_integration_path(product) } if can?(:manage, :plans)
+    if can?(:manage, :plans)
+      actions << { name: 'ActiveDocs', path: admin_service_api_docs_path(product) }
+      actions << { name: 'Integration', path: admin_service_integration_path(product) }
+    elsif can?(:manage, :policy_registry)
+      actions << { name: 'Policies', path: edit_admin_service_policies_path(product) }
+    end
 
     actions
   end

--- a/config/abilities/provider_admin.rb
+++ b/config/abilities/provider_admin.rb
@@ -71,6 +71,7 @@ Ability.define do |user|
     category.forum.account = account
   end
 
+  can :index, Service
   can :create, Service if account.can_create_service?
   can :destroy, Service do |service|
     service.account_id == user.account_id && can?(:manage, :multiple_services) && !service.default_or_last?

--- a/config/abilities/provider_any.rb
+++ b/config/abilities/provider_any.rb
@@ -11,8 +11,7 @@ Ability.define do |user| # rubocop:disable Metrics/BlockLength
 
     can :manage, user
 
-    can(:manage, :policy_registry) if account.tenant? && account.provider_can_use?(:policy_registry)
-    can(:manage, :policy_registry_ui) if account.tenant? && account.provider_can_use?(:policy_registry_ui)
+    can :manage, :policy_registry if account.tenant? && account.provider_can_use?(:policy_registry) && user.has_permission?(:policy_registry)
 
     # Overriding `can :manage, user` and `can :manage, User, :id => user.id`
     cannot :update_permissions, User, &:admin?
@@ -22,7 +21,7 @@ Ability.define do |user| # rubocop:disable Metrics/BlockLength
 
     # Services
     user_accessible_services = user.accessible_services
-    can %i[read show edit update], Service, user_accessible_services.where_values_hash unless user_accessible_services.is_a? ActiveRecord::NullRelation
+    can %i[show edit update], Service, user_accessible_services.where_values_hash unless user_accessible_services.is_a? ActiveRecord::NullRelation
 
     #
     # Events

--- a/config/abilities/provider_member.rb
+++ b/config/abilities/provider_member.rb
@@ -67,4 +67,6 @@ Ability.define do |user|
 
   # Member cannot manage permissions, neither his own, nor other members'
   cannot :update_permissions, User
+
+  can :index, Service if can?(:manage, :plans) || can?(:manage, :policy_registry) || can?(:manage, :monitoring)
 end

--- a/features/menu/context_selector.feature
+++ b/features/menu/context_selector.feature
@@ -93,10 +93,11 @@ Feature: Context selector
         | Backends         |
         | Account Settings |
 
-    Scenario: Member with policy registry permission can see Products and Backends
+    Scenario: Member with policy registry permission can see Products
       Given the user has policy_registry permission
       When they go to the provider dashboard
       Then the current context should be "Dashboard"
       And they should be able to navigate to the following contexts:
         | Dashboard        |
+        | Products         |
         | Account Settings |

--- a/features/provider/dashboard/widgets.feature
+++ b/features/provider/dashboard/widgets.feature
@@ -62,11 +62,9 @@ Feature: Dashboard Widgets
       And they should be able to see the products widget
       And they should be able to see the backends widget
 
-    Scenario: User with policy registry permission doesn't see widgets
+    Scenario: User with policy registry permission sees products
       Given the user has policy_registry permission
       When they go to the provider dashboard
-      Then they should see "Access permissions needed"
-      And there should be a link to "contact foo.3scale.localhost"
-      But they should not see "Banana API"
-      And they should not be able to see the products widget
+      Then they should not see "Access permissions needed"
+      And they should be able to see the products widget
       And they should not be able to see the backends widget

--- a/spec/javascripts/Users/components/PermissionsForm.spec.tsx
+++ b/spec/javascripts/Users/components/PermissionsForm.spec.tsx
@@ -55,8 +55,8 @@ describe('when role is "admin"', () => {
 })
 
 describe('when role is "member"', () => {
-  const FEATURES: Feature[] = ['portal', 'finance', 'settings', 'policy_registry']
-  const FEATURES_FOR_SERVICES: Feature[] = ['partners', 'monitoring', 'plans']
+  const FEATURES: Feature[] = ['portal', 'finance', 'settings']
+  const FEATURES_FOR_SERVICES: Feature[] = ['partners', 'monitoring', 'plans', 'policy_registry']
   const allFeatures: Feature[] = [...FEATURES, ...FEATURES_FOR_SERVICES]
 
   const props = {

--- a/spec/javascripts/Users/utils/utils.spec.ts
+++ b/spec/javascripts/Users/utils/utils.spec.ts
@@ -10,11 +10,11 @@ describe('canFeatureSetServicePermissions', () => {
     expect(canFeatureSetServicePermissions('portal')).toEqual(false)
     expect(canFeatureSetServicePermissions('finance')).toEqual(false)
     expect(canFeatureSetServicePermissions('settings')).toEqual(false)
-    expect(canFeatureSetServicePermissions('policy_registry')).toEqual(false)
 
     expect(canFeatureSetServicePermissions('partners')).toEqual(true)
     expect(canFeatureSetServicePermissions('monitoring')).toEqual(true)
     expect(canFeatureSetServicePermissions('plans')).toEqual(true)
+    expect(canFeatureSetServicePermissions('policy_registry')).toEqual(true)
 
     expect(canFeatureSetServicePermissions(['portal', 'finance', 'settings'])).toEqual(false)
 

--- a/test/decorators/service_decorator_test.rb
+++ b/test/decorators/service_decorator_test.rb
@@ -34,4 +34,37 @@ class ServiceDecoratorTest < Draper::TestCase
     assert_equal [], decorator.published_application_plans
     assert_equal({service: service}, decorator.published_application_plans.context)
   end
+
+  def test_product_link
+    service = Service.new
+    service.id = 2
+    decorator = ServiceDecorator.new(service)
+
+    stub_can :manage, :plans do
+      assert_equal "/apiconfig/services/2", decorator.link
+    end
+
+    stub_can :manage, :monitoring do
+      assert_equal "/services/2/stats/usage", decorator.link
+    end
+
+    stub_can :manage, :partners do
+      assert_equal "/apiconfig/services/2/applications", decorator.link
+    end
+
+    stub_can :manage, :policy_registry do
+      assert_equal "/apiconfig/services/2/policies/edit", decorator.link
+    end
+
+    assert_nil decorator.link
+  end
+
+  private
+
+  def stub_can(action, object)
+    h = Draper::HelperProxy.any_instance
+    h.stubs(:can?).with(action, object).returns(true)
+    yield if block_given?
+    h.stubs(:can?).with(action, object).returns(false)
+  end
 end

--- a/test/integration/admin/api/services/proxy/policies_controller_test.rb
+++ b/test/integration/admin/api/services/proxy/policies_controller_test.rb
@@ -11,45 +11,50 @@ class PoliciesControllerTest < ActionDispatch::IntegrationTest
     @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
   end
 
-  class UpdateTest < PoliciesControllerTest
-    test 'prints chain level errors' do
-      valid_config = { name: 'apicast', configuration: {}, version: 'builtin', enabled: true, removable: false }
-
-      Proxy::PoliciesConfig.stub_const(:MAX_LENGTH, 16.bytes) do
-        put admin_api_service_proxy_policies_path(@service, access_token: @access_token, format: :json), params: {
-          proxy: { policies_config: valid_config }
-        }, as: :json
-      end
-      resp_body = JSON.parse(response.body)
-
-      assert_response :unprocessable_entity
-      assert_equal 'is too long (maximum is 16 characters)', resp_body['errors']['policies_config'][0]
+  class PolicyRegistryAccessTokenScopeTest < PoliciesControllerTest
+    def setup
+      super
+      @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[policy_registry]).value
     end
+  end
 
-    test 'prints policy level errors' do
-      invalid_config = { name: 'apicast', configuration: {}, enabled: true, removable: false }
+  test 'prints chain level errors' do
+    valid_config = { name: 'apicast', configuration: {}, version: 'builtin', enabled: true, removable: false }
 
+    Proxy::PoliciesConfig.stub_const(:MAX_LENGTH, 16.bytes) do
+      put admin_api_service_proxy_policies_path(@service, access_token: @access_token, format: :json), params: {
+        proxy: { policies_config: valid_config }
+      }, as: :json
+    end
+    resp_body = JSON.parse(response.body)
+
+    assert_response :unprocessable_entity
+    assert_equal 'is too long (maximum is 16 characters)', resp_body['errors']['policies_config'][0]
+  end
+
+  test 'prints policy level errors' do
+    invalid_config = { name: 'apicast', configuration: {}, enabled: true, removable: false }
+
+    put admin_api_service_proxy_policies_path(@service, access_token: @access_token, format: :json), params: {
+      proxy: { policies_config: invalid_config}
+    }, as: :json
+    resp_body = JSON.parse(response.body)
+
+    assert_response :unprocessable_entity
+    assert_equal "can't be blank", resp_body['policies_config'][0]['errors']['version'][0]
+  end
+
+  test 'policy level errors are promoted to chain errors as well' do
+    invalid_config = { name: 'apicast', configuration: {}, enabled: true, removable: false }
+
+    Proxy::PoliciesConfig.stub_const(:MAX_LENGTH, 16.bytes) do
       put admin_api_service_proxy_policies_path(@service, access_token: @access_token, format: :json), params: {
         proxy: { policies_config: invalid_config}
       }, as: :json
-      resp_body = JSON.parse(response.body)
-
-      assert_response :unprocessable_entity
-      assert_equal "can't be blank", resp_body['policies_config'][0]['errors']['version'][0]
     end
+    resp_body = JSON.parse(response.body)
 
-    test 'policy level errors are promoted to chain errors as well' do
-      invalid_config = { name: 'apicast', configuration: {}, enabled: true, removable: false }
-
-      Proxy::PoliciesConfig.stub_const(:MAX_LENGTH, 16.bytes) do
-        put admin_api_service_proxy_policies_path(@service, access_token: @access_token, format: :json), params: {
-          proxy: { policies_config: invalid_config}
-        }, as: :json
-      end
-      resp_body = JSON.parse(response.body)
-
-      assert_response :unprocessable_entity
-      assert_same_elements ['contains some invalid policy', 'is too long (maximum is 16 characters)'], resp_body['errors']['policies_config']
-    end
+    assert_response :unprocessable_entity
+    assert_same_elements ['contains some invalid policy', 'is too long (maximum is 16 characters)'], resp_body['errors']['policies_config']
   end
 end

--- a/test/unit/abilities/provider_admin_test.rb
+++ b/test/unit/abilities/provider_admin_test.rb
@@ -188,6 +188,10 @@ module Abilities
       assert_can ability, :manage, :portal
     end
 
+    def test_index_services
+      assert_can ability, :index, Service
+    end
+
     def ability
       Ability.new(@admin)
     end

--- a/test/unit/abilities/provider_any_test.rb
+++ b/test/unit/abilities/provider_any_test.rb
@@ -12,8 +12,20 @@ module Abilities
 
     attr_reader :user, :account
 
-    def test_policies_allowed
+    def test_policies_permissions_for_member
       account.expects(:provider_can_use?).with(:policy_registry).returns(true)
+
+      assert_cannot ability, :manage, :policy_registry
+
+      user.update allowed_sections: [:policy_registry]
+      user.reload
+
+      assert_can ability, :manage, :policy_registry
+    end
+
+    def test_policies_permissions_for_admin
+      account.expects(:provider_can_use?).with(:policy_registry).returns(true)
+      user.make_admin
 
       assert_can ability, :manage, :policy_registry
     end

--- a/test/unit/abilities/provider_member_test.rb
+++ b/test/unit/abilities/provider_member_test.rb
@@ -199,6 +199,20 @@ module Abilities
       assert_cannot ability, :manage, :portal
     end
 
+    def test_index_services
+      @member.stubs(admin_sections: [:plans])
+      assert_can ability, :index, Service
+
+      @member.stubs(admin_sections: [:policy_registry])
+      assert_can ability, :index, Service
+
+      @member.stubs(admin_sections: [:monitoring])
+      assert_can ability, :index, Service
+
+      @member.stubs(admin_sections: %i[portal settings])
+      assert_cannot ability, :index, Service
+    end
+
     private
 
     def ability

--- a/test/unit/presenters/service_actions_presenter_test.rb
+++ b/test/unit/presenters/service_actions_presenter_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ServicesActionsPresenterTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  def setup
+    @provider = FactoryBot.create(:simple_provider)
+    user = FactoryBot.create(:member, account: @provider)
+    @presenter = ServiceActionsPresenter.new(user)
+    Ability.any_instance.expects(:can?).returns(false).at_least_once
+  end
+
+  attr_reader :provider, :presenter
+
+  test "#actions returns the right links according to user permissions" do
+    product = FactoryBot.create(:simple_service, account: provider)
+    id = product.id
+
+    stub_can(:manage, :plans) do
+      actions = presenter.actions(product)
+      assert_equal %w[Edit Overview Applications ActiveDocs Integration], actions.map { _1[:name] }
+      assert_equal %W[
+        /apiconfig/services/#{id}/edit
+        /apiconfig/services/#{id}
+        /apiconfig/services/#{id}/application_plans
+        /apiconfig/services/#{id}/api_docs
+        /apiconfig/services/#{id}/integration
+      ], actions.map { _1[:path] }
+    end
+
+    stub_can(:manage, :monitoring) do
+      actions = presenter.actions(product)
+      assert_equal %w[Analytics], actions.map { _1[:name] }
+      assert_equal %W[/services/#{id}/stats/usage], actions.map { _1[:path] }
+    end
+
+    stub_can(:manage, :applications) do
+      actions = presenter.actions(product)
+      assert_equal %w[Applications], actions.map { _1[:name] }
+      assert_equal %W[/apiconfig/services/#{id}/applications], actions.map { _1[:path] }
+    end
+
+    stub_can(:manage, :policy_registry) do
+      actions = presenter.actions(product)
+      assert_equal %w[Policies], actions.map { _1[:name] }
+      assert_equal %W[/apiconfig/services/#{id}/policies/edit], actions.map { _1[:path] }
+    end
+
+    Ability.any_instance.expects(:can?).returns(true).at_least_once
+    actions = presenter.actions(product)
+    assert_equal %w[Edit Overview Analytics Applications ActiveDocs Integration], actions.map { _1[:name] }
+    assert_equal %W[
+      /apiconfig/services/#{id}/edit
+      /apiconfig/services/#{id}
+      /services/#{id}/stats/usage
+      /apiconfig/services/#{id}/applications
+      /apiconfig/services/#{id}/api_docs
+      /apiconfig/services/#{id}/integration
+    ], actions.map { _1[:path] }
+  end
+
+  private
+
+  def stub_can(action, object)
+    Ability.any_instance.stubs(:can?).with(action, object).returns(true)
+    yield if block_given?
+    Ability.any_instance.stubs(:can?).with(action, object).returns(false)
+  end
+end

--- a/test/unit/user/permissions_test.rb
+++ b/test/unit/user/permissions_test.rb
@@ -186,12 +186,12 @@ class User::PermissionsTest < ActiveSupport::TestCase
 
   test '#service_permissions_selected?' do
     user = FactoryBot.build_stubbed(:simple_user)
-    %i[partners plans monitoring].each do |section|
+    %i[partners plans monitoring policy_registry].each do |section|
       user.stubs(:member_permission_ids).returns([section])
       assert user.service_permissions_selected?
     end
 
-    %i[portal finance settings policy_registry].each do |section|
+    %i[portal finance settings].each do |section|
       user.stubs(:member_permission_ids).returns([section])
       assert_not user.service_permissions_selected?
     end


### PR DESCRIPTION
**What this PR does / why we need it**:

After fixing member permissions per service in https://github.com/3scale/porta/pull/3929, policy registry operations are not working as expected. This PR fixes it.

This PR changes the permission model, and now the `policy_registry` is considered a "service-level" permission, so it can be applied to a subset of serviced, or all services.

This also affects the UI.

1. Member user permissions:

![image](https://github.com/user-attachments/assets/e3133214-1ff7-4b42-9cce-b3139dddfdbe)

2. Dashboard for the user that only has `policy_registry` permission for a single service:

![image](https://github.com/user-attachments/assets/c60c0aa1-ae3a-4426-9eaf-d8dda4977037)

3. Product details for a user with `policy_registry` permission:

![image](https://github.com/user-attachments/assets/255ea9e6-d11a-41d1-855d-6a90ea597db6)

This PR also fixes an issue reported in https://issues.redhat.com/browse/THREESCALE-6482: when the member user only has Analytics permission, they can see "Explore all Products" link on the dashboard, and also "Products" entry in the context selector, they bring them to the Products list path, but the access is denied. 
In this PR products list is shown to any member user that has access to some services with Analytics, Plans or Policy Registry permissions.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11644

also fixes https://issues.redhat.com/browse/THREESCALE-6482

**Verification steps** 

TBD

**Special notes for your reviewer**:
