### PR TITLE
THREESCALE-11794: Refactor authentication flow

### DIFF
--- a/app/controllers/admin/api/account/proxy_configs_controller.rb
+++ b/app/controllers/admin/api/account/proxy_configs_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::Api::Account::ProxyConfigsController < Admin::Api::BaseController
-  include ApiAuthentication::BySSOToken
+  include ApiAuthentication::ByToken
 
   represents :json, entity: ::ProxyConfigRepresenter
   represents :json, collection: ::ProxyConfigsRepresenter

--- a/app/controllers/admin/api/services/proxy/configs_controller.rb
+++ b/app/controllers/admin/api/services/proxy/configs_controller.rb
@@ -2,7 +2,7 @@
 
 class Admin::Api::Services::Proxy::ConfigsController < Admin::Api::Services::BaseController
 
-  include ApiAuthentication::BySSOToken
+  include ApiAuthentication::ByToken
 
   represents :json, entity: ::ProxyConfigRepresenter
   represents :json, collection: ::ProxyConfigsRepresenter

--- a/app/controllers/provider/sessions_controller.rb
+++ b/app/controllers/provider/sessions_controller.rb
@@ -74,47 +74,25 @@ class Provider::SessionsController < FrontendController
   end
 
   def authenticate_user
-    captcha_is_available = request.post? # Internal strategy (user & pass)
-    return if captcha_is_available && !bot_check
+    strategy = Authentication::Strategy::InferService.call(auth_params, domain_account, @provider).result
 
-    params = if domain_account.settings.enforce_sso?
-               sso_params
-             else
-               request.post? ? auth_params : sso_params
-    end
+    return if strategy.bot_protected? && !bot_check
 
-    # TODO: refactor the authentication flow.
-    # Right now, we have a hierarchy of classes, one for each auth strategy, and we manually instance the last child
-    # class, `ProviderOAuth2`, and then try all strategies one by one by calling `super` and going up in the hierarchy
-    # until a strategy works. Due to this, we can't know from the here which strategy was really used.
-    #
-    # The hierarchy right now is:
-    #
-    # `ProviderOAuth2` < `OAuth2Base` < `Internal` < `SSO` < `Base`
-    #
-    # This is very weird because `Internal`, which means "User + pass" is not a kind of `SSO`; and `OAuth2` is not
-    # a kind of `Internal`. Not to mention we are calling `SSO` to something which is merely a token authentication
-    # not related at all with any SSO.
-    strategy = Authentication::Strategy.build_provider(@provider)
-    user = strategy.authenticate(params)
-
+    user = strategy.authenticate(auth_params)
     [user, strategy]
   end
 
   def auth_params
-    params.slice(:username, :password)
-  end
-
-  def sso_params
-    params.permit(%i[token expires_at redirect_url system_name code]).merge(request: request)
+    params.permit(*%i[username password ticket token expires_at redirect_url system_name code]).merge(request:)
   end
 
   def session_return_to
     return_to_params = params.permit(:return_to)[:return_to]
-    if return_to_params
-      return_to = safe_return_to(return_to_params)
-      session[:return_to] = return_to if return_to.present?
-    end
+
+    return unless return_to_params
+
+    return_to = safe_return_to(return_to_params)
+    session[:return_to] = return_to if return_to.present?
   end
 
   def instantiate_sessions_presenter

--- a/app/lib/api_authentication/by_token.rb
+++ b/app/lib/api_authentication/by_token.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module ApiAuthentication
-  module BySSOToken
+  module ByToken
     extend ActiveSupport::Concern
 
-    BySSOTokenError = Class.new(StandardError)
-    UserNotFoundError = Class.new(BySSOTokenError)
-    InvalidSsoTokenError = Class.new(BySSOTokenError)
+    ByTokenError = Class.new(StandardError)
+    UserNotFoundError = Class.new(ByTokenError)
+    InvalidSsoTokenError = Class.new(ByTokenError)
 
     def current_user
       @current_user ||= sso_token ? authenticated_user_by_sso_token : (defined?(super) && super)
@@ -14,17 +14,17 @@ module ApiAuthentication
 
     included do
       before_action :verify_sso_token
-      rescue_from ApiAuthentication::BySSOToken::BySSOTokenError, with: :show_sso_token_error
+      rescue_from ApiAuthentication::ByToken::ByTokenError, with: :show_sso_token_error
     end
 
     private
 
-    def sso_strategy
-      Authentication::Strategy::SSO.new(domain_account, true)
+    def token_strategy
+      Authentication::Strategy::Token.new(domain_account, true)
     end
 
     def authenticated_user_by_sso_token
-      sso_strategy.authenticate_by_token(sso_token) or raise UserNotFoundError
+      token_strategy.authenticate_by_token(sso_token) or raise UserNotFoundError
     end
 
     def verify_sso_token

--- a/app/lib/authentication/strategy.rb
+++ b/app/lib/authentication/strategy.rb
@@ -12,8 +12,6 @@ module Authentication
         build_strategy(:provider_oauth2).new(provider_account, true) # TODO: make this configurable
       end
 
-      protected
-
       def build_strategy(type)
         inflected_type = Rails.autoloaders.main.inflector.camelize(type.to_s, {})
         strategy_class_name = "Authentication::Strategy::#{inflected_type}"

--- a/app/lib/authentication/strategy/base.rb
+++ b/app/lib/authentication/strategy/base.rb
@@ -22,7 +22,11 @@ module Authentication
     class Base
       include System::UrlHelpers.cms_url_helpers
 
-      attr_reader :site_account, :admin_domain, :user_for_signup, :new_user_created
+      attr_reader :site_account, :admin_domain, :user_for_signup, :new_user_created, :error_message
+
+      def self.expected_params
+        raise NotImplementedError, "expected #{self} to implement #{__method__}"
+      end
 
       def initialize(site_account, admin_domain = false)
         @site_account     = site_account
@@ -47,6 +51,11 @@ module Authentication
 
       # Useful for remotely hosted authentication strategies such as Janrain strategy.
       def redirects_to_signup?
+        false
+      end
+
+      # Whether we should run the bot check for this strategy
+      def bot_protected?
         false
       end
 
@@ -82,6 +91,36 @@ module Authentication
         authentication_provider.try(:id)
       rescue Authentication::Strategy::OAuth2Base::MissingAuthenticationProvider
         nil
+      end
+
+      def error_message=(message)
+        @error_message ||= message
+      end
+
+      def inactive_user_message
+        "Your account isn't active or hasn't been approved yet."
+      end
+
+      protected
+
+      def users
+        @_users ||= begin
+                      if admin_domain
+                        site_account.users
+                      else
+                        site_account.buyer_users
+                      end
+                    end
+      end
+
+      # check if the user can login and if not it sets an <tt>error_message</tt>
+      def can_login?(user)
+        if user.can_login?
+          true
+        else
+          self.error_message = inactive_user_message
+          false
+        end
       end
     end
   end

--- a/app/lib/authentication/strategy/cas.rb
+++ b/app/lib/authentication/strategy/cas.rb
@@ -1,10 +1,14 @@
 module Authentication
   module Strategy
-    class Cas < Internal
+    class Cas < Base
+
+      def self.expected_params
+        %i[ticket]
+      end
 
       def authenticate params
 
-        return super unless params[:ticket]
+        return unless params[:ticket]
 
         res = HTTPClient.get validate_url_with_query params[:ticket]
 

--- a/app/lib/authentication/strategy/internal.rb
+++ b/app/lib/authentication/strategy/internal.rb
@@ -1,7 +1,7 @@
 module Authentication
   module Strategy
 
-    class Internal < SSO
+    class Internal < Token
 
       def authenticate params
         authenticate_with_username_and_password(params[:username], params[:password]) || super(params)

--- a/app/lib/authentication/strategy/internal.rb
+++ b/app/lib/authentication/strategy/internal.rb
@@ -1,10 +1,14 @@
 module Authentication
   module Strategy
 
-    class Internal < Token
+    class Internal < Base
+
+      def self.expected_params
+        %i[username password]
+      end
 
       def authenticate params
-        authenticate_with_username_and_password(params[:username], params[:password]) || super(params)
+        authenticate_with_username_and_password(params[:username], params[:password])
       end
 
       def invalid_credentials_message
@@ -15,8 +19,8 @@ module Authentication
         {strategy: 'credentials'}
       end
 
-      def error_message=(message)
-        @error_message ||= message
+      def bot_protected?
+        true
       end
 
       private

--- a/app/lib/authentication/strategy/oauth2_base.rb
+++ b/app/lib/authentication/strategy/oauth2_base.rb
@@ -2,7 +2,7 @@
 
 module Authentication
   module Strategy
-    class OAuth2Base < Authentication::Strategy::Internal
+    class OAuth2Base < Base
 
       def initialize(*)
         super
@@ -26,8 +26,13 @@ module Authentication
 
       self.authenticate_procedure = MissingProcedure
 
+      def self.expected_params
+        %i[system_name code]
+      end
+
       def authenticate(params, procedure: authenticate_procedure)
-        return super(params) unless find_authentication_provider(params[:system_name])
+        return unless find_authentication_provider(params[:system_name])
+
         authenticate_client(params, procedure)
         active_user(@user)
       end

--- a/app/lib/authentication/strategy/token.rb
+++ b/app/lib/authentication/strategy/token.rb
@@ -1,7 +1,7 @@
 module Authentication
   module Strategy
 
-    class SSO < Base
+    class Token < Base
 
       attr_reader :error_message
 

--- a/app/lib/authentication/strategy/token.rb
+++ b/app/lib/authentication/strategy/token.rb
@@ -3,7 +3,9 @@ module Authentication
 
     class Token < Base
 
-      attr_reader :error_message
+      def self.expected_params
+        %i[token expires_at]
+      end
 
       def authenticate(params)
         if site_account.settings.sso_key && params[:token] && params[:expires_at]
@@ -18,10 +20,6 @@ module Authentication
         authenticate_with_sso(token)
       end
 
-      def inactive_user_message
-        "Your account isn't active or hasn't been approved yet."
-      end
-
       def redirect_to_on_successful_login
         if @redirect_url
           begin
@@ -31,28 +29,6 @@ module Authentication
           end
         else
           super
-        end
-      end
-
-      protected
-
-      # check if the user can login and if not it sets an <tt>error_message</tt>
-      def can_login?(user)
-        if user.can_login?
-          true
-        else
-          self.error_message = inactive_user_message
-          false
-        end
-      end
-
-      def users
-        @_users ||= begin
-          if admin_domain
-            site_account.users
-          else
-            site_account.buyer_users
-          end
         end
       end
 

--- a/app/services/authentication/strategy/infer_service.rb
+++ b/app/services/authentication/strategy/infer_service.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Authentication
+  module Strategy
+    class InferService < ThreeScale::Patterns::Service
+
+      def initialize(params, account, provider)
+        @params = params
+        @account = account
+        @provider = provider
+      end
+
+      def call
+        type = infer_type
+
+        return build(:token) if impersonating?(type)
+        return build(:provider_oauth2) if sso_enforced?
+
+        build(type)
+      end
+
+      private
+
+      STRATEGIES = %i[oauth2_base internal token].freeze
+
+      def infer_type
+        given_param_keys = @params.to_h.symbolize_keys.keys
+
+        # Take the first strategy in STRATEGIES which expected_params are received in the request
+        # Ignore :request and :redirect_url params since they are not used for authentication
+        STRATEGIES.find { (given_param_keys - %i[request redirect_url] - strategy_class(_1).expected_params).empty? }
+      end
+
+      def strategy_class(type)
+        Authentication::Strategy.build_strategy(type)
+      end
+
+      def build(type)
+        type = provider? ? :provider_oauth2 : :oauth2 if type == :oauth2_base
+
+        strategy_class(type).new(@provider, provider?)
+      end
+
+      def impersonating?(type)
+        strategy_class(type) == Authentication::Strategy::Token
+      end
+
+      def provider?
+        @account&.provider?
+      end
+
+      def sso_enforced?
+        provider? && @account&.settings&.enforce_sso?
+      end
+    end
+  end
+end

--- a/lib/developer_portal/app/controllers/developer_portal/login_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/login_controller.rb
@@ -25,9 +25,9 @@ class DeveloperPortal::LoginController < DeveloperPortal::BaseController
   def create
     logout_keeping_session!
 
-    return render_login_error if auth_strategy_is_internal? && !bot_check
+    return render_login_error if @strategy.bot_protected? && !bot_check
 
-    if (@user = @strategy.authenticate(params.merge(request: request)))
+    if (@user = @strategy.authenticate(auth_params))
       self.current_user = @user
       create_user_session!
       flash[:notice] = @strategy.new_user_created? ? 'Signed up successfully' : 'Signed in successfully'
@@ -54,6 +54,10 @@ class DeveloperPortal::LoginController < DeveloperPortal::BaseController
 
   private
 
+  def auth_params
+    params.permit(*%i[username password ticket token expires_at redirect_url system_name code]).merge(request:)
+  end
+
   def render_login_error(error_message = nil)
     @session = Session.new
     flash.now[:error] = error_message if error_message
@@ -66,7 +70,7 @@ class DeveloperPortal::LoginController < DeveloperPortal::BaseController
   end
 
   def set_strategy
-    @strategy = Authentication::Strategy.build(site_account)
+    @strategy = Authentication::Strategy::InferService.call(auth_params, nil, site_account).result
   end
 
   def add_authentication_drops(drops = {})
@@ -76,9 +80,5 @@ class DeveloperPortal::LoginController < DeveloperPortal::BaseController
     end
 
     drops
-  end
-
-  def auth_strategy_is_internal?
-    params.key?(:username) || params.key?(:password)
   end
 end

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -127,7 +127,7 @@ class SessionsTest < ActionDispatch::IntegrationTest
     user = FactoryBot.create(:user, account: @buyer, username: 'xi@example.net', password: 'wwwwww')
     user.activate
 
-    Authentication::Strategy::Internal.any_instance.expects(:authenticate_with_sso).with('yabadabado', '2016').returns(user)
+    Authentication::Strategy::Token.any_instance.expects(:authenticate_with_sso).with('yabadabado', '2016').returns(user)
 
     host! @provider.internal_domain
 

--- a/test/unit/authentication/strategy/token_test.rb
+++ b/test/unit/authentication/strategy/token_test.rb
@@ -1,11 +1,10 @@
 require 'test_helper'
 
-class Authentication::Strategy::SsoTest < ActiveSupport::TestCase
+class Authentication::Strategy::TokenTest < ActiveSupport::TestCase
 
   def setup
     @provider = FactoryBot.create(:provider_account)
-    @account  = FactoryBot.create(:buyer_account, provider_account: @provider)
-    @strategy = Authentication::Strategy.build(@provider)
+    @strategy = Authentication::Strategy.build_strategy(:token).new(@provider, true)
   end
 
   def test_authenticate_wrong_credentials
@@ -15,7 +14,7 @@ class Authentication::Strategy::SsoTest < ActiveSupport::TestCase
   end
 
   def test_authenticate_user_id
-    user = FactoryBot.create(:active_user, account: @account)
+    user = FactoryBot.create(:active_user, account: @provider)
 
     stub_extract! [user.id, 'supetramp']
 
@@ -23,7 +22,7 @@ class Authentication::Strategy::SsoTest < ActiveSupport::TestCase
   end
 
   def test_authenticate_username
-    user = FactoryBot.create(:active_user, account: @account)
+    user = FactoryBot.create(:active_user, account: @provider)
 
     stub_extract! [nil, user.username]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The current authentication flow has a weird design, it declares all authentication strategies as a class hierarchy without following any logic:

`ProviderOAuth2` < `OAuth2Base` < `Internal` < `SSO` < `Base`

When a login attempt is received, it always try to log in by `ProviderOAuth2` and goes up through all the class hierarchy until it finds a strategy that works. When the login is successful, the user is returned, but the caller can't know which strategy succeeded.

We need to know which strategy succeeded, for instance in order to decide whether to require the captcha challenge or not.

This PR proposes another approach. It adds a new service which tries to infer the strategy from the received parameters, and then the login is attempted only for that strategy. This way the caller can know what strategy succeeded.

Also it refactors the hierarchy to be like this

```
ProviderOAuth2 <---\
                    Oauth2Base <-----\
OAuth2 <-----------/                  \
                                       \
                 Internal <------------ Base
                                       / /
                 Token <--------------/ /
                 CAS <-----------------/
```

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11794

**Verification steps** 

Everything should work as before. This is what I tried:

- Admin portal
  - internal auth
  - impersonation
  - test oauth2 authentication flow
  - oauth2
  - oauth2 with sso enforced
- developer portal
  - internal auth
  - test oauth2 authentication flow
  - oauth2

**Special notes for your reviewer**:

After these changes, the CAS strategy will stop working. I don't think anybody is using it and I opened a jira issue to remove it completely in another PR: https://issues.redhat.com/browse/THREESCALE-11807
