### PR TITLE
⚰️ Remove `provider/utils.js`

### DIFF
--- a/app/assets/javascripts/provider.js
+++ b/app/assets/javascripts/provider.js
@@ -1,5 +1,3 @@
-//= require provider/utils
-
 /* Modernizr 2.6.2 (Custom Build) | MIT & BSD
  * Build: http://modernizr.com/download/#-input-inputtypes
  */

--- a/app/assets/javascripts/provider/utils.js.coffee
+++ b/app/assets/javascripts/provider/utils.js.coffee
@@ -1,4 +1,0 @@
-window.setLocationHash = (value) ->
-  scroll = $('body').scrollTop()
-  window.location.hash = value
-  $('html,body').scrollTop(scroll)


### PR DESCRIPTION
This function was called by the CMS intro tabs, here:
https://github.com/3scale/porta/pull/3773/files#diff-89e68fd82864e95731204d1b91e2c3d400d39eb941e25795e5a488b5c867d627L23

It was removed because it was totally unnecessary, but the declaration of `setLocationHash` was left behind.