### PR TITLE
THREESCALE-12408: Clean up slow path for authenticating access tokens

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -121,15 +121,7 @@ class AccessToken < ApplicationRecord
     scrubbed = plaintext_value.to_s.scrub
     digest = compute_digest(scrubbed)
 
-    # Fast path: find by digest (new tokens)
-    token = find_by(value: digest)
-    return token if token
-
-    # Reject if the input looks like a stored hash (has our prefix)
-    return nil if scrubbed.start_with?(DIGEST_PREFIX)
-
-    # Slow path: find by plaintext (legacy tokens, no migration)
-    find_by(value: scrubbed)
+    find_by(value: digest)
   rescue ActiveRecord::StatementInvalid, ArgumentError # utf-8 issues
     nil
   end

--- a/test/integration/by_access_token_integration_test.rb
+++ b/test/integration/by_access_token_integration_test.rb
@@ -83,17 +83,6 @@ class ApiAuthentication::ByAccessTokenIntegrationTest < ActionDispatch::Integrat
     assert_response :forbidden
   end
 
-  test 'authentication with legacy unmigrated token succeeds' do
-    token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management')
-    legacy_value = 'legacy_plaintext_token_for_integration'
-    token.update_columns(value: legacy_value)
-
-    get admin_api_accounts_path(format: :xml), params: { access_token: legacy_value }
-
-    assert_response :success
-    # No migration: DB value remains unchanged
-    assert_equal legacy_value, token.reload.read_attribute(:value)
-  end
 
   test 'authentication with leaked database hash fails' do
     token = FactoryBot.create(:access_token, owner: @user, scopes: 'account_management')

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -113,17 +113,6 @@ class AccessTokenTest < ActiveSupport::TestCase
     assert @token.reload.read_attribute(:value).start_with?(AccessToken::DIGEST_PREFIX)
   end
 
-  def test_find_from_value_finds_legacy_token
-    legacy_value = 'legacy_plaintext_token_value_64chars'
-    @token.update_columns(value: legacy_value)
-
-    found = AccessToken.find_from_value(legacy_value)
-
-    assert_equal @token.id, found&.id
-    # No migration: DB value remains unchanged
-    assert_equal legacy_value, @token.reload.read_attribute(:value)
-  end
-
   # compute_digest tests
 
   def test_compute_digest_returns_prefixed_sha384_hex
@@ -190,7 +179,8 @@ class AccessTokenTest < ActiveSupport::TestCase
     # Verify the DB value has our prefix
     assert stored_hash.start_with?(AccessToken::DIGEST_PREFIX)
 
-    # An attacker with access to the DB hash should NOT be able to authenticate
+    # An attacker with access to the DB hash should NOT be able to authenticate:
+    # compute_digest(stored_hash) produces a double-hash that won't match any row.
     found = AccessToken.find_from_value(stored_hash)
 
     assert_nil found, "Security vulnerability: leaked hash was accepted as a valid token"


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow up of https://github.com/3scale/porta/pull/4236. We already ran the migration and hashed all tokens in production. The slow path is dead code now, so this PR removes it.

For onpremises, since they accept having downtime when upgrading, there's no need to include the slow path in the release, they don't need backwards compatibility. They just need to ensure they ran the migration before going live.

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-12408

**Verification steps** 

Everything should work as usual. Test should pass
