### PR TITLE
THREESCALE-9306: Update broken documentation links in the admin portal

### DIFF
--- a/app/javascript/src/ActiveDocs/components/SwaggerUpdateHelpAction.tsx
+++ b/app/javascript/src/ActiveDocs/components/SwaggerUpdateHelpAction.tsx
@@ -12,7 +12,7 @@ const SwaggerUpdateHelpAction: FunctionComponent<Props> = ({ href, title }) => (
   <span className="pf-c-table__column-help-action">
     <Popover
       bodyContent={(
-        <a href={href}>{title}</a>
+        <a href={href} rel="noreferrer" target="_blank">{title}</a>
       )}
     >
       <a className="pf-c-button pf-m-plain">

--- a/app/lib/system/deploy.rb
+++ b/app/lib/system/deploy.rb
@@ -34,7 +34,7 @@ module System
       end
 
       def docs_version
-        @docs_version ||= ThreeScale.saas? || rhoam? ? 'red_hat_3scale/2-saas' : "red_hat_3scale_api_management/#{major_version}.#{minor_version}"
+        @docs_version ||= ThreeScale.saas? || rhoam? ? '2-saas' : "#{major_version}.#{minor_version}"
       end
 
       # RHOAM version has only one segment (release = 'RHOAM')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,12 +32,12 @@
 en:
   # start documentation links
   docs:
-    base_url: 'https://access.redhat.com/documentation/en-us/%{docs_version}/html'
+    base_url: 'https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/%{docs_version}/html'
     hero_api_portal: '%{docs_base_url}/creating_the_developer_portal/index'
     developer_portal:
-      email_configuration: '%{docs_base_url}/creating-developer-portal/email-configuration'
+      email_configuration: '%{docs_base_url}/creating_the_developer_portal/email-configuration'
       liquid_reference: '%{docs_base_url}/liquid_reference/index'
-    terminology: '%{docs_base_url}/terminology'
+    terminology: '%{docs_base_url}/glossary/index'
   # end documentation links
   api_integrations_controller:
     promote_to_production_success: 'Staging configuration promoted to production'
@@ -150,7 +150,7 @@ en:
       base:
         index:
           update_link_text: "Learn how to upgrade to Swagger 2"
-          update_link: "%{docs_base_url}/api-documentation/activedocs-migrate"
+          update_link: "%{docs_base_url}/providing_apis_in_the_developer_portal/activedocs-migrate"
           empty_state:
             title: No ActiveDocs specs yet
             body: Make your API documentation clear, intuitive, and user friendly with 3scale ActiveDocs.
@@ -831,12 +831,8 @@ en:
         enabled_html: "Deployed at %{at}. <a href='%{list}'>See the history.</a>"
         disabled_html: "Not deployed. <a href='%{list}'>See the history.</a>"
 
-        # start documentation links
-        documentation_hosted_url: '%{docs_base_url}/deployment-options/apicast-hosted'
-        documentation_self_managed_url: '%{docs_base_url}/deployment-options/apicast-self-managed-nginx-config-files'
-        documentation_oauth_url: '%{docs_base_url}/deployment-options/apicast-oauth-before-may-2017'
         documentation_response_codes_tracking_url: '%{docs_base_url}/admin_portal_guide/setting-up-and-evaluating-the-threescale-response-codes-log-for-your-api_analytics-for-threescale-apis'
-        # end documentation links
+
         proxy_rule_catch_all_warning: |
           "Catch all" Mapping Rules often lead to double counts when more specific rules are added.
         curl:

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -74,7 +74,7 @@ class ApplicationHelperTest < ActionView::TestCase
     end
 
     test 'docs base url' do
-      assert_equal 'https://access.redhat.com/documentation/en-us/red_hat_3scale/2-saas/html', docs_base_url
+      assert_equal 'https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2-saas/html', docs_base_url
     end
   end
 

--- a/test/unit/lib/system/deploy_test.rb
+++ b/test/unit/lib/system/deploy_test.rb
@@ -45,8 +45,8 @@ class DeployTest < ActiveSupport::TestCase
       assert_equal '13', System::Deploy.info.minor_version
     end
 
-    test 'docs url point to onpremises product docs' do
-      assert_equal 'red_hat_3scale_api_management/2.13', System::Deploy.info.docs_version
+    test 'onpremises docs version is the same as full product version' do
+      assert_equal '2.13', System::Deploy.info.docs_version
     end
   end
 
@@ -61,8 +61,8 @@ class DeployTest < ActiveSupport::TestCase
       assert_equal 'x', System::Deploy.info.minor_version
     end
 
-    test 'docs url point to SaaS product docs' do
-      assert_equal 'red_hat_3scale/2-saas', System::Deploy.info.docs_version
+    test 'SaaS docs version' do
+      assert_equal '2-saas', System::Deploy.info.docs_version
     end
   end
 
@@ -77,8 +77,8 @@ class DeployTest < ActiveSupport::TestCase
       assert_nil System::Deploy.info.minor_version
     end
 
-    test 'docs url point to SaaS product docs' do
-      assert_equal 'red_hat_3scale/2-saas', System::Deploy.info.docs_version
+    test 'SaaS docs version' do
+      assert_equal '2-saas', System::Deploy.info.docs_version
     end
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed some broken link to the 3scale product documentation, and tried to fix it.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-9306

**Verification steps** 

Check that all links point to existing pages in the 3scale product documentation.

**Special notes for your reviewer**:
