### PR TITLE
Add container hosts for development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,6 +23,8 @@ Rails.application.configure do
 
   # Match custom domains on development
   config.hosts << /.+\.localhost/
+  config.hosts << "host.docker.internal"
+  config.hosts << "host.containers.internal"
 
   config.middleware.insert_before ActionDispatch::Static, Rack::Deflater
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is so that other components running in containers could reach porta running on the host machine.
For example, for apisonator:
```
CONFIG_EVENTS_HOOK=http://host.containers.internal:3000/master/events/import
```

**Which issue(s) this PR fixes** 

-none-

**Verification steps** 


**Special notes for your reviewer**:
