### PR TITLE
zync needs plaintext tokens

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -145,8 +145,9 @@ class AccessToken < ApplicationRecord
   # This can't change or it will create new tokens for everyone
   OIDC_SYNC_TOKEN = 'OIDC Synchronization Token'.freeze
 
-  def self.oidc_sync
-    create_with(scopes: %w[account_management], permission: 'ro').find_or_create_by!(name: OIDC_SYNC_TOKEN)
+  def self.refresh_oidc_sync
+    where(name: OIDC_SYNC_TOKEN).delete_all
+    create!(name: OIDC_SYNC_TOKEN, scopes: %w[account_management], permission: 'ro')
   end
 
   def scopes=(values)

--- a/app/workers/zync_worker.rb
+++ b/app/workers/zync_worker.rb
@@ -175,7 +175,7 @@ class ZyncWorker
   def self.provider_access_token(provider)
     user = provider.find_impersonation_admin || provider.first_admin!
 
-    user.access_tokens.oidc_sync.value
+    user.access_tokens.refresh_oidc_sync.plaintext_value
   end
 
   def notification_url


### PR DESCRIPTION
Alternative to #4304

@jlledom , how about something like this instead? I think there is some value in keeping the tokens for auth.

update: if needed we can also memcache the token plaintexts but I doubt it is really needed. Also we can check `Rails.configuration.zync.skip_non_oidc_applications` but either way, unless tests in stg show a significant performance difference, I wouldn't complicate things with such logic.