### PR TITLE
THREESCALE-6512: CSP Headers via account settings

### DIFF
--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -34,7 +34,7 @@ class FrontendController < ApplicationController
 
   before_action :login_required
   before_action :set_display_currency
-  before_action :set_permissions_policy_header
+  before_action :set_security_headers
 
   include RedhatCustomerPortalSupport::ControllerMethods::Banner
 
@@ -174,14 +174,15 @@ class FrontendController < ApplicationController
     ThreeScale::MoneyHelper.display_currency = current_account.currency if current_account
   end
 
-  def set_permissions_policy_header
-    header_value = AccountSettings::SettingCache.fetch(
-      account: domain_account,
-      setting_name: 'permissions_policy_header_admin'
-    )
-
-    # Set header if value exists (even if only a whitespace)
-    response.headers['Permissions-Policy'] = header_value if header_value&.size&.nonzero?
+  def set_security_headers
+    {
+      'Permissions-Policy'                  => 'permissions_policy_header_admin',
+      'Content-Security-Policy'             => 'csp_header_admin',
+      'Content-Security-Policy-Report-Only' => 'csp_report_only_header_admin'
+    }.each do |header, setting_name|
+      value = AccountSettings::SettingCache.fetch(account: domain_account, setting_name: setting_name)
+      response.headers[header] = value if value&.size&.nonzero?
+    end
   end
 
   def quickstarts_presenter

--- a/app/controllers/provider/admin/securities_controller.rb
+++ b/app/controllers/provider/admin/securities_controller.rb
@@ -4,7 +4,7 @@ class Provider::Admin::SecuritiesController < Provider::Admin::BaseController
 
   activate_menu! :account, :integrate, :security
 
-  ACCOUNT_SETTING_TYPES = %w[AccountSetting::PermissionsPolicyHeaderAdmin].freeze
+  ACCOUNT_SETTING_TYPES = %w[PermissionsPolicyHeaderAdmin CspHeaderAdmin CspReportOnlyHeaderAdmin].freeze
 
   before_action :find_settings
   before_action :find_account_settings

--- a/app/controllers/sites/securities_controller.rb
+++ b/app/controllers/sites/securities_controller.rb
@@ -3,7 +3,7 @@
 class Sites::SecuritiesController < Sites::BaseController
   activate_menu :audience, :cms, :security
 
-  ACCOUNT_SETTING_TYPES = %w[AccountSetting::PermissionsPolicyHeaderDeveloper].freeze
+  ACCOUNT_SETTING_TYPES = %w[PermissionsPolicyHeaderDeveloper CspHeaderDeveloper CspReportOnlyHeaderDeveloper].freeze
 
   before_action :find_settings
   before_action :find_account_settings

--- a/app/models/account_setting.rb
+++ b/app/models/account_setting.rb
@@ -3,6 +3,14 @@
 class AccountSetting < ApplicationRecord
   self.store_full_sti_class = false
 
+  def self.find_sti_class(type_name)
+    super
+  rescue ActiveRecord::SubclassNotFound => exception
+    # In case there are records for unknown settings
+    System::ErrorReporting.report_error(exception)
+    self
+  end
+
   # TODO: remove attr_accessible once protected_attributes_continued gem is removed
   attr_accessible :type, :value, :account, :tenant_id
 

--- a/app/models/account_setting/csp_header_admin.rb
+++ b/app/models/account_setting/csp_header_admin.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AccountSetting::CspHeaderAdmin < AccountSetting::HttpHeader
+  def self.display_name = "Content-Security-Policy Header"
+
+  self.default_value = ""
+end

--- a/app/models/account_setting/csp_header_developer.rb
+++ b/app/models/account_setting/csp_header_developer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AccountSetting::CspHeaderDeveloper < AccountSetting::HttpHeader
+  def self.display_name = "Content-Security-Policy Header"
+
+  # Default: empty string = no CSP header sent for developer portal
+  self.default_value = ""
+end

--- a/app/models/account_setting/csp_report_only_header_admin.rb
+++ b/app/models/account_setting/csp_report_only_header_admin.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AccountSetting::CspReportOnlyHeaderAdmin < AccountSetting::HttpHeader
+  def self.display_name = "Content-Security-Policy-Report-Only Header"
+
+  def self.build_default_value
+    asset_host = Rails.configuration.asset_host.presence
+
+    sources = {
+      default_src:     ["'self'"],
+      script_src:      ["'self'", "'unsafe-inline'", "'unsafe-eval'", asset_host].compact,
+      style_src:       ["'self'", "'unsafe-inline'", asset_host].compact,
+      font_src:        ["'self'", "data:", asset_host].compact,
+      img_src:         ["'self'", "data:", "blob:", "https:", asset_host].compact,
+      connect_src:     ["*"],
+      frame_src:       ["'self'"],
+      frame_ancestors: ["'none'"],
+      object_src:      ["'none'"],
+      base_uri:        ["'self'"]
+    }
+
+    if Rails.env.development?
+      webpack = ["localhost:3035", "ws://localhost:3035"]
+      sources[:script_src]  += webpack
+      sources[:style_src]   += webpack
+      sources[:font_src]    += webpack
+      sources[:img_src]     += webpack
+      sources[:connect_src] += webpack
+    end
+
+    sources.map { |directive, values| "#{directive.to_s.tr('_', '-')} #{values.join(' ')}" }.join("; ")
+  end
+
+  self.default_value = build_default_value
+end

--- a/app/models/account_setting/csp_report_only_header_developer.rb
+++ b/app/models/account_setting/csp_report_only_header_developer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AccountSetting::CspReportOnlyHeaderDeveloper < AccountSetting::HttpHeader
+  def self.display_name = "Content-Security-Policy-Report-Only Header"
+
+  self.default_value = ""
+end

--- a/app/models/account_setting/http_header.rb
+++ b/app/models/account_setting/http_header.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AccountSetting::HttpHeaders < AccountSetting
+class AccountSetting::HttpHeader < AccountSetting
   validates :value,
             length: { maximum: 5000 },
             format: {

--- a/app/models/account_setting/permissions_policy_header_admin.rb
+++ b/app/models/account_setting/permissions_policy_header_admin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AccountSetting::PermissionsPolicyHeaderAdmin < AccountSetting::HttpHeaders
+class AccountSetting::PermissionsPolicyHeaderAdmin < AccountSetting::HttpHeader
   def self.display_name = "Permissions-Policy Header"
 
   # Default restrictive policy for admin portal

--- a/app/models/account_setting/permissions_policy_header_developer.rb
+++ b/app/models/account_setting/permissions_policy_header_developer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AccountSetting::PermissionsPolicyHeaderDeveloper < AccountSetting::HttpHeaders
+class AccountSetting::PermissionsPolicyHeaderDeveloper < AccountSetting::HttpHeader
   def self.display_name = "Permissions-Policy Header"
 
   # Default permissive policy for developer portal (empty = no header sent)

--- a/app/services/account_settings/setting_cache.rb
+++ b/app/services/account_settings/setting_cache.rb
@@ -24,7 +24,7 @@ module AccountSettings
       private
 
       def cache_key(account, setting_name)
-        "account:#{account.id}:#{setting_name}"
+        "account_setting:#{account.id}:#{setting_name}"
       end
     end
   end

--- a/app/views/provider/admin/securities/_form.html.slim
+++ b/app/views/provider/admin/securities/_form.html.slim
@@ -14,17 +14,18 @@
             label class="pf-c-radio__label #{'pf-m-disabled' if disabled}" for=id
               = label
 
-  - @account_settings.each do |account_setting|
+  - account_settings.each do |account_setting|
     - setting_name = account_setting.setting_name
+    - hint = account_setting.default_value.presence ? t('provider.admin.securities.form.default_hint', default_value: account_setting.default_value) : t('provider.admin.securities.form.default_hint_none')
     = form.inputs account_setting.display_name do
       label
         input type="checkbox" id="override_#{setting_name}" data-toggle-target=setting_name checked=account_setting.persisted?
-        |  Use custom value instead of server default
+        = t('provider.admin.securities.form.use_custom_value')
       = form.input setting_name.to_sym,
               as: :patternfly_input,
               label: account_setting.display_name,
-              hint: "Default: #{account_setting.default_value.presence || 'none'}",
+              hint: hint,
               input_html: { id: setting_name, placeholder: account_setting.default_value, value: account_setting.value, disabled: account_setting.new_record? }
 
   = form.actions do
-    = form.commit_button 'Update Security Settings'
+    = form.commit_button t('provider.admin.securities.form.submit')

--- a/app/views/provider/admin/securities/edit.html.slim
+++ b/app/views/provider/admin/securities/edit.html.slim
@@ -6,4 +6,4 @@
 
 div class="pf-c-card"
   div class="pf-c-card__body"
-    = render partial: 'form', locals: { url: provider_admin_security_path, settings: @settings, field: :admin_bot_protection_level, selector_label: t('.selector_label') }
+    = render partial: 'form', locals: { url: provider_admin_security_path, settings: @settings, account_settings: @account_settings, field: :admin_bot_protection_level, selector_label: t('.selector_label') }

--- a/app/views/sites/securities/edit.html.slim
+++ b/app/views/sites/securities/edit.html.slim
@@ -6,4 +6,4 @@
 
 div class="pf-c-card"
   div class="pf-c-card__body"
-    = render partial: 'provider/admin/securities/form', locals: { url: admin_site_security_path, settings: @settings, field: :spam_protection_level, selector_label: t('.selector_label') }
+    = render partial: 'provider/admin/securities/form', locals: { url: admin_site_security_path, settings: @settings, account_settings: @account_settings, field: :spam_protection_level, selector_label: t('.selector_label') }

--- a/config/application.rb
+++ b/config/application.rb
@@ -274,7 +274,8 @@ module System
 
     require "three_scale"
 
-    config.middleware.delete ActionDispatch::PermissionsPolicy::Middleware # set by callbacks
+    config.middleware.delete ActionDispatch::PermissionsPolicy::Middleware    # set by callbacks
+    config.middleware.delete ActionDispatch::ContentSecurityPolicy::Middleware # set by callbacks
     config.middleware.use ThreeScale::Middleware::Multitenant, :tenant_id unless ENV["DEBUG_DISABLE_TENANT_CHECK"] == "1"
     config.middleware.insert_before ActionDispatch::Static, ThreeScale::Middleware::PresignedDownloads
     config.middleware.insert_before Rack::Runtime, Rack::UTF8Sanitizer

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,31 +1,3 @@
-# Be sure to restart your server when you modify this file.
-
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
-
-Rails.application.config.to_prepare do
-  Rails.application.config.content_security_policy do |policy|
-    policy.default_src '*', :data, :mediastream, :blob, :filesystem, :ws, :wss, :unsafe_eval, :unsafe_inline
-  end
-end
-
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+# Content-Security-Policy is managed per-account via AccountSetting::CspHeaderAdmin
+# and AccountSetting::CspHeaderDeveloper. See app/models/account_setting/ for defaults.
+# The ActionDispatch::ContentSecurityPolicy::Middleware is removed in config/application.rb.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -692,6 +692,11 @@ en:
           selector_label: Protection against bots on the admin portal
           captcha_hint_false: reCAPTCHA has not been configured correctly, bot protection cannot be enabled.
           captcha_hint_true: reCAPTCHA v3 will invisibly verify interactions to detect bots.
+        form:
+          use_custom_value: Use custom value instead of server default
+          default_hint: "Default: %{default_value}"
+          default_hint_none: "Default: none"
+          submit: Update Security Settings
         update:
           error: There were problems saving the settings
           success: Security settings updated

--- a/features/provider/admin/account/security.feature
+++ b/features/provider/admin/account/security.feature
@@ -1,7 +1,7 @@
 @javascript
 Feature: Provider admin security settings
   As a provider admin
-  I want to configure Permissions-Policy headers in my admin portal 
+  I want to configure security headers in my admin portal
 
   Background:
     Given a provider is logged in
@@ -10,6 +10,8 @@ Feature: Provider admin security settings
     When I go to the provider security settings page
     Then I should see "Security"
     And I should see "Permissions-Policy Header"
+    And I should see "Content-Security-Policy Header"
+    And I should see "Content-Security-Policy-Report-Only Header"
 
   Scenario: Update admin portal Permissions-Policy header
     When I go to the provider security settings page
@@ -38,3 +40,35 @@ Feature: Provider admin security settings
   Scenario: View default value hint
     When I go to the provider security settings page
     Then I should see "camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)"
+
+  Scenario: Update admin portal Content-Security-Policy header
+    When I go to the provider security settings page
+    And I check "override_csp_header_admin"
+    And I fill in "csp_header_admin" with "default-src 'self'"
+    And I press "Update Security Settings"
+    Then I should see "Security settings updated"
+    And the admin portal should have configured CSP header "default-src 'self'"
+
+  Scenario: Uncheck override deletes existing Content-Security-Policy setting
+    Given the provider has configured admin portal CSP "default-src 'self'"
+    When I go to the provider security settings page
+    And I uncheck "override_csp_header_admin"
+    And I press "Update Security Settings"
+    Then I should see "Security settings updated"
+    And the admin portal should not have configured CSP header
+
+  Scenario: Update admin portal Content-Security-Policy-Report-Only header
+    When I go to the provider security settings page
+    And I check "override_csp_report_only_header_admin"
+    And I fill in "csp_report_only_header_admin" with "default-src 'self'"
+    And I press "Update Security Settings"
+    Then I should see "Security settings updated"
+    And the admin portal should have configured CSP Report-Only header "default-src 'self'"
+
+  Scenario: Uncheck override deletes existing Content-Security-Policy-Report-Only setting
+    Given the provider has configured admin portal CSP Report-Only "default-src 'self'"
+    When I go to the provider security settings page
+    And I uncheck "override_csp_report_only_header_admin"
+    And I press "Update Security Settings"
+    Then I should see "Security settings updated"
+    And the admin portal should not have configured CSP Report-Only header

--- a/features/sites/security.feature
+++ b/features/sites/security.feature
@@ -1,7 +1,7 @@
 @javascript
 Feature: Developer portal security settings
   As a provider admin
-  I want to configure Permissions-Policy headers for my developer portal
+  I want to configure security headers for my developer portal
 
   Background:
     Given a provider is logged in
@@ -10,6 +10,8 @@ Feature: Developer portal security settings
     When I go to the developer portal security settings page
     Then I should see "Security"
     And I should see "Permissions-Policy Header"
+    And I should see "Content-Security-Policy Header"
+    And I should see "Content-Security-Policy-Report-Only Header"
 
   Scenario: Update developer portal Permissions-Policy header
     When I go to the developer portal security settings page
@@ -38,3 +40,35 @@ Feature: Developer portal security settings
   Scenario: View permissive default hint
     When I go to the developer portal security settings page
     Then I should see "Default: none"
+
+  Scenario: Update developer portal Content-Security-Policy header
+    When I go to the developer portal security settings page
+    And I check "override_csp_header_developer"
+    And I fill in "csp_header_developer" with "default-src 'self'"
+    And I press "Update Security Settings"
+    Then I should see "Security settings updated"
+    And the developer portal should have configured CSP header "default-src 'self'"
+
+  Scenario: Uncheck override deletes existing Content-Security-Policy setting
+    Given the provider has configured developer portal CSP "default-src 'self'"
+    When I go to the developer portal security settings page
+    And I uncheck "override_csp_header_developer"
+    And I press "Update Security Settings"
+    Then I should see "Security settings updated"
+    And the developer portal should not have configured CSP header
+
+  Scenario: Update developer portal Content-Security-Policy-Report-Only header
+    When I go to the developer portal security settings page
+    And I check "override_csp_report_only_header_developer"
+    And I fill in "csp_report_only_header_developer" with "default-src 'self'"
+    And I press "Update Security Settings"
+    Then I should see "Security settings updated"
+    And the developer portal should have configured CSP Report-Only header "default-src 'self'"
+
+  Scenario: Uncheck override deletes existing Content-Security-Policy-Report-Only setting
+    Given the provider has configured developer portal CSP Report-Only "default-src 'self'"
+    When I go to the developer portal security settings page
+    And I uncheck "override_csp_report_only_header_developer"
+    And I press "Update Security Settings"
+    Then I should see "Security settings updated"
+    And the developer portal should not have configured CSP Report-Only header

--- a/features/step_definitions/security_steps.rb
+++ b/features/step_definitions/security_steps.rb
@@ -1,19 +1,24 @@
 # frozen_string_literal: true
 
-Given('the provider has configured {word} portal Permissions-Policy {string}') do |portal, policy_value|
+def header_setting_type(header_name, portal)
+  class_prefix = header_name.split(/[\s-]/).map(&:capitalize).join
+  "#{class_prefix}Header#{portal.capitalize}"
+end
+
+Given(/^the provider has configured (\w+) portal (.+?) "([^"]*)"$/) do |portal, header_name, value|
   @provider.account_settings.create!(
-    type: "AccountSetting::PermissionsPolicyHeader#{portal.capitalize}",
-    value: policy_value
+    type: header_setting_type(header_name, portal),
+    value: value
   )
 end
 
-Then('the {word} portal should have configured Permissions-Policy header {string}') do |portal, expected_value|
-  setting = @provider.account_settings.find_by(type: "AccountSetting::PermissionsPolicyHeader#{portal.capitalize}")
-  assert_not_nil setting, "Expected #{portal} portal Permissions-Policy setting to exist"
+Then(/^the (\w+) portal should have configured (.+?) header "([^"]*)"$/) do |portal, header_name, expected_value|
+  setting = @provider.account_settings.find_by(type: header_setting_type(header_name, portal))
+  assert_not_nil setting, "Expected #{portal} portal #{header_name} setting to exist"
   assert_equal expected_value, setting.value
 end
 
-Then('the {word} portal should not have configured Permissions-Policy header') do |portal|
-  setting = @provider.account_settings.find_by(type: "AccountSetting::PermissionsPolicyHeader#{portal.capitalize}")
-  assert setting.nil? || setting.value.blank?, "Expected #{portal} portal Permissions-Policy to be blank or not exist"
+Then(/^the (\w+) portal should not have configured (.+?) header$/) do |portal, header_name|
+  setting = @provider.account_settings.find_by(type: header_setting_type(header_name, portal))
+  assert setting.nil? || setting.value.blank?, "Expected #{portal} portal #{header_name} to be blank or not exist"
 end

--- a/lib/developer_portal/app/controllers/developer_portal/application_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/application_controller.rb
@@ -15,14 +15,15 @@ module DeveloperPortal
 
     private
 
-    def set_permissions_policy_header
-      header_value = AccountSettings::SettingCache.fetch(
-        account: site_account,
-        setting_name: 'permissions_policy_header_developer'
-      )
-
-      # Set header only if value is present (even if only whitespaces)
-      response.headers['Permissions-Policy'] = header_value if header_value&.size&.nonzero?
+    def set_security_headers
+      {
+        'Permissions-Policy'                  => 'permissions_policy_header_developer',
+        'Content-Security-Policy'             => 'csp_header_developer',
+        'Content-Security-Policy-Report-Only' => 'csp_report_only_header_developer'
+      }.each do |header, setting_name|
+        value = AccountSettings::SettingCache.fetch(account: site_account, setting_name: setting_name)
+        response.headers[header] = value if value&.size&.nonzero?
+      end
     end
   end
 end

--- a/test/integration/csp_headers_test.rb
+++ b/test/integration/csp_headers_test.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CspHeadersTest < ActionDispatch::IntegrationTest
+
+  test 'admin portal sets Content-Security-Policy header from AccountSetting' do
+    provider = FactoryBot.create(:provider_account)
+    provider.account_settings.create!(
+      type: 'CspHeaderAdmin',
+      value: "default-src 'self'"
+    )
+
+    login_provider provider
+    get edit_provider_admin_security_path
+
+    assert_response :success
+    assert_equal "default-src 'self'", response.headers['Content-Security-Policy']
+  end
+
+  test 'admin portal does not set header when setting is blank' do
+    provider = FactoryBot.create(:provider_account)
+    provider.account_settings.create!(
+      type: 'CspHeaderAdmin',
+      value: ''
+    )
+
+    login_provider provider
+    get edit_provider_admin_security_path
+
+    assert_response :success
+    assert_nil response.headers['Content-Security-Policy']
+  end
+
+  test 'developer portal sets Content-Security-Policy header from AccountSetting' do
+    provider = FactoryBot.create(:provider_account)
+    buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+    user = FactoryBot.create(:user, account: buyer)
+    user.activate!
+
+    provider.account_settings.create!(
+      type: 'CspHeaderDeveloper',
+      value: "default-src 'self'"
+    )
+
+    DeveloperPortal::BaseController.any_instance.stubs(:site_account).returns(provider)
+
+    host! provider.internal_domain
+    login_with user.username, 'superSecret1234#'
+    get '/admin'
+
+    assert_response :success
+    assert_equal "default-src 'self'", response.headers['Content-Security-Policy']
+  end
+
+  test 'developer portal does not set header when setting is blank (default)' do
+    provider = FactoryBot.create(:provider_account)
+    buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+    user = FactoryBot.create(:user, account: buyer)
+    user.activate!
+
+    DeveloperPortal::BaseController.any_instance.stubs(:site_account).returns(provider)
+
+    host! provider.internal_domain
+    login_with user.username, 'superSecret1234#'
+    get '/admin'
+
+    assert_response :success
+    assert_nil response.headers['Content-Security-Policy']
+  end
+
+  test 'developer portal sets Content-Security-Policy header on unauthenticated pages' do
+    provider = FactoryBot.create(:provider_account)
+    provider.account_settings.create!(
+      type: 'CspHeaderDeveloper',
+      value: "default-src 'self'"
+    )
+
+    host! provider.internal_domain
+    get '/login'
+
+    assert_response :success
+    assert_equal "default-src 'self'", response.headers['Content-Security-Policy']
+  end
+
+  test 'admin portal sets Content-Security-Policy-Report-Only header from AccountSetting' do
+    provider = FactoryBot.create(:provider_account)
+    provider.account_settings.create!(
+      type: 'CspReportOnlyHeaderAdmin',
+      value: "default-src 'none'"
+    )
+
+    login_provider provider
+    get edit_provider_admin_security_path
+
+    assert_response :success
+    assert_equal "default-src 'none'", response.headers['Content-Security-Policy-Report-Only']
+  end
+
+  test 'admin portal sets both CSP headers simultaneously' do
+    provider = FactoryBot.create(:provider_account)
+    provider.account_settings.create!(
+      type: 'CspHeaderAdmin',
+      value: "default-src 'self'"
+    )
+    provider.account_settings.create!(
+      type: 'CspReportOnlyHeaderAdmin',
+      value: "default-src 'none'"
+    )
+
+    login_provider provider
+    get edit_provider_admin_security_path
+
+    assert_response :success
+    assert_equal "default-src 'self'", response.headers['Content-Security-Policy']
+    assert_equal "default-src 'none'", response.headers['Content-Security-Policy-Report-Only']
+  end
+
+  test 'developer portal sets Content-Security-Policy-Report-Only header from AccountSetting' do
+    provider = FactoryBot.create(:provider_account)
+    buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+    user = FactoryBot.create(:user, account: buyer)
+    user.activate!
+
+    provider.account_settings.create!(
+      type: 'CspReportOnlyHeaderDeveloper',
+      value: "default-src 'none'"
+    )
+
+    DeveloperPortal::BaseController.any_instance.stubs(:site_account).returns(provider)
+
+    host! provider.internal_domain
+    login_with user.username, 'superSecret1234#'
+    get '/admin'
+
+    assert_response :success
+    assert_equal "default-src 'none'", response.headers['Content-Security-Policy-Report-Only']
+  end
+
+  test 'developer portal sets both CSP headers simultaneously' do
+    provider = FactoryBot.create(:provider_account)
+    buyer = FactoryBot.create(:buyer_account, provider_account: provider)
+    user = FactoryBot.create(:user, account: buyer)
+    user.activate!
+
+    provider.account_settings.create!(
+      type: 'CspHeaderDeveloper',
+      value: "default-src 'self'"
+    )
+    provider.account_settings.create!(
+      type: 'CspReportOnlyHeaderDeveloper',
+      value: "default-src 'none'"
+    )
+
+    DeveloperPortal::BaseController.any_instance.stubs(:site_account).returns(provider)
+
+    host! provider.internal_domain
+    login_with user.username, 'superSecret1234#'
+    get '/admin'
+
+    assert_response :success
+    assert_equal "default-src 'self'", response.headers['Content-Security-Policy']
+    assert_equal "default-src 'none'", response.headers['Content-Security-Policy-Report-Only']
+  end
+end

--- a/test/integration/permissions_policy_headers_test.rb
+++ b/test/integration/permissions_policy_headers_test.rb
@@ -7,7 +7,7 @@ class PermissionsPolicyHeadersTest < ActionDispatch::IntegrationTest
   test 'admin portal sets Permissions-Policy header from AccountSetting' do
     provider = FactoryBot.create(:provider_account)
     provider.account_settings.create!(
-      type: 'AccountSetting::PermissionsPolicyHeaderAdmin',
+      type: 'PermissionsPolicyHeaderAdmin',
       value: 'camera=(), microphone=()'
     )
 
@@ -32,7 +32,7 @@ class PermissionsPolicyHeadersTest < ActionDispatch::IntegrationTest
   test 'admin portal does not set header when setting is blank' do
     provider = FactoryBot.create(:provider_account)
     provider.account_settings.create!(
-      type: 'AccountSetting::PermissionsPolicyHeaderAdmin',
+      type: 'PermissionsPolicyHeaderAdmin',
       value: ''
     )
 
@@ -50,7 +50,7 @@ class PermissionsPolicyHeadersTest < ActionDispatch::IntegrationTest
     user.activate!
 
     provider.account_settings.create!(
-      type: 'AccountSetting::PermissionsPolicyHeaderDeveloper',
+      type: 'PermissionsPolicyHeaderDeveloper',
       value: 'camera=(), geolocation=()'
     )
 
@@ -83,7 +83,7 @@ class PermissionsPolicyHeadersTest < ActionDispatch::IntegrationTest
   test 'developer portal sets Permissions-Policy header on unauthenticated pages' do
     provider = FactoryBot.create(:provider_account)
     provider.account_settings.create!(
-      type: 'AccountSetting::PermissionsPolicyHeaderDeveloper',
+      type: 'PermissionsPolicyHeaderDeveloper',
       value: 'camera=(), geolocation=()'
     )
 
@@ -99,7 +99,7 @@ class PermissionsPolicyHeadersTest < ActionDispatch::IntegrationTest
     login_provider provider
 
     provider.account_settings.create!(
-      type: 'AccountSetting::PermissionsPolicyHeaderDeveloper',
+      type: 'PermissionsPolicyHeaderDeveloper',
       value: 'fullscreen=(self)'
     )
 

--- a/test/integration/secure_headers_test.rb
+++ b/test/integration/secure_headers_test.rb
@@ -15,7 +15,7 @@ class SecureHeadersTest < ActionDispatch::IntegrationTest
     assert_equal 'DENY', response.headers['X-Frame-Options']
     assert_equal 'nosniff', response.headers['X-Content-Type-Options']
     assert_equal '1; mode=block', response.headers['X-XSS-Protection']
-    assert_equal "default-src * data: mediastream: blob: filesystem: ws: wss: 'unsafe-eval' 'unsafe-inline'", response.headers['Content-Security-Policy']
+    assert_not_includes response.headers, 'Content-Security-Policy'
   end
 
   test 'do not add non used secure headers in the response' do

--- a/test/integration/sites/admin_security_test.rb
+++ b/test/integration/sites/admin_security_test.rb
@@ -44,7 +44,7 @@ class Sites::AdminSecurityTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_provider_admin_security_path
 
     @provider.reload
-    setting = @provider.account_settings.find_by(type: 'AccountSetting::PermissionsPolicyHeaderAdmin')
+    setting = @provider.account_settings.find_by(type: 'PermissionsPolicyHeaderAdmin')
     assert_equal policy_value, setting.value
   end
 
@@ -63,7 +63,7 @@ class Sites::AdminSecurityTest < ActionDispatch::IntegrationTest
 
   test 'omitting header field deletes existing setting' do
     @provider.account_settings.create!(
-      type: 'AccountSetting::PermissionsPolicyHeaderAdmin',
+      type: 'PermissionsPolicyHeaderAdmin',
       value: 'camera=()'
     )
 
@@ -73,7 +73,7 @@ class Sites::AdminSecurityTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to edit_provider_admin_security_path
-    assert_nil @provider.account_settings.find_by(type: 'AccountSetting::PermissionsPolicyHeaderAdmin')
+    assert_nil @provider.account_settings.find_by(type: 'PermissionsPolicyHeaderAdmin')
   end
 
   test 'omitting header field when no setting exists does not break' do
@@ -82,7 +82,97 @@ class Sites::AdminSecurityTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to edit_provider_admin_security_path
-    assert_nil @provider.account_settings.find_by(type: 'AccountSetting::PermissionsPolicyHeaderAdmin')
+    assert_nil @provider.account_settings.find_by(type: 'PermissionsPolicyHeaderAdmin')
+  end
+
+  test 'displays Content-Security-Policy Header field' do
+    get edit_provider_admin_security_path
+    assert_response :success
+    assert_match 'Content-Security-Policy Header', response.body
+  end
+
+  test 'updates Content-Security-Policy header' do
+    csp_value = "default-src 'self'; script-src 'self'"
+
+    put provider_admin_security_path, params: {
+      settings: {
+        admin_bot_protection_level: 'none',
+        csp_header_admin: csp_value
+      }
+    }
+
+    assert_redirected_to edit_provider_admin_security_path
+
+    @provider.reload
+    setting = @provider.account_settings.find_by(type: 'CspHeaderAdmin')
+    assert_equal csp_value, setting.value
+  end
+
+  test 'updates Content-Security-Policy header to a blank value' do
+    put provider_admin_security_path, params: {
+      settings: {
+        admin_bot_protection_level: 'none',
+        csp_header_admin: ''
+      }
+    }
+
+    assert_redirected_to edit_provider_admin_security_path
+
+    @provider.reload
+    setting = @provider.account_settings.find_by(type: 'CspHeaderAdmin')
+    assert setting.value.blank?
+  end
+
+  test 'omitting CSP header field deletes existing setting' do
+    @provider.account_settings.create!(
+      type: 'CspHeaderAdmin',
+      value: "default-src 'self'"
+    )
+
+    put provider_admin_security_path, params: {
+      settings: { admin_bot_protection_level: 'none' }
+    }
+
+    assert_redirected_to edit_provider_admin_security_path
+    assert_nil @provider.account_settings.find_by(type: 'CspHeaderAdmin')
+  end
+
+  test 'omitting CSP header field when no setting exists does not break' do
+    put provider_admin_security_path, params: {
+      settings: { admin_bot_protection_level: 'none' }
+    }
+
+    assert_redirected_to edit_provider_admin_security_path
+    assert_nil @provider.account_settings.find_by(type: 'CspHeaderAdmin')
+  end
+
+  test 'updates CSP report-only header setting' do
+    put provider_admin_security_path, params: {
+      settings: {
+        admin_bot_protection_level: 'none',
+        csp_report_only_header_admin: "default-src 'none'"
+      }
+    }
+
+    assert_redirected_to edit_provider_admin_security_path
+
+    @provider.reload
+    setting = @provider.account_settings.find_by(type: 'CspReportOnlyHeaderAdmin')
+    assert_equal "default-src 'none'", setting.value
+  end
+
+  test 'omitting CSP report-only header destroys existing setting' do
+    @provider.account_settings.create!(
+      type: 'CspReportOnlyHeaderAdmin',
+      value: "default-src 'none'"
+    )
+
+    put provider_admin_security_path, params: {
+      settings: { admin_bot_protection_level: 'none' }
+    }
+
+    assert_redirected_to edit_provider_admin_security_path
+    assert_nil @provider.account_settings.find_by(type: 'CspReportOnlyHeaderAdmin')
   end
 
   test 'setting header to space results in header being present in response' do
@@ -98,7 +188,7 @@ class Sites::AdminSecurityTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_provider_admin_security_path
 
     @provider.reload
-    setting = @provider.account_settings.find_by(type: 'AccountSetting::PermissionsPolicyHeaderAdmin')
+    setting = @provider.account_settings.find_by(type: 'PermissionsPolicyHeaderAdmin')
     assert_equal policy_value, setting.value
 
     # Verify the header is present in the response

--- a/test/integration/sites/security_test.rb
+++ b/test/integration/sites/security_test.rb
@@ -44,13 +44,13 @@ class Sites::SecurityTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_admin_site_security_path
 
     @provider.reload
-    setting = @provider.account_settings.find_by(type: 'AccountSetting::PermissionsPolicyHeaderDeveloper')
+    setting = @provider.account_settings.find_by(type: 'PermissionsPolicyHeaderDeveloper')
     assert_equal policy_value, setting.value
   end
 
   test 'omitting header field deletes existing setting' do
     @provider.account_settings.create!(
-      type: 'AccountSetting::PermissionsPolicyHeaderDeveloper',
+      type: 'PermissionsPolicyHeaderDeveloper',
       value: 'camera=()'
     )
 
@@ -59,7 +59,7 @@ class Sites::SecurityTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to edit_admin_site_security_path
-    assert_nil @provider.account_settings.find_by(type: 'AccountSetting::PermissionsPolicyHeaderDeveloper')
+    assert_nil @provider.account_settings.find_by(type: 'PermissionsPolicyHeaderDeveloper')
   end
 
   test 'omitting header field when no setting exists does not break' do
@@ -68,7 +68,74 @@ class Sites::SecurityTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to edit_admin_site_security_path
-    assert_nil @provider.account_settings.find_by(type: 'AccountSetting::PermissionsPolicyHeaderDeveloper')
+    assert_nil @provider.account_settings.find_by(type: 'PermissionsPolicyHeaderDeveloper')
+  end
+
+  test 'displays Content-Security-Policy Header field' do
+    get edit_admin_site_security_path
+    assert_response :success
+    assert_match 'Content-Security-Policy Header', response.body
+  end
+
+  test 'updates Content-Security-Policy header' do
+    csp_value = "default-src 'self'"
+
+    put admin_site_security_path, params: {
+      settings: {
+        spam_protection_level: 'none',
+        csp_header_developer: csp_value
+      }
+    }
+
+    assert_redirected_to edit_admin_site_security_path
+
+    @provider.reload
+    setting = @provider.account_settings.find_by(type: 'CspHeaderDeveloper')
+    assert_equal csp_value, setting.value
+  end
+
+  test 'updates Content-Security-Policy header to a blank value' do
+    put admin_site_security_path, params: {
+      settings: {
+        spam_protection_level: 'none',
+        csp_header_developer: ''
+      }
+    }
+
+    assert_redirected_to edit_admin_site_security_path
+
+    @provider.reload
+    setting = @provider.account_settings.find_by(type: 'CspHeaderDeveloper')
+    assert setting.value.blank?
+  end
+
+  test 'omitting CSP header field deletes existing setting' do
+    @provider.account_settings.create!(
+      type: 'CspHeaderDeveloper',
+      value: "default-src 'self'"
+    )
+
+    put admin_site_security_path, params: {
+      settings: { spam_protection_level: 'none' }
+    }
+
+    assert_redirected_to edit_admin_site_security_path
+    assert_nil @provider.account_settings.find_by(type: 'CspHeaderDeveloper')
+  end
+
+  test 'updates CSP report-only header setting' do
+    put admin_site_security_path, params: {
+      settings: {
+        spam_protection_level: 'none',
+        csp_report_only_header_developer: "default-src 'none'"
+      }
+    }
+
+    assert_redirected_to edit_admin_site_security_path
+
+    @provider.reload
+    setting = @provider.account_settings.find_by(type: 'CspReportOnlyHeaderDeveloper')
+    assert_equal "default-src 'none'", setting.value
   end
 
   test 'updates spam protection level setting' do

--- a/test/test_helpers/provider.rb
+++ b/test/test_helpers/provider.rb
@@ -97,6 +97,12 @@ module TestHelpers
           AccountSetting::PermissionsPolicyHeaderAdmin.create!(account: provider, value: "picture-in-picture=(), geolocation=(self https://example.com/), camera=*")
           AccountSetting::PermissionsPolicyHeaderDeveloper.create!(account: provider, value: "picture-in-picture=(), geolocation=(self https://example.com/), camera=*")
 
+          AccountSetting::CspHeaderAdmin.create!(account: provider, value: "default-src ''")
+          AccountSetting::CspHeaderDeveloper.create!(account: provider, value: "")
+
+          AccountSetting::CspReportOnlyHeaderAdmin.create!(account: provider, value: "default-src 'self'")
+          AccountSetting::CspReportOnlyHeaderDeveloper.create!(account: provider, value: "default-src 'self'")
+
           LatestForumPostsPortlet.create!(provider:, portlet_type: 'LatestForumPostsPortlet', system_name: 'name', posts: forum.posts.count)
           TableOfContentsPortlet.create!(provider:, portlet_type: 'TableOfContentsPortlet', system_name: 'name', section_id: provider.provided_sections.first.id)
           CMS::Redirect.new.tap do |redirect|

--- a/test/unit/account_setting/http_header_test.rb
+++ b/test/unit/account_setting/http_header_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class AccountSetting::HttpHeadersTest < ActiveSupport::TestCase
+class AccountSetting::HttpHeaderTest < ActiveSupport::TestCase
   def setup
     @account = FactoryBot.build(:simple_provider)
     @original_cache = Rails.cache

--- a/test/unit/account_setting_test.rb
+++ b/test/unit/account_setting_test.rb
@@ -7,6 +7,10 @@ class AccountSettingTest < ActiveSupport::TestCase
     assert_equal AccountSetting::PermissionsPolicyHeaderAdmin, AccountSetting.class_for_setting(:permissions_policy_header_admin)
     assert_equal AccountSetting::PermissionsPolicyHeaderDeveloper, AccountSetting.class_for_setting(:permissions_policy_header_developer)
     assert_equal AccountSetting::PermissionsPolicyHeaderAdmin, AccountSetting.class_for_setting('permissions_policy_header_admin')
+    assert_equal AccountSetting::CspHeaderAdmin, AccountSetting.class_for_setting(:csp_header_admin)
+    assert_equal AccountSetting::CspHeaderDeveloper, AccountSetting.class_for_setting(:csp_header_developer)
+    assert_equal AccountSetting::CspReportOnlyHeaderAdmin, AccountSetting.class_for_setting(:csp_report_only_header_admin)
+    assert_equal AccountSetting::CspReportOnlyHeaderDeveloper, AccountSetting.class_for_setting(:csp_report_only_header_developer)
   end
 
   test 'class_for_setting returns nil for non-existent setting' do
@@ -26,6 +30,21 @@ class AccountSettingTest < ActiveSupport::TestCase
       assert_equal klass, AccountSetting.class_for_setting(setting_name),
                    "Failed roundtrip for #{klass.name}: setting_name=#{setting_name}"
     end
+  end
+
+  test 'find_sti_class reports error and falls back to base class for unknown type' do
+    account = FactoryBot.create(:simple_provider)
+    setting = AccountSetting::PermissionsPolicyHeaderAdmin.create!(
+      account: account,
+      value: "camera 'none'"
+    )
+
+    AccountSetting.where(id: setting.id).update_all(type: 'NonExistent')
+
+    System::ErrorReporting.expects(:report_error).with(instance_of(ActiveRecord::SubclassNotFound))
+
+    loaded = AccountSetting.find(setting.id)
+    assert_instance_of AccountSetting, loaded
   end
 
   test 'tenant_id trigger' do

--- a/test/unit/services/account_settings/setting_cache_test.rb
+++ b/test/unit/services/account_settings/setting_cache_test.rb
@@ -17,7 +17,7 @@ class AccountSettings::SettingCacheTest < ActiveSupport::TestCase
 
   test 'fetch returns setting value when it exists' do
     @provider.account_settings.create!(
-      type: 'AccountSetting::PermissionsPolicyHeaderAdmin',
+      type: 'PermissionsPolicyHeaderAdmin',
       value: 'camera=(), microphone=()'
     )
 
@@ -38,7 +38,7 @@ class AccountSettings::SettingCacheTest < ActiveSupport::TestCase
 
   test 'fetch caches the value after first call' do
     @provider.account_settings.create!(
-      type: 'AccountSetting::PermissionsPolicyHeaderDeveloper',
+      type: 'PermissionsPolicyHeaderDeveloper',
       value: 'camera=(), geolocation=()'
     )
 
@@ -46,7 +46,7 @@ class AccountSettings::SettingCacheTest < ActiveSupport::TestCase
       account: @provider, setting_name: :permissions_policy_header_developer
     )
 
-    cache_key = "account:#{@provider.id}:permissions_policy_header_developer"
+    cache_key = "account_setting:#{@provider.id}:permissions_policy_header_developer"
     assert_equal 'camera=(), geolocation=()', Rails.cache.read(cache_key)
   end
 
@@ -55,7 +55,7 @@ class AccountSettings::SettingCacheTest < ActiveSupport::TestCase
       account: @provider, setting_name: :permissions_policy_header_admin, value: 'geolocation=()'
     )
 
-    cache_key = "account:#{@provider.id}:permissions_policy_header_admin"
+    cache_key = "account_setting:#{@provider.id}:permissions_policy_header_admin"
     assert_equal 'geolocation=()', Rails.cache.read(cache_key)
   end
 
@@ -64,7 +64,7 @@ class AccountSettings::SettingCacheTest < ActiveSupport::TestCase
       account: @provider, setting_name: :permissions_policy_header_admin, value: nil
     )
 
-    cache_key = "account:#{@provider.id}:permissions_policy_header_admin"
+    cache_key = "account_setting:#{@provider.id}:permissions_policy_header_admin"
     assert_nil Rails.cache.read(cache_key)
     assert Rails.cache.exist?(cache_key)
   end


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds new fields in the securities forms to allow the user to set CSP headers for the admin and developer portals. It uses the new account settings backend, it adds for now settings:

- Admin portal CSP header value
- Developer portal CSP header value
- Admin portal CSP report-only mode
- Developer portal CSP report-only mode

For the admin portal, we set some default CSP headers which are as much restrictive as they can be considering the user has some freedom to add custom content to the admin portal, like connecting to anywhere via the API Docs screens or loading assets from a CDN or a paperclip source.

For the developer portal, the default is no CSP header.

This follows the same design as https://github.com/3scale/porta/pull/4264. The only thing I had to change is the `edit` -> `_form` template, which was iterating over a generic list of account settings before but it's not enough for the new use case, in which we have a boolean non-text setting, "csp report-only" that must be in the same form as the CSP header value because it's part of the same concept. See:

<img width="894" height="424" alt="image" src="https://github.com/user-attachments/assets/dc451b23-6afd-4977-9077-519da117c036" />

Apart from that, this also:
- Renames the cache key suffix to `account_setting`
- Extracts the cache refresh logic to it's own module for composition

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-6512

**Verification steps** 

Go to screens at:

- Account settings -> Integrate -> Security
- Audience -> Developer portal -> Settings -> Security

And test changing the values of the CSP fields. All changes should apply.
