### PR TITLE
Remove hack in the `Invitations` backend

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -24,7 +24,7 @@ class Invitation < ApplicationRecord
 
   # Build new user on information in this invitation.
   def make_user(params = {})
-    self.user = account.users.build_with_fields params.reverse_merge(email: email, invitation: self, signup_type: :new_signup)
+    self.user = account.users.build_with_fields params.reverse_merge(email: email, signup_type: :new_signup)
   end
 
   def accepted?

--- a/app/models/user/invitations.rb
+++ b/app/models/user/invitations.rb
@@ -15,7 +15,8 @@ module User::Invitations
 
   def destroy_invitation
     if account # some tests fail because of account being nil
-      invit = account.invitations.find_by_email(email) || account.invitations.find_by_user_id(id)
+      invitations = account.invitations
+      invit = invitations.find_by(email: email) || invitations.find_by(user_id: id)
       # halt the destruction if the destruction of invitation failed
       throw :abort if invit && invit.destroy == false
     end

--- a/app/models/user/invitations.rb
+++ b/app/models/user/invitations.rb
@@ -4,7 +4,7 @@ module User::Invitations
   included do
     after_commit :accept_invitation, :on => :create
 
-    has_one :invitation # rubocop:disable Rails/HasManyOrHasOneDependent -- before_destroy :destroy_invitation handles it
+    has_one :invitation, dependent: nil
 
     before_destroy :destroy_invitation
   end

--- a/app/models/user/invitations.rb
+++ b/app/models/user/invitations.rb
@@ -4,7 +4,7 @@ module User::Invitations
   included do
     after_commit :accept_invitation, :on => :create
 
-    has_one :invitation
+    has_one :invitation # rubocop:disable Rails/HasManyOrHasOneDependent -- before_destroy :destroy_invitation handles it
 
     before_destroy :destroy_invitation
   end

--- a/app/models/user/invitations.rb
+++ b/app/models/user/invitations.rb
@@ -4,10 +4,7 @@ module User::Invitations
   included do
     after_commit :accept_invitation, :on => :create
 
-    attr_accessor :invitation
-
-    # TODO: refactor to make this work removing above attribute.
-    # has_one :invitation
+    has_one :invitation
 
     before_destroy :destroy_invitation
   end
@@ -18,7 +15,7 @@ module User::Invitations
 
   def destroy_invitation
     if account # some tests fail because of account being nil
-      invit = account.invitations.find_by_email(email) || account.invitations.find_by_user_id(id) # || eventually invitation
+      invit = account.invitations.find_by_email(email) || account.invitations.find_by_user_id(id)
       # halt the destruction if the destruction of invitation failed
       throw :abort if invit && invit.destroy == false
     end

--- a/test/integration/developer_portal/accounts/invitee_signups_controller_test.rb
+++ b/test/integration/developer_portal/accounts/invitee_signups_controller_test.rb
@@ -46,6 +46,7 @@ class DeveloperPortal::Accounts::InviteeSignupsControllerTest < ActionDispatch::
 
     assert_equal I18n.t('developer_portal.accounts.invitee_signups.create.success'), flash[:notice]
     assert_redirected_to login_path
+    assert invitation.reload.accepted?
   end
 
   test 'create pushes webhook' do

--- a/test/integration/provider/invitee_signups_controller_integration_test.rb
+++ b/test/integration/provider/invitee_signups_controller_integration_test.rb
@@ -26,6 +26,7 @@ class Provider::InviteeSignupsControllerIntegrationTest < ActionDispatch::Integr
 
     assert_equal I18n.t('provider.invitee_signups.create.success'), flash[:success]
     assert_redirected_to provider_login_path
+    assert invitation.reload.accepted?
   end
 
   test 'do not set unpermitted attributes' do

--- a/test/unit/authentication/strategy/oauth2_test.rb
+++ b/test/unit/authentication/strategy/oauth2_test.rb
@@ -334,6 +334,7 @@ class Authentication::Strategy::OAuth2Test < ActiveSupport::TestCase
           assert_equal result.username, user_data[:username]
           assert result.active?
           assert authentication_strategy.error_message.blank?
+          assert invitation.reload.accepted?
         end
       end
     end

--- a/test/unit/authentication/strategy/provider_oauth2_test.rb
+++ b/test/unit/authentication/strategy/provider_oauth2_test.rb
@@ -258,6 +258,7 @@ class Authentication::Strategy::ProviderOAuth2Test < ActiveSupport::TestCase
           assert_equal result.username, user_data[:username]
           assert result.active?
           assert authentication_strategy.error_message.blank?
+          assert invitation.reload.accepted?
         end
       end
     end

--- a/test/unit/invitation_test.rb
+++ b/test/unit/invitation_test.rb
@@ -77,9 +77,10 @@ class InvitationTest < ActiveSupport::TestCase
 
     assert_not_nil user
     assert user.new_record?
-    assert_equal @provider, user.account
+    assert_same @provider, user.account
     assert_equal 'bob@example.net', user.email
     assert_equal 'bobby', user.username
+    assert_same invitation, user.invitation
     assert_equal :new_signup, user.signup_type
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I found this horrible hack while working on https://github.com/3scale/porta/pull/4369 and I couldn't help but fix it in this PR.

The hack comes from Rails 3 times, it seemed to try to fix a Rails bug when using association in the inverse way: Instead of creating the invite from the user, we want to create the user from the invite side. So we are creating the strong side from the weak side of the relation.

I didn't investigate further, so maybe this wasn't the reason of the hack, but anyway, using a has_one association works perfect, all tests pass, etc. So I think whatever the problem was in Rails 3, it's solved now.

You can check the original PR for further info: https://github.com/3scale/system/pull/3483/changes. About this PR, it's a pretty simple change, it should work without issues. The PR also includes the fix for Qlty comments and improves existing tests.

**Which issue(s) this PR fixes** 

No Jira issue

**Verification steps** 

1. Send an invitation, no matter for developer or admin portal user
2. You should receive an email with the activation code, open it on a private window
3. Create the new user, no matter if it's via signup or via SSO
4. The user should work fine: be activaded, be able to login, etc.
5. The Invitation should appear as accepted
6. Remove the user
7. The invitation should disappear from the list, in the invitations screen
