### PR TITLE
THREESCALE-11845: Skip notifications to inactive buyers

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -201,12 +201,7 @@ class Message < ApplicationRecord
   protected
 
   def can_send_message?(recipient)
-    if recipient.emails.present?
-      true
-    else
-      logger.warn "Skipping message notification for Message(id:#{id}) because account has no emails."
-      false
-    end
+    recipient.emails.present? && !recipient.receiver.suspended_or_scheduled_for_deletion?
   end
 
   def attempt_to_send_message(recipient)

--- a/app/views/buyers/accounts/_account_details.html.slim
+++ b/app/views/buyers/accounts/_account_details.html.slim
@@ -8,9 +8,10 @@ table.list
         => link_to 'Impersonate',
                   admin_buyers_account_impersonation_path(account),
                   class: 'action bolt', method: 'post', target: '_blank'
-      => link_to 'Send message',
-                new_provider_admin_messages_outbox_path(to: account),
-                class: 'action message fancybox'
+      - unless account.suspended_or_scheduled_for_deletion?
+        => link_to 'Send message',
+                  new_provider_admin_messages_outbox_path(to: account),
+                  class: 'action message fancybox'
   - if current_account.master? && account.provider?
     tr
       th Public domain


### PR DESCRIPTION
**What this PR does / why we need it**:

We are currently sending email notifications to buyers even when they are suspended. This PR fixes that.

It also removes a UI button to directly send a message to a suspended buyer, since it won't receive the message after this PR.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11845

**Verification steps** 

1. Suspend a buyer:
```ruby
buyer = Account.find(id)
buyer.marked_for_suspension = true
buyer.suspend
```
2. Perform any action that leads to an email notification. For instance, change an application plan, or just send a message to the buyer/all buyers.
3. Before, email was sent to the buyer; now, email is not sent.
