### PR TITLE
THREESCALE-1643: Update notification preferences via API

### DIFF
--- a/app/controllers/admin/api/personal/notification_preferences_controller.rb
+++ b/app/controllers/admin/api/personal/notification_preferences_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Admin::Api::Personal::NotificationPreferencesController < Admin::Api::Personal::BaseController
+  wrap_parameters :notification_preferences
+
+  representer NotificationPreferences
+
+  # Notification Preferences List
+  # GET /admin/api/personal/notification_preferences.json
+  def index
+    respond_with current_user.notification_preferences
+  end
+
+  # Notification Preferences Update
+  # PUT /admin/api/personal/notification_preferences.json
+  def update
+    current_user.notification_preferences.update(new_preferences: notification_preferences_params)
+    respond_with current_user.notification_preferences
+  end
+
+  private
+
+  def notification_preferences_params
+    params.require(:notification_preferences).permit(*NotificationPreferences.available_notifications)
+  end
+end

--- a/app/controllers/admin/api/personal/notification_preferences_controller.rb
+++ b/app/controllers/admin/api/personal/notification_preferences_controller.rb
@@ -14,8 +14,9 @@ class Admin::Api::Personal::NotificationPreferencesController < Admin::Api::Pers
   # Notification Preferences Update
   # PUT /admin/api/personal/notification_preferences.json
   def update
-    current_user.notification_preferences.update(new_preferences: notification_preferences_params)
-    respond_with current_user.notification_preferences
+    prefs = current_user.notification_preferences
+    prefs.update(new_preferences: notification_preferences_params)
+    respond_with prefs.reload
   end
 
   private

--- a/app/models/notification_preferences.rb
+++ b/app/models/notification_preferences.rb
@@ -2,6 +2,7 @@ class NotificationPreferences < ApplicationRecord
   belongs_to :user, inverse_of: :notification_preferences
 
   validates :user, presence: true
+  validate :preferences_valid?
   serialize :preferences, JSON
 
   after_initialize :set_defaults
@@ -33,9 +34,15 @@ class NotificationPreferences < ApplicationRecord
     super Hash(preferences).stringify_keys
   end
 
-  def new_preferences=(updated_preferences)
-    prefs = updated_preferences.transform_values { ActiveModel::Type::Boolean.new.cast(_1) || false }
-    self.preferences = preferences.merge(prefs)
+  # "patches" the notification preferences, setting only the preferences that appear in the hash,
+  # to the corresponding values. The other preferences remain unchanged.
+  # @param [Hash] updated_preferences - new values for the preferences
+  # @example Update preferences
+  #   preferences.update(new_preferences: { account_created: true, limit_alert_reached_provider: false })
+  # Valid values are: true, false, "true", "false". Other values (including empty) will not pass validation.
+  def new_preferences=(updated_preferences = {})
+    transformed = updated_preferences.transform_values { transform_boolean(_1) }
+    self.preferences = preferences.merge(transformed)
   end
 
   def include?(preference)
@@ -58,6 +65,10 @@ class NotificationPreferences < ApplicationRecord
     self.class.default_preferences.stringify_keys
   end
 
+  # Sets the notification preferences:
+  # - enables all preferences, included in the argument
+  # - disables all other preferences, not included in the argument
+  # @param [Array<String>] preferences - list of enabled preferences
   def enabled_notifications=(preferences)
     enabled  = preferences_to_hash(preferences, value: true).stringify_keys
     hidden   = preferences_to_hash(hidden_notifications, value: true)
@@ -79,4 +90,22 @@ class NotificationPreferences < ApplicationRecord
   end
 
   delegate :preferences_to_hash, to: :class
+
+  def transform_boolean(value)
+    case value
+    when "false"
+      false
+    when "true"
+      true
+    else
+      value
+    end
+  end
+
+  def preferences_valid?
+    preferences.each_pair do |key,value|
+      errors.add(:preferences, :invalid_value, key: key) unless [true, false].include? value
+      errors.add(:preferences, :invalid_key, key: key) unless available_notifications.include? key.to_s
+    end
+  end
 end

--- a/app/models/notification_preferences.rb
+++ b/app/models/notification_preferences.rb
@@ -34,7 +34,7 @@ class NotificationPreferences < ApplicationRecord
   end
 
   def new_preferences=(updated_preferences)
