### PR TITLE
THREESCALE-15878: escape PCRE metacharacters in mapping rule patterns

### DIFF
--- a/app/lib/apicast/pcre_escaper.rb
+++ b/app/lib/apicast/pcre_escaper.rb
@@ -11,10 +11,10 @@ module Apicast
       # ? is not valid in path segments, so splitting on the first ? is safe
       path_part, query_part = pattern.split('?', 2)
 
-      escaped_path = path_part.gsub(PATH_METACHARACTERS) { "\\#{Regexp.last_match(0)}" }
+      escaped_path = path_part.gsub(PATH_METACHARACTERS) { |c| "\\#{c}" }
 
       if query_part
-        "#{escaped_path}?#{query_part.gsub(QUERY_METACHARACTERS) { "\\#{Regexp.last_match(0)}" }}"
+        "#{escaped_path}?#{query_part.gsub(QUERY_METACHARACTERS) { |c| "\\#{c}" }}"
       else
         escaped_path
       end

--- a/app/lib/apicast/pcre_escaper.rb
+++ b/app/lib/apicast/pcre_escaper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Apicast
+  module PcreEscaper
+    PATH_METACHARACTERS = /[.()*+]/
+    QUERY_METACHARACTERS = /[.()*+$?\[\]]/
+
+    def self.escape(pattern)
+      return pattern if pattern.blank?
+
+      # ? is not valid in path segments, so splitting on the first ? is safe
+      path_part, query_part = pattern.split('?', 2)
+
+      escaped_path = path_part.gsub(PATH_METACHARACTERS) { "\\#{Regexp.last_match(0)}" }
+
+      if query_part
+        "#{escaped_path}?#{query_part.gsub(QUERY_METACHARACTERS) { "\\#{Regexp.last_match(0)}" }}"
+      else
+        escaped_path
+      end
+    end
+  end
+end

--- a/app/lib/apicast/pcre_escaper.rb
+++ b/app/lib/apicast/pcre_escaper.rb
@@ -11,10 +11,10 @@ module Apicast
       # ? is not valid in path segments, so splitting on the first ? is safe
       path_part, query_part = pattern.split('?', 2)
 
-      escaped_path = path_part.gsub(PATH_METACHARACTERS) { |c| "\\#{c}" }
+      escaped_path = path_part.gsub(PATH_METACHARACTERS) { "\\#{_1}" }
 
       if query_part
-        "#{escaped_path}?#{query_part.gsub(QUERY_METACHARACTERS) { |c| "\\#{c}" }}"
+        "#{escaped_path}?#{query_part.gsub(QUERY_METACHARACTERS) { "\\#{_1}" }}"
       else
         escaped_path
       end

--- a/app/lib/apicast/provider_source.rb
+++ b/app/lib/apicast/provider_source.rb
@@ -47,7 +47,19 @@ module Apicast
       }
 
       ActiveRecord::Associations::Preloader.new(records: Array(provider), associations: {services: [:service_tokens, {backend_api_configs: :backend_api, proxy: [:gateway_configuration, {proxy_rules: :metric}]}]}).call
-      provider.as_json(hash).merge(timestamp: Time.now.utc.iso8601)
+      result = provider.as_json(hash).merge(timestamp: Time.now.utc.iso8601)
+      escape_proxy_rule_patterns!(result)
+      result
+    end
+
+    private
+
+    def escape_proxy_rule_patterns!(result)
+      Array(result['services']).each do |service|
+        Array(service.dig('proxy', 'proxy_rules')).each do |rule|
+          rule['pattern'] = Apicast::PcreEscaper.escape(rule['pattern'])
+        end
+      end
     end
 
     protected

--- a/app/lib/apicast/proxy_rules_source.rb
+++ b/app/lib/apicast/proxy_rules_source.rb
@@ -19,7 +19,9 @@ module Apicast
         config.backend_api.proxy_rules.decorate(context: { backend_api_path: config.path })
       end
 
-      api_proxy_rules.as_json(root: false, methods: METHODS)
+      api_proxy_rules.as_json(root: false, methods: METHODS).each do |rule|
+        rule['pattern'] = PcreEscaper.escape(rule['pattern'])
+      end
     end
   end
 end

--- a/app/models/config_path.rb
+++ b/app/models/config_path.rb
@@ -12,7 +12,8 @@ class ConfigPath
   def to_regex
     return '^(/.*)' if empty?
 
-    "^(#{path}/.*|#{path}/?)"
+    escaped = Apicast::PcreEscaper.escape(path)
+    "^(#{escaped}/.*|#{escaped}/?)"
   end
 
   def empty?

--- a/test/unit/apicast/pcre_escaper_test.rb
+++ b/test/unit/apicast/pcre_escaper_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Apicast::PcreEscaperTest < ActiveSupport::TestCase
+  test 'escapes dots in path' do
+    assert_equal '/foo\\.bar', Apicast::PcreEscaper.escape('/foo.bar')
+  end
+
+  test 'escapes asterisks in path' do
+    assert_equal '/foo\\*', Apicast::PcreEscaper.escape('/foo*')
+  end
+
+  test 'escapes parentheses in path' do
+    assert_equal '/foo\\(bar\\)', Apicast::PcreEscaper.escape('/foo(bar)')
+  end
+
+  test 'escapes plus in path' do
+    assert_equal '/foo\\+bar', Apicast::PcreEscaper.escape('/foo+bar')
+  end
+
+  test 'escapes multiple metacharacters' do
+    assert_equal '/service1\\.svc/data\\(\\*\\)', Apicast::PcreEscaper.escape('/service1.svc/data(*)')
+  end
+
+  test 'preserves template variables' do
+    assert_equal '/foo/{bar}\\.json', Apicast::PcreEscaper.escape('/foo/{bar}.json')
+  end
+
+  test 'preserves trailing dollar anchor' do
+    assert_equal '/foo$', Apicast::PcreEscaper.escape('/foo$')
+  end
+
+  test 'preserves trailing dollar anchor with query string' do
+    assert_equal '/foo$?bar=baz', Apicast::PcreEscaper.escape('/foo$?bar=baz')
+  end
+
+  test 'preserves percent-encoded sequences in path' do
+    assert_equal '/foo%20bar', Apicast::PcreEscaper.escape('/foo%20bar')
+  end
+
+  test 'escapes dollar in query string' do
+    assert_equal '/foo?price=\\$10', Apicast::PcreEscaper.escape('/foo?price=$10')
+  end
+
+  test 'escapes question mark in query string' do
+    assert_equal '/foo?a=b\\?c', Apicast::PcreEscaper.escape('/foo?a=b?c')
+  end
+
+  test 'escapes brackets in query string' do
+    assert_equal '/foo?bar=\\[val\\]', Apicast::PcreEscaper.escape('/foo?bar=[val]')
+  end
+
+  test 'preserves template variables in query string' do
+    assert_equal '/foo?bar={baz}', Apicast::PcreEscaper.escape('/foo?bar={baz}')
+  end
+
+  test 'slash-only pattern is unchanged' do
+    assert_equal '/', Apicast::PcreEscaper.escape('/')
+  end
+
+  test 'blank pattern is returned as-is' do
+    assert_equal '', Apicast::PcreEscaper.escape('')
+    assert_nil Apicast::PcreEscaper.escape(nil)
+  end
+
+  # $ is not escaped in path because PatternParser only allows it at end-of-path
+  # where it serves as an intentional APICast anchor. Mid-path $ (e.g. /micro$oft)
+  # is rejected by PatternParser validation in ProxyRule.
+  test 'does not escape dollar in path since validation only allows it at end' do
+    assert_equal '/foo$', Apicast::PcreEscaper.escape('/foo$')
+    assert_equal '/foo/bar$', Apicast::PcreEscaper.escape('/foo/bar$')
+  end
+
+  test 'escapes all metacharacters in a segment' do
+    assert_equal '/\\(\\.\\*\\)', Apicast::PcreEscaper.escape('/(.*)')
+  end
+
+  test 'complex real-world pattern with dots and colons' do
+    input    = '/business-central/rest/runtime/com.redhat.demos:3.0/start'
+    expected = '/business-central/rest/runtime/com\\.redhat\\.demos:3\\.0/start'
+    assert_equal expected, Apicast::PcreEscaper.escape(input)
+  end
+
+  test 'path with dots and query string with brackets and dollar' do
+    input    = '/api.v2/search?filter=[$10]'
+    expected = '/api\\.v2/search?filter=\\[\\$10\\]'
+    assert_equal expected, Apicast::PcreEscaper.escape(input)
+  end
+end

--- a/test/unit/apicast/provider_source_test.rb
+++ b/test/unit/apicast/provider_source_test.rb
@@ -41,6 +41,23 @@ class Apicast::ProviderSourceTest < ActiveSupport::TestCase
     assert_equal 'plain', service_attributes['proxy']['jwt_claim_with_client_id_type']
   end
 
