### PR TITLE
Upgrade bundler to 2.3.27

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1142,4 +1142,4 @@ DEPENDENCIES
   zip-zip
 
 BUNDLED WITH
-   2.2.25
+   2.3.27


### PR DESCRIPTION
**What this PR does / why we need it**:

We're locking to bundler `2.2.25`, and it's deprecated.

![Screenshot From 2025-04-03 10-55-11](https://github.com/user-attachments/assets/15d7a499-eb74-4348-afbf-9986cf4e1fa9)

We could upgrade to the latest bundler as well, but the version that is currently installed from RPM in the build image (`ubi9`) is `2.3.27`, and it's easier to use that version, because `hermeto` (depnedencies fetcher in productization) doesn't fetch bundler specified in `Gemfile.lock` in the prefetch stage, so we'd need to pull it manually to some Nexus repo (which I get might get discontinued at some point).

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 


**Special notes for your reviewer**:
