### PR TITLE
THREESCALE-14261: Fix object stale check

### DIFF
--- a/app/controllers/admin/api/accounts_controller.rb
+++ b/app/controllers/admin/api/accounts_controller.rb
@@ -6,7 +6,10 @@ class Admin::Api::AccountsController < Admin::Api::BaseController
   # Account List
   # GET /admin/api/accounts.xml
   def index
-    accounts = buyer_accounts.includes(:users, :settings, :payment_detail, :country, :annotations, bought_plans: [:original]) # :issuer is polymorphic
+    accounts = buyer_accounts
+
+    # Only eager load for XML format which uses Account#to_xml that accesses these associations
+    accounts = accounts.includes(:users, :settings, :payment_detail, :country, :annotations, bought_plans: [:original]) if request.format.xml?
 
     if state = params[:state].presence
       accounts = accounts.where(:state => state.to_s)
@@ -116,7 +119,9 @@ class Admin::Api::AccountsController < Admin::Api::BaseController
   end
 
   def preload_to_present(accounts)
-    ActiveRecord::Associations::Preloader.new(records: Array(accounts), associations: [:annotations, {bought_plans: %i[original]}]).call
+    # Only preload for XML format which uses Account#to_xml that accesses these associations
+    ActiveRecord::Associations::Preloader.new(records: Array(accounts), associations: [:annotations, bought_plans: [:original]]).call if request.format.xml?
+
     accounts
   end
 

--- a/app/lib/three_scale/api/responder.rb
+++ b/app/lib/three_scale/api/responder.rb
@@ -8,7 +8,7 @@ class ThreeScale::Api::Responder < ActionController::Responder
 
     case
     when get?
-      display(resource, status: :ok) if controller.stale?(serializable.dup)
+      display(resource, status: :ok) if controller.stale?(serializable)
     when post? # create
       display resource, status: :created, location: api_location
     when put? || patch? # update

--- a/app/lib/three_scale/api/responder.rb
+++ b/app/lib/three_scale/api/responder.rb
@@ -4,15 +4,15 @@ class ThreeScale::Api::Responder < ActionController::Responder
 
   def api_behavior
     resource = serializable
+    return if get? && !controller.stale?(resource)
+
     resource = representer.prepare(resource) unless resource.frozen?
 
     case
-    when get?
-      display(resource, status: :ok) if controller.stale?(serializable)
+    when get? || put? || patch?
+      display(resource, status: :ok)
     when post? # create
       display resource, status: :created, location: api_location
-    when put? || patch? # update
-      display resource, status: :ok
     when delete?
       head :ok
     else

--- a/test/integration/admin/api/account_plans_controller_test.rb
+++ b/test/integration/admin/api/account_plans_controller_test.rb
@@ -10,16 +10,18 @@ class Admin::Api::AccountPlansControllerTest < ActionDispatch::IntegrationTest
     host! @provider.external_admin_domain
   end
 
-  # This simple test is because rails 5.0 upgrade.
-  # The issue was because the responder uses controller.stale?(resource)
-  # https://github.com/3scale/porta/blob/bdc91b894eac16fbd81afd4f05198eb5cb8beee9/app/lib/three_scale/api/responder.rb#L11
-  # Rails 5.0 `ActionController::Base#stale?` uses to_hash on the object and not Rails 4.x
-  # But the +representable+ gem is extending each items with the representer inside the `to_hash`
-  # https://github.com/trailblazer/representable/blob/v2.3.0/lib/representable/hash.rb#L32
-  #
-  # We implicitly extend those items with the JSON representer as to_json uses to_hash
-  # So it works but might also breaks in the future ...
-  def test_get
+  # Originally, this test was added in https://github.com/3scale/porta/commit/379b3dc26189f7dc5c5276de84d70c46ba5ae0b6
+  # and tested that calling #stale? in the controller was not affecting the XML representation of the object -
+  # as after upgrading from rails 4.x to rails 5.0, #stale? started calling #to_hash, breaking the response.
+  # As of today (Rails 7.1) .to_hash is not called by ActionController anymore, so the test was just kept to prevent
+  # potential future regressions
+  # This test demonstrates that +representable+ gem that we use for object representers (to convert objects to XML/JSON)
+  # mutates the caller objects on `.to_hash`.
+  # Specifically, in this test for the Plan object, the `trial_period_days` attribute with nil value is represented as:
+  # - `<trial_period_days>0</trial_period_days>` if `.to_hash` is called before `.to_xml`
+  # - `<trial_period_days/>` if just `.to_xml` is called
+  # Calling `.to_hash` before `.to_json` doesn't have any effect, because `.to_json` calls `.to_hash` anyway.
+  def test_account_plan_representer
     account_plans = @provider.account_plans.to_a
     represented = AccountPlansRepresenter.prepare(account_plans)
 

--- a/test/integration/user-management-api/accounts_test.rb
+++ b/test/integration/user-management-api/accounts_test.rb
@@ -82,6 +82,97 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
         put change_plan_admin_api_account_path(@buyer, format: :xml), params: params.merge({ plan_id: plan.id })
         assert_response :success
       end
+
+      test '#find returns 304 when account has not been modified' do
+        buyer_user = @buyer.users.last!
+
+        # First request - get the account and capture headers
+        get find_admin_api_accounts_path(format: :json), params: params.merge({ user_id: buyer_user.id })
+        assert_response :success
+        etag = response.header['ETag']
+        last_modified = response.header['Last-Modified']
+
+        assert_not_nil etag, 'ETag header should be present'
+        assert_not_nil last_modified, 'Last-Modified header should be present'
+
+        # Second request with If-None-Match and If-Modified-Since headers
+        headers = {
+          'HTTP_IF_NONE_MATCH' => etag,
+          'HTTP_IF_MODIFIED_SINCE' => last_modified
+        }
+        get find_admin_api_accounts_path(format: :json), params: params.merge({ user_id: buyer_user.id }), headers: headers
+        assert_response :not_modified
+      end
+
+      test '#find returns 200 (not 304) when account has been modified' do
+        buyer_user = @buyer.users.last!
+
+        # First request - get the account and capture headers
+        get find_admin_api_accounts_path(format: :json), params: params.merge({ user_id: buyer_user.id })
+        assert_response :success
+        etag = response.header['ETag']
+        last_modified = response.header['Last-Modified']
+
+        assert_not_nil etag, 'ETag header should be present'
+        assert_not_nil last_modified, 'Last-Modified header should be present'
+
+        assert 'approved', @buyer.state
+
+        # Bump updated_at manually, because otherwise it could be the same as last-modified timestamp
+        @buyer.update(state: 'suspended', updated_at: @buyer.updated_at + 1.second)
+
+        # Second request with old ETag and Last-Modified headers
+        # Should return 200 with new content, NOT 304
+        headers = {
+          'HTTP_IF_NONE_MATCH' => etag,
+          'HTTP_IF_MODIFIED_SINCE' => last_modified
+        }
+        get find_admin_api_accounts_path(format: :json), params: params.merge({ user_id: buyer_user.id }), headers: headers
+        assert_response :success, 'Should return 200 because account was modified'
+
+        assert_equal 'suspended', response.parsed_body["account"]["state"]
+      end
+
+      test '#index returns 304 when accounts have not been modified' do
+        get admin_api_accounts_path(format: :json), params: params
+        assert_response :success
+        etag = response.header['ETag']
+        last_modified = response.header['Last-Modified']
+
+        assert_not_nil etag, 'ETag header should be present'
+        assert_not_nil last_modified, 'Last-Modified header should be present'
+
+        # Second request with If-None-Match and If-Modified-Since headers
+        headers = {
+          'HTTP_IF_NONE_MATCH' => etag,
+          'HTTP_IF_MODIFIED_SINCE' => last_modified
+        }
+        get admin_api_accounts_path(format: :json), params: params, headers: headers
+        assert_response :not_modified
+      end
+
+      test '#index returns 200 (not 304) when accounts have been modified' do
+        get admin_api_accounts_path(format: :json), params: params
+        assert_response :success
+        etag = response.header['ETag']
+        last_modified = response.header['Last-Modified']
+
+        assert_not_nil etag, 'ETag header should be present'
+        assert_not_nil last_modified, 'Last-Modified header should be present'
+
+        # Bump updated_at manually, because otherwise it could be the same as last-modified timestamp
+        @buyer.update(org_name: 'Modified Organization', updated_at: @buyer.updated_at + 1.second)
+
+        # Second request with old ETag and Last-Modified headers
+        # Should return 200 with new content, NOT 304
+        headers = {
+          'HTTP_IF_NONE_MATCH' => etag,
+          'HTTP_IF_MODIFIED_SINCE' => last_modified
+        }
+        get admin_api_accounts_path(format: :json), params: params, headers: headers
+        assert_response :success
+        assert_not_equal etag, response.header['ETag'], 'ETag should be different after modification'
+      end
     end
 
     class MemberUserTest < AccessTokenTest

--- a/test/integration/user-management-api/accounts_test.rb
+++ b/test/integration/user-management-api/accounts_test.rb
@@ -116,7 +116,7 @@ class Admin::Api::AccountsTest < ActionDispatch::IntegrationTest
         assert_not_nil etag, 'ETag header should be present'
         assert_not_nil last_modified, 'Last-Modified header should be present'
 
-        assert 'approved', @buyer.state
+        assert_equal 'approved', @buyer.state
 
         # Bump updated_at manually, because otherwise it could be the same as last-modified timestamp
         @buyer.update(state: 'suspended', updated_at: @buyer.updated_at + 1.second)


### PR DESCRIPTION
**What this PR does / why we need it**:

Not sure if this feature has always been broken (without nobody noticing), or it got broken at some point.
Apparently, `.dup` was added explicitly in https://github.com/3scale/porta/pull/1643/changes

But currently, when testing it, I realized that `.dup` creates a new instance of the object, with a `nil` ID, and also `updated_at` (among other fields) are empty, which actually makes this field unusable for figuring out whether the cached object should be returned or not.

Removing it makes the cache work correctly (I think).

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-14261

**Verification steps** 

1. Find an active account in the admin portal
2. Call Account Find endpoint from 3scale API Docs to find this account
3. Check that in the response it's "approved"
4. Suspend the account from the admin portal
5. Call the same Account Find endpoint with the same parameters
6. Verify that the response is `200 OK` and the state of the account is "suspended" - before the fix the response was `304 Not Modified` and the state was "approved".

Note that the bug only manifests in the browser (i.e. via 3scale API Docs) and not simple curl/Postman calls, because it seems that unlike curl, the browser sets the `If-None-Match` header. Without the cache-related headers, the updated object is always returned.

**Special notes for your reviewer**:
