### PR TITLE
Fix a unit test for SuspendInactiveAccountsWorker for invalid accounts

### DIFF
--- a/test/workers/suspend_inactive_accounts_worker_test.rb
+++ b/test/workers/suspend_inactive_accounts_worker_test.rb
@@ -26,7 +26,9 @@ class SuspendInactiveAccountsWorkerTest < ActiveSupport::TestCase
 
   test 'ignores accounts that fail to validate' do
     valid_tenant = FactoryBot.create(:simple_provider)
-    invalid_tenant = FactoryBot.build(:simple_provider, org_name: '')
+    # a blank, but not an empty value, because an empty string causes
+    # OCIError: ORA-01400: cannot insert NULL into ("RAILS"."ACCOUNTS"."ORG_NAME")
+    invalid_tenant = FactoryBot.build(:simple_provider, org_name: ' ')
     invalid_tenant.save!(validate: false)
 
     AutoAccountDeletionQueries.expects(:should_be_suspended).returns(Account.where(id: [valid_tenant.id, invalid_tenant.id]))


### PR DESCRIPTION
A follow-up for https://github.com/3scale/porta/pull/4119 :sweat_smile: 