### PR TITLE
THREESCALE-11735: Impersonation confilcts with recaptcha

### DIFF
--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -19,7 +19,6 @@ class FrontendController < ApplicationController
   # those modules are inter-dependent
   include Liquid::TemplateSupport
   include Liquid::Assigns
-  include CMS::Toolbar
   include CMS::BuiltinPagesSupport
 
   include ThreeScale::Warnings::ControllerExtension

--- a/app/lib/impersonate/signature.rb
+++ b/app/lib/impersonate/signature.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Impersonate
+  class Signature
+    def self.generate(user_id, expires_at)
+      verifier = Rails.application.message_verifier(:impersonate)
+      signing_options = { purpose: :impersonate_admin_login, expires_at: expires_at.utc.floor }
+      verifier.generate(user_id, **signing_options).split("--").last
+    end
+
+    def self.validate(params, user_id)
+      signature = params.delete(:signature)
+      return signature if signature.blank?
+
+      expires_at = Time.at(params.delete(:expires_at).to_i).utc
+      raise ActiveSupport::MessageVerifier::InvalidSignature unless expires_at > Time.now.utc
+
+      valid_signature = signature == generate(user_id, expires_at)
+
+      raise ActiveSupport::MessageVerifier::InvalidSignature unless valid_signature
+
+      true
+    rescue StandardError
+      false
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -172,6 +172,7 @@ without fake Core server your after commit callbacks will crash and you might ge
     get 'sso' => 'sessions#create'
     get 'login'  => 'sessions#new',     :as => :login
     get 'logout' => 'sessions#destroy', :as => :logout
+    get 'impersonate' => 'sessions#impersonate'
 
     get 'admin', to: 'admin#show'
 

--- a/lib/developer_portal/app/controllers/developer_portal/application_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/application_controller.rb
@@ -2,6 +2,7 @@
 
 module DeveloperPortal
   class ApplicationController < ::FrontendController
+    include CMS::Toolbar
 
     before_action :disable_for_suspended_provider_account
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Basically the problem is the impersonation controller redirects directly to the sessions controller bypassing the login screen, so the recaptcha params are not set, which causes the challenge to fail.

I solved this by creating a new action in the sessions controller specially for the impersonation scenario, which doesn't requires passing a recaptcha challenge. Also, this new action implements impersonation by sending the signature of the `user_id` to be logged in. It doesn't use our custom SSO anymore.

Apparently OpenID logins are also failing when recaptcha is enabled. I have to investigate more to figure out the scope of the problem.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11735

**Verification steps** 

**For impersionation**:

1. Enable recaptcha on a provider
2. Login to the master portal
3. Try to impersonate that provider

**For OpenID**:

1. Configure the provider to accept Red Hat SSO logins
2. Logout
3. Try to login using Red Hat SSO Auth


