### PR TITLE
THREESCALE-11836: flash error billing address update

### DIFF
--- a/app/lib/payment_gateways/brain_tree_blue_crypt.rb
+++ b/app/lib/payment_gateways/brain_tree_blue_crypt.rb
@@ -83,7 +83,7 @@ module PaymentGateways
       else
         self.account_billing_address = result
         self.account_credit_card_details = result
-        account.save!
+        account.save
       end
     end
 

--- a/app/lib/payment_gateways/stripe_crypt.rb
+++ b/app/lib/payment_gateways/stripe_crypt.rb
@@ -58,6 +58,7 @@ module PaymentGateways
       payment_method.save
     rescue Stripe::StripeError => exception
       report_error("Failed to update billing address on Stripe: #{exception.message}")
+      false
     end
 
     private

--- a/app/lib/payment_gateways/stripe_crypt.rb
+++ b/app/lib/payment_gateways/stripe_crypt.rb
@@ -20,7 +20,10 @@ module PaymentGateways
       payment_detail.credit_card_partial_number = card.last4
       payment_detail.credit_card_auth_code      = payment_method.customer
       payment_detail.payment_method_id          = payment_method_id
-      payment_detail.save
+      payment_detail.save!
+    rescue StandardError
+      @errors = payment_detail.errors
+      false
     end
 
     def create_stripe_setup_intent

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/braintree_blue_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/braintree_blue_controller.rb
@@ -16,7 +16,6 @@ module DeveloperPortal::Admin::Account
         flash[:error] = 'Invalid merchant id'
         redirect_to action: :show
       end
-      @errors = params[:errors]
     end
 
     def hosted_success
@@ -26,9 +25,9 @@ module DeveloperPortal::Admin::Account
       if @payment_result
         update_user_and_perform_action!(braintree_response)
       else
-        @errors = braintree_response ? braintree_blue_crypt.errors(braintree_response) : ['Invalid Credentials']
-        flash[:notice] = 'Credit card details could not be stored.'
-        redirect_to action: 'edit', errors: @errors
+        errors = braintree_response ? braintree_blue_crypt.errors(braintree_response) : ['Invalid Credentials']
+        flash[:error] = "Credit card details could not be stored: #{errors.to_sentence}"
+        redirect_to action: 'edit'
       end
     end
 

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/braintree_blue_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/braintree_blue_controller.rb
@@ -38,7 +38,8 @@ module DeveloperPortal::Admin::Account
         flash[:notice] = 'Credit card details were successfully stored.'
         redirect_to after_hosted_success_path
       else
-        flash[:notice] = 'Credit Card details could not be stored.'
+        errors = braintree_blue_crypt.account.errors.full_messages.to_sentence
+        flash[:error] = "Credit Card details could not be stored: #{errors}"
         render template: 'accounts/payment_gateways/edit'
       end
     end

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/payment_details_base_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/payment_details_base_controller.rb
@@ -29,7 +29,7 @@ class DeveloperPortal::Admin::Account::PaymentDetailsBaseController < DeveloperP
     if update_billing_address
       redirect_to payment_details_path, notice: 'Your billing address was successfully stored'
     else
-      flash[:notice] = 'Failed to update your billing address data. Check the required fields'
+      flash[:error] = 'Failed to update your billing address data. Check the required fields'
       assign_drops countries: Liquid::Drops::Country.wrap(Country.all)
       render template: 'accounts/payment_gateways/edit'
     end


### PR DESCRIPTION
**What this PR does / why we need it**:

You can read the comment with my summary at the ticket:

https://issues.redhat.com/browse/THREESCALE-11836?focusedId=27958668&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27958668

Basically we have 9 possible scenarios. Only the success scenarios were returning a flash message to UI. Failure scenarios didn't. This is the list of scenarios and the commits that fix them:

- Braintree
  - Send CC and address altogether, success (**worked before**)
  - Send CC and address altogether, fails in Braintree server (https://github.com/3scale/porta/commit/2b6200ca83b0353f756fd3f641d94c680f9be58f)
  - Send CC and address altogether, fails in our DB (https://github.com/3scale/porta/commit/ef464d3bf7ffea88ff198719b38794eae0c2e8dc)
- Stripe
  - Send address, success (**worked before**)
  - Send address, fails in Stripe server (https://github.com/3scale/porta/commit/f0e831832ff150d618b75d0c0f13e12de1158b69)
  - Send address, fails in our DB (**same as above: https://github.com/3scale/porta/commit/f0e831832ff150d618b75d0c0f13e12de1158b69**)
  - Send CC, success (**worked before**)
  - Send CC, fails in Stripe server (**the error is shown by the React component, nothing to do**)
  - Send CC, fails in our DB (https://github.com/3scale/porta/commit/f0dad7a6727e51f30a3f08e377ccf0e82ca74c75)

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11836

**Verification steps** 

Try the scenarios above. The links below can be useful to send wrong data to gateways:

https://docs.stripe.com/testing
https://developer.paypal.com/braintree/docs/reference/general/testing/ruby#card-numbers-with-other-information

