### PR TITLE
THREESCALE-11735: Impersonation and OpenID confilcts with recaptcha [2.16 backport]

### DIFF
--- a/app/controllers/provider/sessions_controller.rb
+++ b/app/controllers/provider/sessions_controller.rb
@@ -20,7 +20,7 @@ class Provider::SessionsController < FrontendController
     session_return_to
     logout_keeping_session!
 
-    @user, strategy = authenticate_user if bot_check
+    @user, strategy = authenticate_user
 
     if @user
       self.current_user = @user
@@ -74,7 +74,8 @@ class Provider::SessionsController < FrontendController
   end
 
   def authenticate_user
-    strategy = Authentication::Strategy.build_provider(@provider)
+    captcha_is_available = request.post? # Internal strategy (user & pass)
+    return if captcha_is_available && !bot_check
 
     params = if domain_account.settings.enforce_sso?
                sso_params
@@ -82,6 +83,19 @@ class Provider::SessionsController < FrontendController
                request.post? ? auth_params : sso_params
     end
 
+    # TODO: refactor the authentication flow.
+    # Right now, we have a hierarchy of classes, one for each auth strategy, and we manually instance the last child
+    # class, `ProviderOAuth2`, and then try all strategies one by one by calling `super` and going up in the hierarchy
+    # until a strategy works. Due to this, we can't know from the here which strategy was really used.
+    #
+    # The hierarchy right now is:
+    #
+    # `ProviderOAuth2` < `OAuth2Base` < `Internal` < `SSO` < `Base`
+    #
+    # This is very weird because `Internal`, which means "User + pass" is not a kind of `SSO`; and `OAuth2` is not
+    # a kind of `Internal`. Not to mention we are calling `SSO` to something which is merely a token authentication
+    # not related at all with any SSO.
+    strategy = Authentication::Strategy.build_provider(@provider)
     user = strategy.authenticate(params)
 
     [user, strategy]


### PR DESCRIPTION
**What this PR does / why we need it**:

Backporting the fix implemented in https://github.com/3scale/porta/pull/4052 for 2.16.

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-11735

**Verification steps** 

Check https://github.com/3scale/porta/pull/4052 description.

**Special notes for your reviewer**:
