### PR TITLE
THREESCALE-12410: Remove `:api` signup type

### DIFF
--- a/app/controllers/admin/api/buyers_users_controller.rb
+++ b/app/controllers/admin/api/buyers_users_controller.rb
@@ -17,7 +17,7 @@ class Admin::Api::BuyersUsersController < Admin::Api::BuyersBaseController
     authorize! :create, user
 
     user.unflattened_attributes = flat_params
-    user.signup_type = :api
+    user.signup_type = :created_by_provider
 
     user.save
 

--- a/app/controllers/admin/api/users_controller.rb
+++ b/app/controllers/admin/api/users_controller.rb
@@ -19,7 +19,7 @@ class Admin::Api::UsersController < Admin::Api::BaseController
     authorize! :create, user
 
     user.unflattened_attributes = flat_params
-    user.signup_type = :api
+    user.signup_type = :created_by_provider
 
     user.save
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,10 +237,6 @@ class User < ApplicationRecord
     signup.minimal?
   end
 
-  def api_signup?
-    signup.api?
-  end
-
   def cas_signup?
     signup.cas?
   end
@@ -437,10 +433,6 @@ class User < ApplicationRecord
       signup_type == :minimal
     end
 
-    def api?
-      signup_type == :api
-    end
-
     def open_id?
       @user.open_id.present?
     end
@@ -450,7 +442,7 @@ class User < ApplicationRecord
     end
 
     def created_by_provider?
-      signup_type == :created_by_provider
+      %i[created_by_provider api].include?(signup_type)
     end
 
     def cas?
@@ -458,11 +450,11 @@ class User < ApplicationRecord
     end
 
     def machine?
-      minimal? || api? || created_by_provider? || open_id? || cas? || oauth2?
+      minimal? || created_by_provider? || open_id? || cas? || oauth2?
     end
 
     def by_user?
-      not machine?
+      !machine?
     end
 
     private

--- a/test/functional/partners/providers_controller_test.rb
+++ b/test/functional/partners/providers_controller_test.rb
@@ -100,6 +100,17 @@ class Partners::ProvidersControllerTest < ActionController::TestCase
     assert_equal true, body['success']
   end
 
+  test 'post without password or open_id rejected' do
+    prepare_master_account
+    post :create, params: provider_params.except(:open_id)
+
+    assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+
+    assert_not body['success']
+    assert body['errors']['user']['password'].present?
+  end
+
   test 'post with weak password rejected when strong passwords enabled' do
     prepare_master_account
 

--- a/test/functional/partners/users_controller_test.rb
+++ b/test/functional/partners/users_controller_test.rb
@@ -82,6 +82,16 @@ class Partners::UsersControllerTest < ActionController::TestCase
     assert body['success']
   end
 
+  test 'create user without password or open_id rejected' do
+    post :create, params: { provider_id: @account.id, api_key: @partner.api_key, email: "foo@example.net", username: "aaron" }
+
+    assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+
+    assert_not body['success']
+    assert body['errors']['password'].present?
+  end
+
   test 'create user with invalid params returns 422' do
     post :create, params: { provider_id: @account.id, api_key: @partner.api_key, email: "invalid-email", username: "aaron" }
 

--- a/test/unit/liquid/drops/user_drop_test.rb
+++ b/test/unit/liquid/drops/user_drop_test.rb
@@ -77,6 +77,18 @@ class Liquid::Drops::UserDropTest < ActiveSupport::TestCase
       assert @user.signup.machine?
       assert_not @drop.password_required?
     end
+
+    test '#password_required? returns false for legacy :api signup type' do
+      @user.signup_type = :api
+
+      assert_not @drop.password_required?
+    end
+
+    test '#password_required? returns false for :created_by_provider signup type' do
+      @user.signup_type = :created_by_provider
+
+      assert_not @drop.password_required?
+    end
   end
 
   class BuyerUserTest < Liquid::Drops::UserDropTest

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -273,6 +273,43 @@ class UserTest < ActiveSupport::TestCase
     assert created_by_provider_user.errors[:password].blank?
   end
 
+  test 'by_user? returns true only for :new_signup, nil, and :partner signup types' do
+    user = User.new
+
+    %i[new_signup partner].each do |type|
+      user.signup_type = type
+      assert user.signup.by_user?
+    end
+
+    user.signup_type = nil
+    assert user.signup.by_user?
+
+    %i[minimal api created_by_provider].each do |type|
+      user.signup_type = type
+      assert_not user.signup.by_user?
+    end
+  end
+
+  test 'by_user? returns false when user has SSO identifiers regardless of signup type' do
+    user = User.new
+    user.signup_type = :new_signup
+
+    user.open_id = 'some-open-id'
+    assert_not user.signup.by_user?
+    user.open_id = nil
+
+    user.stubs(:any_sso_authorizations?).returns(true)
+    assert_not user.signup.by_user?
+    user.unstub(:any_sso_authorizations?)
+
+    user.authentication_id = 'some-auth-id'
+    assert_not user.signup.by_user?
+    user.authentication_id = nil
+
+    user.cas_identifier = 'some-cas-id'
+    assert_not user.signup.by_user?
+  end
+
   test 'reset password' do
     user = FactoryBot.create(:simple_user, username: 'person', password: 'superSecret1234#')
     user.activate!


### PR DESCRIPTION
**What this PR does / why we need it**:

We'd like to remove as many signup types as possible since they complicate all the signup logic and they are created to implement some use cases that might be solved in some other way.

This PR removes the `:api` sigup type. This one is only set by the controllers:

- `app/controllers/admin/api/buyers_users_controller`.rb:20 — buyer users created via API
- `app/controllers/admin/api/users_controller.rb:22` — provider users created via API

And only read from `User::SignupType#by_user?` to determine whether the signup was by human or by machine.

I think this signup type is redundant, because is completely overlapped by `:created_by_provider`. See the table at the jJira issue:

<img width="961" height="377" alt="image" src="https://github.com/user-attachments/assets/435f78a2-b1df-4e2f-8955-f3c524054f2d" />

So this PR removes the `:api` type and assigns to the users created via those endpoints the `:created_by_provider` type.

**Breaking changes**

- Approval email suppression (account/states.rb:178): New API-created buyer users, for buyers that require approval, received the approval email notification before. Now get signup_type = `:created_by_provider`, so `created_by_provider_signup?` returns true, and the approval notification email is suppressed.
  Previously with :api, it was not suppressed. This is the one behavioral change we identified earlier.
- Analytics tracking (user_tracking.rb:95): New API-created users will report signup_type = `:created_by_provider` instead of `:api` in analytics. Not a code breakage, but a data change.

Everything else should behave exactly like it does now, AFAIK.

**Which issue(s) this PR fixes** 

This belongs to https://redhat.atlassian.net/browse/THREESCALE-12410 but it doesn't fix it completely, the logic is so complex I decided to do it type by type, one PR each.

**Verification steps** 

Test should pass

