### PR TITLE
THREESCALE-14170: Bump immutable transitive dependencies

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7316,14 +7316,14 @@ ignore@^7.0.5:
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
 immutable@^3.x.x:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
-  integrity sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==
+  version "3.8.3"
+  resolved "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz#0a8d2494a94d4b2d4f0e99986e74dd25d1e9a859"
+  integrity sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==
 
 immutable@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.0.3.tgz#aa037e2313ea7b5d400cd9298fa14e404c933db1"
-  integrity sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==
+  version "5.1.5"
+  resolved "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz#93ee4db5c2a9ab42a4a783069f3c5d8847d40165"
+  integrity sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade `immutable.js` to solve CVE-2026-29063. I'm not sure we are affected, but updating the dependencies is faster than investigating.

**Changelog**:
- `3.8.2` -> `3.8.3`: The only change is the CVE fix: https://github.com/immutable-js/immutable-js/releases/tag/v3.8.3
- `5.0.3` -> `5.1.5`: No breaking changes announced. Anyway, it's a transitive dependency, and `sass` declares to support any `5.x.x` version.

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-14170

**Verification steps** 

Test should pass, no regressions should happen.
