### PR TITLE
compatibility fix for Ruby 3.1 vs Fedora42 gcc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,7 +436,7 @@ GEM
       responders (>= 2)
     injectedlogger (0.0.13)
     innertube (1.1.0)
-    io-console (0.8.0)
+    io-console (0.5.11)
     irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)


### PR DESCRIPTION
io-console 0.8.0 fails to compile on Fedora 42.

Since it is only a dev dependency, I think better to move it back to the
default gem version coming with Ruby 3.1

We can update it to the default version of next ruby we upgrade to.