### PR TITLE
THREESCALE-11945: Fix the issue with after_commit transaction callbacks

### DIFF
--- a/app/lib/backend/model_extensions/usage_limit.rb
+++ b/app/lib/backend/model_extensions/usage_limit.rb
@@ -8,7 +8,8 @@ module Backend
           # cache associations
           before_destroy :preload_used_associations
 
-          # WARN: last callback is called first, gotcha!
+          # TODO: reverse the order of these callbacks, as the default has changed in Rails 7.1, and then remove the
+          # config.active_record.run_after_transaction_callbacks_in_order_defined setting
           after_commit :update_backend_usage_limit, :unless => :destroyed?
           after_commit :delete_backend_usage_limit
         end

--- a/config/application.rb
+++ b/config/application.rb
@@ -124,6 +124,12 @@ module System
     # database.
     config.active_record.raise_on_assign_to_attr_readonly = false
 
+    # By default (from Rails 7.1), transaction callbacks will run in the order they are defined.
+    # Prior to 7.1 the order in which the callbacks were run was reversed.
+    # This change caused a bug in sending the usage limits to backend (see THREESCALE-11945)
+    # Setting this config to quickly fix the issue, and avoid having to review all callbacks throughout the code base
+    config.active_record.run_after_transaction_callbacks_in_order_defined = false
+
     config.active_job.queue_adapter = :sidekiq
 
     def try_config_for(*args)


### PR DESCRIPTION
**What this PR does / why we need it**:

In the upgrade to [Rails 7.1](https://github.com/3scale/porta/pull/4089), there was something that I missed. Probably because it's not in the generic release notes for [7.1](https://guides.rubyonrails.org/7_1_release_notes.html).

The change is that now order of the `after_commit` callbacks is as it is defined in the code, while prior to 7.1 the order was reversed. See https://guides.rubyonrails.org/active_record_callbacks.html#transactional-callback-ordering

This specifically affected the callbacks on usage limits creation, where two callbacks are defined (and note also the comment that proves the privious statement):

https://github.com/3scale/porta/blob/db92cc6ebe910229de333015975b204ced868273/app/lib/backend/model_extensions/usage_limit.rb#L11-L13

So, after Rails upgrade, the order got reversed, and currently first `update` is performed, and then `delete`, so effectively any change in the usage limits deletes any limits in backend for that metric (thus making system and backend out of sync).

This PR temporarily restores the previous behavior, by setting 
```
config.active_record.run_after_transaction_callbacks_in_order_defined = false
```

This is just to fix the issue that is currently affecting SaaS users.

The idea is to remove that setting, and fix the order of callbacks throughout the code base.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11945

**Verification steps** 

1. Create an application plan with some usage limits
2. Send an `authorize.xml` call to backend and see the metrics with the limits in the `<usage_reports>` section.
3. Update the limits in the application plan by setting a different value.
4. Send an `authorize.xml` call again, and verify that the metric is still in the `<usage_reports>` section (this is the steps that failed before).

**Special notes for your reviewer**:
