### PR TITLE
THREESCALE-14641: Fix OCIError: ORA-01795: maximum number of expressions in a list is 1000 [2.16 backport]

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -51,7 +51,7 @@ class Metric < ApplicationRecord
   scope :order_by_unit, -> { order('unit') }
 
   scope :by_provider, ->(provider) {
-    where.has { ((owner_type == 'Service') & owner_id.in(provider.services.pluck(:id))) | ((owner_type == 'BackendApi') & owner_id.in(provider.backend_apis.pluck(:id))) }
+    where(owner: provider.services).or(where(owner: provider.backend_apis))
   }
 
   # Create one of the predefined, default metrics.

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -401,4 +401,17 @@ class MetricTest < ActiveSupport::TestCase
 
     assert_same_elements [service.metrics.hits, service_metric, backend_api.metrics.hits, backend_metric], Metric.by_provider(provider)
   end
+
+  test '.by_provider with more than 1000 services handles Oracle limit' do
+    skip('Only relevant for Oracle database') unless System::Database.oracle?
+
+    provider = FactoryBot.create(:simple_provider)
+
+    # Create 1001 services to exceed Oracle's 1000 expression limit
+    FactoryBot.create_list(:simple_service, 1001, account: provider)
+
+    # Each service has a default 'hits' metric, so we should have at least 1001 metrics
+    # This would fail with ORA-01795 if the query uses IN with >1000 values
+    assert_operator Metric.by_provider(provider).count, :>=, 1001
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport https://github.com/3scale/porta/pull/4289 to 2.16

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-14641

**Verification steps** 


**Special notes for your reviewer**:
