### PR TITLE
THREESCALE-14969: Allow authentication by zync token

### DIFF
--- a/app/controllers/admin/api/applications_controller.rb
+++ b/app/controllers/admin/api/applications_controller.rb
@@ -1,4 +1,5 @@
 class Admin::Api::ApplicationsController < Admin::Api::BaseController
+  include ApiAuthentication::ByZyncToken
   representer ::Cinstance
 
   paginate only: :index

--- a/app/controllers/admin/api/providers_controller.rb
+++ b/app/controllers/admin/api/providers_controller.rb
@@ -1,4 +1,5 @@
 class Admin::Api::ProvidersController < Admin::Api::BaseController
+  include ApiAuthentication::ByZyncToken
 
   wrap_parameters Account
 

--- a/app/controllers/admin/api/services/proxies_controller.rb
+++ b/app/controllers/admin/api/services/proxies_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::Api::Services::ProxiesController < Admin::Api::Services::BaseController
+  include ApiAuthentication::ByZyncToken
 
   represents :json, entity: ::ProxyRepresenter::JSON
   represents :xml, entity: ::ProxyRepresenter::XML

--- a/app/lib/api_authentication/by_access_token.rb
+++ b/app/lib/api_authentication/by_access_token.rb
@@ -111,7 +111,7 @@ module ApiAuthentication
 
       token = domain_account.access_tokens.find_from_value(given_token)
 
-      return if token.blank? || token.expired?
+      return if token.blank? || token.expired? || token.name == AccessToken::OIDC_SYNC_TOKEN
 
       @authenticated_token = token
     end

--- a/app/lib/api_authentication/by_zync_token.rb
+++ b/app/lib/api_authentication/by_zync_token.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module ApiAuthentication
+  module ByZyncToken
+    extend ActiveSupport::Concern
+
+    included do
+      prepend_before_action :authenticate_zync_request, only: %i[show find]
+    end
+
+    private
+
+    def current_user
+      if @zync_authenticated
+        @current_user ||= User.current = (domain_account.find_impersonation_admin || domain_account.first_admin!)
+      else
+        super
+      end
+    end
+
+    def authenticate_zync_request
+      return unless zync_request?
+      return if domain_account.master?
+
+      @zync_authenticated = true
+    end
+
+    def zync_request?
+      AuthenticatedSystem::Request.new(request).zync?
+    end
+
+    # Force read-only DB transaction for Zync requests.
+    # ByAccessToken's version calls PermissionEnforcer.enforce(authenticated_token) — with
+    # no access token, authenticated_token is nil, level becomes nil, and
+    # requires_transaction? returns nil, skipping enforcement entirely.
+    def enforce_access_token_permission(&block)
+      if @zync_authenticated
+        ApiAuthentication::ByAccessToken::PermissionEnforcer.enforce(OpenStruct.new(permission: 'ro'), &block)
+      else
+        super
+      end
+    end
+  end
+end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -142,12 +142,7 @@ class AccessToken < ApplicationRecord
     find_by(id: id_or_value) || find_from_value(id_or_value)
   end
 
-  # This can't change or it will create new tokens for everyone
   OIDC_SYNC_TOKEN = 'OIDC Synchronization Token'.freeze
-
-  def self.oidc_sync
-    create_with(scopes: %w[account_management], permission: 'ro').find_or_create_by!(name: OIDC_SYNC_TOKEN)
-  end
 
   def scopes=(values)
     super Array(values).select(&:present?)

--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -172,10 +172,8 @@ class ZyncWorker
 
   delegate :provider_access_token, to: :class
 
-  def self.provider_access_token(provider)
-    user = provider.find_impersonation_admin || provider.first_admin!
-
-    user.access_tokens.oidc_sync.value
+  def self.provider_access_token(_provider)
+    'zync'
   end
 
   def notification_url

--- a/test/integration/api_authentication/by_zync_token_test.rb
+++ b/test/integration/api_authentication/by_zync_token_test.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Integration tests for ApiAuthentication::ByZyncToken.
+#
+# Uses a fake controller with fake routes (pattern from forbid_params_test.rb) to
+# avoid coupling to real Admin API controllers and their additional before_actions.
+module ApiAuthentication
+  module ByZyncTokenIntegration
+    # Minimal base that mirrors what real Admin API controllers set up:
+    # ApplicationController -> ByAccessToken -> ByZyncToken.
+    class FakeController < Admin::Api::BaseController
+      include ApiAuthentication::ByZyncToken
+
+      def show
+        render json: { account_id: current_account.id, user_id: current_user.id }
+      end
+
+      def update
+        render plain: 'ok'
+      end
+    end
+
+    # Controller whose show action attempts a DB write — used to prove the
+    # read-only transaction blocks it.
+    class WriteAttemptController < FakeController
+      def show
+        User.where(id: -1).update_all(username: 'hacked')
+        render plain: 'ok'
+      rescue ActiveRecord::StatementInvalid => e
+        render plain: e.message, status: :forbidden
+      end
+    end
+
+    module TestHelpers
+      ZYNC_TOKEN = 'test-zync-token'
+
+      def with_test_routes
+        Rails.application.routes.draw do
+          get '/zync_test/show'          => 'api_authentication/by_zync_token_integration/fake#show'
+          put '/zync_test/update'        => 'api_authentication/by_zync_token_integration/fake#update'
+          get '/zync_test/write_attempt' => 'api_authentication/by_zync_token_integration/write_attempt#show'
+        end
+        yield
+      ensure
+        Rails.application.routes_reloader.reload!
+      end
+
+      def zync_headers(token = ZYNC_TOKEN)
+        { 'X-Zync-Token' => token }
+      end
+    end
+  end
+
+  class ByZyncTokenIntegrationTest < ActionDispatch::IntegrationTest
+    include ByZyncTokenIntegration::TestHelpers
+
+    def setup
+      ThreeScale.config.stubs(:zync_authentication_token).returns(ZYNC_TOKEN)
+      @provider = FactoryBot.create(:provider_account)
+      host! @provider.external_admin_domain
+    end
+  end
+
+  class AccessTokenTest < ByZyncTokenIntegrationTest
+    test 'rejects GET with no auth at all' do
+      with_test_routes do
+        get '/zync_test/show'
+        assert_response :forbidden
+      end
+    end
+
+    test 'regular access token auth still works on Zync-capable endpoints' do
+      user  = FactoryBot.create(:member, account: @provider, admin_sections: %w[partners])
+      token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management', permission: 'rw')
+      with_test_routes do
+        get '/zync_test/show', params: { access_token: token.plaintext_value }
+        assert_response :success
+      end
+    end
+
+    test 'oidc_sync tokens are rejected even on Zync-capable endpoints' do
+      user  = FactoryBot.create(:member, account: @provider, admin_sections: %w[partners])
+      token = FactoryBot.create(:access_token, owner: user, scopes: 'account_management',
+                                name: AccessToken::OIDC_SYNC_TOKEN)
+      with_test_routes do
+        get '/zync_test/show', params: { access_token: token.plaintext_value }
+        assert_response :forbidden
+      end
+    end
+  end
+
+  class ZyncTokenTest < ByZyncTokenIntegrationTest
+    disable_transactional_fixtures!
+
+    test 'rejects GET with an invalid X-Zync-Token' do
+      with_test_routes do
+        get '/zync_test/show', headers: zync_headers('wrong')
+        assert_response :forbidden
+      end
+    end
+
+    test 'rejects requests targeting the master domain even with a valid X-Zync-Token' do
+      host! master_account.internal_admin_domain
+      with_test_routes do
+        get '/zync_test/show', headers: zync_headers
+        assert_response :forbidden
+      end
+    end
+
+    test 'does not authenticate write actions via X-Zync-Token' do
+      with_test_routes do
+        put '/zync_test/update', headers: zync_headers
+        assert_response :forbidden
+      end
+    end
+
+    test 'authenticates GET requests with a valid X-Zync-Token' do
+      with_test_routes do
+        get '/zync_test/show', headers: zync_headers
+        assert_response :success
+      end
+    end
+
+    test 'Zync-authenticated requests enforce a read-only DB transaction' do
+      with_test_routes do
+        get '/zync_test/write_attempt', headers: zync_headers
+        assert_response :forbidden
+        assert_match(/read.only transaction/i, response.body)
+      end
+    end
+  end
+
+  class DomainRoutingTest < ByZyncTokenIntegrationTest
+    disable_transactional_fixtures!
+
+    test 'authenticates as the admin of the provider whose domain is in the Host header' do
+      with_test_routes do
+        get '/zync_test/show', headers: zync_headers
+        assert_response :success
+        assert_equal @provider.id, response.parsed_body['account_id']
+      end
+    end
+
+    test 'X-Forwarded-Host overrides Host header for domain resolution' do
+      provider_b = FactoryBot.create(:provider_account)
+      with_test_routes do
+        get '/zync_test/show', headers: zync_headers.merge('X-Forwarded-Host' => provider_b.internal_admin_domain)
+        assert_response :success
+        assert_equal provider_b.id, response.parsed_body['account_id']
+      end
+    end
+
+    test 'rejects master domain via X-Forwarded-Host even with valid Zync token' do
+      with_test_routes do
+        get '/zync_test/show', headers: zync_headers.merge('X-Forwarded-Host' => master_account.internal_admin_domain)
+        assert_response :forbidden
+      end
+    end
+  end
+end

--- a/test/integration/by_access_token_integration_test.rb
+++ b/test/integration/by_access_token_integration_test.rb
@@ -114,4 +114,15 @@ class ApiAuthentication::ByAccessTokenIntegrationTest < ActionDispatch::Integrat
 
     assert_response :forbidden
   end
+
+  test 'oidc_sync tokens are rejected even with a valid plaintext value' do
+    # Create a token with the oidc_sync name and store its plaintext value
+    token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management',
+                                             name: AccessToken::OIDC_SYNC_TOKEN)
+    plaintext = token.plaintext_value
+
+    get admin_api_accounts_path(format: :xml), params: { access_token: plaintext }
+
+    assert_response :forbidden
+  end
 end

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -312,6 +312,14 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert access_token.valid?
   end
 
+  test 'AccessToken.oidc_sync no longer exists' do
+    assert_not AccessToken.respond_to?(:oidc_sync)
+  end
+
+  test 'OIDC_SYNC_TOKEN constant is still defined for rejection logic' do
+    assert_equal 'OIDC Synchronization Token', AccessToken::OIDC_SYNC_TOKEN
+  end
+
   private
 
   def assert_access_token_audit_all_data(access_token, audit)

--- a/test/unit/api_authentication/by_authentication_token_test.rb
+++ b/test/unit/api_authentication/by_authentication_token_test.rb
@@ -22,7 +22,7 @@ class ApiAuthentication::ByAuthenticationTokenTest < SimpleMiniTest
 
   def mock_token(attributes = {})
     @params = { access_token: 'some-token' }
-    token = mock('access-token', attributes.merge(expired?: false))
+    token = mock('access-token', **attributes, expired?: false, name: 'access-token')
     @access_tokens.expects(:find_from_value).with('some-token').returns(token)
     token
   end

--- a/test/unit/api_authentication/by_zync_token_test.rb
+++ b/test/unit/api_authentication/by_zync_token_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApiAuthentication::ByZyncTokenTest < ActiveSupport::TestCase
+  # Minimal host object that includes ByZyncToken so we can call its methods directly.
+  class Host
+    include ActiveSupport::Callbacks
+    define_callbacks :action
+    include ActiveSupport::Rescuable
+    include AbstractController::Callbacks
+    extend AbstractController::Callbacks::ClassMethods
+
+    include ApiAuthentication::ByAccessToken
+    include ApiAuthentication::ByZyncToken
+
+    attr_reader :request, :domain_account, :params
+
+    def initialize(request:, domain_account:)
+      @request = request
+      @domain_account = domain_account
+      @params = {}
+    end
+  end
+
+  def setup
+    @user    = stub('user')
+    @account = stub('account', master?: false,
+                               find_impersonation_admin: nil,
+                               first_admin!: @user)
+    @request = stub('request', authorization: nil)
+    @host    = Host.new(request: @request, domain_account: @account)
+  end
+
+  # authenticate_zync_request
+
+  test '#authenticate_zync_request sets zync_authenticated flag for a valid Zync request' do
+    AuthenticatedSystem::Request.stubs(:new).with(@request).returns(stub(zync?: true))
+
+    @host.send(:authenticate_zync_request)
+
+    assert @host.instance_variable_get(:@zync_authenticated)
+  end
+
+  test '#authenticate_zync_request is a no-op when X-Zync-Token is wrong' do
+    AuthenticatedSystem::Request.stubs(:new).with(@request).returns(stub(zync?: false))
+
+    @host.send(:authenticate_zync_request)
+
+    assert_nil @host.instance_variable_get(:@zync_authenticated)
+  end
+
+  test '#authenticate_zync_request is a no-op when domain is master' do
+    AuthenticatedSystem::Request.stubs(:new).with(@request).returns(stub(zync?: true))
+    @account.stubs(:master?).returns(true)
+
+    @host.send(:authenticate_zync_request)
+
+    assert_nil @host.instance_variable_get(:@zync_authenticated)
+  end
+
+  # current_user
+
+  test '#current_user falls back to first_admin! when no impersonation admin exists' do
+    AuthenticatedSystem::Request.stubs(:new).with(@request).returns(stub(zync?: true))
+    @host.send(:authenticate_zync_request)
+
+    assert_equal @user, @host.send(:current_user)
+  end
+
+  test '#current_user prefers the impersonation admin over first_admin!' do
+    impersonation_admin = stub('impersonation_admin')
+    @account.stubs(:find_impersonation_admin).returns(impersonation_admin)
+    AuthenticatedSystem::Request.stubs(:new).with(@request).returns(stub(zync?: true))
+    @host.send(:authenticate_zync_request)
+
+    assert_equal impersonation_admin, @host.send(:current_user)
+  end
+
+  test '#current_user delegates to super for non-Zync requests' do
+    AuthenticatedSystem::Request.stubs(:new).with(@request).returns(stub(zync?: false))
+    @host.send(:authenticate_zync_request)
+
+    assert_nil @host.send(:current_user)
+  end
+
+  # enforce_access_token_permission
+
+  class EnforcePermissionTest < ApiAuthentication::ByZyncTokenTest
+    # Read-only transaction enforcement can't run inside a transaction.
+    self.use_transactional_tests = false
+
+    test '#enforce_access_token_permission enforces a read-only DB transaction for Zync requests' do
+      @host.instance_variable_set(:@zync_authenticated, true)
+
+      assert_raises ApiAuthentication::ByAccessToken::PermissionError do
+        @host.send(:enforce_access_token_permission) { User.delete_all }
+      end
+    end
+  end
+
+  test '#enforce_access_token_permission delegates to ByAccessToken for non-Zync requests' do
+    # @zync_authenticated is not set — falls through to ByAccessToken's version.
+    # With no authenticated_token (no access_token param, no HTTP auth) it yields normally.
+    executed = false
+    @host.send(:enforce_access_token_permission) { executed = true }
+    assert executed
+  end
+end

--- a/test/workers/zync_worker_test.rb
+++ b/test/workers/zync_worker_test.rb
@@ -222,4 +222,11 @@ class ZyncWorkerTest < ActiveSupport::TestCase
     assert_equal zync_event.data[:service_id], dependency_event_service.data[:id]
     Sidekiq::Testing.inline! { ZyncWorker.perform_async( dependency_event_service.event_id,  dependency_event_service.data.as_json) }
   end
+
+  test 'provider_access_token returns a non-empty placeholder string' do
+    provider = FactoryBot.create(:provider_account)
+    token = ZyncWorker.provider_access_token(provider)
+    assert_kind_of String, token
+    assert token.present?
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

The issue description explains the situation, but summarizing, https://github.com/3scale/porta/pull/4236 the integration with zync. Porta calls `PUT /tenant` endpoint on zync and pushes the access token to Zync, which will use that access token later to pull data from porta. After https://github.com/3scale/porta/pull/4236, now the access token is sent hashed to zync, which is useless as authentication method, so zync can't retrieve anymore data from porta.

In order to fix it, the approach is to take advantage from the fact that Zync already sends the `X-Zync-Token` header with an auth token in **all** requests to porta. This PR adds a new `ByZyncToken` authentication method for API endpoints, which grants access to the exact few resources Zync needs if they are requested from a request that includes the Zync token, even when they don't include a valid access token.

This is the simpler solution and doesn't require making any changes in Zync itself.However, this is arguably not good news from the security perspective, but the threat vector is not much bigger now than before. This is Claude's description about how this PR affects security:

```
 Attack surface with a leaked X-Zync-Token
  
  Read access on 3 endpoints, any tenant:
  - GET /admin/api/provider.json — provider account details
  - GET /admin/api/services/:id/proxy.json — proxy config, backend URLs, OIDC client secrets
  - GET /admin/api/applications/find.json — application credentials (user keys, app IDs)
  
  Cross-tenant: The token is a shared secret. By setting the Host or X-Forwarded-Host header, an attacker can target any provider, not just one.

  Soft-deleted providers: ProviderDomainConstraint has always used zync? to allow routing to soft-deleted provider domains, because Zync needs to reach them during OIDC cleanup. This was already the case before this PR — a
  leaked Zync token already bypassed the "deleted provider" routing gate. Our PR does not introduce or worsen this behavior.

  Hard limits (unchanged by this PR):
  - Master account is explicitly rejected in authenticate_zync_request
  - Only show/find actions — write actions (update, destroy) are excluded
  - Read-only DB transaction enforced as defense in depth even if the action filter is bypassed
  - Only 3 controllers include ByZyncToken — all other Admin API endpoints are inaccessible

  ---
  How this PR changes the threat model
  
  Before this PR, exploiting a leaked Zync token required two secrets:
  1. X-Zync-Token — for routing (including soft-deleted providers)
  2. A valid oidc_sync access token for the target provider — for Admin API authentication
  
  After this PR, only X-Zync-Token is needed.

  However, those two secrets lived in the same trust boundary: the Zync token travels in every HTTP header, and oidc_sync tokens were stored in plaintext in Zync's database. An attacker with access to Zync's environment could
  extract both trivially. In practice, having one did not meaningfully prevent having the other.
```

Additionally, it's worth to mention that Zync stores a copy of alls OIDC access tokens in plain text in its database. After https://github.com/3scale/porta/pull/4236 all those tokens are going to be gradually replaced by invalid values, but in the meantime we need to immediately invalidate all those tokens, they are a risk and we don't need them now we auth via zync token.

The PR is easy to review commit by commit. Also AI-generated commit messages can be useful as well. I'll add some comments to the PR for further explanation.

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-14969

**Verification steps** 

For the 3 affected endpoints:

- GET /admin/api/provider.json
- GET /admin/api/services/:id/proxy.json
- GET /admin/api/applications/find.json

You should be able to:

- You can call them with the `X-Zync-Token` header and they should work
- You can add the `X-Forwarded-Host` header to target a different endpoint than the one receiving the request.
- You can't send `PUT`, `POST`, or `DELETE` requests to them without an access token
- You can't target the master portal in any way
- No other endpoint accepts `X-Zync-Token` header as authentication method
