### PR TITLE
THREESCALE-11640: Add support for ReCAPTCHA enterprise

### DIFF
--- a/config/examples/settings.yml
+++ b/config/examples/settings.yml
@@ -23,6 +23,9 @@ base: &default
   readonly_custom_domains_settings: <%= ENV.fetch('READONLY_CUSTOM_DOMAINS_SETTINGS', '0') == '1' %>
   recaptcha_private_key: <%= ENV['RECAPTCHA_PRIVATE_KEY'] %>
   recaptcha_public_key: <%= ENV.fetch('RECAPTCHA_PUBLIC_KEY', 'YOUR_RECAPTCHA_PUBLIC_KEY') %>
+  recaptcha_enterprise_api_key: <%= ENV['RECAPTCHA_ENTERPRISE_API_KEY'] %>
+  recaptcha_enterprise_project_id: <%= ENV.fetch('RECAPTCHA_ENTERPRISE_PROJECT_ID', 'YOUR_RECAPTCHA_ENTERPRISE_PROJECT_ID') %>
+  recaptcha_enterprise_enabled: <%= ENV.fetch('RECAPTCHA_ENTERPRISE_ENABLED', '0') == '1' %>
   recaptcha_min_bot_score: <%= ENV.fetch('RECAPTCHA_MIN_BOT_SCORE', '0.5') %>
   report_traffic: false
   secure_cookie: <%= ENV.fetch('FORCE_SSL', '1') == '1' %>

--- a/config/examples/settings.yml
+++ b/config/examples/settings.yml
@@ -23,9 +23,7 @@ base: &default
   readonly_custom_domains_settings: <%= ENV.fetch('READONLY_CUSTOM_DOMAINS_SETTINGS', '0') == '1' %>
   recaptcha_private_key: <%= ENV['RECAPTCHA_PRIVATE_KEY'] %>
   recaptcha_public_key: <%= ENV.fetch('RECAPTCHA_PUBLIC_KEY', 'YOUR_RECAPTCHA_PUBLIC_KEY') %>
-  recaptcha_enterprise_api_key: <%= ENV['RECAPTCHA_ENTERPRISE_API_KEY'] %>
-  recaptcha_enterprise_project_id: <%= ENV.fetch('RECAPTCHA_ENTERPRISE_PROJECT_ID', 'YOUR_RECAPTCHA_ENTERPRISE_PROJECT_ID') %>
-  recaptcha_enterprise_enabled: <%= ENV.fetch('RECAPTCHA_ENTERPRISE_ENABLED', '0') == '1' %>
+  recaptcha_project_id: <%= ENV.fetch('RECAPTCHA_PROJECT_ID', nil) %>
   recaptcha_min_bot_score: <%= ENV.fetch('RECAPTCHA_MIN_BOT_SCORE', '0.5') %>
   report_traffic: false
   secure_cookie: <%= ENV.fetch('FORCE_SSL', '1') == '1' %>

--- a/config/initializers/captchas.rb
+++ b/config/initializers/captchas.rb
@@ -2,9 +2,12 @@
 
 Recaptcha.configure do |config|
   # Do not verify recaptcha keys if it is not correctly configured
-  (config.skip_verify_env ||= []) << Rails.env if Rails.configuration.three_scale.recaptcha_private_key.blank?
+  (config.skip_verify_env ||= []) << Rails.env if Rails.configuration.three_scale.recaptcha_public_key.blank?
   config.site_key = Rails.configuration.three_scale.recaptcha_public_key
   config.secret_key = Rails.configuration.three_scale.recaptcha_private_key
+  config.enterprise = Rails.configuration.three_scale.recaptcha_enterprise_enabled
+  config.enterprise_api_key = Rails.configuration.three_scale.recaptcha_enterprise_api_key
+  config.enterprise_project_id = Rails.configuration.three_scale.recaptcha_enterprise_project_id
 end
 
 module Recaptcha

--- a/config/initializers/captchas.rb
+++ b/config/initializers/captchas.rb
@@ -3,11 +3,16 @@
 Recaptcha.configure do |config|
   # Do not verify recaptcha keys if it is not correctly configured
   (config.skip_verify_env ||= []) << Rails.env if Rails.configuration.three_scale.recaptcha_public_key.blank?
+
+  config.enterprise = Rails.configuration.three_scale.recaptcha_project_id.present?
   config.site_key = Rails.configuration.three_scale.recaptcha_public_key
-  config.secret_key = Rails.configuration.three_scale.recaptcha_private_key
-  config.enterprise = Rails.configuration.three_scale.recaptcha_enterprise_enabled
-  config.enterprise_api_key = Rails.configuration.three_scale.recaptcha_enterprise_api_key
-  config.enterprise_project_id = Rails.configuration.three_scale.recaptcha_enterprise_project_id
+
+  if config.enterprise
+    config.enterprise_api_key = Rails.configuration.three_scale.recaptcha_private_key
+    config.enterprise_project_id = Rails.configuration.three_scale.recaptcha_project_id
+  else
+    config.secret_key = Rails.configuration.three_scale.recaptcha_private_key
+  end
 end
 
 module Recaptcha


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the situation with ReCAPTCHA right now:

- All classic keys are going to be migrated to ReCAPTCHA enterprise at Google Cloud by the end of 2025. That means all keys for our clients on premises, also SaaS keys.
- There are no code changes required. I verified this: I migrated our test key `Test recaptcha 3` to my Google Cloud account and everything works for us. So both SaaS and onpremises will continue to work after the end of 2025.
- At some point in the future, Google will probably stop supporting classic key pairs in their API, but there is no deadline for this AFAIK. If this happens, we should support enterprise keys to not disrupt our users.
- While investigating this, I found adding such support for enterprise keys is almost trivial, so I did it in this PR.
- Enterprise keys grant access to new [features](https://cloud.google.com/recaptcha/docs/using-features), but supporting those features would imply bigger code changes, like stop supporting classic keys or creating a new React component, so I discarded this for now. If a client complains we can consider implementing this.

This table summarizes our support for ReCAPTCHA before and after this PR

||Before|After|
|---|---|---|
|Classic|:white_check_mark:|:white_check_mark:|
|Enterprise w/ classic features|:x:|:white_check_mark:|
|Enterprise fully featured|:x:|:x:|

**About the key migration**

Old classic keys are pairs of keys, we set them to porta through env variables:

`RECAPTCHA_PUBLIC_KEY`
`RECAPTCHA_PRIVATE_KEY`

New enterprise keys are only one key, called **Key ID**. But must be sent to Google along with the **project id** and an **API key**.

- **Project id** is the Google cloud project where key ID and API key belong to.
- **Key ID** is the equivalent to the old public key. It identifies the resource but it's not secret.
- **API Key** is a key that must be created from Google Cloud console and must be given ReCAPTCHA permissions. This one is secret.

On migration, the old public key is converted to a key id under a google cloud project. The API key must be created manually by the user.

I created some env variables to provide these parameters to porta:

- `RECAPTCHA_ENTERPRISE_ENABLED`: This tells porta either to use the classic or the enterprise backend, Defaults to `0`
- `RECAPTCHA_ENTERPRISE_PROJECT_ID`
- `RECAPTCHA_ENTERPRISE_API_KEY`

For the Key ID, we reuse `RECAPTCHA_PUBLIC_KEY`, that way we are aligned with backward compatibility as Google implements it.

**Which issue(s) this PR fixes** 

[THREESCALE-11640](https://issues.redhat.com/browse/THREESCALE-11640)

**Verification steps** 

There are 4 scenarios that must work:

1. Classic keys, not migrated
2. Migrated keys being used as classic keys
3. Migrated keys being used as enterprise keys
4. Enterprise keys

Ask me if you want me to give you test keys or tell you how to create them.
