### PR TITLE
Fix CSS style for dev portal snippets

### DIFF
--- a/app/assets/stylesheets/provider/admin/cms/_cms_intro.scss
+++ b/app/assets/stylesheets/provider/admin/cms/_cms_intro.scss
@@ -73,6 +73,10 @@
      }
     }
   }
+
+  pre code {
+    display: block;
+  }
 }
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Before
<img width="1117" height="960" alt="Screenshot From 2025-08-14 20-06-54" src="https://github.com/user-attachments/assets/e1937eec-f13a-4535-8e52-700ebfbe1548" />

After
<img width="1117" height="960" alt="Screenshot From 2025-08-14 20-06-42" src="https://github.com/user-attachments/assets/c51a23ed-d720-4184-af0c-82a328d8bf0b" />



**Which issue(s) this PR fixes** 

no

**Verification steps** 


**Special notes for your reviewer**:
