### PR TITLE
THREESCALE-12408: Access tokens protection

### DIFF
--- a/app/controllers/provider/admin/user/access_tokens_controller.rb
+++ b/app/controllers/provider/admin/user/access_tokens_controller.rb
@@ -23,13 +23,13 @@ module Provider
         def edit; end
 
         def create
-          @presenter = AccessTokensNewPresenter.new(current_account)
           @access_token = access_tokens.build(access_token_params)
 
           if @access_token.save
-            flash[:token] = @access_token.id
-            redirect_to provider_admin_user_access_tokens_path, success: t('.success')
+            flash.now[:success] = t('.success')
+            render :show, locals: { token: @access_token }
           else
+            @presenter = AccessTokensNewPresenter.new(current_account)
             render :new
           end
         end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,9 +1,15 @@
+# frozen_string_literal: true
+
 class AccessToken < ApplicationRecord
-  TIMESTAMP_FORMAT = '%FT%T%:z'.freeze
+  DIGEST_PREFIX = 'SHA384$'
+
+  TIMESTAMP_FORMAT = '%FT%T%:z'
   PAST_TIME = Time.at(0).utc.freeze
   private_constant :PAST_TIME
 
   belongs_to :owner, class_name: 'User', inverse_of: :access_tokens
+
+  attr_reader :plaintext_value
 
   validates :name, length: { maximum: 255 }
 
@@ -98,14 +104,32 @@ class AccessToken < ApplicationRecord
   validate :validate_scope_exists
   validate :validate_expiration_date, on: %i[create]
 
-  after_initialize :generate_value
+  after_initialize :generate_if_missing, if: :new_record?
 
   attr_accessible :owner, :name, :scopes, :permission, :expires_at
 
-  attr_readonly :value
+  def self.compute_digest(plaintext_value)
+    return nil if plaintext_value.blank?
 
-  def self.find_from_value(value)
-    find_by(value: value.to_s.scrub)
+    hash = OpenSSL::Digest::SHA384.hexdigest(plaintext_value.to_s)
+    "#{DIGEST_PREFIX}#{hash}"
+  end
+
+  def self.find_from_value(plaintext_value)
+    return nil if plaintext_value.blank?
+
+    scrubbed = plaintext_value.to_s.scrub
+    digest = compute_digest(scrubbed)
+
+    # Fast path: find by digest (new tokens)
+    token = find_by(value: digest)
+    return token if token
+
+    # Reject if the input looks like a stored hash (has our prefix)
+    return nil if scrubbed.start_with?(DIGEST_PREFIX)
+
+    # Slow path: find by plaintext (legacy tokens, no migration)
+    find_by(value: scrubbed)
   rescue ActiveRecord::StatementInvalid, ArgumentError # utf-8 issues
     nil
   end
@@ -155,8 +179,12 @@ class AccessToken < ApplicationRecord
     errors.add :expires_at, :invalid, message: "Date must follow ISO8601 format and be future. Example: #{1.week.from_now.utc.iso8601}."
   end
 
-  def generate_value
-    self.value ||= self.class.random_id
+  def generate_if_missing
+    return if persisted?
+    return if @plaintext_value.present?
+
+    @plaintext_value = self.class.random_id
+    self.value = self.class.compute_digest(@plaintext_value)
   end
 
   def available_permissions
@@ -167,8 +195,8 @@ class AccessToken < ApplicationRecord
     PERMISSIONS.key(permission)
   end
 
-  def show_value?(*)
-    saved_changes.include?(:value)
+  def plaintext_value_known?(*)
+    @plaintext_value.present?
   end
 
   def available_scopes
@@ -180,7 +208,7 @@ class AccessToken < ApplicationRecord
   end
 
   def self.random_id
-    SecureRandom.hex(32)
+    SecureRandom.hex(48)
   end
 
   def expired?

--- a/app/representers/access_token_representer.rb
+++ b/app/representers/access_token_representer.rb
@@ -12,5 +12,5 @@ class AccessTokenRepresenter < ThreeScale::Representer
   property :scopes
   property :permission
   property :expires_at
-  property :value, if: :show_value?
+  property :plaintext_value, as: :value, if: :plaintext_value_known?
 end

--- a/app/views/provider/admin/user/access_tokens/index.html.slim
+++ b/app/views/provider/admin/user/access_tokens/index.html.slim
@@ -1,120 +1,67 @@
-- content_for :javascripts
-  = javascript_packs_with_chunks_tag 'access_tokens'
+- content_for :page_header_title, t('.page_header_title')
+= javascript_packs_with_chunks_tag 'access_tokens'
 
-- if flash[:token]
-  - token = @access_tokens.last
-  - content_for :page_header_title, 'Copy the new token and store it somewhere safe'
-  div class="pf-c-card"
-    div class="pf-c-card__body"
-      div class="pf-c-content"
-        p Make sure to copy your new personal access token now. You won't be able to see it again as it isn't stored for security reasons.
-      br
-      dl class="pf-c-description-list pf-m-horizontal"
-        div class="pf-c-description-list__group"
-          dt class="pf-c-description-list__term"
-            span class="pf-c-description-list__text"
-              | Name
-          dd class="pf-c-description-list__description"
-            div class="pf-c-description-list__text"
-              = token.name
-        div class="pf-c-description-list__group"
-          dt class="pf-c-description-list__term"
-            span class="pf-c-description-list__text"
-              | Scopes
-          dd class="pf-c-description-list__description"
-            div class="pf-c-description-list__text"
-              = token.human_scopes.to_sentence
-        div class="pf-c-description-list__group"
-          dt class="pf-c-description-list__term"
-            span class="pf-c-description-list__text"
-              | Permission
-          dd class="pf-c-description-list__description"
-            div class="pf-c-description-list__text"
-             = token.human_permission
-        div class="pf-c-description-list__group"
-          dt class="pf-c-description-list__term"
-            span class="pf-c-description-list__text"
-              | Expires at
-          dd class="pf-c-description-list__description"
-            div class="pf-c-description-list__text"
-              = token.expires_at.present? ? l(token.expires_at) : t('access_token_options.no_expiration')
-        div class="pf-c-description-list__group"
-          dt class="pf-c-description-list__term"
-            span class="pf-c-description-list__text"
-              | Token
-          dd class="pf-c-description-list__description"
-            div class="pf-c-description-list__text"
-             = token.value
+section id="access-tokens"
+  h2 = t('.access_tokens.title')
+  p
+    = t('.access_tokens.description_html', link: link_to(t('.api_docs_link'), provider_admin_api_docs_path))
+    | .
 
-  div class="pf-c-page__main-section"
-    div class="pf-l-flex"
-      div class="pf-l-flex__item pf-m-align-right"
-        = link_to 'I have copied the token', provider_admin_user_access_tokens_path, class: 'pf-c-button pf-m-primary'
-- else
-  - content_for :page_header_title, 'Tokens'
-  section id="access-tokens"
-    h2 Access Tokens
-    p
-      ' Access tokens are personal tokens that let you authenticate against the Account Management API, the Analytics API and the Billing API through HTTP Basic Auth. You can create multiple access tokens with custom scopes and permissions. We suggest you create tokens with the minimal scopes & permissions needed for the task at hand. Use Access Tokens from within the
-      = link_to '3scale API docs', provider_admin_api_docs_path
-      | .
-
-    table class="pf-c-table pf-m-grid-lg" role="grid" aria-label="Access tokens table"
-      - allowed_scopes = current_user.allowed_access_token_scopes
-      thead
-        tr role="row"
-          th role="columnheader" scope="col" Name
-          th role="columnheader" scope="col" Scopes
-          th role="columnheader" scope="col" Expiration
-          th role="columnheader" scope="col" Permission
-          th role="columnheader" scope="col" class="pf-c-table__action pf-m-fit-content"
-            = fancy_link_to 'Add Access Token', new_provider_admin_user_access_token_path, class: 'new' if allowed_scopes.any?
-      tbody role="rowgroup"
-        - if @access_tokens.any? && allowed_scopes.any?
-          - @access_tokens.each do |token|
-            tr role="row"
-              td role="cell" data-label="Name" = token.name
-              td role="cell" data-label="Scopes" = token.human_scopes.to_sentence
-              td role="cell" data-label="Expiration" = token.expires_at.present? ? l(token.expires_at) : t('access_token_options.no_expiration')
-              td role="cell" data-label="Permission" = token.human_permission
-              td role="cell" class="pf-c-table__action"
-                div class="pf-c-overflow-menu"
-                  div class="pf-c-overflow-menu__content"
-                    div class="pf-c-overflow-menu__group pf-m-button-group"
-                      div class="pf-c-overflow-menu__item"
-                        = link_to 'Edit', edit_provider_admin_user_access_token_path(token), class: 'action edit'
-        - else
+  table class="pf-c-table pf-m-grid-lg" role="grid" aria-label="#{t('.access_tokens.table_aria_label')}"
+    - allowed_scopes = current_user.allowed_access_token_scopes
+    thead
+      tr role="row"
+        th role="columnheader" scope="col" = t('.access_tokens.columns.name')
+        th role="columnheader" scope="col" = t('.access_tokens.columns.scopes')
+        th role="columnheader" scope="col" = t('.access_tokens.columns.expiration')
+        th role="columnheader" scope="col" = t('.access_tokens.columns.permission')
+        th role="columnheader" scope="col" class="pf-c-table__action pf-m-fit-content"
+          = fancy_link_to t('.access_tokens.add_button'), new_provider_admin_user_access_token_path, class: 'new' if allowed_scopes.any?
+    tbody role="rowgroup"
+      - if @access_tokens.any? && allowed_scopes.any?
+        - @access_tokens.each do |token|
           tr role="row"
-            td role="cell" colspan='4'
-              - if allowed_scopes.any?
-                | No access tokens yet…
-              - else
-                | You can't create access tokens because you don't have access to the Account Management API, the Analytics API, and/or the Billing API. Please contact an administrator of this account.
-
-  section#service-tokens.Section
-    h2 Service Tokens
-    p
-      ' Service tokens let you authenticate against the Service Management API. Service tokens are auto generated, unique per service and shared between the users of this account. Use Service Tokens from within the
-      = link_to '3scale API docs', provider_admin_api_docs_path
-      | .
-
-    table class="pf-c-table pf-m-grid-lg" role="grid" aria-label="Service tokens table"
-      thead
+            td role="cell" data-label="#{t('.access_tokens.columns.name')}" = token.name
+            td role="cell" data-label="#{t('.access_tokens.columns.scopes')}" = token.human_scopes.to_sentence
+            td role="cell" data-label="#{t('.access_tokens.columns.expiration')}" = token.expires_at.present? ? l(token.expires_at) : t('access_token_options.no_expiration')
+            td role="cell" data-label="#{t('.access_tokens.columns.permission')}" = token.human_permission
+            td role="cell" class="pf-c-table__action"
+              div class="pf-c-overflow-menu"
+                div class="pf-c-overflow-menu__content"
+                  div class="pf-c-overflow-menu__group pf-m-button-group"
+                    div class="pf-c-overflow-menu__item"
+                      = link_to t('.access_tokens.edit_button'), edit_provider_admin_user_access_token_path(token), class: 'action edit'
+      - else
         tr role="row"
-          th role="columnheader" scope="col" class="pf-m-fit-content" Service name
-          th role="columnheader" scope="col" Scope
-          th role="columnheader" scope="col" Permission
-          th role="columnheader" scope="col" Token
-      tbody
-        - accessible_service_tokens = current_user.accessible_service_tokens
-        - if accessible_service_tokens.any?
-          - accessible_service_tokens.each do |service_token|
-            tr role="row"
-              td role="cell" data-label="Service name" = service_token.service.name
-              td role="cell" data-label="Scope" Service management API
-              td role="cell" data-label="Permission" Read & Write
-              td role="cell" data-label="Token"
-                code.u-code = service_token.value
-        - else
+          td role="cell" colspan='4'
+            - if allowed_scopes.any?
+              = t('.access_tokens.empty')
+            - else
+              = t('.access_tokens.no_scopes')
+
+section#service-tokens.Section
+  h2 = t('.service_tokens.title')
+  p
+    = t('.service_tokens.description_html', link: link_to(t('.api_docs_link'), provider_admin_api_docs_path))
+    | .
+
+  table class="pf-c-table pf-m-grid-lg" role="grid" aria-label="#{t('.service_tokens.table_aria_label')}"
+    thead
+      tr role="row"
+        th role="columnheader" scope="col" class="pf-m-fit-content" = t('.service_tokens.columns.service_name')
+        th role="columnheader" scope="col" = t('.service_tokens.columns.scope')
+        th role="columnheader" scope="col" = t('.service_tokens.columns.permission')
+        th role="columnheader" scope="col" = t('.service_tokens.columns.token')
+    tbody
+      - accessible_service_tokens = current_user.accessible_service_tokens
+      - if accessible_service_tokens.any?
+        - accessible_service_tokens.each do |service_token|
           tr role="row"
-            td colspan='4' You don't have access to any service. Contact an admin of this account to request access if needed.
+            td role="cell" data-label="#{t('.service_tokens.columns.service_name')}" = service_token.service.name
+            td role="cell" data-label="#{t('.service_tokens.columns.scope')}" = t('.service_tokens.scope_value')
+            td role="cell" data-label="#{t('.service_tokens.columns.permission')}" = t('.service_tokens.permission_value')
+            td role="cell" data-label="#{t('.service_tokens.columns.token')}"
+              code.u-code = service_token.value
+      - else
+        tr role="row"
+          td colspan='4' = t('.service_tokens.empty')

--- a/app/views/provider/admin/user/access_tokens/show.html.slim
+++ b/app/views/provider/admin/user/access_tokens/show.html.slim
@@ -1,0 +1,50 @@
+- content_for :javascripts
+= javascript_packs_with_chunks_tag 'access_tokens'
+
+- content_for :page_header_title, t('.page_header_title')
+div class="pf-c-card"
+  div class="pf-c-card__body"
+    div class="pf-c-content"
+      p = t('.copy_warning')
+    br
+    dl class="pf-c-description-list pf-m-horizontal"
+      div class="pf-c-description-list__group"
+        dt class="pf-c-description-list__term"
+          span class="pf-c-description-list__text"
+            = t('.fields.name')
+        dd class="pf-c-description-list__description"
+          div class="pf-c-description-list__text"
+            = token.name
+      div class="pf-c-description-list__group"
+        dt class="pf-c-description-list__term"
+          span class="pf-c-description-list__text"
+            = t('.fields.scopes')
+        dd class="pf-c-description-list__description"
+          div class="pf-c-description-list__text"
+            = token.human_scopes.to_sentence
+      div class="pf-c-description-list__group"
+        dt class="pf-c-description-list__term"
+          span class="pf-c-description-list__text"
+            = t('.fields.permission')
+        dd class="pf-c-description-list__description"
+          div class="pf-c-description-list__text"
+           = token.human_permission
+      div class="pf-c-description-list__group"
+        dt class="pf-c-description-list__term"
+          span class="pf-c-description-list__text"
+            = t('.fields.expires_at')
+        dd class="pf-c-description-list__description"
+          div class="pf-c-description-list__text"
+            = token.expires_at.present? ? l(token.expires_at) : t('access_token_options.no_expiration')
+      div class="pf-c-description-list__group"
+        dt class="pf-c-description-list__term"
+          span class="pf-c-description-list__text"
+            = t('.fields.token')
+        dd class="pf-c-description-list__description"
+          div class="pf-c-description-list__text"
+           = token.plaintext_value
+
+div class="pf-c-page__main-section"
+  div class="pf-l-flex"
+    div class="pf-l-flex__item pf-m-align-right"
+      = link_to t('.copied_button'), provider_admin_user_access_tokens_path, class: 'pf-c-button pf-m-primary'

--- a/app/workers/restore_apicast_master_token_worker.rb
+++ b/app/workers/restore_apicast_master_token_worker.rb
@@ -17,6 +17,6 @@ class RestoreApicastMasterTokenWorker < ApplicationJob
     master = Account.master
     access_token = master.access_tokens.find_by!(name: token_name)
     # Need to do that because `:value` is a readonly attribute
-    AccessToken.where(id: access_token.id).limit(1).update_all(value: token) # rubocop:disable Rails/SkipsModelValidations
+    AccessToken.where(id: access_token.id).limit(1).update_all(value: AccessToken.compute_digest(token)) # rubocop:disable Rails/SkipsModelValidations
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -896,9 +896,47 @@ en:
           edit:
             page_header_title: Edit Access Token
             submit_button_label: Update Access Token
+          index:
+            page_header_title: Tokens
+            api_docs_link: 3scale API docs
+            access_tokens:
+              title: Access Tokens
+              description_html: "Access tokens are personal tokens that let you authenticate against the Account Management API, the Analytics API and the Billing API through HTTP Basic Auth. You can create multiple access tokens with custom scopes and permissions. We suggest you create tokens with the minimal scopes & permissions needed for the task at hand. Use Access Tokens from within the %{link}"
+              table_aria_label: Access tokens table
+              add_button: Add Access Token
+              edit_button: Edit
+              empty: No access tokens yet…
+              no_scopes: "You can't create access tokens because you don't have access to the Account Management API, the Analytics API, and/or the Billing API. Please contact an administrator of this account."
+              columns:
+                name: Name
+                scopes: Scopes
+                expiration: Expiration
+                permission: Permission
+            service_tokens:
+              title: Service Tokens
+              description_html: "Service tokens let you authenticate against the Service Management API. Service tokens are auto generated, unique per service and shared between the users of this account. Use Service Tokens from within the %{link}"
+              table_aria_label: Service tokens table
+              scope_value: Service management API
+              permission_value: Read & Write
+              empty: You don't have access to any service. Contact an admin of this account to request access if needed.
+              columns:
+                service_name: Service name
+                scope: Scope
+                permission: Permission
+                token: Token
           new:
             page_header_title: New Access Token
             submit_button_label: Create Access Token
+          show:
+            page_header_title: Copy the new token and store it somewhere safe
+            copy_warning: Make sure to copy your new personal access token now. You won't be able to see it again as it isn't stored for security reasons.
+            copied_button: I have copied the token
+            fields:
+              name: Name
+              scopes: Scopes
+              permission: Permission
+              expires_at: Expires at
+              token: Token
           update:
             success: Access token was successfully updated
         notification_preferences:

--- a/db/migrate/20260310134934_hash_access_token_values.rb
+++ b/db/migrate/20260310134934_hash_access_token_values.rb
@@ -1,0 +1,38 @@
+class HashAccessTokenValues < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction! if System::Database.postgres?
+
+  BATCH_SIZE = 1000
+  DIGEST_PREFIX = 'SHA384$'.freeze
+
+  def up
+    say "Hashing legacy access token values..."
+
+    loop do
+      rows_updated = exec_update(batch_update_sql)
+      break if rows_updated == 0
+
+      sleep(0.1)
+    end
+
+    say "Done."
+  end
+
+  private
+
+  def batch_update_sql
+    if System::Database.mysql?
+      "UPDATE access_tokens SET value = CONCAT('#{DIGEST_PREFIX}', SHA2(value, 384)) " \
+        "WHERE value NOT LIKE '#{DIGEST_PREFIX}%' LIMIT #{BATCH_SIZE}"
+    elsif System::Database.postgres?
+      "UPDATE access_tokens SET value = '#{DIGEST_PREFIX}' || encode(sha384(value::bytea), 'hex') " \
+        "WHERE id IN (SELECT id FROM access_tokens WHERE value NOT LIKE '#{DIGEST_PREFIX}%' LIMIT #{BATCH_SIZE})"
+    elsif System::Database.oracle?
+      "UPDATE access_tokens SET value = '#{DIGEST_PREFIX}' || LOWER(STANDARD_HASH(value, 'SHA384')) " \
+        "WHERE ROWID IN (SELECT ROWID FROM access_tokens WHERE value NOT LIKE '#{DIGEST_PREFIX}%' AND ROWNUM <= #{BATCH_SIZE})"
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -143,21 +143,21 @@ ActiveRecord::Base.transaction do
 
   apicast_access_token = master_user.access_tokens.create!(name: 'APIcast', scopes: %w[account_management], permission: 'ro') do |token|
     if (value = ENV['APICAST_ACCESS_TOKEN'].presence)
-      token.value = value
+      token.value =  AccessToken.compute_digest(value)
     end
-  end.value
+  end.plaintext_value
 
 
   master_access_token = master_user.access_tokens.create!(name: 'Master Token', scopes: %w[account_management], permission: 'rw') do |token|
     if (value = ENV['MASTER_ACCESS_TOKEN'].presence)
-      token.value = value
+      token.value = AccessToken.compute_digest(value)
     end
-  end.value
+  end.plaintext_value
 
   if (admin_access_token = ENV['ADMIN_ACCESS_TOKEN'].presence)
     access_token = user.access_tokens.build(name: 'Administration', permission: 'rw')
     access_token.scopes = access_token.class.scopes.values
-    access_token.value = admin_access_token
+    access_token.value = AccessToken.compute_digest(admin_access_token)
     access_token.save!
   end
 

--- a/spec/acceptance/api/access_token_spec.rb
+++ b/spec/acceptance/api/access_token_spec.rb
@@ -4,12 +4,13 @@ require 'rails_helper'
 
 resource 'AccessToken' do
   let(:resource) { FactoryBot.build(:access_token) }
-  let(:expected_properties) { %w[id name scopes permission value] }
+  let(:expected_properties) { %w[id name scopes permission] }
 
   json(:resource) do
     let(:root) { 'access_token' }
 
     it { subject.should have_properties(expected_properties).from(resource) }
+    it { should include('value' => resource.plaintext_value) }
   end
 
   json(:collection) do
@@ -20,6 +21,7 @@ resource 'AccessToken' do
         subject.each do |subject_access_token|
           subject_access_token.should include('access_token')
           subject_access_token.fetch('access_token').should have_properties(expected_properties).from(resource)
+          subject_access_token.fetch('access_token').should include('value' => resource.plaintext_value)
         end
       end
     end

--- a/spec/acceptance/api/signup_result_with_access_token_spec.rb
+++ b/spec/acceptance/api/signup_result_with_access_token_spec.rb
@@ -11,7 +11,7 @@ resource 'Signup::ResultWithAccessToken' do
     result
   end
   let(:expected_account_properties) { %w[id created_at updated_at admin_domain domain from_email state] }
-  let(:expected_access_token_properties) { %w[id name scopes permission value] }
+  let(:expected_access_token_properties) { %w[id name scopes permission] }
 
   json(:resource) do
     let(:root) { 'signup' }
@@ -19,6 +19,7 @@ resource 'Signup::ResultWithAccessToken' do
     it do
       subject.fetch('account').should have_properties(expected_account_properties).from(resource.account)
       subject.fetch('access_token').should have_properties(expected_access_token_properties).from(resource.access_token)
+      subject.fetch('access_token').should include('value' => resource.access_token.plaintext_value)
     end
 
     it { should_not include('errors') }
@@ -46,6 +47,7 @@ resource 'Signup::ResultWithAccessToken' do
     context 'access_token' do
       subject { xml.root.xpath('./access_token') }
       it { should have_tags(expected_access_token_properties).from(resource.access_token) }
+      it { should have_tag('value', text: resource.access_token.plaintext_value) }
     end
 
     it { should_not have_tag('errors') }

--- a/test/factories/access_token.rb
+++ b/test/factories/access_token.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association :owner, factory: :user
     scopes { ['stats'] }
     permission { 'rw' }
-    sequence(:name)  { |n| "Alaska_#{n}" }
-    sequence(:value) { |n| "wild_#{n}" }
+    sequence(:name) { |n| "Alaska_#{n}" }
+    # value is generated automatically by after_initialize callback in model
   end
 end

--- a/test/functional/admin/api/cms/templates_controller_test.rb
+++ b/test/functional/admin/api/cms/templates_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::Api::CMS::TemplatesControllerTest < ActionController::TestCase
   def setup
     @provider     = FactoryBot.create(:provider_account)
     host! @provider.external_admin_domain
-    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[cms]).value
+    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[cms]).plaintext_value
   end
 
   class TemplatesControllerMethodsTest < Admin::Api::CMS::TemplatesControllerTest

--- a/test/functional/admin/api/credit_cards_controller_test.rb
+++ b/test/functional/admin/api/credit_cards_controller_test.rb
@@ -8,7 +8,7 @@ class Admin::Api::CreditCardsControllerTest < ActionController::TestCase
     provider = FactoryBot.create(:provider_account)
     @buyer   = FactoryBot.create(:buyer_account, provider_account: provider)
     host! provider.external_admin_domain
-    @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
 
     @params = {
       id: @buyer.provider_account_id,

--- a/test/functional/admin/api/services/mapping_rules_controller_test.rb
+++ b/test/functional/admin/api/services/mapping_rules_controller_test.rb
@@ -6,7 +6,7 @@ module Admin::Api::Services
   class MappingRulesControllerTest < ActionController::TestCase
     def setup
       provider = FactoryBot.create(:provider_account)
-      @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).value
+      @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
       assert @service = provider.first_service!
       assert @proxy = @service.proxy
 

--- a/test/functional/api/web_hooks_failures_controller_test.rb
+++ b/test/functional/api/web_hooks_failures_controller_test.rb
@@ -6,7 +6,7 @@ class Admin::Api::WebHooksFailuresControllerTest < ActionController::TestCase
 
   def setup
     @provider = FactoryBot.create(:provider_account)
-    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
     host! @provider.external_admin_domain
   end
 

--- a/test/integration/admin/api/account/authentication_providers_controller_test.rb
+++ b/test/integration/admin/api/account/authentication_providers_controller_test.rb
@@ -108,7 +108,7 @@ class Admin::Api::Account::AuthenticationProvidersControllerTest < ActionDispatc
     FactoryBot.create(:auth0_authentication_provider, account: @provider, account_type: AuthenticationProvider.account_types[:provider])
     FactoryBot.create(:keycloak_authentication_provider, account: @provider, account_type: AuthenticationProvider.account_types[:provider])
     FactoryBot.create(:auth0_authentication_provider, account: FactoryBot.build_stubbed(:simple_provider), account_type: AuthenticationProvider.account_types[:provider])
-    get admin_api_account_authentication_providers_path(format: :json, access_token: @access_token.value)
+    get admin_api_account_authentication_providers_path(format: :json, access_token: @access_token.plaintext_value)
     assert_response :ok
     authentication_providers = JSON.parse(response.body)['authentication_providers']
     assert authentication_providers.present?
@@ -122,7 +122,7 @@ class Admin::Api::Account::AuthenticationProvidersControllerTest < ActionDispatc
     FactoryBot.create(:auth0_authentication_provider, account: @provider, account_type: AuthenticationProvider.account_types[:provider])
     FactoryBot.create(:keycloak_authentication_provider, account: @provider, account_type: AuthenticationProvider.account_types[:provider])
     FactoryBot.create(:auth0_authentication_provider, account: FactoryBot.build_stubbed(:simple_provider), account_type: AuthenticationProvider.account_types[:provider])
-    get admin_api_account_authentication_providers_path(format: :xml, access_token: @access_token.value)
+    get admin_api_account_authentication_providers_path(format: :xml, access_token: @access_token.plaintext_value)
     assert_response :ok
     assert_xml './authentication_providers/authentication_provider', 2
   end
@@ -130,13 +130,13 @@ class Admin::Api::Account::AuthenticationProvidersControllerTest < ActionDispatc
   test '#index ensures provider can use provider_sso' do
     Logic::RollingUpdates.stubs(:enabled?).returns(true)
     @provider.stubs(:provider_can_use?).with(:provider_sso).returns(false)
-    get admin_api_account_authentication_providers_path(format: :json, access_token: @access_token.value)
+    get admin_api_account_authentication_providers_path(format: :json, access_token: @access_token.plaintext_value)
     assert_response :not_found
   end
 
   test '#show returns the requested authentication provider' do
     authentication_provider = FactoryBot.create(:self_authentication_provider, account: @provider, account_type: AuthenticationProvider.account_types[:provider])
-    get admin_api_account_authentication_provider_path(authentication_provider, format: :json, access_token: @access_token.value)
+    get admin_api_account_authentication_provider_path(authentication_provider, format: :json, access_token: @access_token.plaintext_value)
     assert_response :ok
     assert_equal authentication_provider.id, JSON.parse(response.body).dig('authentication_provider', 'id')
   end
@@ -145,7 +145,7 @@ class Admin::Api::Account::AuthenticationProvidersControllerTest < ActionDispatc
     Logic::RollingUpdates.stubs(:enabled?).returns(true)
     @provider.stubs(:provider_can_use?).with(:provider_sso).returns(false)
     authentication_provider = FactoryBot.create(:self_authentication_provider, account: @provider, account_type: AuthenticationProvider.account_types[:provider])
-    get admin_api_account_authentication_provider_path(authentication_provider, format: :json, access_token: @access_token.value)
+    get admin_api_account_authentication_provider_path(authentication_provider, format: :json, access_token: @access_token.plaintext_value)
     assert_response :not_found
   end
 
@@ -161,6 +161,6 @@ class Admin::Api::Account::AuthenticationProvidersControllerTest < ActionDispatc
       client_id: 'cid', client_secret: 'csecret', site: 'http://example',
       kind: 'auth0', skip_ssl_certificate_verification: true, published: true
     }.merge(different_attributes)
-    { authentication_provider: attributes, format: :json, access_token: @access_token.value }
+    { authentication_provider: attributes, format: :json, access_token: @access_token.plaintext_value }
   end
 end

--- a/test/integration/admin/api/account/proxy_configs_controller_test.rb
+++ b/test/integration/admin/api/account/proxy_configs_controller_test.rb
@@ -195,7 +195,7 @@ class Admin::Api::Account::ProxyConfigsControllerTest < ActionDispatch::Integrat
   end
 
   def access_token_value(user:)
-    FactoryBot.create(:access_token, owner: user, scopes: %w[account_management]).value
+    FactoryBot.create(:access_token, owner: user, scopes: %w[account_management]).plaintext_value
   end
 
   def response_proxy_config_ids

--- a/test/integration/admin/api/account_plans_controller_test.rb
+++ b/test/integration/admin/api/account_plans_controller_test.rb
@@ -6,7 +6,7 @@ class Admin::Api::AccountPlansControllerTest < ActionDispatch::IntegrationTest
 
   def setup
     @provider = FactoryBot.create(:provider_account)
-    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
     host! @provider.external_admin_domain
   end
 

--- a/test/integration/admin/api/accounts_controller_test.rb
+++ b/test/integration/admin/api/accounts_controller_test.rb
@@ -42,7 +42,7 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
       buyer_user = FactoryBot.create(:admin, account: buyer)
       buyer_user.update(email: nil)
 
-      get find_admin_api_accounts_path(format: :json, access_token: token.value)
+      get find_admin_api_accounts_path(format: :json, access_token: token.plaintext_value)
       assert_response :not_found
     end
   end
@@ -138,13 +138,13 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
       buyer.payment_detail.destroy!
 
       assert_difference(PaymentDetail.method(:count), 0) do
-        get admin_api_account_path(buyer, format: :xml, access_token: token.value)
+        get admin_api_account_path(buyer, format: :xml, access_token: token.plaintext_value)
         assert_response :success
       end
 
       buyer.settings.destroy!
       assert_difference(Settings.method(:count), 0) do
-        get admin_api_account_path(buyer, format: :xml, access_token: token.value)
+        get admin_api_account_path(buyer, format: :xml, access_token: token.plaintext_value)
         assert_response :success
       end
 
@@ -165,7 +165,7 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
       FactoryBot.create(:webhook, account: provider, account_updated_on: true, active: true)
 
       assert_difference(WebHookWorker.jobs.method(:size)) do
-        put admin_api_account_path(buyer, format: :json), params: { monthly_billing_enabled: true, access_token: token.value }
+        put admin_api_account_path(buyer, format: :json), params: { monthly_billing_enabled: true, access_token: token.plaintext_value }
         assert_response :success
       end
     end
@@ -185,7 +185,7 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
       FactoryBot.create(:webhook, account: provider, account_deleted_on: true, active: true)
 
       assert_difference(WebHookWorker.jobs.method(:size)) do
-        delete admin_api_account_path(buyer, access_token: token.value)
+        delete admin_api_account_path(buyer, access_token: token.plaintext_value)
         assert_response :success
       end
     end
@@ -210,7 +210,7 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def update_params
-    @update_params ||= { monthly_billing_enabled: true, access_token: token.value }
+    @update_params ||= { monthly_billing_enabled: true, access_token: token.plaintext_value }
   end
 
   def token(user: provider.admin_user)

--- a/test/integration/admin/api/api_docs_services_controller_test.rb
+++ b/test/integration/admin/api/api_docs_services_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTest
 
   def setup
-    @token = FactoryBot.create(:access_token, owner: current_account.admin_users.first!, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: current_account.admin_users.first!, scopes: %w[account_management]).plaintext_value
     host! current_account.internal_admin_domain
   end
 
@@ -33,7 +33,7 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
       @provider = FactoryBot.create(:provider_account)
       @service = @provider.default_service
       @api_docs_service = FactoryBot.create(:api_docs_service, account: @provider, service: nil)
-      @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+      @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
     end
 
     BOOLEAN_API_DOCS_SERVICE_PARAMS = %i[published skip_swagger_validations].freeze
@@ -191,7 +191,7 @@ class Admin::Api::ApiDocsServicesControllerTest < ActionDispatch::IntegrationTes
       protected
 
       def path_params
-        { access_token: access_token.value, format: :json }
+        { access_token: access_token.plaintext_value, format: :json }
       end
 
       def api_doc_params(**extra_params)

--- a/test/integration/admin/api/application_plan_limits_controller_test.rb
+++ b/test/integration/admin/api/application_plan_limits_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::Api::ApplicationPlanLimitsControllerTest < ActionDispatch::Integrat
 
   setup do
     @provider = FactoryBot.create(:provider_account)
-    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
     host! @provider.external_admin_domain
     @service = FactoryBot.create(:simple_service, account: @provider)
     @app_plan = FactoryBot.create(:simple_application_plan, issuer: service)

--- a/test/integration/admin/api/application_plan_metric_pricing_rules_controller_test.rb
+++ b/test/integration/admin/api/application_plan_metric_pricing_rules_controller_test.rb
@@ -8,7 +8,7 @@ class Admin::Api::ApplicationPlanMetricPricingRulesControllerTest < ActionDispat
     service  = FactoryBot.create(:service, account: @provider)
     @plan    = FactoryBot.create(:application_plan, issuer: service)
     @metric  = FactoryBot.create(:metric, owner: service)
-    @access_token_value = FactoryBot.create(:access_token, owner: @provider.admin_user, scopes: %w[account_management]).value
+    @access_token_value = FactoryBot.create(:access_token, owner: @provider.admin_user, scopes: %w[account_management]).plaintext_value
 
     host! provider.external_admin_domain
   end

--- a/test/integration/admin/api/application_plans_controller_test.rb
+++ b/test/integration/admin/api/application_plans_controller_test.rb
@@ -6,7 +6,7 @@ class Admin::Api::ApplicationPlansControllerTest < ActionDispatch::IntegrationTe
 
   def setup
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    @token = FactoryBot.create(:access_token, owner: current_account.admin_users.first!, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: current_account.admin_users.first!, scopes: %w[account_management]).plaintext_value
     host! current_account.internal_admin_domain
     @service = FactoryBot.create(:service, account: current_account)
   end

--- a/test/integration/admin/api/authentication_providers_controller_test.rb
+++ b/test/integration/admin/api/authentication_providers_controller_test.rb
@@ -100,7 +100,7 @@ class Admin::Api::AuthenticationProvidersControllerTest < ActionDispatch::Integr
     FactoryBot.create(:redhat_customer_portal_authentication_provider, account: provider)
     FactoryBot.create(:keycloak_authentication_provider, account: provider)
     FactoryBot.create(:redhat_customer_portal_authentication_provider, account: FactoryBot.build_stubbed(:simple_provider))
-    get admin_api_authentication_providers_path(format: :json, access_token: access_token.value)
+    get admin_api_authentication_providers_path(format: :json, access_token: access_token.plaintext_value)
     assert_response :ok
     authentication_providers = JSON.parse(response.body)['authentication_providers']
     assert authentication_providers.present?
@@ -114,14 +114,14 @@ class Admin::Api::AuthenticationProvidersControllerTest < ActionDispatch::Integr
     FactoryBot.create(:redhat_customer_portal_authentication_provider, account: provider)
     FactoryBot.create(:keycloak_authentication_provider, account: provider)
     FactoryBot.create(:redhat_customer_portal_authentication_provider, account: FactoryBot.build_stubbed(:simple_provider))
-    get admin_api_authentication_providers_path(format: :xml, access_token: access_token.value)
+    get admin_api_authentication_providers_path(format: :xml, access_token: access_token.plaintext_value)
     assert_response :ok
     assert_xml './authentication_providers/authentication_provider', 2
   end
 
   test '#show returns the requested authentication provider' do
     authentication_provider = FactoryBot.create(:authentication_provider, account: provider)
-    get admin_api_authentication_provider_path(authentication_provider, format: :json, access_token: access_token.value)
+    get admin_api_authentication_provider_path(authentication_provider, format: :json, access_token: access_token.plaintext_value)
     assert_response :ok
     assert_equal authentication_provider.id, JSON.parse(response.body).dig('authentication_provider', 'id')
   end
@@ -130,7 +130,7 @@ class Admin::Api::AuthenticationProvidersControllerTest < ActionDispatch::Integr
     authentication_provider = FactoryBot.create(:authentication_provider, account: provider)
     AuthenticationProvider.any_instance.expects(:authorization_scope).with('show').returns('show')
     Ability.any_instance.expects(:authorize!).raises(CanCan::AccessDenied)
-    get admin_api_authentication_provider_path(authentication_provider, format: :json, access_token: access_token.value)
+    get admin_api_authentication_provider_path(authentication_provider, format: :json, access_token: access_token.plaintext_value)
     assert_response :forbidden
   end
 
@@ -144,6 +144,6 @@ class Admin::Api::AuthenticationProvidersControllerTest < ActionDispatch::Integr
       token_url: 'http://token_url', user_info_url: 'http://user_info_url', authorize_url: 'http://authorize_url',
       kind: 'github', skip_ssl_certificate_verification: true, automatically_approve_accounts: true
     }.merge(different_attributes)
-    { authentication_provider: attributes, format: format, access_token: access_token.value }
+    { authentication_provider: attributes, format: format, access_token: access_token.plaintext_value }
   end
 end

--- a/test/integration/admin/api/backend_apis/mapping_rules_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/mapping_rules_controller_test.rb
@@ -21,14 +21,14 @@ class Admin::Api::BackendApis::MappingRulesControllerTest < ActionDispatch::Inte
     end
 
     attr_reader :access_token
-    delegate :value, to: :access_token, prefix: true
+    delegate :plaintext_value, to: :access_token, prefix: true
 
     test 'index' do
       FactoryBot.create_list(:proxy_rule, 2, owner: backend_api, proxy: nil) # two more of the same backend api
       FactoryBot.create(:proxy_rule, owner: FactoryBot.create(:backend_api, account: provider), proxy: nil) # other backend api
       FactoryBot.create(:proxy_rule, proxy: FactoryBot.create(:simple_service, account: provider).proxy) # owned by a proxy, not a backend api
 
-      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value }
 
       assert_response :success
       assert(response_mapping_rules = JSON.parse(response.body)['mapping_rules'])
@@ -38,7 +38,7 @@ class Admin::Api::BackendApis::MappingRulesControllerTest < ActionDispatch::Inte
     end
 
     test 'show' do
-      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value }
 
       assert_response :success
       assert_equal mapping_rule.id, JSON.parse(response.body).dig('mapping_rule', 'id')
@@ -46,7 +46,7 @@ class Admin::Api::BackendApis::MappingRulesControllerTest < ActionDispatch::Inte
 
     test 'create' do
       assert_difference(ProxyRule.method(:count)) do
-        post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, **mapping_rule_params }
+        post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value, **mapping_rule_params }
         assert_response :created
       end
 
@@ -58,14 +58,14 @@ class Admin::Api::BackendApis::MappingRulesControllerTest < ActionDispatch::Inte
 
     test 'create without metric_id gives an error' do
       assert_no_difference(ProxyRule.method(:count)) do
-        post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, **mapping_rule_params.except(:metric_id) }
+        post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value, **mapping_rule_params.except(:metric_id) }
         assert_response :unprocessable_entity
         assert_contains JSON.parse(response.body).dig('errors', 'metric_id'), 'can\'t be blank'
       end
     end
 
     test 'update' do
-      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value, **mapping_rule_params }
+      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value, **mapping_rule_params }
       assert_response :success
       mapping_rule.reload
       mapping_rule_params.each do |field_name, expected_value|
@@ -74,13 +74,13 @@ class Admin::Api::BackendApis::MappingRulesControllerTest < ActionDispatch::Inte
     end
 
     test 'update with errors in the model' do
-      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value, http_method: 'invalid' }
+      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value, http_method: 'invalid' }
       assert_response :unprocessable_entity
       assert_contains JSON.parse(response.body).dig('errors', 'http_method'), 'is not included in the list'
     end
 
     test 'destroy' do
-      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value }
       assert_response :success
       assert_raises(ActiveRecord::RecordNotFound) { mapping_rule.reload }
     end
@@ -88,7 +88,7 @@ class Admin::Api::BackendApis::MappingRulesControllerTest < ActionDispatch::Inte
     test 'index can be paginated' do
       FactoryBot.create_list(:proxy_rule, 5, owner: backend_api, proxy_id: nil)
 
-      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, per_page: 3, page: 2 }
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value, per_page: 3, page: 2 }
 
       assert_response :success
       response_ids = JSON.parse(response.body)['mapping_rules'].map { |response| response.dig('mapping_rule', 'id') }
@@ -99,19 +99,19 @@ class Admin::Api::BackendApis::MappingRulesControllerTest < ActionDispatch::Inte
       backend_api = FactoryBot.create(:backend_api, account: provider, state: :deleted)
       mapping_rule = FactoryBot.create(:proxy_rule, owner: backend_api, proxy: nil)
 
-      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :not_found
 
-      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value }
       assert_response :not_found
 
-      post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, **mapping_rule_params }
+      post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value, **mapping_rule_params }
       assert_response :not_found
 
-      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value, **mapping_rule_params }
+      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value, **mapping_rule_params }
       assert_response :not_found
 
-      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value }
       assert_response :not_found
     end
 
@@ -124,7 +124,7 @@ class Admin::Api::BackendApis::MappingRulesControllerTest < ActionDispatch::Inte
       rule_1.move_to_top
       rule_3.move_to_bottom
 
-      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value }
 
       assert_response :success
       assert(response_mapping_rules = JSON.parse(response.body)['mapping_rules'])
@@ -144,42 +144,42 @@ class Admin::Api::BackendApis::MappingRulesControllerTest < ActionDispatch::Inte
     end
 
     attr_reader :member, :access_token
-    delegate :value, to: :access_token, prefix: true
+    delegate :plaintext_value, to: :access_token, prefix: true
 
     test 'member with permission' do
       member.admin_sections = %w[partners plans]
       member.save!
 
-      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value }
       assert_response :success
 
-      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value, **mapping_rule_params }
+      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value, **mapping_rule_params }
       assert_response :success
 
-      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value }
       assert_response :success
 
-      post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, **mapping_rule_params }
+      post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value, **mapping_rule_params }
       assert_response :success
 
-      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :success
     end
 
     test 'member without permission' do
-      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      get admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
 
-      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value, **mapping_rule_params }
+      put admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value, **mapping_rule_params }
       assert_response :forbidden
 
-      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_value }
+      delete admin_api_backend_api_mapping_rule_path(backend_api, mapping_rule), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
 
-      post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value, **mapping_rule_params }
+      post admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value, **mapping_rule_params }
       assert_response :forbidden
 
-      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_mapping_rules_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
     end
   end

--- a/test/integration/admin/api/backend_apis/metric_methods_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metric_methods_controller_test.rb
@@ -22,14 +22,14 @@ class Admin::Api::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
     end
 
     attr_reader :access_token
-    delegate :value, to: :access_token, prefix: true
+    delegate :plaintext_value, to: :access_token, prefix: true
 
     test 'index' do
       FactoryBot.create_list(:metric, 2, owner: backend_api, service_id: nil, parent: hits) # two more method metrics of the backend api
       FactoryBot.create(:metric, owner: FactoryBot.create(:backend_api, account: provider), service_id: nil) # other backend api
       FactoryBot.create(:metric, owner: FactoryBot.create(:service, account: provider)) # owned by service, not a backend api
 
-      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value }
 
       assert_response :success
       assert(response_metrics = JSON.parse(response.body)['methods'])
@@ -39,7 +39,7 @@ class Admin::Api::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
     end
 
     test 'show' do
-      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value }
 
       assert_response :success
       assert_equal method_metric.id, JSON.parse(response.body).dig('method', 'id')
@@ -47,7 +47,7 @@ class Admin::Api::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
 
     test 'create' do
       assert_difference(Metric.method(:count)) do
-        post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+        post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value, friendly_name: 'my friendly name', unit: 'hit' }
         assert_response :created
       end
       method_metric = hits.children.find(JSON.parse(response.body).dig('method', 'id'))
@@ -57,13 +57,13 @@ class Admin::Api::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
     end
 
     test 'create with errors in the model' do
-      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: '' }
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value, friendly_name: '' }
       assert_response :unprocessable_entity
       assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
     end
 
     test 'update' do
-      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value, friendly_name: 'my friendly name', unit: 'hit' }
       assert_response :success
       method_metric.reload
       assert_equal 'my friendly name', method_metric.friendly_name
@@ -71,24 +71,24 @@ class Admin::Api::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
     end
 
     test 'update with errors in the model' do
-      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: '' }
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value, friendly_name: '' }
       assert_response :unprocessable_entity
       assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
     end
 
     test 'system_name can be created but not updated' do
-      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit', system_name: 'first-system-name' }
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value, friendly_name: 'my friendly name', unit: 'hit', system_name: 'first-system-name' }
       method_metric = hits.children.find(JSON.parse(response.body).dig('method', 'id'))
       assert_equal "first-system-name.#{backend_api.id}", method_metric.system_name
 
-      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit', system_name: 'edited' }
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value, friendly_name: 'my friendly name', unit: 'hit', system_name: 'edited' }
       assert_equal "first-system-name.#{backend_api.id}", method_metric.reload.system_name
     end
 
     test 'destroy' do
       method_metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil, parent: hits)
       assert_difference(Metric.method(:count), -1) do
-        delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+        delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value }
         assert_response :success
       end
       assert_raises(ActiveRecord::RecordNotFound) { method_metric.reload }
@@ -97,7 +97,7 @@ class Admin::Api::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
     test 'index can be paginated' do
       FactoryBot.create_list(:metric, 5, owner: backend_api, parent: hits, service_id: nil)
 
-      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, per_page: 3, page: 2 }
+      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value, per_page: 3, page: 2 }
 
       assert_response :success
       response_ids = JSON.parse(response.body)['methods'].map { |response| response.dig('method', 'id') }
@@ -109,28 +109,28 @@ class Admin::Api::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
       hits = backend_api.metrics.hits
       method_metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil, parent: hits)
 
-      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value }
       assert_response :not_found
 
-      delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value }
       assert_response :not_found
 
-      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value, friendly_name: 'my friendly name', unit: 'hit' }
       assert_response :not_found
 
-      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value, friendly_name: 'my friendly name', unit: 'hit' }
       assert_response :not_found
 
-      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value }
       assert_response :not_found
     end
 
     test 'when no params are sent, the error message is the same as in the other metrics endpoint' do
-      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value }
       assert_response :unprocessable_entity
       assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
 
-      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value }
       assert_response :success
     end
   end
@@ -145,42 +145,42 @@ class Admin::Api::BackendApis::MetricMethodsControllerTest < ActionDispatch::Int
     end
 
     attr_reader :member, :access_token
-    delegate :value, to: :access_token, prefix: true
+    delegate :plaintext_value, to: :access_token, prefix: true
 
     test 'member with permission' do
       member.admin_sections = %w[partners plans]
       member.save!
 
-      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value }
       assert_response :success
 
-      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value, friendly_name: 'my friendly name', unit: 'hit' }
       assert_response :success
 
-      delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value }
       assert_response :success
 
-      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value, friendly_name: 'my friendly name', unit: 'hit' }
       assert_response :success
 
-      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value }
       assert_response :success
     end
 
     test 'member without permission' do
-      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
 
-      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      put admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value, friendly_name: 'my friendly name', unit: 'hit' }
       assert_response :forbidden
 
-      delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_value }
+      delete admin_api_backend_api_metric_method_path(backend_api, hits, method_metric), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
 
-      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value, friendly_name: 'my friendly name', unit: 'hit' }
+      post admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value, friendly_name: 'my friendly name', unit: 'hit' }
       assert_response :forbidden
 
-      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_methods_path(backend_api, hits), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
     end
   end

--- a/test/integration/admin/api/backend_apis/metrics_controller_test.rb
+++ b/test/integration/admin/api/backend_apis/metrics_controller_test.rb
@@ -21,14 +21,14 @@ class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
     end
 
     attr_reader :access_token
-    delegate :value, to: :access_token, prefix: true
+    delegate :plaintext_value, to: :access_token, prefix: true
 
     test 'index' do
       FactoryBot.create(:metric, owner: backend_api, parent: backend_api.metrics.hits, service_id: nil) # a method metric
       FactoryBot.create(:metric, owner: FactoryBot.create(:backend_api, account: provider), service_id: nil) # other backend api
       FactoryBot.create(:metric, owner: FactoryBot.create(:service, account: provider)) # owned by a service, not a backend api
 
-      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value }
 
       assert_response :success
       assert(response_metrics = JSON.parse(response.body)['metrics'])
@@ -38,7 +38,7 @@ class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
     end
 
     test 'show' do
-      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value }
 
       assert_response :success
       assert_equal metric.id, JSON.parse(response.body).dig('metric', 'id')
@@ -46,7 +46,7 @@ class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
 
     test 'create' do
       assert_difference(Metric.method(:count)) do
-        post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+        post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value, friendly_name: 'metric friendly name', unit: 'hit' }
         assert_response :created
       end
       metric = backend_api.metrics.find(JSON.parse(response.body).dig('metric', 'id'))
@@ -56,13 +56,13 @@ class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
     end
 
     test 'create with errors in the model' do
-      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: '', unit: 'hit' }
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value, friendly_name: '', unit: 'hit' }
       assert_response :unprocessable_entity
       assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
     end
 
     test 'update' do
-      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value, friendly_name: 'metric friendly name', unit: 'hit' }
       assert_response :success
       metric.reload
       assert_equal 'metric friendly name', metric.friendly_name
@@ -71,22 +71,22 @@ class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
 
     test 'cannot update system_name' do
       old_system_name = metric.system_name
-      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, system_name: 'new_system_name' }
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value, system_name: 'new_system_name' }
       assert_response :success
       assert_equal old_system_name, metric.reload.system_name
     end
 
     test 'system_name can be created but not updated' do
-      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit', system_name: 'first-system-name' }
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value, friendly_name: 'metric friendly name', unit: 'hit', system_name: 'first-system-name' }
       metric = backend_api.metrics.find(JSON.parse(response.body).dig('metric', 'id'))
       assert_equal "first-system-name.#{backend_api.id}", metric.attributes['system_name']
 
-      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit', system_name: 'edited' }
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value, friendly_name: 'metric friendly name', unit: 'hit', system_name: 'edited' }
       assert_equal "first-system-name.#{backend_api.id}", metric.reload.attributes['system_name']
     end
 
     test 'update with errors in the model' do
-      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: '' }
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value, friendly_name: '' }
       assert_response :unprocessable_entity
       assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
     end
@@ -94,7 +94,7 @@ class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
     test 'destroy' do
       metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil)
       assert_difference(Metric.method(:count), -1) do
-        delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+        delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value }
         assert_response :success
       end
       assert_raises(ActiveRecord::RecordNotFound) { metric.reload }
@@ -103,7 +103,7 @@ class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
     test 'index can be paginated' do
       FactoryBot.create_list(:metric, 5, owner: backend_api, service_id: nil)
 
-      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, per_page: 3, page: 2 }
+      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value, per_page: 3, page: 2 }
 
       assert_response :success
       response_ids = JSON.parse(response.body)['metrics'].map { |response| response.dig('metric', 'id') }
@@ -114,29 +114,29 @@ class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
       backend_api = FactoryBot.create(:backend_api, account: provider, state: :deleted)
       metric = FactoryBot.create(:metric, owner: backend_api, service_id: nil)
 
-      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value }
       assert_response :not_found
 
-      delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value }
       assert_response :not_found
 
-      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value, friendly_name: 'metric friendly name', unit: 'hit' }
       assert_response :not_found
 
-      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value, friendly_name: 'metric friendly name', unit: 'hit' }
       assert_response :not_found
 
-      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :not_found
     end
 
     test 'when no params are sent, the error message is the same as in the other metrics endpoint' do
-      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :unprocessable_entity
       assert_contains JSON.parse(response.body).dig('errors', 'friendly_name'), 'can\'t be blank'
       assert_contains JSON.parse(response.body).dig('errors', 'unit'), 'can\'t be blank'
 
-      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value }
       assert_response :success
     end
   end
@@ -151,42 +151,42 @@ class Admin::Api::BackendApis::MetricsControllerTest < ActionDispatch::Integrati
     end
 
     attr_reader :member, :access_token
-    delegate :value, to: :access_token, prefix: true
+    delegate :plaintext_value, to: :access_token, prefix: true
 
     test 'member with permission' do
       member.admin_sections = %w[partners plans]
       member.save!
 
-      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value }
       assert_response :success
 
-      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value, friendly_name: 'metric friendly name', unit: 'hit' }
       assert_response :success
 
-      delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value }
       assert_response :success
 
-      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value, friendly_name: 'metric friendly name', unit: 'hit' }
       assert_response :success
 
-      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :success
     end
 
     test 'member without permission' do
-      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      get admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
 
-      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      put admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value, friendly_name: 'metric friendly name', unit: 'hit' }
       assert_response :forbidden
 
-      delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_value }
+      delete admin_api_backend_api_metric_path(backend_api, metric), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
 
-      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value, friendly_name: 'metric friendly name', unit: 'hit' }
+      post admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value, friendly_name: 'metric friendly name', unit: 'hit' }
       assert_response :forbidden
 
-      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_metrics_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
     end
   end

--- a/test/integration/admin/api/backend_apis_controller_test.rb
+++ b/test/integration/admin/api/backend_apis_controller_test.rb
@@ -13,7 +13,7 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   test 'show' do
     backend_api_configs = FactoryBot.create_list(:backend_api_config, 2, backend_api: backend_api)
 
-    get admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+    get admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value }
 
     assert_response :success
     backend_api_response = JSON.parse(response.body)
@@ -21,7 +21,7 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'destroy' do
-    delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+    delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value }
     assert_response :success
     assert backend_api.reload.deleted?
   end
@@ -29,27 +29,27 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   test 'destroy with errors' do
     provider.default_service.backend_api_configs.create!(backend_api: backend_api, path: 'whatever')
 
-    delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+    delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value }
     refute backend_api.reload.deleted?
     assert_contains JSON.parse(response.body).dig('errors', 'base'), 'cannot be deleted because it is used by at least one Product'
   end
 
   test 'update' do
-    put admin_api_backend_api_path(backend_api), params: { access_token: access_token_value, **permitted_params.merge(forbidden_params) }
+    put admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value, **permitted_params.merge(forbidden_params) }
     assert_response :success
     backend_api.reload
     assert_persists_right_params
   end
 
   test 'update with errors in the model' do
-    put admin_api_backend_api_path(backend_api), params: { access_token: access_token_value, private_endpoint: '' }
+    put admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value, private_endpoint: '' }
     assert_response :unprocessable_entity
     assert_contains JSON.parse(response.body).dig('errors', 'private_endpoint'), 'can\'t be blank'
   end
 
   test 'create' do
     assert_difference(BackendApi.method(:count)) do
-      post admin_api_backend_apis_path, params: { access_token: access_token_value, **permitted_params.merge(forbidden_params) }
+      post admin_api_backend_apis_path, params: { access_token: access_token_plaintext_value, **permitted_params.merge(forbidden_params) }
       assert_response :created
     end
     assert(@backend_api = provider.backend_apis.find_by(id: JSON.parse(response.body).dig('backend_api', 'id')))
@@ -57,7 +57,7 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'create with errors in the model' do
-    post admin_api_backend_apis_path, params: { access_token: access_token_value,  private_endpoint: '' }
+    post admin_api_backend_apis_path, params: { access_token: access_token_plaintext_value,  private_endpoint: '' }
     assert_response :unprocessable_entity
     assert_contains JSON.parse(response.body).dig('errors', 'private_endpoint'), 'can\'t be blank'
   end
@@ -65,7 +65,7 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   test 'index' do
     FactoryBot.create_list(:backend_api, 2, account: provider)
     FactoryBot.create(:backend_api) # belonging to another provider
-    get admin_api_backend_apis_path, params: { access_token: access_token_value }
+    get admin_api_backend_apis_path, params: { access_token: access_token_plaintext_value }
     assert_response :success
     assert(response_collection_backend_apis = JSON.parse(response.body)['backend_apis'])
     assert_equal provider.backend_apis.count, response_collection_backend_apis.length
@@ -77,34 +77,34 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
   test 'index can be paginated' do
     FactoryBot.create_list(:backend_api, 5, account: provider)
     provider.backend_apis.each_with_index { |backend_api, index| backend_api.update_column(:created_at, Date.today - index.days) }
-    get admin_api_backend_apis_path, params: { access_token: access_token_value, per_page: 3, page: 2 }
+    get admin_api_backend_apis_path, params: { access_token: access_token_plaintext_value, per_page: 3, page: 2 }
     assert_response :success
     response_backend_api_ids = JSON.parse(response.body)['backend_apis'].map { |response_backend_api| response_backend_api.dig('backend_api', 'id') }
     assert_equal provider.backend_apis.oldest_first.offset(3).limit(3).select(:id).map(&:id), response_backend_api_ids
   end
 
   test 'system_name can be created but not updated' do
-    post admin_api_backend_apis_path, params: permitted_params.merge(system_name: 'first-system-name', access_token: access_token_value)
+    post admin_api_backend_apis_path, params: permitted_params.merge(system_name: 'first-system-name', access_token: access_token_plaintext_value)
     backend_api = provider.backend_apis.last!
     assert_equal 'first-system-name', backend_api.system_name
 
-    put admin_api_backend_api_path(backend_api), params: permitted_params.merge(forbidden_params).merge(system_name: 'updated-system-name', access_token: access_token_value)
+    put admin_api_backend_api_path(backend_api), params: permitted_params.merge(forbidden_params).merge(system_name: 'updated-system-name', access_token: access_token_plaintext_value)
     assert_equal 'first-system-name', backend_api.reload.system_name
   end
 
   test 'backend api marked as deleted cannot be found' do
     backend_api.mark_as_deleted!
 
-    get admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+    get admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value }
     assert_response :not_found
 
-    delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+    delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value }
     assert_response :not_found
 
-    put admin_api_backend_api_path(backend_api), params: { access_token: access_token_value, **permitted_params }
+    put admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value, **permitted_params }
     assert_response :not_found
 
-    get admin_api_backend_apis_path, params: { access_token: access_token_value }
+    get admin_api_backend_apis_path, params: { access_token: access_token_plaintext_value }
     assert_response :success
     response_backend_api_ids = JSON.parse(response.body)['backend_apis'].map { |response_backend_api| response_backend_api.dig('backend_api', 'id') }
     assert_not_includes response_backend_api_ids, backend_api.id
@@ -121,42 +121,42 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
     end
 
     attr_reader :provider, :backend_api, :member, :access_token
-    delegate :value, to: :access_token, prefix: true
+    delegate :plaintext_value, to: :access_token, prefix: true
 
     test 'member with permission' do
       member.admin_sections = %w[partners plans]
       member.save!
 
-      get admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :success
 
-      delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+      delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
 
-      put admin_api_backend_api_path(backend_api), params: { access_token: access_token_value, **backend_api_params }
+      put admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value, **backend_api_params }
       assert_response :success
 
-      post admin_api_backend_apis_path, params: {access_token: access_token_value, **backend_api_params }
+      post admin_api_backend_apis_path, params: {access_token: access_token_plaintext_value, **backend_api_params }
       assert_response :forbidden
 
-      get admin_api_backend_apis_path, params: { access_token: access_token_value }
+      get admin_api_backend_apis_path, params: { access_token: access_token_plaintext_value }
       assert_response :success
     end
 
     test 'member without permission' do
-      get admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+      get admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
 
-      delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_value }
+      delete admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
 
-      put admin_api_backend_api_path(backend_api), params: { access_token: access_token_value, **backend_api_params }
+      put admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value, **backend_api_params }
       assert_response :forbidden
 
-      post admin_api_backend_apis_path, params: { access_token: access_token_value, **backend_api_params }
+      post admin_api_backend_apis_path, params: { access_token: access_token_plaintext_value, **backend_api_params }
       assert_response :forbidden
 
-      get admin_api_backend_apis_path, params: { access_token: access_token_value }
+      get admin_api_backend_apis_path, params: { access_token: access_token_plaintext_value }
       assert_response :forbidden
     end
 
@@ -173,12 +173,12 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
 
   private
 
-  def access_token_value
-    @access_token_value ||= create_access_token_value(@provider.admin_users.first!)
+  def access_token_plaintext_value
+    @access_token_plaintext_value ||= create_access_token_plaintext_value(@provider.admin_users.first!)
   end
 
-  def create_access_token_value(user)
-    FactoryBot.create(:access_token, owner: user, scopes: %w[account_management], permission: 'rw').value
+  def create_access_token_plaintext_value(user)
+    FactoryBot.create(:access_token, owner: user, scopes: %w[account_management], permission: 'rw').plaintext_value
   end
 
   def backend_api

--- a/test/integration/admin/api/buyers_applications_controller_test.rb
+++ b/test/integration/admin/api/buyers_applications_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::Api::BuyersApplicationsControllerTest < ActionDispatch::Integration
     @service  = FactoryBot.create(:service, account: provider)
     @plan    = FactoryBot.create(:application_plan, issuer: @service)
     @buyer   = FactoryBot.create(:buyer_account, provider_account: provider)
-    @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
 
     host! provider.external_admin_domain
   end
@@ -100,7 +100,7 @@ class Admin::Api::BuyersApplicationsControllerTest < ActionDispatch::Integration
     private
 
     def request_plan_change(new_plan = create_new_plan_same_service)
-      params = { access_token: @access_token.value, plan_id: new_plan.id }
+      params = { access_token: @access_token.plaintext_value, plan_id: new_plan.id }
       put change_plan_admin_api_account_application_path(account_id: @buyer.id, id: @application.id, format: :xml), params: params
     end
 

--- a/test/integration/admin/api/buyers_users_controller_test.rb
+++ b/test/integration/admin/api/buyers_users_controller_test.rb
@@ -65,6 +65,6 @@ class Admin::Api::BuyersUsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   def token_value
-    @token_value ||= FactoryBot.create(:access_token, owner: provider.admin_user, scopes: 'account_management', permission: 'rw').value
+    @token_value ||= FactoryBot.create(:access_token, owner: provider.admin_user, scopes: 'account_management', permission: 'rw').plaintext_value
   end
 end

--- a/test/integration/admin/api/member_permissions_controller_test.rb
+++ b/test/integration/admin/api/member_permissions_controller_test.rb
@@ -11,7 +11,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
     @service2_id = service_ids.last
     @nonexistent_id = service_ids.max + 1
     @user = FactoryBot.create(:active_user, account: provider)
-    @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
 
     host! provider.external_admin_domain
   end
@@ -130,7 +130,7 @@ class Admin::Api::MemberPermissionsControllerTest < ActionDispatch::IntegrationT
 
   test "member user can't update his own permissions" do
     user.update_attribute :role, 'member'
-    token = FactoryBot.create(:access_token, owner: user, scopes: %w[account_management]).value
+    token = FactoryBot.create(:access_token, owner: user, scopes: %w[account_management]).plaintext_value
     # allowed_sections%5B%5D=settings&allowed_service_ids%5B%5D
     params = { allowed_sections: ['settings'], allowed_service_ids: '', access_token: token }
 

--- a/test/integration/admin/api/metric_methods_controller_test.rb
+++ b/test/integration/admin/api/metric_methods_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::Api::MetricMethodsControllerTest < ActionDispatch::IntegrationTest
     @service = FactoryBot.create(:service, account: provider)
     @metric  = @service.metrics.first
     @method_metric  = FactoryBot.create(:metric, owner: @service, parent_id: @metric.id, friendly_name: 'my method')
-    @access_token_value = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management], permission: 'rw').value
+    @access_token_value = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management], permission: 'rw').plaintext_value
 
     host! provider.external_admin_domain
   end

--- a/test/integration/admin/api/objects_controller_test.rb
+++ b/test/integration/admin/api/objects_controller_test.rb
@@ -6,7 +6,7 @@ class Admin::Api::ObjectsControllerTest < ActionDispatch::IntegrationTest
     @provider = FactoryBot.create(:provider_account)
     @service = @provider.default_service
     @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management])
-    @token = @access_token.value
+    @token = @access_token.plaintext_value
 
     host! @provider.external_admin_domain
   end

--- a/test/integration/admin/api/personal/notification_preferences_controller_test.rb
+++ b/test/integration/admin/api/personal/notification_preferences_controller_test.rb
@@ -6,7 +6,7 @@ class Admin::Api::Personal::NotificationPreferencesControllerTest < ActionDispat
   def setup
     provider = FactoryBot.create(:provider_account)
     @user = provider.admin_users.first!
-    @token = FactoryBot.create(:access_token, owner: @user, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: @user, scopes: %w[account_management]).plaintext_value
     host! provider.external_admin_domain
   end
 

--- a/test/integration/admin/api/registry/policies_controller_test.rb
+++ b/test/integration/admin/api/registry/policies_controller_test.rb
@@ -32,7 +32,7 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
   end
 
   test 'POST create returns forbidden when wrong scope' do
-    token_admin_with_wrong_scope = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+    token_admin_with_wrong_scope = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
     assert_no_difference(Policy.method(:count)) do
       post admin_api_registry_policies_path(policy_params(token_admin_with_wrong_scope))
     end
@@ -42,7 +42,7 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
   test 'POST create returns forbidden when no permission' do
     member_user = FactoryBot.create(:member, account: @provider)
 
-    token_member_with_right_scope_but_no_permission = FactoryBot.create(:access_token, owner: member_user, scopes: %w[policy_registry]).value
+    token_member_with_right_scope_but_no_permission = FactoryBot.create(:access_token, owner: member_user, scopes: %w[policy_registry]).plaintext_value
     assert_no_difference(Policy.method(:count)) do
       post admin_api_registry_policies_path(policy_params(token_member_with_right_scope_but_no_permission))
     end
@@ -53,7 +53,7 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     member_user = FactoryBot.create(:member, account: @provider)
     member_user.member_permissions.create!(admin_section: :partners) # not policy_registry
 
-    token_member_with_wrong_scope = FactoryBot.create(:access_token, owner: member_user, scopes: %w[account_management]).value
+    token_member_with_wrong_scope = FactoryBot.create(:access_token, owner: member_user, scopes: %w[account_management]).plaintext_value
     assert_no_difference(Policy.method(:count)) do
       post admin_api_registry_policies_path(policy_params(token_member_with_wrong_scope))
     end
@@ -64,7 +64,7 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     member_user = FactoryBot.create(:member, account: @provider)
     member_user.member_permissions.create!(admin_section: :policy_registry)
 
-    token_member_with_right_scope = FactoryBot.create(:access_token, owner: member_user, scopes: %w[policy_registry]).value
+    token_member_with_right_scope = FactoryBot.create(:access_token, owner: member_user, scopes: %w[policy_registry]).plaintext_value
     assert_difference(@provider.policies.method(:count), 1) do
       post admin_api_registry_policies_path(policy_params(token_member_with_right_scope))
     end
@@ -81,7 +81,7 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
 
   test 'POST create disabled for master' do
     host! master_account.internal_admin_domain
-    access_token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[policy_registry], permission: 'rw').value
+    access_token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[policy_registry], permission: 'rw').plaintext_value
     assert_no_difference(Policy.method(:count)) do
       post admin_api_registry_policies_path(policy_params(access_token))
     end
@@ -90,7 +90,7 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
 
   test 'GET show returns the policy' do
     policy = FactoryBot.create(:policy, account: @provider)
-    get admin_api_registry_policy_path(policy, access_token: @access_token.value)
+    get admin_api_registry_policy_path(policy, access_token: @access_token.plaintext_value)
     assert_response :success
     json = JSON.parse(response.body)['policy']
     assert_equal policy.id, json['id']
@@ -98,14 +98,14 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
 
   test 'GET show finds the policy when name-version is passed as id' do
     policy = FactoryBot.create(:policy, account: @provider, name: 'my_policy', version: '1.0')
-    get admin_api_registry_policy_path('my_policy-1.0', access_token: @access_token.value)
+    get admin_api_registry_policy_path('my_policy-1.0', access_token: @access_token.plaintext_value)
     assert_response :success
     json = JSON.parse(response.body)['policy']
     assert_equal policy.id, json['id']
   end
 
   test 'GET show returns not found when policy does not exist' do
-    get admin_api_registry_policy_path(id: 'inexistent-policy', access_token: @access_token.value)
+    get admin_api_registry_policy_path(id: 'inexistent-policy', access_token: @access_token.plaintext_value)
     assert_response :not_found
   end
 
@@ -113,13 +113,13 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     policy = FactoryBot.create(:policy, account: @provider, name: 'my-policy', version: '1.0')
 
     assert_raises(ActionController::UrlGenerationError) do
-      get admin_api_registry_policy_path('my-policy-1.0.json', access_token: @access_token.value)
+      get admin_api_registry_policy_path('my-policy-1.0.json', access_token: @access_token.plaintext_value)
     end
   end
 
   test 'GET index returns the policies' do
     FactoryBot.create_list(:policy, 3, account: @provider)
-    get admin_api_registry_policies_path(access_token: @access_token.value)
+    get admin_api_registry_policies_path(access_token: @access_token.plaintext_value)
     assert_response :success
     expected_policy_ids = @provider.policies.pluck(:id)
     assert_same_elements expected_policy_ids, JSON.parse(response.body)['policies'].map { |policy| policy.dig('policy', 'id') }
@@ -129,7 +129,7 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     policy = FactoryBot.create(:policy, account: @provider, version: '1.0')
     new_schema = JSON.parse(file_fixture('policies/apicast-policy.json').read).merge('description': 'New description')
     new_schema['version'] = '1.0'
-    put admin_api_registry_policy_path(policy, policy: { schema: new_schema.to_json }, access_token: @access_token.value)
+    put admin_api_registry_policy_path(policy, policy: { schema: new_schema.to_json }, access_token: @access_token.plaintext_value)
     assert_response :success
     assert_equal 'New description', policy.reload.schema['description']
   end
@@ -138,19 +138,19 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     policy = FactoryBot.create(:policy, account: @provider, name: 'my_policy', version: '1.0')
     new_schema = JSON.parse(file_fixture('policies/apicast-policy.json').read).merge('description': 'New description')
     new_schema['version'] = '1.0'
-    put admin_api_registry_policy_path('my_policy-1.0', policy: { schema: new_schema.to_json }, access_token: @access_token.value)
+    put admin_api_registry_policy_path('my_policy-1.0', policy: { schema: new_schema.to_json }, access_token: @access_token.plaintext_value)
     assert_response :success
     assert_equal 'New description', policy.reload.schema['description']
   end
 
   test 'PUT update returns not found when policy does not exist' do
-    put admin_api_registry_policy_path(id: 'inexistent-policy', policy: { version: '1.1' }, access_token: @access_token.value)
+    put admin_api_registry_policy_path(id: 'inexistent-policy', policy: { version: '1.1' }, access_token: @access_token.plaintext_value)
     assert_response :not_found
   end
 
   test 'DELETE destroy deletes the policy' do
     policy = FactoryBot.create(:policy, account: @provider)
-    delete admin_api_registry_policy_path(policy, access_token: @access_token.value)
+    delete admin_api_registry_policy_path(policy, access_token: @access_token.plaintext_value)
     assert_response :success
     assert_empty response.body
   end
@@ -242,11 +242,11 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     private
 
     def try_update_policy(policy_params)
-      put admin_api_registry_policy_path(policy, policy: policy_params, access_token: access_token.value)
+      put admin_api_registry_policy_path(policy, policy: policy_params, access_token: access_token.plaintext_value)
     end
 
     def try_delete_policy
-      delete admin_api_registry_policy_path(policy, access_token: access_token.value)
+      delete admin_api_registry_policy_path(policy, access_token: access_token.plaintext_value)
     end
 
     def add_policy_config_to(proxy, policy: self.policy)
@@ -261,7 +261,7 @@ class Admin::Api::Registry::PoliciesControllerTest < ActionDispatch::Integration
     end
   end
 
-  def policy_params(token = @access_token.value)
+  def policy_params(token = @access_token.plaintext_value)
     @policy_attributes ||= FactoryBot.build(:policy).attributes.symbolize_keys.slice(:name, :version, :schema)
     { policy: @policy_attributes, access_token: token }
   end

--- a/test/integration/admin/api/service_plans_controller_test.rb
+++ b/test/integration/admin/api/service_plans_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::ServicePlansControllerTest < ActionDispatch::IntegrationTest
 
   class ProviderAdminTest < self
     setup do
-      @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+      @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
       host! @provider.external_admin_domain
     end
 

--- a/test/integration/admin/api/services/backend_usages_controller_test.rb
+++ b/test/integration/admin/api/services/backend_usages_controller_test.rb
@@ -18,7 +18,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
     end
 
     attr_reader :access_token
-    delegate :value, to: :access_token, prefix: true
+    delegate :plaintext_value, to: :access_token, prefix: true
 
     test 'create' do
       assert_difference(service.backend_api_configs.method(:count)) do
@@ -159,7 +159,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
     end
 
     attr_reader :member, :access_token
-    delegate :value, to: :access_token, prefix: true
+    delegate :plaintext_value, to: :access_token, prefix: true
 
     test 'with permission to all services' do
       get admin_api_service_backend_usages_path(collection_params)
@@ -237,7 +237,7 @@ class Admin::Api::Services::BackendUsagesControllerTest < ActionDispatch::Integr
   end
 
   def collection_params(other_params = {})
-    { service_id: service.id, access_token: access_token_value }.merge(other_params)
+    { service_id: service.id, access_token: access_token_plaintext_value }.merge(other_params)
   end
 
   def resource_params(other_params = {})

--- a/test/integration/admin/api/services/proxies_controller_test.rb
+++ b/test/integration/admin/api/services/proxies_controller_test.rb
@@ -14,11 +14,11 @@ module Admin::Api::Services
     attr_reader :service, :token
 
     def test_show
-      get admin_api_service_proxy_path(service_id: service.id, format: :xml, access_token: token.value)
+      get admin_api_service_proxy_path(service_id: service.id, format: :xml, access_token: token.plaintext_value)
       assert_response :success
       xml = Hash.from_xml(response.body).fetch('proxy').except('created_at', 'updated_at')
 
-      get admin_api_service_proxy_path(service_id: service.id, format: :json, access_token: token.value)
+      get admin_api_service_proxy_path(service_id: service.id, format: :json, access_token: token.plaintext_value)
       assert_response :success
       json = JSON.parse(response.body).fetch('proxy').except('created_at', 'updated_at')
 
@@ -29,7 +29,7 @@ module Admin::Api::Services
     end
 
     def test_update
-      put admin_api_service_proxy_path(service_id: service.id, format: :xml, access_token: token.value), params: { proxy: { credentials_location: 'headers' } }
+      put admin_api_service_proxy_path(service_id: service.id, format: :xml, access_token: token.plaintext_value), params: { proxy: { credentials_location: 'headers' } }
 
       assert_response :success
 

--- a/test/integration/admin/api/services/proxy/policies_controller_test.rb
+++ b/test/integration/admin/api/services/proxy/policies_controller_test.rb
@@ -8,13 +8,13 @@ class PoliciesControllerTest < ActionDispatch::IntegrationTest
     @provider = FactoryBot.create(:provider_account)
     @service = @provider.default_service
     host! @provider.external_admin_domain
-    @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+    @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
   end
 
   class PolicyRegistryAccessTokenScopeTest < PoliciesControllerTest
     def setup
       super
-      @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[policy_registry]).value
+      @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[policy_registry]).plaintext_value
     end
   end
 

--- a/test/integration/admin/api/services_controller_test.rb
+++ b/test/integration/admin/api/services_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
   class MasterHostTest < Admin::Api::ServicesControllerTest
     setup do
-      @token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[account_management]).value
+      @token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[account_management]).plaintext_value
       host! master_account.internal_admin_domain
     end
 
@@ -125,7 +125,7 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
 
     test 'a member user cannot create a service' do
       member = FactoryBot.create(:member, account: provider)
-      member_access_token_value = FactoryBot.create(:access_token, owner: member, scopes: %w[account_management], permission: 'rw').value
+      member_access_token_value = FactoryBot.create(:access_token, owner: member, scopes: %w[account_management], permission: 'rw').plaintext_value
 
       assert_no_difference(provider_services.method(:count)) do
         post admin_api_services_path(access_token: member_access_token_value, format: :json), params: permitted_params
@@ -243,7 +243,7 @@ class Admin::Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     end
 
     def access_token_value
-      @access_token_value ||= FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management], permission: 'rw').value
+      @access_token_value ||= FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management], permission: 'rw').plaintext_value
     end
 
     def provider_services

--- a/test/integration/admin/api/settings_controller_test.rb
+++ b/test/integration/admin/api/settings_controller_test.rb
@@ -6,7 +6,7 @@ class Admin::Api::SettingsControllerTest < ActionDispatch::IntegrationTest
   def setup
     provider = FactoryBot.create(:provider_account)
     host! provider.external_admin_domain
-    @token = FactoryBot.create(:access_token, owner: provider.admin_user, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: provider.admin_user, scopes: %w[account_management]).plaintext_value
     @settings = provider.settings
   end
 

--- a/test/integration/admin/api/signups_controller_test.rb
+++ b/test/integration/admin/api/signups_controller_test.rb
@@ -21,7 +21,7 @@ class Admin::Api::SignupsControllerTest < ActionDispatch::IntegrationTest
         assert_difference(WebHookWorker.jobs.method(:size)) do
           post admin_api_signup_path, params: {
             format: :json,
-            access_token: token.value,
+            access_token: token.plaintext_value,
             org_name: 'company',
             username: 'person'
           }

--- a/test/integration/api/access_tokens_test.rb
+++ b/test/integration/api/access_tokens_test.rb
@@ -17,14 +17,14 @@ class Admin::Api::AccessTokensTest < ActionDispatch::IntegrationTest
 
     user_id = @admin.id
     assert_difference(AccessToken.method(:count), 1) do
-      post_request(user_id, {access_token: access_token.value})
+      post_request(user_id, {access_token: access_token.plaintext_value})
       assert_response :created, "Not created with response body #{response.body}"
     end
     assert_token_values(user_id)
 
 
     assert_no_difference(AccessToken.method(:count)) do
-      post_request(@member.id, {access_token: access_token.value})
+      post_request(@member.id, {access_token: access_token.plaintext_value})
       assert_response :forbidden, "Not forbidden with response body #{response.body}"
     end
   end
@@ -34,7 +34,7 @@ class Admin::Api::AccessTokensTest < ActionDispatch::IntegrationTest
 
     user_id = @admin.id
     assert_difference(AccessToken.method(:count), 1) do
-      post_request(user_id, {access_token: access_token.value}, {value: 'foobar'})
+      post_request(user_id, {access_token: access_token.plaintext_value}, {value: 'foobar'})
       assert_response :created, "Not created with response body #{response.body}"
     end
     assert_not_equal 'foobar', AccessToken.last!.value
@@ -44,7 +44,7 @@ class Admin::Api::AccessTokensTest < ActionDispatch::IntegrationTest
     access_token = FactoryBot.create(:access_token, owner: @admin, scopes: %w[account_management])
 
     assert_no_difference(AccessToken.method(:count)) do
-      post_request(@admin.id, {access_token: access_token.value}, {scopes: ['wrong']})
+      post_request(@admin.id, {access_token: access_token.plaintext_value}, {scopes: ['wrong']})
       assert_response :unprocessable_entity, "Not created with response body #{response.body}"
       assert_equal ['invalid'], JSON.parse(response.body).dig('errors', 'scopes')
     end
@@ -56,7 +56,7 @@ class Admin::Api::AccessTokensTest < ActionDispatch::IntegrationTest
     user_id = @admin.id
     expires_at = 1.day.from_now.utc.iso8601
     assert_difference(AccessToken.method(:count), 1) do
-      post_request(user_id, {access_token: access_token.value}, { expires_at: })
+      post_request(user_id, {access_token: access_token.plaintext_value}, { expires_at: })
       assert_response :created, "Not created with response body #{response.body}"
     end
     assert_equal expires_at, AccessToken.last!.expires_at.iso8601

--- a/test/integration/api/personal/access_tokens_test.rb
+++ b/test/integration/api/personal/access_tokens_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
 
   class ActionsOnAnAccessToken < Admin::Api::Personal::AccessTokensTest
     test 'using a non-existent ID or value responds with not_found' do
-      perform_request(id: 'wrong', access_token: admin_access_token.value)
+      perform_request(id: 'wrong', access_token: admin_access_token.plaintext_value)
       assert_response :not_found
     end
 
@@ -22,20 +22,20 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
       another_admin = FactoryBot.create(:admin, account: provider, admin_sections: [:partners])
       another_admins_token = FactoryBot.create(:access_token, scopes: %w[account_management], owner: another_admin)
 
-      perform_request(id: admin_access_token.id, access_token: another_admins_token.value)
+      perform_request(id: admin_access_token.id, access_token: another_admins_token.plaintext_value)
       assert_response :not_found
 
-      perform_request(id: admin_access_token.value, access_token: another_admins_token.value)
+      perform_request(id: admin_access_token.id, access_token: another_admins_token.plaintext_value)
       assert_response :not_found
     end
 
     test 'using the token ID works well' do
-      perform_request(id: admin_access_token.id, access_token: admin_access_token.value)
+      perform_request(id: admin_access_token.id, access_token: admin_access_token.plaintext_value)
       assert_it_worked
     end
 
     test 'using the token value works well' do
-      perform_request(id: admin_access_token.value, access_token: admin_access_token.value)
+      perform_request(id: admin_access_token.plaintext_value, access_token: admin_access_token.plaintext_value)
       assert_it_worked
     end
 
@@ -72,7 +72,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
   class Admin::Api::Personal::CreateAccessTokenTest < Admin::Api::Personal::AccessTokensTest
     test 'POST creates an access token for the admin user of the access token' do
       assert_difference admin.access_tokens.method(:count) do
-        create_access_token(access_token: admin_access_token.value, params: access_token_params)
+        create_access_token(access_token: admin_access_token.plaintext_value, params: access_token_params)
         assert_response :created
         assert JSON.parse(response.body).dig('access_token', 'value')
       end
@@ -81,7 +81,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
     test 'POST does not accept a custom value' do
       value = 'foobar'
       assert_difference @admin.access_tokens.method(:count) do
-        create_access_token(access_token: admin_access_token.value, params: access_token_params({ value: value }))
+        create_access_token(access_token: admin_access_token.plaintext_value, params: access_token_params({ value: value }))
         assert_response :created
         assert_not_equal value, JSON.parse(response.body).dig('access_token', 'value')
       end
@@ -89,7 +89,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
 
     test 'POST does not accept a wrong scope' do
       assert_no_difference(AccessToken.method(:count)) do
-        create_access_token(access_token: admin_access_token.value, params: access_token_params({ scopes: %w[wrong] }))
+        create_access_token(access_token: admin_access_token.plaintext_value, params: access_token_params({ scopes: %w[wrong] }))
         assert_response :unprocessable_entity
         assert_equal ['invalid'], JSON.parse(response.body).dig('errors', 'scopes')
       end
@@ -98,7 +98,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
     test 'POST accepts an expiration time' do
       expires_at = 1.day.from_now.utc.iso8601
       assert_difference @admin.access_tokens.method(:count) do
-        create_access_token(access_token: admin_access_token.value, params: access_token_params({ expires_at: }))
+        create_access_token(access_token: admin_access_token.plaintext_value, params: access_token_params({ expires_at: }))
         assert_response :created
         assert_equal expires_at, JSON.parse(response.body).dig('access_token', 'expires_at')
       end
@@ -152,7 +152,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
     end
 
     def get_access_tokens(**query_params)
-      get admin_api_personal_access_tokens_path(access_token: admin_access_token.value, **query_params)
+      get admin_api_personal_access_tokens_path(access_token: admin_access_token.plaintext_value, **query_params)
     end
 
     alias perform_request get_access_tokens
@@ -182,7 +182,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
     unauthorized_access_token = FactoryBot.create(:access_token, owner: unauthorized_member, scopes: %w[account_management])
 
     assert_no_difference(AccessToken.method(:count)) do
-      perform_request(id: 'any', access_token: unauthorized_access_token.value)
+      perform_request(id: 'any', access_token: unauthorized_access_token.plaintext_value)
       assert_response :forbidden
     end
   end
@@ -192,7 +192,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
     wrong_token_scope = FactoryBot.create(:access_token, owner: authorized_member, scopes: %w[finance])
 
     assert_no_difference(AccessToken.method(:count)) do
-      perform_request(id: admin_access_token.id, access_token: wrong_token_scope.value)
+      perform_request(id: admin_access_token.id, access_token: wrong_token_scope.plaintext_value)
       assert_response :forbidden
     end
   end
@@ -202,7 +202,7 @@ class Admin::Api::Personal::AccessTokensTest < ActionDispatch::IntegrationTest
     authorized_member_access_token = FactoryBot.create(:access_token, owner: authorized_member, scopes: %w[account_management])
     access_token = FactoryBot.create(:access_token, owner: authorized_member)
 
-    perform_request(id: access_token.id, access_token: authorized_member_access_token.value)
+    perform_request(id: access_token.id, access_token: authorized_member_access_token.plaintext_value)
     assert_it_worked(access_token)
   end
 

--- a/test/integration/api/sso_tokens_controller_test.rb
+++ b/test/integration/api/sso_tokens_controller_test.rb
@@ -5,7 +5,7 @@ class Admin::Api::SsoTokensControllerTest < ActionDispatch::IntegrationTest
     provider = FactoryBot.create(:provider_account)
     @admin = FactoryBot.create(:simple_admin, account: provider, username: 'alaska123')
     @admin.activate!
-    @access_token = FactoryBot.create(:access_token, owner: @admin, scopes: 'account_management', permission: 'rw').value
+    @access_token = FactoryBot.create(:access_token, owner: @admin, scopes: 'account_management', permission: 'rw').plaintext_value
 
     host! provider.external_admin_domain
   end
@@ -39,7 +39,7 @@ class Admin::Api::SsoTokensControllerTest < ActionDispatch::IntegrationTest
 
     test 'provider_create' do
       FactoryBot.create(:simple_admin, account: @provider, username: ThreeScale.config.impersonation_admin[:username])
-      post provider_create_admin_api_sso_tokens_path(format: :json), params: { provider_id: @provider.id, access_token: @access_token.value }
+      post provider_create_admin_api_sso_tokens_path(format: :json), params: { provider_id: @provider.id, access_token: @access_token.plaintext_value }
       assert_response :success
 
       assert sso_token = JSON.parse(response.body)['sso_token']
@@ -51,7 +51,7 @@ class Admin::Api::SsoTokensControllerTest < ActionDispatch::IntegrationTest
       FactoryBot.create(:simple_admin, account: @provider, username: ThreeScale.config.impersonation_admin[:username])
 
       freeze_time do
-        post provider_create_admin_api_sso_tokens_path(format: :json), params: { provider_id: @provider.id, access_token: @access_token.value, expires_in: 60 }
+        post provider_create_admin_api_sso_tokens_path(format: :json), params: { provider_id: @provider.id, access_token: @access_token.plaintext_value, expires_in: 60 }
         assert_response :success
 
         assert_equal (Time.now.utc + 60).httpdate, response.headers['Expires']

--- a/test/integration/application_controller_test.rb
+++ b/test/integration/application_controller_test.rb
@@ -90,7 +90,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
   test "forgery protection is skipped for API requests with access token" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
-    token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw').value
+    token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw').plaintext_value
     host! provider.external_admin_domain
 
     ApplicationController.any_instance.expects(:verify_authenticity_token).never
@@ -107,7 +107,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
   test "forgery protection is skipped for API requests with basic auth and access token" do
     provider = FactoryBot.create(:provider_account)
     user = provider.admins.first
-    token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw').value
+    token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw').plaintext_value
     host! provider.external_admin_domain
 
     ApplicationController.any_instance.expects(:verify_authenticity_token).never

--- a/test/integration/audited_hacks_async_test.rb
+++ b/test/integration/audited_hacks_async_test.rb
@@ -22,7 +22,7 @@ class AuditedHacksAsyncTest < ActionDispatch::IntegrationTest
 
     @audit_class = Audited.audit_class
 
-    @access_token = FactoryBot.create(:access_token, owner: @admin, scopes: ['account_management']).value
+    @access_token = FactoryBot.create(:access_token, owner: @admin, scopes: ['account_management']).plaintext_value
 
     audit_class.delete_all
   end

--- a/test/integration/by_access_token_integration_test.rb
+++ b/test/integration/by_access_token_integration_test.rb
@@ -24,12 +24,12 @@ class ApiAuthentication::ByAccessTokenIntegrationTest < ActionDispatch::Integrat
     assert_response :forbidden
 
     # valid token
-    get admin_api_accounts_path(format: :xml), params: { access_token: @token.value }
+    get admin_api_accounts_path(format: :xml), params: { access_token: @token.plaintext_value }
     assert_response :success
 
     # token belongs to a different admin domain
     host! provider_2.internal_admin_domain
-    get admin_api_accounts_path(format: :xml), params: { access_token: @token.value }
+    get admin_api_accounts_path(format: :xml), params: { access_token: @token.plaintext_value }
     assert_response :forbidden
 
     host! @provider.external_admin_domain
@@ -41,7 +41,7 @@ class ApiAuthentication::ByAccessTokenIntegrationTest < ActionDispatch::Integrat
     @token.save!
 
     # invalid scope
-    get admin_api_accounts_path(format: :xml), params: { access_token: @token.value }
+    get admin_api_accounts_path(format: :xml), params: { access_token: @token.plaintext_value }
     assert_response :forbidden
 
     @token.scopes = ['account_management']
@@ -50,26 +50,26 @@ class ApiAuthentication::ByAccessTokenIntegrationTest < ActionDispatch::Integrat
     @user.save!
 
     # user does not have a permission
-    get admin_api_accounts_path(format: :xml), params: { access_token: @token.value }
+    get admin_api_accounts_path(format: :xml), params: { access_token: @token.plaintext_value }
     assert_response :forbidden
   end
 
   test 'validates the scope using HttpBasicAuth' do
-    auth_headers = {'Authorization' => "Basic #{Base64.encode64(":#{@token.value}")}"}
+    auth_headers = {'Authorization' => "Basic #{Base64.encode64(":#{@token.plaintext_value}")}"}
     get admin_api_registry_policies_path(format: :json), headers: auth_headers
     assert_response :forbidden
   end
 
   test 'the token has no expiration date' do
-      get admin_api_accounts_path(format: :xml), params: { access_token: @token.value }
+    get admin_api_accounts_path(format: :xml), params: { access_token: @token.plaintext_value }
 
-      assert_response :success
-    end
+    assert_response :success
+  end
 
   test 'the token has a future expiration date' do
     token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management', expires_at: 1.day.from_now.utc.iso8601)
 
-    get admin_api_accounts_path(format: :xml), params: { access_token: token.value }
+    get admin_api_accounts_path(format: :xml), params: { access_token: token.plaintext_value }
 
     assert_response :success
   end
@@ -78,7 +78,39 @@ class ApiAuthentication::ByAccessTokenIntegrationTest < ActionDispatch::Integrat
     token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management')
     token.update_columns(expires_at: 1.minute.ago)
 
-    get admin_api_accounts_path(format: :xml), params: { access_token: token.value }
+    get admin_api_accounts_path(format: :xml), params: { access_token: token.plaintext_value }
+
+    assert_response :forbidden
+  end
+
+  test 'authentication with legacy unmigrated token succeeds' do
+    token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management')
+    legacy_value = 'legacy_plaintext_token_for_integration'
+    token.update_columns(value: legacy_value)
+
+    get admin_api_accounts_path(format: :xml), params: { access_token: legacy_value }
+
+    assert_response :success
+    # No migration: DB value remains unchanged
+    assert_equal legacy_value, token.reload.read_attribute(:value)
+  end
+
+  test 'authentication with leaked database hash fails' do
+    token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management')
+    plaintext = token.plaintext_value
+
+    # Verify the token works with plaintext
+    get admin_api_accounts_path(format: :xml), params: { access_token: plaintext }
+    assert_response :success
+
+    # Get the actual hash stored in the database
+    leaked_hash = token.reload.read_attribute(:value)
+
+    # Verify the stored value has our prefix
+    assert leaked_hash.start_with?(AccessToken::DIGEST_PREFIX)
+
+    # An attacker trying to use the leaked hash directly should be blocked
+    get admin_api_accounts_path(format: :xml), params: { access_token: leaked_hash }
 
     assert_response :forbidden
   end

--- a/test/integration/cms/base_controller_test.rb
+++ b/test/integration/cms/base_controller_test.rb
@@ -14,7 +14,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
 
     test 'responds to json' do
       with_api_routes do
-        get '/cms_api', params: { format: :json, access_token: @token.value }
+        get '/cms_api', params: { format: :json, access_token: @token.plaintext_value }
 
         assert_response :ok
       end
@@ -23,7 +23,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
     %i[xml html].each do |format|
       test "does not respond to #{format.to_s}" do
         with_api_routes do
-          get '/cms_api', params: { format: format, access_token: @token.value }
+          get '/cms_api', params: { format: format, access_token: @token.plaintext_value }
 
           assert_response :not_acceptable
         end
@@ -40,7 +40,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
     test 'admin user with cms scope has permission' do
       token = FactoryBot.create(:access_token, owner: @provider.admin_users.first, scopes: ['cms'], permission: 'rw')
       with_api_routes do
-        get '/cms_api', params: { format: :json, access_token: token.value }
+        get '/cms_api', params: { format: :json, access_token: token.plaintext_value }
         assert_response :ok
       end
     end
@@ -48,7 +48,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
     test 'admin user without cms scope does not have permission' do
       with_api_routes do
         token = FactoryBot.create(:access_token, owner: @provider.admin_users.first)
-        get '/cms_api', params: { format: :json, access_token: token.value }
+        get '/cms_api', params: { format: :json, access_token: token.plaintext_value }
         assert_response :forbidden
       end
     end
@@ -57,7 +57,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
       member = FactoryBot.create(:member, account: @provider, admin_sections: ['portal'])
       token  = FactoryBot.create(:access_token, owner: member, scopes: ['cms'], permission: 'rw')
       with_api_routes do
-        get '/cms_api', params: { format: :json, access_token: token.value }
+        get '/cms_api', params: { format: :json, access_token: token.plaintext_value }
         assert_response :ok
       end
     end
@@ -66,7 +66,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
       member = FactoryBot.create(:member, account: @provider, admin_sections: ['portal'])
       token  = FactoryBot.create(:access_token, owner: member)
       with_api_routes do
-        get '/cms_api', params: { format: :json, access_token: token.value }
+        get '/cms_api', params: { format: :json, access_token: token.plaintext_value }
         assert_response :forbidden
       end
     end
@@ -75,7 +75,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
       member = FactoryBot.create(:member, account: @provider)
       token  = FactoryBot.create(:access_token, owner: member, scopes: ['cms'], permission: 'rw')
       with_api_routes do
-        get '/cms_api', params: { format: :json, access_token: token.value }
+        get '/cms_api', params: { format: :json, access_token: token.plaintext_value }
         assert_response :forbidden
       end
     end
@@ -98,7 +98,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
           token = FactoryBot.create(:access_token, owner: user, permission: 'rw')
           token.update_column(:scopes, ['cms']) # rubocop:disable Rails/SkipsModelValidations It must be done this way because it is invalid now.
           with_api_routes do
-            get '/cms_api', params: { format: :json, access_token: token.value }
+            get '/cms_api', params: { format: :json, access_token: token.plaintext_value }
             assert_response :forbidden
           end
         end
@@ -110,7 +110,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
         [admin, member].each do |user|
           token  = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'], permission: 'rw')
           with_api_routes do
-            get '/cms_api', params: { format: :json, access_token: token.value }
+            get '/cms_api', params: { format: :json, access_token: token.plaintext_value }
             assert_response :forbidden
           end
         end
@@ -124,7 +124,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
         [admin, member].each do |user|
           token  = FactoryBot.create(:access_token, owner: user, scopes: ['cms'], permission: 'rw')
           with_api_routes do
-            get '/cms_api', params: { format: :json, access_token: token.value }
+            get '/cms_api', params: { format: :json, access_token: token.plaintext_value }
             assert_response :success
           end
         end
@@ -136,7 +136,7 @@ class Admin::Api::CMS::BaseControllerTest < ActionDispatch::IntegrationTest
         [admin, member].each do |user|
           token  = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'], permission: 'rw')
           with_api_routes do
-            get '/cms_api', params: { format: :json, access_token: token.value }
+            get '/cms_api', params: { format: :json, access_token: token.plaintext_value }
             assert_response :success
           end
         end

--- a/test/integration/finance/api/invoices_controller_test.rb
+++ b/test/integration/finance/api/invoices_controller_test.rb
@@ -27,7 +27,7 @@ class Finance::Api::InvoicesControllerTest < ActionDispatch::IntegrationTest
 
     def setup
       ThreeScale.config.stubs(onpremises: true)
-      @access_token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[finance]).value
+      @access_token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[finance]).plaintext_value
       @provider = master_account
       @now = Time.zone.now
       @later = @now + 2.months
@@ -66,7 +66,7 @@ class Finance::Api::InvoicesControllerTest < ActionDispatch::IntegrationTest
     @later = @now + 2.months
     @buyer = FactoryBot.create(:buyer_account, provider_account: @provider, created_at: @now)
     @provider.settings.allow_finance!
-    @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[finance]).value
+    @access_token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[finance]).plaintext_value
     host! @provider.external_admin_domain
 
     [@now, @later].each { |datetime| FactoryBot.create(:invoice_counter, provider_account: @provider, invoice_prefix: datetime.strftime('%Y-%m')) }
@@ -195,7 +195,7 @@ class Finance::Api::InvoicesControllerTest < ActionDispatch::IntegrationTest
     assert_difference(Audited.audit_class.method(:count)) do
       Invoice.with_synchronous_auditing do
         assert_difference(Invoice.method(:count)) do
-          post api_invoices_path, params: invoice_params.merge!(access_token: token.value), headers: { accept: Mime[:json] }
+          post api_invoices_path, params: invoice_params.merge!(access_token: token.plaintext_value), headers: { accept: Mime[:json] }
           assert_response :created
         end
       end

--- a/test/integration/finance/api/invoices_test.rb
+++ b/test/integration/finance/api/invoices_test.rb
@@ -34,7 +34,7 @@ module Finance::Api
         member = FactoryBot.create(:member, account: @provider, admin_sections: [:finance])
         token = FactoryBot.create(:access_token, owner: member)
 
-        get "/api/invoices.xml?access_token=#{token.value}"
+        get "/api/invoices.xml?access_token=#{token.plaintext_value}"
 
         assert_response :forbidden
       end
@@ -44,7 +44,7 @@ module Finance::Api
         member = FactoryBot.create(:member, account: @provider, admin_sections: [:finance])
         token = FactoryBot.create(:access_token, owner: member, scopes: ['finance'])
 
-        get "/api/invoices.xml?access_token=#{token.value}"
+        get "/api/invoices.xml?access_token=#{token.plaintext_value}"
 
         assert_response :success
       end
@@ -54,7 +54,7 @@ module Finance::Api
         member = FactoryBot.create(:member, account: @provider, admin_sections: [])
         token = FactoryBot.create(:access_token, owner: member, scopes: ['finance'])
 
-        get "/api/invoices.xml?access_token=#{token.value}"
+        get "/api/invoices.xml?access_token=#{token.plaintext_value}"
 
         assert_response :forbidden
       end

--- a/test/integration/finance/api/line_items_controller_test.rb
+++ b/test/integration/finance/api/line_items_controller_test.rb
@@ -6,7 +6,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
     @provider = FactoryBot.create(:provider_with_billing)
     @buyer = FactoryBot.create(:simple_buyer, provider_account: @provider)
     @provider.settings.allow_finance!
-    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
     host! @provider.external_admin_domain
     @invoice = FactoryBot.create(:invoice, provider_account: @provider, buyer_account: @buyer)
     @line_item = FactoryBot.create(:line_item, invoice: @invoice, name: 'fakeName')
@@ -17,7 +17,7 @@ class Finance::Api::LineItemsControllerTest < ActionDispatch::IntegrationTest
       @buyer = FactoryBot.create(:simple_account, provider_account: master_account)
       @invoice = FactoryBot.create(:invoice, provider_account: master_account, buyer_account: @buyer)
       @line_item = FactoryBot.create(:line_item, invoice: @invoice, name: 'fakeName')
-      @token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[account_management]).value
+      @token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[account_management]).plaintext_value
       host! master_account.internal_admin_domain
     end
 

--- a/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
+++ b/test/integration/finance/api/payment_callbacks/stripe_callbacks_controller_test.rb
@@ -23,7 +23,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       stripe_event = self.stripe_event(type: 'payment_intent.succeeded', payment_intent_data: { id: 'some-payment-intent-id' })
       Stripe::Webhook.expects(:construct_event).returns(stripe_event)
 
-      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.plaintext_value }
       assert_response :no_content
     end
 
@@ -32,7 +32,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       gateway_options.gateway_settings[:endpoint_secret] = ''
       gateway_options.save(validate: false)
 
-      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.plaintext_value }
       assert_response :unprocessable_entity
       assert_equal 'Configuration is missing', response.body
     end
@@ -41,14 +41,14 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       exception = Stripe::SignatureVerificationError.new('invalid signature', 'invalid header content')
       Stripe::Webhook.expects(:construct_event).raises(exception)
 
-      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.plaintext_value }
       assert_response :bad_request
     end
 
     test 'invalid json payload' do
       Stripe::Webhook.expects(:construct_event).raises(JSON::ParserError)
 
-      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.plaintext_value }
       assert_response :bad_request
     end
 
@@ -56,7 +56,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       stripe_event = self.stripe_event(type: 'payment_intent.requires_action', payment_intent_data: { id: 'some-payment-intent-id' })
       Stripe::Webhook.expects(:construct_event).returns(stripe_event)
 
-      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.plaintext_value }
       assert_response :not_found
     end
 
@@ -64,7 +64,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       stripe_event = self.stripe_event(type: 'payment_intent.succeeded', payment_intent_data: { id: 'non-existent-payment-intent-id' })
       Stripe::Webhook.expects(:construct_event).returns(stripe_event)
 
-      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.plaintext_value }
       assert_response :no_content
     end
 
@@ -77,7 +77,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       System::ErrorReporting.expects(:report_error).at_least_once # because the setup doesn't really build all required objects
       System::ErrorReporting.expects(:report_error).with(instance_of(Finance::Api::PaymentCallbacks::StripeCallbacksController::StripeCallbackError), event: stripe_event, payment_intent: payment_intent)
 
-      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.plaintext_value }
       assert_response :no_content
     end
 
@@ -85,7 +85,7 @@ class Finance::Api::PaymentCallbacks::StripeCallbacksControllerTest < ActionDisp
       provider_account.payment_gateway_type = :bogus
       provider_account.save!
 
-      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.value }
+      post api_payment_callbacks_stripe_callbacks_path, params: { access_token: access_token.plaintext_value }
       assert_response :not_found
     end
   end

--- a/test/integration/finance/api/payment_transactions_controller_test.rb
+++ b/test/integration/finance/api/payment_transactions_controller_test.rb
@@ -22,14 +22,14 @@ class Finance::Api::PaymentTransactionsControllerTest < ActionDispatch::Integrat
            "avs_result"=>"Y", "error_code"=>"000", "auth_code"=>"005308"}
     FactoryBot.create :payment_transaction, invoice: invoice, :params => gr
 
-    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.value)
+    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.plaintext_value)
 
     assert_response :ok
     assert_payment_transactions @response.body
   end
 
   test "has payment_transactions root on the xml when the list in empty" do
-    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.value)
+    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.plaintext_value)
 
     assert_response :ok
     assert_xml '/payment_transactions'
@@ -38,7 +38,7 @@ class Finance::Api::PaymentTransactionsControllerTest < ActionDispatch::Integrat
   test "payment_transaction with nil params" do
     FactoryBot.create :payment_transaction, invoice: @invoice, params: nil
 
-    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.value)
+    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.plaintext_value)
     assert_response :ok
   end
 
@@ -61,7 +61,7 @@ class Finance::Api::PaymentTransactionsControllerTest < ActionDispatch::Integrat
     FactoryBot.create(:payment_transaction, success: true, invoice: invoice)
     host! without_finance.internal_admin_domain
 
-    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.value)
+    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.plaintext_value)
     assert_response :forbidden
     assert_match 'Finance module not enabled for the account', @response.body
   end
@@ -73,18 +73,18 @@ class Finance::Api::PaymentTransactionsControllerTest < ActionDispatch::Integrat
     invoice = FactoryBot.create(:invoice, provider_account: without_finance, buyer_account: buyer)
     FactoryBot.create(:payment_transaction, success: true, invoice: invoice)
     host! without_finance.internal_admin_domain
-    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.value)
+    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.plaintext_value)
     assert_response :forbidden
   end
 
   test 'work only on provider admin domain' do
     host! @provider.internal_domain
-    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.value)
+    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.plaintext_value)
     assert_response :not_found
   end
 
   test 'return 404 on non-existent invoice' do
-    get api_invoice_payment_transactions_path(invoice_id: 'WHAT_42_EVER', format: :xml, access_token: access_token.value)
+    get api_invoice_payment_transactions_path(invoice_id: 'WHAT_42_EVER', format: :xml, access_token: access_token.plaintext_value)
     assert_response :not_found
   end
 
@@ -92,11 +92,11 @@ class Finance::Api::PaymentTransactionsControllerTest < ActionDispatch::Integrat
     host! master_account.internal_admin_domain
     invoice = FactoryBot.create(:invoice, provider_account: master_account)
     access_token = FactoryBot.create(:access_token, owner: master_account.first_admin, scopes: ['finance'])
-    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.value)
+    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.plaintext_value)
     assert_response :success
 
     ThreeScale.config.stubs(onpremises: true)
-    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.value)
+    get api_invoice_payment_transactions_path(invoice, format: :xml, access_token: access_token.plaintext_value)
     assert_response :forbidden
   end
 end

--- a/test/integration/master/api/finance/accounts/billing_jobs_controller_test.rb
+++ b/test/integration/master/api/finance/accounts/billing_jobs_controller_test.rb
@@ -16,31 +16,31 @@ class Master::Api::Finance::Accounts::BillingJobsControllerTest < ActionDispatch
 
   test 'create billing job' do
     Finance::BillingService.expects(:async_call).with(@provider, Time.utc(2018,2,8), @provider.buyers.where(id: @buyer.id)).returns(true)
-    post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: @access_token.value }
+    post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: @access_token.plaintext_value }
     assert_response :accepted
   end
 
   test '#create schedules a worker' do
     assert_difference BillingWorker.jobs.method(:size) do
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: @access_token.value }
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: @access_token.plaintext_value }
       assert_response :accepted
     end
   end
 
   test 'create billing job with invalid account_id' do
-    post master_api_provider_account_billing_jobs_path(@provider, account_id: 'invalid_account', date: '2018-02-08'), params: { access_token: @access_token.value }
+    post master_api_provider_account_billing_jobs_path(@provider, account_id: 'invalid_account', date: '2018-02-08'), params: { access_token: @access_token.plaintext_value }
     assert_response :not_found
   end
 
   test 'create billing job with account_id from different scope' do
     other_provider = FactoryBot.create(:provider_with_billing)
     other_buyer = FactoryBot.create(:buyer_account, provider_account: other_provider)
-    post master_api_provider_account_billing_jobs_path(@provider, other_buyer, date: '2018-02-08'), params: { access_token: @access_token.value }
+    post master_api_provider_account_billing_jobs_path(@provider, other_buyer, date: '2018-02-08'), params: { access_token: @access_token.plaintext_value }
     assert_response :not_found
   end
 
   test 'create billing job without a date' do
-    post master_api_provider_account_billing_jobs_path(@provider, @buyer), params: { access_token: @access_token.value }
+    post master_api_provider_account_billing_jobs_path(@provider, @buyer), params: { access_token: @access_token.plaintext_value }
     assert_response :bad_request
   end
 
@@ -49,7 +49,7 @@ class Master::Api::Finance::Accounts::BillingJobsControllerTest < ActionDispatch
     Sidekiq::Testing.inline! do
       billing_options = { only: [@provider.id], buyer_ids: [@buyer.id], now: Time.zone.parse(date).to_date, skip_notifications: true }
       Finance::BillingStrategy.expects(:daily).with(billing_options).returns(mock_billing_success(date, @provider))
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: date), params: { access_token: @access_token.value }
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: date), params: { access_token: @access_token.plaintext_value }
       assert_response :accepted
     end
   end
@@ -60,13 +60,13 @@ class Master::Api::Finance::Accounts::BillingJobsControllerTest < ActionDispatch
     Sidekiq::Testing.inline! do
       billing_options = { only: [@provider.id], buyer_ids: [@buyer.id], now: date_utc, skip_notifications: true }
       Finance::BillingStrategy.expects(:daily).with(billing_options).returns(mock_billing_success(date_utc, @provider))
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: date), params: { access_token: @access_token.value }
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: date), params: { access_token: @access_token.plaintext_value }
       assert_response :accepted
     end
   end
 
   test 'invalid date' do
-    post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: 'not a valid date'), params: { access_token: @access_token.value }
+    post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: 'not a valid date'), params: { access_token: @access_token.plaintext_value }
     assert_response :bad_request
   end
 
@@ -82,33 +82,33 @@ class Master::Api::Finance::Accounts::BillingJobsControllerTest < ActionDispatch
 
     test 'scope account_management is required to create jobs' do
       unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['finance'])
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: unauthorized_token.plaintext_value }
       assert_response :forbidden
 
       authorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'])
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: authorized_token.value }
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: authorized_token.plaintext_value }
       assert_response :accepted
     end
 
     test 'members can create jobs with proper admin permission' do
       unauthorized_member = FactoryBot.create(:member, account: master_account, admin_sections: [])
       unauthorized_token = FactoryBot.create(:access_token, owner: unauthorized_member, scopes: ['account_management'])
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: unauthorized_token.plaintext_value }
       assert_response :forbidden
 
       authorized_member = FactoryBot.create(:member, account: master_account, admin_sections: [:partners])
       authorized_token = FactoryBot.create(:access_token, owner: authorized_member, scopes: ['account_management'])
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: authorized_token.value }
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: authorized_token.plaintext_value }
       assert_response :accepted
     end
 
     test 'only rw access tokens can create jobs' do
       unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'], permission: 'ro')
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: unauthorized_token.plaintext_value }
       assert_response :forbidden
 
       authorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'], permission: 'rw')
-      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: authorized_token.value }
+      post master_api_provider_account_billing_jobs_path(@provider, @buyer, date: '2018-02-08'), params: { access_token: authorized_token.plaintext_value }
       assert_response :accepted
     end
 

--- a/test/integration/master/api/finance/billing_jobs_controller_test.rb
+++ b/test/integration/master/api/finance/billing_jobs_controller_test.rb
@@ -16,13 +16,13 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
 
   test 'create billing job' do
     Finance::BillingService.expects(:async_call).returns(true)
-    post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.value }
+    post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.plaintext_value }
     assert_response :accepted
   end
 
   test '#create schedules a worker' do
     assert_difference BillingWorker.jobs.method(:size) do
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.value }
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.plaintext_value }
       assert_response :accepted
     end
   end
@@ -36,13 +36,13 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
       @provider.buyers.each do |buyer|
         Finance::BillingStrategy.expects(:daily).with(billing_options.merge(buyer_ids: [buyer.id])).returns(mock_billing_success(billing_date, @provider))
       end
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.value }
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.plaintext_value }
       assert_response :accepted
     end
   end
 
   test 'create billing job without a date' do
-    post master_api_provider_billing_jobs_path(@provider), params: { access_token: @access_token.value }
+    post master_api_provider_billing_jobs_path(@provider), params: { access_token: @access_token.plaintext_value }
     assert_response :bad_request
   end
 
@@ -51,7 +51,7 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
     Sidekiq::Testing.inline! do
       billing_options = { only: [@provider.id], buyer_ids: [@buyer.id], now: Time.zone.parse(date).to_date, skip_notifications: true }
       Finance::BillingStrategy.expects(:daily).with(billing_options).returns(mock_billing_success(date, @provider))
-      post master_api_provider_billing_jobs_path(@provider, date: date), params: { access_token: @access_token.value }
+      post master_api_provider_billing_jobs_path(@provider, date: date), params: { access_token: @access_token.plaintext_value }
       assert_response :accepted
     end
   end
@@ -62,25 +62,25 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
     Sidekiq::Testing.inline! do
       billing_options = { only: [@provider.id], buyer_ids: [@buyer.id], now: date_utc, skip_notifications: true }
       Finance::BillingStrategy.expects(:daily).with(billing_options).returns(mock_billing_success(date_utc, @provider))
-      post master_api_provider_billing_jobs_path(@provider, date: date), params: { access_token: @access_token.value }
+      post master_api_provider_billing_jobs_path(@provider, date: date), params: { access_token: @access_token.plaintext_value }
       assert_response :accepted
     end
   end
 
   test 'invalid date' do
-    post master_api_provider_billing_jobs_path(@provider, date: 'not a valid date'), params: { access_token: @access_token.value }
+    post master_api_provider_billing_jobs_path(@provider, date: 'not a valid date'), params: { access_token: @access_token.plaintext_value }
     assert_response :bad_request
   end
 
   test 'forbids for providers without billing enabled' do
     provider = FactoryBot.create(:simple_provider)
-    post master_api_provider_billing_jobs_path(provider, date: '2018-02-08'), params: { access_token: @access_token.value }
+    post master_api_provider_billing_jobs_path(provider, date: '2018-02-08'), params: { access_token: @access_token.plaintext_value }
     assert_response :forbidden
     assert_equal 'Finance module not enabled for the account', JSON.parse(response.body)['error']
 
     FactoryBot.create(:prepaid_billing, account: provider)
     Finance::BillingService.expects(:async_call).returns(true)
-    post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.value }
+    post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: @access_token.plaintext_value }
     assert_response :accepted
   end
 
@@ -96,33 +96,33 @@ class Master::Api::Finance::BillingJobsControllerTest < ActionDispatch::Integrat
 
     test 'scope account_management is required to create jobs' do
       unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['finance'])
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: unauthorized_token.plaintext_value }
       assert_response :forbidden
 
       authorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'])
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: authorized_token.value }
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: authorized_token.plaintext_value }
       assert_response :accepted
     end
 
     test 'members can create jobs with proper admin permission' do
       unauthorized_member = FactoryBot.create(:member, account: master_account, admin_sections: [])
       unauthorized_token = FactoryBot.create(:access_token, owner: unauthorized_member, scopes: ['account_management'])
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: unauthorized_token.plaintext_value }
       assert_response :forbidden
 
       authorized_member = FactoryBot.create(:member, account: master_account, admin_sections: [:partners])
       authorized_token = FactoryBot.create(:access_token, owner: authorized_member, scopes: ['account_management'])
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: authorized_token.value }
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: authorized_token.plaintext_value }
       assert_response :accepted
     end
 
     test 'only rw access tokens can create jobs' do
       unauthorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'], permission: 'ro')
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: unauthorized_token.value }
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: unauthorized_token.plaintext_value }
       assert_response :forbidden
 
       authorized_token = FactoryBot.create(:access_token, owner: @master_admin, scopes: ['account_management'], permission: 'rw')
-      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: authorized_token.value }
+      post master_api_provider_billing_jobs_path(@provider, date: '2018-02-08'), params: { access_token: authorized_token.plaintext_value }
       assert_response :accepted
     end
 

--- a/test/integration/master/api/providers_controller_integration_test.rb
+++ b/test/integration/master/api/providers_controller_integration_test.rb
@@ -124,7 +124,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     token = FactoryBot.create(:access_token, owner: master_account.admins.first, scopes: 'account_management')
     assert_difference Account.method(:count), 1 do
       assert_difference User.method(:count), 2 do # the main user and the impersonation_admin user
-        post master_api_providers_path, params: signup_params({ api_key: '', access_token: token.value })
+        post master_api_providers_path, params: signup_params({ api_key: '', access_token: token.plaintext_value })
         assert_response :created
       end
     end
@@ -134,7 +134,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     assert_no_difference Account.method(:count) do
       user = FactoryBot.create(:member, account: master_account)
       token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
-      post master_api_providers_path, params: signup_params({ access_token: token.value }).except(:api_key)
+      post master_api_providers_path, params: signup_params({ access_token: token.plaintext_value }).except(:api_key)
       assert_response :forbidden
       assert_equal 'Your access token does not have the correct permissions', JSON.parse(response.body)['error']
     end
@@ -144,7 +144,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     assert_difference Account.method(:count) do
       user = FactoryBot.create(:member, account: master_account, member_permission_ids: [:partners])
       token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
-      post master_api_providers_path, params: signup_params({ access_token: token.value }).except(:api_key)
+      post master_api_providers_path, params: signup_params({ access_token: token.plaintext_value }).except(:api_key)
       assert_response :created
     end
   end
@@ -178,7 +178,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
       from_email: 'from@email.com', support_email: 'support@email.com',
       finance_support_email: 'finance@email.com', site_access_code: 'new-access-code',
       account_extra_field: 'testing-account-extra-field', state_event: 'suspend'
-    }, access_token: token.value, format: :json }
+    }, access_token: token.plaintext_value, format: :json }
     put master_api_provider_path(provider, update_params)
     assert_response :ok
 
@@ -198,7 +198,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     provider.schedule_for_deletion!
 
     update_params = { account: { from_email: 'from@email.com', state_event: 'resume'},
-                      access_token: token.value, format: :json }
+                      access_token: token.plaintext_value, format: :json }
     put master_api_provider_path(provider, update_params)
     assert_response :ok
 
@@ -213,7 +213,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     token    = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
 
     freeze_time do
-      delete master_api_provider_path(provider, access_token: token.value, format: :json)
+      delete master_api_provider_path(provider, access_token: token.plaintext_value, format: :json)
       assert_response :ok
       assert_equal '', response.body
       assert provider.reload.scheduled_for_deletion?
@@ -225,7 +225,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     provider = FactoryBot.create(:provider_account, provider_account: master_account)
     user     = FactoryBot.create(:member, account: master_account)
     token    = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
-    delete master_api_provider_path(provider, access_token: token.value, format: :json)
+    delete master_api_provider_path(provider, access_token: token.plaintext_value, format: :json)
     assert_response :forbidden
     assert_equal 'Your access token does not have the correct permissions', JSON.parse(response.body)['error']
   end
@@ -234,7 +234,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     provider = FactoryBot.create(:provider_account, provider_account: master_account)
     token    = FactoryBot.create(:access_token, owner: master_account.admin_users.first, scopes: 'account_management')
 
-    get master_api_provider_path(provider, access_token: token.value, format: :json)
+    get master_api_provider_path(provider, access_token: token.plaintext_value, format: :json)
 
     assert_response :ok
     assert_equal provider.reload.id, JSON.parse(response.body).dig('signup', 'account', 'id')
@@ -277,7 +277,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     test '#plan_upgrade successful upgrade' do
       new_plan = FactoryBot.create(:application_plan, issuer: master_account.default_service)
 
-      put plan_upgrade_master_api_provider_path(provider, access_token: token.value, plan_id: new_plan.id, format: :xml)
+      put plan_upgrade_master_api_provider_path(provider, access_token: token.plaintext_value, plan_id: new_plan.id, format: :xml)
 
       assert_response :ok
       assert_equal new_plan.id, provider.reload.bought_application_plans.first.id
@@ -286,7 +286,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     test '#plan_upgrade missing plan' do
       current_plan_id = provider.reload.bought_application_plans.first.id
       new_plan_id = 999
-      put plan_upgrade_master_api_provider_path(provider, access_token: token.value, plan_id: new_plan_id, format: :xml)
+      put plan_upgrade_master_api_provider_path(provider, access_token: token.plaintext_value, plan_id: new_plan_id, format: :xml)
 
       assert_response :not_found
       assert_equal current_plan_id, provider.reload.bought_application_plans.first.id
@@ -298,7 +298,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
       new_plan = FactoryBot.create(:application_plan_without_rules, issuer: master_account.default_service, name: new_plan_name)
       current_plan_id = provider.reload.bought_application_plans.first.id
 
-      put plan_upgrade_master_api_provider_path(provider, access_token: token.value, plan_id: new_plan.id, format: :xml)
+      put plan_upgrade_master_api_provider_path(provider, access_token: token.plaintext_value, plan_id: new_plan.id, format: :xml)
 
       assert_response :bad_request
       assert_equal current_plan_id, provider.reload.bought_application_plans.first.id

--- a/test/integration/master/api/proxy/configs_controller_test.rb
+++ b/test/integration/master/api/proxy/configs_controller_test.rb
@@ -18,7 +18,7 @@ class Master::Api::Proxy::ConfigsControllerTest < ActionDispatch::IntegrationTes
       production_current_versions << FactoryBot.create_list(:proxy_config, 3, proxy: proxy, environment: 'production').last
     end
 
-    get master_api_proxy_configs_path(environment: 'production'), params: {access_token: @token.value}
+    get master_api_proxy_configs_path(environment: 'production'), params: {access_token: @token.plaintext_value}
     assert_response :success
 
     assert_same_elements production_current_versions.map(&:id),
@@ -30,7 +30,7 @@ class Master::Api::Proxy::ConfigsControllerTest < ActionDispatch::IntegrationTes
     FactoryBot.create(:proxy_config, proxy: proxy, environment: 'sandbox', content: content_hosts('v1.example.com'))
     latest_proxy_config = FactoryBot.create(:proxy_config, proxy: proxy, environment: 'sandbox', content: content_hosts('v2.example.com'))
 
-    get master_api_proxy_configs_path(environment: 'sandbox'), params: {access_token: @token.value, host: 'v2.example.com'}
+    get master_api_proxy_configs_path(environment: 'sandbox'), params: {access_token: @token.plaintext_value, host: 'v2.example.com'}
 
     assert_response :success
     assert_equal [latest_proxy_config.id], proxy_config_ids(response.body)
@@ -38,7 +38,7 @@ class Master::Api::Proxy::ConfigsControllerTest < ActionDispatch::IntegrationTes
 
     FactoryBot.create(:proxy_config, proxy: proxy, environment: 'sandbox', hosts: %w[example.com])
 
-    get master_api_proxy_configs_path(environment: 'sandbox'), params: {access_token: @token.value, host: 'v1.example.com'}
+    get master_api_proxy_configs_path(environment: 'sandbox'), params: {access_token: @token.plaintext_value, host: 'v1.example.com'}
 
     assert_response :success
     assert_empty proxy_config_ids(response.body)
@@ -46,7 +46,7 @@ class Master::Api::Proxy::ConfigsControllerTest < ActionDispatch::IntegrationTes
 
     _old_proxy_config, new_proxy_config = FactoryBot.create_list(:proxy_config, 2, proxy: proxy, environment: 'sandbox', content: content_hosts('foo.example.com'))
 
-    get master_api_proxy_configs_path(environment: 'sandbox'), params: {access_token: @token.value, host: 'foo.example.com'}
+    get master_api_proxy_configs_path(environment: 'sandbox'), params: {access_token: @token.plaintext_value, host: 'foo.example.com'}
 
     assert_equal [new_proxy_config.id], proxy_config_ids(response.body)
   end

--- a/test/integration/multitenant_enforcement_test.rb
+++ b/test/integration/multitenant_enforcement_test.rb
@@ -23,7 +23,7 @@ class MultitenantEnforcementTest < ActionDispatch::IntegrationTest
     service = @provider.first_service!
     plan = FactoryBot.create(:application_plan, issuer: service)
     plan.update_column(:tenant_id, @provider.tenant_id + 1)
-    token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+    token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
     assert_raises ThreeScale::Middleware::Multitenant::TenantChecker::TenantLeak do
       get admin_api_service_application_plans_path(service_id: service.id, format: :json, access_token: token)
     end
@@ -54,7 +54,7 @@ class MultitenantEnforcementTest < ActionDispatch::IntegrationTest
     plan = FactoryBot.create(:application_plan, issuer: service)
     service.update_column(:tenant_id, @provider.tenant_id)
     plan.update_column(:tenant_id, @provider.tenant_id + 1)
-    token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[account_management]).value
+    token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[account_management]).plaintext_value
     get admin_api_service_application_plans_path(service_id: service.id, format: :json, access_token: token)
     assert_response :success
     put admin_api_service_application_plan_path(service_id: service.id, id: plan.id, format: :json), params: {access_token: token, description: "desc1"}
@@ -68,7 +68,7 @@ class MultitenantEnforcementTest < ActionDispatch::IntegrationTest
     service.update_column(:tenant_id, @provider.tenant_id)
     plan.update_column(:tenant_id, @provider.tenant_id + 1)
 
-    token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[account_management]).value
+    token = FactoryBot.create(:access_token, owner: master_account.admin_users.first!, scopes: %w[account_management]).plaintext_value
     auth_pair = []
     auth_pair << ["", token]
     auth_pair << [token, ""]

--- a/test/integration/stats/authentication_test.rb
+++ b/test/integration/stats/authentication_test.rb
@@ -17,7 +17,7 @@ class Stats::AuthenticationTest < ActionDispatch::IntegrationTest
     assert_media_type 'application/json'
 
     token = FactoryBot.create(:access_token, owner: @provider_account.first_admin, scopes: ['stats'])
-    get usage_stats_data_services_path(@service, format: :json), params: params.merge(access_token: token.value)
+    get usage_stats_data_services_path(@service, format: :json), params: params.merge(access_token: token.plaintext_value)
     assert_response :success
     assert_media_type 'application/json'
   end

--- a/test/integration/stats/data/backend_apis_controller_test.rb
+++ b/test/integration/stats/data/backend_apis_controller_test.rb
@@ -15,7 +15,7 @@ class Stats::Data::BackendApisControllerTest < ActionDispatch::IntegrationTest
   attr_reader :provider, :backend_api, :metric, :access_token
 
   test 'usage_response_code with no data as json' do
-    get usage_stats_data_backend_apis_path(backend_api, format: :json, access_token: access_token.value), params: stats_params
+    get usage_stats_data_backend_apis_path(backend_api, format: :json, access_token: access_token.plaintext_value), params: stats_params
 
     assert_response :success
     assert_media_type 'application/json'
@@ -33,18 +33,18 @@ class Stats::Data::BackendApisControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'inexistent source' do
-    get usage_stats_data_backend_apis_path(backend_api_id: 0, format: :json, access_token: access_token.value), params: stats_params
+    get usage_stats_data_backend_apis_path(backend_api_id: 0, format: :json, access_token: access_token.plaintext_value), params: stats_params
     assert_response :not_found
   end
 
   test 'user permissions: usage allowed for members with Analytics permissions' do
     member_user = FactoryBot.create(:member, account: provider)
     member_access_token  = FactoryBot.create(:access_token, owner: member_user, scopes: ['stats'])
-    get usage_stats_data_backend_apis_path(backend_api, format: :json, access_token: member_access_token.value), params: stats_params
+    get usage_stats_data_backend_apis_path(backend_api, format: :json, access_token: member_access_token.plaintext_value), params: stats_params
     assert_response :forbidden
 
     member_user.update(allowed_sections: [:monitoring])
-    get usage_stats_data_backend_apis_path(backend_api, format: :json, access_token: member_access_token.value), params: stats_params
+    get usage_stats_data_backend_apis_path(backend_api, format: :json, access_token: member_access_token.plaintext_value), params: stats_params
     assert_response :success
   end
 

--- a/test/integration/stats/data/base_controller_test.rb
+++ b/test/integration/stats/data/base_controller_test.rb
@@ -15,7 +15,7 @@ class Stats::Data::BaseControllerTest < ActionDispatch::IntegrationTest
   attr_reader :provider, :service, :metric, :access_token
 
   test 'required params' do
-    url_params = { service_id: service.id, format: :json, access_token: access_token.value }
+    url_params = { service_id: service.id, format: :json, access_token: access_token.plaintext_value }
     stats_params = { metric_name: metric.system_name, period: 'day', timezone: ActiveSupport::TimeZone['UTC'].name, skip_change: false }
 
     get usage_stats_data_services_path(url_params), params: stats_params
@@ -61,7 +61,7 @@ class Stats::Data::BaseControllerTest < ActionDispatch::IntegrationTest
 
     buyer_access_token = FactoryBot.create(:access_token, owner: buyer_user, scopes: ['stats'])
 
-    url_params = { service_id: service.id, format: :json, access_token: buyer_access_token.value }
+    url_params = { service_id: service.id, format: :json, access_token: buyer_access_token.plaintext_value }
     stats_params = { metric_name: metric.system_name, period: 'day', timezone: ActiveSupport::TimeZone['UTC'].name, skip_change: false }
 
     get usage_stats_data_services_path(url_params), params: stats_params

--- a/test/integration/stats/data/requests_to_api_test.rb
+++ b/test/integration/stats/data/requests_to_api_test.rb
@@ -21,7 +21,7 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
   test 'usage with access token' do
     member = FactoryBot.create(:member, account: @provider_account, admin_sections: ['monitoring'])
     token  = FactoryBot.create(:access_token, owner: member, scopes: ['stats'])
-    params = { period: 'day', metric_name: 'hits', access_token: token.value }
+    params = { period: 'day', metric_name: 'hits', access_token: token.plaintext_value }
 
     # token includes the right scope, member has the right permission, all services are accessible
     get usage_stats_data_applications_path(@application, format: :json), params: params
@@ -55,7 +55,7 @@ class Stats::Data::RequestsToApiTest < ActionDispatch::IntegrationTest
   test 'summary with access token' do
     member = FactoryBot.create(:member, account: @provider_account, admin_sections: ['monitoring'])
     token  = FactoryBot.create(:access_token, owner: member, scopes: ['stats'])
-    params = { period: 'day', metric_name: 'hits', access_token: token.value }
+    params = { period: 'day', metric_name: 'hits', access_token: token.plaintext_value }
 
     get summary_stats_data_applications_path(@application, format: :json), params: params
     assert_response :success

--- a/test/integration/stats/data/service_controller_test.rb
+++ b/test/integration/stats/data/service_controller_test.rb
@@ -7,7 +7,7 @@ class Stats::Data::ServicesControllerTest < ActionDispatch::IntegrationTest
     @application = FactoryBot.create :cinstance
     host! @application.provider_account.internal_admin_domain
     user = @application.provider_account.admins.first!
-    @token = FactoryBot.create(:access_token, owner: user, scopes: %w[stats], permission: 'rw').value
+    @token = FactoryBot.create(:access_token, owner: user, scopes: %w[stats], permission: 'rw').plaintext_value
   end
 
   attr_reader :application, :token

--- a/test/integration/user-management-api/account_plans_test.rb
+++ b/test/integration/user-management-api/account_plans_test.rb
@@ -24,7 +24,7 @@ class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
       member = FactoryBot.create(:member, account: @provider, admin_sections: %w[])
       token = FactoryBot.create(:access_token, owner: member, scopes: 'account_management')
 
-      get admin_api_account_plans_path(format: :xml), params: { access_token: token.value }
+      get admin_api_account_plans_path(format: :xml), params: { access_token: token.plaintext_value }
       assert_response :forbidden
     end
 
@@ -32,7 +32,7 @@ class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
       member = FactoryBot.create(:member, account: @provider, admin_sections: %w[partners plans])
       token = FactoryBot.create(:access_token, owner: member, scopes: 'account_management')
 
-      get admin_api_account_plans_path(format: :xml), params: { access_token: token.value }
+      get admin_api_account_plans_path(format: :xml), params: { access_token: token.plaintext_value }
       assert_response :success
     end
 
@@ -40,7 +40,7 @@ class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
       admin = FactoryBot.create(:admin, account: @provider, admin_sections: [])
       token = FactoryBot.create(:access_token, owner: admin, scopes: 'account_management')
 
-      get admin_api_account_plans_path(format: :xml), params: { access_token: token.value }
+      get admin_api_account_plans_path(format: :xml), params: { access_token: token.plaintext_value }
       assert_response :success
     end
 
@@ -49,7 +49,7 @@ class Admin::Api::AccountPlansTest < ActionDispatch::IntegrationTest
       admin = FactoryBot.create(:admin, account: @provider, admin_sections: [])
       token = FactoryBot.create(:access_token, owner: admin, scopes: 'account_management')
 
-      get admin_api_account_plans_path(format: :xml), params: { access_token: token.value }
+      get admin_api_account_plans_path(format: :xml), params: { access_token: token.plaintext_value }
       assert_response :success
     end
   end

--- a/test/integration/user-management-api/accounts_test.rb
+++ b/test/integration/user-management-api/accounts_test.rb
@@ -274,7 +274,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
           assert_not settings.monthly_billing_enabled
 
           put admin_api_account_path(@buyer, format: :xml), params: {
-            access_token: token.value,
+            access_token: token.plaintext_value,
             monthly_billing_enabled: true,
             monthly_charging_enabled: true,
             org_name: 'ooooooooo'
@@ -334,7 +334,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
     protected
 
     def access_token_params(token = @token)
-      { access_token: token.value }
+      { access_token: token.plaintext_value }
     end
 
     alias params access_token_params

--- a/test/integration/user-management-api/application_plan_features_test.rb
+++ b/test/integration/user-management-api/application_plan_features_test.rb
@@ -44,7 +44,7 @@ class Admin::Api::ApplicationPlanFeaturesTest < ActionDispatch::IntegrationTest
     private
 
     def access_token_params(token = @token)
-      { access_token: token.value }
+      { access_token: token.plaintext_value }
     end
 
     alias params access_token_params

--- a/test/integration/user-management-api/application_plan_limits_test.rb
+++ b/test/integration/user-management-api/application_plan_limits_test.rb
@@ -47,7 +47,7 @@ class Admin::Api::ApplicationPlanLimitsTest < ActionDispatch::IntegrationTest
     private
 
     def access_token_params(token = @token)
-      { access_token: token.value }
+      { access_token: token.plaintext_value }
     end
 
     alias params access_token_params

--- a/test/integration/user-management-api/application_plan_metric_limits_test.rb
+++ b/test/integration/user-management-api/application_plan_metric_limits_test.rb
@@ -46,7 +46,7 @@ class Admin::Api::ApplicationPlanMetricLimitsTest < ActionDispatch::IntegrationT
     private
 
     def access_token_params(token = @token)
-      { access_token: token.value }
+      { access_token: token.plaintext_value }
     end
 
     alias params access_token_params

--- a/test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
+++ b/test/integration/user-management-api/application_plan_metric_pricing_rules_test.rb
@@ -54,7 +54,7 @@ class Admin::Api::ApplicationPlanMetricPricingRulesTest < ActionDispatch::Integr
     private
 
     def access_token_params(token = @token)
-      { access_token: token.value }
+      { access_token: token.plaintext_value }
     end
 
     alias params access_token_params

--- a/test/integration/user-management-api/application_plan_pricing_rules_test.rb
+++ b/test/integration/user-management-api/application_plan_pricing_rules_test.rb
@@ -46,7 +46,7 @@ class Admin::Api::ApplicationPlanPricingRulesTest < ActionDispatch::IntegrationT
     private
 
     def access_token_params(token = @token)
-      { access_token: token.value }
+      { access_token: token.plaintext_value }
     end
 
     alias params access_token_params

--- a/test/integration/user-management-api/application_plans_test.rb
+++ b/test/integration/user-management-api/application_plans_test.rb
@@ -48,7 +48,7 @@ class Admin::Api::ApplicationPlansTest < ActionDispatch::IntegrationTest
     private
 
     def access_token_params(token = @token)
-      { access_token: token.value }
+      { access_token: token.plaintext_value }
     end
 
     alias params access_token_params

--- a/test/integration/user-management-api/applications_test.rb
+++ b/test/integration/user-management-api/applications_test.rb
@@ -41,17 +41,17 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
 
     get(admin_api_applications_path)
     assert_response :forbidden
-    get admin_api_applications_path, params: { access_token: token.value }
+    get admin_api_applications_path, params: { access_token: token.plaintext_value }
     assert_response :success
     assert_select "applications/application", false
 
     user.update(member_permission_service_ids: [@service.id])
-    get admin_api_applications_path, params: { access_token: token.value, service_id: service_2.id }
+    get admin_api_applications_path, params: { access_token: token.plaintext_value, service_id: service_2.id }
     assert_response :success
     assert_select "applications/application", false
 
     user.update(member_permission_service_ids: [@service.id, service_2.id])
-    get admin_api_applications_path, params: { access_token: token.value }
+    get admin_api_applications_path, params: { access_token: token.plaintext_value }
     assert_response :success
     assert_select "applications/application", 2
     assert_select "applications/application/id", @application.id.to_s
@@ -59,7 +59,7 @@ class EnterpriseApiApplicationsTest < ActionDispatch::IntegrationTest
     assert_select "applications/application/id", application_2.id.to_s
     assert_select "applications/application/service_id", service_2.id.to_s
 
-    get admin_api_applications_path, params: { access_token: token.value, service_id: @service.id }
+    get admin_api_applications_path, params: { access_token: token.plaintext_value, service_id: @service.id }
     assert_response :success
     assert_select "applications/application", 1
     assert_select "applications/application/id", @application.id.to_s

--- a/test/integration/user-management-api/base_controller_test.rb
+++ b/test/integration/user-management-api/base_controller_test.rb
@@ -26,7 +26,7 @@ class Admin::Api::BaseControllerIntegrationTest < ActionDispatch::IntegrationTes
 
   def test_unknown_format
     with_api_routes do
-      get '/api/version/2.php', params: {access_token: @token.value}
+      get '/api/version/2.php', params: {access_token: @token.plaintext_value}
       assert_response :not_acceptable
     end
   end
@@ -37,7 +37,7 @@ class Admin::Api::BaseControllerIntegrationTest < ActionDispatch::IntegrationTes
 
     def setup
       provider = FactoryBot.create(:provider_account)
-      @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).value
+      @token = FactoryBot.create(:access_token, owner: provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
       host! provider.external_admin_domain
     end
 
@@ -131,7 +131,7 @@ class Admin::Api::BaseControllerIntegrationTest < ActionDispatch::IntegrationTes
       @provider = FactoryBot.create(:simple_provider)
       @user = FactoryBot.create(:simple_admin, account: @provider)
       @user.access_tokens.create!(name: 'API', scopes: %w[account_management], permission: 'ro') do |token|
-        token.value = 'access_token'
+        token.value = AccessToken.compute_digest('access_token')
       end
       ThreeScale.config.stubs(tenant_mode: 'multitenant')
     end
@@ -159,7 +159,7 @@ class Admin::Api::BaseControllerIntegrationTest < ActionDispatch::IntegrationTes
       ThreeScale.config.stubs(onpremises: true)
       user = FactoryBot.create(:simple_admin, account: master_account)
       user.access_tokens.create!(name: 'API', scopes: %w[account_management], permission: 'ro') do |token|
-        token.value = 'master_access_token'
+        token.value = AccessToken.compute_digest('master_access_token')
       end
 
       with_api_routes do
@@ -193,7 +193,7 @@ class Admin::Api::BaseControllerIntegrationTest < ActionDispatch::IntegrationTes
 
   def multipart
     boundary = '----0123456789'
-    parts = {body: '{"hello": "world"}', name: 'Multipart request', access_token: @token.value}
+    parts = {body: '{"hello": "world"}', name: 'Multipart request', access_token: @token.plaintext_value}
     body = parts.map do |key, val|
       %(Content-Disposition: form-data; name="#{key}"\r\n\r\n#{val}\r\n)
     end.join("#{boundary}\r\n")

--- a/test/integration/user-management-api/buyers_application_keys_test.rb
+++ b/test/integration/user-management-api/buyers_application_keys_test.rb
@@ -31,10 +31,10 @@ class Admin::Api::BuyersApplicationKeysTest < ActionDispatch::IntegrationTest
 
     post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'))
     assert_response :forbidden
-    post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'), params: { access_token: token.value })
+    post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'), params: { access_token: token.plaintext_value })
     assert_response :not_found
     user.update(member_permission_service_ids: [app.issuer.id])
-    post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'), params: { access_token: token.value })
+    post(admin_api_account_application_keys_path(@buyer, app, key: 'alaska'), params: { access_token: token.plaintext_value })
     assert_response :success
   end
 

--- a/test/integration/user-management-api/buyers_application_plans_test.rb
+++ b/test/integration/user-management-api/buyers_application_plans_test.rb
@@ -34,13 +34,13 @@ class Admin::Api::BuyersApplicationPlansTest < ActionDispatch::IntegrationTest
 
     user.update(member_permission_ids: [:partners], member_permission_service_ids: [])
 
-    get admin_api_account_application_plans_path(@buyer, access_token: token.value, format: :json)
+    get admin_api_account_application_plans_path(@buyer, access_token: token.plaintext_value, format: :json)
     assert_response :success
     assert_equal 0, JSON.parse(response.body)['plans'].count
 
     user.update(member_permission_service_ids: [@provider.default_service.id])
 
-    get admin_api_account_application_plans_path(@buyer, access_token: token.value, format: :json)
+    get admin_api_account_application_plans_path(@buyer, access_token: token.plaintext_value, format: :json)
     assert_response :success
     assert_equal 1, JSON.parse(response.body)['plans'].count
   end

--- a/test/integration/user-management-api/buyers_application_referrer_filters_test.rb
+++ b/test/integration/user-management-api/buyers_application_referrer_filters_test.rb
@@ -28,10 +28,10 @@ class Admin::Api::BuyersApplicationReferrerFiltersTest < ActionDispatch::Integra
 
     get(admin_api_account_application_referrer_filters_path(@buyer, app))
     assert_response :forbidden
-    get(admin_api_account_application_referrer_filters_path(@buyer, app), params: { access_token: token.value })
+    get(admin_api_account_application_referrer_filters_path(@buyer, app), params: { access_token: token.plaintext_value })
     assert_response :not_found
     user.update(member_permission_service_ids: [app.issuer.id])
-    get(admin_api_account_application_referrer_filters_path(@buyer, app), params: { access_token: token.value })
+    get(admin_api_account_application_referrer_filters_path(@buyer, app), params: { access_token: token.plaintext_value })
     assert_response :success
   end
 

--- a/test/integration/user-management-api/buyers_applications_test.rb
+++ b/test/integration/user-management-api/buyers_applications_test.rb
@@ -31,7 +31,7 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
     ReferrerFilter.enable_backend!
     stub_backend_get_keys
 
-    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).value
+    @token = FactoryBot.create(:access_token, owner: @provider.admin_users.first!, scopes: %w[account_management]).plaintext_value
   end
 
   test 'index' do

--- a/test/integration/user-management-api/buyers_users_test.rb
+++ b/test/integration/user-management-api/buyers_users_test.rb
@@ -35,7 +35,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
       User.any_instance.expects(:forget_me).never
 
-      post admin_api_account_users_path(@buyer, format: :xml), params: { username: 'alex', email: 'alex@alaska.hu', access_token: token.value }
+      post admin_api_account_users_path(@buyer, format: :xml), params: { username: 'alex', email: 'alex@alaska.hu', access_token: token.plaintext_value }
       assert_response :success
     end
   end
@@ -47,17 +47,17 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider)
     token = FactoryBot.create(:access_token, owner: user)
 
-    get admin_api_account_users_path(@buyer, format: :xml), params: { access_token: token.value }
+    get admin_api_account_users_path(@buyer, format: :xml), params: { access_token: token.plaintext_value }
     assert_response :forbidden
 
     user.admin_sections = ['partners']
     user.save!
-    get admin_api_account_users_path(@buyer, format: :xml), params: { access_token: token.value }
+    get admin_api_account_users_path(@buyer, format: :xml), params: { access_token: token.plaintext_value }
     assert_response :forbidden
 
     token.scopes = ['account_management']
     token.save!
-    get admin_api_account_users_path(@buyer, format: :xml), params: { access_token: token.value }
+    get admin_api_account_users_path(@buyer, format: :xml), params: { access_token: token.plaintext_value }
     assert_response :success
   end
 
@@ -66,12 +66,12 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
-    get admin_api_account_user_path(@buyer, id: @member.id, format: :xml), params: { access_token: token.value }
+    get admin_api_account_user_path(@buyer, id: @member.id, format: :xml), params: { access_token: token.plaintext_value }
     assert_response :success
 
     user.role = 'admin'
     user.save!
-    get admin_api_account_user_path(@buyer, id: @member.id, format: :xml), params: { access_token: token.value }
+    get admin_api_account_user_path(@buyer, id: @member.id, format: :xml), params: { access_token: token.plaintext_value }
     assert_response :success
   end
 
@@ -80,12 +80,12 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
-    put admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'Alex', access_token: token.value }
+    put admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'Alex', access_token: token.plaintext_value }
     assert_response :success
 
     user.role = 'admin'
     user.save!
-    put admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'Alex', access_token: token.value }
+    put admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'Alex', access_token: token.plaintext_value }
     assert_response :success
   end
 
@@ -94,12 +94,12 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
-    post admin_api_account_users_path(@buyer, format: :xml), params: { username: 'alex', email: 'alex@alaska.hu', access_token: token.value }
+    post admin_api_account_users_path(@buyer, format: :xml), params: { username: 'alex', email: 'alex@alaska.hu', access_token: token.plaintext_value }
     assert_response :forbidden
 
     user.role = 'admin'
     user.save!
-    post admin_api_account_users_path(@buyer, format: :xml), params: { username: 'alex', email: 'alex@alaska.hu', access_token: token.value }
+    post admin_api_account_users_path(@buyer, format: :xml), params: { username: 'alex', email: 'alex@alaska.hu', access_token: token.plaintext_value }
     assert_response :success
   end
 
@@ -108,16 +108,16 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
-    put admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
-    put activate_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put activate_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
 
     user.role = 'admin'
     user.save!
-    put admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
-    put activate_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put activate_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
   end
 
@@ -126,16 +126,16 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['partners'])
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
-    put admin_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put admin_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
-    put member_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put member_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
 
     user.role = 'admin'
     user.save!
-    put admin_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put admin_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
-    put member_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put member_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
   end
 
@@ -145,13 +145,13 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
     User.any_instance.expects(:destroy).returns(true)
-    delete admin_api_account_user_path(@buyer, format: :xml, id: @member.id), params: { access_token: token.value }
+    delete admin_api_account_user_path(@buyer, format: :xml, id: @member.id), params: { access_token: token.plaintext_value }
     assert_response :success
 
     user.role = 'admin'
     user.save!
     User.any_instance.expects(:destroy).returns(true)
-    delete admin_api_account_user_path(@buyer, format: :xml, id: @member.id), params: { access_token: token.value }
+    delete admin_api_account_user_path(@buyer, format: :xml, id: @member.id), params: { access_token: token.plaintext_value }
     assert_response :success
   end
 
@@ -161,19 +161,19 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: user, scopes: ['account_management'])
 
     User.any_instance.expects(:suspend!).returns(true)
-    put suspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put suspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
     User.any_instance.expects(:unsuspend).returns(true)
-    put unsuspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put unsuspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
 
     user.role = 'admin'
     user.save!
     User.any_instance.expects(:suspend!).returns(true)
-    put suspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put suspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
     User.any_instance.expects(:unsuspend).returns(true)
-    put unsuspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.value }
+    put unsuspend_admin_api_account_user_path(@buyer.id, id: @member.id, format: :xml), params: { username: 'alex', access_token: token.plaintext_value }
     assert_response :success
   end
 

--- a/test/integration/user-management-api/credit_cards_test.rb
+++ b/test/integration/user-management-api/credit_cards_test.rb
@@ -50,13 +50,13 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider, admin_sections: ['finance'])
     token = FactoryBot.create(:access_token, owner: user, scopes: 'finance')
 
-    delete admin_api_account_credit_card_path(@buyer, format: :xml), params: { access_token: token.value }
+    delete admin_api_account_credit_card_path(@buyer, format: :xml), params: { access_token: token.plaintext_value }
     assert_response :success
 
     user.role = 'admin'
     user.save!
 
-    delete admin_api_account_credit_card_path(@buyer, format: :xml), params: { access_token: token.value }
+    delete admin_api_account_credit_card_path(@buyer, format: :xml), params: { access_token: token.plaintext_value }
     assert_response :success
   end
 
@@ -247,7 +247,7 @@ class Admin::Api::CreditCardsTest < ActionDispatch::IntegrationTest
       billing_address_country:      'spain',
       credit_card_expiration_year:  '2013',
       credit_card_expiration_month: '12',
-      access_token:                 token.value
+      access_token:                 token.plaintext_value
     }
   end
 end

--- a/test/integration/user-management-api/service_contracts_controller_test.rb
+++ b/test/integration/user-management-api/service_contracts_controller_test.rb
@@ -12,7 +12,7 @@ class Admin::Api::ServiceContractsControllerTest < ActionDispatch::IntegrationTe
 
     @buyer.buy! @application_plan
 
-    @token = FactoryBot.create(:access_token, owner: current_account.admin_users.first!, scopes: 'account_management').value
+    @token = FactoryBot.create(:access_token, owner: current_account.admin_users.first!, scopes: 'account_management').plaintext_value
     host! current_account.internal_admin_domain
   end
 

--- a/test/integration/user-management-api/service_features_test.rb
+++ b/test/integration/user-management-api/service_features_test.rb
@@ -19,10 +19,10 @@ class EnterpriseApiFeaturesTest < ActionDispatch::IntegrationTest
 
     get admin_api_service_feature_path(@service, feature)
     assert_response :forbidden
-    get admin_api_service_feature_path(@service, feature), params: { access_token: token.value }
+    get admin_api_service_feature_path(@service, feature), params: { access_token: token.plaintext_value }
     assert_response :not_found
     user.update(member_permission_service_ids: [@service.id])
-    get admin_api_service_feature_path(@service, feature), params: { access_token: token.value }
+    get admin_api_service_feature_path(@service, feature), params: { access_token: token.plaintext_value }
     assert_response :success
   end
 

--- a/test/integration/user-management-api/service_plans_test.rb
+++ b/test/integration/user-management-api/service_plans_test.rb
@@ -25,10 +25,10 @@ class Admin::Api::ServicePlansTest < ActionDispatch::IntegrationTest
 
     get admin_api_service_service_plan_path(service, plan)
     assert_response :forbidden
-    get admin_api_service_service_plan_path(service, plan), params: { access_token: token.value }
+    get admin_api_service_service_plan_path(service, plan), params: { access_token: token.plaintext_value }
     assert_response :not_found
     user.update(member_permission_service_ids: [service.id])
-    get admin_api_service_service_plan_path(service, plan), params: { access_token: token.value }
+    get admin_api_service_service_plan_path(service, plan), params: { access_token: token.plaintext_value }
     assert_response :success
   end
 

--- a/test/integration/user-management-api/service_subscriptions_controller_test.rb
+++ b/test/integration/user-management-api/service_subscriptions_controller_test.rb
@@ -15,7 +15,7 @@ class Admin::Api::ServiceSubscriptionsControllerTest < ActionDispatch::Integrati
 
     @buyer.buy! @application_plan
 
-    @token = FactoryBot.create(:access_token, owner: current_account.admin_users.first!, scopes: 'account_management').value
+    @token = FactoryBot.create(:access_token, owner: current_account.admin_users.first!, scopes: 'account_management').plaintext_value
     host! current_account.internal_admin_domain
   end
 

--- a/test/integration/user-management-api/services/mapping_rules_test.rb
+++ b/test/integration/user-management-api/services/mapping_rules_test.rb
@@ -19,29 +19,29 @@ class Admin::Api::Services::MappingRulesTest < ActionDispatch::IntegrationTest
     # index
     get(admin_api_service_proxy_mapping_rules_path(access_token_params))
     assert_response :forbidden
-    get(admin_api_service_proxy_mapping_rules_path(access_token_params(token.value)))
+    get(admin_api_service_proxy_mapping_rules_path(access_token_params(token.plaintext_value)))
     assert_response :not_found
     user.update(member_permission_service_ids: [@service.id])
-    get(admin_api_service_proxy_mapping_rules_path(access_token_params(token.value)))
+    get(admin_api_service_proxy_mapping_rules_path(access_token_params(token.plaintext_value)))
     assert_response :success
 
     # show
-    params = access_token_params(token.value).merge(id: @proxy_rule.id)
+    params = access_token_params(token.plaintext_value).merge(id: @proxy_rule.id)
     get(admin_api_service_proxy_mapping_rule_path(params))
     assert_response :success
 
     # create
-    params = access_token_params(token.value).merge(mapping_rule_params)
+    params = access_token_params(token.plaintext_value).merge(mapping_rule_params)
     post(admin_api_service_proxy_mapping_rules_path(params))
     assert_response :success
 
     # update
-    params = access_token_params(token.value).merge(id: @proxy_rule.id).merge(mapping_rule_params)
+    params = access_token_params(token.plaintext_value).merge(id: @proxy_rule.id).merge(mapping_rule_params)
     put(admin_api_service_proxy_mapping_rule_path(params))
     assert_response :success
 
     # destroy
-    params = access_token_params(token.value).merge(id: @proxy_rule.id)
+    params = access_token_params(token.plaintext_value).merge(id: @proxy_rule.id)
     delete(admin_api_service_proxy_mapping_rule_path(params))
     assert_response :success
   end

--- a/test/integration/user-management-api/services/proxies_test.rb
+++ b/test/integration/user-management-api/services/proxies_test.rb
@@ -17,14 +17,14 @@ class Admin::Api::Services::ProxiesTest < ActionDispatch::IntegrationTest
     # show
     get(admin_api_service_proxy_path(access_token_params))
     assert_response :forbidden
-    get(admin_api_service_proxy_path(access_token_params(token.value)))
+    get(admin_api_service_proxy_path(access_token_params(token.plaintext_value)))
     assert_response :not_found
     user.update(member_permission_service_ids: [@service.id])
-    get(admin_api_service_proxy_path(access_token_params(token.value)))
+    get(admin_api_service_proxy_path(access_token_params(token.plaintext_value)))
     assert_response :success
 
     # update
-    params = access_token_params(token.value).merge(proxy: { endpoint: 'https://alaska.wild' })
+    params = access_token_params(token.plaintext_value).merge(proxy: { endpoint: 'https://alaska.wild' })
     put(admin_api_service_proxy_path(params))
     assert_response :success
   end

--- a/test/integration/user-management-api/services/proxy/configs_test.rb
+++ b/test/integration/user-management-api/services/proxy/configs_test.rb
@@ -89,16 +89,16 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
     _proxy_config_old = FactoryBot.create(:proxy_config, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v1.example.com'))
     proxy_config_new  = FactoryBot.create(:proxy_config, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('v2.example.com'))
 
-    get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'v1.example.com', access_token: @token.value }
+    get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'v1.example.com', access_token: @token.plaintext_value }
     assert_empty proxy_config_ids
 
-    get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'v2.example.com', access_token: @token.value }
+    get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'v2.example.com', access_token: @token.plaintext_value }
     assert_equal [proxy_config_new.id], proxy_config_ids
 
 
     _proxy_config_old, proxy_config_new = FactoryBot.create_list(:proxy_config, 2, proxy: @service.proxy, environment: ProxyConfig::ENVIRONMENTS.first, content: content_hosts('foo.example.com'))
 
-    get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'foo.example.com', access_token: @token.value }
+    get admin_api_proxy_configs_path(environment: ProxyConfig::ENVIRONMENTS.first, format: :json), params: { host: 'foo.example.com', access_token: @token.plaintext_value }
     assert_equal [proxy_config_new.id], proxy_config_ids
   end
 
@@ -133,7 +133,7 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
   def host_valid_params
     {
       host:         @config.hosts.first,
-      access_token: @token.value,
+      access_token: @token.plaintext_value,
     }
   end
 
@@ -141,7 +141,7 @@ class Admin::Api::Services::Proxy::ConfigsTest < ActionDispatch::IntegrationTest
     {
       service_id:   @service.id,
       environment:  ProxyConfig::ENVIRONMENTS.first,
-      access_token: @token.value,
+      access_token: @token.plaintext_value,
       format:       :json
     }
   end

--- a/test/integration/user-management-api/services/proxy/policies_test.rb
+++ b/test/integration/user-management-api/services/proxy/policies_test.rb
@@ -74,7 +74,7 @@ class Admin::Api::Services::Proxy::PoliciesTest < ActionDispatch::IntegrationTes
   def valid_params
     {
       service_id:   @service.id,
-      access_token: @token.value,
+      access_token: @token.plaintext_value,
       format:       :json
     }
   end
@@ -92,7 +92,7 @@ class Admin::Api::Services::Proxy::PoliciesTest < ActionDispatch::IntegrationTes
       @service = @provider.default_service
       @another_service = FactoryBot.create(:simple_service, account: @provider)
       @member = FactoryBot.create(:active_user, account: @provider, role: :member)
-      @access_token = FactoryBot.create(:access_token, owner: @member, scopes: %w[policy_registry]).value
+      @access_token = FactoryBot.create(:access_token, owner: @member, scopes: %w[policy_registry]).plaintext_value
 
       host! @provider.external_admin_domain
     end
@@ -124,7 +124,7 @@ class Admin::Api::Services::Proxy::PoliciesTest < ActionDispatch::IntegrationTes
 
     test 'correct member permissions but wrong token scope' do
       member.update(allowed_sections: :policy_registry, allowed_service_ids: [service.id])
-      new_token = FactoryBot.create(:access_token, owner: @member, scopes: %w[stats cms finance]).value
+      new_token = FactoryBot.create(:access_token, owner: @member, scopes: %w[stats cms finance]).plaintext_value
 
       get admin_api_service_proxy_policies_path(service, access_token: new_token, format: :json)
 
@@ -133,7 +133,7 @@ class Admin::Api::Services::Proxy::PoliciesTest < ActionDispatch::IntegrationTes
 
     test 'correct member permissions with invalid scope' do
       member.update(allowed_sections: :policy_registry, allowed_service_ids: [service.id])
-      new_token = FactoryBot.create(:access_token, owner: member.reload, scopes: %w[account_management]).value
+      new_token = FactoryBot.create(:access_token, owner: member.reload, scopes: %w[account_management]).plaintext_value
 
       get admin_api_service_proxy_policies_path(service, access_token: new_token, format: :json)
 
@@ -142,7 +142,7 @@ class Admin::Api::Services::Proxy::PoliciesTest < ActionDispatch::IntegrationTes
 
     test 'correct member permissions with correct scope' do
       member.update(allowed_sections: :policy_registry, allowed_service_ids: [service.id])
-      new_token = FactoryBot.create(:access_token, owner: member.reload, scopes: %w[policy_registry]).value
+      new_token = FactoryBot.create(:access_token, owner: member.reload, scopes: %w[policy_registry]).plaintext_value
 
       get admin_api_service_proxy_policies_path(service, access_token: new_token, format: :json)
 

--- a/test/integration/user-management-api/services_test.rb
+++ b/test/integration/user-management-api/services_test.rb
@@ -19,10 +19,10 @@ class Admin::Api::ServicesTest < ActionDispatch::IntegrationTest
 
     get admin_api_service_path(@service)
     assert_response :forbidden
-    get admin_api_service_path(@service), params: { access_token: token.value }
+    get admin_api_service_path(@service), params: { access_token: token.plaintext_value }
     assert_response :not_found
     user.update(member_permission_service_ids: [@service.id])
-    get admin_api_service_path(@service), params: { access_token: token.value }
+    get admin_api_service_path(@service), params: { access_token: token.plaintext_value }
     assert_response :success
   end
 
@@ -102,7 +102,7 @@ class Admin::Api::ServicesTest < ActionDispatch::IntegrationTest
     _other_service  = FactoryBot.create(:simple_service, account: @provider)
 
     access_token = FactoryBot.create(:access_token, owner: @provider.admins.first, scopes: 'account_management')
-    delete admin_api_service_path @service.id, access_token: access_token.value, format: :json
+    delete admin_api_service_path @service.id, access_token: access_token.plaintext_value, format: :json
 
     assert_response 200
     assert_raise(ActiveRecord::RecordNotFound) { Service.accessible.find(@service.id) }
@@ -123,12 +123,12 @@ class Admin::Api::ServicesTest < ActionDispatch::IntegrationTest
       ro_token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'ro')
       rw_token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw')
 
-      put admin_api_service_path(@service), params: { access_token: rw_token.value, format: :xml, name: 'new service name' }
+      put admin_api_service_path(@service), params: { access_token: rw_token.plaintext_value, format: :xml, name: 'new service name' }
       assert_response :success
       @service.reload
       assert_equal 'new service name', @service.name
 
-      put admin_api_service_path(@service), params: { access_token: ro_token.value, format: :xml, name: 'other service name' }
+      put admin_api_service_path(@service), params: { access_token: ro_token.plaintext_value, format: :xml, name: 'other service name' }
       assert_response :forbidden
       @service.reload
       assert_equal 'new service name', @service.name

--- a/test/integration/user-management-api/signup_test.rb
+++ b/test/integration/user-management-api/signup_test.rb
@@ -35,7 +35,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     user  = FactoryBot.create(:member, account: @provider)
     token = FactoryBot.create(:access_token, owner: user)
 
-    post admin_api_signup_path, params: { format: :xml, access_token: token.value, org_name: 'fiona', username: 'fiona' }
+    post admin_api_signup_path, params: { format: :xml, access_token: token.plaintext_value, org_name: 'fiona', username: 'fiona' }
     assert_response :forbidden
 
     user.admin_sections = ['partners']
@@ -43,7 +43,7 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     token.scopes = ['account_management']
     token.save!
 
-    post admin_api_signup_path, params: { format: :xml, access_token: token.value, org_name: 'fiona', username: 'fiona' }
+    post admin_api_signup_path, params: { format: :xml, access_token: token.plaintext_value, org_name: 'fiona', username: 'fiona' }
     assert_response :created
   end
 

--- a/test/integration/user-management-api/users_test.rb
+++ b/test/integration/user-management-api/users_test.rb
@@ -22,7 +22,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   test 'index with access token as a member' do
     token = FactoryBot.create(:access_token, owner: @member, scopes: ['account_management'])
 
-    get admin_api_users_path(format: :xml), params: { access_token: token.value }
+    get admin_api_users_path(format: :xml), params: { access_token: token.plaintext_value }
 
     assert_response :forbidden
   end
@@ -31,11 +31,11 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(false)
-    get admin_api_users_path(format: :xml), params: { access_token: token.value }
+    get admin_api_users_path(format: :xml), params: { access_token: token.plaintext_value }
     assert_response :forbidden
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    get admin_api_users_path(format: :xml), params: { access_token: token.value }
+    get admin_api_users_path(format: :xml), params: { access_token: token.plaintext_value }
     assert_response :success
   end
 
@@ -45,7 +45,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     impersonation_admin.save!
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    get admin_api_users_path(format: :xml), params: { access_token: token.value }
+    get admin_api_users_path(format: :xml), params: { access_token: token.plaintext_value }
     assert_response :success
     refute_xpath ".//username", /impersonation_admin/
   end
@@ -54,18 +54,18 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: @member, scopes: ['account_management'])
 
     # member's opening his page
-    get admin_api_user_path(format: :xml, id: @member.id), params: { access_token: token.value }
+    get admin_api_user_path(format: :xml, id: @member.id), params: { access_token: token.plaintext_value }
     assert_response :success
 
     # member's opening admin's page
-    get admin_api_user_path(format: :xml, id: admin.id), params: { access_token: token.value }
+    get admin_api_user_path(format: :xml, id: admin.id), params: { access_token: token.plaintext_value }
     assert_response :forbidden
   end
 
   test 'show with access token as an admin' do
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
 
-    get admin_api_user_path(format: :xml, id: @member.id), params: { access_token: token.value }
+    get admin_api_user_path(format: :xml, id: @member.id), params: { access_token: token.plaintext_value }
 
     assert_response :success
   end
@@ -74,28 +74,28 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(false)
-    post admin_api_users_path(format: :xml), params: { username: 'aaa', email: 'aaa@aaa.hu', access_token: token.value }
+    post admin_api_users_path(format: :xml), params: { username: 'aaa', email: 'aaa@aaa.hu', access_token: token.plaintext_value }
     assert_response :forbidden
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
-    post admin_api_users_path(format: :xml), params: { username: 'aaa', email: 'aaa@aaa.hu', access_token: token.value }
+    post admin_api_users_path(format: :xml), params: { username: 'aaa', email: 'aaa@aaa.hu', access_token: token.plaintext_value }
     assert_response :success
   end
 
   test 'update with access token as a member' do
     token = FactoryBot.create(:access_token, owner: @member, scopes: ['account_management'])
 
-    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.value)
+    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.plaintext_value)
     assert_response :success
 
-    put admin_api_user_path(format: :xml, id: admin.id, access_token: token.value)
+    put admin_api_user_path(format: :xml, id: admin.id, access_token: token.plaintext_value)
     assert_response :forbidden
   end
 
   test 'update with access token as an admin' do
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
 
-    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.value)
+    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.plaintext_value)
 
     assert_response :success
   end
@@ -103,7 +103,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   test 'destroy with access token as a member' do
     token = FactoryBot.create(:access_token, owner: @member, scopes: ['account_management'])
 
-    delete admin_api_user_path(format: :xml, id: admin.id, access_token: token.value)
+    delete admin_api_user_path(format: :xml, id: admin.id, access_token: token.plaintext_value)
 
     assert_response :forbidden
   end
@@ -111,7 +111,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   test 'destroy with access token as an admin' do
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
 
-    delete admin_api_user_path(format: :xml, id: @member.id, access_token: token.value)
+    delete admin_api_user_path(format: :xml, id: @member.id, access_token: token.plaintext_value)
 
     assert_response :success
   end
@@ -119,7 +119,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   test 'admin/update_role with access token as a member' do
     token = FactoryBot.create(:access_token, owner: @member, scopes: ['account_management'])
 
-    put admin_api_user_path(format: :xml, id: admin.id, access_token: token.value)
+    put admin_api_user_path(format: :xml, id: admin.id, access_token: token.plaintext_value)
 
     assert_response :forbidden
   end
@@ -127,7 +127,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
   test 'admin/update_role with access token as an admin' do
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
 
-    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.value)
+    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.plaintext_value)
 
     assert_response :success
   end
@@ -136,7 +136,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: admin, scopes: ['account_management'])
     service = @provider.services.default
 
-    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.value), params: { member_permission_service_ids: [service.id], member_permission_ids: %w[monitoring services] }
+    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.plaintext_value), params: { member_permission_service_ids: [service.id], member_permission_ids: %w[monitoring services] }
 
     assert_response :success
 
@@ -150,7 +150,7 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     service = @provider.services.default
     admin_sections = @member.admin_sections
 
-    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.value), params: { member_permission_service_ids: [service.id], member_permission_ids: %w[monitoring] }
+    put admin_api_user_path(format: :xml, id: @member.id, access_token: token.plaintext_value), params: { member_permission_service_ids: [service.id], member_permission_ids: %w[monitoring] }
 
     assert_response :success
 
@@ -165,10 +165,10 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
     admin.activate!
 
-    put suspend_admin_api_user_path(format: :xml, id: admin.id, access_token: token.value)
+    put suspend_admin_api_user_path(format: :xml, id: admin.id, access_token: token.plaintext_value)
     assert_response :forbidden
 
-    put unsuspend_admin_api_user_path(format: :xml, id: admin.id, access_token: token.value)
+    put unsuspend_admin_api_user_path(format: :xml, id: admin.id, access_token: token.plaintext_value)
     assert_response :forbidden
   end
 
@@ -177,10 +177,10 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
 
     @member.activate!
 
-    put suspend_admin_api_user_path(format: :xml, id: @member.id, access_token: token.value)
+    put suspend_admin_api_user_path(format: :xml, id: @member.id, access_token: token.plaintext_value)
     assert_response :success
 
-    put unsuspend_admin_api_user_path(format: :xml, id: @member.id, access_token: token.value)
+    put unsuspend_admin_api_user_path(format: :xml, id: @member.id, access_token: token.plaintext_value)
     assert_response :success
   end
 

--- a/test/integration/user-management-api/web_hooks_failures_test.rb
+++ b/test/integration/user-management-api/web_hooks_failures_test.rb
@@ -18,16 +18,16 @@ class Admin::Api::WebHooksFailuresTest < ActionDispatch::IntegrationTest
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
     # member should not be able to work with webhooks at all
-    get admin_api_webhooks_failures_path, params: { access_token: token.value }
+    get admin_api_webhooks_failures_path, params: { access_token: token.plaintext_value }
     assert_response :forbidden
 
     user.role = 'admin'
     user.save!
-    get admin_api_webhooks_failures_path, params: { access_token: token.value }
+    get admin_api_webhooks_failures_path, params: { access_token: token.plaintext_value }
     assert_response :success
 
     Settings::Switch.any_instance.stubs(:allowed?).returns(false)
-    get admin_api_webhooks_failures_path, params: { access_token: token.value }
+    get admin_api_webhooks_failures_path, params: { access_token: token.plaintext_value }
     assert_response :forbidden
   end
 
@@ -36,7 +36,7 @@ class Admin::Api::WebHooksFailuresTest < ActionDispatch::IntegrationTest
     token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
 
-    delete admin_api_webhooks_failures_path, params: { access_token: token.value }
+    delete admin_api_webhooks_failures_path, params: { access_token: token.plaintext_value }
     assert_response :success
   end
 

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class AccessTokenTest < ActiveSupport::TestCase
 
   def setup
-    @token = FactoryBot.build(:access_token, owner: nil)
+    @token = FactoryBot.create(:access_token)
   end
 
   def test_destroy_dependency
@@ -87,12 +87,113 @@ class AccessTokenTest < ActiveSupport::TestCase
   def test_find_from_id_or_value_and_bang
     FactoryBot.create_list(:access_token, 2).each do |token|
       assert_equal token.id, AccessToken.find_from_id_or_value(token.id).id
-      assert_equal token.id, AccessToken.find_from_id_or_value(token.value).id
+      assert_equal token.id, AccessToken.find_from_id_or_value(token.plaintext_value).id
       assert_equal token.id, AccessToken.find_from_id_or_value!(token.id).id
-      assert_equal token.id, AccessToken.find_from_id_or_value!(token.value).id
+      assert_equal token.id, AccessToken.find_from_id_or_value!(token.plaintext_value).id
     end
     assert_nil AccessToken.find_from_id_or_value('fake')
     assert_raise(ActiveRecord::RecordNotFound) { AccessToken.find_from_id_or_value!('fake') }
+  end
+
+  # find_from_value tests
+
+  def test_find_from_value_returns_nil_for_invalid_token
+    assert_nil AccessToken.find_from_value('nonexistent_token')
+  end
+
+  def test_find_from_value_returns_nil_for_blank_token
+    assert_nil AccessToken.find_from_value('')
+    assert_nil AccessToken.find_from_value(nil)
+  end
+
+  def test_find_from_value_finds_new_token_by_digest
+    found = AccessToken.find_from_value(@token.plaintext_value)
+
+    assert_equal @token.id, found&.id
+    assert @token.reload.read_attribute(:value).start_with?(AccessToken::DIGEST_PREFIX)
+  end
+
+  def test_find_from_value_finds_legacy_token
+    legacy_value = 'legacy_plaintext_token_value_64chars'
+    @token.update_columns(value: legacy_value)
+
+    found = AccessToken.find_from_value(legacy_value)
+
+    assert_equal @token.id, found&.id
+    # No migration: DB value remains unchanged
+    assert_equal legacy_value, @token.reload.read_attribute(:value)
+  end
+
+  # compute_digest tests
+
+  def test_compute_digest_returns_prefixed_sha384_hex
+    digest = AccessToken.compute_digest('test_value')
+
+    assert digest.start_with?(AccessToken::DIGEST_PREFIX)
+    hex_part = digest.delete_prefix(AccessToken::DIGEST_PREFIX)
+    assert_equal 96, hex_part.length
+    assert_match(/\A[0-9a-f]+\z/, hex_part)
+  end
+
+  def test_compute_digest_is_deterministic
+    assert_equal AccessToken.compute_digest('same'), AccessToken.compute_digest('same')
+  end
+
+  def test_compute_digest_returns_nil_for_blank
+    assert_nil AccessToken.compute_digest(nil)
+    assert_nil AccessToken.compute_digest('')
+  end
+
+  # generate_if_missing tests
+
+  def test_generate_if_missing_populates_plaintext_and_digest
+    token = AccessToken.new
+    assert token.plaintext_value.present?
+    assert token.read_attribute(:value).start_with?(AccessToken::DIGEST_PREFIX)
+    assert_equal AccessToken.compute_digest(token.plaintext_value), token.read_attribute(:value)
+  end
+
+  def test_generate_if_missing_does_not_run_on_persisted_records
+    loaded_token = AccessToken.find(@token.id)
+    assert_nil loaded_token.plaintext_value
+  end
+
+  def test_generate_if_missing_does_not_overwrite_existing_plaintext
+    token = AccessToken.new
+    first_plaintext = token.plaintext_value
+    token.send(:generate_if_missing)
+    assert_equal first_plaintext, token.plaintext_value
+  end
+
+  # plaintext_value_known? tests
+
+  def test_show_plaintext_value_true_for_new_token
+    token = FactoryBot.create(:access_token)
+    assert token.plaintext_value_known?
+  end
+
+  def test_show_plaintext_value_false_when_loaded_from_db
+    token = FactoryBot.create(:access_token)
+    loaded_token = AccessToken.find(token.id)
+    assert_not loaded_token.plaintext_value_known?
+  end
+
+  # random_id tests
+
+  def test_random_id_length
+    assert_equal 96, AccessToken.random_id.length
+  end
+
+  def test_find_from_value_rejects_leaked_hash_as_token
+    stored_hash = @token.reload.read_attribute(:value)
+
+    # Verify the DB value has our prefix
+    assert stored_hash.start_with?(AccessToken::DIGEST_PREFIX)
+
+    # An attacker with access to the DB hash should NOT be able to authenticate
+    found = AccessToken.find_from_value(stored_hash)
+
+    assert_nil found, "Security vulnerability: leaked hash was accepted as a valid token"
   end
 
   test 'timestamps filled' do

--- a/test/unit/models_test.rb
+++ b/test/unit/models_test.rb
@@ -72,7 +72,8 @@ class ModelsTest < ActiveSupport::TestCase
         next if column_sql_type.match(/\Acharacter varying\Z/)
         length = column_sql_type.match(/\(([\d]+)\)/)[1].to_i
 
-        object = model.new({column_name => ('a' * (length + 1))}.merge(options), without_protection: true)
+        object = model.new(options, without_protection: true)
+        object.send("#{column_name}=", 'a' * (length + 1))
         object.valid?
 
         column_errors = object.errors[column_name].to_sentence

--- a/test/workers/restore_apicast_master_access_token_worker_test.rb
+++ b/test/workers/restore_apicast_master_access_token_worker_test.rb
@@ -17,6 +17,6 @@ class RestoreApicastMasterTokenWorkerTest < ActiveSupport::TestCase
     end
 
     master_token.reload
-    assert_equal random_token, master_token.value
+    assert_equal AccessToken.compute_digest(random_token), master_token.value
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds some protection to access tokens in our DB, so tokens are not visible in the case the DB is leaked.

This implements two measures to increase protection:

1. Increase token length to 48 bytes, 96 chars.
2. Hash the tokens with SHA-384

Since we want to make this backwards compatible, the current code still allows plain text tokens to exist and be used to authenticate.

The code is designed to be super simple. The day we want to remove the migration code and the support for plain text tokens, we'll only have to remove a few lines in the `find_from_value` method.

A brief explanation of the new design:

- The `value` attribute will always unconditionally hold the value in the DB column. That is: plain text if unmigrated, hash if migrated
- A new in-memory attribute `plaintext_value` holds the plain text value of a hashed token. It's not persisted so it's lost when the instance is removed. This attribute is designed to provide a way to return the original value once in the request response, be it UI or API. The user will have that only opportunity to store it somewhere else. After that, we won't hold the original value anywhere.
- No DB migration, we are reusing the same column to hold the new value.
- Authentication flow:
  1. Hash the received token
  2. Find by value = hash
  3. If nothing found, find by value = received value
  4. If found migrate old value to hash
- If a DB is leaked, the hashes could be used directly as tokens and they would work because we support plain text tokens. In order to avoid that, we use the length to distinguish between original and hashed values. In our DB in SaaS, all tokens are exactly 64 chars long, while from now on, all migrated hashes will be 96 chars long.
- If the received token is 96 chars long, we only find by hash. Otherwise we perform both lookups, hash and original.
- As a trade-off, if some client on premises happened to have an access token exactly 96 characters long, that token will stop working after merging this. But  that's extremely unlikely since they would have needed to edit the token manually.
- The hashing algorithm is SHA-384, I discarded SHA-256 because it generates 64 characters-long hashes, so we couldn't distinguish between orig and hashed values.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-12408

**Verification steps** 

1. Use and old token to performs a request
   - It should work
   - The token should be hashed in DB.
2. Use a new token
   - It should work
3. You should be able to create a token via UI and API, and see the original value once.

**Special notes for your reviewer**:

How to review:

There are 90+ files edited in this PR but most of them are just the result of replacing `access_token.value` by `access_token.plaintext_value` in tests. This PR is better reviewed commit by commit:

- https://github.com/3scale/porta/pull/4236/commits/dc93ca0ecba11f2401feae43234ce17146976860: Increase tokens length to 48 to better resist quantum attacks.
- https://github.com/3scale/porta/pull/4236/commits/d166b4ecc2832ea629c37fa0e33c42f947427ccb: The actual migration code.
- https://github.com/3scale/porta/pull/4236/commits/a8af3782734deb1220d42d88945e80c1299796cc: Edit the UI so the user can see the token. We render instead of redirecting so we keep the plain text value in memory.
- https://github.com/3scale/porta/pull/4236/commits/901e603784f2a78f90593783ee2821e4a1556c59: Same for API endpoints.
- https://github.com/3scale/porta/pull/4236/commits/d523dc279e7dea804d512ab004e6288666b21b92: The seed creates hashed tokens, that way we won't have to worry about this when we decide to remove the migration code.
- https://github.com/3scale/porta/pull/4236/commits/d46fd2c6cfafbbed0318c16ccfdc154fb4306246: When receiving a token from apicast, store it hashed. For the same reason, to not have to worry after removing the migration.
- https://github.com/3scale/porta/pull/4236/commits/e73ea5fa5bd4cd7c1c105dcc3b70e3f27d4708d2: Add a few tests to test the particular features added in this PR.
- https://github.com/3scale/porta/pull/4236/commits/9d65d4f3761d5acea32ff9422ef84469d6c1c019: The big bunch of changes to make tests send the plain text token when performing requests.