-    prefs = updated_preferences.transform_values { |v| ActiveModel::Type::Boolean.new.cast(v) }
+    prefs = updated_preferences.transform_values { ActiveModel::Type::Boolean.new.cast(_1) }
     self.preferences = preferences.merge(prefs)
   end
 

--- a/app/models/notification_preferences.rb
+++ b/app/models/notification_preferences.rb
@@ -33,6 +33,11 @@ class NotificationPreferences < ApplicationRecord
     super Hash(preferences).stringify_keys
   end
 
+  def new_preferences=(updated_preferences)
+    prefs = updated_preferences.transform_values { |v| ActiveModel::Type::Boolean.new.cast(v) }
+    self.preferences = preferences.merge(prefs)
+  end
+
   def include?(preference)
     enabled_notifications.include?(preference.to_s)
   end

--- a/app/models/notification_preferences.rb
+++ b/app/models/notification_preferences.rb
@@ -34,7 +34,7 @@ class NotificationPreferences < ApplicationRecord
   end
 
   def new_preferences=(updated_preferences)
-    prefs = updated_preferences.transform_values { ActiveModel::Type::Boolean.new.cast(_1) }
+    prefs = updated_preferences.transform_values { ActiveModel::Type::Boolean.new.cast(_1) || false }
     self.preferences = preferences.merge(prefs)
   end
 

--- a/app/representers/notification_preferences_representer.rb
+++ b/app/representers/notification_preferences_representer.rb
@@ -3,9 +3,5 @@
 class NotificationPreferencesRepresenter < ThreeScale::Representer
   include ThreeScale::JSONRepresenter
 
-  property :preferences, as: :notification_preferences
-
-  # NotificationPreferences.available_notifications.each do |notification|
-  #   property notification, getter: ->(*) { preferences[notification.to_s] }
-  # end
+  property :preferences, as: :notification_preferences, getter: ->(*) { preferences.sort.to_h }
 end

--- a/app/representers/notification_preferences_representer.rb
+++ b/app/representers/notification_preferences_representer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class NotificationPreferencesRepresenter < ThreeScale::Representer
+  include ThreeScale::JSONRepresenter
+
+  property :preferences, as: :notification_preferences
+
+  # NotificationPreferences.available_notifications.each do |notification|
+  #   property notification, getter: ->(*) { preferences[notification.to_s] }
+  # end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1863,6 +1863,12 @@ en:
               charging_failed: 'Failed to charge the credit card.'
             period:
               invalid_range: 'must be between the provider account creation date and 12 months from now'
+              
+        notification_preferences:
+          attributes:
+            preferences:
+              invalid_value: "invalid value for '%{key}', must be either true or false"
+              invalid_key: "notification '%{key}' is not valid"
 
     models:
       topic_category: category

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -509,11 +509,9 @@ without fake Core server your after commit callbacks will crash and you might ge
 
       namespace :personal, defaults: { format: :json } do
         resources :access_tokens, except: %i[new edit update]
-        resources :notification_preferences do
-          collection do
-            get :index
-            put :update
-          end
+        resources :notification_preferences, only: [] do
+          get :index, on: :collection
+          patch :update, on: :collection
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -509,6 +509,12 @@ without fake Core server your after commit callbacks will crash and you might ge
 
       namespace :personal, defaults: { format: :json } do
         resources :access_tokens, except: %i[new edit update]
+        resources :notification_preferences do
+          collection do
+            get :index
+            put :update
+          end
+        end
       end
 
       # /admin/api/provider

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -7276,7 +7276,7 @@
           }
         }
       },
-      "put": {
+      "patch": {
         "summary": "Notification Preferences Update",
         "description": "Update the notification preferences for the current user.",
         "tags": [
@@ -7293,93 +7293,105 @@
                     "type": "string",
                     "description": "A personal Access Token."
                   },
-                  "application_created": {
-                    "type": "boolean",
-                    "description": "Application created."
-                  },
                   "account_created": {
                     "type": "boolean",
-                    "description": "Account created."
-                  },
-                  "limit_alert_reached_provider": {
-                    "type": "boolean",
-                    "description": "Limit alert reached provider."
-                  },
-                  "limit_violation_reached_provider": {
-                    "type": "boolean",
-                    "description": "Limit violation reached provider."
-                  },
-                  "account_plan_change_requested": {
-                    "type": "boolean",
-                    "description": "Account plan change requested."
+                    "description": "New account created. Sent when a developer account is created."
                   },
                   "account_deleted": {
                     "type": "boolean",
-                    "description": "Account deleted."
+                    "description": "Account deleted. Sent when an account is deleted."
                   },
-                  "cinstance_cancellation": {
+                  "account_plan_change_requested": {
                     "type": "boolean",
-                    "description": "Application cancellation."
+                    "description": "Account plan change request. Sent when a developer requests to change to a different account plan."
                   },
-                  "cinstance_plan_changed": {
+                  "application_created": {
                     "type": "boolean",
-                    "description": "Application plan changed."
+                    "description": "New application created. Sent when a new application is created."
                   },
                   "application_plan_change_requested": {
                     "type": "boolean",
-                    "description": "Application plan change requested."
+                    "description": "Application plan change request. Sent when a request for application plan change is made."
                   },
-                  "service_contract_created": {
+                  "cinstance_cancellation": {
                     "type": "boolean",
-                    "description": "Service contract created."
-                  },
-                  "service_plan_change_requested": {
-                    "type": "boolean",
-                    "description": "Service plan change requested."
-                  },
-                  "service_contract_plan_changed": {
-                    "type": "boolean",
-                    "description": "Service contract plan changed."
+                    "description": "Application deleted. Sent when an application is deleted."
                   },
                   "cinstance_expired_trial": {
                     "type": "boolean",
-                    "description": "Application expired trial."
+                    "description": "Application trial expired. Sent when an application trial period expires."
                   },
-                  "invoices_to_review": {
+                  "cinstance_plan_changed": {
                     "type": "boolean",
-                    "description": "Invoices to review."
+                    "description": "Application plan change. Sent when an application is changed to a different plan."
                   },
-                  "plan_downgraded": {
+                  "credit_card_unstore_failed": {
                     "type": "boolean",
-                    "description": "Plan downgraded."
-                  },
-                  "expired_credit_card_provider": {
-                    "type": "boolean",
-                    "description": "Expired credit card."
-                  },
-                  "unsuccessfully_charged_invoice_provider": {
-                    "type": "boolean",
-                    "description": "Unsuccessfully charged invoice."
-                  },
-                  "message_received": {
-                    "type": "boolean",
-                    "description": "Message received."
+                    "description": "Unstoring credit card failed. Sent when customer’s credit card failed to be unstored from your payment gateway."
                   },
                   "csv_data_export": {
                     "type": "boolean",
-                    "description": "CSV data export."
-                  },
-                  "service_deleted": {
-                    "type": "boolean",
-                    "description": "Service deleted."
-                  },
-                  "weekly_report": {
-                    "type": "boolean",
-                    "description": "Weekly report."
+                    "description": "CSV data export. Sent when a member of your team generates a report with data about messages/ developer accounts/ applications."
                   },
                   "daily_report": {
                     "type": "boolean",
-                    "description": "Daily report."
+                    "description": "Daily report. Contains information about your API(s) performance in the last 24 hours."
+                  },
+                  "expired_credit_card_provider": {
+                    "type": "boolean",
+                    "description": "Expiring credit card. Sent when a customer’s credit card is about to expire."
+                  },
+                  "invoices_to_review": {
+                    "type": "boolean",
+                    "description": "Action required: review invoices. Sent a few days before end of billing cycle so you can review invoices before they are being sent to customers."
+                  },
+                  "limit_alert_reached_provider": {
+                    "type": "boolean",
+                    "description": "'Alert: usage warning. Sent when an application triggers a usage alert for usage levels below 100%."
+                  },
+                  "limit_violation_reached_provider": {
+                    "type": "boolean",
+                    "description": "Alert: usage violation. Sent when an application triggers a usage alert for usage levels of 100% and above."
+                  },
+                  "message_received": {
+                    "type": "boolean",
+                    "description": "New messages. Sent when a developer sends you a new message."
+                  },
+                  "plan_downgraded": {
+                    "type": "boolean",
+                    "description": "Customer downgraded. Sent when a customer changes to a plan with a lower monthly fixed price."
+                  },
+                  "service_contract_cancellation": {
+                    "type": "boolean",
+                    "description": "Service subscription cancelled. Sent when an existing service subscription is cancelled."
+                  },
+                  "service_contract_created": {
+                    "type": "boolean",
+                    "description": "New service subscription. Sent when a new service subscription is started."
+                  },
+                  "service_contract_plan_changed": {
+                    "type": "boolean",
+                    "description": "Service subscription changed. Sent when an existing service subscription is changed."
+                  },
+                  "service_deleted": {
+                    "type": "boolean",
+                    "description": "Service deleted. Sent when a service is deleted."
+                  },
+                  "service_plan_change_requested": {
+                    "type": "boolean",
+                    "description": "Service plan change request. Sent when a developer requests to change to a different service plan."
+                  },
+                  "unsuccessfully_charged_invoice_final_provider": {
+                    "type": "boolean",
+                    "description": "Payment error (final). Sent when the final retry of a payment fails, resulting in a failed invoice."
+                  },
+                  "unsuccessfully_charged_invoice_provider": {
+                    "type": "boolean",
+                    "description": "Payment error (retry). Sent when payment fails, resulting in an unpaid invoice and a retry."
+                  },
+                  "weekly_report": {
+                    "type": "boolean",
+                    "description": "Weekly report. Contains information about your API(s) performance in the last 7 days."
                   }
                 }
               }

--- a/doc/active_docs/account_management_api.json
+++ b/doc/active_docs/account_management_api.json
@@ -7251,6 +7251,149 @@
         }
       }
     },
+    "/admin/api/personal/notification_preferences.json": {
+      "get": {
+        "summary": "Notification Preferences List",
+        "description": "Returns the list of notification preferences for the current user.",
+        "tags": [
+          "Notification Preferences"
+        ],
+        "parameters": [
+          {
+            "name": "access_token",
+            "in": "query",
+            "description": "A personal Access Token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "success",
+            "content": {}
+          }
+        }
+      },
+      "put": {
+        "summary": "Notification Preferences Update",
+        "description": "Update the notification preferences for the current user.",
+        "tags": [
+          "Notification Preferences"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "access_token": {
+                    "type": "string",
+                    "description": "A personal Access Token."
+                  },
+                  "application_created": {
+                    "type": "boolean",
+                    "description": "Application created."
+                  },
+                  "account_created": {
+                    "type": "boolean",
+                    "description": "Account created."
+                  },
+                  "limit_alert_reached_provider": {
+                    "type": "boolean",
+                    "description": "Limit alert reached provider."
+                  },
+                  "limit_violation_reached_provider": {
+                    "type": "boolean",
+                    "description": "Limit violation reached provider."
+                  },
+                  "account_plan_change_requested": {
+                    "type": "boolean",
+                    "description": "Account plan change requested."
+                  },
+                  "account_deleted": {
+                    "type": "boolean",
+                    "description": "Account deleted."
+                  },
+                  "cinstance_cancellation": {
+                    "type": "boolean",
+                    "description": "Application cancellation."
+                  },
+                  "cinstance_plan_changed": {
+                    "type": "boolean",
+                    "description": "Application plan changed."
+                  },
+                  "application_plan_change_requested": {
+                    "type": "boolean",
+                    "description": "Application plan change requested."
+                  },
+                  "service_contract_created": {
+                    "type": "boolean",
+                    "description": "Service contract created."
+                  },
+                  "service_plan_change_requested": {
+                    "type": "boolean",
+                    "description": "Service plan change requested."
+                  },
+                  "service_contract_plan_changed": {
+                    "type": "boolean",
+                    "description": "Service contract plan changed."
+                  },
+                  "cinstance_expired_trial": {
+                    "type": "boolean",
+                    "description": "Application expired trial."
+                  },
+                  "invoices_to_review": {
+                    "type": "boolean",
+                    "description": "Invoices to review."
+                  },
+                  "plan_downgraded": {
+                    "type": "boolean",
+                    "description": "Plan downgraded."
+                  },
+                  "expired_credit_card_provider": {
+                    "type": "boolean",
+                    "description": "Expired credit card."
+                  },
+                  "unsuccessfully_charged_invoice_provider": {
+                    "type": "boolean",
+                    "description": "Unsuccessfully charged invoice."
+                  },
+                  "message_received": {
+                    "type": "boolean",
+                    "description": "Message received."
+                  },
+                  "csv_data_export": {
+                    "type": "boolean",
+                    "description": "CSV data export."
+                  },
+                  "service_deleted": {
+                    "type": "boolean",
+                    "description": "Service deleted."
+                  },
+                  "weekly_report": {
+                    "type": "boolean",
+                    "description": "Weekly report."
+                  },
+                  "daily_report": {
+                    "type": "boolean",
+                    "description": "Daily report."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "success",
+            "content": {}
+          }
+        }
+      }
+    },
     "/admin/api/policies.json": {
       "get": {
         "summary": "APIcast Policy Registry",

--- a/test/integration/admin/api/personal/notification_preferences_controller_test.rb
+++ b/test/integration/admin/api/personal/notification_preferences_controller_test.rb
@@ -29,7 +29,7 @@ class Admin::Api::Personal::NotificationPreferencesControllerTest < ActionDispat
       weekly_report: true,
       daily_report: true
     }
-    put admin_api_personal_notification_preferences_path(format: :json), params: { access_token: token, **update_params }
+    patch admin_api_personal_notification_preferences_path(format: :json), params: { access_token: token, **update_params }
 
     prefs =  JSON.parse(response.body)['notification_preferences']
 
@@ -49,19 +49,21 @@ class Admin::Api::Personal::NotificationPreferencesControllerTest < ActionDispat
       non_existing_notification: false
     }
 
-    put admin_api_personal_notification_preferences_path(format: :json), params: { access_token: token, **update_params }
+    patch admin_api_personal_notification_preferences_path(format: :json), params: { access_token: token, **update_params }
 
     # Strong parameters filter out non-existing preferences
     assert_response :success
     assert_equal previous_prefs, user.notification_preferences.reload.preferences
 
-    update_params = {
-      account_created: 'some-value'
-    }
-    put admin_api_personal_notification_preferences_path(format: :json), params: { access_token: token, **update_params }
+    ['some-value', '', nil].each do |value|
+      update_params = {
+        account_created: value
+      }
+      patch admin_api_personal_notification_preferences_path(format: :json), params: { access_token: token, **update_params }
 
-    assert_response :unprocessable_entity
-    resp = JSON.parse(response.body)
-    assert_equal ["invalid value for 'account_created', must be either true or false"], resp["errors"]["preferences"]
+      assert_response :unprocessable_entity
+      resp = JSON.parse(response.body)
+      assert_equal ["invalid value for 'account_created', must be either true or false"], resp["errors"]["preferences"]
+    end
   end
 end

--- a/test/integration/admin/api/personal/notification_preferences_controller_test.rb
+++ b/test/integration/admin/api/personal/notification_preferences_controller_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Admin::Api::Personal::NotificationPreferencesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    provider = FactoryBot.create(:provider_account)
+    @user = provider.admin_users.first!
+    @token = FactoryBot.create(:access_token, owner: @user, scopes: %w[account_management]).value
+    host! provider.external_admin_domain
+  end
+
+  attr_reader :user, :token
+
+  test 'index' do
+    get admin_api_personal_notification_preferences_path(format: :json, access_token: @token)
+
+    prefs =  JSON.parse(response.body)['notification_preferences']
+
+    assert_response :success
+    assert_same_elements NotificationPreferences.available_notifications, prefs.keys.map(&:to_sym)
+    assert prefs.values.all? { [true, false].include?(_1) }
+  end
+
+  test 'update successfully' do
+    update_params = {
+      application_created: false,
+      account_created: false,
+      weekly_report: true,
+      daily_report: true
+    }
+    put admin_api_personal_notification_preferences_path(format: :json), params: { access_token: token, **update_params }
+
+    prefs =  JSON.parse(response.body)['notification_preferences']
+
+    assert_response :success
+    user.notification_preferences.reload
+    update_params.each_pair do |key, value|
+      assert_equal value, prefs[key.to_s], "Notification '#{key}' should be set to '#{value}'"
+      assert_equal value, user.notification_preferences.include?(key.to_s)
+    end
+  end
+
+  test 'update with wrong parameters' do
+    user.notification_preferences.update(enabled_notifications: ['account_created'])
+    previous_prefs = user.notification_preferences.preferences
+    update_params = {
+      non_existing_notification: false,
+      account_created: 'some-value'
+    }
+    put admin_api_personal_notification_preferences_path(format: :json), params: { access_token: token, **update_params }
+
+    assert_response :success
+    assert_equal previous_prefs, user.notification_preferences.reload.preferences
+  end
+end

--- a/test/models/notification_preferences_test.rb
+++ b/test/models/notification_preferences_test.rb
@@ -58,12 +58,12 @@ class NotificationPreferencesTest < ActiveSupport::TestCase
   end
 
   test 'enabled_notifications' do
-    preferences = NotificationPreferences.new(enabled_notifications: %w(application_created foo))
+    preferences = NotificationPreferences.new(enabled_notifications: %w[application_created foo])
 
     assert_includes preferences.enabled_notifications, 'application_created'
     refute_includes preferences.enabled_notifications, 'foo'
 
-    enabled_notifications = %w(application_created) + hidden_notifications.map(&:to_s)
+    enabled_notifications = %w[application_created] + hidden_notifications.map(&:to_s)
 
     assert_same_elements enabled_notifications, preferences.enabled_notifications
 
@@ -75,10 +75,28 @@ class NotificationPreferencesTest < ActiveSupport::TestCase
   test 'enabled_notifications=' do
     preferences = NotificationPreferences.new
 
-    enabled = preferences.enabled_notifications = %w(application_created)
+    enabled = preferences.enabled_notifications = %w[application_created]
     enabled += hidden_notifications.map(&:to_s)
 
     assert_same_elements enabled, preferences.enabled_notifications
     assert_equal preferences.available_notifications, Set.new(preferences.preferences.keys)
+  end
+
+  test 'new_preferences=' do
+    preferences = NotificationPreferences.new(enabled_notifications: %w[account_created application_created service_contract_created])
+
+    assert preferences.preferences["application_created"]
+    assert_not preferences.preferences["limit_alert_reached_provider"]
+
+    preferences.new_preferences = { application_created: false, limit_alert_reached_provider: true }
+
+    assert_not preferences.preferences["application_created"]
+    assert preferences.preferences["limit_alert_reached_provider"]
+
+    # process string values correctly
+    preferences.new_preferences = { "plan_downgraded" => "true", "service_contract_created" => "false" }
+
+    assert_not preferences.preferences["service_contract_created"]
+    assert preferences.preferences["plan_downgraded"]
   end
 end

--- a/test/models/notification_preferences_test.rb
+++ b/test/models/notification_preferences_test.rb
@@ -88,10 +88,15 @@ class NotificationPreferencesTest < ActiveSupport::TestCase
     assert preferences.preferences["application_created"]
     assert_not preferences.preferences["limit_alert_reached_provider"]
 
+    before_change = preferences.preferences.except("application_created", "limit_alert_reached_provider")
+
     preferences.new_preferences = { application_created: false, limit_alert_reached_provider: true }
 
     assert_not preferences.preferences["application_created"]
     assert preferences.preferences["limit_alert_reached_provider"]
+
+    # the notifications that were not updated by #new_preferences= have not been changed
+    assert_equal before_change, preferences.preferences.except("application_created", "limit_alert_reached_provider")
 
     # process string values correctly
     preferences.new_preferences = { "plan_downgraded" => "true", "service_contract_created" => "false" }

--- a/test/models/notification_preferences_test.rb
+++ b/test/models/notification_preferences_test.rb
@@ -99,4 +99,25 @@ class NotificationPreferencesTest < ActiveSupport::TestCase
     assert_not preferences.preferences["service_contract_created"]
     assert preferences.preferences["plan_downgraded"]
   end
+
+  test 'new_preferences= invalid values' do
+    preferences = FactoryBot.create(:user_with_account).notification_preferences
+    preferences.save
+
+    preferences.new_preferences = { non_existing_preference: true }
+
+    assert_not preferences.valid?
+    assert_equal ["notification 'non_existing_preference' is not valid"], preferences.errors[:preferences]
+
+    preferences.reload
+    new_prefs = { account_created: "asdf", application_created: "", service_contract_created: 1 }
+    preferences.new_preferences = new_prefs
+
+    assert_not preferences.valid?
+    errors = preferences.errors[:preferences]
+    assert_equal 3, errors.size
+    new_prefs.each_key do |key|
+      errors.include?("invalid value for '#{key}', must be either true or false")
+    end
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Update personal notification preferences via API.

It's still to be decided whether we need to support updating preferences of **another** user (e.g. an admin to be able to change preferences of a member).

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-1643

**Verification steps** 

TBD

**Special notes for your reviewer**:
