### PR TITLE
Add new path for Liberation sans font

### DIFF
--- a/app/lib/pdf/styles/base.rb
+++ b/app/lib/pdf/styles/base.rb
@@ -81,6 +81,7 @@ module Pdf::Styles
           expected_locations = %w[
             /usr/share/fonts/liberation
             /usr/share/fonts/liberation-sans
+            /usr/share/fonts/liberation-sans-fonts
             ~/Library/Fonts
             /Library/Fonts
           ]


### PR DESCRIPTION
Generating invoce PDF fails on Fedora 41 becuase the default path for the Liberation Sans font have been moved

Before: `/usr/share/fonts/liberation-sans`
https://packages.fedoraproject.org/pkgs/liberation-fonts/liberation-sans-fonts/fedora-40.html

After: `/usr/share/fonts/liberation-sans-fonts`
https://packages.fedoraproject.org/pkgs/liberation-fonts/liberation-sans-fonts/fedora-41.html

This adds the new path to the list so it can find the font in the new location