### PR TITLE
Upgrade formtastic to 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'braintree', '~> 4.25.0'
 gem 'libxml-ruby', '~> 5.0' # Optional, makes braintree faster
 gem 'bugsnag', '~> 6.26'
 gem 'cancancan', '~> 3.6.0'
-gem 'formtastic', '~> 4.0'
+gem 'formtastic', '~> 5.0'
 gem 'htmlentities', '~>4.3', '>= 4.3.4'
 # TODO: Not actively maintained https://github.com/activeadmin/inherited_resources#notice replace with respond_with and fix things the rails way
 gem 'inherited_resources', '~> 1.14.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,8 +397,8 @@ GEM
       rake
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
-    formtastic (4.0.0)
-      actionpack (>= 5.2.0)
+    formtastic (5.0.0)
+      actionpack (>= 6.0.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -1050,7 +1050,7 @@ DEPENDENCIES
   fakefs
   faraday (~> 2.0, <= 2.9)
   font-awesome-rails (~> 4.7.0.5)
-  formtastic (~> 4.0)
+  formtastic (~> 5.0)
   hashie
   hiredis-client
   html-pipeline (~> 2.14.3)


### PR DESCRIPTION
**What this PR does / why we need it**:

We upgraded to Rails 7.1 in https://github.com/3scale/porta/pull/4089, but the formtastic version that we use (4.0) does not fully support it, because support for 7.1 was added in version 5.0, see the formtastic [CHANGELOG](https://github.com/formtastic/formtastic/blob/master/CHANGELOG.md#500).

This results in a deprecation warning being reported in BugSnag (in staging, which is where Rails 7.1 is currently deployed).

```
DeprecationWarning provider/admin/account/users#edit
DEPRECATION WARNING: Calling silence on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use Rails.application.deprecators.silence instead) (called from input at /opt/system/app/lib/fields/builtin_field.rb:16)
```

**Which issue(s) this PR fixes** 

none

**Verification steps** 


**Special notes for your reviewer**:
