### PR TITLE
THREESCALE-11735: Impersonation and OpenID confilcts with recaptcha

### DIFF
--- a/app/controllers/provider/sessions_controller.rb
+++ b/app/controllers/provider/sessions_controller.rb
@@ -20,7 +20,7 @@ class Provider::SessionsController < FrontendController
     session_return_to
     logout_keeping_session!
 
-    @user, strategy = authenticate_user if bot_check
+    @user, strategy = authenticate_user
 
     if @user
       self.current_user = @user
@@ -75,6 +75,9 @@ class Provider::SessionsController < FrontendController
 
   def authenticate_user
     strategy = Authentication::Strategy.build_provider(@provider)
+    captcha_is_available = request.post? # User & pass strategy
+
+    return if captcha_is_available && !bot_check
 
     params = if domain_account.settings.enforce_sso?
                sso_params


### PR DESCRIPTION
**What this PR does / why we need it**:

Basically the problem is the impersonation controller redirects directly to the sessions controller bypassing the login screen, so the recaptcha params are not set, which causes the challenge to fail.

Same thing happens with open ID. From the login screen we link to an external provider, which ends up querying our sessions controller directly, so again no recaptcha params set.

In a previous PR (https://github.com/3scale/porta/pull/4050) I tried creating a new route only for impersonation, but then I realized OpenID connections were also failing. So I discarded that approach and now I'm simply enforcing recaptcha when the request is POST and bypassing it otherwise.

I don't really like the solution but I think is the less disrupting approach I can take right now. I think our flow is really weird and should be refactored. For instance, we have a hierarchy of classes, one for each auth strategy, and we manually instance the last child class `ProviderOAuth2` and then try all strategies one by one by calling `super` and going up in the hierarchy until a strategy works. Due to this, we can't know from the controller which strategy was really used.

The hierarchy right now is:

`ProviderOAuth2` < `OAuth2Base` < `Internal` < `SSO` < `Base`

This hierarchy is very weird because `Internal`, which means "User + pass" is not a kind of `SSO`, and OAuth2 is not a kind of `Internal`. Not to mention we are calling SSO to something which is merely a token authentication not related at all with any SSO.

In my opinion, we should have an auth service which either infers which strategy to use from the given params, or maybe still try all strategies in a particular order, like we do now, but calling them explicitly and returning an instance of the correct class, so we can at least know which strategy succeeded. Then we could add a `captcha?` method to the strategy classes that returns whether or not the strategy supports captcha.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11735

**Verification steps** 

**For impersionation**:

1. Enable recaptcha on a provider
2. Login to the master portal
3. Try to impersonate that provider

**For OpenID**:

1. Enable recaptcha on a provider
2. Configure the provider to accept Red Hat SSO logins
3. Logout
4. Try to login using Red Hat SSO Auth
