### PR TITLE
Fix default and document the purpose of the setting

### DIFF
--- a/config/examples/sandbox_proxy.yml
+++ b/config/examples/sandbox_proxy.yml
@@ -3,6 +3,8 @@ base: &default
     - echo-api.3scale.net
   ignore_test_failures: []
   # Backend endpoint as visible by apicast (host.containers.internal in podman)
+  # but this should resolve from apicast through DNS as it doesn't read hosts.
+  # If not possible, then set BACKEND_ENDPOINT_OVERRIDE when starting apicast.
   backend_endpoint: <%= ENV.fetch('BACKEND_PUBLIC_URL', 'http://host.docker.internal:3001') %>
   verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>
   # APIcast endpoints as visible from the client
@@ -15,7 +17,9 @@ base: &default
 
 development:
   <<: *default
-  override: 'http://localhost:8091'
+  # apicast as seen from the running porta server for testing an API from UI
+  # you can use this to override the default if needed for whatever reason
+  # override: 'http://localhost:8091'
   debug: true
 
 test:


### PR DESCRIPTION
Porta uses this override value to get address of the test proxy. Which is useful for local dev runs where one wants to access the API from UI.

For example go through the provider initial setup wizard and go through it. Without proper value, accessing the API will fail at the end of the wizard.

https://github.com/3scale/porta/blob/4ee6a660307a740ad4df6c1368ded6aabeff5405/app/services/proxy_test_service.rb#L92-L103