### PR TITLE
THREESCALE-11545: Cleanup `:cookies_serializer` config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -64,17 +64,6 @@ module System
     # Protect from open redirect attacks in `redirect_back_or_to` and `redirect_to`.
     config.action_controller.raise_on_open_redirects = false
 
-    # To migrate an existing application to the `:json` serializer, use the `:hybrid` option.
-    #
-    # Rails transparently deserializes existing (Marshal-serialized) cookies on read and
-    # re-writes them in the JSON format.
-    #
-    # It is fine to use `:hybrid` long term; you should do that until you're confident *all* your cookies
-    # have been converted to JSON. To keep using `:hybrid` long term, move this config to its own
-    # initializer or to `config/application.rb`.
-    # TODO: use the new default - THREESCALE-11545
-    config.action_dispatch.cookies_serializer = :hybrid
-
     config.active_record.belongs_to_required_by_default = false
     config.active_record.include_root_in_json = true
 
@@ -283,8 +272,6 @@ module System
     config.middleware.insert_before 0, ThreeScale::Middleware::Cors if config.three_scale.cors.enabled
 
     config.unicorn = ActiveSupport::OrderedOptions[after_fork: []]
-
-    config.action_dispatch.cookies_serializer = :hybrid
 
     initializer :load_configs, before: :load_config_initializers do
       config.backend_client = { max_tries: 5 }.merge(config_for(:backend))

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,5 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Specify a serializer for the signed and encrypted cookie jars.
-# Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
**What this PR does / why we need it**:

The issue says we set `:hybrid` temporarily for one release, so there's a backwards-compatible transition to `:json`. However, There was an initializer that already sets the cookie serializer to `:json` since 2022 (https://github.com/3scale/porta/commit/0f7e55f730c38fca30ff005c0b32be956b1bf54f#diff-c343f36f0cc538c190ed49c9796fc6e3eaebc48e1d1929676754d3678b66e3b8). So we were already using `:json` all along.

Both (?) occurrences of `:hybrid`, in `application.rb` where being overwritten by the initializer, which is now redundant anyway since `:json` is the default for rails 7.

Summarizing: it's all dead code now.

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-11545

**Verification steps** 

Everything works as usual. Tests pass.
