### PR TITLE
THREESCALE-11879: Order backend API mapping rules

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -19,7 +19,7 @@ class BackendApi < ApplicationRecord
   after_create :create_default_metrics
   before_destroy :avoid_destruction
 
-  has_many :proxy_rules, as: :owner, dependent: :destroy, inverse_of: :owner
+  has_many :proxy_rules, -> { order(position: :asc) }, as: :owner, dependent: :destroy, inverse_of: :owner
   has_many :metrics, as: :owner, dependent: :destroy, inverse_of: :owner
   alias_method :all_metrics, :metrics
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There was no defined order on backend APIs, so the order was defined by the database, and it is error-prone and unpredictable.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11879

**Verification steps** 

The mapping rules should be ordered by position at least in:
- the configuration JSON, found at `/apiconfig/services/{SERVICE_ID}/proxy_configs?environment=staging`
- on the backend API mapping rule page: `/p/admin/backend_apis/{BACKEND_API_ID}/mapping_rules`
- in the API responses, e.g. `/admin/api/backend_apis/{BACKEND_API_ID}/mapping_rules.json`

**Special notes for your reviewer**:
