### PR TITLE
db folder is irrelevant for code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,4 @@ ignore:
   - "features"
   - "test"
   - "spec"
+  - "db"


### PR DESCRIPTION
Basically every migration added or content added to schema files will reduce coverage and fail codecov check.

I don't think anything in this folder can apply for coverage. So lets disable it and get more meaningful stats.

I wonder if we should also add `config` to the list of ignores.