### PR TITLE
THREESCALE-6077: job sync system zync

### DIFF
--- a/app/events/base_event_store_event.rb
+++ b/app/events/base_event_store_event.rb
@@ -22,10 +22,10 @@ class BaseEventStoreEvent < RailsEventStore::Event
 
   class << self
 
-    def create_and_publish!(*args)
-      return unless valid?(*args)
+    def create_and_publish!(...)
+      return unless valid?(...)
 
-      event = create(*args)
+      event = create(...)
 
       PUBLISHER.call(event) && event
     end

--- a/app/events/zync_resync_event.rb
+++ b/app/events/zync_resync_event.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ZyncResyncEvent < BaseEventStoreEvent
+  def self.create(model, provider_id:, service_id: nil)
+    zync = service_id ? { service_id: } : {}
+
+    new(
+      model:,
+      metadata: {
+        provider_id:,
+        zync:
+      }
+    )
+  end
+end

--- a/app/lib/event_store/repository.rb
+++ b/app/lib/event_store/repository.rb
@@ -159,7 +159,8 @@ module EventStore
                       OIDC::ProxyChangedEvent,
                       OIDC::ServiceChangedEvent,
                       Domains::ProviderDomainsChangedEvent,
-                      Domains::ProxyDomainsChangedEvent
+                      Domains::ProxyDomainsChangedEvent,
+                      ZyncResyncEvent
                      )
       subscribe_event(ServiceTokenEventSubscriber.new, ServiceTokenDeletedEvent)
       subscribe_event(ServiceDeletionSubscriber.new, Services::ServiceScheduledForDeletionEvent)

--- a/app/subscribers/publish_zync_event_subscriber.rb
+++ b/app/subscribers/publish_zync_event_subscriber.rb
@@ -27,6 +27,8 @@ class PublishZyncEventSubscriber
         ZyncEvent.create(event, event.service)
       when Domains::ProviderDomainsChangedEvent
         ZyncEvent.create(event, event.provider)
+      when ZyncResyncEvent
+        ZyncEvent.create(event, event.model)
       else raise "Unknown event type #{event.class}"
       end
     end

--- a/lib/tasks/zync.rake
+++ b/lib/tasks/zync.rake
@@ -2,43 +2,63 @@
 
 namespace :zync do
   namespace :resync do
-    def each_with_progress(scope)
+    def each_with_progress(label, scope)
+      puts "== Resyncing #{label} =="
       total_count = scope.count
-      batch_size = 100
       index = 0
 
+      step = [(total_count / 10), 1].max
       progress = -> do
-        break unless (index % batch_size) == 0
+        break unless (index % step).zero?
+
         percent = (index / total_count.to_f) * 100.0
         puts "#{percent.round(2)}% completed"
       end
 
-      scope.find_each(batch_size: batch_size) do |object|
+      scope.find_each(batch_size: 100) do |object|
         index += 1
         yield object
         progress.call
       end
     end
 
-    desc 'Resync provider domains with zync'
-    task provider_domains: :environment do
+    def target_providers
       accounts = Account.providers_with_master
-      if (provider_id = ENV["PROVIDER_ID"])
-        accounts = accounts.where(id: provider_id)
-      end
-      each_with_progress(accounts) { |account| Domains::ProviderDomainsChangedEvent.create_and_publish!(account) }
+      accounts = accounts.where(id: ENV["PROVIDER_ID"]) if ENV["PROVIDER_ID"]
+      accounts
+    end
+
+    desc 'Resync provider domains with zync'
+    task providers: :environment do
+      each_with_progress('providers', target_providers) { |account| ZyncResyncEvent.create_and_publish!(account, provider_id: account.id) }
+    end
+
+    task provider_domains: :providers
+
+    desc 'Resync services with zync'
+    task services: :environment do
+      services = Service.joins(:account).merge(target_providers)
+      each_with_progress('services', services) { |service| ZyncResyncEvent.create_and_publish!(service, provider_id: service.account_id) }
     end
 
     desc 'Resync proxy domains with zync'
-    task proxy_domains: :environment do
-      services = Service.includes(:proxy)
-      if (provider_id = ENV["PROVIDER_ID"])
-        services = services.where(account_id: provider_id)
-      end
-      each_with_progress(services) { |service| Domains::ProxyDomainsChangedEvent.create_and_publish!(service.proxy) }
+    task proxies: :environment do
+      proxies = Proxy.eager_load(:service).joins(service: :account).merge(target_providers)
+      each_with_progress('proxies', proxies) { |proxy| ZyncResyncEvent.create_and_publish!(proxy, provider_id: proxy.service.account_id, service_id: proxy.service_id) }
+    end
+
+    task proxy_domains: :proxies
+
+    desc 'Resync applications with zync'
+    task applications: :environment do
+      cinstances = Cinstance.eager_load(:service).joins(service: :account).merge(target_providers)
+      each_with_progress('applications', cinstances) { |cinstance| ZyncResyncEvent.create_and_publish!(cinstance, provider_id: cinstance.service.account_id, service_id: cinstance.service_id) }
     end
 
     desc 'Resync all domains with zync'
