### PR TITLE
THREESCALE-11764 avoid unnecessary batching when deleting messages

### DIFF
--- a/app/workers/delete_all_stale_objects_worker.rb
+++ b/app/workers/delete_all_stale_objects_worker.rb
@@ -6,14 +6,14 @@ class DeleteAllStaleObjectsWorker < ApplicationJob
 
   def perform(*classes_names)
     classes_names.each do |class_name|
-      delete_all_stale_in_batches class_name.constantize
+      delete_all_stale class_name.constantize
     end
   end
 
   private
 
-  def delete_all_stale_in_batches(model, batch_size: 500)
-    sleep 1 until model.stale.limit(batch_size).delete_all < batch_size
+  def delete_all_stale(model)
+    model.stale.delete_all
   end
 
 end

--- a/test/test_helpers/n_plus_one_control.rb
+++ b/test/test_helpers/n_plus_one_control.rb
@@ -1,11 +1,17 @@
 require "n_plus_one_control/minitest"
 
 # see https://github.com/palkan/n_plus_one_control/pull/57
+# and https://github.com/palkan/n_plus_one_control/issues/61
 NPlusOneControl::MinitestHelper.prepend(Module.new do
+  class NonTransactionalExecutor < NPlusOneControl::Executor
+    self.transaction_begin = -> {}
+    self.transaction_rollback = -> {}
+  end
+
   def assert_number_of_queries(number, matching: nil)
     raise ArgumentError, "Block is required" unless block_given?
 
-    @executor = NPlusOneControl::Executor.new(matching: (matching || NPlusOneControl.default_matching), population: ->(*){}, scale_factors: [1])
+    @executor = NonTransactionalExecutor.new(matching: (matching || NPlusOneControl.default_matching), population: ->(*){}, scale_factors: [1])
     queries = @executor.call { yield }
     counts = queries.map(&:last).map(&:size)
     assert_equal number, counts.max, "expected #{number} queries but performed were #{counts.max}"

--- a/test/workers/delete_all_stale_objects_worker_test.rb
+++ b/test/workers/delete_all_stale_objects_worker_test.rb
@@ -3,30 +3,19 @@
 require 'test_helper'
 
 class DeleteAllStaleObjectsWorkerTest < ActiveSupport::TestCase
-  test "calls #delete_all on the stale relation in batches" do
-    Kernel.stubs(:sleep) # avoid 1 second waits
-
-    relation = mock(:message_relation)
-    relation.expects(:limit).with(500).returns(relation).twice
-    relation.expects(:delete_all).returns(500, 0).twice
-    Message.stubs(:stale).returns(relation)
-
-    relation = mock(:message_recipient_relation)
-    relation.expects(:limit).with(500).returns(relation).twice
-    relation.expects(:delete_all).returns(500, 499).twice
-    MessageRecipient.expects(:stale).returns(relation).twice
-
-    DeleteAllStaleObjectsWorker.perform_now(MessageRecipient.name, Message.name)
-  end
-
   test "actually deleting stuff" do
     message = FactoryBot.create(:message)
     stale_message = FactoryBot.create(:message)
     stale_message.update_column(:sender_id, 0)
+    stale_message2 = FactoryBot.create(:message)
+    stale_message2.update_column(:sender_id, 0)
 
-    DeleteAllStaleObjectsWorker.perform_now(Message.name)
+    assert_number_of_queries(1, matching: /DELETE|SELECT/) do
+      DeleteAllStaleObjectsWorker.perform_now(Message.name)
+    end
 
     assert message.reload
     assert_raise(ActiveRecord::RecordNotFound) { stale_message.reload }
+    assert_raise(ActiveRecord::RecordNotFound) { stale_message2.reload }
   end
 end


### PR DESCRIPTION
Testing showed that deleting without batching these objects is acceptable and I suspect more efficient than batching. Because batching will basically call the same select query many times and my gut feeling is that at some point that would become much more stressful to the database.

originally introduced with #3958