### PR TITLE
Fix cucumber tests for provider accounts users list

### DIFF
--- a/app/presenters/provider/admin/account/users_index_presenter.rb
+++ b/app/presenters/provider/admin/account/users_index_presenter.rb
@@ -7,8 +7,10 @@ class Provider::Admin::Account::UsersIndexPresenter
     @ability = Ability.new(current_user)
 
     pagination_params = { page: params[:page] || 1, per_page: params[:per_page] || 20 }
+    sorting_params = "id asc"
 
-    @users = users.paginate(pagination_params)
+    @users = users.order(sorting_params)
+                  .paginate(pagination_params)
                   .decorate
   end
 

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -12,6 +12,7 @@ Capybara.configure do |config|
   config.always_include_port = true
   config.default_max_wait_time = ENV.fetch('CAPYBARA_MAX_WAIT_TIME', 10).to_i
   config.server = :webrick # default is `:default` (which uses puma)
+  config.default_set_options = { clear: :backspace }
 end
 
 Capybara.register_driver :chrome do |app|


### PR DESCRIPTION
**What this PR does / why we need it**:

Cucumber tests sometimes fail with the following error:
https://app.circleci.com/pipelines/github/3scale/porta/30739/workflows/b0f7ecdd-5c07-433d-a059-c93b7ae75538/jobs/344495/tests

```
Message:Tables were not identical:

  |     Name          |     Email                |     Role   |     Permission groups | (+)                  |
  |     Albert Wesker |     wesker@umbrella.corp |     admin  |     Unlimited access  | (+) Personal details |
  | (-) honk          | (-) honk@umbrella.corp   | (-) member | (-) -                 | (+)                  |
  |     Ada Wong      |     awong@umbrella.corp  |     member |     -                 | (+) Delete\nEdit     |
  | (+) honk          | (+) honk@umbrella.corp   | (+) member | (+) -                 | (+) Delete\nEdit     |
```

It looks like it's because of the last column, but actually the test shouldn't fail if the rest of the values in other columns are identical.

So, I believe the issue is actually because the order of the lines is not the same as stated in the tests as the expected. We did see it happen for some other tests, especially with Postgres. This is normal, I guess, because the DB engines do not usually guarantee the order in the absense of `ORDER BY`.

So, this PR adds explicit ordering by the primary key, as, being auto-incremented, it will order the users by their creation. Many other index pages use `created_at` column, but I don't like it, because if multiple users are created with the same timestamp (can happen because of some automation), the order is unpredictable again, and this also makes UX more sloppy.

Also, when testing locally, I saw another issue - when updating an existing field, the previous value is not being cleared before inserting the new one, so in the same test the usename was set to `hunkhonk`, which also caused the test to fail.

There is an issue here, and the solution was taken from a comment on it: https://github.com/teamcapybara/capybara/issues/2419#issuecomment-1425561799

For some reason, it's not reproduced in CircleCI, but I hope this Capybara setting it won't hurt anyway.

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 

make sure all tests pass

**Special notes for your reviewer**:
