### PR TITLE
THREESCALE-11768: Simplify stale account deletion

### DIFF
--- a/app/workers/delete_account_hierarchy_worker.rb
+++ b/app/workers/delete_account_hierarchy_worker.rb
@@ -1,1 +1,23 @@
-DeleteAccountHierarchyWorker = DeleteObjectHierarchyWorker
+# frozen_string_literal: true
+
+class DeleteAccountHierarchyWorker < DeleteObjectHierarchyWorker
+  include Sidekiq::Throttled::Job
+
+  CONCURRENCY_LIMIT_KEY = "stale_deletion:concurrency_limit"
+  DEFAULT_CONCURRENCY_LIMIT = 3
+
+  sidekiq_throttle concurrency: {
+    limit: ->(*) { (value = Sidekiq.redis { |c| c.get(CONCURRENCY_LIMIT_KEY) }) ? value.to_i : DEFAULT_CONCURRENCY_LIMIT },
+    ttl: 1.hour.to_i
+  }
+
+  class << self
+    def concurrency_limit
+      (value = Sidekiq.redis { |c| c.get(CONCURRENCY_LIMIT_KEY) }) ? value.to_i : DEFAULT_CONCURRENCY_LIMIT
+    end
+
+    def concurrency_limit=(value)
+      Sidekiq.redis { |c| c.set(CONCURRENCY_LIMIT_KEY, value.to_i) }
+    end
+  end
+end

--- a/lib/tasks/multitenant/tenants.rake
+++ b/lib/tasks/multitenant/tenants.rake
@@ -77,37 +77,59 @@ namespace :multitenant do
       Rails.logger.error "Inconsistent tenant_ids for:\n#{inconsistent.map {_1.join(" ")}.join("\n")}"
     end
 
+    # Schedule stale tenants for background deletion, throttled via sidekiq-throttled.
+    #
+    # Usage:
+    #   rake multitenant:tenants:stale_throttled_delete             # default: concurrency=3, 180 days
+    #   rake multitenant:tenants:stale_throttled_delete[1,365]      # concurrency=1, accounts stale for 1+ year
+    #   DRY_RUN=1 rake multitenant:tenants:stale_throttled_delete   # preview without enqueuing
+    #
+    # Control concurrency at runtime from any Rails console (affects all pods immediately):
+    #   DeleteAccountHierarchyWorker.concurrency_limit = 5   # speed up
+    #   DeleteAccountHierarchyWorker.concurrency_limit = 1   # slow down
+    #   DeleteAccountHierarchyWorker.concurrency_limit = 0   # pause (sidekiq-throttled cooldown kicks in)
+    #   DeleteAccountHierarchyWorker.concurrency_limit        # check current value
+    #
+    # Stop and clear remaining queued jobs:
+    #   DeleteAccountHierarchyWorker.concurrency_limit = 0
+    #   Sidekiq::Queue.new("deletion").each { |job| job.delete if job["wrapped"] == "DeleteAccountHierarchyWorker" }
+    #
+    # Note: the concurrency limit is stored in Redis under the key "stale_deletion:concurrency_limit" and
+    # persists until explicitly changed. If jobs in the deletion queue appear to not be running, check:
+    #   redis-cli get stale_deletion:concurrency_limit   # 0 means paused, absent means default (3)
     desc 'Schedule stale tenants background deletion.'
-    task :stale_throttled_delete, %i[concurrency days_since_disabled iteration_wait] => :environment do |_task, args|
-      require "progress_counter"
-
+    task :stale_throttled_delete, %i[concurrency days_since_disabled] => :environment do |_task, args|
       # Not using Account::States::PERIOD_BEFORE_DELETION because customers using this task
       # will probably have FindAndDeleteScheduledAccountsWorker disabled. To err on the safe side
       # we only delete ancient stuff by default.
-      args.with_defaults(:concurrency => 3, :days_since_disabled => 30*6, :iteration_wait => 60)
+      args.with_defaults(concurrency: 3, days_since_disabled: 30 * 6)
       target_concurrency = Integer(args.concurrency)
       since = Integer(args.days_since_disabled).days.ago
-      iteration_wait = Integer(args.iteration_wait)
+      dry_run = ENV["DRY_RUN"].present?
 
