### PR TITLE
make more reliable the tests going over all AR descendants

### DIFF
--- a/app/lib/three_scale/models.rb
+++ b/app/lib/three_scale/models.rb
@@ -9,12 +9,16 @@ module ThreeScale
       @all_models_with_a_table = ApplicationRecord.descendants.select(&:arel_table).reject(&:abstract_class?)
     end
 
+    def three_scale_db_models
+      @three_scale_db_models ||= all_models_with_a_table.reject { _1.name.match(/^.+Test::.+$/) }
+    end
+
     # All actual models excluding abstract and STI base classes
     def leaf_models
       return @leaf_models if defined?(@leaf_models)
 
-      @leaf_models = all_models_with_a_table.select do |model|
-        all_models_with_a_table.none? { _1 != model && _1.base_class == model }
+      @leaf_models = three_scale_db_models.select do |model|
+        three_scale_db_models.none? { _1 != model && _1.base_class == model }
       end
     end
 
@@ -22,12 +26,12 @@ module ThreeScale
     def base_models
       return @base_models if defined?(@base_models)
 
-      @base_models = all_models_with_a_table.select do |model|
+      @base_models = three_scale_db_models.select do |model|
         base_class = model.base_class
         # either current model is the base_class
         base_class == model ||
           # or we can't find a base class amongst the discovered models /which would be very weird/
-          all_models_with_a_table.none? { |potential_parent| potential_parent == base_class }
+          three_scale_db_models.none? { |potential_parent| potential_parent == base_class }
       end
     end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
-  config.cache_classes = false
+  config.cache_classes = true
 
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration

--- a/features/step_definitions/usage_limit_steps.rb
+++ b/features/step_definitions/usage_limit_steps.rb
@@ -51,13 +51,17 @@ end
 
 Then "{plan} should have a usage limit of {int} for metric {string} per {string}" do |plan, value, metric_name, period|
   wait_for_requests
-  metric = plan.service.metrics.find_by_system_name!(metric_name)
-  assert_not_nil plan.usage_limits.find_by_metric_id_and_period_and_value(metric.id, period, value)
+  retry_assertions(times: 5) do
+    metric = plan.service.metrics.find_by_system_name!(metric_name)
+    assert_not_nil plan.usage_limits.find_by_metric_id_and_period_and_value(metric.id, period, value)
+  end
 end
 
 Then "{plan} should not have hourly usage limit for metric {string}" do |plan, metric_name|
-  metric = plan.metrics.find_by_system_name!(metric_name)
-  assert_nil plan.usage_limits.find_by_metric_id_and_period(metric.id, 'hour')
+  retry_assertions(times: 5) do
+    metric = plan.metrics.find_by_system_name!(metric_name)
+    assert_nil plan.usage_limits.find_by_metric_id_and_period(metric.id, 'hour')
+  end
 end
 
 def metrics_container

--- a/features/support/test_helpers.rb
+++ b/features/support/test_helpers.rb
@@ -6,5 +6,6 @@ if defined?(Rails.root)
   World(TestHelpers::Time)
   World(TestHelpers::Country)
   World(TestHelpers::Backend)
+  World(TestHelpers::Retries)
 end
 

--- a/lib/three_scale/tenant_id_integrity_checker.rb
+++ b/lib/three_scale/tenant_id_integrity_checker.rb
@@ -98,7 +98,7 @@ module ThreeScale
     end
 
     def models_with_tenant_id
-      all_models_with_a_table.select! { _1.attribute_names.include? "tenant_id" }
+      three_scale_db_models.select! { _1.attribute_names.include? "tenant_id" }
     end
   end
 end

--- a/test/test_helpers/retries.rb
+++ b/test/test_helpers/retries.rb
@@ -1,0 +1,20 @@
+module TestHelpers
+  module Retries
+    private
+
+    def retry_assertions(times:, interval: 1.second)
+      error = nil
+
+      times.times do
+        return yield
+      rescue Minitest::Assertion => exception
+        error = exception
+        sleep interval
+      end
+
+      raise error
+    end
+  end
+end
+
+ActiveSupport::TestCase.send(:include, TestHelpers::Retries)

--- a/test/unit/cms/portlet_test.rb
+++ b/test/unit/cms/portlet_test.rb
@@ -32,6 +32,7 @@ class CMS::PortletTest < ActiveSupport::TestCase
   end
 
   teardown do
+    ActiveSupport::DescendantsTracker.clear([CustomPortlet])
     CMS::PortletTest.send(:remove_const, :CustomPortlet)
   end
 

--- a/test/unit/cms/portlet_test.rb
+++ b/test/unit/cms/portlet_test.rb
@@ -23,17 +23,10 @@ class CMS::PortletTest < ActiveSupport::TestCase
     assert_equal 'Latest Forum Posts', LatestForumPostsPortlet.model_name.human
   end
 
-  setup do
-    class CustomPortlet < CMS::Portlet::Base
-      attributes :fancyness
-      attr_accessible :fancyness
-      validates_presence_of :fancyness
-    end
-  end
-
-  teardown do
-    ActiveSupport::DescendantsTracker.clear([CustomPortlet])
-    CMS::PortletTest.send(:remove_const, :CustomPortlet)
+  class CustomPortlet < CMS::Portlet::Base
+    attributes :fancyness
+    attr_accessible :fancyness
+    validates_presence_of :fancyness
   end
 
   test 'custom portlet' do

--- a/test/unit/fields_definition_test.rb
+++ b/test/unit/fields_definition_test.rb
@@ -272,23 +272,17 @@ class FieldsDefinitionTest < ActiveSupport::TestCase
   class DefaultTest < ActiveSupport::TestCase
     attr_reader :provider
 
-    setup do
-      class FakeModel < ApplicationRecord
-        self.table_name = 'accounts'
-        include Fields::Fields
+    class FakeModel < ApplicationRecord
+      self.table_name = 'accounts'
+      include Fields::Fields
 
-        required_fields_are :required_one, :required_two
-        optional_fields_are :optional_one, :optional_two
-        default_fields_are :required_one, :optional_one
-      end
-
-      @provider = FactoryBot.create(:simple_provider)
+      required_fields_are :required_one, :required_two
+      optional_fields_are :optional_one, :optional_two
+      default_fields_are :required_one, :optional_one
     end
 
-    teardown do
-      FieldsDefinition.targets.delete FakeModel.name
-      ActiveSupport::DescendantsTracker.clear([FakeModel])
-      DefaultTest.send(:remove_const, :FakeModel)
+    setup do
+      @provider = FactoryBot.create(:simple_provider)
     end
 
     test 'creates default field definitions' do

--- a/test/unit/fields_definition_test.rb
+++ b/test/unit/fields_definition_test.rb
@@ -287,6 +287,7 @@ class FieldsDefinitionTest < ActiveSupport::TestCase
 
     teardown do
       FieldsDefinition.targets.delete FakeModel.name
+      ActiveSupport::DescendantsTracker.clear([FakeModel])
       DefaultTest.send(:remove_const, :FakeModel)
     end
 

--- a/test/unit/indices/indexing_test.rb
+++ b/test/unit/indices/indexing_test.rb
@@ -57,11 +57,11 @@ class IndexingTest < ActiveSupport::TestCase
 
   # the idea is to double check #indexed_models lists all models, assuring we cover them all in tests
   test "all models with index methods are indexed" do
-    exclusions = [ApplicationRecord, Plan, Cinstance, User]
+    exclusions = [Plan, Cinstance, User]
     index_modules = [Searchable, Indices::AccountIndex::ForAccount]
     index_modules << Indices::TopicIndex unless System::Database.oracle?
 
-    models = ActiveRecord::Base.descendants.select do |model|
+    models = three_scale_db_models.select do |model|
       index_modules.any? { |mod| mod === model.new } unless exclusions.include?(model)
     end
 

--- a/test/unit/models_test.rb
+++ b/test/unit/models_test.rb
@@ -56,11 +56,10 @@ class ModelsTest < ActiveSupport::TestCase
     }
 
     Rails.application.eager_load!
-    models = ApplicationRecord.descendants - [BackendApi, Service, Proxy, Topic, Forum]
+    models = three_scale_db_models - [BackendApi, Service, Proxy, Topic, Forum]
 
     validate_columns_for = ->(model, options = {}) do
       model_name = model.name
-      next if model_name.blank? || model_name.match(/^.+Test::.+$/)
       exception_attributes = exceptions.fetch(model_name, [])
       next if exception_attributes == :all
       exception_attributes.concat INHERITANCE_COLUMNS

--- a/test/unit/three_scale/search_test.rb
+++ b/test/unit/three_scale/search_test.rb
@@ -5,20 +5,20 @@ require 'test_helper'
 class ThreeScale::SearchTest < ActiveSupport::TestCase
   class ScopesTest < ActiveSupport::TestCase
 
-    setup do
-      class Model < ApplicationRecord
-        self.table_name = 'accounts'
+    class Model < ApplicationRecord
+      self.table_name = 'accounts'
 
-        include ThreeScale::Search::Scopes
+      include ThreeScale::Search::Scopes
 
-        scope :by_fancy_scope, ->(value) { where(id: value == '1') }
-        scope :by_another_scope, -> { where(created_at: :column) }
-      end
+      scope :by_fancy_scope, ->(value) { where(id: value == '1') }
+      scope :by_another_scope, -> { where(created_at: :column) }
     end
 
     teardown do
-      ActiveSupport::DescendantsTracker.clear([Model])
-      ScopesTest.send(:remove_const, :Model)
+      Model.allowed_sort_columns = []
+      Model.allowed_search_scopes = []
+      Model.default_search_scopes = []
+      Model.sort_columns_joins = {}
     end
 
     test "should have right methods" do

--- a/test/unit/three_scale/search_test.rb
+++ b/test/unit/three_scale/search_test.rb
@@ -4,20 +4,21 @@ require 'test_helper'
 
 class ThreeScale::SearchTest < ActiveSupport::TestCase
   class ScopesTest < ActiveSupport::TestCase
-    class Model < ApplicationRecord
-      self.table_name = 'accounts'
 
-      include ThreeScale::Search::Scopes
+    setup do
+      class Model < ApplicationRecord
+        self.table_name = 'accounts'
 
-      scope :by_fancy_scope, ->(value) { where(id: value == '1') }
-      scope :by_another_scope, -> { where(created_at: :column) }
+        include ThreeScale::Search::Scopes
+
+        scope :by_fancy_scope, ->(value) { where(id: value == '1') }
+        scope :by_another_scope, -> { where(created_at: :column) }
+      end
     end
 
     teardown do
-      Model.allowed_sort_columns = []
-      Model.allowed_search_scopes = []
-      Model.default_search_scopes = []
-      Model.sort_columns_joins = {}
+      ActiveSupport::DescendantsTracker.clear([Model])
+      ScopesTest.send(:remove_const, :Model)
     end
 
     test "should have right methods" do


### PR DESCRIPTION
UPDATE: decided to keep `config.cache_classes` but filter out test models when obtaining them. 29b0e82f46d93dc0fc1cfaffa653eeddbaca1116 can be reviewed separately, it is not related to filtering test models but it made me some troubles so I thought to have them more stable.

Presently tests that iterate over all ActiveRecord descendants intermittently fail when some test ActiveRecord models were created before running them.

This is most prominently the DeleteObjectHierarchyWorkerTest.

Here we enable clearing of descendant objects and clear the test classes in a way compatible with latest Rails 8.0

An alternative approach would be to filter them out within `ThreeScale::Models#all_models_with_a_table` in `app/lib/three_scale/models.rb`.

I'm not sure which approach would be preferable. Let me know if you think the other one makes more sense.

I somehow feel better knowing that the object will not appear in `#descendants` but they will still probably appear in `Klass.subclasses` so it is still not perfect. Thus I will understand if you feel that the simplicity of filtering them out within `#all_models_with_a_table` makes it more understandable.