### PR TITLE
THREESCALE-14477: THREESCALE-14485: Upgrade rack to 2.2.23

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -644,7 +644,7 @@ GEM
     public_suffix (7.0.2)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.20)
+    rack (2.2.23)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-no_animations (1.0.3)


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade `rack` to `2.2.23`.

Fixes the following CVE:
- CVE-2026-34829 3scale-amp2/system-rhel9: Rack: Denial of Service via unbounded multipart file upload
- CVE-2026-22860 3scale-amp2/system-rhel9: Rack Directory Traversal via Rack:Directory


**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-14477

https://redhat.atlassian.net/browse/THREESCALE-14485

**Verification steps** 



**Special notes for your reviewer**:
