### PR TITLE
THREESCALE-16193: Fix plan change permission radio buttons not saving on product usage

### DIFF
--- a/app/views/api/services/usage_rules.html.slim
+++ b/app/views/api/services/usage_rules.html.slim
@@ -60,7 +60,7 @@ div class="pf-c-card"
               span class="pf-c-form__label-text"
                 = t('sites.usage_rules.edit.plans_label')
           = render 'shared/plan_change_settings', setting: :buyer_plan_change_permission,
-                                                  current: @service.buyer_plan_change_permission.to_sym
+                                                  form: form
 
       = form.inputs 'Alerts' do
         div class="pf-c-content"

--- a/app/views/shared/_plan_change_settings.html.slim
+++ b/app/views/shared/_plan_change_settings.html.slim
@@ -2,10 +2,7 @@
 
 div class="pf-c-form__group-control pf-m-stack"
   - allowed_permissions.each do |permission|
-    - id = "settings_#{setting}_#{permission}"
-    - checked = current == permission
-
+    - value = permission.to_s
     div class="pf-c-radio"
-      input class="pf-c-radio__input" name="settings[#{setting}]" id=id type="radio" value=permission checked=checked
-      label class="pf-c-radio__label" for=id
-        = t("formtastic.labels.settings.change_plan_permission.#{permission}")
+      = form.radio_button setting, value, class: "pf-c-radio__input"
+      = form.label "#{setting}_#{value}", t("formtastic.labels.settings.change_plan_permission.#{permission}"), class: "pf-c-radio__label"

--- a/app/views/shared/_plan_change_settings.html.slim
+++ b/app/views/shared/_plan_change_settings.html.slim
@@ -2,7 +2,6 @@
 
 div class="pf-c-form__group-control pf-m-stack"
   - allowed_permissions.each do |permission|
-    - value = permission.to_s
     div class="pf-c-radio"
-      = form.radio_button setting, value, class: "pf-c-radio__input"
-      = form.label "#{setting}_#{value}", t("formtastic.labels.settings.change_plan_permission.#{permission}"), class: "pf-c-radio__label"
+      = form.radio_button setting, permission, class: "pf-c-radio__input"
+      = form.label "#{setting}_#{permission}", t("formtastic.labels.settings.change_plan_permission.#{permission}"), class: "pf-c-radio__label"

--- a/app/views/sites/usage_rules/edit.html.slim
+++ b/app/views/sites/usage_rules/edit.html.slim
@@ -42,7 +42,7 @@ div class="pf-c-card"
                   span class="pf-c-form__label-text"
                     = t('sites.usage_rules.edit.plans_label')
                 = render 'shared/plan_change_settings', setting: :change_account_plan_permission,
-                                                        current: settings.change_account_plan_permission.to_sym
+                                                        form: form
 
       - if can?(:see, :service_plans)
         = form.inputs 'Service plans'
@@ -56,7 +56,7 @@ div class="pf-c-card"
                   span class="pf-c-form__label-text"
                     = t('sites.usage_rules.edit.plans_label')
               = render 'shared/plan_change_settings', setting: :change_service_plan_permission,
-                                                      current: settings.change_service_plan_permission.to_sym
+                                                      form: form
 
       = form.actions do
         = form.commit_button 'Update settings'

--- a/test/functional/sites/usage_rules_controller_test.rb
+++ b/test/functional/sites/usage_rules_controller_test.rb
@@ -46,6 +46,26 @@ class Sites::UsageRulesControllerTest < ActionController::TestCase
     assert_template :edit
   end
 
+  test 'renders correct checked state for change_account_plan_permission' do
+    @provider.settings.account_plans.allow
+    @settings.update!(change_account_plan_permission: 'direct')
+
+    get :edit
+
+    assert_response :success
+    assert_select "input[name='settings[change_account_plan_permission]'][value='direct'][checked='checked']", count: 1
+  end
+
+  test 'renders correct checked state for change_service_plan_permission' do
+    @provider.settings.service_plans.allow
+    @settings.update!(change_service_plan_permission: 'direct')
+
+    get :edit
+
+    assert_response :success
+    assert_select "input[name='settings[change_service_plan_permission]'][value='direct'][checked='checked']", count: 1
+  end
+
   test 'update with valid params' do
     @settings.update(strong_passwords_enabled: true, public_search: true)
     %i[useraccountarea_enabled signups_enabled public_search

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -417,19 +417,33 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
 
       put admin_service_path(service), params: { service: { buyer_plan_change_permission: 'direct' } }
 
+      assert_response :redirect
       assert_equal 'direct', service.reload.buyer_plan_change_permission
     end
 
-    test 'update buyer_plan_change_permission does not change other attributes' do
-      original_name = service.name
-      original_buyers_manage_apps = service.buyers_manage_apps
+    test 'usage rules page renders correct checked state for plan change permission' do
+      service.update!(buyer_plan_change_permission: 'direct')
 
-      put admin_service_path(service), params: { service: { buyer_plan_change_permission: 'direct' } }
+      get usage_rules_admin_service_path(service)
 
+      assert_response :success
+      assert_select "input[name='service[buyer_plan_change_permission]'][value='direct'][checked='checked']", count: 1
+    end
+
+    test 'crafted POST cannot update non-permitted service attributes' do
+      original_account_id = service.account_id
+
+      put admin_service_path(service), params: {
+        service: {
+          buyer_plan_change_permission: 'direct',
+          account_id: 0
+        }
+      }
+
+      assert_response :redirect
       service.reload
       assert_equal 'direct', service.buyer_plan_change_permission
-      assert_equal original_name, service.name
-      assert_equal original_buyers_manage_apps, service.buyers_manage_apps
+      assert_equal original_account_id, service.account_id
     end
 
     test 'member without plans permission cannot access usage rules' do

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -397,6 +397,62 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  class UsageRulesTest < self
+    test 'usage rules page renders plan change radio buttons with correct param name' do
+      get usage_rules_admin_service_path(service)
+      assert_response :success
+      assert_select "input[type=radio][name='service[buyer_plan_change_permission]']", count: 2
+    end
+
+    test 'usage rules page shows all plan change options when finance is allowed' do
+      provider.settings.finance.allow
+
+      get usage_rules_admin_service_path(service)
+      assert_response :success
+      assert_select "input[type=radio][name='service[buyer_plan_change_permission]']", count: 5
+    end
+
+    test 'update buyer_plan_change_permission persists the value' do
+      assert_equal 'request', service.buyer_plan_change_permission
+
+      put admin_service_path(service), params: { service: { buyer_plan_change_permission: 'direct' } }
+
+      assert_equal 'direct', service.reload.buyer_plan_change_permission
+    end
+
+    test 'update buyer_plan_change_permission does not change other attributes' do
+      original_name = service.name
+      original_buyers_manage_apps = service.buyers_manage_apps
+
+      put admin_service_path(service), params: { service: { buyer_plan_change_permission: 'direct' } }
+
+      service.reload
+      assert_equal 'direct', service.buyer_plan_change_permission
+      assert_equal original_name, service.name
+      assert_equal original_buyers_manage_apps, service.buyers_manage_apps
+    end
+
+    test 'member without plans permission cannot access usage rules' do
+      member = FactoryBot.create(:member, account: provider)
+      member.activate!
+      logout! && login!(provider, user: member)
+
+      get usage_rules_admin_service_path(service)
+      assert_response :forbidden
+    end
+
+    test 'member with plans permission can access usage rules' do
+      member = FactoryBot.create(:member, account: provider)
+      member.admin_sections = %w[plans]
+      member.activate!
+      member.save!
+      logout! && login!(provider, user: member)
+
+      get usage_rules_admin_service_path(service)
+      assert_response :success
+    end
+  end
+
   class MemberPermissions < self
     def setup
       super

--- a/test/integration/api/services_controller_test.rb
+++ b/test/integration/api/services_controller_test.rb
@@ -430,41 +430,6 @@ class Api::ServicesControllerTest < ActionDispatch::IntegrationTest
       assert_select "input[name='service[buyer_plan_change_permission]'][value='direct'][checked='checked']", count: 1
     end
 
-    test 'crafted POST cannot update non-permitted service attributes' do
-      original_account_id = service.account_id
-
-      put admin_service_path(service), params: {
-        service: {
-          buyer_plan_change_permission: 'direct',
-          account_id: 0
-        }
-      }
-
-      assert_response :redirect
-      service.reload
-      assert_equal 'direct', service.buyer_plan_change_permission
-      assert_equal original_account_id, service.account_id
-    end
-
-    test 'member without plans permission cannot access usage rules' do
-      member = FactoryBot.create(:member, account: provider)
-      member.activate!
-      logout! && login!(provider, user: member)
-
-      get usage_rules_admin_service_path(service)
-      assert_response :forbidden
-    end
-
-    test 'member with plans permission can access usage rules' do
-      member = FactoryBot.create(:member, account: provider)
-      member.admin_sections = %w[plans]
-      member.activate!
-      member.save!
-      logout! && login!(provider, user: member)
-
-      get usage_rules_admin_service_path(service)
-      assert_response :success
-    end
   end
 
   class MemberPermissions < self


### PR DESCRIPTION
**What this PR does / why we need it**

Fixes the "Developers are allowed to:" radio buttons on the Product Usage Rules page silently failing to save. The success flash appeared but the selected option reverted on reload.



**Before** 
The plan isn’t changing even though it says "Product Information Updated"
<img width="1231" height="474" alt="Screenshot 2026-09-02 at 13 09 46" src="https://github.com/user-attachments/assets/10427e48-057e-45f3-b953-f410014a5827" />

**After**
Plan Change successfully After "Update Product"
<img width="1167" height="522" alt="Screenshot 2026-09-02 at 13 09 36" src="https://github.com/user-attachments/assets/7192fe8e-d25c-4991-8290-386761677a0e" />


**Which issue(s) this PR fixes**

[THREESCALE-16193
](https://redhat.atlassian.net/browse/THREESCALE-16193)
**Verification Steps**

1. Navigate to any Product → Applications → Settings → Usage Rules
2. Under "Developers are allowed to:", select a different option
3. Click "Update product"
4. Reload the page, the selection should persist
5. Repeat on Audience → Settings → Usage Rules to confirm no regression on account-level plan permissions
