### PR TITLE
THREESCALE-15270: Migrate audits.associated_id to bigint

### DIFF
--- a/db/migrate/20260619102359_change_associated_id_to_bigint.rb
+++ b/db/migrate/20260619102359_change_associated_id_to_bigint.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ChangeAssociatedIdToBigint < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction! if System::Database.postgres?
+
+  def up
+    return if System::Database.oracle?
+
+    safety_assured do
+      change_column :audits, :associated_id, :bigint
+    end
+  end
+end

--- a/db/oracle_schema.rb
+++ b/db/oracle_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_26_134251) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_19_102359) do
   create_table "access_tokens", force: :cascade do |t|
     t.integer "owner_id", precision: 38, null: false
     t.text "scopes"

--- a/db/postgres_schema.rb
+++ b/db/postgres_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_26_134251) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_19_102359) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -185,7 +185,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_26_134251) do
     t.string "kind", limit: 255
     t.text "audited_changes"
     t.text "comment"
-    t.integer "associated_id"
+    t.bigint "associated_id"
     t.string "associated_type", limit: 255
     t.string "remote_address", limit: 255
     t.string "request_uuid", limit: 255

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_26_134251) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_19_102359) do
   create_table "access_tokens", charset: "utf8mb3", collation: "utf8mb3_bin", force: :cascade do |t|
     t.bigint "owner_id", null: false
     t.text "scopes"
@@ -184,7 +184,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_26_134251) do
     t.string "kind"
     t.text "audited_changes", size: :medium
     t.text "comment"
-    t.integer "associated_id"
+    t.bigint "associated_id"
     t.string "associated_type"
     t.string "remote_address"
     t.string "request_uuid"


### PR DESCRIPTION
## What this PR does / why we need it

This PR extends the fix introduced in #4262 by adding support for larger values in `audits.associated_id`. It updates the column from `integer` to `bigint` to accommodate account IDs that exceed the 32-bit integer limit.

## Which issue(s) this PR fixes

https://redhat.atlassian.net/browse/THREESCALE-15270

## Verification steps

* Tests should pass
