### PR TITLE
THREESCALE-11725: Update JSON schema validator to V8

### DIFF
--- a/app/javascript/src/Policies/components/PolicyConfig.tsx
+++ b/app/javascript/src/Policies/components/PolicyConfig.tsx
@@ -1,5 +1,5 @@
 import Form from '@rjsf/core'
-import { customizeValidator } from '@rjsf/validator-ajv6'
+import { customizeValidator } from '@rjsf/validator-ajv8'
 
 import { isNotApicastPolicy } from 'Policies/util'
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@patternfly/react-table": "4.113.0",
     "@rjsf/core": "^5.24.1",
     "@rjsf/utils": "^5.24.1",
-    "@rjsf/validator-ajv6": "^5.24.1",
+    "@rjsf/validator-ajv8": "^5.24.1",
     "@stripe/react-stripe-js": "1.16.5",
     "@stripe/stripe-js": "1.50.0",
     "@types/braintree-web": "3.96.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2026,12 +2026,13 @@
     lodash-es "^4.17.21"
     react-is "^18.2.0"
 
-"@rjsf/validator-ajv6@^5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv6/-/validator-ajv6-5.24.1.tgz#325cb8fb5bd5db93c39d44e53c6d3e597760cf43"
-  integrity sha512-MBZLnsd0cmkdeuQJmf4gHP5UTBh7itXOPV+My8JTTzUtHzqgp9QcUvf91DmMNvfjwJdh/Vv8+dvKqeR8y63lPQ==
+"@rjsf/validator-ajv8@^5.24.1":
+  version "5.24.8"
+  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.24.8.tgz#379e9e759cd3f6460638977ebdd21e2f0d997d7d"
+  integrity sha512-0l5/9CL2BhW5tUtP+vKg6o5Wpp5kuee5SPea3STtdBN/xbGf3dUX08jbKcvokTJt5552rFDcNjMZmu+C0H7ezQ==
   dependencies:
-    ajv "^6.12.6"
+    ajv "^8.12.0"
+    ajv-formats "^2.1.1"
     lodash "^4.17.21"
     lodash-es "^4.17.21"
 
@@ -3920,7 +3921,7 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.12.6:
+ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -3949,6 +3950,16 @@ ajv@^8.0.1:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
+
+ajv@^8.12.0:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 amdefine@>=0.0.4:
   version "1.0.1"
@@ -6018,6 +6029,11 @@ fast-safe-stringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
+fast-uri@^3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.6.tgz#88f130b77cfaea2378d56bf970dea21257a68748"
+  integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to update `nanoid` (https://github.com/3scale/porta/pull/3968) I had to update `react-jsonschema-form@1.8.1` to `@rjsf/core@5.24.1`. This package is used from the Policies screen. We have the policies defined in JSON schema format and this package transforms then into HTML forms. The package includes a validator, which last version is V8, but I had to use the deprecated V6 version because our `policies.json` was being considered inavalid by V8, check [this comment](https://github.com/3scale/porta/pull/3968/files#r1920249458) where I explain the issue.

After suggesting some changes to our `policies.json`, a new version has been released which solves the problem, so we are now free to update to the V8 validator.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11725

**Verification steps** 

The policies screen should work normally after the change. You can add and remove policies with the developer tools opened, to  verify no errors appears in the console.

In particular, the **URL Rewriting** policy was impossible to add using the new validator, now you should be able to add it and load it without problems.
