### PR TITLE
fix circleci DNS setup for v2 executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ dnsmasq-container: &dnsmasq-container
     - --log-facility=-
     - --log-queries
     - --no-poll
-    - --server=/circleci.com/dns.podman/circleci-tasks-prod.s3.us-east-1.amazonaws.com/10.89.6.1
+    - --server=/circleci.com/dns.podman/circleci-tasks-prod.s3.us-east-1.amazonaws.com/circleci-binary-releases.s3.amazonaws.com/10.89.6.1
     - --address=/#/127.0.0.1
 
 only-master-filter: &only-master-filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ dnsmasq-container: &dnsmasq-container
     - --log-facility=-
     - --log-queries
     - --no-poll
-    - --server=/circleci-internal-outer-build-agent/circleci-internal-outer-build-agent.ec2.internal/circleci.com/circleci-binary-releases.s3.amazonaws.com/dns.podman/10.89.6.1
+    - --server=/circleci.com/dns.podman/circleci-tasks-prod.s3.us-east-1.amazonaws.com/10.89.6.1
     - --address=/#/127.0.0.1
 
 only-master-filter: &only-master-filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ commands: # reusable commands with parameters
           command: |
             # see https://support.circleci.com/hc/en-us/articles/19306469418139-How-to-detect-when-a-process-is-killed-by-the-OOM-killer
             printf "OOM Control: "
-            cat /sys/fs/cgroup/memory/memory.oom_control | sed -n 3p | tee tmp/oom_num
+            cat /sys/fs/cgroup/memory.events | sed -n 5p | tee tmp/oom_num
             [ "oom_kill 0" = "$(<tmp/oom_num)" ] # fails when a proc was killed by OOM
           when: always
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ disable-internet-access: &disable-internet-access
 enable-internet-access: &enable-internet-access
   run:
     name: Enabled internet access
-    command: sudo mv /etc/resolv.conf.bak /etc/resolv.conf
+    command: sudo tee /etc/resolv.conf < /etc/resolv.conf.bak
     when: always
 
 attach-to-workspace: &attach-to-workspace
@@ -136,14 +136,20 @@ redis-container: &redis-container
 
 dnsmasq-container: &dnsmasq-container
   image: quay.io/3scale/dnsmasq
+  entrypoint:
+    - /bin/bash
+    - -c
   command:
-    - --user=root
-    - --keep-in-foreground
-    - --log-facility=-
-    - --log-queries
-    - --no-poll
-    - --server=/circleci.com/dns.podman/circleci-tasks-prod.s3.us-east-1.amazonaws.com/circleci-binary-releases.s3.amazonaws.com/10.89.6.1
-    - --address=/#/127.0.0.1
+    - |
+      DEFAULT_DNS=$(sed -nEe 's/nameserver\s+(.*)/\1/p' /etc/resolv.conf | head -1)
+      /usr/sbin/dnsmasq \
+      --user=root \
+      --keep-in-foreground \
+      --log-facility=- \
+      --log-queries \
+      --no-poll \
+      --server=/circleci.com/dns.podman/circleci-tasks-prod.s3.us-east-1.amazonaws.com/circleci-binary-releases.s3.amazonaws.com/$DEFAULT_DNS \
+      --address=/#/127.0.0.1
 
 only-master-filter: &only-master-filter
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ dnsmasq-container: &dnsmasq-container
     - --log-facility=-
     - --log-queries
     - --no-poll
-    - --server=/circleci-internal-outer-build-agent/circleci-internal-outer-build-agent.ec2.internal/circleci.com/circleci-binary-releases.s3.amazonaws.com/127.0.0.11
+    - --server=/circleci-internal-outer-build-agent/circleci-internal-outer-build-agent.ec2.internal/circleci.com/circleci-binary-releases.s3.amazonaws.com/10.89.6.1
     - --address=/#/127.0.0.1
 
 only-master-filter: &only-master-filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,14 @@ use-example-config-files: &use-example-config-files
 disable-internet-access: &disable-internet-access
   run:
     name: Disable internet access
-    command: sudo sed -c -i".bak" 's/127\.0\.0\.11$/127.0.0.1/' /etc/resolv.conf
+    command: |
+      cat /etc/resolv.conf
+      sudo sed -c -i".bak" 's/^nameserver.*/nameserver 127.0.0.1/' /etc/resolv.conf
 
 enable-internet-access: &enable-internet-access
   run:
     name: Enabled internet access
-    command: sudo sed -c -i".bak" 's/127\.0\.0\.1$/127.0.0.11/' /etc/resolv.conf
+    command: sudo mv /etc/resolv.conf.bak /etc/resolv.conf
     when: always
 
 attach-to-workspace: &attach-to-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ dnsmasq-container: &dnsmasq-container
     - --log-facility=-
     - --log-queries
     - --no-poll
-    - --server=/circleci-internal-outer-build-agent/circleci-internal-outer-build-agent.ec2.internal/circleci.com/circleci-binary-releases.s3.amazonaws.com/10.89.6.1
+    - --server=/circleci-internal-outer-build-agent/circleci-internal-outer-build-agent.ec2.internal/circleci.com/circleci-binary-releases.s3.amazonaws.com/dns.podman/10.89.6.1
     - --address=/#/127.0.0.1
 
 only-master-filter: &only-master-filter


### PR DESCRIPTION
> We have reverted a change that prevented dnsmasq from binding port 53 on 127.0.0.x address. This should fix the main cause of the issue you reported.
> 
> This change had been put in place to add a DNS resolver to 127.0.0.11, as it had previously been hardcoded to this address and some jobs relied on a dns server being available there.
> 
> I\u2019ve reviewed your build to check for any further potential issues on V2 and noticed that your script also relies on this hardcoded address to replace the resolver with dnsmasq. In order to support v2, please could you update your job\u2019s sed command below
> 
> `sudo sed -c -i".bak" 's/[127.0.0.11](http://127.0.0.11/)$/[127.0.0.1/](http://127.0.0.1/)' /etc/resolv.conf `
>
> with
> 
> `sudo sed -c -i".bak" 's/^nameserver.*/nameserver [127.0.0.1/](http://127.0.0.1/)' /etc/resolv.conf`
> 
> This should enable your job to work on both v1 and v2. Please let us know when you\u2019ve had a chance to try this out and we can arrange re-enabling v2 for your project.
> 
> The opt out on your project is due to expire on the 8th of April, so please let me know if you need further help.