### PR TITLE
fix ThinkingSphinx::QueryError

### DIFF
--- a/app/workers/sphinx_indexation_worker.rb
+++ b/app/workers/sphinx_indexation_worker.rb
@@ -10,14 +10,6 @@ class SphinxIndexationWorker < ApplicationJob
     Rails.logger.info "SphinxIndexationWorker#perform raised #{exception.class} with message #{exception.message}"
   end
 
-  rescue_from(ThinkingSphinx::QueryError) do |exception|
-    if exception.message.include?("unknown column")
-      ThinkingSphinx::Connection.clear
-      Rails.logger.error "Attempting to workaround Searchd error by clearing connection pool."
-    end
-    raise
-  end
-
   def perform(model, id)
     ThinkingSphinx::Processor.new(model: model, id: id).stage
   end

--- a/config/initializers/sphinx.rb
+++ b/config/initializers/sphinx.rb
@@ -1,14 +1,3 @@
-# Patches ThinkingSphinx so `sphinx_internal_class_name` field is enabled
-# for rt indices of Single-table inheritance models
-# upstream https://github.com/pat/thinking-sphinx/pull/1249
-ThinkingSphinx::Configuration::MinimumFields.prepend(Module.new do
-  private
-
-  def indices_of_type(type)
-    super.reject(&method(:inheritance_columns?))
-  end
-end)
-
 # workaround unresolved issue with manticore total_pages
 # fixes SearchPresentersTest#test_pagination
 # see https://github.com/pat/thinking-sphinx/pull/1213

--- a/test/workers/sphinx_indexation_worker_test.rb
+++ b/test/workers/sphinx_indexation_worker_test.rb
@@ -7,24 +7,4 @@ class SphinxIndexationWorkerTest < ActiveSupport::TestCase
     enable_search_jobs!
     SphinxIndexationWorker.perform_now(ThinkingSphinx::Test.indexed_models.sample, 42)
   end
-
-  test "it re-establishes sphinx connections on certain errors" do
-    enable_search_jobs!
-    SphinxIndexationWorker.any_instance.expects(:perform).raises(ThinkingSphinx::QueryError, "unknown column: 'sphinx_internal_class_name' - REPLACE INTO account_core (id, `sphinx_internal_class_name`, `name`, `account_id`, `username`, `user_full_name`, `email`, `user_key`, `app_id`, `app_name`, `user_id`, `sphinx_internal_id`, `sphinx_internal_class`, `sphinx_deleted`, `sphinx_updated_at`, `provider_account_id`, `tenant_id`, `state`) VALUES (14978, 'Account', 'org_name-lkdjfggf-serch-yyith8w', '156', 'username-lkdjfggf-serch-xskw25c', ' ', 'username-lkdjfggf-serch-xskw25c@anything.invalid', 'af61253a5933dd9ba30bebb6661d16d1 ede2926ef59ecdc45da4a8960164ffc2', '3173be1c fc507eb9', 'org_name-lkdjfggf-serch-yyith8w's App ui_accou-lkdjfggf-accont-vmt8wba', '180', 156, 'Account', 0, 1697580778, 2, 2, 'approved')")
-    ThinkingSphinx::Connection.expects(:clear)
-
-    assert_raises(ThinkingSphinx::QueryError) do
-      SphinxIndexationWorker.perform_now(ThinkingSphinx::Test.indexed_models.sample, 42)
-    end
-  end
-
-  test "it doesn't re-establishes sphinx connections on random errors" do
-    enable_search_jobs!
-    SphinxIndexationWorker.any_instance.expects(:perform).raises(RuntimeError, "whatever error")
-    ThinkingSphinx::Connection.expects(:clear).never
-
-    assert_raises(RuntimeError) do
-      SphinxIndexationWorker.perform_now(ThinkingSphinx::Test.indexed_models.sample, 42)
-    end
-  end
 end


### PR DESCRIPTION
Sometimes after start-up Sidekiq pods produce ThinkingSphinx::QueryError

> unknown column: 'sphinx_internal_class_name' - REPLACE INTO account_core (id, `sphinx_internal_class_name`, `name`, `account_id`, `username`, `user_full_name`, `email`, `user_key`, `app_id`, `app_name`, `user_id`, `sphinx_internal_id`, `sphinx_internal_class`, `sphinx_deleted`, `sphinx_updated_at`, `provider_account_id`, `tenant_id`, `state`) VALUES (14978, 'Account', 'org_name-lkdjfggf-serch-yyith8w', '156', 'username-lkdjfggf-serch-xskw25c', ' ', 'username-lkdjfggf-serch-xskw25c@anything.invalid', 'af61253a5933dd9ba30bebb6661d16d1 ede2926ef59ecdc45da4a8960164ffc2', '3173be1c fc507eb9', 'org_name-lkdjfggf-serch-yyith8w's App ui_accou-lkdjfggf-accont-vmt8wba', '180', 156, 'Account', 0, 1697580778, 2, 2, 'approved')

A potential cause for this is load order of thinking-sphinx indices vs the monkey patch we are removing here.

Since we use thinking-sphinx 5.5 which has this logic alread merged in pat/thinking-sphinx#1249 , we can just remove the monkey patch and a race condition should not have any opportunit to happen.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Please remember to ALWAYS open an issue before starting to work on your pull request. Please take the time to validate your intentions for the pull request with the project maintainers before spending the time to work on it, so your time does not go to waste. 
2. If this is your first time, please make sure you've gone through the Contribution guide.
3. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11931

**Verification steps** 

check searching works with sti and non-sti models, e.g. accounts and plans