### PR TITLE
Fix screenshots on failing cucumbers tests

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# IMPORTANT: make sure this hook is defined **before** the one that saves screenshots,
+# because the After hooks run in the reverse order in which they are defined.
+After("@javascript") do
+  Capybara.page&.driver&.quit
+end
+
 Around '@security' do |scenario, block|
   with_forgery_protection(&block)
 end
@@ -198,10 +204,6 @@ After do |scenario| # rubocop:disable Metrics/BlockLength
   rescue Capybara::NotSupportedByDriverError
     # and that is fine! rack-test does not support screenshots
   end
-end
-
-After("@javascript") do
-  Capybara.page&.driver&.quit
 end
 
 After do |scenario|


### PR DESCRIPTION
**What this PR does / why we need it**:

No more blank screenshots and empty HTMLs :face_holding_back_tears: 

The reason is that the `After` hook that shuts down the driver (introduced in https://github.com/3scale/porta/commit/5be8becd679b3c608ac47fa70164bafe220c18e7 for improving memory management) was running **before** the screenshot was performed :upside_down_face: 

Apparently, the `After` hooks in cucumber are executed in the reverse order in which they are defined.
