### PR TITLE
THREESCALE-12410: Remove signup types `:partner` and `:partner:*`

### DIFF
--- a/app/controllers/partners/providers_controller.rb
+++ b/app/controllers/partners/providers_controller.rb
@@ -55,7 +55,7 @@ class Partners::ProvidersController < Partners::BaseController
 
   def user_params
     {
-      signup_type: partner.signup_type,
+      signup_type: :created_by_provider,
       password: permitted_params[:password].presence,
       email: permitted_params[:email],
       first_name: permitted_params[:first_name],

--- a/app/controllers/partners/users_controller.rb
+++ b/app/controllers/partners/users_controller.rb
@@ -27,7 +27,7 @@ class Partners::UsersController < Partners::BaseController
     @user.last_name = params[:last_name].presence
     @user.open_id = params[:open_id].presence
     @user.username = params[:username]
-    @user.signup_type = :partner
+    @user.signup_type = :created_by_provider
     @user.role = :admin
     @user.activate!
     @user.save!

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -10,10 +10,6 @@ class Partner < ApplicationRecord
   validates :name, :api_key, presence: true
   validates :name, :api_key, :system_name, :logout_url, length: { maximum: 255 }
 
-  def signup_type
-    "partner:#{system_name}"
-  end
-
   def can_manage_users?
     case system_name
     when 'appdirect' then false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -421,10 +421,6 @@ class User < ApplicationRecord
       @user = user
     end
 
-    def partner?
-      signup_type.to_s.match(/^partner(:|$)/)
-    end
-
     def new?
       signup_type == :new_signup
     end

--- a/test/functional/partners/providers_controller_test.rb
+++ b/test/functional/partners/providers_controller_test.rb
@@ -49,7 +49,9 @@ class Partners::ProvidersControllerTest < ActionController::TestCase
     assert user.active?
     assert user.valid?
     assert user.account.valid?
-    assert_equal :'partner:someone', user.signup_type
+    assert_equal :created_by_provider, user.signup_type
+    assert user.signup.machine?
+    assert_not user.signup.by_user?
     assert_equal account, user.account
 
     assert_equal provider_params[:open_id], user.open_id
@@ -100,15 +102,19 @@ class Partners::ProvidersControllerTest < ActionController::TestCase
     assert_equal true, body['success']
   end
 
-  test 'post without password or open_id rejected' do
+  test 'post without password or open_id creates user with no password' do
+    # Partner users have signup_type :created_by_provider so password is not required.
+    # A user created this way must go through password reset to set a password and log in.
     prepare_master_account
     post :create, params: provider_params.except(:open_id)
 
-    assert_response :unprocessable_entity
-    body = JSON.parse(response.body)
+    assert_response :success
+    user = assigns(:user)
+    assert user.valid?
+    assert_nil user.password_digest, 'User should have no password when not provided'
 
-    assert_not body['success']
-    assert body['errors']['user']['password'].present?
+    body = JSON.parse(response.body)
+    assert_equal true, body['success']
   end
 
   test 'post with weak password rejected when strong passwords enabled' do

--- a/test/functional/partners/users_controller_test.rb
+++ b/test/functional/partners/users_controller_test.rb
@@ -20,6 +20,9 @@ class Partners::UsersControllerTest < ActionController::TestCase
     assert_equal "foo_last_name", user.last_name
     assert_equal "bar_id", user.open_id
     assert_equal "aaron", user.username
+    assert_equal :created_by_provider, user.signup_type
+    assert user.signup.machine?
+    assert_not user.signup.by_user?
 
     assert_equal "active", user.state
 
@@ -82,14 +85,18 @@ class Partners::UsersControllerTest < ActionController::TestCase
     assert body['success']
   end
 
-  test 'create user without password or open_id rejected' do
+  test 'create user without password or open_id creates user with no password' do
+    # Partner users have signup_type :created_by_provider so password is not required.
+    # A user created this way must go through password reset to set a password and log in.
     post :create, params: { provider_id: @account.id, api_key: @partner.api_key, email: "foo@example.net", username: "aaron" }
 
-    assert_response :unprocessable_entity
-    body = JSON.parse(response.body)
+    assert_response :success
+    user = assigns(:user)
+    assert user.valid?
+    assert_nil user.password_digest, 'User should have no password when not provided'
 
-    assert_not body['success']
-    assert body['errors']['password'].present?
+    body = JSON.parse(response.body)
+    assert body['success']
   end
 
   test 'create user with invalid params returns 422' do

--- a/test/unit/partner_test.rb
+++ b/test/unit/partner_test.rb
@@ -30,12 +30,6 @@ class PartnerTest < ActiveSupport::TestCase
     assert_equal [application_plan], partner.application_plans
   end
 
-  test 'has signup_type' do
-    partner = FactoryBot.build_stubbed(:partner, system_name: 'some-name')
-
-    assert_equal 'partner:some-name', partner.signup_type
-  end
-
   test 'can manage users?' do
     partner = FactoryBot.build_stubbed(:partner)
 

--- a/test/unit/user/signup_type_test.rb
+++ b/test/unit/user/signup_type_test.rb
@@ -2,9 +2,19 @@ require 'test_helper'
 
 class User::SignupTypeTest < ActiveSupport::TestCase
 
-  def test_partner
-    assert signup_type(type: 'partner').partner?
-    assert_not signup_type(type: 'new_signup').partner?
+  test 'created_by_provider? is true for :created_by_provider' do
+    assert signup_type(type: 'created_by_provider').created_by_provider?
+    assert_not signup_type(type: 'new_signup').created_by_provider?
+  end
+
+  test 'machine? is true for :created_by_provider' do
+    assert signup_type(type: 'created_by_provider').machine?
+    assert_not signup_type(type: 'new_signup').machine?
+  end
+
+  test 'by_user? is false for :created_by_provider' do
+    assert_not signup_type(type: 'created_by_provider').by_user?
+    assert signup_type(type: 'new_signup').by_user?
   end
 
   test 'open_id' do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -273,13 +273,11 @@ class UserTest < ActiveSupport::TestCase
     assert created_by_provider_user.errors[:password].blank?
   end
 
-  test 'by_user? returns true only for :new_signup, nil, and :partner signup types' do
+  test 'by_user? returns true only for :new_signup and nil signup types' do
     user = User.new
 
-    %i[new_signup partner].each do |type|
-      user.signup_type = type
-      assert user.signup.by_user?
-    end
+    user.signup_type = :new_signup
+    assert user.signup.by_user?
 
     user.signup_type = nil
     assert user.signup.by_user?


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to get rid of signup types and simplify signup codebase, the current branch removes the partner signup types and replaces them by the `:created_by_provider` type. From now on, partner users are considered regular `:created by provider` users.

Similar to what happened with https://github.com/3scale/porta/pull/4293, the `:partner*` signup types are in fact just a variant of `:created_by_provider`, so the only reason to justify their existence is to keep them for data or analytics purposes. I don't know of any scenario where customers would need such analytics so I don't think `:partner` signup types are justified.

After removing the partner types, the only behavioral change happens when creating a new partner user: Previously it didn't accept creating a user without neither `password` or `open_id`, this PR starts accepting it. If not credentials provided, the new user will have to go through the reset password form in order to get a password. However, this in fact restores the old behavior before https://github.com/3scale/porta/pull/4195.

About the existing users with partner signup types, those are not affected, those users already behave like `:created_by_provider` because  the only behavioral difference between `:partner` and `:created_by_provider` are how password is validated for new users. For existing users there is no difference at all between `:partner` and `:created_by_provider`.

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-12410

**Verification steps** 

Test should pass.
