### PR TITLE
THREESCALE-12470: Use strong passwords for John Doe

### DIFF
--- a/app/controllers/buyers/users_controller.rb
+++ b/app/controllers/buyers/users_controller.rb
@@ -11,6 +11,16 @@ class Buyers::UsersController < Buyers::BaseController
     @users = @account.users.order(:id).paginate(page: params[:page]).decorate
   end
 
+  def show
+    return unless @user.sample_developer_john_doe?
+
+    # Show the password for John Doe only if the user is John Doe
+    password = Logic::SampleDeveloperPassword.for(current_account)
+    @sample_developer_password = password if @user.authenticated?(password)
+  end
+
+  def edit; end
+
   def update
     # TODO: I think this controller is used only on provider side
     user.validate_fields! if current_account.buyer?
@@ -24,10 +34,6 @@ class Buyers::UsersController < Buyers::BaseController
       render :edit
     end
   end
-
-  def show; end
-
-  def edit; end
 
   def destroy
     if user.destroy

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UserDecorator < ApplicationDecorator
+  delegate :sample_developer_john_doe?, to: :object
+
   def full_name
     [first_name, last_name].select(&:present?).join(' ')
   end

--- a/app/lib/authentication/by_password.rb
+++ b/app/lib/authentication/by_password.rb
@@ -45,7 +45,6 @@ module Authentication
 
     def validate_strong_password?
       return false if Rails.configuration.three_scale.strong_passwords_disabled
-      return false if signup.sample_data?
 
       validate_password?
     end

--- a/app/lib/logic/cms.rb
+++ b/app/lib/logic/cms.rb
@@ -45,11 +45,15 @@ module Logic
         after_create :create_cms_assets, if: :provider?
       end
 
-      # TODO: cover by tests
+      def sample_developer_john_doe
+        buyer_users.sample_developer_john_doe.first
+      end
+
       def john_doe_still_here?
-        if john = self.buyer_users.find_by_username('john')
-          john.authenticated?('123456')
-        end
+        john = sample_developer_john_doe
+        return false unless john
+
+        john.authenticated?(Logic::SampleDeveloperPassword.for(self))
       end
 
       # TODO: cover by tests (and make it smarter)

--- a/app/lib/logic/provider_signup.rb
+++ b/app/lib/logic/provider_signup.rb
@@ -70,9 +70,10 @@ module Logic
 
       def signup_user
         email_part = email.split('@')
-        user_attributes = { email: "#{email_part[0]}+test@#{email_part[1]}", username: 'john', first_name: 'John',
-                            last_name: 'Doe', password: '123456', password_confirmation: '123456', signup_type: :sample_data}
-        signup_params = ::Signup::SignupParams.new(plans: [], user_attributes: user_attributes, account_attributes: { org_name: 'Developer' })
+        password = Logic::SampleDeveloperPassword.for(@provider)
+        user_attributes = { email: "#{email_part[0]}+test@#{email_part[1]}", **User::JOHN_DOE_ATTRS,
+                            password: password, password_confirmation: password, signup_type: :minimal }
+        signup_params = ::Signup::SignupParams.new(plans: [], user_attributes: user_attributes, account_attributes: { org_name: User::JOHN_DOE_ORG_NAME })
         ::Signup::DeveloperAccountManager.new(@provider).create(signup_params)
       end
 

--- a/app/lib/logic/sample_developer_password.rb
+++ b/app/lib/logic/sample_developer_password.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Logic
+  module SampleDeveloperPassword
+    SALT      = "onboarding.v1.sample-developer-password"
+    KEY_BYTES = 32
+    LENGTH    = ::Authentication::ByPassword::STRONG_PASSWORD_MIN_SIZE
+
+    def self.subkey
+      Rails.application.key_generator.generate_key(SALT, KEY_BYTES)
+    end
+
+    def self.for(provider)
+      mac = OpenSSL::HMAC.digest("SHA256", subkey, "#{provider.id}:#{provider.created_at.to_i}")
+      Base64.urlsafe_encode64(mac, padding: false)[0, LENGTH]
+    end
+  end
+end

--- a/app/lib/signup/developer_account_manager.rb
+++ b/app/lib/signup/developer_account_manager.rb
@@ -15,7 +15,7 @@ module Signup
 
       # TODO: Temporary here. A new object should have the responsability to activate and approve when needed
       # As part of THREESCALE-1317
-      result.user_activate! if result.user_activate_on_minimal_or_sample_data?
+      result.user_activate! if result.user_activate_on_minimal?
     end
   end
 end

--- a/app/lib/signup/result.rb
+++ b/app/lib/signup/result.rb
@@ -20,7 +20,7 @@ module Signup
     attr_reader :user, :account
 
     delegate :approve, :approve!, :approved?, :approval_required?, :make_pending!,   to: :account, prefix: true
-    delegate :activate, :activate!, :active?, :activate_on_minimal_or_sample_data?,  to: :user, prefix: true
+    delegate :activate, :activate!, :active?, :activate_on_minimal?,  to: :user, prefix: true
     delegate :id, to: :account
 
     def valid?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,6 +132,15 @@ class User < ApplicationRecord
 
   scope :admins, -> { where(role: 'admin') }
 
+  JOHN_DOE_ATTRS = { username: 'john', first_name: 'John', last_name: 'Doe', role: :admin }.freeze
+  JOHN_DOE_ORG_NAME = 'Developer'
+
+  scope :sample_developer_john_doe, -> { where(JOHN_DOE_ATTRS).joins(:account).where(accounts: { org_name: JOHN_DOE_ORG_NAME }) }
+
+  def sample_developer_john_doe?
+    JOHN_DOE_ATTRS.all? { |attr, value| send(attr) == value } && account.org_name == JOHN_DOE_ORG_NAME
+  end
+
   scope :active, -> { where(state: 'active') }
 
   def self.find_by_username_or_email(value)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -437,11 +437,6 @@ class User < ApplicationRecord
       signup_type == :minimal
     end
 
-    def sample_data?
-      # This is true only for John Doe
-      signup_type == :sample_data
-    end
-
     def api?
       signup_type == :api
     end
@@ -463,7 +458,7 @@ class User < ApplicationRecord
     end
 
     def machine?
-      minimal? || sample_data? || api? || created_by_provider? || open_id? || cas? || oauth2?
+      minimal? || api? || created_by_provider? || open_id? || cas? || oauth2?
     end
 
     def by_user?

--- a/app/models/user/states.rb
+++ b/app/models/user/states.rb
@@ -75,8 +75,8 @@ module User::States
     self.activation_code = self.class.make_token
   end
 
-  def activate_on_minimal_or_sample_data?
-    (minimal_signup? || signup.sample_data?) && password.present? && !account.try!(:bought_account_plan).try!(:approval_required?)
+  def activate_on_minimal?
+    minimal_signup? && password.present? && !account.try!(:bought_account_plan).try!(:approval_required?)
   end
 
   def generate_email_verification_token

--- a/app/views/buyers/users/show.html.erb
+++ b/app/views/buyers/users/show.html.erb
@@ -48,4 +48,12 @@
 
   <%= fields_definitions_rows(@user,["name"]) %>
 
+  <% if @sample_developer_password %>
+    <tr>
+      <th>Generated password (please change)</th>
+      <td>
+        <code><%= @sample_developer_password %></code>
+      </td>
+    </tr>
+  <% end %>
 </table>

--- a/features/developer_portal/cms_toolbar.feature
+++ b/features/developer_portal/cms_toolbar.feature
@@ -54,7 +54,5 @@ Feature: CMS Toolbar
       When they visit the developer portal in CMS mode
       Then the cms toolbar should be visible
       And should see "Templates used on this page"
-      And should see the following details:
-        | Username | john   |
-        | Password | 123456 |
+      And should see the sample user credentials
       And should see "Color Theme"

--- a/features/old/signup/providers.feature
+++ b/features/old/signup/providers.feature
@@ -87,9 +87,7 @@ Scenario: Signup, activate, login, create sample data and let a buyer login
   Then I follow "Sign Out bob"
   Then I should see "You have been logged out"
   And I follow "Login"
-  And I fill in the following:
-  | Username or Email |   john |
-  | Password          | 123456 |
+  And I fill in the sample user credentials
   And I press "Sign in"
   Then I should see "Signed in successfully"
   Then I should be on the homepage

--- a/features/step_definitions/strong_passwords_steps.rb
+++ b/features/step_definitions/strong_passwords_steps.rb
@@ -7,3 +7,14 @@ end
 Then /^I should see the error that the password is too weak$/ do
   assert has_content? "is too short (minimum is 15 characters)"
 end
+
+When "(I )(they )fill in the sample user credentials" do
+  fill_in("Username or Email", with: User::JOHN_DOE_ATTRS[:username])
+  fill_in("Password", with: Logic::SampleDeveloperPassword.for(@provider))
+end
+
+Then "(they )should see the sample user credentials" do
+  sample_user_pass = Logic::SampleDeveloperPassword.for(@provider)
+  assert has_content?(User::JOHN_DOE_ATTRS[:username])
+  assert has_content?(sample_user_pass)
+end

--- a/lib/developer_portal/app/views/shared/cms/_toolbar.html.slim
+++ b/lib/developer_portal/app/views/shared/cms/_toolbar.html.slim
@@ -54,9 +54,9 @@ div class="pf-c-drawer pf-m-inline #{'pf-m-expanded' unless hidden}"
               p Testdrive a developer account with:
               dl
                 dt Username:
-                dd john
+                dd = User::JOHN_DOE_ATTRS[:username]
                 dt Password:
-                dd 123456
+                dd = Logic::SampleDeveloperPassword.for(site_account)
 
         - if site_account.cms_toolbar_intro_visible?
           div class="pf-c-drawer__body"

--- a/test/functional/buyers/users_controller_test.rb
+++ b/test/functional/buyers/users_controller_test.rb
@@ -74,6 +74,47 @@ class Buyers::UsersControllerTest < ActionController::TestCase
     assert_response :redirect
   end
 
+  class ShowPageSampleDeveloperTest < ActionController::TestCase
+    tests Buyers::UsersController
+
+    def setup
+      @provider = FactoryBot.create(:provider_account)
+      Logic::ProviderSignup::SampleData.new(@provider).create!
+      @buyer = @provider.buyers.find_by(org_name: 'Developer')
+      @john = @buyer.admins.find_by(username: 'john')
+      host! @provider.internal_admin_domain
+      login_provider @provider
+    end
+
+    test 'show page displays sample password for John Doe with unchanged password' do
+      get :show, params: { account_id: @buyer.id, id: @john.id }
+
+      assert_response :success
+      assert_select 'th', text: 'Generated password (please change)'
+      assert_select 'code', text: Logic::SampleDeveloperPassword.for(@provider)
+    end
+
+    test 'show page does not display sample password after John Doe password is changed' do
+      new_password = 'aNewStrongPassword1'
+      @john.update!(password: new_password, password_confirmation: new_password)
+
+      get :show, params: { account_id: @buyer.id, id: @john.id }
+
+      assert_response :success
+      assert_select 'th', text: 'Sample Password', count: 0
+    end
+
+    test 'show page does not display sample password for a regular buyer user' do
+      regular_user = @buyer.users.find { |u| u != @john }
+      regular_user ||= FactoryBot.create(:user, account: @buyer, email: 'regular@example.com')
+
+      get :show, params: { account_id: @buyer.id, id: regular_user.id }
+
+      assert_response :success
+      assert_select 'th', text: 'Sample Password', count: 0
+    end
+  end
+
   class EditPagePasswordFieldsTest < ActionController::TestCase
     tests Buyers::UsersController
 

--- a/test/integration/buyers/accounts_controller_test.rb
+++ b/test/integration/buyers/accounts_controller_test.rb
@@ -200,7 +200,7 @@ class Buyers::AccountsControllerTest < ActionDispatch::IntegrationTest
       post admin_buyers_accounts_path, params: {
         account: {
           org_name: 'Alaska',
-          user: { email: 'foo@example.com', password: '123456', username: 'hello' }
+          user: { email: 'foo@example.com', password: 'superSecret1234#', username: 'hello' }
         }
       }
 

--- a/test/integration/provider/admin/account/email_configurations_controller_test.rb
+++ b/test/integration/provider/admin/account/email_configurations_controller_test.rb
@@ -117,6 +117,6 @@ class Provider::Admin::Account::EmailConfigurationsControllerTest < ActionDispat
   end
 
   def email_configurations_params
