### PR TITLE
THREESCALE-4086: Stripe rate limit handling

### DIFF
--- a/app/lib/finance/payment.rb
+++ b/app/lib/finance/payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Finance
   module Payment
     class CreditCardError < RuntimeError; end
@@ -7,16 +9,33 @@ module Finance
     class GatewayError < CreditCardError
       attr_reader :response
 
+      # @param [ActiveMerchant::Billing::Response] response
       def initialize(response = nil)
         @response = response
+        super(message)
       end
 
       def message
-        response.try!(:message) || super
+        response&.message || super
       end
     end
 
     CreditCardPurchaseFailed = Class.new(GatewayError)
 
+    # Rate limit error - should be retried immediately, not treated as payment failure
+    class GatewayRateLimitError < GatewayError
+      attr_reader :payment_metadata
+
+      # @param [ActiveMerchant::Billing::Response] response
+      # @param [Hash] payment_metadata
+      def initialize(response = nil, payment_metadata = {})
+        @payment_metadata = payment_metadata
+        super(response)
+      end
+
+      def message
+        response&.message || 'Rate limit exceeded - too many requests to payment gateway'
+      end
+    end
   end
 end

--- a/app/models/finance/billing_strategy.rb
+++ b/app/models/finance/billing_strategy.rb
@@ -89,6 +89,9 @@ class Finance::BillingStrategy < ApplicationRecord
         results.start(billing_strategy)
         ignoring_find_each_scope { billing_strategy.daily(now: now, buyer_ids: options[:buyer_ids], skip_notifications: skip_notifications) }
         results.success(billing_strategy)
+      rescue Finance::Payment::GatewayRateLimitError => exception
+        # Don't treat these as payment failures - rate limit errors should bubble up to be retried by Sidekiq
+        raise exception
       rescue => e
         results.failure(billing_strategy)
         name = billing_strategy.provider.try!(:name)
@@ -352,6 +355,9 @@ class Finance::BillingStrategy < ApplicationRecord
     buyer_accounts.find_each(:batch_size => 20) do |buyer|
       begin
         ignoring_find_each_scope { yield(buyer) }
+      rescue Finance::Payment::GatewayRateLimitError => exception
+        # Do NOT catch and swallow the exception - rate limit errors should bubble up to be retried by Sidekiq
+        raise exception
       rescue => exception
         name = buyer.name
         buyer_id = buyer.id

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -451,6 +451,10 @@ class Invoice < ApplicationRecord
       logger.info("Invoice #{id} (buyer #{buyer_account_id}) was not charged")
       false
     end
+  rescue Finance::Payment::GatewayRateLimitError => e
+    # Rate limit errors should bubble up to Sidekiq for immediate retry with exponential backoff
+    # Don't treat these as payment failures - they are temporary gateway issues
+    raise e
   rescue Finance::Payment::CreditCardError, ActiveMerchant::ActiveMerchantError
     provider.billing_strategy&.error("Error when charging invoice #{id} (buyer #{buyer_account_id})", buyer)
 

--- a/app/services/finance/billing_service.rb
+++ b/app/services/finance/billing_service.rb
@@ -28,8 +28,8 @@ module Finance
 
     def call!
       with_lock { call }
-    rescue LockBillingError, SpuriousBillingError => error
-      report_error(error)
+    rescue LockBillingError, SpuriousBillingError => exception
+      report_error(exception)
       nil
     end
 

--- a/app/services/finance/stripe_charge_service.rb
+++ b/app/services/finance/stripe_charge_service.rb
@@ -20,7 +20,20 @@ class Finance::StripeChargeService
 
   def charge(amount)
     payment_intent = latest_pending_payment_intent
-    payment_intent ? confirm_payment_intent(payment_intent) : create_payment_intent(amount)
+    response = payment_intent ? confirm_payment_intent(payment_intent) : create_payment_intent(amount)
+
+    if rate_limit_error? response
+      payment_metadata = {
+        gateway: gateway.class.name,
+        invoice_id: @invoice&.id,
+        buyer_id: @invoice&.buyer_account&.id,
+        payment_method_id: @payment_method_id,
+        gateway_options: @gateway_options
+      }
+      raise Finance::Payment::GatewayRateLimitError.new(response, payment_metadata)
+    end
+
+    response
   end
 
   protected
@@ -85,5 +98,20 @@ class Finance::StripeChargeService
     return PAYMENT_DESCRIPTION if invoice.blank?
 
     "#{invoice.from.name} #{PAYMENT_DESCRIPTION} #{invoice.friendly_id}".strip
+  end
+
+  # Response body in case of Rate Limit error:
+  # {
+  #   "error": {
+  #     "message": "Request rate limit exceeded. Learn more about rate limits here https://stripe.com/docs/rate-limits.",
+  #     "type": "invalid_request_error",
+  #     "code": "rate_limit",
+  #     "doc_url": "https://stripe.com/docs/error-codes/rate-limit"
+  #   }
+  # }
+  def rate_limit_error?(response)
+    return false if response.success?
+
+    response.params&.dig("error", "code") == 'rate_limit'
   end
 end

--- a/app/workers/billing_worker.rb
+++ b/app/workers/billing_worker.rb
@@ -3,11 +3,11 @@
 class BillingWorker
   include Sidekiq::Job
 
-  sidekiq_options queue: :billing, retry: 3
+  sidekiq_options queue: :billing, retry: 5
 
-  sidekiq_retry_in do |_count|
-    # after lock has been released
-    1.hours + 10
+  sidekiq_retry_in do |_count, _exception|
+    # wait for lock to be released
+    (1.hour + rand(30.minutes.to_i)).to_i
   end
 
   class Callback

--- a/test/test_helpers/billing_results.rb
+++ b/test/test_helpers/billing_results.rb
@@ -30,4 +30,20 @@ module BillingResultsTestHelpers
     billing_results.failure(provider.billing_strategy)
     billing_results
   end
+
+  def mock_stripe_rate_limit_response
+    rate_limit_response = {
+      error: {
+        message: "Request rate limit exceeded. Learn more about rate limits here https://stripe.com/docs/rate-limits.",
+        type: "invalid_request_error",
+        code: "rate_limit",
+        doc_url: "https://stripe.com/docs/error-codes/rate-limit"
+      }
+    }
+    ActiveMerchant::Billing::Response.new(false, rate_limit_response[:error][:message], rate_limit_response.as_json)
+  end
+
+  def mock_gateway_rate_limit_error(payment_metadata = {})
+    Finance::Payment::GatewayRateLimitError.new(mock_stripe_rate_limit_response, payment_metadata)
+  end
 end

--- a/test/unit/finance/billing_strategy_test.rb
+++ b/test/unit/finance/billing_strategy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Finance::BillingStrategyTest < ActiveSupport::TestCase
@@ -14,7 +16,7 @@ class Finance::BillingStrategyTest < ActiveSupport::TestCase
     @bs = @provider.billing_strategy
     @bs.numbering_period = 'monthly'
 
-    @buyer = FactoryBot.create(:buyer_account)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
   end
 
   test 'add_cost' do
@@ -218,6 +220,92 @@ class Finance::BillingStrategyTest < ActiveSupport::TestCase
 
   test 'notify_billing_finished' do
     @bs.notify_billing_finished(Time.utc(1984, 1, 1))
+  end
+
+  test 'self.daily does not mark billing strategy as failed for rate limit errors' do
+    assert @bs.instance_of? Finance::PostpaidBillingStrategy
+
+    Finance::PostpaidBillingStrategy.any_instance.stubs(:daily).raises(mock_gateway_rate_limit_error({ buyer_id: @buyer.id }))
+
+    # These should NOT be called for rate limit errors
+    Rails.logger.expects(:error).never
+    System::ErrorReporting.expects(:report_error).never
+
+    # The rate limit error should be re-raised
+    assert_raises(Finance::Payment::GatewayRateLimitError) do
+      Finance::BillingStrategy.daily(only: [@provider.id])
+    end
+  end
+
+  test 'self.daily marks billing strategy as failed for non-rate-limit errors' do
+    # Stub the instance method to raise a regular error
+    error_message = 'Something went wrong'
+    Finance::PostpaidBillingStrategy.any_instance.stubs(:daily).raises(StandardError.new(error_message))
+
+    # These SHOULD be called for regular errors
+    expected_message = "BillingStrategy #{@bs.id}(#{@provider.name}) failed utterly"
+    Rails.logger.expects(:error).with(expected_message)
+    System::ErrorReporting.expects(:report_error).with(
+      instance_of(StandardError),
+      error_message: expected_message,
+      error_class: 'BillingError'
+    )
+
+    # The error should be re-raised after logging
+    assert_raises(StandardError) do
+      Finance::BillingStrategy.daily(only: [@provider.id])
+    end
+  end
+
+  test "#daily of postpaid billing strategy succeeds" do
+    assert @bs.instance_of? Finance::PostpaidBillingStrategy
+    @bs.update(charging_enabled: true)
+
+    @bs.daily(now: Time.now.utc, buyer_ids: [@buyer.id])
+
+    @bs.expects(:error).never
+    System::ErrorReporting.expects(:report_error).never
+    assert_empty @bs.failed_buyers
+  end
+
+  test 'bill_and_charge_each re-raises rate limit errors without logging' do
+    # These should NOT be called for rate limit errors
+    @bs.expects(:error).never
+    System::ErrorReporting.expects(:report_error).never
+
+    # The rate limit error should be re-raised immediately
+    assert_raises(Finance::Payment::GatewayRateLimitError) do
+      @bs.send(:bill_and_charge_each, { buyer_ids: [@buyer.id] }) do |b|
+        raise mock_gateway_rate_limit_error({ buyer_id: @buyer.id })
+      end
+    end
+
+    # failed_buyers should remain empty for rate limit errors
+    assert_empty @bs.failed_buyers
+  end
+
+  test 'bill_and_charge_each logs and reports non-rate-limit errors' do
+    error_message = 'Payment processing failed'
+
+    # These SHOULD be called for regular errors
+    expected_msg = "Failed to bill or charge #{@buyer.name}(#{@buyer.id}) of provider(#{@provider.id}): #{error_message}\n"
+    @bs.expects(:error).with(expected_msg, @buyer)
+    System::ErrorReporting.expects(:report_error).with(
+      instance_of(StandardError),
+      error_message: expected_msg,
+      error_class: 'BillingError',
+      parameters: { buyer_id: @buyer.id, provider_id: @provider.id }
+    )
+
+    # NOTE: the exception is only re-raised in test environment, in production it is not propagated
+    assert_raises(StandardError, match: error_message) do
+      @bs.send(:bill_and_charge_each, { buyer_ids: [@buyer.id] }) do |b|
+        raise StandardError, error_message
+      end
+    end
+
+    # failed_buyers should include the buyer for regular errors
+    assert_includes @bs.failed_buyers, @buyer.id
   end
 
   def test_create_invoices_to_review_event

--- a/test/unit/finance/payment_test.rb
+++ b/test/unit/finance/payment_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Finance::PaymentTest < ActiveSupport::TestCase
+  include BillingResultsTestHelpers
+
+  test 'GatewayRateLimitError stores payment_metadata' do
+    assert Finance::Payment::GatewayRateLimitError < Finance::Payment::GatewayError
+
+    payment_metadata = { invoice_id: 123, buyer_id: 456, payment_method_id: 'pm_test' }
+    error = Finance::Payment::GatewayRateLimitError.new(mock_stripe_rate_limit_response, payment_metadata)
+
+    assert_equal payment_metadata, error.payment_metadata
+  end
+
+  test 'GatewayRateLimitError fetches message from response or falls back to standard message' do
+    response = stub(success?: false, message: 'Rate limit exceeded')
+    error = Finance::Payment::GatewayRateLimitError.new(response)
+    assert_equal 'Rate limit exceeded', error.message
+
+    error_with_default_message = Finance::Payment::GatewayRateLimitError.new(stub(success?: false, message: nil))
+    assert_equal 'Rate limit exceeded - too many requests to payment gateway', error_with_default_message.message
+  end
+end

--- a/test/unit/invoice_test.rb
+++ b/test/unit/invoice_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class InvoiceTest < ActiveSupport::TestCase
+  include BillingResultsTestHelpers
+
   fixtures :countries
 
   should belong_to :buyer_account
@@ -24,10 +26,10 @@ class InvoiceTest < ActiveSupport::TestCase
     @buyer = FactoryBot.create(:simple_buyer, provider_account: @provider)
 
     @invoice = FactoryBot.create(:invoice,
-                                  period: Month.new(@local_time),
-                                  provider_account: @provider,
-                                  buyer_account: @buyer,
-                                  friendly_id: '0000-00-00000001')
+                                 period: Month.new(@local_time),
+                                 provider_account: @provider,
+                                 buyer_account: @buyer,
+                                 friendly_id: '0000-00-00000001')
     @billing = Finance::BackgroundBilling.new(@invoice)
   end
 
@@ -371,16 +373,16 @@ class InvoiceTest < ActiveSupport::TestCase
   def setup_1984_and_2009_invoices
     travel_to(Time.zone.local(2009, 6, 1)) do
       @invoice_one = FactoryBot.create(:invoice,
-                                        buyer_account: @buyer,
-                                        provider_account: @provider,
-                                        period: Month.new(Time.utc(2009, 6, 1)))
+                                       buyer_account: @buyer,
+                                       provider_account: @provider,
+                                       period: Month.new(Time.utc(2009, 6, 1)))
     end
 
     travel_to(Time.zone.local(1984, 10, 1)) do
       @invoice_two = FactoryBot.create(:invoice,
-                                        provider_account: @provider,
-                                        buyer_account: @buyer,
-                                        period: Month.new(Time.utc(1984, 10, 1)))
+                                       provider_account: @provider,
+                                       buyer_account: @buyer,
+                                       period: Month.new(Time.utc(1984, 10, 1)))
     end
   end
 
@@ -521,6 +523,67 @@ class InvoiceTest < ActiveSupport::TestCase
     refute @invoice.charge!, 'Invoice should not charge!'
   end
 
+  test '#charge! re-raises GatewayRateLimitError without incrementing retry counter' do
+    @buyer.expects(:charge!).raises(mock_gateway_rate_limit_error)
+
+    @provider.stubs(:payment_gateway_configured?).returns(true)
+    @billing.create_line_item!(name: 'Fake', cost: 1.233, description: 'really', quantity: 1)
+    @invoice.issue_and_pay_if_free!
+
+    # Should re-raise the error
+    assert_raises(Finance::Payment::GatewayRateLimitError) do
+      @invoice.charge!(true)
+    end
+
+    # Retry counter should NOT be incremented for rate limit errors
+    assert_equal 0, @invoice.reload.charging_retries_count
+    assert_nil @invoice.last_charging_retry
+
+    # Invoice should remain in pending state, not marked as unpaid
+    assert_equal 'pending', @invoice.state
+  end
+
+  test '#charge! handles CreditCardError by incrementing retry counter and marking as unpaid' do
+    @buyer.expects(:charge!).raises(Finance::Payment::CreditCardError.new('Card declined'))
+    @provider.stubs(:payment_gateway_configured?).returns(true)
+    @billing.create_line_item!(name: 'Fake', cost: 1.233, description: 'really', quantity: 1)
+    @invoice.issue_and_pay_if_free!
+
+    # Mock the mailer
+    InvoiceMessenger.expects(:unsuccessfully_charged_for_buyer).returns(stub(deliver: true))
+
+    @invoice.charge!
+
+    # Retry counter SHOULD be incremented for regular errors
+    assert_equal 1, @invoice.reload.charging_retries_count
+    assert_not_nil @invoice.last_charging_retry
+
+    # Invoice should be marked as unpaid
+    assert_equal 'unpaid', @invoice.state
+  end
+
+  test '#charge! marks invoice as failed after max retries' do
+    @buyer.expects(:charge!).raises(Finance::Payment::CreditCardError.new('Card declined'))
+    @provider.stubs(:payment_gateway_configured?).returns(true)
+    @billing.create_line_item!(name: 'Fake', cost: 1.233, description: 'really', quantity: 1)
+    @invoice.issue_and_pay_if_free!
+
+    # Mark as unpaid first so we can transition to failed
+    @invoice.mark_as_unpaid!
+    @invoice.update_attribute(:charging_retries_count, Invoice::MAX_CHARGE_RETRIES - 1)
+
+    # Mock the mailer for final failure
+    InvoiceMessenger.expects(:unsuccessfully_charged_for_buyer_final).returns(stub(deliver: true))
+
+    @invoice.charge!
+
+    # Should reach max retries
+    assert_equal Invoice::MAX_CHARGE_RETRIES, @invoice.reload.charging_retries_count
+
+    # Invoice should be marked as failed
+    assert_equal 'failed', @invoice.state
+  end
+
   test '#buyer_field_label' do
     @buyer.expects(:field_label).with('vat_rate')
     @invoice.buyer_field_label('vat_rate')
@@ -586,10 +649,13 @@ class InvoiceTest < ActiveSupport::TestCase
 
     test 'jumps the counter when friendly id jumps' do
       invoice = FactoryBot.create(:invoice,
-                                    period: @invoice_period,
-                                    provider_account: @provider,
-                                    buyer_account: @buyer,
-                                    friendly_id: '2018-00000008').reload
+                                  period: @invoice_period,
+                                  provider_account: @provider,
+                                  buyer_account: @buyer)
+
+      invoice.friendly_id = '2018-00000008'
+      invoice.save!
+      invoice.reload
 
       assert_equal 8, invoice.counter.invoice_count
 

--- a/test/unit/services/finance/stripe_charge_service_test.rb
+++ b/test/unit/services/finance/stripe_charge_service_test.rb
@@ -3,6 +3,9 @@
 require 'test_helper'
 
 class Finance::StripeChargeServiceTest < ActiveSupport::TestCase
+
+  include BillingResultsTestHelpers
+
   setup do
     provider_account = FactoryBot.create(:simple_provider, payment_gateway_type: :stripe, payment_gateway_options: { login: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc' })
     buyer_account = FactoryBot.create(:simple_buyer, provider_account: provider_account)
@@ -22,13 +25,13 @@ class Finance::StripeChargeServiceTest < ActiveSupport::TestCase
   attr_reader :gateway, :invoice, :amount, :service
 
   test 'charge' do
-    service.expects(:create_payment_intent).with(amount).returns(true)
+    service.expects(:create_payment_intent).with(amount).returns(ActiveMerchant::Billing::Response.new(true, 'ok'))
     assert service.charge(amount)
   end
 
   test 'charge with existing payment intent' do
     payment_intent = FactoryBot.create(:payment_intent, invoice: invoice, reference: 'some-payment-intent-id', state: 'pending')
-    service.expects(:confirm_payment_intent).with(payment_intent).returns(true)
+    service.expects(:confirm_payment_intent).with(payment_intent).returns(ActiveMerchant::Billing::Response.new(true, 'ok'))
     assert service.charge(amount)
   end
 
@@ -132,6 +135,14 @@ class Finance::StripeChargeServiceTest < ActiveSupport::TestCase
     gateway.expects(:purchase).with(15_000, anything, has_entry(:description, "#{invoice.provider.name} API services #{friendly_id}")).returns(response)
     charge_service = build_charge_service(invoice: invoice)
     assert charge_service.charge(amount)
+  end
+
+  test 'exception is raised when rate limit error is detected' do
+    gateway.expects(:purchase).returns(mock_stripe_rate_limit_response)
+
+    assert_raises(Finance::Payment::GatewayRateLimitError) do
+      service.charge(amount)
+    end
   end
 
   private

--- a/test/unit/services/synchronization/nowait_lock_service_test.rb
+++ b/test/unit/services/synchronization/nowait_lock_service_test.rb
@@ -46,4 +46,17 @@ class Synchronization::NowaitLockServiceTest < ActionDispatch::IntegrationTest
     sleep 0.12
     assert Synchronization::NowaitLockService.call(lock_key, timeout: 100).result
   end
+
+  test "prefixes resource with 'lock:'" do
+    Synchronization::NowaitLockService.call("billing:123", timeout: 1000) do |lock_info|
+      assert_equal 'lock:billing:123', lock_info[:resource]
+    end
+  end
+
+  test "accepts timeout as keyword argument" do
+    timeout_ms = 5000
+    service = Synchronization::NowaitLockService.new(lock_key, timeout: timeout_ms)
+
+    assert_equal timeout_ms, service.send(:timeout)
+  end
 end

--- a/test/workers/billing_worker_test.rb
+++ b/test/workers/billing_worker_test.rb
@@ -80,4 +80,16 @@ class BillingWorkerTest < ActiveSupport::TestCase
     assert_equal master_account.id, provider_id
     assert_equal @provider.id, buyer_id
   end
+
+  test 'all errors use standard retry delay to wait for lock release' do
+    regular_error = StandardError.new('Something went wrong')
+
+    retry_delay_rate_limit = BillingWorker.sidekiq_retry_in_block.call(1, mock_gateway_rate_limit_error)
+    retry_delay_regular = BillingWorker.sidekiq_retry_in_block.call(1, regular_error)
+
+    min_delay = 1.hour.to_i
+    max_delay = (1.hour + 30.minutes).to_i
+    assert_includes min_delay..max_delay, retry_delay_rate_limit, "Payment gateway rate limit errors should wait for lock release"
+    assert_includes min_delay..max_delay, retry_delay_regular, "Regular errors should wait for lock release"
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

This implementation is a **draft** which was implemented by Claude (accurately guided by @mayorova). It is intended to serve as a starting point in discussions about how we can solve the issue ([https://issues.redhat.com/browse/THREESCALE-4086](https://issues.redhat.com/browse/THREESCALE-4086)) and also potentially open a discussion about Billing refactoring.

As it can be clearly seen, our billing process is quite complicated:
- Many classes and modules are involved, and they keep passing control to each other, and the interactions are often back-and-forth, not very intuitive, and it's hard to follow the line of execution.
- Error handling is not very clear either, errors sometimes get re-raised, sometimes "swallowed", and it's not easy to understand what the implications of a raised exceptions are
- There is a number of "TODO" comments asking for refactor, e.g. `Invoice#charge!`.
- The process uses [sidekiq-batch](https://github.com/breamware/sidekiq-batch) gem, which is an open-source alternative to the commercial Sidekiq's Batch feature (paid). In our experience, it has some issues, for example those explained in `THREESCALE_8124`.
- The whole process is not very intuitive (or, I'd even say - anti-intuitive), for example, the main process happens in `Finance::BillingStrategy.daily` method, which looks like it is intended to go over a list of billing strategies (i.e. provider accounts), and inside each strategy execute the daily process for a list of buyer accounts. However, in practice, this method is typically called by the `BillingWorker` job that runs for a single provider and a single buyer.

In general, I think the whole billing process could be refactored to make it significantly simpler and more predictable. We could do it also with Stripe rate limits in mind, to make the implementation more straightforward, and maybe even implement some kind of client-side rate limit (to avoid the error in the first place), rather than reacting to the error and re-try.

However, of course this is a very sensitive piece of logic, and it might be dangerous to modify it significantly (as we know it has been working quite reliably for ages).

So, let's talk :wink: 

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-4086

**Verification steps** 

**Special notes for your reviewer**:

- Check out the doc `STRIPE_RATE_LIMIT_HANDLING.md` that Claude created explaining the implementation in detail.
- Also, take a look at the diagrams Claude has drawn under `docs/`.
- For testing the implemenation (or reproducing the original issue) in development mode, instead of mocking the stripe server, I just hard-coded a simple change in the `activemerchant` gem. Before [this line](https://github.com/activemerchant/active_merchant/blob/v1.137.0/lib/active_merchant/billing/gateways/stripe.rb#L700) I place 
```
        return {"error"=>{"message"=>"Request rate limit exceeded. Learn more about rate limits here https://stripe.com/docs/rate-limits.", "type"=>"invalid_request_error", "code"=>"rate_limit", "doc_url"=>"https://stripe.com/docs/error-codes/rate-limit"}, "response_headers"=>{}} if parameters[:amount].to_i >= 10000
```

So, the invoices with total value > 100 will trigger this error, while the "cheaper" ones should pass successfully. Beware though about the order of invoices - if the first invoice fails, the process will not continue.


I also use these steps to prepare my Rails console for actual test:

1. Prepare
```
# Prerequisites:
# - set up Stripe payment gateway configuration for the provider
# - create a buyer account (under the provider) and set up payment details (credit card and billing address) in the dev portal

buyer = Account.find ID

redis_key = "lock:billing:#{buyer.id}"
redis = System::RedisClientPool.default

def create_invoice(buyer, cost)
  new_invoice = buyer.provider_account.billing_strategy.create_invoice!(buyer_account: buyer, period: Month.new(Time.zone.now))
  billing = Finance::AdminBilling.new(new_invoice)
  line_item_params = {name: 'test', description: 'test description', quantity: 1, cost: cost}
  billing.create_line_item(line_item_params)
  new_invoice.issue
  new_invoice.update_column(:due_on, new_invoice.issued_on)
end
```
2. Create invoices
```
create_invoice(buyer, "10.00")
create_invoice(buyer, "120.00")
```
3. Remove the lock and run the job
```
redis.call("DEL", redis_key)

BillingWorker.perform_async(buyer.id, buyer.provider_account_id, Time.zone.now.to_fs(:iso8601))
```  
