### PR TITLE
2.15 backport: fix circleci DNS setup for v2 executors (#4057)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,14 @@ use-example-config-files: &use-example-config-files
 disable-internet-access: &disable-internet-access
   run:
     name: Disable internet access
-    command: sudo sed -c -i".bak" 's/127\.0\.0\.11$/127.0.0.1/' /etc/resolv.conf
+    command: |
+      cat /etc/resolv.conf
+      sudo sed -c -i".bak" 's/^nameserver.*/nameserver 127.0.0.1/' /etc/resolv.conf
 
 enable-internet-access: &enable-internet-access
   run:
     name: Enabled internet access
-    command: sudo sed -c -i".bak" 's/127\.0\.0\.1$/127.0.0.11/' /etc/resolv.conf
+    command: sudo tee /etc/resolv.conf < /etc/resolv.conf.bak
     when: always
 
 attach-to-workspace: &attach-to-workspace
@@ -138,14 +140,20 @@ redis-container: &redis-container
 
 dnsmasq-container: &dnsmasq-container
   image: quay.io/3scale/dnsmasq
+  entrypoint:
+    - /bin/bash
+    - -c
   command:
-    - --user=root
-    - --keep-in-foreground
-    - --log-facility=-
-    - --log-queries
-    - --no-poll
-    - --server=/circleci-internal-outer-build-agent/circleci-internal-outer-build-agent.ec2.internal/circleci.com/circleci-binary-releases.s3.amazonaws.com/127.0.0.11
-    - --address=/#/127.0.0.1
+    - |
+      DEFAULT_DNS=$(sed -nEe 's/nameserver\s+(.*)/\1/p' /etc/resolv.conf | head -1)
+      /usr/sbin/dnsmasq \
+      --user=root \
+      --keep-in-foreground \
+      --log-facility=- \
+      --log-queries \
+      --no-poll \
+      --server=/circleci.com/dns.podman/circleci-tasks-prod.s3.us-east-1.amazonaws.com/circleci-binary-releases.s3.amazonaws.com/$DEFAULT_DNS \
+      --address=/#/127.0.0.1
 
 only-master-filter: &only-master-filter
   filters:


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry Pick #4057, this might fix the DNS Resolver errors in cucumbers.

**Verification steps** 

- Cucumbers should pass