-      stale_enum = Account.tenants.deleted_since(since).find_each
-      progress = ProgressCounter.new(stale_enum.size)
+      scope = Account.tenants.deleted_since(since)
+      total = scope.count
+      Rails.logger.info "[stale_throttled_delete] #{total} accounts scheduled_for_deletion since #{since.to_date}#{' (DRY RUN)' if dry_run}"
 
-      loop do
-        current_deletion_jobs = scheduled_or_running_background_deletions
-        to_schedule = target_concurrency - current_deletion_jobs.count
-        already_scheduled_providers = current_deletion_jobs.filter_map { provider_being_deleted(_1) }
-
-        to_schedule.times do
-          provider = stale_enum.next # raises StopIteration which will break out of the outer loop
-          redo if already_scheduled_providers.include?(provider.id)
-          DeleteObjectHierarchyWorker.delete_later(provider)
-          progress.call
+      if dry_run
+        scope.find_each do |provider|
+          Rails.logger.info "[stale_throttled_delete] Would delete: id=#{provider.id} org_name=#{provider.org_name} state_changed_at=#{provider.state_changed_at&.to_date}"
         end
-
-        sleep iteration_wait
+        next # `next` exits the task
       end
 
-      Rails.logger.info "all stale tenants should be deleted or scheduled now, quitting"
+      DeleteAccountHierarchyWorker.concurrency_limit = target_concurrency
+      Rails.logger.info "[stale_throttled_delete] Concurrency limit set to #{target_concurrency}"
+      Rails.logger.warn "[stale_throttled_delete] Concurrency is 0 — jobs will be enqueued but NOT processed until raised" if target_concurrency.zero?
+
+      scheduled = 0
+      scope.find_each do |provider|
+        DeleteAccountHierarchyWorker.delete_later(provider)
+        scheduled += 1
+        Rails.logger.info "[stale_throttled_delete] Scheduled #{scheduled}/#{total}: id=#{provider.id} org_name=#{provider.org_name}"
+      end
+
+      Rails.logger.info "[stale_throttled_delete] Done. Scheduled #{scheduled} accounts with concurrency #{target_concurrency}. Jobs will process in the background."
     end
 
     def update_tenant_ids(tenant_id_block, association_block, condition, **args)
@@ -132,20 +154,5 @@ namespace :multitenant do
       proc { |object| (object.tenant_id == nil) | ((object.created_at >= Time.strptime(time_start, '%m/%d/%Y %H:%M %Z')) & (object.created_at <= Time.strptime(time_end, '%m/%d/%Y %H:%M %Z'))) }
     end
 
-    def scheduled_or_running_background_deletions
-      [
-        # I was thinking that future schedules shouldn't count towards concurrency
-        # *Sidekiq::ScheduledSet.new.select { job.queue == "deletion" },
-        *Sidekiq::Queue.new("deletion").to_a,
-        *Sidekiq::Workers.new.filter_map { |_pid, _tid, work| work.job if work.job.queue == "deletion" },
-      ]
-    end
-
-    def provider_being_deleted(job)
-      if job.is_a?(Sidekiq::JobRecord) && job["wrapped"] == DeleteObjectHierarchyWorker.name
-        id = job.args.first["arguments"].first.sub("Plain-Account-", "").to_i
-        id unless id.zero?
-      end
-    end
   end
 end

--- a/test/unit/tasks/multitenant/tenants_test.rb
+++ b/test/unit/tasks/multitenant/tenants_test.rb
@@ -167,137 +167,71 @@ module Tasks
         setup do
           @provider1 = FactoryBot.create(:simple_provider, state: "scheduled_for_deletion", state_changed_at: 7.months.ago)
           @provider2 = FactoryBot.create(:simple_provider, state: "scheduled_for_deletion", state_changed_at: 5.months.ago)
-
-          ActiveJob::Base.queue_adapter = :sidekiq
-          Sidekiq::Testing.disable!
+          Sidekiq.redis { |c| c.del(DeleteAccountHierarchyWorker::CONCURRENCY_LIMIT_KEY) }
         end
 
         teardown do
-          Sidekiq::ScheduledSet.new.each(&:delete)
-          Sidekiq::Queue.new.each(&:delete)
-          assert_empty Sidekiq::Workers.new.to_a
-
-          Sidekiq::Testing.fake!
-          ActiveJob::Base.queue_adapter = Rails.configuration.active_job.queue_adapter
-        end
-
-        test "do not schedule more than target concurrency number of jobs" do
-          exec_task concurrency: 2, since: 1000, wait: 0 # make sure the task file is loaded
-
-          Object.any_instance.stubs(:provider_being_deleted)
-
-          expect_one_more_deletion = proc do
-            DeleteObjectHierarchyWorker.expects(:delete_later)
-          end
-          expect_one_more_deletion.singleton_class.alias_method :activate, :call
-
-          # Note: Couldn't register on one line. Matching seems to happen in reverse order of definition.
-          # by the first iteration we don't allow any jobs to be scheduled
-          #   by the second iteration we allow one to be scheduled
-          #   and by the third iteration we allow 2 jobs but we have only one provider left
-          Object.any_instance.expects(:scheduled_or_running_background_deletions).returns([]).then(expect_one_more_deletion)
-          Object.any_instance.expects(:scheduled_or_running_background_deletions).returns([:x]).then(expect_one_more_deletion)
-          Object.any_instance.expects(:scheduled_or_running_background_deletions).returns([:x, :x])
-
-          exec_task concurrency: 2, since: 0, wait: 0
-        end
-
-        test "we don't schedule accounts already being deleted" do
-          DeleteObjectHierarchyWorker.delete_later(@provider1)
-          DeleteObjectHierarchyWorker.expects(:delete_later).with(@provider2)
-          exec_task concurrency: 3, since: 0, wait: 0
-        end
-
-        test "schedules account deletions ignoring jobs in any queues but deletion" do
-          DeleteObjectHierarchyWorker.set(queue: "default").perform_later("Plain-Account-#{@provider1.id}")
-
-          assert_equal 1, Sidekiq::Queue.new("default").size
-
-          DeleteObjectHierarchyWorker.expects(:delete_later).with(@provider1)
-          DeleteObjectHierarchyWorker.expects(:delete_later).with(@provider2)
-
-          exec_task concurrency: 3, since: 15
+          Sidekiq.redis { |c| c.del(DeleteAccountHierarchyWorker::CONCURRENCY_LIMIT_KEY) }
+          ENV.delete("DRY_RUN")
         end
 
         test "by default only tenants marked more than 6 months ago are deleted" do
-          DeleteObjectHierarchyWorker.expects(:delete_later).with(@provider1)
+          DeleteAccountHierarchyWorker.expects(:delete_later).with(@provider1)
+          DeleteAccountHierarchyWorker.expects(:delete_later).with(@provider2).never
 
           exec_task
         end
 
-        test "tenants already in the deletion queue are not scheduled anymore" do
-          DeleteObjectHierarchyWorker.delete_later(@provider1)
-          DeleteObjectHierarchyWorker.expects(:delete_later).with(@provider2)
-
-          exec_task concurrency: 3, since: 15
-        end
-
-        # this test is not very good because we emulate the API and upstream can potentially break it
-        test "tenants already being processed are not scheduled anymore" do
-          DeleteObjectHierarchyWorker.delete_later(@provider1)
-
-          job = Sidekiq::Queue.new("deletion").to_a.first
-          job_wrapper = OpenStruct.new(job:)
-
-          job.delete
-          assert_equal 0, Sidekiq::Queue.new("deletion").size
-
-          Sidekiq::Workers.stubs(:new).returns([[nil, nil, job_wrapper]])
-          DeleteObjectHierarchyWorker.expects(:delete_later).with(@provider2)
-
-          exec_task concurrency: 3, since: 15
-
-          Sidekiq::Workers.unstub(:new)
-        end
-
-        test "tenant scheduling deduplication is graceful with other job types" do
-          service = FactoryBot.create(:simple_service, account: @provider2)
-
-          # Background deletion of another model
-          DeleteObjectHierarchyWorker.perform_later("Plain-User-#{@provider1.id}")
-          # Other kinds of ActiveJob jobs
-          CreateDefaultProxyWorker.set(queue: "deletion").perform_later(service)
-          # Other kinds of Sidekiq native jobs
-          BackendProviderSyncWorker.set(queue: "deletion").perform_async(@provider1.id)
-
-          # Emulate Mocha StateMachine::State to clear the extra deletion job from the queue
-          clear_deletion_queue = proc { Sidekiq::Queue.new("deletion").each(&:delete) }
-          clear_deletion_queue.singleton_class.alias_method :activate, :call
-
-          DeleteObjectHierarchyWorker.expects(:delete_later).with(@provider1)
-          DeleteObjectHierarchyWorker.expects(:delete_later).with(@provider2)
-
-          exec_task concurrency: 4, since: 15, wait: 0
-        end
-
-        test "jobs scheduled but not yet queued are not taken into account" do
-          DeleteObjectHierarchyWorker.set(wait: 2.days).perform_later("Plain-Account-#{@provider1.id}")
-          assert_equal 1, Sidekiq::ScheduledSet.new.to_a.size
-
-          DeleteObjectHierarchyWorker.expects(:delete_later).with(@provider1)
+        test "enqueues via DeleteAccountHierarchyWorker, not DeleteObjectHierarchyWorker" do
+          DeleteObjectHierarchyWorker.expects(:delete_later).never
+          DeleteAccountHierarchyWorker.expects(:delete_later).with(@provider1)
 
           exec_task
         end
 
         test "only marked for deletion accounts are deleted" do
