### PR TITLE
Memlog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ system-builder-ruby31: &system-builder-ruby31
 
 mysql-container: &mysql-container
   image: cimg/mysql:8.0
+  command: mysqld --performance_schema=0 --table_definition_cache=400 --innodb_buffer_pool_size=16M --innodb_log_buffer_size=4M --tmp_table_size=1M --key_buffer_size=4M --sort_buffer_size=128K --skip-log-bin
   environment:
     MYSQL_ALLOW_EMPTY_PASSWORD: yes
     MYSQL_ROOT_PASSWORD: ''

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,8 @@ commands: # reusable commands with parameters
           command: |
             # see https://support.circleci.com/hc/en-us/articles/19306469418139-How-to-detect-when-a-process-is-killed-by-the-OOM-killer
             printf "OOM Control: "
-            cat /sys/fs/cgroup/memory/memory.oom_control | sed -n 3p
+            cat /sys/fs/cgroup/memory/memory.oom_control | sed -n 3p | tee tmp/oom_num
+            [ 0 = "$(<tmp/oom_num)" ] # fails when a proc was killed by OOM
           when: always
 
 ##################################### CIRCLECI EXECUTORS ############################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ commands: # reusable commands with parameters
           command: |
             while sleep 2; do
               date
-              ps -eo pid,user,%mem,rss,command --sort rss
+              ps -eo pid,user,%mem,rss,command ww --sort rss
               echo
             done
           background: true
@@ -379,7 +379,7 @@ commands: # reusable commands with parameters
             # see https://support.circleci.com/hc/en-us/articles/19306469418139-How-to-detect-when-a-process-is-killed-by-the-OOM-killer
             printf "OOM Control: "
             cat /sys/fs/cgroup/memory/memory.oom_control | sed -n 3p | tee tmp/oom_num
-            [ 0 = "$(<tmp/oom_num)" ] # fails when a proc was killed by OOM
+            [ "oom_kill 0" = "$(<tmp/oom_num)" ] # fails when a proc was killed by OOM
           when: always
 
 ##################################### CIRCLECI EXECUTORS ############################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ attach-to-workspace: &attach-to-workspace
     at: .
 
 system-builder-ruby31: &system-builder-ruby31
-  image: quay.io/3scale/system-builder:stream9
+  image: quay.io/3scale/system-builder:ps
   environment:
     BUNDLE_FROZEN: true
     BUNDLE_PATH: 'vendor/bundle'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,7 @@ commands: # reusable commands with parameters
             echo "bundle exec cucumber --profile ci .circleci/no_internet.feature"
             bundle exec cucumber --profile ci .circleci/no_internet.feature
           environment: *malloc_preload
+      - log-memory-usage-periodic
       - run:
           name: Run cucumber tests
           command: |
@@ -356,7 +357,26 @@ commands: # reusable commands with parameters
       - *store-junit-test-results
       - *store-test-artifacts
       - *store-log-artifacts
+      - store-memory-usage-log
       - codecov/upload
+
+  log-memory-usage-periodic:
+    steps:
+      - run:
+          name: Log process memory usage
+          command: |
+            while sleep 2; do
+              date
+              ps -eo pid,user,%mem,rss,command --sort rss
+              echo
+            done >> tmp/memory_usage.log
+          background: true
+
+  store-memory-usage-log:
+    steps:
+      store_artifacts:
+        path: tmp/memory_usage.log
+        destination: log
 
   print-oom-process-count:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,6 @@ commands: # reusable commands with parameters
       - *store-junit-test-results
       - *store-test-artifacts
       - *store-log-artifacts
-      - store-memory-usage-log
       - codecov/upload
 
   log-memory-usage-periodic:
@@ -369,14 +368,8 @@ commands: # reusable commands with parameters
               date
               ps -eo pid,user,%mem,rss,command --sort rss
               echo
-            done >> tmp/memory_usage.log
+            done
           background: true
-
-  store-memory-usage-log:
-    steps:
-      store_artifacts:
-        path: tmp/memory_usage.log
-        destination: log
 
   print-oom-process-count:
     steps:

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -24,13 +24,19 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Options.chrome
+  # see https://peter.sh/experiments/chromium-command-line-switches
   options.add_argument(WINDOW_SIZE_ARG)
   options.add_argument('--disable-search-engine-choice-screen')
   options.add_argument('--headless=new')
   options.add_argument('--no-sandbox')
+  options.add_argument('--no-zygote') # zygote proc used by sandboxing
   options.add_argument('--disable-popup-blocking')
   options.add_argument('--host-resolver-rules=MAP * ~NOTFOUND , EXCLUDE *localhost*')
-  options.add_argument('--disable-gpu')
+  options.add_argument('--process-per-site')
+  options.add_argument('--disable-gpu') # TODO: gpu-process still started
+  options.add_argument('--disable-gpu-early-init')
+  options.add_argument('--disable-software-rasterizer')
+  options.add_argument('--renderer-process-limit=2')
 
   options.logging_prefs = { performance: 'ALL', browser: 'ALL' }
   options.add_option(:perf_logging_prefs, enableNetwork: true)

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -200,6 +200,10 @@ After do |scenario| # rubocop:disable Metrics/BlockLength
   end
 end
 
+After("@javascript") do
+  Capybara.page&.driver&.quit
+end
+
 After do |scenario|
   if ENV['FAIL_FAST']
     Cucumber.wants_to_quit = true if scenario.failed?


### PR DESCRIPTION
Record memory usage every 2 seconds as cucumbers run. This is to see what is the biggest memory user and fix it if practical. 

In a failing scenario, I see 4 renderer processes being used. With these updates the renderers are limited to 2. But some tests fail.

So I'm thinking they might be using more tabs than necessary. Has to be checked.

[OLD](https://app.circleci.com/pipelines/github/3scale/porta/30812/workflows/5d8d0d9c-7caf-4d9f-a381-ec3bda189e74/jobs/345381) (sorry, clipped lines but not important):
```
Thu Feb 13 17:43:18 UTC 2025
    PID USER     %MEM   RSS COMMAND
    695 default   0.0  1668 /opt/google/chrome/chrome_crashpad_handler --no-peri
    693 default   0.0  3172 /opt/google/chrome/chrome_crashpad_handler --monitor
    680 default   0.0 41248 /usr/local/bin/chromedriver --port=9515
    723 default   0.0 52040 /opt/google/chrome/chrome --type=utility --utility-s
   1918 default   0.0 59936 /opt/google/chrome/chrome --type=renderer --string-a
    700 default   0.1 91696 /opt/google/chrome/chrome --type=zygote --no-zygote-
    701 default   0.1 92000 /opt/google/chrome/chrome --type=zygote --no-sandbox
    722 default   0.1 126960 /opt/google/chrome/chrome --type=utility --utility-
   1917 default   0.2 209276 /opt/google/chrome/chrome --type=renderer --string-
    686 default   0.3 218656 /usr/bin/google-chrome --allow-pre-commit-input --d
   1889 default   0.3 219224 /opt/google/chrome/chrome --type=renderer --string-
    779 default   0.3 237204 /opt/google/chrome/chrome --type=gpu-process --no-s
   1792 default   0.3 257736 /opt/google/chrome/chrome --type=renderer --string-
   1838 default   0.3 267792 /opt/google/chrome/chrome --type=renderer --string-
```

NEW(https://app.circleci.com/pipelines/github/3scale/porta/30818/workflows/5722dae9-a64c-499f-a396-0f6ffee3326c/jobs/345427):
```
Thu Feb 13 22:50:22 UTC 2025
    PID USER     %MEM   RSS COMMAND
    686 default   0.0  1648 /opt/google/chrome/chrome_crashpad_handler --no-periodic-tasks --monitor-self-annotation=ptype=crashpad-handler --database=/opt/ci/.config/google-chrome/Crash Reports --url=https://clients2.google.com/cr/report --annotation=channel= --annotation=lsb-release=CentOS Stream 9 --annotation=plat=Linux --annotation=prod=Chrome_Linux --annotation=ver=133.0.6943.98 --initial-client-fd=4 --shared-client-connection
    684 default   0.0  3184 /opt/google/chrome/chrome_crashpad_handler --monitor-self --monitor-self-annotation=ptype=crashpad-handler --database=/opt/ci/.config/google-chrome/Crash Reports --url=https://clients2.google.com/cr/report --annotation=channel= --annotation=lsb-release=CentOS Stream 9 --annotation=plat=Linux --annotation=prod=Chrome_Linux --annotation=ver=133.0.6943.98 --initial-client-fd=6 --shared-client-connection
    671 default   0.0 51316 /usr/local/bin/chromedriver --port=9515
    712 default   0.1 111588 /opt/google/chrome/chrome --type=utility --utility-sub-type=storage.mojom.StorageService --lang=en-US --service-sandbox-type=utility --host-resolver-rules=MAP * ~NOTFOUND , EXCLUDE *localhost* --no-sandbox --use-angle=swiftshader-webgl --string-annotations --crashpad-handler-pid=684 --enable-crash-reporter=, --noerrdialogs --user-data-dir=/tmp/.org.chromium.Chromium.7s9F1R --change-stack-guard-on-fork=enable --shared-files=v8_context_snapshot_data:100 --field-trial-handle=3,i,4733302729613016158,12238243808268141431,262144 --disable-features=PaintHolding --variations-seed-version --enable-logging --log-level=0
   1689 default   0.1 122312 /opt/google/chrome/chrome --type=renderer --string-annotations --crashpad-handler-pid=684 --enable-crash-reporter=, --noerrdialogs --user-data-dir=/tmp/.org.chromium.Chromium.7s9F1R --change-stack-guard-on-fork=enable --no-sandbox --enable-automation --no-zygote --remote-debugging-port=0 --test-type=webdriver --allow-pre-commit-input --ozone-platform=headless --disable-gpu-compositing --lang=en-US --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=36 --time-ticks-at-unix-epoch=-1739480182862062 --launch-time-ticks=6828441148 --shared-files=v8_context_snapshot_data:100 --field-trial-handle=3,i,4733302729613016158,12238243808268141431,262144 --disable-features=PaintHolding --variations-seed-version --enable-logging --log-level=0
    711 default   0.1 125304 /opt/google/chrome/chrome --type=utility --utility-sub-type=network.mojom.NetworkService --lang=en-US --service-sandbox-type=none --host-resolver-rules=MAP * ~NOTFOUND , EXCLUDE *localhost* --no-sandbox --use-angle=swiftshader-webgl --string-annotations --crashpad-handler-pid=684 --enable-crash-reporter=, --noerrdialogs --user-data-dir=/tmp/.org.chromium.Chromium.7s9F1R --change-stack-guard-on-fork=enable --shared-files=v8_context_snapshot_data:100 --field-trial-handle=3,i,4733302729613016158,12238243808268141431,262144 --disable-features=PaintHolding --variations-seed-version --enable-logging --log-level=0
    770 default   0.2 169676 /opt/google/chrome/chrome --type=gpu-process --no-sandbox --headless=new --ozone-platform=headless --use-angle=swiftshader-webgl --string-annotations --crashpad-handler-pid=684 --enable-crash-reporter=, --noerrdialogs --user-data-dir=/tmp/.org.chromium.Chromium.7s9F1R --change-stack-guard-on-fork=enable --gpu-preferences=UAAAAAAAAAAgAAAEAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAIAAAAAAAAAAgAAAAAAAAA --use-gl=disabled --shared-files --field-trial-handle=3,i,4733302729613016158,12238243808268141431,262144 --disable-features=PaintHolding --variations-seed-version --enable-logging --log-level=0 --no-first-run --ozone-platform=headless --ozone-override-screen-size=800,600
    677 default   0.2 214900 /usr/bin/google-chrome --allow-pre-commit-input --disable-background-networking --disable-client-side-phishing-detection --disable-default-apps --disable-gpu --disable-gpu-early-init --disable-hang-monitor --disable-popup-blocking --disable-prompt-on-repost --disable-search-engine-choice-screen --disable-sync --enable-automation --enable-logging --headless=new --host-resolver-rules=MAP * ~NOTFOUND , EXCLUDE *localhost* --log-level=0 --no-first-run --no-sandbox --no-service-autorun --no-zygote --password-store=basic --process-per-site --remote-debugging-port=0 --renderer-process-limit=2 --test-type=webdriver --use-mock-keychain --user-data-dir=/tmp/.org.chromium.Chromium.7s9F1R --window-size=1280,2048 data:,
    748 default   0.9 700788 /opt/google/chrome/chrome --type=renderer --string-annotations --crashpad-handler-pid=684 --enable-crash-reporter=, --noerrdialogs --user-data-dir=/tmp/.org.chromium.Chromium.7s9F1R --change-stack-guard-on-fork=enable --no-sandbox --enable-automation --no-zygote --remote-debugging-port=0 --test-type=webdriver --allow-pre-commit-input --ozone-platform=headless --disable-gpu-compositing --lang=en-US --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=8 --time-ticks-at-unix-epoch=-1739480182862062 --launch-time-ticks=6659715066 --shared-files=v8_context_snapshot_data:100 --field-trial-handle=3,i,4733302729613016158,12238243808268141431,262144 --disable-features=PaintHolding --variations-seed-version --enable-logging --log-level=0
```

Pity I couldn't get rid of the `gpu-process` althogh I tried `--disable-gpu --disable-software-rasterizer` as advised in https://groups.google.com/a/chromium.org/g/chromium-discuss/c/IIQeveVRLVE?pli=1

P.S. Also in the failing scenario I see mysql using 530MB memory which IMO is too much too.

Update: After adding the restart of chrome after each scenario, I also stopped seeing a Chrome process using 700MB memory like above and don't see any more OOMs. Without the restart all tests passed bu I still saw OOMs from time to time.