### PR TITLE
THREESCALE-12102: Add token exchange enabled OIDC flow toggle

### DIFF
--- a/app/models/oidc_configuration.rb
+++ b/app/models/oidc_configuration.rb
@@ -18,6 +18,7 @@ class OIDCConfiguration < ApplicationRecord
       implicit_flow_enabled
       service_accounts_enabled
       direct_access_grants_enabled
+      token_exchange_enabled
     ].freeze
 
     BOOLEAN_ATTRIBUTES = FLOWS

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2299,6 +2299,7 @@ en:
         standard_flow_enabled: Authorization Code Flow
         implicit_flow_enabled: Implicit Flow
         direct_access_grants_enabled: Direct Access Grant Flow
+        token_exchange_enabled: Token Exchange Flow
 
   config:
     advanced_cms: Advanced CMS

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2226,6 +2226,7 @@ en:
         standard_flow_enabled: Authorization Code Flow
         implicit_flow_enabled: Implicit Flow
         direct_access_grants_enabled: Direct Access Grant Flow
+        token_exchange_enabled: Token Exchange Flow
 
   config:
     advanced_cms: Advanced CMS

--- a/test/models/oidc_configuration_test.rb
+++ b/test/models/oidc_configuration_test.rb
@@ -9,7 +9,8 @@ class OIDCConfigurationTest < ActiveSupport::TestCase
       "service_accounts_enabled" => false,
       "standard_flow_enabled" => false,
       "implicit_flow_enabled" => false,
-      "direct_access_grants_enabled" => false
+      "direct_access_grants_enabled" => false,
+      "token_exchange_enabled" => false
     }
     assert_equal json, JSON.parse(config.config_before_type_cast)
   end
@@ -21,7 +22,8 @@ class OIDCConfigurationTest < ActiveSupport::TestCase
       "service_accounts_enabled" => true,
       "standard_flow_enabled" => false,
       "implicit_flow_enabled" => false,
-      "direct_access_grants_enabled" => false
+      "direct_access_grants_enabled" => false,
+      "token_exchange_enabled" => false
     }
     assert_equal json, config.attributes
   end
@@ -36,7 +38,8 @@ class OIDCConfigurationTest < ActiveSupport::TestCase
       "service_accounts_enabled" => false,
       "standard_flow_enabled" => true,
       "implicit_flow_enabled" => true,
-      "direct_access_grants_enabled" => false
+      "direct_access_grants_enabled" => false,
+      "token_exchange_enabled" => false
     }
 
     assert_equal json, JSON.parse(record.config_before_type_cast)


### PR DESCRIPTION
**What this PR does / why we need it:**

Adds token_exchange_enabled as a new OIDC flow toggle. This allows admins to enable/disable Standard Token Exchange (V2) on Keycloak clients via the 3scale UI and API, instead of configuring Keycloak manually.

**Ticket requirements (THREESCALE-12102):**

1. Add native support in APIcast for validating OBO tokens: (Verified). APIcast validates OBO tokens out of the box since they are standard JWTs. Tested by obtaining an OBO token via Keycloak token exchange and sending it through APIcast, returned HTTP 200.

2. Ensure compatibility with RHBK Standard Token Exchange (V2): This PR (Porta) + companion Zync PR. Adds the UI/API toggle in Porta that flows through Zync to set standard.token.exchange.enabled on the Keycloak client. Verified end-to-end: toggle ON → Keycloak shows true, toggle OFF → shows false.

3. Provide configuration options to enforce policies based on both client and user claims: (Verified). The OBO token contains both client claims (azp, client_id) and user claims (sub, preferred_username, email, roles). APIcast extracts the client identity via jwt_claim_with_client_id (mapped to azp) for rate limiting, and existing policies like keycloak_role_check can enforce rules on user roles. Tested with an unknown client azp → APIcast returned HTTP 403.

**Which issue(s) this PR fixes**

https://redhat.atlassian.net/browse/THREESCALE-12102

**Verification steps**

1. Navigate to a service's Integration > Settings > OpenID Connect > OIDC Authorization Flow
2. Verify a "Token Exchange Flow" checkbox appears
3. Toggle it on/off and save
4. Verify via API: GET /admin/api/services/{id}/proxy/oidc_configuration.json returns token_exchange_enabled: true/false
5. Run tests: bundle exec rails test test/models/oidc_configuration_test.rb

**Note**: End-to-end testing (Porta → Zync → Keycloak → APIcast) was done by temporarily cherry-picking commits from [PR#4310 (OIDC sync token rotation)](https://github.com/3scale/porta/pull/4310/changes). Will re-test after #4310 is merged.