### PR TITLE
THREESCALE-14283: THREESCALE-14519: Upgrade lodash to 4.18.1  [2.16 backport]

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
     "body-parser": "1.20.3",
     "express": "4.21.2",
     "http-proxy-middleware": "2.0.7",
-    "jquery-ui/jquery": "3.7.0"
+    "jquery-ui/jquery": "3.7.0",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7853,10 +7853,10 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+lodash-es@4.18.1, lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash._arraypool@~2.4.1:
   version "2.4.1"
@@ -8113,10 +8113,10 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@^4.15.0, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@4.18.1, lodash@^4.15.0, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes:
- CVE-2026-4800 3scale-amp2/system-rhel9: lodash: Arbitrary code execution via untrusted input in template imports [3amp-2.16]
- CVE-2025-13465 3scale-amp2/system-rhel9: prototype pollution in _.unset and _.omit functions [3amp-2.16]

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-14283
https://redhat.atlassian.net/browse/THREESCALE-14519

**Verification steps** 


**Special notes for your reviewer**:
