### PR TITLE
Exclude URL delimiters from mapped chars

### DIFF
--- a/app/indices/proxy_rules_index.rb
+++ b/app/indices/proxy_rules_index.rb
@@ -9,6 +9,6 @@ ThinkingSphinx::Index.define(:proxy_rule, with: :real_time) do
   has owner_type, type: :string
 
   set_property min_infix_len: 1
-  #                                                    !     '     ()*+,-./    _
-  set_property charset_table: "0..9, A..Z->a..z, a..z, U+21, U+27, U+28..U+2F, U+5F"
+  #                                                    %     -     .     _     ~
+  set_property charset_table: "0..9, A..Z->a..z, a..z, U+25, U+2D, U+2E, U+5F, U+7E"
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Some queries to manticore, for the `proxy_rule` index, are inconsistent and don't return all the matching results. In particular, the Jira issue includes an example with the keyword `foto`.

I tried locally and reproduced the bug, for both sphinx and manticore.

I've been able to solve this by removing some allowed characters from the index. I'm not sure how this affects manticore internals but the truth is having the character `/` as allowed causes the bug.

As I understood it, [charset_table](https://sphinxsearch.com/docs/current/conf-charset-table.html) means the list of characters that are considered valid characters inside a search query. Characters not in `charset_table` will be considered "delimiters" and are ignored in queries.

Since mapping rules are URLs, I think it's correct to accept only URL characters, and only those which are not reserved delimiters according to [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.2)

According to [this SO answer](https://stackoverflow.com/questions/7109143/what-characters-are-valid-in-a-url). Those characters are:

```
A-Z, a-z, 0-9, -, ., _, ~, :, /, ?, #, [, ], @, !, $, &, ', (, ), *, +, ,, ;, %, =
```

But from those, some are reserved delimiters, so I allowed these ones in our manticore index:

```
A-Z, a-z, 0-9, -, ., _, ~, %
```

This solves the issue, though I don't entirely understand why it failed before. I mean, `/` was allowed as a character to be considered in searches, so a query like `/fotos` should work if it actually matches the pattern, which was the problem with that? I looks correct to me.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10930

**Verification steps** 

1. Add the next mapping rules:
```
/biometria-servico/services/eleitoral/fotos
/biometria-servico/services/fotos/eleitoral
/bar/v1/foto/fotos
/bar/v1/something-else/fotos
/bar/v1/something/else/fotos
/bar/v1/someting/else/this/is/even/larger/than/the/one/failing/fotos
/biometria-servico/services/eleitora/fotos
/biometria-servico/services/eleitor/fotos
/biometria-servico/services/eleitoral/a/fotos
/biometria-servico/services/eleitorala/fotos
/biometria-servico/services/eleitorb/fotos
/biometria-servico/services/eleitorbl/fotos
/biometria-servico/services/ases/codObjetoAse/fotos-miniatura
/biometria-servico/services/ases/{codObjetoAse}/fotos-miniatura
/biometria-servico/services/ases/{codObjetoAse}/miniatura-fotos
/biometria-servico/services/eleitoral/biometria/v1/ase/{codObjetoAse}/miniatura-fotos
```
2. Search for `fotos`
3. On `master`, it will return 10 results, on this branch, it will return all 16 results.