-    task domains: [:provider_domains, :proxy_domains]
+    task domains: %i[provider_domains proxy_domains]
+
+    desc 'Full resync'
+    task full: %i[providers services proxies applications]
   end
 end

--- a/test/unit/tasks/zync_test.rb
+++ b/test/unit/tasks/zync_test.rb
@@ -6,14 +6,97 @@ module Tasks
       FactoryBot.create(:provider_account)
     end
 
-    test 'resync provider domains' do
-      Account.providers_with_master.each { |account| Domains::ProviderDomainsChangedEvent.expects(:create_and_publish!).with(account) }
-      execute_rake_task 'zync.rake', 'zync:resync:provider_domains'
+    class DomainsSyncTest < ZyncTest
+      test 'resync provider domains' do
+        active_providers.each { |account| ZyncResyncEvent.expects(:create_and_publish!).with(account, provider_id: account.id) }
+        execute_rake_task 'zync.rake', 'zync:resync:provider_domains'
+      end
+
+      test 'resync proxy domains' do
+        active_proxies.each { |proxy| ZyncResyncEvent.expects(:create_and_publish!).with(proxy, provider_id: proxy.service.account_id, service_id: proxy.service_id) }
+        execute_rake_task 'zync.rake', 'zync:resync:proxy_domains'
+      end
+
+      private
+
+      def active_providers
+        Account.providers_with_master.without_suspended.without_deleted
+      end
+
+      def active_proxies
+        Proxy.eager_load(service: :account).merge(active_providers)
+      end
     end
 
-    test 'resync proxy domains' do
-      Service.all.each { |service| Domains::ProxyDomainsChangedEvent.expects(:create_and_publish!).with(service.proxy) }
-      execute_rake_task 'zync.rake', 'zync:resync:proxy_domains'
+    class FullSyncTest < ZyncTest
+      setup do
+        @providers = FactoryBot.create_list(:provider_account, 3)
+
+        @providers.each do |provider|
+          services = FactoryBot.create_list(:service, 2, account: provider)
+          services.each do |service|
+            plan = FactoryBot.create(:application_plan, issuer: service)
+            FactoryBot.create_list(:cinstance, 3, plan: plan, service: service)
+          end
+        end
+      end
+
+      test 'full resync' do
+        load_collections
+        expect_resync_events
+        execute_rake_task 'zync.rake', 'zync:resync:full'
+      end
+
+      test 'full resync includes suspended providers' do
+        @providers.first.suspend!
+        load_collections
+        expect_resync_events
+        execute_rake_task 'zync.rake', 'zync:resync:full'
+      end
+
+      test 'full resync with suspended PROVIDER_ID' do
+        @providers.first.suspend!
+        ENV['PROVIDER_ID'] = @providers.first.id.to_s
+        load_collections
+        expect_resync_events
+        execute_rake_task 'zync.rake', 'zync:resync:full'
+      ensure
+        ENV.delete('PROVIDER_ID')
+      end
+
+      test 'full resync excludes scheduled for deletion providers' do
+        @providers.first.schedule_for_deletion!
+        load_collections
+        expect_resync_events
+        execute_rake_task 'zync.rake', 'zync:resync:full'
+      end
+
+      test 'full resync with PROVIDER_ID' do
+        ENV['PROVIDER_ID'] = @providers.first.id.to_s
+        load_collections
+        expect_resync_events
+        execute_rake_task 'zync.rake', 'zync:resync:full'
+      ensure
+        ENV.delete('PROVIDER_ID')
+      end
+
+      private
+
+      def load_collections
+        active = Account.providers_with_master
+        active = active.where(id: ENV['PROVIDER_ID']) if ENV['PROVIDER_ID']
+        @all_accounts = active.to_a
+        @all_services = Service.joins(:account).merge(active).to_a
+        @all_proxies = Proxy.eager_load(:service).joins(service: :account).merge(active).to_a
+        @all_cinstances = Cinstance.eager_load(:service).joins(service: :account).merge(active).to_a
+      end
+
+      def expect_resync_events
+        @all_accounts.each { |account| ZyncResyncEvent.expects(:create_and_publish!).with(account, provider_id: account.id) }
+        @all_services.each { |service| ZyncResyncEvent.expects(:create_and_publish!).with(service, provider_id: service.account_id) }
+        @all_proxies.each { |proxy| ZyncResyncEvent.expects(:create_and_publish!).with(proxy, provider_id: proxy.service.account_id, service_id: proxy.service_id) }
+        @all_cinstances.each { |cinstance| ZyncResyncEvent.expects(:create_and_publish!).with(cinstance, provider_id: cinstance.service.account_id, service_id: cinstance.service_id) }
+      end
     end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Just a rake task to dump all existing data from porta to zync, in case we need to do a full resync after say a db reset.

It also adds some tests for the new task.

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-6077

**Verification steps** 

```
bundle exec rails zync:resync:full
```
or

```
PROVIDER_ID=2 bundle exec rails zync:resync:full
```
