### PR TITLE
Fixing flaky tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,6 +56,7 @@
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/promise-function-async": "off",
     "@typescript-eslint/lines-around-comment": "off", // Disabled in favor of lines-around-comment
+    "@typescript-eslint/no-namespace": ["error", { "allowDeclarations": true }], // to allow `declare global { namespace jest { ... } }` for custom Jest matchers
 
     // Override plugin:@typescript-eslint/recommended
     "@typescript-eslint/semi": ["error", "never"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -144,7 +144,9 @@ module.exports = {
   ],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: [
+    '<rootDir>/spec/javascripts/customJestMatchers.ts',
+  ],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/spec/acceptance/api/service_spec.rb
+++ b/spec/acceptance/api/service_spec.rb
@@ -22,6 +22,9 @@ resource "Service" do
   end
 
   api 'service' do
+    # stubbing the subscriber to avoid changing the 'updated_at' timestamp on Proxy, and hence on Service
+    before { allow_any_instance_of(ProxyConfigEventSubscriber).to receive(:call) }
+
     parameter :name, 'Service Name'
 
     get "/admin/api/services.:format", action: :index do

--- a/spec/javascripts/AccessTokens/components/ExpirationDatePicker.spec.tsx
+++ b/spec/javascripts/AccessTokens/components/ExpirationDatePicker.spec.tsx
@@ -80,9 +80,11 @@ describe('select a period', () => {
     const targetDate = futureDateInNDays(targetItem.period)
 
     selectItem(wrapper, targetItem)
-    const value = new Date(wrapper.find(`input#${defaultProps.id}`).prop('value') as string)
+    const inputValue = wrapper.find(`input#${defaultProps.id}`).prop('value') as string
+    const inputDate = new Date(inputValue)
 
-    expect(value).toBeWithinSecondsFrom(targetDate)
+    expect(inputValue).toEqual(inputDate.toISOString())
+    expect(inputDate).toBeWithinSecondsFrom(targetDate)
   })
 })
 
@@ -115,9 +117,11 @@ describe('select "Custom"', () => {
 
       selectItem(wrapper, targetItem)
       const targetDate = pickDate(wrapper)
-      const value = new Date(wrapper.find(`input#${defaultProps.id}`).prop('value') as string)
+      const inputValue = wrapper.find(`input#${defaultProps.id}`).prop('value') as string
+      const inputDate = new Date(inputValue)
 
-      expect(value).toBeWithinSecondsFrom(targetDate)
+      expect(inputValue).toEqual(inputDate.toISOString())
+      expect(inputDate).toBeWithinSecondsFrom(targetDate)
     })
   })
 })

--- a/spec/javascripts/AccessTokens/components/ExpirationDatePicker.spec.tsx
+++ b/spec/javascripts/AccessTokens/components/ExpirationDatePicker.spec.tsx
@@ -25,8 +25,9 @@ const selectItem = (wrapper: ReactWrapper<any, Readonly<object>>, item: Expirati
 
 const pickDate = (wrapper: ReactWrapper<any, Readonly<object>>) => {
   /*
-   * Pick tomorrow, to do so, we get the date selected by default which is today and click the next one.
-   * It could happen that today is the last day in the calendar, in that case we pick the previous day, yesterday.
+   * Pick tomorrow, to do so, we click on the date in the calendar that is already selected (tomorrow is set by default).
+   * The difference between the date loaded by default and the manually selected one is on manual selection the time is 
+   * reset to 00:00:00, while on initial load the current time is set.
    * In any case, we return the picked date to the caller.
    */
   const targetDate = new Date()

--- a/spec/javascripts/customJestMatchers.ts
+++ b/spec/javascripts/customJestMatchers.ts
@@ -1,0 +1,27 @@
+import { expect } from '@jest/globals'
+import {
+  printExpected,
+  printReceived
+} from 'jest-matcher-utils'
+
+const toBeWithinSecondsFrom = (actual: Date, expected: Date, seconds = 1) => {
+  const diff = Math.abs(expected.getTime() - actual.getTime())
+  const pass = diff <= seconds * 1000
+  const message = () => `expected ${printReceived(actual)} ${pass ? 'not ' : ''}to be within ${seconds} seconds from ${printExpected(expected)}, but it was within ${diff / 1000} seconds`
+  return {
+    message,
+    pass
+  }
+}
+
+expect.extend({
+  toBeWithinSecondsFrom
+})
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeWithinSecondsFrom: (expected: Date, seconds?: number) => R;
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing some intermittently failing tests.
See comments inline.

**Which issue(s) this PR fixes** 

none

**Verification steps** 


**Special notes for your reviewer**:

I was also investigating the following issue:
![Screenshot from 2025-02-14 12-56-25](https://github.com/user-attachments/assets/1e5428ed-584d-47c8-ac8b-0e84e79763ee)

I believe the reason this happens is that when the component is loaded the `today` timestamp is fixed, and when the options are selected from the dropdown, the originally fixed time is applied. The test, however, calculates the expected timestamp based on the **current** time, so there might be a discrepancy.

This does not happen too often though, probably only when the component is loaded at the end of the second.

Some of the solutions that we can apply if it starts bothering us:

1. Keep the current implementation, and in the test, instead of `new Date()`, take the initial date from the hidden input, and use the time from it. I don't like it, seems hacky and confusing.

2. Change the implementation, and round the timestamp until the closest end of day (or beginning of day). Then the tests would be easier, because it will always be the same time. But on the other hand, it might be confusing for the user too.

3. Keep the current implementation, and in the test, allow for 1 second discrepancy between the expected and actual values. Also weird, but we can leave a comment explaining why. At least there will be no randomly failing tests (hopefully). Also, 1 second for this feature is not really important.

**UPDATE:** For the jest tests, I've opted (with @jlledom 's blessing) for option 3, here's the fix: https://github.com/3scale/porta/pull/4012/commits/16fce5d908297b91a7cf0f625081d7aba6723804
