### PR TITLE
Remove obsolete gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -179,9 +179,6 @@ end
 
 gem 'mail_view', '~> 2.0.4'
 
-# legacy from rails 2.3 -
-gem 'dynamic_form'
-
 group :test do
   gem 'rack-no_animations', '~> 1.0.3'
   gem 'rails-controller-testing', '~> 1.0.4'

--- a/Gemfile
+++ b/Gemfile
@@ -181,7 +181,6 @@ gem 'mail_view', '~> 2.0.4'
 
 # legacy from rails 2.3 -
 gem 'dynamic_form'
-gem 'record_tag_helper', '~> 1.0'
 
 group :test do
   gem 'rack-no_animations', '~> 1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,8 +682,6 @@ GEM
     rb_sys (0.9.81)
     rbtree (0.4.6)
     recaptcha (5.16.0)
-    record_tag_helper (1.0.1)
-      actionview (>= 5)
     recursive-open-struct (1.1.3)
     redcarpet (3.5.1)
     redis (5.3.0)
@@ -1078,7 +1076,6 @@ DEPENDENCIES
   rails_event_store (~> 0.9.0)
   ratelimit
   recaptcha (~> 5.16.0)
-  record_tag_helper (~> 1.0)
   redcarpet (~> 3.5.1)
   redis
   redlock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,9 +355,6 @@ GEM
       request_store (>= 1.0)
       ruby2_keywords
     dry-initializer (3.0.4)
-    dynamic_form (1.3.1)
-      actionview (> 5.2.0)
-      activemodel (> 5.2.0)
     email_spec (2.2.0)
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
@@ -1008,7 +1005,6 @@ DEPENDENCIES
   diff-lcs (~> 1.2)
   dotenv-rails (~> 2.7)
   draper (~> 4.0.2)
-  dynamic_form
   email_spec
   equivalent-xml
   escape_utils

--- a/app/lib/three_scale/semantic_form_builder.rb
+++ b/app/lib/three_scale/semantic_form_builder.rb
@@ -1,6 +1,8 @@
 module ThreeScale
   class SemanticFormBuilder < ::Formtastic::FormBuilder
     include ThreeScale::BotProtection::Form
+    include ApplicationHelper
+    include ActionView::Helpers::TagHelper
 
     delegate :tag, :site_account, :controller, to: :template
 
@@ -62,6 +64,10 @@ module ThreeScale
       end
 
       action :submit, label: label, as: :button, **opts
+    end
+
+    def error_messages
+      error_messages_for(@object_name, object: @object)
     end
 
     # Adds cancel link to a form.

--- a/app/views/admin/fields_definitions/index.html.erb
+++ b/app/views/admin/fields_definitions/index.html.erb
@@ -32,12 +32,13 @@
 
   <ol id="<%= class_name %>-list" class="fields-definitions-list ui-sortable">
     <% @fields_definitions.by_target(class_name).sort_by(&:pos).each do |fields_definition| %>
-	<li id="<%=dom_id(fields_definition)%>">
-	<span class="name"><%=h fields_definition.name %></span>
-	<span>"<%= h truncate(fields_definition.label, :length => 50) %>"</span>
-	<span class="action-set">
-	  <span class="properties"><%=h retrieve_properties_of fields_definition %></span>
-	  <%= link_to 'Edit', edit_admin_fields_definition_path(fields_definition), :class => 'action edit' %>
+      <li id="<%=dom_id(fields_definition)%>">
+        <span class="name"><%=h fields_definition.name %></span>
+        <span>"<%= h truncate(fields_definition.label, :length => 50) %>"</span>
+        <span class="action-set">
+          <span class="properties"><%=h retrieve_properties_of fields_definition %></span>
+          <%= link_to 'Edit', edit_admin_fields_definition_path(fields_definition), :class => 'action edit' %>
+        </span>
       </li>
     <% end %>
   </ol>

--- a/app/views/buyers/invoices/index.html.erb
+++ b/app/views/buyers/invoices/index.html.erb
@@ -27,7 +27,7 @@
   </thead>
   <tbody role="rowgroup">
     <% @invoices.each do |invoice| %>
-      <tr role="row">
+      <%= content_tag :tr, id: dom_id(invoice), role: "row" do %>
         <td role="cell" data-label="ID"><%= link_to invoice.friendly_id , admin_buyers_or_account_invoice_path(invoice) , title: "Show #{invoice.friendly_id}" %></td>
         <td role="cell" data-label="Month"><%= invoice.name %></td>
         <td role="cell" data-label="State"><%= h invoice.state %></td>
@@ -35,7 +35,7 @@
         <td role="cell" data-label="Download" colspan="2">
           <%= invoice_pdf_link(invoice, label: 'PDF') %>
         </td>
-      </tr>
+      <% end %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/buyers/invoices/index.html.erb
+++ b/app/views/buyers/invoices/index.html.erb
@@ -27,7 +27,7 @@
   </thead>
   <tbody role="rowgroup">
     <% @invoices.each do |invoice| %>
-      <%= content_tag_for(:tr, invoice, role: 'row') do %>
+      <tr role="row">
         <td role="cell" data-label="ID"><%= link_to invoice.friendly_id , admin_buyers_or_account_invoice_path(invoice) , title: "Show #{invoice.friendly_id}" %></td>
         <td role="cell" data-label="Month"><%= invoice.name %></td>
         <td role="cell" data-label="State"><%= h invoice.state %></td>
@@ -35,7 +35,7 @@
         <td role="cell" data-label="Download" colspan="2">
           <%= invoice_pdf_link(invoice, label: 'PDF') %>
         </td>
-       <% end %>
+      </tr>
     <% end %>
   </tbody>
 </table>

--- a/app/views/finance/provider/invoices/index.html.slim
+++ b/app/views/finance/provider/invoices/index.html.slim
@@ -23,7 +23,7 @@
                                                                  body: t('.empty_search.body') }
       - else
         - presenter.invoices.each do |invoice|
-          = content_tag_for(:tr, invoice, role: "row") do
+          tr role="row" class="invoice"
             td role="cell" data-label="Number"
               = link_to(invoice.friendly_id, admin_finance_invoice_path(invoice))
             td role="cell" data-label="Account"
@@ -37,4 +37,3 @@
             - if invoice.pdf.file?
               td role="cell" data-label="Download"
                 = invoice_pdf_link(invoice)
-

--- a/app/views/finance/provider/invoices/index.html.slim
+++ b/app/views/finance/provider/invoices/index.html.slim
@@ -23,7 +23,7 @@
                                                                  body: t('.empty_search.body') }
       - else
         - presenter.invoices.each do |invoice|
-          tr role="row" class="invoice"
+          = content_tag :tr, id: dom_id(invoice), role: "row" do
             td role="cell" data-label="Number"
               = link_to(invoice.friendly_id, admin_finance_invoice_path(invoice))
             td role="cell" data-label="Account"

--- a/app/views/finance/provider/log_entries/index.html.erb
+++ b/app/views/finance/provider/log_entries/index.html.erb
@@ -23,7 +23,7 @@
 
   <tbody role="rowgroup">
     <% @log_entries.each do |entry| %>
-      <%= content_tag_for(:tr, entry, class: entry.level, role: 'row') do %>
+      <%= content_tag(:tr, class: entry.level, role: 'row') do %>
 	      <td role="cell" data-label="Account">
           <%= entry.buyer.try(:name) || '--GLOBAL--' %>
         </td>

--- a/app/views/finance/provider/shared/_line_item.html.erb
+++ b/app/views/finance/provider/shared/_line_item.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag_for :tr, line_item, :class => "line_item" do %>
+<%= content_tag :tr, id: dom_id(line_item), class: "line_item" do %>
   <td role="cell" data-label="Name"><%= h line_item.name %></td>
   <td role="cell" data-label="Description"><%= h line_item.description %></td>
   <td role="cell" data-label="Quantity"><%= h line_item.quantity %></td>

--- a/app/views/finance/provider/shared/_payment_transaction.html.erb
+++ b/app/views/finance/provider/shared/_payment_transaction.html.erb
@@ -1,4 +1,4 @@
-<tr>
+<%= content_tag :tr, id: dom_id(payment_transaction) do %>
   <td role="cell">
     <%= boolean_status_img(payment_transaction.success?) %>
   </td>
@@ -12,4 +12,4 @@
     <%= payment_transaction.amount %>
     <%= payment_transaction.currency %>
   </td>
-</tr>
+<% end %>

--- a/app/views/finance/provider/shared/_payment_transaction.html.erb
+++ b/app/views/finance/provider/shared/_payment_transaction.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag_for(:tr, payment_transaction) do  %>
+<tr>
   <td role="cell">
     <%= boolean_status_img(payment_transaction.success?) %>
   </td>
@@ -12,4 +12,4 @@
     <%= payment_transaction.amount %>
     <%= payment_transaction.currency %>
   </td>
-<% end %>
+</tr>

--- a/app/views/provider/admin/account/invoices/index.html.slim
+++ b/app/views/provider/admin/account/invoices/index.html.slim
@@ -19,7 +19,7 @@
         th role="columnheader" scope="col" Download
     tbody role="rowgroup"
       - @invoices.each do |invoice|
-        tr role="row"
+        = content_tag :tr, id: dom_id(invoice), role: 'row' do
           td role="cell" data-label="ID"
             = link_to invoice.friendly_id, provider_admin_account_invoice_path(invoice), title: "Show #{invoice.friendly_id}"
           td role="cell" data-label="Month"

--- a/app/views/provider/admin/account/invoices/index.html.slim
+++ b/app/views/provider/admin/account/invoices/index.html.slim
@@ -19,7 +19,7 @@
         th role="columnheader" scope="col" Download
     tbody role="rowgroup"
       - @invoices.each do |invoice|
-        = content_tag_for :tr, invoice, role: 'row' do
+        tr role="row"
           td role="cell" data-label="ID"
             = link_to invoice.friendly_id, provider_admin_account_invoice_path(invoice), title: "Show #{invoice.friendly_id}"
           td role="cell" data-label="Month"

--- a/app/views/provider/admin/cms/groups/index.html.erb
+++ b/app/views/provider/admin/cms/groups/index.html.erb
@@ -19,7 +19,7 @@
 
   <tbody role="rowgroup">
     <% @groups.each do |group| %>
-      <%= content_tag_for :tr, group, role: 'row' do %>
+      <%= content_tag :tr, id: dom_id(group), role: 'row' do %>
         <td role="cell" data-label="Name"><%= link_to h(group.name), edit_provider_admin_cms_group_path(group) %></td>
         <td role="cell" data-label="Allowed Sections"><%= group.sections.map(&:title).join(", ") %></td>
         <td role="cell" class="pf-c-table__action actions">

--- a/app/views/provider/admin/cms/sections/index.html.erb
+++ b/app/views/provider/admin/cms/sections/index.html.erb
@@ -8,11 +8,11 @@
     </tr>
 
   <% @sections.each do |section| %>
-    <%= content_tag_for :tr, section do %>
+    <tr>
       <td><%= section.title %></td>
       <td><%= link_to 'Edit', edit_provider_admin_cms_section_path(section) %></td>
       <td><%= link_to 'Destroy', provider_admin_cms_section_path(section), data: {:confirm => 'Are you sure?'}, :method => :delete %></td>
-    <% end %>
+    </tr>
   <% end %>
   </table>
 

--- a/app/views/provider/admin/cms/sections/index.html.erb
+++ b/app/views/provider/admin/cms/sections/index.html.erb
@@ -8,11 +8,11 @@
     </tr>
 
   <% @sections.each do |section| %>
-    <tr>
+    <%= content_tag :tr, id: dom_id(section) do %>
       <td><%= section.title %></td>
       <td><%= link_to 'Edit', edit_provider_admin_cms_section_path(section) %></td>
       <td><%= link_to 'Destroy', provider_admin_cms_section_path(section), data: {:confirm => 'Are you sure?'}, :method => :delete %></td>
-    </tr>
+    <% end %>
   <% end %>
   </table>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1663,6 +1663,11 @@ en:
         invalid_event: 'cannot transition when %{state}'
         invalid_transition: 'cannot transition via "%{event}"'
         not_path_format: 'must be a path separated by "/". E.g. "" or "my/path"'
+      template:
+        header:
+          one: "1 error prohibited this %{model} from being saved"
+          other: "%{count} errors prohibited this %{model} from being saved"
+        body: "There were problems with the following fields:"
       models:
         access_token:
           attributes:

--- a/features/step_definitions/finance/invoicing_steps.rb
+++ b/features/step_definitions/finance/invoicing_steps.rb
@@ -80,9 +80,9 @@ end
 
 Then(/^I should (?:see|still see) (\d+) invoices?$/) do |count|
   if count.to_i == 0
-    page.should have_no_css('tr.invoice')
+    should have_no_xpath("//tr[contains(@id, 'invoice_')]")
   else
-    page.should have_css('tr.invoice', count: count.to_i)
+    should have_xpath("//tr[contains(@id, 'invoice_')]", count: count.to_i)
   end
 end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The features implemented by these gems were removed from Rails at some point and extracted into separate gems. But I think it's better to get rid of them, because they are causing some dependencies issues when upgrading Rails to 7.1, and might cause more in future.

1. `record_tag_helper` transforms
```
<%= content_tag_for(:tr, @article) do %>
```
into 
```
<tr id="article_1234" class="article">
```
so, adds a class, and the ID of the element.

See more at https://github.com/rails/record_tag_helper

I think it's unnecessary, and can be simply removed. I replaced some occurrences with a plain `tr` tag, and for others, that required adding something extra, like an ID, I used `content_tag`, which is very similar to `content_tag_for`, just that it does not use the model attributes.

2. `dynamic_form` gem is ancient, it has not been updated in 14 years. Apparently, we were only using `f.error_messages` on form builders (see [source](https://github.com/joelmoss/dynamic_form/blob/master/lib/action_view/helpers/dynamic_form.rb#L284-L286))

It's worth noting that [`error_messages_for`](https://github.com/joelmoss/dynamic_form/blob/master/lib/action_view/helpers/dynamic_form.rb#L186-L240) which actually is the main method of `dynamic_form` for this "errors" feature, is overriden in the [porta code](https://github.com/3scale/porta/blob/dc978ade606567eae1f62db3b47eae6e670e63f4/app/helpers/application_helper.rb#L224-L266) anyway. So, it was actually pretty easy to get rid of this.
Just for reference, the feature takes care of this error block:
![image](https://github.com/user-attachments/assets/4852df5f-e9d8-4b6b-b61f-3cddfceefe5a)

We only have it in the CMS editor and in Fields Definitions editor.
The easiest way to simulate the error is to add something like this in the controller:
```
    @page.errors.add(:layout, "something is wrong")
    @page.errors.add(:base, "this doesn't look good")
```

Now, I'm not sure whether the place where I've added `error_messages` is the best - well, at least the interface has not changed.
But I don't like having had to include two modules there. Maybe `error_messages_for` should actually be in some other place, not ApplicationHelper. But well, I think it works fine.

**Which issue(s) this PR fixes** 

not registered, it's part of Rails upgrade

**Verification steps** 


**Special notes for your reviewer**:
