### PR TITLE
THREESCALE-11808: Update alert levels in backend:storage:rewrite

### DIFF
--- a/app/lib/backend/storage_rewrite.rb
+++ b/app/lib/backend/storage_rewrite.rb
@@ -47,6 +47,7 @@ module Backend
       REWRITER = ->(service) do
         service.update_backend_service
         service.service_tokens.find_each(&ServiceTokenService.method(:update_backend))
+        service.send(:update_notification_settings)
       end
     end
 

--- a/test/unit/backend/storage_rewrite_test.rb
+++ b/test/unit/backend/storage_rewrite_test.rb
@@ -76,6 +76,20 @@ module Backend
       end
     end
 
+    class ServiceRewriterTest < ActiveSupport::TestCase
+      test 'updates service-related objects' do
+        provider = FactoryBot.create(:simple_provider)
+        service = FactoryBot.create(:simple_service, account: provider)
+
+        Service.any_instance.expects(:update_notification_settings).once
+        Service.any_instance.expects(:update_backend_service).once
+        ServiceTokenService.expects(:update_backend).times(service.service_tokens.count)
+
+        processor = Backend::StorageRewrite::Processor.new
+        processor.rewrite(scope: provider.services)
+      end
+    end
+
     class AsyncProcessorTest < ActiveSupport::TestCase
       test 'calls enqueuer for each collection batch' do
         # ensure all collections have items


### PR DESCRIPTION

**What this PR does / why we need it**:

If the Backend redis is wiped, the data can be repopulated from System via the rake task backend:storage:rewrite, however, this does not push the information about the enabled alert levels (levels of usage at which the notifications are going to be sent).

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11808

**Verification steps** 

- Wipe backend redis
- Set some usage rules for alert levels
- run `bundle exec rake backend:storage:rewrite`

Before the fix, there would be no `alerts/service_id:123/allowed_set` entries (where `123` is a sample service ID)

After the fix, there will be a `alerts/service_id:123/allowed_set` entry for every service.

**Special notes for your reviewer**:
