### PR TITLE
THREESCALE-10168: Add default notification preferences to new users

### DIFF
--- a/app/models/notification_preferences.rb
+++ b/app/models/notification_preferences.rb
@@ -16,7 +16,11 @@ class NotificationPreferences < ApplicationRecord
 
   self.available_notifications = NotificationMailer.available_notifications.freeze
 
-  self.disabled_by_default  = %i(post_created weekly_report daily_report).freeze
+  self.disabled_by_default  = %i[application_created cinstance_cancellation cinstance_expired_trial
+                                 cinstance_plan_changed account_created account_deleted
+                                 unsuccessfully_charged_invoice_provider service_contract_cancellation
+                                 service_contract_created service_contract_plan_changed plan_downgraded service_deleted
+                                 post_created weekly_report daily_report].freeze
   self.enabled_by_default   = (available_notifications - disabled_by_default).freeze
   self.hidden_notifications = NotificationMailer.hidden_notifications.freeze
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,14 @@ class User < ApplicationRecord
           redacted: %i[password_digest].freeze
 
   before_validation :trim_white_space_from_username
+  # after_validation :reset_lost_password_token
+
+  after_create :set_default_notification_preferences
+
   before_destroy :avoid_destruction
+  after_destroy :archive_as_deleted
+
+  after_save :nullify_authentication_id, if: :any_sso_authorizations?
 
   include WebHooksHelpers #TODO: make this inclusion more dsl-ish
   fires_human_web_hooks_on_events
@@ -127,10 +134,7 @@ class User < ApplicationRecord
 
   attr_accessible :member_permission_service_ids, :member_permission_ids, as: %i[admin]
 
-  # after_validation :reset_lost_password_token
 
-  after_save :nullify_authentication_id, if: :any_sso_authorizations?
-  after_destroy :archive_as_deleted
 
   def self.search_states
     %w(pending active)
@@ -475,6 +479,12 @@ class User < ApplicationRecord
 
   def avoid_destruction
     throw :abort unless can_be_destroyed?
+  end
+
+  def set_default_notification_preferences
+    return unless account&.provider?
+
+    create_notification_preferences(preferences: NotificationPreferences.default_preferences)
   end
 
   class << self

--- a/features/buyers/accounts/managing.feature
+++ b/features/buyers/accounts/managing.feature
@@ -9,6 +9,7 @@ Feature: Accounts management
     And there are no events
 
   Scenario: Delete account events
+    Given admin of account "foo.3scale.localhost" has notification "account_deleted" enabled
     When the provider deletes the account named "Alexander"
       Then there should be 1 valid account deleted event
       # TODO

--- a/features/developer_portal/admin/applications/plan_change.feature
+++ b/features/developer_portal/admin/applications/plan_change.feature
@@ -4,6 +4,7 @@ Feature: Developer portal change application plan
   Background:
     Given a provider "foo.3scale.localhost"
     And admin of account "foo.3scale.localhost" has email "admin@foo.3scale.localhost"
+    And admin of account "foo.3scale.localhost" has notification "cinstance_plan_changed" enabled
     And the provider has "multiple_services" visible
     And the provider has "service_plans" visible
     And a product "The API"

--- a/features/developer_portal/signup.feature
+++ b/features/developer_portal/signup.feature
@@ -11,6 +11,9 @@ Feature: Buyer signup
 
   Scenario: Signup creates account created event
     And there are no events
+    And admin of account "foo.3scale.localhost" has notification "account_created" enabled
+    And admin of account "foo.3scale.localhost" has notification "application_created" enabled
+    And admin of account "foo.3scale.localhost" has notification "service_contract_created" enabled
     When a buyer signs up
     Then I should see "We have sent you an email to confirm your email address"
 

--- a/features/notifications/signup.feature
+++ b/features/notifications/signup.feature
@@ -5,6 +5,9 @@ Feature: Notifications
 
   Scenario: Provider Signup Notification
     Given the master account allows signups
+    And admin of account "Master account" has notification "account_created" enabled
+    And admin of account "Master account" has notification "application_created" enabled
+    And admin of account "Master account" has notification "service_contract_created" enabled
     When a provider signs up and activates his account
       Then the master should have plenty of notifications
       And the provider should not have any notifications

--- a/features/old/finance/reporting/buyer.feature
+++ b/features/old/finance/reporting/buyer.feature
@@ -12,6 +12,7 @@ Feature: Billing Reporting
       And all the rolling updates features are off
       And the provider is charging its buyers
       And admin of account "foo.3scale.localhost" has email "admin@foo.3scale.localhost"
+    And admin of account "foo.3scale.localhost" has notification "unsuccessfully_charged_invoice_provider" enabled
       And the default service of the provider has name "My API"
       And the following application plans:
         | Product | Name          | Cost per month |

--- a/features/old/sort_out_these/providers/usage_reports.feature
+++ b/features/old/sort_out_these/providers/usage_reports.feature
@@ -7,7 +7,7 @@ Feature: Usage reports
     Given all the rolling updates features are off
       And a provider "foo.3scale.localhost"
       And admin of account "foo.3scale.localhost" has email "fake@email.com"
-      And admin of account "foo.3scale.localhost" has notification weekly_report enabled
+      And admin of account "foo.3scale.localhost" has notification "weekly_report" enabled
 
   Scenario: usage report sent weekly
     When weekly reports are dispatched

--- a/features/step_definitions/notification_preferences_steps.rb
+++ b/features/step_definitions/notification_preferences_steps.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-Given "admin of {account} has notification {symbol} {enabled}" do |account, key, enabled|
-  account.admins.first.create_notification_preferences(preferences: NotificationPreferences.default_preferences.merge(key => enabled))
+Given "admin of {account} has notification {string} {enabled}" do |account, key, enabled|
+  admin = account.first_admin
+  admin.notification_preferences.preferences = admin.notification_preferences.preferences.merge(key => enabled)
+  admin.notification_preferences.save!
 end
 
 Given /^(?:I|they) check only the following notifications:$/ do |table|

--- a/test/factories/notification.rb
+++ b/test/factories/notification.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory(:notification) do
     association :user, factory: :simple_user
     association :event
-    system_name { NotificationMailer.event_mapping.keys.first.to_s }
+    system_name { NotificationPreferences.enabled_by_default.first.to_s }
   end
 
   factory(:notification_with_parent_event, parent: :notification) do

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -63,6 +63,7 @@ class NotificationsTest < ActiveSupport::TestCase
       @provider = FactoryBot.create(:provider_account)
       @admin = @provider.admins.first
       @admin.update(email: "provider-admin@example.com")
+      @admin.notification_preferences.update(enabled_notifications: %i[application_created])
 
       @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
       @plan  = FactoryBot.create(:application_plan, issuer: @provider.default_service)

--- a/test/integration/provider/admin/applications/applications_controller_test.rb
+++ b/test/integration/provider/admin/applications/applications_controller_test.rb
@@ -39,6 +39,9 @@ class Provider::Admin::ApplicationsTest < ActionDispatch::IntegrationTest
   class ProviderLoggedInTest < Provider::Admin::ApplicationsTest
     setup do
       @provider = FactoryBot.create(:provider_account)
+
+      @provider.first_admin.notification_preferences.update(enabled_notifications: %i[cinstance_plan_changed])
+
       login! @provider
     end
 

--- a/test/test_helpers/provider.rb
+++ b/test/test_helpers/provider.rb
@@ -69,7 +69,6 @@ module TestHelpers
           buyer.save!
           FactoryBot.create(:referrer_filter, application: provider.application_contracts.take)
           FactoryBot.create(:partner, providers: [provider], )
-          NotificationPreferences.create(user: provider.admin_user)
           FactoryBot.create(:prepaid_billing, account: provider)
           service.proxy.gateway_configuration.save!
 

--- a/test/unit/logic/plan_changes_test.rb
+++ b/test/unit/logic/plan_changes_test.rb
@@ -53,6 +53,8 @@ class Logic::PlanChangesTest < ActiveSupport::TestCase
       @buyer = @app.buyer_account
       @user = @buyer.first_admin
       User.stubs(:current).returns(@user)
+
+      @provider.first_admin.notification_preferences.update(enabled_notifications: %i[cinstance_plan_changed application_plan_change_requested])
     end
 
     test '#buyer_changes_plan! - :direct' do

--- a/test/unit/observers/cinstance_observer_test.rb
+++ b/test/unit/observers/cinstance_observer_test.rb
@@ -12,6 +12,8 @@ class CinstanceObserverTest < ActiveSupport::TestCase
 
     @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
 
+    @provider.first_admin.notification_preferences.update(enabled_notifications: %i[application_created cinstance_cancellation cinstance_plan_changed])
+
     Logic::RollingUpdates.stubs(skipped?: true)
   end
 

--- a/test/unit/observers/post_observer_test.rb
+++ b/test/unit/observers/post_observer_test.rb
@@ -8,7 +8,7 @@ class PostObserverTest < ActiveSupport::TestCase
     forum    = FactoryBot.create(:forum, account: provider)
     topic    = FactoryBot.create(:topic, forum: forum)
     admin    = provider.first_admin
-    admin.create_notification_preferences!(preferences: { post_created: true })
+    admin.notification_preferences.update(preferences: { post_created: true })
     user     = FactoryBot.create(:user, account: provider)
 
     assert_difference(Notification.where(title: "New forum post by #{user.username}").method(:count), +1) do

--- a/test/unit/pdf/report_test.rb
+++ b/test/unit/pdf/report_test.rb
@@ -13,7 +13,7 @@ class Pdf::ReportTest < ActiveSupport::TestCase
 
     test 'send_notification!' do
       user = FactoryBot.create(:simple_user, role: :admin, account: @account)
-      user.create_notification_preferences!(enabled_notifications: %w[daily_report])
+      user.notification_preferences.update(enabled_notifications: %w[daily_report])
 
       assert_difference ActionMailer::Base.deliveries.method(:count) do
         assert @report.send_notification!

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -900,4 +900,22 @@ class UserTest < ActiveSupport::TestCase
     assert_equal session1, user.user_sessions.reload.first
     assert_equal 1, user.user_sessions.reload.length
   end
+
+  test 'new provider users have notification preferences' do
+    provider = FactoryBot.create :simple_provider
+    user = FactoryBot.build :user, account: provider
+
+    user.save
+
+    assert user.notification_preferences.persisted?
+  end
+
+  test "new buyer users don't have notification preferences" do
+    buyer = FactoryBot.create :simple_buyer
+    user = FactoryBot.build :user, account: buyer
+
+    user.save
+
+    assert_not user.notification_preferences.persisted?
+  end
 end

--- a/test/workers/delete_object_hierarchy_worker_test.rb
+++ b/test/workers/delete_object_hierarchy_worker_test.rb
@@ -621,6 +621,8 @@ class DeleteObjectHierarchyWorkerTest < ActiveSupport::TestCase
           true
         when MessageRecipient
           object.receiver == master_account
+        when NotificationPreferences
+          object_of_master?(object.user)
         when Plan
           object_of_master?(object.issuer) if object.issuer
         when Post, Topic, TopicCategory

--- a/test/workers/process_notification_event_worker_test.rb
+++ b/test/workers/process_notification_event_worker_test.rb
@@ -23,7 +23,7 @@ class ProcessNotificationEventWorkerTest < ActiveSupport::TestCase
     notification = NotificationEvent.create_and_publish!(:invoices_to_review, event)
     user         = FactoryBot.create(:simple_admin, state: :active, account: provider)
 
-    user.create_notification_preferences!(preferences: { invoices_to_review: true })
+    user.notification_preferences.update(preferences: { invoices_to_review: true })
 
     Sidekiq::Testing.inline! do
       assert_difference Notification.method(:count) do
@@ -113,7 +113,7 @@ class ProcessNotificationEventWorkerTest < ActiveSupport::TestCase
     notification = NotificationEvent.create_and_publish!(:invoices_to_review, event)
     user         = FactoryBot.create(:simple_admin, account: provider)
 
-    user.create_notification_preferences!(preferences: { invoices_to_review: true })
+    user.notification_preferences.update(preferences: { invoices_to_review: true })
 
     Notification.any_instance.stubs(:deliver!).raises(
       ::NotificationDeliveryService::InvalidEventError.new(event))


### PR DESCRIPTION
**What this PR does / why we need it**:

It's good to add some default notification preferences to the DB when a new user is created. This won't change the behavior since porta builds some in-memory notifications when there's no record in the DB. The difference is that having a record in the DB allows us to obfuscate it in staging, so we have a way to disable notifications for all provider users in that environment.

In this PR, I also modified the default notification preferences. Before, the only preferences disabled were:

```
post_created
weekly_report
daily_report
```

Now, everything is disabled. Except:

```
limit_alert_reached_provider
limit_violation_reached_provider
account_plan_change_requested
application_plan_change_requested
service_plan_change_requested
invoices_to_review
credit_card_unstore_failed
expired_credit_card_provider
unsuccessfully_charged_invoice_final_provider
message_received
csv_data_export
```
The aim is to reduce the amount of notifications being sent by default, so we can save resources in Sendgrid.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10168

**Verification steps** 

Create a new user by:

1. api: `POST /admin/api/users.json`
2. invitation
3. SSO singup

In all cases a new record in the `notification_preferences` table should be added for the new user.
