### PR TITLE
THREESCALE-10684: Fix backend modal search

### DIFF
--- a/app/javascript/src/BackendApis/components/BackendSelect.tsx
+++ b/app/javascript/src/BackendApis/components/BackendSelect.tsx
@@ -37,7 +37,6 @@ const BackendSelect: React.FunctionComponent<Props> = ({
     <>
       <SelectWithModal
         cells={cells}
-        fetchItems={() => { throw new Error('Function not implemented.') }} // FIXME: add it or make it optional
         footerLabel="View all backends"
         header="Recently created backends"
         helperTextInvalid={error}

--- a/app/javascript/src/Common/components/SelectWithModal.tsx
+++ b/app/javascript/src/Common/components/SelectWithModal.tsx
@@ -99,7 +99,12 @@ const SelectWithModal = <T extends IRecord>({
   }, [page, shouldHaveModal, modalOpen])
 
   useEffect(() => {
-    if (!fetchItems || !modalOpen) {
+    if (!modalOpen) {
+      return
+    }
+
+    if (!fetchItems) {
+      onLocalSearch(query)
       return
     }
 
@@ -122,7 +127,7 @@ const SelectWithModal = <T extends IRecord>({
 
   const clearResults = () => {
     setQuery('')
-    setSearchResults([], 0)
+    setSearchResults(initialItems, initialItems.length)
   }
 
   const handleModalOnSetPage = (newPage: number) => {
@@ -176,7 +181,7 @@ const SelectWithModal = <T extends IRecord>({
           sortBy={sortBy}
           title={title}
           onClose={handleOnModalClose}
-          onSearch={fetchItems ? setQuery : onLocalSearch}
+          onSearch={setQuery}
           onSelect={handleOnModalSelect}
         />
       )}

--- a/features/api/backend_usages/new.feature
+++ b/features/api/backend_usages/new.feature
@@ -84,3 +84,42 @@ Feature: Product > Integration > Backends > New
       Given they go to the backends of product "My API"
       When they select toolbar action "Add a backend"
       Then the current page is the new backend page for product "My API"
+
+  @search
+  Scenario: Search for a backend
+    # Travel in time to make the order of the entries predictable (as they are sorted by updated_at)
+    Given 5 minutes pass
+    And the provider has the following backend api:
+      | Name             | Mango                           |
+      | System name      | mango                           |
+      | Private Base URL | https://backend.example.org:443 |
+    And 5 minutes pass
+    And 0 products and 20 backend apis
+    When they go to the new backend page for product "My API"
+    And they should see "Add a backend"
+    And they toggle the menu on select "Backend"
+    And they press "View all backends"
+    Then they should see "Select a backend"
+    And they should see 5 pages
+
+    When they search "Mango" using the toolbar
+    Then the search input should be filled with "Mango"
+    And they should see following table:
+      | Name   | Private Base URL                    |
+      | Mango  | https://backend.example.org:443     |
+
+    When they clear the search filter
+    # The backend APIs created by 'And 0 products and 20 backend apis' step
+    Then they should see following table:
+      | Private Base URL                    |
+      | http://api.example.net:80           |
+      | http://api.example.net:80           |
+      | http://api.example.net:80           |
+      | http://api.example.net:80           |
+      | http://api.example.net:80           |
+
+    And they look at the 5th page
+    Then they should see following table:
+      | Name        | Private Base URL                    |
+      | Mango       | https://backend.example.org:443     |
+      | API Backend | https://echo-api.3scale.net:443     |

--- a/features/provider/admin/applications/new.feature
+++ b/features/provider/admin/applications/new.feature
@@ -71,11 +71,12 @@ Feature: Audience's new application page
     # Travel in time to ensure the new products are within the first 20 results
     # (because the products are sorted by updated_at: :desc)
     Given 5 minutes pass
+    And another product "Another product"
+    And 5 minutes pass
     And 18 products and 0 backend apis
     # Bump updated_at for "API" to ensure "My API" is the least recently updated product,
     # so it appears at position 21 (a single entry on page 5)
     And product "API" has name set to "Old"
-    And another product "Another product"
     When they go to the admin portal new application page
     And they select "Jane" from "Account"
     And they toggle the menu on select "Product"

--- a/features/provider/admin/applications/new.feature
+++ b/features/provider/admin/applications/new.feature
@@ -71,7 +71,7 @@ Feature: Audience's new application page
     # Travel in time to ensure the new products are within the first 20 results
     # (because the products are sorted by updated_at: :desc)
     Given 5 minutes pass
-    And 18 products and 1 backend apis
+    And 18 products and 0 backend apis
     # Bump updated_at for "API" to ensure "My API" is the least recently updated product,
     # so it appears at position 21 (a single entry on page 5)
     And product "API" has name set to "Old"

--- a/features/step_definitions/dashboard_steps.rb
+++ b/features/step_definitions/dashboard_steps.rb
@@ -26,8 +26,6 @@ end
 Given "{int} products and {int} backend apis" do |products, backends|
   FactoryBot.create_list(:service, products, account: @provider)
   FactoryBot.create_list(:backend_api, backends, account: @provider)
-
-  visit admin_dashboard_path
 end
 
 Then "the most recently updated products and backends can be found in the dashboard" do


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the search for backend select modal in "Add backend usage" form.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10684

**Verification steps** 

1. Create > 20 backend APIs.
2. Go to `/apiconfig/services/2/backend_usages/new` (or use another service ID)
3. Expand the Backend select
4. Try searching, the results should be filtered.
5. Click on "View all backends"
6. In the modal, try:
   - searching by keyword (e.g. "product")
   - moving through the pages
   - clicking on "x" clear button in the input
   - closing the modal (or clicking Cancel) and opening again - unfiltered results should be shown
   - selecting a value

**Special notes for your reviewer**:
