### PR TITLE
THREESCALE-11466: Remove cms token

### DIFF
--- a/app/controllers/provider/admin/cms/visit_portal_controller.rb
+++ b/app/controllers/provider/admin/cms/visit_portal_controller.rb
@@ -3,9 +3,8 @@
 class Provider::Admin::CMS::VisitPortalController < Provider::Admin::CMS::BaseController
   # Encrypt the CMS token under a temporary SSO token and redirect to the Developer Portal
   def with_token
-    cms_token = current_account.settings.cms_token!
     expires_at = Time.now.utc.round + 1.minute
-    signature = CMS::Signature.generate(cms_token, expires_at)
+    signature = CMS::Signature.generate(current_account.id, expires_at)
 
     redirect_to access_code_url(
       host: current_account.external_domain,

--- a/app/lib/authenticated_system.rb
+++ b/app/lib/authenticated_system.rb
@@ -193,9 +193,9 @@ module AuthenticatedSystem
   # when you cross quarantine (logged-out to logged-in).
   def logout_killing_session!
     logout_keeping_session!
-    cms_token = session[:cms_token]
+    cms_edit = session[:cms_edit]
     reset_session
-    session[:cms_token] = cms_token if cms_token
+    session[:cms_edit] = cms_edit if cms_edit
   end
 
   # Remember_me Tokens

--- a/app/lib/cms/settings.rb
+++ b/app/lib/cms/settings.rb
@@ -14,11 +14,7 @@ module CMS
     end
 
     def admin?
-      valid_token?(user_cms_token)
-    end
-
-    def valid_token?(token)
-      token.present? && token == @settings.cms_token
+      !!@session[:cms_edit]
     end
 
     def escape_html?
@@ -34,10 +30,6 @@ module CMS
     end
 
     private
-
-    def user_cms_token
-      @session[:cms_token]
-    end
 
     def cms_session
       ActiveSupport::StringInquirer.new(@session[:cms] || DEFAULT_MODE)

--- a/app/lib/cms/signature.rb
+++ b/app/lib/cms/signature.rb
@@ -2,10 +2,10 @@
 
 module CMS
   class Signature
-    def self.generate(token, expires_at)
-      verifier = Rails.application.message_verifier(:cms_token)
+    def self.generate(provider_id, expires_at)
+      verifier = Rails.application.message_verifier(:provider_id)
       signing_options = { purpose: :cms_edit_mode, expires_at: expires_at.utc.floor }
-      verifier.generate(token.b, **signing_options).split("--").last
+      verifier.generate(provider_id, **signing_options).split("--").last
     end
   end
 end

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -11,7 +11,7 @@ class Settings < ApplicationRecord
   validates :bg_colour, :link_colour, :text_colour, :menu_bg_colour, :link_label, :link_url, :menu_link_colour, :token_api,
             :content_bg_colour, :tracker_code, :favicon, :plans_tab_bg_colour, :plans_bg_colour, :content_border_colour,
             :cc_privacy_path, :cc_terms_path, :cc_refunds_path, :change_service_plan_permission, :spam_protection_level,
-            :authentication_strategy, :janrain_api_key, :janrain_relying_party, :cms_token, :cas_server_url, :sso_key,
+            :authentication_strategy, :janrain_api_key, :janrain_relying_party, :cas_server_url, :sso_key,
             :admin_bot_protection_level, :sso_login_url, length: { maximum: 255 }
 
   symbolize :spam_protection_level, :admin_bot_protection_level
@@ -69,13 +69,6 @@ class Settings < ApplicationRecord
 
   def authentication_strategy
     ActiveSupport::StringInquirer.new(super)
-  end
-
-  def cms_token!
-    unless cms_token?
-      self.update_attribute(:cms_token, SecureRandom.hex(16))
-    end
-    cms_token
   end
 
   def has_privacy_policy?

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,7 +3,7 @@
 # Configure parameters to be filtered from the log file. Use this to limit dissemination of
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
-Rails.application.config.filter_parameters += %i[activation_code cms_token credit_card credit_card_auth_code
+Rails.application.config.filter_parameters += %i[activation_code credit_card credit_card_auth_code
                                                  credit_card_authorize_net_payment_profile_token credit_card_expires_on
                                                  credit_card_partial_number crypted_password janrain_api_key lost_password_token
                                                  password password_digest payment_gateway_options payment_service_reference salt

--- a/features/developer_portal/cms_toolbar.feature
+++ b/features/developer_portal/cms_toolbar.feature
@@ -38,6 +38,14 @@ Feature: CMS Toolbar
     Then there should not be a CMS toolbar
     And should see "Invalid or expired signature"
 
+  Scenario: Hide the toolbar when the CMS mode expires
+    When they visit the developer portal in CMS mode
+    Then the cms toolbar should be visible
+    Then 2 days pass
+    Then they visit the developer portal home page
+    Then there should not be a CMS toolbar
+    And should see "CMS Edit mode expired"
+
   Rule: There is a John Doe admin user
     Background:
       When the admin user is John Doe

--- a/features/step_definitions/developer_portal/cms_toolbar_steps.rb
+++ b/features/step_definitions/developer_portal/cms_toolbar_steps.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
 Given /^they visit the developer portal in CMS mode(\swith an expired signature)?/ do |token_is_expired|
-  cms_token = @provider.settings.cms_token!
+  provider_id = @provider.id
   expires_at = Time.now.utc.round - 30.seconds
   expires_at += 1.minute unless token_is_expired
-  signature = CMS::Signature.generate(cms_token, expires_at)
+  signature = CMS::Signature.generate(provider_id, expires_at)
 
   visit access_code_url(host: @provider.external_domain,
                         cms: 'draft',
                         expires_at: expires_at.to_i,
                         signature:,
                         access_code: @provider.site_access_code)
+end
+
+Given /^they visit the developer portal home page/ do
+  visit root_url(host: @provider.external_domain)
 end
 
 Given "the CMS toolbar has been previously hidden" do

--- a/lib/developer_portal/lib/cms/toolbar.rb
+++ b/lib/developer_portal/lib/cms/toolbar.rb
@@ -6,7 +6,7 @@ module CMS::Toolbar
   extend ActiveSupport::Concern
 
   included do
-    prepend_before_action :handle_cms_token
+    prepend_before_action :handle_cms_edit
     append_after_action :inject_cms_toolbar, if: :cms_toolbar_enabled?
   end
 
@@ -16,16 +16,17 @@ module CMS::Toolbar
 
   protected
 
-  def handle_cms_token
-    token = validate_and_extract_cms_token
-
-    if cms.valid_token?(token)
-      session[:cms_token] = token
-      Rails.logger.info "CMS edit mode enabled for portal #{site_account.external_domain}"
-    elsif token
-      session[:cms_token] = nil
-      session[:cms] = nil
-      Rails.logger.info "Invalid CMS edit mode signature for portal #{site_account.external_domain}"
+  def handle_cms_edit
+    result = validate_signature
+    case result
+    when :valid
+      enable_edit_mode
+      Rails.logger.debug "CMS edit mode enabled for portal #{site_account.external_domain}"
+    when :not_provided
+      # This request is not attempting to alter the CMS mode, we keep the same mode we have
+    else # :empty, :invalid, whatever
+      disable_edit_mode
+      Rails.logger.debug "CMS edit mode disabled for portal #{site_account.external_domain}. Signature is #{result}"
     end
 
     if (mode = params.delete(:cms).presence)
@@ -39,15 +40,25 @@ module CMS::Toolbar
 
   private
 
-  def validate_and_extract_cms_token
+  def enable_edit_mode
+    session[:cms_edit] = true
+  end
+
+  def disable_edit_mode
+    session.delete :cms_edit
+    session.delete :cms
+  end
+
+  def validate_signature
     signature = params.delete(:signature)
-    return signature if signature.blank?
+    return :not_provided if signature.nil?
+    return :empty if signature.blank?
 
     expires_at = Time.at(params.delete(:expires_at).to_i).utc
     raise ActiveSupport::MessageVerifier::InvalidSignature unless expires_at > Time.now.utc
 
-    cms_token = site_account.settings.cms_token!
-    valid_signature = signature == CMS::Signature.generate(cms_token, expires_at)
+    provider_id = site_account.id
+    valid_signature = signature == CMS::Signature.generate(provider_id, expires_at)
 
     raise ActiveSupport::MessageVerifier::InvalidSignature unless valid_signature
 
@@ -55,12 +66,12 @@ module CMS::Toolbar
     request.query_parameters.delete(:expires_at)
     request.query_parameters.delete(:signature)
 
-    cms_token
+    :valid
   rescue StandardError
     # In the case the signature is invalid or any other problem, I don't think we have to bother the client and
-    # BugSnag with an exception. Better return an empty token which means "Disable CMS edit mode (hide toolbar)"
+    # BugSnag with an exception. Better mark the token as :invalid to Disable CMS edit mode (hide toolbar)
     flash[:error] = 'Disabling CMS edit mode due to an invalid or expired signature'
-    ''
+    :invalid
   end
 
   def cms_toolbar_enabled?

--- a/test/integration/cms/toolbar_test.rb
+++ b/test/integration/cms/toolbar_test.rb
@@ -8,9 +8,9 @@ class CMS::ToolbarTest < ActionDispatch::IntegrationTest
   end
 
   test 'CMS toolbar rendering' do
-    cms_token = @provider.settings.cms_token!
+    provider_id = @provider.id
     expires_at = Time.now.utc.round + 1.minute
-    signature = CMS::Signature.generate(cms_token, expires_at)
+    signature = CMS::Signature.generate(provider_id, expires_at)
     host! @provider.internal_domain
 
     get "/", params: { expires_at: expires_at.to_i, signature: }

--- a/test/unit/models_test.rb
+++ b/test/unit/models_test.rb
@@ -49,7 +49,7 @@ class ModelsTest < ActiveSupport::TestCase
       'ProxyConfig' => %w[hosts],
       'ProxyRule' => %w[metric_system_name owner_type],
       'ServicePlan' => %w[issuer_type],
-      'Settings' => Switches::SWITCHES.map { |switch| "#{switch}_switch" },
+      'Settings' => Switches::SWITCHES.map { |switch| "#{switch}_switch" }  << "cms_token",
       'TableOfContentsPortlet' => %w[content_type],
       'UsageLimit' => %w[period plan_type],
       'UserSession' => %w[key user_agent]


### PR DESCRIPTION
**What this PR does / why we need it**:

In a previous PR we started using the cms token signature instead of the cms token itself in order to enable or disable the CMS Edit mode: https://github.com/3scale/porta/pull/3938

Once we are using the signature, there's no need to keep using the cms token at all. This PR uses the account id instead of the cms token to sign the request.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11466

**Verification steps** 

Everything should work as before:

1. Go to Audiende -> Developer Portal -> Visit Portal
2. The developer portal should load correctly and the CMS toolbar should be visible
3. Copy the URL that includes the token
4. Open a private window and paste the URL
5. The dev. portal should load correctly and the toolbar should be visible
6. Try to modify the signature or the timestamp
7. The dev. portal should load correctly, but you shouldn't see the toolbar.
8. Wait a minute for the token to expire
9. Open a private window and paste the URL
10. The dev. portal should load correctly, but you shouldn't see the toolbar.
