### PR TITLE
THREESCALE-11160: Add oauth2-redirect.hml globally

### DIFF
--- a/lib/developer_portal/app/views/developer_portal/docs.html.liquid
+++ b/lib/developer_portal/app/views/developer_portal/docs.html.liquid
@@ -15,8 +15,9 @@
 
 <script type="text/javascript">
   (function () {
-    var url = "{{spec.url}}";
-    var serviceEndpoint = "{{spec.api_product_production_public_base_url}}"
-    SwaggerUI({ url: url, dom_id: "#swagger-ui-container" }, serviceEndpoint);
+    const url = "{{spec.url}}";
+    const serviceEndpoint = "{{spec.api_product_production_public_base_url}}"
+    const oauth2RedirectUrl = window.location.origin + "/oauth2-redirect.html"
+    SwaggerUI({ url: url, dom_id: "#swagger-ui-container", oauth2RedirectUrl: oauth2RedirectUrl }, serviceEndpoint);
   }());
 </script>

--- a/public/oauth2-redirect.html
+++ b/public/oauth2-redirect.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+    <title>Swagger UI: OAuth2 Redirect</title>
+</head>
+<body>
+<script>
+  'use strict';
+  function run () {
+    var oauth2 = window.opener.swaggerUIRedirectOauth2;
+    var sentState = oauth2.state;
+    var redirectUrl = oauth2.redirectUrl;
+    var isValid, qp, arr;
+
+    if (/code|token|error/.test(window.location.hash)) {
+      qp = window.location.hash.substring(1).replace('?', '&');
+    } else {
+      qp = location.search.substring(1);
+    }
+
+    arr = qp.split("&");
+    arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';});
+    qp = qp ? JSON.parse('{' + arr.join() + '}',
+        function (key, value) {
+          return key === "" ? value : decodeURIComponent(value);
+        }
+    ) : {};
+
+    isValid = qp.state === sentState;
+
+    if ((
+        oauth2.auth.schema.get("flow") === "accessCode" ||
+        oauth2.auth.schema.get("flow") === "authorizationCode" ||
+        oauth2.auth.schema.get("flow") === "authorization_code"
+    ) && !oauth2.auth.code) {
+      if (!isValid) {
+        oauth2.errCb({
+          authId: oauth2.auth.name,
+          source: "auth",
+          level: "warning",
+          message: "Authorization may be unsafe, passed state was changed in server. The passed state wasn't returned from auth server."
+        });
+      }
+
+      if (qp.code) {
+        delete oauth2.state;
+        oauth2.auth.code = qp.code;
+        oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+      } else {
+        let oauthErrorMsg;
+        if (qp.error) {
+          oauthErrorMsg = "["+qp.error+"]: " +
+              (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
+              (qp.error_uri ? "More info: "+qp.error_uri : "");
+        }
+
+        oauth2.errCb({
+          authId: oauth2.auth.name,
+          source: "auth",
+          level: "error",
+          message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server."
+        });
+      }
+    } else {
+      oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+    }
+    window.close();
+  }
+
+  if (document.readyState !== 'loading') {
+    run();
+  } else {
+    document.addEventListener('DOMContentLoaded', function () {
+      run();
+    });
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `/oauth2-redirect.hml` globally to all portals, implementing option 3 of this list of suggestions: https://issues.redhat.com/browse/THREESCALE-11160?focusedId=26750532&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26750532

The content of the file is taken from https://raw.githubusercontent.com/swagger-api/swagger-ui/refs/tags/v5.12.3/dist/oauth2-redirect.html

Adding `oauth2RedirectUrl: oauth2RedirectUrl` is required so that the solution works from any page. Without it, the solution would work if the page where the spec is rendered is "simple", like `/docs`, but in case it's something more complex like `/api/docs/echo`, the redirect URL would be `/api/docs/oauth2-redirect.hml` which will obviously fail.

I didn't want to mess with the routers and controllers and try to catch `oauth2-redirect.hml` at **any** path, as fixing it at the doc template level is easier.

The drawback of this solution is:
- the existing portals will need to apply the change manually (i.e. add this `oauth2RedirectUrl` param)
- the redirect will not work on the admin portal, because we do not override `oauth2RedirectUrl` there, and the redirect page will be `{ADMIN_PORTAL_URL}/apiconfig/services/{SERVICE_ID}/api_docs/{API_DOC_ID}/oauth2-redirect.html` which is of course non-existent. 

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11160

**Verification steps** 

1. Configure a Keycloak server with a realm, a client and a test user. Ensure `Standard Flow` is enabled, and the following parameters are set:
 Valid Redirect URIs: `*`
 Web Origins: `*`

2. Create a new provider (to verify the new default template)*

3. In the new provider admin portal, update the content of the only ActiveDocs spec with the following (replace the placeholders with your values):

```
{
  "openapi": "3.0.0",
  "info": {
    "version": "1.0.0",
    "title": "Echo API",
    "description": "A sample echo API"
  },
  "paths": {
    "/": {
      "get": {
        "description": "Echo API with no parameters",
        "operationId": "echo_no_params",
        "security": [
          {
            "oauth2schema": [
              "read"
            ]
          }
        ],
        "responses": {
          "200": {
            "description": "response"
          }
        }
      }
    }
  },
  "servers": [
    {
      "url": "https://echo-api.3scale.net/"
    }
  ],
  "security": [
    {
      "oauth2schema": [
        "openid"
      ]
    }
  ],
  "components": {
    "securitySchemes": {
      "oauth2schema": {
        "type": "oauth2",
        "description": "OAuth 2.0 example authentication",
        "flows": {
          "authorizationCode": {
            "authorizationUrl": "https://keycloak-daria-tools.apps.dev-eng-hcp-saas-int.dev.3sca.net/auth/realms/threescale/protocol/openid-connect/auth",
            "tokenUrl": "https://keycloak-daria-tools.apps.dev-eng-hcp-saas-int.dev.3sca.net/auth/realms/threescale/protocol/openid-connect/token",
            "scopes": {
              "openid": "OpenID Connect scope"
            }
          }
        }
      }
    }
  }
}
```

4. In the `/docs` template in the CMS, remove the `, serviceEndpoint` from line `:21`. Save and publish. (this is to avoid going through APIcast)

5. Go to the `/docs` page in the dev portal (of the new provider). **NOTE:** you need to close the toolbar

6. Click Authorize, enter the client's ID and Secret in the pop-up, and click Authorize again.

7. Enter the test user username/password (a user created in the realm) if requested.

8. You should be redirected back with no errors. Click Close in the pop-up.

9. Call "Try it out" > "Execute" to test the API. You should see  "HTTP_AUTHORIZATION" header in the response body, whose value looks like a JWT token.
Optionally, you can parse the token (e.g. at https://jwt.io/) and confirm that it is issued by Keycloak for the test user.


**Special notes for your reviewer**:
