### PR TITLE
THREESCALE-14262 - deploy runs seed on empty database

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -3,6 +3,8 @@ namespace :db do
   task :deploy => :environment do
     if ActiveRecord::Migrator.current_version.zero?
       Rake::Task['db:deploy:setup'].invoke
+    elsif !Account.master?
+      Rake::Task['db:deploy:seed'].invoke
     else
       Rake::Task['db:migrate'].invoke
     end
@@ -17,6 +19,10 @@ namespace :db do
       end
 
       Rake::Task['db:schema:load'].invoke
+      Rake::Task['db:deploy:seed'].invoke
+    end
+
+    task seed: :environment do
       Rake::Task['db:seed'].invoke
 
       Rake::Task['countries:import'].invoke


### PR DESCRIPTION
If seeding fails for example because seed password was weak, then currently for a customer it would be a mess to recover from this situation. They will need to clear the database completely.

Not we detect empty database and run the seed on startup.

My tests show that original behavior doesn't change.

I notice a problem though, the code reads to me as if it should work even if the database (not the server, just the database) is not created yet and will try to create. But on postgres at least, if database doesn't exist, `db:deploy` fails. This is no change from current behavior though so I'm leaving it for another life.