### PR TITLE
Add script to suspend inactive providers

### DIFF
--- a/script/suspend_inactive.rb
+++ b/script/suspend_inactive.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Run it with rails runner, for example:
+# $ bundle exec rails runner suspend_inactive.rb
+
+require 'progress_counter'
+
+module SuspendInactiveProviders
+
+  module_function
+
+  PLANS = [
+    2357355454121, # 2013 Enterprise (Trial)
+    2357355852196, # 90 Day Trial (50K calls/day)
+    2357355916595, # Enterprise (Eval)
+    2357355814696, # Developer
+    2357355852194, # Personal (5K calls/day)
+  ]
+
+  def scope
+    Account.providers
+           .includes(:bought_cinstances)
+           .where(state: 'approved')
+           .where(bought_cinstances: { first_daily_traffic_at: ..6.months.ago })
+           .where(bought_cinstances: { plan_id: PLANS })
+  end
+
+  def call
+    total = scope.count
+    puts "Providers count: #{total}"
+
+    providers = scope.find_each
+
+    each_with_progress_counter(providers, total) do |provider|
+      provider.suspend
+    end
+  end
+
+  def each_with_progress_counter(enumerable, count)
+    progress = ProgressCounter.new(count)
+    enumerable.each do |element|
+      progress.call
+      yield element
+    end
+  end
+end
+
+SuspendInactiveProviders.call


### PR DESCRIPTION
**What this PR does / why we need it**:

I wrote this script to suspend inactive providers in SaaS. The intention is not to merge this PR, but use it to review. Then I'll close the PR and run the script on production.

Providers must be suspended if they meet these requirements:

1. Don't have any traffic in the last 6 months
2. Belong to one of these plans:
    - Personal (5K calls/day): `2357355852194`
    - Developer: `2357355814696`
    - Enterprise (Eval): `2357355916595`
    - 90 Day Trial (50K calls/day): `2357355852196`
    - 2013 Enterprise (Trial): `2357355454121`

There are exactly 1757 accounts matching the criteria, which is consistent with the issue description.

I ran this script in staging and took some notes:

1. It takes several minutes to complete.
2. The impact in memory is very small.
3. The impact in CPU is what you can expect during the script execution and Sidekiq jobs performing.
4. Impact in MySQL is also very small.
5. No single email is sent during the process.
6. I observed many `ReverseProviderKeyWorker` jobs failing in Sidekiq, always with the same error: `ThreeScale::Core::ProviderKeyNotFound: Provider key="XXXX" does not exist`

I'm not sure what's the error about. It seems to me this happens because the job changes the provider key and tries to sync backend, but the key doesn't exist in backend (don't know why). @mayorova @akostadinov any ideas?

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11862

**Verification steps** 

After running the script, the company is not destroyed.
