### PR TITLE
THREESCALE-10097: `Account`, `org_name` validate on create

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -263,11 +263,11 @@ class Account < ApplicationRecord
 
   # TODO: multitenant. enable it?
   # validates_uniqueness_of :s3_prefix
-  validates :org_name, presence: true, length: { maximum: 255 },
-                       format: { with: /\A.*[a-zA-Z0-9]+.*\z/, message: :invalid_format }
+  validates :org_name, presence: true
+  validates :org_name, format: { with: /\A.*[a-zA-Z0-9]+.*\z/, message: :invalid_format }, on: :create
 
 
-  validates :org_legaladdress, :domain, :telephone_number, :site_access_code,
+  validates :org_name, :org_legaladdress, :domain, :telephone_number, :site_access_code,
             :billing_address_name, :billing_address_address1, :billing_address_address2, :billing_address_city,
             :billing_address_state, :billing_address_country, :billing_address_zip, :billing_address_phone,
             :org_legaladdress_cont, :city, :state_region, :state, :timezone, :from_email, :primary_business,

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -578,10 +578,16 @@ class AccountTest < ActiveSupport::TestCase
     assert account.valid?
   end
 
-  test "there should be at least one alphanum character anywhere in the org_name" do
+  test "there should be at least one alphanum character anywhere in the org_name during account creation" do
     account = FactoryBot.build(:simple_account, org_name: '.?+@')
     assert_not account.valid?
     assert_includes account.errors.messages[:org_name], "must contain at least one alphanumeric character"
+  end
+
+  test "allows no alphanum characters in the org_name on update" do
+    account = FactoryBot.create(:simple_account, org_name: 'name')
+    account.org_name = '.?+@'
+    assert account.valid?
   end
 
   class DestroyTest < ActiveSupport::TestCase


### PR DESCRIPTION
**What this PR does / why we need it**:

Enforce `org_name` special characters validation only on create, so the domain can be created correctly. On udpate, we accept special characters, so the accounts already having special characters in the name don't become immutable.

**Which issue(s) this PR fixes** 

[THREESCALE-10097](https://issues.redhat.com/browse/THREESCALE-10097)

**Verification steps** 

- Create a new tenant with only special characters in the name
  - You should get errors: `"Domain can't be blank"` and `"Organization/Group Name must contain at least one alphanumeric character"`
- Create a new tenant with special characters: Should work
- Update a tenant with only special characters in the name: Should work

