### PR TITLE
Remove thin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -224,9 +224,7 @@ group :test do
   # IMPORTANT: Load 'mocha' after 'shoulda'.
   gem 'mocha', require: 'mocha/minitest'
 
-  # proxy tests
   gem 'database_cleaner', require: false
-  gem 'thin', require: false
 
   # performance tests
   gem "n_plus_one_control"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,7 +319,6 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    daemons (1.4.1)
     dalli (3.2.4)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
@@ -369,7 +368,6 @@ GEM
     escape_utils (1.2.1)
     et-orbi (1.2.11)
       tzinfo
-    eventmachine (1.2.7)
     execjs (2.8.1)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -883,10 +881,6 @@ GEM
     test_xml (0.1.8)
       diffy (~> 3.0)
       nokogiri (>= 1.3.2)
-    thin (1.8.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thinking-sphinx (5.5.1)
       activerecord (>= 4.2.0)
       builder (>= 2.1.2)
@@ -1125,7 +1119,6 @@ DEPENDENCIES
   svg-graph
   swagger-ui_rails!
   swagger-ui_rails2!
-  thin
   thinking-sphinx (~> 5.5.0)
   ts-datetime-delta
   uglifier


### PR DESCRIPTION
**What this PR does / why we need it**:

I am not sure whether this is used anymore. I tracked down the history, and it seems that it was added for some "proxy tests": https://github.com/3scale/system/commit/154af3a533a2536199c6852b48fb8c1d29e3cb9c

And these tests were already removed in https://github.com/3scale/porta/pull/2549/files

Well, now it's causing an issue when trying to upgrade rails to version 7.1:

```
Bundler could not find compatible versions for gem "rack":
  In Gemfile:
    rails (~> 7.1.5) was resolved to 7.1.5, which depends on
      actionpack (= 7.1.5) was resolved to 7.1.5, which depends on
        rack-session (>= 1.0.1) was resolved to 2.1.1, which depends on
          rack (>= 3.0.0)

    thin was resolved to 1.8.2, which depends on
      rack (>= 1, < 3)
```

It looks like the support was added to master branch: https://github.com/macournoyer/thin/pull/399 However, it has not been released yet, the issue is still open: https://github.com/macournoyer/thin/issues/389


**Which issue(s) this PR fixes** 



**Verification steps** 


**Special notes for your reviewer**:
