### PR TITLE
THREESCALE-11908: Access token fixes

### DIFF
--- a/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx
+++ b/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx
@@ -183,4 +183,4 @@ const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label, tzOffset })
 const ExpirationDatePickerWrapper = (props: Props, containerId: string): void => { createReactWrapper(<ExpirationDatePicker {...props} />, containerId) }
 
 export type { ExpirationItem, Props }
-export { ExpirationDatePicker, ExpirationDatePickerWrapper }
+export { ExpirationDatePicker, ExpirationDatePickerWrapper, TIMESTAMP_FORMAT }

--- a/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx
+++ b/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import { useState } from 'react'
 import {
   Alert,
@@ -14,6 +15,8 @@ import { createReactWrapper } from 'utilities/createReactWrapper'
 import type { FunctionComponent } from 'react'
 
 import './ExpirationDatePicker.scss'
+
+const TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ'
 
 interface ExpirationItem {
   id: string;
@@ -97,6 +100,12 @@ const computeTzMismatchIcon = (tzMismatch: boolean) => {
   )
 }
 
+const computeInputDateValue = (selectedDate: Date | null) => {
+  if (!selectedDate) return ''
+
+  return moment(selectedDate).utc().format(TIMESTAMP_FORMAT)
+}
+
 interface Props {
   id: string;
   label: string | null;
@@ -113,7 +122,7 @@ const ExpirationDatePicker: FunctionComponent<Props> = ({ id, label, tzOffset })
   const fieldHint = computeFieldHint(formattedDateValue)
   const tzMismatch = computeTzMismatch(tzOffset)
   const tzMismatchIcon = computeTzMismatchIcon(tzMismatch)
-  const inputDateValue = selectedDate ? selectedDate.toISOString() : ''
+  const inputDateValue = computeInputDateValue(selectedDate)
   const fieldName = `human_${id}`
   const fieldLabel = label ?? 'Expires in'
 

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -140,7 +140,7 @@ class AccessToken < ApplicationRecord
   def expires_at=(value)
     return if value.blank?
 
-    DateTime.parse(value)
+    DateTime.strptime(value, TIMESTAMP_FORMAT)
 
     super value
   rescue StandardError
@@ -152,7 +152,7 @@ class AccessToken < ApplicationRecord
 
     return true if expires_at > Time.now.utc
 
-    errors.add :expires_at, :invalid, message: "Date must follow ISO8601 format and be future. Example: #{1.week.from_now.utc.iso8601}"
+    errors.add :expires_at, :invalid, message: "Date must follow ISO8601 format and be future. Example: #{1.week.from_now.utc.strftime(TIMESTAMP_FORMAT)}."
   end
 
   def generate_value

--- a/app/presenters/provider/admin/user/access_tokens_new_presenter.rb
+++ b/app/presenters/provider/admin/user/access_tokens_new_presenter.rb
@@ -7,7 +7,7 @@ class Provider::Admin::User::AccessTokensNewPresenter
   end
 
   def provider_timezone_offset
-    @timezone.utc_offset
+    @timezone.now.utc_offset
   end
 
   def date_picker_props

--- a/spec/javascripts/AccessTokens/components/ExpirationDatePicker.spec.tsx
+++ b/spec/javascripts/AccessTokens/components/ExpirationDatePicker.spec.tsx
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme'
+import moment from 'moment'
 
-import { ExpirationDatePicker } from 'AccessTokens/components/ExpirationDatePicker'
+import { ExpirationDatePicker, TIMESTAMP_FORMAT } from 'AccessTokens/components/ExpirationDatePicker'
 
 import type { ExpirationItem, Props } from 'AccessTokens/components/ExpirationDatePicker'
 import type { ReactWrapper } from 'enzyme'
@@ -82,8 +83,9 @@ describe('select a period', () => {
     selectItem(wrapper, targetItem)
     const inputValue = wrapper.find(`input#${defaultProps.id}`).prop('value') as string
     const inputDate = new Date(inputValue)
+    const expectedInputValue = moment(inputDate).utc().format(TIMESTAMP_FORMAT)
 
-    expect(inputValue).toEqual(inputDate.toISOString())
+    expect(inputValue).toEqual(expectedInputValue)
     expect(inputDate).toBeWithinSecondsFrom(targetDate)
   })
 })
@@ -119,8 +121,9 @@ describe('select "Custom"', () => {
       const targetDate = pickDate(wrapper)
       const inputValue = wrapper.find(`input#${defaultProps.id}`).prop('value') as string
       const inputDate = new Date(inputValue)
+      const expectedInputValue = moment(inputDate).utc().format(TIMESTAMP_FORMAT)
 
-      expect(inputValue).toEqual(inputDate.toISOString())
+      expect(inputValue).toEqual(expectedInputValue)
       expect(inputDate).toBeWithinSecondsFrom(targetDate)
     })
   })

--- a/test/unit/presenters/provider/admin/user/access_tokens_new_presenter_test.rb
+++ b/test/unit/presenters/provider/admin/user/access_tokens_new_presenter_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Provider::Admin::User::AccessTokensNewPresenterTest < ActiveSupport::TestCase
+
+  Presenter = Provider::Admin::User::AccessTokensNewPresenter
+
+  setup do
+    @provider = FactoryBot.create(:simple_provider)
+  end
+
+  test "#provider_timezone_offset always returns same offset for timezones without DST" do
+    @provider.timezone = "Minsk"
+    target = Presenter.new(@provider)
+    expected_offset = 10800
+
+    offset_winter = travel_to(Time.utc(2025, 12, 1)) { target.provider_timezone_offset }
+    offset_summer = travel_to(Time.utc(2025, 8, 1)) { target.provider_timezone_offset }
+
+    assert_equal offset_winter, offset_summer
+    assert_equal expected_offset, offset_summer
+  end
+
+  test "#provider_timezone_offset returns different offset in summer and winter, for timezones with DST" do
+    @provider.timezone = "Berlin"
+    target = Presenter.new(@provider)
+    expected_winter_offset = 3600
+    expected_summer_offset = 7200
+
+    offset_winter = travel_to(Time.utc(2025, 12, 1)) { target.provider_timezone_offset }
+    offset_summer = travel_to(Time.utc(2025, 8, 1)) { target.provider_timezone_offset }
+
+    assert_not_equal offset_winter, offset_summer
+    assert_equal expected_winter_offset, offset_winter
+    assert_equal expected_summer_offset, offset_summer
+  end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to validate expiration time for access tokens, we previously used `DateTime.parse` which accepts ISO-8601 timestamps with and without milliseconds component. That way we could accept dates from the react component, which added milliseconds; but also from API, where milliseconds were optional.

In this PR we enforce a single timestamp format, I fixed it to `'%FT%T%:z'`, without milliseconds, so I had to make a few changes in the React component to stop sending milliseconds. Also the API doesn't accept milliseconds anymore.

On the other hand, while investigating this I found a bug in the implementation: The react component always computes the offset from today's date:

https://github.com/3scale/porta/blob/86aad037fad94801bdc4169c2c31cd4a92f8be14/app/javascript/src/AccessTokens/components/ExpirationDatePicker.tsx#L68

But the server took the offset from the time zone:

https://github.com/3scale/porta/blob/86aad037fad94801bdc4169c2c31cd4a92f8be14/app/presenters/provider/admin/user/access_tokens_new_presenter.rb#L10

For time zones with DST, the offset is different in summer, but the server was always taking the offset from winter, so there was a mismatch of offsets in summer.

Now the server also takes the offset from today's date so DST is considered and it matches the offset in the React component.

I also added a couple of tests for this.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11908

**Verification steps** 

- Timestamp format enforcing
  - The UI should work without changes
  - API endpoint should accept only ISO-8601 dates without timestamp
- DST offset mismatch
  - In the new access token form, the time zone mismatch warning shouldn't appear when the time zone for the provider is the same as in the local machine, it's summer and the time zone has DST.
  - Steps to reproduce
    1. Be in a DST time zone, like most in Europe, take a plane otherwise
    2. Be in summer. Easy if you review this PR before November 2025, wait until next summer otherwise
    3. Configure the provider to set the same time zone as in your local machine
    4. You should not see the warning.