### PR TITLE
[WIP] remove to_time_preserves_timezone

### DIFF
--- a/app/lib/month.rb
+++ b/app/lib/month.rb
@@ -79,6 +79,7 @@ class Month < Range
     # This looks too convoluted, but can't really use begin.to_time / end.to_time, because
     # that returns the time in the system local time zone, but Time.zone.local returns
     # it in Rails' local time zone (which can be different apparently).
+    # Update: #to_time should keep timezone now so we may consider using it.
     time_zone = Time.zone
     my_begin = self.begin
     my_end = self.end

--- a/config/application.rb
+++ b/config/application.rb
@@ -101,11 +101,6 @@ module System
     # Reconsider whether to enable again after upgrading to Rails 7.1, where the size of the header is limited to 1KB
     config.action_view.preload_links_header = false
 
-    # TODO: remove this config to get rid of the deprecation before upgrading to Rails 7.2
-    # DEPRECATION WARNING: Support for the pre-Ruby 2.4 behavior of to_time has been deprecated and will be removed in Rails 7.2.
-    # Make Ruby preserve the timezone of the receiver when calling `to_time`.
-    config.active_support.to_time_preserves_timezone = false
-
     # Applying the patch for CVE-2022-32224 broke YAML deserialization because some classes are disallowed in the serialized YAML
     config.active_record.yaml_column_permitted_classes = [Symbol, Time, Date, BigDecimal, OpenStruct,
                                                           ActionController::Parameters,


### PR DESCRIPTION
As a follow up on Rails 7.1 upgrade, lets remove this.

The only place I identified us using `#to_time` is in

`Contract#intersect_with_unpaid_period` which is used for variable cost calculations.

This is tested from `Finance::VariableCostCalculationTest#variable line items are created`.

In that instance the period is actually dates. So `#to_time` returns the dates in the server local timezone regardless of the `to_time_preserves_timezone` setting. So the behavior shouldn't change.

But there is still a small chance where `#to_time` is called somewhere internally. And since providers should be billed in their local timezones,
I think we should simulate that - create a provider with a very different timezone from current and ensure it is billed in that specified timezone.

That's why I leave this a WIP. I'm going away for a week so feel free to pick this up :angel:

P.S. there is also `Finance::BillVariableForPlanChangedTest` where we check whether variable billing would happen in certain timezone conditions. But it doesn't seem to test an actual provider being actually billed on a server with a different time zone. 

there is also a test `Finance::VariableCostCalculationTest##calculate_variable_cost does the calculations in the timezone of the provider` but it is also heavily stubbed so I wouldn't call it trustworthy.