### PR TITLE
Fix table layout for app keys

### DIFF
--- a/app/views/provider/admin/keys/_key.html.erb
+++ b/app/views/provider/admin/keys/_key.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:tr, :id => dom_id(key),
                 :class => 'key', 'data-key' => key.to_param) do %>
   <td>Application key</td>
-  <td class="key" <% if cinstance.backend_version.oauth? %>id="oauth_secret"<% end %>><%= key %>
+  <td class="key" <% if cinstance.backend_version.oauth? %>id="oauth_secret"<% end %>><%= key %></td>
+  <td>
     <%= content_tag(:span, :class => 'delete_key operations', :style => ("display:none;" unless cinstance.can_delete_key?)) do %>
       <% if cinstance.backend_version.oauth? %>
         <%= fancy_link_to("Regenerate", regenerate_provider_admin_application_key_path(:application_id => cinstance.id, :id => cinstance.keys.first),

--- a/app/views/provider/admin/keys/_widget.html.erb
+++ b/app/views/provider/admin/keys/_widget.html.erb
@@ -4,6 +4,7 @@
       <tr>
         <th>Application ID</th>
         <td><%= cinstance.application_id %></td>
+        <td></td>
       </tr>
       <%= render partial: 'provider/admin/keys/key', collection: cinstance.application_keys,
                                                      locals: { cinstance: cinstance } %>
@@ -39,12 +40,15 @@
       <tr>
         <th>Client ID</th>
         <td><%= cinstance.application_id %></td>
+        <td></td>
       </tr>
 
       <tr>
         <th>Client Secret</th>
         <td>
           <span class="key" id="oauth_secret"><%= keys.first %></span>
+        </td>
+        <td>
           <% if keys.empty? %>
             <%= fancy_link_to 'Add Random key', provider_admin_application_keys_path(cinstance),
                                                 method: :post,
@@ -65,16 +69,20 @@
         <th>Redirect URL</th>
         <td>
           <span class="key"><%= cinstance.redirect_url %></span>
+        </td>
+        <td>
           <%= link_to 'Edit', edit_redirect_url_provider_admin_application_path(cinstance),
                               class: 'fancybox action edit',
                               'data-autodimensions': 'true' %>
         </td>
+        <td></td>
       </tr>
     </table>
   </div>
 
 <% else %>
   <table id="keys" class="pf-c-table pf-m-no-border-rows">
+    <tr>
     <%- user_key = cinstance.user_key %>
       <td class="pf-m-fit-content">
         <%= user_key_label(cinstance) %>


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a small change to the application keys table, that fixes the following issue:

When you try to copy an application key by double-clicking, it not only selects the value of the key, but also the "Delete" or "Regenerate" button text, because they are in the same `<td>` element.
![Screenshot From 2025-04-22 12-56-06](https://github.com/user-attachments/assets/71fcb59e-3bb6-451e-aaaf-2e560986f7ea)

So, splitting the key and the "buttons" into different `<td>` elements fixes this issue.

**Which issue(s) this PR fixes** 

none

**Verification steps** 

Check an application details page (with App Id/App Key and OAuth auths), and try to select the value by double-clicking.

**Special notes for your reviewer**:
