### PR TITLE
THREESCALE-11641: Update braintree

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,12 +64,13 @@ gem 'webrick', '~> 1.8.2'
 gem 'yabeda-prometheus-mmap'
 gem 'yabeda-sidekiq'
 
-gem 'activemerchant', '~> 1.107.4'
+gem 'activemerchant', '~> 1.137'
 gem 'audited', '~> 5.0.2'
 gem 'stripe', '~> 5.28.0' # we need the stripe gem because activemerchant can not generate Stripe's "customers"
 
 gem 'acts_as_list', '~> 0.9.17'
-gem 'braintree', '~> 2.93'
+gem 'braintree', '~> 4.25.0'
+gem 'libxml-ruby', '~> 5.0' # Optional, makes braintree faster
 gem 'bugsnag', '~> 6.26'
 gem 'cancancan', '~> 3.6.0'
 gem 'formtastic', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,11 +125,12 @@ GEM
     activejob-uniqueness (0.2.5)
       activejob (>= 4.2, < 7.1)
       redlock (>= 1.2, < 2)
-    activemerchant (1.107.4)
+    activemerchant (1.137.0)
       activesupport (>= 4.2)
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.9)
       nokogiri (~> 1.4)
+      rexml (~> 3.3, >= 3.3.4)
     activemodel (7.0.8.7)
       activesupport (= 7.0.8.7)
     activemodel-serializers-xml (1.0.2)
@@ -223,8 +224,9 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    braintree (2.104.1)
-      builder (>= 2.0.0)
+    braintree (4.25.0)
+      builder (>= 3.2.4)
+      rexml (>= 3.1.9)
     browser (5.3.1)
     bugsnag (6.26.3)
       concurrent-ruby (~> 1.0)
@@ -419,7 +421,7 @@ GEM
     http-form_data (2.3.0)
     http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.14.0)
       actionpack (>= 6.0)
@@ -463,6 +465,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.7.0)
       launchy (~> 2.2)
+    libxml-ruby (5.0.3)
     license_finder (7.1.0)
       bundler
       rubyzip (>= 1, < 3)
@@ -976,7 +979,7 @@ DEPENDENCIES
   active-docs!
   active_record_query_trace
   activejob-uniqueness
-  activemerchant (~> 1.107.4)
+  activemerchant (~> 1.137)
   activemodel-serializers-xml
   activerecord-oracle_enhanced-adapter (~> 7.0.3)
   acts-as-taggable-on (~> 11.0)
@@ -991,7 +994,7 @@ DEPENDENCIES
   baby_squeel (~> 3.0, >= 3.0.0)
   bcrypt (~> 3.1.7)
   bootsnap (~> 1.16)
-  braintree (~> 2.93)
+  braintree (~> 4.25.0)
   browser
   bugsnag (~> 6.26)
   bullet (~> 7.0.7)
@@ -1038,6 +1041,7 @@ DEPENDENCIES
   kubeclient
   launchy
   letter_opener
+  libxml-ruby (~> 5.0)
   license_finder (~> 7.1.0)
   listen
   local-fastimage_resize (~> 3.4.0)


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to update `braintree` or it will stop working at June 30, 2025.

This PR updates `braintree` and adds `libxml-ruby` which allegedly makes Braintree faster. It also updates `activemerchant`, since we were using an old version which wasn't compatible with the newer `braintree` versions

**Which issue(s) this PR fixes** 

[THREESCALE-11641](https://issues.redhat.com/browse/THREESCALE-11641)

**Verification steps** 

I tried this locally, for Braintree and also for Stripe, since I updated `activemerchant`:

1. Try to add an invalid CC
2. Add a valid CC
3. Make a failed payment
4. Make a successful payment

It all worked fine for me.

**Useful links**:

- https://developer.paypal.com/braintree/docs/guides/credit-cards/testing-go-live/ruby#valid-card-numbers
- https://developer.paypal.com/braintree/docs/reference/general/testing/ruby#transaction-amounts
- https://docs.stripe.com/testing?testing-method=card-numbers#cards