+  def test_proxy_rule_patterns_are_pcre_escaped
+    proxy = FactoryBot.build_stubbed(:proxy)
+    proxy.stubs(jwt_claim_with_client_id_type: nil, jwt_claim_with_client_id: nil)
+    service = FactoryBot.build_stubbed(:simple_service, proxy: proxy)
+
+    metric = FactoryBot.build_stubbed(:metric, service: service)
+    rule = FactoryBot.build_stubbed(:proxy_rule, proxy: proxy, pattern: '/api.v2/search(*)', metric: metric)
+    proxy.stubs(proxy_rules: [rule])
+
+    @account.stubs(services: [service])
+
+    result = @source.attributes_for_proxy
+    proxy_rules = result['services'][0]['proxy']['proxy_rules']
+
+    assert_equal '/api\\.v2/search\\(\\*\\)', proxy_rules[0]['pattern']
+  end
+
   def test_policies_with_default_apicast_policy
     ThreeScale.config.stubs(onpremises: true)
     proxy = FactoryBot.build_stubbed(:proxy, policies_config: [{ name: 'cors',

--- a/test/unit/apicast/proxy_rules_source_test.rb
+++ b/test/unit/apicast/proxy_rules_source_test.rb
@@ -53,6 +53,33 @@ class Apicast::ProxyRulesSourceTest < ActiveSupport::TestCase
     assert_equal %w[/test/path/one /test/path/two /test/path/three], source.map { |rule| rule['pattern'] }
   end
 
+  test 'escapes PCRE metacharacters in proxy rule patterns' do
+    rule = FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/api.v2/search(*)')
+
+    source = Apicast::ProxyRulesSource.new(proxy).to_hash
+    rule_hash = find_by_id_in_hash(rule.id, source)
+
+    assert_equal '/api\\.v2/search\\(\\*\\)', rule_hash['pattern']
+  end
+
+  test 'escapes PCRE metacharacters in backend api rule patterns including backend path' do
+    rule = FactoryBot.create(:proxy_rule, owner: backend_api, pattern: '/foo.bar')
+
+    source = Apicast::ProxyRulesSource.new(proxy).to_hash
+    rule_hash = find_by_id_in_hash(rule.id, source)
+
+    assert_equal '/test/path/foo\\.bar', rule_hash['pattern']
+  end
+
+  test 'preserves template variables and dollar anchor when escaping' do
+    rule = FactoryBot.create(:proxy_rule, proxy: proxy, pattern: '/api/{version}/resource$')
+
+    source = Apicast::ProxyRulesSource.new(proxy).to_hash
+    rule_hash = find_by_id_in_hash(rule.id, source)
+
+    assert_equal '/api/{version}/resource$', rule_hash['pattern']
+  end
+
   private
 
   def find_by_id_in_hash(id, hash)

--- a/test/unit/config_path_test.rb
+++ b/test/unit/config_path_test.rb
@@ -24,4 +24,9 @@ class ConfigPathTest < ActiveSupport::TestCase
   test '#to_regex returns the regex for the path if it is informed' do
     assert_equal '^(/some/path/.*|/some/path/?)', ConfigPath.new('/some/path').to_regex
   end
+
+  test '#to_regex escapes PCRE metacharacters in path' do
+    assert_equal '^(/catsv2\\.0/.*|/catsv2\\.0/?)', ConfigPath.new('/catsv2.0').to_regex
+    assert_equal '^(/api\\(v2\\)/.*|/api\\(v2\\)/?)', ConfigPath.new('/api(v2)').to_regex
+  end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

We set regular expressions as values for some fields in the proxy config that is pulled by apicast. Those regular expressions are used directly by apicast in order to match incoming requests.

Some characters in those regexps must be escaped so they are not literally interpreted by the RE engine from apicast. However, we don't have to escape everything blindly. To start, here's the complete list of characters that is initially considered to be escaped:

https://www.pcre.org/original/doc/html/pcrepattern.html#SEC4

And the next table summarizes how this PR implements escaping, and explains why each character is escaped or not:

| PCRE metachar | Valid in RFC 3986 path? | Allowed by PatternParser? | Escaped? |
  |---|---|---|---|
  | `\` | No | No | N/A — cannot appear in pattern |
  | `.` | Yes (unreserved) | Yes | **Yes** — path and query |
  | `^` | No | No | N/A — cannot appear in pattern |
  | `$` | Yes (sub-delim) | Only at end of path | **No** — intentional APICast end-of-path anchor |
  | `\|` | No | No | N/A — cannot appear in pattern |
  | `(` | Yes (sub-delim) | Yes | **Yes** — path and query |
  | `)` | Yes (sub-delim) | Yes | **Yes** — path and query |
  | `[` | No (gen-delim) | Yes, in query string only | **Yes** — query only |
  | `]` | No (gen-delim) | Yes, in query string only | **Yes** — query only |
  | `{` | No | Template variable syntax only | **No** — APICast expands `{name}` before PCRE compilation |
  | `}` | No | Template variable syntax only | **No** — APICast expands `{name}` before PCRE compilation |
  | `*` | Yes (sub-delim) | Yes | **Yes** — path and query |
  | `+` | Yes (sub-delim) | Yes | **Yes** — path and query |
  | `?` | No (gen-delim) | Structural query separator only | **Yes** — query only (any `?` inside the query string is a literal) |

**Which issue(s) this PR fixes** 

https://redhat.atlassian.net/browse/THREESCALE-15878

**Verification steps** 

In any of these screens:
- New/Edit Backend usage
- New/Edit Mapping rule

Insert values similar to these in the URL field:
- `/catsv2.1`
- `/TWAPData;{StartDateTime};{EndDateTime}`
- `/business-central/rest/runtime/com.redhat.demos:3.0/start`
- `/foo?a=b?c`
- `/search?q=[ruby]`
- `/exact/match?query=$10`
- `/exact/match$?query=param`
- `/foo(bar)/baz/v1+v2/endpoint/users/{id}/profile.json`

All of above values should pass validation. Then promote the new proxy config to staging, and download the generated json the see what we are actually sending to apicast. All URLs should have been escaped according to the table above.

