### PR TITLE
THREESCALE-12410: remove `nil` signup type

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -24,7 +24,7 @@ class Invitation < ApplicationRecord
 
   # Build new user on information in this invitation.
   def make_user(params = {})
-    self.user = account.users.build_with_fields params.reverse_merge(email: email, invitation: self)
+    self.user = account.users.build_with_fields params.reverse_merge(email: email, invitation: self, signup_type: :new_signup)
   end
 
   def accepted?

--- a/app/observers/user_observer.rb
+++ b/app/observers/user_observer.rb
@@ -6,13 +6,13 @@ class UserObserver < ActiveRecord::Observer
       # probably to ignore master in tests?
       return if user.account.provider_account.nil?
 
-      if user.new_signup?
-        if user.account.provider?
-          ProviderUserMailer.activation(user).deliver_later
-          ActivationReminderWorker.enqueue(user)
-        else
-          UserMailer.signup_notification(user).deliver_later
-        end
+      return unless user.new_signup? && !user.invitation
+
+      if user.account.provider?
+        ProviderUserMailer.activation(user).deliver_later
+        ActivationReminderWorker.enqueue(user)
+      else
+        UserMailer.signup_notification(user).deliver_later
       end
     end
   end

--- a/test/unit/invitation_test.rb
+++ b/test/unit/invitation_test.rb
@@ -80,6 +80,7 @@ class InvitationTest < ActiveSupport::TestCase
     assert_equal @provider, user.account
     assert_equal 'bob@example.net', user.email
     assert_equal 'bobby', user.username
+    assert_equal :new_signup, user.signup_type
   end
 
   test 'Invitation#accept! accepts the invitation' do

--- a/test/unit/observers/user_observer_test.rb
+++ b/test/unit/observers/user_observer_test.rb
@@ -18,6 +18,14 @@ class UserObserverTest < ActiveSupport::TestCase
     user.save!
   end
 
+  test 'not send signup notification when new user was created via invitation' do
+    buyer_account = FactoryBot.create(:simple_buyer, provider_account: FactoryBot.create(:simple_provider))
+    invitation = FactoryBot.create(:invitation, account: buyer_account)
+    user = invitation.make_user(username: 'invitee', password: 'superSecret1234#')
+    UserMailer.expects(:signup_notification).with(user).never
+    user.save!
+  end
+
   def provider_user
     FactoryBot.build(:simple_user, signup_type: :new_signup, account: FactoryBot.create(:simple_provider))
   end
@@ -25,6 +33,14 @@ class UserObserverTest < ActiveSupport::TestCase
   test 'send provider activation email when new provider user is created' do
     user = provider_user
     ProviderUserMailer.expects(:activation).with(user).returns(mock(deliver_later: true))
+    user.save!
+  end
+
+  test 'not send provider activation email when new provider user is created via invitation' do
+    provider_account = provider_user.account
+    invitation = FactoryBot.create(:invitation, account: provider_account)
+    user = invitation.make_user(username: 'invitee', password: 'superSecret1234#')
+    ProviderUserMailer.expects(:activation).with(user).never
     user.save!
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -251,13 +251,10 @@ class UserTest < ActiveSupport::TestCase
     assert created_by_provider_user.errors[:password].blank?
   end
 
-  test 'by_user? returns true only for :new_signup and nil signup types' do
+  test 'by_user? returns true only for :new_signup signup type' do
     user = User.new
 
     user.signup_type = :new_signup
-    assert user.signup.by_user?
-
-    user.signup_type = nil
     assert user.signup.by_user?
 
     %i[minimal api created_by_provider].each do |type|


### PR DESCRIPTION
**What this PR does / why we need it**:

In the effort to simplify the signup types handling, the initial idea was to remove all signup types and find a way to determine the kind of user via other ways on each point the signup type is referenced.

I abandoned that idea for the moment, I think the result wouldn't necessarily simplify the code. Instead I've been removing/merging signup types to leave only those that makes sense, IMO.

This PR removes the `nil` signup type and merges it with the `:new_signup` type. All users that signed up via invitation will get the `:new_signup` type from now on.

The two types are pretty equivalent, the only place where an invited user diverges from what a self-signed-up does is during the signup process, on the user observer class.

The user observer adds an after commit callback that sends the signup notification:

```
Thank you for signing up for access to the {{ provider.name }} API, your account has been created.
```

Invited users must not receive this notification which makes no sense for them. This PR adds a guard to not send this notification for users having a not `nil` association to `Invitation`.

The PR also updates some tests. That should be it, everything else should behave the same as before.

For existing users in DB with signup type `nil`, no migration path is needed, because they already behave exactly as `:new_signup` users once the signup is completed.

After this PR, there will be only three signup types left:

1. `:new_signup`: Users that signed up themselves, directly or via invitation.
2. `:minimal`: Users created by db seed scripts.
4. `:created_by_provider`: Users created by the provider, via API or UI.

There's an excpetion: the `POST /admin/api/signup` API endpoint also creates users as `:minimal`, but I didn't fix it to not break clients integrations.

This is a summary of the differences between them:

| Signup Type | Password Required | Signup Email | User Auto-Activated | Account Auto-Approved |
|---|---|---|---|---|
| `:new_signup` | yes | yes* | no | no |
| `:minimal` | no | no | yes** | yes** |
| `:created_by_provider` | no | no | no | no |

\* Unless invited
\*\* Only when `approval_required?` is false on the account plan AND the user has a password.

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-12410

**Verification steps** 

1. Signup to the dev portal -> Should receive the signup type
2. Invite a user for the dev -> Should not receive the signup email, but the invitation one
3. Invite a user for the admin portal -> Should not receive the signup email, but the invitation one
