### PR TITLE
workflow_call requires inputs types now

### DIFF
--- a/.github/workflows/container-image-buildx.yml
+++ b/.github/workflows/container-image-buildx.yml
@@ -3,6 +3,7 @@ on:
   workflow_call:
     inputs:
       platforms:
+        type: string
         description: comma-separated list of platforms to build for
         default: linux/amd64,linux/s390x,linux/ppc64le
 


### PR DESCRIPTION
I'm not sure whether `workflow_dispatch` workflows require input types now but this one fails presently without this.