### PR TITLE
🧶 Add tslib to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "showdown": "2.1.0",
     "swagger-client": "^3.36.1",
     "swagger-ui": "5.27.1",
+    "tslib": "2.8.1",
     "validate.js": "^0.13.1",
     "virtual-dom": "^2.1.1",
     "webpack-assets-manifest": "5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11005,6 +11005,11 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@2.8.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -11014,11 +11019,6 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
-
-tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
#4303 broke the image because shared dependencies with patternfly.

✨ Why this happened: Even though webpack-dev-server seems unrelated to PatternFly, it shares the same dependency tree. When `webpack-dev-server` updated, it pulled in new versions of dependencies (like `memfs`) that required newer tslib. Yarn's hoisting algorithm created a split where different packages got different tslib versions, breaking webpack's module resolution.

UPDATE:
Adding a resolution will force all packages to used this version, packages that may depend on tslib@1. It's safer to simply add tslib as a dependency to ensure it is available for react-icons.

The reason exactly why tslib is not available after webpack-dev-server bump is unknown: Claude blames yarn's hoisting algorithm and its dependency resolver. 😕