### PR TITLE
THREESCALE-11852: skip notifications from suspended buyers

### DIFF
--- a/app/events/cinstances/cinstance_cancellation_event.rb
+++ b/app/events/cinstances/cinstance_cancellation_event.rb
@@ -15,6 +15,7 @@ class Cinstances::CinstanceCancellationEvent < ApplicationRelatedEvent
         plan_name:      plan.name,
         plan_id:        cinstance.plan_id,
         service_name:   service.name,
+        account_id:     account.id,
         account_name:   account.name,
         provider:       provider,
         service:        service,

--- a/app/events/invoices/invoices_to_review_event.rb
+++ b/app/events/invoices/invoices_to_review_event.rb
@@ -2,7 +2,8 @@ class Invoices::InvoicesToReviewEvent < BillingRelatedEvent
 
   def self.create(provider)
     new(
-      provider: provider,
+      provider:     provider,
+      account_id:   provider.id,
       metadata: {
         provider_id: provider.id
       }

--- a/app/events/invoices/unsuccessfully_charged_invoice_creatable.rb
+++ b/app/events/invoices/unsuccessfully_charged_invoice_creatable.rb
@@ -3,9 +3,10 @@ module Invoices::UnsuccessfullyChargedInvoiceCreatable
     provider = invoice.provider_account
 
     new(
-      invoice:  invoice,
-      provider: provider,
-      state:    invoice.state,
+      invoice:      invoice,
+      provider:     provider,
+      account_id:   provider.id,
+      state:        invoice.state,
       metadata: {
         provider_id: provider.try!(:id)
       }

--- a/app/events/notification_event.rb
+++ b/app/events/notification_event.rb
@@ -6,11 +6,13 @@ class NotificationEvent < BaseEventStoreEvent
 
   def self.create(system_name, event)
     provider_id = event.try(:provider)&.id || event.metadata[:provider_id]
+    account_id = event.try(:account)&.id || event.try(:account_id)
 
     new(
       parent_event_id: event.event_id,
       system_name:     system_name.to_s,
       provider_id:     provider_id,
+      account_id:      account_id,
       metadata: {
         provider_id: provider_id
       }

--- a/app/workers/process_notification_event_worker.rb
+++ b/app/workers/process_notification_event_worker.rb
@@ -36,9 +36,14 @@ class ProcessNotificationEventWorker
   # @return [Account]
   def create_notifications(event)
     provider = Provider.find(event.provider_id)
-
     if provider.suspended_or_scheduled_for_deletion?
-      Rails.logger.info "[Notification] skipping notifications for event #{event.event_id} of #{provider.state} account #{event.provider_id}"
+      Rails.logger.info "[Notification] skipping notifications for event #{event.event_id} to #{provider.state} provider #{event.provider_id}"
+      return
+    end
+
+    buyer = Account.find_by(id: event.try(:account_id))
+    if buyer&.suspended_or_scheduled_for_deletion?
+      Rails.logger.info "[Notification] skipping notifications for event #{event.event_id} from #{buyer.state} buyer #{buyer.id}"
       return
     end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We already skip notifications **TO** suspended providers:

https://github.com/3scale/porta/blob/7efaabdeec71877d74e580149890ef50c3ec1de5/app/workers/process_notification_event_worker.rb#L40-L43

We also skip notifications **TO** suspended buyers:

https://github.com/3scale/porta/pull/4078

This PR is to skip notification **FROM** suspended buyers. That is, when the event was originated in a suspended buyer.

This is basically the same as https://github.com/3scale/porta/pull/4078 but, for the same event, this one filters notifications to provider, while #4078 filters notification to buyer.

Some events have the `account` or `account_id` attributes, representing the account where the event was originated. When present the worker will use it to check whether the account is suspended. When not provided, the notification is sent.

I added the `account_id` attribute to some relevant events that were lacking it, but not all events as this doesn't make sense for all cases.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11852

**Verification steps** 

1. Perform any action on the buyer that triggers an event. For instance, change an application plan
2. Provider admin users with permission over the service should receive the notification
3. Suspend the buyer
4. Perform the same action again
5. Provider admins should not receive the notification.

