### PR TITLE
Fix the unit test for SuspendInactiveAccountsWorker

### DIFF
--- a/test/workers/suspend_inactive_accounts_worker_test.rb
+++ b/test/workers/suspend_inactive_accounts_worker_test.rb
@@ -26,7 +26,7 @@ class SuspendInactiveAccountsWorkerTest < ActiveSupport::TestCase
 
   test 'ignores accounts that fail to validate' do
     valid_tenant = FactoryBot.create(:simple_provider)
-    invalid_tenant = FactoryBot.build(:simple_provider, org_name: '@@@')
+    invalid_tenant = FactoryBot.build(:simple_provider, org_name: '')
     invalid_tenant.save!(validate: false)
 
     AutoAccountDeletionQueries.expects(:should_be_suspended).returns(Account.where(id: [valid_tenant.id, invalid_tenant.id]))


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the error that resulted because of the combination of https://github.com/3scale/porta/pull/4114 and https://github.com/3scale/porta/pull/4118
