### PR TITLE
Cherry-picking to 2.16: Order backend API mapping rules

### DIFF
--- a/app/models/backend_api.rb
+++ b/app/models/backend_api.rb
@@ -19,7 +19,7 @@ class BackendApi < ApplicationRecord
   after_create :create_default_metrics
   before_destroy :avoid_destruction
 
-  has_many :proxy_rules, as: :owner, dependent: :destroy, inverse_of: :owner
+  has_many :proxy_rules, -> { order(position: :asc) }, as: :owner, dependent: :destroy, inverse_of: :owner
   has_many :metrics, as: :owner, dependent: :destroy, inverse_of: :owner
   alias_method :all_metrics, :metrics
 


### PR DESCRIPTION
cherry-picking https://github.com/3scale/porta/pull/4100 to `3scale-2.16-stable`.