### PR TITLE
THREESCALE-10758: Filter email notifications by service

### DIFF
--- a/app/events/accounts/account_created_event.rb
+++ b/app/events/accounts/account_created_event.rb
@@ -1,10 +1,13 @@
 class Accounts::AccountCreatedEvent < AccountRelatedEvent
 
   def self.create(account, user)
+    service_ids = account.bought_service_contracts.accessible_services.pluck(:id)
+
     new(
       provider: account.provider_account,
       account:  account,
       user:     user,
+      service_ids:,
       metadata: {
         provider_id: account.provider_account_id
       }

--- a/app/events/application_related_event.rb
+++ b/app/events/application_related_event.rb
@@ -1,4 +1,4 @@
-class ApplicationRelatedEvent < AccountRelatedEvent
+class ApplicationRelatedEvent < ServiceRelatedEvent
 
   self.category = :application
 end

--- a/app/events/messages/message_received_event.rb
+++ b/app/events/messages/message_received_event.rb
@@ -1,11 +1,14 @@
 class Messages::MessageReceivedEvent < AccountRelatedEvent
   def self.create(message, recipient)
+    service_ids = message.sender.buyer? ? message.sender.bought_service_contracts.accessible_services.pluck(:id) : []
+
     new(
       message:   message,
       sender:    message.sender,
       recipient: recipient,
       receiver:  recipient.receiver,
       provider:  recipient.receiver,
+      service_ids:,
       metadata: {
         provider_id: recipient.receiver_id
       }

--- a/app/lib/event_store/repository.rb
+++ b/app/lib/event_store/repository.rb
@@ -108,6 +108,7 @@ module EventStore
       end
     end
 
+    # rubocop:disable Lint/MissingSuper
     def initialize(repository = self.class.repository, event_broker = EventBroker.new)
       @client = ::RailsEventStore::Client.new(repository: repository, event_broker: event_broker)
       @facade = Facade.new(repository, event_broker)
@@ -166,6 +167,7 @@ module EventStore
       subscribe_event(ProxyConfigEventSubscriber.new, ProxyConfigs::AffectingObjectChangedEvent)
       subscribe_event(ZyncSubscriber.new, ZyncEvent)
     end
+    # rubocop:enable Lint/MissingSuper
 
     delegate :publish_event, to: :facade
 

--- a/config/abilities/provider_any.rb
+++ b/config/abilities/provider_any.rb
@@ -30,8 +30,11 @@ Ability.define do |user| # rubocop:disable Metrics/BlockLength
 
     if user.has_permission?(:partners)
       can [:show], AccountRelatedEvent do |event|
-        service_id = event.try(:service)&.id || event.try(:service_id)
-        !service_id || user.has_access_to_service?(service_id)
+        next true if user.has_access_to_all_services?
+
+        service_ids = event.try(:service_ids) || [event.try(:service)&.id || event.try(:service_id)].compact
+
+        service_ids.any? { user.has_access_to_service?(_1) }
       end
 
       can [:show], ServiceRelatedEvent do |event|

--- a/test/unit/abilities/provider_any_test.rb
+++ b/test/unit/abilities/provider_any_test.rb
@@ -3,14 +3,24 @@
 require 'test_helper'
 
 module Abilities
-  class ProviderAnyTest < ActiveSupport::TestCase
+
+  class BaseTest < ActiveSupport::TestCase
     setup do
-      @account = FactoryBot.create(:simple_provider)
+      @account = FactoryBot.create(:provider_account)
       @account.stubs(:provider_can_use?).with(any_parameters).returns(false)
       @user  = FactoryBot.create(:simple_user, account: @account)
     end
 
     attr_reader :user, :account
+
+    private
+
+    def ability
+      Ability.new(user)
+    end
+  end
+
+  class ProviderAnyTest < BaseTest
 
     def test_policies_permissions_for_member
       account.expects(:provider_can_use?).with(:policy_registry).returns(true)
@@ -42,7 +52,7 @@ module Abilities
       assert_cannot ability, :manage, :policy_registry
     end
 
-    test 'Cinstance/Application events can show if has :partners and access to the service if there is a service' do
+    test 'Cinstance/Application events can show if has :partners and access to the service if the event includes a service' do
       service = FactoryBot.create(:simple_service, account: @account)
       another_service = FactoryBot.create(:simple_service, account: @account)
       plan = FactoryBot.create(:simple_application_plan, issuer: service)
@@ -71,57 +81,112 @@ module Abilities
         assert_cannot ability, :show, cinstance_event
       end
     end
+  end
 
-    test 'AccountRelatedEvent can show if has :partners and does not have a service' do
-      assert_cannot ability, :show, Accounts::AccountCreatedEvent.create(account, user)
+  class AccountRelatedEventTest < BaseTest
+    setup do
+      # @account has a service and a service plan
+      @service = FactoryBot.create(:simple_service, account: @account)
+      service_plan = FactoryBot.create(:simple_service_plan, issuer: @service)
 
+      # There's a buyer for @account and it's subscribed to the service
+      @buyer = FactoryBot.create(:buyer_account, provider_account: @account)
+      @buyer_user = FactoryBot.create(:simple_user, account: @buyer)
+      FactoryBot.create(:service_contract, plan: service_plan, user_account: @buyer)
+
+      # Another buyer but not subscribed to any service
+      @buyer_no_service =  FactoryBot.create(:buyer_account, provider_account: @account)
+      @buyer_no_service_user = FactoryBot.create(:simple_user, account: @buyer_no_service)
+    end
+
+    test "member has :partners and access to all service can show AccountRelatedEvent when the event doesn't include a service" do
+      user.member_permission_service_ids = nil # All services allowed
       user.member_permission_ids = [:partners]
-      assert_can ability, :show, Accounts::AccountCreatedEvent.create(account, user)
+      assert_can ability, :show, Accounts::AccountCreatedEvent.create(@buyer_no_service, @buyer_no_service_user)
     end
 
-    class ShowAlertRelatedEventTest < ProviderAnyTest
-      setup do
-        service = FactoryBot.create(:simple_service, account: @account)
-        plan = FactoryBot.create(:simple_application_plan, issuer: service)
-        cinstance = FactoryBot.create(:cinstance, plan: plan)
-        alert = FactoryBot.create(:limit_violation, cinstance: cinstance)
-        @limit_violation_reached_provider_event = Alerts::LimitViolationReachedProviderEvent.create(alert)
-      end
-
-      attr_reader :limit_violation_reached_provider_event
-
-      test 'cannot show AlertRelatedEvent when user does not have :monitoring' do
-        assert_not user.has_permission? :monitoring
-        assert_cannot ability, :show, limit_violation_reached_provider_event
-      end
-
-      # If the user has service-related permission, and no :services permission, it means it has access to all services
-      test 'can show AlertRelatedEvent when user has :monitoring and the user has access to all services' do
-        user.member_permission_ids = [:monitoring]
-        assert user.has_permission? :monitoring
-
-        assert_can ability, :show, limit_violation_reached_provider_event
-      end
-
-      test 'cannot show AlertRelatedEvent when user has :monitoring and does not have access to the service' do
-        user.member_permission_ids = [:monitoring]
-        user.member_permission_service_ids = []
-
-        assert_cannot ability, :show, limit_violation_reached_provider_event
-      end
-
-      test 'can show AlertRelatedEvent when user has :monitoring and has access to the service' do
-        user.member_permission_ids = [:monitoring]
-        user.member_permission_service_ids = [limit_violation_reached_provider_event.service.id]
-
-        assert_can ability, :show, limit_violation_reached_provider_event
-      end
+    test "admin can show AccountRelatedEvent when the event doesn't include a service" do
+      admin = account.first_admin
+      ability = Ability.new(admin)
+      assert_can ability, :show, Accounts::AccountCreatedEvent.create(@buyer_no_service, @buyer_no_service_user)
     end
 
-    private
+    test 'member has :partners and access to all services can show AccountRelatedEvent if the event includes a service' do
+      user.member_permission_service_ids = nil
+      user.member_permission_ids = [:partners]
 
-    def ability
-      Ability.new(user)
+      assert_can ability, :show, Accounts::AccountCreatedEvent.create(@buyer, @buyer_user)
+    end
+
+    test 'member has :partners and access to one service can show AccountRelatedEvent if the event includes that service' do
+      user.member_permission_service_ids = [@service.id]
+      user.member_permission_ids = [:partners]
+
+      assert_can ability, :show, Accounts::AccountCreatedEvent.create(@buyer, @buyer_user)
+    end
+
+    test "member has :partners and access to a service can't show AccountRelatedEvent if the event includes another service" do
+      another_service = FactoryBot.create(:simple_service, account: @account)
+      user.member_permission_service_ids = [another_service.id]
+      user.member_permission_ids = [:partners]
+
+      assert_cannot ability, :show, Accounts::AccountCreatedEvent.create(@buyer, @buyer_user)
+    end
+
+    test "member has :partners and access to no service can't show AccountRelatedEvent if the event includes a service" do
+      user.member_permission_service_ids = []
+      user.member_permission_ids = [:partners]
+
+      assert_cannot ability, :show, Accounts::AccountCreatedEvent.create(@buyer, @buyer_user)
+    end
+
+    test 'member has :partners and access to one service can show AccountRelatedEvent if the event includes that service among others' do
+      another_service = FactoryBot.create(:simple_service, account: @account)
+      service_plan = FactoryBot.create(:simple_service_plan, issuer: another_service)
+      FactoryBot.create(:service_contract, plan: service_plan, user_account: @buyer)
+
+      user.member_permission_service_ids = [another_service.id]
+      user.member_permission_ids = [:partners]
+
+      assert_can ability, :show, Accounts::AccountCreatedEvent.create(@buyer, @buyer_user)
+    end
+  end
+
+  class ShowAlertRelatedEventTest < BaseTest
+    setup do
+      service = FactoryBot.create(:simple_service, account: @account)
+      plan = FactoryBot.create(:simple_application_plan, issuer: service)
+      cinstance = FactoryBot.create(:cinstance, plan: plan)
+      alert = FactoryBot.create(:limit_violation, cinstance: cinstance)
+      @limit_violation_reached_provider_event = Alerts::LimitViolationReachedProviderEvent.create(alert)
+    end
+
+    attr_reader :limit_violation_reached_provider_event
+
+    test 'cannot show AlertRelatedEvent when user does not have :monitoring' do
+      assert_not user.has_permission? :monitoring
+      assert_cannot ability, :show, limit_violation_reached_provider_event
+    end
+
+    # If the user has service-related permission, and no :services permission, it means it has access to all services
+    test 'can show AlertRelatedEvent when user has :monitoring and the user has access to all services' do
+      user.member_permission_ids = [:monitoring]
+
+      assert_can ability, :show, limit_violation_reached_provider_event
+    end
+
+    test 'cannot show AlertRelatedEvent when user has :monitoring and does not have access to the service' do
+      user.member_permission_ids = [:monitoring]
+      user.member_permission_service_ids = []
+
+      assert_cannot ability, :show, limit_violation_reached_provider_event
+    end
+
+    test 'can show AlertRelatedEvent when user has :monitoring and has access to the service' do
+      user.member_permission_ids = [:monitoring]
+      user.member_permission_service_ids = [limit_violation_reached_provider_event.service.id]
+
+      assert_can ability, :show, limit_violation_reached_provider_event
     end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Clients complain their inboxes are being spammed with non-relevant emails about notifications they don't care about because their users don't have permissions to manage the services the notifications are about.

We already implement a system to filter such notifications, this is how it works:

1. An event happens
2. It's listened by `PublishNotificationEventSubscriber`:

https://github.com/3scale/porta/blob/a8979588f3cde863765813cce1ca40974cb863a2/app/lib/event_store/repository.rb#L117-L167
https://github.com/3scale/porta/blob/a8979588f3cde863765813cce1ca40974cb863a2/app/lib/event_store/repository.rb#L186-L188
3. A `NotificationEvent` is created:
https://github.com/3scale/porta/blob/25fa9bc53bdd3eeb8f2a9c8e882f771c85c3c3cb/app/subscribers/publish_notification_event_subscriber.rb#L12-L18

4. AFAIK nobody subscribes to it, but after being added, a `ProcessNotificationEventWorker` job is enqueued:
https://github.com/3scale/porta/blob/46eb05a4513e21271498d887c9e55514eba64c85/app/events/notification_event.rb#L20-L22

5. When performed, one `UserNotificationWorker` job is enqueued for each active user in the provider
https://github.com/3scale/porta/blob/7efaabdeec71877d74e580149890ef50c3ec1de5/app/workers/process_notification_event_worker.rb#L37-L55

6. For every user, `should_deliver?` is called:
https://github.com/3scale/porta/blob/7efaabdeec71877d74e580149890ef50c3ec1de5/app/workers/process_notification_event_worker.rb#L26

7. Which calls `permitted?`:
https://github.com/3scale/porta/blob/9833dc482fefef940ba36d71ff587403e3060367/app/models/notification.rb#L38-L40

8. Which checks the permissions:
https://github.com/3scale/porta/blob/9833dc482fefef940ba36d71ff587403e3060367/app/models/notification.rb#L72-L74

9. The event can be `BillingRelatedEvent`, `AccountRelatedEvent` or `ServiceRelatedEvent`. 
   - Billing events are sent to everybody having the `:finance` permission
   - Service events must include the `service` field in their data, and can be notified if the user has access to the service.
   - Account events can include the `service` field in their data or not, and can be notified if the user has access to service or the event doesn't contain a service:

https://github.com/3scale/porta/blob/af8ef719e7ba8ea038ca836fefe0d17ff4b2933c/config/abilities/provider_any.rb#L30-L41

This works fine for those events that can be easily associated to a service, for instance creating an application; but some other events are not, for instance sending a message.

In particular, the client complains about:

1. An account is created with a service subscription of any other product, for example ProductB.
2. An account is created without any service subscription.
3. An account is deleted regardless of any service subscription.
4. A developer user sends a message regardless the service subscriptions the account has.

- 1 and 2 trigger `Accounts::AccountCreatedEvent`
- 3 triggers `Accounts::AccountDeletedEvent`
- 4 triggers `Messages::MessageReceivedEvent`

In order to fix `AccountCreatedEvent` and `MessageReceivedEvent` I made some changes in the ability so it can handle multiple services rather than only one, if any of the services in the event are permitted, then the notification is sent: https://github.com/3scale/porta/pull/4029/commits/0110eb1669c7b05aba994f25ce406aa421dd07f5

Then I added the relevant services to the events: https://github.com/3scale/porta/pull/4029/commits/c06648587d7ad55150c1741abf91bf79deddea3b and https://github.com/3scale/porta/pull/4029/commits/1b45331431d5b0b252998dda26871ea860b378fd

Also made all application events related to `Service` rather than `Account`, I think it's more correct: https://github.com/3scale/porta/pull/4029/commits/0eaca5ed35feb99c2a0784642690f2dec0e519f4

About `AccountDeletedEvent` we have a problem here. The event is created from an observer:

https://github.com/3scale/porta/blob/25fa9bc53bdd3eeb8f2a9c8e882f771c85c3c3cb/app/observers/account_observer.rb#L34-L37

But the received `account` is already deleted and not persisted, so its `bought_service_contracts` association is empty and we can't get the service subscriptions. Maybe the corresponding `ServiceContract` records still exist in DB at this point and can be retrieved, but I think that's error prone so I didn't even try.

For that reason I couldn't implement the filtering for this kind of event.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10758
https://issues.redhat.com/browse/THREESCALE-8720
