### PR TITLE
allow customer oracle client version

### DIFF
--- a/script/oracle/install-instantclient-packages.sh
+++ b/script/oracle/install-instantclient-packages.sh
@@ -9,11 +9,14 @@ declare -a packages=(instantclient-sdk instantclient-odbc)
 
 function install_pkg {
   local package="$1"
+  local path="vendor/oracle"
   local zip="${package}-${oracle_version}.zip"
-  local file="vendor/oracle/${zip}"
+  local file="$path/${zip}"
+  local existing_file="$path/${package}-"*".zip"
 
-  if [ -f "${file}" ]; then
-    echo "[OK] ${file} already present"
+  if [ -f "${existing_file}" ]; then
+    echo "[OK] ${existing_file} already present"
+    file="${existing_file}"
   else
     echo "[INFO] Downloading ${zip} from Oracle servers"
     wget "${oracle_otn}/${zip}" -O "${file}"

--- a/script/oracle/install-instantclient-packages.sh
+++ b/script/oracle/install-instantclient-packages.sh
@@ -3,8 +3,8 @@
 set +o pipefail
 
 # Execute this script by a user with read right ability to /opt/oracle and /opt/system/vendor/oracle
-declare oracle_otn=https://download.oracle.com/otn_software/linux/instantclient/1918000
-declare oracle_version=linux.x64-19.18.0.0.0dbru
+declare oracle_otn=https://download.oracle.com/otn_software/linux/instantclient/1931000v2
+declare oracle_version=linux.x64-19.31.0.0.0dbru
 declare -a packages=(instantclient-sdk instantclient-odbc)
 
 function install_pkg {
@@ -45,6 +45,6 @@ fi
 
 # hack for system-builder ENV
 rm -rf /opt/system/vendor/oracle
-ln -sf /opt/oracle/instantclient_19_18/libsqora.so.19.1 /opt/oracle/instantclient_19_18/libsqora.so
-ln -sf /opt/oracle/instantclient_19_18 /opt/oracle/instantclient
+ln -sf /opt/oracle/instantclient_19_31/libsqora.so.19.1 /opt/oracle/instantclient_19_31/libsqora.so
+ln -sf /opt/oracle/instantclient_19_31 /opt/oracle/instantclient
 cp config/oracle/*.ini /etc/


### PR DESCRIPTION
Presently the oracle client version is hardcoded but it might  be older than what customers want or need to use. This one would use any downloaded version instead of only acepting that particular minor version.