### PR TITLE
Update yarn package-lock

### DIFF
--- a/script/yarn/package-lock.json
+++ b/script/yarn/package-lock.json
@@ -1,7 +1,7 @@
 {
     "name": "yarn-dependency",
     "version": "1.0.0",
-    "lockfileVersion": 2,
+    "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
@@ -25,14 +25,6 @@
             "engines": {
                 "node": ">=4.0.0"
             }
-        }
-    },
-    "dependencies": {
-        "yarn": {
-            "version": "1.22.19",
-            "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz",
-            "integrity": "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==",
-            "dev": true
         }
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We use this file for a single purpose - to instruct the productization build system to prefetch the `yarn` dependency (of the version that is specified), so we can install it with `npm` in a hermetic (with no internet access) build.

There were some issues with the previous version of the file when using with the new dependencies prefetching system (it was still trying to access internet, because of the link), but updating this `package-lock.json` file resolves it.

There were no manual changes, just removing `package-lock.json` and running `npm install` again generated this new version of the file.

**Which issue(s) this PR fixes** 


**Verification steps** 


**Special notes for your reviewer**:
