### PR TITLE
THREESCALE-15279: Expose `audience_mapper_client_id` in application API

### DIFF
--- a/app/models/cinstance.rb
+++ b/app/models/cinstance.rb
@@ -5,7 +5,7 @@ class Cinstance < Contract
 
   self.background_deletion = %i[referrer_filters application_keys alerts]
 
-  delegate :backend_version, to: :service, allow_nil: true
+  delegate :backend_version, :audience_mapper_client_id, to: :service, allow_nil: true
 
   belongs_to :plan, class_name: 'ApplicationPlan', foreign_key: :plan_id, inverse_of: :cinstances
   alias application_plan plan

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -151,9 +151,10 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
     return unless policy&.enabled
 
     config = policy.configuration&.with_indifferent_access || {}
-    return unless config[:auth_type] == 'use_3scale_oidc_issuer_endpoint' || config[:auth_type].blank?
+    auth_type = config[:auth_type]
+    return unless auth_type == 'use_3scale_oidc_issuer_endpoint' || auth_type.blank?
 
-    URI.parse(oidc_issuer_endpoint).user rescue nil
+    issuer_endpoint_client_id
   end
 
   def oidc_configuration
@@ -478,6 +479,14 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def proxy
     self
+  end
+
+  private
+
+  def issuer_endpoint_client_id
+    URI.parse(oidc_issuer_endpoint).user
+  rescue URI::InvalidURIError
+    nil
   end
 
   protected

--- a/app/models/proxy.rb
+++ b/app/models/proxy.rb
@@ -146,6 +146,16 @@ class Proxy < ApplicationRecord # rubocop:disable Metrics/ClassLength
     policies_config.find_by(name: name, version: version)
   end
 
+  def audience_mapper_client_id
+    policy = find_policy_config_by(name: 'token_introspection', version: 'builtin')
+    return unless policy&.enabled
+
+    config = policy.configuration&.with_indifferent_access || {}
+    return unless config[:auth_type] == 'use_3scale_oidc_issuer_endpoint' || config[:auth_type].blank?
+
+    URI.parse(oidc_issuer_endpoint).user rescue nil
+  end
+
   def oidc_configuration
     super || build_oidc_configuration(standard_flow_enabled: true)
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -589,7 +589,7 @@ class Service < ApplicationRecord # rubocop:disable Metrics/ClassLength
   delegate :oauth?, to: :authentication_scheme?
 
   delegate :authentication_method, to: :proxy, prefix: true, allow_nil: true
-  delegate :oidc?, :pending_affecting_changes?, to: :proxy, allow_nil: true
+  delegate :oidc?, :pending_affecting_changes?, :audience_mapper_client_id, to: :proxy, allow_nil: true
 
   def authentication_scheme?
     backend_version.to_s.inquiry

--- a/app/representers/cinstance_representer.rb
+++ b/app/representers/cinstance_representer.rb
@@ -40,6 +40,7 @@ module CinstanceRepresenter
 
   with_options(if: ->(*) { service.oidc? }, render_nil: true) do |oidc|
     oidc.property :oidc_configuration, decorator: OIDCConfigurationRepresenter, wrap: false
+    oidc.property :audience_mapper_client_id
   end
 
   def provider_verification_key

--- a/app/representers/cinstance_representer.rb
+++ b/app/representers/cinstance_representer.rb
@@ -38,9 +38,9 @@ module CinstanceRepresenter
     oauth.property :client_secret
   end
 
-  with_options(if: ->(*) { service.oidc? }, render_nil: true) do |oidc|
-    oidc.property :oidc_configuration, decorator: OIDCConfigurationRepresenter, wrap: false
-    oidc.property :audience_mapper_client_id
+  with_options(if: ->(*) { service.oidc? }, render_nil: true) do
+    property :oidc_configuration, decorator: OIDCConfigurationRepresenter, wrap: false
+    property :audience_mapper_client_id
   end
 
   def provider_verification_key

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -843,6 +843,67 @@ class ProxyTest < ActiveSupport::TestCase
     end
   end
 
+  class AudienceMapperClientIdTest < ActiveSupport::TestCase
+    ISSUER_URL = 'https://introspection-client:s3cr3t@sso.example.com/auth/realms/master'
+    TOKEN_INTROSPECTION_POLICY = { name: 'token_introspection', version: 'builtin' }.freeze
+
+    def proxy_with_policy(config)
+      proxy = FactoryBot.build(:simple_proxy)
+      proxy.policies_config = [TOKEN_INTROSPECTION_POLICY.merge(configuration: config, enabled: true)]
+      proxy
+    end
+
+    test 'returns user from oidc_issuer_endpoint when auth_type is use_3scale_oidc_issuer_endpoint' do
+      proxy = proxy_with_policy('auth_type' => 'use_3scale_oidc_issuer_endpoint')
+      proxy.oidc_issuer_endpoint = ISSUER_URL
+      assert_equal 'introspection-client', proxy.audience_mapper_client_id
+    end
+
+    test 'returns user from oidc_issuer_endpoint when auth_type is blank' do
+      proxy = proxy_with_policy({})
+      proxy.oidc_issuer_endpoint = ISSUER_URL
+      assert_equal 'introspection-client', proxy.audience_mapper_client_id
+    end
+
+    test 'returns nil when auth_type is client_id+client_secret' do
+      proxy = proxy_with_policy('auth_type' => 'client_id+client_secret', 'client_id' => 'my-introspection-client')
+      assert_nil proxy.audience_mapper_client_id
+    end
+
+    test 'returns nil when auth_type is client_secret_jwt' do
+      proxy = proxy_with_policy('auth_type' => 'client_secret_jwt', 'client_id' => 'my-introspection-client')
+      assert_nil proxy.audience_mapper_client_id
+    end
+
+    test 'returns nil when auth_type is private_key_jwt' do
+      proxy = proxy_with_policy('auth_type' => 'private_key_jwt', 'client_id' => 'my-introspection-client')
+      assert_nil proxy.audience_mapper_client_id
+    end
+
+    test 'returns nil when policy is disabled' do
+      proxy = FactoryBot.build(:simple_proxy)
+      proxy.policies_config = [TOKEN_INTROSPECTION_POLICY.merge(configuration: { 'auth_type' => 'use_3scale_oidc_issuer_endpoint' }, enabled: false)]
+      assert_nil proxy.audience_mapper_client_id
+    end
+
+    test 'returns nil when token introspection policy is absent' do
+      proxy = FactoryBot.build(:simple_proxy)
+      assert_nil proxy.audience_mapper_client_id
+    end
+
+    test 'returns nil when oidc_issuer_endpoint has no user' do
+      proxy = proxy_with_policy('auth_type' => 'use_3scale_oidc_issuer_endpoint')
+      proxy.oidc_issuer_endpoint = 'https://sso.example.com/auth/realms/master'
+      assert_nil proxy.audience_mapper_client_id
+    end
+
+    test 'returns nil when oidc_issuer_endpoint is blank' do
+      proxy = proxy_with_policy('auth_type' => 'use_3scale_oidc_issuer_endpoint')
+      proxy.oidc_issuer_endpoint = nil
+      assert_nil proxy.audience_mapper_client_id
+    end
+  end
+
   class StaleObjectErrorTest < ActiveSupport::TestCase
     test 'proxy does not raise stale object error on concurrent touch' do
       class ProxyWithFiber < ::Proxy

--- a/test/unit/proxy_test.rb
+++ b/test/unit/proxy_test.rb
@@ -844,13 +844,16 @@ class ProxyTest < ActiveSupport::TestCase
   end
 
   class AudienceMapperClientIdTest < ActiveSupport::TestCase
-    ISSUER_URL = 'https://introspection-client:s3cr3t@sso.example.com/auth/realms/master'
+    ISSUER_URL = 'https://introspection-client:s3cr3t@sso.example.com/auth/realms/master'.freeze
     TOKEN_INTROSPECTION_POLICY = { name: 'token_introspection', version: 'builtin' }.freeze
 
+    def setup
+      @proxy = FactoryBot.build(:simple_proxy)
+    end
+
     def proxy_with_policy(config)
-      proxy = FactoryBot.build(:simple_proxy)
-      proxy.policies_config = [TOKEN_INTROSPECTION_POLICY.merge(configuration: config, enabled: true)]
-      proxy
+      @proxy.policies_config = [TOKEN_INTROSPECTION_POLICY.merge(configuration: config, enabled: true)]
+      @proxy
     end
 
     test 'returns user from oidc_issuer_endpoint when auth_type is use_3scale_oidc_issuer_endpoint' do


### PR DESCRIPTION
**What this PR does / why we need it**:

More details in the ticket description, but summarizing:

1. When zync creates/updates a client in keycloak, it needs to add the audience mapper for those proxies having the introspection policy enabled
2. The audience mapper must contain the id of the client which is going to introspect the token. This client can be any client with the proper permissions in the auth server, however, when the proxy includes the introspection policy, they might configure it to use the oidc_endpoint user as the client requesting the introspection.
3. Only porta knows this info, so when these particular conditions met, we add this client id to the application endpoint in 3scale, the one which zync calls to fetch info, this way Zync knows which client id put in the mapper.

Some details:

- Adds `Proxy#audience_mapper_client_id` that reads the Token Introspection policy from the live proxy's `policies_config` and returns the userinfo component of `oidc_issuer_endpoint` — the client ID that calls the introspection endpoint
- Only returns a value when `auth_type` is `use_3scale_oidc_issuer_endpoint` (or absent/blank); returns `nil` for `client_id+client_secret`, `client_secret_jwt`, and `private_key_jwt` since those use externally managed clients that Zync doesn't control
- Delegates the value up through `Service` and `Cinstance`, and exposes it in the `CinstanceRepresenter` OIDC block so Zync receives it via `GET /admin/api/applications/find.json`
- When `audience_mapper_client_id` is present, Zync adds an `oidc-audience-mapper` to the Keycloak client, which adds the introspecting client to the token's `aud` claim — fixing the RHBK 26.6.2+ breaking change


**Which issue(s) this PR fixes**

[THREESCALE-15279](https://redhat.atlassian.net/browse/THREESCALE-15279)

**Special notes for your reviewer**:

- Zync counterpart: branch `THREESCALE-15279-token-introspection`
