### PR TITLE
THREESCALE-9037: Do not show 'Visit Portal' if it won't work due to lack of permissions

### DIFF
--- a/app/helpers/vertical_nav_helper.rb
+++ b/app/helpers/vertical_nav_helper.rb
@@ -147,13 +147,11 @@ module VerticalNavHelper
       items << {id: :feature_visibility, title: 'Feature Visibility', path: provider_admin_cms_switches_path}
       # FIXME: should be a link not a href
       items << {id: :ActiveDocs,         title: 'ActiveDocs',         path: admin_api_docs_services_path}          if can?(:manage, :plans)
-    end
 
-    items << {id: 'separator 0'} # Separator
-    items << {title: 'Visit Portal', path: provider_admin_cms_visit_portal_path.html_safe, target: '_blank'}
-    items << {id: 'separator 1'} # Separator
+      items << {id: 'separator 0'} # Separator
+      items << {title: 'Visit Portal', path: provider_admin_cms_visit_portal_path.html_safe, target: '_blank'}
+      items << {id: 'separator 1'} # Separator
 
-    if can?(:manage, :portal)
       items << { title: 'Legal Terms', subItems: [
         {id: :signup_licence,               title: 'Signup',               path: edit_legal_terms_url(CMS::Builtin::LegalTerm::SIGNUP_SYSTEM_NAME)},
         {id: :service_subscription_licence, title: 'Service Subscription', path: edit_legal_terms_url(CMS::Builtin::LegalTerm::SUBSCRIPTION_SYSTEM_NAME)},

--- a/test/helpers/vertical_nav_helper_test.rb
+++ b/test/helpers/vertical_nav_helper_test.rb
@@ -59,6 +59,33 @@ class VerticalNavHelperTest < ActionView::TestCase
       assert_equal([], service_nav_sections.pluck(:title))
     end
 
+    test '#audience_nav_sections' do
+      # admin
+      assert_equal(["Accounts", "Applications", "Billing", "Developer Portal", "Messages"], audience_nav_sections.pluck(:title))
+
+      # member that can't manage portal, settings and plans
+      stubs(:can?).with(:manage, :portal).returns(false)
+      stubs(:can?).with(:manage, :settings).returns(false)
+      stubs(:can?).with(:manage, :plans).returns(false)
+      assert_equal(%w[Accounts Applications Billing Messages], audience_nav_sections.pluck(:title))
+    end
+
+    test '#audience_portal_items' do
+      assert_equal(["Content", "Drafts", "Redirects", "Groups", "Logo", "Feature Visibility", "ActiveDocs", "Visit Portal", "Legal Terms", "Settings", "Docs"], audience_portal_items.pluck(:title).compact)
+
+      stubs(:can?).with(:see, :groups).returns(false)
+      assert_not_includes audience_portal_items.pluck(:title), "Groups"
+
+      stubs(:can?).with(:update, :logo).returns(false)
+      assert_not_includes audience_portal_items.pluck(:title), "Logo"
+
+      stubs(:can?).with(:manage, :plans).returns(false)
+      assert_not_includes audience_portal_items.pluck(:title), "ActiveDocs"
+
+      stubs(:can?).with(:manage, :portal).returns(false)
+      assert_equal(%w[Settings Docs], audience_portal_items.pluck(:title).compact)
+    end
+
     test 'Email configurations' do
       Features::EmailConfigurationConfig.stubs(enabled?: true)
       assert_not_includes account_nav_sections.pluck(:id), :email_configurations


### PR DESCRIPTION
**What this PR does / why we need it**:

This is to solve [THREESCALE-9037|https://issues.redhat.com/browse/THREESCALE-9037]. In fact, after https://github.com/3scale/porta/pull/3938 was merged, the user with no "portal" permission would not be able to go check the portal in "preview" mode, because clicking on "Visit Portal" would bring them to "Access Denied" page, because the `VisitPortalController` checks for this permission.

So, as such a user cannot use the link, I believe it's best to just hide it.

I think ideally, we should still allow the user to see the link and use it, but only allow them to see the published version. But I guess that feature would be more involved, and we can add it in case someone requests.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-9037

**Verification steps** 

Create a member user without a "portal" permission. Make sure that the user can't see the "Visit Portal" link. Note that with the combination of other permissions, the user will either see "Developer Portal" section, but don't see "Visit Portal", or they will not see the "Developer Portal" section at all.

**Special notes for your reviewer**:
