### PR TITLE
THREESCALE-11766 background deletion optimize by caching records

### DIFF
--- a/app/workers/delete_object_hierarchy_worker.rb
+++ b/app/workers/delete_object_hierarchy_worker.rb
@@ -2,7 +2,7 @@
 
 class DeleteObjectHierarchyWorker < ApplicationJob
 
-  WORK_TIME_LIMIT_SECONDS = 5
+  WORK_TIME_LIMIT_SECONDS = 25
   ASSOCIATION_RE = /Association-(?<klass>[:\w]+)-(?<id>\d+):(?<association>\w+)/
   PLAIN_OBJECT_RE = /Plain-([:\w]+)-(\d+)/
 


### PR DESCRIPTION
Increase single loop duration to 25 seconds.

Cache records to avoid the need to reload them from database for each associated object.

You can review by commit.