### PR TITLE
THREESCALE-11844: Allow disabling all notifications via UI

### DIFF
--- a/app/views/provider/admin/user/notification_preferences/show.html.slim
+++ b/app/views/provider/admin/user/notification_preferences/show.html.slim
@@ -19,6 +19,8 @@
                                               method: :patch,
                                               html: { class: 'pf-c-form pf-m-limit-width' } do |f|
 
+        /! Hidden input to allow disabling all notifications
+        = hidden_field_tag 'notification_preferences[enabled_notifications][]', '', id: nil
         - categories.each do |category|
           = f.inputs t(category.title_key, scope: :notification_category_titles) do
             = f.input :enabled_notifications, as: :patternfly_check_boxes,

--- a/features/notification_preferences/update.feature
+++ b/features/notification_preferences/update.feature
@@ -1,0 +1,35 @@
+@javascript
+Feature: Update notification preferences
+  As a provider user
+  I'd like to update the notification preferences page correctly
+
+  Background:
+    Given a provider is logged in
+
+  Scenario: Enable selected notifications
+    When they go to the notification preferences page
+    Then I should see "Notification Preferences"
+    When they check only the following notifications:
+      | New account created             |
+      | Expiring credit card            |
+      | Application plan change request |
+      | Service plan change request     |
+      | Alert: usage violation          |
+      | Weekly report                   |
+    And they press "Update Notification Preferences"
+    Then they should see "Notification preferences successfully updated."
+    And only the following notifications are checked:
+      | New account created             |
+      | Expiring credit card            |
+      | Application plan change request |
+      | Service plan change request     |
+      | Alert: usage violation          |
+      | Weekly report                   |
+
+  Scenario: Disable all notifications
+    When they go to the notification preferences page
+    Then I should see "Notification Preferences"
+    When they disable all notifications
+    And they press "Update Notification Preferences"
+    Then they should see "Notification preferences successfully updated."
+    And all notifications are unchecked

--- a/features/step_definitions/notification_preferences_steps.rb
+++ b/features/step_definitions/notification_preferences_steps.rb
@@ -3,3 +3,47 @@
 Given "admin of {account} has notification {symbol} {enabled}" do |account, key, enabled|
   account.admins.first.create_notification_preferences(preferences: NotificationPreferences.default_preferences.merge(key => enabled))
 end
+
+Given /^(?:I|they) check only the following notifications:$/ do |table|
+  toggle_notification_checkboxes table.raw.flatten.map(&:strip)
+end
+
+Then "only the following notifications are checked:" do |table|
+  assert_notification_checkboxes table.raw.flatten.map(&:strip)
+end
+
+Given "they disable all notifications" do
+  toggle_notification_checkboxes []
+end
+
+Then "all notifications are unchecked" do
+  assert_notification_checkboxes []
+end
+
+def assert_notification_checkboxes(enabled_list)
+  process_notification_checkboxes(
+    enabled_list:,
+    enabled_handler: ->(checkbox, label) { assert checkbox.checked?, "Expected '#{label}' checkbox to be checked" },
+    disabled_handler: ->(checkbox, label) { assert_not checkbox.checked?, "Expected '#{label}' checkbox to be unchecked" }
+  )
+end
+
+def toggle_notification_checkboxes(enabled_list)
+  process_notification_checkboxes(
+    enabled_list:,
+    enabled_handler: ->(checkbox, _) { check(checkbox[:id]) },
+    disabled_handler: ->(checkbox, _) { uncheck(checkbox[:id]) }
+  )
+end
+
+def process_notification_checkboxes(enabled_list:, enabled_handler:, disabled_handler:)
+  all('input[type="checkbox"]').each do |checkbox|
+    label_text = find("label[for='#{checkbox[:id]}']", match: :first).text.strip
+
+    if enabled_list.include?(label_text)
+      enabled_handler.call(checkbox, label_text)
+    else
+      disabled_handler.call(checkbox, label_text)
+    end
+  end
+end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -226,6 +226,9 @@ World(Module.new do
       access_token = AccessToken.find_by(name: $2) || @access_token
       edit_provider_admin_user_access_token_path(access_token)
 
+    when 'the notification preferences page'
+      provider_admin_user_notification_preferences_path
+
     #
     # Account management (Dev portal)
     #


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a but that prevented disabling all notification preferences via UI by adding a hidden input. It's not a problem adding an empty string there, because empty values are going to be [rejected](https://github.com/3scale/porta/blob/master/app/models/notification_preferences.rb#L10).

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11844

**Verification steps** 

Go to the **Notification Preferences** page, disable all notifications, press the submit button.
Make sure that the preferences are updated successfully.

**Special notes for your reviewer**:
