### PR TITLE
`SuspendInactiveAccountsWorker`: Make it iterable

### DIFF
--- a/app/workers/suspend_inactive_accounts_worker.rb
+++ b/app/workers/suspend_inactive_accounts_worker.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class SuspendInactiveAccountsWorker
-  include Sidekiq::Job
+  include Sidekiq::IterableJob
 
-  def perform
-    AutoAccountDeletionQueries.should_be_suspended.find_each(&:suspend!)
+  def build_enumerator(cursor:)
+    active_record_records_enumerator(AutoAccountDeletionQueries.should_be_suspended, cursor:)
+  end
+
+  def each_iteration(account)
+    account.suspend
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

The next change caused a regression that broke `SuspendInactiveAccountsWorker`:

https://github.com/3scale/porta/commit/34857265eac8620ec1122be2b87a42c61ab49055#diff-b3ff5e3df6b875e9ecfde657ae21de84f4f43c942d3232761ed550cf0eecbce0

PR: https://github.com/3scale/porta/pull/3063

When creating a new account, the domain is generated from the name. In the process, the `parameterize` method is called:

https://github.com/3scale/porta/blob/34857265eac8620ec1122be2b87a42c61ab49055/app/lib/signup/domains_builder.rb#L18

This caused errors. When `org_name` was entirely composed of special characters, the resulting domain was empty, which prevented creating the account. In order to improve that, https://github.com/3scale/porta/pull/3063 adds a new validation to forbid special characters in org names. This doesn't solve the problem but at least returns a more meaningful error message in that scenario.

We have a few accounts in SaaS with invalid names (see the list in the linked issue). Those accounts can't be updated anymore because of the validation error.

Many if not all of those accounts are inactive and `SuspendInactiveAccountsWorker` tries to suspend them. Due to the validation problem, the job fails, get rescheduled, and fails again repeatedly until it gets killed by Sidekiq.

This PR adds a few changes to the job, first, it replaces the call to `suspend!` by `suspend`. That way, when an account fails to be suspended, the job doesn't crash and it eventually finishes correctly. All accounts in the scope will be suspended except the failing ones which will remain active.

On the other hand, the job has been converted to an `IterableJob`. This way if the job crashes for some reason, it will be resumed at some point in the 5 seconds interval before crashing. Check this source for more info: https://www.mikeperham.com/2024/07/03/iteration-and-sidekiq-7.3.0/

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-10097

**Verification steps** 

1. Create a few tenants locally.
2. Edit the DB table directly to rename some of them to have names including special characters
3. Manually edit `AutoAccountDeletionQueries#should_be_suspended` to return a scope which includes the renamed accounts.
4. Launch Sidekiq, open a Rails console and execute: `SuspendInactiveAccountsWorker.perform_async`
5. All providers in the scope should be suspended except those with special characters in the name
6. The job should finish successfully without errors.
