### PR TITLE
Update tagRelease action

### DIFF
--- a/.github/workflows/tagRelease.yml
+++ b/.github/workflows/tagRelease.yml
@@ -12,7 +12,7 @@ on:
         description: 'Tag to be created along with release'
         # Input has to be provided for the workflow to run
         required: true
-      git_ref: 
+      git_ref:
         description: 'Git reference to create tag from, can be a commit hash or branch'
         required: true
 
@@ -22,7 +22,12 @@ jobs:
       runs-on: ubuntu-latest
       name: Create Release
       steps:
-        - uses: softprops/action-gh-release@v3 #This action will create the release with the params specified.
-          with:
-           tag_name: ${{ inputs.tag }}
-           target_commitish: ${{ inputs.git_ref }}
+        - name: Create Release
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            gh release create ${{ inputs.tag }} \
+              --repo ${{ github.repository }} \
+              --target ${{ inputs.git_ref }} \
+              --title "${{ inputs.tag }}" \
+              --generate-notes


### PR DESCRIPTION
This PR changes the `tagRelease` Action to remove `softprops/action-gh-release@v2` dependency.

It currently shows the following deprecation:

```
Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: softprops/action-gh-release@v1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

It seems that there is an open PR to fix this: https://github.com/softprops/action-gh-release/pull/774

However, I don't see any point in using a third party action, when we can use the standard `gh` executable with known and predictable functionality, which does pretty much the same thing (maybe with a less verbose/nice-looking output).