-          Account::States::STATES.reject { _1 == :scheduled_for_deletion }.each do |state|
+          non_eligible = Account::States::STATES.reject { _1 == :scheduled_for_deletion }.map do |state|
             FactoryBot.create(:simple_provider, state: state, state_changed_at: 7.months.ago)
           end
 
-          DeleteObjectHierarchyWorker.expects(:delete_later).with(@provider1)
+          DeleteAccountHierarchyWorker.expects(:delete_later).with(@provider1)
+          non_eligible.each { |provider| DeleteAccountHierarchyWorker.expects(:delete_later).with(provider).never }
 
           exec_task
         end
 
-        test "no infinite loop on failure to delete providers" do
-          DeleteObjectHierarchyWorker.expects(:delete_later).times(2)
-          exec_task(concurrency: 1, since: 1, wait: 0)
+        test "custom days_since_disabled includes more accounts" do
+          DeleteAccountHierarchyWorker.expects(:delete_later).with(@provider1)
+          DeleteAccountHierarchyWorker.expects(:delete_later).with(@provider2)
+
+          exec_task(since: 1)
         end
 
-        def exec_task(concurrency: 3, since: nil, wait: nil)
-          raise ArgumentError if wait && !since
+        test "sets the concurrency limit in Redis" do
+          DeleteAccountHierarchyWorker.stubs(:delete_later)
 
-          args = [concurrency, since, wait].compact.map(&:to_s)
+          exec_task(concurrency: 5)
+
+          assert_equal 5, DeleteAccountHierarchyWorker.concurrency_limit
+        end
+
+        test "dry run does not enqueue any jobs" do
+          ENV["DRY_RUN"] = "1"
+          DeleteAccountHierarchyWorker.expects(:delete_later).never
+
+          exec_task
+        end
+
+        test "dry run does not set the concurrency limit" do
+          ENV["DRY_RUN"] = "1"
+
+          exec_task(concurrency: 7)
+
+          assert_equal DeleteAccountHierarchyWorker::DEFAULT_CONCURRENCY_LIMIT, DeleteAccountHierarchyWorker.concurrency_limit
+        end
+
+        def exec_task(concurrency: 3, since: nil)
+          args = [concurrency, since].compact.map(&:to_s)
           execute_rake_task 'multitenant/tenants.rake', 'multitenant:tenants:stale_throttled_delete', *args
         end
       end

--- a/test/workers/delete_account_hierarchy_worker_test.rb
+++ b/test/workers/delete_account_hierarchy_worker_test.rb
@@ -9,6 +9,26 @@ class DeleteAccountHierarchyWorkerTest < ActiveSupport::TestCase
     @provider = FactoryBot.create(:simple_provider)
   end
 
+  test "is a subclass of DeleteObjectHierarchyWorker" do
+    assert DeleteAccountHierarchyWorker < DeleteObjectHierarchyWorker
+  end
+
+  test "uses the deletion queue" do
+    assert_equal "deletion", DeleteAccountHierarchyWorker.new.queue_name
+  end
+
+  test "concurrency_limit defaults to DEFAULT_CONCURRENCY_LIMIT when Redis key is absent" do
+    Sidekiq.redis { |c| c.del(DeleteAccountHierarchyWorker::CONCURRENCY_LIMIT_KEY) }
+    assert_equal DeleteAccountHierarchyWorker::DEFAULT_CONCURRENCY_LIMIT, DeleteAccountHierarchyWorker.concurrency_limit
+  end
+
+  test "concurrency_limit= sets the value in Redis and concurrency_limit reads it back" do
+    DeleteAccountHierarchyWorker.concurrency_limit = 7
+    assert_equal 7, DeleteAccountHierarchyWorker.concurrency_limit
+  ensure
+    Sidekiq.redis { |c| c.del(DeleteAccountHierarchyWorker::CONCURRENCY_LIMIT_KEY) }
+  end
+
   test "compatibility hierarchy" do
     whatever_object = provider.default_service
     DeleteObjectHierarchyWorker.expects(:delete_later).with(provider)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR suggests some changes on the existing rake task to delete accounts scheduled to deletion. The goal is to simplify it. IMO, the weakest part of the task was the homebrew management of concurrency, I think it's not our call to implement such logic, even less as part of a janitor rake task. Instead, we should use `sidekiq-throtled` so the concurrency is delegated to sidekiq itself. The only con of this approach is all jobs will be enqueued immediatelly, taking space in Redis, but in exchange we gain great code simplicity and full control over jobs execution.

I converted `DeleteAccountHierarchyWorker` to a true class which sets it's own concurrency based on a lambda function that allows us to set concurrency in real time whenever we want. To change concurrency, we just need to call:

```ruby
DeleteAccountHierarchyWorker.concurrency_limit = 5   # speed up
DeleteAccountHierarchyWorker.concurrency_limit = 1   # slow down
```

A good advantge of this is we can stop the jobs at every moment:

```ruby
DeleteAccountHierarchyWorker.concurrency_limit = 0   # pause
```

If we think we are messing up things, we can delete all jobs after pausing, effectively stopping the jobs execution:

```ruby
DeleteAccountHierarchyWorker.concurrency_limit = 0
Sidekiq::Queue.new("deletion").each { |job| job.delete if job["wrapped"] == "DeleteAccountHierarchyWorker" }
```

The concurrency feature is backed on a Redis key. The methods `concurrency_limit` and `concurrency_limit=` just read/write to Redis, and default to 3 when no key is present in Redis. The rake task will always call `concurrency_limit=` before enqueuing anyway.

This way we control jobs execution. This, combined with Sidekiq web view and the `:days_since_disabled` parameter, allows us to hold full control over what Sidekiq is doing. This is my suggestion on how to run this in production:

1. Call `Account.tenants.deleted_since(1.year.ago).count`, but trying with different old dates until reaching a scope which returns a small set of accounts to start with.
2. Run the task with the appropriate arguments:
```shell
# 0 Concurrency so jobs don't start immediately, they are enqueued but not performed
# 365 days or any other number of days you took from the previous step
$ bundle exec rails multitenant:tenants:stale_throttled_delete[0,365]
```
3. Then open the Sidekiq web interface and verify the number of jobs matches the number of accounts in the scope
4. From the system console pod, start the jobs:
```shell
$ bundle exec rails runner "DeleteAccountHierarchyWorker.concurrency_limit=3"
```
5. Observe in the logs or the Sidekiq web UI that everything is running as expected.
6. When the task and all jobs finish, check the logs to ensure everything is ok.
7. If everything went fine, repeat from step 1, this time taking a wider scope.

Also, it's worth mentioning I added a dry run mode which doesn't enqueue the jobs but logs the ids of the accounts that will be affected.

Finally, now the task logs everything to the Rails logger, so we can do forensics if anything went wrong.

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-11768

**Verification steps** 

1. Tell the AI agent to create a few dozens of tenants in your local server
2. Tell the AI to mark them as scheduled to deletion in different days during the last two years
3. Follow the steps I mentioned above to run the script and verify yourself that pause/resume mechanism works
