### PR TITLE
THREESCALE-9973: Bullet unused eager loading offences 

### DIFF
--- a/app/controllers/admin/api/application_plan_limits_controller.rb
+++ b/app/controllers/admin/api/application_plan_limits_controller.rb
@@ -14,6 +14,6 @@ class Admin::Api::ApplicationPlanLimitsController < Admin::Api::BaseController
   end
 
   def usage_limits
-    @usage_limits ||= application_plan.usage_limits.includes(plan: [:service], metric: [:owner, :parent])
+    @usage_limits ||= application_plan.usage_limits.includes(metric: [:owner, :parent])
   end
 end

--- a/app/controllers/finance/api/invoices_controller.rb
+++ b/app/controllers/finance/api/invoices_controller.rb
@@ -65,11 +65,11 @@ class Finance::Api::InvoicesController < Finance::Api::BaseController
   private
 
   def invoices
-    @invoices ||= current_account.buyer_invoices.includes(:line_items, {:buyer_account => [:country]}, :provider_account)
+    @invoices ||= current_account.buyer_invoices.includes(:line_items, :provider_account)
   end
 
   def invoice
-    @invoice ||= invoices.find(params[:id])
+    @invoice ||= current_account.buyer_invoices.find(params[:id])
   end
 
   def invoice_params_create

--- a/app/controllers/finance/api/invoices_controller.rb
+++ b/app/controllers/finance/api/invoices_controller.rb
@@ -65,7 +65,10 @@ class Finance::Api::InvoicesController < Finance::Api::BaseController
   private
 
   def invoices
-    @invoices ||= current_account.buyer_invoices.includes(:line_items, :provider_account)
+    @invoices ||= begin
+      includes = request.format.xml? ? %i[line_items provider_account buyer_account] : []
+      current_account.buyer_invoices.includes(includes)
+    end
   end
 
   def invoice

--- a/app/lib/api_docs/provider_data.rb
+++ b/app/lib/api_docs/provider_data.rb
@@ -68,7 +68,7 @@ module ApiDocs
     end
 
     def service_metrics
-      @account.top_level_metrics.includes(:owner)
+      @account.metrics.top_level.includes(:owner)
     end
 
     def backend_api_metrics

--- a/app/lib/applications_controller_methods.rb
+++ b/app/lib/applications_controller_methods.rb
@@ -86,7 +86,7 @@ module ApplicationsControllerMethods
   end
 
   def accessible_services
-    @accessible_services ||= current_user.accessible_services.includes(:application_plans)
+    @accessible_services ||= current_user.accessible_services
   end
 
   def accessible_not_bought_cinstances

--- a/app/lib/applications_controller_methods.rb
+++ b/app/lib/applications_controller_methods.rb
@@ -47,8 +47,7 @@ module ApplicationsControllerMethods
   end
 
   def find_cinstance
-    @cinstance = accessible_not_bought_cinstances.includes(plan: %i[service pricing_rules])
-                                                 .find(params[:id])
+    @cinstance = accessible_not_bought_cinstances.find(params[:id])
   end
 
   def find_buyer

--- a/app/presenters/applications_index_presenter.rb
+++ b/app/presenters/applications_index_presenter.rb
@@ -157,7 +157,7 @@ class ApplicationsIndexPresenter
   private
 
   def plans_for_filter
-    accessible_services.reject { |service| service.application_plans.empty? }
+    accessible_services.includes(:application_plans).reject { |service| service.application_plans.empty? }
                         .map do |service|
                           {
                             groupName: service.name,

--- a/app/presenters/applications_index_presenter.rb
+++ b/app/presenters/applications_index_presenter.rb
@@ -130,11 +130,15 @@ class ApplicationsIndexPresenter
   end
 
   def applications
-    @applications ||= raw_applications.scope_search(search)
-                                      .order_by(*sorting_params)
-                                      .includes(plan: %i[pricing_rules])
-                                      .paginate(pagination_params)
-                                      .decorate
+    query = raw_applications.scope_search(search)
+                            .order_by(*sorting_params)
+                            .paginate(pagination_params)
+    query = if provider.settings.finance.allowed?
+              query.includes(plan: %i[pricing_rules])
+            else
+              query.includes(:plan)
+            end
+    @applications ||= query.decorate
   end
 
   def empty_state?

--- a/app/presenters/applications_index_presenter.rb
+++ b/app/presenters/applications_index_presenter.rb
@@ -130,15 +130,14 @@ class ApplicationsIndexPresenter
   end
 
   def applications
-    query = raw_applications.scope_search(search)
-                            .order_by(*sorting_params)
-                            .paginate(pagination_params)
-    query = if provider.settings.finance.allowed?
-              query.includes(plan: %i[pricing_rules])
-            else
-              query.includes(:plan)
-            end
-    @applications ||= query.decorate
+    @applications ||= begin
+      includes = provider.settings.finance.allowed? ? { plan: %i[pricing_rules] } : :plan
+      raw_applications.scope_search(search)
+                      .order_by(*sorting_params)
+                      .includes(includes)
+                      .paginate(pagination_params)
+                      .decorate
+    end
   end
 
   def empty_state?

--- a/app/presenters/buyers/service_contracts_index_presenter.rb
+++ b/app/presenters/buyers/service_contracts_index_presenter.rb
@@ -37,11 +37,14 @@ class Buyers::ServiceContractsIndexPresenter
   end
 
   def service_contracts
-    @service_contracts ||= raw_service_contracts.scope_search(search)
-                                                .order_by(*sorting_params)
-                                                .includes(plan: %i[pricing_rules], user_account: [:admin_user])
-                                                .paginate(pagination_params)
-                                                .decorate
+    @service_contracts ||= begin
+      account_includes = buyer ? :user_account : { user_account: [:admin_user] }
+      raw_service_contracts.scope_search(search)
+                           .order_by(*sorting_params)
+                           .includes(account_includes, plan: %i[pricing_rules])
+                           .paginate(pagination_params)
+                           .decorate
+    end
   end
 
   def toolbar_props # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -122,7 +122,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "ApplicationPlan", type: :n_plus_one_query, association: :pricing_rules
       Bullet.add_safelist class_name: "ApplicationPlan", type: :n_plus_one_query, association: :usage_limits
       Bullet.add_safelist class_name: "ApplicationPlan", type: :unused_eager_loading, association: :issuer
-      Bullet.add_safelist class_name: "ApplicationPlan", type: :unused_eager_loading, association: :pricing_rules
       Bullet.add_safelist class_name: "BackendApi", type: :counter_cache, association: :backend_api_configs
       Bullet.add_safelist class_name: "CMS::Builtin::Section", type: :n_plus_one_query, association: :children
       Bullet.add_safelist class_name: "CMS::Builtin::Section", type: :n_plus_one_query, association: :parent

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -134,7 +134,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Invoice", type: :counter_cache, association: :payment_transactions
       Bullet.add_safelist class_name: "Invoice", type: :n_plus_one_query, association: :buyer_account
       Bullet.add_safelist class_name: "Invoice", type: :n_plus_one_query, association: :provider_account
-      Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :line_items
       Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :provider_account
       Bullet.add_safelist class_name: "LineItem::PlanCost", type: :n_plus_one_query, association: :contract
       Bullet.add_safelist class_name: "Message", type: :n_plus_one_query, association: :sender

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -110,9 +110,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :country
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :users
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :bought_plans
-      Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :users
-      Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :country
-      Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :bought_plans
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :contracts
       Bullet.add_safelist class_name: "AccountContract", type: :n_plus_one_query, association: :plan
       Bullet.add_safelist class_name: "AccountPlan", type: :n_plus_one_query, association: :customizations
@@ -138,21 +135,12 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Cinstance", type: :n_plus_one_query, association: :user_account
       Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :plan
       Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :service
-      Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :service
-      Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :service
-      Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :plan
       Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :user_account
-      Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :user_account
-      Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :service
       Bullet.add_safelist class_name: "Invoice", type: :counter_cache, association: :payment_transactions
       Bullet.add_safelist class_name: "Invoice", type: :n_plus_one_query, association: :buyer_account
       Bullet.add_safelist class_name: "Invoice", type: :n_plus_one_query, association: :provider_account
       Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :line_items
-      Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :line_items
       Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :buyer_account
-      Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :line_items
-      Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :buyer_account
-      Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :provider_account
       Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :provider_account
       Bullet.add_safelist class_name: "LineItem::PlanCost", type: :n_plus_one_query, association: :contract
       Bullet.add_safelist class_name: "Message", type: :n_plus_one_query, association: :sender
@@ -161,8 +149,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Metric", type: :n_plus_one_query, association: :parent
       Bullet.add_safelist class_name: "Metric", type: :unused_eager_loading, association: :children
       Bullet.add_safelist class_name: "Metric", type: :unused_eager_loading, association: :owner
-      Bullet.add_safelist class_name: "Metric", type: :unused_eager_loading, association: :owner
-      Bullet.add_safelist class_name: "Metric", type: :unused_eager_loading, association: :parent
       Bullet.add_safelist class_name: "Metric", type: :unused_eager_loading, association: :parent
       Bullet.add_safelist class_name: "Post", type: :n_plus_one_query, association: :topic
       Bullet.add_safelist class_name: "ProxyConfig", type: :n_plus_one_query, association: :user
@@ -182,7 +168,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "ServicePlan", type: :n_plus_one_query, association: :service
       Bullet.add_safelist class_name: "Topic", type: :n_plus_one_query, association: :last_user
       Bullet.add_safelist class_name: "Topic", type: :n_plus_one_query, association: :recent_post
-      Bullet.add_safelist class_name: "UsageLimit", type: :unused_eager_loading, association: :plan
       Bullet.add_safelist class_name: "UsageLimit", type: :unused_eager_loading, association: :plan
       Bullet.add_safelist class_name: "UsageLimit", type: :unused_eager_loading, association: :metric
       Bullet.add_safelist class_name: "User", type: :n_plus_one_query, association: :member_permissions

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -158,7 +158,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Service", type: :n_plus_one_query, association: :account
       Bullet.add_safelist class_name: "Service", type: :n_plus_one_query, association: :default_service_plan
       Bullet.add_safelist class_name: "Service", type: :n_plus_one_query, association: :metrics
-      Bullet.add_safelist class_name: "Service", type: :unused_eager_loading, association: :application_plans
       Bullet.add_safelist class_name: "ServiceContract", type: :n_plus_one_query, association: :plan
       Bullet.add_safelist class_name: "ServiceContract", type: :n_plus_one_query, association: :user_account
       Bullet.add_safelist class_name: "ServicePlan", type: :n_plus_one_query, association: :customizations

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -168,7 +168,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "ServicePlan", type: :n_plus_one_query, association: :service
       Bullet.add_safelist class_name: "Topic", type: :n_plus_one_query, association: :last_user
       Bullet.add_safelist class_name: "Topic", type: :n_plus_one_query, association: :recent_post
-      Bullet.add_safelist class_name: "UsageLimit", type: :unused_eager_loading, association: :plan
       Bullet.add_safelist class_name: "UsageLimit", type: :unused_eager_loading, association: :metric
       Bullet.add_safelist class_name: "User", type: :n_plus_one_query, association: :member_permissions
       Bullet.add_safelist class_name: "UserTopic", type: :n_plus_one_query, association: :topic

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -143,7 +143,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Metric", type: :n_plus_one_query, association: :children
       Bullet.add_safelist class_name: "Metric", type: :n_plus_one_query, association: :owner
       Bullet.add_safelist class_name: "Metric", type: :n_plus_one_query, association: :parent
-      Bullet.add_safelist class_name: "Metric", type: :unused_eager_loading, association: :children
       Bullet.add_safelist class_name: "Metric", type: :unused_eager_loading, association: :owner
       Bullet.add_safelist class_name: "Metric", type: :unused_eager_loading, association: :parent
       Bullet.add_safelist class_name: "Post", type: :n_plus_one_query, association: :topic

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -108,8 +108,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :bought_cinstances
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :country
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :users
-      Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :bought_plans
-      Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :contracts
       Bullet.add_safelist class_name: "AccountContract", type: :n_plus_one_query, association: :plan
       Bullet.add_safelist class_name: "AccountPlan", type: :n_plus_one_query, association: :customizations
       Bullet.add_safelist class_name: "AccountPlan", type: :n_plus_one_query, association: :issuer

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -138,7 +138,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Invoice", type: :n_plus_one_query, association: :buyer_account
       Bullet.add_safelist class_name: "Invoice", type: :n_plus_one_query, association: :provider_account
       Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :line_items
-      Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :buyer_account
       Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :provider_account
       Bullet.add_safelist class_name: "LineItem::PlanCost", type: :n_plus_one_query, association: :contract
       Bullet.add_safelist class_name: "Message", type: :n_plus_one_query, association: :sender

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -123,7 +123,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "ApplicationPlan", type: :n_plus_one_query, association: :usage_limits
       Bullet.add_safelist class_name: "ApplicationPlan", type: :unused_eager_loading, association: :issuer
       Bullet.add_safelist class_name: "ApplicationPlan", type: :unused_eager_loading, association: :pricing_rules
-      Bullet.add_safelist class_name: "ApplicationPlan", type: :unused_eager_loading, association: :service
       Bullet.add_safelist class_name: "BackendApi", type: :counter_cache, association: :backend_api_configs
       Bullet.add_safelist class_name: "CMS::Builtin::Section", type: :n_plus_one_query, association: :children
       Bullet.add_safelist class_name: "CMS::Builtin::Section", type: :n_plus_one_query, association: :parent

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -104,7 +104,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :bought_account_contract
       Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :bought_account_plan
       Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :provider_account
-      Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :admin_user
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :admin_users
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :bought_cinstances
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :country


### PR DESCRIPTION
## What this PR does / why we need it

This PR removes **9 `unused_eager_loading` safelist entries** from `config/environments/test.rb` by fixing the underlying causes. The fixes include:
- Removing unused `includes`
- Making eager loading conditional where appropriate
- Moving `includes` to where they are actually needed

It also **deduplicates 15 redundant safelist entries** (no behavior change).

**Related issue:** https://issues.redhat.com/browse/THREESCALE-9973

---

## Commits

- **3fba2ef30**  
  Remove duplicate Bullet safelist entries (15 redundant entries removed, no behavior change)

- **1e2a9f0d9**  
  Remove unused `plan: [:service]` from `ApplicationPlanLimitsController`.  
  `plan` is already in memory via Rails inverse association.  
  ➜ Removes `UsageLimit :plan`

- **d6b116806**  
  Move `.includes(:application_plans)` from `accessible_services` to `plans_for_filter`, where it's actually used.  
  ➜ Removes `Service :application_plans`

- **7a3fbb839**  
  Remove unused `plan: %i[service pricing_rules]` from `find_cinstance`.  
  Single-record finder was inheriting collection-level includes.  
  ➜ Removes `ApplicationPlan :service`

- **e1fced51b**  
  Make `pricing_rules` include conditional on `finance.allowed?`.  
  Always include `:plan` (needed for plan name display), only include `:pricing_rules` when finance is enabled.  
  ➜ Removes `ApplicationPlan :pricing_rules`

- **559460f9b**  
  Remove unused `buyer_account` include from invoices and decouple single invoice finder from collection scope.  
  ➜ Removes `Invoice :buyer_account`

- **56c52c51a**  
  Remove Account :bought_plans and :contracts safelist entries. The underlying code fix (format-conditional   includes) was already merged to master.
  ➜ Removes `Account :bought_plans`, `Account :contracts`

- **0ffff47ba**  
  Make `admin_user` include conditional on buyer context in `ServiceContractsIndexPresenter`.  
  - Global index: needs it  
  - Per-buyer index: does not  
  ➜ Removes `Account :admin_user`

- **b4c99ff61**  
  Use `metrics.top_level` scope instead of `top_level_metrics` association to avoid implicit `:children` include via `has_many :through`.  
  ➜ Removes `Metric :children`

---

## Verification

Each safelist removal is backed by a failing test (without the fix):

| Safelist removed                    | Failing tests | Test file                                                         |
|------------------------------------|--------------|-------------------------------------------------------------------|
| `UsageLimit :plan`                  | 3            | `application_plan_limits_test.rb`                                 |
| `Service :application_plans`        | 10           | `api/applications_controller_test.rb`                             |
| `ApplicationPlan :service`          | 11           | `provider/admin/applications/applications_controller_test.rb`     |
| `ApplicationPlan :pricing_rules`    | 4            | `provider/admin/applications/applications_controller_test.rb`     |
| `Invoice :buyer_account`            | 4            | `finance/api/invoices_controller_test.rb`                         |
| `Account :bought_plans, :contracts` | 1            | `admin/api/accounts_controller_test.rb`                           |
| `Account :admin_user`               | 1            | `buyers/service_contracts_controller_test.rb`                     |
| `Metric :children`                  | 1            | `provider/admin/api_docs/account_data_controller_test.rb`         |

---

## Safelist entries kept (not addressed in this PR)

- `ApplicationPlan :issuer` — also triggered by `Cinstance.serialization_preloading`
- `Cinstance :plan` — triggered when master has a single plan (plan column hidden)
- `Cinstance :service`, `Cinstance :user_account` — separate code paths
- `Account :users`, `Account :country`, `Account :admin_users`, `Account :bought_cinstances` — no test proof found or separate code paths
- `AccountPlan :original`, `ApiDocs::Service :service` — separate code paths
- `Invoice :line_items`, `Invoice :provider_account` — separate code paths
- `Metric :owner`, `Metric :parent` — still required for `application_plan_limits_controller.rb`
- `ServicePlan :pricing_rules`, `UsageLimit :metric` — intentional includes