### PR TITLE
Fix selected item in vert nav for CMS versions

### DIFF
--- a/app/controllers/provider/admin/cms/versions_controller.rb
+++ b/app/controllers/provider/admin/cms/versions_controller.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class Provider::Admin::CMS::VersionsController < Provider::Admin::CMS::BaseController
 
-  activate_menu :audience, :cms
+  activate_menu :audience, :cms, :content
 
   def index
     @page = page


### PR DESCRIPTION
[THREESCALE-9928: Wrong item in vertical nav selected](https://issues.redhat.com/browse/THREESCALE-9928)

Before:
![Screenshot 2025-07-09 at 13 37 05](https://github.com/user-attachments/assets/d9c111c8-e762-4eae-a055-8f9491e9cd90)

After:
![Screenshot 2025-07-09 at 13 37 11](https://github.com/user-attachments/assets/bc772291-559f-4f70-aba3-835ab6f00e94)