-    { email_configuration: { email: 'myemail@example.com', user_name: 'My Username', password: '123456' } }
+    { email_configuration: { email: 'myemail@example.com', user_name: 'My Username', password: 'superSecret1234#' } }
   end
 end

--- a/test/unit/authentication/by_password_test.rb
+++ b/test/unit/authentication/by_password_test.rb
@@ -54,14 +54,6 @@ class Authentication::ByPasswordTest < ActiveSupport::TestCase
 
       assert_equal "is too short (minimum is 15 characters)", @user.errors[:password].first
     end
-
-    test 'password is not validated when user is sample data' do
-      @user.password = "nononono"
-      @user.signup_type = :sample_data
-
-      assert @user.valid?
-      assert @user.errors[:password].blank?
-    end
   end
 
   class ValidationsTest < Authentication::ByPasswordTest
@@ -211,14 +203,6 @@ class Authentication::ByPasswordTest < ActiveSupport::TestCase
         assert_not @user.validate_password?
       end
 
-      test 'returns true when password has changed and user signup is sample data' do
-        @user.password = 'newpassword12345'
-        @user.signup_type = :sample_data
-
-        assert @user.signup.sample_data?
-        assert @user.validate_password?
-      end
-
       test 'returns false when password has not changed and user has existing password regardless of signup type' do
         %i[new_signup minimal api created_by_provider].each do |signup_type|
           @user.signup_type = signup_type
@@ -244,23 +228,16 @@ class Authentication::ByPasswordTest < ActiveSupport::TestCase
         assert_not @user.validate_strong_password?
       end
 
-      test 'returns false when user signup is sample_data' do
+      test 'returns true when strong_passwords_disabled is false and validate_password? is true' do
         @user.password = 'newpassword12345'
-        @user.signup_type = :sample_data
-
-        assert_not @user.validate_strong_password?
-      end
-
-      test 'returns true when strong_passwords_disabled is false and not sample_data and validate_password? is true' do
-        @user.password = 'newpassword12345'
-        @user.signup_type = :new_signup
 
         assert @user.validate_password?
         assert @user.validate_strong_password?
       end
 
-      test 'returns false when strong_passwords_disabled is false and not sample_data but validate_password? is false' do
-        @user.signup_type = :new_signup
+      test 'returns false when strong_passwords_disabled is false but validate_password? is false' do
+        # Change anything except the password field
+        @user.last_name = "Smith"
 
         assert_not @user.validate_password?
         assert_not @user.validate_strong_password?

--- a/test/unit/liquid/drops/user_drop_test.rb
+++ b/test/unit/liquid/drops/user_drop_test.rb
@@ -77,13 +77,6 @@ class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
       assert @user.signup.machine?
       assert_not @drop.password_required?
     end
-
-    test '#password_required? returns false for sample_data signup' do
-      @user.signup_type = :sample_data
-
-      assert @user.signup.sample_data?
-      assert_not @drop.password_required?
-    end
   end
 
   class BuyerUserTest < Liquid::Drops::UserDropTest

--- a/test/unit/logic/cms_test.rb
+++ b/test/unit/logic/cms_test.rb
@@ -1,14 +1,73 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Logic::CMSTest < ActiveSupport::TestCase
-
-  def setup
+  setup do
     @provider = FactoryBot.create(:provider_account)
   end
 
-  test 'cms_toolbar_intro_visible?' do
-    # john still exists
-    # no change has been made to main_layout
+  class SampleDeveloperTest < Logic::CMSTest
+    setup do
+      Logic::ProviderSignup::SampleData.new(@provider).create!
+    end
+
+    test 'sample_developer_john_doe returns John Doe user from the Developer buyer' do
+      john = @provider.sample_developer_john_doe
+      assert john.present?
+      assert_equal 'john', john.username
+      assert_equal 'John', john.first_name
+      assert_equal 'Doe', john.last_name
+      assert_equal :admin, john.role
+      assert_equal 'Developer', john.account.org_name
+    end
+
+    test 'john_doe_still_here? returns true when password is unchanged' do
+      assert @provider.john_doe_still_here?
+    end
+
+    test 'john_doe_still_here? returns false when password has been changed' do
+      john = @provider.sample_developer_john_doe
+      new_password = 'aNewStrongPassword1'
+      john.update!(password: new_password, password_confirmation: new_password)
+
+      assert_not @provider.john_doe_still_here?
+    end
   end
 
+  class SampleDeveloperMissingTest < Logic::CMSTest
+    test 'john_doe_still_here? returns false when no John Doe exists' do
+      assert_not @provider.john_doe_still_here?
+    end
+
+    test 'sample_developer_john_doe returns nil when no matching user exists' do
+      assert_nil @provider.sample_developer_john_doe
+    end
+
+    test 'john_doe_still_here? returns false when a user called John Doe exists but not in the Developer buyer' do
+      other_buyer = FactoryBot.create(:buyer_account, provider_account: @provider, org_name: 'Some Company')
+      FactoryBot.create(:user, account: other_buyer, username: 'john', first_name: 'John', last_name: 'Doe', role: :admin)
+
+      assert_not @provider.john_doe_still_here?
+    end
+
+    test 'sample_developer_john_doe returns nil when a user called John Doe exists but not in the Developer buyer' do
+      other_buyer = FactoryBot.create(:buyer_account, provider_account: @provider, org_name: 'Some Company')
+      FactoryBot.create(:user, account: other_buyer, username: 'john', first_name: 'John', last_name: 'Doe', role: :admin)
+
+      assert_nil @provider.sample_developer_john_doe
+    end
+
+    test 'john_doe_still_here? returns false when the Developer buyer exists but has no John Doe' do
+      FactoryBot.create(:buyer_account, provider_account: @provider, org_name: 'Developer')
+
+      assert_not @provider.john_doe_still_here?
+    end
+
+    test 'sample_developer_john_doe returns nil when the Developer buyer exists but has no John Doe' do
+      FactoryBot.create(:buyer_account, provider_account: @provider, org_name: 'Developer')
+
+      assert_nil @provider.sample_developer_john_doe
+    end
+  end
 end

--- a/test/unit/logic/provider_signup_test.rb
+++ b/test/unit/logic/provider_signup_test.rb
@@ -8,29 +8,29 @@ class Logic::ProviderSignupTest < ActiveSupport::TestCase
       @provider = FactoryBot.create(:provider_account)
     end
 
-    test 'John Doe user is created with weak password when strong passwords enabled' do
+    test 'John Doe user is created with a strong derived password' do
       sample_data = Logic::ProviderSignup::SampleData.new(@provider)
       sample_data.create!
 
       john_doe = @provider.buyer_users.find_by(username: 'john')
       assert john_doe.present?, 'John Doe user should be created'
-      assert john_doe.authenticate('123456'), 'John Doe should have weak password 123456'
+      assert john_doe.authenticate(Logic::SampleDeveloperPassword.for(@provider)), 'John Doe should authenticate with the derived password'
     end
 
-    test 'John Doe signup.machine? returns true' do
+    test 'John Doe is not created with the old weak password 123456' do
       sample_data = Logic::ProviderSignup::SampleData.new(@provider)
       sample_data.create!
 
       john_doe = @provider.buyer_users.find_by(username: 'john')
-      assert john_doe.signup.machine?, 'John Doe should be considered a machine signup'
+      assert_not john_doe.authenticate('123456'), 'John Doe should not authenticate with 123456'
     end
 
-    test 'John Doe signup.sample_data? returns true' do
+    test 'John Doe uses minimal signup type' do
       sample_data = Logic::ProviderSignup::SampleData.new(@provider)
       sample_data.create!
 
       john_doe = @provider.buyer_users.find_by(username: 'john')
-      assert john_doe.signup.sample_data?, 'John Doe should have sample_data? return true'
+      assert john_doe.signup.minimal?, 'John Doe should have minimal signup type'
     end
 
     test 'John Doe is active after creation' do

--- a/test/unit/logic/sample_developer_password_test.rb
+++ b/test/unit/logic/sample_developer_password_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Logic::SampleDeveloperPasswordTest < ActiveSupport::TestCase
+  setup do
+    @provider = FactoryBot.build_stubbed(:provider_account, id: 42, created_at: Time.zone.parse('2024-01-01 00:00:00'))
+  end
+
+  test 'generates a password of the required length' do
+    assert_equal Authentication::ByPassword::STRONG_PASSWORD_MIN_SIZE,
+                 Logic::SampleDeveloperPassword.for(@provider).length
+  end
+
+  test 'generates the expected password' do
+    # Fixed example values, we need to control them in order to get the result we expect
+    # The goal of the test is to ensure the password generation algorithm doesn't change
+    fixed_subkey = ["50fba4e47d27efaced39c6532d64884e94bc7d03dc03c192f37e0877a1f73efc"].pack("H*")
+    Logic::SampleDeveloperPassword.stub(:subkey, fixed_subkey) do
+      provider = stub("provider", id: 42, created_at: Time.utc(2026, 4, 1))
+      assert_equal "xYDM-3YMTOyAcMO", Logic::SampleDeveloperPassword.for(provider)
+    end
+  end
+
+  test 'is deterministic for the same provider' do
+    assert_equal Logic::SampleDeveloperPassword.for(@provider),
+                 Logic::SampleDeveloperPassword.for(@provider)
+  end
+
+  test 'differs for providers with different id' do
+    other = FactoryBot.build_stubbed(:provider_account, id: 99, created_at: @provider.created_at)
+    assert_not_equal Logic::SampleDeveloperPassword.for(@provider),
+                     Logic::SampleDeveloperPassword.for(other)
+  end
+
+  test 'differs for providers with the same id but different created_at' do
+    other = FactoryBot.build_stubbed(:provider_account, id: @provider.id, created_at: @provider.created_at + 1.second)
+    assert_not_equal Logic::SampleDeveloperPassword.for(@provider),
+                     Logic::SampleDeveloperPassword.for(other)
+  end
+
+  test 'produced password can authenticate via BCrypt' do
+    password = Logic::SampleDeveloperPassword.for(@provider)
+    digest   = BCrypt::Password.create(password)
+    assert BCrypt::Password.new(digest) == password
+  end
+end

--- a/test/unit/signup/account_manager_test.rb
+++ b/test/unit/signup/account_manager_test.rb
@@ -234,18 +234,8 @@ module Signup
         assert signup_result.account_approved?
       end
 
-      test 'create developer without account plan approval required and sample_data signup' do
-        @account_plan.update_attribute(:approval_required, false)
-        signup_result = signup_account_manager.create(signup_params(different_user_params: {signup_type: :sample_data}))
-
-        # the user is active and the account is approved
-        assert signup_result.persisted?
-        assert signup_result.user_active?
-        assert signup_result.account_approved?
-      end
-
       test 'create developer with account plan approval required and minimal signup' do
-        # The only difference is result.user_activate_on_minimal_or_sample_data? should return false, and it only happens if the contract_plans goes before this
+        # The only difference is result.user_activate_on_minimal? should return false, and it only happens if the contract_plans goes before this
         @account_plan.update_attribute(:approval_required, true)
         signup_result = signup_account_manager.create(signup_params(different_user_params: {signup_type: :minimal}))
         account = signup_result.account

--- a/test/unit/signup/signup_params_test.rb
+++ b/test/unit/signup/signup_params_test.rb
@@ -42,7 +42,7 @@ module Signup
       FactoryBot.create(:fields_definition, account: provider_account, target: 'Account', name: 'extra_for_account')
 
       user_attributes = { email: 'emailTest@email.com', username: 'john', first_name: 'John', last_name: 'Doe',
-                      password: '123456', password_confirmation: '123456', signup_type: :minimal, 'created_by': 'hi' }
+                      password: 'superSecret1234#', password_confirmation: 'superSecret1234#', signup_type: :minimal, 'created_by': 'hi' }
       account_attributes = { org_name: 'Developer', vat_rate: 33, extra_fields: { extra_for_account: 'itWorks' } }
       signup_params =  Signup::SignupParams.new(user_attributes: user_attributes, account_attributes: account_attributes, plans: [], defaults: {})
 
@@ -73,7 +73,7 @@ module Signup
 
     def user_params
       { email: 'emailTest@email.com', username: 'john', first_name: 'John', last_name: 'Doe',
-        password: '123456', password_confirmation: '123456', signup_type: :minimal }
+        password: 'superSecret1234#', password_confirmation: 'superSecret1234#', signup_type: :minimal }
     end
 
     def account_params

--- a/test/unit/user/signup_type_test.rb
+++ b/test/unit/user/signup_type_test.rb
@@ -12,24 +12,6 @@ class User::SignupTypeTest < ActiveSupport::TestCase
     assert signup_type(open_id: 'foo').machine?
   end
 
-  test 'sample_data? returns true for sample_data signup_type' do
-    assert signup_type(type: 'sample_data').sample_data?
-  end
-
-  test 'sample_data? returns false for other signup_types' do
-    assert_not signup_type(type: 'new_signup').sample_data?
-    assert_not signup_type(type: 'minimal').sample_data?
-    assert_not signup_type(type: 'api').sample_data?
-  end
-
-  test 'machine? returns true for sample_data signup_type' do
-    assert signup_type(type: 'sample_data').machine?
-  end
-
-  test 'by_user? returns false for sample_data signup_type' do
-    assert_not signup_type(type: 'sample_data').by_user?
-  end
-
   private
 
   def signup_type(type: '', open_id: nil)

--- a/test/unit/user/states_test.rb
+++ b/test/unit/user/states_test.rb
@@ -92,7 +92,7 @@ class User::StatesTest < ActiveSupport::TestCase
     end
   end
 
-  class ActivateOnMinimalOrSampleDataTest < ActiveSupport::TestCase
+  class ActivateOnMinimalTest < ActiveSupport::TestCase
     def setup
       @provider = FactoryBot.create(:simple_provider)
       @buyer = FactoryBot.create(:simple_buyer, provider_account: @provider)
@@ -102,35 +102,13 @@ class User::StatesTest < ActiveSupport::TestCase
     test 'returns true for minimal signup with password and no approval required' do
       @user.signup_type = :minimal
 
-      assert @user.activate_on_minimal_or_sample_data?
-    end
-
-    test 'returns true for sample_data signup with password and no approval required' do
-      @user.signup_type = :sample_data
-
-      assert @user.activate_on_minimal_or_sample_data?
-    end
-
-    test 'returns false for sample_data signup without password' do
-      @user.signup_type = :sample_data
-      @user.password = nil
-
-      assert_not @user.activate_on_minimal_or_sample_data?
-    end
-
-    test 'returns false for sample_data signup when approval required' do
-      @user.signup_type = :sample_data
-      account_plan = FactoryBot.create(:account_plan, issuer: @provider, approval_required: true)
-      @buyer.buy!(account_plan)
-
-      assert_not @user.activate_on_minimal_or_sample_data?
+      assert @user.activate_on_minimal?
     end
 
     test 'returns false for new_signup even with password' do
       @user.signup_type = :new_signup
 
-      assert_not @user.activate_on_minimal_or_sample_data?
+      assert_not @user.activate_on_minimal?
     end
   end
 end
-


### PR DESCRIPTION
**What this PR does / why we need it**:

We use always the same hardcoded password `123456` for the sample user John Doe. This PR fixes that by generating a strong password derived from the secret key base + tenant id + tenant creation date.

We need the password to be somehow visible for the provider admin. I'm solving this by showing the password in the CMS toolbar (where the previous `123456` was shown) and also in the user details screen in the admin portal: `/buyers/accounts/3/users/4`. See the screenshots:

<img width="534" height="495" alt="image" src="https://github.com/user-attachments/assets/b1d59834-8e37-423e-809a-eae07c2fb885" />

<img width="496" height="384" alt="image" src="https://github.com/user-attachments/assets/af74739f-fdb7-4ec7-9fd3-cb23f863bb74" />

After this change, the `:sample_data` signup type has been removed. Since it was a workaround to allow John Doe to be an exception on strong passwords. Not needed anymore.

There are a couple of collateral effects of this PR:

1. Everybody in SaaS is using either 123456 or a custom password for John Doe. The new code only shows the password if it matches the new derived one. That means the password will stop being shown for everybody in SaaS, Only new John Does will have a password visible, but there are no new tenant signups in SaaS, so this will in fact remove the feature completely in SaaS.
1. Additionally, on premises, if the secret key changes, the password for John Doe will stop being show to everybody as well

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-12470

**Verification steps** 

- Tests should pass
- When creating new sample data, John Doe should get a strong password correctly
- The password is show in the CMS bar
- The password is shown in the user details screen, but only when the user is a John Doe
