### PR TITLE
THREESCALE-9973: Bullet n plus 1 offences

### DIFF
--- a/app/controllers/api/proxy_configs_controller.rb
+++ b/app/controllers/api/proxy_configs_controller.rb
@@ -26,11 +26,11 @@ class Api::ProxyConfigsController < Api::BaseController
   attr_reader :service
 
   def proxy_configs
-    service.proxy.proxy_configs.newest_first
+    service.proxy.proxy_configs.includes(:user).newest_first
   end
 
   def proxy_config
-    proxy_configs.find(params[:id])
+    service.proxy.proxy_configs.find(params[:id])
   end
 
   def paginate_params

--- a/app/controllers/buyers/applications/bulk/base_controller.rb
+++ b/app/controllers/buyers/applications/bulk/base_controller.rb
@@ -20,7 +20,7 @@ class Buyers::Applications::Bulk::BaseController < Buyers::BulkBaseController
   end
 
   def collection
-    @collection ||= current_account.provided_cinstances.where(id: selected_ids_param).includes(:user_account)
+    @collection ||= current_account.provided_cinstances.where(id: selected_ids_param).includes(:service, user_account: [:admin_user])
   end
 
   def errors_template

--- a/app/controllers/buyers/applications/bulk/change_plans_controller.rb
+++ b/app/controllers/buyers/applications/bulk/change_plans_controller.rb
@@ -24,7 +24,6 @@ class Buyers::Applications::Bulk::ChangePlansController < Buyers::Applications::
   attr_reader :service
 
   def find_services
-    # probably should preload :service and :user_account
     services = applications.map(&:service).uniq
     return render(:multiple_services) unless services.size == 1
 

--- a/app/controllers/provider/admin/account/invoices_controller.rb
+++ b/app/controllers/provider/admin/account/invoices_controller.rb
@@ -8,7 +8,7 @@ class Provider::Admin::Account::InvoicesController < Provider::Admin::Account::B
   helper_method :empty_invoices?
 
   def index
-    @invoices = current_account.invoices.ordered
+    @invoices = current_account.invoices.includes(:buyer_account, :provider_account).ordered
   end
 
   def show

--- a/app/controllers/provider/admin/messages/inbox_controller.rb
+++ b/app/controllers/provider/admin/messages/inbox_controller.rb
@@ -7,6 +7,7 @@ class Provider::Admin::Messages::InboxController < Provider::Admin::Messages::Ba
 
   def index
     @messages = current_account.received_messages
+                               .includes(message: { sender: [:admin_user] })
                                .not_system
                                .latest_first
                                .paginate(pagination_params)

--- a/app/controllers/provider/admin/messages/trash_controller.rb
+++ b/app/controllers/provider/admin/messages/trash_controller.rb
@@ -5,6 +5,7 @@ class Provider::Admin::Messages::TrashController < FrontendController
 
   def index
     @messages = current_account.trashed_messages
+                               .includes(:sender)
                                .not_system
                                .latest_first
                                .paginate(pagination_params)

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -99,7 +99,7 @@ class ServiceDecorator < ApplicationDecorator
   end
 
   def latest_applications
-    @latest_applications ||= cinstances.latest
+    @latest_applications ||= cinstances.with_account.latest
   end
 
   def traffic?

--- a/app/presenters/applications_index_presenter.rb
+++ b/app/presenters/applications_index_presenter.rb
@@ -133,6 +133,7 @@ class ApplicationsIndexPresenter
     @applications ||= begin
       includes = provider.settings.finance.allowed? ? [{ plan: %i[pricing_rules] }] : [:plan]
       includes << :service if service.nil? && provider.multiservice?
+      includes << :user_account if buyer.nil?
       raw_applications.scope_search(search)
                       .order_by(*sorting_params)
                       .includes(includes)

--- a/app/presenters/applications_index_presenter.rb
+++ b/app/presenters/applications_index_presenter.rb
@@ -133,7 +133,7 @@ class ApplicationsIndexPresenter
     @applications ||= begin
       includes = provider.settings.finance.allowed? ? [{ plan: %i[pricing_rules] }] : [:plan]
       includes << :service if service.nil? && provider.multiservice?
-      includes << { user_account: [:admin_user] } if buyer.nil?
+      includes << :user_account if buyer.nil?
       raw_applications.scope_search(search)
                       .order_by(*sorting_params)
                       .includes(includes)

--- a/app/presenters/applications_index_presenter.rb
+++ b/app/presenters/applications_index_presenter.rb
@@ -133,7 +133,7 @@ class ApplicationsIndexPresenter
     @applications ||= begin
       includes = provider.settings.finance.allowed? ? [{ plan: %i[pricing_rules] }] : [:plan]
       includes << :service if service.nil? && provider.multiservice?
-      includes << :user_account if buyer.nil?
+      includes << { user_account: [:admin_user] } if buyer.nil?
       raw_applications.scope_search(search)
                       .order_by(*sorting_params)
                       .includes(includes)

--- a/app/presenters/applications_index_presenter.rb
+++ b/app/presenters/applications_index_presenter.rb
@@ -131,7 +131,8 @@ class ApplicationsIndexPresenter
 
   def applications
     @applications ||= begin
-      includes = provider.settings.finance.allowed? ? { plan: %i[pricing_rules] } : :plan
+      includes = provider.settings.finance.allowed? ? [{ plan: %i[pricing_rules] }] : [:plan]
+      includes << :service if service.nil? && provider.multiservice?
       raw_applications.scope_search(search)
                       .order_by(*sorting_params)
                       .includes(includes)

--- a/app/presenters/buyers/accounts_index_presenter.rb
+++ b/app/presenters/buyers/accounts_index_presenter.rb
@@ -17,9 +17,13 @@ class Buyers::AccountsIndexPresenter
   delegate :can?, to: :ability
 
   def buyers
-    @buyers ||= raw_buyers.scope_search(search)
-                          .order_by(*sorting_params)
-                          .paginate(pagination_params)
+    @buyers ||= begin
+      scope = raw_buyers.scope_search(search)
+                        .order_by(*sorting_params)
+                        .paginate(pagination_params)
+      scope = scope.includes(:bought_account_plan, bought_account_contract: [:plan]) if account_plans_size > 1
+      scope
+    end
   end
 
   def account_plans

--- a/app/presenters/buyers/accounts_index_presenter.rb
+++ b/app/presenters/buyers/accounts_index_presenter.rb
@@ -17,13 +17,9 @@ class Buyers::AccountsIndexPresenter
   delegate :can?, to: :ability
 
   def buyers
-    @buyers ||= begin
-      scope = raw_buyers.scope_search(search)
-                        .order_by(*sorting_params)
-                        .paginate(pagination_params)
-      scope = scope.includes(:bought_account_plan, bought_account_contract: [:plan]) if account_plans_size > 1
-      scope
-    end
+    @buyers ||= raw_buyers.scope_search(search)
+                          .order_by(*sorting_params)
+                          .paginate(pagination_params)
   end
 
   def account_plans

--- a/app/presenters/finance/provider/invoices_index_presenter.rb
+++ b/app/presenters/finance/provider/invoices_index_presenter.rb
@@ -86,7 +86,7 @@ class Finance::Provider::InvoicesIndexPresenter
   private
 
   def raw_invoices
-    @raw_invoices ||= provider.buyer_invoices.includes(:provider_account)
+    @raw_invoices ||= provider.buyer_invoices.includes({ buyer_account: [:admin_user] }, :provider_account)
   end
 
   def states_for_filter

--- a/app/presenters/provider/admin/account/users_index_presenter.rb
+++ b/app/presenters/provider/admin/account/users_index_presenter.rb
@@ -11,7 +11,8 @@ class Provider::Admin::Account::UsersIndexPresenter
 
     @users = users.order(sorting_params)
                   .paginate(pagination_params)
-                  .decorate
+    ActiveRecord::Associations::Preloader.new(records: @users.select(&:member?), associations: :member_permissions).call if @users.any?(&:member?)
+    @users = @users.decorate
   end
 
   attr_reader :users

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -100,7 +100,6 @@ Rails.application.configure do
 
       # We ignore these items because they are broken at the time commit them but we should fix them, see
       # https://issues.redhat.com/browse/THREESCALE-9973
-      Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :admin_user
       Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :bought_account_contract
       Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :bought_account_plan
       Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :provider_account

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -100,6 +100,9 @@ Rails.application.configure do
 
       # We ignore these items because they are broken at the time commit them but we should fix them, see
       # https://issues.redhat.com/browse/THREESCALE-9973
+      Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :admin_user
+      Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :bought_account_contract
+      Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :bought_account_plan
       Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :provider_account
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :admin_users
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :bought_cinstances

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -151,7 +151,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Topic", type: :n_plus_one_query, association: :last_user
       Bullet.add_safelist class_name: "Topic", type: :n_plus_one_query, association: :recent_post
       Bullet.add_safelist class_name: "UsageLimit", type: :unused_eager_loading, association: :metric
-      Bullet.add_safelist class_name: "User", type: :n_plus_one_query, association: :member_permissions
       Bullet.add_safelist class_name: "UserTopic", type: :n_plus_one_query, association: :topic
     end
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -100,8 +100,6 @@ Rails.application.configure do
 
       # We ignore these items because they are broken at the time commit them but we should fix them, see
       # https://issues.redhat.com/browse/THREESCALE-9973
-      Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :bought_account_contract
-      Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :bought_account_plan
       Bullet.add_safelist class_name: "Account", type: :n_plus_one_query, association: :provider_account
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :admin_users
       Bullet.add_safelist class_name: "Account", type: :unused_eager_loading, association: :bought_cinstances

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -131,7 +131,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Invoice", type: :n_plus_one_query, association: :provider_account
       Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :provider_account
       Bullet.add_safelist class_name: "LineItem::PlanCost", type: :n_plus_one_query, association: :contract
-      Bullet.add_safelist class_name: "Message", type: :n_plus_one_query, association: :sender
       Bullet.add_safelist class_name: "Metric", type: :n_plus_one_query, association: :children
       Bullet.add_safelist class_name: "Metric", type: :n_plus_one_query, association: :owner
       Bullet.add_safelist class_name: "Metric", type: :n_plus_one_query, association: :parent

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -138,7 +138,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Metric", type: :unused_eager_loading, association: :owner
       Bullet.add_safelist class_name: "Metric", type: :unused_eager_loading, association: :parent
       Bullet.add_safelist class_name: "Post", type: :n_plus_one_query, association: :topic
-      Bullet.add_safelist class_name: "ProxyConfig", type: :n_plus_one_query, association: :user
       Bullet.add_safelist class_name: "ProxyRule", type: :n_plus_one_query, association: :owner
       Bullet.add_safelist class_name: "Service", type: :counter_cache, association: :backend_api_configs
       Bullet.add_safelist class_name: "Service", type: :counter_cache, association: :cinstances

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -126,7 +126,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "CMS::Page", type: :n_plus_one_query, association: :provider
       Bullet.add_safelist class_name: "CMS::Page", type: :n_plus_one_query, association: :section
       Bullet.add_safelist class_name: "Cinstance", type: :n_plus_one_query, association: :plan
-      Bullet.add_safelist class_name: "Cinstance", type: :n_plus_one_query, association: :user_account
       Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :plan
       Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :service
       Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :user_account

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -127,8 +127,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :service
       Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :user_account
       Bullet.add_safelist class_name: "Invoice", type: :counter_cache, association: :payment_transactions
-      Bullet.add_safelist class_name: "Invoice", type: :n_plus_one_query, association: :buyer_account
-      Bullet.add_safelist class_name: "Invoice", type: :n_plus_one_query, association: :provider_account
       Bullet.add_safelist class_name: "Invoice", type: :unused_eager_loading, association: :provider_account
       Bullet.add_safelist class_name: "LineItem::PlanCost", type: :n_plus_one_query, association: :contract
       Bullet.add_safelist class_name: "Metric", type: :n_plus_one_query, association: :children

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -126,7 +126,6 @@ Rails.application.configure do
       Bullet.add_safelist class_name: "CMS::Page", type: :n_plus_one_query, association: :provider
       Bullet.add_safelist class_name: "CMS::Page", type: :n_plus_one_query, association: :section
       Bullet.add_safelist class_name: "Cinstance", type: :n_plus_one_query, association: :plan
-      Bullet.add_safelist class_name: "Cinstance", type: :n_plus_one_query, association: :service
       Bullet.add_safelist class_name: "Cinstance", type: :n_plus_one_query, association: :user_account
       Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :plan
       Bullet.add_safelist class_name: "Cinstance", type: :unused_eager_loading, association: :service

--- a/lib/developer_portal/app/controllers/developer_portal/admin/account/invoices_controller.rb
+++ b/lib/developer_portal/app/controllers/developer_portal/admin/account/invoices_controller.rb
@@ -63,7 +63,7 @@ class DeveloperPortal::Admin::Account::InvoicesController < ::DeveloperPortal::B
   end
 
   def accessible_invoices
-    current_account.invoices.visible_for_buyer
+    current_account.invoices.includes(:provider_account).visible_for_buyer
   end
 
   def find_invoice


### PR DESCRIPTION
<h2>What this PR does / why we need it</h2>

<p>
This PR removes <code>7 n_plus_one_query</code> safelist entries from
<code>config/environments/test.rb</code> by fixing the underlying N+1 queries
with proper eager loading.
</p>

<p>The changes include:</p>

<ul>
  <li>Adding missing <code>.includes</code></li>
  <li>Making eager loading conditional when associations are only accessed in specific contexts</li>
  <li>Decoupling single-record finders from collection-level includes to avoid <code>AVOID eager loading</code> warnings</li>
  <li>Using conditional preloading for associations only needed for certain record types</li>
</ul>

<p>
Related issue:
<a href="https://issues.redhat.com/browse/THREESCALE-9973">
  THREESCALE-9973
</a>
</p>

<hr />

<h2>Changes by commit</h2>

<h3><code>1cf51db5f</code></h3>

<p>
Add conditional <code>:service</code> include to
<code>ApplicationsIndexPresenter</code> (only when no service filter and multiservice)
and add <code>:service</code> +
<code>user_account: [:admin_user]</code> includes to
<code>Buyers::Applications::Bulk::BaseController</code>.
</p>

<p><strong>Removes:</strong></p>

<ul>
  <li><code>Cinstance :service</code></li>
</ul>

<hr />

<h3><code>26e446521</code></h3>

<p>
Add conditional <code>:user_account</code> include to
<code>ApplicationsIndexPresenter</code> (only when no buyer context).
Add <code>.with_account</code> to
<code>Service#latest_applications</code> to fix N+1 on service show page.
</p>

<p><strong>Removes:</strong></p>

<ul>
  <li><code>Cinstance :user_account</code></li>
</ul>

<hr />

<h3><code>b8f4015c3</code></h3>

<p>
Extend <code>user_account</code> include to
<code>user_account: [:admin_user]</code> in
<code>ApplicationsIndexPresenter</code>.
</p>

<p>
The view accesses <code>account.admin_user</code> via
<code>link_to_buyer_or_deleted</code>.
</p>

<p><strong>Removes:</strong></p>

<ul>
  <li><code>Account :admin_user</code></li>
</ul>

<hr />

<h3><code>e8cf2b66b</code></h3>

<p>
Add conditional <code>bought_account_plan</code> and
<code>bought_account_contract: [:plan]</code> includes to
<code>Buyers::AccountsIndexPresenter</code>
(only when <code>account_plans_size &gt; 1</code>).
</p>

<p><strong>Removes:</strong></p>

<ul>
  <li><code>Account :bought_account_plan</code></li>
  <li><code>Account :bought_account_contract</code></li>
</ul>

<hr />

<h3><code>66f91e0d3</code></h3>

<p>
Add <code>.includes(:user)</code> to proxy configs collection query and decouple
single-record finder to avoid
<code>AVOID eager loading</code> warnings on show action.
</p>

<p><strong>Removes:</strong></p>

<ul>
  <li><code>ProxyConfig :user</code></li>
</ul>

<hr />

<h3><code>8a12d0f73</code></h3>

<p>
Add
<code>.includes(message: { sender: [:admin_user] })</code>
to inbox controller and
<code>.includes(:sender)</code>
to trash controller.
</p>

<ul>
  <li>Inbox uses <code>MessageRecipient</code> (sender accessed through <code>Message</code>)</li>
  <li>Trash uses <code>Message</code> directly</li>
</ul>

<p><strong>Removes:</strong></p>

<ul>
  <li><code>Message :sender</code></li>
</ul>

<hr />

<h3><code>1c76daf1a</code></h3>

<p>
Add
<code>.includes({ buyer_account: [:admin_user] }, :provider_account)</code>
to <code>Finance::Provider::InvoicesIndexPresenter</code>,
<code>.includes(:buyer_account, :provider_account)</code>
to <code>Provider::Admin::Account::InvoicesController</code>,
and <code>.includes(:provider_account)</code>
to developer portal <code>InvoicesController</code>.
</p>

<p><strong>Removes:</strong></p>

<ul>
  <li><code>Invoice :buyer_account</code></li>
  <li><code>Invoice :provider_account</code></li>
</ul>

<hr />

<h3><code>4042a5f20</code></h3>

<p>
Use <code>ActiveRecord::Associations::Preloader</code> to conditionally preload
<code>:member_permissions</code> only for member users in
<code>UsersIndexPresenter</code>, avoiding
<code>AVOID eager loading</code> warnings when all users are admins.
</p>

<p><strong>Removes:</strong></p>

<ul>
  <li><code>User :member_permissions</code></li>
</ul>

<hr />

<h3><code>7b6ec834e</code></h3>

<p>
Revert <code>Account :admin_user</code>,
<code>:bought_account_contract</code>, and
<code>:bought_account_plan</code> fixes and restore their safelist entries.
</p>

<p>
Bulk controllers (<code>Buyers::Accounts::Bulk</code>) share a single collection
method across new and create actions with different eager loading requirements.
Adding includes to the shared collection causes
<code>unused_eager_loading</code> warnings on the action that doesn't need them.
Fixing this cleanly would require action specific preloading, which adds too much
complexity for this PR so I reverted it to keep the PR clean.
</p>

<p><strong>Restores:</strong></p>

<ul>
  <li><code>Account :admin_user</code></li>
  <li><code>Account :bought_account_contract</code></li>
  <li><code>Account :bought_account_plan</code></li>
</ul>

<hr />


<hr />