### PR TITLE
fix: use getter method for bot protection level check

### DIFF
--- a/app/views/provider/admin/securities/_form.html.slim
+++ b/app/views/provider/admin/securities/_form.html.slim
@@ -8,7 +8,7 @@
         - disabled = !Recaptcha.captcha_configured?
         - ThreeScale::BotProtection::LEVELS.each do |label, value|
           - id = "settings_#{field}_#{value}"
-          - checked = settings[field].to_sym == value
+          - checked = settings.public_send(field) == value
           div class="pf-c-radio"
             input class="pf-c-radio__input" name="settings[#{field}]" id=id type="radio" value=value checked=checked disabled=disabled
             label class="pf-c-radio__label #{'pf-m-disabled' if disabled}" for=id

--- a/test/integration/sites/admin_security_test.rb
+++ b/test/integration/sites/admin_security_test.rb
@@ -11,6 +11,12 @@ class Sites::AdminSecurityTest < ActionDispatch::IntegrationTest
     Rails.cache.clear
   end
 
+  test 'edit with nil admin_bot_protection_level' do
+    @provider.settings.update_column(:admin_bot_protection_level, nil)
+    get edit_provider_admin_security_path
+    assert_response :success
+  end
+
   test 'edit without captcha' do
     Recaptcha.expects(:captcha_configured?).returns(false).twice
     get edit_provider_admin_security_path

--- a/test/integration/sites/admin_security_test.rb
+++ b/test/integration/sites/admin_security_test.rb
@@ -15,6 +15,7 @@ class Sites::AdminSecurityTest < ActionDispatch::IntegrationTest
     @provider.settings.update_column(:admin_bot_protection_level, nil)
     get edit_provider_admin_security_path
     assert_response :success
+    assert_xpath '//input[@type="radio"][@name="settings[admin_bot_protection_level]"][@value="none"][@checked]'
   end
 
   test 'edit without captcha' do


### PR DESCRIPTION
**What this PR does / why we need it**:

In the Captcha radio button, the values we expect are either `none` or `captcha`. However, we got a lot of old records in SaaS which value in the column is empty or `NULL`.

Instead of backfilling, I created a small migration code in the settings getter:

https://github.com/3scale/porta/blob/35a270621c8fee28e38d70a01428c3e9026668d4/app/models/settings.rb#L97-L100

In the Permissions Policy PR (https://github.com/3scale/porta/pull/4264) we migrated the form to Patternfly, and in the process we started to call `settings[field]` directly, which bypasses the getter.

**Which issue(s) this PR fixes** 

No Jira issue

**Verification steps** 

1. Set the `admin_bot_protection_level` column to `NULL` in the `settings` table, for a provider, no need for it to be master.
2. Go to Account Settings -> Integrate -> Security
3. Before the patch, it crashes; after the patch, it loads fine.
