### PR TITLE
THREESCALE-12434: Migrate from protected attributes to strong parameters - Part 2

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -42,3 +42,7 @@ directories:
   "test":
     InstanceVariableAssumption:
       enabled: false
+    DuplicateMethodCall:
+      enabled: false
+    UncommunicativeVariableName:
+      enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,13 @@ Rails:
 Rails/RequestReferer:
   EnforcedStyle: referrer
 
+Rails/ActionOrder:
+  Enabled: false
+
+Rails/SkipsModelValidations:
+  Exclude:
+  - 'test/**/*_test.rb'
+
 Lint:
   Enabled: true
 
@@ -20,6 +27,7 @@ Metrics:
 Metrics/BlockLength:
   Exclude:
   - 'test/**/*_test.rb'
+  - 'spec/**/*_spec.rb'
 
 Lint/AssignmentInCondition:
   AllowSafeAssignment: true
@@ -75,12 +83,16 @@ Layout/LineLength:
 
 Metrics/AbcSize:
   Max: 20
+  Exclude:
+  - 'test/**/*_test.rb'
 
 Metrics/MethodLength:
   Max: 20
 
 Metrics/ClassLength:
   Max: 200
+  Exclude:
+  - 'test/**/*_test.rb'
 
 AllCops:
   NewCops: enable

--- a/app/controllers/admin/api/accounts_controller.rb
+++ b/app/controllers/admin/api/accounts_controller.rb
@@ -43,9 +43,8 @@ class Admin::Api::AccountsController < Admin::Api::BaseController
 
     preload_to_present(buyer_account)
 
-    buyer_account.vat_rate = params[:vat_rate].to_f if params[:vat_rate]
     buyer_account.settings.attributes = billing_params
-    buyer_account.update_with_flattened_attributes(flat_params)
+    buyer_account.update(account_params)
 
     respond_with(buyer_account)
   end
@@ -156,7 +155,20 @@ class Admin::Api::AccountsController < Admin::Api::BaseController
     end
   end
 
-  def flat_params
-    super.except(:vat_rate, :id)
+  def account_params
+    defined_fields_names = current_account.defined_fields_names_for(Account)
+    allowed_attrs = defined_fields_names + %w[name]
+    nested_params = {
+      extra_fields: current_account.defined_extra_fields_names_for(Account),
+      annotations: {}
+    }
+
+    if defined_fields_names.include?('billing_address')
+      allowed_attrs += %w[billing_address_name billing_address_address1 billing_address_address2 billing_address_city
+                          billing_address_country billing_address_state billing_address_zip billing_address_phone]
+      nested_params[:billing_address] = %i[name address1 address2 city country state zip phone]
+    end
+
+    params.permit(*allowed_attrs, **nested_params)
   end
 end

--- a/app/controllers/admin/api/accounts_controller.rb
+++ b/app/controllers/admin/api/accounts_controller.rb
@@ -154,21 +154,4 @@ class Admin::Api::AccountsController < Admin::Api::BaseController
       raise ActiveRecord::RecordNotFound
     end
   end
-
-  def account_params
-    defined_fields_names = current_account.defined_fields_names_for(Account)
-    allowed_attrs = defined_fields_names + %w[name]
-    nested_params = {
-      extra_fields: current_account.defined_extra_fields_names_for(Account),
-      annotations: {}
-    }
-
-    if defined_fields_names.include?('billing_address')
-      allowed_attrs += %w[billing_address_name billing_address_address1 billing_address_address2 billing_address_city
-                          billing_address_country billing_address_state billing_address_zip billing_address_phone]
-      nested_params[:billing_address] = %i[name address1 address2 city country state zip phone]
-    end
-
-    params.permit(*allowed_attrs, **nested_params)
-  end
 end

--- a/app/controllers/admin/api/base_controller.rb
+++ b/app/controllers/admin/api/base_controller.rb
@@ -94,4 +94,21 @@ class Admin::Api::BaseController < ApplicationController
   def authorize_service_plans!
     authorize!(:admin, :service_plans) if current_user
   end
+
+  def account_params
+    defined_fields_names = current_account.defined_fields_names_for(Account)
+    allowed_attrs = defined_fields_names + %w[name]
+    nested_params = {
+      extra_fields: current_account.defined_extra_fields_names_for(Account),
+      annotations: {}
+    }
+
+    if defined_fields_names.include?('billing_address')
+      allowed_attrs += %w[billing_address_name billing_address_address1 billing_address_address2 billing_address_city
+                          billing_address_country billing_address_state billing_address_zip billing_address_phone]
+      nested_params[:billing_address] = %w[name address1 address2 city country state zip phone]
+    end
+
+    params.permit(*allowed_attrs, **nested_params)
+  end
 end

--- a/app/controllers/admin/api/buyers_application_plans_controller.rb
+++ b/app/controllers/admin/api/buyers_application_plans_controller.rb
@@ -25,31 +25,11 @@ class Admin::Api::BuyersApplicationPlansController < Admin::Api::BuyersBaseContr
     respond_with(bought_application_plans)
   end
 
-  # swagger
-  ## e = sapi.apis.add
-  ## e.path = "/admin/api/accounts/{account_id}/application_plans/{id}/buy.xml"
-  ## e.responseClass = "application"
-  ## @desc = "Creates an application for a partner on a given application plan (deprecated)."
-  ## e.description   = @desc
-  #
-  ## op = e.operations.add
-  ## op.deprecated = true
-  ## op.nickname   = "buyer_app_plan_buy"
-  ## op.httpMethod = "POST"
-  ## op.summary    = @desc
-  #
-  ## @id = { :name => "id", :description => "ID of the application plan.", :dataType => "int", :allowMultiple => false, :required => true, :paramType => "path" }
-  #
-  ## op.parameters.add @access_token
-  ## op.parameters.add @account_id
-  ## op.parameters.add @id
-  ## op.parameters.add :name => "name", :description => "Name of the application to be created.", :dataType => "string", :allowMultiple => false, :required => true, :paramType => "query"
-  ## op.parameters.add :name => "description", :description => "Description of the application to be created.", :dataType => "string", :allowMultiple => false, :required => true, :paramType => "query"
-  #
-
+  # Creates an application for a partner on a given application plan (deprecated).
+  # POST /admin/api/accounts/{account_id}/application_plans/{id}/buy.xml
   #TODO: deprecate this, beware there are clients using it
   def buy
-    application = buyer.buy(application_plan, application_plan_params)
+    application = buyer.buy(application_plan, contract_params)
     respond_with(application, serialize: application_plan)
   end
 
@@ -63,8 +43,9 @@ class Admin::Api::BuyersApplicationPlansController < Admin::Api::BuyersBaseContr
     @application_plan ||= accessible_application_plans.stock.find(params[:id])
   end
 
-  def application_plan_params
-    attributes = current_account.fields.for(Cinstance)
-    params.slice(*attributes)
+  def contract_params
+    allowed_attrs = current_account.defined_fields_names_for(Cinstance) +
+                    %w[user_key application_id redirect_url first_traffic_at first_daily_traffic_at]
+    params.permit(*allowed_attrs)
   end
 end

--- a/app/controllers/admin/api/buyers_application_plans_controller.rb
+++ b/app/controllers/admin/api/buyers_application_plans_controller.rb
@@ -2,25 +2,8 @@ class Admin::Api::BuyersApplicationPlansController < Admin::Api::BuyersBaseContr
   representer ApplicationPlan
 
   # FIXME: QUESTION: these two should be deprecated or removed directly. Check if they are used, not document it on the active docs.
-  #
-  # swagger
-  ## sapi = source2swagger.namespace("Account Management API")
-  ## e = sapi.apis.add
-  ## e.path = "/admin/api/accounts/{account_id}/application_plans.xml"
-  ## e.responseClass = "List[application_plan]"
-  ## @desc = "Returns the application plans bought by a partner."
-  ## e.description   = @desc
-  #
-  ## op = e.operations.add
-  ## op.nickname   = "buyer_app_plans"
-  ## op.httpMethod = "GET"
-  #
-  ## @access_token = { :name => "access_token", :description => "A personal Access Token", :dataType => "string", :required => true, :paramType => "query" }
-  ## @account_id = { :name => "account_id", :description => "ID of the partner account.", :dataType => "int", :allowMultiple => false, :required => true, :paramType => "path" }
-  #
-  ## op.parameters.add @access_token
-  ## op.parameters.add @account_id
-  #
+  # Returns the application plans bought by a partner.
+  # GET /admin/api/accounts/{account_id}/application_plans.xml
   def index
     respond_with(bought_application_plans)
   end
@@ -45,7 +28,7 @@ class Admin::Api::BuyersApplicationPlansController < Admin::Api::BuyersBaseContr
 
   def contract_params
     allowed_attrs = current_account.defined_fields_names_for(Cinstance) +
-                    %w[user_key application_id redirect_url first_traffic_at first_daily_traffic_at]
+                    %w[redirect_url first_traffic_at first_daily_traffic_at create_origin accepted_at]
     params.permit(*allowed_attrs)
   end
 end

--- a/app/controllers/admin/api/buyers_applications_controller.rb
+++ b/app/controllers/admin/api/buyers_applications_controller.rb
@@ -120,7 +120,7 @@ class Admin::Api::BuyersApplicationsController < Admin::Api::BuyersBaseControlle
 
   def application_params
     allowed_attrs = current_account.defined_fields_names_for(Cinstance) +
-                    %w[user_key application_id redirect_url first_traffic_at first_daily_traffic_at]
+                    %w[user_key application_id redirect_url first_traffic_at first_daily_traffic_at accepted_at create_origin]
     params.permit(*allowed_attrs)
   end
 

--- a/app/controllers/admin/api/buyers_applications_controller.rb
+++ b/app/controllers/admin/api/buyers_applications_controller.rb
@@ -13,9 +13,7 @@ class Admin::Api::BuyersApplicationsController < Admin::Api::BuyersBaseControlle
   # POST /admin/api/accounts/{account_id}/applications.xml
   def create
     application = applications.new(user_account: buyer, plan: application_plan, create_origin: "api")
-    application.unflattened_attributes = application_params
-    application.user_key = params[:user_key] if params[:user_key]
-    application.application_id = params[:application_id] if params[:application_id]
+    application.assign_attributes(application_params)
 
     Array(params[:application_key]).each do |key|
       application.application_keys.build(value: key)
@@ -35,10 +33,7 @@ class Admin::Api::BuyersApplicationsController < Admin::Api::BuyersBaseControlle
   # Application Update
   # PUT /admin/api/accounts/{account_id}/applications/{id}.xml
   def update
-    application.unflattened_attributes = flat_params
-    application.user_key = params[:user_key] if params[:user_key]
-
-    application.save
+    application.update(application_update_params)
 
     respond_with application
   end
@@ -124,15 +119,13 @@ class Admin::Api::BuyersApplicationsController < Admin::Api::BuyersBaseControlle
   end
 
   def application_params
-    flat_params.slice(*application_attributes)
+    allowed_attrs = current_account.defined_fields_names_for(Cinstance) +
+                    %w[user_key application_id redirect_url first_traffic_at first_daily_traffic_at]
+    params.permit(*allowed_attrs)
   end
 
-  def application_attributes
-    current_account.fields.for(Cinstance) + %w|user_key application_id|
-  end
-
-  def flat_params
-    super.except(:account_id)
+  def application_update_params
+    application_params.except(:application_id)
   end
 
   def find_or_create_service_contract

--- a/app/controllers/admin/api/buyers_users_controller.rb
+++ b/app/controllers/admin/api/buyers_users_controller.rb
@@ -16,10 +16,7 @@ class Admin::Api::BuyersUsersController < Admin::Api::BuyersBaseController
 
     authorize! :create, user
 
-    user.unflattened_attributes = flat_params
-    user.signup_type = :created_by_provider
-
-    user.save
+    user.update(user_params.merge(signup_type: :created_by_provider))
 
     respond_with(user)
   end
@@ -37,7 +34,7 @@ class Admin::Api::BuyersUsersController < Admin::Api::BuyersBaseController
   def update
     authorize! :update, user
 
-    user.update_with_flattened_attributes(flat_params)
+    user.update(user_params)
 
     respond_with(user)
   end
@@ -123,4 +120,9 @@ class Admin::Api::BuyersUsersController < Admin::Api::BuyersBaseController
     @user ||= buyer.users.find(params[:id])
   end
 
+  private
+
+  def user_params
+    params.permit(*current_account.defined_fields_names_for(User), :password, :password_confirmation)
+  end
 end

--- a/app/controllers/admin/api/providers_controller.rb
+++ b/app/controllers/admin/api/providers_controller.rb
@@ -13,7 +13,7 @@ class Admin::Api::ProvidersController < Admin::Api::BaseController
   # Provider Account Update
   # PUT /admin/api/provider.xml
   def update
-    current_account.update(provider_params, without_protection: true)
+    current_account.update(provider_params)
     respond_with current_account
   end
 

--- a/app/controllers/admin/api/signups_controller.rb
+++ b/app/controllers/admin/api/signups_controller.rb
@@ -16,7 +16,13 @@ class Admin::Api::SignupsController < Admin::Api::BaseController
   private
 
   def user_params
-    flat_params.merge({signup_type: :minimal})
+    defined_user_fields = current_account.defined_fields_names_for(User)
+    params.permit(*defined_user_fields, :password)
+  end
+
+  def account_params
+    allowed_attrs = current_account.defined_fields_names_for(Account) - %w[billing_address]
+    params.permit(*allowed_attrs, annotations: {})
   end
 
   def check_creation_errors
@@ -31,7 +37,7 @@ class Admin::Api::SignupsController < Admin::Api::BaseController
   end
 
   def signup_params
-    Signup::SignupParams.new(plans: plans, user_attributes: user_params, account_attributes: flat_params, defaults: defaults)
+    Signup::SignupParams.new(plans: plans, user_attributes: user_params.merge(signup_type: :minimal), account_attributes: account_params, defaults: defaults)
   end
 
   def defaults

--- a/app/controllers/admin/api/signups_controller.rb
+++ b/app/controllers/admin/api/signups_controller.rb
@@ -17,12 +17,7 @@ class Admin::Api::SignupsController < Admin::Api::BaseController
 
   def user_params
     defined_user_fields = current_account.defined_fields_names_for(User)
-    params.permit(*defined_user_fields, :password)
-  end
-
-  def account_params
-    allowed_attrs = current_account.defined_fields_names_for(Account) - %w[billing_address]
-    params.permit(*allowed_attrs, annotations: {})
+    params.permit(*defined_user_fields, :password, :password_confirmation)
   end
 
   def check_creation_errors

--- a/app/controllers/admin/api/users_controller.rb
+++ b/app/controllers/admin/api/users_controller.rb
@@ -18,10 +18,7 @@ class Admin::Api::UsersController < Admin::Api::BaseController
 
     authorize! :create, user
 
-    user.unflattened_attributes = flat_params
-    user.signup_type = :created_by_provider
-
-    user.save
+    user.update(user_params.merge(signup_type: :created_by_provider))
 
     respond_with(user)
   end
@@ -39,7 +36,7 @@ class Admin::Api::UsersController < Admin::Api::BaseController
   def update
     authorize! :update, user
 
-    user.update_with_flattened_attributes(flat_params, as: current_user.try(:role))
+    user.update(user_params)
 
     respond_with(user)
   end
@@ -131,7 +128,11 @@ class Admin::Api::UsersController < Admin::Api::BaseController
 
   private
 
-  def flat_params
-    super.except(:id)
+  def user_params
+    defined_fields_names = current_account.provider_account.defined_fields_names_for(User)
+    permission_attrs = [:member_permission_service_ids, { member_permission_service_ids: [], member_permission_ids: [] }]
+    allowed_attrs = defined_fields_names + %w[password password_confirmation cas_identifier]
+    allowed_attrs += permission_attrs if provider_key.present? || current_user.admin?
+    params.permit(*allowed_attrs)
   end
 end

--- a/app/controllers/admin/api/users_controller.rb
+++ b/app/controllers/admin/api/users_controller.rb
@@ -130,6 +130,8 @@ class Admin::Api::UsersController < Admin::Api::BaseController
 
   def user_params
     defined_fields_names = current_account.provider_account.defined_fields_names_for(User)
+    # both `:member_permission_service_ids` and `member_permission_service_ids: []` need to be permitted, because the
+    # value can be either `nil` (meaning all services are allowed), or an array
     permission_attrs = [:member_permission_service_ids, { member_permission_service_ids: [], member_permission_ids: [] }]
     allowed_attrs = defined_fields_names + %w[password password_confirmation cas_identifier]
     allowed_attrs += permission_attrs if provider_key.present? || current_user.admin?

--- a/app/controllers/buyers/accounts_controller.rb
+++ b/app/controllers/buyers/accounts_controller.rb
@@ -30,10 +30,7 @@ class Buyers::AccountsController < Buyers::BaseController
   end
 
   def update
-    vat = account_params[:vat_rate]
-    account.vat_rate = vat if vat # vat_rate is protected attribute
-
-    if account.update(account_params.except(:vat_rate))
+    if account.update(account_params)
       redirect_to admin_buyers_account_path(account), success: t('.success')
     else
       render :edit
@@ -109,13 +106,18 @@ class Buyers::AccountsController < Buyers::BaseController
     Signup::SignupParams.new(plans: [], user_attributes: user_params.merge(signup_type: :created_by_provider), account_attributes: account_params, validate_fields: false)
   end
 
-  # TODO: using `permit` later
   def account_params
-    @account_params ||= params.require(:account).except(:user)
+    defined_builtin_fields_names = current_account.defined_builtin_fields_names_for(Account)
+    defined_extra_fields_names = current_account.defined_extra_fields_names_for(Account)
+    allowed_attrs = defined_builtin_fields_names - %w[billing_address country] + %w[country_id]
+    params.require(:account).permit(*allowed_attrs, extra_fields: defined_extra_fields_names)
   end
 
   def user_params
-    params.require(:account).fetch(:user, {})
+    defined_builtin_fields_names = current_account.defined_builtin_fields_names_for(User)
+    defined_extra_fields_names = current_account.defined_extra_fields_names_for(User)
+    allowed_attrs = defined_builtin_fields_names + %w[password]
+    params.require(:account).fetch(:user, {}).permit(*allowed_attrs, extra_fields: defined_extra_fields_names)
   end
 
   def set_plans

--- a/app/controllers/buyers/groups_controller.rb
+++ b/app/controllers/buyers/groups_controller.rb
@@ -10,7 +10,7 @@ class Buyers::GroupsController < Buyers::BaseController
   def show; end
 
   def update
-    flash[:success] = t('.success') if @account.update(params[:account])
+    flash[:success] = t('.success') if @account.update(groups_params)
 
     redirect_to action: :show, id: @account.id
   end
@@ -27,5 +27,9 @@ class Buyers::GroupsController < Buyers::BaseController
 
   def find_account
     @account = current_account.buyer_accounts.find(params[:account_id])
+  end
+
+  def groups_params
+    params.require(:account).permit(group_ids: [])
   end
 end

--- a/app/controllers/buyers/users_controller.rb
+++ b/app/controllers/buyers/users_controller.rb
@@ -22,10 +22,7 @@ class Buyers::UsersController < Buyers::BaseController
   def edit; end
 
   def update
-    # TODO: I think this controller is used only on provider side
-    user.validate_fields! if current_account.buyer?
-
-    user.attributes = user_params
+    user.assign_attributes(permitted_user_params)
     user.role = user_params.fetch(:role, user.role) if can?(:update_role, user)
 
     if user.save
@@ -86,10 +83,15 @@ class Buyers::UsersController < Buyers::BaseController
     @user = @account.users.find(params[:id]).decorate
   end
 
-  DEFAULT_PARAMS = %i[username email password password_confirmation role].freeze
-
   def user_params
-    @user_params ||= params.require(:user).permit(*DEFAULT_PARAMS, extra_fields: [*user.defined_extra_fields_names])
+    @user_params ||= params.require(:user)
+  end
+
+  def permitted_user_params
+    fields_names = current_account.defined_fields_names_for(User)
+    extra_fields_names = current_account.defined_extra_fields_names_for(User)
+    user_params.permit(*fields_names, :password, :password_confirmation,
+                       extra_fields: extra_fields_names)
   end
 
   def redirect_back_or_show_detail(**opts)

--- a/app/controllers/buyers/users_controller.rb
+++ b/app/controllers/buyers/users_controller.rb
@@ -22,9 +22,7 @@ class Buyers::UsersController < Buyers::BaseController
   def edit; end
 
   def update
-    user.assign_attributes(permitted_user_params)
-    user.role = user_params.fetch(:role, user.role) if can?(:update_role, user)
-
+    user.assign_attributes(user_params)
     if user.save
       redirect_to({ action: :show }, success: t('.success'))
     else
@@ -84,14 +82,11 @@ class Buyers::UsersController < Buyers::BaseController
   end
 
   def user_params
-    @user_params ||= params.require(:user)
-  end
-
-  def permitted_user_params
     fields_names = current_account.defined_fields_names_for(User)
     extra_fields_names = current_account.defined_extra_fields_names_for(User)
-    user_params.permit(*fields_names, :password, :password_confirmation,
-                       extra_fields: extra_fields_names)
+    allowed_attrs = [*fields_names, :password, :password_confirmation]
+    allowed_attrs += [:role] if can?(:update_role, user)
+    params.require(:user).permit(allowed_attrs, extra_fields: extra_fields_names)
   end
 
   def redirect_back_or_show_detail(**opts)

--- a/app/controllers/master/api/providers_controller.rb
+++ b/app/controllers/master/api/providers_controller.rb
@@ -48,9 +48,7 @@ class Master::Api::ProvidersController < Master::Api::BaseController
   # Tenant Update
   # PUT /master/api/providers/{id}.xml
   def update
-    provider_account.assign_attributes(update_params, without_protection: true)
-    provider_account.assign_unflattened_attributes(params.require(:account))
-    provider_account.save
+    provider_account.update(update_account_params)
 
     respond_with signup_result_with_nil_token
   end
@@ -117,14 +115,27 @@ class Master::Api::ProvidersController < Master::Api::BaseController
     render_error "Plan with ID #{plan_id.presence} not found", status: :not_found
   end
 
-  def update_params
-    permitted_params = provider_account.scheduled_for_deletion? ? %i[state_event] : UPDATE_PARAMS
-    params.require(:account).permit(permitted_params)
-  end
-
   def create_params
     defaults = { ApplicationPlan => { :name => 'API signup', :description => 'API signup', :create_origin => 'api' } }
-    Signup::SignupParams.new(plans: plans, user_attributes: flat_params.merge(signup_type: :created_by_provider), account_attributes: flat_params, defaults: defaults)
+    Signup::SignupParams.new(plans: plans, user_attributes: user_params.merge(signup_type: :created_by_provider), account_attributes: create_account_params, defaults: defaults)
+  end
+
+  def user_params
+    defined_fields_names = current_account.defined_fields_names_for(User)
+    params.permit(*defined_fields_names, :password)
+  end
+
+  def permitted_account_attrs
+    current_account.defined_fields_names_for(Account) | UPDATE_PARAMS
+  end
+
+  def create_account_params
+    params.permit(*permitted_account_attrs)
+  end
+
+  def update_account_params
+    allowed_attrs = provider_account.scheduled_for_deletion? ? %i[state_event] : permitted_account_attrs
+    params.require(:account).permit(*allowed_attrs)
   end
 
   def plans

--- a/app/controllers/master/api/providers_controller.rb
+++ b/app/controllers/master/api/providers_controller.rb
@@ -122,7 +122,7 @@ class Master::Api::ProvidersController < Master::Api::BaseController
 
   def user_params
     defined_fields_names = current_account.defined_fields_names_for(User)
-    params.permit(*defined_fields_names, :password)
+    params.permit(*defined_fields_names, :password, :password_confirmation)
   end
 
   def permitted_account_attrs

--- a/app/controllers/partners/users_controller.rb
+++ b/app/controllers/partners/users_controller.rb
@@ -20,13 +20,7 @@ class Partners::UsersController < Partners::BaseController
   end
 
   def create
-    @user = @account.users.build
-    @user.email = params[:email]
-    @user.password = params[:password].presence
-    @user.first_name = params[:first_name].presence
-    @user.last_name = params[:last_name].presence
-    @user.open_id = params[:open_id].presence
-    @user.username = params[:username]
+    @user = @account.users.build(user_params)
     @user.signup_type = :created_by_provider
     @user.role = :admin
     @user.activate!
@@ -41,5 +35,10 @@ class Partners::UsersController < Partners::BaseController
 
   def find_account
     @account = @partner.providers.find(params[:provider_id])
+  end
+
+  def user_params
+    allowed_attrs = %i[email password first_name last_name open_id username]
+    params.permit(*allowed_attrs)
   end
 end

--- a/app/controllers/provider/admin/account/users_controller.rb
+++ b/app/controllers/provider/admin/account/users_controller.rb
@@ -25,7 +25,6 @@ class Provider::Admin::Account::UsersController < Provider::Admin::Account::Base
     @user.validate_fields!
 
     @user.assign_attributes(user_params)
-    @user.role = user_params.fetch(:role, @user.role)
 
     if @user.save
       redirect_to provider_admin_account_users_path, success: t('.success')
@@ -57,7 +56,7 @@ class Provider::Admin::Account::UsersController < Provider::Admin::Account::Base
   end
 
   def user_params
-    allowed_attrs = @user.defined_builtin_fields.map(&:name) + @user.special_fields
+    allowed_attrs = @user.defined_builtin_fields_names + %w[password password_confirmation]
 
     if can?(:update_role, @user)
       allowed_attrs += [:role, { member_permission_ids: [] }]

--- a/app/controllers/provider/admin/accounts_controller.rb
+++ b/app/controllers/provider/admin/accounts_controller.rb
@@ -42,7 +42,7 @@ class Provider::Admin::AccountsController < Provider::Admin::Account::BaseContro
     check_require_billing_information
     respond_to do |format|
       # FIXME: Always false if account does not have billing address. Billing address is set in the next page.
-      if @account.update(account_params)
+      if @account.update(update_account_params)
         format.html { redirect_to_success }
         format.js do
           flash.now[:success] = t('.success')
@@ -59,17 +59,26 @@ class Provider::Admin::AccountsController < Provider::Admin::Account::BaseContro
   private
 
   def signup_params
-    params_required = params.require(:account)
-    account_params = params_required.except(:user)
-    user_params = params_required.fetch(:user, {}).merge(signup_type: :created_by_provider)
-    Signup::SignupParams.new(plans: [], user_attributes: user_params, account_attributes: account_params, validate_fields: false)
+    Signup::SignupParams.new(plans: [], user_attributes: user_params.merge(signup_type: :created_by_provider), account_attributes: account_params, validate_fields: false)
+  end
+
+  def account_params
+    defined_builtin_fields_names = current_account.defined_builtin_fields_names_for(Account)
+    defined_extra_fields_names = current_account.defined_extra_fields_names_for(Account)
+    allowed_attrs = defined_builtin_fields_names - %i[billing_address country] + %i[country_id]
+    params.require(:account).permit(*allowed_attrs, extra_fields: defined_extra_fields_names)
+  end
+
+  def user_params
+    allowed_attrs = current_account.defined_builtin_fields_names_for(User) + %w[password password_confirmation]
+    params.require(:account).fetch(:user, {}).permit(*allowed_attrs, extra_fields: current_account.defined_extra_fields_names_for(User))
   end
 
   def check_provider_signup_possible
     redirect_to admin_buyers_accounts_path, info: t('.not_possible') unless current_account.signup_provider_possible?
   end
 
-  def account_params
+  def update_account_params
     allowed_fields = current_account.editable_defined_fields_for(current_user).map do |field|
       field_name = field.name
       field_name == 'country' ? 'country_id' : field_name

--- a/app/controllers/provider/admin/applications_controller.rb
+++ b/app/controllers/provider/admin/applications_controller.rb
@@ -43,7 +43,7 @@ class Provider::Admin::ApplicationsController < FrontendController
   def update
     # TODO: this is not needed if this controller is used only by providers
     @cinstance.validate_human_edition!
-    @cinstance.attributes = params[:cinstance]
+    @cinstance.assign_attributes(application_params)
 
     respond_to do |format|
       json = @cinstance.to_json(only: %i[id name], methods: %i[errors])

--- a/app/controllers/provider/admin/user/personal_details_controller.rb
+++ b/app/controllers/provider/admin/user/personal_details_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Provider::Admin::User::PersonalDetailsController < Provider::Admin::User::BaseController
   before_action :current_password_verification, only: :update
   activate_menu :account, :personal, :personal_details
@@ -5,7 +7,7 @@ class Provider::Admin::User::PersonalDetailsController < Provider::Admin::User::
   def edit; end
 
   def update
-    if current_user.update(user_params.except(:current_password))
+    if current_user.update(permitted_user_params)
       if current_user.just_changed_password?
         current_user.kill_user_sessions(user_session)
       end
@@ -26,7 +28,12 @@ class Provider::Admin::User::PersonalDetailsController < Provider::Admin::User::
   end
 
   def user_params
-    params.require(:user)
+    @user_params ||= params.require(:user)
+  end
+
+  def permitted_user_params
+    allowed_attrs = current_user.defined_builtin_fields_names + %w[password]
+    user_params.permit(*allowed_attrs, extra_fields: current_user.defined_extra_fields_names)
   end
 
   def current_password_verification

--- a/app/controllers/provider/invitee_signups_controller.rb
+++ b/app/controllers/provider/invitee_signups_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Provider::InviteeSignupsController < FrontendController
   skip_before_action :login_required
 
@@ -10,8 +12,7 @@ class Provider::InviteeSignupsController < FrontendController
 
   layout 'provider/login'
 
-  def show
-  end
+  def show; end
 
   def create
     @user.admin_sections = domain_account.provider_can_use?(:service_permissions) ? [] : ['monitoring']
@@ -53,11 +54,12 @@ class Provider::InviteeSignupsController < FrontendController
   end
 
   def build_user
-    @user = @invitation.make_user(params[:user] || {})
+    @user = @invitation.make_user(user_params)
+  end
 
-    # This is just a sanity guard added when splitting invitation
-    # controllers. Remove when SURE.
-    raise 'Developer invitation used and worked on provider side!' unless @user.account.provider?
+  def user_params
+    defined_fields = domain_account.provider_account.defined_fields_names_for(User)
+    params.fetch(:user, {}).permit(*defined_fields, :password, :password_confirmation)
   end
 
   def invitation_token

--- a/app/controllers/provider/signups_controller.rb
+++ b/app/controllers/provider/signups_controller.rb
@@ -7,7 +7,6 @@ class Provider::SignupsController < Provider::BaseController
   before_action :ensure_signup_possible
 
   skip_before_action :login_required
-  skip_before_action :enable_analytics, only: :test
 
   before_action :cors
   public :cors
@@ -19,19 +18,19 @@ class Provider::SignupsController < Provider::BaseController
 
   self.layoutless_rendering = false
 
-  def show # original iframe form
+  def show
     @provider = master.providers.build
     @user     = @provider.users.build_with_fields
     @plan     = plan
-    @signup_origin = default_params[:origin] || default_params[:signup_origin]
-    @fields = Fields::SignupForm.new(@provider, @user, default_params[:fields])
+    @signup_origin = params[:origin] || params[:signup_origin]
+    @fields = Fields::SignupForm.new(@provider, @user, params[:fields])
   end
 
   def create
     @plan = plan
     provider_account_manager = Signup::ProviderAccountManager.new(master)
     signup_result = provider_account_manager.create(signup_params, &method(:build_signup_result_custom_fields))
-    @fields = Fields::SignupForm.new(@provider, @user, default_params[:fields])
+    @fields = Fields::SignupForm.new(@provider, @user, params[:fields])
 
     return render :show unless signup_result.persisted?
 
@@ -52,20 +51,21 @@ class Provider::SignupsController < Provider::BaseController
   protected
 
   def signup_params
-    Signup::SignupParams.new(plans: [plan], user_attributes: user_params, account_attributes: account_params, validate_fields: true)
+    Signup::SignupParams.new(plans: [plan], user_attributes: user_params.merge(signup_type: :new_signup, username: :admin), account_attributes: account_params.merge(sample_data: true), validate_fields: true)
   end
 
   def account_params
-    params.require(:account).except(:user).merge(sample_data: true)
+    allowed_attrs = master.defined_builtin_fields_names_for(Account) + %w[name subdomain self_subdomain]
+    params.require(:account).permit(*allowed_attrs, extra_fields: master.defined_extra_fields_names_for(Account))
   end
 
   def user_params
-    params.require(:account).fetch(:user, {}).merge(signup_type: :new_signup, username: :admin)
+    params.require(:account).fetch(:user, {}).permit(:first_name, :last_name, :email, :password)
   end
 
   def handle_cache_response
     expires_in 1.hour, public: true
-    fresh_when etag: default_params, last_modified: System::Application.config.boot_time
+    fresh_when etag: params.permit!.to_h, last_modified: System::Application.config.boot_time
   end
 
   def set_analytics_page
@@ -101,12 +101,9 @@ class Provider::SignupsController < Provider::BaseController
   end
 
   def plan
-    plan_ids = default_params[:plan_id].presence
-    master.accessible_services.default.application_plans.published.find(plan_ids) if plan_ids
-  end
-
-  def default_params
-    # permit all since it can have multiple different and dynamic data
-    params.permit!.to_h
+    @plan ||= begin
+      plan_ids = params[:plan_id].presence
+      master.accessible_services.default.application_plans.published.find(plan_ids) if plan_ids
+    end
   end
 end

--- a/app/controllers/sites/dns_controller.rb
+++ b/app/controllers/sites/dns_controller.rb
@@ -8,7 +8,7 @@ class Sites::DnsController < Sites::BaseController
   end
 
   def update
-    if @account.update(site_params, without_protection: true)
+    if @account.update(site_params)
       redirect_to admin_site_dns_url, success: t('.success')
     else
       flash.now[:danger] = @account.errors.full_messages.join(' ')

--- a/app/lib/applications_controller_methods.rb
+++ b/app/lib/applications_controller_methods.rb
@@ -23,7 +23,7 @@ module ApplicationsControllerMethods
 
   # TODO: this should be done by buy! method
   def initialize_cinstance
-    @cinstance = current_account.provider_builds_application_for(@account, @application_plan, params[:cinstance], @service_plan)
+    @cinstance = current_account.provider_builds_application_for(@account, @application_plan, application_params, @service_plan)
     @cinstance.validate_human_edition!
   end
 
@@ -80,8 +80,17 @@ module ApplicationsControllerMethods
                     end
   end
 
+  def cinstance_params
+    @cinstance_params ||= params.require(:cinstance)
+  end
+
+  def application_params
+    allowed_attrs = current_account.defined_builtin_fields_names_for(Cinstance)
+    cinstance_params.permit(*allowed_attrs, extra_fields: current_account.defined_extra_fields_names_for(Cinstance))
+  end
+
   def plan_id
-    @plan_id ||= params.require(:cinstance).permit(:plan_id).tap { |plan_params| plan_params.require(:plan_id) }[:plan_id]
+    @plan_id ||= cinstance_params.permit(:plan_id).require(:plan_id)
   end
 
   def accessible_services

--- a/app/lib/authentication/by_password.rb
+++ b/app/lib/authentication/by_password.rb
@@ -20,8 +20,6 @@ module Authentication
 
       validates :lost_password_token, :password_digest, length: { maximum: 255 }
 
-      attr_accessible :password, :password_confirmation, as: %i[default member admin]
-
       scope :with_valid_password_token, -> { where { lost_password_token_generated_at >= 24.hours.ago } }
 
       alias_method :authenticate_without_normalization, :authenticate

--- a/app/lib/authentication/by_password.rb
+++ b/app/lib/authentication/by_password.rb
@@ -88,10 +88,6 @@ module Authentication
       account.password_login_allowed? && !already_using_password?
     end
 
-    def special_fields
-      %i[password password_confirmation]
-    end
-
     def reset_lost_password_token
       self.lost_password_token = nil
     end

--- a/app/lib/backend/model_extensions/service.rb
+++ b/app/lib/backend/model_extensions/service.rb
@@ -45,7 +45,7 @@ module Backend
 
       def make_default_backend_service
         ThreeScale::Core::Service.make_default(backend_id)
-        account.update!({default_service_id: id}, without_protection: true)
+        account.update!({default_service_id: id})
       end
     end
   end

--- a/app/lib/fields/extra_fields.rb
+++ b/app/lib/fields/extra_fields.rb
@@ -70,19 +70,6 @@ module Fields::ExtraFields
     end
   end
 
-  def update_with_flattened_attributes(flattened_attrs, options = {})
-    assign_unflattened_attributes(flattened_attrs, options)
-    save
-  end
-
-  def assign_unflattened_attributes(attributes, options = {})
-    assign_attributes(nest_extra_fields(attributes), options)
-  end
-
-  def unflattened_attributes=(flattened_attrs)
-    self.attributes = nest_extra_fields(flattened_attrs)
-  end
-
   protected
 
   def encode_string_extra_field(value)
@@ -109,27 +96,5 @@ module Fields::ExtraFields
     else
       value
     end
-  end
-
-  def nest_extra_fields(flattened_attrs)
-    attrs = { }
-    flattened_attrs.each_pair do |key, value|
-      # we don't mind too much about this loose condition, that leads to push into
-      # attrs[:extra_fields] many undesired things, since extra_fields= method will take
-      # care of not allowing those to get in into the db
-      if extra_fields_attribute?(key) || special_field?(key)
-        attrs[key] = value
-      else
-        attrs[:extra_fields] ||= { }
-        attrs[:extra_fields][key] = encode_extra_field(value)
-      end
-    end
-
-    attrs
-  end
-
-  def extra_fields_attribute?(key)
-    respond_to?("#{key}=") &&
-      !(self.class.reflect_on_aggregation(key.to_sym) || self.class.reflect_on_association(key.to_sym))
   end
 end

--- a/app/lib/fields/fields.rb
+++ b/app/lib/fields/fields.rb
@@ -96,15 +96,6 @@ module Fields::Fields
     def has_fields?
       true
     end
-
-    # these fields are here to be able to recognize fields that are not in the
-    # db but still can be updated and such. This is a need given the flatten
-    # params on user-management-api, if that gets removed this won't be needed
-    # e.g. password and password_confirmation in User
-    def special_fields
-      []
-    end
-
   end # ClassMethods
 
   module ActiverecordOverrides
@@ -165,11 +156,6 @@ module Fields::Fields
   def internal_fields
     self.class.internal_fields
   end
-
-  def special_fields
-    self.class.special_fields
-  end
-
 
   # TODO: implementation of field_definitions_object, fields_definitions_source_root_object, validate_fields?
   # is 3scale specific and should be extracted to separate module
@@ -329,10 +315,6 @@ module Fields::Fields
 
   def internal_field?(name)
     field(name) && internal_fields.include?(name.to_s)
-  end
-
-  def special_field?(key)
-    special_fields.include?(key.to_sym)
   end
 
   def field(name)

--- a/app/lib/fields/fields.rb
+++ b/app/lib/fields/fields.rb
@@ -255,6 +255,14 @@ module Fields::Fields
       .by_target(self.class.to_s.underscore)
   end
 
+  def defined_fields_names
+    defined_fields.map(&:name)
+  end
+
+  def defined_builtin_fields_names
+    defined_builtin_fields.map(&:name)
+  end
+
   def visible_defined_fields_for(user)
     defined_fields.select { |field| field.visible_for?(user) }
   end

--- a/app/lib/fields/provider.rb
+++ b/app/lib/fields/provider.rb
@@ -2,31 +2,6 @@
 
 module Fields
   module Provider
-
-    class ProviderFields
-      def initialize(provider)
-        @provider = provider
-      end
-
-      def for(klass)
-        columns = klass.column_names
-        defined = fields_definitions.by_target(klass.name.underscore).map(&:name)
-        protected =  klass.protected_attributes.to_a
-
-        ((columns + defined) - protected).uniq
-      end
-
-      protected
-
-      def fields_definitions
-        @provider.fields_definitions
-      end
-    end
-
-    def fields
-      @provider_fields ||= ProviderFields.new(self)
-    end
-
     def defined_fields_names_for(klass)
       fields_definitions.by_target(klass.name.underscore).map { |fd| fd.name.to_s }
     end

--- a/app/lib/fields/provider.rb
+++ b/app/lib/fields/provider.rb
@@ -26,5 +26,17 @@ module Fields
     def fields
       @provider_fields ||= ProviderFields.new(self)
     end
+
+    def defined_fields_names_for(klass)
+      fields_definitions.by_target(klass.name.underscore).map { |fd| fd.name.to_s }
+    end
+
+    def defined_builtin_fields_names_for(klass)
+      defined_fields_names_for(klass) & klass.builtin_fields
+    end
+
+    def defined_extra_fields_names_for(klass)
+      defined_fields_names_for(klass) - klass.builtin_fields
+    end
   end
 end

--- a/app/lib/signup/signup_params.rb
+++ b/app/lib/signup/signup_params.rb
@@ -13,17 +13,14 @@ module Signup
     def build_user_with_attributes_for_account(account)
       user = account.users.new
       user.validate_fields! if validate_fields
-      user.unflattened_attributes = user_attributes.except(:signup_type)
-      user.signup_type = user_attributes[:signup_type]
+      user.assign_attributes(user_attributes)
       user
     end
 
     def build_account_with_attributes_for_provider_account(provider_account)
       account = provider_account.buyers.new
       account.validate_fields! if validate_fields
-      account.unflattened_attributes = account_attributes
-      vat_rate = account_attributes[:vat_rate]
-      account.vat_rate = vat_rate.to_f if vat_rate
+      account.assign_attributes(account_attributes)
       account
     end
 

--- a/app/lib/signup/signup_params.rb
+++ b/app/lib/signup/signup_params.rb
@@ -38,7 +38,7 @@ module Signup
 
     def prepare_account_attributes(attributes)
       attributes ||= {}
-      attributes.delete('name') if attributes['org_name'].present?
+      attributes.delete('name') if attributes.key?('org_name')
       attributes
     end
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -107,11 +107,6 @@ class Account < ApplicationRecord
   before_validation(on: :create, if: :provider?) { generate_domains }
   before_create :generate_site_access_code
 
-  attr_protected :master, :provider, :buyer, :from_email, :vat_rate, :sample_data, :default_service_id, :s3_prefix,
-                 :provider_account_id, :paid_at, :paid, :signs_legal_terms, :tenant_id, :default_account_plan_id,
-                 :default_service_id, :domain, :subdomain, :self_subdomain, :self_domain,:audit_ids, :partner,
-                 :hosted_proxy_deployed_at
-
   belongs_to :partner
   has_many :users, inverse_of: :account, dependent: :destroy
   has_many :admin_users, -> { admins }, class_name: 'User', inverse_of: :account

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -332,10 +332,6 @@ class Account < ApplicationRecord
                       end
   end
 
-  def special_fields
-    %i[country annotations]
-  end
-
   # Returns the id corresponding to an account with given api key. This function avoids
   # database lookup if possible (uses cache), so it is super fast.
   def self.id_from_api_key(api_key)

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -48,8 +48,6 @@ class Contract < ApplicationRecord
   # TODO: remove with Rails 3
   attr_reader :old_plan, :accepted_on_create
 
-  attr_protected :plan_id, :state, :provider_public_key, :paid_until, :trial_period_expires_at, :setup_fee, :type, :variable_cost_paid_until, :application_id, :user_key, :user_account_id, :tenant_id, :audit_ids
-
   # TODO: unit test this scope
   def self.provided_by(account)
     where.has do

--- a/app/models/contract/trial.rb
+++ b/app/models/contract/trial.rb
@@ -6,8 +6,6 @@ module Contract::Trial
   included do
     before_create :set_trial_period_expires_at, :set_setup_fee
 
-    attr_protected :trial_period_expires_at
-
     sifter :trial_period_expires_on do |date|
       sift(:date, trial_period_expires_at) == sift(:to_date, quoted(date.to_date))
     end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -24,7 +24,7 @@ class Invitation < ApplicationRecord
 
   # Build new user on information in this invitation.
   def make_user(params = {})
-    self.user= account.users.build_with_fields params.reverse_merge(:email => email, :invitation => self)
+    self.user = account.users.build_with_fields params.reverse_merge(email: email, invitation: self)
   end
 
   def accepted?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,14 +109,6 @@ class User < ApplicationRecord
   validate :username_is_unique
   validates :open_id, uniqueness: { case_sensitive: true }, allow_nil: true
 
-  attr_accessible :title, :username, :email, :first_name, :last_name,
-                  :conditions, :cas_identifier, :open_id, :service_conditions,
-                  :job_role, :extra_fields, as: %i[default member admin]
-
-  attr_accessible :member_permission_service_ids, :member_permission_ids, as: %i[admin]
-
-
-
   def self.search_states
     %w(pending active)
   end

--- a/app/models/user/invitations.rb
+++ b/app/models/user/invitations.rb
@@ -5,12 +5,11 @@ module User::Invitations
     after_commit :accept_invitation, :on => :create
 
     attr_accessor :invitation
-    attr_accessible :invitation
 
     # TODO: refactor to make this work removing above attribute.
     # has_one :invitation
 
-    before_destroy  :destroy_invitation
+    before_destroy :destroy_invitation
   end
 
   def accept_invitation

--- a/app/models/user/permissions.rb
+++ b/app/models/user/permissions.rb
@@ -8,8 +8,6 @@ module User::Permissions
   included do
     has_many :member_permissions, dependent: :destroy, autosave: true
 
-    attr_accessible :member_permission_service_ids, :member_permission_ids, :allowed_sections, :allowed_service_ids
-
     alias_method :allowed_sections, :member_permission_ids
     alias_method :allowed_sections=, :member_permission_ids=
     alias_method :allowed_service_ids, :member_permission_service_ids

--- a/app/queries/usage_limit_violations_query.rb
+++ b/app/queries/usage_limit_violations_query.rb
@@ -30,7 +30,7 @@ class UsageLimitViolationsQuery
     end
 
     def account
-      ::Account.new { |a| a.assign_attributes(account_attributes, without_protection: true) }
+      ::Account.new { |a| a.assign_attributes(account_attributes) }
     end
 
     protected

--- a/features/provider/cms/template_versions.feature
+++ b/features/provider/cms/template_versions.feature
@@ -31,7 +31,7 @@ Feature: CMS Template versions
     When they follow "Versions"
     And follow "Revert" in the 1st row
     And confirm the dialog
-    Then a success toast alert is displayed with text "Reverted to version from 24 Dec 2012 12:00:00 UTC"
+    Then they should see a success toast alert with text "Reverted to version from 24 Dec 2012 12:00:00 UTC"
     Then the draft template should contain "Original Prankster"
 
   Scenario: Revert to version from the version itself
@@ -43,5 +43,5 @@ Feature: CMS Template versions
     And the version template should contain "Original Prankster"
     When they follow "Revert"
     And confirm the dialog
-    Then a success toast alert is displayed with text "Reverted to version from 24 Dec 2012 12:00:00 UTC"
+    Then they should see a success toast alert with text "Reverted to version from 24 Dec 2012 12:00:00 UTC"
     Then the draft template should contain "Original Prankster"

--- a/lib/developer_portal/app/controllers/developer_portal/accounts/invitee_signups_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/accounts/invitee_signups_controller.rb
@@ -67,12 +67,6 @@ class DeveloperPortal::Accounts::InviteeSignupsController < DeveloperPortal::Bas
     sso_attributes.all? { |_key, value| value.present? }
   end
 
-  def create_sso_authorization
-    return unless sso_attributes_provided?
-    build_sso_authorization
-    @user.save
-  end
-
   def authentication_provider
     site_account.authentication_providers
       .find_by(system_name: session[:invitation_sso_system_name])
@@ -119,7 +113,12 @@ class DeveloperPortal::Accounts::InviteeSignupsController < DeveloperPortal::Bas
   end
 
   def build_user
-    @user = @invitation.make_user(filter_readonly_params(params[:user], User))
+    @user = @invitation.make_user(user_params)
+  end
+
+  def user_params
+    allowed_attrs = site_account.defined_fields_names_for(User) + %w[password password_confirmation]
+    filter_readonly_params(params[:user], User).permit(*allowed_attrs)
   end
 
   def invitation_token

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/passwords_controller.rb
@@ -45,19 +45,8 @@ class DeveloperPortal::Admin::Account::PasswordsController < ::DeveloperPortal::
     redirect_to new_admin_account_password_url(request_password_reset: true)
   end
 
-  def buyer
-    @buyer ||= @provider.buyers.build do |account|
-      # We need to get all the account params to run the spam check
-      account.unflattened_attributes = account_params
-    end
-  end
-
   def password_params
     params.require(:user).permit(:password, :password_confirmation)
-  end
-
-  def account_params
-    params.fetch(:account, {})
   end
 
   def find_user

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/personal_details_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/personal_details_controller.rb
@@ -14,7 +14,7 @@ class DeveloperPortal::Admin::Account::PersonalDetailsController < ::DeveloperPo
 
   def update
     resource.validate_fields!
-    if resource.errors.empty? && resource.update(user_params)
+    if resource.errors.empty? && resource.update(permitted_user_params)
       resource.kill_user_sessions(user_session) if resource.just_changed_password?
 
       redirect_to admin_account_users_path, notice: 'User was successfully updated.'
@@ -40,9 +40,11 @@ class DeveloperPortal::Admin::Account::PersonalDetailsController < ::DeveloperPo
   end
 
   def user_params
-    filter_readonly_params(params.require(:user), User).permit([:current_password] +
-                                   resource.special_fields +
-                                   resource.defined_fields.map(&:name))
+    @user_params ||= params.require(:user)
+  end
+
+  def permitted_user_params
+    filter_readonly_params(user_params, User).permit(*resource.defined_fields_names, :password, :password_confirmation)
   end
 
   def verify_current_password

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/users_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/users_controller.rb
@@ -57,6 +57,6 @@ class DeveloperPortal::Admin::Account::UsersController < ::DeveloperPortal::Base
   end
 
   def user_params
-    params.require(:user).permit(*@user.defined_fields.map(&:name), *@user.special_fields)
+    params.require(:user).permit(*@user.defined_fields_names, :password, :password_confirmation)
   end
 end

--- a/lib/developer_portal/app/controllers/developer_portal/admin/accounts_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/accounts_controller.rb
@@ -21,7 +21,7 @@ class DeveloperPortal::Admin::AccountsController < DeveloperPortal::BaseControll
     current_account.validate_fields!
 
     respond_to do |format|
-      if current_account.update_with_flattened_attributes(account_params)
+      if current_account.update(account_params)
         flash[:notice] = 'The account information was updated.'.freeze
         format.html { redirect_to admin_account_url }
         format.js   { render js: "jQuery.flash.notice('#{flash[:notice]}')" }
@@ -35,7 +35,9 @@ class DeveloperPortal::Admin::AccountsController < DeveloperPortal::BaseControll
   private
 
   def account_params
-    filter_readonly_params(params.require(:account), Account)
+    defined_fields_names = current_account.provider_account.defined_fields_names_for(Account)
+    allowed_attrs = defined_fields_names - %w[country vat_rate] + %w[country_id]
+    filter_readonly_params(params.require(:account), Account).permit(*allowed_attrs)
   end
 
   def find_countries

--- a/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/applications_controller.rb
@@ -63,7 +63,7 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
       application.validate_fields!
     end
 
-    application.update(application_params)
+    application.update(permitted_application_params)
     assign_drops application: application
     # make sure to prevent xss on js rendering if this notice is changed to include e.g. application name
     if application.valid?
@@ -127,7 +127,7 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
   end
 
   def new_application
-    @cinstance ||= applications.build_with_fields(application_params) do |application|
+    @cinstance ||= applications.build_with_fields(permitted_application_params) do |application|
       application.plan = application.can_change_plan?(service) ? plan : default_plan
     end
   end
@@ -148,10 +148,6 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
     end
   end
 
-  def application_params
-    @application_params ||= accepted_application_params
-  end
-
   def authorize_new_app
     if service
       authorize! :create_application, service
@@ -168,13 +164,14 @@ class DeveloperPortal::Admin::ApplicationsController < ::DeveloperPortal::BaseCo
     authorize! :update, application
   end
 
-  def accepted_application_params
+  def application_params
     # cinstance[*] naming is present for legacy reasons
-    application_attributes = params[:application] || params[:cinstance]
-    return {} unless application_attributes
+    @application_params ||= params[:application] || params.fetch(:cinstance, {})
+  end
 
-    permitted_params = fields_definitions + %i[plan_id redirect_url]
-    application_attributes.permit(*permitted_params)
+  def permitted_application_params
+    permitted_params = fields_definitions + %i[redirect_url]
+    application_params.permit(*permitted_params)
   end
 
   def fields_definitions

--- a/lib/developer_portal/app/controllers/developer_portal/base_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/base_controller.rb
@@ -27,7 +27,7 @@ class DeveloperPortal::BaseController < DeveloperPortal::ApplicationController
   end
 
   def filter_readonly_params(params, resource_class)
-    return {} unless params
+    return ActionController::Parameters.new unless params
 
     read_only_fields = FieldsDefinition.by_provider(site_account).by_target(resource_class.name).read_only.pluck(:name)
     params.except(*read_only_fields)

--- a/lib/developer_portal/app/controllers/developer_portal/base_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/base_controller.rb
@@ -30,6 +30,7 @@ class DeveloperPortal::BaseController < DeveloperPortal::ApplicationController
     return ActionController::Parameters.new unless params
 
     read_only_fields = FieldsDefinition.by_provider(site_account).by_target(resource_class.name).read_only.pluck(:name)
+    read_only_fields += %w[country_id] if read_only_fields.include?('country')
     params.except(*read_only_fields)
   end
 end

--- a/lib/developer_portal/app/controllers/developer_portal/signup_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/signup_controller.rb
@@ -93,7 +93,7 @@ module DeveloperPortal
     end
 
     def user_params
-      allowed_attrs = site_account.defined_fields_names_for(User) + %w[password]
+      allowed_attrs = site_account.defined_fields_names_for(User) + %w[password password_confirmation]
       filter_readonly_params(params.fetch(:account, {})[:user], User).permit(*allowed_attrs)
     end
 

--- a/lib/developer_portal/app/controllers/developer_portal/signup_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/signup_controller.rb
@@ -30,9 +30,6 @@ module DeveloperPortal
     end
 
     def create
-      account_params = filter_readonly_params(params[:account], Account)
-      user_params    = filter_readonly_params(account_params.try(:delete, :user), User)
-
       if signup_user!(account_params, user_params)
         if @user.can_login?
           self.current_user = @user
@@ -88,6 +85,16 @@ module DeveloperPortal
         user_params:    user_params,
         authentication_provider: authentication_provider
       }
+    end
+
+    def account_params
+      allowed_attrs = site_account.defined_fields_names_for(Account) - %w[country vat_rate] + %w[country_id]
+      filter_readonly_params(params.fetch(:account, {}), Account).permit(*allowed_attrs)
+    end
+
+    def user_params
+      allowed_attrs = site_account.defined_fields_names_for(User) + %w[password]
+      filter_readonly_params(params.fetch(:account, {})[:user], User).permit(*allowed_attrs)
     end
 
     def redirect_if_logged_in

--- a/spec/acceptance/api/account_spec.rb
+++ b/spec/acceptance/api/account_spec.rb
@@ -8,11 +8,7 @@ resource "Account" do
   let(:account) { FactoryBot.build(:buyer_account, provider_account: provider) }
   let(:payment_detail) { FactoryBot.create(:payment_detail, account: account) }
 
-  let(:resource) do
-    FieldsDefinition.create_defaults!(master)
-    provider.reload
-    account
-  end
+  let(:resource) { account }
 
   let(:expected_provider_fields) { %w[admin_domain domain admin_base_url base_url from_email support_email finance_support_email site_access_code] }
 

--- a/spec/acceptance/api/account_user_spec.rb
+++ b/spec/acceptance/api/account_user_spec.rb
@@ -7,11 +7,7 @@ resource "User" do
   let(:buyer) { FactoryBot.create(:buyer_account, provider_account: provider) }
   let(:user) { FactoryBot.build(:user, account: buyer) }
 
-  let(:resource) do
-    FieldsDefinition.create_defaults!(master)
-    provider.reload
-    user
-  end
+  let(:resource) { user }
 
   let(:account_id) { buyer.id }
 

--- a/spec/acceptance/api/user_spec.rb
+++ b/spec/acceptance/api/user_spec.rb
@@ -75,13 +75,9 @@ resource "User" do
 
     let(:account_id) { buyer.id }
 
-    let (:user) { FactoryBot.build(:user, account: buyer) }
+    let(:user) { FactoryBot.build(:user, account: buyer) }
 
-    let(:resource) do
-      FieldsDefinition.create_defaults!(master)
-      provider.reload
-      user
-    end
+    let(:resource) { user }
 
     get '/admin/api/accounts/:account_id/users/:id.:format', action: :show
     delete '/admin/api/accounts/:account_id/users/:id', action: :destroy
@@ -147,12 +143,7 @@ resource "User" do
 
     let(:user) { FactoryBot.create(:user, account: provider) }
 
-    # creating new db records for fields that are in db is pathetic as it can get
-    let(:resource) do
-      FieldsDefinition.create_defaults!(master)
-      provider.reload
-      user
-    end
+    let(:resource) { user }
 
     it { should include('id' => user.id, 'state' => user.state, 'role' => user.role.to_s) }
     it { should include('email' => user.email, 'username' => user.username) }

--- a/spec/support/api/context.rb
+++ b/spec/support/api/context.rb
@@ -22,7 +22,11 @@ end
 
 shared_context "provider api", provider: true do
   let(:master) { provider && master_account }
-  let(:provider) { FactoryBot.create(:provider_account, self_domain: 'example.org') }
+  let(:provider) do
+    provider_acc = FactoryBot.create(:provider_account, self_domain: 'example.org')
+    FieldsDefinition.create_defaults!(provider_acc.provider_account)
+    provider_acc
+  end
   let(:provider_key) { provider.provider_key }
 
   parameter :provider_key, 'Provider Key'

--- a/test/functional/buyers/users_controller_test.rb
+++ b/test/functional/buyers/users_controller_test.rb
@@ -144,4 +144,47 @@ class Buyers::UsersControllerTest < ActionController::TestCase
       assert_select 'input[name="user[password_confirmation]"]'
     end
   end
+
+  class UpdateWithRoleTest < ActionController::TestCase
+    def setup
+      @provider = FactoryBot.create(:provider_account)
+      @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+      @user = FactoryBot.create(:user, account: @buyer, username: 'member', role: :member)
+      host! @provider.internal_admin_domain
+      login_provider @provider
+    end
+
+    test 'update allows role when user can update_role' do
+      @controller.stubs(:can?).with(:update_role, @user).returns(true)
+
+      put :update, params: { account_id: @buyer.id, id: @user.id, user: { role: 'admin', username: 'new_username' } }
+
+      assert_response :redirect
+      assert_equal :admin, @user.reload.role
+      assert_equal 'new_username', @user.username
+    end
+
+    test 'setting role to nil value when user can update_role' do
+      @controller.stubs(:can?).with(:update_role, @user).returns(true)
+      @user.update(role: :admin)
+
+      put :update, params: { account_id: @buyer.id, id: @user.id, user: { role: nil, username: 'new_username' } }
+
+      assert_response :redirect
+      # user.role defaults to :member, if the value is missing
+      assert_equal :member, @user.reload.role
+      assert_equal 'new_username', @user.username
+    end
+
+    test 'update does not allow role when user cannot update_role' do
+      @controller.stubs(:can?).with(:update_role, @user).returns(false)
+
+      put :update, params: { account_id: @buyer.id, id: @user.id, user: { role: 'admin', username: 'new_username' } }
+
+      # Role should not change because user cannot update_role
+      assert_equal :member, @user.reload.role
+      # But other attributes should still update
+      assert_equal 'new_username', @user.username
+    end
+  end
 end

--- a/test/functional/developer_portal/admin/account/users_controller_test.rb
+++ b/test/functional/developer_portal/admin/account/users_controller_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DeveloperPortal::Admin::Account::UsersControllerTest < DeveloperPortal::ActionController::TestCase
+  include FieldsDefinitionsHelpers
+
+  def setup
+    super
+    @provider = FactoryBot.create(:provider_account)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+    @admin_user = @buyer.admins.first
+    @member_user = FactoryBot.create(:active_user, account: @buyer)
+
+    host! @provider.external_domain
+    login_as @admin_user
+  end
+
+  test "index shows users list" do
+    get :index
+    assert_response :success
+
+    assigned_drops = assigns(:_assigned_drops)
+
+    assert assigned_drops['users'].is_a?(Liquid::Drops::Collection)
+    assert assigned_drops['pagination'].is_a?(Liquid::Drops::Pagination)
+  end
+
+  test "edit shows user form" do
+    get :edit, params: { id: @member_user.id }
+    assert_response :success
+
+    user_drop = assigns(:_assigned_drops)['user']
+
+    assert user_drop.is_a?(Liquid::Drops::User)
+    assert_equal @member_user.username, user_drop.username
+  end
+
+  test "update with valid params redirects to users list" do
+    put :update, params: {
+      id: @member_user.id,
+      user: { username: "new_username", email: "newemail@example.com" }
+    }
+
+    assert_redirected_to admin_account_users_path
+    assert_equal "User was successfully updated.", flash[:notice]
+
+    @member_user.reload
+    assert_equal "new_username", @member_user.username
+    assert_equal "newemail@example.com", @member_user.email
+  end
+
+  test "update with invalid params renders edit" do
+    put :update, params: {
+      id: @member_user.id,
+      user: { email: "invalid-email" }
+    }
+
+    assert_response :success
+    assert_template :edit
+  end
+
+  test "update can change role when authorized" do
+    put :update, params: {
+      id: @member_user.id,
+      user: { role: "admin" }
+    }
+
+    @member_user.reload
+    assert_equal :admin, @member_user.role
+  end
+
+  test "member cannot change its own role" do
+    login_as @member_user
+
+    put :update, params: {
+      id: @member_user.id,
+      user: { role: "admin" }
+    }
+
+    @member_user.reload
+    assert_equal :member, @member_user.role
+  end
+
+  test "update custom fields that are not read-only" do
+    field_defined(@provider, { target: "User", name: "custom_field" })
+    field_defined(@provider, { target: "User", name: "readonly_field", read_only: true })
+    @member_user.reload
+
+    @member_user.update("custom_field" => "custom", "readonly_field" => "readonly")
+
+    put :update, params: {
+      id: @member_user.id,
+      user: { custom_field: "new custom", readonly_field: "new readonly" }
+    }
+
+    @member_user.reload
+    assert_equal "new custom", @member_user.extra_fields["custom_field"]
+    assert_equal "readonly", @member_user.extra_fields["readonly_field"]
+  end
+
+  test "destroy removes user" do
+    user_to_delete = FactoryBot.create(:active_user, account: @buyer)
+
+    assert_difference "@buyer.users.count", -1 do
+      delete :destroy, params: { id: user_to_delete.id }
+    end
+
+    assert_redirected_to admin_account_users_path
+  end
+end

--- a/test/functional/developer_portal/admin/accounts_controller_test.rb
+++ b/test/functional/developer_portal/admin/accounts_controller_test.rb
@@ -1,14 +1,60 @@
 require 'test_helper'
 
 class DeveloperPortal::Admin::AccountsControllerTest < DeveloperPortal::ActionController::TestCase
+  include FieldsDefinitionsHelpers
+
+  setup do
+    @provider = FactoryBot.create(:simple_provider)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+    FieldsDefinition.create_defaults!(@provider)
+
+    host! @provider.internal_domain
+    login_as @buyer.first_admin
+  end
 
   test "update without account params should respond with 400" do
-    provider = FactoryBot.create(:simple_provider)
-    buyer = FactoryBot.create(:buyer_account, :provider_account => provider)
-
-    host! provider.internal_domain
-    login_as buyer.first_admin
     put :update
     assert_response 400
+  end
+
+  test "extra fields can be updated, except vat_rate" do
+    field_defined(@provider, { target: "Account", name: "custom_field" })
+    field_defined(@provider, { target: "Account", name: "vat_rate" })
+
+    assert_nil @buyer.vat_rate
+
+    put :update, params: {
+      account: {
+        org_name: 'New name',
+        custom_field: 'test',
+        vat_rate: 10
+      }
+    }
+
+    assert_redirected_to '/admin/account'
+    @buyer.reload
+
+    assert_equal 'New name', @buyer.org_name
+    assert_equal 'test', @buyer.extra_fields['custom_field']
+    assert_nil @buyer.vat_rate
+  end
+
+  test 'update country only when not read-only' do
+    country_field = field_defined(@provider, { target: "Account", name: "country" })
+
+    original_country = @buyer.country
+    assert_not_nil original_country
+
+    country = FactoryBot.create(:country, code: "SL", name: "Superland")
+
+    put :update, params: { account: { country_id: country.id } }
+
+    assert_equal 'Superland', @buyer.reload.country.name
+
+    country_field.update(read_only: true)
+
+    put :update, params: { account: { country_id: original_country.id } }
+
+    assert_equal 'Superland', @buyer.reload.country.name
   end
 end

--- a/test/functional/developer_portal/signup_controller_test.rb
+++ b/test/functional/developer_portal/signup_controller_test.rb
@@ -93,6 +93,20 @@ class DeveloperPortal::SignupControllerTest < DeveloperPortal::ActionController:
       post :create, params: valid_buyer_params(plans: [1, 2])
       assert_response :not_found
     end
+
+    test 'signup with non-matching password fails' do
+      assert_no_difference Account.method(:count) do
+        params = valid_buyer_params
+        params[:account][:user][:password_confirmation] = 'non-matching-password'
+
+        post :create, params: params
+
+        assert_response :success
+        signup_result = assigns(:signup_result)
+
+        assert_equal ["Password confirmation doesn't match Password"], signup_result.errors[:user]
+      end
+    end
   end
 
   class WithoutAnyDefaultPlanTest < DeveloperPortal::SignupControllerTest

--- a/test/functional/developer_portal/signup_controller_test.rb
+++ b/test/functional/developer_portal/signup_controller_test.rb
@@ -67,6 +67,18 @@ class DeveloperPortal::SignupControllerTest < DeveloperPortal::ActionController:
       post :create, params: valid_buyer_params
     end
 
+    test '#create should create a valid user' do
+      post :create, params: valid_buyer_params
+
+      account = @provider.buyer_accounts.last
+      assert_equal valid_buyer_params.dig(:account, :org_name), account.org_name
+
+      user_params = valid_buyer_params.dig(:account, :user)
+      user = account.users.find_by(username: user_params[:username])
+      assert_equal user_params[:email], user.email
+      assert_equal :new_signup, user.signup_type
+    end
+
     test '#create successfully from oauth2 should save the id_token' do
       auth_provider = FactoryBot.create(:keycloak_authentication_provider, account: @provider)
       session[:id_token] = 'fake-token'

--- a/test/functional/provider/admin/user/personal_details_controller_test.rb
+++ b/test/functional/provider/admin/user/personal_details_controller_test.rb
@@ -3,11 +3,15 @@
 require 'test_helper'
 
 class Provider::Admin::User::PersonalDetailsControllerTest < ActionController::TestCase
+  include FieldsDefinitionsHelpers
 
   def setup
     @provider = FactoryBot.create(:provider_account)
+    @master = @provider.provider_account
+    FieldsDefinition.create_defaults!(@master)
     host! @provider.external_admin_domain
-    login_as @provider.admins.first
+    @user = @provider.admins.first
+    login_as @user
   end
 
 
@@ -43,11 +47,69 @@ class Provider::Admin::User::PersonalDetailsControllerTest < ActionController::T
     put :update, params: { user: {current_password: 'wrong_password', password: 'new_password', password_confirmation: 'new_password'} }
   end
 
+  test 'user can update permitted builtin and custom fields' do
+    field_defined(@master, { target: 'User', name: 'first_name' })
+    field_defined(@master, { target: 'User', name: 'last_name' })
+    field_defined(@master, { target: 'User', name: 'title' })
+    field_defined(@master, { target: 'User', name: 'job_role' })
+    field_defined(@master, { target: 'User', name: 'custom' })
+
+    put :update, params: { user: {
+      current_password: 'superSecret1234#',
+      username: 'newusername',
+      email: 'newemail@example.com',
+      first_name: 'NewFirstName',
+      last_name: 'NewLastName',
+      title: 'NewTitle',
+      job_role: 'NewJobRole',
+      extra_fields: { custom: 'custom value' }
+    } }
+
+    assert_redirected_to edit_provider_admin_user_personal_details_path
+    @user.reload
+    assert_equal 'newusername', @user.username
+    assert_equal 'newemail@example.com', @user.email
+    assert_equal 'NewFirstName', @user.first_name
+    assert_equal 'NewLastName', @user.last_name
+    assert_equal 'NewTitle', @user.title
+    assert_equal 'NewJobRole', @user.job_role
+    assert_equal 'custom value', @user.extra_fields['custom']
+  end
+
+  test 'user cannot update role attribute' do
+    original_role = @user.role
+
+    put :update, params: { user: {
+      current_password: 'superSecret1234#',
+      username: 'newusername',
+      role: 'member'
+    } }
+
+    assert_redirected_to edit_provider_admin_user_personal_details_path
+    @user.reload
+    assert_equal 'newusername', @user.username
+    assert_equal original_role, @user.role, 'Role should not be updated'
+  end
+
+  test 'user cannot update builtin and custom fields not defined explicitly' do
+    put :update, params: { user: {
+      current_password: 'superSecret1234#',
+      first_name: 'New Name',
+      extra_fields: { custom: 'some_value' }
+    } }
+
+    assert_redirected_to edit_provider_admin_user_personal_details_path
+    @user.reload
+    assert_nil @user.first_name, 'Undefined builtin field should not be set'
+    assert_nil @user.extra_fields['custom'], 'Undefined custom field should not be set'
+  end
+
   class SSOUserWithoutPasswordTest < ActionController::TestCase
     tests Provider::Admin::User::PersonalDetailsController
 
     def setup
       @provider = FactoryBot.create(:provider_account)
+      FieldsDefinition.create_defaults!(@provider.provider_account)
       @user = @provider.admins.first
       # Simulate an SSO user: no password and has authentication_id (makes oauth2? return true)
       @user.update_columns(password_digest: nil, authentication_id: 'sso-user-id')
@@ -89,6 +151,7 @@ class Provider::Admin::User::PersonalDetailsControllerTest < ActionController::T
 
     def setup
       @provider = FactoryBot.create(:provider_account)
+      FieldsDefinition.create_defaults!(@provider.provider_account)
       @user = @provider.admins.first
       host! @provider.external_admin_domain
       login_as @user

--- a/test/integration/admin/api/accounts_controller_test.rb
+++ b/test/integration/admin/api/accounts_controller_test.rb
@@ -56,6 +56,7 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
     test '#update from a member with service_permissions is updated correctly' do
       rolling_updates_on
       rolling_update(:service_permissions, enabled: true)
+      assert_not buyer.settings.monthly_billing_enabled
 
       put admin_api_account_path(buyer, format: :xml), params: update_params
       assert_response :ok
@@ -70,10 +71,17 @@ class Admin::Api::AccountsControllerTest < ActionDispatch::IntegrationTest
 
       FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'my_field')
 
-      put admin_api_account_path(buyer, format: :xml), params: update_params.merge({ extra_fields: { my_field: 4 } }), as: :json
+      put admin_api_account_path(buyer, format: :xml), params: update_params.merge(extra_fields: { my_field: 4 }), as: :json
       assert_response :ok
 
-      assert buyer.reload.extra_fields['my_field'].is_a?(String)
+      my_field = buyer.reload.extra_fields['my_field']
+      assert my_field.is_a?(String)
+      assert_equal "4", my_field
+
+      put admin_api_account_path(buyer, format: :xml), params: update_params.merge(my_field: 'another value'), as: :json
+      assert_response :ok
+
+      assert_equal 'another value', buyer.reload.extra_fields['my_field']
     end
 
     test '#update from a member without service_permissions returns error message in xml' do

--- a/test/integration/admin/api/backend_apis_controller_test.rb
+++ b/test/integration/admin/api/backend_apis_controller_test.rb
@@ -41,6 +41,22 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
     assert_persists_right_params
   end
 
+  test 'update with annotations' do
+    assert_empty backend_api.annotations
+
+    put admin_api_backend_api_path(backend_api), params: {
+      access_token: access_token_plaintext_value,
+      annotations: { managed_by: 'operator' }
+    }
+
+    assert_response :success
+
+    assert_equal({ 'managed_by' => 'operator'}, response.parsed_body[:backend_api][:annotations])
+
+    assert_equal 1, backend_api.reload.annotations.count
+    assert_equal 'operator', backend_api.annotations.where(name: 'managed_by').first.value
+  end
+
   test 'update with errors in the model' do
     put admin_api_backend_api_path(backend_api), params: { access_token: access_token_plaintext_value, private_endpoint: '' }
     assert_response :unprocessable_entity
@@ -54,6 +70,26 @@ class Admin::Api::BackendApisControllerTest < ActionDispatch::IntegrationTest
     end
     assert(@backend_api = provider.backend_apis.find_by(id: JSON.parse(response.body).dig('backend_api', 'id')))
     assert_persists_right_params
+  end
+
+  test 'create with annotations' do
+    assert_difference(BackendApi.method(:count)) do
+      post admin_api_backend_apis_path, params: {
+        access_token: access_token_plaintext_value,
+        name: 'the-name',
+        description: 'New description.',
+        private_endpoint: 'http://custom-api.example.org:80',
+        annotations: { managed_by: 'operator' }
+      }
+      assert_response :created
+    end
+
+    backend_api = response.parsed_body[:backend_api]
+    assert_equal({ 'managed_by' => 'operator'}, backend_api[:annotations])
+
+    persisted_backend_api = BackendApi.find(backend_api[:id])
+    assert_equal 1, persisted_backend_api.annotations.count
+    assert_equal 'operator', persisted_backend_api.annotations.where(name: 'managed_by').first.value
   end
 
   test 'create with errors in the model' do

--- a/test/integration/admin/api/buyers_users_controller_test.rb
+++ b/test/integration/admin/api/buyers_users_controller_test.rb
@@ -3,6 +3,8 @@
 require 'test_helper'
 
 class Admin::Api::BuyersUsersControllerTest < ActionDispatch::IntegrationTest
+  include FieldsDefinitionsHelpers
+
   def setup
     @provider = FactoryBot.create(:provider_account)
     @buyer = FactoryBot.create(:simple_buyer, provider_account: provider)
@@ -13,6 +15,9 @@ class Admin::Api::BuyersUsersControllerTest < ActionDispatch::IntegrationTest
   attr_reader :provider, :buyer
 
   test 'creates a user for its buyer' do
+    field_defined(provider, { target: 'User', name: 'first_name' })
+    field_defined(provider, { target: 'User', name: 'last_name' })
+
     assert_difference(buyer.users.method(:count)) do
       post admin_api_account_users_path(buyer), params: params
     end
@@ -22,6 +27,7 @@ class Admin::Api::BuyersUsersControllerTest < ActionDispatch::IntegrationTest
       assert_equal expected_value, user.public_send(attr_name),
                    "#{attr_name} expected to be #{expected_value} but is #{user.public_send(attr_name)}"
     end
+    assert_equal :created_by_provider, user.signup_type
   end
 
   test 'updates a buyer user with password' do

--- a/test/integration/api/applications_controller_test.rb
+++ b/test/integration/api/applications_controller_test.rb
@@ -82,14 +82,14 @@ class Api::ApplicationsControllerTest < ActionDispatch::IntegrationTest
 
       attr_reader :service_plan, :buyer, :application_plan, :service
 
-      test 'crate application redirects to the provider admin index page' do
+      test 'create application redirects to the provider admin index page' do
         post admin_service_applications_path(service), params: { account_id: buyer.id,
                                                                  cinstance: { service_plan_id: service_plan.id, plan_id: application_plan.id, name: 'My Application' } }
 
         assert_redirected_to provider_admin_application_path(Cinstance.last)
       end
 
-      test 'crate application with no service plan selected' do
+      test 'create application with no service plan selected' do
         post admin_service_applications_path(service), params: { account_id: buyer.id,
                                                                  cinstance: { plan_id: application_plan.id, name: 'My Application' } }
 
@@ -97,7 +97,7 @@ class Api::ApplicationsControllerTest < ActionDispatch::IntegrationTest
         assert_redirected_to provider_admin_application_path(application)
       end
 
-      test 'crate application with no service plan selected and a default service plan' do
+      test 'create application with no service plan selected and a default service plan' do
         default_service_plan = FactoryBot.create(:service_plan, service: service)
         service.update(default_service_plan: default_service_plan)
         post admin_service_applications_path(service), params: { account_id: buyer.id,
@@ -107,7 +107,7 @@ class Api::ApplicationsControllerTest < ActionDispatch::IntegrationTest
         assert_equal default_service_plan, buyer.bought_service_contracts.first.service_plan
       end
 
-      test 'crate application with no service plan selected and no default service plan' do
+      test 'create application with no service plan selected and no default service plan' do
         other_service_plan = FactoryBot.create(:service_plan, service: service)
         service.update(default_service_plan: nil)
         post admin_service_applications_path(service), params: { account_id: buyer.id,
@@ -117,7 +117,7 @@ class Api::ApplicationsControllerTest < ActionDispatch::IntegrationTest
         assert_not_equal other_service_plan, buyer.bought_service_contracts.first.service_plan
       end
 
-      test 'crate application with no service plan selected and a subscription' do
+      test 'create application with no service plan selected and a subscription' do
         subscribed_service_plan = FactoryBot.create(:service_plan, service: service)
         buyer.bought_service_contracts.create(plan: subscribed_service_plan)
         post admin_service_applications_path(service), params: { account_id: buyer.id,

--- a/test/integration/audited_hacks_async_test.rb
+++ b/test/integration/audited_hacks_async_test.rb
@@ -14,6 +14,7 @@ class AuditedHacksAsyncTest < ActionDispatch::IntegrationTest
     Settings::Switch.any_instance.stubs(:allowed?).returns(true)
 
     @provider = FactoryBot.create(:simple_provider)
+    FieldsDefinition.create_defaults!(@provider.provider_account)
     @provider.create_settings # prevent creating settings lazily, as this triggers an Audit creation
     @admin = FactoryBot.create :simple_user, account: @provider, role: 'admin'
     User.current = @admin

--- a/test/integration/buyers/accounts_controller_test.rb
+++ b/test/integration/buyers/accounts_controller_test.rb
@@ -32,9 +32,9 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'hi', user.extra_fields['created_by']
     end
 
-    test 'billing address extra field and webhooks' do
+    test 'legal address extra field and webhooks' do
       FactoryBot.create(:fields_definition, account: @provider,
-                         target: 'Account', name: 'billing_address', read_only: true)
+                         target: 'Account', name: 'org_legaladdress')
 
       @provider.settings.allow_web_hooks!
       WebHook.delete_all
@@ -271,6 +271,36 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
         assert_select '.pf-m-error', false
         assert_response :redirect
       end
+    end
+
+    test 'update account, including optional built-in and custom fields' do
+      FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'custom_account_field')
+      FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'vat_rate')
+      FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'billing_address', read_only: true)
+      FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'country')
+
+      @buyer.delete_billing_address
+      @buyer.save
+      country = Country.find_by_code!('ES')
+
+      # account[country] and account[billing_address] do not appear in the user-facing form,
+      # they are included in the test to verify that these fields are discarded by the controller,
+      # if the form is tampered with
+      put admin_buyers_account_path(@buyer), params: { account: {
+        org_name: 'new name', vat_rate: '33',
+        country_id: country.id.to_s,
+        country: '67',
+        billing_address: 'some address',
+        extra_fields: { custom_account_field: 'custom value' }
+      } }
+
+      assert_redirected_to admin_buyers_account_path(@buyer)
+      @buyer.reload
+      assert_equal 'new name', @buyer.name
+      assert_equal country.id, @buyer.country.id
+      assert_equal country.code, @buyer.billing_address.to_s
+      assert_equal BigDecimal(33), @buyer.vat_rate
+      assert_equal 'custom value', @buyer.extra_fields['custom_account_field']
     end
 
     test "can't manage buyer's of other providers" do

--- a/test/integration/buyers/groups_controller_test.rb
+++ b/test/integration/buyers/groups_controller_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Buyers::GroupsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @provider = FactoryBot.create(:provider_account)
+    @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
+    @group1 = FactoryBot.create(:cms_group, provider: @provider, name: "group1")
+    @group2 = FactoryBot.create(:cms_group, provider: @provider, name: "group2")
+
+    @provider.settings.allow_groups!
+    login! @provider
+  end
+
+  test 'show displays groups for buyer account' do
+    get admin_buyers_account_groups_path(@buyer)
+
+    assert_response :success
+
+    page = Nokogiri::HTML4::Document.parse(response.body)
+    checkboxes = page.xpath("//input[@name='account[group_ids][]'][@type='checkbox'][not(@hidden)]")
+    labels = checkboxes.map { |cb| cb.xpath("following-sibling::label").text }
+
+    assert_same_elements %w[group1 group2], labels
+    assert checkboxes.all? { |cb| cb['checked'].nil? }, "Expected all checkboxes to be unchecked"
+  end
+
+  test 'update sets correctly the groups' do
+    put admin_buyers_account_groups_path(@buyer), params: {
+      account: {
+        group_ids: [@group2.id]
+      }
+    }
+
+    assert_redirected_to admin_buyers_account_groups_path(@buyer, id: @buyer.id)
+    assert_equal 'Account updated', flash[:success]
+    assert_equal [@group2.id], @buyer.reload.group_ids
+
+    put admin_buyers_account_groups_path(@buyer), params: {
+      account: {
+        group_ids: [@group1.id, @group2.id]
+      }
+    }
+    assert_response :redirect
+    assert_same_elements [@group1.id, @group2.id], @buyer.reload.group_ids
+
+    put admin_buyers_account_groups_path(@buyer), params: {
+      account: {
+        group_ids: [""]
+      }
+    }
+    assert_response :redirect
+    assert_empty @buyer.reload.group_ids
+  end
+end

--- a/test/integration/buyers/users_controller_integration_test.rb
+++ b/test/integration/buyers/users_controller_integration_test.rb
@@ -3,6 +3,8 @@
 require 'test_helper'
 
 class Buyers::UsersControllerIntegrationTest < ActionDispatch::IntegrationTest
+  include FieldsDefinitionsHelpers
+
   def setup
     @provider = FactoryBot.create(:provider_account)
     login! provider
@@ -69,6 +71,31 @@ class Buyers::UsersControllerIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal 'Japan', user.field_value('country')
   end
 
+  test 'only update optional fields that are enabled through fields definitions' do
+    field_defined(provider, { target: 'User', name: 'first_name' })
+    field_defined(provider, { target: 'User', name: 'last_name' })
+    provider.reload
+    user = FactoryBot.create(:member, account: buyer)
+    assert_same_elements %w[username email first_name last_name], user.defined_fields_names
+
+    optional_fields = {
+      title: 'Ms.', first_name: 'fn', last_name: 'ln', job_role: 'manager'
+    }
+
+    optional_fields.each_key do |field|
+      assert_nil user.public_send(field), "Field '#{field}' should not be set"
+    end
+
+    put admin_buyers_account_user_path(account_id: buyer.id, id: user.id), params: { user: optional_fields }
+
+    user.reload
+
+    assert_equal 'fn', user.first_name
+    assert_equal 'ln', user.last_name
+    assert_nil user.job_role
+    assert_nil user.title
+  end
+
   test "#activate" do
     user = FactoryBot.create(:pending_user, account: buyer)
     assert_not user.active?
@@ -77,6 +104,66 @@ class Buyers::UsersControllerIntegrationTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_response :ok
+    assert user.reload.active?
+  end
+
+  test "update password" do
+    user = buyer.admin_user
+    new_password = SecureRandom.hex(8)
+    assert_not user.authenticated?(new_password)
+
+    put admin_buyers_account_user_path(account_id: buyer.id, id: user.id), params: {
+      user: {
+        password: new_password,
+        password_confirmation: new_password
+      }
+    }
+
+    user.reload
+    assert user.reload.authenticated?(new_password)
+  end
+
+  test "do not update password in does not match password confirmation" do
+    user = buyer.admin_user
+    new_password = SecureRandom.hex(8)
+    assert_not user.authenticated?(new_password)
+
+    put admin_buyers_account_user_path(account_id: buyer.id, id: user.id), params: {
+      user: {
+        password: new_password,
+        password_confirmation: new_password.reverse
+      }
+    }
+
+    assert_not user.reload.authenticated?(new_password)
+
+    page = Nokogiri::HTML::Document.parse(response.body)
+    password_confirmation_error = page.at_xpath("//input[@id='user_password_confirmation']/following-sibling::p[@class='inline-errors']")
+    assert password_confirmation_error
+    assert_equal "doesn't match Password", password_confirmation_error.text
+  end
+
+  test "update user role" do
+    member = FactoryBot.create(:member, account: buyer)
+    assert member.member?
+
+    put admin_buyers_account_user_path(account_id: buyer.id, id: member.id), params: {
+      user: {
+        role: "admin"
+      }
+    }
+
+    assert member.reload.admin?
+  end
+
+  test "suspend and unsuspend user" do
+    user = buyer.admin_user
+    assert user.active?
+
+    post suspend_admin_buyers_account_user_path(buyer, user)
+    assert user.reload.suspended?
+
+    post unsuspend_admin_buyers_account_user_path(buyer, user)
     assert user.reload.active?
   end
 end

--- a/test/integration/developer_portal/accounts/invitee_signups_controller_test.rb
+++ b/test/integration/developer_portal/accounts/invitee_signups_controller_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class DeveloperPortal::Accounts::InviteeSignupsControllerTest < ActionDispatch::IntegrationTest
   include System::UrlHelpers.cms_url_helpers
+  include FieldsDefinitionsHelpers
 
   def setup
     @buyer = FactoryBot.create(:buyer_account)
@@ -63,6 +64,44 @@ class DeveloperPortal::Accounts::InviteeSignupsControllerTest < ActionDispatch::
 
     assert_equal I18n.t('errors.messages.invitation_already_accepted'), flash[:error]
     assert_redirected_to login_path
+  end
+
+  test 'create sets custom fields that are not read-only' do
+    field_defined(buyer.provider_account, { target: 'User', name: 'department' })
+    field_defined(buyer.provider_account, { target: 'User', name: 'employee_id', read_only: true })
+
+    invitation = FactoryBot.create(:invitation, account: buyer)
+
+    assert_difference(buyer.users.method(:count), +1) do
+      post invitee_signup_path(invitation_token: invitation.token, user: user_params.merge(
+        department: 'Engineering',
+        employee_id: 'EMP-12345'
+      ))
+    end
+
+    assert_equal I18n.t('developer_portal.accounts.invitee_signups.create.success'), flash[:notice]
+    assert_redirected_to login_path
+
+    created_user = invitation.reload.user
+    assert_equal 'Engineering', created_user.extra_fields['department']
+    assert_nil created_user.extra_fields['employee_id']
+  end
+
+  test 'do not set unpermitted attributes' do
+    invitation = FactoryBot.create(:invitation, account: buyer)
+
+    assert_difference(buyer.users.method(:count), +1) do
+      post invitee_signup_path(invitation_token: invitation.token, user: user_params.merge(
+        role: 'superadmin'
+      ))
+    end
+
+    assert_equal I18n.t('developer_portal.accounts.invitee_signups.create.success'), flash[:notice]
+    assert_redirected_to login_path
+
+    created_user = invitation.reload.user
+    assert_equal :member, created_user.role
+    assert_equal 'admin', created_user.username
   end
 
   private

--- a/test/integration/developer_portal/edit_account_test.rb
+++ b/test/integration/developer_portal/edit_account_test.rb
@@ -6,6 +6,7 @@ class DeveloperPortal::EditAccountTest < ActionDispatch::IntegrationTest
   def setup
     @provider = FactoryBot.create(:simple_provider)
     @buyer    = FactoryBot.create(:buyer_account, provider_account: @provider, org_name: 'ontheroad')
+    FieldsDefinition.create_defaults!(@provider)
 
     login_buyer @buyer
 

--- a/test/integration/developer_portal/invitation_signup_test.rb
+++ b/test/integration/developer_portal/invitation_signup_test.rb
@@ -4,6 +4,7 @@ class DeveloperPortal::InvitationSignupTest < ActionDispatch::IntegrationTest
   include System::UrlHelpers.cms_url_helpers
 
   OAuth2 = Authentication::Strategy::OAuth2
+  UserData = ThreeScale::OAuth2::UserData
 
   def setup
     @provider   = FactoryBot.create(:simple_provider)
@@ -24,7 +25,7 @@ class DeveloperPortal::InvitationSignupTest < ActionDispatch::IntegrationTest
     # sso attributes do exist, sso authorization object should be built
     # and therefore, user password should not be required
     OAuth2.any_instance.stubs(:authentication_provider).returns(@auth_provider)
-    OAuth2.any_instance.expects(:user_data).returns({ uid: '12345' })
+    OAuth2.any_instance.expects(:user_data).returns(UserData.new({ uid: '12345' }))
     get "/auth/invitations/#{@invitation.token}/github/callback"
     assert_response :success
     get invitee_signup_path(invitation_token: @invitation.token)
@@ -77,7 +78,7 @@ class DeveloperPortal::InvitationSignupTest < ActionDispatch::IntegrationTest
     assert session[:invitation_sso_uid].blank?
     refute assigns(:user).valid?
 
-    OAuth2.any_instance.expects(:user_data).returns({ uid: '12345' })
+    OAuth2.any_instance.expects(:user_data).returns(UserData.new({ uid: '12345' }))
     get "/auth/invitations/#{@invitation.token}/github/callback"
     assert_response :success
     assert_equal '12345', session[:invitation_sso_uid]
@@ -103,6 +104,7 @@ class DeveloperPortal::InvitationSignupTest < ActionDispatch::IntegrationTest
   end
 
   def test_create
+    FieldsDefinition.create_defaults!(@provider)
     OAuth2.any_instance.stubs(:authentication_provider).returns(@auth_provider)
 
     assert_difference '@buyer.users.count' do

--- a/test/integration/master/api/providers_controller_integration_test.rb
+++ b/test/integration/master/api/providers_controller_integration_test.rb
@@ -10,6 +10,7 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     @service_plan = master_account.default_service_plans.first
     @application_plan = master_account.default_application_plans.first
 
+    FieldsDefinition.create_defaults!(master_account)
     FactoryBot.create(:fields_definition, account: master_account, target: 'Account', name: 'account_extra_field')
     FactoryBot.create(:fields_definition, account: master_account, target: 'User', name: 'user_extra_field')
 
@@ -169,6 +170,15 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     assert_response :unprocessable_entity
   end
 
+  test '#create with annotations' do
+    post master_api_providers_path(format: :json), params: signup_params.merge({ annotations: { managed_by: 'operator' }})
+    assert_response :created
+
+    new_tenant = response.parsed_body[:signup][:account]
+    assert_equal({ 'managed_by' => 'operator'}, new_tenant[:annotations])
+    assert_equal 'operator', Account.find(new_tenant[:id]).annotations.where(name: 'managed_by').first.value
+  end
+
   test '#update' do
     provider = FactoryBot.create(:provider_account, provider_account: master_account)
     user     = FactoryBot.create(:member, account: master_account, admin_sections: ['partners'])
@@ -197,14 +207,35 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     token    = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
     provider.schedule_for_deletion!
 
-    update_params = { account: { from_email: 'from@email.com', state_event: 'resume'},
+    update_params = { account: { from_email: 'from@email.com', state_event: 'resume', org_name: 'new-org-name' },
                       access_token: token.plaintext_value, format: :json }
     put master_api_provider_path(provider, update_params)
     assert_response :ok
 
     provider.reload
+    assert_equal 'approved', provider.state
     assert_not_equal update_params[:account][:from_email], provider.from_email
-    assert_equal 'approved',                           provider.state
+    assert_not_equal 'new-org-name', provider.org_name
+  end
+
+  test '#update with annotations' do
+    provider = FactoryBot.create(:provider_account, provider_account: master_account)
+    user = FactoryBot.create(:member, account: master_account, admin_sections: ['partners'])
+    token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management')
+
+    assert_empty provider.annotations
+
+    put master_api_provider_path(provider, format: :json), params: {
+      annotations: { managed_by: 'operator' },
+      access_token: token.plaintext_value
+    }
+    assert_response :ok
+
+    updated_account = response.parsed_body[:signup][:account]
+    assert_equal({ 'managed_by' => 'operator'}, updated_account[:annotations])
+
+    assert_equal 1, provider.reload.annotations.count
+    assert_equal 'operator', provider.annotations.where(name: 'managed_by').first.value
   end
 
   test '#destroy' do
@@ -260,7 +291,9 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
       email: 'person@example.com',
       password: 'superSecret1234#',
       user_extra_field: 'hi-user',
-      account_extra_field: 'hi-account'
+      account_extra_field: 'hi-account',
+      from_email: 'from@example.com',
+      support_email: 'support@example.com'
     }.merge(different_params)
   end
 

--- a/test/integration/master/api/providers_controller_integration_test.rb
+++ b/test/integration/master/api/providers_controller_integration_test.rb
@@ -105,6 +105,18 @@ class Master::Api::ProvidersControllerIntegrationTest < ActionDispatch::Integrat
     assert_contains JSON.parse(response.body).dig('errors', 'user'), 'Email should look like an email address'
   end
 
+  test 'signup with non-matching password fails' do
+    assert_no_difference Account.method(:count) do
+      post master_api_providers_path(format: :json), params: signup_params.merge({ password_confirmation: 'non-matching-password' })
+
+      assert_response :unprocessable_entity
+  
+      errors = response.parsed_body[:errors]
+      assert_equal ["Users invalid"], errors[:account]
+      assert_equal ["Password confirmation doesn't match Password"], errors[:user]
+    end
+  end
+
   test '#create returns the right errors when user validation fails for xml' do
     post master_api_providers_path(format: :xml), params: signup_params({ email: '' })
     assert_response :unprocessable_entity

--- a/test/integration/multitenant_enforcement_test.rb
+++ b/test/integration/multitenant_enforcement_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class MultitenantEnforcementTest < ActionDispatch::IntegrationTest
   setup do
     @provider = FactoryBot.create(:provider_account)
+    FieldsDefinition.create_defaults!(@provider.provider_account)
   end
 
   test "forbid retrieving objects from multiple tenants" do

--- a/test/integration/provider/admin/account/users_controller_test.rb
+++ b/test/integration/provider/admin/account/users_controller_test.rb
@@ -3,6 +3,7 @@
 require 'test_helper'
 
 class Provider::Admin::Account::UsersControllerTest < ActionDispatch::IntegrationTest
+  include FieldsDefinitionsHelpers
 
   def setup
     @provider             = FactoryBot.create :provider_account
@@ -11,6 +12,7 @@ class Provider::Admin::Account::UsersControllerTest < ActionDispatch::Integratio
     @default_service_ids  = @services.first(2).map(&:id)
     @user                 = FactoryBot.create :simple_user, account: @provider, member_permission_ids: @default_ids,
                                               member_permission_service_ids: @default_service_ids
+    FieldsDefinition.create_defaults!(@provider.provider_account)
 
     login! @provider
   end
@@ -156,5 +158,40 @@ class Provider::Admin::Account::UsersControllerTest < ActionDispatch::Integratio
     assert_response :success
     assert_select 'input[name="user[password]"]'
     assert_select 'input[name="user[password_confirmation]"]'
+  end
+
+  test 'update user fields including optional and custom ones' do
+    field_defined(@provider.provider_account, { target: 'User', name: 'job_role' })
+    field_defined(@provider.provider_account, { target: 'User', name: 'custom_field' })
+
+    put provider_admin_account_user_path(@user), params:
+      {
+        user: {
+          username: 'new_username',
+          job_role: 'developer',
+          extra_fields: {
+            custom_field: 'custom value'
+          }
+        }
+      }
+
+    @user.reload
+
+    assert_equal 'new_username', @user.username
+    assert_equal 'developer', @user.job_role
+    assert_equal 'custom value', @user.extra_fields['custom_field']
+  end
+
+  test 'update password' do
+    put provider_admin_account_user_path(@user), params: { user: { password: 'superSecret1234#', password_confirmation: 'not-matching' } }
+
+    assert_template :edit
+    assert_select 'p.inline-errors', text: "doesn't match Password"
+
+    put provider_admin_account_user_path(@user), params: { user: { password: 'superSecret1234#', password_confirmation: 'superSecret1234#' } }
+
+    assert_redirected_to provider_admin_account_users_path
+    assert_equal "User was successfully updated", flash[:success]
+    assert @user.reload.authenticated?('superSecret1234#')
   end
 end

--- a/test/integration/provider/admin/accounts_controller_test.rb
+++ b/test/integration/provider/admin/accounts_controller_test.rb
@@ -11,6 +11,7 @@ class Provider::Admin::AccountsControllerTest < ActionDispatch::IntegrationTest
     @service_plan = master.default_service_plans.first
     @application_plan = master.default_application_plans.first
     @application_plan.update(system_name: 'enterprise') # for the switches tested later
+    FieldsDefinition.create_defaults!(@master)
     FactoryBot.create(:fields_definition, account: @master, target: 'User', name: 'created_by')
   end
 

--- a/test/integration/provider/invitee_signups_controller_integration_test.rb
+++ b/test/integration/provider/invitee_signups_controller_integration_test.rb
@@ -19,12 +19,31 @@ class Provider::InviteeSignupsControllerIntegrationTest < ActionDispatch::Integr
   end
 
   test 'create' do
+    FieldsDefinition.create_defaults!(provider.provider_account)
     assert_difference(provider.users.method(:count)) do
       post provider_invitee_signup_path(invitation_token: invitation.token, user: user_params)
     end
 
     assert_equal I18n.t('provider.invitee_signups.create.success'), flash[:success]
     assert_redirected_to provider_login_path
+  end
+
+  test 'do not set unpermitted attributes' do
+    FieldsDefinition.create_defaults!(provider.provider_account)
+    invitation = FactoryBot.create(:invitation, account: provider)
+
+    assert_difference(provider.users.method(:count), +1) do
+      post provider_invitee_signup_path(invitation_token: invitation.token, user: user_params.merge(
+        role: 'superadmin'
+      ))
+    end
+
+    assert_equal I18n.t('provider.invitee_signups.create.success'), flash[:success]
+    assert_redirected_to provider_login_path
+
+    created_user = invitation.reload.user
+    assert_equal :member, created_user.role
+    assert_equal 'admin', created_user.username
   end
 
   test 'get asks for upgrade' do

--- a/test/integration/provider/signups_controller_integration_test.rb
+++ b/test/integration/provider/signups_controller_integration_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class Provider::SignupsControllerIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     login! master_account
+    FieldsDefinition.create_defaults!(master_account)
   end
 
   test 'disables x_frame_options header' do

--- a/test/integration/signup_express_test.rb
+++ b/test/integration/signup_express_test.rb
@@ -9,12 +9,17 @@ class SignupExpressTest < ActionDispatch::IntegrationTest
     host! @provider.external_admin_domain
   end
 
-  test 'signup express with org name' do
-    org_name = 'My Company'
-    post admin_api_signup_path(format: :xml), params: params(org_name: org_name)
+  test 'signup express with org name and name work equally' do
+    post admin_api_signup_path(format: :xml), params: params(org_name: 'org name')
     assert_response :success
     doc = Nokogiri::XML::Document.parse(@response.body)
-    assert_equal org_name, doc.xpath('/account/org_name').text
+    assert_equal 'org name', doc.xpath('/account/org_name').text
+
+    params_without_org_name = params(name: 'just name', username: 'another', email: 'another@example.com').except(:org_name)
+    post admin_api_signup_path(format: :xml), params: params_without_org_name
+    assert_response :success
+    doc = Nokogiri::XML::Document.parse(@response.body)
+    assert_equal 'just name', doc.xpath('/account/org_name').text
   end
 
   test 'signup express with account plan that requires approval' do
@@ -47,6 +52,60 @@ class SignupExpressTest < ActionDispatch::IntegrationTest
   test 'do not raise exception when account validations fails' do
     post admin_api_signup_path(format: :xml), params: params(org_name: '')
     assert_response 422
+  end
+
+  test 'set billing_address' do
+    FactoryBot.create(:fields_definition, account: @provider, target: 'Account', name: 'billing_address', read_only: true)
+
+    post admin_api_signup_path(format: :xml), params: params({ org_name: 'alaska', billing_address: 'Calle Napoles 187, Barcelona. Spain' })
+    assert_response :unprocessable_entity
+    doc = Nokogiri::XML::Document.parse(response.body)
+    assert_equal 'Billing address is not correctly set', doc.xpath('//error/errors').text
+
+    billing_address = { name: '3scale', address1: 'Calle Napoles 187', city: 'Barcelona', country:  'Spain' }
+    billing_address_params_nested = billing_address.transform_keys { |k| "billing_address[#{k}]" }
+
+    post admin_api_signup_path(format: :json), params: params(billing_address_params_nested)
+    assert_response :success
+
+    account_billing_address = response.parsed_body[:account][:billing_address]
+    assert_equal '3scale', account_billing_address[:company]
+    assert_equal 'Barcelona', account_billing_address[:city]
+    assert_equal 'Spain', account_billing_address[:country]
+    assert_equal 'Calle Napoles 187', account_billing_address[:address1]
+
+    billing_address_params_strings = billing_address.transform_keys { |k| "billing_address_#{k}" }
+
+    post admin_api_signup_path(format: :json), params: params({ username: 'another-user', email: 'another-user@example.com', **billing_address_params_strings })
+    assert_response :success
+
+    account_billing_address = response.parsed_body[:account][:billing_address]
+    assert_equal '3scale', account_billing_address[:company]
+    assert_equal 'Barcelona', account_billing_address[:city]
+    assert_equal 'Spain', account_billing_address[:country]
+    assert_equal 'Calle Napoles 187', account_billing_address[:address1]
+  end
+
+  test 'signup with annotations' do
+    post admin_api_signup_path(format: :json), params: params.merge({ annotations: { managed_by: 'operator' } })
+
+    assert_response :success
+
+    account = response.parsed_body[:account]
+    assert_equal({ 'managed_by' => 'operator'}, account[:annotations])
+
+    new_account = Account.find(account[:id])
+    assert_equal 'operator', new_account.annotations.where(name: 'managed_by').first.value
+  end
+
+  test 'signup with non-matching password fails' do
+    post admin_api_signup_path(format: :json), params: params.merge({ password_confirmation: 'non-matching-password' })
+
+    assert_response :unprocessable_entity
+
+    errors = response.parsed_body[:errors]
+    assert_equal ["invalid"], errors[:users]
+    assert_equal ["doesn't match Password"], errors[:password_confirmation]
   end
 
   private

--- a/test/integration/user-management-api/accounts_test.rb
+++ b/test/integration/user-management-api/accounts_test.rb
@@ -62,12 +62,30 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
       end
 
       test 'update billing_address' do
+        field_defined(@provider, { target: "Account", name: "billing_address", read_only: true })
         put admin_api_account_path(@buyer, format: :xml), params: params.merge({ org_name: 'alaska', billing_address: 'Calle Napoles 187, Barcelona. Spain' })
         assert_response :unprocessable_entity
 
-        billing_address = { name: '3scale', address1: 'Calle Napoles 187', city: 'Barcelona', country:  'Spain' }.transform_keys { |k| "billing_address[#{k}]" }
-        put admin_api_account_path(@buyer, format: :xml), params: params.merge(billing_address).merge({ org_name: 'alaska' })
+        billing_address = { name: '3scale', address1: 'Calle Napoles 187', city: 'Barcelona', country:  'Spain' }
+
+        billing_address_params_nested = billing_address.transform_keys { |k| "billing_address[#{k}]" }
+        put admin_api_account_path(@buyer, format: :xml), params: params.merge(billing_address_params_nested)
         assert_response :success
+
+        @buyer.reload
+        assert_equal 'Barcelona', @buyer.billing_address_city
+        assert_equal 'Calle Napoles 187', @buyer.billing_address_address1
+
+        # reset to empty to test with another format
+        @buyer.update(billing_address_name: '', billing_address_address1: '', billing_address_city: '', billing_address_country: '')
+
+        billing_address_params_strings = billing_address.transform_keys { |k| "billing_address_#{k}" }
+        put admin_api_account_path(@buyer, format: :xml), params: params.merge(billing_address_params_strings)
+        assert_response :success
+
+        @buyer.reload
+        assert_equal 'Barcelona', @buyer.billing_address_city
+        assert_equal 'Calle Napoles 187', @buyer.billing_address_address1
       end
 
       test '#update' do
@@ -606,6 +624,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
     test 'update with extra fields' do
       field_defined(@provider, { target: "Account", name: "some_extra_field" })
+      field_defined(@provider, { target: "Account", name: "vat_rate" })
 
       put admin_api_account_path(@buyer, format: :xml), params: params.merge({ some_extra_field: "stuff", vat_rate: 33 })
 
@@ -614,7 +633,18 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
 
       @buyer.reload
       assert_equal "stuff", @buyer.extra_fields["some_extra_field"]
-      assert_equal 33, @buyer.vat_rate
+      assert_equal BigDecimal(33), @buyer.vat_rate
+    end
+
+    test 'account update with annotations' do
+      put admin_api_account_path(@buyer, format: :json), params: params.merge({ annotations: { managed_by: 'operator' } })
+
+      assert_response :success
+
+      assert_equal({ 'managed_by' => 'operator'}, response.parsed_body[:account][:annotations])
+
+      assert_equal 1,  @buyer.reload.annotations.count
+      assert_equal 'operator', @buyer.annotations.where(name: 'managed_by').first.value
     end
 
     test 'destroy' do

--- a/test/integration/user-management-api/buyers_application_plans_test.rb
+++ b/test/integration/user-management-api/buyers_application_plans_test.rb
@@ -91,6 +91,38 @@ class Admin::Api::BuyersApplicationPlansTest < ActionDispatch::IntegrationTest
     assert_equal app_plan.id.to_s, xml.xpath('/plan/id').children.text
   end
 
+  test 'buy with different application attributes' do
+    app_plan = FactoryBot.create(:application_plan, issuer: @provider.default_service)
+
+    app_params = {
+      name: 'name_value',
+      description: 'description_value',
+      redirect_url: 'http://example.com',
+      create_origin: 'create_origin_value',
+      user_key: 'user_key_value',
+      application_id: 'application_id_value',
+      accepted_at: Time.utc(2020,01,01).to_s,
+      first_traffic_at: Time.utc(2020,02,02).to_s,
+      first_daily_traffic_at: Time.utc(2020,03,03).to_s
+    }
+
+    assert_difference app_plan.cinstances.method(:count), +1 do
+      post buy_admin_api_account_application_plan_path(@buyer, app_plan, format: :xml), params: {
+        provider_key: @provider.api_key,
+      }.merge(app_params)
+
+      plan_id = Nokogiri::XML::Document.parse(@response.body).xpath('/plan/id').children.text
+      assert_equal app_plan.id.to_s, plan_id
+      app = app_plan.cinstances.first
+
+      app_params.except(:user_key, :application_id).each do |k, v|
+        assert_equal v, app.public_send(k).to_s, "field '#{k}' should equal '#{v}'"
+      end
+      assert_not_equal app_params[:user_key], app.user_key
+      assert_not_equal app_params[:application_id], app.application_id
+    end
+  end
+
   test 'buy an already bought plan' do
     app_plan = FactoryBot.create(:application_plan, issuer: @provider.default_service)
     app_plan.publish!

--- a/test/integration/user-management-api/buyers_applications_test.rb
+++ b/test/integration/user-management-api/buyers_applications_test.rb
@@ -218,15 +218,18 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
   end
 
   test 'create' do
-    post admin_api_account_applications_path(@buyer, format: :xml), params: { plan_id: @hidden_app_plan.id, name: "chucky", description: "rocks awesome", provider_key: @provider.api_key }
+    post admin_api_account_applications_path(@buyer, format: :xml), params: {
+      plan_id: @hidden_app_plan.id,
+      provider_key: @provider.api_key
+    }.merge(app_params)
 
     assert_response :success
-    assert_application(response.body, { name: "chucky", description: "rocks awesome" })
+    assert_application(response.body, { name: app_params[:name], description: app_params[:description] })
 
     created_app = @buyer.bought_cinstances.last
-    assert_equal "chucky",        created_app.name
-    assert_equal "rocks awesome", created_app.description
-    assert_equal 'api',           created_app.create_origin
+    app_params.each do |k, v|
+      assert_equal v, created_app.public_send(k).to_s, "field '#{k}' should equal '#{v}'"
+    end
   end
 
   test 'create forces the subscription to service' do
@@ -296,14 +299,17 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
 
   test 'update' do
     app = @buyer.bought_cinstances.last
-    put admin_api_account_application_path(@buyer, id: app.id, format: :xml), params: { name: "descriptive", provider_key: @provider.api_key, redirect_url: 'http://example.com' }
+
+    put admin_api_account_application_path(@buyer, id: app.id, format: :xml), params: { provider_key: @provider.api_key }.merge(app_params)
 
     assert_response :success
-    assert_application response.body, { name: "descriptive" }
+    assert_application response.body, { id: app.id }
 
     app.reload
-    assert_equal 'descriptive', app.name
-    assert_equal 'http://example.com', app.redirect_url
+    app_params.except(:application_id).each do |k, v|
+      assert_equal v, app.public_send(k).to_s, "field '#{k}' should equal '#{v}'"
+    end
+    assert_not_equal app_params[:application_id], app.application_id
   end
 
   test 'update with long user_key' do
@@ -525,4 +531,20 @@ class Admin::Api::BuyersApplicationsTest < ActionDispatch::IntegrationTest
   end
 
   pending_test 'nothing happens on already resumed one'
+
+  private
+
+  def app_params
+    {
+      name: 'name_value',
+      description: 'description_value',
+      redirect_url: 'http://example.com',
+      create_origin: 'create_origin_value',
+      user_key: 'user_key_value',
+      application_id: 'application_id_value',
+      accepted_at: Time.utc(2020,01,01).to_s,
+      first_traffic_at: Time.utc(2020,02,02).to_s,
+      first_daily_traffic_at: Time.utc(2020,03,03).to_s
+    }
+  end
 end

--- a/test/integration/user-management-api/buyers_users_test.rb
+++ b/test/integration/user-management-api/buyers_users_test.rb
@@ -9,6 +9,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
   def setup
     @provider = FactoryBot.create(:provider_account, domain: 'provider.example.com')
     @provider.default_account_plan = @provider.account_plans.first
+    @token = FactoryBot.create(:access_token, owner: @provider.first_admin, scopes: ['account_management'])
 
     @buyer = FactoryBot.create(:buyer_account, provider_account: @provider)
     @buyer.buy! @provider.default_account_plan
@@ -22,7 +23,7 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
   class AccessTokenWithCallbacks < ActionDispatch::IntegrationTest
     def setup
-      @provider = FactoryBot.create(:simple_provider)
+      @provider = FactoryBot.create(:provider_account)
       @buyer    = FactoryBot.create(:simple_buyer, provider_account: @provider)
 
       host! @provider.external_admin_domain
@@ -303,6 +304,20 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     assert_equal User.find_by(username: "chuck").extra_fields["some_extra_field"], "extra value"
   end
 
+  test 'create sets user signup_type' do
+    post admin_api_account_users_path(account_id: @buyer.id, format: :json), params: {
+      access_token: @token.plaintext_value,
+      username: 'new_user',
+      email: 'new_user@example.com'
+    }
+
+    assert_response :success
+
+    new_user = User.find(response.parsed_body[:user][:id])
+    assert_equal 'new_user@example.com', new_user.email
+    assert_equal :created_by_provider, new_user.signup_type
+  end
+
   test 'create errors' do
     post admin_api_account_users_path(account_id: @buyer.id, format: :xml), params: { username: 'chuck', role: "admin", provider_key: @provider.api_key }
 
@@ -529,6 +544,33 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
 
     chuck.reload
     assert chuck.active?
+  end
+
+  test 'only update optional fields that are enabled through fields definitions' do
+    field_defined(@provider, { target: 'User', name: 'first_name' })
+    field_defined(@provider, { target: 'User', name: 'last_name' })
+    assert_same_elements %w[username email first_name last_name], @member.reload.defined_fields_names
+
+    optional_fields = {
+      title: 'Ms.', first_name: 'fn', last_name: 'ln', job_role: 'manager'
+    }
+
+    optional_fields.each_key do |field|
+      assert_nil @member.public_send(field), "Field '#{field}' should not be set"
+    end
+
+    put admin_api_account_user_path(account_id: @buyer.id, format: :xml, id: @member.id), params: {
+      access_token: @token.plaintext_value,
+      **optional_fields
+    }
+    assert_response :success
+
+    @member.reload
+
+    assert_equal 'fn', @member.first_name
+    assert_equal 'ln', @member.last_name
+    assert_nil @member.job_role
+    assert_nil @member.title
   end
 
   protected

--- a/test/integration/user-management-api/buyers_users_test.rb
+++ b/test/integration/user-management-api/buyers_users_test.rb
@@ -395,6 +395,18 @@ class Admin::Api::BuyerUsersTest < ActionDispatch::IntegrationTest
     chuck.reload
     assert_response :success
     assert chuck.authenticate('updated-password')
+
+    # Password not updated if password confirmation is not correct
+    put admin_api_account_user_path(account_id: @buyer.id,
+                                    format: :xml, id: chuck.id,
+                                    password: "updated-password",
+                                    password_confirmation: "not-matching-password"),
+        params: { provider_key: @provider.api_key }
+    assert_response :unprocessable_entity
+
+    xml = Nokogiri::XML::Document.parse @response.body
+    assert_match "Password confirmation doesn't match Password", xml.xpath('.//errors/error').text
+    assert chuck.reload.authenticate('updated-password')
   end
 
   test 'update also updates extra fields' do

--- a/test/integration/user-management-api/services_test.rb
+++ b/test/integration/user-management-api/services_test.rb
@@ -57,6 +57,26 @@ class Admin::Api::ServicesTest < ActionDispatch::IntegrationTest
     assert @provider.services.find_by(name: 'service foo')
   end
 
+  test 'create with annotations' do
+    Settings::Switch.any_instance.stubs(:allowed?).returns(true)
+
+    assert_difference(Service.method(:count)) do
+      post admin_api_services_path(format: :json), params: {
+        provider_key: @provider.api_key,
+        name: 'annotated service',
+        annotations: { managed_by: 'operator' }
+      }
+      assert_response :created
+    end
+
+    service = response.parsed_body[:service]
+    assert_equal({ 'managed_by' => 'operator'}, service[:annotations])
+
+    persisted_service = Service.find(service[:id])
+    assert_equal 1, persisted_service.annotations.count
+    assert_equal 'operator', persisted_service.annotations.where(name: 'managed_by').first.value
+  end
+
   test 'create with json body parameters' do
     @provider.settings.allow_multiple_services!
     @provider.provider_constraints.update!(max_services: 5)
@@ -91,6 +111,21 @@ class Admin::Api::ServicesTest < ActionDispatch::IntegrationTest
     @service.reload
 
     assert_equal 'supp@topo.com', @service.support_email
+  end
+
+  test 'update with annotations' do
+    put admin_api_service_path(@service, format: :json), params: {
+      provider_key: @provider.api_key,
+      annotations: { managed_by: 'operator' }
+    }
+
+    assert_response :success
+
+    service = response.parsed_body[:service]
+    assert_equal({ 'managed_by' => 'operator'}, service[:annotations])
+
+    assert_equal 1, @service.reload.annotations.count
+    assert_equal 'operator', @service.annotations.where(name: 'managed_by').first.value
   end
 
   pending_test 'update with wrong id' do

--- a/test/integration/user-management-api/signup_test.rb
+++ b/test/integration/user-management-api/signup_test.rb
@@ -71,6 +71,8 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
   end
 
   test 'successful api signup with country' do
+    field_defined(@provider, { target: 'Account', name: 'country' })
+
     post admin_api_signup_path, params: { format: :xml, provider_key: @provider.api_key, org_name: 'fiona', username: 'fiona', country: 'Spain' }
 
     assert_response :created
@@ -113,6 +115,8 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     UserMailer.expects(:deliver_signup_notification).never
 
     field_defined(@provider, { target: 'Account', name: 'account_extra_field' })
+    field_defined(@provider, { target: 'Account', name: 'org_legaladdress' })
+    field_defined(@provider, { target: 'Account', name: 'vat_rate' })
     field_defined(@provider, { target: 'User', name: 'user_extra_field' })
 
     post admin_api_signup_path, params: { format: :xml,
@@ -324,5 +328,29 @@ class Admin::Api::SignupTest < ActionDispatch::IntegrationTest
     assert_equal application_plan_local.id.to_s, xml.xpath(".//account/plans/plan[type[text() = 'application_plan']]/id").text
 
     assert xml.xpath('.//account/applications/application').present?
+  end
+
+  test 'account signup with annotations' do
+    post admin_api_signup_path(format: :json), params: {
+      provider_key: @provider.api_key,
+      org_name: 'annotated account',
+      username: 'annotated',
+      annotations: { managed_by: 'operator' }
+    }
+
+    assert_response :success
+
+    new_account = response.parsed_body[:account]
+    assert_equal({ 'managed_by' => 'operator'}, new_account[:annotations])
+    assert_equal 'operator', Account.find(new_account[:id]).annotations.where(name: 'managed_by').first.value
+  end
+
+  test "account signup sets user's signup_type to minimal" do
+    post admin_api_signup_path(format: :json), params: { provider_key: @provider.api_key, org_name: 'org', username: 'user' }
+
+    assert_response :success
+
+    new_user = User.find_by(username: 'user', account_id: response.parsed_body[:account][:id])
+    assert_equal :minimal, new_user.signup_type
   end
 end

--- a/test/integration/user-management-api/users_test.rb
+++ b/test/integration/user-management-api/users_test.rb
@@ -160,6 +160,18 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     assert_equal admin_sections, @member.admin_sections
   end
 
+  test 'set member permissions with provider key' do
+    service = @provider.services.default
+
+    put admin_api_user_path(format: :xml, id: @member.id), params: { member_permission_service_ids: [service.id], member_permission_ids: %w[monitoring services], provider_key: @provider.api_key }
+
+    assert_response :success
+
+    assert @member.reload
+    assert_equal [service.id], @member.member_permission_service_ids
+    assert_equal Set[ :services, :monitoring ], @member.admin_sections
+  end
+
   test 'suspend/unsuspend with access token as a member' do
     token = FactoryBot.create(:access_token, owner: @member, scopes: ['account_management'])
 
@@ -323,6 +335,22 @@ class Admin::Api::UsersTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
+  end
+
+  test 'create sets user signup_type' do
+    Settings::Switch.any_instance.stubs(:allowed?).returns(true)
+
+    post admin_api_users_path(format: :json), params: {
+      provider_key: @provider.api_key,
+      username: 'new_provider_user',
+      email: 'new_provider_user@example.com'
+    }
+
+    assert_response :success
+
+    new_user = User.find(response.parsed_body[:user][:id])
+    assert_equal 'new_provider_user@example.com', new_user.email
+    assert_equal :created_by_provider, new_user.signup_type
   end
 
   test 'show' do

--- a/test/unit/account/provider_domains_test.rb
+++ b/test/unit/account/provider_domains_test.rb
@@ -41,11 +41,6 @@ class Account::ProviderDomainsTest < ActiveSupport::TestCase
     assert_nil account.dedicated_domain
   end
 
-  test 'domain is excluded from mass assignment ' do
-    account = Account.new(:domain => 'api.example.net')
-    assert_nil account.dedicated_domain
-  end
-
   test '#superdomain returns the domain without www striped' do
     account = Account.new
 

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -183,6 +183,26 @@ class AccountTest < ActiveSupport::TestCase
     assert_equal 2.34, @account.reload.vat_rate
   end
 
+  test 'vat_rate value is converted automatically on update' do
+    assert_nil @account.vat_rate
+
+    @account.update(vat_rate: "23.45")
+    assert_instance_of BigDecimal, @account.vat_rate
+    assert_equal 23.45, @account.vat_rate
+
+    @account.update(vat_rate: Float(45.23))
+    assert_instance_of BigDecimal, @account.vat_rate
+    assert_equal 45.23, @account.vat_rate
+
+    @account.update(vat_rate: Integer(30))
+    assert_instance_of BigDecimal, @account.vat_rate
+    assert_equal 30, @account.vat_rate
+
+    @account.update(vat_rate: 'random-string')
+    assert_instance_of BigDecimal, @account.vat_rate
+    assert_equal 0, @account.vat_rate
+  end
+
   test 'without :timezone set return UTC as default :timezone' do
     assert_equal 'UTC', @account.timezone
   end

--- a/test/unit/developer_portal/base_controller_test.rb
+++ b/test/unit/developer_portal/base_controller_test.rb
@@ -14,9 +14,9 @@ module DeveloperPortal
         params = account.fields_definitions.each_with_object({}) { |fd, p| p[fd.name]=SecureRandom.hex }
         TestController.any_instance.expects(:site_account).returns(account)
 
-        result = TestController.new.send(:filter_readonly_params, params, User)
+        result = TestController.new.send(:filter_readonly_params, ::ActionController::Parameters.new(params), User)
 
-        assert_equal 3, result.size
+        assert_equal 3, result.keys.size
         assert_not_includes result, ro_fields.map(&:name)
       end
 

--- a/test/unit/fields/fields_test.rb
+++ b/test/unit/fields/fields_test.rb
@@ -61,4 +61,29 @@ class Fields::FieldsTest < ActiveSupport::TestCase
       model.fields_definitions_source!
     end
   end
+
+  def test_defined_fields_names
+    field1 = mock('field', name: 'field1')
+    field2 = mock('field', name: 'field2')
+    model = Model.new
+    model.stubs(:defined_fields).returns([field1, field2])
+    assert_same_elements %w[field1 field2], model.defined_fields_names
+  end
+
+  def test_defined_extra_fields_names
+    extra_field = mock('field', name: 'extra')
+    builtin_field = mock('field')
+    model = Model.new
+    model.stubs(:defined_fields).returns([extra_field, builtin_field])
+    model.stubs(:defined_builtin_fields).returns([builtin_field])
+    assert_equal %w[extra], model.defined_extra_fields_names
+  end
+
+  def test_defined_builtin_fields_names
+    field1 = mock('field', name: 'field1')
+    field2 = mock('field', name: 'field2')
+    model = Model.new
+    model.stubs(:defined_builtin_fields).returns([field1, field2])
+    assert_same_elements %w[field1 field2], model.defined_builtin_fields_names
+  end
 end

--- a/test/unit/fields/fields_test.rb
+++ b/test/unit/fields/fields_test.rb
@@ -86,4 +86,15 @@ class Fields::FieldsTest < ActiveSupport::TestCase
     model.stubs(:defined_builtin_fields).returns([field1, field2])
     assert_same_elements %w[field1 field2], model.defined_builtin_fields_names
   end
+
+  def test_provider_fields
+    provider = FactoryBot.create :provider_account
+    FactoryBot.create(:fields_definition, account: provider, target: 'Account', name: 'custom_account')
+    FactoryBot.create(:fields_definition, account: provider, target: 'User', name: 'custom_user')
+    FactoryBot.create(:fields_definition, account: provider, target: 'Cinstance', name: 'custom_application')
+
+    assert_same_elements %w[org_name custom_account], provider.defined_fields_names_for(Account)
+    assert_same_elements %w[username email custom_user], provider.defined_fields_names_for(User)
+    assert_same_elements %w[name description custom_application], provider.defined_fields_names_for(Cinstance)
+  end
 end

--- a/test/unit/lib/applications_controller_methods_test.rb
+++ b/test/unit/lib/applications_controller_methods_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationsControllerMethodsTest < ActiveSupport::TestCase
+
+  class TestController
+    attr_accessor :params
+
+    def initialize
+      @params = ActionController::Parameters.new
+    end
+
+    def self.helper_method(*_methods)
+      # Stub for controller helper_method
+    end
+
+    include ApplicationsControllerMethods
+  end
+
+  setup do
+    @controller = TestController.new
+  end
+
+  class PlanIdTest < ApplicationsControllerMethodsTest
+    test 'plan_id returns the plan_id from cinstance params for simple values' do
+      @controller.params = ActionController::Parameters.new(cinstance: { plan_id: '123' })
+
+      result = @controller.send(:plan_id)
+
+      assert_equal '123', result
+    end
+
+    test 'plan_id raises error when plan_id is missing or is an array or object' do
+      @controller.params = ActionController::Parameters.new(cinstance: {})
+      assert_raises(ActionController::ParameterMissing) do
+        @controller.send(:plan_id)
+      end
+
+      @controller.params = ActionController::Parameters.new(cinstance: { plan_id: %w[1 2 3] })
+      assert_raises(ActionController::ParameterMissing) do
+        @controller.send(:plan_id)
+      end
+
+      @controller.params = ActionController::Parameters.new(cinstance: { plan_id: { invalid: 'param' }})
+      assert_raises(ActionController::ParameterMissing) do
+        @controller.send(:plan_id)
+      end
+    end
+  end
+end

--- a/test/unit/services/signup_service_test.rb
+++ b/test/unit/services/signup_service_test.rb
@@ -12,29 +12,45 @@ class SignupServiceTest < ActiveSupport::TestCase
     assert new_instance_signup_service
   end
 
-  def test_create
+  def test_create_invalid_params
     service = new_instance_signup_service
     assert_difference(User.method(:count), 0) do
-      user = service.create
-      assert_not user.persisted?
+      result = service.create
+      assert_not result.user.persisted?
+      assert_not result.user.persisted?
+      assert_not_empty result.errors[:user]
+      assert_not_empty result.errors[:account]
     end
+  end
 
+  def test_create_valid_params
+    account_params = valid_account_params
+    user_params = valid_user_params
+    service = new_instance_signup_service(account_params, user_params)
+    assert_difference(User.method(:count), +1) do
+      result = service.create
+      assert result.persisted?
+      assert_empty result.errors
+      user = result.user
+      account = result.account
+      assert_equal :new_signup, user.signup_type
+      assert_equal account_params[:org_name], account.org_name
+      assert_equal user_params[:username], user.username
+      assert_equal user_params[:email], user.email
+    end
+  end
+
+  def test_create_with_block
     service = new_instance_signup_service(valid_account_params, valid_user_params)
     assert_difference(User.method(:count), +1) do
-      user = service.create
-      assert user.persisted?
-    end
-
-    service = new_instance_signup_service(valid_account_params, valid_user_params)
-    assert_difference(User.method(:count), +1) do
-      signup = service.create { |_signup| [] }
-      assert signup.persisted?
+      result = service.create { |_signup| [] }
+      assert result.persisted?
     end
 
     service = new_instance_signup_service(valid_account_params, valid_user_params)
     assert_difference(User.method(:count), 0) do
       service.create { |signup| @signup = signup; break }
-      refute @signup.persisted?
+      assert_not @signup.persisted?
     end
   end
 

--- a/test/unit/signup/signup_params_test.rb
+++ b/test/unit/signup/signup_params_test.rb
@@ -42,7 +42,7 @@ module Signup
       FactoryBot.create(:fields_definition, account: provider_account, target: 'Account', name: 'extra_for_account')
 
       user_attributes = { email: 'emailTest@email.com', username: 'john', first_name: 'John', last_name: 'Doe',
-                      password: 'superSecret1234#', password_confirmation: 'superSecret1234#', signup_type: :minimal, 'created_by': 'hi' }
+                      password: 'superSecret1234#', password_confirmation: 'superSecret1234#', signup_type: :minimal, extra_fields: { 'created_by': 'hi' } }
       account_attributes = { org_name: 'Developer', vat_rate: 33, extra_fields: { extra_for_account: 'itWorks' } }
       signup_params =  Signup::SignupParams.new(user_attributes: user_attributes, account_attributes: account_attributes, plans: [], defaults: {})
 
@@ -53,10 +53,27 @@ module Signup
       assert_equal 'itWorks', account.extra_fields[:extra_for_account]
     end
 
+    test "'name' is an alias for 'org_name', but the 'org_name' has priority" do
+      params = signup_params_hash.merge({ account_attributes: ActionController::Parameters.new({ name: 'name' }).permit! })
+      signup_params =  Signup::SignupParams.new(**params)
+
+      # only name provided
+      account = signup_params.build_account_with_attributes_for_provider_account(provider_account)
+      assert_equal 'name', account.name
+      assert_equal 'name', account.org_name
+
+      # both org_name and name (in this order) provided
+      params = signup_params_hash.merge({ account_attributes: ActionController::Parameters.new({ org_name: 'org_name', name: 'name' }).permit! })
+      signup_params =  Signup::SignupParams.new(**params)
+      account = signup_params.build_account_with_attributes_for_provider_account(provider_account)
+      assert_equal 'org_name', account.name
+      assert_equal 'org_name', account.org_name
+    end
+
     private
 
     def signup_params
-      @signup_params ||= Signup::SignupParams.new(user_attributes: user_params, account_attributes: account_params, plans: [], defaults: {})
+      @signup_params ||= Signup::SignupParams.new(**signup_params_hash)
     end
 
     def signup_params_hash
@@ -72,12 +89,16 @@ module Signup
     end
 
     def user_params
-      { email: 'emailTest@email.com', username: 'john', first_name: 'John', last_name: 'Doe',
-        password: 'superSecret1234#', password_confirmation: 'superSecret1234#', signup_type: :minimal }
+      ActionController::Parameters.new(
+        { email: 'emailTest@email.com', username: 'john', first_name: 'John', last_name: 'Doe',
+          password: 'superSecret1234#', password_confirmation: 'superSecret1234#', signup_type: :minimal }
+      ).permit!
     end
 
     def account_params
-      { org_name: 'Developer', vat_rate: 33 }
+      ActionController::Parameters.new(
+        { org_name: 'Developer', vat_rate: 33 }
+      ).permit!
     end
   end
 end

--- a/test/unit/user/roles_test.rb
+++ b/test/unit/user/roles_test.rb
@@ -95,14 +95,6 @@ class User::RolesTest < ActiveSupport::TestCase
     assert_not account.admins.first.provider_admin?
   end
 
-  test 'role is not mass assignable' do
-    user = FactoryBot.create(:user)
-
-    assert_no_change :of => -> { user.role } do
-      user.update(role: :admin)
-    end
-  end
-
   test 'role accepts also string' do
     user = FactoryBot.create(:user)
     user.role = "admin"


### PR DESCRIPTION
**What this PR does / why we need it**:

This is part 2 of the migration from protected attributes to strong parameters. See the first part in https://github.com/3scale/porta/pull/4248

Protected attributes is an old Rails feature which was deprecated a long time ago. We were using [protected_attributes_continued](https://github.com/westonganger/protected_attributes_continued) gem to keep it working, but now it's also discontinued and does not support Rails 7+, so it's a blocker for upgrading to Rails 7.2 for us.

This Part 2 handles the models that can have custom attributes through FieldsDefinitions - Account, User, Cinstance.

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-12434

**Verification steps** 

All tests should pass, and all features should work as before.

**Special notes for your reviewer**:
