### PR TITLE
Fix buttons alignment for email templates and legal terms

### DIFF
--- a/app/views/provider/admin/cms/builtin_legal_terms/edit.html.erb
+++ b/app/views/provider/admin/cms/builtin_legal_terms/edit.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_header_title, "Legal Terms for #{@page.title}" %>
 
+<%= javascript_packs_with_chunks_tag 'cms', 'pf_spacing' %>
+
 <%= cms_form_for(@page) do |f| %>
   <%= render 'form', :f => f %>
 

--- a/app/views/provider/admin/cms/builtin_legal_terms/new.html.erb
+++ b/app/views/provider/admin/cms/builtin_legal_terms/new.html.erb
@@ -2,6 +2,8 @@
   Legal Terms for <%= @page.title %>
 <% end %>
 
+<%= javascript_packs_with_chunks_tag 'cms', 'pf_spacing' %>
+
 <% content_for :page_header_title, "Legal Terms for #{@page.title}" %>
 <%= render 'info' %>
 <%= cms_form_for(@page) do |f| %>

--- a/app/views/provider/admin/cms/email_templates/edit.html.erb
+++ b/app/views/provider/admin/cms/email_templates/edit.html.erb
@@ -2,6 +2,8 @@
 
 <% content_for :page_header_title, "Edit template #{@page.name}" %>
 
+<%= javascript_packs_with_chunks_tag 'cms', 'pf_spacing' %>
+
 <%= cms_form_for(@page) do |f| %>
   <%= render 'form', :f => f %>
 

--- a/app/views/provider/admin/cms/email_templates/new.html.erb
+++ b/app/views/provider/admin/cms/email_templates/new.html.erb
@@ -2,6 +2,8 @@
 
 <% content_for :page_header_title, "Override email #{@page.name}" %>
 
+<%= javascript_packs_with_chunks_tag 'cms', 'pf_spacing' %>
+
 <%= cms_form_for(@page) do |f| %>
   <%= render 'form', :f => f %>
   <%= f.inputs do %>


### PR DESCRIPTION
**What this PR does / why we need it**:

> Replace this with a quick explanation of what's included here. 

This PR changed the button styles:
https://github.com/3scale/porta/pull/4226/changes#diff-65bff2a1c482a83e8d02bb9a899ea7c0f17d1e051fcac6a4d83005090c3fce35R11

<img width="918" height="587" alt="image" src="https://github.com/user-attachments/assets/5eea8719-79e7-4916-b2e4-856c77817a33" />


However, this line was removed in another PR:
https://github.com/3scale/porta/pull/4230/changes#diff-65bff2a1c482a83e8d02bb9a899ea7c0f17d1e051fcac6a4d83005090c3fce35L11

<img width="916" height="387" alt="image" src="https://github.com/user-attachments/assets/933ff217-3417-4d01-991c-045306ab6bec" />

which broke the alignment of buttons in the email templates and legal terms forms.

This PR tries to fix it.

**Before:**
<img width="980" height="572" alt="Screenshot From 2026-04-07 16-23-20" src="https://github.com/user-attachments/assets/f7f8af68-12ba-46cb-864f-5e147ef71653" />

<img width="980" height="572" alt="Screenshot From 2026-04-07 16-25-05" src="https://github.com/user-attachments/assets/dd6d4a46-c130-412f-9db6-41e5bfd64056" />

**After:**
<img width="980" height="572" alt="Screenshot From 2026-04-07 16-43-22" src="https://github.com/user-attachments/assets/af80c8f5-4256-44b1-9cd7-0b8c3bf80a97" />

<img width="980" height="572" alt="Screenshot From 2026-04-07 16-43-58" src="https://github.com/user-attachments/assets/6d93acbc-c48f-4b84-81b2-fce5d840d276" />


**Verification steps** 


**Special notes for your reviewer**:
